### PR TITLE
fix: Remove empty unit attribute from Motion Status sensor (#76)

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -817,7 +817,6 @@ class AdaptiveCoverPositionVerificationSensor(
 class AdaptiveCoverMotionStatusSensor(AdaptiveCoverDiagnosticSensorBase, SensorEntity):
     """Diagnostic sensor showing current motion control state."""
 
-    _attr_native_unit_of_measurement = ""
     _attr_should_poll = False
     _attr_translation_key = "motion_status"
 


### PR DESCRIPTION
## Summary
- Remove `_attr_native_unit_of_measurement = ""` from `AdaptiveCoverMotionStatusSensor`
- With the empty string unit, HA treats the sensor as numeric and crashes when it returns string states like `"waiting_for_data"`, blocking all entities from loading
- Same fix already applied to Position Explanation and Last Skipped Action sensors in `25912bf` — Motion Status was missed

## Testing
- ✅ 442 tests passing
- ✅ Verified no other text sensors have `_attr_native_unit_of_measurement = ""`

## Related Issues
Fixes #76