### PR TITLE
fix: erratic behavior with multiple covers / unavailable entity (#131)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # Adaptive Cover Pro — Developer Handoff
 
-**Date:** 2026-04-05
+**Date:** 2026-04-06
 **Current Version:** v2.14.0
 **Branch:** `main` (stable)
 
@@ -29,6 +29,7 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 |---|-------|-------|
 | [#33](https://github.com/jrhubott/adaptive-cover/issues/33) | Better support for venetian blinds | KNX: single entity exposes both position + tilt. Needs config flow enhancement for dual-axis single-entity covers. |
 | [#128](https://github.com/jrhubott/adaptive-cover-pro/issues/128) | Sunset position not reached/maintained | Awaiting user response to clarifying questions. May be related to #127 (fixed in v2.14.0). |
+| [#131](https://github.com/jrhubott/adaptive-cover-pro/issues/131) | Erratic behavior with multiple cover entities (one unavailable) | Investigated. Commented asking user to upgrade to v2.14.0 and remove unavailable cover. Four root causes identified — three already fixed in v2.13.9–v2.14.0; remaining race condition (override detected after command sent) + shared `state_change_data` + commands to unavailable entities tracked on branch `fix/issue-131-multi-cover-unavailable-entity`. Awaiting user response. |
 | [#134](https://github.com/jrhubott/adaptive-cover-pro/issues/134) | Climate mode does not work | Fixed in PR #135 (merged main). Root cause: temp/presence entities never passed to ClimateProvider. Awaiting release. |
 
 ## Known Gotchas


### PR DESCRIPTION
## Summary

Investigation of Issue #131 — erratic cover behavior when one of two assigned cover entities is unavailable/disconnected.

**No code changes in this PR yet.** This PR tracks the investigation findings and outlines the remaining fixes to be landed once the user confirms their behaviour persists after upgrading to v2.14.0.

---

## Investigation Findings

Four root causes were identified:

### 1. ✅ Fixed in v2.14.0 — Constant repositioning at 0%/100%
The position-delta check was bypassed for special positions (0%, 100%, default, sunset) without verifying the cover was already at target. Fixed in PR #130 (Issue #127).

### 2. ✅ Fixed in v2.13.9 — Reconciliation ignoring `auto_control=OFF`
The reconciliation timer (runs every 1 min) was resending the stale target position even when Automatic Control was OFF. Fixed: `CoverCommandService` now checks `_auto_control_enabled` and skips non-safety targets when the toggle is off.

### 3. ✅ Fixed in v2.13.9 — Reconciliation fighting manual overrides
Reconciliation was resending the integration's target, undoing user-initiated manual moves. Fixed: coordinator syncs `manager.manual_controlled → _cmd_svc.manual_override_entities` each cycle; reconciliation skips entities in that set.

### 4. ⚠️ Remaining — Race condition: manual override detected after command sent
In `_async_update_data()`:
```python
if self.state_change:
    await self.async_handle_state_change(state, options)   # sends to ALL covers ← first
if self.cover_state_change:
    await self.async_handle_cover_state_change(state)      # detects override ← second
```
When a sun/temperature entity changes at the same time the user manually moves a cover, the calculated position is sent to **all** covers before the manual override is detected — effectively undoing the move. The override is then set, but the cover has already been commanded back. This is the most likely cause of the reported "~10 second" window.

**Fix:** Move `async_handle_cover_state_change()` (override detection) to run **before** `async_handle_state_change()` (command dispatch) so the `manual_override` flag is set before `_build_position_context()` reads it.

### 5. ⚠️ Remaining — Shared `state_change_data` single variable
`state_change_data` is a single shared object on the coordinator. With 2 cover entities, if both fire state change events in rapid succession (e.g. unavailable cover transitions + active cover is manually moved), only the last event's data is retained. Manual override detection may process the wrong entity.

**Fix:** Convert `state_change_data` to a per-entity queue/dict, or process each cover state change event atomically before the next can overwrite it.

### 6. ⚠️ Remaining — Commands sent to unavailable entities
When `_get_current_position()` returns `None` (unavailable entity), `_check_position_delta()` returns `True` ("send to be safe"). `_prepare_service_call()` sets `target_call` and `wait_for_target` before the actual `async_call`, so even when the service call fails with `HomeAssistantError`, the reconciliation timer keeps retrying against that entity indefinitely.

**Fix:** Add an entity state check (unavailable/unknown) at the top of `apply_position()` and skip with reason `"entity_unavailable"`. Also filter state-change events from unavailable covers in `async_check_cover_state_change()` to avoid unnecessary refresh cycles.

---

## Planned Code Changes (pending user confirmation)

- [ ] Reorder override detection before command dispatch in `_async_update_data()`
- [ ] Add `entity_unavailable` skip in `apply_position()`
- [ ] Filter unavailable/unknown cover state change events in `async_check_cover_state_change()`
- [ ] Add tests: manual override race condition, unavailable entity skip, multi-cover `state_change_data` isolation
- [ ] Update HANDOFF.md on merge

## Related Issues
Related to #131
