### PR TITLE
fix: manual override reset - restore correct pipeline position & bypass time delta gate

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -15,7 +15,7 @@
 
 ## Tests
 
-**1090 passing, 0 failing** (+7 new tests for time window gating and motion control switch).
+**1093 passing, 0 failing** (+3 new tests for manual override reset fix).
 Run: `source venv/bin/activate && python -m pytest tests/ -v`
 
 ## Open Issues
@@ -29,7 +29,8 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 - **`PipelineResult.tilt` not copied in registry (fixed v2.13.1):** `PipelineRegistry.evaluate()` now copies `tilt` alongside `climate_data`. Before v2.13.1, handler-set `tilt` values were silently dropped (only mattered for Issue #33 dual-axis).
 - **`cover.default` property removed:** `AdaptiveGeneralCover` and `SunGeometry` no longer expose `.default`. Any code accessing it will get `AttributeError` immediately. Use `snapshot.default_position` in pipeline handlers; use `compute_effective_default()` elsewhere.
 - **Time window gate moved into pipeline:** `SolarHandler` and `GlareZoneHandler` now self-gate on `snapshot.in_time_window` (returning `None` when outside the window). The `in_time_window` gate has been **removed** from `CoverCommandService.apply_position()` — `PositionContext` no longer has an `in_time_window` field. The pipeline still always runs; it is each handler's responsibility to check `snapshot.in_time_window` if needed. The `auto_control` gate remains in `CoverCommandService`.
-- **Motion Control switch:** A new "Motion Control" switch entity is conditionally shown when `CONF_MOTION_SENSORS` are configured. Its state is stored in `ToggleManager.motion_control` (default `True`) and passed to `PipelineSnapshot.motion_control_enabled`. `MotionTimeoutHandler` checks this field and passes through (returns `None`) when the switch is off, allowing lower-priority handlers to run as if motion timeout were inactive.
+- **Motion Control switch:** A new "Motion Control" switch entity is conditionally shown when `CONF_MOTION_SENSORS` are configured.
+- **Manual override reset now sends correct position (fixed):** `reset_if_needed()` now runs BEFORE `_calculate_cover_state()` so the pipeline sees the cleared state. It returns the set of expired entity IDs; the coordinator calls `_async_send_after_override_clear()` with `force=True` for those covers. The reset button now resets the override first, calls `async_refresh()` so the pipeline runs without the override, then sends `coordinator.state` (the true post-override position — climate, solar, or default — whichever handler wins). The old pre-refresh send used `ManualOverrideHandler`'s simplified solar/default position which was wrong when climate mode was active. Its state is stored in `ToggleManager.motion_control` (default `True`) and passed to `PipelineSnapshot.motion_control_enabled`. `MotionTimeoutHandler` checks this field and passes through (returns `None`) when the switch is off, allowing lower-priority handlers to run as if motion timeout were inactive.
 - **`NormalCoverState` is test-only:** `NormalCoverState` in `calculation.py` is no longer used by production code (coordinator stores `_cover_data` directly). It remains for backward compat with existing tests. Do not re-introduce it into coordinator logic.
 - **`ClimateCoverState` takes a `PipelineSnapshot`:** Constructor changed from `(cover, climate_data, default_position=X)` to `(snapshot, climate_data)`. Use `make_snapshot_for_cover(cover, h_def)` from `tests/conftest.py` in tests.
 - **Pipeline helpers are the canonical position helpers:** All handlers and `ClimateCoverState` use `pipeline/helpers.py` — `compute_solar_position()`, `compute_default_position()`, `apply_snapshot_limits()`, `compute_raw_calculated_position()`. Do not inline these patterns in new handlers.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,7 +1,7 @@
 # Adaptive Cover Pro — Developer Handoff
 
 **Date:** 2026-04-04
-**Current Version:** v2.13.6-beta.2
+**Current Version:** v2.13.6-beta.3
 **Branch:** `feature/true-sunset-sunrise-default-position` (in progress)
 
 > Quick start: read this file, then `git status && git log --oneline -5`.
@@ -40,6 +40,7 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 
 | Version | Date | Summary |
 |---------|------|----------|
+| [v2.13.6-beta.3](https://github.com/jrhubott/adaptive-cover-pro/releases/tag/v2.13.6-beta.3) | 2026-04-04 | Fix: manual override reset now sends correct pipeline position (climate-aware). |
 | [v2.13.6-beta.2](https://github.com/jrhubott/adaptive-cover-pro/releases/tag/v2.13.6-beta.2) | 2026-04-04 | Pipeline time window gate moved to handlers; Motion Control switch. |
 | [v2.13.5](https://github.com/jrhubott/adaptive-cover-pro/releases/tag/v2.13.5) | 2026-04-04 | Pipeline consolidation refactor, true sunset/sunrise default position. |
 | [v2.13.1](https://github.com/jrhubott/adaptive-cover-pro/releases/tag/v2.13.1) | 2026-04-03 | Climate Status sensor fix (#103), pipeline tilt field propagation fix. |

--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import dataclasses
-
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -67,37 +64,9 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
         for entity in self._entities:
             if self.coordinator.manager.is_cover_manual(entity):
                 _LOGGER.debug("Resetting manual override for: %s", entity)
-
-                # Move to current calculated position, all gate checks applied
-                # except manual_override (we're in the process of clearing it).
-                target_position = self.coordinator.state
-                options = self.coordinator.config_entry.options
-                ctx = self.coordinator._build_position_context(entity, options)
-                # Override manual_override gate — we're intentionally resetting it
-                ctx = dataclasses.replace(ctx, manual_override=False)
-                outcome, _ = await self.coordinator._cmd_svc.apply_position(
-                    entity, target_position, "manual_reset", context=ctx
-                )
-                if outcome == "sent":
-                    # Wait for cover to reach target, but no longer than 30 seconds
-                    deadline = asyncio.get_event_loop().time() + 30
-                    while self.coordinator.wait_for_target.get(entity):
-                        if asyncio.get_event_loop().time() >= deadline:
-                            _LOGGER.debug(
-                                "Timed out waiting for %s to reach target position",
-                                entity,
-                            )
-                            break
-                        await asyncio.sleep(1)
-                else:
-                    _LOGGER.debug(
-                        "Manual override reset: delta too small for %s, skipping position change",
-                        entity,
-                    )
-
                 self.coordinator.manager.reset(entity)
-                # Suppress re-detection: any cover state events arriving during
-                # refresh should not be treated as a new manual override.
+                # Suppress re-detection: cover state events during refresh must
+                # not be treated as a new manual override.
                 self.coordinator.wait_for_target[entity] = True
                 self.coordinator.cover_state_change = False
                 reset_entities.append(entity)
@@ -106,7 +75,34 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
                     "Resetting manual override for %s is not needed since it is already auto-controlled",
                     entity,
                 )
+
+        if not reset_entities:
+            return
+
+        # Refresh so the pipeline re-runs without the override active,
+        # producing the correct post-override position (climate, solar,
+        # default — whichever handler wins now).
         await self.coordinator.async_refresh()
-        # Unblock state tracking now that refresh has consumed any pending events.
+
+        # Send the fresh pipeline position to every reset cover.
+        # Using the standard context means all normal gates apply (auto_control,
+        # delta, time threshold) except manual_override which is already cleared.
+        # force=True is not needed here because the cover was manually moved
+        # away from the calculated position, so the delta will naturally be large.
+        options = self.coordinator.config_entry.options
         for entity in reset_entities:
-            self.coordinator.wait_for_target[entity] = False
+            ctx = self.coordinator._build_position_context(entity, options)
+            outcome, _ = await self.coordinator._cmd_svc.apply_position(
+                entity, self.coordinator.state, "manual_reset", context=ctx
+            )
+            if outcome != "sent":
+                _LOGGER.debug(
+                    "Manual override reset: no position change sent for %s (%s)",
+                    entity,
+                    outcome,
+                )
+            # If sent, apply_position already set wait_for_target=True;
+            # let normal cover-state-change detection clear it on arrival.
+            # If not sent, unblock state tracking now.
+            if outcome != "sent":
+                self.coordinator.wait_for_target[entity] = False

--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -85,13 +85,13 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
         await self.coordinator.async_refresh()
 
         # Send the fresh pipeline position to every reset cover.
-        # Using the standard context means all normal gates apply (auto_control,
-        # delta, time threshold) except manual_override which is already cleared.
-        # force=True is not needed here because the cover was manually moved
-        # away from the calculated position, so the delta will naturally be large.
+        # force=True bypasses all gate checks (delta, time threshold, auto_control).
+        # This is required because the cover's last_updated timestamp was set when
+        # the user manually moved it, so _check_time_delta would fire and block
+        # the command even though this is an intentional user reset action.
         options = self.coordinator.config_entry.options
         for entity in reset_entities:
-            ctx = self.coordinator._build_position_context(entity, options)
+            ctx = self.coordinator._build_position_context(entity, options, force=True)
             outcome, _ = await self.coordinator._cmd_svc.apply_position(
                 entity, self.coordinator.state, "manual_reset", context=ctx
             )

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -729,13 +729,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         cover_data = self.get_blind_data(options=options)
         self._update_manager_and_covers()
 
-        # Calculate cover state
+        # Reset expired manual overrides BEFORE running the pipeline so the
+        # pipeline sees the cleared state and computes the correct position.
+        auto_expired = await self.manager.reset_if_needed()
+
+        # Calculate cover state (pipeline runs with up-to-date override state)
         state = self._calculate_cover_state(cover_data, options)
-        await self.manager.reset_if_needed()
 
         # Handle types of changes
         if self.state_change:
             await self.async_handle_state_change(state, options)
+        elif auto_expired:
+            # One or more manual overrides just timed out.  Proactively send
+            # the fresh pipeline position so covers don't linger at the
+            # user-moved position until the next solar/entity-state event.
+            await self._async_send_after_override_clear(state, options)
         if self.cover_state_change:
             await self.async_handle_cover_state_change(state)
         if self.first_refresh:
@@ -812,6 +820,31 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             inverse_state=self._inverse_state,
             force=force,
         )
+
+    async def _async_send_after_override_clear(self, state: int, options: dict) -> None:
+        """Send the current pipeline position after a manual override clears.
+
+        Called when a manual override expires (auto-expiry timer) or when the
+        reset button clears it.  Uses force=True so the command is sent
+        regardless of delta/time thresholds — the cover may be far from the
+        calculated position after sitting in manual for an extended period.
+
+        Args:
+            state: Post-reset pipeline position (already computed without override).
+            options: Config entry options dict.
+
+        """
+        self.logger.debug(
+            "Sending pipeline position %s after manual override cleared", state
+        )
+        sun_just_appeared = self._check_sun_validity_transition()
+        for cover in self.entities:
+            ctx = self._build_position_context(
+                cover, options, force=True, sun_just_appeared=sun_just_appeared
+            )
+            await self._cmd_svc.apply_position(
+                cover, state, "manual_override_cleared", context=ctx
+            )
 
     async def async_handle_state_change(self, state: int, options):
         """Send position commands to all covers when a tracked entity changes."""

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -172,14 +172,21 @@ class AdaptiveCoverManager:
         """
         self.manual_control[cover] = True
 
-    async def reset_if_needed(self):
+    async def reset_if_needed(self) -> set[str]:
         """Reset expired manual overrides.
 
         Checks all covers with manual control timestamps and resets those where
         configured duration has elapsed. Called on every coordinator update to
         ensure timely automatic reset.
 
+        Returns:
+            Set of entity IDs whose manual override just expired this call.
+            Empty set when nothing changed. The coordinator uses this to
+            proactively send the current pipeline position to those covers
+            so they don't linger at the user-moved position.
+
         """
+        expired: set[str] = set()
         current_time = dt.datetime.now(dt.UTC)
         manual_control_time_copy = dict(self.manual_control_time)
         for entity_id, last_updated in manual_control_time_copy.items():
@@ -189,6 +196,8 @@ class AdaptiveCoverManager:
                     entity_id,
                 )
                 self.reset(entity_id)
+                expired.add(entity_id)
+        return expired
 
     def reset(self, entity_id):
         """Reset manual control.

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -20,5 +20,5 @@
     "astral",
     "pandas"
   ],
-  "version": "2.13.6-beta.3"
+  "version": "2.13.6-beta.4"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -20,5 +20,5 @@
     "astral",
     "pandas"
   ],
-  "version": "2.13.6-beta.2"
+  "version": "2.13.6-beta.3"
 }

--- a/release_notes/v2.13.6-beta.3.md
+++ b/release_notes/v2.13.6-beta.3.md
@@ -1,0 +1,31 @@
+# Adaptive Cover Pro v2.13.6-beta.3
+
+## 🐛 Bug Fix: Manual Override Reset Position
+
+This beta fixes a critical bug where covers did not return to their correct pipeline-calculated position after canceling a manual override (both via button press and auto-expiry timer).
+
+### 🔧 Changes
+
+- **Auto-expiry timeout:** `reset_if_needed()` now runs BEFORE the pipeline calculation so the override is cleared when the position is computed. When an override expires, the system immediately sends the correct position via `manual_override_cleared` reason with `force=True`.
+
+- **Reset button:** Removed the pre-refresh position send (which was sending the simplified `ManualOverrideHandler` position). New flow: reset override → `async_refresh()` (pipeline runs correctly) → send `coordinator.state` (the true post-override position). This fixes the scenario where climate mode is active and the climate-controlled position differs from the solar/default position.
+
+- **Position accuracy:** Both paths now send whatever position the pipeline computes after the override is cleared—whether that's climate-controlled, solar-tracked, or default—instead of the simplified override-active position.
+
+### ✨ Benefits
+
+- Covers return to the correct climate-aware position after manual override expires
+- Reset button sends the authoritative pipeline position, not a simplified approximation
+- No more covers lingering at user-moved positions for minutes until the next sun update
+
+### 🧪 Testing
+
+- ✅ 1093 tests passing
+- ✅ Added 3 new tests: auto-expiry return value, reset-button climate scenario, position verification
+- ✅ Updated button press tests to reflect new post-refresh-send flow
+
+---
+
+**Python:** 3.11+  
+**Home Assistant:** 2024.5.0+  
+**Pre-release:** Yes

--- a/release_notes/v2.13.6-beta.4.md
+++ b/release_notes/v2.13.6-beta.4.md
@@ -1,0 +1,24 @@
+# Adaptive Cover Pro v2.13.6-beta.4
+
+## 🐛 Bug Fix: Reset Button Blocked by Time Delta Gate
+
+Fixes a regression where pressing the Reset Manual Override button caused `time_delta_too_small` to be logged and the cover never moved.
+
+### Root Cause
+
+`_check_time_delta` reads `entity.last_updated` from HA state — this timestamp is set whenever the cover reports any state change, including the user's manual move. If the reset button was pressed within the configured time threshold (default: 2 minutes) of the manual move, the time delta gate blocked the command.
+
+### Fix
+
+The reset button now builds its context with `force=True`, bypassing all gate checks (delta, time threshold, auto_control). This is correct for an intentional user-initiated reset action — the user is explicitly requesting the cover return to its pipeline position.
+
+### 🧪 Testing
+
+- ✅ 1093 tests passing
+- ✅ Reset button tests updated to assert `force=True` and reflect correct skip reasons
+
+---
+
+**Python:** 3.11+  
+**Home Assistant:** 2024.5.0+  
+**Pre-release:** Yes

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -210,7 +210,10 @@ def test_cancel_grace_period_handles_missing_entity():
 
 @pytest.mark.asyncio
 async def test_reset_button_clears_manual_override_and_sends_post_refresh_position():
-    """Reset button must reset override, refresh, then send the fresh pipeline position."""
+    """Reset button must reset override, refresh, then send the fresh pipeline position.
+
+    Also verifies force=True is used so time_delta_too_small cannot block the send.
+    """
     from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
     from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 
@@ -223,15 +226,12 @@ async def test_reset_button_clears_manual_override_and_sends_post_refresh_positi
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True, manual_override=False,
         sun_just_appeared=False, min_change=2, time_threshold=2,
-        special_positions=[0, 100], inverse_state=False,
+        special_positions=[0, 100], inverse_state=False, force=True,
     )
     coordinator._cmd_svc.apply_position = AsyncMock(return_value=("sent", "set_cover_position"))
     coordinator.wait_for_target = {entity_id: False}
     coordinator.cover_state_change = False
-
-    # coordinator.state returns the post-refresh pipeline position
     coordinator.state = POST_REFRESH_STATE
-
     coordinator.async_refresh = AsyncMock()
 
     button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
@@ -243,6 +243,13 @@ async def test_reset_button_clears_manual_override_and_sends_post_refresh_positi
     # Manager reset must be called before the refresh
     coordinator.manager.reset.assert_called_once_with(entity_id)
     coordinator.async_refresh.assert_called_once()
+
+    # _build_position_context must be called with force=True so time/delta gates are bypassed
+    coordinator._build_position_context.assert_called_once()
+    build_kwargs = coordinator._build_position_context.call_args
+    assert build_kwargs.kwargs.get("force") is True or (
+        len(build_kwargs.args) >= 3 and build_kwargs.args[2] is True
+    ), "_build_position_context must be called with force=True"
 
     # apply_position must be called AFTER refresh with the fresh pipeline position
     coordinator._cmd_svc.apply_position.assert_called_once()
@@ -291,11 +298,15 @@ async def test_reset_button_suppresses_redetection_during_refresh():
 
 @pytest.mark.asyncio
 async def test_reset_button_clears_wait_for_target_when_no_command_sent():
-    """wait_for_target must be False after reset when apply_position is skipped."""
+    """wait_for_target must be False after reset when apply_position is skipped.
+
+    With force=True, the only remaining skip reason is no_capable_service
+    (cover doesn't support positioning commands).
+    """
     from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
     from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 
-    entity_id = "cover.already_correct"
+    entity_id = "cover.no_position_support"
 
     coordinator = MagicMock()
     coordinator.manager.is_cover_manual.return_value = True
@@ -304,10 +315,10 @@ async def test_reset_button_clears_wait_for_target_when_no_command_sent():
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True, manual_override=False,
         sun_just_appeared=False, min_change=2, time_threshold=2,
-        special_positions=[0, 100], inverse_state=False,
+        special_positions=[0, 100], inverse_state=False, force=True,
     )
-    # Simulate delta too small — command skipped
-    coordinator._cmd_svc.apply_position = AsyncMock(return_value=("skipped", "delta_too_small"))
+    # Simulate cover without positioning capability — the only skip that survives force=True
+    coordinator._cmd_svc.apply_position = AsyncMock(return_value=("skipped", "no_capable_service"))
     coordinator.async_refresh = AsyncMock()
     coordinator.wait_for_target = {entity_id: True}  # was True from suppression
     coordinator.cover_state_change = False
@@ -396,7 +407,7 @@ async def test_reset_button_sends_correct_position_with_climate_mode():
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True, manual_override=False,
         sun_just_appeared=False, min_change=2, time_threshold=2,
-        special_positions=[0, 100], inverse_state=False,
+        special_positions=[0, 100], inverse_state=False, force=True,
     )
     coordinator._cmd_svc.apply_position = AsyncMock(return_value=("sent", "set_cover_position"))
     coordinator.wait_for_target = {entity_id: False}

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -209,66 +209,66 @@ def test_cancel_grace_period_handles_missing_entity():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_manual_override_and_stays_cleared():
-    """Reset button must clear manual override and leave it cleared after refresh."""
+async def test_reset_button_clears_manual_override_and_sends_post_refresh_position():
+    """Reset button must reset override, refresh, then send the fresh pipeline position."""
     from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
     from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 
     entity_id = "cover.living_room"
+    POST_REFRESH_STATE = 52  # position pipeline returns after override is cleared
 
-    # Build a minimal coordinator mock
     coordinator = MagicMock()
     coordinator.manager.is_cover_manual.return_value = True
-    coordinator.state = 75
     coordinator.config_entry.options = {}
-    # _build_position_context returns a PositionContext; apply_position returns ("sent", svc)
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True, manual_override=False,
         sun_just_appeared=False, min_change=2, time_threshold=2,
         special_positions=[0, 100], inverse_state=False,
     )
     coordinator._cmd_svc.apply_position = AsyncMock(return_value=("sent", "set_cover_position"))
-    coordinator.async_refresh = AsyncMock()
-    # Simulate cover reaching target immediately
     coordinator.wait_for_target = {entity_id: False}
     coordinator.cover_state_change = False
 
-    # Build button with the mocked coordinator
-    config_entry = MagicMock()
-    config_entry.options = {"entities": [entity_id]}
+    # coordinator.state returns the post-refresh pipeline position
+    coordinator.state = POST_REFRESH_STATE
+
+    coordinator.async_refresh = AsyncMock()
+
     button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
     button.coordinator = coordinator
     button._entities = [entity_id]
 
     await button.async_press()
 
-    # apply_position was called for the entity
-    coordinator._cmd_svc.apply_position.assert_called_once()
-    # Manager reset was called
+    # Manager reset must be called before the refresh
     coordinator.manager.reset.assert_called_once_with(entity_id)
-    # Refresh was called
     coordinator.async_refresh.assert_called_once()
-    # After refresh, wait_for_target was cleared (False), not left suppressing events
-    assert coordinator.wait_for_target[entity_id] is False
+
+    # apply_position must be called AFTER refresh with the fresh pipeline position
+    coordinator._cmd_svc.apply_position.assert_called_once()
+    call_args = coordinator._cmd_svc.apply_position.call_args
+    assert call_args[0][0] == entity_id          # entity
+    assert call_args[0][1] == POST_REFRESH_STATE  # fresh state, not pre-refresh
+    assert call_args[0][2] == "manual_reset"      # reason
 
 
 @pytest.mark.asyncio
 async def test_reset_button_suppresses_redetection_during_refresh():
-    """wait_for_target must be True while async_refresh runs, then cleared."""
+    """wait_for_target must be True while async_refresh runs to block re-detection."""
     from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 
     entity_id = "cover.bedroom"
     states_during_refresh = []
 
     async def capture_refresh():
-        # Record wait_for_target value at the moment refresh runs
+        # Record wait_for_target state at the moment async_refresh executes
         states_during_refresh.append(coordinator.wait_for_target.get(entity_id))
 
     coordinator = MagicMock()
     coordinator.manager.is_cover_manual.return_value = True
     coordinator.state = 50
     coordinator.config_entry.options = {}
-    from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True, manual_override=False,
         sun_just_appeared=False, min_change=2, time_threshold=2,
@@ -279,63 +279,142 @@ async def test_reset_button_suppresses_redetection_during_refresh():
     coordinator.wait_for_target = {entity_id: False}
     coordinator.cover_state_change = False
 
-    config_entry = MagicMock()
-    config_entry.options = {"entities": [entity_id]}
     button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
     button.coordinator = coordinator
     button._entities = [entity_id]
 
     await button.async_press()
 
-    # During refresh, suppression must be active (True)
+    # During refresh the suppression flag must be active
     assert states_during_refresh == [True]
-    # After refresh, suppression must be cleared (False)
-    assert coordinator.wait_for_target[entity_id] is False
 
 
 @pytest.mark.asyncio
-async def test_reset_button_times_out_if_cover_never_reaches_target():
-    """Button must not hang forever when cover never reaches the target position."""
-    import time
-
+async def test_reset_button_clears_wait_for_target_when_no_command_sent():
+    """wait_for_target must be False after reset when apply_position is skipped."""
     from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 
-    entity_id = "cover.stuck"
+    entity_id = "cover.already_correct"
 
     coordinator = MagicMock()
     coordinator.manager.is_cover_manual.return_value = True
-    coordinator.state = 80
+    coordinator.state = 50
     coordinator.config_entry.options = {}
-    from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True, manual_override=False,
         sun_just_appeared=False, min_change=2, time_threshold=2,
         special_positions=[0, 100], inverse_state=False,
     )
-    coordinator._cmd_svc.apply_position = AsyncMock(return_value=("sent", "set_cover_position"))
+    # Simulate delta too small — command skipped
+    coordinator._cmd_svc.apply_position = AsyncMock(return_value=("skipped", "delta_too_small"))
     coordinator.async_refresh = AsyncMock()
-    # Cover never clears wait_for_target — simulates position mismatch
-    coordinator.wait_for_target = {entity_id: True}
+    coordinator.wait_for_target = {entity_id: True}  # was True from suppression
     coordinator.cover_state_change = False
 
     button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
     button.coordinator = coordinator
     button._entities = [entity_id]
 
-    start = time.monotonic()
-    # Patch event loop time so the 30-second timeout fires immediately
-    fake_time = [0.0]
+    await button.async_press()
 
-    async def fast_sleep(delay):
-        fake_time[0] += 31  # Jump past the 30-second deadline
+    # No command sent — wait_for_target must be cleared so state tracking resumes
+    assert coordinator.wait_for_target[entity_id] is False
 
-    with patch("asyncio.get_event_loop") as mock_loop:
-        mock_loop.return_value.time.side_effect = lambda: fake_time[0]
-        with patch("asyncio.sleep", side_effect=fast_sleep):
-            await button.async_press()
 
-    elapsed = time.monotonic() - start
-    # Should complete almost instantly (well under a real second)
-    assert elapsed < 5
-    # Refresh was still called despite the timeout
-    coordinator.async_refresh.assert_called_once()
+# ---------------------------------------------------------------------------
+# reset_if_needed — returns expired set
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_if_needed_returns_expired_entity_ids():
+    """reset_if_needed() must return the set of entity IDs whose override just expired."""
+    from custom_components.adaptive_cover_pro.managers.manual_override import AdaptiveCoverManager
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration={"seconds": 1},
+        logger=MagicMock(),
+    )
+
+    entity_a = "cover.a"
+    entity_b = "cover.b"
+
+    # Mark both as manual with a timestamp old enough to expire
+    old_time = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=10)
+    manager.manual_control[entity_a] = True
+    manager.manual_control_time[entity_a] = old_time
+    manager.manual_control[entity_b] = True
+    manager.manual_control_time[entity_b] = old_time
+
+    expired = await manager.reset_if_needed()
+
+    assert expired == {entity_a, entity_b}
+    assert not manager.is_cover_manual(entity_a)
+    assert not manager.is_cover_manual(entity_b)
+
+
+@pytest.mark.asyncio
+async def test_reset_if_needed_returns_empty_when_nothing_expired():
+    """reset_if_needed() must return an empty set when no overrides have expired."""
+    from custom_components.adaptive_cover_pro.managers.manual_override import AdaptiveCoverManager
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration={"minutes": 30},
+        logger=MagicMock(),
+    )
+
+    entity = "cover.recent"
+    manager.manual_control[entity] = True
+    manager.manual_control_time[entity] = dt.datetime.now(dt.UTC)  # just set
+
+    expired = await manager.reset_if_needed()
+
+    assert expired == set()
+    assert manager.is_cover_manual(entity)
+
+
+@pytest.mark.asyncio
+async def test_reset_button_sends_correct_position_with_climate_mode():
+    """Button must send the post-refresh pipeline position, not the pre-refresh override pos.
+
+    Covers the climate-mode scenario where ManualOverrideHandler returns solar/default
+    but ClimateHandler wins after the override is cleared.
+    """
+    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
+
+    entity_id = "cover.climate_room"
+    CLIMATE_POSITION = 70   # what ClimateHandler returns after override clears
+    SOLAR_POSITION = 45     # what ManualOverrideHandler was returning during override
+
+    coordinator = MagicMock()
+    coordinator.manager.is_cover_manual.return_value = True
+    coordinator.config_entry.options = {}
+    coordinator._build_position_context.return_value = PositionContext(
+        auto_control=True, manual_override=False,
+        sun_just_appeared=False, min_change=2, time_threshold=2,
+        special_positions=[0, 100], inverse_state=False,
+    )
+    coordinator._cmd_svc.apply_position = AsyncMock(return_value=("sent", "set_cover_position"))
+    coordinator.wait_for_target = {entity_id: False}
+    coordinator.cover_state_change = False
+
+    # Simulate: after refresh the pipeline now returns the climate position
+    coordinator.state = CLIMATE_POSITION
+
+    coordinator.async_refresh = AsyncMock()
+
+    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
+    button.coordinator = coordinator
+    button._entities = [entity_id]
+
+    await button.async_press()
+
+    # The position sent must be the post-refresh climate position, not the solar one
+    call_args = coordinator._cmd_svc.apply_position.call_args
+    sent_position = call_args[0][1]
+    assert sent_position == CLIMATE_POSITION
+    assert sent_position != SOLAR_POSITION


### PR DESCRIPTION
Merges fixes for manual override reset on both the button press and auto-expiry timer paths.

## Changes

- **Auto-expiry timer:** reset_if_needed() now runs BEFORE pipeline calculation so the override is cleared when position is computed. Returns expired entity IDs so coordinator calls _async_send_after_override_clear() with force=True.

- **Reset button:** Removed pre-refresh position send. New flow: reset override → async_refresh() → send coordinator.state AFTER refresh. Uses force=True to bypass time_delta_too_small gate that was blocking sends within 2 minutes of the manual move.

## Testing

- ✅ 1093 tests passing
- ✅ 3 new tests for auto-expiry and climate mode scenarios

## Related Issues

Fixes the issue where covers don't return to correct pipeline position after pressing the reset button when the time delta gate blocks the send.