### PR TITLE
feat: runtime configuration services (Issue #221)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1006,7 +1006,9 @@ def _check_cover_capabilities(
 
     if known:
         has_pos = {eid for eid, caps in known.items() if caps.get("has_set_position")}
-        no_pos = {eid for eid, caps in known.items() if not caps.get("has_set_position")}
+        no_pos = {
+            eid for eid, caps in known.items() if not caps.get("has_set_position")
+        }
 
         if has_pos and no_pos:
             warnings.append(

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -50,7 +50,9 @@ class PositionContext:
     special_positions: list[int]
     inverse_state: bool = False
     force: bool = False  # Skip all gate checks when True
-    is_safety: bool = False  # Safety-critical target (persists across window boundaries)
+    is_safety: bool = (
+        False  # Safety-critical target (persists across window boundaries)
+    )
     use_my_position: bool = (
         False  # Route through send_my_position() on non-position-capable covers
     )

--- a/custom_components/adaptive_cover_pro/migrations.py
+++ b/custom_components/adaptive_cover_pro/migrations.py
@@ -23,7 +23,7 @@ _PRUNE_V1_FLAG = "_orphan_prune_v1"
 # Format: suffix appended to entry_id (i.e. the part after the first underscore).
 _LEGACY_BINARY_SENSOR_SUFFIXES = frozenset(
     [
-        "_Sun Infront",   # superseded by _sun_motion
+        "_Sun Infront",  # superseded by _sun_motion
         "_Manual Override",  # superseded by _manual_override
     ]
 )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -138,9 +138,7 @@ class ClimateCoverState:
             or self.climate_data.blind_type == CoverType.TILT.value
         )
         result = self.tilt_state() if is_tilt else self.normal_type_cover()
-        return apply_snapshot_limits(
-            self.snapshot, result, sun_valid=False
-        )
+        return apply_snapshot_limits(self.snapshot, result, sun_valid=False)
 
     def _solar_position(self) -> int:
         """Compute solar-tracked position with limits applied."""

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -42,3 +42,884 @@ export_config:
       selector:
         config_entry:
           integration: adaptive_cover_pro
+
+set_position_limits:
+  name: Set position limits
+  description: >-
+    Update position-limit options (default height, min/max position, open/close
+    threshold, inverse state). Changes are persisted and take effect after reload.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    default_height:
+      name: Default height
+      description: "Default cover position when sun is not visible (0–100%)."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    min_position:
+      name: Minimum position
+      description: "Minimum position the cover may move to (0–99%)."
+      selector:
+        number:
+          min: 0
+          max: 99
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    enable_min_position:
+      name: Enable min position only during sun tracking
+      description: "If true, min_position applies only while sun is tracked."
+      selector:
+        boolean:
+    max_position:
+      name: Maximum position
+      description: "Maximum position the cover may move to (1–100%)."
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    enable_max_position:
+      name: Enable max position only during sun tracking
+      description: "If true, max_position applies only while sun is tracked."
+      selector:
+        boolean:
+    open_close_threshold:
+      name: Open/close threshold
+      description: "Position below which open/close-only covers are closed (1–99%)."
+      selector:
+        number:
+          min: 1
+          max: 99
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    inverse_state:
+      name: Inverse state
+      description: "Invert position (0%=open, 100%=closed) for covers that report state inversely."
+      selector:
+        boolean:
+
+set_sunset_sunrise:
+  name: Set sunset / sunrise positions
+  description: >-
+    Update sunset position and offset settings. Closes issue #129 — use an
+    automation to drive sunset_position from a sensor (e.g. mosquito activity).
+    Pass null to clear an optional field.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    sunset_position:
+      name: Sunset position
+      description: "Position to move to at end of time window. Null = use default_height."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    sunset_offset:
+      name: Sunset offset
+      description: "Minutes to shift the end-of-window trigger relative to sunset (-120–120)."
+      selector:
+        number:
+          min: -120
+          max: 120
+          mode: box
+          unit_of_measurement: minutes
+    sunrise_offset:
+      name: Sunrise offset
+      description: "Minutes to shift the start-of-window trigger relative to sunrise (-120–120)."
+      selector:
+        number:
+          min: -120
+          max: 120
+          mode: box
+          unit_of_measurement: minutes
+    sunset_use_my:
+      name: Use Somfy My position at sunset
+      description: "If true, use my_position_value instead of sunset_position at end of window."
+      selector:
+        boolean:
+    my_position_value:
+      name: Somfy My position
+      description: "The 'My' preset position (1–99%). Required when sunset_use_my or any custom_position_use_my is true."
+      selector:
+        number:
+          min: 1
+          max: 99
+          mode: slider
+          unit_of_measurement: "%"
+
+set_automation_timing:
+  name: Set automation timing
+  description: >-
+    Update delta thresholds, time window start/end, and return_sunset.
+    start_time and start_entity are mutually exclusive; same for end_time/end_entity.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    delta_position:
+      name: Position delta threshold
+      description: "Minimum position change (%) required before sending a cover command (1–90)."
+      selector:
+        number:
+          min: 1
+          max: 90
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    delta_time:
+      name: Time delta threshold
+      description: "Minimum time (minutes) between cover commands (2–60)."
+      selector:
+        number:
+          min: 2
+          max: 60
+          mode: box
+          unit_of_measurement: minutes
+    start_time:
+      name: Start time
+      description: "Fixed time to start the tracking window (HH:MM:SS). Mutually exclusive with start_entity."
+      selector:
+        time:
+    start_entity:
+      name: Start entity
+      description: "Entity whose state provides the start time. Mutually exclusive with start_time."
+      selector:
+        entity:
+          domain:
+            - sensor
+            - input_datetime
+    end_time:
+      name: End time
+      description: "Fixed time to end the tracking window (HH:MM:SS). Mutually exclusive with end_entity."
+      selector:
+        time:
+    end_entity:
+      name: End entity
+      description: "Entity whose state provides the end time. Mutually exclusive with end_time."
+      selector:
+        entity:
+          domain:
+            - sensor
+            - input_datetime
+    return_sunset:
+      name: Return to sunset position at end time
+      description: "If true, force-send sunset_position when the time window ends."
+      selector:
+        boolean:
+
+set_manual_override:
+  name: Set manual override settings
+  description: Update manual override duration, reset behavior, and detection threshold.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    manual_override_duration:
+      name: Override duration
+      description: "How long a manual override lasts before automatic control resumes."
+      selector:
+        duration:
+    manual_override_reset:
+      name: Reset override on time window start
+      description: "If true, clear any active manual override when the time window starts."
+      selector:
+        boolean:
+    manual_threshold:
+      name: Manual detection threshold
+      description: "Position change (%) that triggers manual override detection (0–99). Null = any change."
+      selector:
+        number:
+          min: 0
+          max: 99
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    manual_ignore_intermediate:
+      name: Ignore intermediate states
+      description: "If true, ignore opening/closing transitional states for manual override detection."
+      selector:
+        boolean:
+
+set_force_override:
+  name: Set force override
+  description: >-
+    Update force-override sensors, position, and min-mode. When any sensor is ON,
+    the cover moves to force_override_position bypassing automatic control.
+    Pass null or an empty list to clear sensors.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    force_override_sensors:
+      name: Force override sensors
+      description: "Binary sensors that trigger the force override. Empty list = disable."
+      selector:
+        entity:
+          domain: binary_sensor
+          multiple: true
+    force_override_position:
+      name: Force override position
+      description: "Position to move to when a force override sensor is active (0–100%)."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    force_override_min_mode:
+      name: Minimum position mode
+      description: "If true, treat force_override_position as a minimum floor rather than a fixed target."
+      selector:
+        boolean:
+
+set_custom_position:
+  name: Set custom position slot
+  description: >-
+    Update one custom position slot (1–4). A slot is active when sensor and
+    position are both set. Pass null for sensor and position to clear the slot.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    slot:
+      name: Slot
+      description: "Which custom position slot to update (1–4)."
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 4
+          step: 1
+          mode: slider
+    sensor:
+      name: Trigger sensor
+      description: "Binary sensor that activates this custom position. Null = clear slot."
+      selector:
+        entity:
+          domain: binary_sensor
+    position:
+      name: Position
+      description: "Target position (0–100%) when the sensor is active. Null = clear slot."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    priority:
+      name: Priority
+      description: "Pipeline priority (1–99, default 77). Higher = evaluated earlier."
+      selector:
+        number:
+          min: 1
+          max: 99
+          step: 1
+          mode: slider
+    min_mode:
+      name: Minimum position mode
+      description: "If true, treat position as a minimum floor."
+      selector:
+        boolean:
+    use_my:
+      name: Use Somfy My position
+      description: "If true, use my_position_value instead of position when sensor is active."
+      selector:
+        boolean:
+
+set_motion:
+  name: Set motion settings
+  description: Update motion sensors and no-motion timeout. Pass an empty list to disable motion control.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    motion_sensors:
+      name: Motion sensors
+      description: "Binary sensors (motion/occupancy/presence) that indicate occupancy. Empty list = disable."
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class:
+            - motion
+            - occupancy
+            - presence
+          multiple: true
+    motion_timeout:
+      name: No-motion timeout
+      description: "Seconds to wait after last motion before applying the motion-timeout position (30–3600)."
+      selector:
+        number:
+          min: 30
+          max: 3600
+          step: 30
+          mode: slider
+          unit_of_measurement: seconds
+
+set_light_cloud:
+  name: Set light & cloud settings
+  description: >-
+    Update weather entity, sunny-state filter, lux/irradiance thresholds,
+    cloud coverage threshold, and the cloud suppression toggle.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    weather_entity:
+      name: Weather entity
+      description: "Weather entity used to read conditions (domain: weather). Null = none."
+      selector:
+        entity:
+          domain: weather
+    weather_state:
+      name: Sunny weather states
+      description: "Weather condition states considered 'sunny' for sun-tracking purposes."
+      selector:
+        select:
+          multiple: true
+          options:
+            - clear-night
+            - clear
+            - cloudy
+            - fog
+            - hail
+            - lightning
+            - lightning-rainy
+            - partlycloudy
+            - pouring
+            - rainy
+            - snowy
+            - snowy-rainy
+            - sunny
+            - windy
+            - windy-variant
+            - exceptional
+    lux_entity:
+      name: Lux sensor
+      description: "Illuminance sensor entity. Null = none."
+      selector:
+        entity:
+          domain: sensor
+          device_class: illuminance
+    lux_threshold:
+      name: Lux threshold
+      description: "Lux value above which the cover is considered in direct sunlight."
+      selector:
+        number:
+          min: 0
+          max: 100000
+          mode: box
+          unit_of_measurement: lux
+    irradiance_entity:
+      name: Irradiance sensor
+      description: "Solar irradiance sensor entity. Null = none."
+      selector:
+        entity:
+          domain: sensor
+          device_class: irradiance
+    irradiance_threshold:
+      name: Irradiance threshold
+      description: "W/m² above which the cover is considered in direct sunlight."
+      selector:
+        number:
+          min: 0
+          max: 2000
+          mode: box
+          unit_of_measurement: W/m²
+    cloud_coverage_entity:
+      name: Cloud coverage sensor
+      description: "Sensor reporting cloud coverage percentage. Null = none."
+      selector:
+        entity:
+          domain: sensor
+    cloud_coverage_threshold:
+      name: Cloud coverage threshold
+      description: "Cloud coverage percentage above which the sky is considered overcast."
+      selector:
+        number:
+          min: 0
+          max: 100
+          mode: box
+          unit_of_measurement: "%"
+    cloud_suppression:
+      name: Enable cloud suppression
+      description: "If true, suppress solar positioning when cloud coverage exceeds the threshold."
+      selector:
+        boolean:
+
+set_climate:
+  name: Set climate settings
+  description: >-
+    Update climate mode and related temperature/presence options.
+    Enforces temp_low < temp_high.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    climate_mode:
+      name: Enable climate mode
+      description: "Master toggle for temperature-aware positioning."
+      selector:
+        boolean:
+    temp_entity:
+      name: Indoor temperature entity
+      description: "Climate or sensor entity for indoor temperature. Null = none."
+      selector:
+        entity:
+          domain:
+            - climate
+            - sensor
+    temp_low:
+      name: Low temperature threshold
+      description: "Below this temperature (°), winter strategy applies (0–90)."
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+    temp_high:
+      name: High temperature threshold
+      description: "Above this temperature (°), summer strategy applies (0–90)."
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+    outside_temp:
+      name: Outdoor temperature entity
+      description: "Sensor entity for outdoor temperature. Null = none."
+      selector:
+        entity:
+          domain: sensor
+    outside_threshold:
+      name: Outdoor temperature threshold
+      description: "Outdoor temperature (°) above which summer strategy is forced (0–100)."
+      selector:
+        number:
+          min: 0
+          max: 100
+          mode: slider
+          unit_of_measurement: "°"
+    presence_entity:
+      name: Presence entity
+      description: "Entity indicating occupancy (device_tracker, zone, binary_sensor, input_boolean). Null = none."
+      selector:
+        entity:
+          domain:
+            - device_tracker
+            - zone
+            - binary_sensor
+            - input_boolean
+    transparent_blind:
+      name: Transparent blind
+      description: "If true, treat the blind as semi-transparent for climate calculations."
+      selector:
+        boolean:
+    winter_close_insulation:
+      name: Close for winter insulation
+      description: "If true, fully close the cover on cold days to improve insulation."
+      selector:
+        boolean:
+
+set_weather_safety:
+  name: Set weather safety settings
+  description: >-
+    Update wind, rain, and severe-weather override settings. The weather handler
+    priority-overrides automatic control to protect covers from damage.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    weather_bypass_auto_control:
+      name: Bypass automatic control
+      description: "If true, weather override ignores the Automatic Control toggle."
+      selector:
+        boolean:
+    weather_wind_speed_sensor:
+      name: Wind speed sensor
+      description: "Sensor entity for wind speed. Null = none."
+      selector:
+        entity:
+          domain: sensor
+    weather_wind_direction_sensor:
+      name: Wind direction sensor
+      description: "Sensor entity for wind direction (degrees). Null = none."
+      selector:
+        entity:
+          domain: sensor
+    weather_wind_speed_threshold:
+      name: Wind speed threshold
+      description: "Wind speed above which the cover is retracted (units must match sensor)."
+      selector:
+        number:
+          min: 0
+          max: 200
+          step: 1
+          mode: slider
+    weather_wind_direction_tolerance:
+      name: Wind direction tolerance
+      description: "Degrees either side of the window azimuth within which wind is considered a threat (5–180°)."
+      selector:
+        number:
+          min: 5
+          max: 180
+          step: 5
+          mode: slider
+          unit_of_measurement: "°"
+    weather_rain_sensor:
+      name: Rain sensor
+      description: "Sensor entity for rain accumulation. Null = none."
+      selector:
+        entity:
+          domain: sensor
+    weather_rain_threshold:
+      name: Rain threshold
+      description: "Rain accumulation above which the cover is retracted."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 0.5
+          mode: slider
+    weather_is_raining_sensor:
+      name: Is raining sensor
+      description: "Binary sensor indicating active rain. Null = none."
+      selector:
+        entity:
+          domain: binary_sensor
+    weather_is_windy_sensor:
+      name: Is windy sensor
+      description: "Binary sensor indicating dangerous wind. Null = none."
+      selector:
+        entity:
+          domain: binary_sensor
+    weather_severe_sensors:
+      name: Severe weather sensors
+      description: "Binary sensors that indicate severe weather conditions (OR logic). Empty list = none."
+      selector:
+        entity:
+          domain: binary_sensor
+          multiple: true
+    weather_override_position:
+      name: Weather override position
+      description: "Position to move to when a weather condition is triggered (0–100%)."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    weather_override_min_mode:
+      name: Minimum position mode
+      description: "If true, treat weather_override_position as a minimum floor."
+      selector:
+        boolean:
+    weather_timeout:
+      name: Weather clear timeout
+      description: "Seconds to wait after conditions clear before resuming automatic control (0–3600)."
+      selector:
+        number:
+          min: 0
+          max: 3600
+          step: 30
+          mode: slider
+          unit_of_measurement: seconds
+
+set_sun_tracking:
+  name: Set sun tracking settings
+  description: Update azimuth, field-of-view, elevation limits, and sun-tracking toggle.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    enable_sun_tracking:
+      name: Enable sun tracking
+      description: "Master toggle for solar-position-based cover control."
+      selector:
+        boolean:
+    set_azimuth:
+      name: Window azimuth
+      description: "Compass direction the window faces (0–359°)."
+      selector:
+        number:
+          min: 0
+          max: 359
+          mode: slider
+          unit_of_measurement: "°"
+    fov_left:
+      name: Field of view left
+      description: "Degrees to the left of the azimuth within which the sun affects this cover (0–180°)."
+      selector:
+        number:
+          min: 0
+          max: 180
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+    fov_right:
+      name: Field of view right
+      description: "Degrees to the right of the azimuth within which the sun affects this cover (0–180°)."
+      selector:
+        number:
+          min: 0
+          max: 180
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+    min_elevation:
+      name: Minimum sun elevation
+      description: "Sun elevation (°) below which the cover is not moved. Null = no minimum."
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+    max_elevation:
+      name: Maximum sun elevation
+      description: "Sun elevation (°) above which the cover is fully opened. Null = no maximum."
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+    distance_shaded_area:
+      name: Distance to shaded area
+      description: "Distance (m) from the window to the edge of the shaded area (0.1–5 m)."
+      selector:
+        number:
+          min: 0.1
+          max: 5
+          step: 0.1
+          mode: slider
+          unit_of_measurement: m
+
+set_blind_spot:
+  name: Set blind spot
+  description: >-
+    Update blind spot zone angles. blind_spot_right must be greater than
+    blind_spot_left. Enforced at validation time.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    blind_spot:
+      name: Enable blind spot
+      description: "If true, the blind spot zone is active."
+      selector:
+        boolean:
+    blind_spot_left:
+      name: Blind spot left edge
+      description: "Left edge of the blind spot zone in degrees from window azimuth (0–359°)."
+      selector:
+        number:
+          min: 0
+          max: 359
+          mode: slider
+          unit_of_measurement: "°"
+    blind_spot_right:
+      name: Blind spot right edge
+      description: "Right edge of the blind spot zone in degrees from window azimuth (1–360°). Must be greater than left edge."
+      selector:
+        number:
+          min: 0
+          max: 360
+          mode: slider
+          unit_of_measurement: "°"
+    blind_spot_elevation:
+      name: Blind spot elevation
+      description: "Maximum sun elevation (°) for the blind spot to apply. Null = always apply."
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 1
+          mode: slider
+          unit_of_measurement: "°"
+
+set_interpolation:
+  name: Set interpolation
+  description: Enable position interpolation and configure the start/end range and lookup table.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    interp:
+      name: Enable interpolation
+      description: "If true, apply interpolation mapping to the calculated position."
+      selector:
+        boolean:
+    interp_start:
+      name: Interpolation start
+      description: "Calculated position (%) at which interpolation begins. Null = none."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    interp_end:
+      name: Interpolation end
+      description: "Calculated position (%) at which interpolation ends. Null = none."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    interp_list:
+      name: Interpolation input list
+      description: "List of input positions (strings) for the interpolation lookup table."
+      selector:
+        text:
+    interp_list_new:
+      name: Interpolation output list
+      description: "List of output positions (strings) mapped from interp_list."
+      selector:
+        text:
+
+set_geometry:
+  name: Set geometry
+  description: >-
+    Update cover geometry dimensions. Supply only the fields applicable to your
+    cover type (vertical blind, awning, or tilt). Invalid cross-type fields are
+    rejected with an error message.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    window_height:
+      name: Window height
+      description: "Window height in metres (0.1–6 m). Vertical blind and awning only."
+      selector:
+        number:
+          min: 0.1
+          max: 6
+          step: 0.01
+          mode: slider
+          unit_of_measurement: m
+    window_width:
+      name: Window width
+      description: "Window width in centimetres (10–500 cm). Vertical blind only."
+      selector:
+        number:
+          min: 10
+          max: 500
+          step: 1
+          mode: slider
+          unit_of_measurement: cm
+    window_depth:
+      name: Window depth
+      description: "Window reveal depth in metres (0–0.5 m). Vertical blind only."
+      selector:
+        number:
+          min: 0
+          max: 0.5
+          step: 0.01
+          mode: slider
+          unit_of_measurement: m
+    sill_height:
+      name: Sill height
+      description: "Window sill height from floor in metres (0–3 m). Vertical blind only."
+      selector:
+        number:
+          min: 0
+          max: 3
+          step: 0.01
+          mode: slider
+          unit_of_measurement: m
+    length_awning:
+      name: Awning length
+      description: "Awning projection length in metres (0.3–6 m). Awning only."
+      selector:
+        number:
+          min: 0.3
+          max: 6
+          step: 0.01
+          mode: slider
+          unit_of_measurement: m
+    angle:
+      name: Awning angle
+      description: "Awning tilt angle in degrees (0–45°). Awning only."
+      selector:
+        number:
+          min: 0
+          max: 45
+          mode: slider
+          unit_of_measurement: "°"
+    slat_depth:
+      name: Slat depth
+      description: "Venetian slat depth in centimetres (0.1–15 cm). Tilt only."
+      selector:
+        number:
+          min: 0.1
+          max: 15
+          step: 0.1
+          mode: slider
+          unit_of_measurement: cm
+    slat_distance:
+      name: Slat distance
+      description: "Distance between venetian slats in centimetres (0.1–15 cm). Tilt only."
+      selector:
+        number:
+          min: 0.1
+          max: 15
+          step: 0.1
+          mode: slider
+          unit_of_measurement: cm
+    tilt_mode:
+      name: Tilt mode
+      description: "Slat angle calculation mode (mode1 or mode2). Tilt only."
+      selector:
+        select:
+          options:
+            - mode1
+            - mode2
+
+set_option:
+  name: Set option (generic)
+  description: >-
+    Generic escape hatch — update any single supported option by key name.
+    Identity keys (name, mode, group, linked_device_id) are rejected.
+    See the integration documentation for the full list of supported option keys.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    option:
+      name: Option key
+      description: "The internal option key to update (e.g. 'default_percentage', 'sunset_position')."
+      required: true
+      selector:
+        text:
+    value:
+      name: Value
+      description: "New value for the option. Pass null to clear an optional field."
+      required: true
+      selector:
+        text:

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 
 from ..const import DOMAIN
 from .export_service import EXPORT_CONFIG_SCHEMA, async_handle_export
+from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,6 +149,8 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     )
     hass.services.async_register(DOMAIN, "emergency_stop", handle_emergency_stop)
 
+    register_options_services(hass)
+
 
 async def async_unload_services(hass: HomeAssistant) -> None:
     """Remove integration services when the last config entry is unloaded."""
@@ -157,3 +160,5 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "integration_enable")
     hass.services.async_remove(DOMAIN, "integration_disable")
     hass.services.async_remove(DOMAIN, "emergency_stop")
+    for name in OPTIONS_SERVICE_NAMES:
+        hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -1,0 +1,876 @@
+"""Services for mutating config_entry.options at runtime (Issue #221).
+
+Each service accepts a target (cover entity_id) and a set of option fields to update.
+Changes are persisted to config_entry.options; the existing update listener performs
+a full reload so all state-change listeners and pipeline handlers pick up new values.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.core import ServiceCall, ServiceValidationError
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+from ..const import (
+    CONF_AWNING_ANGLE,
+    CONF_AZIMUTH,
+    CONF_BLIND_SPOT_ELEVATION,
+    CONF_BLIND_SPOT_LEFT,
+    CONF_BLIND_SPOT_RIGHT,
+    CONF_CLIMATE_MODE,
+    CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_CLOUD_COVERAGE_THRESHOLD,
+    CONF_CLOUD_SUPPRESSION,
+    CONF_CUSTOM_POSITION_1,
+    CONF_CUSTOM_POSITION_2,
+    CONF_CUSTOM_POSITION_3,
+    CONF_CUSTOM_POSITION_4,
+    CONF_CUSTOM_POSITION_MIN_MODE_1,
+    CONF_CUSTOM_POSITION_MIN_MODE_2,
+    CONF_CUSTOM_POSITION_MIN_MODE_3,
+    CONF_CUSTOM_POSITION_MIN_MODE_4,
+    CONF_CUSTOM_POSITION_PRIORITY_1,
+    CONF_CUSTOM_POSITION_PRIORITY_2,
+    CONF_CUSTOM_POSITION_PRIORITY_3,
+    CONF_CUSTOM_POSITION_PRIORITY_4,
+    CONF_CUSTOM_POSITION_SENSOR_1,
+    CONF_CUSTOM_POSITION_SENSOR_2,
+    CONF_CUSTOM_POSITION_SENSOR_3,
+    CONF_CUSTOM_POSITION_SENSOR_4,
+    CONF_CUSTOM_POSITION_USE_MY_1,
+    CONF_CUSTOM_POSITION_USE_MY_2,
+    CONF_CUSTOM_POSITION_USE_MY_3,
+    CONF_CUSTOM_POSITION_USE_MY_4,
+    CONF_DEFAULT_HEIGHT,
+    CONF_DELTA_POSITION,
+    CONF_DELTA_TIME,
+    CONF_DEVICE_ID,
+    CONF_DISTANCE,
+    CONF_ENABLE_BLIND_SPOT,
+    CONF_ENABLE_MAX_POSITION,
+    CONF_ENABLE_MIN_POSITION,
+    CONF_ENABLE_SUN_TRACKING,
+    CONF_END_ENTITY,
+    CONF_END_TIME,
+    CONF_ENTITIES,
+    CONF_FOV_LEFT,
+    CONF_FOV_RIGHT,
+    CONF_FORCE_OVERRIDE_MIN_MODE,
+    CONF_FORCE_OVERRIDE_POSITION,
+    CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_HEIGHT_WIN,
+    CONF_INTERP,
+    CONF_INTERP_END,
+    CONF_INTERP_LIST,
+    CONF_INTERP_LIST_NEW,
+    CONF_INTERP_START,
+    CONF_INVERSE_STATE,
+    CONF_IRRADIANCE_ENTITY,
+    CONF_IRRADIANCE_THRESHOLD,
+    CONF_LENGTH_AWNING,
+    CONF_LUX_ENTITY,
+    CONF_LUX_THRESHOLD,
+    CONF_MANUAL_IGNORE_INTERMEDIATE,
+    CONF_MANUAL_OVERRIDE_DURATION,
+    CONF_MANUAL_OVERRIDE_RESET,
+    CONF_MANUAL_THRESHOLD,
+    CONF_MAX_ELEVATION,
+    CONF_MAX_POSITION,
+    CONF_MIN_ELEVATION,
+    CONF_MIN_POSITION,
+    CONF_MODE,
+    CONF_MOTION_SENSORS,
+    CONF_MOTION_TIMEOUT,
+    CONF_MY_POSITION_VALUE,
+    CONF_OPEN_CLOSE_THRESHOLD,
+    CONF_OUTSIDE_THRESHOLD,
+    CONF_OUTSIDETEMP_ENTITY,
+    CONF_PRESENCE_ENTITY,
+    CONF_RETURN_SUNSET,
+    CONF_SILL_HEIGHT,
+    CONF_START_ENTITY,
+    CONF_START_TIME,
+    CONF_SUNRISE_OFFSET,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_POS,
+    CONF_SUNSET_USE_MY,
+    CONF_TEMP_ENTITY,
+    CONF_TEMP_HIGH,
+    CONF_TEMP_LOW,
+    CONF_TILT_DEPTH,
+    CONF_TILT_DISTANCE,
+    CONF_TILT_MODE,
+    CONF_TRANSPARENT_BLIND,
+    CONF_WEATHER_BYPASS_AUTO_CONTROL,
+    CONF_WEATHER_ENTITY,
+    CONF_WEATHER_IS_RAINING_SENSOR,
+    CONF_WEATHER_IS_WINDY_SENSOR,
+    CONF_WEATHER_OVERRIDE_MIN_MODE,
+    CONF_WEATHER_OVERRIDE_POSITION,
+    CONF_WEATHER_RAIN_SENSOR,
+    CONF_WEATHER_RAIN_THRESHOLD,
+    CONF_WEATHER_SEVERE_SENSORS,
+    CONF_WEATHER_STATE,
+    CONF_WEATHER_TIMEOUT,
+    CONF_WEATHER_WIND_DIRECTION_SENSOR,
+    CONF_WEATHER_WIND_DIRECTION_TOLERANCE,
+    CONF_WEATHER_WIND_SPEED_SENSOR,
+    CONF_WEATHER_WIND_SPEED_THRESHOLD,
+    CONF_WINDOW_DEPTH,
+    CONF_WINDOW_WIDTH,
+    CONF_WINTER_CLOSE_INSULATION,
+    DOMAIN,
+    SensorType,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Keys that cannot be mutated via services (identity + install-time structural)
+IDENTITY_KEYS: frozenset[str] = frozenset(
+    {"name", CONF_MODE, CONF_ENTITIES, CONF_DEVICE_ID}
+)
+
+# HA service call plumbing keys to strip when building a patch
+_PLUMBING_KEYS: frozenset[str] = frozenset({"entity_id", "device_id", "area_id"})
+
+_TIME_RE = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+
+# ---------------------------------------------------------------------------
+# Per-field validators
+# ---------------------------------------------------------------------------
+
+
+def _num(min_val: float, max_val: float):
+    return vol.Any(
+        None, vol.All(vol.Coerce(float), vol.Range(min=min_val, max=max_val))
+    )
+
+
+def _bool_v():
+    return vol.Any(None, bool)
+
+
+def _entity_v():
+    return vol.Any(None, str)
+
+
+def _entities_v():
+    return vol.Any(None, [str])
+
+
+def _duration_v():
+    return vol.Any(None, dict)
+
+
+def _time_v():
+    def _check(v):
+        if v is not None and not _TIME_RE.match(str(v)):
+            raise vol.Invalid(f"Time must be HH:MM:SS, got: {v!r}")
+        return v
+
+    return vol.Any(None, _check)
+
+
+def _select_v(*options: str):
+    return vol.Any(None, vol.In(list(options)))
+
+
+# Maps option key → validator callable. Used by validate_options_patch and set_option.
+FIELD_VALIDATORS: dict[str, Any] = {
+    # Geometry — vertical blind
+    CONF_HEIGHT_WIN: _num(0.1, 6),
+    CONF_WINDOW_WIDTH: _num(10, 500),
+    CONF_WINDOW_DEPTH: _num(0.0, 0.5),
+    CONF_SILL_HEIGHT: _num(0.0, 3.0),
+    # Geometry — awning
+    CONF_LENGTH_AWNING: _num(0.3, 6),
+    CONF_AWNING_ANGLE: _num(0, 45),
+    # Geometry — tilt/venetian
+    CONF_TILT_DEPTH: _num(0.1, 15),
+    CONF_TILT_DISTANCE: _num(0.1, 15),
+    CONF_TILT_MODE: _select_v("mode1", "mode2"),
+    # Sun tracking
+    CONF_ENABLE_SUN_TRACKING: _bool_v(),
+    CONF_AZIMUTH: _num(0, 359),
+    CONF_FOV_LEFT: _num(0, 180),
+    CONF_FOV_RIGHT: _num(0, 180),
+    CONF_MIN_ELEVATION: _num(0, 90),
+    CONF_MAX_ELEVATION: _num(0, 90),
+    CONF_DISTANCE: _num(0.1, 5),
+    # Blind spot
+    CONF_ENABLE_BLIND_SPOT: _bool_v(),
+    CONF_BLIND_SPOT_LEFT: _num(0, 359),
+    CONF_BLIND_SPOT_RIGHT: _num(0, 360),
+    CONF_BLIND_SPOT_ELEVATION: _num(0, 90),
+    # Position limits & sunset/sunrise
+    CONF_DEFAULT_HEIGHT: _num(0, 100),
+    CONF_MAX_POSITION: _num(1, 100),
+    CONF_ENABLE_MAX_POSITION: _bool_v(),
+    CONF_MIN_POSITION: _num(0, 99),
+    CONF_ENABLE_MIN_POSITION: _bool_v(),
+    CONF_SUNSET_POS: _num(0, 100),
+    CONF_MY_POSITION_VALUE: _num(1, 99),
+    CONF_SUNSET_USE_MY: _bool_v(),
+    CONF_SUNSET_OFFSET: _num(-120, 120),
+    CONF_SUNRISE_OFFSET: _num(-120, 120),
+    CONF_OPEN_CLOSE_THRESHOLD: _num(1, 99),
+    CONF_INVERSE_STATE: _bool_v(),
+    CONF_INTERP: _bool_v(),
+    # Interpolation
+    CONF_INTERP_START: _num(0, 100),
+    CONF_INTERP_END: _num(0, 100),
+    CONF_INTERP_LIST: vol.Any(None, list),
+    CONF_INTERP_LIST_NEW: vol.Any(None, list),
+    # Automation timing
+    CONF_DELTA_POSITION: _num(1, 90),
+    CONF_DELTA_TIME: _num(2, 60),
+    CONF_START_TIME: _time_v(),
+    CONF_START_ENTITY: _entity_v(),
+    CONF_END_TIME: _time_v(),
+    CONF_END_ENTITY: _entity_v(),
+    CONF_RETURN_SUNSET: _bool_v(),
+    # Manual override
+    CONF_MANUAL_OVERRIDE_DURATION: _duration_v(),
+    CONF_MANUAL_OVERRIDE_RESET: _bool_v(),
+    CONF_MANUAL_THRESHOLD: _num(0, 99),
+    CONF_MANUAL_IGNORE_INTERMEDIATE: _bool_v(),
+    # Force override
+    CONF_FORCE_OVERRIDE_SENSORS: _entities_v(),
+    CONF_FORCE_OVERRIDE_POSITION: _num(0, 100),
+    CONF_FORCE_OVERRIDE_MIN_MODE: _bool_v(),
+    # Custom positions 1–4
+    CONF_CUSTOM_POSITION_SENSOR_1: _entity_v(),
+    CONF_CUSTOM_POSITION_1: _num(0, 100),
+    CONF_CUSTOM_POSITION_PRIORITY_1: _num(1, 99),
+    CONF_CUSTOM_POSITION_MIN_MODE_1: _bool_v(),
+    CONF_CUSTOM_POSITION_USE_MY_1: _bool_v(),
+    CONF_CUSTOM_POSITION_SENSOR_2: _entity_v(),
+    CONF_CUSTOM_POSITION_2: _num(0, 100),
+    CONF_CUSTOM_POSITION_PRIORITY_2: _num(1, 99),
+    CONF_CUSTOM_POSITION_MIN_MODE_2: _bool_v(),
+    CONF_CUSTOM_POSITION_USE_MY_2: _bool_v(),
+    CONF_CUSTOM_POSITION_SENSOR_3: _entity_v(),
+    CONF_CUSTOM_POSITION_3: _num(0, 100),
+    CONF_CUSTOM_POSITION_PRIORITY_3: _num(1, 99),
+    CONF_CUSTOM_POSITION_MIN_MODE_3: _bool_v(),
+    CONF_CUSTOM_POSITION_USE_MY_3: _bool_v(),
+    CONF_CUSTOM_POSITION_SENSOR_4: _entity_v(),
+    CONF_CUSTOM_POSITION_4: _num(0, 100),
+    CONF_CUSTOM_POSITION_PRIORITY_4: _num(1, 99),
+    CONF_CUSTOM_POSITION_MIN_MODE_4: _bool_v(),
+    CONF_CUSTOM_POSITION_USE_MY_4: _bool_v(),
+    # Motion
+    CONF_MOTION_SENSORS: _entities_v(),
+    CONF_MOTION_TIMEOUT: _num(30, 3600),
+    # Light & Cloud
+    CONF_WEATHER_ENTITY: _entity_v(),
+    CONF_WEATHER_STATE: vol.Any(None, list),
+    CONF_LUX_ENTITY: _entity_v(),
+    CONF_LUX_THRESHOLD: vol.Any(None, vol.Coerce(float)),
+    CONF_IRRADIANCE_ENTITY: _entity_v(),
+    CONF_IRRADIANCE_THRESHOLD: vol.Any(None, vol.Coerce(float)),
+    CONF_CLOUD_COVERAGE_ENTITY: _entity_v(),
+    CONF_CLOUD_COVERAGE_THRESHOLD: vol.Any(None, vol.Coerce(float)),
+    CONF_CLOUD_SUPPRESSION: _bool_v(),
+    # Climate
+    CONF_CLIMATE_MODE: _bool_v(),
+    CONF_TEMP_ENTITY: _entity_v(),
+    CONF_TEMP_LOW: _num(0, 90),
+    CONF_TEMP_HIGH: _num(0, 90),
+    CONF_OUTSIDETEMP_ENTITY: _entity_v(),
+    CONF_OUTSIDE_THRESHOLD: _num(0, 100),
+    CONF_PRESENCE_ENTITY: _entity_v(),
+    CONF_TRANSPARENT_BLIND: _bool_v(),
+    CONF_WINTER_CLOSE_INSULATION: _bool_v(),
+    # Weather safety
+    CONF_WEATHER_BYPASS_AUTO_CONTROL: _bool_v(),
+    CONF_WEATHER_WIND_SPEED_SENSOR: _entity_v(),
+    CONF_WEATHER_WIND_DIRECTION_SENSOR: _entity_v(),
+    CONF_WEATHER_WIND_SPEED_THRESHOLD: _num(0, 200),
+    CONF_WEATHER_WIND_DIRECTION_TOLERANCE: _num(5, 180),
+    CONF_WEATHER_RAIN_SENSOR: _entity_v(),
+    CONF_WEATHER_RAIN_THRESHOLD: _num(0, 100),
+    CONF_WEATHER_IS_RAINING_SENSOR: _entity_v(),
+    CONF_WEATHER_IS_WINDY_SENSOR: _entity_v(),
+    CONF_WEATHER_SEVERE_SENSORS: _entities_v(),
+    CONF_WEATHER_OVERRIDE_POSITION: _num(0, 100),
+    CONF_WEATHER_OVERRIDE_MIN_MODE: _bool_v(),
+    CONF_WEATHER_TIMEOUT: _num(0, 3600),
+}
+
+# ---------------------------------------------------------------------------
+# Section key sets (used for building service-call patches)
+# ---------------------------------------------------------------------------
+
+_SECTION_POSITION_LIMITS = frozenset(
+    {
+        CONF_DEFAULT_HEIGHT,
+        CONF_MIN_POSITION,
+        CONF_ENABLE_MIN_POSITION,
+        CONF_MAX_POSITION,
+        CONF_ENABLE_MAX_POSITION,
+        CONF_OPEN_CLOSE_THRESHOLD,
+        CONF_INVERSE_STATE,
+    }
+)
+
+_SECTION_SUNSET_SUNRISE = frozenset(
+    {
+        CONF_SUNSET_POS,
+        CONF_SUNSET_OFFSET,
+        CONF_SUNRISE_OFFSET,
+        CONF_SUNSET_USE_MY,
+        CONF_MY_POSITION_VALUE,
+    }
+)
+
+_SECTION_AUTOMATION_TIMING = frozenset(
+    {
+        CONF_DELTA_POSITION,
+        CONF_DELTA_TIME,
+        CONF_START_TIME,
+        CONF_START_ENTITY,
+        CONF_END_TIME,
+        CONF_END_ENTITY,
+        CONF_RETURN_SUNSET,
+    }
+)
+
+_SECTION_MANUAL_OVERRIDE = frozenset(
+    {
+        CONF_MANUAL_OVERRIDE_DURATION,
+        CONF_MANUAL_OVERRIDE_RESET,
+        CONF_MANUAL_THRESHOLD,
+        CONF_MANUAL_IGNORE_INTERMEDIATE,
+    }
+)
+
+_SECTION_FORCE_OVERRIDE = frozenset(
+    {
+        CONF_FORCE_OVERRIDE_SENSORS,
+        CONF_FORCE_OVERRIDE_POSITION,
+        CONF_FORCE_OVERRIDE_MIN_MODE,
+    }
+)
+
+_SECTION_MOTION = frozenset({CONF_MOTION_SENSORS, CONF_MOTION_TIMEOUT})
+
+_SECTION_LIGHT_CLOUD = frozenset(
+    {
+        CONF_WEATHER_ENTITY,
+        CONF_WEATHER_STATE,
+        CONF_LUX_ENTITY,
+        CONF_LUX_THRESHOLD,
+        CONF_IRRADIANCE_ENTITY,
+        CONF_IRRADIANCE_THRESHOLD,
+        CONF_CLOUD_COVERAGE_ENTITY,
+        CONF_CLOUD_COVERAGE_THRESHOLD,
+        CONF_CLOUD_SUPPRESSION,
+    }
+)
+
+_SECTION_CLIMATE = frozenset(
+    {
+        CONF_CLIMATE_MODE,
+        CONF_TEMP_ENTITY,
+        CONF_TEMP_LOW,
+        CONF_TEMP_HIGH,
+        CONF_OUTSIDETEMP_ENTITY,
+        CONF_OUTSIDE_THRESHOLD,
+        CONF_PRESENCE_ENTITY,
+        CONF_TRANSPARENT_BLIND,
+        CONF_WINTER_CLOSE_INSULATION,
+    }
+)
+
+_SECTION_WEATHER_SAFETY = frozenset(
+    {
+        CONF_WEATHER_BYPASS_AUTO_CONTROL,
+        CONF_WEATHER_WIND_SPEED_SENSOR,
+        CONF_WEATHER_WIND_DIRECTION_SENSOR,
+        CONF_WEATHER_WIND_SPEED_THRESHOLD,
+        CONF_WEATHER_WIND_DIRECTION_TOLERANCE,
+        CONF_WEATHER_RAIN_SENSOR,
+        CONF_WEATHER_RAIN_THRESHOLD,
+        CONF_WEATHER_IS_RAINING_SENSOR,
+        CONF_WEATHER_IS_WINDY_SENSOR,
+        CONF_WEATHER_SEVERE_SENSORS,
+        CONF_WEATHER_OVERRIDE_POSITION,
+        CONF_WEATHER_OVERRIDE_MIN_MODE,
+        CONF_WEATHER_TIMEOUT,
+    }
+)
+
+_SECTION_SUN_TRACKING = frozenset(
+    {
+        CONF_ENABLE_SUN_TRACKING,
+        CONF_AZIMUTH,
+        CONF_FOV_LEFT,
+        CONF_FOV_RIGHT,
+        CONF_MIN_ELEVATION,
+        CONF_MAX_ELEVATION,
+        CONF_DISTANCE,
+    }
+)
+
+_SECTION_BLIND_SPOT = frozenset(
+    {
+        CONF_ENABLE_BLIND_SPOT,
+        CONF_BLIND_SPOT_LEFT,
+        CONF_BLIND_SPOT_RIGHT,
+        CONF_BLIND_SPOT_ELEVATION,
+    }
+)
+
+_SECTION_INTERPOLATION = frozenset(
+    {
+        CONF_INTERP,
+        CONF_INTERP_START,
+        CONF_INTERP_END,
+        CONF_INTERP_LIST,
+        CONF_INTERP_LIST_NEW,
+    }
+)
+
+_SECTION_GEOMETRY_VERTICAL = frozenset(
+    {CONF_HEIGHT_WIN, CONF_WINDOW_WIDTH, CONF_WINDOW_DEPTH, CONF_SILL_HEIGHT}
+)
+_SECTION_GEOMETRY_AWNING = frozenset(
+    {CONF_LENGTH_AWNING, CONF_AWNING_ANGLE, CONF_HEIGHT_WIN}
+)
+_SECTION_GEOMETRY_TILT = frozenset(
+    {CONF_TILT_DEPTH, CONF_TILT_DISTANCE, CONF_TILT_MODE}
+)
+_SECTION_GEOMETRY_ALL = (
+    _SECTION_GEOMETRY_VERTICAL | _SECTION_GEOMETRY_AWNING | _SECTION_GEOMETRY_TILT
+)
+
+# All settable keys (union of all sections)
+ALL_SETTABLE_KEYS: frozenset[str] = (
+    _SECTION_POSITION_LIMITS
+    | _SECTION_SUNSET_SUNRISE
+    | _SECTION_AUTOMATION_TIMING
+    | _SECTION_MANUAL_OVERRIDE
+    | _SECTION_FORCE_OVERRIDE
+    | _SECTION_MOTION
+    | _SECTION_LIGHT_CLOUD
+    | _SECTION_CLIMATE
+    | _SECTION_WEATHER_SAFETY
+    | _SECTION_SUN_TRACKING
+    | _SECTION_BLIND_SPOT
+    | _SECTION_INTERPOLATION
+    | _SECTION_GEOMETRY_ALL
+    | frozenset(
+        {
+            CONF_CUSTOM_POSITION_SENSOR_1,
+            CONF_CUSTOM_POSITION_1,
+            CONF_CUSTOM_POSITION_PRIORITY_1,
+            CONF_CUSTOM_POSITION_MIN_MODE_1,
+            CONF_CUSTOM_POSITION_USE_MY_1,
+            CONF_CUSTOM_POSITION_SENSOR_2,
+            CONF_CUSTOM_POSITION_2,
+            CONF_CUSTOM_POSITION_PRIORITY_2,
+            CONF_CUSTOM_POSITION_MIN_MODE_2,
+            CONF_CUSTOM_POSITION_USE_MY_2,
+            CONF_CUSTOM_POSITION_SENSOR_3,
+            CONF_CUSTOM_POSITION_3,
+            CONF_CUSTOM_POSITION_PRIORITY_3,
+            CONF_CUSTOM_POSITION_MIN_MODE_3,
+            CONF_CUSTOM_POSITION_USE_MY_3,
+            CONF_CUSTOM_POSITION_SENSOR_4,
+            CONF_CUSTOM_POSITION_4,
+            CONF_CUSTOM_POSITION_PRIORITY_4,
+            CONF_CUSTOM_POSITION_MIN_MODE_4,
+            CONF_CUSTOM_POSITION_USE_MY_4,
+        }
+    )
+)
+
+# Custom position slot key maps
+_CUSTOM_SLOT_KEYS: dict[int, dict[str, str]] = {
+    i: {
+        "sensor": f"custom_position_sensor_{i}",
+        "position": f"custom_position_{i}",
+        "priority": f"custom_position_priority_{i}",
+        "min_mode": f"custom_position_min_mode_{i}",
+        "use_my": f"custom_position_use_my_{i}",
+    }
+    for i in range(1, 5)
+}
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_patch(call_data: dict, allowed_keys: frozenset[str]) -> dict:
+    """Extract allowed keys from a service call's data dict.
+
+    Keys whose value is None are included (they signal "clear this option").
+    HA plumbing keys (entity_id, device_id, area_id) are always excluded.
+    """
+    return {
+        k: v
+        for k, v in call_data.items()
+        if k in allowed_keys and k not in _PLUMBING_KEYS
+    }
+
+
+def _validate_fields(patch: dict) -> None:
+    """Validate each field in *patch* using FIELD_VALIDATORS.
+
+    Raises ServiceValidationError on the first invalid field.
+    """
+    for key, value in patch.items():
+        validator = FIELD_VALIDATORS.get(key)
+        if validator is None:
+            raise ServiceValidationError(
+                f"Option '{key}' is not supported by this service."
+            )
+        try:
+            validator(value)
+        except vol.Invalid as exc:
+            raise ServiceValidationError(
+                f"Invalid value for '{key}': {exc.msg} (got {value!r})"
+            ) from exc
+
+
+def _cross_field_validate(patch: dict, current: dict) -> None:
+    """Validate cross-field invariants on the merged options.
+
+    Only checks invariants that involve at least one key present in *patch*
+    so that unrelated existing options don't produce false errors.
+    """
+    merged = {**current, **patch}
+    # Remove keys explicitly cleared (value=None) from the merged view
+    merged_active = {k: v for k, v in merged.items() if v is not None}
+
+    # Blind spot ordering
+    if CONF_BLIND_SPOT_LEFT in patch or CONF_BLIND_SPOT_RIGHT in patch:
+        left = merged_active.get(CONF_BLIND_SPOT_LEFT)
+        right = merged_active.get(CONF_BLIND_SPOT_RIGHT)
+        if left is not None and right is not None and right <= left:
+            raise ServiceValidationError(
+                f"blind_spot_right ({right}) must be greater than blind_spot_left ({left})."
+            )
+
+    # Temperature ordering
+    if CONF_TEMP_LOW in patch or CONF_TEMP_HIGH in patch:
+        low = merged_active.get(CONF_TEMP_LOW)
+        high = merged_active.get(CONF_TEMP_HIGH)
+        if low is not None and high is not None and low >= high:
+            raise ServiceValidationError(
+                f"temp_low ({low}) must be less than temp_high ({high})."
+            )
+
+    # Custom position slot completeness
+    for i in range(1, 5):
+        slot = _CUSTOM_SLOT_KEYS[i]
+        s_key, p_key = slot["sensor"], slot["position"]
+        if s_key in patch or p_key in patch:
+            sensor_set = merged_active.get(s_key) is not None
+            pos_set = merged_active.get(p_key) is not None
+            if sensor_set != pos_set:
+                missing = p_key if sensor_set else s_key
+                present = s_key if sensor_set else p_key
+                raise ServiceValidationError(
+                    f"Custom position slot {i}: '{present}' is set but '{missing}' is missing. "
+                    "Set both or clear both."
+                )
+
+    # Time window mutual exclusion
+    if CONF_START_TIME in patch or CONF_START_ENTITY in patch:
+        st = merged_active.get(CONF_START_TIME)
+        se = merged_active.get(CONF_START_ENTITY)
+        if st and st != "00:00:00" and se:
+            raise ServiceValidationError(
+                f"start_time ('{st}') and start_entity ('{se}') are mutually exclusive. "
+                "Set one or the other, not both."
+            )
+
+    if CONF_END_TIME in patch or CONF_END_ENTITY in patch:
+        et = merged_active.get(CONF_END_TIME)
+        ee = merged_active.get(CONF_END_ENTITY)
+        if et and et != "00:00:00" and ee:
+            raise ServiceValidationError(
+                f"end_time ('{et}') and end_entity ('{ee}') are mutually exclusive. "
+                "Set one or the other, not both."
+            )
+
+    # sunset_use_my requires my_position_value
+    if CONF_SUNSET_USE_MY in patch or CONF_MY_POSITION_VALUE in patch:
+        if merged_active.get(CONF_SUNSET_USE_MY) and not merged_active.get(
+            CONF_MY_POSITION_VALUE
+        ):
+            raise ServiceValidationError(
+                "sunset_use_my=true requires my_position_value to be set."
+            )
+
+
+def validate_options_patch(
+    patch: dict,
+    current_options: dict,
+    sensor_type: str | None = None,
+) -> dict:
+    """Validate a patch dict and return it (unchanged).
+
+    Raises ServiceValidationError if any field is invalid, out of range,
+    targets an identity key, or violates a cross-field invariant.
+    """
+    if not patch:
+        raise ServiceValidationError("No fields provided — nothing to update.")
+
+    # Reject identity keys
+    bad = set(patch) & IDENTITY_KEYS
+    if bad:
+        raise ServiceValidationError(
+            f"The following options cannot be changed via services: {sorted(bad)}. "
+            "Use the integration's Options flow to change them."
+        )
+
+    # Geometry keys must match the cover's sensor_type
+    if sensor_type is not None:
+        vertical_only = (
+            _SECTION_GEOMETRY_VERTICAL
+            - _SECTION_GEOMETRY_AWNING
+            - _SECTION_GEOMETRY_TILT
+        )
+        awning_only = (
+            _SECTION_GEOMETRY_AWNING
+            - _SECTION_GEOMETRY_VERTICAL
+            - _SECTION_GEOMETRY_TILT
+        )
+        tilt_only = (
+            _SECTION_GEOMETRY_TILT
+            - _SECTION_GEOMETRY_VERTICAL
+            - _SECTION_GEOMETRY_AWNING
+        )
+        if sensor_type != SensorType.BLIND and set(patch) & vertical_only:
+            raise ServiceValidationError(
+                f"Geometry fields {sorted(set(patch) & vertical_only)} are only valid for "
+                f"vertical blind covers (this cover is '{sensor_type}')."
+            )
+        if sensor_type != SensorType.AWNING and set(patch) & awning_only:
+            raise ServiceValidationError(
+                f"Geometry fields {sorted(set(patch) & awning_only)} are only valid for "
+                f"awning covers (this cover is '{sensor_type}')."
+            )
+        if sensor_type != SensorType.TILT and set(patch) & tilt_only:
+            raise ServiceValidationError(
+                f"Geometry fields {sorted(set(patch) & tilt_only)} are only valid for "
+                f"tilt covers (this cover is '{sensor_type}')."
+            )
+
+    _validate_fields(patch)
+    _cross_field_validate(patch, current_options)
+    return patch
+
+
+async def apply_options_patch(hass: HomeAssistant, coord: Any, patch: dict) -> dict:
+    """Merge *patch* into the coordinator's config_entry.options and persist.
+
+    Keys with value=None are removed from the options (clearing optional fields).
+    Keys absent from *patch* are left unchanged.
+    Returns the resulting options dict.
+    """
+    entry = coord.config_entry
+    current = dict(entry.options)
+
+    new_options = dict(current)
+    for key, value in patch.items():
+        if value is None:
+            new_options.pop(key, None)
+        else:
+            new_options[key] = value
+
+    hass.config_entries.async_update_entry(entry, options=new_options)
+    return new_options
+
+
+# ---------------------------------------------------------------------------
+# Service handlers
+# ---------------------------------------------------------------------------
+
+
+def _make_section_handler(hass: HomeAssistant, allowed_keys: frozenset[str]):
+    """Return an async service handler for a section-specific service."""
+
+    from . import _resolve_targets  # noqa: PLC0415  (avoids circular at module level)
+
+    async def _handler(call: ServiceCall) -> None:
+        patch = _build_patch(call.data, allowed_keys)
+        targets = _resolve_targets(hass, call)
+        for coord in targets:
+            sensor_type = coord.config_entry.data.get("sensor_type")
+            validate_options_patch(patch, dict(coord.config_entry.options), sensor_type)
+            await apply_options_patch(hass, coord, patch)
+            _LOGGER.debug(
+                "options updated for entry %s: %s",
+                coord.config_entry.entry_id,
+                list(patch),
+            )
+
+    return _handler
+
+
+async def _handle_set_custom_position(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Handle set_custom_position — routes slot 1–4 to the right option keys."""
+    from . import _resolve_targets  # noqa: PLC0415
+
+    slot = call.data.get("slot")
+    if slot not in (1, 2, 3, 4):
+        raise ServiceValidationError(f"'slot' must be 1, 2, 3, or 4 (got {slot!r}).")
+
+    slot_keys = _CUSTOM_SLOT_KEYS[slot]
+    # Map human-readable service field names → actual option keys
+    field_map = {
+        "sensor": slot_keys["sensor"],
+        "position": slot_keys["position"],
+        "priority": slot_keys["priority"],
+        "min_mode": slot_keys["min_mode"],
+        "use_my": slot_keys["use_my"],
+    }
+
+    # Build patch: only include fields that were supplied in the call
+    patch: dict[str, Any] = {}
+    for service_field, option_key in field_map.items():
+        if service_field in call.data:
+            patch[option_key] = call.data[service_field]
+
+    if not patch:
+        raise ServiceValidationError("No slot fields provided — nothing to update.")
+
+    targets = _resolve_targets(hass, call)
+    for coord in targets:
+        validate_options_patch(patch, dict(coord.config_entry.options))
+        await apply_options_patch(hass, coord, patch)
+        _LOGGER.debug(
+            "custom_position slot %d updated for entry %s: %s",
+            slot,
+            coord.config_entry.entry_id,
+            list(patch),
+        )
+
+
+async def _handle_set_option(hass: HomeAssistant, call: ServiceCall) -> None:
+    """Handle generic set_option service."""
+    from . import _resolve_targets  # noqa: PLC0415
+
+    option = call.data.get("option")
+    if not option:
+        raise ServiceValidationError("'option' field is required.")
+
+    if option in IDENTITY_KEYS:
+        raise ServiceValidationError(
+            f"'{option}' cannot be changed via services. "
+            "Use the integration's Options flow."
+        )
+
+    if option not in FIELD_VALIDATORS:
+        raise ServiceValidationError(
+            f"Unknown option '{option}'. "
+            f"See the integration documentation for supported option keys."
+        )
+
+    value = call.data.get("value")
+    patch = {option: value}
+
+    targets = _resolve_targets(hass, call)
+    for coord in targets:
+        sensor_type = coord.config_entry.data.get("sensor_type")
+        validate_options_patch(patch, dict(coord.config_entry.options), sensor_type)
+        await apply_options_patch(hass, coord, patch)
+        _LOGGER.debug(
+            "set_option '%s' -> %r for entry %s",
+            option,
+            value,
+            coord.config_entry.entry_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register_options_services(hass: HomeAssistant) -> None:
+    """Register all options-mutation services. Called from async_setup_services."""
+
+    def _section_handler(allowed_keys: frozenset[str]):
+        return _make_section_handler(hass, allowed_keys)
+
+    hass.services.async_register(
+        DOMAIN, "set_position_limits", _section_handler(_SECTION_POSITION_LIMITS)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_sunset_sunrise", _section_handler(_SECTION_SUNSET_SUNRISE)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_automation_timing", _section_handler(_SECTION_AUTOMATION_TIMING)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_manual_override", _section_handler(_SECTION_MANUAL_OVERRIDE)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_force_override", _section_handler(_SECTION_FORCE_OVERRIDE)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_motion", _section_handler(_SECTION_MOTION)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_light_cloud", _section_handler(_SECTION_LIGHT_CLOUD)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_climate", _section_handler(_SECTION_CLIMATE)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_weather_safety", _section_handler(_SECTION_WEATHER_SAFETY)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_sun_tracking", _section_handler(_SECTION_SUN_TRACKING)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_blind_spot", _section_handler(_SECTION_BLIND_SPOT)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_interpolation", _section_handler(_SECTION_INTERPOLATION)
+    )
+    hass.services.async_register(
+        DOMAIN, "set_geometry", _section_handler(_SECTION_GEOMETRY_ALL)
+    )
+
+    async def _custom_pos_handler(call: ServiceCall) -> None:
+        await _handle_set_custom_position(hass, call)
+
+    hass.services.async_register(DOMAIN, "set_custom_position", _custom_pos_handler)
+
+    async def _set_option_handler(call: ServiceCall) -> None:
+        await _handle_set_option(hass, call)
+
+    hass.services.async_register(DOMAIN, "set_option", _set_option_handler)
+
+
+# Service names registered by this module (for unload)
+OPTIONS_SERVICE_NAMES: tuple[str, ...] = (
+    "set_position_limits",
+    "set_sunset_sunrise",
+    "set_automation_timing",
+    "set_manual_override",
+    "set_force_override",
+    "set_custom_position",
+    "set_motion",
+    "set_light_cloud",
+    "set_climate",
+    "set_weather_safety",
+    "set_sun_tracking",
+    "set_blind_spot",
+    "set_interpolation",
+    "set_geometry",
+    "set_option",
+)

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1091,6 +1091,198 @@
     "emergency_stop": {
       "name": "Emergency stop",
       "description": "Panic button — sends stop_cover to every configured cover on the targeted instances (capability-checked), then disables the integration. With no target, acts on all ACP instances."
+    },
+    "export_config": {
+      "name": "Export configuration",
+      "description": "Returns the cover configuration as JSON for use in the simulation notebook.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Cover configuration",
+          "description": "The Adaptive Cover Pro configuration entry to export."
+        }
+      }
+    },
+    "set_position_limits": {
+      "name": "Set position limits",
+      "description": "Update default height, min/max position, open/close threshold, and inverse state.",
+      "fields": {
+        "default_height": { "name": "Default height", "description": "Default cover position when sun is not visible (0–100%)." },
+        "min_position": { "name": "Minimum position", "description": "Minimum position the cover may move to (0–99%)." },
+        "enable_min_position": { "name": "Enable min position only during tracking", "description": "If true, min_position applies only while sun is tracked." },
+        "max_position": { "name": "Maximum position", "description": "Maximum position the cover may move to (1–100%)." },
+        "enable_max_position": { "name": "Enable max position only during tracking", "description": "If true, max_position applies only while sun is tracked." },
+        "open_close_threshold": { "name": "Open/close threshold", "description": "Position below which open/close-only covers are closed (1–99%)." },
+        "inverse_state": { "name": "Inverse state", "description": "Invert position for covers that report state inversely." }
+      }
+    },
+    "set_sunset_sunrise": {
+      "name": "Set sunset / sunrise positions",
+      "description": "Update sunset position and offset settings. Pass null to clear an optional field.",
+      "fields": {
+        "sunset_position": { "name": "Sunset position", "description": "Position to move to at end of time window. Null = use default_height." },
+        "sunset_offset": { "name": "Sunset offset", "description": "Minutes to shift end-of-window trigger relative to sunset (-120–120)." },
+        "sunrise_offset": { "name": "Sunrise offset", "description": "Minutes to shift start-of-window trigger relative to sunrise (-120–120)." },
+        "sunset_use_my": { "name": "Use Somfy My at sunset", "description": "If true, use my_position_value instead of sunset_position at end of window." },
+        "my_position_value": { "name": "Somfy My position", "description": "The 'My' preset position (1–99%)." }
+      }
+    },
+    "set_automation_timing": {
+      "name": "Set automation timing",
+      "description": "Update delta thresholds, time window start/end, and return_sunset.",
+      "fields": {
+        "delta_position": { "name": "Position delta threshold", "description": "Minimum position change (%) before sending a cover command (1–90)." },
+        "delta_time": { "name": "Time delta threshold", "description": "Minimum time (minutes) between cover commands (2–60)." },
+        "start_time": { "name": "Start time", "description": "Fixed time to start tracking window (HH:MM:SS). Mutually exclusive with start_entity." },
+        "start_entity": { "name": "Start entity", "description": "Entity whose state provides the start time. Mutually exclusive with start_time." },
+        "end_time": { "name": "End time", "description": "Fixed time to end tracking window (HH:MM:SS). Mutually exclusive with end_entity." },
+        "end_entity": { "name": "End entity", "description": "Entity whose state provides the end time. Mutually exclusive with end_time." },
+        "return_sunset": { "name": "Return to sunset position at end", "description": "If true, force-send sunset_position when time window ends." }
+      }
+    },
+    "set_manual_override": {
+      "name": "Set manual override settings",
+      "description": "Update manual override duration, reset behavior, and detection threshold.",
+      "fields": {
+        "manual_override_duration": { "name": "Override duration", "description": "How long a manual override lasts before automatic control resumes." },
+        "manual_override_reset": { "name": "Reset on window start", "description": "If true, clear any active manual override when the time window starts." },
+        "manual_threshold": { "name": "Detection threshold", "description": "Position change (%) that triggers manual override detection (0–99)." },
+        "manual_ignore_intermediate": { "name": "Ignore intermediate states", "description": "If true, ignore opening/closing states for manual override detection." }
+      }
+    },
+    "set_force_override": {
+      "name": "Set force override",
+      "description": "Update force-override sensors, position, and min-mode.",
+      "fields": {
+        "force_override_sensors": { "name": "Force override sensors", "description": "Binary sensors that trigger the force override. Empty list = disable." },
+        "force_override_position": { "name": "Force override position", "description": "Position to move to when a force override sensor is active (0–100%)." },
+        "force_override_min_mode": { "name": "Minimum position mode", "description": "If true, treat force_override_position as a minimum floor." }
+      }
+    },
+    "set_custom_position": {
+      "name": "Set custom position slot",
+      "description": "Update one custom position slot (1–4). Pass null for sensor and position to clear the slot.",
+      "fields": {
+        "slot": { "name": "Slot", "description": "Which custom position slot to update (1–4)." },
+        "sensor": { "name": "Trigger sensor", "description": "Binary sensor that activates this custom position. Null = clear slot." },
+        "position": { "name": "Position", "description": "Target position (0–100%) when the sensor is active. Null = clear slot." },
+        "priority": { "name": "Priority", "description": "Pipeline priority (1–99, default 77)." },
+        "min_mode": { "name": "Minimum position mode", "description": "If true, treat position as a minimum floor." },
+        "use_my": { "name": "Use Somfy My", "description": "If true, use my_position_value instead of position." }
+      }
+    },
+    "set_motion": {
+      "name": "Set motion settings",
+      "description": "Update motion sensors and no-motion timeout.",
+      "fields": {
+        "motion_sensors": { "name": "Motion sensors", "description": "Binary sensors indicating occupancy. Empty list = disable motion control." },
+        "motion_timeout": { "name": "No-motion timeout", "description": "Seconds to wait after last motion before applying motion-timeout position (30–3600)." }
+      }
+    },
+    "set_light_cloud": {
+      "name": "Set light & cloud settings",
+      "description": "Update weather entity, sunny-state filter, lux/irradiance/cloud thresholds, and cloud suppression.",
+      "fields": {
+        "weather_entity": { "name": "Weather entity", "description": "Weather entity for condition readings. Null = none." },
+        "weather_state": { "name": "Sunny weather states", "description": "Weather condition states considered sunny for sun tracking." },
+        "lux_entity": { "name": "Lux sensor", "description": "Illuminance sensor entity. Null = none." },
+        "lux_threshold": { "name": "Lux threshold", "description": "Lux value above which the cover is in direct sunlight." },
+        "irradiance_entity": { "name": "Irradiance sensor", "description": "Solar irradiance sensor entity. Null = none." },
+        "irradiance_threshold": { "name": "Irradiance threshold", "description": "W/m² above which the cover is in direct sunlight." },
+        "cloud_coverage_entity": { "name": "Cloud coverage sensor", "description": "Sensor reporting cloud coverage percentage. Null = none." },
+        "cloud_coverage_threshold": { "name": "Cloud coverage threshold", "description": "Cloud coverage percentage above which sky is considered overcast." },
+        "cloud_suppression": { "name": "Enable cloud suppression", "description": "Suppress solar positioning when cloud coverage exceeds threshold." }
+      }
+    },
+    "set_climate": {
+      "name": "Set climate settings",
+      "description": "Update climate mode and temperature/presence options. Enforces temp_low < temp_high.",
+      "fields": {
+        "climate_mode": { "name": "Enable climate mode", "description": "Master toggle for temperature-aware positioning." },
+        "temp_entity": { "name": "Indoor temperature entity", "description": "Climate or sensor entity for indoor temperature. Null = none." },
+        "temp_low": { "name": "Low temperature threshold", "description": "Below this temperature (°), winter strategy applies (0–90)." },
+        "temp_high": { "name": "High temperature threshold", "description": "Above this temperature (°), summer strategy applies (0–90)." },
+        "outside_temp": { "name": "Outdoor temperature entity", "description": "Sensor entity for outdoor temperature. Null = none." },
+        "outside_threshold": { "name": "Outdoor temperature threshold", "description": "Outdoor temperature (°) above which summer strategy is forced (0–100)." },
+        "presence_entity": { "name": "Presence entity", "description": "Entity indicating occupancy. Null = none." },
+        "transparent_blind": { "name": "Transparent blind", "description": "If true, treat the blind as semi-transparent for climate calculations." },
+        "winter_close_insulation": { "name": "Close for winter insulation", "description": "If true, fully close the cover on cold days to improve insulation." }
+      }
+    },
+    "set_weather_safety": {
+      "name": "Set weather safety settings",
+      "description": "Update wind, rain, and severe-weather override settings.",
+      "fields": {
+        "weather_bypass_auto_control": { "name": "Bypass automatic control", "description": "If true, weather override ignores the Automatic Control toggle." },
+        "weather_wind_speed_sensor": { "name": "Wind speed sensor", "description": "Sensor entity for wind speed. Null = none." },
+        "weather_wind_direction_sensor": { "name": "Wind direction sensor", "description": "Sensor entity for wind direction. Null = none." },
+        "weather_wind_speed_threshold": { "name": "Wind speed threshold", "description": "Wind speed above which the cover is retracted." },
+        "weather_wind_direction_tolerance": { "name": "Wind direction tolerance", "description": "Degrees either side of window azimuth considered a wind threat (5–180°)." },
+        "weather_rain_sensor": { "name": "Rain sensor", "description": "Sensor entity for rain accumulation. Null = none." },
+        "weather_rain_threshold": { "name": "Rain threshold", "description": "Rain accumulation above which the cover is retracted." },
+        "weather_is_raining_sensor": { "name": "Is raining sensor", "description": "Binary sensor indicating active rain. Null = none." },
+        "weather_is_windy_sensor": { "name": "Is windy sensor", "description": "Binary sensor indicating dangerous wind. Null = none." },
+        "weather_severe_sensors": { "name": "Severe weather sensors", "description": "Binary sensors for severe weather (OR logic). Empty list = none." },
+        "weather_override_position": { "name": "Weather override position", "description": "Position to move to when weather override is triggered (0–100%)." },
+        "weather_override_min_mode": { "name": "Minimum position mode", "description": "If true, treat weather_override_position as a minimum floor." },
+        "weather_timeout": { "name": "Weather clear timeout", "description": "Seconds to wait after conditions clear before resuming automatic control (0–3600)." }
+      }
+    },
+    "set_sun_tracking": {
+      "name": "Set sun tracking settings",
+      "description": "Update azimuth, field-of-view, elevation limits, and sun-tracking toggle.",
+      "fields": {
+        "enable_sun_tracking": { "name": "Enable sun tracking", "description": "Master toggle for solar-position-based cover control." },
+        "set_azimuth": { "name": "Window azimuth", "description": "Compass direction the window faces (0–359°)." },
+        "fov_left": { "name": "Field of view left", "description": "Degrees to the left of azimuth within which sun affects this cover (0–180°)." },
+        "fov_right": { "name": "Field of view right", "description": "Degrees to the right of azimuth within which sun affects this cover (0–180°)." },
+        "min_elevation": { "name": "Minimum sun elevation", "description": "Sun elevation (°) below which the cover is not moved. Null = no minimum." },
+        "max_elevation": { "name": "Maximum sun elevation", "description": "Sun elevation (°) above which the cover is fully opened. Null = no maximum." },
+        "distance_shaded_area": { "name": "Distance to shaded area", "description": "Distance (m) from window to edge of shaded area (0.1–5 m)." }
+      }
+    },
+    "set_blind_spot": {
+      "name": "Set blind spot",
+      "description": "Update blind spot zone angles. blind_spot_right must be greater than blind_spot_left.",
+      "fields": {
+        "blind_spot": { "name": "Enable blind spot", "description": "If true, the blind spot zone is active." },
+        "blind_spot_left": { "name": "Left edge", "description": "Left edge of the blind spot zone in degrees from window azimuth (0–359°)." },
+        "blind_spot_right": { "name": "Right edge", "description": "Right edge of the blind spot zone (1–360°). Must be greater than left edge." },
+        "blind_spot_elevation": { "name": "Elevation limit", "description": "Maximum sun elevation (°) for the blind spot to apply. Null = always apply." }
+      }
+    },
+    "set_interpolation": {
+      "name": "Set interpolation",
+      "description": "Enable position interpolation and configure the start/end range and lookup table.",
+      "fields": {
+        "interp": { "name": "Enable interpolation", "description": "If true, apply interpolation mapping to the calculated position." },
+        "interp_start": { "name": "Interpolation start", "description": "Calculated position (%) at which interpolation begins. Null = none." },
+        "interp_end": { "name": "Interpolation end", "description": "Calculated position (%) at which interpolation ends. Null = none." },
+        "interp_list": { "name": "Input list", "description": "Input positions for the interpolation lookup table." },
+        "interp_list_new": { "name": "Output list", "description": "Output positions mapped from interp_list." }
+      }
+    },
+    "set_geometry": {
+      "name": "Set geometry",
+      "description": "Update cover geometry dimensions. Supply only fields applicable to your cover type.",
+      "fields": {
+        "window_height": { "name": "Window height", "description": "Window height in metres (0.1–6 m). Vertical blind and awning only." },
+        "window_width": { "name": "Window width", "description": "Window width in centimetres (10–500 cm). Vertical blind only." },
+        "window_depth": { "name": "Window depth", "description": "Window reveal depth in metres (0–0.5 m). Vertical blind only." },
+        "sill_height": { "name": "Sill height", "description": "Window sill height from floor in metres (0–3 m). Vertical blind only." },
+        "length_awning": { "name": "Awning length", "description": "Awning projection length in metres (0.3–6 m). Awning only." },
+        "angle": { "name": "Awning angle", "description": "Awning tilt angle in degrees (0–45°). Awning only." },
+        "slat_depth": { "name": "Slat depth", "description": "Venetian slat depth in centimetres (0.1–15 cm). Tilt only." },
+        "slat_distance": { "name": "Slat distance", "description": "Distance between slats in centimetres (0.1–15 cm). Tilt only." },
+        "tilt_mode": { "name": "Tilt mode", "description": "Slat angle calculation mode (mode1 or mode2). Tilt only." }
+      }
+    },
+    "set_option": {
+      "name": "Set option (generic)",
+      "description": "Generic escape hatch — update any single supported option by key name. Identity keys are rejected.",
+      "fields": {
+        "option": { "name": "Option key", "description": "The internal option key to update (e.g. 'default_percentage', 'sunset_position')." },
+        "value": { "name": "Value", "description": "New value for the option. Pass null to clear an optional field." }
+      }
     }
   }
 }

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -301,7 +301,7 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
     ),
     MatrixCase(
         id="state_change_force_override_released",
-        is_safety_bypass=True,   # force=True bypasses auto_control gate
+        is_safety_bypass=True,  # force=True bypasses auto_control gate
         is_safety_target=False,  # but is NOT a persistent safety target (#223)
         setup=lambda _: None,
         trigger=_trigger_force_override_released,

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1104,7 +1104,11 @@ def test_capability_listing_not_in_summary():
     """Full capability listing (entity: set position, open...) is not in _build_config_summary."""
     from homeassistant.components.cover import CoverEntityFeature
 
-    feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    feats = (
+        CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+    )
     hass = _make_hass({"cover.living_room": {"supported_features": feats}})
     cfg = {CONF_ENTITIES: ["cover.living_room"]}
     summary = _build_config_summary(cfg, SensorType.BLIND, hass)
@@ -1176,7 +1180,9 @@ def test_capabilities_section_warns_on_open_close_only():
 
 def test_capabilities_section_unavailable_entity():
     """Unavailable entity renders ⚠️ not-ready warning."""
-    hass = _make_hass({"cover.blind": {"state": "unavailable", "supported_features": 0}})
+    hass = _make_hass(
+        {"cover.blind": {"state": "unavailable", "supported_features": 0}}
+    )
     # check_cover_features returns None for unavailable state
     cfg = {CONF_ENTITIES: ["cover.blind"]}
     result = _build_cover_capabilities_text(cfg, SensorType.BLIND, hass)
@@ -1187,7 +1193,11 @@ def test_capabilities_section_assumed_state_warning():
     """Cover with assumed_state attribute renders ⚠️ assumed-state warning."""
     from homeassistant.components.cover import CoverEntityFeature
 
-    feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    feats = (
+        CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+    )
     hass = _make_hass(
         {"cover.blind": {"supported_features": feats, "assumed_state": True}}
     )
@@ -1223,7 +1233,11 @@ def test_capabilities_section_tilt_type_mismatch():
     """Tilt sensor_type with no set_tilt_position cover renders mismatch warning."""
     from homeassistant.components.cover import CoverEntityFeature
 
-    feats = CoverEntityFeature.SET_POSITION | CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
+    feats = (
+        CoverEntityFeature.SET_POSITION
+        | CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+    )
     hass = _make_hass({"cover.blind": {"supported_features": feats}})
     cfg = {CONF_ENTITIES: ["cover.blind"]}
     result = _build_cover_capabilities_text(cfg, SensorType.TILT, hass)

--- a/tests/test_entity_migration.py
+++ b/tests/test_entity_migration.py
@@ -66,7 +66,9 @@ def _seed_legacy_orphans(
     return orphans
 
 
-def _seed_modern_entity(hass: HomeAssistant, entry: MockConfigEntry) -> er.RegistryEntry:
+def _seed_modern_entity(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> er.RegistryEntry:
     """Inject a modern binary_sensor entity (should never be removed)."""
     registry = er.async_get(hass)
     return registry.async_get_or_create(
@@ -92,13 +94,17 @@ async def test_prune_removes_legacy_orphans(hass: HomeAssistant) -> None:
 
     registry = er.async_get(hass)
     for eid in orphan_entity_ids:
-        assert registry.async_get(eid) is not None, f"Orphan {eid} should exist pre-migration"
+        assert registry.async_get(eid) is not None, (
+            f"Orphan {eid} should exist pre-migration"
+        )
 
     await async_prune_legacy_entities(hass, entry)
     await hass.async_block_till_done()
 
     for eid in orphan_entity_ids:
-        assert registry.async_get(eid) is None, f"Orphan {eid} should be removed post-migration"
+        assert registry.async_get(eid) is None, (
+            f"Orphan {eid} should be removed post-migration"
+        )
 
 
 @pytest.mark.integration
@@ -121,13 +127,17 @@ async def test_prune_leaves_modern_entities_intact(hass: HomeAssistant) -> None:
 async def test_prune_sets_flag(hass: HomeAssistant) -> None:
     """Migration writes the _orphan_prune_v1 flag to entry.options."""
     entry = _make_entry(hass)
-    assert not entry.options.get(_PRUNE_V1_FLAG), "Flag should not be set before migration"
+    assert not entry.options.get(_PRUNE_V1_FLAG), (
+        "Flag should not be set before migration"
+    )
 
     await async_prune_legacy_entities(hass, entry)
     await hass.async_block_till_done()
 
     updated_entry = hass.config_entries.async_get_entry(ENTRY_ID)
-    assert updated_entry.options.get(_PRUNE_V1_FLAG) is True, "Flag should be set after migration"
+    assert updated_entry.options.get(_PRUNE_V1_FLAG) is True, (
+        "Flag should be set after migration"
+    )
 
 
 @pytest.mark.integration
@@ -168,32 +178,46 @@ async def test_prune_no_effect_when_no_orphans(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     registry = er.async_get(hass)
-    assert registry.async_get(modern.entity_id) is not None, "Modern entity should still exist"
+    assert registry.async_get(modern.entity_id) is not None, (
+        "Modern entity should still exist"
+    )
     updated_entry = hass.config_entries.async_get_entry(ENTRY_ID)
     assert updated_entry.options.get(_PRUNE_V1_FLAG) is True
 
 
 @pytest.mark.integration
-async def test_prune_does_not_touch_non_binary_sensor_domains(hass: HomeAssistant) -> None:
+async def test_prune_does_not_touch_non_binary_sensor_domains(
+    hass: HomeAssistant,
+) -> None:
     """Entities on sensor, switch, and button domains are never touched."""
     entry = _make_entry(hass)
     registry = er.async_get(hass)
 
     # Seed a sensor and a switch with legacy-looking names to confirm they're safe
     sensor_entry = registry.async_get_or_create(
-        "sensor", DOMAIN, f"{ENTRY_ID}_Manual Override",
-        config_entry=entry, suggested_object_id="manual_override_sensor",
+        "sensor",
+        DOMAIN,
+        f"{ENTRY_ID}_Manual Override",
+        config_entry=entry,
+        suggested_object_id="manual_override_sensor",
     )
     switch_entry = registry.async_get_or_create(
-        "switch", DOMAIN, f"{ENTRY_ID}_Sun Infront",
-        config_entry=entry, suggested_object_id="sun_infront_switch",
+        "switch",
+        DOMAIN,
+        f"{ENTRY_ID}_Sun Infront",
+        config_entry=entry,
+        suggested_object_id="sun_infront_switch",
     )
 
     await async_prune_legacy_entities(hass, entry)
     await hass.async_block_till_done()
 
-    assert registry.async_get(sensor_entry.entity_id) is not None, "Sensor entity must not be removed"
-    assert registry.async_get(switch_entry.entity_id) is not None, "Switch entity must not be removed"
+    assert registry.async_get(sensor_entry.entity_id) is not None, (
+        "Sensor entity must not be removed"
+    )
+    assert registry.async_get(switch_entry.entity_id) is not None, (
+        "Switch entity must not be removed"
+    )
 
 
 @pytest.mark.integration

--- a/tests/test_global_services.py
+++ b/tests/test_global_services.py
@@ -55,6 +55,14 @@ def _make_hass(coordinators: dict) -> MagicMock:
     return hass
 
 
+def _get_handler(hass: MagicMock, service_name: str):
+    """Return the registered handler for a service by name (not by position)."""
+    for call in hass.services.async_register.call_args_list:
+        if call[0][1] == service_name:
+            return call[0][2]
+    raise ValueError(f"Service {service_name!r} was never registered")
+
+
 def _make_call(entity_id=None, device_id=None, area_id=None) -> MagicMock:
     call = MagicMock()
     call.data = {}
@@ -181,9 +189,7 @@ async def test_integration_enable_no_target_enables_all():
     hass = _make_hass({"entry_a": coord_a, "entry_b": coord_b})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-3][0][
-        2
-    ]  # 3rd-from-last = enable
+    handler = _get_handler(hass, "integration_enable")
 
     call = _make_call()
     await handler(call)
@@ -199,7 +205,7 @@ async def test_integration_enable_sends_no_commands():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-3][0][2]
+    handler = _get_handler(hass, "integration_enable")
 
     call = _make_call()
     await handler(call)
@@ -220,9 +226,7 @@ async def test_integration_disable_calls_stop_in_flight():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-2][0][
-        2
-    ]  # 2nd-from-last = disable
+    handler = _get_handler(hass, "integration_disable")
 
     call = _make_call()
     await handler(call)
@@ -238,7 +242,7 @@ async def test_integration_disable_sets_enabled_false():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-2][0][2]
+    handler = _get_handler(hass, "integration_disable")
 
     call = _make_call()
     await handler(call)
@@ -253,7 +257,7 @@ async def test_integration_disable_cancels_timers_and_clears_state():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-2][0][2]
+    handler = _get_handler(hass, "integration_disable")
 
     call = _make_call()
     await handler(call)
@@ -275,9 +279,7 @@ async def test_emergency_stop_calls_stop_all():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-1][0][
-        2
-    ]  # last = emergency_stop
+    handler = _get_handler(hass, "emergency_stop")
 
     call = _make_call()
     await handler(call)
@@ -293,7 +295,7 @@ async def test_emergency_stop_also_disables_integration():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-1][0][2]
+    handler = _get_handler(hass, "emergency_stop")
 
     call = _make_call()
     await handler(call)
@@ -308,7 +310,7 @@ async def test_emergency_stop_with_entity_filter_narrows_stop():
     hass = _make_hass({"entry_a": coord_a})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-1][0][2]
+    handler = _get_handler(hass, "emergency_stop")
 
     call = _make_call(entity_id="cover.a")
     await handler(call)
@@ -324,7 +326,7 @@ async def test_emergency_stop_no_target_hits_all_instances():
     hass = _make_hass({"entry_a": coord_a, "entry_b": coord_b})
 
     await async_setup_services(hass)
-    handler = hass.services.async_register.call_args_list[-1][0][2]
+    handler = _get_handler(hass, "emergency_stop")
 
     call = _make_call()
     await handler(call)

--- a/tests/test_init_entity_tracking.py
+++ b/tests/test_init_entity_tracking.py
@@ -43,8 +43,12 @@ async def _setup_entry_capture_tracked(
     )
     entry.add_to_hass(hass)
 
-    hass.states.async_set("sun.sun", "above_horizon", {"azimuth": 180.0, "elevation": 45.0})
-    hass.states.async_set("cover.test_blind", "open", {"current_position": 100, "supported_features": 143})
+    hass.states.async_set(
+        "sun.sun", "above_horizon", {"azimuth": 180.0, "elevation": 45.0}
+    )
+    hass.states.async_set(
+        "cover.test_blind", "open", {"current_position": 100, "supported_features": 143}
+    )
 
     tracked_calls: list[list[str]] = []
 
@@ -57,7 +61,13 @@ async def _setup_entry_capture_tracked(
             tracked_calls.append(list(entity_ids))
         return original(hass_, entity_ids, callback)
 
-    with patch("custom_components.adaptive_cover_pro.async_track_state_change_event", side_effect=_capture), _patch_coordinator_refresh():
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.async_track_state_change_event",
+            side_effect=_capture,
+        ),
+        _patch_coordinator_refresh(),
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -132,5 +142,10 @@ async def test_unset_climate_entities_not_in_tracked_list(hass) -> None:
     _, calls = await _setup_entry_capture_tracked(hass, entry_id="track_none_01")
     all_tracked = [e for call in calls for e in call]
     # None of these should appear when not configured
-    for entity_id in ["sensor.cloud_coverage", "sensor.lux", "sensor.irradiance", "sensor.outside_temp"]:
+    for entity_id in [
+        "sensor.cloud_coverage",
+        "sensor.lux",
+        "sensor.irradiance",
+        "sensor.outside_temp",
+    ]:
         assert entity_id not in all_tracked

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -452,12 +452,14 @@ async def test_state_change_clears_state_change_flag_outside_window():
 # ---------------------------------------------------------------------------
 
 
-def _make_sun_data_utc(*, sunset_utc_hour: int, sunset_utc_minute: int = 0,
-                       sunrise_utc_hour: int = 5) -> MagicMock:
+def _make_sun_data_utc(
+    *, sunset_utc_hour: int, sunset_utc_minute: int = 0, sunrise_utc_hour: int = 5
+) -> MagicMock:
     """Return a mock SunData whose sunset/sunrise methods return UTC naive datetimes."""
     today = dt.date.today()
-    sunset_dt = dt.datetime(today.year, today.month, today.day,
-                            sunset_utc_hour, sunset_utc_minute, 0)
+    sunset_dt = dt.datetime(
+        today.year, today.month, today.day, sunset_utc_hour, sunset_utc_minute, 0
+    )
     sunrise_dt = dt.datetime(today.year, today.month, today.day, sunrise_utc_hour, 0, 0)
     sun = MagicMock()
     sun.sunset.return_value = sunset_dt
@@ -489,13 +491,17 @@ class TestIssue215EuropeParisSunsetConfig:
         sent, the value would still be 0 (closed), not 100 (open). The fact that the user
         observed 100% is therefore external to ACP.
         """
-        from custom_components.adaptive_cover_pro.helpers import compute_effective_default
+        from custom_components.adaptive_cover_pro.helpers import (
+            compute_effective_default,
+        )
 
         # Paris April sunset ~18:45 UTC; 23:58 CEST = 21:58 UTC
-        sun_data = _make_sun_data_utc(sunset_utc_hour=18, sunset_utc_minute=45,
-                                      sunrise_utc_hour=5)
-        now_utc = dt.datetime(dt.date.today().year, dt.date.today().month,
-                              dt.date.today().day, 21, 58, 0)
+        sun_data = _make_sun_data_utc(
+            sunset_utc_hour=18, sunset_utc_minute=45, sunrise_utc_hour=5
+        )
+        now_utc = dt.datetime(
+            dt.date.today().year, dt.date.today().month, dt.date.today().day, 21, 58, 0
+        )
 
         with _freeze_helpers_now(now_utc):
             effective, is_sunset_active = compute_effective_default(
@@ -520,13 +526,17 @@ class TestIssue215EuropeParisSunsetConfig:
 
         Regression guard: end_time transitions before sunset+offset should send h_def.
         """
-        from custom_components.adaptive_cover_pro.helpers import compute_effective_default
+        from custom_components.adaptive_cover_pro.helpers import (
+            compute_effective_default,
+        )
 
         # Same Paris April config, but now=17:00 UTC — before sunset+20=19:05 UTC
-        sun_data = _make_sun_data_utc(sunset_utc_hour=18, sunset_utc_minute=45,
-                                      sunrise_utc_hour=5)
-        now_utc = dt.datetime(dt.date.today().year, dt.date.today().month,
-                              dt.date.today().day, 17, 0, 0)
+        sun_data = _make_sun_data_utc(
+            sunset_utc_hour=18, sunset_utc_minute=45, sunrise_utc_hour=5
+        )
+        now_utc = dt.datetime(
+            dt.date.today().year, dt.date.today().month, dt.date.today().day, 17, 0, 0
+        )
 
         with _freeze_helpers_now(now_utc):
             effective, is_sunset_active = compute_effective_default(
@@ -837,7 +847,7 @@ class TestIssue215StaleSafetyTarget:
         manager = MagicMock()
         manager.is_cover_manual.side_effect = [
             False,  # was_manual check (before handle_state_change)
-            True,   # is_cover_manual check (after handle_state_change)
+            True,  # is_cover_manual check (after handle_state_change)
         ]
         manager.handle_state_change = MagicMock()
         coordinator.manager = manager
@@ -1086,8 +1096,11 @@ class TestIssue223OverrideClearSafetyTag:
         # Step 3: Reconciliation — must NOT resend (target was cleared)
         await svc._reconcile(dt.datetime.now(UTC))
 
-        hass.services.async_call.assert_not_called(), (
-            "Reconciliation must not resend the override-clear target outside the "
-            "time window — the entity was not safety-tagged and was cleaned up "
-            "when the window closed (fix for issue #223)."
+        (
+            hass.services.async_call.assert_not_called(),
+            (
+                "Reconciliation must not resend the override-clear target outside the "
+                "time window — the entity was not safety-tagged and was cleaned up "
+                "when the window closed (fix for issue #223)."
+            ),
         )

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -579,7 +579,10 @@ class TestGlareZoneDescribeSkip:
             active_zone_names=set(),
             in_time_window=True,
         )
-        assert self.handler.describe_skip(snap) == "no active glare zones or sun not in FOV"
+        assert (
+            self.handler.describe_skip(snap)
+            == "no active glare zones or sun not in FOV"
+        )
 
     def test_describe_skip_sun_not_valid(self) -> None:
         """Sun not in FOV → same 'no active glare zones' message."""
@@ -594,7 +597,10 @@ class TestGlareZoneDescribeSkip:
             active_zone_names={"desk"},
             in_time_window=True,
         )
-        assert self.handler.describe_skip(snap) == "no active glare zones or sun not in FOV"
+        assert (
+            self.handler.describe_skip(snap)
+            == "no active glare zones or sun not in FOV"
+        )
 
 
 class TestGlareZoneReasonString:
@@ -743,9 +749,9 @@ class TestGlareZoneRegressionMaxVsMin:
         )
         glare_cfg = GlareZonesConfig(
             zones=[
-                GlareZone(name="zone_far", x=0.0, y=350.0, radius=0.0),   # 3.5 m
-                GlareZone(name="zone_mid", x=0.0, y=150.0, radius=0.0),   # 1.5 m
-                GlareZone(name="zone_near", x=0.0, y=50.0, radius=0.0),   # 0.5 m
+                GlareZone(name="zone_far", x=0.0, y=350.0, radius=0.0),  # 3.5 m
+                GlareZone(name="zone_mid", x=0.0, y=150.0, radius=0.0),  # 1.5 m
+                GlareZone(name="zone_near", x=0.0, y=50.0, radius=0.0),  # 0.5 m
             ],
             window_width=400.0,
         )

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -339,7 +339,10 @@ def test_all_entity_subclasses_have_availability_factories():
     assert not missing, (
         "New AdaptiveCoverBaseEntity subclass(es) found without a factory in "
         "ENTITY_FACTORIES (test_sensor_availability.py):\n"
-        + "\n".join(f"  - {cls.__module__}.{cls.__name__}" for cls in sorted(missing, key=lambda c: c.__name__))
+        + "\n".join(
+            f"  - {cls.__module__}.{cls.__name__}"
+            for cls in sorted(missing, key=lambda c: c.__name__)
+        )
         + "\n\nAdd a factory lambda for each class so the startup-race availability "
         "test covers it automatically."
     )

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -1,0 +1,1183 @@
+"""Tests for runtime options-mutation services (Issue #221).
+
+Covers:
+- Pure unit tests for validate_options_patch, _validate_fields, _cross_field_validate
+- Integration tests for all 15 per-section + generic set_option services
+- Reload propagation (async_update_entry called)
+- Custom position slot routing
+- List-field replace semantics
+- Null/clearing semantics
+- Identity-key rejection
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_AZIMUTH,
+    CONF_BLIND_SPOT_LEFT,
+    CONF_BLIND_SPOT_RIGHT,
+    CONF_CLIMATE_MODE,
+    CONF_CLOUD_SUPPRESSION,
+    CONF_DEFAULT_HEIGHT,
+    CONF_DELTA_POSITION,
+    CONF_ENABLE_MAX_POSITION,
+    CONF_ENABLE_MIN_POSITION,
+    CONF_ENABLE_SUN_TRACKING,
+    CONF_END_ENTITY,
+    CONF_END_TIME,
+    CONF_FORCE_OVERRIDE_MIN_MODE,
+    CONF_FORCE_OVERRIDE_POSITION,
+    CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_FOV_LEFT,
+    CONF_FOV_RIGHT,
+    CONF_INTERP,
+    CONF_INVERSE_STATE,
+    CONF_MANUAL_OVERRIDE_DURATION,
+    CONF_MANUAL_OVERRIDE_RESET,
+    CONF_MAX_POSITION,
+    CONF_MIN_POSITION,
+    CONF_MOTION_SENSORS,
+    CONF_MOTION_TIMEOUT,
+    CONF_MY_POSITION_VALUE,
+    CONF_RETURN_SUNSET,
+    CONF_SENSOR_TYPE,
+    CONF_START_ENTITY,
+    CONF_START_TIME,
+    CONF_SUNRISE_OFFSET,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_POS,
+    CONF_SUNSET_USE_MY,
+    CONF_TEMP_HIGH,
+    CONF_TEMP_LOW,
+    CONF_WEATHER_BYPASS_AUTO_CONTROL,
+    CONF_WEATHER_OVERRIDE_POSITION,
+    CONF_WEATHER_SEVERE_SENSORS,
+    CONF_WEATHER_TIMEOUT,
+    CONF_WEATHER_WIND_SPEED_THRESHOLD,
+    DOMAIN,
+    SensorType,
+)
+from custom_components.adaptive_cover_pro.services.options_service import (
+    ALL_SETTABLE_KEYS,
+    FIELD_VALIDATORS,
+    IDENTITY_KEYS,
+    _cross_field_validate,
+    apply_options_patch,
+    validate_options_patch,
+)
+from tests.ha_helpers import (
+    VERTICAL_OPTIONS,
+    _patch_coordinator_refresh,
+)
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _setup(
+    hass: HomeAssistant,
+    entry_id: str = "opts_01",
+    cover_type: str = SensorType.BLIND,
+    options: dict | None = None,
+    name: str = "Options Cover",
+) -> MockConfigEntry:
+    opts = dict(VERTICAL_OPTIONS) if options is None else options
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": name, CONF_SENSOR_TYPE: cover_type},
+        options=opts,
+        entry_id=entry_id,
+        title=name,
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def _call(
+    hass: HomeAssistant,
+    service: str,
+    data: dict,
+    target_entity: str = "cover.test_blind",
+) -> None:
+    hass.states.async_set(target_entity, "open", {"current_position": 50})
+    await hass.services.async_call(
+        DOMAIN,
+        service,
+        data,
+        blocking=True,
+        target={"entity_id": [target_entity]},
+    )
+    await hass.async_block_till_done()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — validate_options_patch (pure, no HA)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOptionsPatch:
+    """Unit tests for validate_options_patch."""
+
+    def test_empty_patch_raises(self):
+        with pytest.raises(ServiceValidationError, match="No fields"):
+            validate_options_patch({}, {})
+
+    def test_identity_key_rejected(self):
+        for key in IDENTITY_KEYS:
+            with pytest.raises(ServiceValidationError, match="cannot be changed"):
+                validate_options_patch({key: "x"}, {})
+
+    def test_valid_default_height(self):
+        patch = {CONF_DEFAULT_HEIGHT: 75}
+        result = validate_options_patch(patch, {})
+        assert result == patch
+
+    def test_default_height_out_of_range(self):
+        with pytest.raises(ServiceValidationError, match="default_percentage"):
+            validate_options_patch({CONF_DEFAULT_HEIGHT: 150}, {})
+
+    def test_none_value_passes_validation(self):
+        result = validate_options_patch({CONF_SUNSET_POS: None}, {})
+        assert result[CONF_SUNSET_POS] is None
+
+    def test_geometry_wrong_cover_type_rejected(self):
+        with pytest.raises(ServiceValidationError, match="only valid for"):
+            validate_options_patch(
+                {"window_width": 100},
+                {},
+                sensor_type=SensorType.AWNING,
+            )
+
+    def test_geometry_correct_cover_type_accepted(self):
+        result = validate_options_patch(
+            {"window_height": 2.5},
+            {},
+            sensor_type=SensorType.BLIND,
+        )
+        assert result["window_height"] == 2.5
+
+    def test_awning_field_accepted_for_awning_type(self):
+        result = validate_options_patch(
+            {"length_awning": 3.0},
+            {},
+            sensor_type=SensorType.AWNING,
+        )
+        assert result["length_awning"] == 3.0
+
+    def test_tilt_field_accepted_for_tilt_type(self):
+        result = validate_options_patch(
+            {"slat_depth": 3.0},
+            {},
+            sensor_type=SensorType.TILT,
+        )
+        assert result["slat_depth"] == 3.0
+
+
+class TestFieldValidators:
+    """Unit tests for FIELD_VALIDATORS entries."""
+
+    def test_numeric_ranges(self):
+        valid_cases = [
+            (CONF_DEFAULT_HEIGHT, 0),
+            (CONF_DEFAULT_HEIGHT, 100),
+            (CONF_MIN_POSITION, 0),
+            (CONF_MIN_POSITION, 99),
+            (CONF_MAX_POSITION, 1),
+            (CONF_MAX_POSITION, 100),
+            (CONF_AZIMUTH, 0),
+            (CONF_AZIMUTH, 359),
+            (CONF_MOTION_TIMEOUT, 30),
+            (CONF_MOTION_TIMEOUT, 3600),
+        ]
+        for key, value in valid_cases:
+            FIELD_VALIDATORS[key](value)  # should not raise
+
+    def test_numeric_out_of_range_raises(self):
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS[CONF_DEFAULT_HEIGHT](101)
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS[CONF_AZIMUTH](360)
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS[CONF_MOTION_TIMEOUT](29)
+
+    def test_none_always_accepted(self):
+        for _key, validator in FIELD_VALIDATORS.items():
+            validator(None)  # should not raise for any field
+
+    def test_bool_field_accepts_bool(self):
+        FIELD_VALIDATORS[CONF_ENABLE_MIN_POSITION](True)
+        FIELD_VALIDATORS[CONF_ENABLE_MIN_POSITION](False)
+        FIELD_VALIDATORS[CONF_ENABLE_MIN_POSITION](None)
+
+    def test_time_field_validates_format(self):
+        FIELD_VALIDATORS[CONF_START_TIME]("08:00:00")
+        FIELD_VALIDATORS[CONF_START_TIME]("00:00:00")
+        FIELD_VALIDATORS[CONF_START_TIME](None)
+
+    def test_time_field_rejects_bad_format(self):
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS[CONF_START_TIME]("8:00")
+
+    def test_tilt_mode_select(self):
+        FIELD_VALIDATORS["tilt_mode"]("mode1")
+        FIELD_VALIDATORS["tilt_mode"]("mode2")
+        FIELD_VALIDATORS["tilt_mode"](None)
+
+    def test_tilt_mode_rejects_invalid(self):
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS["tilt_mode"]("mode3")
+
+
+class TestCrossFieldValidate:
+    """Unit tests for _cross_field_validate."""
+
+    def test_blind_spot_right_must_exceed_left(self):
+        with pytest.raises(ServiceValidationError, match="blind_spot_right"):
+            _cross_field_validate(
+                {CONF_BLIND_SPOT_LEFT: 30, CONF_BLIND_SPOT_RIGHT: 20},
+                {},
+            )
+
+    def test_blind_spot_equal_raises(self):
+        with pytest.raises(ServiceValidationError, match="blind_spot_right"):
+            _cross_field_validate(
+                {CONF_BLIND_SPOT_LEFT: 30, CONF_BLIND_SPOT_RIGHT: 30},
+                {},
+            )
+
+    def test_blind_spot_valid(self):
+        _cross_field_validate(
+            {CONF_BLIND_SPOT_LEFT: 10, CONF_BLIND_SPOT_RIGHT: 30},
+            {},
+        )
+
+    def test_temp_low_must_be_less_than_high(self):
+        with pytest.raises(ServiceValidationError, match="temp_low"):
+            _cross_field_validate({CONF_TEMP_LOW: 25, CONF_TEMP_HIGH: 20}, {})
+
+    def test_temp_equal_raises(self):
+        with pytest.raises(ServiceValidationError, match="temp_low"):
+            _cross_field_validate({CONF_TEMP_LOW: 22, CONF_TEMP_HIGH: 22}, {})
+
+    def test_temp_ordering_valid(self):
+        _cross_field_validate({CONF_TEMP_LOW: 18, CONF_TEMP_HIGH: 26}, {})
+
+    def test_custom_slot_sensor_without_position_raises(self):
+        with pytest.raises(ServiceValidationError, match="slot 1"):
+            _cross_field_validate(
+                {"custom_position_sensor_1": "binary_sensor.x"},
+                {},  # no existing position_1
+            )
+
+    def test_custom_slot_position_without_sensor_raises(self):
+        with pytest.raises(ServiceValidationError, match="slot 2"):
+            _cross_field_validate(
+                {"custom_position_2": 80},
+                {},  # no existing sensor_2
+            )
+
+    def test_custom_slot_both_set_valid(self):
+        _cross_field_validate(
+            {
+                "custom_position_sensor_3": "binary_sensor.x",
+                "custom_position_3": 60,
+            },
+            {},
+        )
+
+    def test_custom_slot_both_none_clears_slot(self):
+        _cross_field_validate(
+            {"custom_position_sensor_1": None, "custom_position_1": None},
+            {"custom_position_sensor_1": "binary_sensor.x", "custom_position_1": 50},
+        )
+
+    def test_start_time_and_entity_mutually_exclusive(self):
+        with pytest.raises(ServiceValidationError, match="mutually exclusive"):
+            _cross_field_validate(
+                {CONF_START_TIME: "08:00:00", CONF_START_ENTITY: "sensor.x"},
+                {},
+            )
+
+    def test_end_time_and_entity_mutually_exclusive(self):
+        with pytest.raises(ServiceValidationError, match="mutually exclusive"):
+            _cross_field_validate(
+                {CONF_END_TIME: "20:00:00", CONF_END_ENTITY: "sensor.x"},
+                {},
+            )
+
+    def test_start_time_00_00_00_with_entity_is_ok(self):
+        # "00:00:00" is the default; setting entity alongside it should not error
+        _cross_field_validate(
+            {CONF_START_TIME: "00:00:00", CONF_START_ENTITY: "sensor.x"},
+            {},
+        )
+
+    def test_sunset_use_my_without_value_raises(self):
+        with pytest.raises(ServiceValidationError, match="my_position_value"):
+            _cross_field_validate({CONF_SUNSET_USE_MY: True}, {})
+
+    def test_sunset_use_my_with_existing_value_valid(self):
+        _cross_field_validate(
+            {CONF_SUNSET_USE_MY: True},
+            {CONF_MY_POSITION_VALUE: 50},
+        )
+
+    def test_cross_field_check_not_triggered_when_key_absent(self):
+        # If neither blind_spot_left nor blind_spot_right is in patch,
+        # don't check blind spot ordering (existing options may not even have these)
+        _cross_field_validate(
+            {CONF_DEFAULT_HEIGHT: 60},
+            {},
+        )
+
+
+class TestApplyOptionsPatch:
+    """Unit tests for apply_options_patch."""
+
+    async def test_none_removes_key(self):
+        hass = MagicMock()
+        hass.config_entries = MagicMock()
+        coord = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = {CONF_SUNSET_POS: 30, CONF_DEFAULT_HEIGHT: 60}
+
+        result = await apply_options_patch(hass, coord, {CONF_SUNSET_POS: None})
+
+        assert CONF_SUNSET_POS not in result
+        assert result[CONF_DEFAULT_HEIGHT] == 60
+
+    async def test_non_none_updates_key(self):
+        hass = MagicMock()
+        hass.config_entries = MagicMock()
+        coord = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = {CONF_DEFAULT_HEIGHT: 60}
+
+        result = await apply_options_patch(hass, coord, {CONF_DEFAULT_HEIGHT: 75})
+
+        assert result[CONF_DEFAULT_HEIGHT] == 75
+
+    async def test_absent_key_unchanged(self):
+        hass = MagicMock()
+        hass.config_entries = MagicMock()
+        coord = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = {CONF_DEFAULT_HEIGHT: 60, CONF_AZIMUTH: 180}
+
+        result = await apply_options_patch(hass, coord, {CONF_DEFAULT_HEIGHT: 75})
+
+        assert result[CONF_AZIMUTH] == 180
+
+    async def test_async_update_entry_called(self):
+        hass = MagicMock()
+        hass.config_entries = MagicMock()
+        coord = MagicMock()
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = {CONF_DEFAULT_HEIGHT: 60}
+
+        await apply_options_patch(hass, coord, {CONF_DEFAULT_HEIGHT: 75})
+
+        hass.config_entries.async_update_entry.assert_called_once()
+        call_kwargs = hass.config_entries.async_update_entry.call_args
+        assert call_kwargs[1]["options"][CONF_DEFAULT_HEIGHT] == 75
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — services via real HA
+# ---------------------------------------------------------------------------
+
+
+class TestServiceRegistration:
+    """Integration tests for service registration."""
+
+    async def test_all_options_services_registered(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="reg_01")
+        for service in [
+            "set_position_limits",
+            "set_sunset_sunrise",
+            "set_automation_timing",
+            "set_manual_override",
+            "set_force_override",
+            "set_custom_position",
+            "set_motion",
+            "set_light_cloud",
+            "set_climate",
+            "set_weather_safety",
+            "set_sun_tracking",
+            "set_blind_spot",
+            "set_interpolation",
+            "set_geometry",
+            "set_option",
+        ]:
+            assert hass.services.has_service(DOMAIN, service), (
+                f"Service '{service}' not registered"
+            )
+
+
+class TestSetPositionLimits:
+    """Integration tests for set_position_limits service."""
+
+    async def test_updates_default_height(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="pos_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_position_limits", {CONF_DEFAULT_HEIGHT: 75})
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_DEFAULT_HEIGHT] == 75
+
+    async def test_updates_multiple_fields(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="pos_02")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_position_limits",
+                {
+                    CONF_MIN_POSITION: 10,
+                    CONF_ENABLE_MIN_POSITION: True,
+                    CONF_MAX_POSITION: 95,
+                    CONF_ENABLE_MAX_POSITION: False,
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MIN_POSITION] == 10
+        assert new_opts[CONF_ENABLE_MIN_POSITION] is True
+        assert new_opts[CONF_MAX_POSITION] == 95
+
+    async def test_invalid_min_position_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="pos_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(hass, "set_position_limits", {CONF_MIN_POSITION: 150})
+
+    async def test_inverse_state_bool(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="pos_inv_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_position_limits", {CONF_INVERSE_STATE: True})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_INVERSE_STATE] is True
+
+
+class TestSetSunsetSunrise:
+    """Integration tests for set_sunset_sunrise service."""
+
+    async def test_updates_sunset_position(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ss_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_sunset_sunrise", {CONF_SUNSET_POS: 25})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_SUNSET_POS] == 25
+
+    async def test_clears_sunset_position_with_null(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_SUNSET_POS: 30}
+        await _setup(hass, entry_id="ss_null_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_sunset_sunrise", {CONF_SUNSET_POS: None})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert CONF_SUNSET_POS not in new_opts
+
+    async def test_updates_offsets(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ss_off_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_sunset_sunrise",
+                {CONF_SUNSET_OFFSET: -30, CONF_SUNRISE_OFFSET: 15},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_SUNSET_OFFSET] == -30
+        assert new_opts[CONF_SUNRISE_OFFSET] == 15
+
+    async def test_sunset_use_my_requires_my_value(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ss_my_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(hass, "set_sunset_sunrise", {CONF_SUNSET_USE_MY: True})
+
+    async def test_sunset_use_my_with_value_accepted(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ss_my_ok_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_sunset_sunrise",
+                {CONF_SUNSET_USE_MY: True, CONF_MY_POSITION_VALUE: 50},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_SUNSET_USE_MY] is True
+        assert new_opts[CONF_MY_POSITION_VALUE] == 50
+
+
+class TestSetAutomationTiming:
+    """Integration tests for set_automation_timing service."""
+
+    async def test_updates_delta_position(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="at_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_automation_timing", {CONF_DELTA_POSITION: 10})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_DELTA_POSITION] == 10
+
+    async def test_start_time_and_entity_mutual_exclusion(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="at_excl_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_automation_timing",
+                {CONF_START_TIME: "08:00:00", CONF_START_ENTITY: "sensor.x"},
+            )
+
+    async def test_end_time_and_entity_mutual_exclusion(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="at_excl_02")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_automation_timing",
+                {CONF_END_TIME: "20:00:00", CONF_END_ENTITY: "sensor.x"},
+            )
+
+    async def test_return_sunset_bool(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="at_ret_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_automation_timing", {CONF_RETURN_SUNSET: True})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_RETURN_SUNSET] is True
+
+
+class TestSetManualOverride:
+    """Integration tests for set_manual_override service."""
+
+    async def test_updates_duration(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="mo_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_manual_override",
+                {
+                    CONF_MANUAL_OVERRIDE_DURATION: {
+                        "hours": 1,
+                        "minutes": 30,
+                        "seconds": 0,
+                    }
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MANUAL_OVERRIDE_DURATION] == {
+            "hours": 1,
+            "minutes": 30,
+            "seconds": 0,
+        }
+
+    async def test_reset_flag(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="mo_rst_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_manual_override",
+                {CONF_MANUAL_OVERRIDE_RESET: True},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MANUAL_OVERRIDE_RESET] is True
+
+
+class TestSetForceOverride:
+    """Integration tests for set_force_override service."""
+
+    async def test_updates_position(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="fo_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_force_override",
+                {CONF_FORCE_OVERRIDE_POSITION: 0, CONF_FORCE_OVERRIDE_MIN_MODE: True},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_FORCE_OVERRIDE_POSITION] == 0
+        assert new_opts[CONF_FORCE_OVERRIDE_MIN_MODE] is True
+
+    async def test_sensors_replace_not_append(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.old"]}
+        await _setup(hass, entry_id="fo_list_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_force_override",
+                {CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.new"]},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_FORCE_OVERRIDE_SENSORS] == ["binary_sensor.new"]
+
+    async def test_clears_sensors_with_empty_list(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.x"]}
+        await _setup(hass, entry_id="fo_clear_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_force_override",
+                {CONF_FORCE_OVERRIDE_SENSORS: []},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_FORCE_OVERRIDE_SENSORS] == []
+
+
+class TestSetCustomPosition:
+    """Integration tests for set_custom_position service."""
+
+    async def test_slot_1_routing(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cp_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_custom_position",
+                {
+                    "slot": 1,
+                    "sensor": "binary_sensor.high_sun",
+                    "position": 80,
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_sensor_1"] == "binary_sensor.high_sun"
+        assert new_opts["custom_position_1"] == 80
+
+    async def test_slot_2_routing(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cp_02")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_custom_position",
+                {"slot": 2, "sensor": "binary_sensor.y", "position": 50},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_sensor_2"] == "binary_sensor.y"
+        assert new_opts["custom_position_2"] == 50
+
+    async def test_slot_4_routing(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cp_04")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_custom_position",
+                {
+                    "slot": 4,
+                    "sensor": "binary_sensor.z",
+                    "position": 30,
+                    "priority": 90,
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_sensor_4"] == "binary_sensor.z"
+        assert new_opts["custom_position_4"] == 30
+        assert new_opts["custom_position_priority_4"] == 90
+
+    async def test_invalid_slot_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cp_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_custom_position",
+                {"slot": 5, "sensor": "binary_sensor.x", "position": 50},
+            )
+
+    async def test_sensor_without_position_raises(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cp_inc_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_custom_position",
+                {"slot": 1, "sensor": "binary_sensor.x"},
+            )
+
+    async def test_clear_slot_with_null(self, hass: HomeAssistant):
+        opts = {
+            **VERTICAL_OPTIONS,
+            "custom_position_sensor_1": "binary_sensor.old",
+            "custom_position_1": 70,
+        }
+        await _setup(hass, entry_id="cp_clr_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_custom_position",
+                {"slot": 1, "sensor": None, "position": None},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert "custom_position_sensor_1" not in new_opts
+        assert "custom_position_1" not in new_opts
+
+
+class TestSetMotion:
+    """Integration tests for set_motion service."""
+
+    async def test_updates_timeout(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="mot_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_motion", {CONF_MOTION_TIMEOUT: 600})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MOTION_TIMEOUT] == 600
+
+    async def test_sensors_replace_semantics(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_MOTION_SENSORS: ["binary_sensor.a"]}
+        await _setup(hass, entry_id="mot_list_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_motion",
+                {CONF_MOTION_SENSORS: ["binary_sensor.b", "binary_sensor.c"]},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MOTION_SENSORS] == ["binary_sensor.b", "binary_sensor.c"]
+
+    async def test_invalid_timeout_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="mot_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(hass, "set_motion", {CONF_MOTION_TIMEOUT: 10})  # below 30
+
+
+class TestSetLightCloud:
+    """Integration tests for set_light_cloud service."""
+
+    async def test_updates_cloud_suppression(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="lc_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_light_cloud", {CONF_CLOUD_SUPPRESSION: True})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_CLOUD_SUPPRESSION] is True
+
+    async def test_weather_state_list_replaced(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="lc_ws_01")
+        new_states = ["sunny", "clear"]
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_light_cloud", {"weather_state": new_states})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["weather_state"] == new_states
+
+
+class TestSetClimate:
+    """Integration tests for set_climate service."""
+
+    async def test_updates_climate_mode(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cl_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_climate", {CONF_CLIMATE_MODE: True})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_CLIMATE_MODE] is True
+
+    async def test_temp_ordering_enforced(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cl_temp_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_climate",
+                {CONF_TEMP_LOW: 28, CONF_TEMP_HIGH: 20},
+            )
+
+    async def test_temp_ordering_valid(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cl_temp_ok_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_climate",
+                {CONF_TEMP_LOW: 18, CONF_TEMP_HIGH: 26},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_TEMP_LOW] == 18
+        assert new_opts[CONF_TEMP_HIGH] == 26
+
+
+class TestSetWeatherSafety:
+    """Integration tests for set_weather_safety service."""
+
+    async def test_updates_wind_threshold(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ws_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_weather_safety",
+                {CONF_WEATHER_WIND_SPEED_THRESHOLD: 40},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_WEATHER_WIND_SPEED_THRESHOLD] == 40
+
+    async def test_updates_override_position_and_timeout(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ws_02")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_weather_safety",
+                {
+                    CONF_WEATHER_OVERRIDE_POSITION: 0,
+                    CONF_WEATHER_TIMEOUT: 600,
+                    CONF_WEATHER_BYPASS_AUTO_CONTROL: True,
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_WEATHER_OVERRIDE_POSITION] == 0
+        assert new_opts[CONF_WEATHER_TIMEOUT] == 600
+        assert new_opts[CONF_WEATHER_BYPASS_AUTO_CONTROL] is True
+
+    async def test_severe_sensors_replace(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_WEATHER_SEVERE_SENSORS: ["binary_sensor.old"]}
+        await _setup(hass, entry_id="ws_sev_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_weather_safety",
+                {
+                    CONF_WEATHER_SEVERE_SENSORS: [
+                        "binary_sensor.new1",
+                        "binary_sensor.new2",
+                    ]
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_WEATHER_SEVERE_SENSORS] == [
+            "binary_sensor.new1",
+            "binary_sensor.new2",
+        ]
+
+
+class TestSetSunTracking:
+    """Integration tests for set_sun_tracking service."""
+
+    async def test_updates_azimuth(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="st_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_sun_tracking", {CONF_AZIMUTH: 270})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_AZIMUTH] == 270
+
+    async def test_updates_fov(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="st_fov_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_sun_tracking",
+                {CONF_FOV_LEFT: 60, CONF_FOV_RIGHT: 75},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_FOV_LEFT] == 60
+        assert new_opts[CONF_FOV_RIGHT] == 75
+
+    async def test_enables_disable_sun_tracking(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="st_tog_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_sun_tracking", {CONF_ENABLE_SUN_TRACKING: False})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_ENABLE_SUN_TRACKING] is False
+
+
+class TestSetBlindSpot:
+    """Integration tests for set_blind_spot service."""
+
+    async def test_updates_blind_spot_angles(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="bs_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_blind_spot",
+                {CONF_BLIND_SPOT_LEFT: 10, CONF_BLIND_SPOT_RIGHT: 40},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_BLIND_SPOT_LEFT] == 10
+        assert new_opts[CONF_BLIND_SPOT_RIGHT] == 40
+
+    async def test_right_must_exceed_left(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="bs_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_blind_spot",
+                {CONF_BLIND_SPOT_LEFT: 50, CONF_BLIND_SPOT_RIGHT: 30},
+            )
+
+
+class TestSetInterpolation:
+    """Integration tests for set_interpolation service."""
+
+    async def test_updates_interp_toggle(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="ip_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_interpolation", {CONF_INTERP: True})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_INTERP] is True
+
+
+class TestSetGeometry:
+    """Integration tests for set_geometry service."""
+
+    async def test_updates_window_height_for_blind(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="geo_01", cover_type=SensorType.BLIND)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_geometry", {"window_height": 3.0})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["window_height"] == 3.0
+
+    async def test_awning_field_rejected_for_blind_cover(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="geo_err_01", cover_type=SensorType.BLIND)
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(hass, "set_geometry", {"length_awning": 2.5})
+
+    async def test_awning_geometry_accepted_for_awning(self, hass: HomeAssistant):
+        from tests.ha_helpers import HORIZONTAL_OPTIONS
+
+        await _setup(
+            hass,
+            entry_id="geo_awn_01",
+            cover_type=SensorType.AWNING,
+            options=dict(HORIZONTAL_OPTIONS),
+        )
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_geometry", {"length_awning": 3.5})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["length_awning"] == 3.5
+
+
+class TestSetOption:
+    """Integration tests for generic set_option service."""
+
+    async def test_updates_known_option(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="so_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_option",
+                {"option": "default_percentage", "value": 70},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["default_percentage"] == 70
+
+    async def test_clears_option_with_null(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_SUNSET_POS: 25}
+        await _setup(hass, entry_id="so_null_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_option",
+                {"option": "sunset_position", "value": None},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert "sunset_position" not in new_opts
+
+    async def test_identity_key_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="so_id_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(hass, "set_option", {"option": "name", "value": "x"})
+
+    async def test_unknown_key_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="so_unk_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_option",
+                {"option": "nonexistent_option_xyz", "value": 42},
+            )
+
+    async def test_invalid_value_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="so_val_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_option",
+                {"option": "default_percentage", "value": 999},
+            )
+
+    async def test_all_settable_keys_in_field_validators(self):
+        for key in ALL_SETTABLE_KEYS:
+            assert key in FIELD_VALIDATORS, (
+                f"'{key}' is in ALL_SETTABLE_KEYS but missing from FIELD_VALIDATORS"
+            )
+
+
+class TestReloadPropagation:
+    """Integration tests verifying async_update_entry is called per service invocation."""
+
+    async def test_options_mutated_and_reload_triggered(self, hass: HomeAssistant):
+        """Each service call must call async_update_entry once per target."""
+        await _setup(hass, entry_id="rl_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(
+                hass.config_entries, "async_reload", new_callable=AsyncMock
+            ) as mock_reload,
+        ):
+            await _call(
+                hass,
+                "set_position_limits",
+                {CONF_DEFAULT_HEIGHT: 80},
+            )
+
+        mock_update.assert_called_once()
+        # Reload is triggered by the update listener registered in __init__.py;
+        # within tests the listener may or may not fire depending on HA's
+        # listener wiring — so we just verify async_update_entry was called.
+        _ = mock_reload  # captured but listener-wiring is HA-internal
+
+    async def test_no_update_when_no_fields_provided(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="rl_err_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            pytest.raises((ServiceValidationError, Exception)),
+        ):
+            # Service called with empty data (no option fields)
+            await hass.services.async_call(
+                DOMAIN,
+                "set_position_limits",
+                {},
+                blocking=True,
+                target={"entity_id": ["cover.test_blind"]},
+            )
+
+        mock_update.assert_not_called()

--- a/tests/test_solar_math_review.py
+++ b/tests/test_solar_math_review.py
@@ -37,7 +37,10 @@ from tests.cover_helpers import (
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-def _common_kwargs(mock_sun_data, mock_logger, *, sol_elev: float = 45.0, sol_azi: float = 180.0):
+
+def _common_kwargs(
+    mock_sun_data, mock_logger, *, sol_elev: float = 45.0, sol_azi: float = 180.0
+):
     """Return base kwargs for building cover instances. sol_elev and sol_azi can be overridden."""
     return {
         "logger": mock_logger,
@@ -69,8 +72,12 @@ def _make_sun_geometry(
         sun_data = MagicMock()
         sun_data.timezone = "UTC"
         now_utc = datetime.now(UTC).replace(tzinfo=None)
-        sun_data.sunset.return_value = (now_utc + timedelta(hours=12)).replace(tzinfo=None)
-        sun_data.sunrise.return_value = (now_utc - timedelta(hours=6)).replace(tzinfo=None)
+        sun_data.sunset.return_value = (now_utc + timedelta(hours=12)).replace(
+            tzinfo=None
+        )
+        sun_data.sunrise.return_value = (now_utc - timedelta(hours=6)).replace(
+            tzinfo=None
+        )
 
     config = make_cover_config(
         win_azi=win_azi,
@@ -94,7 +101,9 @@ def _make_sun_geometry(
     )
 
 
-def _make_full_day_sun_data(azimuth: float = 180.0, elevation: float = 30.0) -> MagicMock:
+def _make_full_day_sun_data(
+    azimuth: float = 180.0, elevation: float = 30.0
+) -> MagicMock:
     """Build a mock SunData where the sun is at constant azimuth/elevation all day.
 
     sunrise and sunset are placed at the very start and end of the time grid so
@@ -125,6 +134,7 @@ def _make_full_day_sun_data(azimuth: float = 180.0, elevation: float = 30.0) -> 
 # ===========================================================================
 # 1. Gamma sign convention
 # ===========================================================================
+
 
 class TestGammaSignConvention:
     """Verify sign convention: positive gamma = sun to the LEFT of window normal."""
@@ -162,6 +172,7 @@ class TestGammaSignConvention:
 # ===========================================================================
 # 2. valid_elevation with partial limits
 # ===========================================================================
+
 
 class TestValidElevationPartialLimits:
     """valid_elevation with only min or only max configured."""
@@ -207,6 +218,7 @@ class TestValidElevationPartialLimits:
 # 3. FOV boundary (gamma == fov_left / fov_right)
 # ===========================================================================
 
+
 class TestFOVBoundary:
     """Behavior at exact FOV boundary — the valid property uses strict inequalities."""
 
@@ -244,6 +256,7 @@ class TestFOVBoundary:
 # 4. control_state_reason missing branches
 # ===========================================================================
 
+
 class TestControlStateReasonAllBranches:
     """All branches of control_state_reason including previously untested ones."""
 
@@ -256,14 +269,30 @@ class TestControlStateReasonAllBranches:
             distance=0.5,
         )
         with (
-            patch.object(AdaptiveVerticalCover, "direct_sun_valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "sunset_valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "valid_elevation",
-                         new_callable=PropertyMock, return_value=True),
+            patch.object(
+                AdaptiveVerticalCover,
+                "direct_sun_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "sunset_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "valid_elevation",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
         ):
             assert cover.control_state_reason == "Default: FOV Exit"
 
@@ -276,14 +305,30 @@ class TestControlStateReasonAllBranches:
             distance=0.5,
         )
         with (
-            patch.object(AdaptiveVerticalCover, "direct_sun_valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "sunset_valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "valid_elevation",
-                         new_callable=PropertyMock, return_value=False),
+            patch.object(
+                AdaptiveVerticalCover,
+                "direct_sun_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "sunset_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "valid_elevation",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
         ):
             assert cover.control_state_reason == "Default: Elevation Limit"
 
@@ -296,14 +341,30 @@ class TestControlStateReasonAllBranches:
             distance=0.5,
         )
         with (
-            patch.object(AdaptiveVerticalCover, "direct_sun_valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "sunset_valid",
-                         new_callable=PropertyMock, return_value=False),
-            patch.object(AdaptiveVerticalCover, "valid",
-                         new_callable=PropertyMock, return_value=True),
-            patch.object(AdaptiveVerticalCover, "is_sun_in_blind_spot",
-                         new_callable=PropertyMock, return_value=True),
+            patch.object(
+                AdaptiveVerticalCover,
+                "direct_sun_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "sunset_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "valid",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+            patch.object(
+                AdaptiveVerticalCover,
+                "is_sun_in_blind_spot",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
         ):
             assert cover.control_state_reason == "Default: Blind Spot"
 
@@ -311,6 +372,7 @@ class TestControlStateReasonAllBranches:
 # ===========================================================================
 # 5. Tilt cover negative discriminant
 # ===========================================================================
+
 
 class TestTiltNegativeDiscriminant:
     """Tilt calculation when slat geometry cannot block the sun (negative discriminant)."""
@@ -332,7 +394,9 @@ class TestTiltNegativeDiscriminant:
         )
 
     @pytest.mark.unit
-    def test_negative_discriminant_percentage_returns_zero(self, mock_sun_data, mock_logger):
+    def test_negative_discriminant_percentage_returns_zero(
+        self, mock_sun_data, mock_logger
+    ):
         """calculate_percentage() returns 0 (closed) when discriminant is negative."""
         cover = build_tilt_cover(
             **_common_kwargs(mock_sun_data, mock_logger),
@@ -357,7 +421,9 @@ class TestTiltNegativeDiscriminant:
         assert 0.0 < result <= 90.0, f"Expected angle in (0, 90], got {result}"
 
     @pytest.mark.unit
-    def test_discriminant_boundary_s_over_d_equals_one(self, mock_sun_data, mock_logger):
+    def test_discriminant_boundary_s_over_d_equals_one(
+        self, mock_sun_data, mock_logger
+    ):
         """With s/d = 1, discriminant = tan(beta)^2 which is non-negative for all beta."""
         # slat_distance=depth → s/d=1, discriminant = tan(beta)^2 - 1 + 1 = tan(beta)^2 >= 0
         cover = build_tilt_cover(
@@ -374,6 +440,7 @@ class TestTiltNegativeDiscriminant:
 # ===========================================================================
 # 6. Horizontal awning division-by-zero guard
 # ===========================================================================
+
 
 class TestHorizontalDivisionByZeroGuard:
     """Horizontal awning geometry.
@@ -460,6 +527,7 @@ class TestHorizontalDivisionByZeroGuard:
 # 7. Non-zero sill_height
 # ===========================================================================
 
+
 class TestSillHeight:
     """Sill height parameter reduces required blind coverage."""
 
@@ -528,11 +596,14 @@ class TestSillHeight:
 # 8. effective_distance_override (GlareZoneHandler path)
 # ===========================================================================
 
+
 class TestEffectiveDistanceOverride:
     """Non-None effective_distance_override uses the supplied distance."""
 
     @pytest.mark.unit
-    def test_override_larger_distance_gives_taller_shadow(self, mock_sun_data, mock_logger):
+    def test_override_larger_distance_gives_taller_shadow(
+        self, mock_sun_data, mock_logger
+    ):
         """Override with larger distance → taller shadow than using self.distance."""
         cover = build_vertical_cover(
             **_common_kwargs(mock_sun_data, mock_logger),
@@ -547,7 +618,9 @@ class TestEffectiveDistanceOverride:
         )
 
     @pytest.mark.unit
-    def test_override_smaller_distance_gives_shorter_shadow(self, mock_sun_data, mock_logger):
+    def test_override_smaller_distance_gives_shorter_shadow(
+        self, mock_sun_data, mock_logger
+    ):
         """Override with smaller distance → shorter shadow than using self.distance."""
         cover = build_vertical_cover(
             **_common_kwargs(mock_sun_data, mock_logger),
@@ -566,9 +639,9 @@ class TestEffectiveDistanceOverride:
             h_win=2.0,
             distance=0.5,
         )
-        assert cover.calculate_position(effective_distance_override=None) == pytest.approx(
-            cover.calculate_position()
-        )
+        assert cover.calculate_position(
+            effective_distance_override=None
+        ) == pytest.approx(cover.calculate_position())
 
     @pytest.mark.unit
     def test_override_source_recorded_as_glare_zone(self, mock_sun_data, mock_logger):
@@ -597,6 +670,7 @@ class TestEffectiveDistanceOverride:
 # 9. solar_times() method
 # ===========================================================================
 
+
 class TestSolarTimes:
     """solar_times() returns the FOV entry/exit time window for the current day.
 
@@ -612,8 +686,11 @@ class TestSolarTimes:
         sun_data = _make_full_day_sun_data(azimuth=0.0, elevation=30.0)
         config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
         sg = SunGeometry(
-            sol_azi=0.0, sol_elev=30.0,
-            sun_data=sun_data, config=config, logger=MagicMock(),
+            sol_azi=0.0,
+            sol_elev=30.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
         )
         start, end = sg.solar_times()
         assert start is None
@@ -626,8 +703,11 @@ class TestSolarTimes:
         sun_data = _make_full_day_sun_data(azimuth=180.0, elevation=30.0)
         config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
         sg = SunGeometry(
-            sol_azi=180.0, sol_elev=30.0,
-            sun_data=sun_data, config=config, logger=MagicMock(),
+            sol_azi=180.0,
+            sol_elev=30.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
         )
         start, end = sg.solar_times()
         assert start is not None
@@ -643,8 +723,11 @@ class TestSolarTimes:
         sun_data = _make_full_day_sun_data(azimuth=180.0, elevation=0.0)
         config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
         sg = SunGeometry(
-            sol_azi=180.0, sol_elev=0.0,
-            sun_data=sun_data, config=config, logger=MagicMock(),
+            sol_azi=180.0,
+            sol_elev=0.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
         )
         start, end = sg.solar_times()
         assert start is None
@@ -658,8 +741,11 @@ class TestSolarTimes:
         sun_data = _make_full_day_sun_data(azimuth=226.0, elevation=30.0)
         config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
         sg = SunGeometry(
-            sol_azi=226.0, sol_elev=30.0,
-            sun_data=sun_data, config=config, logger=MagicMock(),
+            sol_azi=226.0,
+            sol_elev=30.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
         )
         start, end = sg.solar_times()
         assert start is None
@@ -670,10 +756,15 @@ class TestSolarTimes:
         """Times where elevation is below min_elevation are excluded."""
         # Sun at elevation 10°; min_elevation=15° → all points excluded
         sun_data = _make_full_day_sun_data(azimuth=180.0, elevation=10.0)
-        config = make_cover_config(win_azi=180, fov_left=45, fov_right=45, min_elevation=15.0)
+        config = make_cover_config(
+            win_azi=180, fov_left=45, fov_right=45, min_elevation=15.0
+        )
         sg = SunGeometry(
-            sol_azi=180.0, sol_elev=10.0,
-            sun_data=sun_data, config=config, logger=MagicMock(),
+            sol_azi=180.0,
+            sol_elev=10.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
         )
         start, end = sg.solar_times()
         assert start is None


### PR DESCRIPTION
## Summary

- Adds 15 HA services under `adaptive_cover_pro` that let automations, scripts, and templates mutate `config_entry.options` at runtime without opening the Options UI
- Changes persist via `async_update_entry` and trigger a full reload through the existing `_async_update_listener`
- Per-section services for ergonomic Dev-Tools use, plus a generic `set_option` escape hatch

**Services added:**
`set_position_limits`, `set_sunset_sunrise`, `set_automation_timing`, `set_manual_override`, `set_force_override`, `set_custom_position`, `set_motion`, `set_light_cloud`, `set_climate`, `set_weather_safety`, `set_sun_tracking`, `set_blind_spot`, `set_interpolation`, `set_geometry`, `set_option`

**Validation:**
- Per-field range/type validation reusing the same constraints as `config_flow.py`
- Cross-field rules: blind-spot ordering (`right > left`), temp ordering (`low < high`), custom-position slot completeness, time-window mutual exclusion, `sunset_use_my` dependency
- `null` values clear a key from `entry.options`; omitted fields are left unchanged
- Identity keys (`name`, `sensor_type`, `entities`, `linked_device_id`) are rejected

**Also fixes** `test_global_services.py` brittle positional handler lookup (`[-3]`, `[-2]`, `[-1]`) — replaced with `_get_handler(hass, name)` so it survives future service additions.

## Testing

- ✅ 90 new tests in `tests/test_services_options.py` (unit + integration)
- ✅ 2243 tests passing, 0 failing
- ✅ `services/options_service.py` at 98% coverage
- ✅ Lint clean (`ruff check`, `ruff format`)

## Related Issues

Closes #221. Refs #129.