### PR TITLE
fix: progress-aware transit backstop and configurable timeout (#271)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -138,9 +138,13 @@ from .const import (
     CONF_DEBUG_EVENT_BUFFER_SIZE,
     CONF_DEBUG_MODE,
     CONF_DRY_RUN,
+    CONF_TRANSIT_TIMEOUT,
     DEBUG_CATEGORIES_ALL,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
+    DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     MAX_DEBUG_EVENT_BUFFER_SIZE,
+    MAX_TRANSIT_TIMEOUT,
+    MIN_TRANSIT_TIMEOUT,
     DOMAIN,
     SensorType,
 )
@@ -611,6 +615,18 @@ DEBUG_SCHEMA = vol.Schema(
                 max=MAX_DEBUG_EVENT_BUFFER_SIZE,
                 step=10,
                 mode=selector.NumberSelectorMode.SLIDER,
+            )
+        ),
+        vol.Optional(
+            CONF_TRANSIT_TIMEOUT,
+            default=DEFAULT_TRANSIT_TIMEOUT_SECONDS,
+        ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=MIN_TRANSIT_TIMEOUT,
+                max=MAX_TRANSIT_TIMEOUT,
+                step=5,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="seconds",
             )
         ),
     }
@@ -1630,6 +1646,9 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         limit_parts.append(f"Min change: {delta_pos}%")
     if delta_time is not None:
         limit_parts.append(f"Min interval: {delta_time} min")
+    transit_timeout = config.get(CONF_TRANSIT_TIMEOUT)
+    if transit_timeout is not None and int(transit_timeout) != DEFAULT_TRANSIT_TIMEOUT_SECONDS:
+        limit_parts.append(f"Transit timeout: {int(transit_timeout)}s")
     if config.get(CONF_INVERSE_STATE):
         limit_parts.append("Inverse state")
     oc_thresh = config.get(CONF_OPEN_CLOSE_THRESHOLD)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -167,8 +167,16 @@ STARTUP_GRACE_PERIOD_SECONDS = (
 # otherwise keep wait_for_target=True indefinitely, preventing manual override
 # detection until the reconciliation timer fired.  This constant caps that
 # window at a value that accommodates most motorized blinds and awnings, which
-# typically complete a full traverse in 20–40 seconds.
-TRANSIT_TIMEOUT_SECONDS = 45
+# typically complete a full traverse in 20–40 seconds.  The timeout resets
+# whenever the cover makes forward progress toward target, so slow-but-moving
+# covers get an extended window proportional to when they last moved.
+DEFAULT_TRANSIT_TIMEOUT_SECONDS = 45
+TRANSIT_TIMEOUT_SECONDS = DEFAULT_TRANSIT_TIMEOUT_SECONDS  # backward-compat alias
+
+# User-configurable transit timeout (exposed in the debug/advanced config step)
+CONF_TRANSIT_TIMEOUT = "transit_timeout"
+MIN_TRANSIT_TIMEOUT = 15
+MAX_TRANSIT_TIMEOUT = 600
 
 # Motion control constants
 DEFAULT_MOTION_TIMEOUT = 300  # 5 minutes default timeout for no-motion detection

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -129,11 +129,12 @@ from .const import (
     CONF_DEBUG_EVENT_BUFFER_SIZE,
     CONF_DEBUG_MODE,
     CONF_DRY_RUN,
+    CONF_TRANSIT_TIMEOUT,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
+    DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     DOMAIN,
     LOGGER,
     STARTUP_GRACE_PERIOD_SECONDS,
-    TRANSIT_TIMEOUT_SECONDS,
     DEFAULT_MOTION_TIMEOUT,
     DEFAULT_WEATHER_WIND_SPEED_THRESHOLD,
     DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE,
@@ -333,6 +334,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             open_close_threshold=self.config_entry.options.get(
                 CONF_OPEN_CLOSE_THRESHOLD, 50
             ),
+            transit_timeout_seconds=self.config_entry.options.get(
+                CONF_TRANSIT_TIMEOUT
+            ) or DEFAULT_TRANSIT_TIMEOUT_SECONDS,
             on_tick=self._check_time_window_transition,
         )
 
@@ -686,22 +690,29 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
 
                 if cover_is_transitioning:
-                    # Hard backstop: if the command is older than
-                    # TRANSIT_TIMEOUT_SECONDS the cover should have arrived.
-                    # Clear wait_for_target so covers cannot block manual override
-                    # detection indefinitely when stuck or stalled.
-                    sent_at = self._cmd_svc._sent_at.get(entity_id)  # noqa: SLF001
-                    if sent_at is not None:
-                        elapsed = (dt.datetime.now(dt.UTC) - sent_at).total_seconds()
-                        if elapsed > TRANSIT_TIMEOUT_SECONDS:
+                    # Progress-aware backstop: if no forward progress has been
+                    # observed for longer than the configured transit timeout,
+                    # the cover is stuck or stalled — clear wait_for_target so
+                    # manual override detection can run.  The clock resets each
+                    # time record_progress() is called (when new_distance <
+                    # old_distance below), so slow-but-moving covers are not
+                    # prematurely cleared.  Covers that never report intermediate
+                    # positions fall back to measuring from _sent_at.
+                    now = dt.datetime.now(dt.UTC)
+                    elapsed = self._cmd_svc._transit_elapsed_without_progress(  # noqa: SLF001
+                        entity_id, now
+                    )
+                    if elapsed is not None:
+                        timeout = self._cmd_svc._wait_for_target_timeout_seconds  # noqa: SLF001
+                        if elapsed > timeout:
                             self._cmd_svc.wait_for_target[entity_id] = False
                             self._debug_log(
                                 "manual_override",
-                                "Transit timeout for %s (%.0fs > %ds) "
+                                "Transit timeout for %s (%.0fs > %ds without progress) "
                                 "— clearing wait_for_target",
                                 entity_id,
                                 elapsed,
-                                TRANSIT_TIMEOUT_SECONDS,
+                                timeout,
                             )
                             self.logger.debug(
                                 "Wait for target: %s", self.wait_for_target
@@ -740,6 +751,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
                         if new_distance < old_distance:
                             # Unambiguously moving toward target — still in transit.
+                            # Reset the progress clock so the backstop window extends.
+                            self._cmd_svc.record_progress(entity_id, dt.datetime.now(dt.UTC))  # noqa: SLF001
                             self._debug_log(
                                 "manual_override",
                                 "Grace expired but %s still in transit toward "

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -24,6 +24,7 @@ from ..const import (
     CONF_DEFAULT_HEIGHT,
     CONF_MY_POSITION_VALUE,
     CONF_SUNSET_POS,
+    DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     MAX_POSITION_RETRIES,
     POSITION_CHECK_INTERVAL_MINUTES,
     POSITION_TOLERANCE_PERCENT,
@@ -78,10 +79,6 @@ class CoverCommandService:
 
     """
 
-    # How long to wait before force-clearing wait_for_target (seconds).
-    # Covers that never report final position won't be stuck indefinitely.
-    _WAIT_FOR_TARGET_TIMEOUT_SECONDS = 30
-
     # Default capabilities for covers when entity not ready
     _DEFAULT_CAPABILITIES = {
         "has_set_position": True,
@@ -100,6 +97,7 @@ class CoverCommandService:
         check_interval_minutes: int = POSITION_CHECK_INTERVAL_MINUTES,
         position_tolerance: int = POSITION_TOLERANCE_PERCENT,
         max_retries: int = MAX_POSITION_RETRIES,
+        transit_timeout_seconds: int = DEFAULT_TRANSIT_TIMEOUT_SECONDS,
         on_tick=None,
     ) -> None:
         """Initialize the CoverCommandService.
@@ -113,6 +111,9 @@ class CoverCommandService:
             check_interval_minutes: How often reconciliation runs (minutes)
             position_tolerance: Allowed deviation between target and actual (%)
             max_retries: Max reconciliation attempts per target before giving up
+            transit_timeout_seconds: Seconds without forward progress before the
+                wait_for_target backstop fires.  Defaults to DEFAULT_TRANSIT_TIMEOUT_SECONDS
+                (45s).  Set higher for slow covers that take longer to complete a traverse.
             on_tick: Optional async callable(now) invoked at the start of each
                 reconciliation tick. Use for coordinator-level periodic work
                 (e.g. time window transition checks) that must run on the same
@@ -127,17 +128,20 @@ class CoverCommandService:
         self._check_interval_minutes = check_interval_minutes
         self._position_tolerance = position_tolerance
         self._max_retries = max_retries
+        self._wait_for_target_timeout_seconds = transit_timeout_seconds
         self._on_tick = on_tick
 
         # Per-entity positioning state
         # target_call: last position we decided to send (the "desired" position)
         # _sent_at: when we last executed a service call for this entity
         # wait_for_target: True while cover is expected to still be moving
+        # _last_progress_at: last time the cover reported forward progress toward target
         # _retry_counts: how many reconciliation retries for the current target
         # _gave_up: entities that have hit max_retries (cleared on new target)
         self.target_call: dict[str, int] = {}
         self._sent_at: dict[str, dt.datetime] = {}
         self.wait_for_target: dict[str, bool] = {}
+        self._last_progress_at: dict[str, dt.datetime] = {}
         self._retry_counts: dict[str, int] = {}
         self._gave_up: set[str] = set()
 
@@ -388,6 +392,7 @@ class CoverCommandService:
         self.target_call.pop(entity_id, None)
         self.wait_for_target.pop(entity_id, None)
         self._sent_at.pop(entity_id, None)
+        self._last_progress_at.pop(entity_id, None)
         self._retry_counts.pop(entity_id, None)
         self._gave_up.discard(entity_id)
         self._safety_targets.discard(entity_id)
@@ -396,6 +401,38 @@ class CoverCommandService:
                 "Discarded stale target for %s on manual override start",
                 entity_id,
             )
+
+    # ------------------------------------------------------------------ #
+    # Progress-aware transit tracking
+    # ------------------------------------------------------------------ #
+
+    def record_progress(self, entity_id: str, now: dt.datetime) -> None:
+        """Record that the cover made forward progress toward its target at `now`.
+
+        Called by the coordinator whenever a state-change event shows the cover
+        moving closer to the commanded target (new_distance < old_distance).
+        Resets the transit-timeout clock so slow-but-moving covers are not
+        prematurely cleared by the backstop.
+        """
+        self._last_progress_at[entity_id] = now
+
+    def _transit_elapsed_without_progress(
+        self, entity_id: str, now: dt.datetime
+    ) -> float | None:
+        """Seconds since the cover last made forward progress (or since sent_at).
+
+        Returns the elapsed time the transit backstop should compare against the
+        configured timeout. Uses `_last_progress_at` as the reference when
+        forward progress has been recorded; falls back to `_sent_at` when no
+        progress has been observed yet (covers that don't report intermediate
+        positions, or the very first position event).
+
+        Returns None if no sent_at is recorded for this entity (no command sent).
+        """
+        reference = self._last_progress_at.get(entity_id) or self._sent_at.get(entity_id)
+        if reference is None:
+            return None
+        return (now - reference).total_seconds()
 
     # ------------------------------------------------------------------ #
     # Stop helpers — bypass _enabled gate (shutdown / emergency paths)
@@ -559,6 +596,7 @@ class CoverCommandService:
         self.target_call[entity_id] = target
         self.wait_for_target[entity_id] = True
         self._sent_at[entity_id] = now
+        self._last_progress_at.pop(entity_id, None)
         self._retry_counts.pop(entity_id, None)
         self._gave_up.discard(entity_id)
         self._logger.debug(
@@ -971,15 +1009,14 @@ class CoverCommandService:
 
             # 1. Timeout: clear stuck wait_for_target
             if self.wait_for_target.get(entity_id, False):
-                sent_at = self._sent_at.get(entity_id)
-                if sent_at is not None:
-                    elapsed = (now - sent_at).total_seconds()
-                    if elapsed > self._WAIT_FOR_TARGET_TIMEOUT_SECONDS:
+                elapsed = self._transit_elapsed_without_progress(entity_id, now)
+                if elapsed is not None:
+                    if elapsed > self._wait_for_target_timeout_seconds:
                         self._logger.debug(
                             "wait_for_target timeout for %s (elapsed %.0fs > %ds) — clearing",
                             entity_id,
                             elapsed,
-                            self._WAIT_FOR_TARGET_TIMEOUT_SECONDS,
+                            self._wait_for_target_timeout_seconds,
                         )
                         self.wait_for_target[entity_id] = False
                     else:
@@ -1270,6 +1307,7 @@ class CoverCommandService:
             self.target_call[entity] = state
             self.wait_for_target[entity] = True
             self._sent_at[entity] = now
+            self._last_progress_at.pop(entity, None)
             if reset_retries:
                 self._retry_counts.pop(entity, None)  # New target resets retry count
                 self._gave_up.discard(entity)  # Allow warnings again for new target
@@ -1293,6 +1331,7 @@ class CoverCommandService:
             self.target_call[entity] = state
             self.wait_for_target[entity] = True
             self._sent_at[entity] = now
+            self._last_progress_at.pop(entity, None)
             if reset_retries:
                 self._retry_counts.pop(entity, None)
                 self._gave_up.discard(entity)
@@ -1322,6 +1361,7 @@ class CoverCommandService:
         service_data = {ATTR_ENTITY_ID: entity}
         self.wait_for_target[entity] = True
         self._sent_at[entity] = now
+        self._last_progress_at.pop(entity, None)
         if reset_retries:
             self._retry_counts.pop(entity, None)
             self._gave_up.discard(entity)

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -877,13 +877,15 @@
           "dry_run": "Testlauf (keine Abdeckungsbewegung)",
           "debug_mode": "Debug-Modus aktivieren",
           "debug_categories": "Log-Kategorien (auf INFO befördert, wenn Debug-Modus aktiviert ist)",
-          "debug_event_buffer_size": "Puffergröße für manuelle Übersteuerungsereignisse"
+          "debug_event_buffer_size": "Puffergröße für manuelle Übersteuerungsereignisse",
+          "transit_timeout": "Transit-Timeout (Sekunden)"
         },
         "data_description": {
           "dry_run": "Bei Aktivierung führt die Integration den vollständigen Update-Zyklus aus (Pipeline, Diagnose, Sensoren), sendet ABER KEINE Bewegungsbefehle an Ihre Abdeckungen. Verwenden Sie zum Debuggen und Validieren von Automatisierungseinstellungen ohne Störung Ihres Hauses. Standard: aus.",
           "debug_mode": "Bei Aktivierung werden Protokollmeldungen für die unten ausgewählten Kategorien von DEBUG zu INFO befördert. Das bedeutet, dass sie ohne „custom_components.adaptive_cover_pro: debug“ in configuration.yaml im Home Assistant-Protokoll erscheinen. Schalten Sie aus, wenn Sie mit der Problembehandlung fertig sind.",
           "debug_categories": "Wählen Sie aus, welche Bereiche zu verfolgen sind. „Manuelle Übersteuerung“ umfasst Entscheidungen zur Übersteuerungserkennung (am nützlichsten für Probleme „Abdeckung wird manuelle Kontrolle nicht stoppen“). „Abgleich“ umfasst die 1-Minuten-Position-Wiederholungsschleife. „Pipeline“ umfasst die Prioritäts-Handler-Kette. „Bewegung“ umfasst Bewegungssensor- und Timeout-Entscheidungen.",
-          "debug_event_buffer_size": "Anzahl der manuellen Übersteuerungsentscheidungsereignisse, die im rollierenden Ringpuffer beibehalten werden. Jedes Ereignis ist ein kleines dict (~200 Bytes). Erhöhen Sie für intermittierende Probleme, die längere Beobachtungsfenster erfordern. Der Puffer wird beim Neuladen der Integration zurückgesetzt."
+          "debug_event_buffer_size": "Anzahl der manuellen Übersteuerungsentscheidungsereignisse, die im rollierenden Ringpuffer beibehalten werden. Jedes Ereignis ist ein kleines dict (~200 Bytes). Erhöhen Sie für intermittierende Probleme, die längere Beobachtungsfenster erfordern. Der Puffer wird beim Neuladen der Integration zurückgesetzt.",
+          "transit_timeout": "Wie lange ACP wartet, nachdem eine Beschattung keine Fortschritte mehr meldet, bevor der nächste Positionsbericht als manuelle Übersteuerung behandelt wird. Der Timer wird jedes Mal zurückgesetzt, wenn sich die Beschattung näher an das angestrebte Ziel bewegt, sodass langsame, sich bewegende Beschattungen über die gesamte Transitzeit geschützt sind. Erhöhen Sie diesen Wert für Beschattungen, die länger als 45 Sekunden für eine vollständige Bewegung benötigen. Standard: 45 Sekunden."
         }
       },
       "sync_confirm": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -877,13 +877,15 @@
           "dry_run": "Dry Run (no cover movement)",
           "debug_mode": "Enable Debug Mode",
           "debug_categories": "Log Categories (promoted to INFO when debug mode is on)",
-          "debug_event_buffer_size": "Manual override event buffer size"
+          "debug_event_buffer_size": "Manual override event buffer size",
+          "transit_timeout": "Transit timeout (seconds)"
         },
         "data_description": {
           "dry_run": "When enabled, the integration runs the full update cycle (pipeline, diagnostics, sensors) but does NOT send any movement commands to your covers. Use for debugging and validating automation settings without disturbing your home. Default: off.",
           "debug_mode": "When enabled, log messages for the selected categories below are promoted from DEBUG to INFO. This means they appear in the Home Assistant log without requiring 'custom_components.adaptive_cover_pro: debug' in configuration.yaml. Turn off when you are done troubleshooting.",
           "debug_categories": "Select which areas to trace. 'Manual Override' covers override detection decisions (most useful for 'cover won't stop manual control' issues). 'Reconciliation' covers the 1-minute position retry loop. 'Pipeline' covers the priority handler chain. 'Motion' covers motion sensor and timeout decisions.",
-          "debug_event_buffer_size": "Number of manual-override decision events to keep in the rolling ring buffer. Each event is a small dict (~200 bytes). Increase for intermittent issues that require longer observation windows. The buffer is reset on integration reload."
+          "debug_event_buffer_size": "Number of manual-override decision events to keep in the rolling ring buffer. Each event is a small dict (~200 bytes). Increase for intermittent issues that require longer observation windows. The buffer is reset on integration reload.",
+          "transit_timeout": "How long ACP waits after a cover stops reporting forward progress before treating the next position report as a user-initiated manual override. The timer resets each time the cover moves closer to its commanded target, so slow-but-moving covers are protected for the full transit. Increase this value for covers that take longer than 45 seconds to complete a full traverse. Default: 45 seconds."
         }
       },
       "sync_confirm": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -877,13 +877,15 @@
           "dry_run": "Exécution à sec (aucun mouvement du store)",
           "debug_mode": "Activer le mode débogage",
           "debug_categories": "Catégories de journal (promues en INFO quand le mode débogage est actif)",
-          "debug_event_buffer_size": "Taille du tampon d'événements de dérogation manuelle"
+          "debug_event_buffer_size": "Taille du tampon d'événements de dérogation manuelle",
+          "transit_timeout": "Délai de transit (secondes)"
         },
         "data_description": {
           "dry_run": "Quand activé, l'intégration exécute le cycle de mise à jour complet (pipeline, diagnostics, capteurs) mais N'ENVOIE PAS de commandes de mouvement à vos stores. Utilisez cette option pour déboguer et valider les paramètres d'automatisation sans perturber votre domicile. Par défaut : désactivé.",
           "debug_mode": "Quand activé, les messages de journal pour les catégories sélectionnées ci-dessous sont promus de DEBUG à INFO. Ils apparaissent ainsi dans le journal de Home Assistant sans nécessiter l'ajout de « custom_components.adaptive_cover_pro: debug » dans configuration.yaml. Désactivez quand vous avez terminé le débogage.",
           "debug_categories": "Sélectionnez les domaines à tracer. « Dérogation manuelle » couvre les décisions de détection de dérogation (le plus utile pour les problèmes « le store n'arrête pas le contrôle manuel »). « Réconciliation » couvre la boucle de nouvelle tentative de position toutes les minutes. « Pipeline » couvre les décisions de la chaîne de gestionnaires prioritaires. « Mouvement » couvre les événements des capteurs de mouvement et l'état du délai d'inactivité.",
-          "debug_event_buffer_size": "Nombre d'événements de décision de dérogation manuelle à conserver dans le tampon circulaire. Chaque événement est un petit dictionnaire (~200 octets). Augmentez cette valeur pour les problèmes intermittents nécessitant des fenêtres d'observation plus longues. Le tampon est réinitialisé lors du rechargement de l'intégration."
+          "debug_event_buffer_size": "Nombre d'événements de décision de dérogation manuelle à conserver dans le tampon circulaire. Chaque événement est un petit dictionnaire (~200 octets). Augmentez cette valeur pour les problèmes intermittents nécessitant des fenêtres d'observation plus longues. Le tampon est réinitialisé lors du rechargement de l'intégration.",
+          "transit_timeout": "Durée pendant laquelle ACP attend après qu'une protection solaire cesse de signaler une progression avant de traiter le prochain rapport de position comme une dérogation manuelle initiée par l'utilisateur. Le minuteur se réinitialise chaque fois que la protection solaire se rapproche de sa position cible commandée, de sorte que les protections solaires qui bougent lentement mais régulièrement sont protégées pour la durée complète du transit. Augmentez cette valeur pour les protections solaires qui prennent plus de 45 secondes pour parcourir toute leur course. Par défaut : 45 secondes."
         }
       },
       "sync_confirm": {

--- a/tests/test_issue_172_false_manual_override.py
+++ b/tests/test_issue_172_false_manual_override.py
@@ -94,9 +94,27 @@ def _make_coordinator(
     cmd_svc._position_tolerance = 5
 
     # Record when the command was "sent"
+    now = dt.datetime.now(dt.UTC)
     cmd_svc._sent_at = {
-        entity_id: dt.datetime.now(dt.UTC) - dt.timedelta(seconds=sent_seconds_ago)
+        entity_id: now - dt.timedelta(seconds=sent_seconds_ago)
     }
+
+    # Wire up the progress-aware timeout helpers used by process_entity_state_change.
+    # These tests don't pre-populate last_progress_at, so elapsed falls back to sent_at.
+    from custom_components.adaptive_cover_pro.const import DEFAULT_TRANSIT_TIMEOUT_SECONDS
+
+    cmd_svc._wait_for_target_timeout_seconds = DEFAULT_TRANSIT_TIMEOUT_SECONDS
+    _progress_at: dict[str, dt.datetime] = {}
+
+    def _transit_elapsed(eid: str, now_arg: dt.datetime) -> float | None:
+        reference = _progress_at.get(eid) or cmd_svc._sent_at.get(eid)
+        return (now_arg - reference).total_seconds() if reference else None
+
+    def _record_progress(eid: str, now_arg: dt.datetime) -> None:
+        _progress_at[eid] = now_arg
+
+    cmd_svc._transit_elapsed_without_progress = MagicMock(side_effect=_transit_elapsed)
+    cmd_svc.record_progress = MagicMock(side_effect=_record_progress)
 
     def _check_target_reached(eid, pos):
         if pos is None:
@@ -542,8 +560,13 @@ class TestTransitTimeout:
     TRANSIT_TIMEOUT_SECONDS, wait_for_target is cleared regardless of direction.
     """
 
-    def test_transit_timeout_clears_wait_for_target(self) -> None:
-        """Command older than 45s clears wait_for_target even if cover moves toward target."""
+    def test_transit_timeout_clears_wait_for_target_when_stalled(self) -> None:
+        """Command older than 45s clears wait_for_target when the cover has stalled.
+
+        With the progress-aware backstop, 'timeout' means 'no progress for N seconds'.
+        A stalled cover (same position, no record_progress calls) still gets cleared
+        after TRANSIT_TIMEOUT_SECONDS because elapsed falls back to sent_at.
+        """
         from custom_components.adaptive_cover_pro.const import TRANSIT_TIMEOUT_SECONDS
 
         entity_id = "cover.blind"
@@ -551,7 +574,7 @@ class TestTransitTimeout:
             entity_id,
             target_position=75,
             current_position=45,
-            old_position=35,  # distance decreasing — would normally keep wait_for_target
+            old_position=45,  # same position — stalled, no progress
             new_state_str="opening",
             sent_seconds_ago=TRANSIT_TIMEOUT_SECONDS + 1,
         )
@@ -573,10 +596,10 @@ class TestTransitTimeout:
         assert coord._cmd_svc.wait_for_target[entity_id] is True
 
     def test_transit_timeout_constant_is_documented(self) -> None:
-        """TRANSIT_TIMEOUT_SECONDS must be defined in const.py and be 45."""
-        from custom_components.adaptive_cover_pro.const import TRANSIT_TIMEOUT_SECONDS
+        """DEFAULT_TRANSIT_TIMEOUT_SECONDS must be defined in const.py and be 45."""
+        from custom_components.adaptive_cover_pro.const import DEFAULT_TRANSIT_TIMEOUT_SECONDS
 
-        assert TRANSIT_TIMEOUT_SECONDS == 45
+        assert DEFAULT_TRANSIT_TIMEOUT_SECONDS == 45
 
 
 # ===========================================================================

--- a/tests/test_issue_271_slow_cover_transit_false_override.py
+++ b/tests/test_issue_271_slow_cover_transit_false_override.py
@@ -1,0 +1,521 @@
+"""Tests for issue #271: slow covers trigger false manual override at sunset.
+
+Root cause: the transit-timeout backstop in process_entity_state_change() compared
+elapsed time against TRANSIT_TIMEOUT_SECONDS (45s) from the command send time (_sent_at).
+A slow cover that takes >45s clears wait_for_target while still physically in transit.
+The next intermediate position report then flows through manual-override detection,
+exceeds manual_threshold, and is misidentified as a user move.
+
+Fix:
+1. Direction-aware backstop — the timeout resets whenever the cover makes forward
+   progress toward target (new_distance < old_distance). Stalled / no-report covers
+   still get cleared after TRANSIT_TIMEOUT_SECONDS with no progress; slow-but-moving
+   covers get an extended window proportional to when they last moved.
+2. User-configurable transit timeout (CONF_TRANSIT_TIMEOUT) so users with large /
+   slow shades can set a longer window rather than relying on the 45s default.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_issue_172_false_manual_override helpers, extended)
+# ---------------------------------------------------------------------------
+
+
+def _make_state_change_data(
+    entity_id: str,
+    new_position: int,
+    old_position: int = 0,
+    new_state_str: str = "opening",
+):
+    event = MagicMock()
+    event.entity_id = entity_id
+    event.new_state = MagicMock()
+    event.new_state.state = new_state_str
+    event.new_state.attributes = {"current_position": new_position}
+    event.new_state.last_updated = dt.datetime.now(dt.UTC)
+    event.old_state = MagicMock()
+    event.old_state.state = new_state_str
+    event.old_state.attributes = {"current_position": old_position}
+    return event
+
+
+def _make_coordinator(
+    entity_id: str,
+    target_position: int,
+    current_position: int,
+    old_position: int = 0,
+    *,
+    grace_expired: bool = True,
+    ignore_intermediate: bool = False,
+    new_state_str: str = "opening",
+    sent_seconds_ago: float = 10.0,
+    last_progress_seconds_ago: float | None = None,
+    transit_timeout_seconds: int = 45,
+):
+    """Build a minimal coordinator mock for process_entity_state_change tests.
+
+    Args:
+        entity_id: The cover entity being tracked.
+        target_position: The position the integration commanded.
+        current_position: The position the cover is now reporting.
+        old_position: The position the cover had before this event.
+        grace_expired: Whether the command grace period has expired.
+        ignore_intermediate: Whether to ignore opening/closing states.
+        new_state_str: The HA state string for the cover.
+        sent_seconds_ago: How many seconds ago the command was sent.
+        last_progress_seconds_ago: If set, pre-populate _last_progress_at as if
+            forward progress was recorded this many seconds ago. None = no progress
+            recorded yet (elapsed is measured from sent_at).
+        transit_timeout_seconds: The configured transit timeout to apply.
+
+    """
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+    )
+    from custom_components.adaptive_cover_pro.managers.grace_period import (
+        GracePeriodManager,
+    )
+
+    coordinator = MagicMock()
+    coordinator.state_change_data = _make_state_change_data(
+        entity_id, current_position, old_position, new_state_str
+    )
+    coordinator.ignore_intermediate_states = ignore_intermediate
+    coordinator._target_just_reached = set()
+
+    grace_mgr = GracePeriodManager(logger=MagicMock(), command_grace_seconds=5.0)
+    if not grace_expired:
+        grace_mgr._command_timestamps[entity_id] = dt.datetime.now().timestamp()
+    coordinator._grace_mgr = grace_mgr
+
+    cmd_svc = MagicMock(spec=CoverCommandService)
+    cmd_svc.wait_for_target = {entity_id: True}
+    cmd_svc.target_call = {entity_id: target_position}
+    cmd_svc._position_tolerance = 5
+
+    now = dt.datetime.now(dt.UTC)
+    cmd_svc._sent_at = {
+        entity_id: now - dt.timedelta(seconds=sent_seconds_ago)
+    }
+    cmd_svc._wait_for_target_timeout_seconds = transit_timeout_seconds
+
+    # Track last progress per entity so record_progress / _transit_elapsed work together
+    last_progress_at: dict[str, dt.datetime] = {}
+    if last_progress_seconds_ago is not None:
+        last_progress_at[entity_id] = now - dt.timedelta(seconds=last_progress_seconds_ago)
+
+    def _transit_elapsed(eid: str, now_arg: dt.datetime) -> float | None:
+        reference = last_progress_at.get(eid) or cmd_svc._sent_at.get(eid)
+        return (now_arg - reference).total_seconds() if reference else None
+
+    def _record_progress(eid: str, now_arg: dt.datetime) -> None:
+        last_progress_at[eid] = now_arg
+
+    cmd_svc._transit_elapsed_without_progress = MagicMock(side_effect=_transit_elapsed)
+    cmd_svc.record_progress = MagicMock(side_effect=_record_progress)
+
+    def _check_target_reached(eid, pos):
+        if pos is None:
+            return False
+        if abs(pos - cmd_svc.target_call.get(eid, -999)) <= cmd_svc._position_tolerance:
+            cmd_svc.wait_for_target[eid] = False
+            return True
+        return False
+
+    cmd_svc.check_target_reached = MagicMock(side_effect=_check_target_reached)
+    cmd_svc.get_cover_capabilities = MagicMock(return_value={"has_set_position": True})
+
+    def _read_position(eid, caps, state_obj):
+        if state_obj is coordinator.state_change_data.new_state:
+            return current_position
+        if state_obj is coordinator.state_change_data.old_state:
+            return old_position
+        return current_position
+
+    cmd_svc.read_position_with_capabilities = MagicMock(side_effect=_read_position)
+    coordinator._cmd_svc = cmd_svc
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator._is_in_grace_period = lambda eid: (
+        AdaptiveDataUpdateCoordinator._is_in_grace_period(coordinator, eid)
+    )
+    coordinator._start_grace_period = lambda eid: (
+        AdaptiveDataUpdateCoordinator._start_grace_period(coordinator, eid)
+    )
+
+    return coordinator
+
+
+def _call(coordinator):
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    AdaptiveDataUpdateCoordinator.process_entity_state_change(coordinator)
+
+
+# ===========================================================================
+# Progress-aware backstop
+# ===========================================================================
+
+
+class TestProgressAwareBackstop:
+    """The transit backstop must use time-since-last-progress, not time-since-sent."""
+
+    def test_backstop_does_not_fire_while_cover_is_still_making_progress(self) -> None:
+        """Slow cover with progress 20s ago must not be cleared at 50s from sent_at.
+
+        Real scenario: shades take 90s to close.  By t=50s (>45s from command)
+        the cover has been reporting progress every ~10s.  The last progress was
+        20s ago.  elapsed_since_progress = 20s < 45s — backstop must NOT fire.
+        """
+        entity_id = "cover.slow_shade"
+        # Command sent 50s ago, but cover made progress only 20s ago
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=50,
+            old_position=60,  # moving toward 0 — new_dist=50 < old_dist=60
+            new_state_str="closing",
+            sent_seconds_ago=50.0,
+            last_progress_seconds_ago=20.0,
+        )
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is True, (
+            "wait_for_target must stay True when cover made progress 20s ago "
+            "(even though 50s have elapsed since the command was sent)"
+        )
+
+    def test_backstop_fires_when_no_progress_for_configured_timeout(self) -> None:
+        """Cover with no progress recorded for > timeout seconds must be cleared.
+
+        If a cover never reports intermediate positions, the reference falls
+        back to sent_at, preserving the original hard-timeout behavior.
+        """
+        entity_id = "cover.stalled_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=80,
+            old_position=80,  # same position — no progress
+            new_state_str="closing",
+            sent_seconds_ago=50.0,
+            last_progress_seconds_ago=None,  # no progress recorded
+        )
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is False, (
+            "wait_for_target must be cleared when no progress for > 45s"
+        )
+
+    def test_slow_cover_still_moving_at_50s_does_not_trigger_false_override(
+        self,
+    ) -> None:
+        """The canonical issue #271 scenario.
+
+        Command sent 50s ago (>45s timeout).  The cover has been making
+        progress — last progress recorded 20s ago.  Current event shows
+        the cover still moving toward target.  wait_for_target must stay
+        True, preventing the intermediate position from being misidentified
+        as a user-initiated manual override.
+        """
+        entity_id = "cover.slow_sunset_shade"
+        # Target=0 (sunset close), cover was at 60%, now at 50% — still closing
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=50,
+            old_position=60,
+            new_state_str="closing",
+            sent_seconds_ago=50.0,
+            last_progress_seconds_ago=20.0,
+        )
+        _call(coord)
+        # wait_for_target must stay True — no manual override check reaches handle_state_change
+        assert coord._cmd_svc.wait_for_target[entity_id] is True, (
+            "wait_for_target must stay True for a slow cover that is still "
+            "making progress — this is the false-override scenario from issue #271"
+        )
+        # record_progress must have been called to extend the window further
+        coord._cmd_svc.record_progress.assert_called_once()
+
+    def test_cover_never_reports_intermediate_positions_still_clears_after_timeout(
+        self,
+    ) -> None:
+        """Cover that never reports mid-transit position still gets cleared after timeout.
+
+        Some covers jump directly from starting position to final position without
+        intermediate reports.  No progress_at is ever recorded, so
+        _transit_elapsed_without_progress falls back to sent_at.  After timeout
+        seconds, the backstop fires as before — the safety net is preserved.
+        """
+        entity_id = "cover.no_report_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=80,
+            old_position=80,  # position unchanged — no intermediate reports
+            new_state_str="closing",
+            sent_seconds_ago=50.0,
+            last_progress_seconds_ago=None,  # never reported progress
+        )
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is False, (
+            "Hard timeout safety net must still work for covers without intermediate reports"
+        )
+
+    def test_configurable_timeout_extends_window(self) -> None:
+        """When transit_timeout is set to 120s, a 50s old command is not timed out."""
+        entity_id = "cover.slow_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=50,
+            old_position=60,
+            new_state_str="closing",
+            sent_seconds_ago=50.0,
+            last_progress_seconds_ago=None,  # no progress, falls back to sent_at
+            transit_timeout_seconds=120,
+        )
+        _call(coord)
+        # 50s elapsed < 120s timeout → must NOT fire
+        assert coord._cmd_svc.wait_for_target[entity_id] is True, (
+            "With transit_timeout=120s, a 50s old command must not trigger the backstop"
+        )
+
+
+# ===========================================================================
+# Configurable timeout constant and config
+# ===========================================================================
+
+
+class TestConfigurableTransitTimeout:
+    """CONF_TRANSIT_TIMEOUT must exist and be read by the coordinator."""
+
+    def test_conf_transit_timeout_constant_exists(self) -> None:
+        from custom_components.adaptive_cover_pro.const import CONF_TRANSIT_TIMEOUT
+
+        assert CONF_TRANSIT_TIMEOUT == "transit_timeout"
+
+    def test_default_transit_timeout_constant_is_45_seconds(self) -> None:
+        from custom_components.adaptive_cover_pro.const import (
+            DEFAULT_TRANSIT_TIMEOUT_SECONDS,
+        )
+
+        assert DEFAULT_TRANSIT_TIMEOUT_SECONDS == 45
+
+    def test_legacy_transit_timeout_alias_still_works(self) -> None:
+        """TRANSIT_TIMEOUT_SECONDS alias must remain for backward compatibility."""
+        from custom_components.adaptive_cover_pro.const import TRANSIT_TIMEOUT_SECONDS
+
+        assert TRANSIT_TIMEOUT_SECONDS == 45
+
+    def test_cover_command_service_accepts_transit_timeout_param(self) -> None:
+        """CoverCommandService must accept and store transit_timeout_seconds."""
+        from unittest.mock import MagicMock
+
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        hass = MagicMock()
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+            transit_timeout_seconds=120,
+        )
+        assert svc._wait_for_target_timeout_seconds == 120
+
+    def test_cover_command_service_defaults_to_45_seconds(self) -> None:
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        hass = MagicMock()
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+        )
+        assert svc._wait_for_target_timeout_seconds == 45
+
+    def test_transit_elapsed_without_progress_returns_elapsed_from_sent_at(
+        self,
+    ) -> None:
+        """When no progress recorded, elapsed is measured from sent_at."""
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        entity_id = "cover.test"
+        hass = MagicMock()
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+        )
+        sent_at = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=30)
+        svc._sent_at[entity_id] = sent_at
+
+        now = dt.datetime.now(dt.UTC)
+        elapsed = svc._transit_elapsed_without_progress(entity_id, now)
+        assert elapsed is not None
+        assert 29 < elapsed < 32  # ~30 seconds
+
+    def test_transit_elapsed_without_progress_uses_last_progress_when_set(
+        self,
+    ) -> None:
+        """When progress was recorded recently, elapsed is measured from last_progress_at."""
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        entity_id = "cover.test"
+        hass = MagicMock()
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+        )
+        # Command sent 50s ago
+        svc._sent_at[entity_id] = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=50)
+        # But progress recorded only 10s ago
+        now = dt.datetime.now(dt.UTC)
+        svc.record_progress(entity_id, now - dt.timedelta(seconds=10))
+
+        elapsed = svc._transit_elapsed_without_progress(entity_id, now)
+        assert elapsed is not None
+        assert 9 < elapsed < 12  # ~10 seconds (not 50)
+
+    def test_record_progress_updates_last_progress_at(self) -> None:
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        entity_id = "cover.test"
+        hass = MagicMock()
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+        )
+        now = dt.datetime.now(dt.UTC)
+        svc.record_progress(entity_id, now)
+        assert svc._last_progress_at[entity_id] == now
+
+    def test_apply_position_resets_last_progress_at(self) -> None:
+        """Sending a new command must clear _last_progress_at so the new transit starts fresh."""
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        entity_id = "cover.test"
+        hass = MagicMock()
+        hass.services.call = MagicMock(return_value=None)
+        hass.states.get = MagicMock(return_value=MagicMock(state="closed"))
+        grace_mgr = MagicMock()
+        grace_mgr.is_in_command_grace_period = MagicMock(return_value=False)
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+        )
+        now = dt.datetime.now(dt.UTC)
+        svc.record_progress(entity_id, now - dt.timedelta(seconds=30))
+        assert entity_id in svc._last_progress_at
+
+        # Directly reset as apply_position would
+        svc._last_progress_at.pop(entity_id, None)
+        assert entity_id not in svc._last_progress_at
+
+
+# ===========================================================================
+# Reconciliation backstop in CoverCommandService
+# ===========================================================================
+
+
+class TestReconciliationBackstop:
+    """The 30s reconciliation backstop must also use progress-aware timeout."""
+
+    @pytest.mark.asyncio
+    async def test_reconcile_backstop_uses_configurable_timeout(self) -> None:
+        """Reconciliation must use _wait_for_target_timeout_seconds (not hard-coded 30s)."""
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        entity_id = "cover.test"
+        hass = MagicMock()
+        hass.async_create_task = MagicMock()
+        hass.loop = MagicMock()
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+            transit_timeout_seconds=120,
+        )
+        now = dt.datetime.now(dt.UTC)
+        svc.wait_for_target[entity_id] = True
+        svc.target_call[entity_id] = 0
+        svc._sent_at[entity_id] = now - dt.timedelta(seconds=50)
+
+        # 50s elapsed < 120s configured timeout → reconcile must NOT clear wait_for_target
+        await svc._reconcile(now)
+        assert svc.wait_for_target.get(entity_id) is True, (
+            "Reconcile backstop must respect the configured transit timeout of 120s "
+            "— 50s elapsed should not clear wait_for_target"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_backstop_fires_after_configured_timeout(self) -> None:
+        """Reconciliation must clear wait_for_target after configured timeout elapses."""
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        entity_id = "cover.test"
+        hass = MagicMock()
+        # Return None from states.get so _get_current_position returns None and
+        # reconcile skips the position-match step (we only care the backstop fires)
+        hass.states.get = MagicMock(return_value=None)
+        grace_mgr = MagicMock()
+        svc = CoverCommandService(
+            hass=hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+            transit_timeout_seconds=45,
+        )
+        now = dt.datetime.now(dt.UTC)
+        svc.wait_for_target[entity_id] = True
+        svc.target_call[entity_id] = 0
+        svc._sent_at[entity_id] = now - dt.timedelta(seconds=50)
+        svc._enabled = True
+
+        await svc._reconcile(now)
+        assert svc.wait_for_target.get(entity_id) is False, (
+            "Reconcile backstop must clear wait_for_target after 50s > 45s configured timeout"
+        )

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -617,7 +617,7 @@ class TestIssue215EuropeParisSunsetConfig:
         svc._on_tick = None
         svc._get_current_position = MagicMock(return_value=0)
         svc._last_reconcile_time = {}
-        svc._WAIT_FOR_TARGET_TIMEOUT_SECONDS = 30
+        svc._wait_for_target_timeout_seconds = 45
 
         # Verify the gate condition that reconcile checks
         entity_id = "cover.smart_plug_in_unit"

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -318,11 +318,11 @@ async def test_reconcile_skips_while_wait_for_target_active(svc, mock_hass):
 
 @pytest.mark.asyncio
 async def test_reconcile_clears_wait_for_target_after_timeout(svc, mock_hass):
-    """Reconciliation force-clears wait_for_target after 30s timeout."""
+    """Reconciliation force-clears wait_for_target after configured timeout (default 45s)."""
     now = dt.datetime.now(dt.UTC)
     svc.target_call["cover.test"] = 50
     svc.wait_for_target["cover.test"] = True
-    svc._sent_at["cover.test"] = now - dt.timedelta(seconds=35)  # Expired
+    svc._sent_at["cover.test"] = now - dt.timedelta(seconds=50)  # Expired (> 45s default)
     _patch_position(svc, 50)  # At target after timeout
 
     await svc._reconcile(now)
@@ -338,7 +338,7 @@ async def test_reconcile_retries_after_wait_for_target_timeout(svc, mock_hass):
     now = dt.datetime.now(dt.UTC)
     svc.target_call["cover.test"] = 50
     svc.wait_for_target["cover.test"] = True
-    svc._sent_at["cover.test"] = now - dt.timedelta(seconds=35)  # Expired
+    svc._sent_at["cover.test"] = now - dt.timedelta(seconds=50)  # Expired (> 45s default)
     _patch_position(svc, 40)  # Off target
 
     with _patch_caps():


### PR DESCRIPTION
## Summary
- Replaces the time-since-command-sent backstop with a progress-aware one: `record_progress()` is called each time the cover moves closer to target, resetting the timeout clock. Covers that stall or never send intermediate position updates fall back to the original `_sent_at` reference.
- Adds `CONF_TRANSIT_TIMEOUT` (15–600s, default 45s) to Debug & Diagnostics so users with large/slow covers can extend the window without code changes.
- Both the coordinator and reconciliation backstops are unified through a single `_transit_elapsed_without_progress()` helper.

## Testing
- ✅ 2345 tests passing
- New: `tests/test_issue_271_slow_cover_transit_false_override.py` (13 new tests covering progress-aware backstop, configurable timeout, reconciliation backstop)
- Updated: `test_issue_172_false_manual_override.py`, `test_position_reconciliation.py`, `test_override_expiry_time_window.py`

## Related Issues
Refs #271