### PR TITLE
fix: numpy serialization, time window gating, manual override detection (#145, #147, #149)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,8 @@
 # Adaptive Cover Pro — Developer Handoff
 
 **Date:** 2026-04-07
-**Current Version:** v2.14.1
-**Branch:** `main` (stable, PR #151 just merged)
+**Current Version:** v2.14.2-beta.1
+**Branch:** `fix/issues-145-147-149-time-window-manual-override-numpy` (feature branch, PR #150 open)
 
 > Quick start: read this file, then `git status && git log --oneline -5`.
 > Architecture, patterns, and workflow rules: see `CLAUDE.md`.
@@ -10,6 +10,7 @@
 ---
 
 **Recent Merges:**
+- `fix/issues-145-147-149-time-window-manual-override-numpy` — PR #150 open, beta v2.14.2-beta.1 released for testing (issues #149 numpy serialization, #145 time window, #147 manual override)
 - `fix/issues-146-148-config-summary-duration-icons` — Format DurationSelector dict in config summary (#148: raw dict rendered as `{'hours': 5...}`); remove emojis from all 13 translation files (#146). PR #151, merged to main.
 - `fix/issue-140-display-rounding` — Round display values at presentation boundary; Target Position shows `42%` not `42.0%`, Sun Position shows `180.5°` not `180.456°` (PR #143, merged to main).
 - `fix/issue-139-auto-control-off-covers-still-move` — Skip cover reposition on override expiry when automatic control is OFF (PR #141, merged to main).
@@ -18,13 +19,14 @@
 
 ## Tests
 
-**1421 passing, 0 failing** (+11 new `_format_duration` tests for issue #148).
+**1450 passing, 0 failing** (+40 new tests for issues #145, #147, #149).
 Run: `source venv/bin/activate && python -m pytest tests/ -v`
 
 ## Open PRs (Awaiting Merge to Main)
 
 | PR | Branch | Issue | Beta | Status | Notes |
 |----|--------|-------|------|--------|-------|
+| [#150](https://github.com/jrhubott/adaptive-cover-pro/pull/150) | `fix/issues-145-147-149-time-window-manual-override-numpy` | [#145](https://github.com/jrhubott/adaptive-cover-pro/issues/145) [#147](https://github.com/jrhubott/adaptive-cover-pro/issues/147) [#149](https://github.com/jrhubott/adaptive-cover-pro/issues/149) | [v2.14.2-beta.1](https://github.com/jrhubott/adaptive-cover-pro/releases/tag/v2.14.2-beta.1) | 🟡 Awaiting user confirmation | numpy serialization fix, time window gate for climate/cloud handlers, manual override detection during wait_for_target |
 | — | `feature/integration-test-coverage-expansion` | — | — | 🟠 Open — not yet beta-tested | 116 new integration tests (1280→1396); covers coordinator update cycle, inverse state, effective default, position limits, multi-cover, weather/motion interactions |
 
 ## Open Issues
@@ -33,6 +35,9 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 |---|-------|-------|
 | [#33](https://github.com/jrhubott/adaptive-cover/issues/33) | Better support for venetian blinds | KNX: single entity exposes both position + tilt. Needs config flow enhancement for dual-axis single-entity covers. |
 | [#132](https://github.com/jrhubott/adaptive-cover-pro/issues/132) | Cover oscillates from 100% to 98% despite 10% delta threshold | Possible interaction with position limits or delta checking logic. |
+| [#145](https://github.com/jrhubott/adaptive-cover-pro/issues/145) | Start and end time not respected | Fixed in PR #150 / beta v2.14.2-beta.1 — awaiting user confirmation. |
+| [#147](https://github.com/jrhubott/adaptive-cover-pro/issues/147) | Manual override ignored during morning operations | Fixed in PR #150 / beta v2.14.2-beta.1 — awaiting user confirmation. |
+| [#149](https://github.com/jrhubott/adaptive-cover-pro/issues/149) | Download diagnostics HTTP error | Fixed in PR #150 / beta v2.14.2-beta.1 — awaiting user confirmation. |
 | [#146](https://github.com/jrhubott/adaptive-cover-pro/issues/146) | Remove icons from translations | Fixed in PR #151 / main — awaiting issue close by author. |
 | [#148](https://github.com/jrhubott/adaptive-cover-pro/issues/148) | Configuration Summary unformatted time | Fixed in PR #151 / main — awaiting issue close by author. |
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -27,7 +27,6 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 | PR | Branch | Issue | Beta | Status | Notes |
 |----|--------|-------|------|--------|-------|
 | [#150](https://github.com/jrhubott/adaptive-cover-pro/pull/150) | `fix/issues-145-147-149-time-window-manual-override-numpy` | [#145](https://github.com/jrhubott/adaptive-cover-pro/issues/145) [#147](https://github.com/jrhubott/adaptive-cover-pro/issues/147) [#149](https://github.com/jrhubott/adaptive-cover-pro/issues/149) | [v2.14.2-beta.1](https://github.com/jrhubott/adaptive-cover-pro/releases/tag/v2.14.2-beta.1) | 🟡 Awaiting user confirmation | numpy serialization fix, time window gate for climate/cloud handlers, manual override detection during wait_for_target |
-| — | `feature/integration-test-coverage-expansion` | — | — | 🟠 Open — not yet beta-tested | 116 new integration tests (1280→1396); covers coordinator update cycle, inverse state, effective default, position limits, multi-cover, weather/motion interactions |
 
 ## Open Issues
 
@@ -35,6 +34,7 @@ Run: `source venv/bin/activate && python -m pytest tests/ -v`
 |---|-------|-------|
 | [#33](https://github.com/jrhubott/adaptive-cover/issues/33) | Better support for venetian blinds | KNX: single entity exposes both position + tilt. Needs config flow enhancement for dual-axis single-entity covers. |
 | [#132](https://github.com/jrhubott/adaptive-cover-pro/issues/132) | Cover oscillates from 100% to 98% despite 10% delta threshold | Possible interaction with position limits or delta checking logic. |
+| [#131](https://github.com/jrhubott/adaptive-cover-pro/issues/131) | Erratic behavior with multiple covers / unavailable entity | Most underlying bugs fixed in v2.14.1+; awaiting user confirmation on v2.14.2-beta.1. |
 | [#145](https://github.com/jrhubott/adaptive-cover-pro/issues/145) | Start and end time not respected | Fixed in PR #150 / beta v2.14.2-beta.1 — awaiting user confirmation. |
 | [#147](https://github.com/jrhubott/adaptive-cover-pro/issues/147) | Manual override ignored during morning operations | Fixed in PR #150 / beta v2.14.2-beta.1 — awaiting user confirmation. |
 | [#149](https://github.com/jrhubott/adaptive-cover-pro/issues/149) | Download diagnostics HTTP error | Fixed in PR #150 / beta v2.14.2-beta.1 — awaiting user confirmation. |

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -536,6 +536,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     "Target just reached for %s — skipping manual override check for this event",
                     entity_id,
                 )
+            else:
+                # Grace period expired but the cover is not at the commanded target.
+                # This indicates the user may have moved the cover manually after
+                # the command was sent (Issue #147).  Clear wait_for_target so that
+                # async_handle_cover_state_change() / handle_state_change() can
+                # evaluate the position delta and detect the manual override.
+                # The grace period is the safety gate; once it expires we must not
+                # continue blocking override detection indefinitely.
+                self._cmd_svc.wait_for_target[entity_id] = False
+                self.logger.debug(
+                    "Grace period expired, cover %s not at target — clearing wait_for_target "
+                    "to allow manual override detection (position=%s)",
+                    entity_id,
+                    position,
+                )
             self.logger.debug("Wait for target: %s", self.wait_for_target)
         else:
             self.logger.debug("No wait for target call for %s", entity_id)

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -169,7 +169,7 @@ class AdaptiveGeneralCover(ABC):
         """Check if sun is in front of window within field of view."""
         azi_min = self.config.fov_left
         azi_max = self.config.fov_right
-        valid = (
+        valid = bool(
             (self.gamma < azi_min) & (self.gamma > -azi_max) & (self.valid_elevation)
         )
         self.logger.debug("Sun in front of window (ignoring blindspot)? %s", valid)

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -107,7 +107,7 @@ class SunGeometry:
         """
         azi_min = self.config.fov_left
         azi_max = self.config.fov_right
-        valid = (
+        valid = bool(
             (self.gamma < azi_min) & (self.gamma > -azi_max) & (self.valid_elevation)
         )
         self.logger.debug("Sun in front of window (ignoring blindspot)? %s", valid)
@@ -158,7 +158,7 @@ class SunGeometry:
                     self.sol_elev <= self.config.blind_spot_elevation
                 )
             self.logger.debug("Is sun in blind spot? %s", blindspot)
-            return blindspot
+            return bool(blindspot)
         return False
 
     @property

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -45,7 +45,7 @@ class SafetyMarginCalculator:
             t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
                 90 - SAFETY_MARGIN_GAMMA_THRESHOLD
             )
-            t = np.clip(t, 0, 1)
+            t = float(np.clip(t, 0, 1))
             smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
             margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
 
@@ -54,14 +54,14 @@ class SafetyMarginCalculator:
             t = (
                 SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
             ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
-            margin += SAFETY_MARGIN_LOW_ELEV_MAX * np.clip(t, 0, 1)
+            margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
         elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
             t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
                 90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
             )
-            margin += SAFETY_MARGIN_HIGH_ELEV_MAX * np.clip(t, 0, 1)
+            margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
 
-        return margin
+        return float(margin)
 
 
 class EdgeCaseHandler:
@@ -102,6 +102,6 @@ class EdgeCaseHandler:
             from numpy import tan
 
             simple_height = distance * tan(rad(sol_elev))
-            return (True, np.clip(simple_height, 0, h_win))
+            return (True, float(np.clip(simple_height, 0, h_win)))
 
         return (False, 0.0)

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -20,5 +20,5 @@
     "astral",
     "pandas"
   ],
-  "version": "2.14.1"
+  "version": "2.14.2-beta.1"
 }

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -290,6 +290,8 @@ class ClimateHandler(OverrideHandler):
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
         """Run climate strategy and return position when climate mode is active."""
+        if not snapshot.in_time_window:
+            return None
         if not snapshot.climate_mode_enabled:
             return None
         if snapshot.climate_readings is None or snapshot.climate_options is None:
@@ -339,6 +341,8 @@ class ClimateHandler(OverrideHandler):
 
     def describe_skip(self, snapshot: PipelineSnapshot) -> str:
         """Reason when climate handler does not match."""
+        if not snapshot.in_time_window:
+            return "outside time window"
         if not snapshot.climate_mode_enabled:
             return "climate mode not enabled"
         return "climate readings or options unavailable"

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -24,6 +24,8 @@ class CloudSuppressionHandler(OverrideHandler):
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
         """Return default position when no direct sun is detected."""
+        if not snapshot.in_time_window:
+            return None
         if snapshot.climate_readings is None:
             return None
         if snapshot.climate_options is None:
@@ -50,6 +52,8 @@ class CloudSuppressionHandler(OverrideHandler):
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
+    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
         """Reason when cloud suppression is not active."""
+        if not snapshot.in_time_window:
+            return "outside time window"
         return "cloud suppression inactive (direct sun present or feature disabled)"

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -37,7 +37,7 @@ def interpolate_position(
         normal_range = list(map(int, normal_list))
         new_range = list(map(int, new_list))
     if new_range:
-        state = np.interp(state, normal_range, new_range)
+        state = float(np.interp(state, normal_range, new_range))
     return state
 
 

--- a/release_notes/v2.14.2-beta.1.md
+++ b/release_notes/v2.14.2-beta.1.md
@@ -1,0 +1,78 @@
+## 🐛 Three Bug Fixes: Diagnostics Crash, Time Window, Manual Override
+
+### 🐛 Bug Fixes
+
+#### Fix #149 — Diagnostics HTTP error on HA 2026.4.1
+Home Assistant 2026.4.1 (Python 3.14) tightened JSON serialisation and now
+rejects `numpy` scalar types (`numpy.bool_`, `numpy.float64`) in entity state
+attributes.  ACP was leaking these types through the geometric calculation
+engine, causing a `TypeError: Type is not JSON serializable: numpy.bool` for
+every entity state serialisation — breaking the HA REST API, the state machine
+view, and the "Download diagnostics" button.
+
+**Affected:** All users on HA 2026.4.1+ with any ACP cover configured.
+
+Fixed by wrapping all `numpy` returns (`np.clip`, `np.interp`, bitwise `&`
+comparisons) in native Python `float()` / `bool()` at the calculation boundary
+before they can reach entity attributes or diagnostics.
+
+#### Fix #145 — Start/end time not respected when climate mode is enabled
+The `ClimateHandler` (priority 50) and `CloudSuppressionHandler` (priority 60)
+were missing the `in_time_window` gate that was correctly added to
+`SolarHandler` in a recent refactor.  This caused covers to move based on
+temperature strategy (e.g. fully open for winter heating at sunrise, fully
+closed for summer cooling) regardless of the user's configured start/end
+operational time window.
+
+**Affected:** Users with climate mode enabled and a start/end time configured.
+Covers behaved as if opening at sunrise and closing at sunset, ignoring the
+time limits.
+
+Fixed by adding `if not snapshot.in_time_window: return None` to both handlers,
+matching the existing behaviour of `SolarHandler` and `GlareZoneHandler`.
+
+#### Fix #147 — Manual override not detected during morning cover operations
+When sun tracking sent a position command (`wait_for_target=True`), a user
+manually moving the cover after the 5-second grace period expired was not
+detected as a manual override.
+
+The root cause: `process_entity_state_change()` left `wait_for_target=True`
+when the grace period expired but the cover had not reached the commanded
+position.  This caused `handle_state_change()` to skip manual override
+detection, and the next reconciliation cycle re-sent the automated command —
+fighting the user's manual adjustment.
+
+**Affected:** Users manually moving covers shortly after automated morning
+positioning commands (or any sun-tracking command). The override was silently
+ignored and covers resumed automatic movement within ~30–60 seconds.
+
+Fixed by clearing `wait_for_target` when the grace period expires and the cover
+is not at the commanded target, allowing the manual override detection to
+evaluate the position delta normally.  The 5-second grace period itself is
+unchanged — moves during grace are still fully suppressed.
+
+### 🧪 Testing
+
+This beta targets three distinct scenarios:
+
+**#149 (Diagnostics crash):**
+- Upgrade to this beta and verify the "Download diagnostics" button works
+- Check that HA's Developer Tools → States page loads without errors
+- Particularly relevant for HA 2026.4.1+ users
+
+**#145 (Time window):**
+- Configure a start time of e.g. 08:00 and end time of 20:00 with climate mode ON
+- Before the start time or after the end time, verify covers hold the default/sunset position
+- Verify that covers resume sun tracking (or climate strategy) once inside the window
+
+**#147 (Manual override):**
+- During active sun tracking (morning opening), manually move a cover via wall switch or HA
+- Verify that "Manual Override" is detected within a few seconds
+- Verify that covers do NOT resume automatic movement until the override duration expires
+
+### 📦 Installation
+
+Install via HACS or manually copy `custom_components/adaptive_cover_pro` to your
+config directory.  Restart Home Assistant after installation.
+
+> ⚠️ This is a beta release. Install on a test instance first if possible.

--- a/tests/test_manual_override_during_tracking.py
+++ b/tests/test_manual_override_during_tracking.py
@@ -1,0 +1,317 @@
+"""Tests for manual override detection during active sun tracking.
+
+Issue #147: When the sun tracking sends a command (wait_for_target=True), a
+user manually moving the cover after the grace period expires is not detected
+as a manual override.
+
+Root cause: process_entity_state_change() left wait_for_target=True when the
+grace period expired but the cover hadn't reached the target.  This caused
+handle_state_change() to skip manual override detection (it guards on
+wait_target_call).
+
+Fix: clear wait_for_target when the grace period has expired and the cover is
+not at the commanded target — allowing handle_state_change() to evaluate the
+position change normally.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_state_change_data(entity_id: str, new_position: int):
+    """Build a mock StateChangedData with a cover reporting *new_position*."""
+    event = MagicMock()
+    event.entity_id = entity_id
+    event.new_state = MagicMock()
+    event.new_state.state = "stopped"
+    event.new_state.attributes = {"current_position": new_position}
+    event.new_state.last_updated = dt.datetime.now(dt.UTC)
+    return event
+
+
+def _make_coordinator(
+    entity_id: str,
+    target_position: int,
+    current_position: int,
+    *,
+    grace_expired: bool = True,
+    ignore_intermediate: bool = False,
+):
+    """Build a minimal coordinator mock suitable for process_entity_state_change.
+
+    Args:
+        entity_id: The cover entity being tracked.
+        target_position: The position the integration commanded.
+        current_position: The position the cover is now reporting.
+        grace_expired: Whether the command grace period has expired.
+        ignore_intermediate: Whether to ignore opening/closing states.
+    """
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+        PositionContext,
+    )
+    from custom_components.adaptive_cover_pro.managers.grace_period import GracePeriodManager
+
+    coordinator = MagicMock()
+    coordinator.state_change_data = _make_state_change_data(entity_id, current_position)
+    coordinator.ignore_intermediate_states = ignore_intermediate
+    coordinator._target_just_reached = set()
+
+    # GracePeriodManager — expired means no timestamp recorded
+    grace_mgr = GracePeriodManager(logger=MagicMock(), command_grace_seconds=5.0)
+    if not grace_expired:
+        # Simulate an active (fresh) grace period
+        grace_mgr._command_timestamps[entity_id] = dt.datetime.now().timestamp()
+    coordinator._grace_mgr = grace_mgr
+
+    # CoverCommandService — has a target and wait_for_target=True
+    cmd_svc = MagicMock(spec=CoverCommandService)
+    cmd_svc.wait_for_target = {entity_id: True}
+    cmd_svc.target_call = {entity_id: target_position}
+    cmd_svc._position_tolerance = 5
+
+    def _check_target_reached(eid, pos):
+        if pos is None:
+            return False
+        if abs(pos - cmd_svc.target_call.get(eid, -999)) <= cmd_svc._position_tolerance:
+            cmd_svc.wait_for_target[eid] = False
+            return True
+        return False
+
+    cmd_svc.check_target_reached = MagicMock(side_effect=_check_target_reached)
+    cmd_svc.get_cover_capabilities = MagicMock(return_value={"has_set_position": True})
+    cmd_svc.read_position_with_capabilities = MagicMock(return_value=current_position)
+    coordinator._cmd_svc = cmd_svc
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator._is_in_grace_period = (
+        lambda eid: AdaptiveDataUpdateCoordinator._is_in_grace_period(coordinator, eid)
+    )
+
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Tests for process_entity_state_change
+# ---------------------------------------------------------------------------
+
+
+class TestProcessEntityStateChange:
+    """process_entity_state_change must clear wait_for_target when the grace
+    period expires but the cover is NOT at the commanded target."""
+
+    def _call(self, coordinator):
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+        AdaptiveDataUpdateCoordinator.process_entity_state_change(coordinator)
+
+    # ------------------------------------------------------------------
+    # Behaviour that must NOT change (regression guards)
+    # ------------------------------------------------------------------
+
+    def test_grace_period_active_leaves_wait_for_target_true(self) -> None:
+        """While in grace period, wait_for_target must remain True."""
+        entity_id = "cover.test"
+        coord = _make_coordinator(
+            entity_id, target_position=30, current_position=50,
+            grace_expired=False,
+        )
+        self._call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is True
+
+    def test_target_reached_marks_target_just_reached(self) -> None:
+        """When cover arrives at the target, entity is added to _target_just_reached."""
+        entity_id = "cover.test"
+        coord = _make_coordinator(
+            entity_id, target_position=30, current_position=32,  # within tolerance
+            grace_expired=True,
+        )
+        self._call(coord)
+        assert entity_id in coord._target_just_reached
+        # wait_for_target cleared by check_target_reached
+        assert coord._cmd_svc.wait_for_target[entity_id] is False
+
+    def test_intermediate_state_ignored_when_flag_set(self) -> None:
+        """'opening'/'closing' states are skipped when ignore_intermediate_states=True."""
+        entity_id = "cover.test"
+        coord = _make_coordinator(
+            entity_id, target_position=30, current_position=50,
+            grace_expired=True,
+        )
+        coord.state_change_data.new_state.state = "opening"
+        coord.ignore_intermediate_states = True
+        self._call(coord)
+        # Nothing should have changed
+        assert coord._cmd_svc.wait_for_target[entity_id] is True
+        assert entity_id not in coord._target_just_reached
+
+    # ------------------------------------------------------------------
+    # The fix: clearing wait_for_target on target-not-reached
+    # ------------------------------------------------------------------
+
+    def test_grace_expired_target_not_reached_clears_wait_for_target(self) -> None:
+        """Grace period expired and cover is NOT at target → wait_for_target cleared.
+
+        This is the core fix for Issue #147.  The cover diverged from the
+        commanded target (user manual move), so we must clear wait_for_target
+        to allow handle_state_change() to detect the manual override.
+        """
+        entity_id = "cover.test"
+        coord = _make_coordinator(
+            entity_id, target_position=30, current_position=95,  # user moved to 95%
+            grace_expired=True,
+        )
+        self._call(coord)
+
+        assert coord._cmd_svc.wait_for_target[entity_id] is False, (
+            "wait_for_target must be cleared when grace expires and cover is not at target"
+        )
+
+    def test_grace_expired_target_not_reached_does_not_add_to_target_just_reached(self) -> None:
+        """When target is not reached, entity must NOT be added to _target_just_reached."""
+        entity_id = "cover.test"
+        coord = _make_coordinator(
+            entity_id, target_position=30, current_position=95,
+            grace_expired=True,
+        )
+        self._call(coord)
+        assert entity_id not in coord._target_just_reached
+
+
+# ---------------------------------------------------------------------------
+# Integration: after fix, manual override detection works
+# ---------------------------------------------------------------------------
+
+
+class TestManualOverrideAfterGracePeriod:
+    """With the fix, handle_state_change can detect manual overrides after
+    the grace period expires — even when wait_for_target was originally True."""
+
+    def test_manual_move_detected_after_grace_period(self) -> None:
+        """User moving cover significantly away from target must set manual control.
+
+        Scenario:
+        1. Sun tracking sends command to 30% → wait_for_target=True
+        2. Grace period (5 s) expires
+        3. Cover is at 95% (user moved it via wall switch)
+        4. After process_entity_state_change clears wait_for_target,
+           handle_state_change must flag the entity as manually controlled.
+        """
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            AdaptiveCoverManager,
+        )
+
+        entity_id = "cover.living_room"
+        target = 30
+        user_position = 95
+
+        # Real manager to detect the override
+        manager = AdaptiveCoverManager(
+            hass=MagicMock(),
+            reset_duration={"hours": 1},
+            logger=MagicMock(),
+        )
+        manager.add_covers([entity_id])
+
+        event = _make_state_change_data(entity_id, user_position)
+
+        # After the fix, wait_for_target is cleared; handle_state_change sees False
+        wait_for_target = {entity_id: False}
+
+        manager.handle_state_change(
+            states_data=event,
+            our_state=target,
+            blind_type="cover_blind",
+            allow_reset=True,
+            wait_target_call=wait_for_target,
+            manual_threshold=5,
+        )
+
+        assert manager.is_cover_manual(entity_id), (
+            "Manual override must be detected when cover is far from commanded target"
+        )
+
+    def test_small_delta_not_detected_as_manual(self) -> None:
+        """Position change smaller than threshold is not a manual override."""
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            AdaptiveCoverManager,
+        )
+
+        entity_id = "cover.bedroom"
+        target = 30
+        motor_rounding = 32  # 2% difference — below threshold
+
+        manager = AdaptiveCoverManager(
+            hass=MagicMock(),
+            reset_duration={"hours": 1},
+            logger=MagicMock(),
+        )
+        manager.add_covers([entity_id])
+
+        event = _make_state_change_data(entity_id, motor_rounding)
+        wait_for_target = {entity_id: False}
+
+        manager.handle_state_change(
+            states_data=event,
+            our_state=target,
+            blind_type="cover_blind",
+            allow_reset=True,
+            wait_target_call=wait_for_target,
+            manual_threshold=5,
+        )
+
+        assert not manager.is_cover_manual(entity_id), (
+            "Small motor-rounding differences must not trigger manual override"
+        )
+
+    def test_move_during_grace_period_not_detected(self) -> None:
+        """Position changes during the grace period must never trigger manual detection.
+
+        Even if the position diverges significantly, we cannot trust the reading
+        while the motor is still responding to our command.
+        """
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            AdaptiveCoverManager,
+        )
+
+        entity_id = "cover.kitchen"
+        target = 30
+        user_position = 95
+
+        manager = AdaptiveCoverManager(
+            hass=MagicMock(),
+            reset_duration={"hours": 1},
+            logger=MagicMock(),
+        )
+        manager.add_covers([entity_id])
+
+        event = _make_state_change_data(entity_id, user_position)
+        # wait_for_target still True (grace period active — coordinator bails early,
+        # so handle_state_change is never reached)
+        wait_for_target = {entity_id: True}
+
+        manager.handle_state_change(
+            states_data=event,
+            our_state=target,
+            blind_type="cover_blind",
+            allow_reset=True,
+            wait_target_call=wait_for_target,
+            manual_threshold=5,
+        )
+
+        # Guard still in handle_state_change for any call paths that bypass
+        # the coordinator's early-return
+        assert not manager.is_cover_manual(entity_id)

--- a/tests/test_numpy_serialization.py
+++ b/tests/test_numpy_serialization.py
@@ -1,0 +1,352 @@
+"""Tests ensuring no numpy scalar types leak into entity attributes or diagnostics.
+
+Issue #149: HA 2026.4.1 (Python 3.14 + updated orjson) raises TypeError when
+numpy.bool_, numpy.float64, or numpy.int64 values appear in entity state
+attributes.  These tests guard against regressions in the calculation engine,
+geometry utilities, and diagnostics builder.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tests.cover_helpers import build_vertical_cover
+
+
+# ---------------------------------------------------------------------------
+# Helper: verify an object and all nested values are native Python types
+# ---------------------------------------------------------------------------
+
+
+def _check_native_types(obj, path: str = "root") -> list[str]:
+    """Recursively walk *obj* and return a list of paths with numpy scalar types.
+
+    Returns an empty list if every leaf is a native Python type (or None).
+    """
+    violations: list[str] = []
+    numpy_scalar = (np.generic,)  # covers bool_, int64, float64, etc.
+
+    if isinstance(obj, numpy_scalar):
+        violations.append(f"{path}: {type(obj).__module__}.{type(obj).__name__}")
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            violations.extend(_check_native_types(v, f"{path}.{k}"))
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            violations.extend(_check_native_types(v, f"{path}[{i}]"))
+    return violations
+
+
+def _assert_json_serialisable(obj, label: str) -> None:
+    """Assert that *obj* can be JSON-serialised without errors."""
+    try:
+        json.dumps(obj)
+    except TypeError as exc:
+        pytest.fail(f"{label} is not JSON serialisable: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _sun_data():
+    return MagicMock()
+
+
+@pytest.fixture
+def _logger():
+    return MagicMock()
+
+
+@pytest.fixture
+def _base_params(_sun_data, _logger):
+    return {
+        "logger": _logger,
+        "sol_azi": 180.0,
+        "sol_elev": 45.0,
+        "sun_data": _sun_data,
+        "win_azi": 180,
+        "fov_left": 90,
+        "fov_right": 90,
+        "h_def": 50,
+        "sunset_pos": 0,
+        "sunset_off": 0,
+        "sunrise_off": 0,
+        "max_pos": 100,
+        "min_pos": 0,
+        "max_pos_bool": False,
+        "min_pos_bool": False,
+        "blind_spot_left": None,
+        "blind_spot_right": None,
+        "blind_spot_elevation": None,
+        "blind_spot_on": False,
+        "min_elevation": None,
+        "max_elevation": None,
+        "distance": 0.5,
+        "h_win": 2.1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# geometry.SafetyMarginCalculator
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyMarginCalculatorTypes:
+    """SafetyMarginCalculator.calculate() must return a native Python float."""
+
+    def test_returns_python_float_at_threshold(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
+
+        result = SafetyMarginCalculator.calculate(gamma=45.0, sol_elev=30.0)
+        assert isinstance(result, float), f"Expected float, got {type(result)}"
+        assert not isinstance(result, np.floating), "Got numpy float, expected Python float"
+
+    def test_returns_python_float_extreme_gamma(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
+
+        result = SafetyMarginCalculator.calculate(gamma=80.0, sol_elev=10.0)
+        assert isinstance(result, float)
+        assert not isinstance(result, np.floating)
+
+    def test_returns_python_float_low_elevation(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
+
+        result = SafetyMarginCalculator.calculate(gamma=10.0, sol_elev=5.0)
+        assert isinstance(result, float)
+        assert not isinstance(result, np.floating)
+
+    def test_returns_python_float_high_elevation(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
+
+        result = SafetyMarginCalculator.calculate(gamma=10.0, sol_elev=80.0)
+        assert isinstance(result, float)
+        assert not isinstance(result, np.floating)
+
+    def test_json_serialisable(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
+
+        result = SafetyMarginCalculator.calculate(gamma=70.0, sol_elev=8.0)
+        _assert_json_serialisable(result, "SafetyMarginCalculator.calculate()")
+
+
+# ---------------------------------------------------------------------------
+# geometry.EdgeCaseHandler
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCaseHandlerTypes:
+    """EdgeCaseHandler.check_and_handle() must return native Python types."""
+
+    def test_low_elevation_returns_python_types(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import EdgeCaseHandler
+
+        is_edge, pos = EdgeCaseHandler.check_and_handle(
+            sol_elev=1.0, gamma=10.0, distance=3.0, h_win=2.5
+        )
+        assert isinstance(is_edge, bool), f"is_edge should be bool, got {type(is_edge)}"
+        assert isinstance(pos, float), f"pos should be float, got {type(pos)}"
+        assert not isinstance(pos, np.floating), "pos should be Python float, not numpy"
+
+    def test_extreme_gamma_returns_python_types(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import EdgeCaseHandler
+
+        is_edge, pos = EdgeCaseHandler.check_and_handle(
+            sol_elev=30.0, gamma=86.0, distance=3.0, h_win=2.5
+        )
+        assert isinstance(is_edge, bool)
+        assert isinstance(pos, float)
+        assert not isinstance(pos, np.floating)
+
+    def test_high_elevation_returns_python_float(self) -> None:
+        """The high-elevation branch uses np.clip — must be wrapped in float()."""
+        from custom_components.adaptive_cover_pro.geometry import EdgeCaseHandler
+
+        is_edge, pos = EdgeCaseHandler.check_and_handle(
+            sol_elev=89.0, gamma=10.0, distance=3.0, h_win=2.5
+        )
+        assert is_edge is True
+        assert isinstance(pos, float)
+        assert not isinstance(pos, np.floating)
+
+    def test_no_edge_case_returns_python_types(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import EdgeCaseHandler
+
+        is_edge, pos = EdgeCaseHandler.check_and_handle(
+            sol_elev=30.0, gamma=20.0, distance=3.0, h_win=2.5
+        )
+        assert isinstance(is_edge, bool)
+        assert isinstance(pos, float)
+
+    def test_json_serialisable(self) -> None:
+        from custom_components.adaptive_cover_pro.geometry import EdgeCaseHandler
+
+        is_edge, pos = EdgeCaseHandler.check_and_handle(89.0, 10.0, 3.0, 2.5)
+        _assert_json_serialisable({"is_edge": is_edge, "pos": pos}, "EdgeCaseHandler result")
+
+
+# ---------------------------------------------------------------------------
+# SunGeometry validity properties
+# ---------------------------------------------------------------------------
+
+
+class TestSunGeometryTypes:
+    """SunGeometry boolean properties must return native Python bools."""
+
+    def _make_geometry(self, gamma=10.0, elev=30.0):
+        from custom_components.adaptive_cover_pro.engine.sun_geometry import SunGeometry
+        from custom_components.adaptive_cover_pro.config_types import CoverConfig
+
+        config = MagicMock(spec=CoverConfig)
+        config.win_azi = 180
+        config.fov_left = 75
+        config.fov_right = 75
+        config.min_elevation = None
+        config.max_elevation = None
+        config.blind_spot_left = None
+        config.blind_spot_right = None
+        config.blind_spot_on = False
+        config.blind_spot_elevation = None
+        config.sunset_off = 0
+        config.sunrise_off = 0
+
+        sun_data = MagicMock()
+        sun_data.sunset.return_value.replace.return_value = MagicMock()
+        sun_data.sunrise.return_value.replace.return_value = MagicMock()
+
+        sol_azi = (config.win_azi - gamma) % 360
+        return SunGeometry(
+            sol_azi=float(sol_azi),
+            sol_elev=float(elev),
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
+        )
+
+    def test_valid_elevation_is_python_bool(self) -> None:
+        geom = self._make_geometry()
+        result = geom.valid_elevation
+        assert isinstance(result, bool), f"Expected bool, got {type(result)}"
+        assert not isinstance(result, np.bool_), "Got numpy.bool_, expected Python bool"
+
+    def test_valid_is_python_bool(self) -> None:
+        geom = self._make_geometry()
+        result = geom.valid
+        assert isinstance(result, bool), f"Expected bool, got {type(result)}"
+        assert not isinstance(result, np.bool_), "Got numpy.bool_, expected Python bool"
+
+    def test_valid_false_for_sun_outside_fov(self) -> None:
+        """valid should be False (Python bool) when sun is outside FOV."""
+        geom = self._make_geometry(gamma=80.0)  # beyond fov_right=75
+        result = geom.valid
+        assert result is False
+        assert isinstance(result, bool)
+
+    def test_is_sun_in_blind_spot_is_python_bool_when_disabled(self) -> None:
+        geom = self._make_geometry()
+        result = geom.is_sun_in_blind_spot
+        assert isinstance(result, bool), f"Expected bool, got {type(result)}"
+
+    def test_is_sun_in_blind_spot_is_python_bool_when_enabled(self) -> None:
+        geom = self._make_geometry(gamma=10.0, elev=25.0)
+        geom.config.blind_spot_on = True
+        geom.config.blind_spot_left = 20
+        geom.config.blind_spot_right = 5
+        geom.config.blind_spot_elevation = None
+        result = geom.is_sun_in_blind_spot
+        assert isinstance(result, bool), f"Expected bool, got {type(result)}"
+        assert not isinstance(result, np.bool_)
+
+    def test_valid_json_serialisable(self) -> None:
+        geom = self._make_geometry()
+        _assert_json_serialisable(
+            {"valid": geom.valid, "valid_elevation": geom.valid_elevation},
+            "SunGeometry bools",
+        )
+
+
+# ---------------------------------------------------------------------------
+# position_utils.interpolate_position
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolatePositionTypes:
+    """interpolate_position() must return a Python float (not numpy.float64)."""
+
+    def test_returns_python_float_when_interpolated(self) -> None:
+        from custom_components.adaptive_cover_pro.position_utils import interpolate_position
+
+        result = interpolate_position(50.0, 10.0, 90.0, None, None)
+        assert isinstance(result, (int, float)), f"Expected numeric, got {type(result)}"
+        assert not isinstance(result, np.floating), "Got numpy float"
+
+    def test_returns_original_when_no_range(self) -> None:
+        from custom_components.adaptive_cover_pro.position_utils import interpolate_position
+
+        result = interpolate_position(50.0, None, None, None, None)
+        assert not isinstance(result, np.generic)
+
+    def test_json_serialisable_interpolated(self) -> None:
+        from custom_components.adaptive_cover_pro.position_utils import interpolate_position
+
+        result = interpolate_position(50.0, 10.0, 90.0, None, None)
+        _assert_json_serialisable(result, "interpolate_position()")
+
+
+# ---------------------------------------------------------------------------
+# Vertical cover _last_calc_details
+# ---------------------------------------------------------------------------
+
+
+class TestVerticalCoverCalcDetailsTypes:
+    """_last_calc_details on AdaptiveVerticalCover must contain only native types."""
+
+    def _cover(self, params, gamma: float, sol_elev: float):
+        p = params.copy()
+        p["sol_azi"] = (p["win_azi"] - gamma) % 360
+        p["sol_elev"] = sol_elev
+        return build_vertical_cover(**p)
+
+    def test_normal_case_details_are_native_types(self, _base_params) -> None:
+        cover = self._cover(_base_params, gamma=20.0, sol_elev=30.0)
+        cover.calculate_position()
+        details = cover._last_calc_details
+        assert details is not None
+        violations = _check_native_types(details)
+        assert not violations, f"numpy types in _last_calc_details: {violations}"
+
+    def test_edge_case_high_elevation_details_are_native_types(self, _base_params) -> None:
+        """High-elevation edge case branch must produce native types in details."""
+        cover = self._cover(_base_params, gamma=10.0, sol_elev=89.0)
+        cover.calculate_position()
+        details = cover._last_calc_details
+        assert details is not None
+        violations = _check_native_types(details)
+        assert not violations, f"numpy types in _last_calc_details: {violations}"
+
+    def test_extreme_gamma_details_are_native_types(self, _base_params) -> None:
+        """Gamma-safety-margin branch (>45°) must produce native types."""
+        cover = self._cover(_base_params, gamma=75.0, sol_elev=20.0)
+        cover.calculate_position()
+        details = cover._last_calc_details
+        violations = _check_native_types(details)
+        assert not violations, f"numpy types in _last_calc_details: {violations}"
+
+    def test_low_elevation_details_are_native_types(self, _base_params) -> None:
+        """Low-elevation edge case branch must produce native types."""
+        cover = self._cover(_base_params, gamma=10.0, sol_elev=1.0)
+        cover.calculate_position()
+        details = cover._last_calc_details
+        violations = _check_native_types(details)
+        assert not violations, f"numpy types in _last_calc_details: {violations}"
+
+    def test_calc_details_json_serialisable(self, _base_params) -> None:
+        cover = self._cover(_base_params, gamma=20.0, sol_elev=30.0)
+        cover.calculate_position()
+        _assert_json_serialisable(cover._last_calc_details, "_last_calc_details")

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -401,3 +401,78 @@ class TestWinterInsulation:
         )
         result = self.handler.evaluate(snap)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #145 — ClimateHandler must respect in_time_window
+# ---------------------------------------------------------------------------
+
+
+class TestClimateHandlerTimeWindow:
+    """ClimateHandler must return None when outside the configured time window.
+
+    Before the fix, ClimateHandler ignored ``snapshot.in_time_window``, which
+    caused covers to move based on temperature strategy (e.g. full-open for
+    winter heating) even when the user had configured start/end time limits.
+    """
+
+    handler = ClimateHandler()
+
+    def _active_snap(self, *, in_time_window: bool) -> object:
+        """Build a snapshot that would normally trigger climate action."""
+        cover = _make_blind_cover(direct_sun_valid=True)
+        cover.valid = True
+        return make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=15.0,  # winter — would normally open to 100%
+                is_presence=True,
+            ),
+            climate_options=_make_options(temp_low=18.0),
+            in_time_window=in_time_window,
+        )
+
+    def test_returns_none_outside_time_window(self) -> None:
+        """Climate handler must return None when in_time_window=False."""
+        snap = self._active_snap(in_time_window=False)
+        result = self.handler.evaluate(snap)
+        assert result is None, (
+            "ClimateHandler should return None outside the time window "
+            f"but returned {result}"
+        )
+
+    def test_returns_result_inside_time_window(self) -> None:
+        """Climate handler must return a result when in_time_window=True."""
+        snap = self._active_snap(in_time_window=True)
+        result = self.handler.evaluate(snap)
+        assert result is not None
+
+    def test_describe_skip_outside_window(self) -> None:
+        """describe_skip() should mention 'time window' when outside window."""
+        snap = self._active_snap(in_time_window=False)
+        reason = self.handler.describe_skip(snap)
+        assert "time window" in reason.lower(), (
+            f"Expected 'time window' in describe_skip reason but got: {reason!r}"
+        )
+
+    def test_summer_returns_none_outside_window(self) -> None:
+        """Summer cooling must also be gated by time window."""
+        cover = _make_blind_cover(direct_sun_valid=False)
+        cover.valid = False
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=30.0,
+                is_presence=True,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(
+                temp_high=26.0,
+                temp_summer_outside=20.0,
+            ),
+            in_time_window=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is None

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -141,3 +141,64 @@ class TestCloudSuppressionHandler:
     def test_name(self) -> None:
         """CloudSuppressionHandler name is 'cloud_suppression'."""
         assert CloudSuppressionHandler.name == "cloud_suppression"
+
+
+# ---------------------------------------------------------------------------
+# Issue #145 — CloudSuppressionHandler must respect in_time_window
+# ---------------------------------------------------------------------------
+
+
+class TestCloudHandlerTimeWindow:
+    """CloudSuppressionHandler must return None outside the time window.
+
+    Before the fix, CloudSuppressionHandler ignored ``snapshot.in_time_window``.
+    """
+
+    handler = CloudSuppressionHandler()
+
+    def test_returns_none_outside_time_window(self) -> None:
+        """Cloud suppression must be inactive outside the time window."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            default_position=30,
+            in_time_window=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is None, (
+            "CloudSuppressionHandler should return None outside the time window "
+            f"but returned {result}"
+        )
+
+    def test_returns_result_inside_time_window(self) -> None:
+        """Cloud suppression should activate when inside the time window."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            default_position=30,
+            in_time_window=True,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+
+    def test_describe_skip_outside_window(self) -> None:
+        """describe_skip() should mention 'time window' when outside window."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            in_time_window=False,
+        )
+        reason = self.handler.describe_skip(snap)
+        assert "time window" in reason.lower(), (
+            f"Expected 'time window' in describe_skip reason but got: {reason!r}"
+        )
+
+    def test_lux_threshold_outside_window_returns_none(self) -> None:
+        """Lux-based suppression must also be gated by time window."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=True, lux_below_threshold=True),
+            climate_options=_make_options(enabled=True),
+            in_time_window=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is None


### PR DESCRIPTION
## Summary

Three independent bug fixes targeting reported issues in v2.14.1.

### Fix #149 — Diagnostics HTTP error (numpy not JSON serializable)

HA 2026.4.1 (Python 3.14) tightened JSON serialisation and now rejects `numpy` scalar types in entity state attributes. ACP was leaking `numpy.bool_` and `numpy.float64` through the geometric calculation engine, causing `TypeError: Type is not JSON serializable: numpy.bool` — breaking the REST API, the state machine view, and the Download diagnostics button for all users on HA 2026.4.1+.

**Changes:** `geometry.py`, `position_utils.py`, `engine/sun_geometry.py`, `engine/covers/base.py` — wrap all `np.clip()`, `np.interp()`, and bitwise `&` comparison results in native `float()` / `bool()` at the calculation boundary.

### Fix #145 — Start/end time not respected with climate mode enabled

`ClimateHandler` (priority 50) and `CloudSuppressionHandler` (priority 60) were missing the `in_time_window` gate added to `SolarHandler` in a prior refactor. Covers moved based on temperature strategy (full-open for winter heating, full-close for summer cooling) regardless of the user's configured operational time window — appearing to open at sunrise and close at sunset.

**Changes:** Added `if not snapshot.in_time_window: return None` to both handlers' `evaluate()` and updated `describe_skip()` to report `"outside time window"`.

### Fix #147 — Manual override not detected during morning sun tracking

When sun tracking sent a command (`wait_for_target=True`), a user manually moving the cover after the 5-second grace period expired was not detected as a manual override. `process_entity_state_change()` left `wait_for_target=True` when grace expired but the cover hadn't reached the target, causing `handle_state_change()` to skip override detection and the reconciliation cycle to re-send the automated command.

**Changes:** `coordinator.py` — when grace period expires and the cover is not at the commanded target, clear `wait_for_target` so manual override detection can proceed normally. Grace period itself (5 s) is unchanged.

## Testing

- ✅ 1450 tests passing (was 1410, +40 new tests)
- ✅ 24 new numpy type-safety tests
- ✅ 8 new time-window tests for ClimateHandler and CloudSuppressionHandler
- ✅ 8 new manual override / grace period interaction tests

## Related Issues

Fixes #149
Fixes #145
Fixes #147