### PR TITLE
fix: rename diagnostic event buffer label and move transit timeout to manual override screen

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -467,6 +467,18 @@ MANUAL_OVERRIDE_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_MANUAL_IGNORE_INTERMEDIATE, default=False
         ): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_TRANSIT_TIMEOUT,
+            default=DEFAULT_TRANSIT_TIMEOUT_SECONDS,
+        ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=MIN_TRANSIT_TIMEOUT,
+                max=MAX_TRANSIT_TIMEOUT,
+                step=5,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="seconds",
+            )
+        ),
     }
 )
 
@@ -615,18 +627,6 @@ DEBUG_SCHEMA = vol.Schema(
                 max=MAX_DEBUG_EVENT_BUFFER_SIZE,
                 step=10,
                 mode=selector.NumberSelectorMode.SLIDER,
-            )
-        ),
-        vol.Optional(
-            CONF_TRANSIT_TIMEOUT,
-            default=DEFAULT_TRANSIT_TIMEOUT_SECONDS,
-        ): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=MIN_TRANSIT_TIMEOUT,
-                max=MAX_TRANSIT_TIMEOUT,
-                step=5,
-                mode=selector.NumberSelectorMode.SLIDER,
-                unit_of_measurement="seconds",
             )
         ),
     }
@@ -1378,6 +1378,12 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         mo_parts.append("resets on next move")
     if config.get(CONF_MANUAL_IGNORE_INTERMEDIATE):
         mo_parts.append("ignores intermediate positions")
+    transit_timeout = config.get(CONF_TRANSIT_TIMEOUT)
+    if (
+        transit_timeout is not None
+        and int(transit_timeout) != DEFAULT_TRANSIT_TIMEOUT_SECONDS
+    ):
+        mo_parts.append(f"transit timeout: {int(transit_timeout)}s")
     mo_str = f" ({', '.join(mo_parts)})" if mo_parts else ""
     lines.append(
         f"✋ Manual override: pauses automatic control when you move the cover"
@@ -1641,12 +1647,6 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         limit_parts.append(f"Min change: {delta_pos}%")
     if delta_time is not None:
         limit_parts.append(f"Min interval: {delta_time} min")
-    transit_timeout = config.get(CONF_TRANSIT_TIMEOUT)
-    if (
-        transit_timeout is not None
-        and int(transit_timeout) != DEFAULT_TRANSIT_TIMEOUT_SECONDS
-    ):
-        limit_parts.append(f"Transit timeout: {int(transit_timeout)}s")
     if config.get(CONF_INVERSE_STATE):
         limit_parts.append("Inverse state")
     oc_thresh = config.get(CONF_OPEN_CLOSE_THRESHOLD)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -173,7 +173,7 @@ STARTUP_GRACE_PERIOD_SECONDS = (
 DEFAULT_TRANSIT_TIMEOUT_SECONDS = 45
 TRANSIT_TIMEOUT_SECONDS = DEFAULT_TRANSIT_TIMEOUT_SECONDS  # backward-compat alias
 
-# User-configurable transit timeout (exposed in the debug/advanced config step)
+# User-configurable transit timeout (exposed in the manual override config step)
 CONF_TRANSIT_TIMEOUT = "transit_timeout"
 MIN_TRANSIT_TIMEOUT = 15
 MAX_TRANSIT_TIMEOUT = 600

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -142,13 +142,15 @@
           "manual_override_duration": "Dauer der manuellen Übersteuerung",
           "manual_override_reset": "Dauer der manuellen Übersteuerung zurücksetzen",
           "manual_threshold": "Schwellwert der manuellen Übersteuerung",
-          "manual_ignore_intermediate": "Zwischenpositionen während manueller Übersteuerung ignorieren (Öffnen und Schließen)"
+          "manual_ignore_intermediate": "Zwischenpositionen während manueller Übersteuerung ignorieren (Öffnen und Schließen)",
+          "transit_timeout": "Transitzeit-Timeout (Sekunden)"
         },
         "data_description": {
           "manual_override_duration": "Wie lange (in Minuten) die automatische Kontrolle nach manueller Anpassung pausiert. Wenn Sie die Beschattung manuell bewegen, pausiert die automatische Kontrolle. Typische Werte: 10-15 Min. (kurze Pause, Verfolgung wird bald fortgesetzt), 30 Min. (mittlere Pause, ausgewogen), 60-120 Min. (lange Pause, manuelle Position länger behalten), 0 (deaktiviert, Verfolgung wird sofort fortgesetzt – nicht empfohlen). Gibt Ihnen Kontrolle, wenn Sie sie möchten, setzt die Automatisierung später fort.",
           "manual_override_reset": "Setzen Sie den Timer für die manuelle Übersteuerung nach jeder manuellen Anpassung zurück. Wenn aktiviert, startet jede manuelle Änderung die Übersteuerungsdauer neu. Wenn deaktiviert, gilt die Dauer nur für die erste manuelle Anpassung (nachfolgende Änderungen verlängern die Pause nicht). Aktivieren Sie dies, wenn Sie möchten, dass der Übersteuerungszeitraum bei jeder manuellen Anpassung ‚erneuert' wird.",
           "manual_threshold": "Positionsdifferenz (%), die als ‚manuelle Übersteuerung' zählt (Standardwert: 1 %). Wenn Sie die Beschattung manuell um diesen Betrag bewegen, wird die Erkennungsüberschreibung ausgelöst. Typische Werte: 1-2 % (empfindlich, erkennt kleine Anpassungen), 5 % (weniger empfindlich, empfohlen), 10 % (nur große manuelle Änderungen zählen). Verhindert versehentliche Erkennungsüberschreibung durch kleine Motorabweichungen oder Positionsabweichungen.",
-          "manual_ignore_intermediate": "Ignorieren Sie Zwischenpositionen während manueller Öffnungs- und Schließvorgänge. Aktivieren Sie dies, um zu verhindern, dass die Erkennungsüberschreibung bei Übergangspositionen ausgelöst wird, während sich die Beschattung zu Ihrer Zielposition bewegt. Nützlich, wenn Ihre Beschattung viele Zwischenwerte während der Bewegung meldet."
+          "manual_ignore_intermediate": "Ignorieren Sie Zwischenpositionen während manueller Öffnungs- und Schließvorgänge. Aktivieren Sie dies, um zu verhindern, dass die Erkennungsüberschreibung bei Übergangspositionen ausgelöst wird, während sich die Beschattung zu Ihrer Zielposition bewegt. Nützlich, wenn Ihre Beschattung viele Zwischenwerte während der Bewegung meldet.",
+          "transit_timeout": "Zeitspanne, die ACP wartet, nachdem eine Beschattung aufgehört hat, Fortschritt zu melden, bevor die nächste Positionsmeldung als manuelle Übersteuerung durch den Benutzer behandelt wird. Der Timer wird zurückgesetzt, sobald sich die Beschattung dem angesteuerten Ziel nähert, sodass langsame, aber sich bewegende Beschattungen über die gesamte Fahrtdauer geschützt sind. Erhöhen Sie diesen Wert für Beschattungen, die länger als 45 Sekunden für einen vollständigen Durchgang benötigen. Standard: 45 Sekunden."
         }
       },
       "force_override": {
@@ -620,13 +622,15 @@
           "manual_override_duration": "Dauer der manuellen Übersteuerung",
           "manual_override_reset": "Dauer der manuellen Übersteuerung zurücksetzen",
           "manual_threshold": "Schwellwert der manuellen Übersteuerung",
-          "manual_ignore_intermediate": "Zwischenpositionen während manueller Übersteuerung ignorieren (Öffnen und Schließen)"
+          "manual_ignore_intermediate": "Zwischenpositionen während manueller Übersteuerung ignorieren (Öffnen und Schließen)",
+          "transit_timeout": "Transitzeit-Timeout (Sekunden)"
         },
         "data_description": {
           "manual_override_duration": "Wie lange (Minuten) die automatische Steuerung nach manueller Anpassung pausiert. Wenn Sie den Behang manuell bewegen, pausiert die automatische Steuerung. Typische Werte: 10–15 Min (kurze Pause, Verfolgung bald fortgesetzt), 30 Min (mittlere Pause, ausgewogen), 60–120 Min (lange Pause, manuelle Position länger beibehalten), 0 (deaktiviert, sofort automatische Steuerung fortsetzen – nicht empfohlen). Gibt Ihnen Kontrolle, wenn Sie sie wollen, setzt Automatisierung später fort.",
           "manual_override_reset": "Setzen Sie den Übersteuerungstimer nach jeder manuellen Anpassung zurück. Wenn aktiviert, startet jede manuelle Änderung die Übersteuerungsdauer neu. Wenn deaktiviert, gilt die Dauer nur für die erste manuelle Anpassung (nachfolgende Änderungen verlängern die Pause nicht). Aktivieren Sie dies, wenn Sie möchten, dass die Übersteuerungsperiode mit jedem manuellen Eingriff 'erneuert' wird.",
           "manual_threshold": "Positionsdifferenz (%), die als 'manuelle Übersteuerung' gilt (Standard: 1%). Wenn Sie den Behang manuell um diesen Betrag bewegen, wird die Übersteuerungserkennung ausgelöst. Typische Werte: 1–2% (empfindlich, erkennt kleine Anpassungen), 5% (weniger empfindlich, empfohlen), 10% (nur große manuelle Änderungen zählen). Verhindert versehentliche Übersteuerungserkennung durch kleine Motordriften oder Positionsmeldungsvariationen.",
-          "manual_ignore_intermediate": "Ignorieren Sie Zwischenpositionen während manueller Öffnungs- und Schließvorgänge. Aktivieren Sie dies, um zu verhindern, dass die Übersteuerungserkennung von Übergangspositionen während der Bewegung des Behangs zu Ihrer Zielposition ausgelöst wird. Nützlich, wenn Ihr Behang viele Zwischenwerte während der Bewegung meldet."
+          "manual_ignore_intermediate": "Ignorieren Sie Zwischenpositionen während manueller Öffnungs- und Schließvorgänge. Aktivieren Sie dies, um zu verhindern, dass die Übersteuerungserkennung von Übergangspositionen während der Bewegung des Behangs zu Ihrer Zielposition ausgelöst wird. Nützlich, wenn Ihr Behang viele Zwischenwerte während der Bewegung meldet.",
+          "transit_timeout": "Zeitspanne, die ACP wartet, nachdem eine Beschattung aufgehört hat, Fortschritt zu melden, bevor die nächste Positionsmeldung als manuelle Übersteuerung durch den Benutzer behandelt wird. Der Timer wird zurückgesetzt, sobald sich die Beschattung dem angesteuerten Ziel nähert, sodass langsame, aber sich bewegende Beschattungen über die gesamte Fahrtdauer geschützt sind. Erhöhen Sie diesen Wert für Beschattungen, die länger als 45 Sekunden für einen vollständigen Durchgang benötigen. Standard: 45 Sekunden."
         }
       },
       "force_override": {
@@ -877,15 +881,13 @@
           "dry_run": "Testlauf (keine Abdeckungsbewegung)",
           "debug_mode": "Debug-Modus aktivieren",
           "debug_categories": "Log-Kategorien (auf INFO befördert, wenn Debug-Modus aktiviert ist)",
-          "debug_event_buffer_size": "Puffergröße für manuelle Übersteuerungsereignisse",
-          "transit_timeout": "Transit-Timeout (Sekunden)"
+          "debug_event_buffer_size": "Größe des Diagnose-Ereignispuffers"
         },
         "data_description": {
           "dry_run": "Bei Aktivierung führt die Integration den vollständigen Update-Zyklus aus (Pipeline, Diagnose, Sensoren), sendet ABER KEINE Bewegungsbefehle an Ihre Abdeckungen. Verwenden Sie zum Debuggen und Validieren von Automatisierungseinstellungen ohne Störung Ihres Hauses. Standard: aus.",
           "debug_mode": "Bei Aktivierung werden Protokollmeldungen für die unten ausgewählten Kategorien von DEBUG zu INFO befördert. Das bedeutet, dass sie ohne „custom_components.adaptive_cover_pro: debug“ in configuration.yaml im Home Assistant-Protokoll erscheinen. Schalten Sie aus, wenn Sie mit der Problembehandlung fertig sind.",
           "debug_categories": "Wählen Sie aus, welche Bereiche zu verfolgen sind. „Manuelle Übersteuerung“ umfasst Entscheidungen zur Übersteuerungserkennung (am nützlichsten für Probleme „Abdeckung wird manuelle Kontrolle nicht stoppen“). „Abgleich“ umfasst die 1-Minuten-Position-Wiederholungsschleife. „Pipeline“ umfasst die Prioritäts-Handler-Kette. „Bewegung“ umfasst Bewegungssensor- und Timeout-Entscheidungen.",
-          "debug_event_buffer_size": "Anzahl der manuellen Übersteuerungsentscheidungsereignisse, die im rollierenden Ringpuffer beibehalten werden. Jedes Ereignis ist ein kleines dict (~200 Bytes). Erhöhen Sie für intermittierende Probleme, die längere Beobachtungsfenster erfordern. Der Puffer wird beim Neuladen der Integration zurückgesetzt.",
-          "transit_timeout": "Wie lange ACP wartet, nachdem eine Beschattung keine Fortschritte mehr meldet, bevor der nächste Positionsbericht als manuelle Übersteuerung behandelt wird. Der Timer wird jedes Mal zurückgesetzt, wenn sich die Beschattung näher an das angestrebte Ziel bewegt, sodass langsame, sich bewegende Beschattungen über die gesamte Transitzeit geschützt sind. Erhöhen Sie diesen Wert für Beschattungen, die länger als 45 Sekunden für eine vollständige Bewegung benötigen. Standard: 45 Sekunden."
+          "debug_event_buffer_size": "Anzahl der Diagnoseereignisse, die im rollierenden Ringpuffer beibehalten werden. Der Puffer erfasst Entscheidungen und Statusübergänge in allen Pipeline-Subsystemen — manuelle Übersteuerung, Bewegung, Wetter, Zeitfenster-Planung, Beschattungsbefehle und Pipeline. Jedes Ereignis ist ein kleines Dict (~200 Bytes). Erhöhen Sie den Wert für intermittierende Probleme, die längere Beobachtungsfenster erfordern. Der Puffer wird bei der Neuladen der Integration zurückgesetzt."
         }
       },
       "sync_confirm": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -142,13 +142,15 @@
           "manual_override_duration": "Duration of manual override",
           "manual_override_reset": "Reset Manual override duration",
           "manual_threshold": "Manual override threshold",
-          "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)"
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "transit_timeout": "Transit timeout (seconds)"
         },
         "data_description": {
           "manual_override_duration": "How long (minutes) to pause automatic control after manual adjustment. When you manually move the cover, automatic control pauses. Typical values: 10-15 min (short pause, resume tracking soon), 30 min (medium pause, balanced), 60-120 min (long pause, keep manual position longer), 0 (disabled, immediately resume automatic control - not recommended). Gives you control when you want it, resumes automation later.",
           "manual_override_reset": "Reset the manual override timer after each manual adjustment. If enabled, each manual change restarts the override duration. If disabled, the duration only applies to the first manual adjustment (subsequent changes don't extend the pause). Enable this if you want the override period to 'renew' with each manual touch.",
           "manual_threshold": "Position difference (%) that counts as 'manual override' (default: 1%). If you manually move cover by this amount, override detection triggers. Typical values: 1-2% (sensitive, detects small adjustments), 5% (less sensitive, recommended), 10% (only large manual changes count). Prevents accidental override detection from small motor drifts or position reporting variations.",
-          "manual_ignore_intermediate": "Ignore intermediate positions during manual opening and closing operations. Enable this to prevent override detection from transitional positions while the cover is moving to your target position. Useful if your cover reports many intermediate values during movement."
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual opening and closing operations. Enable this to prevent override detection from transitional positions while the cover is moving to your target position. Useful if your cover reports many intermediate values during movement.",
+          "transit_timeout": "How long ACP waits after a cover stops reporting forward progress before treating the next position report as a user-initiated manual override. The timer resets each time the cover moves closer to its commanded target, so slow-but-moving covers are protected for the full transit. Increase this value for covers that take longer than 45 seconds to complete a full traverse. Default: 45 seconds."
         }
       },
       "force_override": {
@@ -620,13 +622,15 @@
           "manual_override_duration": "Duration of manual override",
           "manual_override_reset": "Reset Manual override duration",
           "manual_threshold": "Manual override threshold",
-          "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)"
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "transit_timeout": "Transit timeout (seconds)"
         },
         "data_description": {
           "manual_override_duration": "How long (minutes) to pause automatic control after manual adjustment. When you manually move the cover, automatic control pauses. Typical values: 10-15 min (short pause, resume tracking soon), 30 min (medium pause, balanced), 60-120 min (long pause, keep manual position longer), 0 (disabled, immediately resume automatic control - not recommended). Gives you control when you want it, resumes automation later.",
           "manual_override_reset": "Reset the manual override timer after each manual adjustment. If enabled, each manual change restarts the override duration. If disabled, the duration only applies to the first manual adjustment (subsequent changes don't extend the pause). Enable this if you want the override period to 'renew' with each manual touch.",
           "manual_threshold": "Position difference (%) that counts as 'manual override' (default: 1%). If you manually move cover by this amount, override detection triggers. Typical values: 1-2% (sensitive, detects small adjustments), 5% (less sensitive, recommended), 10% (only large manual changes count). Prevents accidental override detection from small motor drifts or position reporting variations.",
-          "manual_ignore_intermediate": "Ignore intermediate positions during manual opening and closing operations. Enable this to prevent override detection from transitional positions while the cover is moving to your target position. Useful if your cover reports many intermediate values during movement."
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual opening and closing operations. Enable this to prevent override detection from transitional positions while the cover is moving to your target position. Useful if your cover reports many intermediate values during movement.",
+          "transit_timeout": "How long ACP waits after a cover stops reporting forward progress before treating the next position report as a user-initiated manual override. The timer resets each time the cover moves closer to its commanded target, so slow-but-moving covers are protected for the full transit. Increase this value for covers that take longer than 45 seconds to complete a full traverse. Default: 45 seconds."
         }
       },
       "force_override": {
@@ -872,20 +876,18 @@
       },
       "debug": {
         "title": "Debug & Diagnostics",
-        "description": "Enable debug mode to collect detailed troubleshooting data without editing configuration.yaml. When active, selected categories are logged at INFO level and a ring buffer of manual-override decisions is kept in memory and exposed in the HA Diagnostics download.\n\n{cover_capabilities}",
+        "description": "Enable debug mode to collect detailed troubleshooting data without editing configuration.yaml. When active, selected categories are logged at INFO level and a diagnostic event ring buffer is kept in memory and exposed in the HA Diagnostics download.\n\n{cover_capabilities}",
         "data": {
           "dry_run": "Dry Run (no cover movement)",
           "debug_mode": "Enable Debug Mode",
           "debug_categories": "Log Categories (promoted to INFO when debug mode is on)",
-          "debug_event_buffer_size": "Manual override event buffer size",
-          "transit_timeout": "Transit timeout (seconds)"
+          "debug_event_buffer_size": "Diagnostic event buffer size"
         },
         "data_description": {
           "dry_run": "When enabled, the integration runs the full update cycle (pipeline, diagnostics, sensors) but does NOT send any movement commands to your covers. Use for debugging and validating automation settings without disturbing your home. Default: off.",
           "debug_mode": "When enabled, log messages for the selected categories below are promoted from DEBUG to INFO. This means they appear in the Home Assistant log without requiring 'custom_components.adaptive_cover_pro: debug' in configuration.yaml. Turn off when you are done troubleshooting.",
           "debug_categories": "Select which areas to trace. 'Manual Override' covers override detection decisions (most useful for 'cover won't stop manual control' issues). 'Reconciliation' covers the 1-minute position retry loop. 'Pipeline' covers the priority handler chain. 'Motion' covers motion sensor and timeout decisions.",
-          "debug_event_buffer_size": "Number of manual-override decision events to keep in the rolling ring buffer. Each event is a small dict (~200 bytes). Increase for intermittent issues that require longer observation windows. The buffer is reset on integration reload.",
-          "transit_timeout": "How long ACP waits after a cover stops reporting forward progress before treating the next position report as a user-initiated manual override. The timer resets each time the cover moves closer to its commanded target, so slow-but-moving covers are protected for the full transit. Increase this value for covers that take longer than 45 seconds to complete a full traverse. Default: 45 seconds."
+          "debug_event_buffer_size": "Number of diagnostic events to keep in the rolling ring buffer. The buffer captures decisions and state transitions across all pipeline subsystems — manual override, motion, weather, time-window scheduling, cover commands, and the pipeline. Each event is a small dict (~200 bytes). Increase for intermittent issues that require longer observation windows. The buffer is reset on integration reload."
         }
       },
       "sync_confirm": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -142,13 +142,15 @@
           "manual_override_duration": "Durée de la dérogation manuelle",
           "manual_override_reset": "Réinitialiser la durée de la dérogation manuelle",
           "manual_threshold": "Seuil de dérogation manuelle",
-          "manual_ignore_intermediate": "Ignorer les positions intermédiaires lors de la dérogation manuelle (ouverture et fermeture)"
+          "manual_ignore_intermediate": "Ignorer les positions intermédiaires lors de la dérogation manuelle (ouverture et fermeture)",
+          "transit_timeout": "Délai de transit (secondes)"
         },
         "data_description": {
           "manual_override_duration": "Combien de temps (minutes) pour mettre en pause le contrôle automatique après ajustement manuel. Quand vous déplacez manuellement le store, le contrôle automatique met en pause. Valeurs typiques : 10-15 min (pause courte, reprendre le suivi bientôt), 30 min (pause moyenne, équilibrée), 60-120 min (pause longue, garder la position manuelle plus longtemps), 0 (désactivé, reprendre immédiatement le contrôle automatique - non recommandé). Vous donne le contrôle quand vous le voulez, reprend l'automatisation plus tard.",
           "manual_override_reset": "Réinitialisez le minuteur de dérogation manuelle après chaque ajustement manuel. S'il est activé, chaque changement manuel redémarre la durée de dérogation. S'il est désactivé, la durée s'applique uniquement au premier ajustement manuel (les changements ultérieurs ne prolongent pas la pause). Activez ceci si vous voulez que la période de dérogation se « renouvelle » à chaque toucher manuel.",
           "manual_threshold": "Différence de position (%) qui compte comme « dérogation manuelle » (par défaut : 1%). Si vous déplacez manuellement le store de ce montant, la détection de dérogation se déclenche. Valeurs typiques : 1-2% (sensible, détecte les petits ajustements), 5% (moins sensible, recommandé), 10% (seuls les grands changements manuels comptent). Empêche la détection accidentelle de dérogation due à de petites dérives de moteur ou aux variations de rapports de position.",
-          "manual_ignore_intermediate": "Ignorez les positions intermédiaires lors des opérations d'ouverture et de fermeture manuelles. Activez ceci pour empêcher la détection de dérogation des positions transitoires tandis que le store se déplace vers votre position cible. Utile si votre store signale de nombreuses valeurs intermédiaires pendant le mouvement."
+          "manual_ignore_intermediate": "Ignorez les positions intermédiaires lors des opérations d'ouverture et de fermeture manuelles. Activez ceci pour empêcher la détection de dérogation des positions transitoires tandis que le store se déplace vers votre position cible. Utile si votre store signale de nombreuses valeurs intermédiaires pendant le mouvement.",
+          "transit_timeout": "Durée pendant laquelle ACP attend après l'arrêt du signalement de progression d'une protection avant de traiter le prochain rapport de position comme une dérogation manuelle initiée par l'utilisateur. Le minuteur se réinitialise chaque fois que la protection se rapproche de sa cible commandée, de sorte que les protections se déplaçant lentement mais continuellement sont protégées pendant l'intégralité du transit. Augmentez cette valeur pour les protections qui prennent plus de 45 secondes pour un parcours complet. Par défaut : 45 secondes."
         }
       },
       "force_override": {
@@ -620,13 +622,15 @@
           "manual_override_duration": "Durée de la dérogation manuelle",
           "manual_override_reset": "Réinitialiser la durée de la dérogation manuelle",
           "manual_threshold": "Seuil de dérogation manuelle",
-          "manual_ignore_intermediate": "Ignorer les positions intermédiaires lors de la dérogation manuelle (ouverture et fermeture)"
+          "manual_ignore_intermediate": "Ignorer les positions intermédiaires lors de la dérogation manuelle (ouverture et fermeture)",
+          "transit_timeout": "Délai de transit (secondes)"
         },
         "data_description": {
           "manual_override_duration": "Combien de temps (minutes) pour mettre en pause le contrôle automatique après ajustement manuel. Quand vous déplacez manuellement le store, le contrôle automatique met en pause. Valeurs typiques : 10-15 min (pause courte, reprendre le suivi bientôt), 30 min (pause moyenne, équilibrée), 60-120 min (pause longue, garder la position manuelle plus longtemps), 0 (désactivé, reprendre immédiatement le contrôle automatique - non recommandé). Vous donne le contrôle quand vous le voulez, reprend l'automatisation plus tard.",
           "manual_override_reset": "Réinitialisez le minuteur de dérogation manuelle après chaque ajustement manuel. S'il est activé, chaque changement manuel redémarre la durée de dérogation. S'il est désactivé, la durée s'applique uniquement au premier ajustement manuel (les changements ultérieurs ne prolongent pas la pause). Activez ceci si vous voulez que la période de dérogation se « renouvelle » à chaque toucher manuel.",
           "manual_threshold": "Différence de position (%) qui compte comme « dérogation manuelle » (par défaut : 1%). Si vous déplacez manuellement le store de ce montant, la détection de dérogation se déclenche. Valeurs typiques : 1-2% (sensible, détecte les petits ajustements), 5% (moins sensible, recommandé), 10% (seuls les grands changements manuels comptent). Empêche la détection accidentelle de dérogation due à de petites dérives de moteur ou aux variations de rapports de position.",
-          "manual_ignore_intermediate": "Ignorez les positions intermédiaires lors des opérations d'ouverture et de fermeture manuelles. Activez ceci pour empêcher la détection de dérogation des positions transitoires tandis que le store se déplace vers votre position cible. Utile si votre store signale de nombreuses valeurs intermédiaires pendant le mouvement."
+          "manual_ignore_intermediate": "Ignorez les positions intermédiaires lors des opérations d'ouverture et de fermeture manuelles. Activez ceci pour empêcher la détection de dérogation des positions transitoires tandis que le store se déplace vers votre position cible. Utile si votre store signale de nombreuses valeurs intermédiaires pendant le mouvement.",
+          "transit_timeout": "Durée pendant laquelle ACP attend après l'arrêt du signalement de progression d'une protection avant de traiter le prochain rapport de position comme une dérogation manuelle initiée par l'utilisateur. Le minuteur se réinitialise chaque fois que la protection se rapproche de sa cible commandée, de sorte que les protections se déplaçant lentement mais continuellement sont protégées pendant l'intégralité du transit. Augmentez cette valeur pour les protections qui prennent plus de 45 secondes pour un parcours complet. Par défaut : 45 secondes."
         }
       },
       "force_override": {
@@ -877,15 +881,13 @@
           "dry_run": "Exécution à sec (aucun mouvement du store)",
           "debug_mode": "Activer le mode débogage",
           "debug_categories": "Catégories de journal (promues en INFO quand le mode débogage est actif)",
-          "debug_event_buffer_size": "Taille du tampon d'événements de dérogation manuelle",
-          "transit_timeout": "Délai de transit (secondes)"
+          "debug_event_buffer_size": "Taille du tampon d'événements de diagnostic"
         },
         "data_description": {
           "dry_run": "Quand activé, l'intégration exécute le cycle de mise à jour complet (pipeline, diagnostics, capteurs) mais N'ENVOIE PAS de commandes de mouvement à vos stores. Utilisez cette option pour déboguer et valider les paramètres d'automatisation sans perturber votre domicile. Par défaut : désactivé.",
           "debug_mode": "Quand activé, les messages de journal pour les catégories sélectionnées ci-dessous sont promus de DEBUG à INFO. Ils apparaissent ainsi dans le journal de Home Assistant sans nécessiter l'ajout de « custom_components.adaptive_cover_pro: debug » dans configuration.yaml. Désactivez quand vous avez terminé le débogage.",
           "debug_categories": "Sélectionnez les domaines à tracer. « Dérogation manuelle » couvre les décisions de détection de dérogation (le plus utile pour les problèmes « le store n'arrête pas le contrôle manuel »). « Réconciliation » couvre la boucle de nouvelle tentative de position toutes les minutes. « Pipeline » couvre les décisions de la chaîne de gestionnaires prioritaires. « Mouvement » couvre les événements des capteurs de mouvement et l'état du délai d'inactivité.",
-          "debug_event_buffer_size": "Nombre d'événements de décision de dérogation manuelle à conserver dans le tampon circulaire. Chaque événement est un petit dictionnaire (~200 octets). Augmentez cette valeur pour les problèmes intermittents nécessitant des fenêtres d'observation plus longues. Le tampon est réinitialisé lors du rechargement de l'intégration.",
-          "transit_timeout": "Durée pendant laquelle ACP attend après qu'une protection solaire cesse de signaler une progression avant de traiter le prochain rapport de position comme une dérogation manuelle initiée par l'utilisateur. Le minuteur se réinitialise chaque fois que la protection solaire se rapproche de sa position cible commandée, de sorte que les protections solaires qui bougent lentement mais régulièrement sont protégées pour la durée complète du transit. Augmentez cette valeur pour les protections solaires qui prennent plus de 45 secondes pour parcourir toute leur course. Par défaut : 45 secondes."
+          "debug_event_buffer_size": "Nombre d'événements de diagnostic à conserver dans le tampon circulaire roulant. Le tampon capture les décisions et transitions d'état dans tous les sous-systèmes du pipeline — dérogation manuelle, mouvement, météo, programmation par fenêtre temporelle, commandes de protection et pipeline. Chaque événement est un petit dictionnaire (~200 octets). Augmentez pour les problèmes intermittents qui nécessitent des fenêtres d'observation plus longues. Le tampon est réinitialisé au rechargement de l'intégration."
         }
       },
       "sync_confirm": {

--- a/tests/test_config_flow_schema_placement.py
+++ b/tests/test_config_flow_schema_placement.py
@@ -1,0 +1,37 @@
+"""Tests asserting each CONF_* key lives on its correct config-flow step."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro import config_flow as cf
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DEBUG_EVENT_BUFFER_SIZE,
+    CONF_DEBUG_MODE,
+    CONF_MANUAL_OVERRIDE_DURATION,
+    CONF_TRANSIT_TIMEOUT,
+)
+
+
+def _schema_keys(schema) -> set[str]:
+    return {str(k) for k in schema.schema}
+
+
+@pytest.mark.parametrize(
+    "conf_key, expected_schema_name, forbidden_schema_name",
+    [
+        (CONF_TRANSIT_TIMEOUT, "MANUAL_OVERRIDE_SCHEMA", "DEBUG_SCHEMA"),
+        (CONF_DEBUG_EVENT_BUFFER_SIZE, "DEBUG_SCHEMA", "MANUAL_OVERRIDE_SCHEMA"),
+        (CONF_MANUAL_OVERRIDE_DURATION, "MANUAL_OVERRIDE_SCHEMA", "DEBUG_SCHEMA"),
+        (CONF_DEBUG_MODE, "DEBUG_SCHEMA", "MANUAL_OVERRIDE_SCHEMA"),
+    ],
+)
+def test_conf_key_lives_on_correct_step(
+    conf_key: str, expected_schema_name: str, forbidden_schema_name: str
+) -> None:
+    expected = _schema_keys(getattr(cf, expected_schema_name))
+    forbidden = _schema_keys(getattr(cf, forbidden_schema_name))
+    assert conf_key in expected, f"{conf_key} should be in {expected_schema_name}"
+    assert conf_key not in forbidden, (
+        f"{conf_key} should NOT be in {forbidden_schema_name}"
+    )

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -78,8 +78,10 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_TIMEOUT,
     CONF_WEATHER_WIND_SPEED_SENSOR,
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
+    CONF_TRANSIT_TIMEOUT,
     CONF_WINDOW_DEPTH,
     CONF_WINDOW_WIDTH,
+    DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     SensorType,
 )
 
@@ -618,6 +620,37 @@ def test_manual_override_duration_shown():
     # Raw dict must NOT appear
     assert "{'hours'" not in summary
     assert "hours" not in summary or "5 h" in summary
+
+
+def test_transit_timeout_non_default_shown_in_manual_override_section():
+    """Non-default transit_timeout appears in the manual override line, not Position Limits."""
+    non_default = DEFAULT_TRANSIT_TIMEOUT_SECONDS + 30
+    cfg = {CONF_TRANSIT_TIMEOUT: non_default}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    lines = summary.splitlines()
+    mo_line = next((ln for ln in lines if "Manual override" in ln), None)
+    assert mo_line is not None, "Manual override line missing from summary"
+    assert f"transit timeout: {non_default}s" in mo_line, (
+        f"Expected 'transit timeout: {non_default}s' in manual override line; got: {mo_line!r}"
+    )
+    # Must NOT appear under Position Limits
+    in_position_limits = False
+    in_pl_section = False
+    for line in lines:
+        if "**Position Limits**" in line:
+            in_pl_section = True
+        elif line.startswith("**") and in_pl_section:
+            in_pl_section = False
+        if in_pl_section and "transit timeout" in line.lower():
+            in_position_limits = True
+    assert not in_position_limits, "transit_timeout must not appear under Position Limits"
+
+
+def test_transit_timeout_default_not_shown():
+    """Default transit_timeout is not surfaced in the summary."""
+    cfg = {CONF_TRANSIT_TIMEOUT: DEFAULT_TRANSIT_TIMEOUT_SECONDS}
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "transit timeout" not in summary.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -222,3 +222,50 @@ def test_en_blind_spot_descriptions_do_not_mention_window_azimuth() -> None:
                 f"{step_key}.blind_spot.data_description.{key} still references "
                 f"'window azimuth' — Option 2 requires FOV-left-edge framing"
             )
+
+
+# ---------------------------------------------------------------------------
+# Event buffer label honesty + transit_timeout step placement
+# ---------------------------------------------------------------------------
+
+
+def test_debug_event_buffer_label_not_manual_override_specific() -> None:
+    """The event buffer is shared across all pipeline subsystems — label must not claim it is manual-override-specific."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    debug = en["options"]["step"]["debug"]
+    label = debug["data"]["debug_event_buffer_size"]
+    desc = debug["data_description"]["debug_event_buffer_size"]
+    assert "manual override" not in label.lower(), (
+        f"Buffer is shared across handlers; label is misleading: {label!r}"
+    )
+    desc_lower = desc.lower()
+    consumers_mentioned = sum(
+        kw in desc_lower
+        for kw in (
+            "manual override",
+            "motion",
+            "weather",
+            "pipeline",
+            "cover command",
+            "time window",
+        )
+    )
+    assert consumers_mentioned >= 2, (
+        f"Description should reference multiple consumers; got: {desc!r}"
+    )
+
+
+def test_transit_timeout_on_manual_override_step_not_debug() -> None:
+    """transit_timeout belongs on the manual_override step, not debug."""
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    mo = en["options"]["step"]["manual_override"]
+    assert "transit_timeout" in mo.get("data", {}), (
+        "transit_timeout must be labelled on the manual_override step"
+    )
+    assert "transit_timeout" in mo.get("data_description", {}), (
+        "transit_timeout must have a data_description on the manual_override step"
+    )
+    debug = en["options"]["step"]["debug"]
+    assert "transit_timeout" not in debug.get("data", {}), (
+        "transit_timeout must NOT appear on the debug step"
+    )


### PR DESCRIPTION
## Summary
- Renamed the "Manual override event buffer size" label on the Debug & Diagnostics screen to "Diagnostic event buffer size" — the underlying ring buffer is shared across manual override, motion, weather, time-window, cover commands, and the pipeline, not just manual override
- Moved the Transit timeout setting from the Debug screen to the Manual Override screen, where it belongs (it controls how long to wait after a cover stops moving before treating the next position report as a user-initiated override)
- Updated `_build_config_summary()` to show transit timeout in the manual override section
- Synced DE/FR translations

## Testing
- ✅ 2445 tests passing
- ✅ New schema-placement regression tests prevent future misplacement
- ✅ New translation label-honesty tests catch misleading labels
- ✅ New summary section tests verify transit timeout appears in the right section