### PR TITLE
fix: treat unavailable weather entity as sunny in cloud suppression

### DIFF
--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -124,6 +124,9 @@ class ClimateProvider:
             self._logger.debug("is_sunny(): No weather entity defined")
             return True
         weather_state = get_safe_state(self._hass, weather_entity)
+        if weather_state is None:
+            self._logger.debug("is_sunny(): Weather entity unavailable, assuming sunny")
+            return True
         if weather_condition is not None:
             matches = weather_state in weather_condition
             self._logger.debug("is_sunny(): Weather: %s = %s", weather_state, matches)

--- a/tests/test_state/test_climate_provider.py
+++ b/tests/test_state/test_climate_provider.py
@@ -226,6 +226,26 @@ class TestSunny:
         )
         assert readings.is_sunny is True
 
+    @pytest.mark.unit
+    def test_unavailable_weather_entity_returns_true(self, provider, mock_hass):
+        """Unavailable weather entity → True (assume sunny, don't suppress)."""
+        mock_hass.states.get.return_value = _mock_state("weather.home", "unavailable")
+        readings = provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny", "partlycloudy"],
+        )
+        assert readings.is_sunny is True
+
+    @pytest.mark.unit
+    def test_missing_weather_entity_returns_true(self, provider, mock_hass):
+        """Missing weather entity (states.get returns None) → True."""
+        mock_hass.states.get.return_value = None
+        readings = provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny", "partlycloudy"],
+        )
+        assert readings.is_sunny is True
+
 
 # ---------------------------------------------------------------------------
 # Lux


### PR DESCRIPTION
## Summary
When a configured weather entity becomes unavailable (or is removed from HA), `_read_sunny()` in `ClimateProvider` was evaluating `None in weather_condition` which always returns `False`, causing cloud suppression to activate via the "weather not sunny" condition even when lux/irradiance/cloud coverage were all fine.

Added a `None` guard after `get_safe_state()` so an unavailable weather entity is treated as sunny (skip check) — consistent with how the lux, irradiance, and cloud coverage readers already handle unavailable sensors.

## Testing
- ✅ 2 new regression tests: `test_unavailable_weather_entity_returns_true`, `test_missing_weather_entity_returns_true`
- ✅ 2153 tests passing

## Related Issues
Refs #222