### PR TITLE
fix: Remove empty unit from Last Cover Action sensor

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -730,9 +730,6 @@ class AdaptiveCoverLastActionSensor(AdaptiveCoverAdvancedDiagnosticSensor):
     # Override parent class to enable by default (matches P0 classification and docs)
     _attr_entity_registry_enabled_default = True
 
-    # Exclude from logbook/history to prevent clutter (diagnostic data, not activity tracking)
-    _attr_native_unit_of_measurement = ""  # Empty string triggers logbook exclusion
-
     def __init__(
         self,
         config_entry_id: str,


### PR DESCRIPTION
## Summary

Fixes startup crash caused by the Last Cover Action sensor having an empty unit string, which Home Assistant interprets as a numeric sensor. This also resolves cascading switch setup failures.

## Problem
- Sensor returns text values like "No action recorded"
- Empty unit string () causes HA to expect numeric values
- ValueError crash: "Sensor has... unit '' thus indicating it has a numeric value; however, it has the non-numeric value: 'No action recorded'"
- Switch entities fail to complete setup because coordinator.async_refresh() crashes

## Solution
Remove  line from  class. Text sensors without device_class/state_class should not set a unit at all.

## Testing
- ✅ Linting clean
- Tested on Home Assistant 2024.5.0+
- Sensor returns text correctly
- Switch entities complete setup successfully

## Impact
- User impact: None - sensor continues to work as text sensor
- Fixes cascading switch setup failures
- No breaking changes