### PR TITLE
fix: resume automatic positioning when motion detected during timeout pending

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -463,10 +463,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         if new_state.state == "on":
             # Motion detected - immediate response
-            was_timeout_active = self._motion_mgr._motion_timeout_active
-            self._motion_mgr.record_motion_detected()
+            # Returns True if timeout was active (expired) or pending (task
+            # still running), so we refresh in both cases, not just when the
+            # timeout had already fully expired.
+            needs_refresh = self._motion_mgr.record_motion_detected()
 
-            if was_timeout_active:
+            if needs_refresh:
                 self.logger.info("Motion detected - resuming automatic sun positioning")
                 self.state_change = True
                 await self.async_refresh()

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -110,17 +110,28 @@ class MotionManager:
         self.cancel_motion_timeout()
         self._motion_timeout_active = True
 
-    def record_motion_detected(self) -> None:
+    def record_motion_detected(self) -> bool:
         """Record that motion was detected right now.
 
         Updates last_motion_time, cancels any running timeout task, and
         clears the active flag so covers resume automatic sun positioning.
-        The caller is responsible for calling async_refresh if needed.
+
+        Returns:
+            True if a timeout was active (expired) or pending (task still
+            running), indicating the coordinator should call async_refresh
+            to resume automatic sun positioning.  False when motion was
+            already the current state (no refresh needed).
 
         """
+        had_pending = (
+            self._motion_timeout_task is not None
+            and not self._motion_timeout_task.done()
+        )
+        had_active = self._motion_timeout_active
         self.cancel_motion_timeout()
         self._last_motion_time = dt.datetime.now().timestamp()
         self._motion_timeout_active = False
+        return had_active or had_pending
 
     # --- Timeout management ---
 

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -302,6 +302,158 @@ async def test_async_check_motion_state_change_on():
 
 
 @pytest.mark.asyncio
+async def test_async_check_motion_state_change_on_during_timeout_pending():
+    """Motion detected while timeout is pending (task running, not yet expired).
+
+    This is the core regression test: when motion status is 'timeout_pending',
+    a new motion event must cancel the timeout AND trigger an async_refresh so
+    the cover resumes automatic positioning and the sensor updates immediately.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, _ = _make_coordinator_with_motion_mgr(
+        sensors=["binary_sensor.motion_living_room"]
+    )
+    # Timeout is PENDING: task is running but has NOT expired yet
+    coordinator._motion_mgr._motion_timeout_active = False
+    pending_task = MagicMock()
+    pending_task.done.return_value = False
+    coordinator._motion_mgr._motion_timeout_task = pending_task
+
+    coordinator.state_change = False
+    coordinator.async_refresh = AsyncMock()
+
+    event = MagicMock()
+    event.data = {
+        "entity_id": "binary_sensor.motion_living_room",
+        "new_state": MagicMock(state="on"),
+    }
+
+    await AdaptiveDataUpdateCoordinator.async_check_motion_state_change(
+        coordinator, event
+    )
+
+    # Timeout task must be cancelled
+    pending_task.cancel.assert_called_once()
+    assert coordinator._motion_mgr._motion_timeout_task is None
+
+    # Refresh must be triggered even though _motion_timeout_active was False
+    assert coordinator.state_change is True
+    coordinator.async_refresh.assert_called_once()
+
+    # Active flag must remain False (timeout never expired)
+    assert coordinator._motion_mgr._motion_timeout_active is False
+
+
+@pytest.mark.asyncio
+async def test_async_check_motion_state_change_on_no_timeout_no_refresh():
+    """Motion detected when no timeout is pending or active — no refresh needed.
+
+    Motion-to-motion transitions (sensor stays on, flickers, etc.) should not
+    cause an unnecessary coordinator refresh.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, _ = _make_coordinator_with_motion_mgr(
+        sensors=["binary_sensor.motion_living_room"]
+    )
+    # Neither timeout active nor pending — already in motion_detected state
+    coordinator._motion_mgr._motion_timeout_active = False
+    coordinator._motion_mgr._motion_timeout_task = None
+    coordinator._motion_mgr._last_motion_time = 1700000000.0  # prior motion recorded
+
+    coordinator.state_change = False
+    coordinator.async_refresh = AsyncMock()
+
+    event = MagicMock()
+    event.data = {
+        "entity_id": "binary_sensor.motion_living_room",
+        "new_state": MagicMock(state="on"),
+    }
+
+    await AdaptiveDataUpdateCoordinator.async_check_motion_state_change(
+        coordinator, event
+    )
+
+    # No refresh — was already in motion_detected state
+    assert coordinator.state_change is False
+    coordinator.async_refresh.assert_not_called()
+
+
+# --- MotionManager.record_motion_detected return value tests ---
+
+
+def test_record_motion_detected_returns_true_when_timeout_active():
+    """record_motion_detected returns True when timeout had fully expired."""
+    hass = MagicMock()
+    logger = MagicMock()
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
+    mgr._motion_timeout_active = True
+    mgr._motion_timeout_task = None
+
+    result = mgr.record_motion_detected()
+
+    assert result is True
+    assert mgr._motion_timeout_active is False
+
+
+def test_record_motion_detected_returns_true_when_task_pending():
+    """record_motion_detected returns True when timeout task was still running."""
+    hass = MagicMock()
+    logger = MagicMock()
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
+    mgr._motion_timeout_active = False
+    task = MagicMock()
+    task.done.return_value = False
+    mgr._motion_timeout_task = task
+
+    result = mgr.record_motion_detected()
+
+    assert result is True
+    assert mgr._motion_timeout_active is False
+    assert mgr._motion_timeout_task is None
+    task.cancel.assert_called_once()
+
+
+def test_record_motion_detected_returns_false_when_no_timeout():
+    """record_motion_detected returns False when no timeout was pending or active."""
+    hass = MagicMock()
+    logger = MagicMock()
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
+    mgr._motion_timeout_active = False
+    mgr._motion_timeout_task = None
+
+    result = mgr.record_motion_detected()
+
+    assert result is False
+    assert mgr.last_motion_time is not None
+
+
+def test_record_motion_detected_returns_false_when_task_done():
+    """record_motion_detected returns False when timeout task had already completed."""
+    hass = MagicMock()
+    logger = MagicMock()
+    mgr = MotionManager(hass=hass, logger=logger)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
+    mgr._motion_timeout_active = False
+    task = MagicMock()
+    task.done.return_value = True  # task completed but flag somehow not set
+    mgr._motion_timeout_task = task
+
+    result = mgr.record_motion_detected()
+
+    # done() task is treated the same as no task — not pending
+    assert result is False
+
+
+@pytest.mark.asyncio
 async def test_async_check_motion_state_change_off():
     """Test motion state change handler for motion stopped."""
     from custom_components.adaptive_cover_pro.coordinator import (


### PR DESCRIPTION
## Summary

When the motion timeout was pending (task running but not yet expired), new motion sensor 'on' events were silently ignored because the refresh guard only checked `_motion_timeout_active`, which remains False until the timeout fully expires.

The Motion Status sensor would get stuck on 'timeout_pending' and covers would not resume automatic sun positioning even when motion was detected.

## Fix

Modified `MotionManager.record_motion_detected()` to return a boolean indicating whether a timeout was **active** (fully expired) or **pending** (task still running). The coordinator now uses this return value to determine whether to call `async_refresh()`, ensuring both cases trigger the refresh.

## Testing

- ✅ 1099 tests passing (up from 1093)
- ✅ 6 new tests covering: timeout_pending → motion detected, motion-to-motion with no timeout, and all 4 state combinations for `record_motion_detected()` return value
- ✅ Existing motion control tests still pass
- ✅ No regression in other subsystems (pipeline, diagnostics, sensor behavior)
