### PR TITLE
fix: add missing 'min' unit to manual override duration in config summary

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -867,7 +867,7 @@ def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa
     # Manual override (70)
     mo_parts = []
     if manual_dur is not None:
-        mo_parts.append(f"pauses for {manual_dur}")
+        mo_parts.append(f"pauses for {manual_dur} min")
     threshold = config.get(CONF_MANUAL_THRESHOLD)
     if threshold is not None:
         mo_parts.append(f"threshold {threshold}%")


### PR DESCRIPTION
Fixes test failures in test_config_flow_summary.py by adding the missing 'min' unit suffix to the manual override duration in the configuration summary display.