### PR TITLE
fix: convert UTC sun-sensor times to local timezone

### DIFF
--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from dateutil import parser
 from homeassistant.core import HomeAssistant, split_entity_id
+from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
     from .sun import SunData
@@ -37,9 +38,19 @@ def get_timedelta_str(string: str):
 
 
 def get_datetime_from_str(string: str):
-    """Convert datetime string to datetime."""
-    if string is not None:
-        return parser.parse(string, ignoretz=True)
+    """Convert a datetime string to a naive-local datetime.
+
+    Tz-aware inputs (e.g., sun-sensor UTC values like "2026-04-18T04:46:00+00:00")
+    are converted to HA's configured local timezone and then stripped of tzinfo so
+    downstream naive comparisons work correctly in non-UTC installs.
+    Tz-naive inputs (e.g., static "06:30") are returned unchanged.
+    """
+    if string is None:
+        return None
+    parsed = parser.parse(string)
+    if parsed.tzinfo is not None:
+        parsed = dt_util.as_local(parsed).replace(tzinfo=None)
+    return parsed
 
 
 def get_last_updated(entity_id: str, hass: HomeAssistant):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,8 @@
 """Tests for helper functions."""
 
 import datetime as dt
-from unittest.mock import MagicMock
+import zoneinfo
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -119,6 +120,53 @@ def test_get_datetime_from_str_parses_datetime():
 def test_get_datetime_from_str_returns_none_for_none():
     """Test get_datetime_from_str returns None when input is None."""
     assert get_datetime_from_str(None) is None
+
+
+@pytest.mark.unit
+def test_get_datetime_from_str_converts_utc_iso_to_local_wallclock():
+    """ISO 8601 UTC string is converted to local-time wall clock.
+
+    A sun sensor value "2026-04-18T04:46:00+00:00" read in America/New_York
+    (UTC-4 DST) must become 00:46 local naive, not 04:46.
+    """
+    ny = zoneinfo.ZoneInfo("America/New_York")
+    with patch(
+        "homeassistant.util.dt.DEFAULT_TIME_ZONE", ny
+    ):
+        result = get_datetime_from_str("2026-04-18T04:46:00+00:00")
+
+    # In April NY is UTC-4, so 04:46 UTC == 00:46 local
+    assert result.hour == 0
+    assert result.minute == 46
+    assert result.day == 18
+    assert result.tzinfo is None
+
+
+@pytest.mark.unit
+def test_get_datetime_from_str_preserves_naive_static_time():
+    """Static "06:30" has no tzinfo — parsed as-is, naive, wall-clock preserved."""
+    ny = zoneinfo.ZoneInfo("America/New_York")
+    with patch(
+        "homeassistant.util.dt.DEFAULT_TIME_ZONE", ny
+    ):
+        result = get_datetime_from_str("06:30")
+
+    assert result.hour == 6
+    assert result.minute == 30
+    assert result.tzinfo is None
+
+
+@pytest.mark.unit
+def test_get_datetime_from_str_preserves_naive_iso_datetime():
+    """ISO string without tzinfo is treated as naive-local, not shifted."""
+    ny = zoneinfo.ZoneInfo("America/New_York")
+    with patch(
+        "homeassistant.util.dt.DEFAULT_TIME_ZONE", ny
+    ):
+        result = get_datetime_from_str("2024-06-21T20:00:00")
+
+    assert result == dt.datetime(2024, 6, 21, 20, 0, 0)
+    assert result.tzinfo is None
 
 
 @pytest.mark.unit

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import zoneinfo
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -586,3 +587,51 @@ async def test_check_transition_no_on_window_open_no_error():
         await mgr.check_transition(track_end_time=True, refresh_callback=close_cb)
 
     close_cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# UTC→local timezone conversion for sun entity strings (#226)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_after_start_time_with_utc_iso_sun_sensor_string():
+    """Entity state is a real UTC ISO string — is converted through to local wall-clock.
+
+    Regression: before the fix, "04:46 UTC" was compared as naive 04:46 in a
+    non-UTC zone, causing the window to activate hours early.
+
+    Setup: local timezone America/New_York (UTC-4 DST). Sunrise UTC is 04:46,
+    which is 00:46 local. Freeze "now" at 01:00 local (after 00:46 local sunrise)
+    so after_start_time should be True.
+    """
+
+    mgr = _make_manager()
+    mgr.update_config(
+        start_time=None,
+        start_time_entity="sensor.sun_next_rising",
+        end_time=None,
+        end_time_entity=None,
+    )
+
+    ny = zoneinfo.ZoneInfo("America/New_York")
+    # "now" is 01:00 local NY — after 00:46 local sunrise
+    frozen_now = dt.datetime(2026, 4, 18, 1, 0, 0)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.get_safe_state",
+            return_value="2026-04-18T04:46:00+00:00",
+        ),
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", ny),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.time_window.dt"
+        ) as mock_dt,
+    ):
+        # "now" is 01:00 local NY — after 00:46 local sunrise (04:46 UTC converted)
+        mock_dt.datetime.now.return_value = frozen_now
+        mock_dt.date.today.return_value = dt.date(2026, 4, 18)
+        mock_dt.timedelta = dt.timedelta
+        result = mgr.after_start_time
+
+    assert result is True


### PR DESCRIPTION
## Summary
Fix `get_datetime_from_str()` to correctly convert UTC ISO 8601 strings from sun sensors (e.g., `sensor.sun_next_rising`) to HA's configured local timezone before comparison. Previously, `ignoretz=True` stripped the timezone and left the UTC wall-clock value, causing time windows to open/close hours early for non-UTC users.

## Testing
- ✅ 2274 tests passing

## Related Issues
Refs #226