### PR TITLE
fix: decouple force from is_safety in PositionContext (#223)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1159,6 +1159,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         options: dict,
         *,
         force: bool = False,
+        is_safety: bool = False,
         sun_just_appeared: bool = False,
     ) -> PositionContext:
         """Build a PositionContext for the given cover entity.
@@ -1169,7 +1170,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         Args:
             entity: Cover entity ID
             options: Config entry options dict
-            force: If True, all gate checks are bypassed
+            force: If True, all gate checks are bypassed (delta, time, manual
+                override).  Use for any intentional non-solar reposition.
+            is_safety: If True, the target is classified as safety-critical
+                (force override, weather) and will persist across window
+                boundaries — reconciliation will resend it even when outside
+                the active-hours window or with auto control off.  Must be
+                kept independent of ``force``: override-clear and toggle
+                actions need ``force=True`` (bypass gates) but
+                ``is_safety=False`` (don't persist past the window).
             sun_just_appeared: Pre-computed sun transition flag. Call
                 ``_check_sun_validity_transition()`` once before a multi-entity
                 loop and pass the result here so the stateful transition check
@@ -1185,6 +1194,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             special_positions=build_special_positions(options),
             inverse_state=self._inverse_state,
             force=force,
+            is_safety=is_safety,
             use_my_position=self._pipeline_result.use_my_position
             if self._pipeline_result
             else False,
@@ -1317,7 +1327,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
         for cover in self.entities:
             ctx = self._build_position_context(
-                cover, options, force=use_force, sun_just_appeared=sun_just_appeared
+                cover,
+                options,
+                force=use_force,
+                is_safety=is_safety,
+                sun_just_appeared=sun_just_appeared,
             )
             await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
         self.state_change = False
@@ -1421,7 +1435,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
                 continue
             ctx = self._build_position_context(
-                cover, options, force=is_safety, sun_just_appeared=sun_just_appeared
+                cover,
+                options,
+                force=is_safety,
+                is_safety=is_safety,
+                sun_just_appeared=sun_just_appeared,
             )
             await self._cmd_svc.apply_position(cover, state, "startup", context=ctx)
         self.first_refresh = False

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -386,6 +386,7 @@ class DiagnosticsBuilder:
                 "is_sunny": climate_data.is_sunny,
                 "lux_below_threshold": climate_data.lux_below_threshold,
                 "irradiance_below_threshold": climate_data.irradiance_below_threshold,
+                "cloud_coverage_above_threshold": climate_data.cloud_coverage_above_threshold,
             }
 
         return diagnostics

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -50,6 +50,7 @@ class PositionContext:
     special_positions: list[int]
     inverse_state: bool = False
     force: bool = False  # Skip all gate checks when True
+    is_safety: bool = False  # Safety-critical target (persists across window boundaries)
     use_my_position: bool = (
         False  # Route through send_my_position() on non-position-capable covers
     )
@@ -147,7 +148,7 @@ class CoverCommandService:
         # so it doesn't fight the user by resending the old integration target.
         # Updated by the coordinator after every manual override state change.
         # Safety handlers (force override, weather) overwrite target_call via
-        # apply_position(force=True) so they always take effect regardless.
+        # apply_position(is_safety=True) so they always take effect regardless.
         self._manual_override_entities: set[str] = set()
 
         # Whether automatic control is currently enabled.  Synced by the
@@ -156,10 +157,10 @@ class CoverCommandService:
         # doesn't fight the user's intention to pause automation.
         self._auto_control_enabled: bool = True
 
-        # Entities whose current target_call was set via apply_position(force=True).
+        # Entities whose current target_call was set via apply_position(is_safety=True).
         # These are safety targets (force override, weather) and reconciliation
-        # must still resend them even when _auto_control_enabled is False.
-        # Cleared when a subsequent non-force target overwrites the entry.
+        # must still resend them even when _auto_control_enabled is False or the
+        # time window is closed.  Cleared when a non-safety target overwrites the entry.
         self._safety_targets: set[str] = set()
 
         # Whether the coordinator's operational time window is currently active.
@@ -260,8 +261,8 @@ class CoverCommandService:
 
         Called by the coordinator after each update cycle so reconciliation
         knows which entities to skip.  Safety handlers (force override,
-        weather) overwrite target_call via apply_position(force=True) so they
-        always take effect regardless of this set.
+        weather) overwrite target_call via apply_position(is_safety=True) so
+        they always take effect regardless of this set.
         """
         self._manual_override_entities = set(entities)
 
@@ -276,7 +277,7 @@ class CoverCommandService:
 
         Called by the coordinator each update cycle so reconciliation knows
         whether to resend non-safety targets.  When False, only targets that
-        were sent via apply_position(force=True) — i.e. safety overrides —
+        were sent via apply_position(is_safety=True) — i.e. safety overrides —
         are eligible for reconciliation resends.
         """
         self._auto_control_enabled = value
@@ -292,7 +293,7 @@ class CoverCommandService:
 
         Called by the coordinator each update cycle so reconciliation knows
         whether to resend non-safety targets.  When False, only safety targets
-        (sent via apply_position(force=True)) are eligible for reconciliation.
+        (sent via apply_position(is_safety=True)) are eligible for reconciliation.
         """
         self._in_time_window = value
 
@@ -812,7 +813,7 @@ class CoverCommandService:
             entity_id,
             position,
             context.inverse_state,
-            is_safety=context.force,
+            is_safety=context.is_safety,
             use_my_position=context.use_my_position,
         )
         if service is None:
@@ -938,10 +939,10 @@ class CoverCommandService:
         3. If entity is in ``_manual_override_entities`` → skip resend so
            reconciliation does not fight the user's intentional move.
            Safety handlers (force override, weather) overwrite ``target_call``
-           via ``apply_position(force=True)`` so they are always protected.
+           via ``apply_position(is_safety=True)`` so they are always protected.
         4. If ``_auto_control_enabled`` is False and the entity is not in
            ``_safety_targets`` → skip.  Safety targets (set via
-           ``apply_position(force=True)``) are still resent so covers reach
+           ``apply_position(is_safety=True)``) are still resent so covers reach
            a safe position regardless of the automatic control toggle.
         5. If ``_in_time_window`` is False and entity is not in ``_safety_targets``
            → skip.  Prevents stale daytime targets from being resent overnight.
@@ -986,8 +987,8 @@ class CoverCommandService:
             # 2. Skip entities under manual override — the user moved the cover
             # intentionally; resending the integration's stale target would fight
             # the user.  Safety handlers (force override, weather) bypass this by
-            # calling apply_position(force=True) which overwrites target_call with
-            # the safety position, so they are always protected by reconciliation.
+            # calling apply_position(is_safety=True) which overwrites target_call
+            # with the safety position, so they are always protected by reconciliation.
             if entity_id in self._manual_override_entities:
                 self._logger.debug(
                     "Reconcile: %s in manual override — skipping resend", entity_id
@@ -996,7 +997,7 @@ class CoverCommandService:
 
             # 3. Skip non-safety targets when automatic control is off.  Safety
             # targets (force override, weather) are still resent because they
-            # were placed via apply_position(force=True) and are tracked in
+            # were placed via apply_position(is_safety=True) and are tracked in
             # _safety_targets — covers must reach a safe position regardless of
             # the automatic control toggle.
             if not self._auto_control_enabled and entity_id not in self._safety_targets:
@@ -1216,8 +1217,9 @@ class CoverCommandService:
                 ``_execute_command`` so reconciliation retries do not reset the
                 counter they themselves manage.
             is_safety: If True, this target was set via a safety override
-                (force=True path).  Adds the entity to ``_safety_targets`` so
-                reconciliation will resend it even when automatic control is off.
+                (force override, weather handler).  Adds the entity to
+                ``_safety_targets`` so reconciliation will resend it even when
+                automatic control is off or outside the time window.
                 Non-safety targets remove the entity from ``_safety_targets``.
             use_my_position: If True and the cover lacks set_cover_position,
                 send cover.stop_cover to trigger the hardware My preset instead

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -53,6 +53,7 @@ class ClimateCoverData:
     lux_below_threshold: bool
     irradiance_below_threshold: bool
     winter_close_insulation: bool
+    cloud_coverage_above_threshold: bool = False
 
     @property
     def get_current_temperature(self) -> float | None:
@@ -320,6 +321,7 @@ class ClimateHandler(OverrideHandler):
             lux_below_threshold=r.lux_below_threshold,
             irradiance_below_threshold=r.irradiance_below_threshold,
             winter_close_insulation=opts.winter_close_insulation,
+            cloud_coverage_above_threshold=r.cloud_coverage_above_threshold,
         )
 
         climate_cover_state = ClimateCoverState(snapshot, climate_data)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -34,23 +34,28 @@ class CloudSuppressionHandler(OverrideHandler):
             return None
 
         r = snapshot.climate_readings
-        suppressed = (
-            not r.is_sunny
-            or r.lux_below_threshold
-            or r.irradiance_below_threshold
-            or r.cloud_coverage_above_threshold
-        )
-        if not suppressed:
+        triggers = []
+        if not r.is_sunny:
+            triggers.append("weather not sunny")
+        if r.lux_below_threshold:
+            triggers.append("lux below threshold")
+        if r.irradiance_below_threshold:
+            triggers.append("irradiance below threshold")
+        if r.cloud_coverage_above_threshold:
+            triggers.append("cloud coverage above threshold")
+
+        if not triggers:
             return None
 
         position = compute_default_position(snapshot)
         pos_label = (
             "sunset position" if snapshot.is_sunset_active else "default position"
         )
+        trigger_detail = ", ".join(triggers)
         return PipelineResult(
             position=position,
             control_method=ControlMethod.CLOUD,
-            reason=f"cloud/low-light suppression — no direct sun detected → {pos_label} {position}%",
+            reason=f"cloud/low-light suppression — {trigger_detail} → {pos_label} {position}%",
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -3,10 +3,20 @@
 Invariant under test
 ---------------------
 When ``automatic_control=False``, any coordinator call-site that is NOT a
-declared safety bypass must NOT invoke ``apply_position`` with
-``context.force=True``.  Safety bypasses (ForceOverrideHandler,
-WeatherOverrideHandler with ``bypass_auto_control=True``) are expected to call
-``apply_position`` with ``force=True`` regardless of the toggle.
+declared force bypass must NOT invoke ``apply_position`` with
+``context.force=True``.  Force bypasses come in two distinct sub-types:
+
+* **Safety targets** (ForceOverrideHandler, WeatherOverrideHandler):
+  ``context.force=True`` AND ``context.is_safety=True``.
+  Reconciliation resends their targets even when auto_control=OFF or outside
+  the time window.
+
+* **Non-safety force bypasses** (force_override_released, manual_override_clear):
+  ``context.force=True`` AND ``context.is_safety=False``.
+  Gate checks (delta, time, manual override) are bypassed so the command
+  goes out immediately, but the target is NOT persisted across window
+  boundaries.  The cover gets one best-effort attempt; reconciliation stops
+  once the window closes (fix for issue #223).
 
 Why this test exists
 --------------------
@@ -19,18 +29,26 @@ decision table in one place so:
    allowlist test (see ``test_force_apply_allowlist.py``).
 2. Any missing gate fails the ``assert_not_called_with_force`` helper rather
    than silently passing.
+3. The ``is_safety_target`` column documents whether the target should persist
+   across window boundaries — making the force vs. safety distinction explicit.
 
 Decision table (all rows assume ``automatic_control=False``)
 ------------------------------------------------------------
-+--------------------------------+------------------+--------------------------+
-| id                             | entry point      | is_safety_bypass         |
-+================================+==================+==========================+
-| manual_override_expiry         | _async_send_…    | False (coord gates it)   |
-| state_change_force_override    | async_handle_…   | True  (force=True ok)    |
-| state_change_weather_bypass    | async_handle_…   | True  (force=True ok)    |
-| first_refresh_safety           | async_handle_…   | True  (force=True ok)    |
-| window_close_return_sunset     | _check_time_…    | False (coord gates it)   |
-+--------------------------------+------------------+--------------------------+
++----------------------------------+------------------+------------------+-----------------+
+| id                               | entry point      | is_safety_bypass | is_safety_target|
++==================================+==================+==================+=================+
+| manual_override_expiry           | _async_send_…    | False (gated)    | False           |
+| state_change_force_override      | async_handle_…   | True             | True            |
+| state_change_weather_bypass      | async_handle_…   | True             | True            |
+| first_refresh_safety             | async_handle_…   | True             | True            |
+| window_close_return_sunset       | _check_time_…    | False (gated)    | False           |
+| state_change_force_override_rls  | async_handle_…   | True (force=True)| False (no tag)  |
++----------------------------------+------------------+------------------+-----------------+
+
+``state_change_force_override_rls``: when force override releases, the coordinator
+must bypass gate checks (force=True) so the cover returns to calculated position
+immediately, but the resulting target is NOT a safety target (is_safety=False) —
+it should not be resent by reconciliation outside the time window.
 
 Rows for state_change_solar and first_refresh_non_safety are omitted because
 those paths call apply_position with ``force=False`` and rely on the *service*
@@ -82,9 +100,11 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
     cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
     coord._cmd_svc = cmd_svc
 
-    # _build_position_context: preserve the force kwarg in the returned PositionContext
-    # so callers can inspect which force value the coordinator actually passed.
-    def _fake_build_ctx(entity, options, *, force=False, sun_just_appeared=False):
+    # _build_position_context: preserve force and is_safety kwargs in the returned
+    # PositionContext so callers can inspect which values the coordinator passed.
+    def _fake_build_ctx(
+        entity, options, *, force=False, is_safety=False, sun_just_appeared=False
+    ):
         return PositionContext(
             auto_control=False,  # reflects automatic_control=False
             manual_override=False,
@@ -93,6 +113,7 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
             time_threshold=0,
             special_positions=[0, 100],
             force=force,
+            is_safety=is_safety,
         )
 
     coord._build_position_context = _fake_build_ctx
@@ -116,6 +137,18 @@ def _force_calls(coord: AdaptiveDataUpdateCoordinator) -> list:
     return result
 
 
+def _safety_target_calls(coord: AdaptiveDataUpdateCoordinator) -> list:
+    """Return every apply_position call that passed context.is_safety=True."""
+    result = []
+    for call in coord._cmd_svc.apply_position.call_args_list:
+        ctx = call.kwargs.get("context") or (
+            call.args[3] if len(call.args) > 3 else None
+        )
+        if ctx is not None and getattr(ctx, "is_safety", False):
+            result.append(call)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Matrix definition
 # ---------------------------------------------------------------------------
@@ -123,10 +156,23 @@ def _force_calls(coord: AdaptiveDataUpdateCoordinator) -> list:
 
 @dataclass
 class MatrixCase:
-    """One row of the control-gate decision table."""
+    """One row of the control-gate decision table.
+
+    is_safety_bypass: True if this path calls apply_position(force=True) even
+        when automatic_control=False (gate bypass).  False if the coordinator
+        guards the call behind automatic_control / check_adaptive_time.
+
+    is_safety_target: True if the resulting PositionContext should have
+        is_safety=True (entity added to _safety_targets, persists across window
+        boundaries).  Meaningful only when is_safety_bypass=True.  Genuine
+        safety handlers (force override, weather) set this True; transitional
+        paths (force_override_released, override_clear) set this False — they
+        bypass gates for a one-shot send but do not persist the target.
+    """
 
     id: str
     is_safety_bypass: bool
+    is_safety_target: bool
     setup: Callable[[AdaptiveDataUpdateCoordinator], None]
     trigger: Callable[[AdaptiveDataUpdateCoordinator], Awaitable[None]]
 
@@ -194,36 +240,71 @@ async def _trigger_window_close_return_sunset(coord):
     await coord._check_time_window_transition(dt.datetime.now(dt.UTC))
 
 
+async def _trigger_force_override_released(coord):
+    """Trigger: force override just transitioned on → off.
+
+    Pipeline result is now solar (bypass_auto_control=False) but
+    prev_force_override=True.  The coordinator must send with force=True so
+    gate checks don't block the return to calculated position (#177), but the
+    resulting context must have is_safety=False so the target is NOT persisted
+    across window boundaries (#223).
+    """
+    coord._pipeline_result = _make_pipeline_result(bypass=False)
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.is_active = True
+    coord._check_sun_validity_transition = MagicMock(return_value=False)
+    coord.state_change = True
+    with patch.object(
+        type(coord),
+        "is_force_override_active",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
+        await coord.async_handle_state_change(50, {}, prev_force_override=True)
+
+
 CONTROL_GATE_MATRIX: list[MatrixCase] = [
     MatrixCase(
         id="manual_override_expiry",
         is_safety_bypass=False,
+        is_safety_target=False,
         setup=lambda _: None,
         trigger=_trigger_manual_override_expiry,
     ),
     MatrixCase(
         id="state_change_force_override",
         is_safety_bypass=True,
+        is_safety_target=True,
         setup=lambda _: None,
         trigger=_trigger_state_change_force_override,
     ),
     MatrixCase(
         id="state_change_weather_bypass",
         is_safety_bypass=True,
+        is_safety_target=True,
         setup=lambda _: None,
         trigger=_trigger_state_change_weather_bypass,
     ),
     MatrixCase(
         id="first_refresh_safety",
         is_safety_bypass=True,
+        is_safety_target=True,
         setup=lambda _: None,
         trigger=_trigger_first_refresh_safety,
     ),
     MatrixCase(
         id="window_close_return_sunset",
         is_safety_bypass=False,
+        is_safety_target=False,
         setup=lambda _: None,
         trigger=_trigger_window_close_return_sunset,
+    ),
+    MatrixCase(
+        id="state_change_force_override_released",
+        is_safety_bypass=True,   # force=True bypasses auto_control gate
+        is_safety_target=False,  # but is NOT a persistent safety target (#223)
+        setup=lambda _: None,
+        trigger=_trigger_force_override_released,
     ),
 ]
 
@@ -237,31 +318,60 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_auto_control_gate(case: MatrixCase):
-    """Invariant: non-safety paths must not call apply_position(force=True) when auto_control=OFF.
+    """Two invariants checked for every coordinator entry point.
 
-    If this test fails on a non-safety row, a coordinator call site is missing
-    an ``automatic_control`` gate.  Add the gate (matching the pattern in
-    ``_async_send_after_override_clear``) and update ``test_force_apply_allowlist.py``.
+    Invariant 1 — force gate:
+        Non-safety-bypass paths must NOT call apply_position(force=True) when
+        automatic_control=False.  The coordinator must guard the call.  Safety
+        bypasses (force/weather override, force_override_released) ARE allowed
+        to call with force=True regardless of the toggle.
 
-    If this test fails on a safety row, a legitimate safety bypass stopped
-    working — investigate the handler's ``bypass_auto_control`` flag.
+        Failure on a non-safety row → missing automatic_control gate.
+        Failure on a safety row → legitimate bypass stopped working.
+
+    Invariant 2 — safety-target classification:
+        Calls with force=True must use is_safety=True only for genuine safety
+        handlers (ForceOverride, Weather).  Transitional bypasses
+        (force_override_released, override_clear) must use is_safety=False so
+        the target is not persisted across window boundaries (fix #223).
+
+        Failure on a safety-target row → handler lost its safety classification.
+        Failure on a non-safety-target force-bypass row → target is incorrectly
+        persisted; reconciliation will resend it outside the time window.
     """
     coord = _base_coord()
     case.setup(coord)
     await case.trigger(coord)
 
     forced = _force_calls(coord)
+    safety_tagged = _safety_target_calls(coord)
 
+    # --- Invariant 1: force gate ---
     if case.is_safety_bypass:
         assert forced, (
-            f"[{case.id}] Safety bypass must call apply_position(context.force=True) "
+            f"[{case.id}] Force bypass must call apply_position(context.force=True) "
             f"when automatic_control=False, but no force=True call was recorded. "
             f"All calls: {coord._cmd_svc.apply_position.call_args_list}"
         )
     else:
         assert not forced, (
-            f"[{case.id}] Non-safety path called apply_position(context.force=True) "
+            f"[{case.id}] Non-bypass path called apply_position(context.force=True) "
             f"with automatic_control=False — add an automatic_control gate before the "
             f"apply_position call (see _async_send_after_override_clear for the pattern). "
             f"Offending calls: {forced}"
         )
+
+    # --- Invariant 2: safety-target classification ---
+    if case.is_safety_bypass:
+        if case.is_safety_target:
+            assert safety_tagged, (
+                f"[{case.id}] Genuine safety handler must pass is_safety=True so "
+                f"reconciliation persists the target across window boundaries. "
+                f"All calls: {coord._cmd_svc.apply_position.call_args_list}"
+            )
+        else:
+            assert not safety_tagged, (
+                f"[{case.id}] Transitional force bypass must NOT pass is_safety=True — "
+                f"the target should not persist across window boundaries (fix #223). "
+                f"Offending calls: {safety_tagged}"
+            )

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -145,11 +145,12 @@ class TestStateChangeWithSolarTracking:
             coordinator, state=55, options={}
         )
 
-        # _build_position_context must be called WITHOUT force=True
+        # _build_position_context must be called WITHOUT force=True or is_safety
         coordinator._build_position_context.assert_called_once_with(
             "cover.test",
             {},
             force=False,
+            is_safety=False,
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
 
@@ -227,6 +228,7 @@ class TestStateChangeWithDefaultPosition:
             "cover.blind",
             {},
             force=False,
+            is_safety=False,
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
 
@@ -440,6 +442,7 @@ class TestStateChangeWithSafetyHandlerBypass:
             "cover.test",
             {"test": True},
             force=True,  # ← safety bypass
+            is_safety=True,  # ← safety target classification
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
 
@@ -547,6 +550,7 @@ class TestForceOverrideRelease:
             "cover.test",
             {},
             force=True,  # ← must bypass time/position delta gates
+            is_safety=False,  # ← force override release is NOT a safety target
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
 
@@ -590,6 +594,7 @@ class TestForceOverrideRelease:
             "cover.test",
             {},
             force=False,  # ← normal solar tracking respects gates
+            is_safety=False,
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
 
@@ -620,6 +625,7 @@ class TestForceOverrideRelease:
             "cover.test",
             {},
             force=True,  # ← safety bypass from bypass_auto_control
+            is_safety=True,  # ← force override active = safety target
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
 

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -614,6 +614,44 @@ class TestClimateDiagnostics:
         assert "active_temperature" not in diag
         assert "climate_strategy" not in diag
 
+    def test_climate_conditions_includes_cloud_coverage_above_threshold(
+        self, builder: DiagnosticsBuilder
+    ):
+        """climate_conditions must include cloud_coverage_above_threshold (Issue #222)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(
+            control_method=ControlMethod.WINTER,
+            climate_data=cd,
+        )
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        conditions = diag["climate_conditions"]
+        assert "cloud_coverage_above_threshold" in conditions
+        assert conditions["cloud_coverage_above_threshold"] is False
+
+    def test_climate_conditions_cloud_coverage_true_when_active(
+        self, builder: DiagnosticsBuilder
+    ):
+        """cloud_coverage_above_threshold is True when the flag is set."""
+        cd = ClimateCoverData(
+            temp_low=20.0,
+            temp_high=25.0,
+            temp_switch=True,
+            blind_type="cover_blind",
+            transparent_blind=False,
+            temp_summer_outside=22.5,
+            outside_temperature="22.5",
+            inside_temperature="23.0",
+            is_presence=True,
+            is_sunny=True,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            winter_close_insulation=False,
+            cloud_coverage_above_threshold=True,
+        )
+        pr = _make_pr(control_method=ControlMethod.CLOUD, climate_data=cd)
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        assert diag["climate_conditions"]["cloud_coverage_above_threshold"] is True
+
 
 # ---------------------------------------------------------------------------
 # Last action diagnostics

--- a/tests/test_force_apply_allowlist.py
+++ b/tests/test_force_apply_allowlist.py
@@ -17,22 +17,40 @@ bypass all CoverCommandService gate checks (auto_control, delta, time_delta,
 etc.).  Every such site must either:
 
 a) Pre-gate on ``self.automatic_control`` (non-safety paths), or
-b) Be a declared safety bypass (ForceOverrideHandler, WeatherOverrideHandler).
+b) Be a declared force bypass (safety handler OR transitional path).
 
 In both cases, a human reviewer must acknowledge the site by adding it to the
 allowlist here AND adding a row to ``test_auto_control_gate_matrix.py``.
 
+force=True vs is_safety=True — two independent flags
+------------------------------------------------------
+``force=True`` means "bypass gate checks (delta, time, manual override) for
+this one send".  It does NOT automatically classify the target as a safety
+target.
+
+``is_safety=True`` means "this target is safety-critical and must persist across
+window boundaries — reconciliation resends it even when outside the time window
+or with auto_control=OFF".  Only genuine safety handlers (ForceOverride,
+WeatherOverride) should set this True.
+
+Transitional paths that need to bypass gates for a one-shot send (e.g.
+``_async_send_after_override_clear``) use ``force=True, is_safety=False`` (the
+default) — they get through the gates but do not persist as safety targets.
+This decoupling was introduced in the fix for issue #223.
+
 How to respond when this test fails
 -------------------------------------
 1. Identify the new ``force=True`` call site in ``coordinator.py``.
-2. Decide: is this a safety bypass (force/weather override) or a non-safety path?
-   - **Non-safety:** Add an ``automatic_control`` early-return guard *before* the
-     ``_build_position_context`` call (see ``_async_send_after_override_clear`` or
-     ``_on_window_closed`` for the pattern).
-   - **Safety bypass:** Document why ``automatic_control=OFF`` must not block this
-     path.
+2. Decide: does this path bypass ``automatic_control`` intentionally?
+   - **Non-bypass (gated):** Add an ``automatic_control`` early-return guard
+     *before* the ``_build_position_context`` call (see
+     ``_async_send_after_override_clear`` for the pattern).
+   - **Intentional bypass:** Decide whether it is a safety target (ForceOverride,
+     Weather) or a transitional one-shot (override clear, force_released).
+     Transitional paths use the default ``is_safety=False``.
 3. Add the enclosing function name to ``ALLOWED_LITERAL_FORCE_TRUE_SITES`` below.
-4. Add a row to ``CONTROL_GATE_MATRIX`` in ``test_auto_control_gate_matrix.py``.
+4. Add a row to ``CONTROL_GATE_MATRIX`` in ``test_auto_control_gate_matrix.py``
+   with the correct ``is_safety_bypass`` and ``is_safety_target`` values.
 """
 
 from __future__ import annotations

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -138,12 +138,19 @@ async def test_override_clear_uses_force_true_inside_window():
         coordinator, state=75, options={"test_option": True}
     )
 
-    # _build_position_context must be called with force=True
+    # _build_position_context must be called with force=True but NOT is_safety
+    # (override clear bypasses gates but is not a safety-critical target)
     coordinator._build_position_context.assert_called_once_with(
         "cover.test_blind",
         {"test_option": True},
         force=True,
         sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+    )
+    ctx = coordinator._build_position_context.call_args
+    assert not ctx.kwargs.get("is_safety", False), (
+        "_async_send_after_override_clear must NOT pass is_safety=True — "
+        "override-clear targets are NOT safety targets and must not persist "
+        "across window boundaries (fix for issue #223)"
     )
 
 
@@ -880,4 +887,207 @@ class TestIssue215StaleSafetyTarget:
         assert entity_id not in svc.target_call, (
             "After discard_target, entity must not appear in target_call — "
             "reconcile loop has nothing to process"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #223: override-clear must NOT safety-tag the target
+# ---------------------------------------------------------------------------
+
+
+class TestIssue223OverrideClearSafetyTag:
+    """Regression tests for issue #223.
+
+    Root cause: _async_send_after_override_clear called apply_position with
+    force=True (to bypass delta gates), but force=True was conflated with
+    is_safety=True, adding the entity to _safety_targets.  When the window
+    later closed, clear_non_safety_targets() preserved the entity and
+    reconciliation bypassed the time-window guard, resending the stale target.
+
+    Fix: decouple force (bypass gates) from is_safety (safety target
+    classification) by adding an explicit is_safety field to PositionContext.
+    _async_send_after_override_clear still uses force=True but is_safety
+    defaults to False, so the target is cleaned up normally when the window
+    closes.
+    """
+
+    def _make_svc(self):
+        import logging
+
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        hass = MagicMock()
+        mock_state = MagicMock()
+        mock_state.attributes = {"supported_features": 143}
+        mock_state.last_updated = None
+        hass.states.get.return_value = mock_state
+        hass.services.async_call = AsyncMock()
+        grace_mgr = MagicMock()
+        return CoverCommandService(
+            hass=hass,
+            logger=logging.getLogger("test"),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+        )
+
+    @pytest.mark.asyncio
+    async def test_override_clear_does_not_safety_tag_entity(self):
+        """Override-clear apply_position must NOT add entity to _safety_targets.
+
+        force=True is still used to bypass delta/time gates, but is_safety must
+        remain False so the target does not persist across window boundaries.
+        """
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            PositionContext,
+        )
+
+        svc = self._make_svc()
+        svc._enabled = True
+        entity_id = "cover.bedroom_blind"
+
+        ctx = PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=5,
+            time_threshold=2,
+            special_positions=[0, 100],
+            force=True,
+            is_safety=False,  # override clear: bypass gates but NOT safety
+        )
+        await svc.apply_position(entity_id, 55, "manual_override_cleared", context=ctx)
+
+        assert entity_id not in svc._safety_targets, (
+            "Override-clear target must NOT be tagged as a safety target. "
+            "is_safety=False ensures the target is cleaned up when the window "
+            "closes (fix for issue #223)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_override_clear_target_cleared_by_window_close(self):
+        """After override-clear, clear_non_safety_targets() must remove the target.
+
+        If the entity was incorrectly safety-tagged, clear_non_safety_targets()
+        would preserve it and reconciliation would resend it outside the window.
+        """
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            PositionContext,
+        )
+
+        svc = self._make_svc()
+        svc._enabled = True
+        entity_id = "cover.bedroom_blind"
+
+        ctx = PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=5,
+            time_threshold=2,
+            special_positions=[0, 100],
+            force=True,
+            is_safety=False,
+        )
+        await svc.apply_position(entity_id, 55, "manual_override_cleared", context=ctx)
+
+        # Simulate window closing
+        svc.clear_non_safety_targets()
+
+        assert entity_id not in svc.target_call, (
+            "After window close, override-clear target must be removed — "
+            "it was not safety-tagged so clear_non_safety_targets() must clear it."
+        )
+
+    @pytest.mark.asyncio
+    async def test_safety_handler_still_tags_entity(self):
+        """Safety handlers (force override, weather) must still tag entities.
+
+        Verifies that the fix does not accidentally break genuine safety targets.
+        """
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            PositionContext,
+        )
+
+        svc = self._make_svc()
+        svc._enabled = True
+        entity_id = "cover.bedroom_blind"
+
+        ctx = PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=5,
+            time_threshold=2,
+            special_positions=[0, 100],
+            force=True,
+            is_safety=True,  # genuine safety handler
+        )
+        await svc.apply_position(entity_id, 0, "force_override", context=ctx)
+
+        assert entity_id in svc._safety_targets, (
+            "Safety handler target must be tagged — reconciliation needs it to "
+            "persist across window boundaries."
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_skips_override_clear_target_outside_window(self):
+        """Full scenario: override clears → window closes → reconcile must skip.
+
+        This is the exact bug from issue #223: the cover should NOT be resent
+        after the window closes if the override expired during the window.
+        """
+        import logging
+
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+            PositionContext,
+        )
+
+        hass = MagicMock()
+        mock_state = MagicMock()
+        mock_state.attributes = {"supported_features": 143, "current_position": 55}
+        mock_state.last_updated = None
+        mock_state.state = "open"
+        hass.states.get.return_value = mock_state
+        hass.services.async_call = AsyncMock()
+
+        svc = CoverCommandService(
+            hass=hass,
+            logger=logging.getLogger("test"),
+            cover_type="cover_blind",
+            grace_mgr=MagicMock(),
+        )
+        svc._enabled = True
+        entity_id = "cover.bedroom_blind"
+
+        # Step 1: Override clears inside window → apply_position(force=True, is_safety=False)
+        ctx = PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=5,
+            time_threshold=2,
+            special_positions=[0, 100],
+            force=True,
+            is_safety=False,
+        )
+        await svc.apply_position(entity_id, 55, "manual_override_cleared", context=ctx)
+        svc.wait_for_target[entity_id] = False  # cover reached position
+
+        # Step 2: Window closes → clear_non_safety_targets removes the target
+        svc.in_time_window = False
+        svc.clear_non_safety_targets()
+
+        # Reset the mock so we only track calls made BY reconciliation
+        hass.services.async_call.reset_mock()
+
+        # Step 3: Reconciliation — must NOT resend (target was cleared)
+        await svc._reconcile(dt.datetime.now(UTC))
+
+        hass.services.async_call.assert_not_called(), (
+            "Reconciliation must not resend the override-clear target outside the "
+            "time window — the entity was not safety-tagged and was cleaned up "
+            "when the window closed (fix for issue #223)."
         )

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -235,3 +235,84 @@ class TestCloudHandlerTimeWindow:
         )
         result = self.handler.evaluate(snap)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Reason string includes specific trigger labels (Issue #222)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudHandlerReasonString:
+    """Reason string must identify which condition(s) triggered suppression."""
+
+    handler = CloudSuppressionHandler()
+
+    def test_reason_includes_weather_not_sunny(self) -> None:
+        """Reason must mention 'weather not sunny' when is_sunny is False."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "weather not sunny" in result.reason
+
+    def test_reason_includes_lux_below_threshold(self) -> None:
+        """Reason must mention 'lux below threshold' when lux fires."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=True, lux_below_threshold=True),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "lux below threshold" in result.reason
+
+    def test_reason_includes_irradiance_below_threshold(self) -> None:
+        """Reason must mention 'irradiance below threshold' when irradiance fires."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(
+                is_sunny=True, irradiance_below_threshold=True
+            ),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "irradiance below threshold" in result.reason
+
+    def test_reason_includes_cloud_coverage_above_threshold(self) -> None:
+        """Reason must mention 'cloud coverage above threshold' when cloud fires."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(
+                is_sunny=True, cloud_coverage_above_threshold=True
+            ),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "cloud coverage above threshold" in result.reason
+
+    def test_reason_lists_multiple_triggers(self) -> None:
+        """When multiple conditions fire, all should appear in the reason string."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(
+                is_sunny=False,
+                lux_below_threshold=True,
+                cloud_coverage_above_threshold=True,
+            ),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "weather not sunny" in result.reason
+        assert "lux below threshold" in result.reason
+        assert "cloud coverage above threshold" in result.reason
+
+    def test_reason_does_not_say_no_direct_sun_detected(self) -> None:
+        """Old generic phrase 'no direct sun detected' must not appear (Issue #222)."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "no direct sun detected" not in result.reason

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -646,25 +646,47 @@ async def test_reconcile_with_force_override_sensor_scenario(svc, mock_hass):
 
 
 # ------------------------------------------------------------------ #
-# Bug fix: force=True commands mark safety targets;
-#          _reconcile skips non-safety targets when auto_control is off
+# is_safety flag controls safety target classification;
+# force flag is independent (bypasses gates only);
+# _reconcile skips non-safety targets when auto_control is off
 # ------------------------------------------------------------------ #
 
 
 @pytest.mark.asyncio
-async def test_force_apply_marks_safety_target(svc, mock_hass):
-    """apply_position(force=True) adds entity to _safety_targets."""
+async def test_safety_apply_marks_safety_target(svc, mock_hass):
+    """apply_position(is_safety=True) adds entity to _safety_targets."""
     _patch_position(svc, 30)
     with _patch_caps():
         await svc.apply_position(
-            "cover.test", 0, "force_override", context=_ctx(force=True)
+            "cover.test", 0, "force_override", context=_ctx(force=True, is_safety=True)
         )
     assert "cover.test" in svc._safety_targets
 
 
 @pytest.mark.asyncio
-async def test_non_force_apply_removes_from_safety_targets(svc, mock_hass):
-    """apply_position(force=False) removes entity from _safety_targets.
+async def test_force_without_is_safety_does_not_mark_safety_target(svc, mock_hass):
+    """apply_position(force=True, is_safety=False) does NOT add entity to _safety_targets.
+
+    force=True only bypasses gate checks (delta, time, manual override).
+    Safety target classification is controlled exclusively by is_safety.
+    Callers like _async_send_after_override_clear use force=True to bypass
+    gates but is_safety=False so the target does not persist across window
+    boundaries (fix for issue #223).
+    """
+    _patch_position(svc, 30)
+    with _patch_caps():
+        await svc.apply_position(
+            "cover.test",
+            0,
+            "manual_override_cleared",
+            context=_ctx(force=True, is_safety=False),
+        )
+    assert "cover.test" not in svc._safety_targets
+
+
+@pytest.mark.asyncio
+async def test_non_safety_apply_removes_from_safety_targets(svc, mock_hass):
+    """apply_position(is_safety=False) removes entity from _safety_targets.
 
     When a safety override clears and normal solar tracking resumes, the
     entity should no longer be treated as a safety target.
@@ -720,7 +742,7 @@ async def test_reconcile_still_resends_safety_target_when_auto_control_off(
     svc.wait_for_target["cover.test"] = False
     _patch_position(svc, 50)  # Cover hasn't reached safety position yet
 
-    # Mark as safety target (sent via force=True)
+    # Mark as safety target (sent via is_safety=True)
     svc._safety_targets.add("cover.test")
     # Automatic control is off
     svc.auto_control_enabled = False
@@ -785,7 +807,7 @@ async def test_reconcile_resends_safety_target_outside_time_window(svc, mock_has
     svc.wait_for_target["cover.test"] = False
     _patch_position(svc, 50)  # Cover hasn't reached safety position yet
 
-    # Mark as safety target (sent via force=True)
+    # Mark as safety target (sent via is_safety=True)
     svc._safety_targets.add("cover.test")
     # Time window is closed
     svc.in_time_window = False
@@ -932,7 +954,7 @@ async def test_safety_target_cleared_on_open_close_non_force(svc, mock_hass):
 
 @pytest.mark.asyncio
 async def test_safety_target_set_on_open_close_force(svc, mock_hass):
-    """Force apply on open/close-only covers marks entity as safety target."""
+    """Safety apply on open/close-only covers marks entity as safety target."""
     with patch(
         "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
         return_value={
@@ -943,7 +965,7 @@ async def test_safety_target_set_on_open_close_force(svc, mock_hass):
         },
     ):
         await svc.apply_position(
-            "cover.test", 0, "force_override", context=_ctx(force=True)
+            "cover.test", 0, "force_override", context=_ctx(force=True, is_safety=True)
         )
     assert "cover.test" in svc._safety_targets
 


### PR DESCRIPTION
## Summary
- Decouple `force` (bypass gate checks) from `is_safety` (safety target classification) in `PositionContext` — same class of bug as #215/#216, now fixed universally
- `_async_send_after_override_clear` uses `force=True` to bypass delta gates but `is_safety=False` (default) so the target is not persisted across window boundaries
- All 4 non-genuine-safety callers of `force=True` are now correctly classified; the 2 genuine safety callers (force override active, weather) remain `is_safety=True`
- Matrix test extended with `is_safety_target` column and `force_override_released` row to make the force/safety distinction an explicit, tested invariant going forward

## Testing
- ✅ 2128 tests passing
- New `TestIssue223OverrideClearSafetyTag` regression tests (4 tests) cover the full scenario: override clear → window close → reconciliation skip
- New matrix row `state_change_force_override_released` asserts `force=True, is_safety=False`

## Related Issues
Refs #223