### PR TITLE
fix: Update Help and Known Issues links to correct repo (#67)

### DIFF
--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -13,9 +13,9 @@
     "sensor",
     "weather"
   ],
-  "documentation": "https://github.com/jrhubott/adaptive-cover",
+  "documentation": "https://github.com/jrhubott/adaptive-cover-pro",
   "iot_class": "calculated",
-  "issue_tracker": "https://github.com/jrhubott/adaptive-cover/issues",
+  "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": [
     "astral",
     "pandas"


### PR DESCRIPTION
## Summary
- Update `documentation` URL in manifest.json from `adaptive-cover` to `adaptive-cover-pro`
- Update `issue_tracker` URL in manifest.json from `adaptive-cover` to `adaptive-cover-pro`

The "Help" and "Known Issues" links on the HA integration page were pointing to the old repository.

## Testing
- ✅ All existing tests pass (no behavioral changes)
- ✅ Linting passes

## Related Issues
Fixes #67