### PR TITLE
fix: restore climate_data on pipeline result when handler defers (#240)

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/handler.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 from .types import PipelineResult, PipelineSnapshot
 
@@ -23,6 +24,17 @@ class OverrideHandler(ABC):
     @abstractmethod
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
         """Return PipelineResult to claim position, or None to pass."""
+
+    def contribute(self, snapshot: PipelineSnapshot) -> dict[str, Any]:  # noqa: ARG002
+        """Expose optional data regardless of whether evaluate() returned a result.
+
+        Override to publish fields (e.g. ``climate_data``) that should appear
+        on the final PipelineResult even when this handler does not win the
+        position.  Returned keys must match PipelineResult attribute names.
+        The registry fills only None fields on the winner — winner values always
+        take precedence.  Default returns {} (opt-in).
+        """
+        return {}
 
     def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
         """Reason string when this handler does not match."""

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -8,7 +8,7 @@ climate strategy self-contained in one plugin handler file.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 
@@ -303,8 +303,12 @@ class ClimateHandler(OverrideHandler):
     name = "climate"
     priority = 50
 
-    def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
-        """Run climate strategy and return position when climate mode is active."""
+    def _build_climate_data(self, snapshot: PipelineSnapshot) -> ClimateCoverData | None:
+        """Build ClimateCoverData from the snapshot, or None when not applicable.
+
+        Single source of truth — both evaluate() and contribute() delegate here
+        so ClimateCoverData is constructed in exactly one place.
+        """
         if not snapshot.in_time_window:
             return None
         if not snapshot.climate_mode_enabled:
@@ -314,8 +318,7 @@ class ClimateHandler(OverrideHandler):
 
         opts = snapshot.climate_options
         r = snapshot.climate_readings
-
-        climate_data = ClimateCoverData(
+        return ClimateCoverData(
             temp_low=opts.temp_low,
             temp_high=opts.temp_high,
             temp_switch=opts.temp_switch,
@@ -331,6 +334,12 @@ class ClimateHandler(OverrideHandler):
             winter_close_insulation=opts.winter_close_insulation,
             cloud_coverage_above_threshold=r.cloud_coverage_above_threshold,
         )
+
+    def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
+        """Run climate strategy and return position when climate mode is active."""
+        climate_data = self._build_climate_data(snapshot)
+        if climate_data is None:
+            return None
 
         climate_cover_state = ClimateCoverState(snapshot, climate_data)
         raw_position = climate_cover_state.get_state()
@@ -359,6 +368,18 @@ class ClimateHandler(OverrideHandler):
             climate_data=climate_data,
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
+
+    def contribute(self, snapshot: PipelineSnapshot) -> dict[str, Any]:
+        """Surface climate_data on the winner's result even when evaluate() deferred.
+
+        Called by the registry after evaluation so that GLARE_CONTROL defers
+        (evaluate() returns None) still populate climate diagnostics on the
+        winning SolarHandler/GlareZoneHandler result.
+        """
+        climate_data = self._build_climate_data(snapshot)
+        if climate_data is None:
+            return {}
+        return {"climate_data": climate_data}
 
     def describe_skip(self, snapshot: PipelineSnapshot) -> str:
         """Reason when climate handler does not match."""

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -79,11 +79,15 @@ class PipelineRegistry:
                     )
                 )
 
-        # Field-level merge: fill None optional fields on the winner's result
-        # from lower-priority handlers.  This allows sensor-populating data
-        # (e.g. climate_data) to surface even when the climate handler doesn't
-        # win the position.  Winner's values always take precedence.
+        # Field-level merge: fill None optional fields on the winner's result.
+        # Two sources, tried in order:
+        #   1. Lower-priority handlers that also matched (existing behaviour).
+        #   2. Every handler's contribute() output — handlers that returned None
+        #      from evaluate() (e.g. ClimateHandler deferring GLARE_CONTROL) can
+        #      still surface metadata this way (Issue #240).
+        # Winner's non-None values are never overwritten.
         _MERGEABLE = ("climate_state", "climate_strategy", "climate_data", "tilt")
+        contributions: list[dict[str, object]] = [h.contribute(snapshot) for h, _ in evaluated]
         merged: dict[str, object] = {}
         for field_name in _MERGEABLE:
             if getattr(winner, field_name) is None:
@@ -92,6 +96,12 @@ class PipelineRegistry:
                     if val is not None:
                         merged[field_name] = val
                         break
+                else:
+                    for contrib in contributions:
+                        val = contrib.get(field_name)
+                        if val is not None:
+                            merged[field_name] = val
+                            break
 
         return PipelineResult(
             position=winner.position,

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -559,3 +559,90 @@ class TestClimateHandlerPositionLimits:
             f"Expected winter heating position 100 but got {result.position}. "
             "Sun-only max limit must not clamp climate handler output."
         )
+
+
+# ---------------------------------------------------------------------------
+# ClimateHandler.contribute() — surfaces climate_data when evaluate() defers
+# ---------------------------------------------------------------------------
+
+
+class TestClimateHandlerContribute:
+    """ClimateHandler.contribute() must expose climate_data even when evaluate() returns None.
+
+    Issue #240: The GLARE_CONTROL defer path returns None from evaluate() so the
+    pipeline falls through to GlareZone/Solar.  contribute() is the hook the
+    registry uses to harvest climate_data regardless of the evaluate() outcome.
+    """
+
+    handler = ClimateHandler()
+
+    def test_contribute_returns_climate_data_when_deferring(self) -> None:
+        """Intermediate temp + presence + sunny → evaluate() is None but contribute() yields climate_data."""
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=22.0,
+                is_presence=True,
+                is_sunny=True,
+            ),
+            climate_options=_make_options(temp_low=18.0, temp_high=26.0),
+        )
+        assert self.handler.evaluate(snap) is None, "sanity: should defer on GLARE_CONTROL"
+        contrib = self.handler.contribute(snap)
+        assert "climate_data" in contrib
+        assert isinstance(contrib["climate_data"], ClimateCoverData)
+        assert contrib["climate_data"].is_presence is True
+        assert contrib["climate_data"].is_sunny is True
+
+    def test_contribute_returns_empty_when_climate_mode_off(self) -> None:
+        """Climate mode disabled → contribute() returns {}."""
+        snap = make_snapshot(climate_mode_enabled=False)
+        assert self.handler.contribute(snap) == {}
+
+    def test_contribute_returns_empty_when_readings_none(self) -> None:
+        """Missing readings → contribute() returns {}."""
+        snap = make_snapshot(
+            climate_mode_enabled=True,
+            climate_readings=None,
+            climate_options=_make_options(),
+        )
+        assert self.handler.contribute(snap) == {}
+
+    def test_contribute_returns_empty_when_options_none(self) -> None:
+        """Missing options → contribute() returns {}."""
+        snap = make_snapshot(
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(),
+            climate_options=None,
+        )
+        assert self.handler.contribute(snap) == {}
+
+    def test_contribute_returns_empty_outside_time_window(self) -> None:
+        """Outside the time window → contribute() returns {}."""
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(inside_temperature=22.0),
+            climate_options=_make_options(),
+            in_time_window=False,
+        )
+        assert self.handler.contribute(snap) == {}
+
+    def test_contribute_climate_data_consistent_with_evaluate_when_handler_wins(self) -> None:
+        """When evaluate() wins, contribute() returns the same climate_data (single source of truth)."""
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(inside_temperature=15.0),
+            climate_options=_make_options(temp_low=18.0),
+        )
+        result = self.handler.evaluate(snap)
+        contrib = self.handler.contribute(snap)
+        assert result is not None, "winter should win"
+        assert "climate_data" in contrib
+        assert contrib["climate_data"].inside_temperature == result.climate_data.inside_temperature
+        assert contrib["climate_data"].is_winter == result.climate_data.is_winter

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -416,3 +416,41 @@ class TestDefaultHandler:
 # Handler result structure
 # (Parametrized integration tests removed — will be replaced in Task 16)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# contribute() default contract
+# ---------------------------------------------------------------------------
+
+
+class TestOverrideHandlerContributeDefault:
+    """Every OverrideHandler exposes contribute(); default returns {}."""
+
+    def test_default_contribute_is_empty_dict(self) -> None:
+        """OverrideHandler.contribute() default returns {} — handlers opt in by overriding."""
+        from custom_components.adaptive_cover_pro.pipeline.handler import OverrideHandler
+        from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+        class _Dummy(OverrideHandler):
+            name = "dummy"
+            priority = 0
+
+            def evaluate(self, snapshot):
+                return None
+
+        snap = make_snapshot()
+        assert _Dummy().contribute(snap) == {}
+
+    def test_non_climate_handlers_return_empty_by_default(self) -> None:
+        """Unmodified handlers return {} from contribute() — no accidental merges."""
+        snap = make_snapshot()
+        for handler in [
+            ForceOverrideHandler(),
+            ManualOverrideHandler(),
+            MotionTimeoutHandler(),
+            SolarHandler(),
+            DefaultHandler(),
+        ]:
+            assert handler.contribute(snap) == {}, (
+                f"{handler.__class__.__name__}.contribute() should return {{}}"
+            )

--- a/tests/test_pipeline/test_pipeline_integration.py
+++ b/tests/test_pipeline/test_pipeline_integration.py
@@ -271,6 +271,50 @@ class TestClimateDataPropagation:
         assert result.climate_data is not None
         assert result.climate_data.is_summer is True
 
+    def test_registry_climate_data_populated_when_climate_defers_glare_control(
+        self,
+    ) -> None:
+        """climate_data must be present when ClimateHandler returns None for GLARE_CONTROL.
+
+        Regression for Issue #240: intermediate temp + presence + sunny causes ClimateHandler
+        to defer (returns None) so SolarHandler wins.  Before the fix, climate_data was lost
+        because the merge loop only iterated matching results.  After the fix,
+        ClimateHandler.contribute() surfaces climate_data regardless.
+        """
+        from unittest.mock import MagicMock
+
+        cover = MagicMock()
+        cover.direct_sun_valid = True
+        cover.valid = True
+        cover.calculate_percentage = MagicMock(return_value=55.0)
+        cover.logger = MagicMock()
+        config = MagicMock()
+        config.min_pos = None
+        config.max_pos = None
+        config.min_pos_sun_only = False
+        config.max_pos_sun_only = False
+        cover.config = config
+
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_climate_readings_intermediate(),
+            climate_options=_climate_options_intermediate(),
+            direct_sun_valid=True,
+            calculate_percentage_return=55.0,
+        )
+        result = self.registry.evaluate(snap)
+        assert result.control_method == ControlMethod.SOLAR, (
+            "ClimateHandler should defer (GLARE_CONTROL) so SolarHandler wins"
+        )
+        assert result.climate_data is not None, (
+            "REGRESSION (Issue #240): climate_data was dropped when ClimateHandler "
+            "returned None for the GLARE_CONTROL defer path"
+        )
+        assert isinstance(result.climate_data, ClimateCoverData)
+        assert result.climate_data.is_presence is True
+        assert result.climate_data.is_sunny is True
+
     def test_registry_copies_tilt_from_winning_handler(self) -> None:
         """Registry result copies tilt field from the winning handler's result."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary
Since v2.18.0 (PR #232), `ClimateHandler.evaluate()` returns `None` on the GLARE_CONTROL path so that Solar/GlareZone handlers can win. This also dropped `climate_data` from the winning result, causing the `climate_status` sensor to report `unknown` whenever intermediate-season glare control fired with climate mode enabled.

Fix: add a `contribute()` hook to `OverrideHandler`. `ClimateHandler` overrides it to surface `climate_data` regardless of whether `evaluate()` returned a result. The registry calls `contribute()` on all handlers as a fallback in the field-level merge. `ClimateCoverData` construction is extracted to a single `_build_climate_data()` helper — zero duplication.

## Testing
- ✅ 2270 tests passing
- New regression tests in `TestClimateHandlerContribute` and `TestClimateDataPropagation`

## Related Issues
Refs #240