### PR TITLE
fix: Control Method sensor shows enum repr instead of value

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -866,7 +866,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 "state": state,
                 "start": start,
                 "end": end,
-                "control": self.control_method,
+                "control": self.control_method.value,
                 "sun_motion": normal_cover.direct_sun_valid,
                 "manual_override": self.manager.binary_cover_manual,
                 "manual_list": self.manager.manual_controlled,


### PR DESCRIPTION
## Summary

Fixes Control Method sensor displaying `ControlMethod.DEFAULT` instead of `default`.

**Root cause:** Python 3.11+ changed `str()` behavior on `str, Enum` subclasses — `str(ControlMethod.DEFAULT)` now returns `"ControlMethod.DEFAULT"` rather than `"default"`. Home Assistant's state machine calls `str()` when storing the sensor state.

**Fix:** Use `.value` when storing `control_method` in the coordinator states dict (one-line change in `coordinator.py`).

## Testing

- ✅ 313 tests passing