### PR TITLE
fix: dispatch sunset_pos when astronomical window opens after end_time

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -342,6 +342,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Track sun validity transitions (for responsive sun in-front detection)
         self._last_sun_validity_state: bool | None = None
 
+        # Track sunset-window transitions so covers reposition when the
+        # astronomical sunset window opens after the user's end_time (issue #266).
+        self._prev_sunset_active: bool | None = None
+
         # Time of the last successful _async_update_data() completion.
         # HA's DataUpdateCoordinator only exposes last_update_success (bool);
         # we track the timestamp ourselves so diagnostics can report it.
@@ -2107,21 +2111,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
                 return
             options = self.config_entry.options
-            # Compute the current effective default (may already be sunset_pos)
-            h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
-            sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-            sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
-            sunrise_off = int(
-                options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
-            )
-            cover_data = self.get_blind_data(options=options)
-            effective_pos, is_sunset = compute_effective_default(
-                h_def=h_def,
-                sunset_pos=sunset_pos_cfg,
-                sun_data=cover_data.sun_data,
-                sunset_off=sunset_off,
-                sunrise_off=sunrise_off,
-            )
+            effective_pos, is_sunset = self._compute_current_effective_default(options)
             pos_to_send = (
                 inverse_state(effective_pos) if self._inverse_state else effective_pos
             )
@@ -2155,6 +2145,81 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             refresh_callback=_on_window_closed,
             on_window_open=_on_window_open,
         )
+        await self._check_sunset_window_transition()
+
+    def _compute_current_effective_default(self, options: dict) -> tuple[int, bool]:
+        """Return (effective_pos, is_sunset_active) for the current moment.
+
+        Shared by _on_window_closed and _check_sunset_window_transition so the
+        same options-reading and compute_effective_default call is not duplicated.
+        """
+        h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
+        sunset_pos_cfg = options.get(CONF_SUNSET_POS)
+        sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
+        sunrise_off = int(
+            options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
+        )
+        cover_data = self.get_blind_data(options=options)
+        return compute_effective_default(
+            h_def=h_def,
+            sunset_pos=sunset_pos_cfg,
+            sun_data=cover_data.sun_data,
+            sunset_off=sunset_off,
+            sunrise_off=sunrise_off,
+        )
+
+    async def _check_sunset_window_transition(self) -> None:
+        """Dispatch sunset_pos when the astronomical sunset window opens after end_time.
+
+        Handles the case where end_time fires before sunset+offset: _on_window_closed
+        sends the daytime default (is_sunset_active=False at that moment). When the
+        sunset window later opens, this detects the False→True transition and sends
+        the sunset position (issue #266).
+
+        Mirrors the _last_sun_validity_state pattern: _prev_sunset_active=None on
+        startup prevents spurious dispatch when HA restarts mid-sunset.
+        """
+        if not self._track_end_time:
+            return
+        if not self.automatic_control:
+            self.logger.debug(
+                "Sunset window opened but automatic control is OFF — skipping reposition"
+            )
+            return
+        options = self.config_entry.options
+        sunset_pos_cfg = options.get(CONF_SUNSET_POS)
+        if sunset_pos_cfg is None:
+            return
+
+        _effective_pos, is_sunset = self._compute_current_effective_default(options)
+
+        if self._prev_sunset_active is None:
+            self._prev_sunset_active = is_sunset
+            return
+
+        just_opened = (not self._prev_sunset_active) and is_sunset
+        self._prev_sunset_active = is_sunset
+
+        if not just_opened:
+            return
+
+        pos_to_send = (
+            inverse_state(int(sunset_pos_cfg)) if self._inverse_state else int(sunset_pos_cfg)
+        )
+        self.logger.info(
+            "Sunset window opened after end_time — dispatching sunset position %s%% "
+            "to %s cover(s) (issue #266)",
+            pos_to_send,
+            len(self.entities),
+        )
+        for cover_entity in self.entities:
+            if self.manager.is_cover_manual(cover_entity):
+                continue
+            ctx = self._build_position_context(cover_entity, options, force=False)
+            await self._cmd_svc.apply_position(
+                cover_entity, pos_to_send, "sunset_window_opened", context=ctx
+            )
+        await self.async_refresh()
 
     def _check_sun_validity_transition(self) -> bool:
         """Check if sun validity state has changed from False to True.

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -42,6 +42,7 @@ Decision table (all rows assume ``automatic_control=False``)
 | state_change_weather_bypass      | async_handle_…   | True             | True            |
 | first_refresh_safety             | async_handle_…   | True             | True            |
 | window_close_return_sunset       | _check_time_…    | False (gated)    | False           |
+| sunset_window_opened             | _check_sunset_…  | False (gated)    | False           |
 | state_change_force_override_rls  | async_handle_…   | True (force=True)| False (no tag)  |
 +----------------------------------+------------------+------------------+-----------------+
 
@@ -242,6 +243,23 @@ async def _trigger_window_close_return_sunset(coord):
     await coord._check_time_window_transition(dt.datetime.now(dt.UTC))
 
 
+async def _trigger_sunset_window_opened(coord):
+    """Trigger: astronomical sunset window opens after end_time (issue #266).
+
+    _check_sunset_window_transition is called directly with the coordinator
+    gated by automatic_control=False.  The method must return early without
+    dispatching (non-bypass, gated path).
+    """
+    coord._track_end_time = True
+    coord._prev_sunset_active = False
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {"sunset_position": 0}
+    coord._inverse_state = False
+    coord._compute_current_effective_default = MagicMock(return_value=(0, True))
+    coord.async_refresh = AsyncMock()
+    await coord._check_sunset_window_transition()
+
+
 async def _trigger_force_override_released(coord):
     """Trigger: force override just transitioned on → off.
 
@@ -300,6 +318,13 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
         is_safety_target=False,
         setup=lambda _: None,
         trigger=_trigger_window_close_return_sunset,
+    ),
+    MatrixCase(
+        id="sunset_window_opened",
+        is_safety_bypass=False,
+        is_safety_target=False,
+        setup=lambda _: None,
+        trigger=_trigger_sunset_window_opened,
     ),
     MatrixCase(
         id="state_change_force_override_released",

--- a/tests/test_issue_266_sunset_transition.py
+++ b/tests/test_issue_266_sunset_transition.py
@@ -1,0 +1,243 @@
+"""Regression tests for issue #266: sunset position not sent when end_time < sunset+offset.
+
+When the user's end_time fires before the astronomical sunset window opens,
+_on_window_closed sends the daytime default (is_sunset_active=False at that moment).
+Later, when is_sunset_active flips True, _check_sunset_window_transition must detect
+the transition and dispatch the sunset position.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import CONF_SUNSET_POS
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
+from custom_components.adaptive_cover_pro.managers.toggles import ToggleManager
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_coord(
+    *,
+    track_end_time: bool = True,
+    automatic_control: bool = True,
+    sunset_pos: int | None = 0,
+    inverse_state: bool = False,
+    n_entities: int = 1,
+) -> AdaptiveDataUpdateCoordinator:
+    """Minimal coordinator fixture for _check_sunset_window_transition tests."""
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._toggles = ToggleManager()
+    coord.automatic_control = automatic_control
+    coord._track_end_time = track_end_time
+    coord._inverse_state = inverse_state
+    coord._prev_sunset_active: bool | None = None
+
+    entities = [MagicMock() for _ in range(n_entities)]
+    coord.entities = entities
+
+    options = {}
+    if sunset_pos is not None:
+        options[CONF_SUNSET_POS] = sunset_pos
+    config_entry = MagicMock()
+    config_entry.options = options
+    coord.config_entry = config_entry
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
+    coord._cmd_svc = cmd_svc
+
+    coord.async_refresh = AsyncMock()
+
+    manager = MagicMock()
+    manager.is_cover_manual.return_value = False
+    coord.manager = manager
+
+    def _fake_build_ctx(entity, options, *, force=False, is_safety=False, **_):
+        return PositionContext(
+            auto_control=automatic_control,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=2,
+            time_threshold=0,
+            special_positions=[0, 100],
+            force=force,
+            is_safety=is_safety,
+        )
+
+    coord._build_position_context = _fake_build_ctx
+
+    return coord
+
+
+def _seed_sunset_state(coord, *, prev: bool | None, current_is_sunset: bool, pos: int = 0):
+    """Seed _prev_sunset_active and mock _compute_current_effective_default."""
+    coord._prev_sunset_active = prev
+    coord._compute_current_effective_default = MagicMock(return_value=(pos, current_is_sunset))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sunset_window_opens_after_end_time_dispatches_sunset_pos():
+    """Core regression: transition False→True dispatches sunset_pos to all covers."""
+    coord = _make_coord(sunset_pos=0, n_entities=2)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True, pos=0)
+
+    await coord._check_sunset_window_transition()
+
+    assert coord._cmd_svc.apply_position.call_count == 2
+    for call in coord._cmd_svc.apply_position.call_args_list:
+        trigger = call.args[2] if len(call.args) > 2 else call.kwargs.get("trigger", "")
+        assert trigger == "sunset_window_opened", f"Expected trigger 'sunset_window_opened', got {trigger!r}"
+    coord.async_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_dispatch_when_sunset_already_active_in_previous_cycle():
+    """No dispatch when is_sunset_active was already True (no transition)."""
+    coord = _make_coord(sunset_pos=0)
+    _seed_sunset_state(coord, prev=True, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_dispatch_when_return_sunset_disabled():
+    """No dispatch when return_sunset (track_end_time) is False."""
+    coord = _make_coord(track_end_time=False, sunset_pos=0)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_dispatch_when_automatic_control_off():
+    """No dispatch when automatic_control is False (non-bypass gate)."""
+    coord = _make_coord(automatic_control=False, sunset_pos=0)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_no_dispatch_when_sunset_pos_not_configured():
+    """No dispatch when sunset_pos is not configured (None)."""
+    coord = _make_coord(sunset_pos=None)
+    # _compute_current_effective_default won't be called because we return early
+    coord._prev_sunset_active = False
+    # No sunset_pos in options → return early before checking transition
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_skips_covers_with_active_manual_override():
+    """Cover with active manual override is skipped; others proceed."""
+    coord = _make_coord(sunset_pos=0, n_entities=2)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True)
+
+    # First entity has manual override active
+    def _manual_for_first(entity):
+        return entity is coord.entities[0]
+
+    coord.manager.is_cover_manual.side_effect = _manual_for_first
+
+    await coord._check_sunset_window_transition()
+
+    # Only second entity gets a command
+    assert coord._cmd_svc.apply_position.call_count == 1
+    called_entity = coord._cmd_svc.apply_position.call_args.args[0]
+    assert called_entity is coord.entities[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_transition_detected_only_once_per_day():
+    """apply_position called exactly once even when invoked multiple times with is_sunset=True."""
+    coord = _make_coord(sunset_pos=0)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+    # Second call: _prev_sunset_active is now True, is_sunset still True → no transition
+    await coord._check_sunset_window_transition()
+
+    assert coord._cmd_svc.apply_position.call_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_prev_sunset_active_initial_none_does_not_dispatch():
+    """On HA restart mid-sunset (_prev_sunset_active=None), no spurious dispatch.
+
+    Mirrors the _last_sun_validity_state=None pattern: first call initializes
+    state without dispatching, so covers aren't blindly repositioned on startup.
+    """
+    coord = _make_coord(sunset_pos=0)
+    # _prev_sunset_active starts as None (fresh coordinator)
+    assert coord._prev_sunset_active is None
+    coord._compute_current_effective_default = MagicMock(return_value=(0, True))
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    # State should be initialized
+    assert coord._prev_sunset_active is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_inverse_state_position_is_inverted():
+    """With inverse_state=True, sunset_pos=0 is sent as 100."""
+    coord = _make_coord(sunset_pos=0, inverse_state=True)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True, pos=0)
+
+    await coord._check_sunset_window_transition()
+
+    assert coord._cmd_svc.apply_position.call_count == 1
+    sent_pos = coord._cmd_svc.apply_position.call_args.args[1]
+    assert sent_pos == 100
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_end_time_after_sunset_does_not_double_dispatch():
+    """When end_time fires after sunset is already active, no follow-up dispatch.
+
+    If end_time > sunset+offset, _on_window_closed already sent sunset_pos.
+    _prev_sunset_active should be True when _check_sunset_window_transition runs,
+    so the transition guard prevents a second send.
+    """
+    coord = _make_coord(sunset_pos=0)
+    # Simulate: sunset window was already active when the last update ran
+    _seed_sunset_state(coord, prev=True, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()


### PR DESCRIPTION
## Summary
When end_time was configured before astronomical sunset + sunset_offset, _on_window_closed sent the daytime default (100%) because the sunset window hadn't opened yet. When the sunset window later opened, nothing triggered a reposition — covers stayed at 100% all night.

Added `_check_sunset_window_transition()` which detects the `is_sunset_active` False→True transition and dispatches the configured sunset position. Extracted `_compute_current_effective_default()` to share the options-reading logic with `_on_window_closed` (no duplication). Uses the same `force=False, is_safety=False` classification as `_on_window_closed`: gate checks apply but the target is not persisted across window boundaries.

## Testing
- ✅ 2324 tests passing (10 new regression tests covering the transition detection, once-per-day semantics, manual override skip, HA-restart safety, and inverse_state)

## Related Issues
Refs #266