### PR TITLE
fix: respect auto_control gate when force=True (#293)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1238,6 +1238,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         *,
         force: bool = False,
         is_safety: bool = False,
+        bypass_auto_control: bool = False,
         sun_just_appeared: bool = False,
     ) -> PositionContext:
         """Build a PositionContext for the given cover entity.
@@ -1248,8 +1249,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         Args:
             entity: Cover entity ID
             options: Config entry options dict
-            force: If True, all gate checks are bypassed (delta, time, manual
-                override).  Use for any intentional non-solar reposition.
+            force: If True, delta/time/manual_override gate checks are bypassed.
+                Use for any intentional non-solar reposition.  NOTE: force=True
+                does NOT bypass auto_control_off — pass bypass_auto_control=True
+                or is_safety=True for that.
             is_safety: If True, the target is classified as safety-critical
                 (force override, weather) and will persist across window
                 boundaries — reconciliation will resend it even when outside
@@ -1257,6 +1260,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 kept independent of ``force``: override-clear and toggle
                 actions need ``force=True`` (bypass gates) but
                 ``is_safety=False`` (don't persist past the window).
+            bypass_auto_control: If True, the auto_control_off gate is bypassed
+                for this one-shot call without classifying the target as a
+                safety target.  Use only for sanctioned transition actions
+                (e.g. switch return-to-default at the moment auto_control
+                toggles off).  Not used by the regular update loop.
             sun_just_appeared: Pre-computed sun transition flag. Call
                 ``_check_sun_validity_transition()`` once before a multi-entity
                 loop and pass the result here so the stateful transition check
@@ -1273,6 +1281,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             inverse_state=self._inverse_state,
             force=force,
             is_safety=is_safety,
+            bypass_auto_control=bypass_auto_control,
             use_my_position=self._pipeline_result.use_my_position
             if self._pipeline_result
             else False,
@@ -1426,7 +1435,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         events = self._pending_cover_events[:]
         self._pending_cover_events.clear()
 
-        if not (self.manual_toggle and self.automatic_control):
+        # NB (issue #293): observation is not action.  When automatic_control
+        # is OFF we still drain events so the user's manual response is recorded
+        # and any latched target gets discarded via the existing
+        # discard_target() call below.  Only manual_toggle=False (the user has
+        # globally disabled manual override detection) short-circuits the loop.
+        if not self.manual_toggle:
             self._manual_gate_closed_log(
                 "state_change", [e.entity_id for e in events]
             )

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -51,9 +51,12 @@ class PositionContext:
     time_threshold: int
     special_positions: list[int]
     inverse_state: bool = False
-    force: bool = False  # Skip all gate checks when True
+    force: bool = False  # Skip delta/time/manual_override gates (NOT auto_control)
     is_safety: bool = (
-        False  # Safety-critical target (persists across window boundaries)
+        False  # Safety-critical target (persists across window boundaries; bypasses auto_control)
+    )
+    bypass_auto_control: bool = (
+        False  # Sanctioned one-shot bypass of auto_control gate (e.g. switch return-to-default)
     )
     use_my_position: bool = (
         False  # Route through send_my_position() on non-position-capable covers
@@ -784,13 +787,19 @@ class CoverCommandService:
             and detail is the service name or skip reason.
 
         """
-        # ----- gate checks (bypassed when context.force is True) -----
+        # ----- gate checks -----
+        # Three bypass channels (in order of priority):
+        #   - is_safety=True: genuine safety override (force_override, weather)
+        #   - bypass_auto_control=True: sanctioned one-shot transition (switch
+        #     return-to-default at the moment auto_control toggles off)
+        #   - force=True alone: bypasses delta/time/manual_override BUT NOT
+        #     auto_control (issue #293)
         _trigger = reason
         _inverse = context.inverse_state
         _current = self._get_current_position(entity_id)
 
         # Hard kill switch — blocks ALL commands, including safety overrides and
-        # force=True calls.  Must be checked before the context.force branch.
+        # force=True calls.  Must be checked before any bypass branch.
         if not self._enabled:
             return self._skip(
                 entity_id,
@@ -801,17 +810,23 @@ class CoverCommandService:
                 current_position=_current,
             )
 
-        if not context.force:
-            if not context.auto_control:
-                return self._skip(
-                    entity_id,
-                    "auto_control_off",
-                    position,
-                    trigger=_trigger,
-                    inverse_state=_inverse,
-                    current_position=_current,
-                )
+        # auto_control gate — bypassed only by is_safety or bypass_auto_control,
+        # NOT by plain force=True (issue #293).
+        if (
+            not context.is_safety
+            and not context.bypass_auto_control
+            and not context.auto_control
+        ):
+            return self._skip(
+                entity_id,
+                "auto_control_off",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=_current,
+            )
 
+        if not context.force:
             if not self._check_position_delta(
                 entity_id,
                 position,

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -271,8 +271,13 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
                 )
                 options = self.coordinator.config_entry.options
                 for entity in self.coordinator.entities:
+                    # Sanctioned one-shot transition: auto_control was just
+                    # toggled OFF; honor the user's "return to default" choice
+                    # by bypassing the auto_control gate exactly once.  Without
+                    # bypass_auto_control=True the gate (issue #293) would
+                    # correctly skip this command.
                     ctx = self.coordinator._build_position_context(
-                        entity, options, force=True
+                        entity, options, force=True, bypass_auto_control=True
                     )
                     await self.coordinator._cmd_svc.apply_position(
                         entity, default_position, "auto_control_off", context=ctx

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -104,7 +104,8 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
     # _build_position_context: preserve force and is_safety kwargs in the returned
     # PositionContext so callers can inspect which values the coordinator passed.
     def _fake_build_ctx(
-        entity, options, *, force=False, is_safety=False, sun_just_appeared=False
+        entity, options, *, force=False, is_safety=False,
+        bypass_auto_control=False, sun_just_appeared=False,
     ):
         return PositionContext(
             auto_control=False,  # reflects automatic_control=False
@@ -115,6 +116,7 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
             special_positions=[0, 100],
             force=force,
             is_safety=is_safety,
+            bypass_auto_control=bypass_auto_control,
         )
 
     coord._build_position_context = _fake_build_ctx
@@ -283,6 +285,31 @@ async def _trigger_force_override_released(coord):
         await coord.async_handle_state_change(50, {}, prev_force_override=True)
 
 
+async def _trigger_switch_auto_control_off_return(coord):
+    """Trigger: AdaptiveCoverSwitch.async_turn_off with return_to_default_toggle on.
+
+    Issue #293: this is the only sanctioned caller that bypasses the
+    auto_control gate via bypass_auto_control=True (rather than is_safety=True).
+    """
+    from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
+
+    coord.return_to_default_toggle = True
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {"default_height": 60}
+    coord.manager.manual_controlled = []
+    coord.async_refresh = AsyncMock()
+
+    switch = object.__new__(AdaptiveCoverSwitch)
+    switch.coordinator = coord
+    switch._key = "automatic_control"
+    switch._name = "automatic_control"
+    switch._initial_state = True
+    switch._attr_is_on = True
+    switch.schedule_update_ha_state = MagicMock()
+
+    await switch.async_turn_off()
+
+
 CONTROL_GATE_MATRIX: list[MatrixCase] = [
     MatrixCase(
         id="manual_override_expiry",
@@ -332,6 +359,19 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
         is_safety_target=False,  # but is NOT a persistent safety target (#223)
         setup=lambda _: None,
         trigger=_trigger_force_override_released,
+    ),
+    MatrixCase(
+        # Issue #293: switch toggles auto_control off → return-to-default fires
+        # one-shot via the new bypass_auto_control=True channel.  Calls with
+        # force=True (so the matrix invariant 1 marks it as a bypass row), but
+        # is_safety=False — the target should NOT persist across window
+        # boundaries.  The bypass_auto_control flag is what actually lets the
+        # command through the auto_control gate after the issue #293 fix.
+        id="switch_auto_control_off_return_to_default",
+        is_safety_bypass=True,
+        is_safety_target=False,
+        setup=lambda _: None,
+        trigger=_trigger_switch_auto_control_off_return,
     ),
 ]
 

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -707,8 +707,13 @@ class TestCoverStateChangeTriggerManualOverride:
         coordinator.manager.handle_state_change.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_manual_override_detection_skipped_when_auto_control_off(self):
-        """handle_state_change NOT called when automatic_control is False."""
+    async def test_manual_override_detection_runs_when_auto_control_off(self):
+        """Issue #293: handle_state_change IS called even when automatic_control=False.
+
+        Observation is not action — recording manual overrides when the user
+        toggles auto control off lets reconciliation back off and surfaces the
+        user's intent in diagnostics.  Only manual_toggle=False short-circuits.
+        """
         from custom_components.adaptive_cover_pro.coordinator import (
             AdaptiveDataUpdateCoordinator,
         )
@@ -724,7 +729,7 @@ class TestCoverStateChangeTriggerManualOverride:
             coordinator, state=50
         )
 
-        coordinator.manager.handle_state_change.assert_not_called()
+        coordinator.manager.handle_state_change.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_cover_state_change_flag_cleared(self):

--- a/tests/test_coordinator_logging.py
+++ b/tests/test_coordinator_logging.py
@@ -142,17 +142,16 @@ class TestApplyPositionGateLogging:
         assert svc.target_call["cover.test"] == 60
 
     @pytest.mark.asyncio
-    async def test_force_bypasses_all_gates(self):
-        """force=True skips all gate checks and sends command."""
+    async def test_force_bypasses_delta_and_manual_override_gates(self):
+        """force=True bypasses delta/time/manual_override but NOT auto_control (issue #293)."""
         svc = _make_cmd_svc()
 
         with patch(
             "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
             return_value={"has_set_position": True, "has_set_tilt_position": False},
         ):
-            # All gates would fail — but force=True bypasses them
             ctx = _make_context(
-                auto_control=False,
+                auto_control=True,
                 manual_override=True,
                 force=True,
             )
@@ -283,8 +282,13 @@ class TestManualGateClosedLogging:
         assert any("manual override detection gate closed" in c for c in calls)
 
     @pytest.mark.asyncio
-    async def test_state_change_logs_when_auto_control_off(self):
-        """async_handle_cover_state_change emits debug log when automatic_control is False."""
+    async def test_state_change_does_NOT_log_gate_closed_when_only_auto_control_off(self):
+        """Issue #293: auto_control off no longer closes the manual-override gate.
+
+        Only manual_toggle=False emits the "gate closed" log line; with
+        automatic_control=False the handler now observes events and records
+        manual overrides (observation is not action).
+        """
         from custom_components.adaptive_cover_pro.coordinator import (
             AdaptiveDataUpdateCoordinator,
         )
@@ -296,7 +300,7 @@ class TestManualGateClosedLogging:
             coord, state=50
         )
         calls = [str(c) for c in coord.logger.debug.call_args_list]
-        assert any("manual override detection gate closed" in c for c in calls)
+        assert not any("manual override detection gate closed" in c for c in calls)
 
     @pytest.mark.asyncio
     async def test_service_call_logs_when_manual_toggle_off(self):

--- a/tests/test_cover_command_force_gate.py
+++ b/tests/test_cover_command_force_gate.py
@@ -1,0 +1,136 @@
+"""Issue #293 — auto_control gate must not be bypassed by force=True alone.
+
+When auto_control is OFF, only callers passing is_safety=True (force_override,
+weather override) or bypass_auto_control=True (the sanctioned switch
+return-to-default one-shot) may move covers. Plain force=True (e.g.
+manual_reset, after_override_clear, switch turn_on) MUST still respect
+auto_control=False.
+
+The corollary: is_safety=True callers MUST continue to bypass the gate so
+weather and force_override safety overrides work even when auto control is off.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
+)
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return h
+
+
+@pytest.fixture
+def svc(hass):
+    s = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+    )
+    s._enabled = True
+    return s
+
+
+def _ctx(*, force=False, is_safety=False, auto_control=True):
+    return PositionContext(
+        auto_control=auto_control,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=1,
+        time_threshold=0,
+        special_positions=[0, 100],
+        force=force,
+        is_safety=is_safety,
+    )
+
+
+def _patch_caps(*, has_set_position=True):
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value={
+            "has_set_position": has_set_position,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defect A — force=True alone must NOT bypass auto_control_off
+# ---------------------------------------------------------------------------
+
+
+class TestForceWithoutSafetyDoesNotBypassAutoControl:
+    """When auto_control is off and is_safety is False, the gate must hold."""
+
+    @pytest.mark.asyncio
+    async def test_force_only_skipped_when_auto_control_off(self, svc, hass):
+        with _patch_caps():
+            outcome, detail = await svc.apply_position(
+                "cover.test",
+                100,
+                "manual_reset",
+                _ctx(force=True, is_safety=False, auto_control=False),
+            )
+
+        assert outcome == "skipped"
+        assert detail == "auto_control_off"
+        assert svc.last_skipped_action["reason"] == "auto_control_off"
+        hass.services.async_call.assert_not_called()
+        assert svc.target_call.get("cover.test") is None
+        assert svc.wait_for_target.get("cover.test") is not True
+
+
+# ---------------------------------------------------------------------------
+# Safety regression — is_safety=True MUST still bypass auto_control_off
+# ---------------------------------------------------------------------------
+
+
+class TestSafetyBypassStillWorks:
+    """Safety overrides (force_override, weather) bypass auto_control_off."""
+
+    @pytest.mark.asyncio
+    async def test_is_safety_proceeds_when_auto_control_off(self, svc, hass):
+        with _patch_caps():
+            outcome, _detail = await svc.apply_position(
+                "cover.test",
+                0,
+                "force_override",
+                _ctx(force=True, is_safety=True, auto_control=False),
+            )
+
+        assert outcome == "sent"
+        hass.services.async_call.assert_awaited_once()
+        assert svc.target_call["cover.test"] == 0
+        assert "cover.test" in svc._safety_targets
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "trigger",
+        ["force_override", "weather", "synthetic_safety"],
+    )
+    async def test_safety_callers_bypass_gate(self, svc, hass, trigger):
+        with _patch_caps():
+            outcome, _ = await svc.apply_position(
+                f"cover.{trigger}",
+                25,
+                trigger,
+                _ctx(force=True, is_safety=True, auto_control=False),
+            )
+
+        assert outcome == "sent"
+        assert svc.target_call[f"cover.{trigger}"] == 25
+        assert f"cover.{trigger}" in svc._safety_targets

--- a/tests/test_issue_293_force_true_auto_off.py
+++ b/tests/test_issue_293_force_true_auto_off.py
@@ -1,0 +1,148 @@
+"""Issue #293 — full reproduction: auto_control=OFF + force=True caller +
+non-position-capable cover (awning).
+
+Re-creates the exact diagnostic timeline observed in the user's report:
+- Skip recorded with reason auto_control_off (the regular update cycle)
+- A force=True (is_safety=False) caller fires within the same window — should
+  be skipped, NOT sent (Defect A fix)
+- User's manual response feeds into async_handle_cover_state_change — must
+  be observed, registering a manual override and discarding any latched
+  target (Defect B fix)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
+)
+
+
+def _patch_caps_awning():
+    """Awning capability profile from the user's diagnostic file."""
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value={
+            "has_set_position": False,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
+    )
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return h
+
+
+@pytest.fixture
+def cmd_svc(hass):
+    s = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_awning",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+    )
+    s._enabled = True
+    return s
+
+
+def _ctx(*, force=False, is_safety=False, bypass_auto_control=False, auto_control=False):
+    return PositionContext(
+        auto_control=auto_control,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=1,
+        time_threshold=0,
+        special_positions=[0, 100],
+        force=force,
+        is_safety=is_safety,
+        bypass_auto_control=bypass_auto_control,
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_repro_no_command_escapes_when_auto_off(cmd_svc, hass):
+    """Sequence: regular update skip → force=True caller skip → no command sent.
+
+    Defect A: the force=True caller (e.g. the post-fix incorrect call we are
+    guarding against) must be skipped now, not sent.
+    """
+    with _patch_caps_awning():
+        # 1. Regular update: solar pipeline result with auto_control=False
+        outcome1, detail1 = await cmd_svc.apply_position(
+            "cover.awning",
+            18,
+            "solar",
+            context=_ctx(force=False, is_safety=False, auto_control=False),
+        )
+
+        # 2. Same cycle: a force=True caller (manual_reset / after_override_clear)
+        outcome2, detail2 = await cmd_svc.apply_position(
+            "cover.awning",
+            100,
+            "force_caller",
+            context=_ctx(force=True, is_safety=False, auto_control=False),
+        )
+
+    assert outcome1 == "skipped"
+    assert detail1 == "auto_control_off"
+    assert outcome2 == "skipped"
+    assert detail2 == "auto_control_off"
+
+    # No service call escaped to HA — this is the user-visible fix.
+    hass.services.async_call.assert_not_called()
+    assert cmd_svc.target_call.get("cover.awning") is None
+    assert cmd_svc.wait_for_target.get("cover.awning") is not True
+
+
+@pytest.mark.asyncio
+async def test_full_repro_user_recovery_observed():
+    """Defect B: even with auto_control=False, the user's manual move registers.
+
+    Drives async_handle_cover_state_change with auto_control=False and verifies
+    that handle_state_change is called and discard_target fires when the
+    observation flips the entity to manual.
+    """
+    coord = MagicMock()
+    coord.manual_toggle = True
+    coord.automatic_control = False
+    coord.target_call = {"cover.awning": 100}  # latched by hypothetical earlier escape
+    coord.wait_for_target = {"cover.awning": True}
+    coord._cover_type = "cover_awning"
+    coord.manual_reset = False
+    coord.manual_threshold = 5
+    coord.logger = MagicMock()
+    coord.cover_state_change = True
+    coord._is_in_startup_grace_period = MagicMock(return_value=False)
+    coord._target_just_reached = set()
+    coord._cmd_svc = MagicMock()
+
+    coord.manager = MagicMock()
+    # was_manual=False before observation, became_manual=True after
+    coord.manager.is_cover_manual.side_effect = [False, True]
+
+    user_event = MagicMock()
+    user_event.entity_id = "cover.awning"
+    user_event.new_state = MagicMock()
+    user_event.new_state.attributes = {"current_position": 30}
+    coord._pending_cover_events = [user_event]
+
+    await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(coord, 50)
+
+    # Manual override must register, and discard_target must clear the latched
+    # target so reconciliation cannot resurrect it.
+    coord.manager.handle_state_change.assert_called_once()
+    coord._cmd_svc.discard_target.assert_called_once_with("cover.awning")

--- a/tests/test_issue_293_state_change_observed_when_auto_off.py
+++ b/tests/test_issue_293_state_change_observed_when_auto_off.py
@@ -1,0 +1,98 @@
+"""Issue #293 (Defect B) — state changes must register manual overrides
+even when auto_control is OFF.
+
+Today, async_handle_cover_state_change early-returns when auto_control=False.
+The user's manual response to an unwanted move (e.g. issue #293's awning
+closing) cannot register, leaving wait_for_target=True latched and the
+diagnostics file blind to the user's intent.
+
+The fix: gate the early-return on manual_toggle ONLY. Observation of state
+changes is not the same as taking action — recording manual overrides when
+auto_control is off lets reconciliation back off via the existing
+_manual_override_entities check at cover_command.py:1033 and surfaces the
+user's intent in diagnostics.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+
+
+def _event(entity_id, position):
+    e = MagicMock()
+    e.entity_id = entity_id
+    e.new_state = MagicMock()
+    e.new_state.attributes = {"current_position": position}
+    return e
+
+
+def _make_coord_auto_off():
+    """Build a minimal coordinator stub with auto_control=False, manual_toggle=True."""
+    coord = MagicMock()
+    coord.manual_toggle = True
+    coord.automatic_control = False  # ← key: auto control is OFF
+    coord.target_call = {"cover.a": 100}
+    coord.wait_for_target = {"cover.a": True}  # latched by prior unwanted command
+    coord._cover_type = "cover_awning"
+    coord.manual_reset = False
+    coord.manual_threshold = 5
+    coord.logger = MagicMock()
+    coord.cover_state_change = True
+    coord._is_in_startup_grace_period = MagicMock(return_value=False)
+    coord._target_just_reached = set()
+    coord._cmd_svc = MagicMock()
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_state_change_observed_when_auto_control_off():
+    """Manual override observation must run even when automatic_control=False."""
+    coord = _make_coord_auto_off()
+    coord.manager = MagicMock()
+    coord.manager.is_cover_manual.return_value = False
+    coord._pending_cover_events = [_event("cover.a", 30)]  # user moved cover
+
+    await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(coord, 50)
+
+    # The user's manual move MUST be observed.
+    assert coord.manager.handle_state_change.call_count == 1
+    assert coord.manager.handle_state_change.call_args.args[0].entity_id == "cover.a"
+
+
+@pytest.mark.asyncio
+async def test_discard_target_called_when_observation_flips_to_manual():
+    """When observation registers a manual override, latched target must be cleared.
+
+    Without this, the unwanted force=True command's target_call would persist
+    and reconciliation could resurrect it.
+    """
+    coord = _make_coord_auto_off()
+    coord.manager = MagicMock()
+    # is_cover_manual returns False (was_manual) before handle_state_change,
+    # then True (became manual) after — simulate via side_effect.
+    coord.manager.is_cover_manual.side_effect = [False, True]
+    coord._pending_cover_events = [_event("cover.a", 30)]
+
+    await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(coord, 50)
+
+    coord._cmd_svc.discard_target.assert_called_once_with("cover.a")
+
+
+@pytest.mark.asyncio
+async def test_manual_toggle_off_still_short_circuits():
+    """Regression: when manual_toggle=False, early-return still short-circuits."""
+    coord = _make_coord_auto_off()
+    coord.manual_toggle = False  # globally disable manual override detection
+    coord.manager = MagicMock()
+    coord._pending_cover_events = [_event("cover.a", 30)]
+
+    await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(coord, 50)
+
+    # When manual_toggle is off, observation does not run.
+    coord.manager.handle_state_change.assert_not_called()

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -158,17 +158,32 @@ async def test_apply_sends_when_all_gates_pass(svc, mock_hass):
 
 
 @pytest.mark.asyncio
-async def test_apply_force_bypasses_all_gates(svc, mock_hass):
-    """force=True sends command even when all gates would fail."""
+async def test_apply_force_bypasses_delta_and_manual_override_gates(svc, mock_hass):
+    """force=True bypasses delta/time/manual_override but NOT auto_control (issue #293)."""
     with _patch_caps():
         outcome, _ = await svc.apply_position(
             "cover.test",
             0,
             "sunset",
-            context=_ctx(auto_control=False, manual_override=True, force=True),
+            context=_ctx(auto_control=True, manual_override=True, force=True),
         )
     assert outcome == "sent"
     mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_force_does_NOT_bypass_auto_control(svc, mock_hass):
+    """Issue #293: force=True alone must not bypass auto_control_off."""
+    with _patch_caps():
+        outcome, detail = await svc.apply_position(
+            "cover.test",
+            0,
+            "sunset",
+            context=_ctx(auto_control=False, manual_override=True, force=True),
+        )
+    assert outcome == "skipped"
+    assert detail == "auto_control_off"
+    mock_hass.services.async_call.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_switch_auto_control_off_return.py
+++ b/tests/test_switch_auto_control_off_return.py
@@ -1,0 +1,136 @@
+"""Issue #293 — switch return-to-default uses bypass_auto_control=True.
+
+When the auto_control switch is toggled OFF and return_to_default_toggle is
+enabled, the integration moves covers to the default position as a one-shot
+transition action.  Without an explicit bypass channel, the auto_control gate
+fix (issue #293) would skip this legitimate caller too.
+
+This test asserts that the switch path passes bypass_auto_control=True so
+return-to-default still works after the gate fix.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
+)
+from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
+
+
+def _patch_caps(*, has_set_position=True):
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value={
+            "has_set_position": has_set_position,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
+    )
+
+
+def _make_coord_with_real_cmd_svc(hass):
+    """Build a coordinator stub backed by a real CoverCommandService."""
+    coord = MagicMock()
+    coord.logger = MagicMock()
+    coord.entities = ["cover.test"]
+    coord.return_to_default_toggle = True
+    coord.automatic_control = False  # toggle just flipped to off
+    coord.manager.manual_controlled = []
+    coord.config_entry.options = {"default_height": 60}
+    coord.async_refresh = AsyncMock()
+
+    cmd_svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+    )
+    cmd_svc._enabled = True
+    coord._cmd_svc = cmd_svc
+
+    def _build_ctx(entity, options, *, force=False, is_safety=False,
+                   bypass_auto_control=False, sun_just_appeared=False):
+        return PositionContext(
+            auto_control=False,
+            manual_override=False,
+            sun_just_appeared=sun_just_appeared,
+            min_change=1,
+            time_threshold=0,
+            special_positions=[0, 100],
+            force=force,
+            is_safety=is_safety,
+            bypass_auto_control=bypass_auto_control,
+        )
+
+    coord._build_position_context = _build_ctx
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_return_to_default_fires_when_auto_control_toggled_off():
+    """The sanctioned one-shot return-to-default still fires after #293 fix."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    coord = _make_coord_with_real_cmd_svc(hass)
+
+    switch = object.__new__(AdaptiveCoverSwitch)
+    switch.coordinator = coord
+    switch._key = "automatic_control"
+    switch._name = "test_switch"
+    switch._initial_state = True
+    switch._attr_is_on = True
+    switch.schedule_update_ha_state = MagicMock()
+
+    with _patch_caps():
+        await switch.async_turn_off()
+
+    # The return-to-default command must have been sent.
+    hass.services.async_call.assert_awaited()
+    assert coord._cmd_svc.target_call.get("cover.test") == 60
+
+
+@pytest.mark.asyncio
+async def test_return_to_default_skipped_without_bypass_flag():
+    """Sanity: the same call pattern WITHOUT bypass_auto_control would be skipped.
+
+    This proves the bypass_auto_control flag is the load-bearing mechanism.
+    """
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    cmd_svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+    )
+    cmd_svc._enabled = True
+
+    ctx = PositionContext(
+        auto_control=False,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=1,
+        time_threshold=0,
+        special_positions=[0, 100],
+        force=True,
+        is_safety=False,
+        bypass_auto_control=False,  # MISSING — should be skipped
+    )
+
+    with _patch_caps():
+        outcome, detail = await cmd_svc.apply_position(
+            "cover.test", 60, "auto_control_off", context=ctx
+        )
+
+    assert outcome == "skipped"
+    assert detail == "auto_control_off"
+    hass.services.async_call.assert_not_called()


### PR DESCRIPTION
## Summary

- `apply_position` auto_control gate is no longer bypassed by plain `force=True` (Defect A from issue #293)
- `async_handle_cover_state_change` now observes manual moves even when `auto_control=False` (Defect B)
- Adds `PositionContext.bypass_auto_control` for the sanctioned switch return-to-default one-shot
- Updates `test_auto_control_gate_matrix.py` with a new row locking down the new bypass channel

## Testing

- ✅ 2391 tests passing
- New tests: 4 files covering both defects, the safety bypass regression, the switch return-to-default, and the end-to-end repro (non-position-capable cover, exact diagnostic timeline)
- Updated tests: 3 existing tests that encoded the buggy behavior are inverted/renamed to assert the correct semantics

## Related Issues

Refs #293