### PR TITLE
Update config_flow.py - motion sensor

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -507,7 +507,7 @@ AUTOMATION_CONFIG = vol.Schema(
             selector.EntitySelectorConfig(
                 domain=["binary_sensor"],
                 multiple=True,
-                device_class="motion",
+#                device_class=["motion", "occupancy"],
             )
         ),
         vol.Optional(CONF_MOTION_TIMEOUT, default=DEFAULT_MOTION_TIMEOUT): selector.NumberSelector(


### PR DESCRIPTION
Removed device_class for motion sensor to allow for other types of sensors (mainly occupancy sensors)

<!--- Provide a general summary of your changes in the Title above -->

## Description

I removed (commented out) `device_class="motion",`
The other solution, would be to use `device_class=["motion", "occupancy"],` (which is what I coded, I only commented it out afterwards) to only allow motion or occupancy sensors **but** I don't see the point of being this limiting. For instance, you might have a sensor detecting your computer is on (because you have HASS.Agent or a power metering plug or whatever); computer _on_ means you're working with a screen and want glare control. If it goes into standby mode, boom "occupancy" clears.


## Motivation and Context

If fixes issue https://github.com/jrhubott/adaptive-cover-pro/issues/52.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (non-breaking which updates existing code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other


## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
