### PR TITLE
ci: test against Python 3.12 and 3.13, set minimum to 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   test:
-    name: Test (Python 3.13)
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.12", "3.13"]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ classifiers = [
   "Intended Audience :: Developers",
   "Natural Language :: English",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3",
 ]
 description = "Adaptive Cover Pro"
@@ -21,7 +22,7 @@ version = "2.0.2"
 
 [tool.poetry.dependencies]
 homeassistant = ">=2025.11.0"
-python = "^3.11"
+python = "^3.12"
 
 [tool.poetry.group.dev.dependencies]
 hass-nabucasa = "0.75.1"


### PR DESCRIPTION
## Summary
Updated test matrix to run against both Python 3.12 and 3.13. Set pyproject.toml minimum Python version to 3.12 to align with Home Assistant 2024.5.0+ requirements.

## Changes
- Updated .github/workflows/tests.yml: Matrix now tests [3.12, 3.13], job name is dynamic
- Updated pyproject.toml: Minimum Python bumped to ^3.12, added 3.13 classifier
- Codecov upload runs only on Python 3.13

## Testing
- Matrix will test both Python 3.12 and 3.13
- Coverage uploaded once per run (3.13 only)