### PR TITLE
fix: decouple cloud suppression lux/irradiance from climate-mode toggles

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1726,17 +1726,27 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         wiring test (test_coordinator_climate_wiring.py) will catch any mismatch.
         """
         cloud_suppression_enabled = bool(options.get(CONF_CLOUD_SUPPRESSION, False))
+        lux_entity = options.get(CONF_LUX_ENTITY)
+        irradiance_entity = options.get(CONF_IRRADIANCE_ENTITY)
+        # Cloud suppression is documented as independent of Climate Mode, so let
+        # it read lux/irradiance even when the climate-mode toggles are off.
+        use_lux = bool(self._toggles.lux_toggle) or (
+            cloud_suppression_enabled and lux_entity is not None
+        )
+        use_irradiance = bool(self._toggles.irradiance_toggle) or (
+            cloud_suppression_enabled and irradiance_entity is not None
+        )
         self._weather_readings = self._climate_provider.read(
             temp_entity=options.get(CONF_TEMP_ENTITY),
             outside_entity=options.get(CONF_OUTSIDETEMP_ENTITY),
             presence_entity=options.get(CONF_PRESENCE_ENTITY),
             weather_entity=options.get(CONF_WEATHER_ENTITY),
             weather_condition=options.get(CONF_WEATHER_STATE),
-            use_lux=bool(self._toggles.lux_toggle),
-            lux_entity=options.get(CONF_LUX_ENTITY),
+            use_lux=use_lux,
+            lux_entity=lux_entity,
             lux_threshold=options.get(CONF_LUX_THRESHOLD),
-            use_irradiance=bool(self._toggles.irradiance_toggle),
-            irradiance_entity=options.get(CONF_IRRADIANCE_ENTITY),
+            use_irradiance=use_irradiance,
+            irradiance_entity=irradiance_entity,
             irradiance_threshold=options.get(CONF_IRRADIANCE_THRESHOLD),
             use_cloud_coverage=cloud_suppression_enabled,
             cloud_coverage_entity=options.get(CONF_CLOUD_COVERAGE_ENTITY),

--- a/tests/test_coordinator_climate_wiring.py
+++ b/tests/test_coordinator_climate_wiring.py
@@ -333,3 +333,106 @@ class TestClimateProviderApiCoverage:
                 f"Options key {opt_key!r} should map to read() kwarg "
                 f"{read_kwarg!r}={expected!r}, but got {kwargs.get(read_kwarg)!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Cloud suppression lux/irradiance wiring (Issue #268)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudSuppressionWiring:
+    """Guard that cloud suppression can read lux/irradiance without Climate Mode.
+
+    Cloud suppression is documented as independent of climate mode. These tests
+    enforce that use_lux/use_irradiance are True whenever cloud_suppression is
+    enabled and the matching entity is configured — regardless of the legacy
+    lux/irradiance toggle switches (which only exist in Climate Mode).
+    """
+
+    @pytest.mark.unit
+    def test_cloud_suppression_forces_use_lux_when_lux_entity_configured(self):
+        """use_lux must be True when cloud_suppression=True and lux_entity is set,
+        even when lux_toggle is None (climate mode off).
+        """
+        coord = _make_coordinator()
+        coord._toggles.lux_toggle = None
+        options = {
+            CONF_CLOUD_SUPPRESSION: True,
+            CONF_LUX_ENTITY: "sensor.lux",
+            CONF_LUX_THRESHOLD: 1000,
+        }
+        coord._read_climate_state(options)
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("use_lux") is True, (
+            "REGRESSION (Issue #268): use_lux must be True when cloud_suppression "
+            "is enabled with a lux entity — cloud suppression does not require "
+            "Climate Mode."
+        )
+
+    @pytest.mark.unit
+    def test_cloud_suppression_forces_use_irradiance_when_irradiance_entity_configured(self):
+        """use_irradiance must be True when cloud_suppression=True and irradiance_entity
+        is set, even when irradiance_toggle is None (climate mode off).
+        """
+        coord = _make_coordinator()
+        coord._toggles.irradiance_toggle = None
+        options = {
+            CONF_CLOUD_SUPPRESSION: True,
+            CONF_IRRADIANCE_ENTITY: "sensor.solar",
+            CONF_IRRADIANCE_THRESHOLD: 150,
+        }
+        coord._read_climate_state(options)
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("use_irradiance") is True, (
+            "REGRESSION (Issue #268): use_irradiance must be True when cloud_suppression "
+            "is enabled with an irradiance entity — cloud suppression does not require "
+            "Climate Mode."
+        )
+
+    @pytest.mark.unit
+    def test_cloud_suppression_without_lux_entity_keeps_use_lux_false(self):
+        """use_lux stays False when cloud_suppression=True but no lux_entity is
+        configured — nothing to read.
+        """
+        coord = _make_coordinator()
+        coord._toggles.lux_toggle = None
+        options = {CONF_CLOUD_SUPPRESSION: True}
+        coord._read_climate_state(options)
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("use_lux") is False
+
+    @pytest.mark.unit
+    def test_cloud_suppression_off_with_lux_entity_keeps_use_lux_false(self):
+        """When cloud_suppression=False and lux_toggle=False, use_lux is False —
+        existing toggle gating is preserved.
+        """
+        coord = _make_coordinator()
+        coord._toggles.lux_toggle = False
+        options = {
+            CONF_CLOUD_SUPPRESSION: False,
+            CONF_LUX_ENTITY: "sensor.lux",
+        }
+        coord._read_climate_state(options)
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("use_lux") is False
+
+    @pytest.mark.unit
+    def test_cloud_suppression_on_overrides_lux_toggle_false(self):
+        """use_lux must be True when cloud_suppression=True + lux_entity configured,
+        even when lux_toggle=False (user disabled lux for Climate handler).
+        Cloud suppression is independent; the Climate handler gates itself via
+        climate_mode_enabled, not via use_lux.
+        """
+        coord = _make_coordinator()
+        coord._toggles.lux_toggle = False
+        options = {
+            CONF_CLOUD_SUPPRESSION: True,
+            CONF_LUX_ENTITY: "sensor.lux",
+            CONF_LUX_THRESHOLD: 1000,
+        }
+        coord._read_climate_state(options)
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("use_lux") is True, (
+            "REGRESSION (Issue #268): cloud suppression must be able to read lux "
+            "even when the climate-mode lux toggle is off."
+        )


### PR DESCRIPTION
## Summary
Cloud suppression was silently ignoring lux and irradiance sensors when Climate Mode was disabled. The lux/irradiance reads were gated on the legacy climate-mode toggle switches, which only exist when Climate Mode is on. Now `use_lux`/`use_irradiance` are also set True when cloud suppression is enabled with the matching entity configured, regardless of the toggle state. Climate Mode behavior is unchanged — the ClimateHandler already gates itself via `climate_mode_enabled`, not `use_lux`.

## Testing
- ✅ 2329 tests passing
- Added `TestCloudSuppressionWiring` with 5 tests covering: lux/irradiance forced True with cloud suppression, boundary cases when no entity configured, toggle=False with suppression on, and suppression off preserving existing behavior.

## Related Issues
Refs #268