### PR TITLE
fix: Prevent manual override re-detection after reset button press

### DIFF
--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -62,6 +62,7 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle the button press."""
+        reset_entities = []
         for entity in self._entities:
             if self.coordinator.manager.is_cover_manual(entity):
                 _LOGGER.debug("Resetting manual override for: %s", entity)
@@ -73,7 +74,15 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
                     entity, target_position, options
                 ):
                     await self.coordinator.async_set_position(entity, target_position)
+                    # Wait for cover to reach target, but no longer than 30 seconds
+                    deadline = asyncio.get_event_loop().time() + 30
                     while self.coordinator.wait_for_target.get(entity):
+                        if asyncio.get_event_loop().time() >= deadline:
+                            _LOGGER.debug(
+                                "Timed out waiting for %s to reach target position",
+                                entity,
+                            )
+                            break
                         await asyncio.sleep(1)
                 else:
                     _LOGGER.debug(
@@ -82,9 +91,17 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
                     )
 
                 self.coordinator.manager.reset(entity)
+                # Suppress re-detection: any cover state events arriving during
+                # refresh should not be treated as a new manual override.
+                self.coordinator.wait_for_target[entity] = True
+                self.coordinator.cover_state_change = False
+                reset_entities.append(entity)
             else:
                 _LOGGER.debug(
                     "Resetting manual override for %s is not needed since it is already auto-controlled",
                     entity,
                 )
         await self.coordinator.async_refresh()
+        # Unblock state tracking now that refresh has consumed any pending events.
+        for entity in reset_entities:
+            self.coordinator.wait_for_target[entity] = False

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -1,7 +1,8 @@
 """Tests for manual override detection with grace period."""
 
+import asyncio
 import datetime as dt
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -169,3 +170,125 @@ def test_cancel_grace_period_handles_missing_entity():
     # Tracking should still be empty
     assert "cover.test" not in coordinator._grace_period_tasks
     assert "cover.test" not in coordinator._command_timestamps
+
+
+# ---------------------------------------------------------------------------
+# Reset button tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_button_clears_manual_override_and_stays_cleared():
+    """Reset button must clear manual override and leave it cleared after refresh."""
+    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+
+    entity_id = "cover.living_room"
+
+    # Build a minimal coordinator mock
+    coordinator = MagicMock()
+    coordinator.manager.is_cover_manual.return_value = True
+    coordinator.state = 75
+    coordinator.config_entry.options = {}
+    coordinator.check_position_delta.return_value = True
+    coordinator.async_set_position = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    # Simulate cover reaching target immediately
+    coordinator.wait_for_target = {entity_id: False}
+    coordinator.cover_state_change = False
+
+    # Build button with the mocked coordinator
+    config_entry = MagicMock()
+    config_entry.options = {"entities": [entity_id]}
+    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
+    button.coordinator = coordinator
+    button._entities = [entity_id]
+
+    await button.async_press()
+
+    # Manager reset was called
+    coordinator.manager.reset.assert_called_once_with(entity_id)
+    # Refresh was called
+    coordinator.async_refresh.assert_called_once()
+    # After refresh, wait_for_target was cleared (False), not left suppressing events
+    assert coordinator.wait_for_target[entity_id] is False
+
+
+@pytest.mark.asyncio
+async def test_reset_button_suppresses_redetection_during_refresh():
+    """wait_for_target must be True while async_refresh runs, then cleared."""
+    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+
+    entity_id = "cover.bedroom"
+    states_during_refresh = []
+
+    async def capture_refresh():
+        # Record wait_for_target value at the moment refresh runs
+        states_during_refresh.append(coordinator.wait_for_target.get(entity_id))
+
+    coordinator = MagicMock()
+    coordinator.manager.is_cover_manual.return_value = True
+    coordinator.state = 50
+    coordinator.config_entry.options = {}
+    coordinator.check_position_delta.return_value = True
+    coordinator.async_set_position = AsyncMock()
+    coordinator.async_refresh = AsyncMock(side_effect=capture_refresh)
+    coordinator.wait_for_target = {entity_id: False}
+    coordinator.cover_state_change = False
+
+    config_entry = MagicMock()
+    config_entry.options = {"entities": [entity_id]}
+    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
+    button.coordinator = coordinator
+    button._entities = [entity_id]
+
+    await button.async_press()
+
+    # During refresh, suppression must be active (True)
+    assert states_during_refresh == [True]
+    # After refresh, suppression must be cleared (False)
+    assert coordinator.wait_for_target[entity_id] is False
+
+
+@pytest.mark.asyncio
+async def test_reset_button_times_out_if_cover_never_reaches_target():
+    """Button must not hang forever when cover never reaches the target position."""
+    import time
+
+    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+
+    entity_id = "cover.stuck"
+
+    coordinator = MagicMock()
+    coordinator.manager.is_cover_manual.return_value = True
+    coordinator.state = 80
+    coordinator.config_entry.options = {}
+    coordinator.check_position_delta.return_value = True
+    coordinator.async_set_position = AsyncMock()
+    coordinator.async_refresh = AsyncMock()
+    # Cover never clears wait_for_target — simulates position mismatch
+    coordinator.wait_for_target = {entity_id: True}
+    coordinator.cover_state_change = False
+
+    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
+    button.coordinator = coordinator
+    button._entities = [entity_id]
+
+    start = time.monotonic()
+    # Patch event loop time so the 30-second timeout fires immediately
+    fake_time = [0.0]
+
+    original_sleep = asyncio.sleep
+
+    async def fast_sleep(delay):
+        fake_time[0] += 31  # Jump past the 30-second deadline
+
+    with patch("asyncio.get_event_loop") as mock_loop:
+        mock_loop.return_value.time.side_effect = lambda: fake_time[0]
+        with patch("asyncio.sleep", side_effect=fast_sleep):
+            await button.async_press()
+
+    elapsed = time.monotonic() - start
+    # Should complete almost instantly (well under a real second)
+    assert elapsed < 5
+    # Refresh was still called despite the timeout
+    coordinator.async_refresh.assert_called_once()


### PR DESCRIPTION
## Summary

- After `manager.reset()` clears the manual override, `wait_for_target` is re-enabled and `cover_state_change` is cleared before `async_refresh()` runs, so any cover settling events are suppressed and cannot immediately re-flag the override.
- `wait_for_target` is cleared back to `False` immediately after `async_refresh()` returns, restoring normal state-change tracking.
- Added a 30-second timeout to the `wait_for_target` polling loop so the button press cannot hang indefinitely when a cover reports a rounded/mismatched position.

## Testing

- ✅ 334 tests passing
- ✅ 3 new regression tests added to `tests/test_manual_override.py`
  - Reset clears override and stays cleared after refresh
  - `wait_for_target` is `True` during refresh (suppressing re-detection), `False` after
  - Timeout fires and button completes even when cover never reaches exact target