### PR TITLE
fix: round display values at presentation boundary (#140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -632,6 +632,47 @@ class MyDiagnosticSensor(AdaptiveCoverDiagnosticSensor):
 - ✅ History is still recorded for debugging
 - ❌ Don't use empty unit for numeric sensors (breaks statistics)
 
+### Display Rounding & Precision (Issue #140)
+
+Values displayed to users (sensor states, entity attributes, diagnostic data) must be cleanly formatted. Rounding happens **only at the presentation boundary** — never inside the calculation engine, pipeline, or managers.
+
+**Principle: Two-Layer Rounding**
+
+| Layer | Where | What it does |
+|-------|-------|--------------|
+| `suggested_display_precision` | Sensor class attribute | Controls HA frontend decimal places for the primary `native_value`. User-overridable. Does not alter stored history/statistics precision. |
+| Explicit `round()` in attributes | `extra_state_attributes` properties and `DiagnosticsBuilder` | Rounds values surfaced in Developer Tools, REST API, and templates. Required because `suggested_display_precision` only affects `native_value`. |
+
+**Sensor display precision:**
+
+| Sensor | `suggested_display_precision` | Rationale |
+|--------|-------------------------------|-----------|
+| Target Position (`AdaptiveCoverSensorEntity`) | `0` | Positions are integers (0–100%) |
+| Sun Position (`AdaptiveCoverSunPositionSensor`) | `1` | 0.1° is sufficient for azimuth display |
+
+**Attribute rounding rules:**
+
+| Value type | Round to | Examples |
+|------------|----------|----------|
+| Sun angles (azimuth, elevation, gamma) | 1 decimal | `180.5°`, `34.2°`, `-12.7°` |
+| Temperatures | 1 decimal | `22.3°C` |
+| Positions (%) | integer | `42%` |
+| Safety margins, distances | 4 decimals | Already handled in `_last_calc_details` |
+| Timestamps, durations | no rounding | ISO-8601 strings, integer seconds |
+
+**Where to round:**
+
+- **`diagnostics/builder.py` → `_build_solar()`** — round `sun_azimuth`, `sun_elevation`, `gamma` to 1 decimal before storing in diagnostics dict.
+- **`sensor.py` → `extra_state_attributes`** — round float attributes (`elevation`, `gamma`, `gamma_absolute_angle`, temperatures) to 1 decimal in Sun Position, Decision Trace, and Climate Status sensors.
+- **`coordinator.py` → `_calculate_cover_state()`** — wrap final return in `int(round(state))` to catch numpy float64 from `interpolate_position()`.
+
+**NEVER round inside:**
+- ❌ `engine/covers/*.py` — calculation engine uses full float precision
+- ❌ `pipeline/helpers.py` — `compute_solar_position()` already does `int(round())` at the boundary
+- ❌ `pipeline/handlers/*.py` — handlers pass through int positions
+- ❌ `managers/*.py` — internal state tracking needs full precision
+- ❌ `state/*.py` — providers pass through raw HA entity values
+
 ### Motion Control Pattern
 
 **Added in v2.7.5** - Occupancy-based automatic control with debouncing.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1365,7 +1365,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._inverse_state and not self._use_interpolation:
             state = inverse_state(state)
 
-        return state
+        # interpolate_position() returns numpy float64; inverse_state() returns int.
+        # Always coerce to plain Python int so sensors/diagnostics never see a float.
+        return int(round(state))
 
     # --- Toggle property delegates (switch entities use setattr) ---
 

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -134,14 +134,19 @@ class DiagnosticsBuilder:
 
     @staticmethod
     def _build_solar(ctx: DiagnosticContext) -> dict:
-        """Build solar position diagnostics."""
+        """Build solar position diagnostics.
+
+        Sun angles are rounded to 1 decimal place here — the single rounding
+        point for all consumers (sensors, Decision Trace, REST API).  Full
+        float precision is kept inside the calculation engine and pipeline.
+        """
         diagnostics: dict = {}
         sun_azimuth, sun_elevation = ctx.pos_sun
-        diagnostics["sun_azimuth"] = sun_azimuth
-        diagnostics["sun_elevation"] = sun_elevation
+        diagnostics["sun_azimuth"] = round(sun_azimuth, 1) if sun_azimuth is not None else None
+        diagnostics["sun_elevation"] = round(sun_elevation, 1) if sun_elevation is not None else None
 
         if ctx.cover and hasattr(ctx.cover, "gamma"):
-            diagnostics["gamma"] = ctx.cover.gamma
+            diagnostics["gamma"] = round(ctx.cover.gamma, 1)
 
         return diagnostics
 
@@ -310,10 +315,22 @@ class DiagnosticsBuilder:
             climate_data = result.climate_data
             diagnostics["climate_control_method"] = result.control_method
 
-            diagnostics["active_temperature"] = climate_data.get_current_temperature
+            # Round temperatures to 1 decimal — presentation boundary.
+            raw_temp = climate_data.get_current_temperature
+            diagnostics["active_temperature"] = (
+                round(raw_temp, 1) if isinstance(raw_temp, (int, float)) else raw_temp
+            )
+
+            def _round_temp(val: object) -> object:
+                """Round a temperature value to 1 decimal if numeric."""
+                try:
+                    return round(float(val), 1)  # type: ignore[arg-type]
+                except (TypeError, ValueError):
+                    return val
+
             diagnostics["temperature_details"] = {
-                "inside_temperature": climate_data.inside_temperature,
-                "outside_temperature": climate_data.outside_temperature,
+                "inside_temperature": _round_temp(climate_data.inside_temperature),
+                "outside_temperature": _round_temp(climate_data.outside_temperature),
                 "temp_switch": climate_data.temp_switch,
             }
 

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -184,6 +184,7 @@ class AdaptiveCoverSensorEntity(AdaptiveCoverSensorBase, SensorEntity):
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_suggested_display_precision = 0  # Positions are integers (0–100%)
 
     def __init__(
         self,
@@ -303,6 +304,7 @@ class AdaptiveCoverSunPositionSensor(AdaptiveCoverDiagnosticSensorBase, SensorEn
 
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = "°"
+    _attr_suggested_display_precision = 1  # 0.1° is sufficient for azimuth display
 
     def __init__(
         self,
@@ -348,7 +350,7 @@ class AdaptiveCoverSunPositionSensor(AdaptiveCoverDiagnosticSensorBase, SensorEn
         # Elevation
         elevation = diagnostics.get("sun_elevation")
         if elevation is not None:
-            attrs["elevation"] = elevation
+            attrs["elevation"] = round(elevation, 1)
 
         # Elevation limits from config
         min_elev = config.get("min_elevation")
@@ -361,8 +363,9 @@ class AdaptiveCoverSunPositionSensor(AdaptiveCoverDiagnosticSensorBase, SensorEn
         # Gamma
         gamma = diagnostics.get("gamma")
         if gamma is not None:
+            gamma = round(gamma, 1)
             attrs["gamma"] = gamma
-            abs_gamma = abs(gamma)
+            abs_gamma = round(abs(gamma), 1)
             if abs_gamma < 10:
                 interpretation = "nearly perpendicular"
             elif abs_gamma < 45:
@@ -923,13 +926,13 @@ class AdaptiveCoverClimateStatusSensor(AdaptiveCoverDiagnosticSensorBase, Sensor
 
         active_temp = diagnostics.get("active_temperature")
         if active_temp is not None:
-            attrs["active_temperature"] = active_temp
+            attrs["active_temperature"] = active_temp  # already rounded in builder
             attrs["temperature_unit"] = self._temp_unit
 
         temp_details = diagnostics.get("temperature_details", {})
         if temp_details:
-            attrs["indoor_temperature"] = temp_details.get("inside_temperature")
-            attrs["outdoor_temperature"] = temp_details.get("outside_temperature")
+            attrs["indoor_temperature"] = temp_details.get("inside_temperature")  # rounded in builder
+            attrs["outdoor_temperature"] = temp_details.get("outside_temperature")  # rounded in builder
             attrs["temp_switch"] = temp_details.get("temp_switch")
 
         climate_conditions = diagnostics.get("climate_conditions", {})

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -157,10 +157,31 @@ class TestSolarDiagnostics:
         assert diag["sun_azimuth"] == 200.5
         assert diag["sun_elevation"] == 30.2
 
+    def test_sun_values_rounded_to_one_decimal(self, builder: DiagnosticsBuilder):
+        """Raw float sun values are rounded to 1 decimal place."""
+        diag, _ = builder.build(_base_ctx(pos_sun=[200.5678, 30.2341]))
+        assert diag["sun_azimuth"] == 200.6
+        assert diag["sun_elevation"] == 30.2
+
+    def test_sun_azimuth_none_handling(self, builder: DiagnosticsBuilder):
+        """None azimuth is preserved as None (not raised as error)."""
+        diag, _ = builder.build(_base_ctx(pos_sun=[None, 30.2]))
+        assert diag["sun_azimuth"] is None
+
+    def test_sun_elevation_none_handling(self, builder: DiagnosticsBuilder):
+        """None elevation is preserved as None."""
+        diag, _ = builder.build(_base_ctx(pos_sun=[180.0, None]))
+        assert diag["sun_elevation"] is None
+
     def test_gamma_present_when_cover_has_it(self, builder: DiagnosticsBuilder):
         """Gamma is included when cover has the attribute."""
         diag, _ = builder.build(_base_ctx())
         assert "gamma" in diag
+
+    def test_gamma_rounded_to_one_decimal(self, builder: DiagnosticsBuilder):
+        """Gamma is rounded to 1 decimal place."""
+        diag, _ = builder.build(_base_ctx(cover=_make_cover(gamma=12.3456)))
+        assert diag["gamma"] == 12.3
 
     def test_gamma_absent_when_no_cover(self, builder: DiagnosticsBuilder):
         """Gamma is absent when cover is None."""
@@ -500,6 +521,82 @@ class TestClimateDiagnostics:
         assert diag["climate_strategy"] == "winter_heating"
         assert "temperature_details" in diag
         assert "climate_conditions" in diag
+
+    def test_active_temperature_rounded_to_one_decimal(self, builder: DiagnosticsBuilder):
+        """active_temperature is rounded to 1 decimal place."""
+        cd = ClimateCoverData(
+            temp_low=20.0,
+            temp_high=25.0,
+            temp_switch=True,
+            blind_type="cover_blind",
+            transparent_blind=False,
+            temp_summer_outside=22.5,
+            outside_temperature="22.567",  # string from HA entity
+            inside_temperature="23.0",
+            is_presence=True,
+            is_sunny=True,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            winter_close_insulation=False,
+        )
+        pr = _make_pr(
+            control_method=ControlMethod.WINTER,
+            climate_data=cd,
+        )
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        assert diag["active_temperature"] == 22.6  # 22.567 rounded to 1 dp
+
+    def test_temperature_details_rounded_to_one_decimal(self, builder: DiagnosticsBuilder):
+        """inside/outside temperatures in temperature_details are rounded to 1 decimal."""
+        cd = ClimateCoverData(
+            temp_low=20.0,
+            temp_high=25.0,
+            temp_switch=False,
+            blind_type="cover_blind",
+            transparent_blind=False,
+            temp_summer_outside=22.5,
+            outside_temperature="19.8765",
+            inside_temperature="21.2341",
+            is_presence=True,
+            is_sunny=True,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            winter_close_insulation=False,
+        )
+        pr = _make_pr(
+            control_method=ControlMethod.WINTER,
+            climate_data=cd,
+        )
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        details = diag["temperature_details"]
+        assert details["inside_temperature"] == 21.2
+        assert details["outside_temperature"] == 19.9
+
+    def test_temperature_details_none_preserved(self, builder: DiagnosticsBuilder):
+        """None temperatures pass through without error."""
+        cd = ClimateCoverData(
+            temp_low=20.0,
+            temp_high=25.0,
+            temp_switch=False,
+            blind_type="cover_blind",
+            transparent_blind=False,
+            temp_summer_outside=22.5,
+            outside_temperature=None,
+            inside_temperature=None,
+            is_presence=True,
+            is_sunny=True,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            winter_close_insulation=False,
+        )
+        pr = _make_pr(
+            control_method=ControlMethod.WINTER,
+            climate_data=cd,
+        )
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        details = diag["temperature_details"]
+        assert details["inside_temperature"] is None
+        assert details["outside_temperature"] is None
 
     def test_climate_data_absent_when_not_climate_mode(
         self, builder: DiagnosticsBuilder

--- a/tests/test_display_rounding.py
+++ b/tests/test_display_rounding.py
@@ -1,0 +1,126 @@
+"""Tests for display rounding (Issue #140).
+
+Verifies that:
+- coordinator.state always returns a plain Python int (not numpy float64)
+- Sensor classes declare correct suggested_display_precision
+- DiagnosticsBuilder rounds sun angles and temperatures at the presentation boundary
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from custom_components.adaptive_cover_pro.sensor import (
+    AdaptiveCoverSensorEntity,
+    AdaptiveCoverSunPositionSensor,
+)
+
+
+# ---------------------------------------------------------------------------
+# coordinator.state — interpolation float guard
+# ---------------------------------------------------------------------------
+
+
+class TestCoordinatorStateIntCoercion:
+    """coordinator.state must always return a plain Python int."""
+
+    def _invoke_state(self, pipeline_position: int, interpolated: float) -> int:
+        """Invoke the state property with interpolation returning a numpy float.
+
+        We instantiate the coordinator via object.__new__ so no HA setup is
+        required.  _pipeline_bypasses_auto_control is a property derived from
+        _pipeline_result.bypass_auto_control, so we set it there.
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = object.__new__(AdaptiveDataUpdateCoordinator)
+        pr = SimpleNamespace(position=pipeline_position, bypass_auto_control=False)
+        coord._pipeline_result = pr
+        coord._use_interpolation = True
+        coord._inverse_state = False
+        # Interpolation args — values don't matter since we patch the function
+        coord.start_value = 0
+        coord.end_value = 100
+        coord.normal_list = None
+        coord.new_list = None
+
+        with patch(
+            "custom_components.adaptive_cover_pro.coordinator.interpolate_position",
+            return_value=np.float64(interpolated),
+        ):
+            return AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    def test_interpolation_returns_int_not_numpy_float(self):
+        """When interpolation is active, state returns plain int, not numpy float64."""
+        result = self._invoke_state(pipeline_position=42, interpolated=42.7)
+        assert isinstance(result, int), f"Expected int, got {type(result)}"
+        assert result == 43
+
+    def test_interpolation_rounds_correctly(self):
+        """Interpolated float rounds to nearest integer."""
+        result = self._invoke_state(pipeline_position=50, interpolated=34.6)
+        assert result == 35
+
+    def test_interpolation_floor_case(self):
+        """Values below .5 round down."""
+        result = self._invoke_state(pipeline_position=50, interpolated=34.4)
+        assert result == 34
+
+    def test_no_interpolation_already_int(self):
+        """Without interpolation, the pipeline int passes through cleanly."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = object.__new__(AdaptiveDataUpdateCoordinator)
+        pr = SimpleNamespace(position=55, bypass_auto_control=False)
+        coord._pipeline_result = pr
+        coord._use_interpolation = False
+        coord._inverse_state = False
+
+        result = AdaptiveDataUpdateCoordinator.state.fget(coord)
+        assert isinstance(result, int)
+        assert result == 55
+
+    def test_safety_bypass_returns_pipeline_int_directly(self):
+        """Safety override path returns the pipeline int without post-processing."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = object.__new__(AdaptiveDataUpdateCoordinator)
+        pr = SimpleNamespace(position=0, bypass_auto_control=True)
+        coord._pipeline_result = pr
+
+        result = AdaptiveDataUpdateCoordinator.state.fget(coord)
+        assert isinstance(result, int)
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Sensor class attributes — suggested_display_precision
+# ---------------------------------------------------------------------------
+
+
+class TestSensorDisplayPrecision:
+    """Sensor classes must declare the correct suggested_display_precision.
+
+    HA defines suggested_display_precision as a cached_property on SensorEntity
+    that reads self._attr_suggested_display_precision.  We verify by reading the
+    property via an instantiated object rather than the class dict directly.
+    """
+
+    def test_target_position_sensor_precision_is_zero(self):
+        """AdaptiveCoverSensorEntity (Target Position) displays 0 decimals."""
+        inst = object.__new__(AdaptiveCoverSensorEntity)
+        assert inst.suggested_display_precision == 0
+
+    def test_sun_position_sensor_precision_is_one(self):
+        """AdaptiveCoverSunPositionSensor (Sun Position) displays 1 decimal."""
+        inst = object.__new__(AdaptiveCoverSunPositionSensor)
+        assert inst.suggested_display_precision == 1


### PR DESCRIPTION
## Summary
Fixes Issue #140 by implementing clean rounding for all user-facing numeric values (sensor states, attributes, diagnostics) while preserving full precision in the calculation engine.

## Problem
- Target Position sensor displayed `1.0%` instead of `1%`
- Sun Position sensor displayed `1.00°` instead of `1°`
- Temperatures and other float values lacked consistent formatting

## Solution
Two-layer rounding approach (no precision loss in calculations):

1. **`suggested_display_precision`** on sensor classes (HA-native frontend formatting)
   - Target Position: 0 decimals (positions are integers 0-100%)
   - Sun Position: 1 decimal (0.1° sufficient for azimuth)

2. **Explicit rounding at presentation boundary**
   - diagnostics/builder.py: round sun angles (1dp) and temperatures (1dp)
   - sensor.py: round attribute values (1dp for angles, 1dp for temps)
   - coordinator.state: wrap in `int(round())` to catch numpy float64 from interpolation

## Technical Details
- No changes to calculation engine, pipeline, handlers, or managers
- Full float precision preserved internally
- Rounding only at data egress points (sensors, diagnostics)
- 14 new tests covering rounding behavior and sensor configuration

## Testing
- ✅ 1410 tests passing (1396 original + 14 new)
- ✅ All existing diagnostic tests still pass
- ✅ Temperature rounding handles None values correctly
- ✅ Sun angle rounding verified with edge cases

Fixes #140