### PR TITLE
refactor: Full integration rewrite (Phases 1A-3)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -45,15 +45,10 @@ from .const import (
     COMMAND_GRACE_PERIOD_SECONDS,
     CONF_AZIMUTH,
     CONF_BLIND_SPOT_ELEVATION,
-    CONF_BLIND_SPOT_LEFT,
-    CONF_BLIND_SPOT_RIGHT,
     CONF_CLIMATE_MODE,
     CONF_DEFAULT_HEIGHT,
     CONF_DELTA_POSITION,
     CONF_DELTA_TIME,
-    CONF_ENABLE_BLIND_SPOT,
-    CONF_ENABLE_MAX_POSITION,
-    CONF_ENABLE_MIN_POSITION,
     CONF_END_ENTITY,
     CONF_END_TIME,
     CONF_ENTITIES,
@@ -73,10 +68,6 @@ from .const import (
     CONF_MANUAL_OVERRIDE_DURATION,
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MANUAL_THRESHOLD,
-    CONF_MAX_ELEVATION,
-    CONF_MAX_POSITION,
-    CONF_MIN_ELEVATION,
-    CONF_MIN_POSITION,
     CONF_OPEN_CLOSE_THRESHOLD,
     CONF_RETURN_SUNSET,
     CONF_START_ENTITY,
@@ -103,9 +94,9 @@ from .const import (
     POSITION_TOLERANCE_PERCENT,
     STARTUP_GRACE_PERIOD_SECONDS,
     DEFAULT_MOTION_TIMEOUT,
-    ControlStatus,
 )
-from .enums import ClimateStrategy, ControlMethod
+from .diagnostics.builder import DiagnosticContext, DiagnosticsBuilder
+from .enums import ControlMethod
 from .helpers import (
     get_datetime_from_str,
     get_safe_state,
@@ -221,14 +212,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Motion control tracking
         self._motion_mgr = MotionManager(hass=self.hass, logger=self.logger)
         # Override pipeline
-        self._pipeline = PipelineRegistry([
-            ForceOverrideHandler(),
-            MotionTimeoutHandler(),
-            ManualOverrideHandler(),
-            ClimateHandler(),
-            SolarHandler(),
-            DefaultHandler(),
-        ])
+        self._pipeline = PipelineRegistry(
+            [
+                ForceOverrideHandler(),
+                MotionTimeoutHandler(),
+                ManualOverrideHandler(),
+                ClimateHandler(),
+                SolarHandler(),
+                DefaultHandler(),
+            ]
+        )
         self._pipeline_result = None
         self._update_listener = None
         self._scheduled_time = dt.datetime.now()
@@ -251,6 +244,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         # Sun data provider
         self._sun_provider = SunProvider(hass=self.hass)
+
+        # Diagnostics builder (extracted from coordinator)
+        self._diagnostics_builder = DiagnosticsBuilder()
 
         # Track position explanation for change detection logging
         self._last_position_explanation: str = ""
@@ -1332,373 +1328,62 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.climate_state,
         )
 
-    def _build_solar_diagnostics(self) -> dict:
-        """Build solar position diagnostics."""
-        diagnostics = {}
-        sun_azimuth, sun_elevation = self.pos_sun
-        diagnostics["sun_azimuth"] = sun_azimuth
-        diagnostics["sun_elevation"] = sun_elevation
-
-        # Gamma (surface solar azimuth)
-        if self.normal_cover_state and hasattr(self.normal_cover_state.cover, "gamma"):
-            diagnostics["gamma"] = self.normal_cover_state.cover.gamma
-
-        return diagnostics
-
-    def _get_control_state_reason(self) -> str:
-        """Get the current control state reason including coordinator-level overrides.
-
-        Combines cover-level sun position reasons with coordinator-level override
-        states (force override, motion timeout, manual override). Coordinator-level
-        states take priority over cover-level sun position reasons.
-
-        Returns:
-            Human-readable reason string for current cover control state.
-
-        """
-        if self.is_force_override_active:
-            return "Force Override"
-        if self.is_motion_timeout_active:
-            return "Motion Timeout"
-        if self.manager.binary_cover_manual:
-            return "Manual Override"
-        if self.normal_cover_state and self.normal_cover_state.cover:
-            return self.normal_cover_state.cover.control_state_reason
-        return "Unknown"
-
-    _CLIMATE_STRATEGY_LABELS: dict[ClimateStrategy, str] = {
-        ClimateStrategy.WINTER_HEATING: "Winter Heating",
-        ClimateStrategy.SUMMER_COOLING: "Summer Cooling",
-        ClimateStrategy.LOW_LIGHT: "Low Light",
-        ClimateStrategy.GLARE_CONTROL: "Glare Control",
-    }
-
-    def _build_position_explanation(self) -> str:
-        """Build a human-readable explanation of the full position decision chain.
-
-        Returns:
-            Single-line string describing each step from raw calculation to final
-            position (e.g. "Sun tracking (45%) → Climate: Winter Heating → 100%").
-
-        """
-        options = self.config_entry.options
-
-        # Priority overrides
-        if self.is_force_override_active:
-            pos = options.get(CONF_FORCE_OVERRIDE_POSITION, 0)
-            return f"Force override active → {pos}%"
-
-        if self.is_motion_timeout_active:
-            return f"No motion detected → default {self.default_state}%"
-
-        if self.manager.binary_cover_manual:
-            return "Manual override active"
-
-        # Outside time window
-        if not self.check_adaptive_time:
-            sunset_pos = options.get(CONF_SUNSET_POS)
-            default_height = options.get(CONF_DEFAULT_HEIGHT, 0)
-            if sunset_pos is not None:
-                return f"Outside time window → Sunset Position ({sunset_pos}%)"
-            return f"Outside time window → Default Position ({default_height}%)"
-
-        # Build the decision chain
-        parts = []
-
-        # Step 1: Sun position condition and raw calculated value
-        if self.normal_cover_state and self.normal_cover_state.cover:
-            cover = self.normal_cover_state.cover
-            if cover.direct_sun_valid:
-                parts.append(f"Sun tracking ({self.raw_calculated_position}%)")
-            elif cover.sunset_valid and cover.sunset_pos is not None:
-                parts.append(f"Sunset Position ({round(cover.sunset_pos)}%)")
-            else:
-                reason = cover.control_state_reason
-                parts.append(f"{reason} → Default Position ({round(cover.default)}%)")
-
-        # Step 2: Position limits on the non-climate path
-        if not self._switch_mode:
-            min_pos = options.get(CONF_MIN_POSITION)
-            max_pos = options.get(CONF_MAX_POSITION)
-            enable_min = options.get(CONF_ENABLE_MIN_POSITION, False)
-            enable_max = options.get(CONF_ENABLE_MAX_POSITION, False)
-            if min_pos is not None and enable_min and self.default_state == min_pos:
-                parts.append(f"min limit ({min_pos}%) → {self.default_state}%")
-            elif max_pos is not None and enable_max and self.default_state == max_pos:
-                parts.append(f"max limit ({max_pos}%) → {self.default_state}%")
-
-        # Step 3: Climate mode override
-        if self._switch_mode and self.climate_state is not None:
-            strategy_label = (
-                self._CLIMATE_STRATEGY_LABELS.get(self.climate_strategy, "Active")
-                if self.climate_strategy
-                else "Active"
-            )
-            parts.append(f"Climate: {strategy_label} → {self.climate_state}%")
-
-        # Step 4: Interpolation / inverse state
-        final = self.state
-        if self._use_interpolation:
-            parts.append(f"interpolated → {final}%")
-        elif self._inverse_state:
-            parts.append(f"inversed → {final}%")
-
-        return " → ".join(parts) if parts else "Unknown"
-
-    def _build_position_diagnostics(self) -> dict:
-        """Build position diagnostics.
-
-        Returns:
-            Dictionary containing calculated position (before limits), climate
-            position (if enabled), control status, and control state reason
-
-        """
-        diagnostics = {}
-
-        # Use raw calculated position (before min/max limits) for diagnostic
-        diagnostics["calculated_position"] = self.raw_calculated_position
-
-        if self.climate_state is not None:
-            diagnostics["calculated_position_climate"] = self.climate_state
-
-        # Control status determination
-        control_status = self._determine_control_status()
-        diagnostics["control_status"] = control_status
-
-        # Human-readable reason for current state (including coordinator-level overrides)
-        diagnostics["control_state_reason"] = self._get_control_state_reason()
-
-        # Full decision chain explanation
-        explanation = self._build_position_explanation()
-        diagnostics["position_explanation"] = explanation
-        if explanation != self._last_position_explanation:
-            self.logger.debug("Position explanation changed: %s", explanation)
-            self._last_position_explanation = explanation
-
-        # Delta thresholds (for debugging position_delta_too_small / time_delta_too_small)
-        diagnostics["delta_position_threshold"] = self.min_change
-        diagnostics["delta_time_threshold_minutes"] = self.time_threshold
-
-        # Position delta from last action
-        last_action = self.last_cover_action
-        if last_action.get("position") is not None:
-            diagnostics["position_delta_from_last_action"] = abs(
-                self.raw_calculated_position - last_action["position"]
-            )
-
-        # Time since last action
-        if last_action.get("timestamp"):
-            try:
-                last_ts = dt.datetime.fromisoformat(last_action["timestamp"])
-                if last_ts.tzinfo is None:
-                    last_ts = last_ts.replace(tzinfo=dt.UTC)
-                now_utc = dt.datetime.now(dt.UTC)
-                elapsed = (now_utc - last_ts).total_seconds()
-                diagnostics["seconds_since_last_action"] = round(elapsed)
-            except (ValueError, AttributeError):
-                pass
-
-        # Vertical cover calculation details (edge case, safety margin, distances)
-        if self.normal_cover_state and self.normal_cover_state.cover:
-            cover = self.normal_cover_state.cover
-            calc_details = getattr(cover, "_last_calc_details", None)
-            if calc_details is not None:
-                diagnostics["calculation_details"] = calc_details
-
-        # Coordinator last update time
-        diagnostics["last_updated"] = dt.datetime.now(dt.UTC).isoformat()
-
-        return diagnostics
-
-    def _build_time_window_diagnostics(self) -> dict:
-        """Build time window diagnostics.
-
-        Returns:
-            Dictionary containing time window state checks and configured times
-
-        """
-        return {
-            "time_window": {
-                "check_adaptive_time": self.check_adaptive_time,
-                "after_start_time": self.after_start_time,
-                "before_end_time": self.before_end_time,
-                "start_time": self._start_time,
-                "end_time": self._end_time,
-            }
-        }
-
-    def _build_sun_validity_diagnostics(self) -> dict:
-        """Build sun validity diagnostics.
-
-        Returns:
-            Dictionary containing sun validity state (in field of view, elevation
-            valid, in blind spot)
-
-        """
-        diagnostics = {}
-        if self.normal_cover_state and self.normal_cover_state.cover:
-            cover = self.normal_cover_state.cover
-            diagnostics["sun_validity"] = {
-                "valid": cover.valid,
-                "valid_elevation": cover.valid_elevation,
-                "in_blind_spot": getattr(cover, "in_blind_spot", None),
-            }
-        return diagnostics
-
-    def _build_climate_diagnostics(self) -> dict:
-        """Build climate mode diagnostics.
-
-        Returns:
-            Dictionary containing climate control method, active temperature,
-            temperature details, and climate conditions (summer/winter/presence/
-            sunny/lux/irradiance)
-
-        """
-        diagnostics = {}
-        if self._climate_mode and self.climate_data is not None:
-            diagnostics["climate_control_method"] = self.control_method
-
-            # Active temperature and temperature details
-            diagnostics["active_temperature"] = (
-                self.climate_data.get_current_temperature
-            )
-            diagnostics["temperature_details"] = {
-                "inside_temperature": self.climate_data.inside_temperature,
-                "outside_temperature": self.climate_data.outside_temperature,
-                "temp_switch": self.climate_data.temp_switch,
-            }
-
-            # Which strategy branch was taken
-            if self.climate_strategy is not None:
-                diagnostics["climate_strategy"] = self.climate_strategy.value
-
-            # Climate conditions
-            diagnostics["climate_conditions"] = {
-                "is_summer": self.climate_data.is_summer,
-                "is_winter": self.climate_data.is_winter,
-                "is_presence": self.climate_data.is_presence,
-                "is_sunny": self.climate_data.is_sunny,
-                "lux_active": self.climate_data.lux
-                if self.climate_data._use_lux
-                else None,
-                "irradiance_active": self.climate_data.irradiance
-                if self.climate_data._use_irradiance
-                else None,
-            }
-
-        return diagnostics
-
-    def _build_last_action_diagnostics(self) -> dict:
-        """Build last action diagnostics.
-
-        Returns:
-            Dictionary containing last cover action details (entity, service,
-            position, timestamp, etc.) if any action has been taken
-
-        """
-        diagnostics = {}
-        if self.last_cover_action.get("entity_id"):
-            diagnostics["last_cover_action"] = self.last_cover_action.copy()
-        if self.last_skipped_action.get("entity_id"):
-            diagnostics["last_skipped_action"] = self.last_skipped_action.copy()
-        return diagnostics
-
-    def _build_configuration_diagnostics(self) -> dict:
-        """Build configuration diagnostics.
-
-        Returns:
-            Dictionary containing current configuration settings (azimuth, FOV,
-            elevation limits, blind spot, position limits, inverse state,
-            interpolation)
-
-        """
-        options = self.config_entry.options
-        return {
-            "configuration": {
-                "azimuth": options.get(CONF_AZIMUTH),
-                "fov_left": options.get(CONF_FOV_LEFT),
-                "fov_right": options.get(CONF_FOV_RIGHT),
-                "min_elevation": options.get(CONF_MIN_ELEVATION),
-                "max_elevation": options.get(CONF_MAX_ELEVATION),
-                "enable_blind_spot": options.get(CONF_ENABLE_BLIND_SPOT, False),
-                "blind_spot_elevation": options.get(CONF_BLIND_SPOT_ELEVATION),
-                "blind_spot_left": options.get(CONF_BLIND_SPOT_LEFT),
-                "blind_spot_right": options.get(CONF_BLIND_SPOT_RIGHT),
-                "min_position": options.get(CONF_MIN_POSITION),
-                "max_position": options.get(CONF_MAX_POSITION),
-                "enable_min_position": options.get(CONF_ENABLE_MIN_POSITION, False),
-                "enable_max_position": options.get(CONF_ENABLE_MAX_POSITION, False),
-                "inverse_state": options.get(CONF_INVERSE_STATE, False),
-                "interpolation": options.get(CONF_INTERP, False),
-                "force_override_sensors": options.get(CONF_FORCE_OVERRIDE_SENSORS, []),
-                "force_override_position": options.get(CONF_FORCE_OVERRIDE_POSITION, 0),
-                "force_override_active": self.is_force_override_active,
-                "motion_sensors": options.get(CONF_MOTION_SENSORS, []),
-                "motion_timeout": options.get(
-                    CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT
-                ),
-                "motion_detected": self.is_motion_detected,
-                "motion_timeout_active": self._motion_mgr._motion_timeout_active,
-            }
-        }
-
     def build_diagnostic_data(self) -> dict:
-        """Build complete diagnostic data.
+        """Build complete diagnostic data via the extracted DiagnosticsBuilder.
 
-        Combines all diagnostic categories (solar, position, time window,
-        sun validity, climate, last action, configuration) into single
-        dictionary for diagnostic sensors.
+        Constructs a DiagnosticContext from coordinator state, delegates to
+        the builder, and handles position-explanation change-detection logging.
 
         Returns:
             Dictionary containing all diagnostic data
 
         """
-        return {
-            **self._build_solar_diagnostics(),
-            **self._build_position_diagnostics(),
-            **self._build_time_window_diagnostics(),
-            **self._build_sun_validity_diagnostics(),
-            **self._build_climate_diagnostics(),
-            **self._build_last_action_diagnostics(),
-            **self._build_configuration_diagnostics(),
-        }
+        ctx = DiagnosticContext(
+            pos_sun=self.pos_sun,
+            normal_cover_state=self.normal_cover_state,
+            raw_calculated_position=self.raw_calculated_position,
+            climate_state=self.climate_state,
+            climate_data=self.climate_data,
+            climate_strategy=self.climate_strategy,
+            climate_mode=self._climate_mode,
+            control_method=self.control_method,
+            pipeline_result=self._pipeline_result,
+            is_force_override_active=self.is_force_override_active,
+            is_motion_timeout_active=self.is_motion_timeout_active,
+            is_manual_override_active=self.manager.binary_cover_manual,
+            check_adaptive_time=self.check_adaptive_time,
+            after_start_time=self.after_start_time,
+            before_end_time=self.before_end_time,
+            start_time=self._start_time,
+            end_time=self._end_time,
+            automatic_control=self.automatic_control,
+            last_cover_action=self.last_cover_action,
+            last_skipped_action=self.last_skipped_action,
+            min_change=self.min_change,
+            time_threshold=self.time_threshold,
+            switch_mode=self._switch_mode,
+            inverse_state=self._inverse_state,
+            use_interpolation=self._use_interpolation,
+            default_state=self.default_state,
+            final_state=self.state,
+            config_options=dict(self.config_entry.options),
+            motion_detected=self.is_motion_detected,
+            motion_timeout_active=self._motion_mgr._motion_timeout_active,
+            force_override_sensors=self.config_entry.options.get(
+                CONF_FORCE_OVERRIDE_SENSORS, []
+            ),
+            force_override_position=self.config_entry.options.get(
+                CONF_FORCE_OVERRIDE_POSITION, 0
+            ),
+        )
 
-    def _determine_control_status(self) -> str:
-        """Determine current control status.
+        diagnostics, explanation = self._diagnostics_builder.build(ctx)
 
-        Uses the pipeline result's control method when available to avoid
-        duplicating the priority logic.  Force override and motion timeout
-        are also checked directly so they take effect even outside the
-        time window (when the pipeline does not run).
+        if explanation != self._last_position_explanation:
+            self.logger.debug("Position explanation changed: %s", explanation)
+            self._last_position_explanation = explanation
 
-        Returns:
-            Control status string: AUTOMATIC_CONTROL_OFF, FORCE_OVERRIDE_ACTIVE,
-            MANUAL_OVERRIDE, OUTSIDE_TIME_WINDOW, SUN_NOT_VISIBLE, or ACTIVE
-
-        """
-        if not self.automatic_control:
-            return ControlStatus.AUTOMATIC_CONTROL_OFF
-
-        # Safety overrides checked directly (apply even outside time window)
-        if self.is_force_override_active:
-            return ControlStatus.FORCE_OVERRIDE_ACTIVE
-
-        if self.is_motion_timeout_active:
-            return ControlStatus.MOTION_TIMEOUT
-
-        # Pipeline-derived statuses (only when pipeline has run)
-        if self._pipeline_result is not None:
-            method = self._pipeline_result.control_method
-            if method == ControlMethod.MANUAL:
-                return ControlStatus.MANUAL_OVERRIDE
-
-        if not self.check_adaptive_time:
-            return ControlStatus.OUTSIDE_TIME_WINDOW
-
-        if self.normal_cover_state and not self.normal_cover_state.cover.valid:
-            return ControlStatus.SUN_NOT_VISIBLE
-
-        return ControlStatus.ACTIVE
+        return diagnostics
 
     @property
     def state(self) -> int:
@@ -1732,9 +1417,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             state = self.interpolate_states(state)
 
         if self._inverse_state and self._use_interpolation:
-            self.logger.info(
-                "Inverse state is not supported with interpolation"
-            )
+            self.logger.info("Inverse state is not supported with interpolation")
 
         if self._inverse_state and not self._use_interpolation:
             state = inverse_state(state)

--- a/custom_components/adaptive_cover_pro/diagnostics/__init__.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/__init__.py
@@ -1,0 +1,5 @@
+"""Diagnostics package for Adaptive Cover Pro."""
+
+from .builder import DiagnosticContext, DiagnosticsBuilder
+
+__all__ = ["DiagnosticContext", "DiagnosticsBuilder"]

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -1,0 +1,421 @@
+"""Diagnostics builder for Adaptive Cover Pro.
+
+Extracts all diagnostic data assembly from the coordinator into a
+standalone, testable class.  The builder operates on a ``DiagnosticContext``
+dataclass that bundles every piece of coordinator state it needs, so it
+never accesses the coordinator directly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..const import ControlStatus
+from ..enums import ClimateStrategy, ControlMethod
+
+
+# ---------------------------------------------------------------------------
+# Context dataclass – the coordinator populates this before calling build()
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiagnosticContext:
+    """Snapshot of coordinator state needed to build diagnostics."""
+
+    # Sun / cover state
+    pos_sun: list  # [azimuth, elevation]
+    normal_cover_state: Any  # NormalCoverState | None
+
+    # Position
+    raw_calculated_position: int
+    climate_state: int | None
+    climate_data: Any  # ClimateCoverData | None
+    climate_strategy: Any  # ClimateStrategy | None
+    climate_mode: bool
+    control_method: Any  # ControlMethod enum
+    pipeline_result: Any  # PipelineResult | None
+
+    # Overrides
+    is_force_override_active: bool
+    is_motion_timeout_active: bool
+    is_manual_override_active: bool
+
+    # Time window
+    check_adaptive_time: bool
+    after_start_time: bool
+    before_end_time: bool
+    start_time: Any
+    end_time: Any
+
+    # Automation
+    automatic_control: bool
+    last_cover_action: dict = field(default_factory=dict)
+    last_skipped_action: dict = field(default_factory=dict)
+    min_change: int = 1
+    time_threshold: int = 2
+
+    # Modes / transforms
+    switch_mode: bool = False
+    inverse_state: bool = False
+    use_interpolation: bool = False
+    default_state: int = 0
+    final_state: int = 0  # coordinator.state (after interpolation/inverse)
+
+    # Configuration snapshot
+    config_options: dict = field(default_factory=dict)
+
+    # Motion manager state
+    motion_detected: bool = True
+    motion_timeout_active: bool = False
+
+    # Force override config
+    force_override_sensors: list = field(default_factory=list)
+    force_override_position: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Strategy label map (moved from coordinator class attribute)
+# ---------------------------------------------------------------------------
+
+_CLIMATE_STRATEGY_LABELS: dict[ClimateStrategy, str] = {
+    ClimateStrategy.WINTER_HEATING: "Winter Heating",
+    ClimateStrategy.SUMMER_COOLING: "Summer Cooling",
+    ClimateStrategy.LOW_LIGHT: "Low Light",
+    ClimateStrategy.GLARE_CONTROL: "Glare Control",
+}
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+class DiagnosticsBuilder:
+    """Assembles diagnostic data from a ``DiagnosticContext``."""
+
+    # -- public API ---------------------------------------------------------
+
+    def build(self, ctx: DiagnosticContext) -> tuple[dict, str]:
+        """Build complete diagnostic data.
+
+        Returns:
+            A tuple of (diagnostics_dict, position_explanation_string).
+
+        """
+        diagnostics: dict = {}
+        diagnostics.update(self._build_solar(ctx))
+        diagnostics.update(self._build_position(ctx))
+        diagnostics.update(self._build_time_window(ctx))
+        diagnostics.update(self._build_sun_validity(ctx))
+        diagnostics.update(self._build_climate(ctx))
+        diagnostics.update(self._build_last_action(ctx))
+        diagnostics.update(self._build_configuration(ctx))
+
+        explanation = diagnostics.get("position_explanation", "")
+        return diagnostics, explanation
+
+    # -- private helpers ----------------------------------------------------
+
+    @staticmethod
+    def _build_solar(ctx: DiagnosticContext) -> dict:
+        """Build solar position diagnostics."""
+        diagnostics: dict = {}
+        sun_azimuth, sun_elevation = ctx.pos_sun
+        diagnostics["sun_azimuth"] = sun_azimuth
+        diagnostics["sun_elevation"] = sun_elevation
+
+        if ctx.normal_cover_state and hasattr(ctx.normal_cover_state.cover, "gamma"):
+            diagnostics["gamma"] = ctx.normal_cover_state.cover.gamma
+
+        return diagnostics
+
+    @staticmethod
+    def _get_control_state_reason(ctx: DiagnosticContext) -> str:
+        """Get the current control state reason including coordinator-level overrides."""
+        if ctx.is_force_override_active:
+            return "Force Override"
+        if ctx.is_motion_timeout_active:
+            return "Motion Timeout"
+        if ctx.is_manual_override_active:
+            return "Manual Override"
+        if ctx.normal_cover_state and ctx.normal_cover_state.cover:
+            return ctx.normal_cover_state.cover.control_state_reason
+        return "Unknown"
+
+    @staticmethod
+    def _build_position_explanation(ctx: DiagnosticContext) -> str:
+        """Build a human-readable explanation of the full position decision chain."""
+        options = ctx.config_options
+
+        # Priority overrides
+        if ctx.is_force_override_active:
+            pos = ctx.force_override_position
+            return f"Force override active → {pos}%"
+
+        if ctx.is_motion_timeout_active:
+            return f"No motion detected → default {ctx.default_state}%"
+
+        if ctx.is_manual_override_active:
+            return "Manual override active"
+
+        # Outside time window
+        if not ctx.check_adaptive_time:
+            from ..const import CONF_DEFAULT_HEIGHT, CONF_SUNSET_POS
+
+            sunset_pos = options.get(CONF_SUNSET_POS)
+            default_height = options.get(CONF_DEFAULT_HEIGHT, 0)
+            if sunset_pos is not None:
+                return f"Outside time window → Sunset Position ({sunset_pos}%)"
+            return f"Outside time window → Default Position ({default_height}%)"
+
+        # Build the decision chain
+        parts: list[str] = []
+
+        # Step 1: Sun position condition and raw calculated value
+        if ctx.normal_cover_state and ctx.normal_cover_state.cover:
+            cover = ctx.normal_cover_state.cover
+            if cover.direct_sun_valid:
+                parts.append(f"Sun tracking ({ctx.raw_calculated_position}%)")
+            elif cover.sunset_valid and cover.sunset_pos is not None:
+                parts.append(f"Sunset Position ({round(cover.sunset_pos)}%)")
+            else:
+                reason = cover.control_state_reason
+                parts.append(f"{reason} → Default Position ({round(cover.default)}%)")
+
+        # Step 2: Position limits on the non-climate path
+        if not ctx.switch_mode:
+            from ..const import (
+                CONF_ENABLE_MAX_POSITION,
+                CONF_ENABLE_MIN_POSITION,
+                CONF_MAX_POSITION,
+                CONF_MIN_POSITION,
+            )
+
+            min_pos = options.get(CONF_MIN_POSITION)
+            max_pos = options.get(CONF_MAX_POSITION)
+            enable_min = options.get(CONF_ENABLE_MIN_POSITION, False)
+            enable_max = options.get(CONF_ENABLE_MAX_POSITION, False)
+            if min_pos is not None and enable_min and ctx.default_state == min_pos:
+                parts.append(f"min limit ({min_pos}%) → {ctx.default_state}%")
+            elif max_pos is not None and enable_max and ctx.default_state == max_pos:
+                parts.append(f"max limit ({max_pos}%) → {ctx.default_state}%")
+
+        # Step 3: Climate mode override
+        if ctx.switch_mode and ctx.climate_state is not None:
+            strategy_label = (
+                _CLIMATE_STRATEGY_LABELS.get(ctx.climate_strategy, "Active")
+                if ctx.climate_strategy
+                else "Active"
+            )
+            parts.append(f"Climate: {strategy_label} → {ctx.climate_state}%")
+
+        # Step 4: Interpolation / inverse state
+        final = ctx.final_state
+        if ctx.use_interpolation:
+            parts.append(f"interpolated → {final}%")
+        elif ctx.inverse_state:
+            parts.append(f"inversed → {final}%")
+
+        return " → ".join(parts) if parts else "Unknown"
+
+    @staticmethod
+    def _determine_control_status(ctx: DiagnosticContext) -> str:
+        """Determine current control status."""
+        if not ctx.automatic_control:
+            return ControlStatus.AUTOMATIC_CONTROL_OFF
+
+        if ctx.is_force_override_active:
+            return ControlStatus.FORCE_OVERRIDE_ACTIVE
+
+        if ctx.is_motion_timeout_active:
+            return ControlStatus.MOTION_TIMEOUT
+
+        if ctx.pipeline_result is not None:
+            method = ctx.pipeline_result.control_method
+            if method == ControlMethod.MANUAL:
+                return ControlStatus.MANUAL_OVERRIDE
+
+        if not ctx.check_adaptive_time:
+            return ControlStatus.OUTSIDE_TIME_WINDOW
+
+        if ctx.normal_cover_state and not ctx.normal_cover_state.cover.valid:
+            return ControlStatus.SUN_NOT_VISIBLE
+
+        return ControlStatus.ACTIVE
+
+    @classmethod
+    def _build_position(cls, ctx: DiagnosticContext) -> dict:
+        """Build position diagnostics."""
+        diagnostics: dict = {}
+
+        diagnostics["calculated_position"] = ctx.raw_calculated_position
+
+        if ctx.climate_state is not None:
+            diagnostics["calculated_position_climate"] = ctx.climate_state
+
+        diagnostics["control_status"] = cls._determine_control_status(ctx)
+        diagnostics["control_state_reason"] = cls._get_control_state_reason(ctx)
+
+        explanation = cls._build_position_explanation(ctx)
+        diagnostics["position_explanation"] = explanation
+
+        # Delta thresholds
+        diagnostics["delta_position_threshold"] = ctx.min_change
+        diagnostics["delta_time_threshold_minutes"] = ctx.time_threshold
+
+        # Position delta from last action
+        last_action = ctx.last_cover_action
+        if last_action.get("position") is not None:
+            diagnostics["position_delta_from_last_action"] = abs(
+                ctx.raw_calculated_position - last_action["position"]
+            )
+
+        # Time since last action
+        if last_action.get("timestamp"):
+            try:
+                last_ts = dt.datetime.fromisoformat(last_action["timestamp"])
+                if last_ts.tzinfo is None:
+                    last_ts = last_ts.replace(tzinfo=dt.UTC)
+                now_utc = dt.datetime.now(dt.UTC)
+                elapsed = (now_utc - last_ts).total_seconds()
+                diagnostics["seconds_since_last_action"] = round(elapsed)
+            except (ValueError, AttributeError):
+                pass
+
+        # Vertical cover calculation details
+        if ctx.normal_cover_state and ctx.normal_cover_state.cover:
+            cover = ctx.normal_cover_state.cover
+            calc_details = getattr(cover, "_last_calc_details", None)
+            if calc_details is not None:
+                diagnostics["calculation_details"] = calc_details
+
+        diagnostics["last_updated"] = dt.datetime.now(dt.UTC).isoformat()
+
+        return diagnostics
+
+    @staticmethod
+    def _build_time_window(ctx: DiagnosticContext) -> dict:
+        """Build time window diagnostics."""
+        return {
+            "time_window": {
+                "check_adaptive_time": ctx.check_adaptive_time,
+                "after_start_time": ctx.after_start_time,
+                "before_end_time": ctx.before_end_time,
+                "start_time": ctx.start_time,
+                "end_time": ctx.end_time,
+            }
+        }
+
+    @staticmethod
+    def _build_sun_validity(ctx: DiagnosticContext) -> dict:
+        """Build sun validity diagnostics."""
+        diagnostics: dict = {}
+        if ctx.normal_cover_state and ctx.normal_cover_state.cover:
+            cover = ctx.normal_cover_state.cover
+            diagnostics["sun_validity"] = {
+                "valid": cover.valid,
+                "valid_elevation": cover.valid_elevation,
+                "in_blind_spot": getattr(cover, "in_blind_spot", None),
+            }
+        return diagnostics
+
+    @staticmethod
+    def _build_climate(ctx: DiagnosticContext) -> dict:
+        """Build climate mode diagnostics."""
+        diagnostics: dict = {}
+        if ctx.climate_mode and ctx.climate_data is not None:
+            diagnostics["climate_control_method"] = ctx.control_method
+
+            diagnostics["active_temperature"] = ctx.climate_data.get_current_temperature
+            diagnostics["temperature_details"] = {
+                "inside_temperature": ctx.climate_data.inside_temperature,
+                "outside_temperature": ctx.climate_data.outside_temperature,
+                "temp_switch": ctx.climate_data.temp_switch,
+            }
+
+            if ctx.climate_strategy is not None:
+                diagnostics["climate_strategy"] = ctx.climate_strategy.value
+
+            diagnostics["climate_conditions"] = {
+                "is_summer": ctx.climate_data.is_summer,
+                "is_winter": ctx.climate_data.is_winter,
+                "is_presence": ctx.climate_data.is_presence,
+                "is_sunny": ctx.climate_data.is_sunny,
+                "lux_active": ctx.climate_data.lux
+                if ctx.climate_data._use_lux
+                else None,
+                "irradiance_active": ctx.climate_data.irradiance
+                if ctx.climate_data._use_irradiance
+                else None,
+            }
+
+        return diagnostics
+
+    @staticmethod
+    def _build_last_action(ctx: DiagnosticContext) -> dict:
+        """Build last action diagnostics."""
+        diagnostics: dict = {}
+        if ctx.last_cover_action.get("entity_id"):
+            diagnostics["last_cover_action"] = ctx.last_cover_action.copy()
+        if ctx.last_skipped_action.get("entity_id"):
+            diagnostics["last_skipped_action"] = ctx.last_skipped_action.copy()
+        return diagnostics
+
+    @staticmethod
+    def _build_configuration(ctx: DiagnosticContext) -> dict:
+        """Build configuration diagnostics."""
+        from ..const import (
+            CONF_AZIMUTH,
+            CONF_BLIND_SPOT_ELEVATION,
+            CONF_BLIND_SPOT_LEFT,
+            CONF_BLIND_SPOT_RIGHT,
+            CONF_ENABLE_BLIND_SPOT,
+            CONF_ENABLE_MAX_POSITION,
+            CONF_ENABLE_MIN_POSITION,
+            CONF_FOV_LEFT,
+            CONF_FOV_RIGHT,
+            CONF_FORCE_OVERRIDE_POSITION,
+            CONF_FORCE_OVERRIDE_SENSORS,
+            CONF_INTERP,
+            CONF_INVERSE_STATE,
+            CONF_MAX_ELEVATION,
+            CONF_MAX_POSITION,
+            CONF_MIN_ELEVATION,
+            CONF_MIN_POSITION,
+            CONF_MOTION_SENSORS,
+            CONF_MOTION_TIMEOUT,
+            DEFAULT_MOTION_TIMEOUT,
+        )
+
+        options = ctx.config_options
+        return {
+            "configuration": {
+                "azimuth": options.get(CONF_AZIMUTH),
+                "fov_left": options.get(CONF_FOV_LEFT),
+                "fov_right": options.get(CONF_FOV_RIGHT),
+                "min_elevation": options.get(CONF_MIN_ELEVATION),
+                "max_elevation": options.get(CONF_MAX_ELEVATION),
+                "enable_blind_spot": options.get(CONF_ENABLE_BLIND_SPOT, False),
+                "blind_spot_elevation": options.get(CONF_BLIND_SPOT_ELEVATION),
+                "blind_spot_left": options.get(CONF_BLIND_SPOT_LEFT),
+                "blind_spot_right": options.get(CONF_BLIND_SPOT_RIGHT),
+                "min_position": options.get(CONF_MIN_POSITION),
+                "max_position": options.get(CONF_MAX_POSITION),
+                "enable_min_position": options.get(CONF_ENABLE_MIN_POSITION, False),
+                "enable_max_position": options.get(CONF_ENABLE_MAX_POSITION, False),
+                "inverse_state": options.get(CONF_INVERSE_STATE, False),
+                "interpolation": options.get(CONF_INTERP, False),
+                "force_override_sensors": options.get(CONF_FORCE_OVERRIDE_SENSORS, []),
+                "force_override_position": options.get(CONF_FORCE_OVERRIDE_POSITION, 0),
+                "force_override_active": ctx.is_force_override_active,
+                "motion_sensors": options.get(CONF_MOTION_SENSORS, []),
+                "motion_timeout": options.get(
+                    CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT
+                ),
+                "motion_detected": ctx.motion_detected,
+                "motion_timeout_active": ctx.motion_timeout_active,
+            }
+        }

--- a/tests/test_diagnostics/__init__.py
+++ b/tests/test_diagnostics/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the diagnostics package."""

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -1,0 +1,601 @@
+"""Tests for the DiagnosticsBuilder."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.diagnostics.builder import (
+    DiagnosticContext,
+    DiagnosticsBuilder,
+)
+from custom_components.adaptive_cover_pro.const import ControlStatus
+from custom_components.adaptive_cover_pro.enums import ClimateStrategy, ControlMethod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cover(
+    *,
+    gamma: float = 10.0,
+    valid: bool = True,
+    valid_elevation: bool = True,
+    in_blind_spot: bool = False,
+    direct_sun_valid: bool = True,
+    sunset_valid: bool = False,
+    sunset_pos: float | None = None,
+    default: float = 0.0,
+    control_state_reason: str = "Sun in FOV",
+    calc_details: dict | None = None,
+) -> SimpleNamespace:
+    """Create a minimal cover mock."""
+    cover = SimpleNamespace(
+        gamma=gamma,
+        valid=valid,
+        valid_elevation=valid_elevation,
+        in_blind_spot=in_blind_spot,
+        direct_sun_valid=direct_sun_valid,
+        sunset_valid=sunset_valid,
+        sunset_pos=sunset_pos,
+        default=default,
+        control_state_reason=control_state_reason,
+    )
+    if calc_details is not None:
+        cover._last_calc_details = calc_details
+    return cover
+
+
+def _make_normal_cover_state(cover=None) -> SimpleNamespace:
+    """Wrap a cover mock in a NormalCoverState-like object."""
+    if cover is None:
+        cover = _make_cover()
+    return SimpleNamespace(cover=cover)
+
+
+def _base_ctx(**overrides) -> DiagnosticContext:
+    """Return a DiagnosticContext with sensible defaults.
+
+    All overrides are passed as keyword arguments.
+    """
+    defaults = {
+        "pos_sun": [180.0, 45.0],
+        "normal_cover_state": _make_normal_cover_state(),
+        "raw_calculated_position": 50,
+        "climate_state": None,
+        "climate_data": None,
+        "climate_strategy": None,
+        "climate_mode": False,
+        "control_method": ControlMethod.SOLAR,
+        "pipeline_result": None,
+        "is_force_override_active": False,
+        "is_motion_timeout_active": False,
+        "is_manual_override_active": False,
+        "check_adaptive_time": True,
+        "after_start_time": True,
+        "before_end_time": True,
+        "start_time": None,
+        "end_time": None,
+        "automatic_control": True,
+        "last_cover_action": {},
+        "last_skipped_action": {},
+        "min_change": 1,
+        "time_threshold": 2,
+        "switch_mode": False,
+        "inverse_state": False,
+        "use_interpolation": False,
+        "default_state": 0,
+        "final_state": 50,
+        "config_options": {},
+        "motion_detected": True,
+        "motion_timeout_active": False,
+        "force_override_sensors": [],
+        "force_override_position": 0,
+    }
+    defaults.update(overrides)
+    return DiagnosticContext(**defaults)
+
+
+@pytest.fixture
+def builder() -> DiagnosticsBuilder:
+    """Create a DiagnosticsBuilder instance."""
+    return DiagnosticsBuilder()
+
+
+# ---------------------------------------------------------------------------
+# build() returns tuple
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReturnType:
+    """Verify build() returns (dict, str)."""
+
+    def test_returns_tuple(self, builder: DiagnosticsBuilder):
+        """Build returns a 2-tuple."""
+        ctx = _base_ctx()
+        result = builder.build(ctx)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_diagnostics_is_dict(self, builder: DiagnosticsBuilder):
+        """First element is a dict."""
+        diag, _ = builder.build(_base_ctx())
+        assert isinstance(diag, dict)
+
+    def test_explanation_is_str(self, builder: DiagnosticsBuilder):
+        """Second element is a string."""
+        _, explanation = builder.build(_base_ctx())
+        assert isinstance(explanation, str)
+
+
+# ---------------------------------------------------------------------------
+# Solar diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestSolarDiagnostics:
+    """Solar diagnostics section tests."""
+
+    def test_sun_azimuth_and_elevation(self, builder: DiagnosticsBuilder):
+        """Sun azimuth and elevation appear in output."""
+        diag, _ = builder.build(_base_ctx(pos_sun=[200.5, 30.2]))
+        assert diag["sun_azimuth"] == 200.5
+        assert diag["sun_elevation"] == 30.2
+
+    def test_gamma_present_when_cover_has_it(self, builder: DiagnosticsBuilder):
+        """Gamma is included when cover state has the attribute."""
+        diag, _ = builder.build(_base_ctx())
+        assert "gamma" in diag
+
+    def test_gamma_absent_when_no_cover_state(self, builder: DiagnosticsBuilder):
+        """Gamma is absent when no cover state."""
+        diag, _ = builder.build(_base_ctx(normal_cover_state=None))
+        assert "gamma" not in diag
+
+
+# ---------------------------------------------------------------------------
+# Control status determination
+# ---------------------------------------------------------------------------
+
+
+class TestControlStatus:
+    """Control status determination tests."""
+
+    def test_automatic_control_off(self, builder: DiagnosticsBuilder):
+        """Returns AUTOMATIC_CONTROL_OFF when automatic control is disabled."""
+        diag, _ = builder.build(_base_ctx(automatic_control=False))
+        assert diag["control_status"] == ControlStatus.AUTOMATIC_CONTROL_OFF
+
+    def test_force_override_active(self, builder: DiagnosticsBuilder):
+        """Returns FORCE_OVERRIDE_ACTIVE when force override is on."""
+        diag, _ = builder.build(_base_ctx(is_force_override_active=True))
+        assert diag["control_status"] == ControlStatus.FORCE_OVERRIDE_ACTIVE
+
+    def test_motion_timeout(self, builder: DiagnosticsBuilder):
+        """Returns MOTION_TIMEOUT when motion timeout is active."""
+        diag, _ = builder.build(_base_ctx(is_motion_timeout_active=True))
+        assert diag["control_status"] == ControlStatus.MOTION_TIMEOUT
+
+    def test_manual_override_via_pipeline(self, builder: DiagnosticsBuilder):
+        """Returns MANUAL_OVERRIDE when pipeline says manual."""
+        pr = SimpleNamespace(control_method=ControlMethod.MANUAL)
+        diag, _ = builder.build(_base_ctx(pipeline_result=pr))
+        assert diag["control_status"] == ControlStatus.MANUAL_OVERRIDE
+
+    def test_outside_time_window(self, builder: DiagnosticsBuilder):
+        """Returns OUTSIDE_TIME_WINDOW when not in adaptive time."""
+        diag, _ = builder.build(_base_ctx(check_adaptive_time=False))
+        assert diag["control_status"] == ControlStatus.OUTSIDE_TIME_WINDOW
+
+    def test_sun_not_visible(self, builder: DiagnosticsBuilder):
+        """Returns SUN_NOT_VISIBLE when cover is not valid."""
+        cover = _make_cover(valid=False)
+        ncs = _make_normal_cover_state(cover)
+        diag, _ = builder.build(_base_ctx(normal_cover_state=ncs))
+        assert diag["control_status"] == ControlStatus.SUN_NOT_VISIBLE
+
+    def test_active(self, builder: DiagnosticsBuilder):
+        """Returns ACTIVE in normal conditions."""
+        diag, _ = builder.build(_base_ctx())
+        assert diag["control_status"] == ControlStatus.ACTIVE
+
+    def test_priority_force_over_motion(self, builder: DiagnosticsBuilder):
+        """Force override takes priority over motion timeout."""
+        diag, _ = builder.build(
+            _base_ctx(
+                is_force_override_active=True,
+                is_motion_timeout_active=True,
+            )
+        )
+        assert diag["control_status"] == ControlStatus.FORCE_OVERRIDE_ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# Control state reason
+# ---------------------------------------------------------------------------
+
+
+class TestControlStateReason:
+    """Control state reason string tests."""
+
+    def test_force_override(self, builder: DiagnosticsBuilder):
+        """Force override reason string."""
+        diag, _ = builder.build(_base_ctx(is_force_override_active=True))
+        assert diag["control_state_reason"] == "Force Override"
+
+    def test_motion_timeout(self, builder: DiagnosticsBuilder):
+        """Motion timeout reason string."""
+        diag, _ = builder.build(_base_ctx(is_motion_timeout_active=True))
+        assert diag["control_state_reason"] == "Motion Timeout"
+
+    def test_manual_override(self, builder: DiagnosticsBuilder):
+        """Manual override reason string."""
+        diag, _ = builder.build(_base_ctx(is_manual_override_active=True))
+        assert diag["control_state_reason"] == "Manual Override"
+
+    def test_cover_reason_passthrough(self, builder: DiagnosticsBuilder):
+        """Cover-level reason passes through when no overrides active."""
+        cover = _make_cover(control_state_reason="Sun below min elevation")
+        ncs = _make_normal_cover_state(cover)
+        diag, _ = builder.build(_base_ctx(normal_cover_state=ncs))
+        assert diag["control_state_reason"] == "Sun below min elevation"
+
+    def test_unknown_when_no_cover(self, builder: DiagnosticsBuilder):
+        """Returns Unknown when no cover state available."""
+        diag, _ = builder.build(_base_ctx(normal_cover_state=None))
+        assert diag["control_state_reason"] == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Position explanation
+# ---------------------------------------------------------------------------
+
+
+class TestPositionExplanation:
+    """Position explanation string tests."""
+
+    def test_force_override_explanation(self, builder: DiagnosticsBuilder):
+        """Force override produces correct explanation."""
+        _, explanation = builder.build(
+            _base_ctx(
+                is_force_override_active=True,
+                force_override_position=75,
+            )
+        )
+        assert "Force override active" in explanation
+        assert "75%" in explanation
+
+    def test_motion_timeout_explanation(self, builder: DiagnosticsBuilder):
+        """Motion timeout produces correct explanation."""
+        _, explanation = builder.build(
+            _base_ctx(is_motion_timeout_active=True, default_state=30)
+        )
+        assert "No motion detected" in explanation
+        assert "30%" in explanation
+
+    def test_manual_override_explanation(self, builder: DiagnosticsBuilder):
+        """Manual override produces correct explanation."""
+        _, explanation = builder.build(_base_ctx(is_manual_override_active=True))
+        assert "Manual override active" in explanation
+
+    def test_outside_time_window_sunset_pos(self, builder: DiagnosticsBuilder):
+        """Outside time window with sunset position configured."""
+        from custom_components.adaptive_cover_pro.const import CONF_SUNSET_POS
+
+        _, explanation = builder.build(
+            _base_ctx(
+                check_adaptive_time=False,
+                config_options={CONF_SUNSET_POS: 20},
+            )
+        )
+        assert "Sunset Position" in explanation
+        assert "20%" in explanation
+
+    def test_outside_time_window_default(self, builder: DiagnosticsBuilder):
+        """Outside time window with default height."""
+        from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+        _, explanation = builder.build(
+            _base_ctx(
+                check_adaptive_time=False,
+                config_options={CONF_DEFAULT_HEIGHT: 10},
+            )
+        )
+        assert "Default Position" in explanation
+        assert "10%" in explanation
+
+    def test_sun_tracking_explanation(self, builder: DiagnosticsBuilder):
+        """Sun tracking shows raw calculated position."""
+        _, explanation = builder.build(_base_ctx(raw_calculated_position=65))
+        assert "Sun tracking" in explanation
+        assert "65%" in explanation
+
+    def test_climate_mode_explanation(self, builder: DiagnosticsBuilder):
+        """Climate mode shows strategy label and position."""
+        _, explanation = builder.build(
+            _base_ctx(
+                switch_mode=True,
+                climate_state=100,
+                climate_strategy=ClimateStrategy.WINTER_HEATING,
+            )
+        )
+        assert "Climate: Winter Heating" in explanation
+        assert "100%" in explanation
+
+    def test_inverse_state_explanation(self, builder: DiagnosticsBuilder):
+        """Inverse state shows inversed label."""
+        _, explanation = builder.build(_base_ctx(inverse_state=True, final_state=50))
+        assert "inversed" in explanation
+
+    def test_interpolation_explanation(self, builder: DiagnosticsBuilder):
+        """Interpolation shows interpolated label."""
+        _, explanation = builder.build(
+            _base_ctx(use_interpolation=True, final_state=42)
+        )
+        assert "interpolated" in explanation
+        assert "42%" in explanation
+
+    def test_sunset_position_during_time_window(self, builder: DiagnosticsBuilder):
+        """Sunset position within time window shows sunset label."""
+        cover = _make_cover(
+            direct_sun_valid=False,
+            sunset_valid=True,
+            sunset_pos=15.0,
+        )
+        ncs = _make_normal_cover_state(cover)
+        _, explanation = builder.build(_base_ctx(normal_cover_state=ncs))
+        assert "Sunset Position" in explanation
+        assert "15%" in explanation
+
+
+# ---------------------------------------------------------------------------
+# Position diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestPositionDiagnostics:
+    """Position diagnostics section tests."""
+
+    def test_calculated_position(self, builder: DiagnosticsBuilder):
+        """Calculated position appears in output."""
+        diag, _ = builder.build(_base_ctx(raw_calculated_position=42))
+        assert diag["calculated_position"] == 42
+
+    def test_climate_position_present(self, builder: DiagnosticsBuilder):
+        """Climate position appears when climate state is set."""
+        diag, _ = builder.build(_base_ctx(climate_state=80))
+        assert diag["calculated_position_climate"] == 80
+
+    def test_climate_position_absent(self, builder: DiagnosticsBuilder):
+        """Climate position absent when climate state is None."""
+        diag, _ = builder.build(_base_ctx(climate_state=None))
+        assert "calculated_position_climate" not in diag
+
+    def test_delta_thresholds(self, builder: DiagnosticsBuilder):
+        """Delta thresholds are included."""
+        diag, _ = builder.build(_base_ctx(min_change=5, time_threshold=10))
+        assert diag["delta_position_threshold"] == 5
+        assert diag["delta_time_threshold_minutes"] == 10
+
+    def test_position_delta_from_last_action(self, builder: DiagnosticsBuilder):
+        """Position delta from last action is computed."""
+        diag, _ = builder.build(
+            _base_ctx(
+                raw_calculated_position=60,
+                last_cover_action={"position": 50},
+            )
+        )
+        assert diag["position_delta_from_last_action"] == 10
+
+    def test_last_updated_present(self, builder: DiagnosticsBuilder):
+        """Last updated timestamp is present."""
+        diag, _ = builder.build(_base_ctx())
+        assert "last_updated" in diag
+
+    def test_calculation_details_included(self, builder: DiagnosticsBuilder):
+        """Calculation details from cover are included."""
+        details = {"edge_case": True, "safety_margin": 1.1}
+        cover = _make_cover(calc_details=details)
+        ncs = _make_normal_cover_state(cover)
+        diag, _ = builder.build(_base_ctx(normal_cover_state=ncs))
+        assert diag["calculation_details"] == details
+
+
+# ---------------------------------------------------------------------------
+# Time window diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestTimeWindowDiagnostics:
+    """Time window diagnostics section tests."""
+
+    def test_time_window_keys(self, builder: DiagnosticsBuilder):
+        """Time window keys are present."""
+        diag, _ = builder.build(_base_ctx())
+        tw = diag["time_window"]
+        assert "check_adaptive_time" in tw
+        assert "after_start_time" in tw
+        assert "before_end_time" in tw
+        assert "start_time" in tw
+        assert "end_time" in tw
+
+
+# ---------------------------------------------------------------------------
+# Sun validity diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestSunValidityDiagnostics:
+    """Sun validity diagnostics section tests."""
+
+    def test_sun_validity_present(self, builder: DiagnosticsBuilder):
+        """Sun validity fields are present when cover state exists."""
+        diag, _ = builder.build(_base_ctx())
+        sv = diag["sun_validity"]
+        assert sv["valid"] is True
+        assert sv["valid_elevation"] is True
+        assert sv["in_blind_spot"] is False
+
+    def test_sun_validity_absent_when_no_cover(self, builder: DiagnosticsBuilder):
+        """Sun validity absent when no cover state."""
+        diag, _ = builder.build(_base_ctx(normal_cover_state=None))
+        assert "sun_validity" not in diag
+
+
+# ---------------------------------------------------------------------------
+# Climate diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestClimateDiagnostics:
+    """Climate diagnostics section tests."""
+
+    def _make_climate_data(self):
+        cd = MagicMock()
+        cd.get_current_temperature = 22.5
+        cd.inside_temperature = 23.0
+        cd.outside_temperature = 18.0
+        cd.temp_switch = "inside"
+        cd.is_summer = False
+        cd.is_winter = True
+        cd.is_presence = True
+        cd.is_sunny = True
+        cd._use_lux = False
+        cd._use_irradiance = False
+        cd.lux = None
+        cd.irradiance = None
+        return cd
+
+    def test_climate_data_present(self, builder: DiagnosticsBuilder):
+        """Climate data fields appear when climate mode is enabled."""
+        cd = self._make_climate_data()
+        diag, _ = builder.build(
+            _base_ctx(
+                climate_mode=True,
+                climate_data=cd,
+                climate_strategy=ClimateStrategy.WINTER_HEATING,
+                control_method=ControlMethod.WINTER,
+            )
+        )
+        assert diag["active_temperature"] == 22.5
+        assert diag["climate_strategy"] == "winter_heating"
+        assert "temperature_details" in diag
+        assert "climate_conditions" in diag
+
+    def test_climate_data_absent_when_not_climate_mode(
+        self, builder: DiagnosticsBuilder
+    ):
+        """Climate data absent when climate mode is off."""
+        diag, _ = builder.build(_base_ctx(climate_mode=False))
+        assert "active_temperature" not in diag
+        assert "climate_strategy" not in diag
+
+
+# ---------------------------------------------------------------------------
+# Last action diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestLastActionDiagnostics:
+    """Last action diagnostics section tests."""
+
+    def test_last_cover_action_present(self, builder: DiagnosticsBuilder):
+        """Last cover action appears when entity_id is set."""
+        action = {"entity_id": "cover.test", "position": 50}
+        diag, _ = builder.build(_base_ctx(last_cover_action=action))
+        assert diag["last_cover_action"]["entity_id"] == "cover.test"
+
+    def test_last_cover_action_absent(self, builder: DiagnosticsBuilder):
+        """Last cover action absent when empty."""
+        diag, _ = builder.build(_base_ctx(last_cover_action={}))
+        assert "last_cover_action" not in diag
+
+    def test_last_skipped_action_present(self, builder: DiagnosticsBuilder):
+        """Last skipped action appears when entity_id is set."""
+        action = {"entity_id": "cover.skip", "reason": "delta"}
+        diag, _ = builder.build(_base_ctx(last_skipped_action=action))
+        assert diag["last_skipped_action"]["entity_id"] == "cover.skip"
+
+
+# ---------------------------------------------------------------------------
+# Configuration diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurationDiagnostics:
+    """Configuration diagnostics section tests."""
+
+    def test_configuration_keys(self, builder: DiagnosticsBuilder):
+        """All expected configuration keys are present."""
+        diag, _ = builder.build(_base_ctx())
+        config = diag["configuration"]
+        expected_keys = {
+            "azimuth",
+            "fov_left",
+            "fov_right",
+            "min_elevation",
+            "max_elevation",
+            "enable_blind_spot",
+            "blind_spot_elevation",
+            "blind_spot_left",
+            "blind_spot_right",
+            "min_position",
+            "max_position",
+            "enable_min_position",
+            "enable_max_position",
+            "inverse_state",
+            "interpolation",
+            "force_override_sensors",
+            "force_override_position",
+            "force_override_active",
+            "motion_sensors",
+            "motion_timeout",
+            "motion_detected",
+            "motion_timeout_active",
+        }
+        assert expected_keys == set(config.keys())
+
+    def test_configuration_reflects_context(self, builder: DiagnosticsBuilder):
+        """Configuration reflects context state values."""
+        diag, _ = builder.build(
+            _base_ctx(
+                is_force_override_active=True,
+                motion_detected=False,
+                motion_timeout_active=True,
+            )
+        )
+        config = diag["configuration"]
+        assert config["force_override_active"] is True
+        assert config["motion_detected"] is False
+        assert config["motion_timeout_active"] is True
+
+
+# ---------------------------------------------------------------------------
+# Full integration
+# ---------------------------------------------------------------------------
+
+
+class TestFullBuild:
+    """Full build integration tests."""
+
+    def test_all_sections_present(self, builder: DiagnosticsBuilder):
+        """Verify that build() produces all expected top-level keys."""
+        diag, explanation = builder.build(_base_ctx())
+        assert "sun_azimuth" in diag
+        assert "calculated_position" in diag
+        assert "control_status" in diag
+        assert "time_window" in diag
+        assert "sun_validity" in diag
+        assert "configuration" in diag
+        assert "position_explanation" in diag
+        assert isinstance(explanation, str)
+        assert len(explanation) > 0
+
+    def test_explanation_matches_diagnostics(self, builder: DiagnosticsBuilder):
+        """The explanation returned as second element matches the one in dict."""
+        diag, explanation = builder.build(_base_ctx())
+        assert diag["position_explanation"] == explanation

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -371,26 +371,40 @@ def test_determine_control_status_motion_timeout():
     """Test control status returns MOTION_TIMEOUT when active."""
     from custom_components.adaptive_cover_pro.const import ControlStatus
     from custom_components.adaptive_cover_pro.enums import ControlMethod
-    from custom_components.adaptive_cover_pro.coordinator import (
-        AdaptiveDataUpdateCoordinator,
+    from custom_components.adaptive_cover_pro.diagnostics.builder import (
+        DiagnosticContext,
+        DiagnosticsBuilder,
     )
     from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
-    coordinator = MagicMock()
-    coordinator._automatic_control = True
-
-    # Mock property access for direct checks in _determine_control_status
-    type(coordinator).is_force_override_active = property(lambda self: False)
-    type(coordinator).is_motion_timeout_active = property(lambda self: True)
-
-    # Pipeline result indicates motion timeout
-    coordinator._pipeline_result = PipelineResult(
+    pipeline_result = PipelineResult(
         position=60,
         control_method=ControlMethod.MOTION,
         reason="motion timeout active",
     )
 
-    result = AdaptiveDataUpdateCoordinator._determine_control_status(coordinator)
+    ctx = DiagnosticContext(
+        pos_sun=[180.0, 45.0],
+        normal_cover_state=None,
+        raw_calculated_position=60,
+        climate_state=None,
+        climate_data=None,
+        climate_strategy=None,
+        climate_mode=False,
+        control_method=ControlMethod.MOTION,
+        pipeline_result=pipeline_result,
+        is_force_override_active=False,
+        is_motion_timeout_active=True,
+        is_manual_override_active=False,
+        check_adaptive_time=True,
+        after_start_time=True,
+        before_end_time=True,
+        start_time=None,
+        end_time=None,
+        automatic_control=True,
+    )
+
+    result = DiagnosticsBuilder._determine_control_status(ctx)
     assert result == ControlStatus.MOTION_TIMEOUT
 
 
@@ -398,26 +412,40 @@ def test_determine_control_status_force_override_precedence():
     """Test force override takes precedence over motion timeout."""
     from custom_components.adaptive_cover_pro.const import ControlStatus
     from custom_components.adaptive_cover_pro.enums import ControlMethod
-    from custom_components.adaptive_cover_pro.coordinator import (
-        AdaptiveDataUpdateCoordinator,
+    from custom_components.adaptive_cover_pro.diagnostics.builder import (
+        DiagnosticContext,
+        DiagnosticsBuilder,
     )
     from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
-    coordinator = MagicMock()
-    coordinator._automatic_control = True
-
-    # Both active: force override takes precedence
-    type(coordinator).is_force_override_active = property(lambda self: True)
-    type(coordinator).is_motion_timeout_active = property(lambda self: True)
-
-    # Pipeline result indicates force override (highest priority)
-    coordinator._pipeline_result = PipelineResult(
+    pipeline_result = PipelineResult(
         position=0,
         control_method=ControlMethod.FORCE,
         reason="force override active",
     )
 
-    result = AdaptiveDataUpdateCoordinator._determine_control_status(coordinator)
+    ctx = DiagnosticContext(
+        pos_sun=[180.0, 45.0],
+        normal_cover_state=None,
+        raw_calculated_position=0,
+        climate_state=None,
+        climate_data=None,
+        climate_strategy=None,
+        climate_mode=False,
+        control_method=ControlMethod.FORCE,
+        pipeline_result=pipeline_result,
+        is_force_override_active=True,
+        is_motion_timeout_active=True,
+        is_manual_override_active=False,
+        check_adaptive_time=True,
+        after_start_time=True,
+        before_end_time=True,
+        start_time=None,
+        end_time=None,
+        automatic_control=True,
+    )
+
+    result = DiagnosticsBuilder._determine_control_status(ctx)
     assert result == ControlStatus.FORCE_OVERRIDE_ACTIVE
 
 
@@ -490,31 +518,40 @@ def test_build_configuration_diagnostics_includes_motion_data():
         CONF_MOTION_SENSORS,
         CONF_MOTION_TIMEOUT,
     )
-    from custom_components.adaptive_cover_pro.coordinator import (
-        AdaptiveDataUpdateCoordinator,
+    from custom_components.adaptive_cover_pro.diagnostics.builder import (
+        DiagnosticContext,
+        DiagnosticsBuilder,
     )
+    from custom_components.adaptive_cover_pro.enums import ControlMethod
 
-    coordinator, hass = _make_coordinator_with_motion_mgr(
-        sensors=["binary_sensor.motion_living_room"],
-        timeout_seconds=300,
-    )
-
-    def get_option(key, default=None):
-        options_map = {
+    ctx = DiagnosticContext(
+        pos_sun=[180.0, 45.0],
+        normal_cover_state=None,
+        raw_calculated_position=0,
+        climate_state=None,
+        climate_data=None,
+        climate_strategy=None,
+        climate_mode=False,
+        control_method=ControlMethod.SOLAR,
+        pipeline_result=None,
+        is_force_override_active=False,
+        is_motion_timeout_active=False,
+        is_manual_override_active=False,
+        check_adaptive_time=True,
+        after_start_time=True,
+        before_end_time=True,
+        start_time=None,
+        end_time=None,
+        automatic_control=True,
+        motion_detected=True,
+        motion_timeout_active=False,
+        config_options={
             CONF_MOTION_SENSORS: ["binary_sensor.motion_living_room"],
             CONF_MOTION_TIMEOUT: 300,
-        }
-        return options_map.get(key, default)
+        },
+    )
 
-    coordinator.config_entry.options.get.side_effect = get_option
-
-    # Mock is_force_override_active
-    type(coordinator).is_force_override_active = property(lambda self: False)
-
-    # Mock is_motion_detected
-    type(coordinator).is_motion_detected = property(lambda self: True)
-
-    result = AdaptiveDataUpdateCoordinator._build_configuration_diagnostics(coordinator)
+    result = DiagnosticsBuilder._build_configuration(ctx)
 
     config = result["configuration"]
     assert "motion_sensors" in config

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -6,6 +6,7 @@ Tests cover:
 """
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
@@ -14,7 +15,17 @@ from custom_components.adaptive_cover_pro.calculation import (
     ClimateCoverData,
     ClimateCoverState,
 )
-from custom_components.adaptive_cover_pro.enums import ClimateStrategy
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
+    CONF_ENABLE_MIN_POSITION,
+    CONF_MIN_POSITION,
+    CONF_SUNSET_POS,
+)
+from custom_components.adaptive_cover_pro.diagnostics.builder import (
+    DiagnosticContext,
+    DiagnosticsBuilder,
+)
+from custom_components.adaptive_cover_pro.enums import ClimateStrategy, ControlMethod
 
 
 # ---------------------------------------------------------------------------
@@ -64,6 +75,75 @@ def make_climate_state(cover, climate_data):
     """Build a ClimateCoverState, mocking sun data to avoid HA calls."""
     state = ClimateCoverState(cover, climate_data)
     return state
+
+
+def _make_cover(
+    *,
+    direct_sun_valid=True,
+    sunset_valid=False,
+    sunset_pos=None,
+    control_state_reason="Sun in FOV",
+    default=50.0,
+):
+    """Create a minimal cover mock for position explanation tests."""
+    return SimpleNamespace(
+        gamma=10.0,
+        valid=True,
+        valid_elevation=True,
+        in_blind_spot=False,
+        direct_sun_valid=direct_sun_valid,
+        sunset_valid=sunset_valid,
+        sunset_pos=sunset_pos,
+        default=default,
+        control_state_reason=control_state_reason,
+    )
+
+
+def _make_ncs(cover=None):
+    """Wrap a cover mock in a NormalCoverState-like object."""
+    if cover is None:
+        cover = _make_cover()
+    return SimpleNamespace(cover=cover)
+
+
+def _base_ctx(**overrides):
+    """Return a DiagnosticContext with sensible defaults."""
+    defaults = {  # noqa: C408
+        "pos_sun": [180.0, 45.0],
+        "normal_cover_state": _make_ncs(),
+        "raw_calculated_position": 50,
+        "climate_state": None,
+        "climate_data": None,
+        "climate_strategy": None,
+        "climate_mode": False,
+        "control_method": ControlMethod.SOLAR,
+        "pipeline_result": None,
+        "is_force_override_active": False,
+        "is_motion_timeout_active": False,
+        "is_manual_override_active": False,
+        "check_adaptive_time": True,
+        "after_start_time": True,
+        "before_end_time": True,
+        "start_time": None,
+        "end_time": None,
+        "automatic_control": True,
+        "last_cover_action": {},
+        "last_skipped_action": {},
+        "min_change": 1,
+        "time_threshold": 2,
+        "switch_mode": False,
+        "inverse_state": False,
+        "use_interpolation": False,
+        "default_state": 50,
+        "final_state": 50,
+        "config_options": {},
+        "motion_detected": True,
+        "motion_timeout_active": False,
+        "force_override_sensors": [],
+        "force_override_position": 0,
+    }
+    defaults.update(overrides)
+    return DiagnosticContext(**defaults)
 
 
 # ---------------------------------------------------------------------------
@@ -120,6 +200,12 @@ def vertical_cover(mock_sun_data, mock_logger):
         distance=0.5,
         h_win=2.0,
     )
+
+
+@pytest.fixture
+def builder():
+    """Create a DiagnosticsBuilder instance."""
+    return DiagnosticsBuilder()
 
 
 # ---------------------------------------------------------------------------
@@ -477,217 +563,175 @@ class TestClimateStrategyNormalWithoutPresence:
 
 
 class TestBuildPositionExplanation:
-    """_build_position_explanation returns correct strings for all scenarios."""
+    """DiagnosticsBuilder._build_position_explanation returns correct strings."""
 
-    def _make_coordinator(self):
-        """Build a minimal mock coordinator with the real method bound."""
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
-        # Bind the real method
-        coord._build_position_explanation = (
-            AdaptiveDataUpdateCoordinator._build_position_explanation.__get__(coord)
-        )
-        coord._CLIMATE_STRATEGY_LABELS = (
-            AdaptiveDataUpdateCoordinator._CLIMATE_STRATEGY_LABELS
-        )
-
-        # Defaults — no overrides
-        coord.is_force_override_active = False
-        coord.is_motion_timeout_active = False
-        coord.manager = MagicMock()
-        coord.manager.binary_cover_manual = False
-        coord.check_adaptive_time = True
-        coord._switch_mode = False
-        coord._use_interpolation = False
-        coord._inverse_state = False
-        coord.climate_state = None
-        coord.climate_strategy = None
-        coord.default_state = 50
-        coord.raw_calculated_position = 50
-
-        # Normal cover state mock
-        cover_mock = MagicMock()
-        cover_mock.direct_sun_valid = True
-        cover_mock.sunset_valid = False
-        cover_mock.sunset_pos = None
-        cover_mock.control_state_reason = "Direct Sun"
-        cover_mock.default = 50
-        normal_state = MagicMock()
-        normal_state.cover = cover_mock
-        coord.normal_cover_state = normal_state
-
-        coord.config_entry = MagicMock()
-        coord.config_entry.options = {}
-
-        # state property
-        type(coord).state = PropertyMock(return_value=50)
-
-        return coord
-
-    def test_force_override(self):
+    def test_force_override(self, builder):
         """Force override active → explains override position."""
-        coord = self._make_coordinator()
-        coord.is_force_override_active = True
-        coord.config_entry.options = {"force_override_position": 0}
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                is_force_override_active=True,
+                force_override_position=0,
+            )
+        )
         assert "Force override" in result
         assert "0%" in result
 
-    def test_motion_timeout(self):
+    def test_motion_timeout(self, builder):
         """Motion timeout active → explains default position."""
-        coord = self._make_coordinator()
-        coord.is_motion_timeout_active = True
-        coord.default_state = 30
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(is_motion_timeout_active=True, default_state=30)
+        )
         assert "motion" in result.lower()
         assert "30%" in result
 
-    def test_manual_override(self):
+    def test_manual_override(self, builder):
         """Manual override → explains manual control."""
-        coord = self._make_coordinator()
-        coord.manager.binary_cover_manual = True
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(is_manual_override_active=True)
+        )
         assert "manual" in result.lower()
 
-    def test_outside_time_window_with_sunset_position(self):
+    def test_outside_time_window_with_sunset_position(self, builder):
         """Outside time window with sunset position set → shows Sunset Position."""
-        coord = self._make_coordinator()
-        coord.check_adaptive_time = False
-        coord.config_entry.options = {"sunset_position": 30}
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                check_adaptive_time=False,
+                config_options={CONF_SUNSET_POS: 30},
+            )
+        )
         assert "Sunset Position" in result
         assert "30%" in result
 
-    def test_outside_time_window_without_sunset_position(self):
+    def test_outside_time_window_without_sunset_position(self, builder):
         """Outside time window without sunset position → shows Default Position."""
-        coord = self._make_coordinator()
-        coord.check_adaptive_time = False
-        coord.config_entry.options = {"default_percentage": 100}
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                check_adaptive_time=False,
+                config_options={CONF_DEFAULT_HEIGHT: 100},
+            )
+        )
         assert "Default Position" in result
         assert "100%" in result
 
-    def test_sunset_offset_with_sunset_position(self):
+    def test_sunset_offset_with_sunset_position(self, builder):
         """In window but sunset_valid with sunset_pos set → shows Sunset Position."""
-        coord = self._make_coordinator()
-        coord.normal_cover_state.cover.direct_sun_valid = False
-        coord.normal_cover_state.cover.sunset_valid = True
-        coord.normal_cover_state.cover.sunset_pos = 20
-
-        result = coord._build_position_explanation()
+        cover = _make_cover(direct_sun_valid=False, sunset_valid=True, sunset_pos=20)
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(normal_cover_state=_make_ncs(cover))
+        )
         assert "Sunset Position" in result
         assert "20%" in result
 
-    def test_default_fov_exit_without_sunset(self):
+    def test_default_fov_exit_without_sunset(self, builder):
         """In window, FOV exit, no sunset → shows Default Position."""
-        coord = self._make_coordinator()
-        coord.normal_cover_state.cover.direct_sun_valid = False
-        coord.normal_cover_state.cover.sunset_valid = False
-        coord.normal_cover_state.cover.sunset_pos = None
-        coord.normal_cover_state.cover.control_state_reason = "Default: FOV Exit"
-        coord.normal_cover_state.cover.default = 100
-
-        result = coord._build_position_explanation()
+        cover = _make_cover(
+            direct_sun_valid=False,
+            sunset_valid=False,
+            sunset_pos=None,
+            control_state_reason="Default: FOV Exit",
+            default=100,
+        )
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(normal_cover_state=_make_ncs(cover))
+        )
         assert "FOV Exit" in result
         assert "Default Position" in result
         assert "100%" in result
 
-    def test_sun_tracking_no_limits(self):
+    def test_sun_tracking_no_limits(self, builder):
         """Sun tracking, no limits, no climate → shows raw tracking position."""
-        coord = self._make_coordinator()
-        coord.raw_calculated_position = 65
-        coord.normal_cover_state.cover.direct_sun_valid = True
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(raw_calculated_position=65)
+        )
         assert "Sun tracking" in result
         assert "65%" in result
 
-    def test_sun_tracking_with_min_limit(self):
+    def test_sun_tracking_with_min_limit(self, builder):
         """Sun tracking below min_position → shows limit applied."""
-        coord = self._make_coordinator()
-        coord.raw_calculated_position = 30
-        coord.default_state = 60  # min limit bumped it to 60
-        coord.normal_cover_state.cover.direct_sun_valid = True
-        coord.config_entry.options = {
-            "min_position": 60,
-            "enable_min_position": True,
-        }
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                raw_calculated_position=30,
+                default_state=60,
+                config_options={
+                    CONF_MIN_POSITION: 60,
+                    CONF_ENABLE_MIN_POSITION: True,
+                },
+            )
+        )
         assert "Sun tracking" in result
         assert "min limit" in result
         assert "60%" in result
 
-    def test_climate_winter_heating(self):
+    def test_climate_winter_heating(self, builder):
         """Sun tracking + climate winter heating → shows winter heating decision."""
-        coord = self._make_coordinator()
-        coord.raw_calculated_position = 45
-        coord._switch_mode = True
-        coord.climate_state = 100
-        coord.climate_strategy = ClimateStrategy.WINTER_HEATING
-        type(coord).state = PropertyMock(return_value=100)
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                raw_calculated_position=45,
+                switch_mode=True,
+                climate_state=100,
+                climate_strategy=ClimateStrategy.WINTER_HEATING,
+                final_state=100,
+            )
+        )
         assert "Sun tracking" in result
         assert "Winter Heating" in result
         assert "100%" in result
 
-    def test_climate_summer_cooling(self):
+    def test_climate_summer_cooling(self, builder):
         """Sun tracking + climate summer cooling → shows summer cooling."""
-        coord = self._make_coordinator()
-        coord.raw_calculated_position = 45
-        coord._switch_mode = True
-        coord.climate_state = 0
-        coord.climate_strategy = ClimateStrategy.SUMMER_COOLING
-        type(coord).state = PropertyMock(return_value=0)
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                raw_calculated_position=45,
+                switch_mode=True,
+                climate_state=0,
+                climate_strategy=ClimateStrategy.SUMMER_COOLING,
+                final_state=0,
+            )
+        )
         assert "Summer Cooling" in result
         assert "0%" in result
 
-    def test_climate_low_light(self):
+    def test_climate_low_light(self, builder):
         """Default position + climate low light strategy."""
-        coord = self._make_coordinator()
-        coord.normal_cover_state.cover.direct_sun_valid = False
-        coord.normal_cover_state.cover.control_state_reason = "Default: FOV Exit"
-        coord.normal_cover_state.cover.default = 0
-        coord.raw_calculated_position = 0
-        coord._switch_mode = True
-        coord.climate_state = 0
-        coord.climate_strategy = ClimateStrategy.LOW_LIGHT
-        type(coord).state = PropertyMock(return_value=0)
-
-        result = coord._build_position_explanation()
+        cover = _make_cover(
+            direct_sun_valid=False,
+            control_state_reason="Default: FOV Exit",
+            default=0,
+        )
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                normal_cover_state=_make_ncs(cover),
+                raw_calculated_position=0,
+                switch_mode=True,
+                climate_state=0,
+                climate_strategy=ClimateStrategy.LOW_LIGHT,
+                final_state=0,
+            )
+        )
         assert "FOV Exit" in result
         assert "Low Light" in result
 
-    def test_sun_tracking_with_interpolation(self):
+    def test_sun_tracking_with_interpolation(self, builder):
         """Interpolation applied → shows interpolated final value."""
-        coord = self._make_coordinator()
-        coord.raw_calculated_position = 72
-        coord._use_interpolation = True
-        type(coord).state = PropertyMock(return_value=65)
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                raw_calculated_position=72,
+                use_interpolation=True,
+                final_state=65,
+            )
+        )
         assert "interpolated" in result
         assert "65%" in result
 
-    def test_sun_tracking_with_inverse(self):
+    def test_sun_tracking_with_inverse(self, builder):
         """Inverse state applied → shows inversed final value."""
-        coord = self._make_coordinator()
-        coord.raw_calculated_position = 72
-        coord._inverse_state = True
-        type(coord).state = PropertyMock(return_value=28)
-
-        result = coord._build_position_explanation()
+        result = DiagnosticsBuilder._build_position_explanation(
+            _base_ctx(
+                raw_calculated_position=72,
+                inverse_state=True,
+                final_state=28,
+            )
+        )
         assert "invers" in result.lower()
         assert "28%" in result
 
@@ -698,70 +742,97 @@ class TestBuildPositionExplanation:
 
 
 class TestPositionExplanationChangeDetection:
-    """_build_position_diagnostics logs position explanation only when it changes."""
+    """build_diagnostic_data logs position explanation only when it changes.
 
-    def _make_coordinator_with_diagnostics(self):
-        """Build a minimal mock coordinator with real _build_position_diagnostics bound."""
+    These tests verify the change-detection logging that happens in the
+    coordinator's build_diagnostic_data delegate.  Since the builder itself
+    is a pure function, we test the coordinator's thin wrapper behavior.
+    """
+
+    def _make_coordinator_mock(self, explanation="Sun tracking (50%)"):
+        """Build a mock coordinator with a real DiagnosticsBuilder."""
         from custom_components.adaptive_cover_pro.coordinator import (
             AdaptiveDataUpdateCoordinator,
         )
 
         coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
-        coord._build_position_explanation = MagicMock(return_value="Sun tracking (50%)")
+        coord._diagnostics_builder = DiagnosticsBuilder()
         coord._last_position_explanation = ""
         coord.logger = MagicMock()
-        coord.logger.debug = MagicMock()
 
-        # Minimal stubs needed by the real _build_position_diagnostics
+        # Minimal stubs for DiagnosticContext construction
+        coord.pos_sun = [180.0, 45.0]
+        coord.normal_cover_state = _make_ncs()
         coord.raw_calculated_position = 50
         coord.climate_state = None
-        coord._determine_control_status = MagicMock(return_value="solar")
-        coord._get_control_state_reason = MagicMock(return_value="Direct Sun")
+        coord.climate_data = None
+        coord.climate_strategy = None
+        coord._climate_mode = False
+        coord.control_method = ControlMethod.SOLAR
+        coord._pipeline_result = None
+        type(coord).is_force_override_active = PropertyMock(return_value=False)
+        type(coord).is_motion_timeout_active = PropertyMock(return_value=False)
+        coord.manager = MagicMock()
+        coord.manager.binary_cover_manual = False
+        type(coord).check_adaptive_time = PropertyMock(return_value=True)
+        type(coord).after_start_time = PropertyMock(return_value=True)
+        type(coord).before_end_time = PropertyMock(return_value=True)
+        coord._start_time = None
+        coord._end_time = None
+        type(coord).automatic_control = PropertyMock(return_value=True)
+        type(coord).last_cover_action = PropertyMock(return_value={})
+        type(coord).last_skipped_action = PropertyMock(return_value={})
         coord.min_change = 5
         coord.time_threshold = 2
-        coord.last_cover_action = {
-            "entity_id": None,
-            "position": None,
-            "timestamp": None,
-        }
-        coord.last_skipped_action = {"entity_id": None}
-        coord.normal_cover_state = None
+        coord._switch_mode = False
+        coord._inverse_state = False
+        coord._use_interpolation = False
+        coord.default_state = 50
+        type(coord).state = PropertyMock(return_value=50)
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = {}
+        type(coord).is_motion_detected = PropertyMock(return_value=True)
+        coord._motion_mgr = MagicMock()
+        coord._motion_mgr._motion_timeout_active = False
 
-        coord._build_position_diagnostics = (
-            AdaptiveDataUpdateCoordinator._build_position_diagnostics.__get__(coord)
+        # Bind the real method
+        coord.build_diagnostic_data = (
+            AdaptiveDataUpdateCoordinator.build_diagnostic_data.__get__(coord)
         )
         return coord
 
     def test_logs_on_first_call(self):
         """First call logs the explanation (empty → something)."""
-        coord = self._make_coordinator_with_diagnostics()
-        coord._build_position_diagnostics()
+        coord = self._make_coordinator_mock()
+        coord.build_diagnostic_data()
         coord.logger.debug.assert_called()
         calls = [str(c) for c in coord.logger.debug.call_args_list]
         assert any("Position explanation changed" in c for c in calls)
 
     def test_logs_on_change(self):
         """Logs when explanation changes between calls."""
-        coord = self._make_coordinator_with_diagnostics()
+        coord = self._make_coordinator_mock()
         coord._last_position_explanation = "Sun tracking (40%)"
-        coord._build_position_explanation.return_value = "Sun tracking (50%)"
-        coord._build_position_diagnostics()
+        coord.build_diagnostic_data()
         calls = [str(c) for c in coord.logger.debug.call_args_list]
         assert any("Position explanation changed" in c for c in calls)
 
     def test_no_log_when_unchanged(self):
         """Does NOT log when explanation is the same as last time."""
-        coord = self._make_coordinator_with_diagnostics()
-        coord._last_position_explanation = "Sun tracking (50%)"
-        coord._build_position_explanation.return_value = "Sun tracking (50%)"
-        coord._build_position_diagnostics()
+        coord = self._make_coordinator_mock()
+        # First call to set the explanation
+        coord.build_diagnostic_data()
+        coord.logger.debug.reset_mock()
+        # Second call with same state — should NOT log
+        coord.build_diagnostic_data()
         calls = [str(c) for c in coord.logger.debug.call_args_list]
         assert not any("Position explanation changed" in c for c in calls)
 
     def test_updates_stored_explanation(self):
         """Stored explanation is updated after a change."""
-        coord = self._make_coordinator_with_diagnostics()
+        coord = self._make_coordinator_mock()
         coord._last_position_explanation = "Sun tracking (40%)"
-        coord._build_position_explanation.return_value = "Manual override active"
-        coord._build_position_diagnostics()
-        assert coord._last_position_explanation == "Manual override active"
+        coord.build_diagnostic_data()
+        # The explanation should now match the current state
+        assert coord._last_position_explanation != "Sun tracking (40%)"
+        assert len(coord._last_position_explanation) > 0


### PR DESCRIPTION
## Summary
This PR brings the remaining phases of the integration rewrite to dev (Phase 0 already merged via #78).

### Phases included:
- **Phase 1A** — ClimateProvider isolates ClimateCoverData from HA state reads
- **Phase 1B** — SunProvider removes hass from cover calculations (calculation.py + sun.py = 0 HA imports)
- **Phase 2** — Override pipeline with 6 pluggable handlers replaces if/elif chains
- **Phase 3** — DiagnosticsBuilder extracted from coordinator

### Results
- coordinator.py: 2,700 → 1,839 lines (-32%)
- Tests: 442 → 657 (+215)
- Coverage: 38% → 58%
- calculation.py + sun.py: 0 homeassistant imports