### PR TITLE
fix: exempt sunset position from min/max position limits (#128)

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -85,6 +85,8 @@ def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
     """
     if snapshot.cover.direct_sun_valid:
         return compute_solar_position(snapshot)
+    if snapshot.is_sunset_active:
+        return snapshot.default_position
     return apply_snapshot_limits(
         snapshot,
         snapshot.default_position,
@@ -99,6 +101,10 @@ def compute_default_position(snapshot: PipelineSnapshot) -> int:
     and applies configured min/max position limits with ``sun_valid=False`` so
     sun-only limits are not enforced when the sun is outside the FOV.
 
+    When ``snapshot.is_sunset_active`` is True, limits are bypassed entirely —
+    the sunset position is an explicit user configuration for nighttime and
+    should not be clamped by min/max safety limits (#128).
+
     Args:
         snapshot: Current pipeline snapshot.
 
@@ -106,6 +112,8 @@ def compute_default_position(snapshot: PipelineSnapshot) -> int:
         Effective default position (0–100, limited).
 
     """
+    if snapshot.is_sunset_active:
+        return snapshot.default_position
     return apply_snapshot_limits(
         snapshot,
         snapshot.default_position,

--- a/release_notes/v2.14.4-beta.1.md
+++ b/release_notes/v2.14.4-beta.1.md
@@ -1,14 +1,14 @@
-## 🐛 Fix covers opening at midnight (#179)
+## Fix: Sunset Position Not Reached (#128)
 
-### 🐛 Bug Fixes
+### 🐛 Bug Fix
 
-- **Covers no longer move outside the configured time window on HA restart** — `async_handle_first_refresh` now checks the time window before commanding covers. If Home Assistant restarts at midnight (a common setup), covers will no longer be repositioned until the window opens.
-- **Reconciliation timer respects the time window** — the per-minute reconciliation loop now skips non-safety targets when outside the operational window, preventing stale daytime positions from being resent overnight.
-- **Stale targets cleared on window close** — when the time window transitions to inactive, leftover `target_call` entries are purged so reconciliation has nothing to resend.
+**Sunset position no longer clamped by min/max position limits.**
 
-Safety overrides (force override, weather safety, end-time default) are unaffected and continue to work at any hour.
+When `min_position` was configured with "Apply min only during sun tracking" set to OFF (the default), the sunset position was incorrectly clamped to the minimum. For example, `min_position=50%` and `sunset_position=0%` would result in the cover staying at 50% after sunset instead of closing to 0%.
+
+The sunset position is an explicit user configuration for nighttime behavior — it is now exempt from min/max clamping regardless of the "Apply min only during sun tracking" toggle.
 
 ### 🧪 Testing
 
-- 4 new regression tests covering: skip outside window, safety target still resent, window reopen resumes, clear non-safety targets
-- 1757 tests passing
+- 4 new regression tests for the sunset position exemption
+- 1761 tests passing

--- a/tests/test_pipeline/test_helpers.py
+++ b/tests/test_pipeline/test_helpers.py
@@ -40,7 +40,8 @@ def _make_cover(*, direct_sun_valid=True, calc_pct=50.0):
 
 def _make_snapshot(*, calc_pct=50.0, default_position=30, direct_sun_valid=True,
                    min_pos=None, max_pos=None,
-                   min_pos_sun_only=False, max_pos_sun_only=False):
+                   min_pos_sun_only=False, max_pos_sun_only=False,
+                   is_sunset_active=False):
     return SimpleNamespace(
         cover=_make_cover(direct_sun_valid=direct_sun_valid, calc_pct=calc_pct),
         config=_make_config(
@@ -50,6 +51,7 @@ def _make_snapshot(*, calc_pct=50.0, default_position=30, direct_sun_valid=True,
             max_pos_sun_only=max_pos_sun_only,
         ),
         default_position=default_position,
+        is_sunset_active=is_sunset_active,
     )
 
 
@@ -176,6 +178,36 @@ class TestComputeDefaultPosition:
         )
         assert compute_default_position(snap) == 30
 
+    def test_sunset_active_skips_min_limit(self):
+        """Sunset position is not clamped by min_pos even when always-apply is set (#128)."""
+        snap = _make_snapshot(
+            default_position=0,
+            min_pos=50,
+            min_pos_sun_only=False,  # always apply — but sunset exempts it
+            is_sunset_active=True,
+        )
+        assert compute_default_position(snap) == 0
+
+    def test_sunset_active_skips_max_limit(self):
+        """Sunset position is not clamped by max_pos (e.g. sunset_pos=100, max=80)."""
+        snap = _make_snapshot(
+            default_position=100,
+            max_pos=80,
+            max_pos_sun_only=False,
+            is_sunset_active=True,
+        )
+        assert compute_default_position(snap) == 100
+
+    def test_sunset_inactive_still_applies_min_limit(self):
+        """Normal default position (not sunset) still respects min_pos. Regression guard."""
+        snap = _make_snapshot(
+            default_position=0,
+            min_pos=50,
+            min_pos_sun_only=False,
+            is_sunset_active=False,
+        )
+        assert compute_default_position(snap) == 50
+
 
 # ---------------------------------------------------------------------------
 # compute_raw_calculated_position
@@ -213,3 +245,14 @@ class TestComputeRawCalculatedPosition:
         """Max limit is applied in the default path."""
         snap = _make_snapshot(default_position=95, direct_sun_valid=False, max_pos=80)
         assert compute_raw_calculated_position(snap) == 80
+
+    def test_sunset_active_skips_limits_in_default_path(self):
+        """Sunset position bypasses min/max limits in the default path (#128)."""
+        snap = _make_snapshot(
+            default_position=0,
+            min_pos=50,
+            min_pos_sun_only=False,
+            direct_sun_valid=False,
+            is_sunset_active=True,
+        )
+        assert compute_raw_calculated_position(snap) == 0

--- a/tests/test_position_limits.py
+++ b/tests/test_position_limits.py
@@ -197,10 +197,14 @@ def test_issue_24_sunset_position_with_conditional_min_pos(mock_sun_data, mock_l
 def test_sunset_position_with_always_min_pos(mock_sun_data, mock_logger):
     """Test sunset_position with enable_min_position = False (always apply).
 
-    When min_pos_bool=False (enable_min_position=False), min_pos is always
-    applied including during the sunset window.  After sunset, the effective
-    default = sunset_pos = 0, but min_pos = 35 is always enforced, so the
-    result should be max(0, 35) = 35.
+    Even when min_pos_bool=False (enable_min_position=False, meaning "always
+    apply min_pos"), the sunset position is exempt from min/max clamping (#128).
+    The sunset position is an explicit user configuration for nighttime and
+    must not be overridden by daytime safety limits.
+
+    After sunset: effective default = sunset_pos = 0.
+    min_pos = 35 with always-apply setting.
+    Expected: 0 (sunset position wins, limits bypassed).
     """
     from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
         DefaultHandler,
@@ -267,9 +271,9 @@ def test_sunset_position_with_always_min_pos(mock_sun_data, mock_logger):
 
         result = PipelineRegistry([DefaultHandler()]).evaluate(snapshot)
 
-        # min_pos_bool=False means min_pos always applied.
-        # max(sunset_pos=0, min_pos=35) = 35
-        assert result.position == 35, f"Expected 35 (min_pos always applied), got {result.position}"
+        # Sunset position is exempt from min/max limits (#128).
+        # sunset_pos=0 must not be clamped to min_pos=35.
+        assert result.position == 0, f"Expected 0 (sunset position exempt from min_pos), got {result.position}"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Exempt sunset position from min/max position limits in `compute_default_position()`
- Previously, a `min_position` setting could prevent covers from reaching the configured sunset position
- Fixes #128

## Testing
- ✅ Existing tests passing
- ✅ New regression tests added

## Related Issues
Fixes #128