### PR TITLE
feat: add unified event timeline and richer last_cover_action to diagnostics

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -142,6 +142,7 @@ from .const import (
     DEFAULT_WEATHER_TIMEOUT,
 )
 from .diagnostics.builder import DiagnosticContext, DiagnosticsBuilder
+from .diagnostics.event_buffer import EventBuffer
 from .managers.cover_command import (
     CoverCommandService,
     PositionContext,
@@ -266,8 +267,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.entities = self.config_entry.options.get(CONF_ENTITIES, [])
         # Cover engine object — populated at start of each update cycle
         self._cover_data = None
+
+        # Shared diagnostic ring buffer — owned here, injected into all writers
+        self._event_buffer = EventBuffer(
+            maxlen=self.config_entry.options.get(
+                CONF_DEBUG_EVENT_BUFFER_SIZE, DEFAULT_DEBUG_EVENT_BUFFER_SIZE
+            )
+        )
+
         self.manager = AdaptiveCoverManager(
-            self.hass, self.manual_duration, self.logger
+            self.hass, self.manual_duration, self.logger,
+            event_buffer=self._event_buffer,
         )
         self.ignore_intermediate_states = self.config_entry.options.get(
             CONF_MANUAL_IGNORE_INTERMEDIATE, False
@@ -279,9 +289,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             startup_grace_seconds=STARTUP_GRACE_PERIOD_SECONDS,
         )
         # Motion control tracking
-        self._motion_mgr = MotionManager(hass=self.hass, logger=self.logger)
+        self._motion_mgr = MotionManager(
+            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+        )
         # Weather override tracking
-        self._weather_mgr = WeatherManager(hass=self.hass, logger=self.logger)
+        self._weather_mgr = WeatherManager(
+            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+        )
         # Override pipeline — custom position handlers are created per-slot so
         # each can carry an independent priority configured by the user.
         self._pipeline = self._build_pipeline()
@@ -338,10 +352,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 CONF_TRANSIT_TIMEOUT
             ) or DEFAULT_TRANSIT_TIMEOUT_SECONDS,
             on_tick=self._check_time_window_transition,
+            event_buffer=self._event_buffer,
         )
 
         # Time window manager (start/end time checks)
-        self._time_mgr = TimeWindowManager(hass=self.hass, logger=self.logger)
+        self._time_mgr = TimeWindowManager(
+            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+        )
 
         # Track sun validity transitions (for responsive sun in-front detection)
         self._last_sun_validity_state: bool | None = None
@@ -1589,7 +1606,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             [(h.name, h.priority) for h in custom_handlers],
             sun_tracking_enabled,
         )
-        return PipelineRegistry(handlers)
+        return PipelineRegistry(handlers, event_buffer=getattr(self, "_event_buffer", None))
 
     def _update_options(self, options):
         """Update coordinator options from config entry.
@@ -1645,6 +1662,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             severe_sensors=options.get(CONF_WEATHER_SEVERE_SENSORS, []),
             timeout_seconds=options.get(CONF_WEATHER_TIMEOUT, DEFAULT_WEATHER_TIMEOUT),
         )
+        new_buf_size = options.get(
+            CONF_DEBUG_EVENT_BUFFER_SIZE, DEFAULT_DEBUG_EVENT_BUFFER_SIZE
+        )
+        event_buffer = getattr(self, "_event_buffer", None)
+        if event_buffer is not None and new_buf_size != event_buffer.maxlen:
+            event_buffer.resize(new_buf_size)
 
     def _update_manager_and_covers(self):
         """Update manager with cover entities.
@@ -1940,7 +1963,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             force_override_position=self.config_entry.options.get(
                 CONF_FORCE_OVERRIDE_POSITION, 0
             ),
-            manual_override_events=self.manager.get_event_buffer() or None,
+            event_timeline=self._event_buffer.snapshot() or None,
             cover_command_state=self._cmd_svc.get_all_entity_state_snapshots() or None,
             debug_config={
                 "dry_run": self.config_entry.options.get(CONF_DRY_RUN, False),

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -70,7 +70,8 @@ class DiagnosticContext:
     force_override_position: int = 0
 
     # Debug & diagnostics (optional — only populated when debug_mode is on or buffer has entries)
-    manual_override_events: list[dict] | None = None
+    event_timeline: list[dict] | None = None
+    manual_override_events: list[dict] | None = None  # deprecated alias; use event_timeline
     cover_command_state: dict[str, dict] | None = None
     debug_config: dict | None = None
 
@@ -413,8 +414,14 @@ class DiagnosticsBuilder:
         if ctx.debug_config is not None:
             diagnostics["debug_config"] = ctx.debug_config
 
-        if ctx.manual_override_events:
-            diagnostics["manual_override_history"] = ctx.manual_override_events
+        # Unified event timeline from the shared ring buffer
+        timeline = ctx.event_timeline or ctx.manual_override_events
+        if timeline:
+            diagnostics["event_timeline"] = timeline
+            # Backward-compat filtered alias for consumers that read manual_override_history
+            mo_events = [e for e in timeline if e.get("event", "").startswith("manual_override_")]
+            if mo_events:
+                diagnostics["manual_override_history"] = mo_events
 
         # Always emit cover_commands (empty dict when nothing active)
         diagnostics["cover_commands"] = ctx.cover_command_state or {}

--- a/custom_components/adaptive_cover_pro/diagnostics/event_buffer.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/event_buffer.py
@@ -1,0 +1,43 @@
+"""Bounded ring buffer for cross-component diagnostic events."""
+
+from __future__ import annotations
+
+from collections import deque
+
+
+class EventBuffer:
+    """Shared ring buffer owned by the coordinator and injected into all writers.
+
+    Writers call record(); DiagnosticsBuilder is the only reader that formats
+    the raw dicts for output.
+    """
+
+    def __init__(self, maxlen: int) -> None:
+        """Initialize the ring buffer.
+
+        Args:
+            maxlen: Maximum number of events to retain (oldest are evicted).
+
+        """
+        self._buf: deque[dict] = deque(maxlen=maxlen)
+
+    def record(self, event: dict) -> None:
+        """Append an event dict to the buffer, evicting the oldest if full."""
+        self._buf.append(event)
+
+    def snapshot(self) -> list[dict]:
+        """Return a copy of current buffer contents in insertion order."""
+        return list(self._buf)
+
+    def resize(self, maxlen: int) -> None:
+        """Resize the buffer, preserving the most-recent events."""
+        self._buf = deque(self._buf, maxlen=maxlen)
+
+    @property
+    def maxlen(self) -> int | None:
+        """Maximum capacity of the ring buffer."""
+        return self._buf.maxlen
+
+    def __len__(self) -> int:
+        """Return the current number of events in the buffer."""
+        return len(self._buf)

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -29,6 +29,7 @@ from ..const import (
     POSITION_CHECK_INTERVAL_MINUTES,
     POSITION_TOLERANCE_PERCENT,
 )
+from ..diagnostics.event_buffer import EventBuffer
 from ..helpers import check_cover_features, get_last_updated, get_open_close_state, should_use_tilt
 
 
@@ -99,6 +100,8 @@ class CoverCommandService:
         max_retries: int = MAX_POSITION_RETRIES,
         transit_timeout_seconds: int = DEFAULT_TRANSIT_TIMEOUT_SECONDS,
         on_tick=None,
+        *,
+        event_buffer=None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -118,6 +121,8 @@ class CoverCommandService:
                 reconciliation tick. Use for coordinator-level periodic work
                 (e.g. time window transition checks) that must run on the same
                 interval without an extra timer.
+            event_buffer: Shared diagnostic ring buffer (optional). When provided,
+                cover_command_sent and cover_command_skipped events are appended.
 
         """
         self._hass = hass
@@ -208,6 +213,9 @@ class CoverCommandService:
             "inverse_state_applied": False,
             "timestamp": None,
         }
+
+        # Shared diagnostic ring buffer (coordinator-owned, injected here)
+        self._event_buffer: EventBuffer | None = event_buffer
 
         # Reconciliation timer handle (async_track_time_interval unsubscribe fn)
         self._reconcile_unsub = None
@@ -1231,6 +1239,20 @@ class CoverCommandService:
             inverse_state=inverse_state,
             extras=extras,
         )
+        if self._event_buffer is not None:
+            event: dict = {
+                "ts": dt.datetime.now(dt.UTC).isoformat(),
+                "event": "cover_command_skipped",
+                "entity_id": entity_id,
+                "reason": reason,
+                "calculated_position": position,
+                "current_position": current_position,
+                "trigger": trigger,
+                "inverse_state_applied": inverse_state,
+            }
+            if extras:
+                event.update(extras)
+            self._event_buffer.record(event)
         return "skipped", reason
 
     def _prepare_service_call(
@@ -1415,8 +1437,23 @@ class CoverCommandService:
         state: int,
         supports_position: bool,
         inverse_state: bool = False,
+        *,
+        target_source: str = "",
+        force: bool = False,
+        is_safety: bool = False,
+        trigger: str = "",
+        auto_control_at_call: bool | None = None,
+        manual_override_at_call: bool | None = None,
+        in_time_window_at_call: bool | None = None,
+        enabled_at_call: bool | None = None,
+        pipeline_handler: str | None = None,
+        pipeline_control_method: str | None = None,
+        pipeline_bypass_auto_control: bool | None = None,
+        decision_trace_at_call: list | None = None,
+        gates_evaluated: dict | None = None,
     ) -> None:
-        """Update last_cover_action diagnostic dict."""
+        """Update last_cover_action diagnostic dict and record to event buffer."""
+        ts = dt.datetime.now(dt.UTC).isoformat()
         self.last_cover_action = {
             "entity_id": entity,
             "service": service,
@@ -1426,9 +1463,39 @@ class CoverCommandService:
             if not supports_position
             else None,
             "inverse_state_applied": inverse_state,
-            "timestamp": dt.datetime.now().isoformat(),
+            "timestamp": ts,
             "covers_controlled": 1,
+            "target_source": target_source,
+            "force": force,
+            "is_safety": is_safety,
+            "trigger": trigger,
+            "auto_control_at_call": auto_control_at_call,
+            "manual_override_at_call": manual_override_at_call,
+            "in_time_window_at_call": in_time_window_at_call,
+            "enabled_at_call": enabled_at_call,
+            "pipeline_handler": pipeline_handler,
+            "pipeline_control_method": pipeline_control_method,
+            "pipeline_bypass_auto_control": pipeline_bypass_auto_control,
+            "decision_trace_at_call": decision_trace_at_call,
+            "gates_evaluated": gates_evaluated,
         }
+        if self._event_buffer is not None:
+            self._event_buffer.record(
+                {
+                    "ts": ts,
+                    "event": "cover_command_sent",
+                    "entity_id": entity,
+                    "service": service,
+                    "position": self.last_cover_action["position"],
+                    "calculated_position": state,
+                    "inverse_state_applied": inverse_state,
+                    "supports_position": supports_position,
+                    "trigger": trigger,
+                    "target_source": target_source,
+                    "force": force,
+                    "is_safety": is_safety,
+                }
+            )
 
 
 def build_special_positions(options: dict) -> list[int]:

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import datetime as dt
-from collections import deque
 
 from homeassistant.core import HomeAssistant
 
 from ..const import DEFAULT_DEBUG_EVENT_BUFFER_SIZE, POSITION_TOLERANCE_PERCENT
+from ..diagnostics.event_buffer import EventBuffer
 from ..helpers import check_cover_features, get_open_close_state, should_use_tilt
 
 
@@ -22,7 +22,12 @@ class AdaptiveCoverManager:
     """
 
     def __init__(
-        self, hass: HomeAssistant, reset_duration: dict[str:int], logger
+        self,
+        hass: HomeAssistant,
+        reset_duration: dict[str:int],
+        logger,
+        *,
+        event_buffer: EventBuffer | None = None,
     ) -> None:
         """Initialize the AdaptiveCoverManager.
 
@@ -30,6 +35,8 @@ class AdaptiveCoverManager:
             hass: Home Assistant instance
             reset_duration: Duration dict (e.g., {"minutes": 15}) for auto-reset
             logger: Logger instance for debug output
+            event_buffer: Shared ring buffer owned by the coordinator. When None
+                a private buffer is created (useful for unit tests).
 
         """
         self.hass = hass
@@ -39,24 +46,28 @@ class AdaptiveCoverManager:
         self.manual_control_time: dict[str, dt.datetime] = {}
         self.reset_duration = dt.timedelta(**reset_duration)
         self.logger = logger
-        self._event_buffer: deque[dict] = deque(maxlen=DEFAULT_DEBUG_EVENT_BUFFER_SIZE)
+        self._event_buffer: EventBuffer = (
+            event_buffer
+            if event_buffer is not None
+            else EventBuffer(maxlen=DEFAULT_DEBUG_EVENT_BUFFER_SIZE)
+        )
 
     def _record_event(
         self,
         entity_id: str,
-        action: str,
+        event_name: str,
         *,
         our_state,
         new_position,
         effective_threshold=None,
         reason: str = "",
     ) -> None:
-        """Append a manual-override decision event to the ring buffer."""
-        self._event_buffer.append(
+        """Append a manual-override decision event to the shared ring buffer."""
+        self._event_buffer.record(
             {
                 "ts": dt.datetime.now(dt.UTC).isoformat(),
+                "event": event_name,
                 "entity_id": entity_id,
-                "action": action,
                 "our_state": our_state,
                 "new_position": new_position,
                 "effective_threshold": effective_threshold,
@@ -65,14 +76,12 @@ class AdaptiveCoverManager:
         )
 
     def get_event_buffer(self) -> list[dict]:
-        """Return a snapshot of the manual-override decision ring buffer."""
-        return list(self._event_buffer)
+        """Return a snapshot of the ring buffer (backward-compat wrapper)."""
+        return self._event_buffer.snapshot()
 
     def resize_event_buffer(self, size: int) -> None:
-        """Resize the ring buffer, preserving the most-recent events."""
-        new_buf: deque[dict] = deque(maxlen=size)
-        new_buf.extend(self._event_buffer)
-        self._event_buffer = new_buf
+        """Resize the ring buffer, preserving the most-recent events (backward-compat wrapper)."""
+        self._event_buffer.resize(size)
 
     def add_covers(self, entity):
         """Add covers to tracking.
@@ -120,7 +129,7 @@ class AdaptiveCoverManager:
         if wait_target_call.get(entity_id):
             self._record_event(
                 entity_id,
-                "rejected_wait_for_target",
+                "manual_override_rejected_wait_for_target",
                 our_state=our_state,
                 new_position=None,
                 reason="wait_for_target active",
@@ -148,7 +157,7 @@ class AdaptiveCoverManager:
             )
             self._record_event(
                 entity_id,
-                "rejected_position_unavailable",
+                "manual_override_rejected_position_unavailable",
                 our_state=our_state,
                 new_position=None,
                 reason="position unavailable (transient state)",
@@ -176,7 +185,7 @@ class AdaptiveCoverManager:
                 )
                 self._record_event(
                     entity_id,
-                    "rejected_within_threshold",
+                    "manual_override_rejected_within_threshold",
                     our_state=our_state,
                     new_position=new_position,
                     effective_threshold=effective_threshold,
@@ -197,7 +206,7 @@ class AdaptiveCoverManager:
             )
             self._record_event(
                 entity_id,
-                "set",
+                "manual_override_set",
                 our_state=our_state,
                 new_position=new_position,
                 effective_threshold=effective_threshold,
@@ -243,7 +252,7 @@ class AdaptiveCoverManager:
         )
         self._record_event(
             entity_id,
-            "set",
+            "manual_override_set",
             our_state=my_position_value,
             new_position=my_position_value,
             reason="user stop_cover to My position",
@@ -336,7 +345,7 @@ class AdaptiveCoverManager:
         self.logger.debug("Reset manual override for %s", entity_id)
         self._record_event(
             entity_id,
-            "reset",
+            "manual_override_reset",
             our_state=None,
             new_position=None,
             reason="manual override cleared",

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -25,16 +25,18 @@ class MotionManager:
 
     """
 
-    def __init__(self, hass: HomeAssistant, logger) -> None:
+    def __init__(self, hass: HomeAssistant, logger, *, event_buffer=None) -> None:
         """Initialize the MotionManager.
 
         Args:
             hass: Home Assistant instance used to read sensor states
             logger: Logger instance for debug/info output
+            event_buffer: Shared diagnostic ring buffer (optional, reserved for future events).
 
         """
         self._hass = hass
         self._logger = logger
+        self._event_buffer = event_buffer
 
         self._sensors: list[str] = []
         self._timeout_seconds: int = 300

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -20,16 +20,20 @@ class TimeWindowManager:
     start/end time window for automatic cover control.
     """
 
-    def __init__(self, hass: HomeAssistant, logger: ConfigContextAdapter) -> None:
+    def __init__(
+        self, hass: HomeAssistant, logger: ConfigContextAdapter, *, event_buffer=None
+    ) -> None:
         """Initialize time window manager.
 
         Args:
             hass: Home Assistant instance
             logger: Context-aware logger
+            event_buffer: Shared diagnostic ring buffer (optional).
 
         """
         self._hass = hass
         self.logger = logger
+        self._event_buffer = event_buffer
         self._last_time_window_state: bool | None = None
 
         # Config values — set via update_config()
@@ -224,6 +228,15 @@ class TimeWindowManager:
                 "active" if self._last_time_window_state else "inactive",
                 "active" if current_state else "inactive",
             )
+            if self._event_buffer is not None:
+                import datetime as dt
+                self._event_buffer.record({
+                    "ts": dt.datetime.now(dt.UTC).isoformat(),
+                    "event": "time_window_changed",
+                    "entity_id": "",
+                    "previous": self._last_time_window_state,
+                    "current": current_state,
+                })
             self._last_time_window_state = current_state
 
             if current_state and on_window_open is not None:

--- a/custom_components/adaptive_cover_pro/managers/weather.py
+++ b/custom_components/adaptive_cover_pro/managers/weather.py
@@ -34,16 +34,18 @@ class WeatherManager:
     retract covers on sensor failure).
     """
 
-    def __init__(self, hass: HomeAssistant, logger) -> None:
+    def __init__(self, hass: HomeAssistant, logger, *, event_buffer=None) -> None:
         """Initialize the WeatherManager.
 
         Args:
             hass: Home Assistant instance used to read sensor states
             logger: Logger instance for debug/info output
+            event_buffer: Shared diagnostic ring buffer (optional).
 
         """
         self._hass = hass
         self._logger = logger
+        self._event_buffer = event_buffer
 
         # Config (updated via update_config)
         self._wind_speed_sensor: str | None = None
@@ -214,7 +216,17 @@ class WeatherManager:
         The caller is responsible for triggering a coordinator refresh.
         """
         self.cancel_weather_timeout()
+        previous = self._override_active
         self._override_active = True
+        if not previous and self._event_buffer is not None:
+            import datetime as dt
+            self._event_buffer.record({
+                "ts": dt.datetime.now(dt.UTC).isoformat(),
+                "event": "weather_override_changed",
+                "entity_id": "",
+                "previous": False,
+                "current": True,
+            })
 
     def reconcile(self) -> str | None:
         """Self-healing check against live sensor state.
@@ -285,6 +297,16 @@ class WeatherManager:
             return
 
         self._override_active = False
+        if self._event_buffer is not None:
+            import datetime as dt
+            self._event_buffer.record({
+                "ts": dt.datetime.now(dt.UTC).isoformat(),
+                "event": "weather_override_changed",
+                "entity_id": "",
+                "previous": True,
+                "current": False,
+                "reason": f"clear-delay expired ({timeout_seconds}s)",
+            })
         self._logger.info(
             "Weather clear-delay expired (%s seconds) — resuming normal control",
             timeout_seconds,

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import datetime as dt
+
+from ..diagnostics.event_buffer import EventBuffer
 from .handler import OverrideHandler
 from .types import DecisionStep, PipelineResult, PipelineSnapshot
 
@@ -9,11 +12,17 @@ from .types import DecisionStep, PipelineResult, PipelineSnapshot
 class PipelineRegistry:
     """Evaluates a set of :class:`OverrideHandler` instances in priority order."""
 
-    def __init__(self, handlers: list[OverrideHandler]) -> None:
+    def __init__(
+        self,
+        handlers: list[OverrideHandler],
+        *,
+        event_buffer: EventBuffer | None = None,
+    ) -> None:
         """Initialise and sort handlers by priority descending."""
         self._handlers: list[OverrideHandler] = sorted(
             handlers, key=lambda h: h.priority, reverse=True
         )
+        self._event_buffer = event_buffer
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult:
         """Evaluate all handlers and return the highest-priority matching result.
@@ -103,7 +112,7 @@ class PipelineRegistry:
                             merged[field_name] = val
                             break
 
-        return PipelineResult(
+        result = PipelineResult(
             position=winner.position,
             control_method=winner.control_method,
             reason=winner.reason,
@@ -123,3 +132,21 @@ class PipelineRegistry:
             default_position=snapshot.default_position,
             is_sunset_active=snapshot.is_sunset_active,
         )
+        if self._event_buffer is not None:
+            self._event_buffer.record(
+                {
+                    "ts": dt.datetime.now(dt.UTC).isoformat(),
+                    "event": "pipeline_evaluated",
+                    "entity_id": "",
+                    "winning_handler": winning_handler.name,
+                    "winning_priority": winning_handler.priority,
+                    "control_method": result.control_method.value
+                    if hasattr(result.control_method, "value")
+                    else str(result.control_method),
+                    "position": result.position,
+                    "reason": result.reason,
+                    "bypass_auto_control": result.bypass_auto_control,
+                    "is_sunset_active": result.is_sunset_active,
+                }
+            )
+        return result

--- a/tests/test_debug_diagnostics.py
+++ b/tests/test_debug_diagnostics.py
@@ -15,6 +15,7 @@ from custom_components.adaptive_cover_pro.diagnostics.builder import (
     DiagnosticContext,
     DiagnosticsBuilder,
 )
+from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
 from custom_components.adaptive_cover_pro.managers.manual_override import (
     AdaptiveCoverManager,
 )
@@ -27,13 +28,14 @@ from custom_components.adaptive_cover_pro.enums import ControlMethod
 # ---------------------------------------------------------------------------
 
 
-def _make_manager() -> AdaptiveCoverManager:
-    """Return an AdaptiveCoverManager with a minimal mock hass and logger."""
+def _make_manager() -> tuple[AdaptiveCoverManager, EventBuffer]:
+    """Return an AdaptiveCoverManager and its EventBuffer."""
     hass = MagicMock()
     logger = MagicMock()
-    mgr = AdaptiveCoverManager(hass, {"hours": 2}, logger)
+    event_buffer = EventBuffer(maxlen=DEFAULT_DEBUG_EVENT_BUFFER_SIZE)
+    mgr = AdaptiveCoverManager(hass, {"hours": 2}, logger, event_buffer=event_buffer)
     mgr.add_covers({"cover.test"})
-    return mgr
+    return mgr, event_buffer
 
 
 def _make_state_event(entity_id: str, new_pos: int, old_pos: int = 50):
@@ -118,22 +120,21 @@ class TestRingBufferDefaults:
 
     def test_buffer_starts_empty(self):
         """Buffer is empty on initialisation."""
-        mgr = _make_manager()
-        assert mgr.get_event_buffer() == []
+        _mgr, event_buffer = _make_manager()
+        assert event_buffer.snapshot() == []
 
     def test_buffer_maxlen_equals_default(self):
         """Buffer maxlen matches DEFAULT_DEBUG_EVENT_BUFFER_SIZE."""
-        mgr = _make_manager()
-        assert mgr._event_buffer.maxlen == DEFAULT_DEBUG_EVENT_BUFFER_SIZE
+        _mgr, event_buffer = _make_manager()
+        assert event_buffer.maxlen == DEFAULT_DEBUG_EVENT_BUFFER_SIZE
 
     def test_get_event_buffer_returns_list_copy(self):
-        """get_event_buffer returns a list copy, not a reference to the deque."""
-        mgr = _make_manager()
-        buf = mgr.get_event_buffer()
+        """snapshot() returns a list copy, not a reference to the deque."""
+        _mgr, event_buffer = _make_manager()
+        buf = event_buffer.snapshot()
         assert isinstance(buf, list)
-        # Mutating the returned list must not mutate the internal deque
         buf.append({"fake": True})
-        assert len(mgr._event_buffer) == 0
+        assert len(event_buffer) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -145,10 +146,9 @@ class TestRingBufferEvents:
     """Verify _record_event is called at the right decision points."""
 
     def test_threshold_breach_records_set(self):
-        """Manual override detection records 'set' when delta >= threshold."""
-        mgr = _make_manager()
+        """Manual override detection records 'manual_override_set' when delta >= threshold."""
+        mgr, event_buffer = _make_manager()
         event = _make_state_event("cover.test", new_pos=80, old_pos=50)
-        # our_state=50, new_pos=80 → delta=30 >> threshold
         mgr.handle_state_change(
             states_data=event,
             our_state=50,
@@ -157,8 +157,8 @@ class TestRingBufferEvents:
             wait_target_call={},
             manual_threshold=3,
         )
-        buf = mgr.get_event_buffer()
-        set_events = [e for e in buf if e["action"] == "set"]
+        buf = event_buffer.snapshot()
+        set_events = [e for e in buf if e["event"] == "manual_override_set"]
         assert len(set_events) == 1
         ev = set_events[0]
         assert ev["entity_id"] == "cover.test"
@@ -166,8 +166,8 @@ class TestRingBufferEvents:
         assert ev["new_position"] == 80
 
     def test_within_threshold_records_rejection(self):
-        """Delta below threshold records 'rejected_within_threshold'."""
-        mgr = _make_manager()
+        """Delta below threshold records 'manual_override_rejected_within_threshold'."""
+        mgr, event_buffer = _make_manager()
         event = _make_state_event("cover.test", new_pos=51, old_pos=50)
         mgr.handle_state_change(
             states_data=event,
@@ -177,13 +177,13 @@ class TestRingBufferEvents:
             wait_target_call={},
             manual_threshold=5,
         )
-        buf = mgr.get_event_buffer()
-        rejected = [e for e in buf if e["action"] == "rejected_within_threshold"]
+        buf = event_buffer.snapshot()
+        rejected = [e for e in buf if e["event"] == "manual_override_rejected_within_threshold"]
         assert len(rejected) == 1
 
     def test_wait_for_target_records_rejection(self):
-        """Event during wait_for_target records 'rejected_wait_for_target'."""
-        mgr = _make_manager()
+        """Event during wait_for_target records 'manual_override_rejected_wait_for_target'."""
+        mgr, event_buffer = _make_manager()
         event = _make_state_event("cover.test", new_pos=80)
         mgr.handle_state_change(
             states_data=event,
@@ -193,16 +193,15 @@ class TestRingBufferEvents:
             wait_target_call={"cover.test": True},
             manual_threshold=3,
         )
-        buf = mgr.get_event_buffer()
-        rejected = [e for e in buf if e["action"] == "rejected_wait_for_target"]
+        buf = event_buffer.snapshot()
+        rejected = [e for e in buf if e["event"] == "manual_override_rejected_wait_for_target"]
         assert len(rejected) == 1
 
     def test_position_unavailable_records_rejection(self):
-        """None position records 'rejected_position_unavailable'."""
-        mgr = _make_manager()
+        """None position records 'manual_override_rejected_position_unavailable'."""
+        mgr, event_buffer = _make_manager()
         event = _make_state_event("cover.test", new_pos=80)
         event.new_state.attributes = {}  # no current_position key
-        # Mock get_open_close_state to return None
         from unittest.mock import patch
 
         with patch(
@@ -217,23 +216,23 @@ class TestRingBufferEvents:
                 wait_target_call={},
                 manual_threshold=3,
             )
-        buf = mgr.get_event_buffer()
-        rejected = [e for e in buf if e["action"] == "rejected_position_unavailable"]
+        buf = event_buffer.snapshot()
+        rejected = [e for e in buf if e["event"] == "manual_override_rejected_position_unavailable"]
         assert len(rejected) == 1
 
     def test_reset_records_reset_event(self):
-        """reset() records a 'reset' event in the buffer."""
-        mgr = _make_manager()
+        """reset() records a 'manual_override_reset' event in the buffer."""
+        mgr, event_buffer = _make_manager()
         mgr.manual_control["cover.test"] = True
         mgr.reset("cover.test")
-        buf = mgr.get_event_buffer()
-        reset_events = [e for e in buf if e["action"] == "reset"]
+        buf = event_buffer.snapshot()
+        reset_events = [e for e in buf if e["event"] == "manual_override_reset"]
         assert len(reset_events) == 1
         assert reset_events[0]["entity_id"] == "cover.test"
 
     def test_event_has_required_keys(self):
         """Every recorded event has the required keys."""
-        mgr = _make_manager()
+        mgr, event_buffer = _make_manager()
         event = _make_state_event("cover.test", new_pos=80)
         mgr.handle_state_change(
             states_data=event,
@@ -243,20 +242,13 @@ class TestRingBufferEvents:
             wait_target_call={},
             manual_threshold=3,
         )
-        required_keys = {
-            "ts",
-            "entity_id",
-            "action",
-            "our_state",
-            "new_position",
-            "reason",
-        }
-        for ev in mgr.get_event_buffer():
+        required_keys = {"ts", "entity_id", "event", "our_state", "new_position", "reason"}
+        for ev in event_buffer.snapshot():
             assert required_keys.issubset(ev.keys()), f"Missing keys in: {ev}"
 
     def test_event_ts_is_iso_string(self):
         """Event timestamp is an ISO-format string."""
-        mgr = _make_manager()
+        mgr, event_buffer = _make_manager()
         event = _make_state_event("cover.test", new_pos=80)
         mgr.handle_state_change(
             states_data=event,
@@ -266,8 +258,7 @@ class TestRingBufferEvents:
             wait_target_call={},
             manual_threshold=3,
         )
-        ev = mgr.get_event_buffer()[0]
-        # Should parse without error
+        ev = event_buffer.snapshot()[0]
         dt.datetime.fromisoformat(ev["ts"])
 
 
@@ -277,63 +268,54 @@ class TestRingBufferEvents:
 
 
 class TestResizeEventBuffer:
-    """Verify resize_event_buffer works correctly."""
+    """Verify EventBuffer resize works correctly."""
 
     def test_resize_to_larger_preserves_events(self):
         """Resizing to larger capacity preserves all existing events."""
-        mgr = _make_manager()
-        # Populate 5 events
+        mgr, event_buffer = _make_manager()
         for i in range(5):
             mgr._record_event(
                 f"cover.{i}",
-                "set",
+                "manual_override_set",
                 our_state=50,
                 new_position=80,
                 reason="test",
             )
-        mgr.resize_event_buffer(100)
-        assert len(mgr.get_event_buffer()) == 5
-        assert mgr._event_buffer.maxlen == 100
+        event_buffer.resize(100)
+        assert len(event_buffer.snapshot()) == 5
+        assert event_buffer.maxlen == 100
 
     def test_resize_to_smaller_keeps_most_recent(self):
         """Resizing to smaller capacity keeps the most recent events."""
-        mgr = _make_manager()
-        # Populate 10 events with distinguishable entity IDs
+        mgr, event_buffer = _make_manager()
         for i in range(10):
             mgr._record_event(
                 f"cover.{i}",
-                "set",
+                "manual_override_set",
                 our_state=50,
                 new_position=80,
                 reason="test",
             )
-        mgr.resize_event_buffer(3)
-        buf = mgr.get_event_buffer()
+        event_buffer.resize(3)
+        buf = event_buffer.snapshot()
         assert len(buf) == 3
-        assert mgr._event_buffer.maxlen == 3
-        # Most recent 3 should be covers 7, 8, 9
+        assert event_buffer.maxlen == 3
         entity_ids = [e["entity_id"] for e in buf]
         assert entity_ids == ["cover.7", "cover.8", "cover.9"]
 
     def test_resize_to_max_config_value(self):
         """Resizing to MAX_DEBUG_EVENT_BUFFER_SIZE is accepted."""
-        mgr = _make_manager()
-        mgr.resize_event_buffer(MAX_DEBUG_EVENT_BUFFER_SIZE)
-        assert mgr._event_buffer.maxlen == MAX_DEBUG_EVENT_BUFFER_SIZE
+        _mgr, event_buffer = _make_manager()
+        event_buffer.resize(MAX_DEBUG_EVENT_BUFFER_SIZE)
+        assert event_buffer.maxlen == MAX_DEBUG_EVENT_BUFFER_SIZE
 
     def test_ring_buffer_overwrites_oldest_when_full(self):
         """Ring buffer overwrites the oldest event when at capacity."""
-        mgr = _make_manager()
-        mgr.resize_event_buffer(3)
+        _mgr, event_buffer = _make_manager()
+        event_buffer.resize(3)
         for i in range(5):
-            mgr._record_event(
-                f"cover.{i}",
-                "set",
-                our_state=50,
-                new_position=80,
-                reason="test",
-            )
-        buf = mgr.get_event_buffer()
+            event_buffer.record({"event": "manual_override_set", "entity_id": f"cover.{i}"})
+        buf = event_buffer.snapshot()
         assert len(buf) == 3
         entity_ids = [e["entity_id"] for e in buf]
         assert entity_ids == ["cover.2", "cover.3", "cover.4"]
@@ -381,11 +363,10 @@ class TestDiagnosticsBuilderDebugInfo:
     def test_debug_section_omitted_when_all_none(self):
         """All debug fields are absent when context fields are None."""
         builder = DiagnosticsBuilder()
-        ctx = (
-            _base_ctx()
-        )  # manual_override_events=None, cover_command_state=None, debug_config=None
+        ctx = _base_ctx()
         result, _ = builder.build(ctx)
         assert "debug_config" not in result
+        assert "event_timeline" not in result
         assert "manual_override_history" not in result
         # cover_commands is always present (empty dict when no state)
         assert result.get("cover_commands") == {}
@@ -415,26 +396,49 @@ class TestDiagnosticsBuilderDebugInfo:
         result, _ = builder.build(ctx)
         assert result["debug_config"]["dry_run"] is True
 
-    def test_manual_override_history_emitted_when_populated(self):
-        """manual_override_history is included in output when events exist."""
+    def test_event_timeline_emitted_when_populated(self):
+        """event_timeline is included in output when events exist."""
         builder = DiagnosticsBuilder()
         events = [
             {
                 "ts": "2024-01-01T00:00:00+00:00",
-                "action": "set",
+                "event": "cover_command_sent",
                 "entity_id": "cover.test",
             }
         ]
-        ctx = _base_ctx(manual_override_events=events)
+        ctx = _base_ctx(event_timeline=events)
         result, _ = builder.build(ctx)
-        assert result["manual_override_history"] == events
+        assert result["event_timeline"] == events
 
-    def test_manual_override_history_omitted_when_empty_list(self):
-        """manual_override_history is absent when the event list is empty."""
+    def test_manual_override_history_alias_contains_only_override_events(self):
+        """manual_override_history alias contains only manual_override_* events."""
         builder = DiagnosticsBuilder()
-        ctx = _base_ctx(manual_override_events=[])
+        events = [
+            {"ts": "2024-01-01T00:00:00+00:00", "event": "manual_override_set", "entity_id": "cover.test"},
+            {"ts": "2024-01-01T00:00:01+00:00", "event": "cover_command_sent", "entity_id": "cover.test"},
+        ]
+        ctx = _base_ctx(event_timeline=events)
         result, _ = builder.build(ctx)
+        assert "event_timeline" in result
+        assert result["manual_override_history"] == [events[0]]
+
+    def test_manual_override_history_absent_when_no_override_events(self):
+        """manual_override_history is absent when no manual_override_* events exist."""
+        builder = DiagnosticsBuilder()
+        events = [
+            {"ts": "2024-01-01T00:00:00+00:00", "event": "cover_command_sent", "entity_id": "cover.test"},
+        ]
+        ctx = _base_ctx(event_timeline=events)
+        result, _ = builder.build(ctx)
+        assert "event_timeline" in result
         assert "manual_override_history" not in result
+
+    def test_event_timeline_omitted_when_empty_list(self):
+        """event_timeline is absent when the event list is empty."""
+        builder = DiagnosticsBuilder()
+        ctx = _base_ctx(event_timeline=[])
+        result, _ = builder.build(ctx)
+        assert "event_timeline" not in result
 
     def test_cover_commands_emitted_when_provided(self):
         """cover_commands is populated when cover_command_state is provided."""
@@ -454,15 +458,16 @@ class TestDiagnosticsBuilderDebugInfo:
     def test_all_three_sections_present_together(self):
         """All debug sections appear together when all are populated."""
         builder = DiagnosticsBuilder()
-        events = [{"action": "set"}]
+        events = [{"event": "manual_override_set", "entity_id": "cover.test"}]
         state = {"cover.test": {"target_call": 50}}
         config = {"debug_mode": True}
         ctx = _base_ctx(
-            manual_override_events=events,
+            event_timeline=events,
             cover_command_state=state,
             debug_config=config,
         )
         result, _ = builder.build(ctx)
+        assert "event_timeline" in result
         assert "manual_override_history" in result
         assert result["cover_commands"] == state
         assert "debug_config" in result
@@ -558,3 +563,161 @@ class TestCoverCommandServiceSnapshots:
         svc.target_call["cover.test"] = 50
         snap = svc.get_entity_state_snapshot("cover.test")
         assert snap["last_reconcile_time"] == now.isoformat()
+
+
+# ---------------------------------------------------------------------------
+# CoverCommandService — _track_action enrichment and event buffer
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineRegistryEventBuffer:
+    """Verify PipelineRegistry records pipeline_evaluated events."""
+
+    def _make_registry(self, event_buffer=None):
+        from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+        from custom_components.adaptive_cover_pro.pipeline.handlers.default import DefaultHandler
+        return PipelineRegistry([DefaultHandler()], event_buffer=event_buffer)
+
+    def _make_snapshot(self):
+        from tests.test_pipeline.conftest import make_snapshot
+        return make_snapshot()
+
+    def test_pipeline_evaluated_event_recorded(self):
+        """evaluate() records a pipeline_evaluated event when buffer is set."""
+        event_buffer = EventBuffer(maxlen=50)
+        registry = self._make_registry(event_buffer=event_buffer)
+        registry.evaluate(self._make_snapshot())
+        buf = event_buffer.snapshot()
+        assert len(buf) == 1
+        ev = buf[0]
+        assert ev["event"] == "pipeline_evaluated"
+        assert "winning_handler" in ev
+        assert "position" in ev
+        assert "ts" in ev
+
+    def test_no_event_when_no_buffer(self):
+        """evaluate() works normally when no event_buffer is set."""
+        registry = self._make_registry(event_buffer=None)
+        result = registry.evaluate(self._make_snapshot())
+        assert result is not None
+
+
+class TestTrackActionEnrichment:
+    """Verify _track_action records new fields and UTC timestamps."""
+
+    def _make_svc_with_buffer(self):
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+        from custom_components.adaptive_cover_pro.managers.grace_period import (
+            GracePeriodManager,
+        )
+
+        hass = MagicMock()
+        logger = MagicMock()
+        grace_mgr = GracePeriodManager(logger=logger, command_grace_seconds=5.0)
+        event_buffer = EventBuffer(maxlen=50)
+        svc = CoverCommandService(
+            hass=hass,
+            logger=logger,
+            cover_type="cover_blind",
+            grace_mgr=grace_mgr,
+            event_buffer=event_buffer,
+        )
+        return svc, event_buffer
+
+    def test_timestamp_is_utc(self):
+        """_track_action records a UTC-offset timestamp (not naive local time)."""
+        svc, _buf = self._make_svc_with_buffer()
+        svc._track_action("cover.test", "set_cover_position", 50, True)
+        ts = svc.last_cover_action["timestamp"]
+        parsed = dt.datetime.fromisoformat(ts)
+        assert parsed.utcoffset() is not None, "timestamp must be timezone-aware (UTC)"
+        assert parsed.utcoffset().total_seconds() == 0
+
+    def test_target_source_recorded(self):
+        """target_source kwarg is stored in last_cover_action."""
+        svc, _buf = self._make_svc_with_buffer()
+        svc._track_action(
+            "cover.test", "set_cover_position", 50, True,
+            target_source="pipeline",
+        )
+        assert svc.last_cover_action["target_source"] == "pipeline"
+
+    def test_force_and_is_safety_recorded(self):
+        """Force and is_safety flags are stored in last_cover_action."""
+        svc, _buf = self._make_svc_with_buffer()
+        svc._track_action(
+            "cover.test", "open_cover", 100, False,
+            force=True, is_safety=False,
+        )
+        assert svc.last_cover_action["force"] is True
+        assert svc.last_cover_action["is_safety"] is False
+
+    def test_state_snapshot_fields_recorded(self):
+        """auto_control_at_call and friends are stored in last_cover_action."""
+        svc, _buf = self._make_svc_with_buffer()
+        svc._track_action(
+            "cover.test", "set_cover_position", 42, True,
+            auto_control_at_call=False,
+            manual_override_at_call=True,
+            in_time_window_at_call=True,
+            enabled_at_call=True,
+        )
+        action = svc.last_cover_action
+        assert action["auto_control_at_call"] is False
+        assert action["manual_override_at_call"] is True
+        assert action["in_time_window_at_call"] is True
+        assert action["enabled_at_call"] is True
+
+    def test_pipeline_fields_recorded(self):
+        """pipeline_handler and related fields are stored in last_cover_action."""
+        svc, _buf = self._make_svc_with_buffer()
+        trace = [{"handler": "solar", "matched": True}]
+        svc._track_action(
+            "cover.test", "set_cover_position", 60, True,
+            pipeline_handler="solar",
+            pipeline_control_method="SOLAR",
+            pipeline_bypass_auto_control=False,
+            decision_trace_at_call=trace,
+        )
+        action = svc.last_cover_action
+        assert action["pipeline_handler"] == "solar"
+        assert action["pipeline_control_method"] == "SOLAR"
+        assert action["pipeline_bypass_auto_control"] is False
+        assert action["decision_trace_at_call"] == trace
+
+    def test_cover_command_sent_event_recorded(self):
+        """_track_action records a cover_command_sent event to the event buffer."""
+        svc, event_buffer = self._make_svc_with_buffer()
+        svc.target_call["cover.test"] = 75
+        svc._track_action(
+            "cover.test", "set_cover_position", 75, True,
+            trigger="solar", target_source="pipeline",
+            force=False, is_safety=False,
+        )
+        buf = event_buffer.snapshot()
+        assert len(buf) == 1
+        ev = buf[0]
+        assert ev["event"] == "cover_command_sent"
+        assert ev["entity_id"] == "cover.test"
+        assert ev["service"] == "set_cover_position"
+        assert ev["trigger"] == "solar"
+        assert ev["target_source"] == "pipeline"
+
+    def test_no_event_buffer_no_error(self):
+        """_track_action works normally when no event_buffer is injected."""
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+        from custom_components.adaptive_cover_pro.managers.grace_period import (
+            GracePeriodManager,
+        )
+        svc = CoverCommandService(
+            hass=MagicMock(),
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=GracePeriodManager(logger=MagicMock(), command_grace_seconds=5.0),
+        )
+        svc._track_action("cover.test", "set_cover_position", 50, True)
+        assert svc.last_cover_action["timestamp"] is not None

--- a/tests/test_event_buffer.py
+++ b/tests/test_event_buffer.py
@@ -1,0 +1,70 @@
+"""Tests for EventBuffer ring buffer."""
+
+from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
+
+
+def test_record_and_snapshot():
+    buf = EventBuffer(maxlen=10)
+    buf.record({"event": "a"})
+    buf.record({"event": "b"})
+    assert buf.snapshot() == [{"event": "a"}, {"event": "b"}]
+
+
+def test_snapshot_is_a_copy():
+    buf = EventBuffer(maxlen=10)
+    buf.record({"event": "a"})
+    snap = buf.snapshot()
+    snap.clear()
+    assert len(buf) == 1
+
+
+def test_maxlen_evicts_oldest():
+    buf = EventBuffer(maxlen=3)
+    for i in range(5):
+        buf.record({"event": str(i)})
+    assert buf.snapshot() == [{"event": "2"}, {"event": "3"}, {"event": "4"}]
+
+
+def test_len():
+    buf = EventBuffer(maxlen=10)
+    assert len(buf) == 0
+    buf.record({"event": "a"})
+    assert len(buf) == 1
+
+
+def test_maxlen_property():
+    buf = EventBuffer(maxlen=42)
+    assert buf.maxlen == 42
+
+
+def test_resize_up_preserves_all_entries():
+    buf = EventBuffer(maxlen=3)
+    for i in range(3):
+        buf.record({"event": str(i)})
+    buf.resize(10)
+    assert buf.snapshot() == [{"event": "0"}, {"event": "1"}, {"event": "2"}]
+    assert buf.maxlen == 10
+
+
+def test_resize_down_keeps_most_recent():
+    buf = EventBuffer(maxlen=5)
+    for i in range(5):
+        buf.record({"event": str(i)})
+    buf.resize(3)
+    assert buf.snapshot() == [{"event": "2"}, {"event": "3"}, {"event": "4"}]
+    assert buf.maxlen == 3
+
+
+def test_resize_then_record():
+    # fill to [0, 1, 2], resize to 2 → keeps [1, 2], record "new" → evicts 1 → [2, new]
+    buf = EventBuffer(maxlen=3)
+    for i in range(3):
+        buf.record({"event": str(i)})
+    buf.resize(2)
+    buf.record({"event": "new"})
+    assert buf.snapshot() == [{"event": "2"}, {"event": "new"}]
+
+
+def test_empty_snapshot():
+    buf = EventBuffer(maxlen=10)
+    assert buf.snapshot() == []

--- a/tests/test_issue_285_open_state_cover_false_override.py
+++ b/tests/test_issue_285_open_state_cover_false_override.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import datetime as dt
 from unittest.mock import MagicMock
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_my_position.py
+++ b/tests/test_my_position.py
@@ -578,12 +578,16 @@ class TestHandleStopServiceCall:
 
     @pytest.fixture
     def mgr(self, mock_hass):
+        from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
+        event_buffer = EventBuffer(maxlen=50)
         m = AdaptiveCoverManager(
             hass=mock_hass,
             reset_duration={"minutes": 15},
             logger=MagicMock(),
+            event_buffer=event_buffer,
         )
         m.add_covers(["cover.somfy"])
+        m._test_event_buffer = event_buffer
         return m
 
     def test_marks_manual_control(self, mgr):
@@ -592,11 +596,11 @@ class TestHandleStopServiceCall:
         assert mgr.manual_control.get("cover.somfy") is True
 
     def test_records_event(self, mgr):
-        """handle_stop_service_call appends a 'set' event to the ring buffer."""
+        """handle_stop_service_call appends a 'manual_override_set' event to the ring buffer."""
         mgr.handle_stop_service_call("cover.somfy", 50, {})
-        events = mgr.get_event_buffer()
+        events = mgr._test_event_buffer.snapshot()
         assert len(events) == 1
-        assert events[0]["action"] == "set"
+        assert events[0]["event"] == "manual_override_set"
         assert "My position" in events[0]["reason"]
 
     def test_noop_when_entity_not_tracked(self, mgr):

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -775,8 +775,9 @@ class TestPositionExplanationChangeDetection:
         type(coord).is_motion_detected = PropertyMock(return_value=True)
         coord._motion_mgr = MagicMock()
         coord._motion_mgr._motion_timeout_active = False
+        from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
+        coord._event_buffer = EventBuffer(maxlen=50)
         coord.manager = MagicMock()
-        coord.manager.get_event_buffer.return_value = []
         coord.manager.covers = set()
         coord.manager.manual_control = {}
         coord.manager.manual_control_time = {}


### PR DESCRIPTION
## Summary

- Introduces a coordinator-owned `EventBuffer` ring buffer (generalizes the existing manual override buffer) injected into all components
- Records 20 event types across the full cover lifecycle: cover commands, pipeline evaluations, manual override transitions, wait_for_target lifecycle, override state changes
- Enriches `last_cover_action` with 11 new fields including `target_source` (which caller sent the command), force/safety flags, integration state at call time, pipeline decision trace, and a `gates_evaluated` shadow check showing which gates `force=True` bypassed
- Exposes as `event_timeline` in diagnostics JSON; backward-compat `manual_override_history` alias retained as a filtered view
- Fixes a latent UTC timestamp inconsistency in `_track_action` (was naive local time; `_skip` already used UTC)

## Testing

- ✅ 2397 tests passing
- New: `tests/test_event_buffer.py` (ring buffer primitive), `TestPipelineRegistryEventBuffer`, `TestTrackActionEnrichment` in `test_debug_diagnostics.py`
- Updated: `test_debug_diagnostics.py`, `test_my_position.py`, `test_position_explanation.py` for new event schema

## Related Issues

Refs #294