### PR TITLE
fix: Move Window Width field under Window Height in geometry config

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -143,6 +143,15 @@ GEOMETRY_VERTICAL_SCHEMA = vol.Schema(
                 unit_of_measurement="m",
             )
         ),
+        vol.Optional(CONF_WINDOW_WIDTH, default=100): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=10,
+                max=500,
+                step=1,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="cm",
+            )
+        ),
         vol.Required(CONF_DISTANCE, default=0.5): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0.1,
@@ -168,15 +177,6 @@ GEOMETRY_VERTICAL_SCHEMA = vol.Schema(
                 step=0.01,
                 mode=selector.NumberSelectorMode.SLIDER,
                 unit_of_measurement="m",
-            )
-        ),
-        vol.Optional(CONF_WINDOW_WIDTH, default=100): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=10,
-                max=500,
-                step=1,
-                mode=selector.NumberSelectorMode.SLIDER,
-                unit_of_measurement="cm",
             )
         ),
     }


### PR DESCRIPTION
Reorders Cover Geometry configuration fields to show Window Width immediately below Window Height for better UX.