### PR TITLE
fix: Save current cover settings before sync, return to menu after

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2265,6 +2265,11 @@ class OptionsFlowHandler(OptionsFlow):
         """Confirm and execute sync to selected covers."""
         if user_input is not None:
             if user_input.get("confirm"):
+                # Save current cover's settings first so sync copies the latest values
+                self.hass.config_entries.async_update_entry(
+                    self._config_entry,
+                    options=dict(self.options),
+                )
                 shared_options = _extract_shared_options(
                     self._config_entry, categories=self.selected_sync_categories
                 )
@@ -2275,8 +2280,7 @@ class OptionsFlowHandler(OptionsFlow):
                             target,
                             options={**target.options, **shared_options},
                         )
-                return self.async_abort(reason="sync_complete")  # type: ignore[return-value]
-            return self.async_abort(reason="user_cancelled")  # type: ignore[return-value]
+            return await self.async_step_init()
 
         # Build summary of selected targets
         target_titles = []

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -701,7 +701,7 @@
       },
       "sync_confirm": {
         "title": "Copy Settings — Confirm",
-        "description": "The following categories will be overwritten:\n\n{categories_summary}\n\nOn these covers:\n\n{entries_summary}\n\nEach cover will keep its own name, entities, azimuth, and device association.",
+        "description": "Your current settings will be saved before copying.\n\nThe following categories will be overwritten:\n\n{categories_summary}\n\nOn these covers:\n\n{entries_summary}\n\nEach cover will keep its own name, entities, azimuth, and device association.",
         "data": {
           "confirm": "Confirm sync"
         }


### PR DESCRIPTION
## Summary

Fixed two issues with the Copy Settings (sync) flow:

1. **Stale settings**: Sync was reading from persisted config entry options, ignoring any unsaved edits made before syncing. Now saves the current cover's in-memory settings first so the latest values are always copied.

2. **Lost changes after sync**: After sync completed the flow exited entirely, discarding all in-memory edits to the current cover. Now returns to the options menu instead so the user can continue editing or hit Done.

Also added a note to the confirm dialog informing the user their settings will be saved before copying.

## Testing

1. Open options flow, change a setting
2. Go to Sync, select a target cover and categories
3. Confirm — verify synced cover received the updated (unsaved) value
4. Verify you return to the options menu, not exited