### PR TITLE
feat: raise window_depth maximum to 5.0m

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -195,7 +195,7 @@ GEOMETRY_VERTICAL_SCHEMA = vol.Schema(
         vol.Optional(CONF_WINDOW_DEPTH, default=0.0): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0.0,
-                max=0.5,
+                max=5.0,
                 step=0.01,
                 mode=selector.NumberSelectorMode.SLIDER,
                 unit_of_measurement="m",

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -836,11 +836,11 @@ set_geometry:
           unit_of_measurement: m
     window_depth:
       name: Window depth
-      description: "Window reveal depth in metres (0–0.5 m). Vertical blind only."
+      description: "Window reveal depth in metres (0–5 m). Vertical blind only."
       selector:
         number:
           min: 0
-          max: 0.5
+          max: 5.0
           step: 0.01
           mode: slider
           unit_of_measurement: m

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -186,7 +186,7 @@ FIELD_VALIDATORS: dict[str, Any] = {
     # Geometry — vertical blind
     CONF_HEIGHT_WIN: _num(0.1, 6),
     CONF_WINDOW_WIDTH: _num(0.1, 5),
-    CONF_WINDOW_DEPTH: _num(0.0, 0.5),
+    CONF_WINDOW_DEPTH: _num(0.0, 5.0),
     CONF_SILL_HEIGHT: _num(0.0, 3.0),
     # Geometry — awning
     CONF_LENGTH_AWNING: _num(0.3, 6),

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1278,7 +1278,7 @@
           "name": "Neigungs-Modus"
         },
         "window_depth": {
-          "description": "Fensterrahmen-Tiefe in Metern (0–0,5 m). Nur Vertikaljalousie.",
+          "description": "Fensterrahmen-Tiefe in Metern (0–5 m). Nur Vertikaljalousie.",
           "name": "Fenstertiefe"
         },
         "window_height": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1269,7 +1269,7 @@
       "fields": {
         "window_height": { "name": "Window height", "description": "Window height in metres (0.1–6 m). Vertical blind and awning only." },
         "window_width": { "name": "Window width", "description": "Window width in metres (0.1–5 m). Vertical blind only." },
-        "window_depth": { "name": "Window depth", "description": "Window reveal depth in metres (0–0.5 m). Vertical blind only." },
+        "window_depth": { "name": "Window depth", "description": "Window reveal depth in metres (0–5 m). Vertical blind only." },
         "sill_height": { "name": "Sill height", "description": "Window sill height from floor in metres (0–3 m). Vertical blind only." },
         "length_awning": { "name": "Awning length", "description": "Awning projection length in metres (0.3–6 m). Awning only." },
         "angle": { "name": "Awning angle", "description": "Awning tilt angle in degrees (0–45°). Awning only." },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1278,7 +1278,7 @@
           "name": "Mode d'inclinaison"
         },
         "window_depth": {
-          "description": "Profondeur du rejingot de la fenêtre en mètres (0–0,5 m). Stores verticaux uniquement.",
+          "description": "Profondeur du rejingot de la fenêtre en mètres (0–5 m). Stores verticaux uniquement.",
           "name": "Profondeur de la fenêtre"
         },
         "window_height": {

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -567,6 +567,15 @@ class TestWindowDepth:
         position = cover.calculate_position()
         assert 0 <= position <= cover.h_win
 
+    def test_window_depth_large_value_clipped(self, base_cover_params):
+        """window_depth=5.0m (new max) must produce a finite position clipped to [0, h_win]."""
+        params = dict(base_cover_params)
+        params["window_depth"] = 5.0
+        cover = build_vertical_cover(**params)
+        position = cover.calculate_position()
+        assert 0 <= position <= cover.h_win
+        assert not (position != position)  # not NaN
+
 
 class TestSmoothTransitions:
     """Test that transitions are smooth across angle ranges."""

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -44,6 +44,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MAX_POSITION,
     CONF_MIN_POSITION,
     CONF_MOTION_SENSORS,
+    CONF_WINDOW_DEPTH,
     CONF_MOTION_TIMEOUT,
     CONF_MY_POSITION_VALUE,
     CONF_RETURN_SUNSET,
@@ -239,6 +240,19 @@ class TestFieldValidators:
     def test_tilt_mode_rejects_invalid(self):
         with pytest.raises(Exception):
             FIELD_VALIDATORS["tilt_mode"]("mode3")
+
+    def test_window_depth_bounds(self):
+        FIELD_VALIDATORS[CONF_WINDOW_DEPTH](0.0)
+        FIELD_VALIDATORS[CONF_WINDOW_DEPTH](0.5)
+        FIELD_VALIDATORS[CONF_WINDOW_DEPTH](5.0)
+
+    def test_window_depth_above_max_rejected(self):
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS[CONF_WINDOW_DEPTH](5.01)
+
+    def test_window_depth_negative_rejected(self):
+        with pytest.raises(Exception):
+            FIELD_VALIDATORS[CONF_WINDOW_DEPTH](-0.01)
 
 
 class TestCrossFieldValidate:


### PR DESCRIPTION
## Summary
Raises the `window_depth` configuration maximum from 0.5m to 5.0m. Users with deep architectural reveals (recessed windows, thick masonry, balcony overhangs) can now enter realistic values. The underlying math scales naturally — only the UI slider, options-service validator, services.yaml, and service description needed updating.

## Testing
- ✅ 2349 tests passing
- New bounds tests: 0.0, 0.5, 5.0 accepted; 5.01 and negative rejected
- New geometry smoke test: window_depth=5.0 produces a finite position clipped to [0, h_win]

## Related Issues
Refs #276