### PR TITLE
fix: Correct motion override startup behavior and pipeline bypass

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -122,6 +122,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(coordinator._stop_position_verification)
 
     await coordinator.async_config_entry_first_refresh()
+    coordinator._check_initial_motion_state()
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -447,7 +447,7 @@ MOTION_OVERRIDE_SCHEMA = vol.Schema(
             selector.EntitySelectorConfig(
                 domain=["binary_sensor"],
                 multiple=True,
-                device_class=["motion", "occupancy"],
+                device_class=["motion", "occupancy", "presence"],
             )
         ),
         vol.Optional(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -596,6 +596,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Cancel motion timeout task."""
         self._motion_mgr.cancel_motion_timeout()
 
+    def _check_initial_motion_state(self) -> None:
+        """Set no-motion state immediately if all sensors are off at startup.
+
+        Prevents the Motion Status sensor from showing ``waiting_for_data``
+        indefinitely when sensors are already off when HA starts.
+        """
+        if not self.config_entry.options.get(CONF_MOTION_SENSORS):
+            return
+        if not self.is_motion_detected:
+            self._motion_mgr.set_no_motion()
+
     def _start_weather_timeout(self) -> None:
         """Start weather clear-delay timeout."""
 
@@ -1311,9 +1322,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 CONF_WEATHER_BYPASS_AUTO_CONTROL, True
             ):
                 return self.config_entry.options.get(CONF_WEATHER_OVERRIDE_POSITION, 0)
-        if self.is_motion_timeout_active:
-            return self.default_state
-
         # Use pipeline result if available, otherwise default_state (outside time window)
         if self._pipeline_result is not None:
             state = self._pipeline_result.position

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -101,6 +101,15 @@ class MotionManager:
 
     # --- Motion event handling ---
 
+    def set_no_motion(self) -> None:
+        """Immediately activate the no-motion state without waiting for a timeout.
+
+        Used at startup when all sensors are already off so the feature does not
+        stay stuck in ``waiting_for_data`` until a sensor first turns on then off.
+        """
+        self.cancel_motion_timeout()
+        self._motion_timeout_active = True
+
     def record_motion_detected(self) -> None:
         """Record that motion was detected right now.
 

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -736,6 +736,9 @@ class AdaptiveCoverMotionStatusSensor(AdaptiveCoverDiagnosticSensorBase, SensorE
         if not self.config_entry.options.get(CONF_MOTION_SENSORS):
             return "not_configured"
         mgr = self.coordinator._motion_mgr
+        if mgr._motion_timeout_active:
+            return "no_motion"
+
         if mgr.last_motion_time is None:
             return "waiting_for_data"
 
@@ -745,9 +748,6 @@ class AdaptiveCoverMotionStatusSensor(AdaptiveCoverDiagnosticSensorBase, SensorE
         task = mgr._motion_timeout_task
         if task is not None and not task.done():
             return "timeout_pending"
-
-        if mgr._motion_timeout_active:
-            return "no_motion"
 
         return "waiting_for_data"
 

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -451,8 +451,12 @@ def test_determine_control_status_force_override_precedence():
     assert result == ControlStatus.FORCE_OVERRIDE_ACTIVE
 
 
-def test_state_property_motion_timeout_returns_default():
-    """Test state property returns default position during motion timeout."""
+def test_state_property_motion_timeout_uses_pipeline_result():
+    """Test state property uses pipeline result position during motion timeout.
+
+    The pipeline MotionTimeoutHandler computes position with min/max limits applied.
+    The state property must not bypass the pipeline result with raw default_state.
+    """
     from custom_components.adaptive_cover_pro.enums import ControlMethod
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
@@ -462,20 +466,24 @@ def test_state_property_motion_timeout_returns_default():
     coordinator = MagicMock()
     coordinator.default_state = 60
     coordinator.logger = MagicMock()
+    coordinator._use_interpolation = False
+    coordinator._inverse_state = False
+    coordinator._pipeline_bypasses_auto_control = False
 
     # Mock property access for direct checks in state property
     type(coordinator).is_force_override_active = property(lambda self: False)
     type(coordinator).is_motion_timeout_active = property(lambda self: True)
 
-    # Pipeline result indicates motion timeout with default position
+    # Pipeline result has limits applied — position differs from raw default_state
     coordinator._pipeline_result = PipelineResult(
-        position=60,
+        position=10,
         control_method=ControlMethod.MOTION,
-        reason="motion timeout active",
+        reason="motion timeout active — default position 10%",
     )
 
     result = AdaptiveDataUpdateCoordinator.state.fget(coordinator)
-    assert result == 60
+    # Must return the pipeline result (10), not the raw default_state (60)
+    assert result == 10
 
 
 def test_state_property_force_override_precedence():
@@ -778,3 +786,102 @@ def test_motion_status_sensor_no_timestamp_device_class():
         getattr(AdaptiveCoverMotionStatusSensor, "_attr_device_class", None)
         != SensorDeviceClass.TIMESTAMP
     )
+
+
+# --- Startup initialization tests ---
+
+
+def test_set_no_motion_activates_immediately():
+    """set_no_motion() sets _motion_timeout_active without starting a task."""
+    hass = MagicMock()
+    logger = MagicMock()
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
+
+    mgr.set_no_motion()
+
+    assert mgr._motion_timeout_active is True
+    assert mgr._motion_timeout_task is None
+
+
+def test_set_no_motion_cancels_pending_timeout():
+    """set_no_motion() cancels any running timeout task."""
+    hass = MagicMock()
+    logger = MagicMock()
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
+
+    task = MagicMock()
+    task.done.return_value = False
+    mgr._motion_timeout_task = task
+
+    mgr.set_no_motion()
+
+    task.cancel.assert_called_once()
+    assert mgr._motion_timeout_active is True
+
+
+def test_check_initial_motion_state_all_off_sets_no_motion():
+    """_check_initial_motion_state sets no_motion when all sensors are off at startup."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from custom_components.adaptive_cover_pro.const import CONF_MOTION_SENSORS
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options.get.return_value = ["binary_sensor.motion"]
+    type(coordinator).is_motion_detected = property(lambda self: False)
+
+    AdaptiveDataUpdateCoordinator._check_initial_motion_state(coordinator)
+
+    coordinator._motion_mgr.set_no_motion.assert_called_once()
+
+
+def test_check_initial_motion_state_sensor_on_no_action():
+    """_check_initial_motion_state does nothing when motion is detected at startup."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options.get.return_value = ["binary_sensor.motion"]
+    type(coordinator).is_motion_detected = property(lambda self: True)
+
+    AdaptiveDataUpdateCoordinator._check_initial_motion_state(coordinator)
+
+    coordinator._motion_mgr.set_no_motion.assert_not_called()
+
+
+def test_check_initial_motion_state_no_sensors_noop():
+    """_check_initial_motion_state does nothing when no motion sensors are configured."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = MagicMock()
+    coordinator.config_entry.options.get.return_value = []
+
+    AdaptiveDataUpdateCoordinator._check_initial_motion_state(coordinator)
+
+    coordinator._motion_mgr.set_no_motion.assert_not_called()
+
+
+def test_motion_status_sensor_startup_no_motion():
+    """Sensor shows no_motion at startup when sensors are configured but all off.
+
+    set_no_motion() sets _motion_timeout_active=True without last_motion_time.
+    The sensor must check _motion_timeout_active before last_motion_time so it
+    shows no_motion rather than waiting_for_data.
+    """
+    coordinator = MagicMock()
+    coordinator._motion_mgr = _make_motion_mgr(
+        last_motion_time=None,
+        timeout_active=True,
+        timeout_task=None,
+    )
+    type(coordinator).is_motion_detected = property(lambda self: False)
+
+    sensor = _make_motion_status_sensor(coordinator)
+    assert sensor.native_value == "no_motion"
+
+


### PR DESCRIPTION
Three bugs fixed:

1. State property was bypassing the pipeline result for motion timeout, returning raw default_state instead of the pipeline-computed position with min/max limits, interpolation, and inverse state applied.

2. Motion Status sensor showed waiting_for_data indefinitely at startup when all sensors were already off — added set_no_motion() to MotionManager and _check_initial_motion_state() to coordinator so the feature initializes to no_motion immediately on first refresh.

3. Entity selector for motion sensors was missing the presence device class, preventing Bluetooth presence sensors from being selectable.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- fixes:

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<!-- A picture tell a thousand words -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking which updates existing code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
