### PR TITLE
fix: config summary incorrect when sun tracking disabled

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -965,8 +965,11 @@ def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa
     has_custom_position = bool(_custom_slots)
     has_cloud = bool(config.get(CONF_CLOUD_SUPPRESSION))
     has_climate = bool(config.get(CONF_CLIMATE_MODE))
+    sun_tracking_enabled = config.get(CONF_ENABLE_SUN_TRACKING, True)
     has_glare = (
-        bool(config.get(CONF_ENABLE_GLARE_ZONES)) and sensor_type == SensorType.BLIND
+        bool(config.get(CONF_ENABLE_GLARE_ZONES))
+        and sensor_type == SensorType.BLIND
+        and sun_tracking_enabled
     )
 
     lines: list[str] = []
@@ -1182,22 +1185,28 @@ def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa
     fov_r = config.get(CONF_FOV_RIGHT)
     min_elev = config.get(CONF_MIN_ELEVATION)
     max_elev = config.get(CONF_MAX_ELEVATION)
-    sun_parts = []
-    if azimuth is not None:
-        sun_parts.append(f"azimuth {azimuth}°")
-    if fov_l is not None and fov_r is not None:
-        sun_parts.append(f"±{fov_l}°/{fov_r}° field of view")
-    elev_parts = []
-    if min_elev is not None:
-        elev_parts.append(f"above {min_elev}°")
-    if max_elev is not None:
-        elev_parts.append(f"below {max_elev}°")
-    if elev_parts:
-        sun_parts.append(f"elevation {' and '.join(elev_parts)}")
-    sun_desc = f" ({', '.join(sun_parts)})" if sun_parts else ""
-    lines.append(
-        f"☀️ Tracks the sun{sun_desc} and calculates position to block direct sunlight."
-    )
+    if sun_tracking_enabled:
+        sun_parts = []
+        if azimuth is not None:
+            sun_parts.append(f"azimuth {azimuth}°")
+        if fov_l is not None and fov_r is not None:
+            sun_parts.append(f"±{fov_l}°/{fov_r}° field of view")
+        elev_parts = []
+        if min_elev is not None:
+            elev_parts.append(f"above {min_elev}°")
+        if max_elev is not None:
+            elev_parts.append(f"below {max_elev}°")
+        if elev_parts:
+            sun_parts.append(f"elevation {' and '.join(elev_parts)}")
+        sun_desc = f" ({', '.join(sun_parts)})" if sun_parts else ""
+        lines.append(
+            f"☀️ Tracks the sun{sun_desc} and calculates position to block direct sunlight."
+        )
+    else:
+        lines.append(
+            "☀️ Sun tracking disabled — covers hold position; climate, manual override, "
+            "custom positions, and other overrides remain active."
+        )
 
     # Timing window
     start_time = config.get(CONF_START_TIME)
@@ -1309,7 +1318,8 @@ def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa
     if has_custom_position:
         for _slot, _eid, _pos, _pri in _custom_slots:
             pos_map.append(f"🎯 Custom #{_slot} on → {_pos}% (priority {_pri})")
-    pos_map.append("☀️ Tracking sun → calculated position")
+    if sun_tracking_enabled:
+        pos_map.append("☀️ Tracking sun → calculated position")
     min_p = config.get(CONF_MIN_POSITION, 0)
     max_p = config.get(CONF_MAX_POSITION, 100)
     if min_p != 0 or max_p != 100:
@@ -1337,10 +1347,10 @@ def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa
         (75, "Motion", has_motion),
         (60, "Cloud", has_cloud),
         (50, "Climate", has_climate),
-        (40, "Solar", True),
+        (40, "Solar", sun_tracking_enabled),
         (0, "Default", True),
     ]
-    if sensor_type == SensorType.BLIND or sensor_type is None:
+    if (sensor_type == SensorType.BLIND or sensor_type is None) and sun_tracking_enabled:
         _chain_entries.append((45, "Glare", has_glare))
     # Insert one entry per custom slot at its configured priority
     for _slot, _eid, _pos, _pri in _custom_slots:

--- a/release_notes/v2.15.2.md
+++ b/release_notes/v2.15.2.md
@@ -1,7 +1,21 @@
-## 🔧 Linting & Code Quality
+## ☀️ Sun Tracking Toggle + Dry-Run Mode
 
-### 🧪 Maintenance
-- Fix all ruff linting errors and establish per-file-ignore rules for cleaner code analysis
+### ✨ Features
+
+- **Enable/Disable sun tracking** — new toggle in the integration options to pause automatic sun-position tracking without disabling the integration entirely. When disabled, covers hold their last position and no outbound commands are sent during sun updates.
+
+- **Dry-run mode** — new "Dry Run (no cover movement)" toggle in the Debug & Diagnostics config step. When enabled, the full update cycle runs normally (pipeline evaluation, diagnostics, sensors, logging) but no outbound cover commands are sent to Home Assistant. Useful for validating automation settings and reproducing issues without physically moving covers.
+  - Dry-run fires after all existing gates (delta, time, manual override) so skip reasons still surface correctly
+  - `last_cover_action` is populated with the intended action plus a `dry_run: true` marker
+  - `last_skipped_action` records reason `dry_run`
+  - INFO-level `[dry_run] would send …` log line for easy visibility
+  - `dry_run` flag included in the debug_config diagnostics payload
+
+### 🔧 Maintenance
+- Fix all ruff linting errors and establish per-file-ignore rules
+
+### 🧪 Testing
+- 1904 tests passing
 
 ---
 

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -7,6 +7,7 @@ from custom_components.adaptive_cover_pro.config_flow import _build_config_summa
 from custom_components.adaptive_cover_pro.const import (
     CONF_AWNING_ANGLE,
     CONF_AZIMUTH,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_BLIND_SPOT_ELEVATION,
     CONF_BLIND_SPOT_LEFT,
     CONF_BLIND_SPOT_RIGHT,
@@ -950,3 +951,46 @@ def test_full_vertical_config_smoke():
     assert "95%" in summary
     assert "Inverse state" in summary
     assert "Position calibration" in summary
+
+
+# ---------------------------------------------------------------------------
+# Sun tracking toggle
+# ---------------------------------------------------------------------------
+
+
+def test_sun_tracking_disabled_shows_disabled_message():
+    """When enable_sun_tracking is False, summary says tracking is disabled."""
+    cfg = {CONF_ENABLE_SUN_TRACKING: False, CONF_AZIMUTH: 180}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Sun tracking disabled" in summary
+    assert "Tracks the sun" not in summary
+
+
+def test_sun_tracking_enabled_shows_tracking_message():
+    """When enable_sun_tracking is True (default), summary says it tracks the sun."""
+    cfg = {CONF_ENABLE_SUN_TRACKING: True, CONF_AZIMUTH: 180}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Tracks the sun" in summary
+    assert "Sun tracking disabled" not in summary
+
+
+def test_sun_tracking_default_enabled_shows_tracking_message():
+    """When enable_sun_tracking is absent (defaults to True), summary shows tracking."""
+    cfg = {CONF_AZIMUTH: 180}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Tracks the sun" in summary
+    assert "Sun tracking disabled" not in summary
+
+
+def test_sun_tracking_disabled_hides_glare_zones():
+    """Glare zone entry is omitted when sun tracking is disabled."""
+    cfg = {CONF_ENABLE_SUN_TRACKING: False, CONF_ENABLE_GLARE_ZONES: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Glare" not in summary
+
+
+def test_sun_tracking_disabled_priority_chain_shows_solar_inactive():
+    """Priority chain marks Solar (and Glare) as inactive when sun tracking is off."""
+    cfg = {CONF_ENABLE_SUN_TRACKING: False, CONF_ENABLE_GLARE_ZONES: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "❌Solar" in summary or "Solar" not in summary or "✅Solar" not in summary


### PR DESCRIPTION
## Summary
Config Summary showed incorrect information when Solar Tracking was disabled — still said "Tracks the sun", showed glare zones as active, and marked Solar as active in the priority chain.

Root cause: `_build_config_summary()` never read `CONF_ENABLE_SUN_TRACKING`.

Fix gates the solar narrative, glare zone display, Position Map entry, and priority chain Solar/Glare entries on the `enable_sun_tracking` option.

## Testing
- ✅ 1909 tests passing
- 5 new regression tests for sun-tracking-disabled summary behavior

## Related Issues
Fixes #190