### PR TITLE
refactor: redesign config summary — drop Position Map, enrich How It Decides

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1070,10 +1070,73 @@ def _build_cover_capabilities_text(
     return "\n".join(lines)
 
 
+async def _compute_todays_sun_times(
+    hass: HomeAssistant, config: dict
+) -> dict | None:
+    """Compute today's raw/effective sunrise/sunset + solar-control window.
+
+    Runs the pandas/astral-heavy work in an executor. Returns ``None`` on any
+    failure so the summary renders gracefully when location/astral data is
+    unavailable. All returned datetimes are naive local (HA-configured TZ).
+    """
+    from datetime import timedelta
+
+    from homeassistant.util import dt as dt_util
+
+    from .config_types import CoverConfig
+    from .engine.sun_geometry import SunGeometry
+    from .state.sun_provider import SunProvider
+
+    def _to_local(value):
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=dt_util.UTC)
+        return dt_util.as_local(value).replace(tzinfo=None)
+
+    def _compute() -> dict | None:
+        try:
+            sun_data = SunProvider(hass).create_sun_data(hass.config.time_zone)
+            sunrise_raw_utc = sun_data.sunrise()
+            sunset_raw_utc = sun_data.sunset()
+
+            cfg = CoverConfig.from_options(config)
+            geometry = SunGeometry(0.0, 0.0, sun_data, cfg, _LOGGER)
+            solar_start_utc, solar_end_utc = geometry.solar_times()
+
+            sunrise_local = _to_local(sunrise_raw_utc)
+            sunset_local = _to_local(sunset_raw_utc)
+            sunrise_eff = (
+                sunrise_local + timedelta(minutes=int(cfg.sunrise_off))
+                if sunrise_local is not None
+                else None
+            )
+            sunset_eff = (
+                sunset_local + timedelta(minutes=int(cfg.sunset_off))
+                if sunset_local is not None
+                else None
+            )
+
+            return {
+                "sunrise_raw": sunrise_local,
+                "sunset_raw": sunset_local,
+                "sunrise_eff": sunrise_eff,
+                "sunset_eff": sunset_eff,
+                "solar_start": _to_local(solar_start_utc),
+                "solar_end": _to_local(solar_end_utc),
+            }
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug("Failed to compute today's sun times", exc_info=True)
+            return None
+
+    return await hass.async_add_executor_job(_compute)
+
+
 def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     config: dict,
     sensor_type: str | None,
     hass: HomeAssistant | None = None,
+    sun_times: dict | None = None,
 ) -> str:
     """Build a narrative summary of the current configuration.
 
@@ -1434,6 +1497,50 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 )
             lines.append(
                 f"{indent}🌄 After sunrise{sunrise_off_str} → {default_pos}% (tracking resumes)."
+            )
+
+    # Today's Sun — raw sunrise/sunset, effective (with offsets), and solar-control window
+    if sun_times is not None:
+        indent = "\u00a0" * 4
+        sub_indent = "\u00a0" * 8
+
+        def _fmt_dt(value) -> str | None:
+            if value is None:
+                return None
+            return value.strftime("%H:%M")
+
+        def _eff_suffix(raw, eff, offset_min: int) -> str:
+            if offset_min == 0 or raw is None or eff is None:
+                return ""
+            sign = "+" if offset_min > 0 else "−"
+            return f" (effective {_fmt_dt(eff)}, {sign}{abs(int(offset_min))} min)"
+
+        sunrise_raw = sun_times.get("sunrise_raw")
+        sunset_raw = sun_times.get("sunset_raw")
+        sunrise_eff = sun_times.get("sunrise_eff")
+        sunset_eff = sun_times.get("sunset_eff")
+        solar_start = sun_times.get("solar_start")
+        solar_end = sun_times.get("solar_end")
+
+        lines.append(f"{indent}🌞 Today's sun:")
+        if sunrise_raw is not None:
+            lines.append(
+                f"{sub_indent}🌅 Sunrise: {_fmt_dt(sunrise_raw)}"
+                f"{_eff_suffix(sunrise_raw, sunrise_eff, int(sunrise_off))}"
+            )
+        if sunset_raw is not None:
+            lines.append(
+                f"{sub_indent}🌇 Sunset: {_fmt_dt(sunset_raw)}"
+                f"{_eff_suffix(sunset_raw, sunset_eff, int(sunset_off))}"
+            )
+        if solar_start is not None and solar_end is not None:
+            lines.append(
+                f"{sub_indent}🕶️ Solar control window: "
+                f"{_fmt_dt(solar_start)} → {_fmt_dt(solar_end)}"
+            )
+        else:
+            lines.append(
+                f"{sub_indent}🕶️ Solar control window: sun does not enter window today"
             )
 
     # Blind spot
@@ -2462,7 +2569,10 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Show a read-only summary of all collected configuration before creating the entry."""
         if user_input is not None:
             return await self.async_step_update()
-        summary_text = _build_config_summary(self.config, self.type_blind, self.hass)
+        sun_times = await _compute_todays_sun_times(self.hass, self.config)
+        summary_text = _build_config_summary(
+            self.config, self.type_blind, self.hass, sun_times
+        )
         return self.async_show_form(
             step_id="summary",
             data_schema=vol.Schema({}),
@@ -3272,7 +3382,10 @@ class OptionsFlowHandler(OptionsFlow):
         """Show a read-only summary of the current configuration."""
         if user_input is not None:
             return await self.async_step_init()
-        summary_text = _build_config_summary(self.options, self.sensor_type, self.hass)
+        sun_times = await _compute_todays_sun_times(self.hass, self.options)
+        summary_text = _build_config_summary(
+            self.options, self.sensor_type, self.hass, sun_times
+        )
         return self.async_show_form(
             step_id="summary",
             data_schema=vol.Schema({}),

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1499,50 +1499,6 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 f"{indent}🌄 After sunrise{sunrise_off_str} → {default_pos}% (tracking resumes)."
             )
 
-    # Today's Sun — raw sunrise/sunset, effective (with offsets), and solar-control window
-    if sun_times is not None:
-        indent = "\u00a0" * 4
-        sub_indent = "\u00a0" * 8
-
-        def _fmt_dt(value) -> str | None:
-            if value is None:
-                return None
-            return value.strftime("%H:%M")
-
-        def _eff_suffix(raw, eff, offset_min: int) -> str:
-            if offset_min == 0 or raw is None or eff is None:
-                return ""
-            sign = "+" if offset_min > 0 else "−"
-            return f" (effective {_fmt_dt(eff)}, {sign}{abs(int(offset_min))} min)"
-
-        sunrise_raw = sun_times.get("sunrise_raw")
-        sunset_raw = sun_times.get("sunset_raw")
-        sunrise_eff = sun_times.get("sunrise_eff")
-        sunset_eff = sun_times.get("sunset_eff")
-        solar_start = sun_times.get("solar_start")
-        solar_end = sun_times.get("solar_end")
-
-        lines.append(f"{indent}🌞 Today's sun:")
-        if sunrise_raw is not None:
-            lines.append(
-                f"{sub_indent}🌅 Sunrise: {_fmt_dt(sunrise_raw)}"
-                f"{_eff_suffix(sunrise_raw, sunrise_eff, int(sunrise_off))}"
-            )
-        if sunset_raw is not None:
-            lines.append(
-                f"{sub_indent}🌇 Sunset: {_fmt_dt(sunset_raw)}"
-                f"{_eff_suffix(sunset_raw, sunset_eff, int(sunset_off))}"
-            )
-        if solar_start is not None and solar_end is not None:
-            lines.append(
-                f"{sub_indent}🕶️ Solar control window: "
-                f"{_fmt_dt(solar_start)} → {_fmt_dt(solar_end)}"
-            )
-        else:
-            lines.append(
-                f"{sub_indent}🕶️ Solar control window: sun does not enter window today"
-            )
-
     # Blind spot
     if config.get(CONF_ENABLE_BLIND_SPOT):
         bs_l = config.get(CONF_BLIND_SPOT_LEFT)
@@ -1618,18 +1574,38 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             pos_map.append(
                 f"🎯 Custom #{_slot} on → {_pos_label(_pos, _use_my)} (priority {_pri})"
             )
+    def _fmt_sun_dt(value) -> str | None:
+        return value.strftime("%H:%M") if value is not None else None
+
+    _solar_start = sun_times.get("solar_start") if sun_times else None
+    _solar_end = sun_times.get("solar_end") if sun_times else None
+    _sunset_eff = sun_times.get("sunset_eff") if sun_times else None
+    _sunrise_eff = sun_times.get("sunrise_eff") if sun_times else None
+
+    sunset_pos = config.get(CONF_SUNSET_POS)
+    if sunset_pos is not None:
+        _sunset_today = (
+            f" (today ~{_fmt_sun_dt(_sunset_eff)})" if _sunset_eff is not None else ""
+        )
+        pos_map.append(
+            f"🌅 After sunset{_sunset_today} → "
+            f"{_pos_label(int(sunset_pos), bool(config.get(CONF_SUNSET_USE_MY)))}"
+        )
+        _sunrise_today = (
+            f" (today ~{_fmt_sun_dt(_sunrise_eff)})" if _sunrise_eff is not None else ""
+        )
+        pos_map.append(f"🌄 After sunrise{_sunrise_today} → {default_pos}%")
     if sun_tracking_enabled:
-        pos_map.append("☀️ Tracking sun → calculated position")
+        if _solar_start is not None and _solar_end is not None:
+            _window = f" (today {_fmt_sun_dt(_solar_start)} → {_fmt_sun_dt(_solar_end)})"
+        else:
+            _window = ""
+        pos_map.append(f"☀️ Tracking sun{_window} → calculated position")
     min_p = config.get(CONF_MIN_POSITION, 0)
     max_p = config.get(CONF_MAX_POSITION, 100)
     if min_p != 0 or max_p != 100:
         pos_map.append(f"   (clamped to {min_p}%–{max_p}%)")
-    sunset_pos = config.get(CONF_SUNSET_POS)
-    if sunset_pos is not None:
-        pos_map.append(
-            f"🌅 After sunset → {_pos_label(int(sunset_pos), bool(config.get(CONF_SUNSET_USE_MY)))}"
-        )
-    pos_map.append(f"🌙 No sun / default → {default_pos}%")
+    pos_map.append(f"🌙 Default → {default_pos}%")
     for line in pos_map:
         lines.append(line)
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1142,8 +1142,9 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
 
     Produces four sections:
       1. Your Cover  — what is controlled and physical setup
-      2. How It Decides — plain-English explanation of the active decision chain
-      3. Position Limits — compact one-liner for range/default/flags
+      2. How It Decides — full decision chain: each rule's trigger, target, and
+         today's sun times inline; priority badge [N] at end of each rule
+      3. Position Limits — compact one-liner for range/default/delta/flags
       4. Decision Priority — compact chain showing active/inactive handlers
     """
     # ---- Gather all values up front ----------------------------------------
@@ -1201,6 +1202,27 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         if use_my:
             return f"My (not set → {raw_pct}%)"
         return f"{raw_pct}%"
+
+    def _badge(priority: int) -> str:
+        """Render a priority badge suffix: two nbsp + [N]."""
+        return f"\u00a0\u00a0[{priority}]"
+
+    def _fmt_sun_dt(value) -> str | None:
+        """Format a sun-times datetime as HH:MM; None passes through."""
+        return value.strftime("%H:%M") if value is not None else None
+
+    def _offset_str(minutes: int) -> str:
+        """Format a minutes offset as (+N min) / (-N min); 0 → empty."""
+        if minutes > 0:
+            return f"+{minutes} min"
+        if minutes < 0:
+            return f"{minutes} min"
+        return ""
+
+    _solar_start = sun_times.get("solar_start") if sun_times else None
+    _solar_end = sun_times.get("solar_end") if sun_times else None
+    _sunset_eff = sun_times.get("sunset_eff") if sun_times else None
+    _sunrise_eff = sun_times.get("sunrise_eff") if sun_times else None
 
     lines: list[str] = []
 
@@ -1279,9 +1301,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     if has_force:
         n = len(config.get(CONF_FORCE_OVERRIDE_SENSORS) or [])
         sensor_word = "sensor" if n == 1 else "sensors"
+        min_mode_str = (
+            " (as minimum)" if config.get(CONF_FORCE_OVERRIDE_MIN_MODE) else ""
+        )
         lines.append(
-            f"🔒 Force override: if any of {n} {sensor_word} is on → covers go to {force_pos}% "
-            f"(overrides everything else)."
+            f"🔒 Force override: if any of {n} {sensor_word} is on → covers go to "
+            f"{force_pos}%{min_mode_str} (overrides everything else)"
+            f"{_badge(100)}"
         )
 
     # Weather safety override (90)
@@ -1289,13 +1315,18 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         wx_parts = []
         wind_sensor = config.get(CONF_WEATHER_WIND_SPEED_SENSOR)
         wind_thresh = config.get(CONF_WEATHER_WIND_SPEED_THRESHOLD)
+        wind_dir_sensor = config.get(CONF_WEATHER_WIND_DIRECTION_SENSOR)
+        wind_dir_tol = config.get(CONF_WEATHER_WIND_DIRECTION_TOLERANCE)
         rain_sensor = config.get(CONF_WEATHER_RAIN_SENSOR)
         rain_thresh = config.get(CONF_WEATHER_RAIN_THRESHOLD)
         is_rain = config.get(CONF_WEATHER_IS_RAINING_SENSOR)
         is_wind = config.get(CONF_WEATHER_IS_WINDY_SENSOR)
         severe = config.get(CONF_WEATHER_SEVERE_SENSORS) or []
         if wind_sensor and wind_thresh is not None:
-            wx_parts.append(f"wind > {wind_thresh}")
+            wind_part = f"wind > {wind_thresh}"
+            if wind_dir_sensor and wind_dir_tol is not None:
+                wind_part += f" from window ±{wind_dir_tol}°"
+            wx_parts.append(wind_part)
         if rain_sensor and rain_thresh is not None:
             wx_parts.append(f"rain > {rain_thresh}")
         if is_rain:
@@ -1307,8 +1338,18 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         wx_condition = " or ".join(wx_parts) if wx_parts else "weather condition"
         wx_delay = config.get(CONF_WEATHER_TIMEOUT)
         delay_str = f" (waits {wx_delay}s after clearing)" if wx_delay else ""
+        weather_min_str = (
+            " (as minimum)" if config.get(CONF_WEATHER_OVERRIDE_MIN_MODE) else ""
+        )
+        bypass_str = (
+            " ⚠️ halts all automation while triggered"
+            if config.get(CONF_WEATHER_BYPASS_AUTO_CONTROL)
+            else ""
+        )
         lines.append(
-            f"🌧️ Weather safety: if {wx_condition} → covers retract to {weather_pos}%{delay_str}."
+            f"🌧️ Weather safety: if {wx_condition} → covers retract to "
+            f"{weather_pos}%{weather_min_str}{delay_str}{bypass_str}"
+            f"{_badge(90)}"
         )
 
     # Manual override (80)
@@ -1320,17 +1361,26 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         mo_parts.append(f"threshold {threshold}%")
     if config.get(CONF_MANUAL_OVERRIDE_RESET):
         mo_parts.append("resets on next move")
+    if config.get(CONF_MANUAL_IGNORE_INTERMEDIATE):
+        mo_parts.append("ignores intermediate positions")
     mo_str = f" ({', '.join(mo_parts)})" if mo_parts else ""
     lines.append(
-        f"✋ Manual override: pauses automatic control when you move the cover{mo_str}."
+        f"✋ Manual override: pauses automatic control when you move the cover"
+        f"{mo_str}{_badge(80)}"
     )
 
     # Custom positions — each slot at its own configured priority
     if has_custom_position:
         for _slot, _eid, _pos, _pri, _use_my in _custom_slots:
             target = _pos_label(_pos, _use_my)
+            cp_min = (
+                " (as minimum)"
+                if config.get(f"custom_position_min_mode_{_slot}")
+                else ""
+            )
             lines.append(
-                f"🎯 Custom #{_slot}: if {_eid} is on → {target} (priority {_pri})."
+                f"🎯 Custom #{_slot}: if {_eid} is on → {target}{cp_min}"
+                f"{_badge(_pri)}"
             )
 
     # Motion timeout (75)
@@ -1339,7 +1389,8 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         sensor_word = "sensor" if n == 1 else "sensors"
         lines.append(
             f"🚶 Motion-based: if no occupancy for {motion_timeout}s "
-            f"({n} {sensor_word}) → covers return to default ({default_pos}%)."
+            f"({n} {sensor_word}) → covers return to default ({default_pos}%)"
+            f"{_badge(75)}"
         )
 
     # Cloud suppression (60)
@@ -1356,9 +1407,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         if v := config.get(CONF_CLOUD_COVERAGE_ENTITY):
             t = config.get(CONF_CLOUD_COVERAGE_THRESHOLD)
             cloud_parts.append(f"cloud > {t}%" if t is not None else f"cloud ({v})")
+        wx_states = config.get(CONF_WEATHER_STATE) or []
+        if wx_states and config.get(CONF_WEATHER_ENTITY):
+            cloud_parts.append(f"weather in {{{', '.join(wx_states)}}}")
         cloud_str = f" when {', '.join(cloud_parts)}" if cloud_parts else ""
         lines.append(
-            f"☁️ Cloud suppression: skips sun tracking{cloud_str} → default ({default_pos}%)."
+            f"☁️ Cloud suppression: skips sun tracking{cloud_str} → "
+            f"default ({default_pos}%){_badge(60)}"
         )
     elif any(
         [
@@ -1391,15 +1446,26 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             cl_parts.append(f"using {temp_entity}")
         outside = config.get(CONF_OUTSIDETEMP_ENTITY)
         if outside:
-            cl_parts.append(f"outside: {outside}")
+            out_thresh = config.get(CONF_OUTSIDE_THRESHOLD)
+            if out_thresh is not None:
+                cl_parts.append(f"outside: {outside} > {out_thresh}°C")
+            else:
+                cl_parts.append(f"outside: {outside}")
         weather_ent = config.get(CONF_WEATHER_ENTITY)
         if weather_ent:
             cl_parts.append(f"weather: {weather_ent}")
         presence = config.get(CONF_PRESENCE_ENTITY)
         if presence:
             cl_parts.append(f"presence: {presence}")
+        if config.get(CONF_TRANSPARENT_BLIND):
+            cl_parts.append("transparent blind")
+        if config.get(CONF_WINTER_CLOSE_INSULATION):
+            cl_parts.append("closes fully in winter for insulation")
         cl_str = f" ({', '.join(cl_parts)})" if cl_parts else ""
-        lines.append(f"🌡️ Climate mode: adjusts strategy for heating/cooling{cl_str}.")
+        lines.append(
+            f"🌡️ Climate mode: adjusts strategy for heating/cooling"
+            f"{cl_str}{_badge(50)}"
+        )
 
     # Glare zones — vertical only (45, below climate)
     if has_glare:
@@ -1416,7 +1482,8 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             gz_parts.append(f"{width}cm window")
         gz_str = f" ({', '.join(gz_parts)})" if gz_parts else ""
         lines.append(
-            f"🔆 Glare zones: lowers blind further to protect floor areas from glare{gz_str}."
+            f"🔆 Glare zones: lowers blind further to protect floor areas from glare"
+            f"{gz_str}{_badge(45)}"
         )
 
     # Solar tracking — baseline calculation (40)
@@ -1439,16 +1506,27 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         if elev_parts:
             sun_parts.append(f"elevation {' and '.join(elev_parts)}")
         sun_desc = f" ({', '.join(sun_parts)})" if sun_parts else ""
+        # Today's solar window annotation
+        if _solar_start is not None and _solar_end is not None:
+            today_str = (
+                f" (today: sun in window {_fmt_sun_dt(_solar_start)} → "
+                f"{_fmt_sun_dt(_solar_end)})"
+            )
+        elif sun_times is not None:
+            today_str = " (today: sun does not enter window)"
+        else:
+            today_str = ""
         lines.append(
-            f"☀️ Tracks the sun{sun_desc} and calculates position to block direct sunlight."
+            f"☀️ Tracks the sun{sun_desc} and calculates position to block "
+            f"direct sunlight{today_str}{_badge(40)}"
         )
     else:
         lines.append(
             "☀️ Sun tracking disabled — covers hold position; climate, manual override, "
-            "custom positions, and other overrides remain active."
+            f"custom positions, and other overrides remain active{_badge(40)}"
         )
 
-    # Timing window
+    # Timing window (sub-bullet under ☀️)
     start_time = config.get(CONF_START_TIME)
     start_entity = config.get(CONF_START_ENTITY)
     end_time = config.get(CONF_END_TIME)
@@ -1472,34 +1550,40 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         indent = "\u00a0" * 4
         lines.append(f"{indent}🕒 {timing_str}.")
         if sunset_pos is not None:
-            # Build offset annotation strings (omitted when offset is 0)
-            def _offset_str(minutes: int) -> str:
-                if minutes > 0:
-                    return f" (+{minutes} min)"
-                if minutes < 0:
-                    return f" ({minutes} min)"
-                return ""
+            # Merge today's effective time and the offset into one parenthetical
+            def _sun_annotation(today_dt, offset_min: int) -> str:
+                parts = []
+                if today_dt is not None:
+                    parts.append(f"today ~{_fmt_sun_dt(today_dt)}")
+                off = _offset_str(int(offset_min))
+                if off:
+                    parts.append(off)
+                return f" ({', '.join(parts)})" if parts else ""
 
-            sunset_off_str = _offset_str(int(sunset_off))
-            sunrise_off_str = _offset_str(int(sunrise_off))
+            sunset_ann = _sun_annotation(_sunset_eff, sunset_off)
+            sunrise_ann = _sun_annotation(_sunrise_eff, sunrise_off)
             has_end_time = bool(end_time or end_entity)
             _sunset_use_my = bool(config.get(CONF_SUNSET_USE_MY))
             _sunset_target = _pos_label(int(sunset_pos), _sunset_use_my)
             if has_end_time and int(sunset_pos) != int(default_pos):
                 lines.append(f"{indent}🔚 After end time → {default_pos}%.")
                 lines.append(
-                    f"{indent}🌅 After sunset{sunset_off_str} → {_sunset_target}."
+                    f"{indent}🌅 After sunset{sunset_ann} → {_sunset_target}."
                 )
             else:
                 label = "end time/sunset" if has_end_time else "sunset"
                 lines.append(
-                    f"{indent}🌅 After {label}{sunset_off_str} → {_sunset_target}."
+                    f"{indent}🌅 After {label}{sunset_ann} → {_sunset_target}."
                 )
             lines.append(
-                f"{indent}🌄 After sunrise{sunrise_off_str} → {default_pos}% (tracking resumes)."
+                f"{indent}🌄 After sunrise{sunrise_ann} → {default_pos}% (tracking resumes)."
             )
+            if config.get(CONF_RETURN_SUNSET):
+                lines.append(
+                    f"{indent}🔚 Return to sunset position at end time: on"
+                )
 
-    # Blind spot
+    # Blind spot (sub-bullet / informational, no priority of its own)
     if config.get(CONF_ENABLE_BLIND_SPOT):
         bs_l = config.get(CONF_BLIND_SPOT_LEFT)
         bs_r = config.get(CONF_BLIND_SPOT_RIGHT)
@@ -1514,6 +1598,9 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             f"🟥 Blind spot: ignores sun at {bs_str} (e.g. tree or roof overhang)."
         )
 
+    # Default fallback (priority 0) — shown as the final row of the chain
+    lines.append(f"🌙 Default (no rule matches) → {default_pos}%{_badge(0)}")
+
     # =========================================================================
     # Section 3: Position Limits
     # =========================================================================
@@ -1525,9 +1612,15 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     if min_pos is not None or max_pos is not None:
         lo_str = f"{min_pos}%" if min_pos is not None else "0%"
         hi_str = f"{max_pos}%" if max_pos is not None else "100%"
-        qualifier = ""
-        if enable_min or enable_max:
+        # Per-side tracking-only qualifier for precision
+        if enable_min and enable_max:
             qualifier = " (during sun tracking only)"
+        elif enable_min and not enable_max:
+            qualifier = " (min during sun tracking only)"
+        elif enable_max and not enable_min:
+            qualifier = " (max during sun tracking only)"
+        else:
+            qualifier = ""
         limit_parts.append(f"Range: {lo_str}–{hi_str}{qualifier}")
     if default_pos is not None:
         limit_parts.append(f"Default: {default_pos}%")
@@ -1539,8 +1632,16 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         limit_parts.append(f"Min interval: {delta_time} min")
     if config.get(CONF_INVERSE_STATE):
         limit_parts.append("Inverse state")
+    oc_thresh = config.get(CONF_OPEN_CLOSE_THRESHOLD)
+    if oc_thresh is not None:
+        limit_parts.append(f"Open/close threshold: {oc_thresh}%")
     if config.get(CONF_INTERP):
-        limit_parts.append("Position calibration on")
+        interp_lo = config.get(CONF_INTERP_START)
+        interp_hi = config.get(CONF_INTERP_END)
+        if interp_lo is not None and interp_hi is not None:
+            limit_parts.append(f"Calibration {interp_lo}→{interp_hi}")
+        else:
+            limit_parts.append("Position calibration on")
     if limit_parts:
         lines.append("")
         lines.append("**Position Limits**")
@@ -1557,57 +1658,6 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             "⚠️ Somfy My preset is enabled for one or more targets but "
             "My Preset Value is not set — falls back to configured %."
         )
-
-    # =========================================================================
-    # Section 3b: Position Map (what position in each scenario)
-    # =========================================================================
-    lines.append("")
-    lines.append("**Position Map** (what your covers do in each situation)")
-
-    pos_map: list[str] = []
-    if has_force:
-        pos_map.append(f"🔒 Safety override active → {force_pos}%")
-    if has_weather:
-        pos_map.append(f"🌧️ Weather danger → {weather_pos}%")
-    if has_custom_position:
-        for _slot, _eid, _pos, _pri, _use_my in _custom_slots:
-            pos_map.append(
-                f"🎯 Custom #{_slot} on → {_pos_label(_pos, _use_my)} (priority {_pri})"
-            )
-    def _fmt_sun_dt(value) -> str | None:
-        return value.strftime("%H:%M") if value is not None else None
-
-    _solar_start = sun_times.get("solar_start") if sun_times else None
-    _solar_end = sun_times.get("solar_end") if sun_times else None
-    _sunset_eff = sun_times.get("sunset_eff") if sun_times else None
-    _sunrise_eff = sun_times.get("sunrise_eff") if sun_times else None
-
-    sunset_pos = config.get(CONF_SUNSET_POS)
-    if sunset_pos is not None:
-        _sunset_today = (
-            f" (today ~{_fmt_sun_dt(_sunset_eff)})" if _sunset_eff is not None else ""
-        )
-        pos_map.append(
-            f"🌅 After sunset{_sunset_today} → "
-            f"{_pos_label(int(sunset_pos), bool(config.get(CONF_SUNSET_USE_MY)))}"
-        )
-        _sunrise_today = (
-            f" (today ~{_fmt_sun_dt(_sunrise_eff)})" if _sunrise_eff is not None else ""
-        )
-        pos_map.append(f"🌄 After sunrise{_sunrise_today} → {default_pos}%")
-    if sun_tracking_enabled:
-        if _solar_start is not None and _solar_end is not None:
-            _window = f" (today {_fmt_sun_dt(_solar_start)} → {_fmt_sun_dt(_solar_end)})"
-        else:
-            _window = ""
-        pos_map.append(f"☀️ Tracking sun{_window} → calculated position")
-    min_p = config.get(CONF_MIN_POSITION, 0)
-    max_p = config.get(CONF_MAX_POSITION, 100)
-    if min_p != 0 or max_p != 100:
-        pos_map.append(f"   (clamped to {min_p}%–{max_p}%)")
-    pos_map.append(f"🌙 Default → {default_pos}%")
-    for line in pos_map:
-        lines.append(line)
 
     # =========================================================================
     # Section 4: Decision Priority (compact reference)

--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -52,6 +52,52 @@ class CoverConfig:
     min_elevation: int | None
     max_elevation: int | None
 
+    @classmethod
+    def from_options(cls, options: dict) -> CoverConfig:
+        """Build a CoverConfig from a raw options/config dict (CONF_* keys)."""
+        from .const import (
+            CONF_AZIMUTH,
+            CONF_BLIND_SPOT_ELEVATION,
+            CONF_BLIND_SPOT_LEFT,
+            CONF_BLIND_SPOT_RIGHT,
+            CONF_DEFAULT_HEIGHT,
+            CONF_ENABLE_BLIND_SPOT,
+            CONF_ENABLE_MAX_POSITION,
+            CONF_ENABLE_MIN_POSITION,
+            CONF_FOV_LEFT,
+            CONF_FOV_RIGHT,
+            CONF_MAX_ELEVATION,
+            CONF_MAX_POSITION,
+            CONF_MIN_ELEVATION,
+            CONF_MIN_POSITION,
+            CONF_SUNRISE_OFFSET,
+            CONF_SUNSET_OFFSET,
+            CONF_SUNSET_POS,
+        )
+
+        return cls(
+            win_azi=options.get(CONF_AZIMUTH) or 180,
+            fov_left=options.get(CONF_FOV_LEFT) or 90,
+            fov_right=options.get(CONF_FOV_RIGHT) or 90,
+            h_def=options.get(CONF_DEFAULT_HEIGHT) or 0,
+            sunset_pos=options.get(CONF_SUNSET_POS),
+            sunset_off=options.get(CONF_SUNSET_OFFSET) or 0,
+            sunrise_off=options.get(
+                CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET)
+            )
+            or 0,
+            max_pos=options.get(CONF_MAX_POSITION) or 100,
+            min_pos=options.get(CONF_MIN_POSITION) or 0,
+            max_pos_sun_only=options.get(CONF_ENABLE_MAX_POSITION, False),
+            min_pos_sun_only=options.get(CONF_ENABLE_MIN_POSITION, False),
+            blind_spot_left=options.get(CONF_BLIND_SPOT_LEFT),
+            blind_spot_right=options.get(CONF_BLIND_SPOT_RIGHT),
+            blind_spot_elevation=options.get(CONF_BLIND_SPOT_ELEVATION),
+            blind_spot_on=options.get(CONF_ENABLE_BLIND_SPOT, False),
+            min_elevation=options.get(CONF_MIN_ELEVATION, None),
+            max_elevation=options.get(CONF_MAX_ELEVATION, None),
+        )
+
 
 @dataclass
 class VerticalConfig:

--- a/custom_components/adaptive_cover_pro/services/configuration_service.py
+++ b/custom_components/adaptive_cover_pro/services/configuration_service.py
@@ -20,28 +20,11 @@ from ..config_types import (
 )
 from ..const import (
     CONF_AWNING_ANGLE,
-    CONF_AZIMUTH,
-    CONF_BLIND_SPOT_ELEVATION,
-    CONF_BLIND_SPOT_LEFT,
-    CONF_BLIND_SPOT_RIGHT,
-    CONF_DEFAULT_HEIGHT,
     CONF_DISTANCE,
-    CONF_ENABLE_BLIND_SPOT,
     CONF_ENABLE_GLARE_ZONES,
-    CONF_ENABLE_MAX_POSITION,
-    CONF_ENABLE_MIN_POSITION,
-    CONF_FOV_LEFT,
-    CONF_FOV_RIGHT,
     CONF_HEIGHT_WIN,
     CONF_LENGTH_AWNING,
-    CONF_MAX_ELEVATION,
-    CONF_MAX_POSITION,
-    CONF_MIN_ELEVATION,
-    CONF_MIN_POSITION,
     CONF_SILL_HEIGHT,
-    CONF_SUNRISE_OFFSET,
-    CONF_SUNSET_OFFSET,
-    CONF_SUNSET_POS,
     CONF_TILT_DEPTH,
     CONF_TILT_DISTANCE,
     CONF_TILT_MODE,
@@ -81,28 +64,7 @@ class ConfigurationService:
             CoverConfig with common configuration values
 
         """
-        return CoverConfig(
-            win_azi=options.get(CONF_AZIMUTH) or 180,
-            fov_left=options.get(CONF_FOV_LEFT) or 90,
-            fov_right=options.get(CONF_FOV_RIGHT) or 90,
-            h_def=options.get(CONF_DEFAULT_HEIGHT) or 0,
-            sunset_pos=options.get(CONF_SUNSET_POS),
-            sunset_off=options.get(CONF_SUNSET_OFFSET) or 0,
-            sunrise_off=options.get(
-                CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET)
-            )
-            or 0,
-            max_pos=options.get(CONF_MAX_POSITION) or 100,
-            min_pos=options.get(CONF_MIN_POSITION) or 0,
-            max_pos_sun_only=options.get(CONF_ENABLE_MAX_POSITION, False),
-            min_pos_sun_only=options.get(CONF_ENABLE_MIN_POSITION, False),
-            blind_spot_left=options.get(CONF_BLIND_SPOT_LEFT),
-            blind_spot_right=options.get(CONF_BLIND_SPOT_RIGHT),
-            blind_spot_elevation=options.get(CONF_BLIND_SPOT_ELEVATION),
-            blind_spot_on=options.get(CONF_ENABLE_BLIND_SPOT, False),
-            min_elevation=options.get(CONF_MIN_ELEVATION, None),
-            max_elevation=options.get(CONF_MAX_ELEVATION, None),
-        )
+        return CoverConfig.from_options(options)
 
     def get_vertical_data(self, options: dict) -> VerticalConfig:
         """Extract vertical blind configuration.

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1328,7 +1328,8 @@ def test_capabilities_section_position_limits_ignored_warning():
 
 
 # ---------------------------------------------------------------------------
-# Section: Position Map sun-time annotations
+# Section: How It Decides — sun-time annotations (Position Map removed, all
+# trigger→target content now lives under How It Decides)
 # ---------------------------------------------------------------------------
 
 
@@ -1361,32 +1362,33 @@ def _sun_times(
     }
 
 
-def test_position_map_no_times_without_sun_times():
-    """Without sun_times no time annotations appear in position map rows."""
+def test_no_times_without_sun_times():
+    """Without sun_times no time annotations appear anywhere."""
     cfg = _full_vertical()
     summary = _build_config_summary(cfg, SensorType.BLIND)
     assert "today" not in summary
 
 
-def test_position_map_tracking_row_shows_solar_window():
-    """Tracking sun row includes today's solar control window when sun_times provided."""
+def test_sun_tracking_row_shows_solar_window():
+    """Sun tracking line includes today's solar control window when sun_times provided."""
     cfg = {CONF_ENABLE_SUN_TRACKING: True}
     summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=_sun_times())
-    assert "☀️ Tracking sun (today 07:14 → 18:30) → calculated position" in summary
+    assert "(today: sun in window 07:14 → 18:30)" in summary
+    # Sun tracking rule line still carries its existing "Tracks the sun" phrasing
+    assert "Tracks the sun" in summary
 
 
-def test_position_map_tracking_row_no_window_when_solar_times_none():
-    """Tracking sun row shows no annotation when solar_start/solar_end are None."""
+def test_sun_tracking_row_no_window_when_solar_times_none():
+    """Sun tracking line shows 'does not enter window' when solar_start/solar_end are None."""
     cfg = {CONF_ENABLE_SUN_TRACKING: True}
     summary = _build_config_summary(
         cfg, SensorType.BLIND, sun_times=_sun_times(solar_start=None, solar_end=None)
     )
-    assert "☀️ Tracking sun → calculated position" in summary
-    assert "today" not in summary
+    assert "(today: sun does not enter window)" in summary
 
 
-def test_position_map_after_sunset_row_shows_effective_sunset():
-    """After sunset row includes effective sunset time when sunset_pos configured."""
+def test_after_sunset_row_shows_effective_sunset():
+    """After sunset sub-bullet includes effective sunset time when sunset_pos configured."""
     cfg = {CONF_SUNSET_POS: 30}
     summary = _build_config_summary(
         cfg, SensorType.BLIND, sun_times=_sun_times(sunset_eff=(19, 45))
@@ -1394,8 +1396,8 @@ def test_position_map_after_sunset_row_shows_effective_sunset():
     assert "🌅 After sunset (today ~19:45) → 30%" in summary
 
 
-def test_position_map_after_sunrise_row_shows_when_sunset_pos_configured():
-    """After sunrise row appears with time annotation when sunset_pos is configured."""
+def test_after_sunrise_row_shows_when_sunset_pos_configured():
+    """After sunrise sub-bullet shows today's effective sunrise time when sunset_pos configured."""
     cfg = {CONF_SUNSET_POS: 30}
     summary = _build_config_summary(
         cfg, SensorType.BLIND, sun_times=_sun_times(sunrise_eff=(6, 42))
@@ -1403,18 +1405,282 @@ def test_position_map_after_sunrise_row_shows_when_sunset_pos_configured():
     assert "🌄 After sunrise (today ~06:42) → 0%" in summary
 
 
-def test_position_map_after_sunrise_row_absent_without_sunset_pos():
-    """After sunrise row does not appear when sunset_pos is not configured."""
+def test_after_sunrise_row_absent_without_sunset_pos():
+    """After sunrise sub-bullet does not appear when sunset_pos is not configured."""
     cfg = {}
     summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=_sun_times())
     assert "🌄 After sunrise" not in summary
 
 
-def test_position_map_default_row_always_present():
-    """Default row always appears as plain 🌙 Default label."""
+def test_default_row_always_present():
+    """Default fallback line always renders under How It Decides."""
     for cfg in [{}, {CONF_SUNSET_POS: 30}, {CONF_ENABLE_SUN_TRACKING: False}]:
         summary = _build_config_summary(cfg, SensorType.BLIND)
-        assert "🌙 Default → 0%" in summary
+        assert "🌙 Default (no rule matches) → 0%" in summary
+
+
+def test_sunset_today_and_offset_merged_in_one_parenthetical():
+    """When both today's time and an offset are present, they share one parenthetical."""
+    cfg = {CONF_SUNSET_POS: 30, CONF_SUNSET_OFFSET: 30}
+    summary = _build_config_summary(
+        cfg, SensorType.BLIND, sun_times=_sun_times(sunset_eff=(20, 15))
+    )
+    assert "🌅 After sunset (today ~20:15, +30 min) → 30%" in summary
+
+
+# ---------------------------------------------------------------------------
+# Position Map section is gone — every place it lived is now the HID chain
+# ---------------------------------------------------------------------------
+
+
+def test_position_map_section_absent():
+    """Position Map header never renders — its content moved to How It Decides."""
+    cfg = _full_vertical()
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=_sun_times())
+    assert "**Position Map**" not in summary
+    assert "Position Map" not in summary
+
+
+# ---------------------------------------------------------------------------
+# Priority badges — each rule in How It Decides ends with [N]
+# ---------------------------------------------------------------------------
+
+
+def test_priority_badges_on_every_rule():
+    """Each HID rule line carries a [N] priority badge; badges match the chain."""
+    cfg = _full_vertical()
+    cfg["custom_position_sensor_1"] = "binary_sensor.movie"
+    cfg["custom_position_1"] = 40
+    cfg["custom_position_priority_1"] = 77
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    for badge in ("[100]", "[90]", "[80]", "[77]", "[75]", "[60]", "[50]", "[45]", "[40]", "[0]"):
+        assert badge in summary, f"expected {badge} badge on some rule"
+
+
+def test_priority_badge_default_zero():
+    """Default fallback line shows the [0] badge."""
+    summary = _build_config_summary({}, SensorType.BLIND)
+    assert "🌙 Default (no rule matches) → 0%" in summary
+    # [0] appears on the same line as the default fallback
+    for line in summary.splitlines():
+        if "🌙 Default" in line:
+            assert "[0]" in line
+            break
+    else:
+        raise AssertionError("No default fallback line found")
+
+
+# ---------------------------------------------------------------------------
+# Newly rendered behavior-affecting options
+# ---------------------------------------------------------------------------
+
+
+def test_return_sunset_line_rendered():
+    """CONF_RETURN_SUNSET toggles a '🔚 Return to sunset position at end time: on' line."""
+    from custom_components.adaptive_cover_pro.const import CONF_RETURN_SUNSET
+
+    cfg = {CONF_SUNSET_POS: 30, CONF_RETURN_SUNSET: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Return to sunset position at end time: on" in summary
+
+
+def test_return_sunset_line_absent_when_false():
+    """CONF_RETURN_SUNSET=False omits the 🔚 line."""
+    from custom_components.adaptive_cover_pro.const import CONF_RETURN_SUNSET
+
+    cfg = {CONF_SUNSET_POS: 30, CONF_RETURN_SUNSET: False}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Return to sunset position at end time" not in summary
+
+
+def test_manual_ignore_intermediate_shown():
+    """CONF_MANUAL_IGNORE_INTERMEDIATE adds 'ignores intermediate positions' annotation."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MANUAL_IGNORE_INTERMEDIATE,
+    )
+
+    cfg = {CONF_MANUAL_IGNORE_INTERMEDIATE: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "ignores intermediate positions" in summary
+
+
+def test_weather_wind_direction_shown():
+    """Wind direction sensor + tolerance render on the weather safety line."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_WEATHER_WIND_DIRECTION_SENSOR,
+        CONF_WEATHER_WIND_DIRECTION_TOLERANCE,
+    )
+
+    cfg = {
+        CONF_WEATHER_WIND_SPEED_SENSOR: "sensor.wind",
+        CONF_WEATHER_WIND_SPEED_THRESHOLD: 60,
+        CONF_WEATHER_WIND_DIRECTION_SENSOR: "sensor.wind_dir",
+        CONF_WEATHER_WIND_DIRECTION_TOLERANCE: 45,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "from window ±45°" in summary
+
+
+def test_weather_bypass_auto_control_warning():
+    """CONF_WEATHER_BYPASS_AUTO_CONTROL renders a ⚠️ halt-annotation."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_WEATHER_BYPASS_AUTO_CONTROL,
+    )
+
+    cfg = {
+        CONF_WEATHER_IS_RAINING_SENSOR: "binary_sensor.rain",
+        CONF_WEATHER_BYPASS_AUTO_CONTROL: True,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "halts all automation while triggered" in summary
+
+
+def test_weather_override_min_mode_shown():
+    """CONF_WEATHER_OVERRIDE_MIN_MODE renders '(as minimum)' on the weather line."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_WEATHER_OVERRIDE_MIN_MODE,
+    )
+
+    cfg = {
+        CONF_WEATHER_IS_RAINING_SENSOR: "binary_sensor.rain",
+        CONF_WEATHER_OVERRIDE_POSITION: 0,
+        CONF_WEATHER_OVERRIDE_MIN_MODE: True,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    # "(as minimum)" belongs on the weather safety line, not the force line
+    wx_line = next(ln for ln in summary.splitlines() if "Weather safety" in ln)
+    assert "(as minimum)" in wx_line
+
+
+def test_force_override_min_mode_shown():
+    """CONF_FORCE_OVERRIDE_MIN_MODE renders '(as minimum)' on the force line."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_FORCE_OVERRIDE_MIN_MODE,
+    )
+
+    cfg = {
+        CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.safety"],
+        CONF_FORCE_OVERRIDE_POSITION: 100,
+        CONF_FORCE_OVERRIDE_MIN_MODE: True,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    force_line = next(ln for ln in summary.splitlines() if "Force override" in ln)
+    assert "(as minimum)" in force_line
+
+
+def test_custom_position_min_mode_shown():
+    """custom_position_min_mode_N renders '(as minimum)' on the custom slot line."""
+    cfg = {
+        "custom_position_sensor_1": "binary_sensor.movie",
+        "custom_position_1": 40,
+        "custom_position_priority_1": 77,
+        "custom_position_min_mode_1": True,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    custom_line = next(ln for ln in summary.splitlines() if "Custom #1" in ln)
+    assert "(as minimum)" in custom_line
+
+
+def test_weather_state_list_in_cloud_line():
+    """CONF_WEATHER_STATE list renders as 'weather in {state, state}' on the cloud line."""
+    from custom_components.adaptive_cover_pro.const import CONF_WEATHER_STATE
+
+    cfg = {
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_WEATHER_ENTITY: "weather.home",
+        CONF_WEATHER_STATE: ["cloudy", "rainy"],
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "weather in {cloudy, rainy}" in summary
+
+
+def test_outside_threshold_shown_on_climate_line():
+    """CONF_OUTSIDE_THRESHOLD annotates the outside temp entity on the climate line."""
+    cfg = {
+        CONF_CLIMATE_MODE: True,
+        CONF_OUTSIDETEMP_ENTITY: "sensor.outdoor",
+        CONF_OUTSIDE_THRESHOLD: 28,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "sensor.outdoor > 28°C" in summary
+
+
+def test_transparent_blind_note_on_climate_line():
+    """CONF_TRANSPARENT_BLIND adds a 'transparent blind' note on climate line."""
+    from custom_components.adaptive_cover_pro.const import CONF_TRANSPARENT_BLIND
+
+    cfg = {CONF_CLIMATE_MODE: True, CONF_TRANSPARENT_BLIND: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    climate_line = next(ln for ln in summary.splitlines() if "Climate mode" in ln)
+    assert "transparent blind" in climate_line
+
+
+def test_winter_close_insulation_note_on_climate_line():
+    """CONF_WINTER_CLOSE_INSULATION adds a 'closes fully in winter' note."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_WINTER_CLOSE_INSULATION,
+    )
+
+    cfg = {CONF_CLIMATE_MODE: True, CONF_WINTER_CLOSE_INSULATION: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "closes fully in winter for insulation" in summary
+
+
+def test_open_close_threshold_in_position_limits():
+    """CONF_OPEN_CLOSE_THRESHOLD renders under Position Limits."""
+    from custom_components.adaptive_cover_pro.const import CONF_OPEN_CLOSE_THRESHOLD
+
+    cfg = {CONF_MIN_POSITION: 0, CONF_OPEN_CLOSE_THRESHOLD: 50}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Open/close threshold: 50%" in summary
+
+
+def test_interp_start_end_in_position_limits():
+    """CONF_INTERP_START and CONF_INTERP_END render as 'Calibration N→M' when set."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_INTERP_END,
+        CONF_INTERP_START,
+    )
+
+    cfg = {
+        CONF_MIN_POSITION: 0,
+        CONF_INTERP: True,
+        CONF_INTERP_START: 10,
+        CONF_INTERP_END: 90,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Calibration 10→90" in summary
+
+
+def test_interp_without_start_end_falls_back():
+    """CONF_INTERP=True without start/end falls back to the plain 'on' note."""
+    cfg = {CONF_MIN_POSITION: 0, CONF_INTERP: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Position calibration on" in summary
+
+
+def test_min_only_qualifier_is_min_specific():
+    """When only enable_min_position is True, qualifier reads 'min during sun tracking only'."""
+    cfg = {
+        CONF_MIN_POSITION: 10,
+        CONF_MAX_POSITION: 90,
+        CONF_ENABLE_MIN_POSITION: True,
+        CONF_ENABLE_MAX_POSITION: False,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "(min during sun tracking only)" in summary
+
+
+def test_max_only_qualifier_is_max_specific():
+    """When only enable_max_position is True, qualifier reads 'max during sun tracking only'."""
+    cfg = {
+        CONF_MIN_POSITION: 10,
+        CONF_MAX_POSITION: 90,
+        CONF_ENABLE_MIN_POSITION: False,
+        CONF_ENABLE_MAX_POSITION: True,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "(max during sun tracking only)" in summary
 
 
 async def test_compute_todays_sun_times_returns_expected_shape():

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1328,7 +1328,7 @@ def test_capabilities_section_position_limits_ignored_warning():
 
 
 # ---------------------------------------------------------------------------
-# Section: Today's Sun
+# Section: Position Map sun-time annotations
 # ---------------------------------------------------------------------------
 
 
@@ -1361,72 +1361,60 @@ def _sun_times(
     }
 
 
-def test_todays_sun_absent_when_sun_times_none():
-    """Without sun_times the Today's Sun block must not render."""
+def test_position_map_no_times_without_sun_times():
+    """Without sun_times no time annotations appear in position map rows."""
     cfg = _full_vertical()
     summary = _build_config_summary(cfg, SensorType.BLIND)
-    assert "Today's sun" not in summary
-    assert "Solar control window" not in summary
+    assert "today" not in summary
 
 
-def test_todays_sun_raw_only_when_offsets_zero():
-    """Zero offsets → raw times with no (effective …) annotation."""
-    cfg = {
-        CONF_SUNRISE_OFFSET: 0,
-        CONF_SUNSET_OFFSET: 0,
-    }
-    sun_times = _sun_times()
-    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
-    assert "🌞 Today's sun:" in summary
-    assert "🌅 Sunrise: 06:30" in summary
-    assert "🌇 Sunset: 19:45" in summary
-    assert "effective" not in summary
-    assert "🕶️ Solar control window: 07:14 → 18:30" in summary
+def test_position_map_tracking_row_shows_solar_window():
+    """Tracking sun row includes today's solar control window when sun_times provided."""
+    cfg = {CONF_ENABLE_SUN_TRACKING: True}
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=_sun_times())
+    assert "☀️ Tracking sun (today 07:14 → 18:30) → calculated position" in summary
 
 
-def test_todays_sun_positive_offset_renders_effective_plus():
-    """Positive sunrise offset → shows effective time with + sign."""
-    cfg = {
-        CONF_SUNRISE_OFFSET: 12,
-        CONF_SUNSET_OFFSET: 0,
-    }
-    sun_times = _sun_times(sunrise_eff=(6, 42))
-    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
-    assert "🌅 Sunrise: 06:30 (effective 06:42, +12 min)" in summary
-    # sunset offset is 0 → no (effective) annotation on sunset line
-    assert "🌇 Sunset: 19:45" in summary
-    assert "Sunset: 19:45 (effective" not in summary
-
-
-def test_todays_sun_negative_offset_renders_effective_minus():
-    """Negative sunset offset → shows effective time with Unicode minus sign."""
-    cfg = {
-        CONF_SUNRISE_OFFSET: 0,
-        CONF_SUNSET_OFFSET: -12,
-    }
-    sun_times = _sun_times(sunset_eff=(19, 33))
-    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
-    assert "🌇 Sunset: 19:45 (effective 19:33, −12 min)" in summary
-
-
-def test_todays_sun_window_missing_renders_fallback():
-    """solar_start/solar_end both None → fallback message."""
-    cfg = {CONF_SUNRISE_OFFSET: 0, CONF_SUNSET_OFFSET: 0}
-    sun_times = _sun_times(solar_start=None, solar_end=None)
-    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
-    assert (
-        "🕶️ Solar control window: sun does not enter window today"
-        in summary
+def test_position_map_tracking_row_no_window_when_solar_times_none():
+    """Tracking sun row shows no annotation when solar_start/solar_end are None."""
+    cfg = {CONF_ENABLE_SUN_TRACKING: True}
+    summary = _build_config_summary(
+        cfg, SensorType.BLIND, sun_times=_sun_times(solar_start=None, solar_end=None)
     )
+    assert "☀️ Tracking sun → calculated position" in summary
+    assert "today" not in summary
 
 
-def test_todays_sun_renders_even_without_timing_config():
-    """Today's Sun block shows even when user has no start/end/sunset_pos configured."""
-    cfg = {}  # no timing_parts, no sunset_pos → timing block is skipped
-    sun_times = _sun_times()
-    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
-    assert "🌞 Today's sun:" in summary
-    assert "🌅 Sunrise: 06:30" in summary
+def test_position_map_after_sunset_row_shows_effective_sunset():
+    """After sunset row includes effective sunset time when sunset_pos configured."""
+    cfg = {CONF_SUNSET_POS: 30}
+    summary = _build_config_summary(
+        cfg, SensorType.BLIND, sun_times=_sun_times(sunset_eff=(19, 45))
+    )
+    assert "🌅 After sunset (today ~19:45) → 30%" in summary
+
+
+def test_position_map_after_sunrise_row_shows_when_sunset_pos_configured():
+    """After sunrise row appears with time annotation when sunset_pos is configured."""
+    cfg = {CONF_SUNSET_POS: 30}
+    summary = _build_config_summary(
+        cfg, SensorType.BLIND, sun_times=_sun_times(sunrise_eff=(6, 42))
+    )
+    assert "🌄 After sunrise (today ~06:42) → 0%" in summary
+
+
+def test_position_map_after_sunrise_row_absent_without_sunset_pos():
+    """After sunrise row does not appear when sunset_pos is not configured."""
+    cfg = {}
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=_sun_times())
+    assert "🌄 After sunrise" not in summary
+
+
+def test_position_map_default_row_always_present():
+    """Default row always appears as plain 🌙 Default label."""
+    for cfg in [{}, {CONF_SUNSET_POS: 30}, {CONF_ENABLE_SUN_TRACKING: False}]:
+        summary = _build_config_summary(cfg, SensorType.BLIND)
+        assert "🌙 Default → 0%" in summary
 
 
 async def test_compute_todays_sun_times_returns_expected_shape():

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1325,3 +1325,193 @@ def test_capabilities_section_position_limits_ignored_warning():
     assert "Position limits" in result
     assert "limits will be ignored" in result
     assert "cover.blind" in result
+
+
+# ---------------------------------------------------------------------------
+# Section: Today's Sun
+# ---------------------------------------------------------------------------
+
+
+def _sun_times(
+    *,
+    sunrise_raw=(6, 30),
+    sunset_raw=(19, 45),
+    sunrise_eff=None,
+    sunset_eff=None,
+    solar_start=(7, 14),
+    solar_end=(18, 30),
+):
+    """Build a sun_times dict with HH:MM tuples; None entries pass through."""
+    import datetime as dt
+
+    today = dt.date(2026, 4, 18)
+
+    def _dt(hm):
+        if hm is None:
+            return None
+        return dt.datetime(today.year, today.month, today.day, hm[0], hm[1])
+
+    return {
+        "sunrise_raw": _dt(sunrise_raw),
+        "sunset_raw": _dt(sunset_raw),
+        "sunrise_eff": _dt(sunrise_eff) if sunrise_eff else _dt(sunrise_raw),
+        "sunset_eff": _dt(sunset_eff) if sunset_eff else _dt(sunset_raw),
+        "solar_start": _dt(solar_start),
+        "solar_end": _dt(solar_end),
+    }
+
+
+def test_todays_sun_absent_when_sun_times_none():
+    """Without sun_times the Today's Sun block must not render."""
+    cfg = _full_vertical()
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Today's sun" not in summary
+    assert "Solar control window" not in summary
+
+
+def test_todays_sun_raw_only_when_offsets_zero():
+    """Zero offsets → raw times with no (effective …) annotation."""
+    cfg = {
+        CONF_SUNRISE_OFFSET: 0,
+        CONF_SUNSET_OFFSET: 0,
+    }
+    sun_times = _sun_times()
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
+    assert "🌞 Today's sun:" in summary
+    assert "🌅 Sunrise: 06:30" in summary
+    assert "🌇 Sunset: 19:45" in summary
+    assert "effective" not in summary
+    assert "🕶️ Solar control window: 07:14 → 18:30" in summary
+
+
+def test_todays_sun_positive_offset_renders_effective_plus():
+    """Positive sunrise offset → shows effective time with + sign."""
+    cfg = {
+        CONF_SUNRISE_OFFSET: 12,
+        CONF_SUNSET_OFFSET: 0,
+    }
+    sun_times = _sun_times(sunrise_eff=(6, 42))
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
+    assert "🌅 Sunrise: 06:30 (effective 06:42, +12 min)" in summary
+    # sunset offset is 0 → no (effective) annotation on sunset line
+    assert "🌇 Sunset: 19:45" in summary
+    assert "Sunset: 19:45 (effective" not in summary
+
+
+def test_todays_sun_negative_offset_renders_effective_minus():
+    """Negative sunset offset → shows effective time with Unicode minus sign."""
+    cfg = {
+        CONF_SUNRISE_OFFSET: 0,
+        CONF_SUNSET_OFFSET: -12,
+    }
+    sun_times = _sun_times(sunset_eff=(19, 33))
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
+    assert "🌇 Sunset: 19:45 (effective 19:33, −12 min)" in summary
+
+
+def test_todays_sun_window_missing_renders_fallback():
+    """solar_start/solar_end both None → fallback message."""
+    cfg = {CONF_SUNRISE_OFFSET: 0, CONF_SUNSET_OFFSET: 0}
+    sun_times = _sun_times(solar_start=None, solar_end=None)
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
+    assert (
+        "🕶️ Solar control window: sun does not enter window today"
+        in summary
+    )
+
+
+def test_todays_sun_renders_even_without_timing_config():
+    """Today's Sun block shows even when user has no start/end/sunset_pos configured."""
+    cfg = {}  # no timing_parts, no sunset_pos → timing block is skipped
+    sun_times = _sun_times()
+    summary = _build_config_summary(cfg, SensorType.BLIND, sun_times=sun_times)
+    assert "🌞 Today's sun:" in summary
+    assert "🌅 Sunrise: 06:30" in summary
+
+
+async def test_compute_todays_sun_times_returns_expected_shape():
+    """_compute_todays_sun_times returns a dict with all expected keys in local TZ."""
+    import datetime as dt
+    from unittest.mock import MagicMock, patch
+
+    from custom_components.adaptive_cover_pro.config_flow import (
+        _compute_todays_sun_times,
+    )
+
+    fake_sunrise_utc = dt.datetime(2026, 4, 18, 10, 30, tzinfo=dt.UTC)
+    fake_sunset_utc = dt.datetime(2026, 4, 18, 23, 45, tzinfo=dt.UTC)
+    fake_solar_start_utc = dt.datetime(2026, 4, 18, 11, 14, tzinfo=dt.UTC)
+    fake_solar_end_utc = dt.datetime(2026, 4, 18, 22, 30, tzinfo=dt.UTC)
+
+    sun_data_stub = MagicMock()
+    sun_data_stub.sunrise.return_value = fake_sunrise_utc
+    sun_data_stub.sunset.return_value = fake_sunset_utc
+
+    geom_stub = MagicMock()
+    geom_stub.solar_times.return_value = (fake_solar_start_utc, fake_solar_end_utc)
+
+    hass = MagicMock()
+    hass.config.time_zone = "UTC"
+
+    async def _run_executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    hass.async_add_executor_job = _run_executor
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.state.sun_provider."
+            "SunProvider.create_sun_data",
+            return_value=sun_data_stub,
+        ),
+        patch(
+            "custom_components.adaptive_cover_pro.engine.sun_geometry.SunGeometry",
+            return_value=geom_stub,
+        ),
+    ):
+        result = await _compute_todays_sun_times(
+            hass, {CONF_SUNRISE_OFFSET: 12, CONF_SUNSET_OFFSET: -12}
+        )
+
+    assert result is not None
+    assert set(result.keys()) == {
+        "sunrise_raw",
+        "sunset_raw",
+        "sunrise_eff",
+        "sunset_eff",
+        "solar_start",
+        "solar_end",
+    }
+    # All datetimes returned as naive (tz-stripped after local conversion)
+    for value in result.values():
+        if value is not None:
+            assert value.tzinfo is None
+    # Effective = raw + offset
+    assert result["sunrise_eff"] - result["sunrise_raw"] == dt.timedelta(minutes=12)
+    assert result["sunset_eff"] - result["sunset_raw"] == dt.timedelta(minutes=-12)
+
+
+async def test_compute_todays_sun_times_returns_none_on_failure():
+    """_compute_todays_sun_times returns None when SunProvider raises."""
+    from unittest.mock import MagicMock, patch
+
+    from custom_components.adaptive_cover_pro.config_flow import (
+        _compute_todays_sun_times,
+    )
+
+    hass = MagicMock()
+    hass.config.time_zone = "UTC"
+
+    async def _run_executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    hass.async_add_executor_job = _run_executor
+
+    with patch(
+        "custom_components.adaptive_cover_pro.state.sun_provider."
+        "SunProvider.create_sun_data",
+        side_effect=RuntimeError("no location"),
+    ):
+        result = await _compute_todays_sun_times(hass, {})
+
+    assert result is None

--- a/tests/test_config_ux_simplification.py
+++ b/tests/test_config_ux_simplification.py
@@ -298,7 +298,7 @@ class TestPositionMapInSummary:
         config = self._base_config(**{CONF_DEFAULT_HEIGHT: 60})
         result = _build_config_summary(config, SensorType.BLIND)
         assert "60%" in result
-        assert "No sun / default" in result
+        assert "🌙 Default" in result
 
     def test_position_map_shows_sunset(self):
         """Position map shows sunset position when configured."""

--- a/tests/test_config_ux_simplification.py
+++ b/tests/test_config_ux_simplification.py
@@ -273,7 +273,7 @@ class TestSyncCategoriesSplit:
 
 
 class TestPositionMapInSummary:
-    """Test the Position Map section in config summary."""
+    """Rule targets and positions now live under How It Decides (Position Map removed)."""
 
     def _base_config(self, **overrides):
         """Create a base config for summary testing."""
@@ -288,26 +288,27 @@ class TestPositionMapInSummary:
         return config
 
     def test_position_map_section_present(self):
-        """Summary includes Position Map section."""
+        """Position Map section removed; How It Decides now carries per-rule targets."""
         config = self._base_config()
         result = _build_config_summary(config, SensorType.BLIND)
-        assert "**Position Map**" in result
+        assert "**Position Map**" not in result
+        assert "**How It Decides**" in result
 
     def test_position_map_shows_default(self):
-        """Position map shows the default position."""
+        """Default-fallback line renders under How It Decides."""
         config = self._base_config(**{CONF_DEFAULT_HEIGHT: 60})
         result = _build_config_summary(config, SensorType.BLIND)
         assert "60%" in result
         assert "🌙 Default" in result
 
     def test_position_map_shows_sunset(self):
-        """Position map shows sunset position when configured."""
+        """Sunset row renders under How It Decides when configured."""
         config = self._base_config(**{CONF_SUNSET_POS: 0})
         result = _build_config_summary(config, SensorType.BLIND)
         assert "After sunset" in result
 
     def test_position_map_shows_force_override(self):
-        """Position map shows force override position when configured."""
+        """Force override row renders under How It Decides."""
         config = self._base_config(
             **{
                 CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.rain"],
@@ -315,11 +316,11 @@ class TestPositionMapInSummary:
             }
         )
         result = _build_config_summary(config, SensorType.BLIND)
-        assert "Safety override" in result
+        assert "Force override" in result
         assert "100%" in result
 
     def test_position_map_shows_weather_override(self):
-        """Position map shows weather override position when configured."""
+        """Weather safety row renders under How It Decides."""
         config = self._base_config(
             **{
                 CONF_WEATHER_WIND_SPEED_SENSOR: "sensor.wind",
@@ -327,23 +328,23 @@ class TestPositionMapInSummary:
             }
         )
         result = _build_config_summary(config, SensorType.BLIND)
-        assert "Weather danger" in result
+        assert "Weather safety" in result
 
     def test_position_map_shows_sun_tracking(self):
-        """Position map always shows sun tracking line."""
+        """Sun tracking row renders under How It Decides."""
         config = self._base_config()
         result = _build_config_summary(config, SensorType.BLIND)
-        assert "Tracking sun" in result
+        assert "Tracks the sun" in result
 
     def test_position_map_shows_clamp_range(self):
-        """Position map shows clamp range when min/max differ from defaults."""
+        """Position Limits section shows the clamp range when min/max differ from defaults."""
         config = self._base_config(**{CONF_MIN_POSITION: 10, CONF_MAX_POSITION: 90})
         result = _build_config_summary(config, SensorType.BLIND)
         assert "10%" in result
         assert "90%" in result
 
     def test_position_map_no_clamp_at_defaults(self):
-        """Position map omits clamp line when min=0 and max=100."""
+        """Position Limits omits clamp qualifier when min=0 and max=100."""
         config = self._base_config(**{CONF_MIN_POSITION: 0, CONF_MAX_POSITION: 100})
         result = _build_config_summary(config, SensorType.BLIND)
         assert "clamped" not in result


### PR DESCRIPTION
## Summary

- **Removes the Position Map section** — every row duplicated a trigger→target mapping already present in How It Decides; the duplication was confusing and the section has been eliminated entirely
- **Inlines today's sun times into How It Decides** — solar control window (`today: sun in window HH:MM → HH:MM`) appears on the ☀️ tracking line; effective sunset/sunrise times appear as parenthetical annotations on the 🌅/🌄 sub-bullets
- **Adds `[priority]` badges to every rule** so the decision chain order is visible inline without needing to scroll to Decision Priority
- **Surfaces 14 previously-unrendered behavior-affecting options**: `return_sunset`, `manual_ignore_intermediate`, wind direction + tolerance, weather bypass warning, force/weather/custom `min_mode` flags, `weather_state` list, climate `outside_threshold` / `transparent_blind` / `winter_close_insulation`, `open_close_threshold`, `interp_start`/`interp_end` calibration range, per-side min/max qualifier in Position Limits

## Testing

- ✅ 2308 tests passing
- ✅ Lint clean (`./scripts/lint`)
- New tests added for every newly-rendered option, position map absence, and priority badge presence