### PR TITLE
feat: add enabled_handlers attribute to decision_trace sensor

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -22,8 +22,26 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_CLIMATE_MODE,
+    CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_CLOUD_SUPPRESSION,
+    CONF_CUSTOM_POSITION_1,
+    CONF_CUSTOM_POSITION_2,
+    CONF_CUSTOM_POSITION_3,
+    CONF_CUSTOM_POSITION_4,
+    CONF_CUSTOM_POSITION_SENSOR_1,
+    CONF_CUSTOM_POSITION_SENSOR_2,
+    CONF_CUSTOM_POSITION_SENSOR_3,
+    CONF_CUSTOM_POSITION_SENSOR_4,
+    CONF_ENABLE_GLARE_ZONES,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_MOTION_SENSORS,
+    CONF_WEATHER_ENTITY,
+    CONF_WEATHER_IS_RAINING_SENSOR,
+    CONF_WEATHER_IS_WINDY_SENSOR,
+    CONF_WEATHER_RAIN_SENSOR,
+    CONF_WEATHER_SEVERE_SENSORS,
+    CONF_WEATHER_WIND_SPEED_SENSOR,
     DOMAIN,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
@@ -1061,6 +1079,12 @@ class AdaptiveCoverDecisionTraceSensor(AdaptiveCoverDiagnosticSensorBase, Sensor
         # Operational time window
         attrs["in_time_window"] = self.coordinator.check_adaptive_time
 
+        # Configured pipeline handlers — read by the card's decision-strip to
+        # hide handlers the user hasn't set up. Names match the card-normalized
+        # form (force, manual, motion, cloud) — not the pipeline's internal
+        # names (force_override, manual_override, motion_timeout, cloud_suppression).
+        attrs["enabled_handlers"] = self._configured_handlers()
+
         diagnostics = self.coordinator.data.diagnostics if self.coordinator.data else {}
         if diagnostics:
             attrs["sun_azimuth"] = diagnostics.get("sun_azimuth")
@@ -1081,6 +1105,61 @@ class AdaptiveCoverDecisionTraceSensor(AdaptiveCoverDiagnosticSensorBase, Sensor
                 )
 
         return attrs or None
+
+    def _configured_handlers(self) -> list[str]:
+        """Return the list of pipeline handlers that are configured to fire.
+
+        Configuration-based, not runtime-based: a handler is "enabled" if the
+        user has set it up in options, regardless of whether its runtime
+        switch is currently on. Names match the card's normalized handler
+        names so the card can use the list directly without translation.
+        """
+        opts = self.config_entry.options
+        enabled: list[str] = ["manual", "default"]
+
+        if opts.get(CONF_FORCE_OVERRIDE_SENSORS):
+            enabled.append("force")
+
+        if any(
+            opts.get(k)
+            for k in (
+                CONF_WEATHER_ENTITY,
+                CONF_WEATHER_WIND_SPEED_SENSOR,
+                CONF_WEATHER_RAIN_SENSOR,
+                CONF_WEATHER_IS_RAINING_SENSOR,
+                CONF_WEATHER_IS_WINDY_SENSOR,
+                CONF_WEATHER_SEVERE_SENSORS,
+            )
+        ):
+            enabled.append("weather")
+
+        if any(
+            opts.get(s) and opts.get(p) is not None
+            for s, p in (
+                (CONF_CUSTOM_POSITION_SENSOR_1, CONF_CUSTOM_POSITION_1),
+                (CONF_CUSTOM_POSITION_SENSOR_2, CONF_CUSTOM_POSITION_2),
+                (CONF_CUSTOM_POSITION_SENSOR_3, CONF_CUSTOM_POSITION_3),
+                (CONF_CUSTOM_POSITION_SENSOR_4, CONF_CUSTOM_POSITION_4),
+            )
+        ):
+            enabled.append("custom_position")
+
+        if opts.get(CONF_MOTION_SENSORS):
+            enabled.append("motion")
+
+        if opts.get(CONF_CLOUD_SUPPRESSION) and opts.get(CONF_CLOUD_COVERAGE_ENTITY):
+            enabled.append("cloud")
+
+        if opts.get(CONF_CLIMATE_MODE):
+            enabled.append("climate")
+
+        if opts.get(CONF_ENABLE_GLARE_ZONES):
+            enabled.append("glare_zone")
+
+        if opts.get(CONF_ENABLE_SUN_TRACKING, True):
+            enabled.append("solar")
+
+        return enabled
 
 
 class AdaptiveCoverLastSkippedActionSensor(

--- a/tests/test_decision_trace_enabled_handlers.py
+++ b/tests/test_decision_trace_enabled_handlers.py
@@ -1,0 +1,255 @@
+"""Tests for the `enabled_handlers` attribute on the decision_trace sensor.
+
+The card's decision-strip reads this attribute as the sole source of truth for
+which pipeline handlers to render. Handlers not in the list are hidden by the
+card. The attribute is configuration-driven — it answers "is this handler
+configured to ever fire?", not "did it fire this tick?".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_CLIMATE_MODE,
+    CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_CLOUD_SUPPRESSION,
+    CONF_CUSTOM_POSITION_1,
+    CONF_CUSTOM_POSITION_SENSOR_1,
+    CONF_ENABLE_GLARE_ZONES,
+    CONF_ENABLE_SUN_TRACKING,
+    CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_MOTION_SENSORS,
+    CONF_SENSOR_TYPE,
+    CONF_WEATHER_ENTITY,
+    SensorType,
+)
+from custom_components.adaptive_cover_pro.sensor import AdaptiveCoverDecisionTraceSensor
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config.units.temperature_unit = "°C"
+    return hass
+
+
+def _make_config_entry(options: dict | None = None):
+    entry = MagicMock()
+    entry.entry_id = "test_enabled_handlers_entry"
+    entry.data = {"name": "Test", CONF_SENSOR_TYPE: SensorType.BLIND}
+    entry.options = options or {}
+    return entry
+
+
+def _make_coordinator():
+    coord = MagicMock()
+    coord.data = None
+    coord._pipeline_result = None
+    coord.logger = MagicMock()
+    coord.hass = _make_hass()
+    coord.check_adaptive_time = True
+    return coord
+
+
+def _make_sensor(options: dict | None = None) -> AdaptiveCoverDecisionTraceSensor:
+    return AdaptiveCoverDecisionTraceSensor(
+        "test_enabled_handlers_entry",
+        _make_hass(),
+        _make_config_entry(options),
+        "Test",
+        _make_coordinator(),
+    )
+
+
+def _enabled(options: dict | None = None) -> set[str]:
+    sensor = _make_sensor(options)
+    attrs = sensor.extra_state_attributes or {}
+    return set(attrs.get("enabled_handlers", []))
+
+
+# ---------------------------------------------------------------------------
+# Always-on handlers
+# ---------------------------------------------------------------------------
+
+
+def test_enabled_handlers_attribute_present():
+    """Even with empty options, the attribute is emitted."""
+    sensor = _make_sensor({})
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    assert "enabled_handlers" in attrs
+    assert isinstance(attrs["enabled_handlers"], list)
+
+
+def test_manual_and_default_always_enabled():
+    enabled = _enabled({})
+    assert "manual" in enabled
+    assert "default" in enabled
+
+
+def test_solar_enabled_by_default():
+    """CONF_ENABLE_SUN_TRACKING defaults to True — solar should be enabled."""
+    enabled = _enabled({})
+    assert "solar" in enabled
+
+
+def test_solar_disabled_when_sun_tracking_off():
+    enabled = _enabled({CONF_ENABLE_SUN_TRACKING: False})
+    assert "solar" not in enabled
+
+
+# ---------------------------------------------------------------------------
+# Configuration-gated handlers
+# ---------------------------------------------------------------------------
+
+
+def test_force_disabled_when_no_sensors_configured():
+    enabled = _enabled({})
+    assert "force" not in enabled
+
+
+def test_force_enabled_when_sensors_configured():
+    enabled = _enabled({CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.x"]})
+    assert "force" in enabled
+
+
+def test_force_disabled_when_empty_list():
+    enabled = _enabled({CONF_FORCE_OVERRIDE_SENSORS: []})
+    assert "force" not in enabled
+
+
+def test_motion_disabled_when_no_sensors_configured():
+    enabled = _enabled({})
+    assert "motion" not in enabled
+
+
+def test_motion_enabled_when_sensors_configured():
+    enabled = _enabled({CONF_MOTION_SENSORS: ["binary_sensor.m"]})
+    assert "motion" in enabled
+
+
+def test_climate_disabled_by_default():
+    enabled = _enabled({})
+    assert "climate" not in enabled
+
+
+def test_climate_enabled_when_climate_mode_on():
+    enabled = _enabled({CONF_CLIMATE_MODE: True})
+    assert "climate" in enabled
+
+
+def test_weather_disabled_when_no_weather_config():
+    enabled = _enabled({})
+    assert "weather" not in enabled
+
+
+def test_weather_enabled_when_weather_entity_set():
+    enabled = _enabled({CONF_WEATHER_ENTITY: "weather.home"})
+    assert "weather" in enabled
+
+
+def test_glare_zone_disabled_by_default():
+    enabled = _enabled({})
+    assert "glare_zone" not in enabled
+
+
+def test_glare_zone_enabled_when_flag_on():
+    enabled = _enabled({CONF_ENABLE_GLARE_ZONES: True})
+    assert "glare_zone" in enabled
+
+
+def test_cloud_disabled_when_only_flag_on():
+    """Cloud requires BOTH suppression flag AND coverage entity."""
+    enabled = _enabled({CONF_CLOUD_SUPPRESSION: True})
+    assert "cloud" not in enabled
+
+
+def test_cloud_disabled_when_only_entity_set():
+    enabled = _enabled({CONF_CLOUD_COVERAGE_ENTITY: "sensor.cloud"})
+    assert "cloud" not in enabled
+
+
+def test_cloud_enabled_when_both_set():
+    enabled = _enabled(
+        {CONF_CLOUD_SUPPRESSION: True, CONF_CLOUD_COVERAGE_ENTITY: "sensor.cloud"}
+    )
+    assert "cloud" in enabled
+
+
+def test_custom_position_disabled_by_default():
+    enabled = _enabled({})
+    assert "custom_position" not in enabled
+
+
+def test_custom_position_enabled_when_pair_configured():
+    enabled = _enabled(
+        {CONF_CUSTOM_POSITION_SENSOR_1: "binary_sensor.cp1", CONF_CUSTOM_POSITION_1: 50}
+    )
+    assert "custom_position" in enabled
+
+
+def test_custom_position_disabled_when_only_sensor_set():
+    enabled = _enabled({CONF_CUSTOM_POSITION_SENSOR_1: "binary_sensor.cp1"})
+    assert "custom_position" not in enabled
+
+
+# ---------------------------------------------------------------------------
+# Composition / completeness
+# ---------------------------------------------------------------------------
+
+
+def test_full_configuration_enables_everything():
+    enabled = _enabled(
+        {
+            CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.x"],
+            CONF_MOTION_SENSORS: ["binary_sensor.m"],
+            CONF_CLIMATE_MODE: True,
+            CONF_WEATHER_ENTITY: "weather.home",
+            CONF_ENABLE_GLARE_ZONES: True,
+            CONF_CLOUD_SUPPRESSION: True,
+            CONF_CLOUD_COVERAGE_ENTITY: "sensor.cloud",
+            CONF_CUSTOM_POSITION_SENSOR_1: "binary_sensor.cp1",
+            CONF_CUSTOM_POSITION_1: 50,
+            CONF_ENABLE_SUN_TRACKING: True,
+        }
+    )
+    assert enabled == {
+        "force",
+        "weather",
+        "manual",
+        "custom_position",
+        "motion",
+        "cloud",
+        "climate",
+        "glare_zone",
+        "solar",
+        "default",
+    }
+
+
+def test_minimal_configuration_enables_only_always_on():
+    enabled = _enabled({CONF_ENABLE_SUN_TRACKING: False})
+    assert enabled == {"manual", "default"}
+
+
+def test_handler_names_match_card_normalized_form():
+    """Card uses 'force', 'manual', 'motion', 'cloud' — not the pipeline names
+    'force_override', 'manual_override', 'motion_timeout', 'cloud_suppression'.
+    """
+    enabled = _enabled(
+        {
+            CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.x"],
+            CONF_MOTION_SENSORS: ["binary_sensor.m"],
+            CONF_CLOUD_SUPPRESSION: True,
+            CONF_CLOUD_COVERAGE_ENTITY: "sensor.cloud",
+        }
+    )
+    assert "force_override" not in enabled
+    assert "manual_override" not in enabled
+    assert "motion_timeout" not in enabled
+    assert "cloud_suppression" not in enabled
+    assert "force" in enabled
+    assert "manual" in enabled
+    assert "motion" in enabled
+    assert "cloud" in enabled


### PR DESCRIPTION
## Summary
Adds an \`enabled_handlers: list[str]\` attribute to the \`decision_trace\` sensor listing the pipeline handlers that are configured to ever fire. The companion Lovelace card ([adaptive-cover-pro-card#40](https://github.com/jrhubott/adaptive-cover-pro-card/pull/40)) uses this to hide handlers the user hasn't set up — so a user without force-override sensors no longer sees a perpetually-skipped \`Force Override\` row in the decision strip.

Configuration-based, not runtime-based: a handler is enabled if its options are populated, regardless of whether its runtime switch (Manual Override, Climate Mode, Motion Control) is currently on. The runtime switch state is a separate concern.

Handler names use the card-normalized form (\`force\`, \`manual\`, \`motion\`, \`cloud\`) rather than the pipeline's internal names (\`force_override\`, \`manual_override\`, etc.) so the card consumes the list directly without translation.

## Logic per handler
| Handler | Enabled when |
|---|---|
| \`force\` | \`CONF_FORCE_OVERRIDE_SENSORS\` non-empty |
| \`weather\` | Any of \`CONF_WEATHER_*\` set |
| \`manual\` | Always |
| \`custom_position\` | Any custom position sensor + value pair configured |
| \`motion\` | \`CONF_MOTION_SENSORS\` non-empty |
| \`cloud\` | \`CONF_CLOUD_SUPPRESSION=true\` AND \`CONF_CLOUD_COVERAGE_ENTITY\` set |
| \`climate\` | \`CONF_CLIMATE_MODE=true\` |
| \`glare_zone\` | \`CONF_ENABLE_GLARE_ZONES=true\` |
| \`solar\` | \`CONF_ENABLE_SUN_TRACKING\` (defaults true) |
| \`default\` | Always |

## Testing
- ✅ 24 new tests in \`tests/test_decision_trace_enabled_handlers.py\` covering each handler's enable/disable conditions, name normalization, and full/minimal config permutations
- ✅ Full integration test suite passes (2437 tests)

## Related
Refs jrhubott/adaptive-cover-pro-card#39