### PR TITLE
fix: normalize next-occurrence sun sensor start time in time window (#226)

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -386,6 +386,7 @@ class DiagnosticsBuilder:
                 "is_sunny": climate_data.is_sunny,
                 "lux_below_threshold": climate_data.lux_below_threshold,
                 "irradiance_below_threshold": climate_data.irradiance_below_threshold,
+                "cloud_coverage_above_threshold": climate_data.cloud_coverage_above_threshold,
             }
 
         return diagnostics

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -53,6 +53,7 @@ class ClimateCoverData:
     lux_below_threshold: bool
     irradiance_below_threshold: bool
     winter_close_insulation: bool
+    cloud_coverage_above_threshold: bool = False
 
     @property
     def get_current_temperature(self) -> float | None:
@@ -320,6 +321,7 @@ class ClimateHandler(OverrideHandler):
             lux_below_threshold=r.lux_below_threshold,
             irradiance_below_threshold=r.irradiance_below_threshold,
             winter_close_insulation=opts.winter_close_insulation,
+            cloud_coverage_above_threshold=r.cloud_coverage_above_threshold,
         )
 
         climate_cover_state = ClimateCoverState(snapshot, climate_data)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -34,23 +34,28 @@ class CloudSuppressionHandler(OverrideHandler):
             return None
 
         r = snapshot.climate_readings
-        suppressed = (
-            not r.is_sunny
-            or r.lux_below_threshold
-            or r.irradiance_below_threshold
-            or r.cloud_coverage_above_threshold
-        )
-        if not suppressed:
+        triggers = []
+        if not r.is_sunny:
+            triggers.append("weather not sunny")
+        if r.lux_below_threshold:
+            triggers.append("lux below threshold")
+        if r.irradiance_below_threshold:
+            triggers.append("irradiance below threshold")
+        if r.cloud_coverage_above_threshold:
+            triggers.append("cloud coverage above threshold")
+
+        if not triggers:
             return None
 
         position = compute_default_position(snapshot)
         pos_label = (
             "sunset position" if snapshot.is_sunset_active else "default position"
         )
+        trigger_detail = ", ".join(triggers)
         return PipelineResult(
             position=position,
             control_method=ControlMethod.CLOUD,
-            reason=f"cloud/low-light suppression — no direct sun detected → {pos_label} {position}%",
+            reason=f"cloud/low-light suppression — {trigger_detail} → {pos_label} {position}%",
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -614,6 +614,44 @@ class TestClimateDiagnostics:
         assert "active_temperature" not in diag
         assert "climate_strategy" not in diag
 
+    def test_climate_conditions_includes_cloud_coverage_above_threshold(
+        self, builder: DiagnosticsBuilder
+    ):
+        """climate_conditions must include cloud_coverage_above_threshold (Issue #222)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(
+            control_method=ControlMethod.WINTER,
+            climate_data=cd,
+        )
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        conditions = diag["climate_conditions"]
+        assert "cloud_coverage_above_threshold" in conditions
+        assert conditions["cloud_coverage_above_threshold"] is False
+
+    def test_climate_conditions_cloud_coverage_true_when_active(
+        self, builder: DiagnosticsBuilder
+    ):
+        """cloud_coverage_above_threshold is True when the flag is set."""
+        cd = ClimateCoverData(
+            temp_low=20.0,
+            temp_high=25.0,
+            temp_switch=True,
+            blind_type="cover_blind",
+            transparent_blind=False,
+            temp_summer_outside=22.5,
+            outside_temperature="22.5",
+            inside_temperature="23.0",
+            is_presence=True,
+            is_sunny=True,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            winter_close_insulation=False,
+            cloud_coverage_above_threshold=True,
+        )
+        pr = _make_pr(control_method=ControlMethod.CLOUD, climate_data=cd)
+        diag, _ = builder.build(_base_ctx(climate_mode=True, pipeline_result=pr))
+        assert diag["climate_conditions"]["cloud_coverage_above_threshold"] is True
+
 
 # ---------------------------------------------------------------------------
 # Last action diagnostics

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -235,3 +235,84 @@ class TestCloudHandlerTimeWindow:
         )
         result = self.handler.evaluate(snap)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Reason string includes specific trigger labels (Issue #222)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudHandlerReasonString:
+    """Reason string must identify which condition(s) triggered suppression."""
+
+    handler = CloudSuppressionHandler()
+
+    def test_reason_includes_weather_not_sunny(self) -> None:
+        """Reason must mention 'weather not sunny' when is_sunny is False."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "weather not sunny" in result.reason
+
+    def test_reason_includes_lux_below_threshold(self) -> None:
+        """Reason must mention 'lux below threshold' when lux fires."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=True, lux_below_threshold=True),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "lux below threshold" in result.reason
+
+    def test_reason_includes_irradiance_below_threshold(self) -> None:
+        """Reason must mention 'irradiance below threshold' when irradiance fires."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(
+                is_sunny=True, irradiance_below_threshold=True
+            ),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "irradiance below threshold" in result.reason
+
+    def test_reason_includes_cloud_coverage_above_threshold(self) -> None:
+        """Reason must mention 'cloud coverage above threshold' when cloud fires."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(
+                is_sunny=True, cloud_coverage_above_threshold=True
+            ),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "cloud coverage above threshold" in result.reason
+
+    def test_reason_lists_multiple_triggers(self) -> None:
+        """When multiple conditions fire, all should appear in the reason string."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(
+                is_sunny=False,
+                lux_below_threshold=True,
+                cloud_coverage_above_threshold=True,
+            ),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "weather not sunny" in result.reason
+        assert "lux below threshold" in result.reason
+        assert "cloud coverage above threshold" in result.reason
+
+    def test_reason_does_not_say_no_direct_sun_detected(self) -> None:
+        """Old generic phrase 'no direct sun detected' must not appear (Issue #222)."""
+        snap = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "no direct sun detected" not in result.reason

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import pytest
 from unittest.mock import MagicMock
 
 
@@ -272,3 +273,518 @@ class TestGlareZoneHandlerLogic:
     def test_name(self) -> None:
         """GlareZoneHandler name is 'glare_zone'."""
         assert GlareZoneHandler.name == "glare_zone"
+
+
+class TestGlareZoneBoundaryAtBaseDistance:
+    """Regression for the >= vs > boundary comparison in the issue #213 fix.
+
+    The fix changed the condition from ``max_distance > base_distance``
+    (inverted) to ``min_distance >= base_distance``.  A zone at exactly
+    base_distance is already in shadow — the handler must NOT fire.
+    """
+
+    handler = GlareZoneHandler()
+
+    def test_zone_at_exact_base_distance_falls_through(self) -> None:
+        """Zone at exactly base_distance is already in shadow — returns None.
+
+        nearest_y = 200cm → effective_distance = 2.0m = base_distance exactly.
+        The >= check means min_distance >= base_distance → handler falls through.
+        """
+        cover = _make_vertical_cover(distance=2.0, gamma=0.0, direct_sun_valid=True)
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=200.0, radius=0.0)],
+            window_width=400.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        assert self.handler.evaluate(snap) is None
+
+    def test_zone_barely_closer_than_base_fires(self) -> None:
+        """Zone 1 cm closer than base (1.99 m < 2.0 m) triggers the handler."""
+        cover = _make_vertical_cover(
+            distance=2.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=20.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=199.0, radius=0.0)],  # 1.99 m
+            window_width=400.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+
+    def test_zone_barely_farther_than_base_falls_through(self) -> None:
+        """Zone 1 cm farther than base (2.01 m > 2.0 m) — already in shadow."""
+        cover = _make_vertical_cover(distance=2.0, gamma=0.0, direct_sun_valid=True)
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=201.0, radius=0.0)],  # 2.01 m
+            window_width=400.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        assert self.handler.evaluate(snap) is None
+
+
+class TestGlareZonePositionFloor:
+    """Verify the max(state, 1) clamp prevents position 0."""
+
+    handler = GlareZoneHandler()
+
+    def test_position_floors_at_1_when_calculate_returns_zero(self) -> None:
+        """calculate_percentage returning 0 must produce position 1, not 0."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=0.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=50.0, radius=0.0)],  # 0.5 m
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position >= 1
+
+    def test_position_floors_at_1_when_calculate_returns_negative(self) -> None:
+        """calculate_percentage returning a negative value must also floor at 1."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=-5.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=50.0, radius=0.0)],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position >= 1
+
+
+class TestGlareZonePositionLimits:
+    """Verify apply_snapshot_limits is applied to the glare-zone position."""
+
+    handler = GlareZoneHandler()
+
+    def _closer_zone_snap(self, cover) -> object:
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=50.0, radius=0.0)],  # 0.5 m
+            window_width=200.0,
+        )
+        return make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+
+    def test_min_position_applied(self) -> None:
+        """When calculated position is below min_pos, output is clamped to min_pos."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=5.0,
+        )
+        cover.config.min_pos = 20
+        cover.config.min_pos_sun_only = False  # always enforce
+        snap = self._closer_zone_snap(cover)
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position >= 20
+
+    def test_max_position_applied(self) -> None:
+        """When calculated position is above max_pos, output is clamped to max_pos."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=95.0,
+        )
+        cover.config.max_pos = 80
+        cover.config.max_pos_sun_only = False  # always enforce
+        snap = self._closer_zone_snap(cover)
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position <= 80
+
+
+class TestGlareZoneWithGamma:
+    """Non-zero sun angles affect zone reachability through the window."""
+
+    handler = GlareZoneHandler()
+
+    def test_positive_gamma_zone_reachable_through_wide_window(self) -> None:
+        """At gamma=30°, a centred zone at 2 m depth is still reachable.
+
+        x_at_window = 0 + 200 * tan(30°) ≈ 115 cm < 200 cm (half-width) → reachable.
+        Effective distance 2.0 m < base 5.0 m → handler fires.
+        """
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=30.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=25.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=200.0, radius=0.0)],
+            window_width=400.0,  # half-width = 200 cm
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+
+    def test_gamma_blocks_zone_outside_narrow_window(self) -> None:
+        """At gamma=-60°, a zone's entry point falls outside the window — blocked.
+
+        x_at_window = 0 + 100 * tan(-60°) ≈ -173 cm; half-width = 100 cm → blocked.
+        All zones return None → handler returns None.
+        """
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=-60.0,
+            direct_sun_valid=True,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],
+            window_width=200.0,  # half-width = 100 cm
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        assert self.handler.evaluate(snap) is None
+
+
+class TestGlareZoneAllGeometryBlocked:
+    """When geometry blocks every zone, evaluate() returns None."""
+
+    handler = GlareZoneHandler()
+
+    def test_all_zones_outside_window_returns_none(self) -> None:
+        """Zones far off-centre (x=500) are blocked by the narrow window."""
+        cover = _make_vertical_cover(distance=5.0, gamma=0.0, direct_sun_valid=True)
+        glare_cfg = GlareZonesConfig(
+            zones=[
+                GlareZone(name="zone_a", x=500.0, y=200.0, radius=0.0),
+                GlareZone(name="zone_b", x=600.0, y=150.0, radius=0.0),
+            ],
+            window_width=100.0,  # half-width = 50 cm; both x > 50
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"zone_a", "zone_b"},
+        )
+        assert self.handler.evaluate(snap) is None
+
+    def test_zone_behind_wall_returns_none(self) -> None:
+        """Zone with radius > y (nearest_y <= 0) is behind the window wall."""
+        cover = _make_vertical_cover(distance=5.0, gamma=0.0, direct_sun_valid=True)
+        glare_cfg = GlareZonesConfig(
+            # y=50, radius=60 → nearest_y = 50 - 60 = -10 ≤ 0 → blocked
+            zones=[GlareZone(name="desk", x=0.0, y=50.0, radius=60.0)],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        assert self.handler.evaluate(snap) is None
+
+
+class TestGlareZoneRawCalculatedPosition:
+    """The result must always include raw_calculated_position for diagnostics."""
+
+    handler = GlareZoneHandler()
+
+    def test_result_includes_raw_calculated_position(self) -> None:
+        """raw_calculated_position is set on the PipelineResult when handler fires."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=40.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],  # 1 m
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.raw_calculated_position is not None
+
+
+class TestGlareZoneDescribeSkip:
+    """describe_skip returns the correct message for each non-fire path."""
+
+    handler = GlareZoneHandler()
+
+    def test_describe_skip_no_active_zones(self) -> None:
+        """No active zones → standard 'no active glare zones' message."""
+        snap = make_snapshot(
+            cover_type="cover_blind",
+            glare_zones=GlareZonesConfig(
+                zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],
+                window_width=200.0,
+            ),
+            active_zone_names=set(),
+            in_time_window=True,
+        )
+        assert self.handler.describe_skip(snap) == "no active glare zones or sun not in FOV"
+
+    def test_describe_skip_sun_not_valid(self) -> None:
+        """Sun not in FOV → same 'no active glare zones' message."""
+        cover = _make_vertical_cover(direct_sun_valid=False)
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=GlareZonesConfig(
+                zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],
+                window_width=200.0,
+            ),
+            active_zone_names={"desk"},
+            in_time_window=True,
+        )
+        assert self.handler.describe_skip(snap) == "no active glare zones or sun not in FOV"
+
+
+class TestGlareZoneReasonString:
+    """The reason string must contain effective distance and zone name."""
+
+    handler = GlareZoneHandler()
+
+    def test_reason_contains_effective_distance(self) -> None:
+        """Reason includes the effective distance formatted to 2 decimal places."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=30.0,
+        )
+        # y=100, radius=0 → nearest_y=100 cm → 1.00 m effective distance
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "1.00m" in result.reason
+
+    def test_reason_contains_zone_name(self) -> None:
+        """Reason includes the contributing zone name."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=30.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="my_monitor", x=0.0, y=100.0, radius=0.0)],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"my_monitor"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "my_monitor" in result.reason
+
+    def test_reason_contains_position_percentage(self) -> None:
+        """Reason includes the final position as 'position N%'."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=25.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=100.0, radius=0.0)],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert "position" in result.reason
+        assert "%" in result.reason
+
+
+class TestGlareZoneLargeRadius:
+    """Zone radius affects nearest_y and therefore effective distance."""
+
+    handler = GlareZoneHandler()
+
+    def test_large_radius_brings_zone_very_close_to_window(self) -> None:
+        """A large radius makes nearest_y very small → very small effective distance.
+
+        y=200, radius=190 → nearest_y = 200 - 190 = 10 cm = 0.10 m.
+        0.10 m << base 5.0 m → handler fires with override 0.10.
+        """
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=5.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=200.0, radius=190.0)],
+            window_width=400.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+        first_call = cover.calculate_percentage.call_args_list[0]
+        override = first_call.kwargs.get("effective_distance_override")
+        assert override == pytest.approx(0.10, abs=0.01)
+
+    def test_radius_larger_than_y_is_behind_wall(self) -> None:
+        """Zone with radius > y extends behind the window wall — returns None.
+
+        y=50, radius=60 → nearest_y = 50 - 60 = -10 ≤ 0 → geometry blocks it.
+        """
+        cover = _make_vertical_cover(distance=5.0, gamma=0.0, direct_sun_valid=True)
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=50.0, radius=60.0)],
+            window_width=200.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+        )
+        assert self.handler.evaluate(snap) is None
+
+
+class TestGlareZoneRegressionMaxVsMin:
+    """Explicit regression tests for the issue #213 bug (max→min, >=→<=)."""
+
+    handler = GlareZoneHandler()
+
+    def test_uses_min_not_max_distance_across_three_zones(self) -> None:
+        """With zones at 0.5, 1.5, and 3.5 m, handler uses 0.5 m (the minimum).
+
+        The old buggy code would have used 3.5 m (max), computing a more-open
+        position and failing to protect the nearest zone.
+        """
+        cover = _make_vertical_cover(
+            distance=4.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=10.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[
+                GlareZone(name="zone_far", x=0.0, y=350.0, radius=0.0),   # 3.5 m
+                GlareZone(name="zone_mid", x=0.0, y=150.0, radius=0.0),   # 1.5 m
+                GlareZone(name="zone_near", x=0.0, y=50.0, radius=0.0),   # 0.5 m
+            ],
+            window_width=400.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"zone_far", "zone_mid", "zone_near"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        first_call = cover.calculate_percentage.call_args_list[0]
+        override = first_call.kwargs.get("effective_distance_override")
+        assert override == pytest.approx(0.5, abs=0.01), (
+            f"Expected 0.5 m (closest zone), got {override} — "
+            "old bug would have passed 3.5 m (farthest zone)"
+        )
+
+    def test_zone_farther_than_base_does_not_fire_old_bug(self) -> None:
+        """Single zone at 6 m with base 4 m must NOT fire.
+
+        Under the old buggy code (max_distance > base_distance → fire), a zone
+        at 6 m > 4 m would incorrectly have triggered the handler, overriding
+        with a MORE open position (less protection) than SolarHandler.
+        """
+        cover = _make_vertical_cover(
+            distance=4.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=80.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="couch", x=0.0, y=600.0, radius=0.0)],  # 6 m
+            window_width=400.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"couch"},
+        )
+        assert self.handler.evaluate(snap) is None


### PR DESCRIPTION
## Summary
When `sensor.sun_next_rising` / `sensor.sun_next_setting` are used as start/end time entities, the integration breaks after sunrise passes. These sensors use \"next occurrence\" semantics — once the event passes, the sensor flips to tomorrow's datetime. This caused `start_time > end_time`, triggering an error log and making `after_start_time` return `False`, which disabled cover tracking for the entire day.

Fix adds `_normalize_entity_start_time()` in `TimeWindowManager` to detect when a start time entity has rolled to tomorrow while end time is still today (`now < end_time`), and rewrites start to today's date — correctly treating the start event as already passed.

## Testing
- ✅ 2147 tests passing
- Added 4 regression tests covering: normalization when sensor rolled to tomorrow, `is_active` correctness, no normalization when start is genuinely future today, backward compatibility with static time config

## Related Issues
Refs #226