### PR TITLE
feat: Add wind/cloud stub handlers and dual-axis tilt hook

### DIFF
--- a/custom_components/adaptive_cover_pro/enums.py
+++ b/custom_components/adaptive_cover_pro/enums.py
@@ -73,7 +73,7 @@ class ControlMethod(StrEnum):
     """What is currently driving the cover position.
 
     Priority order (highest to lowest):
-    FORCE > MOTION > MANUAL > SUMMER/WINTER > SOLAR > DEFAULT
+    FORCE > WIND > MOTION > MANUAL > CLOUD > SUMMER/WINTER > SOLAR > DEFAULT
     """
 
     SOLAR = "solar"
@@ -96,3 +96,9 @@ class ControlMethod(StrEnum):
 
     FORCE = "force_override"
     """A force override binary sensor is active; cover moves to the override position."""
+
+    WIND = "wind_override"
+    """Wind speed exceeds threshold; covers retract for safety."""
+
+    CLOUD = "cloud_suppression"
+    """Cloud coverage suppresses solar radiation; covers use default position."""

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -1,0 +1,33 @@
+"""Cloud suppression handler — use default position when cloud coverage is high."""
+
+from __future__ import annotations
+
+from ..handler import OverrideHandler
+from ..types import PipelineContext, PipelineResult
+from ...enums import ControlMethod
+
+
+class CloudSuppressionHandler(OverrideHandler):
+    """Uses default position when cloud coverage suppresses solar radiation.
+
+    Priority 60: between manual_override (70) and climate (50).
+    Currently a stub — will be fully implemented when cloud/lux
+    suppression configuration is added (Issue #31).
+    """
+
+    name = "cloud_suppression"
+    priority = 60
+
+    def evaluate(self, ctx: PipelineContext) -> PipelineResult | None:
+        """Return default position when cloud coverage suppresses solar radiation."""
+        if not ctx.cloud_suppression_active:
+            return None
+        return PipelineResult(
+            position=ctx.default_position,
+            control_method=ControlMethod.CLOUD,
+            reason=f"Cloud suppression active → default {ctx.default_position}%",
+        )
+
+    def describe_skip(self, ctx: PipelineContext) -> str:  # noqa: ARG002
+        """Reason when cloud suppression is not active."""
+        return "cloud suppression not active"

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/wind.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/wind.py
@@ -1,0 +1,33 @@
+"""Wind override handler — safety retraction when wind exceeds threshold."""
+
+from __future__ import annotations
+
+from ..handler import OverrideHandler
+from ..types import PipelineContext, PipelineResult
+from ...enums import ControlMethod
+
+
+class WindOverrideHandler(OverrideHandler):
+    """Retracts covers when wind speed exceeds threshold.
+
+    Priority 90: between force_override (100) and motion_timeout (80).
+    Currently a stub — will be fully implemented when wind sensor
+    configuration is added (Issue #28).
+    """
+
+    name = "wind"
+    priority = 90
+
+    def evaluate(self, ctx: PipelineContext) -> PipelineResult | None:
+        """Return retract position when wind speed exceeds threshold."""
+        if not ctx.wind_active:
+            return None
+        return PipelineResult(
+            position=ctx.wind_retract_position,
+            control_method=ControlMethod.WIND,
+            reason=f"Wind override active → {ctx.wind_retract_position}%",
+        )
+
+    def describe_skip(self, ctx: PipelineContext) -> str:  # noqa: ARG002
+        """Reason when wind override is not active."""
+        return "wind override not active"

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -25,6 +25,11 @@ class PipelineContext:
     climate_is_summer: bool
     climate_is_winter: bool
 
+    # Extensibility hooks (default False = disabled)
+    wind_active: bool = False
+    wind_retract_position: int = 100
+    cloud_suppression_active: bool = False
+
 
 @dataclass(frozen=True)
 class DecisionStep:
@@ -44,3 +49,4 @@ class PipelineResult:
     control_method: ControlMethod
     reason: str
     decision_trace: list[DecisionStep] = field(default_factory=list)
+    tilt: int | None = None

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -1,0 +1,123 @@
+"""Tests for CloudSuppressionHandler stub."""
+
+from __future__ import annotations
+
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
+    CloudSuppressionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineContext
+
+
+def make_ctx(
+    *,
+    calculated_position: int = 50,
+    climate_position: int | None = None,
+    default_position: int = 0,
+    raw_calculated_position: int = 50,
+    in_time_window: bool = True,
+    direct_sun_valid: bool = False,
+    force_override_active: bool = False,
+    force_override_position: int = 0,
+    motion_timeout_active: bool = False,
+    manual_override_active: bool = False,
+    climate_mode_enabled: bool = False,
+    climate_is_summer: bool = False,
+    climate_is_winter: bool = False,
+    wind_active: bool = False,
+    wind_retract_position: int = 100,
+    cloud_suppression_active: bool = False,
+) -> PipelineContext:
+    """Build a PipelineContext with sensible defaults."""
+    return PipelineContext(
+        calculated_position=calculated_position,
+        climate_position=climate_position,
+        default_position=default_position,
+        raw_calculated_position=raw_calculated_position,
+        in_time_window=in_time_window,
+        direct_sun_valid=direct_sun_valid,
+        force_override_active=force_override_active,
+        force_override_position=force_override_position,
+        motion_timeout_active=motion_timeout_active,
+        manual_override_active=manual_override_active,
+        climate_mode_enabled=climate_mode_enabled,
+        climate_is_summer=climate_is_summer,
+        climate_is_winter=climate_is_winter,
+        wind_active=wind_active,
+        wind_retract_position=wind_retract_position,
+        cloud_suppression_active=cloud_suppression_active,
+    )
+
+
+class TestCloudSuppressionHandler:
+    """Tests for CloudSuppressionHandler stub."""
+
+    handler = CloudSuppressionHandler()
+
+    def test_returns_none_when_inactive_default(self) -> None:
+        """Return None when cloud_suppression_active is False (default)."""
+        ctx = make_ctx()
+        assert self.handler.evaluate(ctx) is None
+
+    def test_returns_none_when_explicitly_inactive(self) -> None:
+        """Return None when cloud_suppression_active is explicitly False."""
+        ctx = make_ctx(cloud_suppression_active=False)
+        assert self.handler.evaluate(ctx) is None
+
+    def test_returns_result_when_active(self) -> None:
+        """Return a PipelineResult when cloud_suppression_active is True."""
+        ctx = make_ctx(cloud_suppression_active=True, default_position=30)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+
+    def test_uses_default_position(self) -> None:
+        """Use default_position from context."""
+        ctx = make_ctx(cloud_suppression_active=True, default_position=40)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert result.position == 40
+
+    def test_default_position_zero(self) -> None:
+        """Handle default_position=0 correctly (falsy value)."""
+        ctx = make_ctx(cloud_suppression_active=True, default_position=0)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert result.position == 0
+
+    def test_control_method_is_cloud(self) -> None:
+        """Result must use ControlMethod.CLOUD."""
+        ctx = make_ctx(cloud_suppression_active=True, default_position=20)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert result.control_method == ControlMethod.CLOUD
+
+    def test_reason_is_non_empty(self) -> None:
+        """Result must have a non-empty reason string."""
+        ctx = make_ctx(cloud_suppression_active=True, default_position=10)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert isinstance(result.reason, str)
+        assert len(result.reason) > 0
+
+    def test_reason_mentions_cloud(self) -> None:
+        """Reason string should mention cloud."""
+        ctx = make_ctx(cloud_suppression_active=True, default_position=10)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert "cloud" in result.reason.lower()
+
+    def test_priority_is_60(self) -> None:
+        """Priority must be 60."""
+        assert CloudSuppressionHandler.priority == 60
+
+    def test_name_is_cloud_suppression(self) -> None:
+        """Handler name must be 'cloud_suppression'."""
+        assert CloudSuppressionHandler.name == "cloud_suppression"
+
+    def test_describe_skip_mentions_cloud(self) -> None:
+        """describe_skip returns a non-empty string mentioning cloud."""
+        ctx = make_ctx(cloud_suppression_active=False)
+        reason = self.handler.describe_skip(ctx)
+        assert isinstance(reason, str)
+        assert len(reason) > 0
+        assert "cloud" in reason.lower()

--- a/tests/test_pipeline/test_wind_handler.py
+++ b/tests/test_pipeline/test_wind_handler.py
@@ -1,0 +1,121 @@
+"""Tests for WindOverrideHandler stub."""
+
+from __future__ import annotations
+
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.handlers.wind import WindOverrideHandler
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineContext
+
+
+def make_ctx(
+    *,
+    calculated_position: int = 50,
+    climate_position: int | None = None,
+    default_position: int = 0,
+    raw_calculated_position: int = 50,
+    in_time_window: bool = True,
+    direct_sun_valid: bool = False,
+    force_override_active: bool = False,
+    force_override_position: int = 0,
+    motion_timeout_active: bool = False,
+    manual_override_active: bool = False,
+    climate_mode_enabled: bool = False,
+    climate_is_summer: bool = False,
+    climate_is_winter: bool = False,
+    wind_active: bool = False,
+    wind_retract_position: int = 100,
+    cloud_suppression_active: bool = False,
+) -> PipelineContext:
+    """Build a PipelineContext with sensible defaults."""
+    return PipelineContext(
+        calculated_position=calculated_position,
+        climate_position=climate_position,
+        default_position=default_position,
+        raw_calculated_position=raw_calculated_position,
+        in_time_window=in_time_window,
+        direct_sun_valid=direct_sun_valid,
+        force_override_active=force_override_active,
+        force_override_position=force_override_position,
+        motion_timeout_active=motion_timeout_active,
+        manual_override_active=manual_override_active,
+        climate_mode_enabled=climate_mode_enabled,
+        climate_is_summer=climate_is_summer,
+        climate_is_winter=climate_is_winter,
+        wind_active=wind_active,
+        wind_retract_position=wind_retract_position,
+        cloud_suppression_active=cloud_suppression_active,
+    )
+
+
+class TestWindOverrideHandler:
+    """Tests for WindOverrideHandler stub."""
+
+    handler = WindOverrideHandler()
+
+    def test_returns_none_when_inactive_default(self) -> None:
+        """Return None when wind_active is False (default)."""
+        ctx = make_ctx()
+        assert self.handler.evaluate(ctx) is None
+
+    def test_returns_none_when_explicitly_inactive(self) -> None:
+        """Return None when wind_active is explicitly False."""
+        ctx = make_ctx(wind_active=False)
+        assert self.handler.evaluate(ctx) is None
+
+    def test_returns_result_when_active(self) -> None:
+        """Return a PipelineResult when wind_active is True."""
+        ctx = make_ctx(wind_active=True)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+
+    def test_uses_wind_retract_position(self) -> None:
+        """Use wind_retract_position from context."""
+        ctx = make_ctx(wind_active=True, wind_retract_position=25)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert result.position == 25
+
+    def test_default_retract_position_is_100(self) -> None:
+        """Default wind_retract_position is 100 (fully retracted)."""
+        ctx = make_ctx(wind_active=True)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert result.position == 100
+
+    def test_control_method_is_wind(self) -> None:
+        """Result must use ControlMethod.WIND."""
+        ctx = make_ctx(wind_active=True)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert result.control_method == ControlMethod.WIND
+
+    def test_reason_is_non_empty(self) -> None:
+        """Result must have a non-empty reason string."""
+        ctx = make_ctx(wind_active=True)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert isinstance(result.reason, str)
+        assert len(result.reason) > 0
+
+    def test_reason_mentions_wind(self) -> None:
+        """Reason string should mention wind."""
+        ctx = make_ctx(wind_active=True)
+        result = self.handler.evaluate(ctx)
+        assert result is not None
+        assert "wind" in result.reason.lower()
+
+    def test_priority_is_90(self) -> None:
+        """Priority must be 90."""
+        assert WindOverrideHandler.priority == 90
+
+    def test_name_is_wind(self) -> None:
+        """Handler name must be 'wind'."""
+        assert WindOverrideHandler.name == "wind"
+
+    def test_describe_skip_mentions_wind(self) -> None:
+        """describe_skip returns a non-empty string mentioning wind."""
+        ctx = make_ctx(wind_active=False)
+        reason = self.handler.describe_skip(ctx)
+        assert isinstance(reason, str)
+        assert len(reason) > 0
+        assert "wind" in reason.lower()


### PR DESCRIPTION
## Summary
I added extensibility hooks from the design spec:

- **Wind override stub** — priority 90, skeleton for Issue #28
- **Cloud suppression stub** — priority 60, skeleton for Issue #31  
- **WIND + CLOUD** added to ControlMethod enum
- **PipelineResult.tilt** field for future dual-axis venetian blind support (#33)

## Testing
- 679 tests passing (657 + 22 new)