### PR TITLE
feat: surface manual-override gate state in logs and diagnostics

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -531,6 +531,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return
 
         if not self.manual_toggle or not self.automatic_control:
+            self._manual_gate_closed_log("service_call", list(tracked))
             return
 
         my_position_value = self.config_entry.options.get(CONF_MY_POSITION_VALUE)
@@ -877,6 +878,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     def _cancel_motion_timeout(self) -> None:
         """Cancel motion timeout task."""
         self._motion_mgr.cancel_motion_timeout()
+
+    def _manual_gate_closed_log(
+        self, where: str, entity_ids: list[str] | None = None
+    ) -> None:
+        """Emit a single debug line when the manual-override detection gate is closed."""
+        self.logger.debug(
+            "manual override detection gate closed at %s "
+            "(manual_toggle=%s, automatic_control=%s) — skipping %s",
+            where,
+            self.manual_toggle,
+            self.automatic_control,
+            entity_ids if entity_ids is not None else "<no entities>",
+        )
 
     def _check_initial_motion_state(self) -> None:
         """Initialize motion state from current sensor readings at startup/reload.
@@ -1401,56 +1415,63 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         events = self._pending_cover_events[:]
         self._pending_cover_events.clear()
 
-        if self.manual_toggle and self.automatic_control:
-            # Check startup grace period FIRST; suppress all events during
-            # HA restart when covers respond slowly.
-            if self._is_in_startup_grace_period():
-                entity_ids = [e.entity_id for e in events]
+        if not (self.manual_toggle and self.automatic_control):
+            self._manual_gate_closed_log(
+                "state_change", [e.entity_id for e in events]
+            )
+            self.cover_state_change = False
+            self.logger.debug("Cover state change handled")
+            return
+
+        # Check startup grace period FIRST; suppress all events during
+        # HA restart when covers respond slowly.
+        if self._is_in_startup_grace_period():
+            entity_ids = [e.entity_id for e in events]
+            self.logger.debug(
+                "Position changes for %s ignored (in startup grace period)",
+                entity_ids,
+            )
+            self.cover_state_change = False
+            return
+
+        for event_data in events:
+            entity_id = event_data.entity_id
+
+            # Skip manual override detection when the cover just reached its
+            # commanded target in this same event.  process_entity_state_change()
+            # adds the entity to _target_just_reached when check_target_reached()
+            # clears wait_for_target; without this guard the small positional
+            # difference allowed by POSITION_TOLERANCE_PERCENT would be
+            # misidentified as a user-initiated manual override.
+            if entity_id in self._target_just_reached:
+                self._target_just_reached.discard(entity_id)
                 self.logger.debug(
-                    "Position changes for %s ignored (in startup grace period)",
-                    entity_ids,
+                    "Skipping manual override check for %s — cover just reached commanded target",
+                    entity_id,
                 )
-                self.cover_state_change = False
-                return
+                continue
 
-            for event_data in events:
-                entity_id = event_data.entity_id
+            # Use target_call if available (contains actual sent position),
+            # otherwise fall back to calculated state.
+            # This is critical for open/close-only covers where the calculated
+            # state gets transformed (via threshold) to 0 or 100 before sending.
+            expected_position = self.target_call.get(entity_id, state)
 
-                # Skip manual override detection when the cover just reached its
-                # commanded target in this same event.  process_entity_state_change()
-                # adds the entity to _target_just_reached when check_target_reached()
-                # clears wait_for_target; without this guard the small positional
-                # difference allowed by POSITION_TOLERANCE_PERCENT would be
-                # misidentified as a user-initiated manual override.
-                if entity_id in self._target_just_reached:
-                    self._target_just_reached.discard(entity_id)
-                    self.logger.debug(
-                        "Skipping manual override check for %s — cover just reached commanded target",
-                        entity_id,
-                    )
-                    continue
-
-                # Use target_call if available (contains actual sent position),
-                # otherwise fall back to calculated state.
-                # This is critical for open/close-only covers where the calculated
-                # state gets transformed (via threshold) to 0 or 100 before sending.
-                expected_position = self.target_call.get(entity_id, state)
-
-                was_manual = self.manager.is_cover_manual(entity_id)
-                self.manager.handle_state_change(
-                    event_data,
-                    expected_position,
-                    self._cover_type,
-                    self.manual_reset,
-                    self.wait_for_target,
-                    self.manual_threshold,
-                )
-                # When a cover transitions into manual override, discard any
-                # pre-existing integration target (including safety-tagged
-                # end-time defaults) so reconciliation cannot resurrect it
-                # later (issue #215/#216).
-                if not was_manual and self.manager.is_cover_manual(entity_id):
-                    self._cmd_svc.discard_target(entity_id)
+            was_manual = self.manager.is_cover_manual(entity_id)
+            self.manager.handle_state_change(
+                event_data,
+                expected_position,
+                self._cover_type,
+                self.manual_reset,
+                self.wait_for_target,
+                self.manual_threshold,
+            )
+            # When a cover transitions into manual override, discard any
+            # pre-existing integration target (including safety-tagged
+            # end-time defaults) so reconciliation cannot resurrect it
+            # later (issue #215/#216).
+            if not was_manual and self.manager.is_cover_manual(entity_id):
+                self._cmd_svc.discard_target(entity_id)
 
         self.cover_state_change = False
         self.logger.debug("Cover state change handled")
@@ -1954,6 +1975,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             ),
             covers=_covers,
             manual_override_state=_manual_override_state,
+            manual_toggle=self.manual_toggle,
+            enabled_toggle=self.enabled_toggle if self.enabled_toggle is not None else True,
         )
 
         diagnostics, explanation = self._diagnostics_builder.build(ctx)

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -88,6 +88,10 @@ class DiagnosticContext:
     # Manual override live state (per-entity map)
     manual_override_state: dict | None = None
 
+    # Manual override detection toggles
+    manual_toggle: bool = True
+    enabled_toggle: bool = True
+
 
 # ---------------------------------------------------------------------------
 # Strategy label map (moved from coordinator class attribute)
@@ -521,5 +525,7 @@ class DiagnosticsBuilder:
                 ),
                 "motion_detected": ctx.motion_detected,
                 "motion_timeout_active": ctx.motion_timeout_active,
+                "manual_toggle": ctx.manual_toggle,
+                "enabled_toggle": ctx.enabled_toggle,
             }
         }

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -54,6 +54,7 @@ async def async_setup_entry(
         "Manual Override",
         True,
         "manual_toggle",
+        display_name="Manual Override Detection",
     )
     control_switch = AdaptiveCoverSwitch(
         config_entry.entry_id,
@@ -197,13 +198,14 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         device_class: SwitchDeviceClass | None = None,
         *,
         enabled_default: bool = True,
+        display_name: str | None = None,
     ) -> None:
         """Initialize the switch."""
         super().__init__(entry_id, hass, config_entry, coordinator)
         self._state: bool | None = None
         self._key = key
         self._attr_translation_key = key
-        self._switch_name = switch_name
+        self._switch_name = display_name or switch_name
         self._attr_device_class = device_class
         self._initial_state = initial_state
         self._attr_unique_id = f"{entry_id}_{switch_name}"

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1023,6 +1023,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "manual_toggle": {
+        "name": "Manuelle Übersteuerungserkennung",
+        "state": {
+          "on": "An",
+          "off": "Aus"
+        }
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1023,6 +1023,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "manual_toggle": {
+        "name": "Manual Override Detection",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1023,6 +1023,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "manual_toggle": {
+        "name": "Détection de Dérogation Manuelle",
+        "state": {
+          "on": "Activé",
+          "off": "Désactivé"
+        }
       }
     }
   },

--- a/tests/test_coordinator_logging.py
+++ b/tests/test_coordinator_logging.py
@@ -239,3 +239,123 @@ class TestCancelMotionTimeoutLogging:
         coord._cancel_motion_timeout()
 
         mock_task.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Manual override detection gate — debug log emitted when gate is closed
+# ---------------------------------------------------------------------------
+
+
+class TestManualGateClosedLogging:
+    """Both coordinator gate sites emit a debug log when manual_toggle or automatic_control is off."""
+
+    def _make_state_change_coordinator(self, *, manual_toggle, automatic_control):
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = MagicMock()
+        coord.manual_toggle = manual_toggle
+        coord.automatic_control = automatic_control
+        coord.logger = MagicMock()
+        coord.cover_state_change = True
+        coord._pending_cover_events = []
+        coord._is_in_startup_grace_period = MagicMock(return_value=False)
+        coord._manual_gate_closed_log = (
+            AdaptiveDataUpdateCoordinator._manual_gate_closed_log.__get__(coord)
+        )
+        return coord
+
+    @pytest.mark.asyncio
+    async def test_state_change_logs_when_manual_toggle_off(self):
+        """async_handle_cover_state_change emits debug log when manual_toggle is False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = self._make_state_change_coordinator(
+            manual_toggle=False, automatic_control=True
+        )
+        await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(
+            coord, state=50
+        )
+        calls = [str(c) for c in coord.logger.debug.call_args_list]
+        assert any("manual override detection gate closed" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_state_change_logs_when_auto_control_off(self):
+        """async_handle_cover_state_change emits debug log when automatic_control is False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = self._make_state_change_coordinator(
+            manual_toggle=True, automatic_control=False
+        )
+        await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(
+            coord, state=50
+        )
+        calls = [str(c) for c in coord.logger.debug.call_args_list]
+        assert any("manual override detection gate closed" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_service_call_logs_when_manual_toggle_off(self):
+        """async_check_cover_service_call emits debug log when manual_toggle is False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        event = MagicMock()
+        event.data = {
+            "domain": "cover",
+            "service": "stop_cover",
+            "service_data": {"entity_id": "cover.test"},
+        }
+        event.context = MagicMock()
+        event.context.id = "ctx-001"
+
+        coord = MagicMock()
+        coord.entities = ["cover.test"]
+        coord.manual_toggle = False
+        coord.automatic_control = True
+        coord.logger = MagicMock()
+        coord._cmd_svc._acp_stop_contexts = []
+        coord._manual_gate_closed_log = (
+            AdaptiveDataUpdateCoordinator._manual_gate_closed_log.__get__(coord)
+        )
+
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(coord, event)
+
+        calls = [str(c) for c in coord.logger.debug.call_args_list]
+        assert any("manual override detection gate closed" in c for c in calls)
+
+    @pytest.mark.asyncio
+    async def test_service_call_logs_when_auto_control_off(self):
+        """async_check_cover_service_call emits debug log when automatic_control is False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        event = MagicMock()
+        event.data = {
+            "domain": "cover",
+            "service": "stop_cover",
+            "service_data": {"entity_id": "cover.test"},
+        }
+        event.context = MagicMock()
+        event.context.id = "ctx-001"
+
+        coord = MagicMock()
+        coord.entities = ["cover.test"]
+        coord.manual_toggle = True
+        coord.automatic_control = False
+        coord.logger = MagicMock()
+        coord._cmd_svc._acp_stop_contexts = []
+        coord._manual_gate_closed_log = (
+            AdaptiveDataUpdateCoordinator._manual_gate_closed_log.__get__(coord)
+        )
+
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(coord, event)
+
+        calls = [str(c) for c in coord.logger.debug.call_args_list]
+        assert any("manual override detection gate closed" in c for c in calls)

--- a/tests/test_debug_diagnostics.py
+++ b/tests/test_debug_diagnostics.py
@@ -340,6 +340,37 @@ class TestResizeEventBuffer:
 
 
 # ---------------------------------------------------------------------------
+# DiagnosticsBuilder — configuration section toggle fields
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurationToggleFields:
+    """Verify manual_toggle and enabled_toggle appear in configuration output."""
+
+    def test_manual_toggle_false_appears_in_configuration(self):
+        """manual_toggle=False is reflected in configuration diagnostics."""
+        builder = DiagnosticsBuilder()
+        ctx = _base_ctx(manual_toggle=False, enabled_toggle=True)
+        result, _ = builder.build(ctx)
+        assert result["configuration"]["manual_toggle"] is False
+
+    def test_enabled_toggle_false_appears_in_configuration(self):
+        """enabled_toggle=False is reflected in configuration diagnostics."""
+        builder = DiagnosticsBuilder()
+        ctx = _base_ctx(manual_toggle=True, enabled_toggle=False)
+        result, _ = builder.build(ctx)
+        assert result["configuration"]["enabled_toggle"] is False
+
+    def test_both_toggles_true_by_default(self):
+        """When both toggles are True, both appear in configuration as True."""
+        builder = DiagnosticsBuilder()
+        ctx = _base_ctx(manual_toggle=True, enabled_toggle=True)
+        result, _ = builder.build(ctx)
+        assert result["configuration"]["manual_toggle"] is True
+        assert result["configuration"]["enabled_toggle"] is True
+
+
+# ---------------------------------------------------------------------------
 # DiagnosticsBuilder — debug info section
 # ---------------------------------------------------------------------------
 

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -714,6 +714,8 @@ class TestConfigurationDiagnostics:
             "motion_timeout",
             "motion_detected",
             "motion_timeout_active",
+            "manual_toggle",
+            "enabled_toggle",
         }
         assert expected_keys == set(config.keys())
 

--- a/tests/test_switch_actions.py
+++ b/tests/test_switch_actions.py
@@ -182,6 +182,47 @@ async def test_turn_off_non_automatic_control_key_no_special_logic():
 
 
 # ---------------------------------------------------------------------------
+# Switch display name — manual_toggle uses "Manual Override Detection"
+# ---------------------------------------------------------------------------
+
+
+def test_manual_toggle_switch_display_name():
+    """manual_toggle switch displays 'Manual Override Detection' but unique_id preserves 'Manual Override'."""
+    coord = _make_coordinator()
+    entry = _make_config_entry()
+    switch = AdaptiveCoverSwitch(
+        entry_id="entry_abc",
+        hass=coord.hass,
+        config_entry=entry,
+        coordinator=coord,
+        switch_name="Manual Override",
+        initial_state=True,
+        key="manual_toggle",
+        display_name="Manual Override Detection",
+    )
+    assert switch.name == "Manual Override Detection"
+    assert switch._attr_unique_id == "entry_abc_Manual Override"
+    assert switch._attr_translation_key == "manual_toggle"
+
+
+def test_switch_without_display_name_uses_switch_name():
+    """A switch without display_name falls back to switch_name for the name property."""
+    coord = _make_coordinator()
+    entry = _make_config_entry()
+    switch = AdaptiveCoverSwitch(
+        entry_id="entry_abc",
+        hass=coord.hass,
+        config_entry=entry,
+        coordinator=coord,
+        switch_name="Automatic Control",
+        initial_state=True,
+        key="automatic_control",
+    )
+    assert switch.name == "Automatic Control"
+    assert switch._attr_unique_id == "entry_abc_Automatic Control"
+
+
+# ---------------------------------------------------------------------------
 # Conditional switch creation — integration
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `_manual_gate_closed_log()` shared helper; both `async_check_cover_service_call` and `async_handle_cover_state_change` now emit a DEBUG log when `manual_toggle` or `automatic_control` is off — no more silent returns
- Surface `manual_toggle` and `enabled_toggle` booleans in diagnostics JSON under `configuration`
- Rename "Manual Override" switch display name to "Manual Override Detection" (entity `unique_id` unchanged, registry entries preserved)
- Sync DE/FR translations

## Testing
- ✅ 2370 tests passing

## Related Issues
Refs #280