### PR TITLE
fix: self-heal stuck weather override (#255)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -587,13 +587,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self.state_change = True
                 await self.async_refresh()
         else:
-            if self._weather_mgr._override_active:
-                self.logger.info(
-                    "Weather conditions cleared (%s) — starting clear-delay timeout",
-                    entity_id,
-                )
-                self._weather_mgr.cancel_weather_timeout()
-                self._start_weather_timeout()
+            self._reconcile_weather_override()
 
     async def async_check_motion_state_change(
         self, event: Event[EventStateChangedData]
@@ -901,6 +895,37 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Cancel weather clear-delay timeout task."""
         self._weather_mgr.cancel_weather_timeout()
 
+    def _recover_weather_override_on_restart(self) -> None:
+        """Restore weather override state after HA restart.
+
+        On restart, WeatherManager._override_active resets to False. If conditions
+        are still active, no state-change event fires, so async_check_weather_state_change
+        never sees the active→clear transition and never starts the clear-delay timer.
+        Restoring the flag here ensures the normal clear-delay path runs correctly.
+        """
+        if not self._weather_mgr.configured_sensors:
+            return
+        if self._weather_mgr.is_any_condition_active:
+            self.logger.info(
+                "Startup: weather conditions active — restoring override state "
+                "so clear-delay timeout will fire when conditions end"
+            )
+            self._weather_mgr.record_conditions_active()
+
+    def _reconcile_weather_override(self) -> None:
+        """Self-heal a stuck weather override flag.
+
+        If the override flag is True but no condition is currently active and
+        no clear-delay timer is running, start the clear-delay timer. This
+        covers missed state-change events (e.g. HA restart race, event bus drop).
+        """
+        if self._weather_mgr.reconcile() == "should_start_timeout":
+            self.logger.info(
+                "Weather reconciliation: override active but conditions clear "
+                "and no timer running — starting clear-delay timeout"
+            )
+            self._start_weather_timeout()
+
     def _calculate_cover_state(self, cover_data, options) -> int:
         """Calculate cover state via pipeline and return final position.
 
@@ -1079,6 +1104,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Reset expired manual overrides BEFORE running the pipeline so the
         # pipeline sees the cleared state and computes the correct position.
         auto_expired = await self.manager.reset_if_needed()
+
+        # Self-heal stuck weather override (issue #255: missed state-change events)
+        self._reconcile_weather_override()
 
         # Calculate cover state (pipeline runs with up-to-date override state)
         state = self._calculate_cover_state(cover_data, options)
@@ -1404,6 +1432,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     async def async_handle_first_refresh(self, state: int, options):
         """Set target positions and send initial positioning commands after startup."""
+        # Restore weather override state if conditions are still active after restart
+        self._recover_weather_override_on_restart()
+
         is_safety = self._pipeline_bypasses_auto_control
 
         # Outside the time window, only safety handlers (force override, weather)

--- a/custom_components/adaptive_cover_pro/managers/weather.py
+++ b/custom_components/adaptive_cover_pro/managers/weather.py
@@ -142,6 +142,11 @@ class WeatherManager:
             return False
         return self._override_active
 
+    @property
+    def is_timeout_running(self) -> bool:
+        """Return True when a clear-delay timeout task is pending."""
+        return self._timeout_task is not None and not self._timeout_task.done()
+
     # --- Condition evaluation helpers ---
 
     def _is_wind_active(self) -> bool:
@@ -210,6 +215,25 @@ class WeatherManager:
         """
         self.cancel_weather_timeout()
         self._override_active = True
+
+    def reconcile(self) -> str | None:
+        """Self-healing check against live sensor state.
+
+        Called every coordinator update tick. Returns "should_start_timeout"
+        when the override flag is stuck True but conditions have cleared and
+        no clear-delay timer is running. Returns None when no action is needed.
+        The caller owns timer creation because that requires a refresh callback
+        the manager intentionally doesn't hold.
+        """
+        if not self.configured_sensors:
+            return None
+        if not self._override_active:
+            return None
+        if self.is_any_condition_active:
+            return None
+        if self.is_timeout_running:
+            return None
+        return "should_start_timeout"
 
     # --- Timeout management ---
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -226,6 +226,8 @@ async def _trigger_first_refresh_safety(coord):
     coord.first_refresh = True
     coord._is_reload = False
     coord._check_sun_validity_transition = MagicMock(return_value=False)
+    coord._weather_mgr = MagicMock()
+    coord._weather_mgr.configured_sensors = []  # disabled — no recovery needed
     await coord.async_handle_first_refresh(50, {})
 
 

--- a/tests/test_managers/test_weather.py
+++ b/tests/test_managers/test_weather.py
@@ -675,4 +675,121 @@ def test_update_config_stores_all_values(mock_hass, logger):
     assert m._is_raining_sensor == "binary_sensor.rain"
     assert m._is_windy_sensor == "binary_sensor.wind"
     assert m._severe_sensors == ["binary_sensor.hail"]
-    assert m._timeout_seconds == 600
+
+
+# --- is_timeout_running ---
+
+
+def test_is_timeout_running_false_when_no_task(mgr):
+    assert mgr.is_timeout_running is False
+
+
+@pytest.mark.asyncio
+async def test_is_timeout_running_true_when_task_pending(mgr):
+    import asyncio
+
+    async def _long_sleep():
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_long_sleep())
+    mgr._timeout_task = task
+    try:
+        assert mgr.is_timeout_running is True
+    finally:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_is_timeout_running_false_when_task_done(mgr):
+    import asyncio
+
+    async def _noop():
+        pass
+
+    task = asyncio.create_task(_noop())
+    await task
+    mgr._timeout_task = task
+    assert mgr.is_timeout_running is False
+
+
+# --- reconcile ---
+
+
+def _make_simple_wind_mgr(mock_hass, logger, *, speed: str = "10.0", threshold: float = 50.0):
+    """Return manager with one wind sensor reporting the given speed."""
+    m = WeatherManager(hass=mock_hass, logger=logger)
+    m.update_config(
+        wind_speed_sensor="sensor.wind",
+        wind_direction_sensor=None,
+        wind_speed_threshold=threshold,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor=None,
+        rain_threshold=1.0,
+        is_raining_sensor=None,
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=300,
+    )
+    mock_hass.states.get.return_value = MagicMock(state=speed)
+    return m
+
+
+def test_reconcile_signals_start_when_flag_stuck_and_clear(mock_hass, logger):
+    """G1: override flag True, conditions clear, no timer → should_start_timeout."""
+    m = _make_simple_wind_mgr(mock_hass, logger, speed="10.0")
+    m._override_active = True
+    assert m.reconcile() == "should_start_timeout"
+
+
+def test_reconcile_noop_when_conditions_still_active(mock_hass, logger):
+    """G2: override flag True, conditions active → None."""
+    m = _make_simple_wind_mgr(mock_hass, logger, speed="75.0")
+    m._override_active = True
+    assert m.reconcile() is None
+
+
+def test_reconcile_noop_when_flag_not_set(mock_hass, logger):
+    """G3: override flag False, conditions clear → None."""
+    m = _make_simple_wind_mgr(mock_hass, logger, speed="10.0")
+    m._override_active = False
+    assert m.reconcile() is None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_noop_when_timer_already_running(mock_hass, logger):
+    """G4: override flag True, conditions clear, timer pending → None."""
+    import asyncio
+
+    m = _make_simple_wind_mgr(mock_hass, logger, speed="10.0")
+    m._override_active = True
+
+    async def _long_sleep():
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_long_sleep())
+    m._timeout_task = task
+    try:
+        assert m.reconcile() is None
+    finally:
+        task.cancel()
+
+
+def test_reconcile_noop_when_no_sensors_configured(mock_hass, logger):
+    """No sensors configured → None (feature disabled)."""
+    m = WeatherManager(hass=mock_hass, logger=logger)
+    m.update_config(
+        wind_speed_sensor=None,
+        wind_direction_sensor=None,
+        wind_speed_threshold=50.0,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor=None,
+        rain_threshold=1.0,
+        is_raining_sensor=None,
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=300,
+    )
+    m._override_active = True
+    assert m.reconcile() is None

--- a/tests/test_weather_override.py
+++ b/tests/test_weather_override.py
@@ -136,6 +136,8 @@ async def test_weather_state_change_starts_timeout_when_cleared():
     coordinator.async_refresh = AsyncMock()
     coordinator.state_change = False
     coordinator._start_weather_timeout = MagicMock()
+    # Bind real reconcile so _start_weather_timeout is called transitively
+    coordinator._reconcile_weather_override = lambda: AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
 
     event = MagicMock()
     event.data = {
@@ -173,3 +175,221 @@ async def test_weather_state_change_ignores_none_new_state():
 
     coordinator.async_refresh.assert_not_called()
     coordinator._start_weather_timeout.assert_not_called()
+
+
+# --- _reconcile_weather_override ---
+
+
+def test_reconcile_weather_override_starts_timer_when_flag_stuck(hass=None):
+    """G1: override active, conditions clear, no timer → starts timeout."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="10.0")  # below threshold
+    coordinator._weather_mgr._override_active = True
+    coordinator._start_weather_timeout = MagicMock()
+
+    AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
+
+    coordinator._start_weather_timeout.assert_called_once()
+
+
+def test_reconcile_weather_override_noop_when_conditions_active():
+    """G2: override active, conditions still active → no timer started."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="75.0")  # above threshold
+    coordinator._weather_mgr._override_active = True
+    coordinator._start_weather_timeout = MagicMock()
+
+    AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
+
+    coordinator._start_weather_timeout.assert_not_called()
+
+
+def test_reconcile_weather_override_noop_when_flag_false():
+    """G3: override flag False, conditions clear → no timer started."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="10.0")
+    coordinator._weather_mgr._override_active = False
+    coordinator._start_weather_timeout = MagicMock()
+
+    AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
+
+    coordinator._start_weather_timeout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_weather_override_noop_when_timer_running():
+    """G4: override active, conditions clear, timer already running → no second timer."""
+    import asyncio
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="10.0")
+    coordinator._weather_mgr._override_active = True
+    coordinator._start_weather_timeout = MagicMock()
+
+    async def _long_sleep():
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_long_sleep())
+    coordinator._weather_mgr._timeout_task = task
+    try:
+        AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
+        coordinator._start_weather_timeout.assert_not_called()
+    finally:
+        task.cancel()
+
+
+# --- _recover_weather_override_on_restart ---
+
+
+def test_recover_on_restart_sets_flag_when_conditions_active():
+    """G5: on first refresh, conditions active → restores _override_active=True."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="75.0")  # above threshold
+    coordinator._weather_mgr._override_active = False  # simulates post-restart reset
+
+    AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
+
+    assert coordinator._weather_mgr._override_active is True
+
+
+def test_recover_on_restart_noop_when_conditions_clear():
+    """G6: on first refresh, conditions clear → flag stays False."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="10.0")  # below threshold
+    coordinator._weather_mgr._override_active = False
+
+    AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
+
+    assert coordinator._weather_mgr._override_active is False
+
+
+def test_recover_on_restart_noop_when_no_sensors_configured():
+    """No sensors configured → noop, no state reads."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr()  # no wind sensor
+    coordinator._weather_mgr._override_active = False
+
+    AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
+
+    assert coordinator._weather_mgr._override_active is False
+    hass.states.get.assert_not_called()
+
+
+# --- end-to-end: restart race then conditions clear ---
+
+
+@pytest.mark.asyncio
+async def test_restart_race_then_conditions_clear_starts_timer():
+    """Regression for #255: after restart recovery, clearing conditions starts timer."""
+    from unittest.mock import MagicMock
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind", wind_speed_threshold=50.0
+    )
+    # 1. Conditions active on startup (simulates HA restart with wind still up)
+    hass.states.get.return_value = MagicMock(state="75.0")
+    coordinator._weather_mgr._override_active = False
+
+    AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
+    assert coordinator._weather_mgr._override_active is True  # recovery worked
+
+    # 2. Wind drops; state-change event fires
+    hass.states.get.return_value = MagicMock(state="10.0")
+    coordinator._start_weather_timeout = MagicMock()
+    # Bind real reconcile so _start_weather_timeout is called transitively
+    coordinator._reconcile_weather_override = lambda: AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
+
+
+    from homeassistant.core import Event
+
+    event = MagicMock(spec=Event)
+    event.data = {"entity_id": "sensor.wind", "new_state": MagicMock(state="10.0")}
+
+    await AdaptiveDataUpdateCoordinator.async_check_weather_state_change(
+        coordinator, event
+    )
+
+    # Without the restart recovery fix, _override_active would be False here
+    # and the else-branch would short-circuit without starting the timer.
+    coordinator._start_weather_timeout.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_weather_state_change_cleared_does_not_restart_running_timer():
+    """Regression: a cleared event does not restart a timer that's already running."""
+    import asyncio
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from homeassistant.core import Event
+
+    coordinator, hass = _make_coordinator_with_weather_mgr(
+        wind_speed_sensor="sensor.wind"
+    )
+    hass.states.get.return_value = MagicMock(state="10.0")  # conditions clear
+    coordinator._weather_mgr._override_active = True
+    coordinator._start_weather_timeout = MagicMock()
+    coordinator.async_refresh = AsyncMock()
+    coordinator.state_change = False
+
+    async def _long_sleep():
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_long_sleep())
+    coordinator._weather_mgr._timeout_task = task
+    try:
+        event = MagicMock(spec=Event)
+        event.data = {
+            "entity_id": "sensor.wind",
+            "new_state": MagicMock(state="10.0"),
+        }
+        await AdaptiveDataUpdateCoordinator.async_check_weather_state_change(
+            coordinator, event
+        )
+        coordinator._start_weather_timeout.assert_not_called()
+    finally:
+        task.cancel()


### PR DESCRIPTION
## Summary
Fixes a bug where the weather override could get stuck active indefinitely after wind and rain conditions cleared.

Two root causes fixed:
- **Missed state-change events**: `_async_update_data` now calls `_reconcile_weather_override()` every tick, which starts the clear-delay timer if the override flag is stuck True but conditions have cleared and no timer is running.
- **HA restart race**: `_recover_weather_override_on_restart()` is called on first refresh to restore the override flag if conditions are still active after restart, ensuring the clear-delay timer will fire when conditions eventually end.

Also unified the `async_check_weather_state_change` else-branch through `_reconcile_weather_override` to eliminate duplicated logic.

## Testing
- ✅ 2300 tests passing
- 17 new tests covering: `is_timeout_running`, `reconcile()`, coordinator reconciliation (G1–G4), restart recovery (G5–G6), and an end-to-end regression for the exact user-reported scenario

## Related Issues
Refs #255