### PR TITLE
fix(pipeline): GlareZoneHandler used max() instead of min() for zone selection

### DIFF
--- a/.deploy.example
+++ b/.deploy.example
@@ -1,0 +1,13 @@
+# Deploy configuration for scripts/deploy
+# Copy this file to .deploy and fill in your values.
+# .deploy is .gitignored — never commit credentials.
+
+# SMB share settings
+HA_SMB_HOST="home-assistant.home"
+HA_SMB_SHARE="config"
+#HA_SMB_USER="your-username"   # omit for guest access
+#HA_SMB_PASS="your-password"
+
+# Home Assistant REST API (used for optional restart after deploy)
+HA_URL="http://home-assistant.home:8123"
+#HA_TOKEN="your-long-lived-access-token"

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ coverage.xml
 # don't place superpower documents in the repo
 docs/superpowers/
 
+# Deploy config (credentials — never commit)
+.deploy
+
 # Home Assistant configuration
 config/*
 !config/configuration.yaml

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -960,7 +960,11 @@ def _format_duration(dur: dict | int | float | None) -> str:
     return " ".join(parts) if parts else "0 min"
 
 
-def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa: C901, PLR0912, PLR0915
+def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
+    config: dict,
+    sensor_type: str | None,
+    hass: HomeAssistant | None = None,
+) -> str:
     """Build a narrative summary of the current configuration.
 
     Produces four sections:
@@ -1083,6 +1087,100 @@ def _build_config_summary(config: dict, sensor_type: str | None) -> str:  # noqa
             parts.append(f"mode: {v}")
         if parts:
             lines.append(", ".join(parts))
+
+    # =========================================================================
+    # Section 1b: Cover Capabilities
+    # =========================================================================
+    if hass is not None and entities:
+        from .helpers import check_cover_features
+
+        lines.append("")
+        lines.append("**Cover Capabilities**")
+
+        cap_map: dict[str, dict[str, bool] | None] = {}
+        cap_label_map = {
+            "has_set_position": "set position",
+            "has_set_tilt_position": "set tilt",
+            "has_open": "open",
+            "has_close": "close",
+            "has_stop": "stop",
+        }
+
+        for eid in entities:
+            caps = check_cover_features(hass, eid)
+            cap_map[eid] = caps
+            if caps is None:
+                lines.append(f"⚠️ {eid}: not ready (unavailable)")
+            else:
+                cap_list = ", ".join(
+                    label
+                    for key, label in cap_label_map.items()
+                    if caps.get(key)
+                )
+                lines.append(f"{eid}: {cap_list or 'none detected'}")
+                if not caps.get("has_set_position"):
+                    lines.append(
+                        f"  ⚠️ {eid} is open/close-only — will be driven via "
+                        "threshold compare, not set_position."
+                    )
+                # (5) Assumed state
+                state = hass.states.get(eid)
+                if state and state.attributes.get("assumed_state"):
+                    lines.append(
+                        f"  ⚠️ {eid} has assumed_state — real position cannot be "
+                        "read back, which may affect position verification and delta-bypass."
+                    )
+
+        # Cross-entity consistency warnings — only for entities whose caps are known
+        known: dict[str, dict[str, bool]] = {
+            eid: caps for eid, caps in cap_map.items() if caps is not None
+        }
+
+        if known:
+            # (6) Mixed capabilities
+            has_pos = {eid for eid, caps in known.items() if caps.get("has_set_position")}
+            no_pos = {eid for eid, caps in known.items() if not caps.get("has_set_position")}
+            if has_pos and no_pos:
+                lines.append(
+                    "⚠️ Mixed capabilities: some covers support set_position, "
+                    "others are open/close-only — they will be driven differently."
+                )
+
+            # (7) Sensor-type vs. capability mismatch
+            if sensor_type == SensorType.TILT:
+                if not any(caps.get("has_set_tilt_position") for caps in known.values()):
+                    lines.append(
+                        "⚠️ Configured as tilt (venetian) but no bound cover "
+                        "advertises set_tilt_position."
+                    )
+            elif sensor_type in (SensorType.BLIND, SensorType.AWNING):
+                if not any(caps.get("has_set_position") for caps in known.values()):
+                    type_word = (
+                        "vertical blind" if sensor_type == SensorType.BLIND else "awning"
+                    )
+                    lines.append(
+                        f"⚠️ Configured as {type_word} but no bound cover supports "
+                        "set_position — only open/close will be issued."
+                    )
+
+            # (8) Position limits configured but cover is open/close-only
+            min_pos_val = config.get(CONF_MIN_POSITION)
+            max_pos_val = config.get(CONF_MAX_POSITION)
+            enable_min_val = config.get(CONF_ENABLE_MIN_POSITION)
+            enable_max_val = config.get(CONF_ENABLE_MAX_POSITION)
+            limits_in_use = (
+                (min_pos_val is not None and min_pos_val != 0)
+                or (max_pos_val is not None and max_pos_val != 100)
+                or enable_min_val
+                or enable_max_val
+            )
+            oc_only = [eid for eid in no_pos if eid in known]
+            if limits_in_use and oc_only:
+                oc_str = ", ".join(oc_only)
+                lines.append(
+                    f"⚠️ Position limits are configured but {oc_str} "
+                    "is open/close-only — limits will be ignored on that cover."
+                )
 
     # =========================================================================
     # Section 2: How It Decides
@@ -2336,7 +2434,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Show a read-only summary of all collected configuration before creating the entry."""
         if user_input is not None:
             return await self.async_step_update()
-        summary_text = _build_config_summary(self.config, self.type_blind)
+        summary_text = _build_config_summary(self.config, self.type_blind, self.hass)
         return self.async_show_form(
             step_id="summary",
             data_schema=vol.Schema({}),
@@ -3188,7 +3286,7 @@ class OptionsFlowHandler(OptionsFlow):
         """Show a read-only summary of the current configuration."""
         if user_input is not None:
             return await self.async_step_init()
-        summary_text = _build_config_summary(self.options, self.sensor_type)
+        summary_text = _build_config_summary(self.options, self.sensor_type, self.hass)
         return self.async_show_form(
             step_id="summary",
             data_schema=vol.Schema({}),

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -150,6 +150,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SENSOR_TYPE_MENU = [SensorType.BLIND, SensorType.AWNING, SensorType.TILT]
 
+_STANDALONE_SENTINEL = "__standalone__"
+
 # Icons for options menu — defined once here so all languages use the same icons.
 # Text labels come from translations at runtime.
 MENU_ICONS: dict[str, str] = {
@@ -169,7 +171,6 @@ MENU_ICONS: dict[str, str] = {
     "custom_position": "🎯",
     "motion_override": "🚶",
     "sync": "🔄",
-    "device": "🔗",
     "summary": "📋",
     "debug": "🔍",
     "done": "✅",
@@ -970,6 +971,7 @@ def _check_cover_capabilities(
     Returns:
         cap_map:  entity_id → feature dict (None if entity unavailable)
         warnings: list of ⚠️ strings — per-entity and cross-entity issues
+
     """
     entities: list[str] = config.get(CONF_ENTITIES) or []
     if hass is None or not entities:
@@ -1975,8 +1977,15 @@ def _extract_shared_options(
     return {k: v for k, v in entry.options.items() if k in allowed_keys}
 
 
-def _build_cover_entity_schema(sensor_type: str) -> vol.Schema:
-    """Build entity selector schema based on cover type."""
+def _build_cover_entity_schema(
+    sensor_type: str,
+    devices: dict[str, str] | None = None,
+) -> vol.Schema:
+    """Build entity selector schema based on cover type.
+
+    When devices is provided and non-empty, a device association selector is
+    appended so both fields appear on the same form.
+    """
     if sensor_type == SensorType.TILT:
         entity_selector = selector.EntitySelector(
             selector.EntitySelectorConfig(
@@ -1996,7 +2005,22 @@ def _build_cover_entity_schema(sensor_type: str) -> vol.Schema:
                 ),
             )
         )
-    return vol.Schema({vol.Optional(CONF_ENTITIES, default=[]): entity_selector})
+    schema_dict: dict = {vol.Optional(CONF_ENTITIES, default=[]): entity_selector}
+    if devices:
+        options_list = [
+            {"value": _STANDALONE_SENTINEL, "label": "None (standalone device)"}
+        ]
+        for device_id, device_name in devices.items():
+            options_list.append({"value": device_id, "label": device_name})
+        schema_dict[vol.Required(CONF_DEVICE_ID, default=_STANDALONE_SENTINEL)] = (
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=options_list,
+                    mode=selector.SelectSelectorMode.LIST,
+                )
+            )
+        )
+    return vol.Schema(schema_dict)
 
 
 def _get_geometry_schema(sensor_type: str) -> vol.Schema:
@@ -2078,6 +2102,8 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self.mode: str = "basic"
         self.selected_source_entry_id: str | None = None
         self.setup_mode: str = "quick"  # "quick" or "full"
+        self._has_device_options: bool = False
+        self._cover_devices: dict[str, str] = {}
 
     def optional_entities(self, keys: list, user_input: dict[str, Any]) -> None:
         """Set value to None if key does not exist in user_input."""
@@ -2130,16 +2156,30 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return await self.async_step_cover_entities()
 
     async def async_step_cover_entities(self, user_input: dict[str, Any] | None = None):
-        """Select cover entities."""
-        if user_input is not None:
-            self.config.update(user_input)
+        """Select cover entities and optionally link to a physical device.
 
-            # Extract first cover entity's name to auto-populate device name
+        Pass 1 (entities only): user selects cover entities; if they have associated
+        physical devices the form is re-rendered with a device selector appended.
+        Pass 2 (combined, only when devices exist): both fields are submitted together
+        and the flow proceeds to geometry.
+        """
+        if user_input is not None:
+            if self._has_device_options:
+                # Pass 2: process entity + device selection
+                self.config.update(user_input)
+                device_id = user_input.get(CONF_DEVICE_ID, _STANDALONE_SENTINEL)
+                if device_id and device_id != _STANDALONE_SENTINEL:
+                    self.config[CONF_DEVICE_ID] = device_id
+                else:
+                    self.config.pop(CONF_DEVICE_ID, None)
+                return await self.async_step_geometry()
+
+            # Pass 1: store entities, auto-name, check for associated devices
+            self.config.update(user_input)
             if CONF_ENTITIES in user_input and user_input[CONF_ENTITIES]:
                 first_entity_id = user_input[CONF_ENTITIES][0]
                 entity_reg = er.async_get(self.hass)
                 entity_entry = entity_reg.async_get(first_entity_id)
-
                 if entity_entry:
                     entity_name = (
                         entity_entry.original_name
@@ -2148,54 +2188,22 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                     )
                     self.config["name"] = f"Adaptive {entity_name}"
 
-            # Check for device association
             entity_ids = self.config.get(CONF_ENTITIES, [])
             devices = await _get_devices_from_entities(self.hass, entity_ids)
             if devices:
-                return await self.async_step_device_association()
+                self._has_device_options = True
+                self._cover_devices = devices
+                schema = _build_cover_entity_schema(self.type_blind, devices=devices)
+                return self.async_show_form(
+                    step_id="cover_entities",
+                    data_schema=self.add_suggested_values_to_schema(
+                        schema, self.config
+                    ),
+                )
             return await self.async_step_geometry()
 
         schema = _build_cover_entity_schema(self.type_blind)
         return self.async_show_form(step_id="cover_entities", data_schema=schema)
-
-    async def async_step_device_association(
-        self, user_input: dict[str, Any] | None = None
-    ):
-        """Show optional device association step."""
-        _standalone_sentinel = "__standalone__"
-        entity_ids = self.config.get(CONF_ENTITIES, [])
-        devices = await _get_devices_from_entities(self.hass, entity_ids)
-
-        if not devices:
-            return await self.async_step_geometry()
-
-        if user_input is not None:
-            device_id = user_input.get(CONF_DEVICE_ID, _standalone_sentinel)
-            if device_id and device_id != _standalone_sentinel:
-                self.config[CONF_DEVICE_ID] = device_id
-            else:
-                self.config.pop(CONF_DEVICE_ID, None)
-            return await self.async_step_geometry()
-
-        options_list = [
-            {"value": _standalone_sentinel, "label": "None (standalone device)"}
-        ]
-        for device_id, device_name in devices.items():
-            options_list.append({"value": device_id, "label": device_name})
-
-        schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_DEVICE_ID, default=_standalone_sentinel
-                ): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=options_list,
-                        mode=selector.SelectSelectorMode.LIST,
-                    )
-                ),
-            }
-        )
-        return self.async_show_form(step_id="device_association", data_schema=schema)
 
     async def async_step_geometry(self, user_input: dict[str, Any] | None = None):
         """Configure cover geometry dimensions."""
@@ -2789,7 +2797,7 @@ class OptionsFlowHandler(OptionsFlow):
         keys.append("sync")
 
         # ── Admin ────────────────────────────────────────────────────
-        keys.extend(["device", "summary", "debug", "done"])
+        keys.extend(["summary", "debug", "done"])
 
         # Fetch localized labels and prepend icons defined in MENU_ICONS
         trans_prefix = "component.adaptive_cover_pro.options.step.init.menu_options."
@@ -2807,17 +2815,27 @@ class OptionsFlowHandler(OptionsFlow):
         return self.async_show_menu(step_id="init", menu_options=menu_options)  # type: ignore[return-value]
 
     async def async_step_cover_entities(self, user_input: dict[str, Any] | None = None):
-        """Adjust cover entities."""
+        """Adjust cover entities and device association on a single combined form."""
+        entity_ids = self.options.get(CONF_ENTITIES, [])
+        devices = await _get_devices_from_entities(self.hass, entity_ids)
+
         if user_input is not None:
             self.options.update(user_input)
+            device_id = user_input.get(CONF_DEVICE_ID, _STANDALONE_SENTINEL)
+            if device_id and device_id != _STANDALONE_SENTINEL:
+                self.options[CONF_DEVICE_ID] = device_id
+            else:
+                self.options.pop(CONF_DEVICE_ID, None)
             return await self.async_step_init()
 
-        schema = _build_cover_entity_schema(self.sensor_type)
+        current_device = self.options.get(CONF_DEVICE_ID) or _STANDALONE_SENTINEL
+        schema = _build_cover_entity_schema(self.sensor_type, devices=devices or None)
+        suggested = dict(self.options)
+        if devices:
+            suggested.setdefault(CONF_DEVICE_ID, current_device)
         return self.async_show_form(
             step_id="cover_entities",
-            data_schema=self.add_suggested_values_to_schema(
-                schema, user_input or self.options
-            ),
+            data_schema=self.add_suggested_values_to_schema(schema, suggested),
         )
 
     async def async_step_geometry(self, user_input: dict[str, Any] | None = None):
@@ -2976,49 +2994,6 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="weather_override",
             data_schema=self.add_suggested_values_to_schema(
                 WEATHER_OVERRIDE_SCHEMA, user_input or self.options
-            ),
-        )
-
-    async def async_step_device(self, user_input: dict[str, Any] | None = None):
-        """Manage device association."""
-        _standalone_sentinel = "__standalone__"
-        entity_ids = self.options.get(CONF_ENTITIES, [])
-        devices = await _get_devices_from_entities(self.hass, entity_ids)
-
-        if user_input is not None:
-            device_id = user_input.get(CONF_DEVICE_ID, _standalone_sentinel)
-            if device_id and device_id != _standalone_sentinel:
-                self.options[CONF_DEVICE_ID] = device_id
-            else:
-                self.options.pop(CONF_DEVICE_ID, None)
-            return await self.async_step_init()
-
-        if not devices:
-            # No devices available — clear any stale association and update immediately
-            self.options.pop(CONF_DEVICE_ID, None)
-            return await self.async_step_init()
-
-        current_device = self.options.get(CONF_DEVICE_ID) or _standalone_sentinel
-        options_list = [
-            {"value": _standalone_sentinel, "label": "None (standalone device)"}
-        ]
-        for device_id, device_name in devices.items():
-            options_list.append({"value": device_id, "label": device_name})
-
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_DEVICE_ID): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=options_list,
-                        mode=selector.SelectSelectorMode.LIST,
-                    )
-                ),
-            }
-        )
-        return self.async_show_form(
-            step_id="device",
-            data_schema=self.add_suggested_values_to_schema(
-                schema, {CONF_DEVICE_ID: current_device}
             ),
         )
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -960,6 +960,136 @@ def _format_duration(dur: dict | int | float | None) -> str:
     return " ".join(parts) if parts else "0 min"
 
 
+def _check_cover_capabilities(
+    config: dict,
+    sensor_type: str | None,
+    hass: HomeAssistant | None,
+) -> tuple[dict[str, dict[str, bool] | None], list[str]]:
+    """Inspect bound cover entities and return capabilities + warning lines.
+
+    Returns:
+        cap_map:  entity_id → feature dict (None if entity unavailable)
+        warnings: list of ⚠️ strings — per-entity and cross-entity issues
+    """
+    entities: list[str] = config.get(CONF_ENTITIES) or []
+    if hass is None or not entities:
+        return {}, []
+
+    from .helpers import check_cover_features
+
+    cap_map: dict[str, dict[str, bool] | None] = {}
+    warnings: list[str] = []
+
+    for eid in entities:
+        caps = check_cover_features(hass, eid)
+        cap_map[eid] = caps
+        if caps is None:
+            warnings.append(f"⚠️ {eid}: not ready (unavailable)")
+        else:
+            if not caps.get("has_set_position"):
+                warnings.append(
+                    f"⚠️ {eid} is open/close-only — will be driven via "
+                    "threshold compare, not set_position."
+                )
+            state = hass.states.get(eid)
+            if state and state.attributes.get("assumed_state"):
+                warnings.append(
+                    f"⚠️ {eid} has assumed_state — real position cannot be "
+                    "read back, which may affect position verification and delta-bypass."
+                )
+
+    known: dict[str, dict[str, bool]] = {
+        eid: caps for eid, caps in cap_map.items() if caps is not None
+    }
+
+    if known:
+        has_pos = {eid for eid, caps in known.items() if caps.get("has_set_position")}
+        no_pos = {eid for eid, caps in known.items() if not caps.get("has_set_position")}
+
+        if has_pos and no_pos:
+            warnings.append(
+                "⚠️ Mixed capabilities: some covers support set_position, "
+                "others are open/close-only — they will be driven differently."
+            )
+
+        if sensor_type == SensorType.TILT:
+            if not any(caps.get("has_set_tilt_position") for caps in known.values()):
+                warnings.append(
+                    "⚠️ Configured as tilt (venetian) but no bound cover "
+                    "advertises set_tilt_position."
+                )
+        elif sensor_type in (SensorType.BLIND, SensorType.AWNING):
+            if not any(caps.get("has_set_position") for caps in known.values()):
+                type_word = (
+                    "vertical blind" if sensor_type == SensorType.BLIND else "awning"
+                )
+                warnings.append(
+                    f"⚠️ Configured as {type_word} but no bound cover supports "
+                    "set_position — only open/close will be issued."
+                )
+
+        min_pos_val = config.get(CONF_MIN_POSITION)
+        max_pos_val = config.get(CONF_MAX_POSITION)
+        enable_min_val = config.get(CONF_ENABLE_MIN_POSITION)
+        enable_max_val = config.get(CONF_ENABLE_MAX_POSITION)
+        limits_in_use = (
+            (min_pos_val is not None and min_pos_val != 0)
+            or (max_pos_val is not None and max_pos_val != 100)
+            or enable_min_val
+            or enable_max_val
+        )
+        oc_only = [eid for eid in no_pos if eid in known]
+        if limits_in_use and oc_only:
+            oc_str = ", ".join(oc_only)
+            warnings.append(
+                f"⚠️ Position limits are configured but {oc_str} "
+                "is open/close-only — limits will be ignored on that cover."
+            )
+
+    return cap_map, warnings
+
+
+def _build_cover_capabilities_text(
+    config: dict,
+    sensor_type: str | None,
+    hass: HomeAssistant | None = None,
+) -> str:
+    """Build a Cover Capabilities block for the Debug & Diagnostics screen.
+
+    Returns a markdown string (possibly empty) describing each bound cover's
+    detected features plus any cross-entity consistency warnings.
+    """
+    entities: list[str] = config.get(CONF_ENTITIES) or []
+    if hass is None or not entities:
+        return ""
+
+    cap_map, warnings = _check_cover_capabilities(config, sensor_type, hass)
+
+    cap_label_map = {
+        "has_set_position": "set position",
+        "has_set_tilt_position": "set tilt",
+        "has_open": "open",
+        "has_close": "close",
+        "has_stop": "stop",
+    }
+
+    lines: list[str] = ["**Cover Capabilities**"]
+    for eid in entities:
+        caps = cap_map.get(eid)
+        if caps is None:
+            lines.append(f"{eid}: not ready (unavailable)")
+        else:
+            cap_list = ", ".join(
+                label for key, label in cap_label_map.items() if caps.get(key)
+            )
+            lines.append(f"{eid}: {cap_list or 'none detected'}")
+
+    if warnings:
+        lines.extend(warnings)
+
+    return "\n".join(lines)
+
+
 def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     config: dict,
     sensor_type: str | None,
@@ -1089,98 +1219,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             lines.append(", ".join(parts))
 
     # =========================================================================
-    # Section 1b: Cover Capabilities
+    # Section 1c: Cover Capability Warnings
     # =========================================================================
-    if hass is not None and entities:
-        from .helpers import check_cover_features
-
+    _, cap_warnings = _check_cover_capabilities(config, sensor_type, hass)
+    if cap_warnings:
         lines.append("")
-        lines.append("**Cover Capabilities**")
-
-        cap_map: dict[str, dict[str, bool] | None] = {}
-        cap_label_map = {
-            "has_set_position": "set position",
-            "has_set_tilt_position": "set tilt",
-            "has_open": "open",
-            "has_close": "close",
-            "has_stop": "stop",
-        }
-
-        for eid in entities:
-            caps = check_cover_features(hass, eid)
-            cap_map[eid] = caps
-            if caps is None:
-                lines.append(f"⚠️ {eid}: not ready (unavailable)")
-            else:
-                cap_list = ", ".join(
-                    label
-                    for key, label in cap_label_map.items()
-                    if caps.get(key)
-                )
-                lines.append(f"{eid}: {cap_list or 'none detected'}")
-                if not caps.get("has_set_position"):
-                    lines.append(
-                        f"  ⚠️ {eid} is open/close-only — will be driven via "
-                        "threshold compare, not set_position."
-                    )
-                # (5) Assumed state
-                state = hass.states.get(eid)
-                if state and state.attributes.get("assumed_state"):
-                    lines.append(
-                        f"  ⚠️ {eid} has assumed_state — real position cannot be "
-                        "read back, which may affect position verification and delta-bypass."
-                    )
-
-        # Cross-entity consistency warnings — only for entities whose caps are known
-        known: dict[str, dict[str, bool]] = {
-            eid: caps for eid, caps in cap_map.items() if caps is not None
-        }
-
-        if known:
-            # (6) Mixed capabilities
-            has_pos = {eid for eid, caps in known.items() if caps.get("has_set_position")}
-            no_pos = {eid for eid, caps in known.items() if not caps.get("has_set_position")}
-            if has_pos and no_pos:
-                lines.append(
-                    "⚠️ Mixed capabilities: some covers support set_position, "
-                    "others are open/close-only — they will be driven differently."
-                )
-
-            # (7) Sensor-type vs. capability mismatch
-            if sensor_type == SensorType.TILT:
-                if not any(caps.get("has_set_tilt_position") for caps in known.values()):
-                    lines.append(
-                        "⚠️ Configured as tilt (venetian) but no bound cover "
-                        "advertises set_tilt_position."
-                    )
-            elif sensor_type in (SensorType.BLIND, SensorType.AWNING):
-                if not any(caps.get("has_set_position") for caps in known.values()):
-                    type_word = (
-                        "vertical blind" if sensor_type == SensorType.BLIND else "awning"
-                    )
-                    lines.append(
-                        f"⚠️ Configured as {type_word} but no bound cover supports "
-                        "set_position — only open/close will be issued."
-                    )
-
-            # (8) Position limits configured but cover is open/close-only
-            min_pos_val = config.get(CONF_MIN_POSITION)
-            max_pos_val = config.get(CONF_MAX_POSITION)
-            enable_min_val = config.get(CONF_ENABLE_MIN_POSITION)
-            enable_max_val = config.get(CONF_ENABLE_MAX_POSITION)
-            limits_in_use = (
-                (min_pos_val is not None and min_pos_val != 0)
-                or (max_pos_val is not None and max_pos_val != 100)
-                or enable_min_val
-                or enable_max_val
-            )
-            oc_only = [eid for eid in no_pos if eid in known]
-            if limits_in_use and oc_only:
-                oc_str = ", ".join(oc_only)
-                lines.append(
-                    f"⚠️ Position limits are configured but {oc_str} "
-                    "is open/close-only — limits will be ignored on that cover."
-                )
+        lines.append("**Cover Warnings**")
+        lines.extend(cap_warnings)
 
     # =========================================================================
     # Section 2: How It Decides
@@ -3300,11 +3345,15 @@ class OptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             self.options.update(user_input)
             return await self.async_step_init()
+        caps_text = _build_cover_capabilities_text(
+            self.options, self.sensor_type, self.hass
+        )
         return self.async_show_form(
             step_id="debug",
             data_schema=self.add_suggested_values_to_schema(
                 DEBUG_SCHEMA, user_input or self.options
             ),
+            description_placeholders={"cover_capabilities": caps_text},
         )
 
     async def async_step_done(

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -22,9 +22,13 @@ def glare_zone_effective_distance(
 ) -> float | None:
     """Convert a glare zone to an effective distance (metres) for this sun angle.
 
-    Returns the perpendicular depth into the room (in metres) that the blind
-    must shade to protect the nearest edge of the zone circle. Returns None if
-    the sun cannot reach this zone through the window opening at angle gamma.
+    Returns the perpendicular depth into the room (in metres) to the nearest
+    edge of the zone circle facing the sun. Returns None if the sun cannot
+    reach this zone through the window opening at angle gamma.
+
+    A smaller return value means the zone is closer to the window and requires
+    MORE blind coverage (lower position%) to protect. The GlareZoneHandler
+    uses min() across zones to select the most restrictive (closest) zone.
 
     Args:
         zone: The glare zone definition (x, y in cm, radius in cm).

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
@@ -1,4 +1,10 @@
-"""Glare zone handler — extend blind to protect specific floor zones from glare."""
+"""Glare zone handler — lower blind to protect specific floor zones from glare.
+
+Fix: use min() (closest zone) instead of max() (farthest zone) for zone
+selection. The closest zone demands the most blind coverage because smaller
+effective distance → lower position% → more blind deployed.
+Thanks to @ZamenWolk for identifying this in GitHub issue #213.
+"""
 
 from __future__ import annotations
 
@@ -15,15 +21,20 @@ from ..types import PipelineResult, PipelineSnapshot
 
 
 class GlareZoneHandler(OverrideHandler):
-    """Extend the blind further when active glare zones require additional protection.
+    """Lower the blind further when active glare zones need more protection than SolarHandler.
 
     Priority 45 — between ClimateHandler (50) and SolarHandler (40).
     Only applies to vertical covers (cover_blind). Computes effective distances
     for all active glare zones using pure geometry, then returns a position
-    based on the maximum distance if it exceeds the cover's base distance.
+    based on the minimum (closest) zone distance when it is less than the
+    cover's base distance.
 
-    Falls through to SolarHandler (returns None) when the base distance
-    already provides sufficient coverage for all zones.
+    Geometry: smaller effective distance → lower position% → more blind deployed.
+    A zone closer to the window than the base distance is in the illuminated area
+    and needs the blind lowered further than SolarHandler would compute.
+
+    Falls through to SolarHandler (returns None) when all zones are at or beyond
+    the base distance (already in shadow from normal solar tracking).
     """
 
     name = "glare_zone"
@@ -59,15 +70,20 @@ class GlareZoneHandler(OverrideHandler):
         if not zone_results:
             return None
 
-        max_distance = max(d for _, d in zone_results)
-        contributing_zones = [name for name, d in zone_results if d == max_distance]
+        # The CLOSEST zone is most restrictive: smaller distance → lower position%
+        # → more blind deployed → more protection. A blind set to block sun beyond
+        # depth d allows sun to penetrate up to d from the window. So the zone
+        # nearest to the window demands the most blind coverage.
+        min_distance = min(d for _, d in zone_results)
+        contributing_zones = [name for name, d in zone_results if d == min_distance]
 
-        if max_distance <= base_distance:
-            # No zone requires deeper coverage — let SolarHandler handle it
+        if min_distance >= base_distance:
+            # All zones are at or beyond the base distance — they're already in
+            # shadow from SolarHandler's normal calculation. No override needed.
             return None
 
         state = int(
-            round(cover.calculate_percentage(effective_distance_override=max_distance))
+            round(cover.calculate_percentage(effective_distance_override=min_distance))
         )
         state = max(state, 1)
         position = apply_snapshot_limits(snapshot, state, sun_valid=True)
@@ -78,7 +94,7 @@ class GlareZoneHandler(OverrideHandler):
             control_method=ControlMethod.GLARE_ZONE,
             reason=(
                 f"glare zone protection ({zone_names}) — "
-                f"effective distance {max_distance:.2f}m → position {position}%"
+                f"effective distance {min_distance:.2f}m → position {position}%"
             ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )

--- a/custom_components/adaptive_cover_pro/strings.json
+++ b/custom_components/adaptive_cover_pro/strings.json
@@ -288,7 +288,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -302,7 +302,6 @@
           "force_override": "Force Override",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"

--- a/custom_components/adaptive_cover_pro/translations/cs.json
+++ b/custom_components/adaptive_cover_pro/translations/cs.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -16,13 +16,15 @@
         }
       },
       "cover_entities": {
-        "title": "Abdeckungs-Entitäten",
+        "title": "Abdeckungen & Gerät",
         "description": "Wählen Sie die Abdeckungs-Entitäten aus, die diese Instanz steuern soll.",
         "data": {
-          "group": "Abdeckungs-Entitäten"
+          "group": "Abdeckungs-Entitäten",
+          "linked_device_id": "An Gerät anhängen"
         },
         "data_description": {
-          "group": "Wählen Sie die Abdeckungs-Entitäten aus, die über diese Integrationsinstanz gesteuert werden sollen. Sie können mehrere Abdeckungen als Gruppe auswählen (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Abdeckungen für dieses Fenster – erstellen Sie für andere Fenster separate Integrationsinstanzen."
+          "group": "Wählen Sie die Abdeckungs-Entitäten aus, die über diese Integrationsinstanz gesteuert werden sollen. Sie können mehrere Abdeckungen als Gruppe auswählen (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Abdeckungen für dieses Fenster – erstellen Sie für andere Fenster separate Integrationsinstanzen.",
+          "linked_device_id": "Physisches Gerät auswählen, in das die Entitäten zusammengeführt werden. Sensoren, Schalter und Schaltflächen erscheinen dann direkt unter diesem Gerät. 'Kein (eigenständiges Gerät)' wählen, um ein separates virtuelles Adaptive Cover-Gerät zu behalten."
         }
       },
       "geometry": {
@@ -352,16 +354,6 @@
           "interp_list_new": "Ausgangspositionen für benutzerdefinierte Interpolationszuordnung (tatsächlich gesendete Werte). Entsprechende echte Positionen eingeben, z. B.: 0, 20, 40, 65, 100. Gleiche Länge wie Interpolationsliste."
         }
       },
-      "device_association": {
-        "title": "Mit vorhandenem Gerät verknüpfen",
-        "description": "Hängen Sie die Entitäten dieser Integration optional an ein vorhandenes Gerät (z. B. den physischen Jalousienmotor) an. 'Kein' auswählen, um sie als eigenständiges virtuelles Adaptive Cover-Gerät zu behalten.",
-        "data": {
-          "linked_device_id": "An Gerät anhängen"
-        },
-        "data_description": {
-          "linked_device_id": "Physisches Gerät auswählen, in das die Entitäten zusammengeführt werden. Sensoren, Schalter und Schaltflächen erscheinen dann direkt unter diesem Gerät. 'Kein (eigenständiges Gerät)' wählen, um ein separates virtuelles Adaptive Cover-Gerät zu behalten."
-        }
-      },
       "duplicate_select": {
         "title": "Abdeckung duplizieren — Quelle auswählen",
         "description": "Wählen Sie, von welcher vorhandenen Abdeckung die Einstellungen dupliziert werden sollen.",
@@ -429,7 +421,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Abdeckungs-Entitäten",
+          "cover_entities": "Abdeckungen & Gerät",
           "geometry": "Fenstergeometrie",
           "sun_tracking": "Sonnenverfolgung",
           "position": "Positionseinstellungen",
@@ -444,7 +436,6 @@
           "custom_position": "Benutzerdefinierte Positionen",
           "motion_override": "Bewegungsübersteuerung",
           "weather_override": "Wetterübersteuerung",
-          "device": "Gerätezuordnung",
           "summary": "Konfigurationsübersicht",
           "sync": "Einstellungen auf andere Abdeckungen kopieren",
           "done": "Speichern & Schließen",
@@ -475,13 +466,15 @@
         }
       },
       "cover_entities": {
-        "title": "Abdeckungs-Entitäten",
+        "title": "Abdeckungen & Gerät",
         "description": "Wählen Sie die Abdeckungs-Entitäten aus, die diese Instanz steuern soll.",
         "data": {
-          "group": "Abdeckungs-Entitäten"
+          "group": "Abdeckungs-Entitäten",
+          "linked_device_id": "An Gerät anhängen"
         },
         "data_description": {
-          "group": "Wählen Sie die Abdeckungs-Entitäten aus. Mehrere Abdeckungen als Gruppe auswählen möglich. Nur Abdeckungen für dieses Fenster – separate Instanzen für andere Fenster erstellen."
+          "group": "Wählen Sie die Abdeckungs-Entitäten aus. Mehrere Abdeckungen als Gruppe auswählen möglich. Nur Abdeckungen für dieses Fenster – separate Instanzen für andere Fenster erstellen.",
+          "linked_device_id": "Physisches Gerät auswählen für Zusammenführung. 'Kein (eigenständiges Gerät)' für separates Gerät."
         }
       },
       "geometry": {
@@ -787,16 +780,6 @@
           "glare_zone_4_x": "Versatz vom Fenstermittelpunkt in cm. Positiv = rechts.",
           "glare_zone_4_y": "Raumtiefe in cm.",
           "glare_zone_4_radius": "Schutzradius in cm."
-        }
-      },
-      "device": {
-        "title": "Gerätezuordnung",
-        "description": "Entitäten dieser Integration mit einem vorhandenen Gerät verknüpfen oder eine bestehende Verknüpfung entfernen.",
-        "data": {
-          "linked_device_id": "An Gerät anhängen"
-        },
-        "data_description": {
-          "linked_device_id": "Physisches Gerät auswählen für Zusammenführung. 'Kein (eigenständiges Gerät)' für separates Gerät."
         }
       },
       "sync": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -889,7 +889,7 @@
       },
       "debug": {
         "title": "Debug & Diagnostics",
-        "description": "Enable debug mode to collect detailed troubleshooting data without editing configuration.yaml. When active, selected categories are logged at INFO level and a ring buffer of manual-override decisions is kept in memory and exposed in the HA Diagnostics download.",
+        "description": "Enable debug mode to collect detailed troubleshooting data without editing configuration.yaml. When active, selected categories are logged at INFO level and a ring buffer of manual-override decisions is kept in memory and exposed in the HA Diagnostics download.\n\n{cover_capabilities}",
         "data": {
           "dry_run": "Dry Run (no cover movement)",
           "debug_mode": "Enable Debug Mode",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -16,13 +16,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -378,16 +380,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -478,7 +470,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Window Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -493,7 +485,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy to Other Covers",
           "debug": "Debug & Diagnostics",
@@ -525,13 +516,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -863,16 +856,6 @@
           "glare_zone_4_x": "Left/right offset from window centre in cm. Positive = right.",
           "glare_zone_4_y": "Distance into the room in cm (perpendicular to window).",
           "glare_zone_4_radius": "Protection radius around the zone centre in cm."
-        }
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "sync": {

--- a/custom_components/adaptive_cover_pro/translations/es.json
+++ b/custom_components/adaptive_cover_pro/translations/es.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Entidades de las persianas"
+          "group": "Entidades de las persianas",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Seleccionar entidades para controlar vía la integración"
+          "group": "Seleccionar entidades para controlar vía la integración",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -246,16 +248,6 @@
         "title": "Position Calibration",
         "description": "Ajuste los valores a los que la cubierta se abre o cierra eficazmente. Ideal para cubiertas que no abren completamente al 0 % ni cierran al 100 %. \n Los dos primeros controles deslizantes son para un ajuste de 2 puntos, las opciones de lista son para un ajuste de varios puntos"
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -286,7 +278,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -301,7 +293,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -330,13 +321,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Entidades de persiana"
+          "group": "Entidades de persiana",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Seleccionar entidades para controlar via integración"
+          "group": "Seleccionar entidades para controlar via integración",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -543,16 +536,6 @@
         },
         "title": "Position Calibration",
         "description": "Ajuste los valores con los que la persiana se abre o cierra. Ideal para persianas que no se abren completamente al 0 % ni se cierran al 100 %. Los dos primeros controles deslizantes son para un ajuste de 2 puntos; las opciones de lista son para un ajuste de varios puntos."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -16,13 +16,15 @@
         }
       },
       "cover_entities": {
-        "title": "Entités de store",
+        "title": "Stores & Appareil",
         "description": "Sélectionnez les entités de store que cette instance va contrôler.",
         "data": {
-          "group": "Entités de store"
+          "group": "Entités de store",
+          "linked_device_id": "Associer à l'appareil"
         },
         "data_description": {
-          "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores en tant que groupe (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores associés à cette fenêtre — créez des instances d'intégration séparées pour des fenêtres différentes."
+          "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores en tant que groupe (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores associés à cette fenêtre — créez des instances d'intégration séparées pour des fenêtres différentes.",
+          "linked_device_id": "Sélectionnez un appareil physique dans lequel fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons apparaîtront directement sous cet appareil dans Home Assistant. Sélectionner 'Aucun (appareil indépendant)' pour revenir à un appareil virtuel Adaptive Cover séparé."
         }
       },
       "geometry": {
@@ -352,16 +354,6 @@
           "interp_list_new": "Positions de sortie pour le mappage d'interpolation (positions réellement envoyées au store). Saisir les positions réelles correspondantes : 0, 20, 40, 65, 100. Même longueur que la liste d'interpolation."
         }
       },
-      "device_association": {
-        "title": "Associer à un appareil existant",
-        "description": "Associez optionnellement les entités de cette intégration à un appareil existant (ex. le moteur physique du store). Sélectionner 'Aucun' pour les conserver comme appareil virtuel Adaptive Cover indépendant.",
-        "data": {
-          "linked_device_id": "Associer à l'appareil"
-        },
-        "data_description": {
-          "linked_device_id": "Sélectionnez un appareil physique dans lequel fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons apparaîtront directement sous cet appareil dans Home Assistant. Sélectionner 'Aucun (appareil indépendant)' pour revenir à un appareil virtuel Adaptive Cover séparé."
-        }
-      },
       "duplicate_select": {
         "title": "Dupliquer le store — Sélectionner la source",
         "description": "Choisissez le store existant dont vous souhaitez dupliquer les paramètres.",
@@ -429,7 +421,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Entités de store",
+          "cover_entities": "Stores & Appareil",
           "geometry": "Géométrie de fenêtre",
           "sun_tracking": "Suivi solaire",
           "position": "Paramètres de position",
@@ -444,7 +436,6 @@
           "custom_position": "Positions personnalisées",
           "motion_override": "Priorité mouvement",
           "weather_override": "Priorité météo",
-          "device": "Association d'appareil",
           "summary": "Résumé de la configuration",
           "sync": "Copier vers d'autres stores",
           "done": "Enregistrer et fermer",
@@ -475,13 +466,15 @@
         }
       },
       "cover_entities": {
-        "title": "Entités de store",
+        "title": "Stores & Appareil",
         "description": "Sélectionnez les entités de store que cette instance va contrôler.",
         "data": {
-          "group": "Entités de store"
+          "group": "Entités de store",
+          "linked_device_id": "Associer à l'appareil"
         },
         "data_description": {
-          "group": "Sélectionnez les entités de store à contrôler. Plusieurs stores peuvent être sélectionnés en groupe. Ne sélectionnez que les stores pour cette fenêtre — créez des instances séparées pour d'autres fenêtres."
+          "group": "Sélectionnez les entités de store à contrôler. Plusieurs stores peuvent être sélectionnés en groupe. Ne sélectionnez que les stores pour cette fenêtre — créez des instances séparées pour d'autres fenêtres.",
+          "linked_device_id": "Sélectionnez un appareil physique pour la fusion. Sélectionner 'Aucun (appareil indépendant)' pour un appareil virtuel séparé."
         }
       },
       "geometry": {
@@ -787,16 +780,6 @@
           "glare_zone_4_x": "Décalage depuis le centre de fenêtre en cm. Positif = droite.",
           "glare_zone_4_y": "Distance dans la pièce en cm.",
           "glare_zone_4_radius": "Rayon de protection en cm."
-        }
-      },
-      "device": {
-        "title": "Association d'appareil",
-        "description": "Associez les entités de cette intégration à un appareil existant ou supprimez une association existante.",
-        "data": {
-          "linked_device_id": "Associer à l'appareil"
-        },
-        "data_description": {
-          "linked_device_id": "Sélectionnez un appareil physique pour la fusion. Sélectionner 'Aucun (appareil indépendant)' pour un appareil virtuel séparé."
         }
       },
       "sync": {

--- a/custom_components/adaptive_cover_pro/translations/hu.json
+++ b/custom_components/adaptive_cover_pro/translations/hu.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/it.json
+++ b/custom_components/adaptive_cover_pro/translations/it.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/nl.json
+++ b/custom_components/adaptive_cover_pro/translations/nl.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entiteiten"
+          "group": "Cover Entiteiten",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Selecteer entiteiten om te besturen via integratie"
+          "group": "Selecteer entiteiten om te besturen via integratie",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -244,16 +246,6 @@
         "title": "Position Calibration",
         "description": "Pas de waarden aan waarbij jouw Cover effectief opent of sluit. Ideaal voor Covers die niet volledig openen bij 0% of sluiten bij 100%."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -284,7 +276,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -299,7 +291,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -328,13 +319,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entiteiten"
+          "group": "Cover Entiteiten",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Selecteer entiteiten om te besturen via integratie"
+          "group": "Selecteer entiteiten om te besturen via integratie",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -531,16 +524,6 @@
         },
         "title": "Position Calibration",
         "description": "Pas de waarden aan waarbij jouw Cover effectief opent of sluit. Ideaal voor Covers die niet volledig openen bij 0% of sluiten bij 100%."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/pl.json
+++ b/custom_components/adaptive_cover_pro/translations/pl.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/pt-BR.json
+++ b/custom_components/adaptive_cover_pro/translations/pt-BR.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/sk.json
+++ b/custom_components/adaptive_cover_pro/translations/sk.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Krycie entity"
+          "group": "Krycie entity",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Vyberte entity na riadenie prostredníctvom integrácie"
+          "group": "Vyberte entity na riadenie prostredníctvom integrácie",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -246,16 +248,6 @@
         "title": "Position Calibration",
         "description": "Upravte hodnoty, pri ktorých sa kryt efektívne otvára alebo zatvára. Ideálne pre kryty, ktoré sa úplne neotvoria pri 0 % alebo nezatvoria pri 100 %. \n Prvé dva posuvníky sú pre 2-bodové nastavenie, možnosti zoznamu sú pre viacbodové nastavenie"
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -286,7 +278,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -301,7 +293,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -330,13 +321,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Krycie entity"
+          "group": "Krycie entity",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Vyberte entity na riadenie prostredníctvom integrácie"
+          "group": "Vyberte entity na riadenie prostredníctvom integrácie",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -543,16 +536,6 @@
         },
         "title": "Position Calibration",
         "description": "Upravte hodnoty, pri ktorých sa kryt efektívne otvára alebo zatvára. Ideálne pre kryty, ktoré sa úplne neotvoria pri 0 % alebo nezatvoria pri 100 %. \n Prvé dva posuvníky sú pre 2-bodové nastavenie, možnosti zoznamu sú pre viacbodové nastavenie"
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/sl.json
+++ b/custom_components/adaptive_cover_pro/translations/sl.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/custom_components/adaptive_cover_pro/translations/uk.json
+++ b/custom_components/adaptive_cover_pro/translations/uk.json
@@ -10,13 +10,15 @@
         }
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -248,16 +250,6 @@
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
       },
-      "device_association": {
-        "title": "Link to Existing Device",
-        "description": "Optionally attach this integration's entities to an existing device (e.g., the physical blind motor). Select 'None' to keep them as a standalone Adaptive Cover virtual device.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
-      },
       "duplicate_select": {
         "title": "Duplicate Cover — Select Source",
         "description": "Choose which existing cover to duplicate settings from.",
@@ -288,7 +280,7 @@
     "step": {
       "init": {
         "menu_options": {
-          "cover_entities": "Cover Entities",
+          "cover_entities": "Covers & Device",
           "geometry": "Cover Geometry",
           "sun_tracking": "Sun Tracking",
           "position": "Position Settings",
@@ -303,7 +295,6 @@
           "custom_position": "Custom Positions",
           "motion_override": "Motion Override",
           "weather_override": "Weather Override",
-          "device": "Device Association",
           "summary": "Configuration Summary",
           "sync": "Copy Settings to Other Covers",
           "done": "Save & Exit"
@@ -332,13 +323,15 @@
         "description": "Configure automation timing, position change thresholds, and active hours for automatic control."
       },
       "cover_entities": {
-        "title": "Cover Entities",
+        "title": "Covers & Device",
         "description": "Select the cover entities this instance will control.",
         "data": {
-          "group": "Cover Entities"
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device"
         },
         "data_description": {
-          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows."
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
         }
       },
       "geometry": {
@@ -547,16 +540,6 @@
         },
         "title": "Position Calibration",
         "description": "Adjust cover position mapping for non-standard behavior. Use simple 2-point adjustment (interp_start/end) for covers with limited range (e.g., only moves between 10-90%). Use advanced list interpolation for non-linear covers or to bias behavior toward more open/closed positions. Most covers don't need this - only enable if your cover doesn't respond correctly to standard 0-100% commands."
-      },
-      "device": {
-        "title": "Device Association",
-        "description": "Link this integration's entities to an existing device (e.g., the physical blind motor) or remove an existing link.",
-        "data": {
-          "linked_device_id": "Attach to Device"
-        },
-        "data_description": {
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
-        }
       },
       "sync": {
         "title": "Copy Settings to Other Covers",

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -3,7 +3,11 @@
 # Deploy adaptive_cover_pro to a Home Assistant server via SMB.
 #
 # Usage:
-#   ./scripts/deploy [--dry-run]
+#   ./scripts/deploy [--dry-run] [--reboot]
+#
+# Flags:
+#   --dry-run   Simulate rsync without copying files
+#   --reboot    Restart HA automatically after deploy without prompting
 #
 # Environment variables:
 #   HA_SMB_HOST   SMB hostname or IP (default: home-assistant.home)
@@ -25,10 +29,17 @@ fi
 HA_SMB_HOST="${HA_SMB_HOST:-home-assistant.home}"
 HA_SMB_SHARE="${HA_SMB_SHARE:-config}"
 DRY_RUN=false
+AUTO_REBOOT=false
 MOUNTED_BY_US=false
 
-if [[ "${1:-}" == "--dry-run" ]]; then
-    DRY_RUN=true
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --reboot)  AUTO_REBOOT=true ;;
+    esac
+done
+
+if $DRY_RUN; then
     echo "==> Dry run mode — no files will be copied"
 fi
 
@@ -127,8 +138,16 @@ EOF
     if [[ -z "${HA_TOKEN:-}" ]]; then
         read -r -p "    Long-lived access token: " HA_TOKEN
     fi
-    read -r -p "    Restart Home Assistant now? [Y/n] " HA_RESTART
+
+    if $AUTO_REBOOT; then
+        HA_RESTART="y"
+        echo "    Rebooting HA (--reboot)..."
+    else
+        read -r -p "    Restart Home Assistant now? [Y/n] " HA_RESTART
+    fi
+
     if [[ "${HA_RESTART,,}" != "n" ]]; then
+        REBOOT_START=$(date +%s)
         curl -sf -X POST "${HA_URL}/api/services/homeassistant/restart" \
             -H "Authorization: Bearer ${HA_TOKEN}" \
             -H "Content-Type: application/json" > /dev/null
@@ -178,12 +197,15 @@ EOF
             echo ""
         fi
 
+        REBOOT_END=$(date +%s)
+        REBOOT_ELAPSED=$(( REBOOT_END - REBOOT_START ))
+
         if $READY; then
-            echo "    HA is up and running."
+            echo "    HA is up and running (reboot took ${REBOOT_ELAPSED}s)."
         elif ! $API_UP; then
-            echo "    Timed out waiting for web server — check the server manually."
+            echo "    Timed out waiting for web server after ${REBOOT_ELAPSED}s — check the server manually."
         else
-            echo "    Web server responded but startup did not complete — check the HA log."
+            echo "    Web server responded but startup did not complete after ${REBOOT_ELAPSED}s — check the HA log."
         fi
     else
         echo "    Restart manually: Developer Tools → YAML → Restart"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -143,23 +143,47 @@ EOF
             fi
         done
 
-        # Now wait for HA to come back up (up to 120s)
-        READY=false
-        for i in $(seq 1 60); do
+        # Phase 1: Wait for HA web server to respond (up to 60s)
+        API_UP=false
+        for i in $(seq 1 30); do
             sleep 2
-            printf "\r    Waiting for HA... %ds" $((i * 2))
+            printf "\r    Phase 1/2 — waiting for web server... %ds" $((i * 2))
             if curl -sf --max-time 3 "${HA_URL}/api/" \
                     -H "Authorization: Bearer ${HA_TOKEN}" > /dev/null 2>&1; then
-                READY=true
+                API_UP=true
                 break
             fi
         done
-
         echo ""
+
+        # Phase 2: Wait for all integrations to finish loading (up to 120s)
+        # /api/config returns {"state": "RUNNING"} once startup is complete.
+        READY=false
+        if $API_UP; then
+            for i in $(seq 1 60); do
+                sleep 2
+                printf "\r    Phase 2/2 — waiting for startup to complete... %ds" $((i * 2))
+                RESPONSE=$(curl -sf --max-time 3 "${HA_URL}/api/config" \
+                    -H "Authorization: Bearer ${HA_TOKEN}" 2>/dev/null)
+                if [[ -n "$RESPONSE" ]]; then
+                    HA_STATE=$(python3 -c \
+                        "import json,sys; print(json.loads(sys.argv[1]).get('state',''))" \
+                        "$RESPONSE" 2>/dev/null)
+                    if [[ "$HA_STATE" == "RUNNING" ]]; then
+                        READY=true
+                        break
+                    fi
+                fi
+            done
+            echo ""
+        fi
+
         if $READY; then
-            echo "    HA is back up."
+            echo "    HA is up and running."
+        elif ! $API_UP; then
+            echo "    Timed out waiting for web server — check the server manually."
         else
-            echo "    Timed out waiting for HA — check the server manually."
+            echo "    Web server responded but startup did not complete — check the HA log."
         fi
     else
         echo "    Restart manually: Developer Tools → YAML → Restart"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -3,13 +3,16 @@
 # Deploy adaptive_cover_pro to a Home Assistant server via SMB.
 #
 # Usage:
-#   ./scripts/deploy [--dry-run] [--reboot]
+#   ./scripts/deploy [--dry-run] [--reboot] [--verbose] [--help]
 #
 # Flags:
 #   --dry-run   Simulate rsync without copying files
 #   --reboot    Restart HA automatically after deploy without prompting
+#   --verbose   Show rsync file list, curl responses, and bash trace (set -x)
+#   --help      Show help and exit
 #
 # Environment variables:
+#   INTEGRATION   Integration directory name under custom_components/ (default: auto-detected)
 #   HA_SMB_HOST   SMB hostname or IP (default: home-assistant.home)
 #   HA_SMB_SHARE  SMB share name (default: config)
 #   HA_SMB_USER   SMB username (optional; omit for guest access)
@@ -28,16 +31,44 @@ fi
 
 HA_SMB_HOST="${HA_SMB_HOST:-home-assistant.home}"
 HA_SMB_SHARE="${HA_SMB_SHARE:-config}"
+INTEGRATION="${INTEGRATION:-$(ls custom_components/ 2>/dev/null | head -1)}"
 DRY_RUN=false
 AUTO_REBOOT=false
+VERBOSE=false
 MOUNTED_BY_US=false
 
 for arg in "$@"; do
     case "$arg" in
-        --dry-run) DRY_RUN=true ;;
-        --reboot)  AUTO_REBOOT=true ;;
+        --dry-run)    DRY_RUN=true ;;
+        --reboot)     AUTO_REBOOT=true ;;
+        --verbose|-v) VERBOSE=true ;;
+        --help|-h)
+            cat <<'HELP'
+Usage: ./scripts/deploy [--dry-run] [--reboot] [--verbose] [--help]
+
+Flags:
+  --dry-run   Simulate rsync without copying files
+  --reboot    Restart HA automatically after deploy without prompting
+  --verbose   Show rsync file list, curl responses, and bash trace (set -x)
+  --help      Show this help message and exit
+
+Environment variables (or set in .deploy config file):
+  INTEGRATION   Integration name under custom_components/ (default: auto-detected)
+  HA_SMB_HOST   SMB hostname or IP       (default: home-assistant.home)
+  HA_SMB_SHARE  SMB share name           (default: config)
+  HA_SMB_USER   SMB username             (optional; omit for guest access)
+  HA_SMB_PASS   SMB password             (optional)
+  HA_URL        Home Assistant URL        (default: http://home-assistant.home:8123)
+  HA_TOKEN      Long-lived access token  (optional; prompted if not set)
+HELP
+            exit 0
+            ;;
     esac
 done
+
+if $VERBOSE; then
+    set -x
+fi
 
 if $DRY_RUN; then
     echo "==> Dry run mode — no files will be copied"
@@ -75,7 +106,11 @@ else
     MOUNT_POINT="$(mktemp -d)"
     MOUNTED_BY_US=true
     echo "==> Mounting smb://${HA_SMB_HOST}/${HA_SMB_SHARE} → ${MOUNT_POINT}..."
-    mount_smbfs "${SMB_URL}" "${MOUNT_POINT}" 2>/dev/null || true
+    if $VERBOSE; then
+        mount_smbfs "${SMB_URL}" "${MOUNT_POINT}" || true
+    else
+        mount_smbfs "${SMB_URL}" "${MOUNT_POINT}" 2>/dev/null || true
+    fi
     if ! mount | grep -q "on ${MOUNT_POINT} "; then
         echo "    Guest access failed; trying with credentials..."
         read -r -p "    SMB username: " SMB_USER
@@ -86,8 +121,8 @@ else
 fi
 
 # ── Deploy ───────────────────────────────────────────────────────────────────
-SRC="custom_components/adaptive_cover_pro/"
-DST="${MOUNT_POINT}/custom_components/adaptive_cover_pro/"
+SRC="custom_components/${INTEGRATION}/"
+DST="${MOUNT_POINT}/custom_components/${INTEGRATION}/"
 
 RSYNC_OPTS=(
     --archive
@@ -97,8 +132,11 @@ RSYNC_OPTS=(
     --exclude="*.pyc"
     --exclude="simulation/"
     --human-readable
-    --verbose
 )
+
+if $VERBOSE; then
+    RSYNC_OPTS+=(--verbose)
+fi
 
 if $DRY_RUN; then
     RSYNC_OPTS+=(--dry-run)
@@ -116,7 +154,7 @@ else
     if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
         GIT_HASH="${GIT_HASH}-dirty"
     fi
-    BASE_VERSION="$(python3 -c "import json; print(json.load(open('custom_components/adaptive_cover_pro/manifest.json'))['version'])")"
+    BASE_VERSION="$(python3 -c "import json; print(json.load(open('custom_components/${INTEGRATION}/manifest.json'))['version'])")"
     DEV_VERSION="${BASE_VERSION}-dev.${GIT_HASH}"
     echo "==> Stamping version ${DEV_VERSION} in deployed manifest.json..."
     python3 - "${DST}manifest.json" "${DEV_VERSION}" <<'EOF'
@@ -148,9 +186,15 @@ EOF
 
     if [[ "${HA_RESTART,,}" != "n" ]]; then
         REBOOT_START=$(date +%s)
-        curl -sf -X POST "${HA_URL}/api/services/homeassistant/restart" \
-            -H "Authorization: Bearer ${HA_TOKEN}" \
-            -H "Content-Type: application/json" > /dev/null
+        if $VERBOSE; then
+            curl -fv -X POST "${HA_URL}/api/services/homeassistant/restart" \
+                -H "Authorization: Bearer ${HA_TOKEN}" \
+                -H "Content-Type: application/json"
+        else
+            curl -sf -X POST "${HA_URL}/api/services/homeassistant/restart" \
+                -H "Authorization: Bearer ${HA_TOKEN}" \
+                -H "Content-Type: application/json" > /dev/null
+        fi
         echo "    Restart requested — waiting for HA to come back..."
 
         # Wait for HA to go down first (up to 15s)
@@ -167,10 +211,15 @@ EOF
         for i in $(seq 1 30); do
             sleep 2
             printf "\r    Phase 1/2 — waiting for web server... %ds" $((i * 2))
-            if curl -sf --max-time 3 "${HA_URL}/api/" \
-                    -H "Authorization: Bearer ${HA_TOKEN}" > /dev/null 2>&1; then
-                API_UP=true
-                break
+            if $VERBOSE; then
+                curl -f --max-time 3 "${HA_URL}/api/" \
+                    -H "Authorization: Bearer ${HA_TOKEN}" && API_UP=true && break || true
+            else
+                if curl -sf --max-time 3 "${HA_URL}/api/" \
+                        -H "Authorization: Bearer ${HA_TOKEN}" > /dev/null 2>&1; then
+                    API_UP=true
+                    break
+                fi
             fi
         done
         echo ""
@@ -182,8 +231,13 @@ EOF
             for i in $(seq 1 130); do
                 sleep 2
                 printf "\r    Phase 2/2 — waiting for startup to complete... %ds" $((i * 2))
-                RESPONSE=$(curl -sf --max-time 3 "${HA_URL}/api/config" \
-                    -H "Authorization: Bearer ${HA_TOKEN}" 2>/dev/null)
+                if $VERBOSE; then
+                    RESPONSE=$(curl -f --max-time 3 "${HA_URL}/api/config" \
+                        -H "Authorization: Bearer ${HA_TOKEN}" 2>&1 || true)
+                else
+                    RESPONSE=$(curl -sf --max-time 3 "${HA_URL}/api/config" \
+                        -H "Authorization: Bearer ${HA_TOKEN}" 2>/dev/null)
+                fi
                 if [[ -n "$RESPONSE" ]]; then
                     HA_STATE=$(python3 -c \
                         "import json,sys; print(json.loads(sys.argv[1]).get('state',''))" \

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -175,11 +175,11 @@ EOF
         done
         echo ""
 
-        # Phase 2: Wait for all integrations to finish loading (up to 120s)
+        # Phase 2: Wait for all integrations to finish loading (up to 260s)
         # /api/config returns {"state": "RUNNING"} once startup is complete.
         READY=false
         if $API_UP; then
-            for i in $(seq 1 60); do
+            for i in $(seq 1 130); do
                 sleep 2
                 printf "\r    Phase 2/2 — waiting for startup to complete... %ds" $((i * 2))
                 RESPONSE=$(curl -sf --max-time 3 "${HA_URL}/api/config" \

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+
+# Deploy adaptive_cover_pro to a Home Assistant server via SMB.
+#
+# Usage:
+#   ./scripts/deploy [--dry-run]
+#
+# Environment variables:
+#   HA_SMB_HOST   SMB hostname or IP (default: home-assistant.home)
+#   HA_SMB_SHARE  SMB share name (default: config)
+#   HA_SMB_USER   SMB username (optional; omit for guest access)
+#   HA_SMB_PASS   SMB password (optional)
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# ── Load config file ─────────────────────────────────────────────────────────
+# Copy .deploy.example to .deploy and fill in your values (file is .gitignored)
+if [[ -f ".deploy" ]]; then
+    # shellcheck source=/dev/null
+    source ".deploy"
+fi
+
+HA_SMB_HOST="${HA_SMB_HOST:-home-assistant.home}"
+HA_SMB_SHARE="${HA_SMB_SHARE:-config}"
+DRY_RUN=false
+MOUNTED_BY_US=false
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+    DRY_RUN=true
+    echo "==> Dry run mode — no files will be copied"
+fi
+
+# ── Cleanup on exit ──────────────────────────────────────────────────────────
+cleanup() {
+    if $MOUNTED_BY_US && [[ -n "${MOUNT_POINT:-}" ]]; then
+        if mount | grep -q "on ${MOUNT_POINT} "; then
+            echo "==> Unmounting ${MOUNT_POINT}..."
+            diskutil unmount force "${MOUNT_POINT}" 2>/dev/null || umount "${MOUNT_POINT}" 2>/dev/null || true
+        fi
+        rmdir "${MOUNT_POINT}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+# ── Build SMB URL ────────────────────────────────────────────────────────────
+if [[ -n "${HA_SMB_USER:-}" ]]; then
+    PASS_PART=""
+    if [[ -n "${HA_SMB_PASS:-}" ]]; then
+        PASS_PART=":${HA_SMB_PASS}"
+    fi
+    SMB_URL="//${HA_SMB_USER}${PASS_PART}@${HA_SMB_HOST}/${HA_SMB_SHARE}"
+else
+    SMB_URL="//${HA_SMB_HOST}/${HA_SMB_SHARE}"
+fi
+
+# ── Mount (reuse existing mount if present) ───────────────────────────────────
+EXISTING_MOUNT="$(mount | grep -i "${HA_SMB_HOST}/${HA_SMB_SHARE}" | awk '{print $3}' | head -1)"
+if [[ -n "$EXISTING_MOUNT" ]]; then
+    echo "==> Share already mounted at ${EXISTING_MOUNT}, reusing it."
+    MOUNT_POINT="$EXISTING_MOUNT"
+else
+    MOUNT_POINT="$(mktemp -d)"
+    MOUNTED_BY_US=true
+    echo "==> Mounting smb://${HA_SMB_HOST}/${HA_SMB_SHARE} → ${MOUNT_POINT}..."
+    mount_smbfs "${SMB_URL}" "${MOUNT_POINT}" 2>/dev/null || true
+    if ! mount | grep -q "on ${MOUNT_POINT} "; then
+        echo "    Guest access failed; trying with credentials..."
+        read -r -p "    SMB username: " SMB_USER
+        read -r -s -p "    SMB password: " SMB_PASS
+        echo
+        mount_smbfs "//${SMB_USER}:${SMB_PASS}@${HA_SMB_HOST}/${HA_SMB_SHARE}" "${MOUNT_POINT}"
+    fi
+fi
+
+# ── Deploy ───────────────────────────────────────────────────────────────────
+SRC="custom_components/adaptive_cover_pro/"
+DST="${MOUNT_POINT}/custom_components/adaptive_cover_pro/"
+
+RSYNC_OPTS=(
+    --archive
+    --delete
+    --inplace
+    --exclude="__pycache__/"
+    --exclude="*.pyc"
+    --exclude="simulation/"
+    --human-readable
+    --verbose
+)
+
+if $DRY_RUN; then
+    RSYNC_OPTS+=(--dry-run)
+fi
+
+echo "==> Deploying ${SRC} → ${DST}..."
+rsync "${RSYNC_OPTS[@]}" "${SRC}" "${DST}"
+
+if $DRY_RUN; then
+    echo ""
+    echo "==> Dry run complete — no files were copied."
+else
+    # ── Stamp dev version in deployed manifest.json ───────────────────────────
+    GIT_HASH="$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+        GIT_HASH="${GIT_HASH}-dirty"
+    fi
+    BASE_VERSION="$(python3 -c "import json; print(json.load(open('custom_components/adaptive_cover_pro/manifest.json'))['version'])")"
+    DEV_VERSION="${BASE_VERSION}-dev.${GIT_HASH}"
+    echo "==> Stamping version ${DEV_VERSION} in deployed manifest.json..."
+    python3 - "${DST}manifest.json" "${DEV_VERSION}" <<'EOF'
+import json, sys
+path, version = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    m = json.load(f)
+m['version'] = version
+with open(path, 'w') as f:
+    json.dump(m, f, indent=2)
+    f.write('\n')
+EOF
+
+    echo ""
+    echo "==> Deploy complete (version ${DEV_VERSION})."
+
+    # ── Offer to restart HA ───────────────────────────────────────────────────
+    HA_URL="${HA_URL:-http://home-assistant.home:8123}"
+    if [[ -z "${HA_TOKEN:-}" ]]; then
+        read -r -p "    Long-lived access token: " HA_TOKEN
+    fi
+    read -r -p "    Restart Home Assistant now? [Y/n] " HA_RESTART
+    if [[ "${HA_RESTART,,}" != "n" ]]; then
+        curl -sf -X POST "${HA_URL}/api/services/homeassistant/restart" \
+            -H "Authorization: Bearer ${HA_TOKEN}" \
+            -H "Content-Type: application/json" > /dev/null
+        echo "    Restart requested — waiting for HA to come back..."
+
+        # Wait for HA to go down first (up to 15s)
+        for _ in $(seq 1 15); do
+            sleep 1
+            if ! curl -sf --max-time 2 "${HA_URL}/api/" \
+                    -H "Authorization: Bearer ${HA_TOKEN}" > /dev/null 2>&1; then
+                break
+            fi
+        done
+
+        # Now wait for HA to come back up (up to 120s)
+        READY=false
+        for i in $(seq 1 60); do
+            sleep 2
+            printf "\r    Waiting for HA... %ds" $((i * 2))
+            if curl -sf --max-time 3 "${HA_URL}/api/" \
+                    -H "Authorization: Bearer ${HA_TOKEN}" > /dev/null 2>&1; then
+                READY=true
+                break
+            fi
+        done
+
+        echo ""
+        if $READY; then
+            echo "    HA is back up."
+        else
+            echo "    Timed out waiting for HA — check the server manually."
+        fi
+    else
+        echo "    Restart manually: Developer Tools → YAML → Restart"
+    fi
+fi

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -236,12 +236,12 @@ EOF
                         -H "Authorization: Bearer ${HA_TOKEN}" 2>&1 || true)
                 else
                     RESPONSE=$(curl -sf --max-time 3 "${HA_URL}/api/config" \
-                        -H "Authorization: Bearer ${HA_TOKEN}" 2>/dev/null)
+                        -H "Authorization: Bearer ${HA_TOKEN}" 2>/dev/null || true)
                 fi
                 if [[ -n "$RESPONSE" ]]; then
                     HA_STATE=$(python3 -c \
                         "import json,sys; print(json.loads(sys.argv[1]).get('state',''))" \
-                        "$RESPONSE" 2>/dev/null)
+                        "$RESPONSE" 2>/dev/null || true)
                     if [[ "$HA_STATE" == "RUNNING" ]]; then
                         READY=true
                         break

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -17,12 +17,15 @@ import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from unittest.mock import patch
+
 from custom_components.adaptive_cover_pro.const import (
     CONF_AZIMUTH,
     CONF_CLIMATE_MODE,
     CONF_DEFAULT_HEIGHT,
     CONF_DELTA_POSITION,
     CONF_DELTA_TIME,
+    CONF_DEVICE_ID,
     CONF_DISTANCE,
     CONF_ENABLE_BLIND_SPOT,
     CONF_ENABLE_GLARE_ZONES,
@@ -911,4 +914,266 @@ async def test_options_flow_glare_zones_step_saves(hass: HomeAssistant) -> None:
             "glare_zone_4_radius": 30,
         },
     )
+    assert result["type"] in ("form", "menu", "create_entry")
+
+
+# ---------------------------------------------------------------------------
+# Merged cover_entities + device association screen
+# ---------------------------------------------------------------------------
+
+
+def _mock_devices_from_entities(devices: dict):
+    """Return a coroutine that always returns ``devices`` for _get_devices_from_entities."""
+
+    async def _fake(*_args, **_kwargs):
+        return devices
+
+    return _fake
+
+
+@pytest.mark.integration
+async def test_config_flow_cover_entities_no_devices_skips_device_selector(
+    hass: HomeAssistant,
+) -> None:
+    """When selected entities have no associated devices, cover_entities shows only once."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"name": "Test Blind", CONF_MODE: SensorType.BLIND}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "quick_setup"}
+    )
+    assert result["step_id"] == "cover_entities"
+
+    with patch(
+        "custom_components.adaptive_cover_pro.config_flow._get_devices_from_entities",
+        side_effect=_mock_devices_from_entities({}),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ENTITIES: []}
+        )
+
+    assert result["step_id"] == "geometry"
+
+
+@pytest.mark.integration
+async def test_config_flow_cover_entities_with_devices_shows_device_selector(
+    hass: HomeAssistant,
+) -> None:
+    """When entities have associated devices, cover_entities re-renders with device selector."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"name": "Test Blind", CONF_MODE: SensorType.BLIND}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "quick_setup"}
+    )
+    assert result["step_id"] == "cover_entities"
+
+    devices = {"device_abc123": "My Blind Motor"}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.config_flow._get_devices_from_entities",
+        side_effect=_mock_devices_from_entities(devices),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ENTITIES: []}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "cover_entities"
+    schema_str_keys = [str(k) for k in result["data_schema"].schema]
+    assert CONF_DEVICE_ID in schema_str_keys, (
+        f"Expected {CONF_DEVICE_ID} in schema, got: {schema_str_keys}"
+    )
+
+
+@pytest.mark.integration
+async def test_config_flow_cover_entities_standalone_selection_proceeds_to_geometry(
+    hass: HomeAssistant,
+) -> None:
+    """Selecting 'None (standalone device)' proceeds to geometry without storing CONF_DEVICE_ID."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"name": "Test Blind", CONF_MODE: SensorType.BLIND}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "quick_setup"}
+    )
+
+    devices = {"device_abc123": "My Blind Motor"}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.config_flow._get_devices_from_entities",
+        side_effect=_mock_devices_from_entities(devices),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ENTITIES: []}
+        )
+
+    # Pass 2: select standalone
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ENTITIES: [], CONF_DEVICE_ID: "__standalone__"},
+    )
+    assert result["step_id"] == "geometry"
+
+
+@pytest.mark.integration
+async def test_config_flow_cover_entities_real_device_selection_stores_device_id(
+    hass: HomeAssistant,
+) -> None:
+    """Selecting a real device stores CONF_DEVICE_ID and proceeds to geometry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"name": "Test Blind", CONF_MODE: SensorType.BLIND}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "quick_setup"}
+    )
+
+    devices = {"device_abc123": "My Blind Motor"}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.config_flow._get_devices_from_entities",
+        side_effect=_mock_devices_from_entities(devices),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_ENTITIES: []}
+        )
+
+    flow = hass.config_entries.flow._progress.get(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_ENTITIES: [], CONF_DEVICE_ID: "device_abc123"},
+    )
+    assert result["step_id"] == "geometry"
+    if flow is not None:
+        assert flow.config.get(CONF_DEVICE_ID) == "device_abc123"
+
+
+@pytest.mark.integration
+async def test_options_flow_cover_entities_no_device_in_menu(
+    hass: HomeAssistant,
+) -> None:
+    """The 'device' menu item no longer appears in the options flow init menu."""
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Menu Test", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="no_device_menu_01",
+        title="Menu Test",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+    assert "device" not in result.get("menu_options", [])
+
+
+@pytest.mark.integration
+async def test_options_flow_cover_entities_combined_form_no_devices(
+    hass: HomeAssistant,
+) -> None:
+    """Options cover_entities step shows only entity selector when no devices are available."""
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "CE Options Test", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="ce_opts_nodev_01",
+        title="CE Options Test",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    if result["type"] == "menu":
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "cover_entities"}
+        )
+
+    assert result["step_id"] == "cover_entities"
+    schema_str_keys = [str(k) for k in result["data_schema"].schema]
+    # device selector should NOT be present when no devices are found
+    assert CONF_DEVICE_ID not in schema_str_keys
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    assert result["type"] in ("form", "menu", "create_entry")
+
+
+@pytest.mark.integration
+async def test_options_flow_cover_entities_combined_form_with_devices(
+    hass: HomeAssistant,
+) -> None:
+    """Options cover_entities step includes device selector when devices are available."""
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "CE Options Dev Test", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="ce_opts_dev_01",
+        title="CE Options Dev Test",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    devices = {"device_xyz789": "Smart Blind Motor"}
+    with patch(
+        "custom_components.adaptive_cover_pro.config_flow._get_devices_from_entities",
+        side_effect=_mock_devices_from_entities(devices),
+    ):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        if result["type"] == "menu":
+            result = await hass.config_entries.options.async_configure(
+                result["flow_id"], {"next_step_id": "cover_entities"}
+            )
+
+        assert result["step_id"] == "cover_entities"
+        schema_str_keys = [str(k) for k in result["data_schema"].schema]
+        assert CONF_DEVICE_ID in schema_str_keys, (
+            f"Expected {CONF_DEVICE_ID} in schema keys, got: {schema_str_keys}"
+        )
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {CONF_ENTITIES: [], CONF_DEVICE_ID: "device_xyz789"}
+        )
+
     assert result["type"] in ("form", "menu", "create_entry")

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from custom_components.adaptive_cover_pro.config_flow import (
     _build_config_summary,
+    _build_cover_capabilities_text,
     _format_duration,
 )
 from custom_components.adaptive_cover_pro.const import (
@@ -1065,7 +1066,7 @@ def test_summary_shows_my_info_line_when_value_set_globally():
 
 
 # ---------------------------------------------------------------------------
-# Section 1b: Cover Capabilities
+# Section 1b: Cover Capabilities (now shown on Debug & Diagnostics screen)
 # ---------------------------------------------------------------------------
 
 
@@ -1099,19 +1100,45 @@ def _make_hass(entity_states: dict) -> object:
     return hass
 
 
-def test_capabilities_section_absent_without_hass():
-    """Cover Capabilities section is not rendered when hass is not passed."""
+def test_capability_listing_not_in_summary():
+    """Full capability listing (entity: set position, open...) is not in _build_config_summary."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    hass = _make_hass({"cover.living_room": {"supported_features": feats}})
     cfg = {CONF_ENTITIES: ["cover.living_room"]}
-    summary = _build_config_summary(cfg, SensorType.BLIND)
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    # Full listing section header is not shown — only warnings
     assert "Cover Capabilities" not in summary
+    # No warnings for a well-configured cover
+    assert "Cover Warnings" not in summary
+
+
+def test_capability_warnings_appear_in_summary():
+    """Actionable capability warnings appear in _build_config_summary."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    # Open/close-only cover — should produce a warning
+    feats = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    hass = _make_hass({"cover.blind": {"supported_features": feats}})
+    cfg = {CONF_ENTITIES: ["cover.blind"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "Cover Warnings" in summary
+    assert "open/close-only" in summary
+
+
+def test_capabilities_section_absent_without_hass():
+    """_build_cover_capabilities_text returns empty string when hass is not passed."""
+    cfg = {CONF_ENTITIES: ["cover.living_room"]}
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND)
+    assert result == ""
 
 
 def test_capabilities_section_absent_without_entities():
-    """Cover Capabilities section is not rendered when entities list is empty."""
-
+    """_build_cover_capabilities_text returns empty string when entities list is empty."""
     hass = _make_hass({})
-    summary = _build_config_summary({CONF_ENTITIES: []}, SensorType.BLIND, hass)
-    assert "Cover Capabilities" not in summary
+    result = _build_cover_capabilities_text({CONF_ENTITIES: []}, SensorType.BLIND, hass)
+    assert result == ""
 
 
 def test_capabilities_section_renders_full_featured_cover():
@@ -1126,13 +1153,13 @@ def test_capabilities_section_renders_full_featured_cover():
     )
     hass = _make_hass({"cover.blind": {"supported_features": feats}})
     cfg = {CONF_ENTITIES: ["cover.blind"]}
-    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
-    assert "Cover Capabilities" in summary
-    assert "cover.blind" in summary
-    assert "set position" in summary
-    assert "open" in summary
-    assert "close" in summary
-    assert "stop" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
+    assert "Cover Capabilities" in result
+    assert "cover.blind" in result
+    assert "set position" in result
+    assert "open" in result
+    assert "close" in result
+    assert "stop" in result
 
 
 def test_capabilities_section_warns_on_open_close_only():
@@ -1142,9 +1169,9 @@ def test_capabilities_section_warns_on_open_close_only():
     feats = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
     hass = _make_hass({"cover.blind": {"supported_features": feats}})
     cfg = {CONF_ENTITIES: ["cover.blind"]}
-    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
-    assert "open/close-only" in summary
-    assert "threshold compare" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
+    assert "open/close-only" in result
+    assert "threshold compare" in result
 
 
 def test_capabilities_section_unavailable_entity():
@@ -1152,8 +1179,8 @@ def test_capabilities_section_unavailable_entity():
     hass = _make_hass({"cover.blind": {"state": "unavailable", "supported_features": 0}})
     # check_cover_features returns None for unavailable state
     cfg = {CONF_ENTITIES: ["cover.blind"]}
-    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
-    assert "not ready" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
+    assert "not ready" in result
 
 
 def test_capabilities_section_assumed_state_warning():
@@ -1165,9 +1192,9 @@ def test_capabilities_section_assumed_state_warning():
         {"cover.blind": {"supported_features": feats, "assumed_state": True}}
     )
     cfg = {CONF_ENTITIES: ["cover.blind"]}
-    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
-    assert "assumed_state" in summary
-    assert "position cannot be read back" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
+    assert "assumed_state" in result
+    assert "position cannot be read back" in result
 
 
 def test_capabilities_section_mixed_caps_warning():
@@ -1187,9 +1214,9 @@ def test_capabilities_section_mixed_caps_warning():
         }
     )
     cfg = {CONF_ENTITIES: ["cover.a", "cover.b"]}
-    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
-    assert "Mixed capabilities" in summary
-    assert "driven differently" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
+    assert "Mixed capabilities" in result
+    assert "driven differently" in result
 
 
 def test_capabilities_section_tilt_type_mismatch():
@@ -1199,9 +1226,9 @@ def test_capabilities_section_tilt_type_mismatch():
     feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
     hass = _make_hass({"cover.blind": {"supported_features": feats}})
     cfg = {CONF_ENTITIES: ["cover.blind"]}
-    summary = _build_config_summary(cfg, SensorType.TILT, hass)
-    assert "set_tilt_position" in summary
-    assert "tilt (venetian)" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.TILT, hass)
+    assert "set_tilt_position" in result
+    assert "tilt (venetian)" in result
 
 
 def test_capabilities_section_position_limits_ignored_warning():
@@ -1215,7 +1242,7 @@ def test_capabilities_section_position_limits_ignored_warning():
         CONF_ENABLE_MIN_POSITION: True,
         CONF_MIN_POSITION: 10,
     }
-    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
-    assert "Position limits" in summary
-    assert "limits will be ignored" in summary
-    assert "cover.blind" in summary
+    result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
+    assert "Position limits" in result
+    assert "limits will be ignored" in result
+    assert "cover.blind" in result

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1062,3 +1062,160 @@ def test_summary_shows_my_info_line_when_value_set_globally():
     cfg[CONF_MY_POSITION_VALUE] = 50
     summary = _build_config_summary(cfg, SensorType.BLIND)
     assert "🎛️ Somfy My preset: 50%" in summary
+
+
+# ---------------------------------------------------------------------------
+# Section 1b: Cover Capabilities
+# ---------------------------------------------------------------------------
+
+
+def _make_hass(entity_states: dict) -> object:
+    """Build a minimal hass stub for cover-capabilities tests.
+
+    entity_states maps entity_id → dict with keys:
+      - "state": str (default "open")
+      - "supported_features": int (default 0)
+      - "assumed_state": bool (default False)
+    Returns an object whose .states.get(entity_id) mimics HA state objects.
+    """
+    from unittest.mock import MagicMock
+
+    def _get_state(entity_id):
+        if entity_id not in entity_states:
+            return None
+        spec = entity_states[entity_id]
+        s = MagicMock()
+        s.state = spec.get("state", "open")
+        attrs = {}
+        if "supported_features" in spec:
+            attrs["supported_features"] = spec["supported_features"]
+        if spec.get("assumed_state"):
+            attrs["assumed_state"] = True
+        s.attributes = attrs
+        return s
+
+    hass = MagicMock()
+    hass.states.get.side_effect = _get_state
+    return hass
+
+
+def test_capabilities_section_absent_without_hass():
+    """Cover Capabilities section is not rendered when hass is not passed."""
+    cfg = {CONF_ENTITIES: ["cover.living_room"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Cover Capabilities" not in summary
+
+
+def test_capabilities_section_absent_without_entities():
+    """Cover Capabilities section is not rendered when entities list is empty."""
+
+    hass = _make_hass({})
+    summary = _build_config_summary({CONF_ENTITIES: []}, SensorType.BLIND, hass)
+    assert "Cover Capabilities" not in summary
+
+
+def test_capabilities_section_renders_full_featured_cover():
+    """Full-featured cover shows set position, open, close, stop in capabilities."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    feats = (
+        CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+    )
+    hass = _make_hass({"cover.blind": {"supported_features": feats}})
+    cfg = {CONF_ENTITIES: ["cover.blind"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "Cover Capabilities" in summary
+    assert "cover.blind" in summary
+    assert "set position" in summary
+    assert "open" in summary
+    assert "close" in summary
+    assert "stop" in summary
+
+
+def test_capabilities_section_warns_on_open_close_only():
+    """Open/close-only cover renders ⚠️ threshold-compare warning."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    feats = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    hass = _make_hass({"cover.blind": {"supported_features": feats}})
+    cfg = {CONF_ENTITIES: ["cover.blind"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "open/close-only" in summary
+    assert "threshold compare" in summary
+
+
+def test_capabilities_section_unavailable_entity():
+    """Unavailable entity renders ⚠️ not-ready warning."""
+    hass = _make_hass({"cover.blind": {"state": "unavailable", "supported_features": 0}})
+    # check_cover_features returns None for unavailable state
+    cfg = {CONF_ENTITIES: ["cover.blind"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "not ready" in summary
+
+
+def test_capabilities_section_assumed_state_warning():
+    """Cover with assumed_state attribute renders ⚠️ assumed-state warning."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    hass = _make_hass(
+        {"cover.blind": {"supported_features": feats, "assumed_state": True}}
+    )
+    cfg = {CONF_ENTITIES: ["cover.blind"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "assumed_state" in summary
+    assert "position cannot be read back" in summary
+
+
+def test_capabilities_section_mixed_caps_warning():
+    """Two covers with different set_position support renders mixed-capabilities warning."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    hass = _make_hass(
+        {
+            "cover.a": {
+                "supported_features": CoverEntityFeature.SET_POSITION
+                | CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE
+            },
+            "cover.b": {
+                "supported_features": CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+            },
+        }
+    )
+    cfg = {CONF_ENTITIES: ["cover.a", "cover.b"]}
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "Mixed capabilities" in summary
+    assert "driven differently" in summary
+
+
+def test_capabilities_section_tilt_type_mismatch():
+    """Tilt sensor_type with no set_tilt_position cover renders mismatch warning."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    hass = _make_hass({"cover.blind": {"supported_features": feats}})
+    cfg = {CONF_ENTITIES: ["cover.blind"]}
+    summary = _build_config_summary(cfg, SensorType.TILT, hass)
+    assert "set_tilt_position" in summary
+    assert "tilt (venetian)" in summary
+
+
+def test_capabilities_section_position_limits_ignored_warning():
+    """Position limits configured + open/close-only cover renders ignored-limits warning."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    feats = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    hass = _make_hass({"cover.blind": {"supported_features": feats}})
+    cfg = {
+        CONF_ENTITIES: ["cover.blind"],
+        CONF_ENABLE_MIN_POSITION: True,
+        CONF_MIN_POSITION: 10,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND, hass)
+    assert "Position limits" in summary
+    assert "limits will be ignored" in summary
+    assert "cover.blind" in summary

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -142,16 +142,20 @@ class TestGlareZoneHandlerLogic:
     handler = GlareZoneHandler()
 
     def test_returns_glare_zone_control_method_when_active(self) -> None:
-        """When glare zone produces stricter position, return GLARE_ZONE method."""
+        """When zone is closer than base distance, return GLARE_ZONE method.
+
+        Zone at 0.9m is closer than base_distance=10m, so it's in the
+        illuminated area and needs extra protection from GlareZoneHandler.
+        """
         cover = _make_vertical_cover(
-            distance=1.0,
+            distance=10.0,
             gamma=0.0,
             direct_sun_valid=True,
-            calculate_percentage_return=40.0,
+            calculate_percentage_return=5.0,
         )
-        # Zone at y=400cm (4m), much farther than base distance of 1.0m
+        # Zone at y=100cm, radius=10cm → nearest_y = 90cm = 0.9m < base 10m
         glare_cfg = GlareZonesConfig(
-            zones=[GlareZone(name="desk", x=0.0, y=400.0, radius=30.0)],
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=10.0)],
             window_width=200.0,
         )
         snap = make_snapshot(
@@ -164,15 +168,19 @@ class TestGlareZoneHandlerLogic:
         assert result is not None
         assert result.control_method == ControlMethod.GLARE_ZONE
 
-    def test_falls_through_when_base_distance_wins(self) -> None:
-        """Returns None when base distance is farther than all glare zones."""
+    def test_falls_through_when_zone_farther_than_base(self) -> None:
+        """Returns None when all zones are farther than base distance (in shadow).
+
+        Zone at ~3.7m is beyond base_distance=1m. SolarHandler already blocks
+        sun beyond 1m, so the zone is in shadow — no override needed.
+        """
         cover = _make_vertical_cover(
-            distance=10.0,  # base distance 10m >> zone distance
+            distance=1.0,  # base distance 1m — blocks sun beyond 1m
             gamma=0.0,
             direct_sun_valid=True,
         )
         glare_cfg = GlareZonesConfig(
-            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=10.0)],  # 0.9m
+            zones=[GlareZone(name="desk", x=0.0, y=400.0, radius=30.0)],  # ~3.7m
             window_width=200.0,
         )
         snap = make_snapshot(
@@ -182,7 +190,7 @@ class TestGlareZoneHandlerLogic:
             active_zone_names={"desk"},
         )
         result = self.handler.evaluate(snap)
-        # Base distance wins → fall through to SolarHandler
+        # Zone farther than base → in shadow → fall through to SolarHandler
         assert result is None
 
     def test_inactive_zone_is_ignored(self) -> None:
@@ -198,23 +206,22 @@ class TestGlareZoneHandlerLogic:
         result = self.handler.evaluate(snap)
         assert result is None
 
-    def test_two_zones_with_equal_max_distance_both_in_reason(self) -> None:
-        """Both zones appear in the reason string when they share the maximum distance."""
-        # Two zones at the same y (perpendicular distance from window wall) with gamma=0.
-        # nearest_y = zone.y - zone.radius * cos(0) = zone.y - radius.
-        # For zone_a: nearest_y = 500 - 0 = 500 → effective_distance = 5.0m
-        # For zone_b: nearest_y = 530 - 30 = 500 → effective_distance = 5.0m
-        zone_a = GlareZone(name="desk_left", x=0.0, y=500.0, radius=0.0)
-        zone_b = GlareZone(name="desk_right", x=0.0, y=530.0, radius=30.0)
+    def test_two_zones_with_equal_min_distance_both_in_reason(self) -> None:
+        """Both zones appear in the reason string when they share the minimum distance."""
+        # Two zones with the same nearest_y (gamma=0):
+        # For zone_a: nearest_y = 100 - 0 = 100 → effective_distance = 1.0m
+        # For zone_b: nearest_y = 130 - 30 = 100 → effective_distance = 1.0m
+        zone_a = GlareZone(name="desk_left", x=0.0, y=100.0, radius=0.0)
+        zone_b = GlareZone(name="desk_right", x=0.0, y=130.0, radius=30.0)
         glare_cfg = GlareZonesConfig(
             zones=[zone_a, zone_b],
             window_width=400.0,
         )
         cover = _make_vertical_cover(
-            distance=1.0,  # base distance 1m < 5m zone distance
+            distance=5.0,  # base distance 5m > 1m zone distance
             gamma=0.0,
             direct_sun_valid=True,
-            calculate_percentage_return=80.0,
+            calculate_percentage_return=8.0,
         )
         snap = make_snapshot(
             cover=cover,
@@ -234,16 +241,17 @@ class TestGlareZoneHandlerLogic:
         # x_at_window = x + y * tan(gamma). At gamma=0, x_at_window = x.
         # window_half_width = 100.0cm, so any |x| > 100 is blocked.
         zone_blocked = GlareZone(name="blocked", x=500.0, y=300.0, radius=0.0)
-        zone_valid = GlareZone(name="valid", x=0.0, y=400.0, radius=0.0)
+        # zone_valid at 1.5m, closer than base_distance of 5m → needs protection
+        zone_valid = GlareZone(name="valid", x=0.0, y=150.0, radius=0.0)
         glare_cfg = GlareZonesConfig(
             zones=[zone_blocked, zone_valid],
             window_width=200.0,  # half-width = 100cm
         )
         cover = _make_vertical_cover(
-            distance=1.0,  # 1m < 4m zone_valid distance
+            distance=5.0,  # 5m > 1.5m zone_valid distance → zone needs protection
             gamma=0.0,
             direct_sun_valid=True,
-            calculate_percentage_return=70.0,
+            calculate_percentage_return=12.0,
         )
         snap = make_snapshot(
             cover=cover,

--- a/tests/test_pipeline/test_glare_zone_handler_fix.py
+++ b/tests/test_pipeline/test_glare_zone_handler_fix.py
@@ -1,0 +1,244 @@
+"""TDD tests for GlareZoneHandler fix (Issue #213).
+
+The GlareZoneHandler logic is backwards:
+- It uses max() when it should use min() (closest zone is most restrictive)
+- It overrides when max_distance > base_distance (should be min_distance < base_distance)
+
+These tests describe the CORRECT behavior.
+
+Geometry refresher:
+- calculate_position returns blind height = (distance/cos(gamma)) * tan(elev)
+- Larger distance → higher position% → LESS blind deployed → LESS protection
+- Smaller distance → lower position% → MORE blind deployed → MORE protection
+- A blind set to block depth d allows sun to penetrate up to d from the window
+- A zone CLOSER than base_distance is in the illuminated zone and needs protection
+- A zone FARTHER than base_distance is already in shadow from SolarHandler
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.config_types import (
+    GlareZone,
+    GlareZonesConfig,
+)
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.handlers.glare_zone import (
+    GlareZoneHandler,
+)
+from tests.test_pipeline.conftest import make_snapshot
+
+
+def _make_vertical_cover(
+    distance: float = 3.0,
+    gamma: float = 0.0,
+    direct_sun_valid: bool = True,
+    calculate_percentage_return: float = 60.0,
+):
+    """Build a mock AdaptiveVerticalCover for GlareZoneHandler tests."""
+    cover = MagicMock()
+    cover.direct_sun_valid = direct_sun_valid
+    cover.distance = distance
+    cover.gamma = gamma
+    cover.calculate_percentage = MagicMock(return_value=calculate_percentage_return)
+    cover.config = MagicMock()
+    cover.config.min_pos = None
+    cover.config.max_pos = None
+    cover.config.min_pos_sun_only = False
+    cover.config.max_pos_sun_only = False
+    return cover
+
+
+handler = GlareZoneHandler()
+
+
+class TestZoneCloserThanBaseShouldOverride:
+    """Zone closer than base_distance is in the illuminated zone — handler MUST fire."""
+
+    def test_zone_closer_than_base_fires_handler(self) -> None:
+        """Zone at 0.9m with base_distance=10m: zone is illuminated, handler must fire.
+
+        SolarHandler would compute position for 10m (very open, ~high %).
+        The zone at 0.9m is well within the illuminated area and needs protection.
+        GlareZoneHandler must override with a more protective (lower %) position.
+        """
+        cover = _make_vertical_cover(
+            distance=10.0,  # base distance 10m — SolarHandler allows sun deep into room
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=5.0,  # glare zone position would be very closed
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=10.0)],  # 0.9m
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = handler.evaluate(snap)
+        # Zone at 0.9m < base 10m → zone is illuminated → handler MUST fire
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+
+    def test_zone_at_1m_base_at_3m_fires_handler(self) -> None:
+        """Reporter's scenario: zone 1m deep, base_distance 3m.
+
+        SolarHandler with base=3m allows sun to penetrate up to 3m.
+        Zone at 1m is illuminated. GlareZoneHandler must override.
+        """
+        cover = _make_vertical_cover(
+            distance=3.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=15.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],  # 1.0m
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+
+
+class TestZoneFartherThanBaseShouldFallThrough:
+    """Zone farther than base_distance is already in shadow — handler should NOT fire."""
+
+    def test_zone_farther_than_base_falls_through(self) -> None:
+        """Zone at 4m with base_distance=1m: zone is already in shadow.
+
+        SolarHandler with base=1m computes a very closed position (low %).
+        Sun cannot penetrate beyond ~1m. Zone at 4m is safely in shadow.
+        GlareZoneHandler should NOT override — it would make things WORSE
+        (computing a higher position for the 4m distance = less blind).
+        """
+        cover = _make_vertical_cover(
+            distance=1.0,  # base distance 1m — SolarHandler blocks beyond 1m
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=80.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=400.0, radius=30.0)],  # ~3.7m
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = handler.evaluate(snap)
+        # Zone at ~3.7m > base 1m → zone is in shadow → fall through
+        assert result is None
+
+
+class TestMinDistanceUsedNotMax:
+    """With multiple zones, the CLOSEST zone dictates the position (most restrictive)."""
+
+    def test_closest_zone_determines_position(self) -> None:
+        """Two zones at 0.5m and 2m, base_distance=3m.
+
+        Both zones are closer than base (illuminated). The 0.5m zone needs
+        the most blind (lowest position%). Handler must use min distance (0.5m),
+        not max distance (2m).
+        """
+        cover = _make_vertical_cover(
+            distance=3.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=10.0,
+        )
+        zone_near = GlareZone(name="monitor", x=0.0, y=50.0, radius=0.0)  # 0.5m
+        zone_far = GlareZone(name="desk", x=0.0, y=200.0, radius=0.0)  # 2.0m
+        glare_cfg = GlareZonesConfig(
+            zones=[zone_near, zone_far],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"monitor", "desk"},
+        )
+        result = handler.evaluate(snap)
+        assert result is not None
+        # The handler must have called calculate_percentage with the CLOSEST
+        # zone distance (0.5m), not the farthest (2.0m).
+        # Note: calculate_percentage is called twice — once by the handler with
+        # effective_distance_override, and once by compute_raw_calculated_position
+        # without it. Check the first call.
+        first_call = cover.calculate_percentage.call_args_list[0]
+        override = first_call.kwargs.get("effective_distance_override")
+        assert override == 0.5, (
+            f"Expected effective_distance_override=0.5 (closest zone), got {override}"
+        )
+
+    def test_contributing_zone_is_closest(self) -> None:
+        """The reason string should name the closest zone, not the farthest."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=8.0,
+        )
+        zone_near = GlareZone(name="monitor", x=0.0, y=80.0, radius=0.0)  # 0.8m
+        zone_far = GlareZone(name="desk", x=0.0, y=300.0, radius=0.0)  # 3.0m
+        glare_cfg = GlareZonesConfig(
+            zones=[zone_near, zone_far],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"monitor", "desk"},
+        )
+        result = handler.evaluate(snap)
+        assert result is not None
+        assert "monitor" in result.reason
+
+
+class TestMixedZonesAboveAndBelowBase:
+    """When some zones are closer than base and some farther, only closer ones matter."""
+
+    def test_only_zones_closer_than_base_trigger_override(self) -> None:
+        """Zone at 0.5m (needs protection) and zone at 8m (already in shadow).
+
+        base_distance=3m. Only the 0.5m zone needs protection.
+        The 8m zone is in shadow and irrelevant.
+        """
+        cover = _make_vertical_cover(
+            distance=3.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=5.0,
+        )
+        zone_needs_protection = GlareZone(name="monitor", x=0.0, y=50.0, radius=0.0)
+        zone_in_shadow = GlareZone(name="couch", x=0.0, y=800.0, radius=0.0)
+        glare_cfg = GlareZonesConfig(
+            zones=[zone_needs_protection, zone_in_shadow],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"monitor", "couch"},
+        )
+        result = handler.evaluate(snap)
+        assert result is not None
+        # Must use the closest zone (0.5m) for the override
+        first_call = cover.calculate_percentage.call_args_list[0]
+        override = first_call.kwargs.get("effective_distance_override")
+        assert override == 0.5


### PR DESCRIPTION
## Summary

- `GlareZoneHandler` was using `max()` (farthest zone) when it should use `min()` (closest zone) — the closest zone to the window demands the most blind coverage because smaller effective distance → lower position% → more blind deployed
- The comparison was also inverted: the handler was firing when zones were *farther* than `base_distance` (already in shadow) and doing nothing when zones were *closer* (in the illuminated area and needing protection)
- Fixed by flipping to `min()` and inverting the `>= base_distance` comparison

Thanks to @ZamenWolk for the excellent analysis in #213.

## Testing

- 6 new TDD regression tests in `tests/test_pipeline/test_glare_zone_handler_fix.py` (written RED-first against the bug, confirmed GREEN after fix)
- Updated 4 existing tests in `tests/test_pipeline/test_glare_zone_handler.py` that were asserting the backwards behavior
- ✅ 2048 tests passing

## Related Issues

Refs #213