### PR TITLE
fix: skip stop_cover on stationary covers to prevent Somfy My-position trigger (#197)

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ If you have multiple ACP instances (one per room), these services let you contro
 |---|---|
 | `adaptive_cover_pro.integration_enable` | Re-enables targeted instances. Covers stay where they are; positioning resumes on the next update cycle. |
 | `adaptive_cover_pro.integration_disable` | Disables targeted instances. In-flight ACP moves are stopped immediately, timers cancelled, state cleared. |
-| `adaptive_cover_pro.emergency_stop` | **Panic button.** Sends `cover.stop_cover` to *every* configured cover on targeted instances (capability-checked), then disables the integration. With no target, acts on all ACP instances. |
+| `adaptive_cover_pro.emergency_stop` | **Panic button.** Sends `cover.stop_cover` to every cover that is actively **opening or closing** on targeted instances (capability-checked), then disables the integration. Stationary covers are not sent `stop_cover` — this prevents Somfy "My" / favorite-position triggers on motors that move to a preset when stopped while idle. With no target, acts on all ACP instances. |
 
 All three services accept the standard Home Assistant `target:` block — `entity_id`, `device_id`, or `area_id`. The UI picker filters by ACP entities; you can also target by device or area in automations/scripts. Covers not managed by ACP are silently ignored.
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -361,6 +361,19 @@ class CoverCommandService:
     # Stop helpers — bypass _enabled gate (shutdown / emergency paths)
     # ------------------------------------------------------------------ #
 
+    def _is_cover_in_motion(self, entity_id: str) -> bool:
+        """Return True only if HA reports the cover as opening or closing.
+
+        cover.stop_cover is overloaded on some hardware (Somfy "My", Hunter
+        Douglas favorite, etc.) — on stationary covers it triggers a preset
+        position move instead of a no-op.  Callers in shutdown/emergency
+        paths must gate on actual motion to avoid triggering that preset.
+        """
+        state_obj = self._hass.states.get(entity_id)
+        if state_obj is None:
+            return False
+        return state_obj.state in ("opening", "closing")
+
     async def stop_in_flight(
         self, entities: set[str] | None = None
     ) -> list[str]:
@@ -385,17 +398,29 @@ class CoverCommandService:
         }
         for eid in candidates:
             caps = check_cover_features(self._hass, eid)
-            if caps and caps.get("has_stop"):
-                if self._dry_run:
-                    self._logger.info("[dry_run] would stop_cover %s", eid)
-                else:
-                    await self._hass.services.async_call(
-                        "cover", "stop_cover", {"entity_id": eid}
-                    )
+            if not (caps and caps.get("has_stop")):
+                continue
+            if not self._is_cover_in_motion(eid):
+                state_val = getattr(self._hass.states.get(eid), "state", None)
+                self._logger.debug(
+                    "stop_in_flight: skipping %s — not in motion (state=%s); "
+                    "clearing stale wait_for_target",
+                    eid,
+                    state_val,
+                )
                 self.wait_for_target[eid] = False
                 self._sent_at.pop(eid, None)
-                stopped.append(eid)
-                self._logger.debug("stop_in_flight: stopped %s", eid)
+                continue
+            if self._dry_run:
+                self._logger.info("[dry_run] would stop_cover %s", eid)
+            else:
+                await self._hass.services.async_call(
+                    "cover", "stop_cover", {"entity_id": eid}
+                )
+            self.wait_for_target[eid] = False
+            self._sent_at.pop(eid, None)
+            stopped.append(eid)
+            self._logger.debug("stop_in_flight: stopped %s", eid)
         return stopped
 
     async def stop_all(self, entity_ids: list[str]) -> list[str]:
@@ -414,15 +439,24 @@ class CoverCommandService:
         stopped: list[str] = []
         for eid in entity_ids:
             caps = check_cover_features(self._hass, eid)
-            if caps and caps.get("has_stop"):
-                if self._dry_run:
-                    self._logger.info("[dry_run] would stop_cover %s", eid)
-                else:
-                    await self._hass.services.async_call(
-                        "cover", "stop_cover", {"entity_id": eid}
-                    )
-                stopped.append(eid)
-                self._logger.debug("stop_all: stopped %s", eid)
+            if not (caps and caps.get("has_stop")):
+                continue
+            if not self._is_cover_in_motion(eid):
+                state_val = getattr(self._hass.states.get(eid), "state", None)
+                self._logger.debug(
+                    "stop_all: skipping %s — not in motion (state=%s)",
+                    eid,
+                    state_val,
+                )
+                continue
+            if self._dry_run:
+                self._logger.info("[dry_run] would stop_cover %s", eid)
+            else:
+                await self._hass.services.async_call(
+                    "cover", "stop_cover", {"entity_id": eid}
+                )
+            stopped.append(eid)
+            self._logger.debug("stop_all: stopped %s", eid)
         return stopped
 
     # ------------------------------------------------------------------ #

--- a/release_notes/v2.16.1.md
+++ b/release_notes/v2.16.1.md
@@ -1,0 +1,16 @@
+## 🐛 Bug Fix
+
+### 🐛 Bug Fixes
+
+- **Emergency stop no longer moves stationary Somfy covers to "My" preset position** (#197).
+  `cover.stop_cover` is now only sent to covers whose HA state is `opening` or `closing`.
+  Covers that are already stationary are left untouched — the integration gate still closes
+  immediately so no further ACP commands can fire.
+  This also applies to `integration_disable`, which uses the same in-flight stop path.
+
+### 🧪 Testing
+
+- Added regression tests: `test_stop_in_flight_skips_stationary_cover_somfy_my`,
+  `test_stop_all_skips_stationary_cover_somfy_my`,
+  `test_stop_all_stops_only_moving_covers_in_mixed_set`
+- Updated existing `stop_in_flight` / `stop_all` unit tests to stub HA cover state

--- a/tests/test_integration_enabled_kill_switch.py
+++ b/tests/test_integration_enabled_kill_switch.py
@@ -439,11 +439,33 @@ def _patch_caps_with_stop(has_stop=True):
     )
 
 
+def _stub_cover_state(mock_hass, entity_id: str, state_str: str) -> None:
+    """Make mock_hass.states.get(entity_id) return a state object with state=state_str."""
+    state_obj = MagicMock()
+    state_obj.state = state_str
+    original = mock_hass.states.get.side_effect or (lambda _eid: MagicMock())
+
+    def _side_effect(eid):
+        if eid == entity_id:
+            return state_obj
+        return original(eid)
+
+    mock_hass.states.get.side_effect = _side_effect
+
+
+def _stub_all_covers_state(mock_hass, state_str: str) -> None:
+    """Make mock_hass.states.get always return a state object with state=state_str."""
+    state_obj = MagicMock()
+    state_obj.state = state_str
+    mock_hass.states.get.return_value = state_obj
+
+
 @pytest.mark.asyncio
 async def test_stop_in_flight_sends_stop_to_waiting_entities(svc, mock_hass):
     """stop_in_flight sends stop_cover to every entity with wait_for_target=True."""
     svc.wait_for_target["cover.a"] = True
     svc.wait_for_target["cover.b"] = True
+    _stub_all_covers_state(mock_hass, "opening")
 
     with _patch_caps_with_stop(has_stop=True):
         stopped = await svc.stop_in_flight()
@@ -459,6 +481,7 @@ async def test_stop_in_flight_sends_stop_to_waiting_entities(svc, mock_hass):
 async def test_stop_in_flight_skips_covers_without_has_stop(svc, mock_hass):
     """stop_in_flight skips entities whose cover does not support STOP."""
     svc.wait_for_target["cover.nostop"] = True
+    _stub_all_covers_state(mock_hass, "opening")
 
     with _patch_caps_with_stop(has_stop=False):
         stopped = await svc.stop_in_flight()
@@ -471,6 +494,7 @@ async def test_stop_in_flight_skips_covers_without_has_stop(svc, mock_hass):
 async def test_stop_in_flight_skips_entities_not_waiting(svc, mock_hass):
     """stop_in_flight ignores entities where wait_for_target is False."""
     svc.wait_for_target["cover.settled"] = False
+    _stub_all_covers_state(mock_hass, "opening")
 
     with _patch_caps_with_stop(has_stop=True):
         stopped = await svc.stop_in_flight()
@@ -486,9 +510,71 @@ async def test_stop_in_flight_clears_wait_for_target(svc, mock_hass):
     svc._sent_at["cover.moving"] = __import__("datetime").datetime.now(
         __import__("datetime").timezone.utc
     )
+    _stub_all_covers_state(mock_hass, "opening")
 
     with _patch_caps_with_stop(has_stop=True):
         await svc.stop_in_flight()
 
     assert svc.wait_for_target["cover.moving"] is False
     assert "cover.moving" not in svc._sent_at
+
+
+# ---------------------------------------------------------------------------
+# Somfy "My" position regression tests (Issue #197)
+# stop_cover must NOT be sent to stationary covers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stop_in_flight_skips_stationary_cover_somfy_my(svc, mock_hass):
+    """stop_in_flight must not send stop_cover to a cover that is stationary.
+
+    On Somfy RTS/io awnings, stop_cover sent to a stationary cover triggers
+    the "My" preset position instead of being a no-op.  The in-flight
+    bookkeeping (wait_for_target, _sent_at) should still be cleaned up.
+    """
+    svc.wait_for_target["cover.awning"] = True
+    svc._sent_at["cover.awning"] = __import__("datetime").datetime.now(
+        __import__("datetime").timezone.utc
+    )
+    _stub_all_covers_state(mock_hass, "open")  # already stationary
+
+    with _patch_caps_with_stop(has_stop=True):
+        stopped = await svc.stop_in_flight()
+
+    assert stopped == []
+    mock_hass.services.async_call.assert_not_called()
+    # Stale bookkeeping must be cleared even though no stop was sent
+    assert svc.wait_for_target["cover.awning"] is False
+    assert "cover.awning" not in svc._sent_at
+
+
+@pytest.mark.asyncio
+async def test_stop_all_skips_stationary_cover_somfy_my(svc, mock_hass):
+    """stop_all must not send stop_cover to a cover that is not in motion.
+
+    This is the emergency_stop path — blanket stop should only fire against
+    covers that are actively opening or closing.
+    """
+    _stub_all_covers_state(mock_hass, "closed")
+
+    with _patch_caps_with_stop(has_stop=True):
+        stopped = await svc.stop_all(["cover.awning"])
+
+    assert stopped == []
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stop_all_stops_only_moving_covers_in_mixed_set(svc, mock_hass):
+    """stop_all sends stop_cover only to the cover that is opening, not the closed one."""
+    _stub_cover_state(mock_hass, "cover.moving", "opening")
+    _stub_cover_state(mock_hass, "cover.idle", "closed")
+
+    with _patch_caps_with_stop(has_stop=True):
+        stopped = await svc.stop_all(["cover.moving", "cover.idle"])
+
+    assert stopped == ["cover.moving"]
+    assert mock_hass.services.async_call.call_count == 1
+    call_args = mock_hass.services.async_call.call_args
+    assert call_args.args == ("cover", "stop_cover", {"entity_id": "cover.moving"})

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -1284,6 +1284,9 @@ async def test_stop_in_flight_dry_run_no_send(svc, mock_hass):
     """stop_in_flight with dry_run=True skips async_call but still clears wait_for_target."""
     svc.dry_run = True
     svc.wait_for_target["cover.test"] = True
+    state_obj = MagicMock()
+    state_obj.state = "opening"
+    mock_hass.states.get.return_value = state_obj
     with patch(
         "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
         return_value={"has_stop": True},
@@ -1298,6 +1301,9 @@ async def test_stop_in_flight_dry_run_no_send(svc, mock_hass):
 async def test_stop_all_dry_run_no_send(svc, mock_hass):
     """stop_all with dry_run=True skips async_call but still reports stopped entities."""
     svc.dry_run = True
+    state_obj = MagicMock()
+    state_obj.state = "closing"
+    mock_hass.states.get.return_value = state_obj
     with patch(
         "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
         return_value={"has_stop": True},


### PR DESCRIPTION
## Summary

- **Root cause:** `stop_all()` and `stop_in_flight()` fired `cover.stop_cover` against every configured cover without checking whether the cover was actually moving. On Somfy RTS/io awnings (and similar hardware), `cover.stop_cover` sent to a **stationary** cover triggers the motor's "My" preset position — actively moving the cover rather than stopping it.
- **Fix:** Added `_is_cover_in_motion()` helper that reads `hass.states.get(entity_id).state`. Only covers in `opening` or `closing` state receive the stop command. Stationary covers are skipped with a debug log. The integration gate (`enabled_toggle = False`), timer cancels, and target clears still run unconditionally so freeze-in-place semantics are preserved.
- Both the `emergency_stop` path (`stop_all`) and the `integration_disable` path (`stop_in_flight`) are gated. Stale `wait_for_target`/`_sent_at` bookkeeping is still cleared on stationary-skip in `stop_in_flight`.

## Testing

- ✅ 1957 tests passing
- ✅ 3 new regression tests: stationary skip for `stop_in_flight`, `stop_all`, and mixed set (only moving cover stopped)
- ✅ `ruff check` clean

## Related Issues

Fixes #197
Refs #186, PR #189