### PR TITLE
feat: translate services section into DE and FR

### DIFF
--- a/.claude/skills/acp-translate/SKILL.md
+++ b/.claude/skills/acp-translate/SKILL.md
@@ -5,7 +5,7 @@ description: Sync DE/FR translations with en.json, add a new language, drop a la
 
 # ACP Translate
 
-Maintains the `custom_components/adaptive_cover_pro/translations/` directory. `en.json` is the single source of truth; every other language file must match its structure exactly, **except** the `services` section which is intentionally English-only (HA falls back to English for locales missing that section).
+Maintains the `custom_components/adaptive_cover_pro/translations/` directory. `en.json` is the single source of truth; every other language file must match its structure exactly, including the `services` section.
 
 Officially shipped languages: **en, de, fr**. Any new language is added only on explicit maintainer request via this skill.
 
@@ -50,7 +50,7 @@ Use when `translations/en.json` has changed and DE/FR need to catch up.
 
 ### Steps
 
-1. **Diff.** Load all three translation files via Bash+Python (see **Reading Translation Files** — do NOT use the Read tool). Flatten each to dot-path keys (skip any `services.*` paths in all three). For each non-en file compute:
+1. **Diff.** Load all three translation files via Bash+Python (see **Reading Translation Files** — do NOT use the Read tool). Flatten each to dot-path keys. For each non-en file compute:
    - `added`: keys in en but not in target
    - `removed`: keys in target but not in en
    - `changed`: keys where the en value text changed since the target was last generated. Detect by heuristic: if `target[k]` looks like an obvious placeholder (equals `en[k]` verbatim, or is a short English phrase when the rest of the file is clearly in the target language), treat it as changed. When unsure, retranslate — cost of a re-translation is negligible.
@@ -92,10 +92,10 @@ Use to rebuild DE/FR from scratch **or** to add a brand-new language.
    - The domain-term glossary (see below) — customized per language
 
    The subagent's job:
-   - Load the full en.json tree excluding `services.*` via Bash+Python (see **Reading Translation Files**).
+   - Load the full en.json tree via Bash+Python (see **Reading Translation Files**).
    - **Pass 1 — Haiku bulk:** Run the Haiku translation prompt on all keys. Capture output as a JSON object.
    - **Pass 2 — Sonnet review (data_descriptions only):** Filter the Haiku output to include ONLY keys containing `.data_description.` — do not send any other keys to Sonnet. Run the Sonnet review prompt on this filtered subset. Merge corrected values back into the Haiku output.
-   - Write `translations/<lang>.json` via Bash+Python: same nested structure as en.json (minus `services`), 2-space indent, `ensure_ascii=False`, trailing newline.
+   - Write `translations/<lang>.json` via Bash+Python: same nested structure as en.json, 2-space indent, `ensure_ascii=False`, trailing newline.
    - Return a summary: key count written, how many data_description keys were reviewed by Sonnet, placeholder warnings, cost estimate.
 
 4. **Update tooling.** After subagents return:
@@ -153,7 +153,6 @@ python3 -c "
 import json
 with open('/path/to/en.json') as f:
     d = json.load(f)
-d.pop('services', None)
 print(json.dumps(d, ensure_ascii=False))
 "
 ```
@@ -307,7 +306,7 @@ Non-EN translation files must:
 - Be valid JSON, 2-space indent.
 - Use `ensure_ascii=False` (keep accented characters as-is, not `\uXXXX`).
 - End with exactly one trailing newline.
-- Preserve en.json's nested structure for every top-level section **except** `services`, which is omitted entirely.
+- Preserve en.json's nested structure for every top-level section, including `services`.
 - Contain no `mdi:` icon references, no zero-width characters, no empty string values.
 
 ---
@@ -315,7 +314,6 @@ Non-EN translation files must:
 ## Safety Rules
 
 - **Never delete `en.json`.**
-- **Never translate the `services` section into any non-EN file.**
 - **Never write a translation file without running the validator and tests afterwards.**
 - **Never silently drop keys from a target file.** If a key was removed from en.json, the Sync operation must list it under "removed" in the report.
 - **If Haiku output fails JSON parse**, retry once; if still failing, dispatch Sonnet for that batch as a fallback. Do not return partial results.

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1078,5 +1078,487 @@
         "weather_override": "Wetter-Übersteuerung"
       }
     }
+  },
+  "services": {
+    "emergency_stop": {
+      "description": "Panik-Button — sendet stop_cover an alle konfigurierten Beschattungen auf den Zielinstanzen (Fähigkeitsprüfung), dann deaktiviert die Integration. Ohne Ziel wirkt auf alle ACP-Instanzen.",
+      "name": "Notfallstopp"
+    },
+    "export_config": {
+      "description": "Gibt die Beschattungskonfiguration als JSON zur Verwendung im Simulationsnotebook zurück.",
+      "fields": {
+        "config_entry_id": {
+          "description": "Der Adaptive Cover Pro Konfigurationseintrag zum Exportieren.",
+          "name": "Beschattungskonfiguration"
+        }
+      },
+      "name": "Konfiguration exportieren"
+    },
+    "integration_disable": {
+      "description": "Deaktiviert Adaptive Cover Pro auf den Zielinstanzen. Laufende Beschattungsbewegungen werden sofort gestoppt, aufgeschobene Timer abgebrochen und Abgleichstatus gelöscht.",
+      "name": "Integration deaktivieren"
+    },
+    "integration_enable": {
+      "description": "Reaktiviert Adaptive Cover Pro auf den Zielinstanzen. Beschattungen bleiben wo sie sind; die Positionierung setzt sich beim nächsten natürlichen Update-Zyklus fort.",
+      "name": "Integration aktivieren"
+    },
+    "set_automation_timing": {
+      "description": "Aktualisiert Positions- und Zeitschwellen, Zeitfenster Start/Ende und return_sunset.",
+      "fields": {
+        "delta_position": {
+          "description": "Minimale Positionsänderung (%) vor dem Versenden eines Beschattungsbefehls (1–90).",
+          "name": "Positionsänderungsschwelle"
+        },
+        "delta_time": {
+          "description": "Minimale Zeit (Minuten) zwischen Beschattungsbefehlen (2–60).",
+          "name": "Zeitschwelle"
+        },
+        "end_entity": {
+          "description": "Entity, deren Status die Endzeit bereitstellt. Schließt sich gegenseitig mit end_time aus.",
+          "name": "End-Entity"
+        },
+        "end_time": {
+          "description": "Feste Zeit zum Beenden des Tracking-Fensters (HH:MM:SS). Schließt sich gegenseitig mit end_entity aus.",
+          "name": "Endzeit"
+        },
+        "return_sunset": {
+          "description": "Wenn wahr, Sunset-Position beim Fenster-Ende erzwingen.",
+          "name": "Rückkehr zur Sonnenuntergangsposition am Ende"
+        },
+        "start_entity": {
+          "description": "Entity, deren Status die Startzeit bereitstellt. Schließt sich gegenseitig mit start_time aus.",
+          "name": "Start-Entity"
+        },
+        "start_time": {
+          "description": "Feste Zeit zum Starten des Tracking-Fensters (HH:MM:SS). Schließt sich gegenseitig mit start_entity aus.",
+          "name": "Startzeit"
+        }
+      },
+      "name": "Automatisierungs-Timing einstellen"
+    },
+    "set_blind_spot": {
+      "description": "Aktualisiert Blendungszonenwinkelbereiche. blind_spot_right muss größer als blind_spot_left sein.",
+      "fields": {
+        "blind_spot": {
+          "description": "Wenn wahr, ist die Blendungszone aktiv.",
+          "name": "Blendungszone aktivieren"
+        },
+        "blind_spot_elevation": {
+          "description": "Maximale Sonnenhöhe (°) für die Blendungszone. Null = immer aktiv.",
+          "name": "Höhenlimit"
+        },
+        "blind_spot_left": {
+          "description": "Linke Kante der Blendungszone in Grad nach innen von der linken FOV-Grenze (0 = an der FOV-Kante, Bereich 0–359°).",
+          "name": "Linke Kante (von FOV-Links)"
+        },
+        "blind_spot_right": {
+          "description": "Rechte Kante der Blendungszone in Grad nach innen von der linken FOV-Grenze. Muss größer als linke Kante sein (Bereich 1–360°).",
+          "name": "Rechte Kante (von FOV-Links)"
+        }
+      },
+      "name": "Blendungszone einstellen"
+    },
+    "set_climate": {
+      "description": "Aktualisiert Klimamodus und Temperatur-/Anwesenheitsoptionen. Erzwingt temp_low < temp_high.",
+      "fields": {
+        "climate_mode": {
+          "description": "Hauptschalter für temperaturgesteuerte Positionierung.",
+          "name": "Klimamodus aktivieren"
+        },
+        "outside_temp": {
+          "description": "Sensor-Entity für Außentemperatur. Null = kein.",
+          "name": "Außentemperatur-Entity"
+        },
+        "outside_threshold": {
+          "description": "Außentemperatur (°), über der Sommerstrategie erzwungen wird (0–100).",
+          "name": "Außentemperatur-Schwellwert"
+        },
+        "presence_entity": {
+          "description": "Entity, die Anwesenheit anzeigt. Null = kein.",
+          "name": "Anwesenheits-Entity"
+        },
+        "temp_entity": {
+          "description": "Klima- oder Sensor-Entity für Innentemperatur. Null = kein.",
+          "name": "Innentemperatur-Entity"
+        },
+        "temp_high": {
+          "description": "Oberhalb dieser Temperatur (°) wird die Sommerstrategie angewendet (0–90).",
+          "name": "Schwellwert hohe Temperatur"
+        },
+        "temp_low": {
+          "description": "Unterhalb dieser Temperatur (°) wird die Winterstrategie angewendet (0–90).",
+          "name": "Schwellwert niedrige Temperatur"
+        },
+        "transparent_blind": {
+          "description": "Wenn wahr, wird die Jalousie für Klimaberechnungen als halbtransparent behandelt.",
+          "name": "Transparente Jalousie"
+        },
+        "winter_close_insulation": {
+          "description": "Wenn wahr, wird die Beschattung an kalten Tagen vollständig geschlossen, um die Wärmeisolation zu verbessern.",
+          "name": "Für Winterisolation schließen"
+        }
+      },
+      "name": "Klimaeinstellungen festlegen"
+    },
+    "set_custom_position": {
+      "description": "Aktualisiert einen Custom-Position-Slot (1–4). Null für Sensor und Position zum Löschen des Slots.",
+      "fields": {
+        "min_mode": {
+          "description": "Wenn wahr, wird die Position als minimale Untergrenze behandelt.",
+          "name": "Minimum-Position-Modus"
+        },
+        "position": {
+          "description": "Zielposition (0–100%) wenn der Sensor aktiv ist. Null = Slot löschen.",
+          "name": "Position"
+        },
+        "priority": {
+          "description": "Pipeline-Priorität (1–99, Standard 77).",
+          "name": "Priorität"
+        },
+        "sensor": {
+          "description": "Binärsensor, der diese Custom-Position aktiviert. Null = Slot löschen.",
+          "name": "Auslöse-Sensor"
+        },
+        "slot": {
+          "description": "Welcher Custom-Position-Slot aktualisiert wird (1–4).",
+          "name": "Slot"
+        },
+        "use_my": {
+          "description": "Wenn wahr, wird my_position_value statt Position verwendet.",
+          "name": "Somfy My verwenden"
+        }
+      },
+      "name": "Custom-Position-Slot einstellen"
+    },
+    "set_force_override": {
+      "description": "Aktualisiert Zwangsübersteuerungs-Sensoren, Position und Minimum-Modus.",
+      "fields": {
+        "force_override_min_mode": {
+          "description": "Wenn wahr, wird force_override_position als minimale Untergrenze behandelt.",
+          "name": "Minimum-Position-Modus"
+        },
+        "force_override_position": {
+          "description": "Position zum Bewegen wenn ein Zwangsübersteuerungs-Sensor aktiv ist (0–100%).",
+          "name": "Zwangsübersteuerungs-Position"
+        },
+        "force_override_sensors": {
+          "description": "Binärsensoren, die die Zwangsübersteuerung auslösen. Leere Liste = deaktivieren.",
+          "name": "Zwangsübersteuerungs-Sensoren"
+        }
+      },
+      "name": "Zwangsübersteuerung einstellen"
+    },
+    "set_geometry": {
+      "description": "Aktualisiert Beschattungsgeometrie-Abmessungen. Geben Sie nur anwendbare Felder für Ihren Beschattungstyp an.",
+      "fields": {
+        "angle": {
+          "description": "Markisen-Neigungswinkel in Grad (0–45°). Nur Markise.",
+          "name": "Markisen-Winkel"
+        },
+        "length_awning": {
+          "description": "Markisen-Ausfahrlänge in Metern (0,3–6 m). Nur Markise.",
+          "name": "Markisenlänge"
+        },
+        "sill_height": {
+          "description": "Fensterbrett-Höhe vom Boden in Metern (0–3 m). Nur Vertikaljalousie.",
+          "name": "Fensterbrett-Höhe"
+        },
+        "slat_depth": {
+          "description": "Tiefe der Venezianischer-Lamellen in Zentimetern (0,1–15 cm). Nur Neigung.",
+          "name": "Lamellen-Tiefe"
+        },
+        "slat_distance": {
+          "description": "Abstand zwischen Lamellen in Zentimetern (0,1–15 cm). Nur Neigung.",
+          "name": "Lamellen-Abstand"
+        },
+        "tilt_mode": {
+          "description": "Berechnungsmodus für Neigungswinkel (mode1 oder mode2). Nur Neigung.",
+          "name": "Neigungs-Modus"
+        },
+        "window_depth": {
+          "description": "Fensterrahmen-Tiefe in Metern (0–0,5 m). Nur Vertikaljalousie.",
+          "name": "Fenstertiefe"
+        },
+        "window_height": {
+          "description": "Fensterhöhe in Metern (0,1–6 m). Nur Vertikaljalousie und Markise.",
+          "name": "Fensterhöhe"
+        },
+        "window_width": {
+          "description": "Fensterbreite in Metern (0,1–5 m). Nur Vertikaljalousie.",
+          "name": "Fensterbreite"
+        }
+      },
+      "name": "Geometrie einstellen"
+    },
+    "set_interpolation": {
+      "description": "Aktiviert Positions-Interpolation und konfiguriert Start-/Endbereich und Nachschlagetabelle.",
+      "fields": {
+        "interp": {
+          "description": "Wenn wahr, wird Interpolationszuordnung auf die berechnete Position angewendet.",
+          "name": "Interpolation aktivieren"
+        },
+        "interp_end": {
+          "description": "Berechnete Position (%) bei der die Interpolation endet. Null = kein.",
+          "name": "Interpolation-Ende"
+        },
+        "interp_list": {
+          "description": "Eingabepositionen für die Interpolations-Nachschlagetabelle.",
+          "name": "Eingabeliste"
+        },
+        "interp_list_new": {
+          "description": "Ausgabepositionen zugeordnet von interp_list.",
+          "name": "Ausgabeliste"
+        },
+        "interp_start": {
+          "description": "Berechnete Position (%) bei der die Interpolation beginnt. Null = kein.",
+          "name": "Interpolation-Start"
+        }
+      },
+      "name": "Interpolation einstellen"
+    },
+    "set_light_cloud": {
+      "description": "Aktualisiert Wetter-Entity, Sonnig-Status-Filter, Lux-/Bestrahlungs-/Bewölkungs-Schwellwerte und Bewölkungs-Suppression.",
+      "fields": {
+        "cloud_coverage_entity": {
+          "description": "Sensor meldet Bewölkungsprozentsatz. Null = kein.",
+          "name": "Bewölkungssensor"
+        },
+        "cloud_coverage_threshold": {
+          "description": "Bewölkungsprozentsatz über dem der Himmel als bedeckt gilt.",
+          "name": "Bewölkungs-Schwellwert"
+        },
+        "cloud_suppression": {
+          "description": "Sonnenpositionierung unterdrücken wenn Bewölkung Schwellwert überschreitet.",
+          "name": "Bewölkungs-Suppression aktivieren"
+        },
+        "irradiance_entity": {
+          "description": "Solar-Bestrahlungssensor-Entity. Null = kein.",
+          "name": "Bestrahlungssensor"
+        },
+        "irradiance_threshold": {
+          "description": "W/m² oberhalb dessen die Beschattung in direktem Sonnenlicht ist.",
+          "name": "Bestrahlung-Schwellwert"
+        },
+        "lux_entity": {
+          "description": "Lichtsensor-Entity. Null = kein.",
+          "name": "Lux-Sensor"
+        },
+        "lux_threshold": {
+          "description": "Lux-Wert oberhalb dessen die Beschattung in direktem Sonnenlicht ist.",
+          "name": "Lux-Schwellwert"
+        },
+        "weather_entity": {
+          "description": "Wetter-Entity für Bedingungslesestoff. Null = kein.",
+          "name": "Wetter-Entity"
+        },
+        "weather_state": {
+          "description": "Wetterbedingungszustände als sonnig für Sonnenverfolgung betrachtet.",
+          "name": "Sonnige Wetterzustände"
+        }
+      },
+      "name": "Licht- & Bewölkungseinstellungen festlegen"
+    },
+    "set_manual_override": {
+      "description": "Aktualisiert Dauer der manuellen Übersteuerung, Rücksetzverhalten und Erkennungsschwelle.",
+      "fields": {
+        "manual_ignore_intermediate": {
+          "description": "Wenn wahr, werden Öffnungs-/Schließungszustände für Erkennung ignoriert.",
+          "name": "Zwischenzustände ignorieren"
+        },
+        "manual_override_duration": {
+          "description": "Wie lange eine manuelle Übersteuerung andauert vor Wiederaufnahme der automatischen Kontrolle.",
+          "name": "Übersteuerungs-Dauer"
+        },
+        "manual_override_reset": {
+          "description": "Wenn wahr, wird jede aktive manuelle Übersteuerung beim Fenster-Start gelöscht.",
+          "name": "Rücksetzung bei Fenster-Start"
+        },
+        "manual_threshold": {
+          "description": "Positionsänderung (%) die manuelle Übersteuerung auslöst (0–99).",
+          "name": "Erkennungsschwelle"
+        }
+      },
+      "name": "Einstellungen für manuelle Übersteuerung festlegen"
+    },
+    "set_motion": {
+      "description": "Aktualisiert Bewegungssensoren und Keine-Bewegungs-Timeout.",
+      "fields": {
+        "motion_sensors": {
+          "description": "Binärsensoren zeigen Anwesenheit an. Leere Liste = Bewegungssteuerung deaktivieren.",
+          "name": "Bewegungssensoren"
+        },
+        "motion_timeout": {
+          "description": "Sekunden zu warten nach letzter Bewegung vor Anwendung der Keine-Bewegungs-Position (30–3600).",
+          "name": "Keine-Bewegungs-Timeout"
+        }
+      },
+      "name": "Bewegungseinstellungen festlegen"
+    },
+    "set_option": {
+      "description": "Generischer Ausweg — aktualisiert jede unterstützte Option nach Schlüsselnamen. Identitätsschlüssel werden abgelehnt.",
+      "fields": {
+        "option": {
+          "description": "Der interne Optionsschlüssel zum Aktualisieren (z. B. 'default_percentage', 'sunset_position').",
+          "name": "Optionsschlüssel"
+        },
+        "value": {
+          "description": "Neuer Wert für die Option. Null zum Löschen eines optionalen Feldes.",
+          "name": "Wert"
+        }
+      },
+      "name": "Option einstellen (allgemein)"
+    },
+    "set_position_limits": {
+      "description": "Aktualisiert Standardhöhe, Min/Max-Position, Öffnungs-/Schließungsschwelle und inversen Status.",
+      "fields": {
+        "default_height": {
+          "description": "Standardposition der Beschattung wenn Sonne nicht sichtbar ist (0–100%).",
+          "name": "Standardhöhe"
+        },
+        "enable_max_position": {
+          "description": "Wenn wahr, wird max_position nur während Sonnenverfolgung angewendet.",
+          "name": "Maximum-Position nur während Verfolgung aktivieren"
+        },
+        "enable_min_position": {
+          "description": "Wenn wahr, wird min_position nur während Sonnenverfolgung angewendet.",
+          "name": "Minimum-Position nur während Verfolgung aktivieren"
+        },
+        "inverse_state": {
+          "description": "Position für Beschattungen invertieren, die Status invers melden.",
+          "name": "Inverser Status"
+        },
+        "max_position": {
+          "description": "Maximale Position, zu der sich die Beschattung bewegen kann (1–100%).",
+          "name": "Maximale Position"
+        },
+        "min_position": {
+          "description": "Minimale Position, zu der sich die Beschattung bewegen kann (0–99%).",
+          "name": "Minimale Position"
+        },
+        "open_close_threshold": {
+          "description": "Position unterhalb derer Öffnungs-/Schließungs-Beschattungen geschlossen sind (1–99%).",
+          "name": "Öffnungs-/Schließungs-Schwellwert"
+        }
+      },
+      "name": "Positionslimits einstellen"
+    },
+    "set_sun_tracking": {
+      "description": "Aktualisiert Azimut, Sichtfeld, Höhenlimits und Sonnenverfolgungsschalter.",
+      "fields": {
+        "distance_shaded_area": {
+          "description": "Entfernung (m) von Fenster zu Schattenbereichskante (0,1–5 m).",
+          "name": "Entfernung zum Schattenbereich"
+        },
+        "enable_sun_tracking": {
+          "description": "Hauptschalter für sonnenpositions-basierte Beschattungssteuerung.",
+          "name": "Sonnenverfolgung aktivieren"
+        },
+        "fov_left": {
+          "description": "Grad links vom Azimut innerhalb derer die Sonne diese Beschattung beeinflußt (0–180°).",
+          "name": "Sichtfeld links"
+        },
+        "fov_right": {
+          "description": "Grad rechts vom Azimut innerhalb derer die Sonne diese Beschattung beeinflußt (0–180°).",
+          "name": "Sichtfeld rechts"
+        },
+        "max_elevation": {
+          "description": "Sonnenhöhe (°) oberhalb derer die Beschattung vollständig geöffnet wird. Null = kein Maximum.",
+          "name": "Maximale Sonnenhöhe"
+        },
+        "min_elevation": {
+          "description": "Sonnenhöhe (°) unterhalb derer die Beschattung nicht bewegt wird. Null = kein Minimum.",
+          "name": "Minimale Sonnenhöhe"
+        },
+        "set_azimuth": {
+          "description": "Kompassrichtung dem Fenster zugewandt (0–359°).",
+          "name": "Fenster-Azimut"
+        }
+      },
+      "name": "Sonnenverfolgungseinstellungen einstellen"
+    },
+    "set_sunset_sunrise": {
+      "description": "Aktualisiert Sonnenuntergangsposition und Offset-Einstellungen. Null zum Löschen eines optionalen Feldes.",
+      "fields": {
+        "my_position_value": {
+          "description": "Die 'Mein'-Preset-Position (1–99%).",
+          "name": "Somfy Mein Position"
+        },
+        "sunrise_offset": {
+          "description": "Minuten zum Verschieben von Fenster-Start relativ zu Sonnenaufgang (-120–120).",
+          "name": "Sonnenaufgangs-Offset"
+        },
+        "sunset_offset": {
+          "description": "Minuten zum Verschieben von Fenster-Ende relativ zu Sonnenuntergang (-120–120).",
+          "name": "Sonnenuntergangs-Offset"
+        },
+        "sunset_position": {
+          "description": "Position zum Bewegen beim Fenster-Ende. Null = default_height verwenden.",
+          "name": "Sonnenuntergangsposition"
+        },
+        "sunset_use_my": {
+          "description": "Wenn wahr, wird my_position_value statt sunset_position am Fenster-Ende verwendet.",
+          "name": "Somfy Mein beim Sonnenuntergang verwenden"
+        }
+      },
+      "name": "Sonnenuntergangs-/Sonnenaufgangspositionen einstellen"
+    },
+    "set_weather_safety": {
+      "description": "Aktualisiert Wind-, Regen- und Extremwetter-Übersteuerungs-Einstellungen.",
+      "fields": {
+        "weather_bypass_auto_control": {
+          "description": "Wenn wahr, ignoriert Wetter-Übersteuerung den Schalter Automatische Kontrolle.",
+          "name": "Automatische Kontrolle umgehen"
+        },
+        "weather_is_raining_sensor": {
+          "description": "Binärsensor zeigt aktiven Regen an. Null = kein.",
+          "name": "Es regnet Sensor"
+        },
+        "weather_is_windy_sensor": {
+          "description": "Binärsensor zeigt gefährlichen Wind an. Null = kein.",
+          "name": "Es ist windig Sensor"
+        },
+        "weather_override_min_mode": {
+          "description": "Wenn wahr, wird weather_override_position als minimale Untergrenze behandelt.",
+          "name": "Minimum-Position-Modus"
+        },
+        "weather_override_position": {
+          "description": "Position zum Bewegen wenn Wetter-Übersteuerung ausgelöst wird (0–100%).",
+          "name": "Wetter-Übersteuerungs-Position"
+        },
+        "weather_rain_sensor": {
+          "description": "Sensor-Entity für Regenmenge. Null = kein.",
+          "name": "Regensensor"
+        },
+        "weather_rain_threshold": {
+          "description": "Regenmenge oberhalb derer die Beschattung eingezogen wird.",
+          "name": "Regen-Schwellwert"
+        },
+        "weather_severe_sensors": {
+          "description": "Binärsensoren für Extremwetter (ODER-Logik). Leere Liste = kein.",
+          "name": "Extremwetter-Sensoren"
+        },
+        "weather_timeout": {
+          "description": "Sekunden zu warten nach Auflösung der Bedingungen vor Wiederaufnahme der automatischen Kontrolle (0–3600).",
+          "name": "Wetter-Klaren-Timeout"
+        },
+        "weather_wind_direction_sensor": {
+          "description": "Sensor-Entity für Windrichtung. Null = kein.",
+          "name": "Windrichtungs-Sensor"
+        },
+        "weather_wind_direction_tolerance": {
+          "description": "Grad links/rechts vom Fenster-Azimut als Windbedrohung (5–180°).",
+          "name": "Windrichtungs-Toleranz"
+        },
+        "weather_wind_speed_sensor": {
+          "description": "Sensor-Entity für Windgeschwindigkeit. Null = kein.",
+          "name": "Windgeschwindigkeits-Sensor"
+        },
+        "weather_wind_speed_threshold": {
+          "description": "Windgeschwindigkeit oberhalb derer die Beschattung eingezogen wird.",
+          "name": "Windgeschwindigkeits-Schwellwert"
+        }
+      },
+      "name": "Wetter-Sicherheitseinstellungen einstellen"
+    }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1078,5 +1078,487 @@
         "weather_override": "Dérogation météo"
       }
     }
+  },
+  "services": {
+    "emergency_stop": {
+      "description": "Bouton de panique — envoie stop_cover à chaque protection configurée sur les instances ciblées (vérification des capacités), puis désactive l'intégration. Sans cible, agit sur toutes les instances ACP.",
+      "name": "Arrêt d'urgence"
+    },
+    "export_config": {
+      "description": "Retourne la configuration de la protection au format JSON pour utilisation dans le notebook de simulation.",
+      "fields": {
+        "config_entry_id": {
+          "description": "Entrée de configuration Adaptive Cover Pro à exporter.",
+          "name": "Configuration de la protection"
+        }
+      },
+      "name": "Exporter la configuration"
+    },
+    "integration_disable": {
+      "description": "Désactive Adaptive Cover Pro sur les instances ciblées. Les mouvements en cours des protections ACP sont arrêtés immédiatement, les minuteries différées annulées, et l'état de réconciliation effacé.",
+      "name": "Désactiver l'intégration"
+    },
+    "integration_enable": {
+      "description": "Réactive Adaptive Cover Pro sur les instances ciblées. Les protections restent où elles sont ; le positionnement reprend au prochain cycle de mise à jour naturel.",
+      "name": "Activer l'intégration"
+    },
+    "set_automation_timing": {
+      "description": "Mettre à jour les seuils de delta, la fenêtre de temps début/fin, et return_sunset.",
+      "fields": {
+        "delta_position": {
+          "description": "Changement de position minimum (%) avant l'envoi d'une commande de protection (1–90).",
+          "name": "Seuil de delta de position"
+        },
+        "delta_time": {
+          "description": "Temps minimum (minutes) entre les commandes de protection (2–60).",
+          "name": "Seuil de delta de temps"
+        },
+        "end_entity": {
+          "description": "Entité dont l'état fournit l'heure de fin. Mutuellement exclusif avec end_time.",
+          "name": "Entité de fin"
+        },
+        "end_time": {
+          "description": "Heure fixe pour terminer la fenêtre de suivi (HH:MM:SS). Mutuellement exclusif avec end_entity.",
+          "name": "Heure de fin"
+        },
+        "return_sunset": {
+          "description": "Si vrai, force l'envoi de sunset_position lorsque la fenêtre de temps se termine.",
+          "name": "Retourner à la position du coucher au moment de la fin"
+        },
+        "start_entity": {
+          "description": "Entité dont l'état fournit l'heure de début. Mutuellement exclusif avec start_time.",
+          "name": "Entité de début"
+        },
+        "start_time": {
+          "description": "Heure fixe pour commencer la fenêtre de suivi (HH:MM:SS). Mutuellement exclusif avec start_entity.",
+          "name": "Heure de début"
+        }
+      },
+      "name": "Définir le minutage de l'automatisation"
+    },
+    "set_blind_spot": {
+      "description": "Mettre à jour les angles de la zone d'éblouissement. blind_spot_right doit être supérieur à blind_spot_left.",
+      "fields": {
+        "blind_spot": {
+          "description": "Si vrai, la zone d'éblouissement est active.",
+          "name": "Activer la zone d'éblouissement"
+        },
+        "blind_spot_elevation": {
+          "description": "Élévation solaire maximale (°) pour que la zone d'éblouissement s'applique. Null = toujours appliquer.",
+          "name": "Limite d'élévation"
+        },
+        "blind_spot_left": {
+          "description": "Bord gauche de la zone d'éblouissement en degrés vers l'intérieur de la limite gauche de votre FOV (0 = au bord gauche du FOV, plage 0–359°).",
+          "name": "Bord gauche (du FOV gauche)"
+        },
+        "blind_spot_right": {
+          "description": "Bord droit de la zone d'éblouissement en degrés vers l'intérieur de la limite gauche de votre FOV. Doit être supérieur au bord gauche (plage 1–360°).",
+          "name": "Bord droit (du FOV gauche)"
+        }
+      },
+      "name": "Définir la zone d'éblouissement"
+    },
+    "set_climate": {
+      "description": "Mettre à jour le mode climatique et les options de température/présence. Force temp_low < temp_high.",
+      "fields": {
+        "climate_mode": {
+          "description": "Interrupteur principal pour le positionnement conscient de la température.",
+          "name": "Activer le mode climatique"
+        },
+        "outside_temp": {
+          "description": "Entité capteur pour la température extérieure. Null = aucun.",
+          "name": "Entité de température extérieure"
+        },
+        "outside_threshold": {
+          "description": "Température extérieure (°) au-dessus de laquelle la stratégie estivale est forcée (0–100).",
+          "name": "Seuil de température extérieure"
+        },
+        "presence_entity": {
+          "description": "Entité indiquant l'occupation. Null = aucun.",
+          "name": "Entité de présence"
+        },
+        "temp_entity": {
+          "description": "Entité climatique ou capteur pour la température intérieure. Null = aucun.",
+          "name": "Entité de température intérieure"
+        },
+        "temp_high": {
+          "description": "Au-dessus de cette température (°), la stratégie estivale s'applique (0–90).",
+          "name": "Seuil de haute température"
+        },
+        "temp_low": {
+          "description": "En dessous de cette température (°), la stratégie hivernale s'applique (0–90).",
+          "name": "Seuil de basse température"
+        },
+        "transparent_blind": {
+          "description": "Si vrai, traiter le store comme semi-transparent pour les calculs climatiques.",
+          "name": "Store transparent"
+        },
+        "winter_close_insulation": {
+          "description": "Si vrai, fermer complètement la protection les jours froids pour améliorer l'isolation.",
+          "name": "Fermer pour l'isolation hivernale"
+        }
+      },
+      "name": "Définir les paramètres climatiques"
+    },
+    "set_custom_position": {
+      "description": "Mettre à jour un emplacement de position personnalisée (1–4). Passer null pour le capteur et la position pour effacer l'emplacement.",
+      "fields": {
+        "min_mode": {
+          "description": "Si vrai, traiter la position comme un plancher minimum.",
+          "name": "Mode de position minimale"
+        },
+        "position": {
+          "description": "Position cible (0–100%) lorsque le capteur est actif. Null = effacer l'emplacement.",
+          "name": "Position"
+        },
+        "priority": {
+          "description": "Priorité du pipeline (1–99, par défaut 77).",
+          "name": "Priorité"
+        },
+        "sensor": {
+          "description": "Capteur binaire qui active cette position personnalisée. Null = effacer l'emplacement.",
+          "name": "Capteur de déclenchement"
+        },
+        "slot": {
+          "description": "Quel emplacement de position personnalisée mettre à jour (1–4).",
+          "name": "Emplacement"
+        },
+        "use_my": {
+          "description": "Si vrai, utiliser my_position_value au lieu de position.",
+          "name": "Utiliser Somfy My"
+        }
+      },
+      "name": "Définir l'emplacement de la position personnalisée"
+    },
+    "set_force_override": {
+      "description": "Mettre à jour les capteurs de dérogation forcée, la position, et le mode minimum.",
+      "fields": {
+        "force_override_min_mode": {
+          "description": "Si vrai, traiter force_override_position comme un plancher minimum.",
+          "name": "Mode de position minimale"
+        },
+        "force_override_position": {
+          "description": "Position vers laquelle se déplacer lorsqu'un capteur de dérogation forcée est actif (0–100%).",
+          "name": "Position de dérogation forcée"
+        },
+        "force_override_sensors": {
+          "description": "Capteurs binaires qui déclenchent la dérogation forcée. Liste vide = désactiver.",
+          "name": "Capteurs de dérogation forcée"
+        }
+      },
+      "name": "Définir la dérogation forcée"
+    },
+    "set_geometry": {
+      "description": "Mettre à jour les dimensions de la géométrie de la protection. Fournir uniquement les champs applicables à votre type de protection.",
+      "fields": {
+        "angle": {
+          "description": "Angle d'inclinaison du store banne en degrés (0–45°). Stores bannes uniquement.",
+          "name": "Angle du store banne"
+        },
+        "length_awning": {
+          "description": "Longueur de projection du store banne en mètres (0,3–6 m). Stores bannes uniquement.",
+          "name": "Longueur du store banne"
+        },
+        "sill_height": {
+          "description": "Hauteur de l'appui de fenêtre depuis le sol en mètres (0–3 m). Stores verticaux uniquement.",
+          "name": "Hauteur de l'appui"
+        },
+        "slat_depth": {
+          "description": "Profondeur de la lamelle vénitienne en centimètres (0,1–15 cm). Inclinaison uniquement.",
+          "name": "Profondeur de la lamelle"
+        },
+        "slat_distance": {
+          "description": "Distance entre les lamelles en centimètres (0,1–15 cm). Inclinaison uniquement.",
+          "name": "Distance entre les lamelles"
+        },
+        "tilt_mode": {
+          "description": "Mode de calcul de l'angle de la lamelle (mode1 ou mode2). Inclinaison uniquement.",
+          "name": "Mode d'inclinaison"
+        },
+        "window_depth": {
+          "description": "Profondeur du rejingot de la fenêtre en mètres (0–0,5 m). Stores verticaux uniquement.",
+          "name": "Profondeur de la fenêtre"
+        },
+        "window_height": {
+          "description": "Hauteur de la fenêtre en mètres (0,1–6 m). Stores verticaux et stores bannes uniquement.",
+          "name": "Hauteur de la fenêtre"
+        },
+        "window_width": {
+          "description": "Largeur de la fenêtre en mètres (0,1–5 m). Stores verticaux uniquement.",
+          "name": "Largeur de la fenêtre"
+        }
+      },
+      "name": "Définir la géométrie"
+    },
+    "set_interpolation": {
+      "description": "Activer l'interpolation de position et configurer la plage de début/fin et la table de consultation.",
+      "fields": {
+        "interp": {
+          "description": "Si vrai, appliquer le mappage d'interpolation à la position calculée.",
+          "name": "Activer l'interpolation"
+        },
+        "interp_end": {
+          "description": "Position calculée (%) à laquelle l'interpolation se termine. Null = aucun.",
+          "name": "Fin d'interpolation"
+        },
+        "interp_list": {
+          "description": "Positions d'entrée pour la table de consultation d'interpolation.",
+          "name": "Liste d'entrée"
+        },
+        "interp_list_new": {
+          "description": "Positions de sortie mappées depuis interp_list.",
+          "name": "Liste de sortie"
+        },
+        "interp_start": {
+          "description": "Position calculée (%) à laquelle l'interpolation commence. Null = aucun.",
+          "name": "Début d'interpolation"
+        }
+      },
+      "name": "Définir l'interpolation"
+    },
+    "set_light_cloud": {
+      "description": "Mettre à jour l'entité météo, le filtre d'état ensoleillé, les seuils de lux/irradiance/couverture nuageuse, et la suppression des nuages.",
+      "fields": {
+        "cloud_coverage_entity": {
+          "description": "Capteur signalant le pourcentage de couverture nuageuse. Null = aucun.",
+          "name": "Capteur de couverture nuageuse"
+        },
+        "cloud_coverage_threshold": {
+          "description": "Pourcentage de couverture nuageuse au-dessus duquel le ciel est considéré comme couvert.",
+          "name": "Seuil de couverture nuageuse"
+        },
+        "cloud_suppression": {
+          "description": "Supprimer le positionnement solaire lorsque la couverture nuageuse dépasse le seuil.",
+          "name": "Activer la suppression des nuages"
+        },
+        "irradiance_entity": {
+          "description": "Entité capteur d'irradiance solaire. Null = aucun.",
+          "name": "Capteur d'irradiance"
+        },
+        "irradiance_threshold": {
+          "description": "W/m² au-dessus duquel la protection est en lumière directe.",
+          "name": "Seuil d'irradiance"
+        },
+        "lux_entity": {
+          "description": "Entité capteur d'illuminance. Null = aucun.",
+          "name": "Capteur de lux"
+        },
+        "lux_threshold": {
+          "description": "Valeur de lux au-dessus de laquelle la protection est en lumière directe.",
+          "name": "Seuil de lux"
+        },
+        "weather_entity": {
+          "description": "Entité météo pour les lectures de condition. Null = aucun.",
+          "name": "Entité météo"
+        },
+        "weather_state": {
+          "description": "États des conditions météorologiques considérés comme ensoleillés pour le suivi solaire.",
+          "name": "États météorologiques ensoleillés"
+        }
+      },
+      "name": "Définir les paramètres de lumière et de nuages"
+    },
+    "set_manual_override": {
+      "description": "Mettre à jour la durée de la dérogation manuelle, le comportement de réinitialisation, et le seuil de détection.",
+      "fields": {
+        "manual_ignore_intermediate": {
+          "description": "Si vrai, ignorer les états d'ouverture/fermeture pour la détection de la dérogation manuelle.",
+          "name": "Ignorer les états intermédiaires"
+        },
+        "manual_override_duration": {
+          "description": "Durée pendant laquelle une dérogation manuelle dure avant que le contrôle automatique reprenne.",
+          "name": "Durée de la dérogation"
+        },
+        "manual_override_reset": {
+          "description": "Si vrai, effacer toute dérogation manuelle active lorsque la fenêtre de temps commence.",
+          "name": "Réinitialiser au démarrage de la fenêtre"
+        },
+        "manual_threshold": {
+          "description": "Changement de position (%) qui déclenche la détection de la dérogation manuelle (0–99).",
+          "name": "Seuil de détection"
+        }
+      },
+      "name": "Définir les paramètres de la dérogation manuelle"
+    },
+    "set_motion": {
+      "description": "Mettre à jour les capteurs de mouvement et le délai d'inactivité.",
+      "fields": {
+        "motion_sensors": {
+          "description": "Capteurs binaires indiquant l'occupation. Liste vide = désactiver le contrôle de mouvement.",
+          "name": "Capteurs de mouvement"
+        },
+        "motion_timeout": {
+          "description": "Secondes à attendre après le dernier mouvement avant d'appliquer la position de timeout de mouvement (30–3600).",
+          "name": "Délai d'inactivité"
+        }
+      },
+      "name": "Définir les paramètres de mouvement"
+    },
+    "set_option": {
+      "description": "Échappatoire générique — mettre à jour n'importe quelle option unique supportée par clé de nom. Les clés d'identité sont rejetées.",
+      "fields": {
+        "option": {
+          "description": "Clé d'option interne à mettre à jour (p. ex. 'default_percentage', 'sunset_position').",
+          "name": "Clé d'option"
+        },
+        "value": {
+          "description": "Nouvelle valeur pour l'option. Passer null pour effacer un champ optionnel.",
+          "name": "Valeur"
+        }
+      },
+      "name": "Définir l'option (générique)"
+    },
+    "set_position_limits": {
+      "description": "Mettre à jour la hauteur par défaut, la position min/max, le seuil d'ouverture/fermeture, et l'état inverse.",
+      "fields": {
+        "default_height": {
+          "description": "Position de protection par défaut lorsque le soleil n'est pas visible (0–100%).",
+          "name": "Hauteur par défaut"
+        },
+        "enable_max_position": {
+          "description": "Si vrai, max_position s'applique uniquement lors du suivi du soleil.",
+          "name": "Activer la position max uniquement pendant le suivi"
+        },
+        "enable_min_position": {
+          "description": "Si vrai, min_position s'applique uniquement lors du suivi du soleil.",
+          "name": "Activer la position min uniquement pendant le suivi"
+        },
+        "inverse_state": {
+          "description": "Inverser la position pour les protections qui signalent l'état de manière inverse.",
+          "name": "État inverse"
+        },
+        "max_position": {
+          "description": "Position maximale vers laquelle la protection peut se déplacer (1–100%).",
+          "name": "Position maximale"
+        },
+        "min_position": {
+          "description": "Position minimale vers laquelle la protection peut se déplacer (0–99%).",
+          "name": "Position minimale"
+        },
+        "open_close_threshold": {
+          "description": "Position en dessous de laquelle les protections ouvertes/fermées uniquement sont fermées (1–99%).",
+          "name": "Seuil d'ouverture/fermeture"
+        }
+      },
+      "name": "Définir les limites de position"
+    },
+    "set_sun_tracking": {
+      "description": "Mettre à jour l'azimut, le champ de vision, les limites d'élévation, et l'interrupteur de suivi solaire.",
+      "fields": {
+        "distance_shaded_area": {
+          "description": "Distance (m) de la fenêtre au bord de la zone ombragée (0,1–5 m).",
+          "name": "Distance vers la zone ombragée"
+        },
+        "enable_sun_tracking": {
+          "description": "Interrupteur principal pour le contrôle des protections basé sur la position solaire.",
+          "name": "Activer le suivi solaire"
+        },
+        "fov_left": {
+          "description": "Degrés à gauche de l'azimut dans lesquels le soleil affecte cette protection (0–180°).",
+          "name": "Champ de vision gauche"
+        },
+        "fov_right": {
+          "description": "Degrés à droite de l'azimut dans lesquels le soleil affecte cette protection (0–180°).",
+          "name": "Champ de vision droit"
+        },
+        "max_elevation": {
+          "description": "Élévation solaire (°) au-dessus de laquelle la protection est complètement ouverte. Null = pas de maximum.",
+          "name": "Élévation solaire maximale"
+        },
+        "min_elevation": {
+          "description": "Élévation solaire (°) en dessous de laquelle la protection n'est pas déplacée. Null = pas de minimum.",
+          "name": "Élévation solaire minimale"
+        },
+        "set_azimuth": {
+          "description": "Direction cardinale vers laquelle la fenêtre fait face (0–359°).",
+          "name": "Azimut de la fenêtre"
+        }
+      },
+      "name": "Définir les paramètres de suivi solaire"
+    },
+    "set_sunset_sunrise": {
+      "description": "Mettre à jour les paramètres de position et de décalage du coucher/lever de soleil. Passer null pour effacer un champ optionnel.",
+      "fields": {
+        "my_position_value": {
+          "description": "La position du préréglage 'My' (1–99%).",
+          "name": "Position Somfy My"
+        },
+        "sunrise_offset": {
+          "description": "Minutes pour décaler le déclenchement du début de la fenêtre par rapport au lever de soleil (-120–120).",
+          "name": "Décalage du lever de soleil"
+        },
+        "sunset_offset": {
+          "description": "Minutes pour décaler le déclenchement de la fin de la fenêtre par rapport au coucher de soleil (-120–120).",
+          "name": "Décalage du coucher de soleil"
+        },
+        "sunset_position": {
+          "description": "Position vers laquelle se déplacer à la fin de la fenêtre de temps. Null = utiliser default_height.",
+          "name": "Position du coucher de soleil"
+        },
+        "sunset_use_my": {
+          "description": "Si vrai, utiliser my_position_value au lieu de sunset_position à la fin de la fenêtre.",
+          "name": "Utiliser Somfy My au coucher de soleil"
+        }
+      },
+      "name": "Définir les positions du coucher/lever de soleil"
+    },
+    "set_weather_safety": {
+      "description": "Mettre à jour les paramètres de dérogation pour le vent, la pluie et les conditions météorologiques graves.",
+      "fields": {
+        "weather_bypass_auto_control": {
+          "description": "Si vrai, la dérogation météorologiquement ignore le bouton Contrôle automatique.",
+          "name": "Contourner le contrôle automatique"
+        },
+        "weather_is_raining_sensor": {
+          "description": "Capteur binaire indiquant une pluie active. Null = aucun.",
+          "name": "Capteur de pluie active"
+        },
+        "weather_is_windy_sensor": {
+          "description": "Capteur binaire indiquant un vent dangereux. Null = aucun.",
+          "name": "Capteur de vent dangereux"
+        },
+        "weather_override_min_mode": {
+          "description": "Si vrai, traiter weather_override_position comme un plancher minimum.",
+          "name": "Mode de position minimale"
+        },
+        "weather_override_position": {
+          "description": "Position vers laquelle se déplacer lorsque la dérogation météorologique est déclenchée (0–100%).",
+          "name": "Position de dérogation météorologique"
+        },
+        "weather_rain_sensor": {
+          "description": "Entité capteur pour l'accumulation de pluie. Null = aucun.",
+          "name": "Capteur de pluie"
+        },
+        "weather_rain_threshold": {
+          "description": "Accumulation de pluie au-dessus de laquelle la protection est rétractée.",
+          "name": "Seuil de pluie"
+        },
+        "weather_severe_sensors": {
+          "description": "Capteurs binaires pour conditions météorologiques graves (logique OR). Liste vide = aucun.",
+          "name": "Capteurs de conditions graves"
+        },
+        "weather_timeout": {
+          "description": "Secondes à attendre après l'amélioration des conditions avant de reprendre le contrôle automatique (0–3600).",
+          "name": "Délai d'amélioration météorologique"
+        },
+        "weather_wind_direction_sensor": {
+          "description": "Entité capteur pour la direction du vent. Null = aucun.",
+          "name": "Capteur de direction du vent"
+        },
+        "weather_wind_direction_tolerance": {
+          "description": "Degrés de part et d'autre de l'azimut de la fenêtre considérés comme une menace de vent (5–180°).",
+          "name": "Tolérance de direction du vent"
+        },
+        "weather_wind_speed_sensor": {
+          "description": "Entité capteur pour la vitesse du vent. Null = aucun.",
+          "name": "Capteur de vitesse du vent"
+        },
+        "weather_wind_speed_threshold": {
+          "description": "Vitesse du vent au-dessus de laquelle la protection est rétractée.",
+          "name": "Seuil de vitesse du vent"
+        }
+      },
+      "name": "Définir les paramètres de sécurité météorologique"
+    }
   }
 }

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -6,12 +6,11 @@ Usage:
     ./scripts/validate_translations.py de         # Show detailed report for one language
     ./scripts/validate_translations.py --ci       # CI mode: exit 1 if any language has missing/extra keys
 
-Shipped languages: en (source), de, fr. The `services` section in en.json is
-intentionally English-only — HA falls back to English for locales missing it —
-so DE/FR files omit that section entirely.
+Shipped languages: en (source), de, fr. All sections including `services` must be
+present in every language file.
 
 STATUS LEGEND:
-  ✅ Complete     — key structure matches en.json (minus services), no untranslated strings
+  ✅ Complete     — key structure matches en.json, no untranslated strings
   🔄 In Progress  — key structure matches, but some values still match English
   ❌ Needs Work   — key structure does not match (missing or extra keys)
 """
@@ -37,9 +36,7 @@ EN_FILE = TRANSLATIONS_DIR / "en.json"
 
 LANGUAGES = ["de", "fr"]
 
-# The `services` section is intentionally English-only. HA falls back to English
-# for locales missing a `services` block, so DE/FR omit it to minimise maintenance.
-EN_ONLY_SECTIONS = ("services",)
+EN_ONLY_SECTIONS: tuple[str, ...] = ()
 
 # Values that are intentionally identical in all languages (technical identifiers,
 # placeholders, format strings, etc.)
@@ -137,12 +134,7 @@ def _strip_en_only_sections(en_flat: dict[str, str]) -> dict[str, str]:
 
 
 def analyse_language(lang: str, en_flat_full: dict[str, str]) -> dict:
-    """Return analysis dict for a single language.
-
-    `en_flat_full` is the entire flattened en.json. Non-en files are not expected
-    to carry EN_ONLY_SECTIONS (e.g. `services`), so we compare against en_flat
-    with those sections stripped.
-    """
+    """Return analysis dict for a single language."""
     en_flat = _strip_en_only_sections(en_flat_full)
     lang_file = TRANSLATIONS_DIR / f"{lang}.json"
 
@@ -353,7 +345,6 @@ def main() -> int:
 
     # Dashboard mode
     analyses = [analyse_language(lang, en_flat) for lang in LANGUAGES]
-    # Total reported in dashboard is the translatable-key count (excluding EN_ONLY_SECTIONS)
     print_dashboard(analyses, len(_strip_en_only_sections(en_flat)))
 
     if args.ci:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,9 +1,8 @@
 """Tests for translation files — structural parity with en.json + content hygiene.
 
 The integration ships English, German, and French. `en.json` is the single
-source of truth. The `services` section is intentionally English-only (HA
-falls back to English for locales missing it), so DE/FR must match en.json
-exactly for every section *except* `services`.
+source of truth. DE/FR must match en.json exactly for every section including
+`services`.
 """
 
 from __future__ import annotations
@@ -24,9 +23,7 @@ TRANSLATIONS_DIR = (
 
 SHIPPED_LANGUAGES = {"en", "de", "fr"}
 
-# Top-level sections in en.json that are intentionally *not* carried by other
-# languages. HA falls back to English for any locale missing these.
-EN_ONLY_SECTIONS = ("services",)
+EN_ONLY_SECTIONS: tuple[str, ...] = ()
 
 TRANSLATION_FILES = sorted(TRANSLATIONS_DIR.glob("*.json"))
 LANGUAGE_CODES = [f.stem for f in TRANSLATION_FILES]
@@ -128,19 +125,8 @@ def test_all_translations_have_title_and_config(lang_file: Path) -> None:
     assert "config" in data, f"{lang_file.name} missing 'config'"
 
 
-def test_non_en_files_omit_services_section() -> None:
-    """DE/FR must not carry a `services` section — HA falls back to English."""
-    for lang_file in TRANSLATION_FILES:
-        if lang_file.stem == "en":
-            continue
-        data = _load(lang_file)
-        assert (
-            "services" not in data
-        ), f"{lang_file.name} carries a `services` section — it must be English-only"
-
-
 # ---------------------------------------------------------------------------
-# Structural parity — every non-en file has the same keys as en.json minus services.*
+# Structural parity — every non-en file has the same keys as en.json
 # ---------------------------------------------------------------------------
 
 
@@ -158,7 +144,7 @@ def test_key_structure_matches_en(lang_file: Path) -> None:
     extra = target_keys - en_keys
 
     assert not missing and not extra, (
-        f"{lang_file.name} key-set differs from en.json (minus {EN_ONLY_SECTIONS}):\n"
+        f"{lang_file.name} key-set differs from en.json:\n"
         f"  Missing ({len(missing)}): {sorted(missing)[:10]}{'...' if len(missing) > 10 else ''}\n"
         f"  Extra   ({len(extra)}): {sorted(extra)[:10]}{'...' if len(extra) > 10 else ''}"
     )


### PR DESCRIPTION
## Summary
- Add German and French translations for all 224 service strings
- Update acp-translate skill, validator, and tests to include `services` in all language files (previously English-only)

## Testing
- ✅ 21 translation tests passing
- ✅ Validator passes with 0 missing/extra keys for DE and FR

Closes #260