### PR TITLE
fix: detect transit progress by position delta for all cover types (#285)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -685,18 +685,91 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 # If ignore_intermediate_states is True, those transitional events
                 # are already filtered out above, so we only reach here with final
                 # states and always clear wait_for_target.
+                #
+                # However, some covers (French volet-roulant, some Zigbee rolling
+                # shutters) never emit transitional states at all — they stay "open"
+                # or "closed" throughout transit and simply update current_position.
+                # The direction/progress check therefore runs for ALL covers based
+                # on position delta, regardless of the HA state string (Issue #285).
                 cover_is_transitioning = event.new_state.state in (
                     "opening",
                     "closing",
                 )
 
-                if cover_is_transitioning:
+                old_position = self._cmd_svc.read_position_with_capabilities(  # noqa: SLF001
+                    entity_id, caps, event.old_state
+                )
+                target = self._cmd_svc.target_call.get(entity_id)
+
+                # Step-motor pause (Issue #186) takes highest priority: some covers
+                # briefly report "open"/"closed" at an intermediate position between
+                # motor pulses before resuming transit.  If the *new* state is
+                # non-transitional and the *old* state was transitional, the cover
+                # just paused mid-transit — restart grace period to let the motor
+                # resume.  This must be checked before the direction/progress block
+                # so that forward-progress detection (Issue #285) does not short-
+                # circuit the grace-period restart.
+                was_transitioning = (
+                    event.old_state is not None
+                    and event.old_state.state in ("opening", "closing")
+                )
+                if (
+                    not cover_is_transitioning
+                    and was_transitioning
+                    and target is not None
+                    and position is not None
+                    and position != target
+                ):
+                    self._start_grace_period(entity_id)
+                    self._debug_log(
+                        "manual_override",
+                        "Cover %s paused mid-transit at %s (target %s) "
+                        "— restarting grace period",
+                        entity_id,
+                        position,
+                        target,
+                    )
+                    self.logger.debug("Wait for target: %s", self.wait_for_target)
+                    return
+
+                # Direction/progress check: runs for all covers where positions and
+                # target are known, EXCEPT when HA explicitly reports "stopped" (an
+                # unambiguous halt signal).  This extends the progress-aware backstop
+                # from Issue #271 to covers that never emit "opening"/"closing".
+                if (
+                    old_position is not None
+                    and position is not None
+                    and target is not None
+                    and event.new_state.state != "stopped"
+                ):
+                    old_distance = abs(old_position - target)
+                    new_distance = abs(position - target)
+
+                    if new_distance < old_distance:
+                        # Unambiguously moving toward target — still in transit.
+                        # Reset the progress clock so the backstop window extends.
+                        now = dt.datetime.now(dt.UTC)
+                        self._cmd_svc.record_progress(entity_id, now)  # noqa: SLF001
+                        self._debug_log(
+                            "manual_override",
+                            "Grace expired but %s still in transit toward "
+                            "target %s (was %s, now %s, state=%s) "
+                            "— keeping wait_for_target",
+                            entity_id,
+                            target,
+                            old_position,
+                            position,
+                            event.new_state.state,
+                        )
+                        self.logger.debug("Wait for target: %s", self.wait_for_target)
+                        return
+
                     # Progress-aware backstop: if no forward progress has been
                     # observed for longer than the configured transit timeout,
                     # the cover is stuck or stalled — clear wait_for_target so
                     # manual override detection can run.  The clock resets each
                     # time record_progress() is called (when new_distance <
-                    # old_distance below), so slow-but-moving covers are not
+                    # old_distance above), so slow-but-moving covers are not
                     # prematurely cleared.  Covers that never report intermediate
                     # positions fall back to measuring from _sent_at.
                     now = dt.datetime.now(dt.UTC)
@@ -720,114 +793,35 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                             )
                             return
 
-                    # Cover is within the transit window — check direction.
-                    # If the cover is moving closer to the target it is still
-                    # responding to our command; keep wait_for_target=True.
-                    # If it moved away or stalled at the same position, clear
-                    # it so manual override detection can run (Issue #147).
-                    #
-                    # Special case — hardware startup delay (Issue #147 v2):
-                    # Some covers have a 10–30+ second delay before the motor
-                    # physically starts.  The first state event fires while the
-                    # cover is still at the pre-command position (old_pos ==
-                    # new_pos == 0 when commanding to 100%).  The state
-                    # transitions from a non-moving state (e.g. "closed") to
-                    # "opening", signalling that the command was received.
-                    # Distinguish this from a mid-transit stall (cover was
-                    # already "opening" but position hasn't changed) by checking
-                    # whether old_state was itself transitional: if not, the
-                    # cover just started and we should keep wait_for_target=True.
-                    old_position = self._cmd_svc.read_position_with_capabilities(
-                        entity_id, caps, event.old_state
-                    )
-                    target = self._cmd_svc.target_call.get(entity_id)
-
-                    if (
-                        old_position is not None
-                        and position is not None
-                        and target is not None
-                    ):
-                        old_distance = abs(old_position - target)
-                        new_distance = abs(position - target)
-
-                        if new_distance < old_distance:
-                            # Unambiguously moving toward target — still in transit.
-                            # Reset the progress clock so the backstop window extends.
-                            self._cmd_svc.record_progress(entity_id, dt.datetime.now(dt.UTC))  # noqa: SLF001
+                    if new_distance == old_distance:
+                        # Positions equal — could be startup delay or stall.
+                        # Startup delay: motor just engaged; state transitions from
+                        # non-transitional (e.g. "closed") to something else.
+                        # Stall: state didn't change and cover was already in transit;
+                        # fall through to clear (e.g. opening→opening same position).
+                        # open→open same position with no state change is also a
+                        # genuine stop — fall through (Issue #172 regression guard).
+                        old_state_str = (
+                            event.old_state.state
+                            if event.old_state is not None
+                            else None
+                        )
+                        new_state_str = event.new_state.state
+                        state_changed = old_state_str != new_state_str
+                        if old_state_str not in ("opening", "closing") and state_changed:
                             self._debug_log(
                                 "manual_override",
-                                "Grace expired but %s still in transit toward "
-                                "target %s (was %s, now %s) — keeping wait_for_target",
+                                "Grace expired but %s position unchanged at %s "
+                                "(startup delay — old state was %s) "
+                                "— keeping wait_for_target",
                                 entity_id,
-                                target,
-                                old_position,
                                 position,
+                                old_state_str,
                             )
                             self.logger.debug(
                                 "Wait for target: %s", self.wait_for_target
                             )
                             return
-
-                        if new_distance == old_distance:
-                            # Positions equal — could be startup delay or stall.
-                            # If old_state was not transitional the motor just
-                            # engaged; keep wait_for_target (startup delay).
-                            # If old_state was already opening/closing, the cover
-                            # stalled mid-transit; fall through to clear.
-                            old_state_str = (
-                                event.old_state.state
-                                if event.old_state is not None
-                                else None
-                            )
-                            if old_state_str not in ("opening", "closing"):
-                                self._debug_log(
-                                    "manual_override",
-                                    "Grace expired but %s position unchanged at %s "
-                                    "(startup delay — old state was %s) "
-                                    "— keeping wait_for_target",
-                                    entity_id,
-                                    position,
-                                    old_state_str,
-                                )
-                                self.logger.debug(
-                                    "Wait for target: %s", self.wait_for_target
-                                )
-                                return
-
-                # Non-transitional state, cover stalled, or moved away from target.
-                #
-                # Special case — step-motor shades (Issue #186): some covers
-                # briefly report "open" at an intermediate position between
-                # motor pulses before resuming transit.  If the *new* state is
-                # non-transitional ("open"/"closed") and the *old* state was
-                # transitional ("opening"/"closing"), the cover just paused
-                # mid-transit.  Restart the grace period to allow the motor to
-                # resume without triggering a false manual override.
-                # This does NOT apply to stalls (opening→opening still at same
-                # position), which fall through here with cover_is_transitioning=True.
-                was_transitioning = (
-                    event.old_state is not None
-                    and event.old_state.state in ("opening", "closing")
-                )
-                target = self._cmd_svc.target_call.get(entity_id)
-                if (
-                    not cover_is_transitioning
-                    and was_transitioning
-                    and target is not None
-                    and position is not None
-                    and position != target
-                ):
-                    self._start_grace_period(entity_id)
-                    self._debug_log(
-                        "manual_override",
-                        "Cover %s paused mid-transit at %s (target %s) "
-                        "— restarting grace period",
-                        entity_id,
-                        position,
-                        target,
-                    )
-                    self.logger.debug("Wait for target: %s", self.wait_for_target)
-                    return
 
                 # Clear wait_for_target to allow manual override detection.
                 self._cmd_svc.wait_for_target[entity_id] = False

--- a/tests/test_issue_285_open_state_cover_false_override.py
+++ b/tests/test_issue_285_open_state_cover_false_override.py
@@ -1,0 +1,300 @@
+"""Tests for issue #285: false manual override for covers that stay "open" mid-transit.
+
+Root cause: process_entity_state_change() gates the entire progress-aware transit
+backstop on cover_is_transitioning (HA state in "opening"/"closing"). Covers that
+stay "open" while current_position updates skip the direction check entirely, causing
+wait_for_target to be cleared prematurely. The next position update then triggers a
+false manual override.
+
+Fix: lift the direction/progress check outside the cover_is_transitioning gate so it
+applies whenever old_position, position, and target are all known.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_issue_271 helpers)
+# ---------------------------------------------------------------------------
+
+
+def _make_state_change_data(
+    entity_id: str,
+    new_position: int,
+    old_position: int = 0,
+    new_state_str: str = "opening",
+):
+    event = MagicMock()
+    event.entity_id = entity_id
+    event.new_state = MagicMock()
+    event.new_state.state = new_state_str
+    event.new_state.attributes = {"current_position": new_position}
+    event.new_state.last_updated = dt.datetime.now(dt.UTC)
+    event.old_state = MagicMock()
+    event.old_state.state = new_state_str
+    event.old_state.attributes = {"current_position": old_position}
+    return event
+
+
+def _make_coordinator(
+    entity_id: str,
+    target_position: int,
+    current_position: int,
+    old_position: int = 0,
+    *,
+    grace_expired: bool = True,
+    ignore_intermediate: bool = False,
+    new_state_str: str = "opening",
+    sent_seconds_ago: float = 10.0,
+    last_progress_seconds_ago: float | None = None,
+    transit_timeout_seconds: int = 45,
+):
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+    )
+    from custom_components.adaptive_cover_pro.managers.grace_period import (
+        GracePeriodManager,
+    )
+
+    coordinator = MagicMock()
+    coordinator.state_change_data = _make_state_change_data(
+        entity_id, current_position, old_position, new_state_str
+    )
+    coordinator.ignore_intermediate_states = ignore_intermediate
+    coordinator._target_just_reached = set()
+
+    grace_mgr = GracePeriodManager(logger=MagicMock(), command_grace_seconds=5.0)
+    if not grace_expired:
+        grace_mgr._command_timestamps[entity_id] = dt.datetime.now().timestamp()
+    coordinator._grace_mgr = grace_mgr
+
+    cmd_svc = MagicMock(spec=CoverCommandService)
+    cmd_svc.wait_for_target = {entity_id: True}
+    cmd_svc.target_call = {entity_id: target_position}
+    cmd_svc._position_tolerance = 5
+
+    now = dt.datetime.now(dt.UTC)
+    cmd_svc._sent_at = {entity_id: now - dt.timedelta(seconds=sent_seconds_ago)}
+    cmd_svc._wait_for_target_timeout_seconds = transit_timeout_seconds
+
+    last_progress_at: dict[str, dt.datetime] = {}
+    if last_progress_seconds_ago is not None:
+        last_progress_at[entity_id] = now - dt.timedelta(seconds=last_progress_seconds_ago)
+
+    def _transit_elapsed(eid: str, now_arg: dt.datetime) -> float | None:
+        reference = last_progress_at.get(eid) or cmd_svc._sent_at.get(eid)
+        return (now_arg - reference).total_seconds() if reference else None
+
+    def _record_progress(eid: str, now_arg: dt.datetime) -> None:
+        last_progress_at[eid] = now_arg
+
+    cmd_svc._transit_elapsed_without_progress = MagicMock(side_effect=_transit_elapsed)
+    cmd_svc.record_progress = MagicMock(side_effect=_record_progress)
+
+    def _check_target_reached(eid, pos):
+        if pos is None:
+            return False
+        if abs(pos - cmd_svc.target_call.get(eid, -999)) <= cmd_svc._position_tolerance:
+            cmd_svc.wait_for_target[eid] = False
+            return True
+        return False
+
+    cmd_svc.check_target_reached = MagicMock(side_effect=_check_target_reached)
+    cmd_svc.get_cover_capabilities = MagicMock(return_value={"has_set_position": True})
+
+    def _read_position(eid, caps, state_obj):
+        if state_obj is coordinator.state_change_data.new_state:
+            return current_position
+        if state_obj is coordinator.state_change_data.old_state:
+            return old_position
+        return current_position
+
+    cmd_svc.read_position_with_capabilities = MagicMock(side_effect=_read_position)
+    coordinator._cmd_svc = cmd_svc
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator._is_in_grace_period = lambda eid: (
+        AdaptiveDataUpdateCoordinator._is_in_grace_period(coordinator, eid)
+    )
+    coordinator._start_grace_period = lambda eid: (
+        AdaptiveDataUpdateCoordinator._start_grace_period(coordinator, eid)
+    )
+
+    return coordinator
+
+
+def _call(coordinator):
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    AdaptiveDataUpdateCoordinator.process_entity_state_change(coordinator)
+
+
+# ===========================================================================
+# Issue #285: covers that stay "open" while moving
+# ===========================================================================
+
+
+class TestOpenStateCoverMakingProgress:
+    """Covers that never emit 'opening'/'closing' must not trigger false overrides."""
+
+    def test_open_state_cover_making_progress_keeps_wait_for_target(self) -> None:
+        """Cover stays 'open' while current_position moves toward target.
+
+        Real scenario (Issue #285): some covers (French volet-roulant, some Zigbee
+        rolling shutters) never emit 'opening'/'closing'. They stay 'open' the whole
+        time and just update current_position. A position change from 60→50 toward
+        target=0 is integration-initiated transit, not a manual override.
+        """
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=50,
+            old_position=60,
+            new_state_str="open",
+            sent_seconds_ago=10.0,
+        )
+        coord.state_change_data.old_state.state = "open"
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is True, (
+            "wait_for_target must stay True: cover is moving toward target "
+            "even though HA state stays 'open' throughout transit"
+        )
+
+    def test_open_state_cover_making_progress_records_progress(self) -> None:
+        """record_progress must be called when an open-state cover moves toward target."""
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=50,
+            old_position=60,
+            new_state_str="open",
+            sent_seconds_ago=10.0,
+        )
+        coord.state_change_data.old_state.state = "open"
+        _call(coord)
+        assert coord._cmd_svc.record_progress.called, (
+            "record_progress must be called so the progress backstop window extends"
+        )
+
+    def test_open_state_cover_stalled_beyond_timeout_clears_wait_for_target(self) -> None:
+        """Open-state cover with no progress for > timeout must still be cleared.
+
+        The hard-timeout safety net must work even when the cover never emits
+        'opening'/'closing'. old_position == current_position means no movement.
+        """
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=80,
+            old_position=80,
+            new_state_str="open",
+            sent_seconds_ago=50.0,
+            transit_timeout_seconds=45,
+        )
+        coord.state_change_data.old_state.state = "open"
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is False, (
+            "Hard timeout backstop must still fire for open-state covers with no progress"
+        )
+
+    def test_open_state_cover_drifting_away_from_target_clears_wait_for_target(self) -> None:
+        """Open-state cover moving away from target must be detected as manual override.
+
+        Position 60→70 while target=0 means the cover moved away — genuine user action.
+        """
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=70,
+            old_position=60,
+            new_state_str="open",
+            sent_seconds_ago=10.0,
+        )
+        coord.state_change_data.old_state.state = "open"
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is False, (
+            "Cover moving away from target must clear wait_for_target (genuine manual move)"
+        )
+
+    def test_open_state_cover_progress_backstop_resets_window(self) -> None:
+        """Open-state cover: progress window extends when moving, even past sent_at timeout.
+
+        sent 50s ago (> 45s default), but last forward progress was only 20s ago.
+        The cover is still actively closing — must not be cleared.
+        """
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=0,
+            current_position=40,
+            old_position=50,
+            new_state_str="open",
+            sent_seconds_ago=50.0,
+            last_progress_seconds_ago=20.0,
+            transit_timeout_seconds=45,
+        )
+        coord.state_change_data.old_state.state = "open"
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is True, (
+            "Progress-aware backstop must work for open-state covers: "
+            "20s since last progress < 45s timeout, cover still moving forward"
+        )
+
+
+# ===========================================================================
+# Regression guards — existing behaviour must not change
+# ===========================================================================
+
+
+class TestRegressionExistingBehaviour:
+    """Existing test scenarios must continue to behave identically after the fix."""
+
+    def test_open_from_open_same_position_still_clears_wait_for_target(self) -> None:
+        """Cover stuck at same position with open→open must still clear wait_for_target.
+
+        Issue #172 regression guard. old_position == new_position == 51, state stays
+        'open'. No state transition and no movement — genuine stop, not startup delay.
+        """
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=100,
+            current_position=51,
+            old_position=51,
+            new_state_str="open",
+        )
+        coord.state_change_data.old_state.state = "open"
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is False, (
+            "Stalled open→open (no movement) must clear wait_for_target — Issue #172 guard"
+        )
+
+    def test_opening_state_cover_forward_progress_still_works(self) -> None:
+        """The original 'opening' code path must still keep wait_for_target=True."""
+        entity_id = "cover.patio_shade"
+        coord = _make_coordinator(
+            entity_id,
+            target_position=100,
+            current_position=60,
+            old_position=40,
+            new_state_str="opening",
+        )
+        coord.state_change_data.old_state.state = "opening"
+        _call(coord)
+        assert coord._cmd_svc.wait_for_target[entity_id] is True, (
+            "opening→opening with forward progress must still keep wait_for_target=True"
+        )


### PR DESCRIPTION
## Summary
Some covers never emit `opening`/`closing` states — they stay `open` throughout transit and simply update `current_position`. The transit backstop in `process_entity_state_change()` was gated on the HA state string, so these covers skipped the direction/progress check entirely. `wait_for_target` got cleared immediately, and the next position update was misidentified as a manual override.

This fix lifts the direction check outside the `cover_is_transitioning` gate so it runs for all cover types based on position delta. The step-motor pause check (Issue #186) is moved before the direction check so it still takes priority. Covers reporting `stopped` state are excluded from forward-progress detection since that's an explicit halt signal.

## Testing
- ✅ 2377 tests passing
- 7 new regression tests in `test_issue_285_open_state_cover_false_override.py`
- All Issue #172 and Issue #271 tests still pass

## Related Issues
Refs #285