### PR TITLE
fix: skip cover reposition on override expiry when automatic control is OFF (#139)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,8 @@
 # Adaptive Cover Pro — Developer Handoff
 
-**Date:** 2026-04-05
-**Current Version:** v2.14.0
-**Branch:** `main` (stable)
+**Date:** 2026-04-06
+**Current Version:** v2.14.1
+**Branch:** `fix/issue-139-auto-control-off-covers-still-move`
 
 > Quick start: read this file, then `git status && git log --oneline -5`.
 > Architecture, patterns, and workflow rules: see `CLAUDE.md`.
@@ -16,12 +16,14 @@
 
 ## Tests
 
-**1246 passing, 0 failing** (+25 new tests for climate provider wiring and end-to-end climate strategy coverage).
+**1280 passing, 0 failing** (+5 new tests: auto_control guard in `_async_send_after_override_clear`, issue #139).
 Run: `source venv/bin/activate && python -m pytest tests/ -v`
 
 ## Open PRs (Awaiting Merge to Main)
 
-*(None at this time.)*
+| PR | Branch | Issue | Beta | Status | Notes |
+|----|--------|-------|------|--------|-------|
+| — | `fix/issue-139-auto-control-off-covers-still-move` | [#139](https://github.com/jrhubott/adaptive-cover-pro/issues/139) | — | 🟠 Open — not yet beta-tested | Skip cover reposition on override expiry when auto control is OFF |
 
 ## Open Issues
 
@@ -29,9 +31,11 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 |---|-------|-------|
 | [#33](https://github.com/jrhubott/adaptive-cover/issues/33) | Better support for venetian blinds | KNX: single entity exposes both position + tilt. Needs config flow enhancement for dual-axis single-entity covers. |
 | [#128](https://github.com/jrhubott/adaptive-cover-pro/issues/128) | Sunset position not reached/maintained | Awaiting user response to clarifying questions. May be related to #127 (fixed in v2.14.0). |
-| [#134](https://github.com/jrhubott/adaptive-cover-pro/issues/134) | Climate mode does not work | Fixed in PR #135 (merged main). Root cause: temp/presence entities never passed to ClimateProvider. Awaiting release. |
+| [#139](https://github.com/jrhubott/adaptive-cover-pro/issues/139) | Covers move despite Automatic Control OFF | Root cause (v2.13.8 reconciliation bug) fixed in v2.13.9. Edge case in `_async_send_after_override_clear` fixed on this branch. |
 
 ## Known Gotchas
+
+- **Override expiry forced reposition despite auto_control=False (fixed issue #139, branch):** `_async_send_after_override_clear()` used `force=True`, bypassing the `auto_control` gate. If the user turned Automatic Control OFF while a manual override was active, the cover would be force-repositioned to the pipeline position when the override timer expired. Fixed by adding an `automatic_control` guard before the entity loop (same pattern as the existing time-window guard). Regression: this path (force=True, inside window, auto_control=ON) continues to work as before.
 
 - **Climate mode temp/presence never read (fixed PR #135, unreleased):** `_read_weather_conditions()` (now `_read_climate_state()`) was missing `temp_entity`, `outside_entity`, and `presence_entity` kwargs in the `ClimateProvider.read()` call since v2.12.0. `inside_temperature`/`outside_temperature` were always `None`; `is_presence` was always `True`. Summer/winter strategies never activated — climate mode silently degraded to solar tracking. Fixed in PR #135 with structural regression guard test.
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -888,6 +888,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         ``TimeWindowManager.check_transition``) will send the correct position
         at the appropriate time.
 
+        **Automatic-control guard:** If the user has turned off Automatic
+        Control the integration must not force covers back to the calculated
+        position when an override expires.  The user deliberately paused
+        automation; the cover should stay wherever the user left it.
+
         Args:
             state: Post-reset pipeline position (already computed without override).
             options: Config entry options dict.
@@ -898,6 +903,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 "Manual override cleared but outside active-hours window — "
                 "skipping reposition (pipeline position was %s; will apply when "
                 "window opens)",
+                state,
+            )
+            return
+
+        if not self.automatic_control:
+            self.logger.debug(
+                "Manual override cleared but automatic control is OFF — "
+                "skipping reposition (pipeline position was %s)",
                 state,
             )
             return

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -26,10 +26,11 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def _make_coordinator(*, check_adaptive_time: bool):
+def _make_coordinator(*, check_adaptive_time: bool, automatic_control: bool = True):
     """Build a minimal mock coordinator for testing _async_send_after_override_clear."""
     coordinator = MagicMock()
     coordinator.check_adaptive_time = check_adaptive_time
+    coordinator.automatic_control = automatic_control
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
@@ -179,3 +180,115 @@ async def test_override_clear_inside_window_multiple_covers():
     calls = [call.args[0] for call in coordinator._cmd_svc.apply_position.call_args_list]
     assert "cover.blind_1" in calls
     assert "cover.blind_2" in calls
+
+
+# ---------------------------------------------------------------------------
+# _async_send_after_override_clear — automatic-control guard (issue #139)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_override_clear_skips_send_when_auto_control_off():
+    """Override expiry with Automatic Control OFF must NOT send a cover command.
+
+    Reproduces issue #139:
+    - User turns off Automatic Control to manage covers manually
+    - A previously set manual override expires naturally
+    - Integration must NOT force-reposition the cover despite the expiry
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=False)
+
+    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, state=0, options={}
+    )
+
+    # apply_position must NOT be called when auto control is off
+    coordinator._cmd_svc.apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_override_clear_logs_debug_when_auto_control_off():
+    """A debug message must be logged when send is skipped because auto control is OFF."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=False)
+
+    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, state=0, options={}
+    )
+
+    coordinator.logger.debug.assert_called()
+    logged_args = [call[0][0] for call in coordinator.logger.debug.call_args_list]
+    assert any("automatic control is OFF" in msg for msg in logged_args)
+
+
+@pytest.mark.asyncio
+async def test_override_clear_sends_when_auto_control_on_inside_window():
+    """Override expiry with Automatic Control ON and inside the window sends normally.
+
+    Regression guard: the auto-control check must not suppress the existing
+    inside-window behaviour.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=True)
+
+    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, state=40, options={}
+    )
+
+    coordinator._cmd_svc.apply_position.assert_called_once_with(
+        "cover.test_blind", 40, "manual_override_cleared",
+        context=coordinator._build_position_context.return_value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_override_clear_auto_control_off_multiple_covers():
+    """Auto-control guard applies to all covers — no commands sent for any of them."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=False)
+    coordinator.entities = ["cover.blind_a", "cover.blind_b", "cover.blind_c"]
+
+    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, state=0, options={}
+    )
+
+    coordinator._cmd_svc.apply_position.assert_not_called()
+    coordinator._build_position_context.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_override_clear_outside_window_takes_precedence_over_auto_control():
+    """Time-window check runs before auto-control check — both logged for correct reason.
+
+    When both conditions are False (outside window AND auto-control off), the
+    time-window guard fires first (early return) and auto-control is never checked.
+    Either way, no command is sent.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(check_adaptive_time=False, automatic_control=False)
+
+    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, state=0, options={}
+    )
+
+    # No command regardless of which guard fires
+    coordinator._cmd_svc.apply_position.assert_not_called()
+    # The time-window message is emitted (first guard)
+    logged_args = [call[0][0] for call in coordinator.logger.debug.call_args_list]
+    assert any("outside active-hours window" in msg or "outside" in msg.lower() for msg in logged_args)


### PR DESCRIPTION
## Summary

Fixes issue #139: covers being force-repositioned when a manual override expires, even with Automatic Control turned OFF.

### Root Cause Analysis

The issue has two layers:

1. **v2.13.8 reconciliation bug** (root cause reported by user on v2.13.8) — reconciliation loop didn't check `auto_control_enabled`, so it kept resending the last target every 60 seconds despite Automatic Control being OFF. **Fixed in v2.13.9.**

2. **Edge case in current code (v2.14.1)** — `_async_send_after_override_clear()` uses `force=True` to bypass gate checks, which also bypasses the `auto_control` check. If a user turns Automatic Control OFF while a manual override is active, the cover gets force-repositioned when the override timer expires. **This PR fixes that.**

### Changes

- Add `automatic_control` guard to `_async_send_after_override_clear()` (mirrors existing `check_adaptive_time` guard)
- If Automatic Control is OFF, skip reposition and log debug message
- Time-window guard still runs first (correct priority)
- Reset button unaffected (bypasses this method entirely)

### Testing

- ✅ 1280 passing, 0 failing (1275 baseline → +5 new tests)
- New tests cover: auto_control OFF/ON, multiple covers, guard precedence
- Regression: existing inside-window behavior preserved when auto_control ON

## Related Issues

Fixes #139
