### PR TITLE
fix: saturate horizontal awning extension at awn_length

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
@@ -42,8 +42,9 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
            length = gap × sin(sun_angle) / sin(awning_closure_angle)
 
         Returns:
-            Awning extension length in meters (may exceed awn_length if full
-            extension insufficient to block sun).
+            Awning extension length in meters, saturated at awn_length.
+            When the geometric solution exceeds full extension, the awning
+            is reported fully extended (100%) rather than overflowing.
 
         """
         awn_angle = 90 - self.awn_angle
@@ -73,9 +74,7 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
             vertical_position,
             length,
         )
-        return float(
-            np.clip(length, 0, self.awn_length * 2)
-        )  # Clip to 2× max as sanity bound
+        return float(np.clip(length, 0, self.awn_length))
 
     def calculate_percentage(self) -> float:
         """Convert awning extension to percentage for Home Assistant.

--- a/tests/test_adaptive_horizontal_cover.py
+++ b/tests/test_adaptive_horizontal_cover.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from tests.cover_helpers import build_horizontal_cover
+
 
 class TestAdaptiveHorizontalCover:
     """Test AdaptiveHorizontalCover calculations."""
@@ -40,7 +42,7 @@ class TestAdaptiveHorizontalCover:
     def test_calculate_percentage_standard(self, horizontal_cover_instance):
         """Test percentage conversion for awning."""
         percentage = horizontal_cover_instance.calculate_percentage()
-        assert 0 <= percentage <= 200  # Can exceed 100% in some cases
+        assert 0 <= percentage <= 100
 
     @pytest.mark.unit
     def test_calculate_percentage_with_different_awning_length(
@@ -50,7 +52,7 @@ class TestAdaptiveHorizontalCover:
         horizontal_cover_instance.awn_length = 3.0
         percentage = horizontal_cover_instance.calculate_percentage()
         # Longer awning means smaller percentage for same extension
-        assert 0 <= percentage <= 200
+        assert 0 <= percentage <= 100
 
     @pytest.mark.unit
     @pytest.mark.parametrize("angle", [0, 15, 30, 45])
@@ -59,3 +61,26 @@ class TestAdaptiveHorizontalCover:
         horizontal_cover_instance.awn_angle = angle
         result = horizontal_cover_instance.calculate_position()
         assert result >= 0
+
+    @pytest.mark.unit
+    def test_calculate_position_saturates_at_awn_length(
+        self, mock_sun_data, mock_logger
+    ):
+        """Regression (#209): extension must saturate at awn_length, never exceed it.
+
+        Low sun (15°) + tall window (3 m) + short awning (1 m) forces the raw
+        trig result to ~11.2 m.  Old code clipped at 2×awn_length (2.0 m → 200%);
+        new code clips at awn_length (1.0 m → 100%).
+        """
+        cover = build_horizontal_cover(
+            logger=mock_logger,
+            sol_azi=180.0,
+            sol_elev=15.0,
+            sun_data=mock_sun_data,
+            h_win=3.0,
+            distance=0.5,
+            awn_length=1.0,
+            awn_angle=0.0,
+        )
+        assert cover.calculate_position() == pytest.approx(1.0)
+        assert cover.calculate_percentage() == pytest.approx(100.0)

--- a/tests/test_solar_math_review.py
+++ b/tests/test_solar_math_review.py
@@ -463,7 +463,7 @@ class TestHorizontalDivisionByZeroGuard:
             awn_angle=45.0,
         )
         result = cover.calculate_position()
-        assert 0.0 <= result <= 6.0  # clipped to 2×awn_length
+        assert 0.0 <= result <= 3.0  # clipped to awn_length
 
     @pytest.mark.unit
     def test_percentage_always_bounded(self, mock_sun_data, mock_logger):


### PR DESCRIPTION
## Summary
Tightens the horizontal awning clamp from `2× awn_length` to `awn_length`, matching physical reality. An awning cannot extend past its installed length, so the sanity bound was too permissive. In practice the downstream pipeline already clips to 100%, so no user-visible behavior changes.

## Testing
- ✅ 2276 tests passing
- New regression test covers low-sun + short-awning saturation path

## Related Issues
Refs #209