### PR TITLE
fix: min-mode floor uses default position when sun tracking is off

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1015,6 +1015,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             custom_position_sensors=self._read_custom_position_sensor_states(options),
             my_position_value=options.get(CONF_MY_POSITION_VALUE),
             sunset_use_my=bool(options.get(CONF_SUNSET_USE_MY, False)),
+            enable_sun_tracking=bool(options.get(CONF_ENABLE_SUN_TRACKING, True)),
         )
         self._pipeline_result = self._pipeline.evaluate(snapshot)
 

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -83,7 +83,7 @@ def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
         Solar-tracked position (1–100) when sun is valid, else effective default.
 
     """
-    if snapshot.cover.direct_sun_valid:
+    if snapshot.cover.direct_sun_valid and snapshot.enable_sun_tracking:
         return compute_solar_position(snapshot)
     if snapshot.is_sunset_active:
         return snapshot.default_position

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -91,6 +91,13 @@ class PipelineSnapshot:
     # Users can disable this if they want weather override to respect the auto-control toggle.
     weather_bypass_auto_control: bool = True
 
+    # When False, sun-tracking is disabled (CONF_ENABLE_SUN_TRACKING=False).
+    # compute_raw_calculated_position() must skip the solar branch so that
+    # min-mode floors are measured against what the pipeline would actually
+    # command (the default position), not a solar geometry result that will
+    # never be applied.  Defaults to True for backward compatibility (#264).
+    enable_sun_tracking: bool = True
+
     # Minimum position mode: when True, the configured position acts as a floor —
     # the handler returns max(configured, raw_calculated) instead of always returning configured.
     force_override_min_mode: bool = False

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -80,6 +80,7 @@ def make_snapshot(
     custom_position_sensors: list[tuple[str, bool, int, int, bool, bool]] | None = None,
     my_position_value: int | None = None,
     sunset_use_my: bool = False,
+    enable_sun_tracking: bool = True,
     # Convenience: configure mock cover
     direct_sun_valid: bool = False,
     calculate_percentage_return: float = 50.0,
@@ -121,4 +122,5 @@ def make_snapshot(
         else [],
         my_position_value=my_position_value,
         sunset_use_my=sunset_use_my,
+        enable_sun_tracking=enable_sun_tracking,
     )

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -11,6 +11,12 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import (
     MotionTimeoutHandler,
     SolarHandler,
 )
+from custom_components.adaptive_cover_pro.pipeline.handlers.weather import (
+    WeatherOverrideHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
 
 from tests.test_pipeline.conftest import make_snapshot
 
@@ -182,6 +188,137 @@ class TestForceOverrideHandlerMinMode:
         result = self.handler.evaluate(snap)
         assert result is not None
         assert result.control_method == ControlMethod.FORCE
+
+
+# ---------------------------------------------------------------------------
+# Min-mode with sun tracking disabled — regression tests for issue #264
+# ---------------------------------------------------------------------------
+
+
+class TestForceOverrideHandlerMinModeWithSunTrackingOff:
+    """Force override min-mode floors correctly when sun tracking is disabled.
+
+    Regression tests for #264: with tracking off and default=100, a
+    configured floor of 80 must yield max(80, 100)=100, not max(80, 29)=80.
+    """
+
+    handler = ForceOverrideHandler()
+
+    def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
+        """Min-mode floor measured against default position, not solar, when tracking off."""
+        snap = make_snapshot(
+            force_override_sensors={"binary_sensor.s": True},
+            force_override_position=80,
+            force_override_min_mode=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=100,
+            enable_sun_tracking=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 100
+
+    def test_min_mode_floor_still_enforced_when_default_below_floor(self) -> None:
+        """Floor is enforced when default position is below the configured floor."""
+        snap = make_snapshot(
+            force_override_sensors={"binary_sensor.s": True},
+            force_override_position=80,
+            force_override_min_mode=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=50,
+            enable_sun_tracking=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 80
+
+    def test_min_mode_sun_tracking_enabled_unchanged_regression(self) -> None:
+        """Regression guard: solar floor semantics unchanged when tracking is on."""
+        snap = make_snapshot(
+            force_override_sensors={"binary_sensor.s": True},
+            force_override_position=80,
+            force_override_min_mode=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=100,
+            enable_sun_tracking=True,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 80  # max(80, 29) = 80 — solar floor applies
+
+
+class TestWeatherOverrideHandlerMinModeWithSunTrackingOff:
+    """Weather override min-mode floors correctly when sun tracking is disabled."""
+
+    handler = WeatherOverrideHandler()
+
+    def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
+        """Min-mode floor measured against default position, not solar, when tracking off."""
+        snap = make_snapshot(
+            weather_override_active=True,
+            weather_override_position=80,
+            weather_override_min_mode=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=100,
+            enable_sun_tracking=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 100
+
+    def test_min_mode_sun_tracking_enabled_unchanged_regression(self) -> None:
+        """Regression guard: solar floor semantics unchanged when tracking is on."""
+        snap = make_snapshot(
+            weather_override_active=True,
+            weather_override_position=80,
+            weather_override_min_mode=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=100,
+            enable_sun_tracking=True,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 80  # max(80, 29) = 80 — solar floor applies
+
+
+class TestCustomPositionHandlerMinModeWithSunTrackingOff:
+    """Custom position min-mode floors correctly when sun tracking is disabled."""
+
+    def _make_handler(self) -> CustomPositionHandler:
+        return CustomPositionHandler(slot=1, entity_id="binary_sensor.cp1", position=80, priority=77)
+
+    def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
+        """Min-mode floor measured against default position, not solar, when tracking off."""
+        handler = self._make_handler()
+        snap = make_snapshot(
+            custom_position_sensors=[("binary_sensor.cp1", True, 80, 77, True, False)],
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=100,
+            enable_sun_tracking=False,
+        )
+        result = handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 100
+
+    def test_min_mode_sun_tracking_enabled_unchanged_regression(self) -> None:
+        """Regression guard: solar floor semantics unchanged when tracking is on."""
+        handler = self._make_handler()
+        snap = make_snapshot(
+            custom_position_sensors=[("binary_sensor.cp1", True, 80, 77, True, False)],
+            direct_sun_valid=True,
+            calculate_percentage_return=29.0,
+            default_position=100,
+            enable_sun_tracking=True,
+        )
+        result = handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 80  # max(80, 29) = 80 — solar floor applies
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_helpers.py
+++ b/tests/test_pipeline/test_helpers.py
@@ -51,6 +51,7 @@ def _make_snapshot(
     min_pos_sun_only=False,
     max_pos_sun_only=False,
     is_sunset_active=False,
+    enable_sun_tracking=True,
 ):
     return SimpleNamespace(
         cover=_make_cover(direct_sun_valid=direct_sun_valid, calc_pct=calc_pct),
@@ -62,6 +63,7 @@ def _make_snapshot(
         ),
         default_position=default_position,
         is_sunset_active=is_sunset_active,
+        enable_sun_tracking=enable_sun_tracking,
     )
 
 
@@ -295,3 +297,53 @@ class TestComputeRawCalculatedPosition:
             is_sunset_active=True,
         )
         assert compute_raw_calculated_position(snap) == 0
+
+    def test_returns_default_when_sun_valid_but_tracking_disabled(self):
+        """Returns default when direct_sun_valid=True but enable_sun_tracking=False.
+
+        Regression test for #264: the raw baseline must reflect what the
+        pipeline would actually command, not the solar geometry result.
+        """
+        snap = _make_snapshot(
+            calc_pct=70,
+            default_position=30,
+            direct_sun_valid=True,
+            enable_sun_tracking=False,
+        )
+        assert compute_raw_calculated_position(snap) == 30
+
+    def test_min_mode_floor_uses_default_when_tracking_disabled(self):
+        """Min-mode floor is measured against default, not solar, when tracking is off.
+
+        Regression test for #264 core scenario: default=100, sun geometrically
+        valid (solar=29), tracking off.  max(80, raw) must be max(80, 100)=100,
+        not max(80, 29)=80.
+        """
+        snap = _make_snapshot(
+            calc_pct=29,
+            default_position=100,
+            direct_sun_valid=True,
+            enable_sun_tracking=False,
+        )
+        assert compute_raw_calculated_position(snap) == 100
+
+    def test_tracking_enabled_still_returns_solar_when_sun_valid(self):
+        """Regression guard: solar result unchanged when enable_sun_tracking=True."""
+        snap = _make_snapshot(
+            calc_pct=70,
+            default_position=30,
+            direct_sun_valid=True,
+            enable_sun_tracking=True,
+        )
+        assert compute_raw_calculated_position(snap) == 70
+
+    def test_tracking_disabled_default_path_applies_limits(self):
+        """Default path applies max_pos when tracking is disabled."""
+        snap = _make_snapshot(
+            calc_pct=90,
+            default_position=90,
+            direct_sun_valid=True,
+            enable_sun_tracking=False,
+            max_pos=80,
+        )
+        assert compute_raw_calculated_position(snap) == 80

--- a/tests/test_pipeline/test_sun_tracking_toggle.py
+++ b/tests/test_pipeline/test_sun_tracking_toggle.py
@@ -124,3 +124,33 @@ def test_sun_tracking_disabled_pipeline_falls_through_to_default():
 
     assert result is not None
     assert result.control_method == ControlMethod.DEFAULT
+
+
+@pytest.mark.unit
+def test_force_override_min_mode_with_sun_tracking_off_uses_default():
+    """Force override min-mode floors against default position when sun tracking is off.
+
+    End-to-end regression test for #264: with tracking off (default=100) and
+    a geometrically valid sun (solar=29), the min-mode floor of 80 must resolve
+    to max(80, 100)=100, not max(80, 29)=80.
+    """
+    from custom_components.adaptive_cover_pro.enums import ControlMethod
+    from tests.test_pipeline.conftest import make_snapshot
+
+    coord = _make_coordinator({CONF_ENABLE_SUN_TRACKING: False})
+    registry = coord._build_pipeline()
+
+    snap = make_snapshot(
+        direct_sun_valid=True,
+        calculate_percentage_return=29.0,
+        default_position=100,
+        force_override_sensors={"binary_sensor.wind": True},
+        force_override_position=80,
+        force_override_min_mode=True,
+        enable_sun_tracking=False,
+    )
+    result = registry.evaluate(snap)
+
+    assert result is not None
+    assert result.control_method == ControlMethod.FORCE
+    assert result.position == 100  # max(80, default=100) = 100


### PR DESCRIPTION
## Summary
When `enable_sun_tracking` is False, the min-mode floor for Force Override, Weather Override, and Custom Position was measured against the raw solar geometry result instead of the effective default position. With sun tracking off, `compute_raw_calculated_position()` now falls through to the default-position branch instead of the solar branch.

## Testing
- ✅ 2313 tests passing
- New regression tests in `test_helpers.py`, `test_handlers.py`, and `test_sun_tracking_toggle.py`

## Related Issues
Refs #264