### PR TITLE
fix: Pass climate_data through pipeline result to diagnostics (#103)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-03
 **Current Version:** v2.13.0
-**Branch:** `main` (clean)
+**Branch:** `fix/issue-103-climate-status-sensor` (in progress)
 
 > Quick start: read this file, then `git status && git log --oneline -5`.
 > Architecture, patterns, and workflow rules: see `CLAUDE.md`.
@@ -13,18 +13,23 @@
 
 Released **v2.13.0** — safety overrides bypass Automatic Control, config flow polish (Position Calibration rename/move, menu label alignment, copy dialog pre-selection fix, sync category improvements), Window Width moved to Cover Geometry, self-explanatory entity icons (Issue #100). See `release_notes/v2.13.0.md` for full details.
 
-No work in progress. Main is clean.
+**In progress:** Fix for Issue #103 (Climate Status sensor always unknown). Branch `fix/issue-103-climate-status-sensor` — production code complete, tests passing, awaiting PR.
 
 ## Tests
 
-**1011 passing, 0 failing.**
+**1017 passing, 0 failing.**
 Run: `source venv/bin/activate && python -m pytest tests/ -v`
 
 ## Open Issues
 
 | # | Title | Notes |
 |---|-------|-------|
+| [#103](https://github.com/jrhubott/adaptive-cover-pro/issues/103) | Climate status sensor not working | Fix on branch `fix/issue-103-climate-status-sensor` — pending PR/merge. |
 | [#33](https://github.com/jrhubott/adaptive-cover/issues/33) | Better support for venetian blinds | KNX: single entity exposes both position + tilt. Needs config flow enhancement for dual-axis single-entity covers. |
+
+## Known Gotchas
+
+- **`PipelineResult.tilt` not copied in registry (pre-v2.13.0):** Fixed in the Issue #103 branch — `PipelineRegistry.evaluate()` now copies `tilt` alongside `climate_data`. Before this fix, if any handler returned a `tilt` value it would be silently dropped. No handler currently sets `tilt`, but this will matter for Issue #33 (venetian dual-axis).
 
 ## Pending Upstream PRs
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -721,6 +721,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._pipeline_result.climate_state is not None:
             self.climate_state = self._pipeline_result.climate_state
             self.climate_strategy = self._pipeline_result.climate_strategy
+            self.climate_data = self._pipeline_result.climate_data
 
         return self.state
 

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -322,6 +322,7 @@ class ClimateHandler(OverrideHandler):
             reason=f"climate mode active ({season}) — position {position}%",
             climate_state=position,
             climate_strategy=climate_cover_state.climate_strategy,
+            climate_data=climate_data,
         )
 
     def describe_skip(self, snapshot: PipelineSnapshot) -> str:

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -52,8 +52,10 @@ class PipelineRegistry:
                     control_method=result.control_method,
                     reason=result.reason,
                     decision_trace=trace,
+                    tilt=result.tilt,
                     climate_state=result.climate_state,
                     climate_strategy=result.climate_strategy,
+                    climate_data=result.climate_data,
                     bypass_auto_control=result.bypass_auto_control,
                 )
 

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..enums import ClimateStrategy, ControlMethod
 
@@ -101,6 +101,7 @@ class PipelineResult:
     # Optional climate diagnostics set by ClimateHandler
     climate_state: int | None = None
     climate_strategy: ClimateStrategy | None = None
+    climate_data: Any = None  # ClimateCoverData | None — avoids circular import
 
     # When True, this result is applied even when automatic_control is OFF.
     # Set by safety handlers (ForceOverrideHandler, WeatherOverrideHandler) so

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+    ClimateCoverData,
     ClimateHandler,
 )
 from custom_components.adaptive_cover_pro.pipeline.types import ClimateOptions
@@ -199,6 +200,47 @@ class TestClimateHandlerMetadata:
     def test_name(self) -> None:
         """ClimateHandler name is 'climate'."""
         assert ClimateHandler.name == "climate"
+
+    def test_climate_data_populated_on_result(self) -> None:
+        """PipelineResult.climate_data is a ClimateCoverData when ClimateHandler fires."""
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(inside_temperature=30.0),
+            climate_options=_make_options(temp_high=26.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.climate_data is not None
+        assert isinstance(result.climate_data, ClimateCoverData)
+
+    def test_climate_data_reflects_readings(self) -> None:
+        """climate_data on result carries the actual sensor readings."""
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=30.0,
+                is_presence=True,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(temp_high=26.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        cd = result.climate_data
+        assert cd is not None
+        assert cd.is_summer is True
+        assert cd.is_presence is True
+        assert cd.is_sunny is True
+
+    def test_climate_data_none_when_handler_skipped(self) -> None:
+        """climate_data is None when ClimateHandler does not fire (mode off)."""
+        snap = make_snapshot(climate_mode_enabled=False)
+        result = self.handler.evaluate(snap)
+        assert result is None  # handler returns None — no PipelineResult at all
 
 
 class TestWinterInsulation:

--- a/tests/test_pipeline/test_pipeline_integration.py
+++ b/tests/test_pipeline/test_pipeline_integration.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+    ClimateCoverData,
+    ClimateHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
     CloudSuppressionHandler,
 )
@@ -35,6 +39,44 @@ def _make_registry() -> PipelineRegistry:
             SolarHandler(),
             DefaultHandler(),
         ]
+    )
+
+
+def _make_climate_registry() -> PipelineRegistry:
+    """Registry that includes the ClimateHandler for climate-specific tests."""
+    return PipelineRegistry(
+        [
+            ForceOverrideHandler(),
+            MotionTimeoutHandler(),
+            ManualOverrideHandler(),
+            ClimateHandler(),
+            SolarHandler(),
+            DefaultHandler(),
+        ]
+    )
+
+
+def _climate_readings_summer() -> ClimateReadings:
+    return ClimateReadings(
+        outside_temperature=None,
+        inside_temperature=30.0,
+        is_presence=True,
+        is_sunny=True,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+
+
+def _climate_options_summer() -> ClimateOptions:
+    return ClimateOptions(
+        temp_low=18.0,
+        temp_high=26.0,
+        temp_switch=False,
+        transparent_blind=False,
+        temp_summer_outside=None,
+        cloud_suppression_enabled=False,
+        winter_close_insulation=False,
     )
 
 
@@ -154,3 +196,74 @@ class TestPipelineIntegration:
         matched = [s for s in result.decision_trace if s.matched]
         assert len(matched) == 1
         assert matched[0].handler == "solar"
+
+
+class TestClimateDataPropagation:
+    """Verify climate_data flows from ClimateHandler through the registry."""
+
+    registry = _make_climate_registry()
+
+    def test_registry_copies_climate_data_when_climate_wins(self) -> None:
+        """Registry result carries climate_data when ClimateHandler is the winner."""
+        from unittest.mock import MagicMock
+
+        cover = MagicMock()
+        cover.direct_sun_valid = True
+        cover.valid = True
+        cover.calculate_percentage = MagicMock(return_value=60.0)
+        cover.default = 0.0
+        cover.logger = MagicMock()
+        config = MagicMock()
+        config.min_pos = None
+        config.max_pos = None
+        config.min_pos_sun_only = False
+        config.max_pos_sun_only = False
+        cover.config = config
+
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_climate_readings_summer(),
+            climate_options=_climate_options_summer(),
+        )
+        result = self.registry.evaluate(snap)
+        assert result.control_method.name == "SUMMER"
+        assert result.climate_data is not None
+        assert isinstance(result.climate_data, ClimateCoverData)
+        assert result.climate_data.is_summer is True
+
+    def test_registry_climate_data_none_when_non_climate_handler_wins(self) -> None:
+        """climate_data is None on registry result when a non-climate handler wins."""
+        snap = make_snapshot(
+            manual_override_active=True,
+            climate_mode_enabled=True,
+            climate_readings=_climate_readings_summer(),
+            climate_options=_climate_options_summer(),
+        )
+        result = self.registry.evaluate(snap)
+        assert result.control_method.name == "MANUAL"
+        assert result.climate_data is None
+
+    def test_registry_copies_tilt_from_winning_handler(self) -> None:
+        """Registry result copies tilt field from the winning handler's result."""
+        from unittest.mock import patch
+        from custom_components.adaptive_cover_pro.pipeline.handlers.solar import (
+            SolarHandler,
+        )
+        from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+        from custom_components.adaptive_cover_pro.enums import ControlMethod as CM
+
+        # Patch SolarHandler to return a result with tilt=45
+        with patch.object(
+            SolarHandler,
+            "evaluate",
+            return_value=PipelineResult(
+                position=50,
+                control_method=CM.SOLAR,
+                reason="test",
+                tilt=45,
+            ),
+        ):
+            snap = make_snapshot(direct_sun_valid=True)
+            result = self.registry.evaluate(snap)
+        assert result.tilt == 45


### PR DESCRIPTION
## Summary

Fixes Issue #103 — Climate Status sensor staying in 'unknown' state when climate mode is enabled.

## Root Cause

`ClimateCoverData` was constructed inside `ClimateHandler.evaluate()` but never propagated back to the coordinator. The `DiagnosticContext.climate_data` was always `None`, causing `_build_climate()` to skip the entire diagnostics block.

## Changes

- Add `climate_data` field to `PipelineResult` (avoids circular import)
- Set `climate_data` in `ClimateHandler.evaluate()` return value
- Copy `climate_data` (and `tilt`) through `PipelineRegistry.evaluate()`
- Store `self.climate_data` from pipeline result in coordinator

## Bonus Fix

Also fixes latent bug: `PipelineRegistry` was not copying the `tilt` field. No handler currently sets tilt, but this will matter for Issue #33 (venetian dual-axis).

## Testing

- 6 new tests covering climate_data propagation end-to-end
- 1017 total tests passing (up from 1011)
- All existing tests still pass

Fixes #103