### PR TITLE
docs: clarify blind_spot angles are measured from FOV left boundary

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1595,7 +1595,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             bs_parts.append(f"up to {bs_e}° elevation")
         bs_str = " ".join(bs_parts)
         lines.append(
-            f"🟥 Blind spot: ignores sun at {bs_str} (e.g. tree or roof overhang)."
+            f"🟥 Blind spot: ignores sun at {bs_str} inward from FOV left (e.g. tree or roof overhang)."
         )
 
     # Default fallback (priority 0) — shown as the final row of the chain

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -720,8 +720,9 @@ set_sun_tracking:
 set_blind_spot:
   name: Set blind spot
   description: >-
-    Update blind spot zone angles. blind_spot_right must be greater than
-    blind_spot_left. Enforced at validation time.
+    Update blind spot zone angles. Angles are measured inward from your FOV
+    left boundary (not from window azimuth). blind_spot_right must be greater
+    than blind_spot_left. Enforced at validation time.
   target:
     entity:
       integration: adaptive_cover_pro
@@ -733,7 +734,7 @@ set_blind_spot:
         boolean:
     blind_spot_left:
       name: Blind spot left edge
-      description: "Left edge of the blind spot zone in degrees from window azimuth (0–359°)."
+      description: "Left edge of the blind spot zone in degrees inward from your FOV left boundary (0 = at the FOV left edge, range 0–359°)."
       selector:
         number:
           min: 0
@@ -742,7 +743,7 @@ set_blind_spot:
           unit_of_measurement: "°"
     blind_spot_right:
       name: Blind spot right edge
-      description: "Right edge of the blind spot zone in degrees from window azimuth (1–360°). Must be greater than left edge."
+      description: "Right edge of the blind spot zone in degrees inward from your FOV left boundary. Must be greater than left edge (range 1–360°)."
       selector:
         number:
           min: 0

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -310,8 +310,8 @@
       },
       "blind_spot": {
         "data": {
-          "blind_spot_left": "Blindfleck-Start links",
-          "blind_spot_right": "Blindfleck-Ende rechts",
+          "blind_spot_left": "Blindfleck linke Kante (von FOV-Links)",
+          "blind_spot_right": "Blindfleck rechte Kante (von FOV-Links)",
           "blind_spot_elevation": "Blindfleck-Höhe"
         },
         "data_description": {
@@ -788,8 +788,8 @@
       },
       "blind_spot": {
         "data": {
-          "blind_spot_left": "Blindfleck-Start links",
-          "blind_spot_right": "Blindfleck-Ende rechts",
+          "blind_spot_left": "Blindfleck linke Kante (von FOV-Links)",
+          "blind_spot_right": "Blindfleck rechte Kante (von FOV-Links)",
           "blind_spot_elevation": "Blindfleck-Höhe"
         },
         "data_description": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -310,8 +310,8 @@
       },
       "blind_spot": {
         "data": {
-          "blind_spot_left": "Start blindspot left",
-          "blind_spot_right": "End blindspot right",
+          "blind_spot_left": "Blind spot left edge (from FOV left)",
+          "blind_spot_right": "Blind spot right edge (from FOV left)",
           "blind_spot_elevation": "Blindspot elevation"
         },
         "data_description": {
@@ -788,8 +788,8 @@
       },
       "blind_spot": {
         "data": {
-          "blind_spot_left": "Start blindspot left",
-          "blind_spot_right": "End blindspot right",
+          "blind_spot_left": "Blind spot left edge (from FOV left)",
+          "blind_spot_right": "Blind spot right edge (from FOV left)",
           "blind_spot_elevation": "Blindspot elevation"
         },
         "data_description": {
@@ -1245,8 +1245,8 @@
       "description": "Update blind spot zone angles. blind_spot_right must be greater than blind_spot_left.",
       "fields": {
         "blind_spot": { "name": "Enable blind spot", "description": "If true, the blind spot zone is active." },
-        "blind_spot_left": { "name": "Left edge", "description": "Left edge of the blind spot zone in degrees from window azimuth (0–359°)." },
-        "blind_spot_right": { "name": "Right edge", "description": "Right edge of the blind spot zone (1–360°). Must be greater than left edge." },
+        "blind_spot_left": { "name": "Left edge (from FOV left)", "description": "Left edge of the blind spot zone in degrees inward from your FOV left boundary (0 = at the FOV left edge, range 0–359°)." },
+        "blind_spot_right": { "name": "Right edge (from FOV left)", "description": "Right edge of the blind spot zone in degrees inward from your FOV left boundary. Must be greater than left edge (range 1–360°)." },
         "blind_spot_elevation": { "name": "Elevation limit", "description": "Maximum sun elevation (°) for the blind spot to apply. Null = always apply." }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -310,8 +310,8 @@
       },
       "blind_spot": {
         "data": {
-          "blind_spot_left": "Début zone cachée à gauche",
-          "blind_spot_right": "Fin zone cachée à droite",
+          "blind_spot_left": "Bord gauche de la zone cachée (depuis FOV gauche)",
+          "blind_spot_right": "Bord droit de la zone cachée (depuis FOV gauche)",
           "blind_spot_elevation": "Élévation zone cachée"
         },
         "data_description": {
@@ -788,8 +788,8 @@
       },
       "blind_spot": {
         "data": {
-          "blind_spot_left": "Début zone cachée à gauche",
-          "blind_spot_right": "Fin zone cachée à droite",
+          "blind_spot_left": "Bord gauche de la zone cachée (depuis FOV gauche)",
+          "blind_spot_right": "Bord droit de la zone cachée (depuis FOV gauche)",
           "blind_spot_elevation": "Élévation zone cachée"
         },
         "data_description": {

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -502,6 +502,7 @@ def test_blind_spot_shown_when_enabled():
     assert "10°" in summary
     assert "20°" in summary
     assert "40°" in summary
+    assert "FOV left" in summary
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -1,0 +1,42 @@
+"""Docstring hygiene for services.yaml (Issue #211 Option 2)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+SERVICES_YAML = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "services.yaml"
+)
+
+
+def _load():
+    with SERVICES_YAML.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def test_set_blind_spot_left_description_uses_fov_frame():
+    svc = _load()["set_blind_spot"]["fields"]["blind_spot_left"]
+    desc = svc["description"]
+    assert "window azimuth" not in desc.lower()
+    assert "fov left" in desc.lower()
+
+
+def test_set_blind_spot_right_description_uses_fov_frame():
+    svc = _load()["set_blind_spot"]["fields"]["blind_spot_right"]
+    desc = svc["description"]
+    assert "window azimuth" not in desc.lower()
+    assert "fov left" in desc.lower()
+    assert "greater than" in desc.lower()
+
+
+def test_set_blind_spot_service_description_mentions_fov_frame():
+    svc = _load()["set_blind_spot"]
+    desc = svc["description"].lower()
+    assert "fov" in desc or "field of view" in desc

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -206,3 +206,33 @@ def test_no_invisible_unicode_chars(lang_file: Path) -> None:
                 f"{lang_file.name}: invisible Unicode char U+{ord(char):04X} "
                 f"found in value: {value!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Issue #211 Option 2 — blind_spot labels are FOV-relative, not azimuth-relative
+# ---------------------------------------------------------------------------
+
+
+def test_en_blind_spot_labels_name_fov_frame() -> None:
+    """EN labels for blind_spot_left/right must name the FOV reference frame."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    for step_key in ("options", "config"):
+        bs = en[step_key]["step"]["blind_spot"]["data"]
+        assert "FOV" in bs["blind_spot_left"], (
+            f"{step_key}.blind_spot.data.blind_spot_left label must mention 'FOV'"
+        )
+        assert "FOV" in bs["blind_spot_right"], (
+            f"{step_key}.blind_spot.data.blind_spot_right label must mention 'FOV'"
+        )
+
+
+def test_en_blind_spot_descriptions_do_not_mention_window_azimuth() -> None:
+    """Helper text must not contradict services.yaml by saying 'from window azimuth'."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    for step_key in ("options", "config"):
+        dd = en[step_key]["step"]["blind_spot"]["data_description"]
+        for key in ("blind_spot_left", "blind_spot_right"):
+            assert "window azimuth" not in dd[key].lower(), (
+                f"{step_key}.blind_spot.data_description.{key} still references "
+                f"'window azimuth' — Option 2 requires FOV-left-edge framing"
+            )


### PR DESCRIPTION
## Summary
Clarifies that `blind_spot_left` and `blind_spot_right` are measured inward from the FOV left boundary, not from window azimuth. Fixes a contradiction in `services.yaml` and updates UI labels across EN/DE/FR translations.

- Updated `services.yaml` to remove the "from window azimuth" wording that contradicted the config-flow descriptions
- Renamed labels to "Blind spot left/right edge (from FOV left)" in all three shipped languages
- Updated config summary to show "inward from FOV left" so users see the reference frame on the summary screen
- Added tests asserting the corrected wording in services.yaml, translations, and config summary

## Testing
- ✅ 2275 tests passing
- ✅ All translations validated (DE/FR 766/766 complete)

## Related Issues
Refs #211