### PR TITLE
fix: custom position covers no longer send redundant commands

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -169,6 +169,7 @@ from .pipeline.handlers import (
 )
 from .pipeline.registry import PipelineRegistry
 from .pipeline.types import ClimateOptions, PipelineSnapshot
+from .enums import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
 from .state.cover_provider import CoverProvider
 from .state.snapshot import CoverStateSnapshot, SunSnapshot
@@ -1429,7 +1430,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         position change should not count against the time threshold.
         """
         sun_just_appeared = self._check_sun_validity_transition()
-        is_safety = self._pipeline_bypasses_auto_control
+        is_safety = self._pipeline_is_safety_handler
         force_override_released = (
             prev_force_override and not self.is_force_override_active
         )
@@ -1458,7 +1459,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
         else:
             reason = (
-                self._pipeline_result.control_method.value if is_safety else "solar"
+                self._pipeline_result.control_method.value
+                if self._pipeline_bypasses_auto_control
+                else "solar"
             )
         for cover in self.entities:
             ctx = self._build_position_context(
@@ -1551,7 +1554,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     async def async_handle_first_refresh(self, state: int, options):
         """Set target positions and send initial positioning commands after startup."""
-        is_safety = self._pipeline_bypasses_auto_control
+        is_safety = self._pipeline_is_safety_handler
 
         # Outside the time window, only safety handlers (force override, weather)
         # are allowed to move covers on startup.  This prevents covers from
@@ -2151,8 +2154,31 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         Safety handlers (ForceOverrideHandler, WeatherOverrideHandler) set
         bypass_auto_control=True so that wind/rain/force protection still
         operates when the user has paused normal sun-tracking automation.
+        CustomPositionHandler also sets this flag to defeat the auto_control
+        gate, but is NOT a safety handler — see _pipeline_is_safety_handler.
         """
         return self._pipeline_result.bypass_auto_control
+
+    @property
+    def _pipeline_is_safety_handler(self) -> bool:
+        """True only when the active pipeline result came from a genuine safety handler.
+
+        Genuine safety handlers (ForceOverrideHandler, WeatherOverrideHandler)
+        require force=True so wind/rain/force protection bypasses delta and time
+        gates and always acts immediately.
+
+        Other handlers that set bypass_auto_control=True (e.g.
+        CustomPositionHandler) want to defeat the auto_control gate but must
+        still be subject to the same-position short-circuit and delta/time gates
+        so they don't issue redundant set_cover_position calls on every update
+        cycle (issue #290).
+        """
+        if self._pipeline_result is None:
+            return False
+        return self._pipeline_result.control_method in (
+            ControlMethod.FORCE,
+            ControlMethod.WEATHER,
+        )
 
     @property
     def manual_toggle(self):

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -692,6 +692,8 @@ class CoverCommandService:
         - sun_just_appeared (cover may need to re-confirm same position)
         - moves to/from special positions (0, 100, default, sunset)
 
+        Same-position short-circuit is handled upstream in apply_position and
+        applies to all callers including force=True (issue #290).
         """
         position = self._get_current_position(entity)
         if position is None:
@@ -705,14 +707,6 @@ class CoverCommandService:
                 target,
             )
             return True
-
-        if position == target:
-            self._logger.debug(
-                "Delta check: %s already at target %s%% — no command needed",
-                entity,
-                target,
-            )
-            return False  # Cover is already at the desired position; skip regardless of special status
 
         if target in special_positions:
             self._logger.debug(
@@ -820,6 +814,26 @@ class CoverCommandService:
             return self._skip(
                 entity_id,
                 "auto_control_off",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=_current,
+            )
+
+        # Same-position short-circuit — applies to ALL callers, including force=True.
+        # Issuing set_cover_position with the current position is always a no-op
+        # physically but causes audible relay clicks on many motors (issue #290).
+        # sun_just_appeared is the one exception: the sun transitioning in/out of
+        # validity is a sentinel that we must re-confirm the cover position even
+        # if it hasn't changed numerically.
+        if (
+            not context.sun_just_appeared
+            and _current is not None
+            and _current == position
+        ):
+            return self._skip(
+                entity_id,
+                "same_position",
                 position,
                 trigger=_trigger,
                 inverse_state=_inverse,

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -20,5 +20,5 @@
     "astral",
     "pandas"
   ],
-  "version": "2.18.4"
+  "version": "2.18.5-beta.1"
 }

--- a/release_notes/v2.18.5-beta.1.md
+++ b/release_notes/v2.18.5-beta.1.md
@@ -1,0 +1,29 @@
+## 🎯 Fix: Custom Position Covers No Longer Click Continuously
+
+Beta.1 fixes a regression introduced in v2.18.3 where covers using custom position sensors sent redundant `set_cover_position` commands on every sun update (every few seconds), causing audible relay clicks.
+
+### 🔑 Highlights
+
+- Custom position covers no longer send redundant positioning commands every few seconds (#290).
+
+### 🐛 Bug Fixes
+
+- **Custom position covers send redundant commands on every sun update (#290):**
+  In v2.18.3, `CustomPositionHandler` gained `bypass_auto_control=True` to defeat
+  the auto-control gate. This flag was incorrectly equated with "safety handler" in
+  `async_handle_state_change`, causing `force=True` to be passed to the position
+  context on every update. With `force=True`, the same-position short-circuit in
+  `CoverCommandService` was bypassed, and a `set_cover_position` command was sent
+  on every `sun.sun` attribute change — typically every few seconds — even when the
+  cover was already at the target position, producing audible relay clicks.
+
+  The fix adds a `_pipeline_is_safety_handler` property that returns `True` only for
+  genuine safety handlers (force override, weather). Custom positions continue to
+  bypass the auto-control gate via `bypass_auto_control` but no longer trigger
+  `force=True`. As defence in depth, the same-position short-circuit is also moved
+  to a top-level guard in `apply_position` that applies to all callers — including
+  future force=True paths — so this class of regression cannot recur.
+
+### 🧪 Testing
+
+- 2493 tests passing

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -63,6 +63,10 @@ def _make_coordinator(
         pipeline_result = _make_pipeline_result()
     coordinator._pipeline_result = pipeline_result
     coordinator._pipeline_bypasses_auto_control = pipeline_result.bypass_auto_control
+    coordinator._pipeline_is_safety_handler = pipeline_result.control_method in (
+        ControlMethod.FORCE,
+        ControlMethod.WEATHER,
+    )
 
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
@@ -222,6 +226,50 @@ class TestStateChangeWithDefaultPosition:
 
         await AdaptiveDataUpdateCoordinator.async_handle_state_change(
             coordinator, state=0, options={}
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.blind",
+            {},
+            force=False,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #290: Custom position must NOT use force=True context
+# ---------------------------------------------------------------------------
+
+
+class TestCustomPositionNoRedundantCommands:
+    """Custom position handler must not trigger force=True in position context.
+
+    bypass_auto_control=True on a CustomPositionHandler result exists only to
+    defeat the auto_control_off gate.  It must NOT cascade to force=True, which
+    would bypass the same-position short-circuit and resend set_cover_position
+    on every sun.sun update (every few seconds), causing audible relay clicks.
+    """
+
+    @pytest.mark.asyncio
+    async def test_custom_position_does_not_use_force_context(self):
+        """Custom position pipeline result must call _build_position_context with force=False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=60,
+            control_method=ControlMethod.CUSTOM_POSITION,
+            bypass_auto_control=True,
+        )
+        coordinator = _make_coordinator(
+            entities=["cover.blind"],
+            pipeline_result=result,
+        )
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator, state=60, options={}
         )
 
         coordinator._build_position_context.assert_called_once_with(

--- a/tests/test_cover_command_force_gate.py
+++ b/tests/test_cover_command_force_gate.py
@@ -134,3 +134,35 @@ class TestSafetyBypassStillWorks:
         assert outcome == "sent"
         assert svc.target_call[f"cover.{trigger}"] == 25
         assert f"cover.{trigger}" in svc._safety_targets
+
+
+# ---------------------------------------------------------------------------
+# Issue #290: same-position short-circuit must apply even when force=True
+# ---------------------------------------------------------------------------
+
+
+class TestSamePositionBypassesForceGate:
+    """Covers already at target must never receive a redundant command, even with force=True.
+
+    Prior to the fix, the same-position guard lived inside ``if not context.force:``,
+    so force=True callers (including custom positions after the v2.18.3 regression)
+    always resent the command, causing audible relay clicks every few seconds.
+    """
+
+    @pytest.mark.asyncio
+    async def test_force_true_same_position_is_skipped(self, svc, hass):
+        """apply_position with force=True and cover already at target must skip."""
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=60),
+        ):
+            outcome, detail = await svc.apply_position(
+                "cover.test",
+                60,
+                "custom_position",
+                _ctx(force=True, is_safety=False, auto_control=True),
+            )
+
+        assert outcome == "skipped"
+        assert detail == "same_position"
+        hass.services.async_call.assert_not_called()

--- a/tests/test_delta_position.py
+++ b/tests/test_delta_position.py
@@ -38,25 +38,37 @@ def test_check_position_delta_respects_threshold():
 
 
 def test_check_position_delta_already_at_target_zero():
-    """Cover already at 0% with target 0% — no command needed (Issue #127)."""
+    """_check_position_delta bypasses delta for special target 0% (issue #290).
+
+    Same-position short-circuit was moved to apply_position (issue #290) so
+    it applies to force=True callers too.  _check_position_delta no longer
+    returns False for same-position — it returns True (bypass) when the target
+    is a special position, which is the case for 0%.
+    """
     svc = _make_cmd_svc(current_position=0)
     result = svc._check_position_delta(
         "cover.test", 0, min_change=1, special_positions=[0, 100]
     )
-    assert result is False
+    assert result is True  # special target bypass; same-position caught upstream
 
 
 def test_check_position_delta_already_at_target_hundred():
-    """Cover already at 100% with target 100% — no command needed (Issue #127)."""
+    """_check_position_delta bypasses delta for special target 100% (issue #290).
+
+    Same-position short-circuit lives in apply_position (issue #290), not here.
+    """
     svc = _make_cmd_svc(current_position=100)
     result = svc._check_position_delta(
         "cover.test", 100, min_change=1, special_positions=[0, 100]
     )
-    assert result is False
+    assert result is True  # special target bypass; same-position caught upstream
 
 
 def test_check_position_delta_already_at_target_default():
-    """Cover already at default_height% with matching target — no command needed (Issue #127)."""
+    """_check_position_delta bypasses delta for special target = default_height (issue #290).
+
+    Same-position short-circuit lives in apply_position (issue #290), not here.
+    """
     from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
 
     svc = _make_cmd_svc(current_position=40)
@@ -64,7 +76,7 @@ def test_check_position_delta_already_at_target_default():
     result = svc._check_position_delta(
         "cover.test", 40, min_change=1, special_positions=special
     )
-    assert result is False
+    assert result is True  # special target bypass; same-position caught upstream
 
 
 def test_check_position_delta_transition_to_zero_from_five():

--- a/tests/test_get_diagnostics_service.py
+++ b/tests/test_get_diagnostics_service.py
@@ -11,7 +11,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.services.diagnostics_service import (
-    GET_DIAGNOSTICS_SCHEMA,
     async_handle_get_diagnostics,
 )
 from custom_components.adaptive_cover_pro.const import DOMAIN
@@ -29,7 +28,7 @@ def make_coordinator(entry_id="entry-1", name="Test Cover", cover_type="cover_bl
     coord.config_entry.domain = DOMAIN
     coord._cover_type = cover_type  # noqa: SLF001
     coord.last_update_success = True
-    coord._last_update_success_time = dt.datetime(2026, 4, 28, 12, 0, 0, tzinfo=dt.timezone.utc)  # noqa: SLF001
+    coord._last_update_success_time = dt.datetime(2026, 4, 28, 12, 0, 0, tzinfo=dt.UTC)  # noqa: SLF001
     coord.entities = [f"cover.{name.lower().replace(' ', '_')}"]
     coord.data = MagicMock()
     coord.data.diagnostics = {"pipeline": {"handler": "solar"}, "sun": {"elevation": 25.5}}
@@ -140,7 +139,7 @@ async def test_sanitizer_handles_numpy_datetime_enum_dataclass():
     coord = make_coordinator()
     coord.data.diagnostics = {
         "numpy_val": numpy_val,
-        "timestamp": dt.datetime(2026, 4, 28, tzinfo=dt.timezone.utc),
+        "timestamp": dt.datetime(2026, 4, 28, tzinfo=dt.UTC),
         "colour": Colour.RED,
         "point": Point(1.0, 2.0),
         "tags": {"b", "a"},

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -339,6 +339,7 @@ def _make_state_change_coordinator(
         return_value=("sent", "set_cover_position")
     )
     coordinator._pipeline_bypasses_auto_control = bypass_auto_control
+    coordinator._pipeline_is_safety_handler = bypass_auto_control
     coordinator._pipeline_result = MagicMock()
     coordinator._pipeline_result.control_method.value = "force"
     coordinator.state_change = True

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -1070,6 +1070,8 @@ async def test_same_position_skips_even_for_special_target(svc, mock_hass):
     The same-position short-circuit runs BEFORE the special-positions bypass.
     Regression: without this guard, covers at 0%/100% would receive a command
     every time_threshold minutes because the special-bypass would always fire.
+    Since issue #290, the skip reason is "same_position" (caught by the top-level
+    guard in apply_position that applies even to force=True callers).
     """
     _patch_position(svc, 100)  # cover is already at 100%
     outcome, reason = await svc.apply_position(
@@ -1079,7 +1081,7 @@ async def test_same_position_skips_even_for_special_target(svc, mock_hass):
         context=_ctx(min_change=1, special_positions=[0, 100, 50]),
     )
     assert outcome == "skipped"
-    assert reason == "delta_too_small"
+    assert reason == "same_position"
 
 
 @pytest.mark.asyncio
@@ -1093,7 +1095,7 @@ async def test_same_position_skips_for_zero_special(svc, mock_hass):
         context=_ctx(min_change=1, special_positions=[0, 100]),
     )
     assert outcome == "skipped"
-    assert reason == "delta_too_small"
+    assert reason == "same_position"
 
 
 @pytest.mark.asyncio

--- a/tests/test_safety_override_bypass.py
+++ b/tests/test_safety_override_bypass.py
@@ -392,6 +392,71 @@ class TestCoordinatorBypassProperty:
 
 
 # ---------------------------------------------------------------------------
+# Issue #290: _pipeline_is_safety_handler property (unit tests via unbound call)
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineIsSafetyHandlerProperty:
+    """_pipeline_is_safety_handler must return True only for genuine safety handlers.
+
+    FORCE and WEATHER are genuine safety handlers — they bypass delta/time gates
+    via force=True because wind/rain protection must act immediately.
+    CUSTOM_POSITION (and all others) set bypass_auto_control=True only to defeat
+    the auto_control_off gate, and must NOT trigger force=True (issue #290).
+    """
+
+    def _make_coord_with_result(self, control_method: ControlMethod) -> MagicMock:
+        coord = MagicMock()
+        coord._pipeline_result = PipelineResult(
+            position=60,
+            control_method=control_method,
+            reason="test",
+            bypass_auto_control=True,
+        )
+        return coord
+
+    def test_custom_position_is_not_safety_handler(self) -> None:
+        """CUSTOM_POSITION must return False — it bypasses auto_control, not delta/time gates."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = self._make_coord_with_result(ControlMethod.CUSTOM_POSITION)
+        result = AdaptiveDataUpdateCoordinator._pipeline_is_safety_handler.fget(coord)
+        assert result is False
+
+    def test_force_is_safety_handler(self) -> None:
+        """FORCE must return True — wind/rain protection requires bypassing delta/time gates."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = self._make_coord_with_result(ControlMethod.FORCE)
+        result = AdaptiveDataUpdateCoordinator._pipeline_is_safety_handler.fget(coord)
+        assert result is True
+
+    def test_weather_is_safety_handler(self) -> None:
+        """WEATHER must return True — storm protection requires bypassing delta/time gates."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = self._make_coord_with_result(ControlMethod.WEATHER)
+        result = AdaptiveDataUpdateCoordinator._pipeline_is_safety_handler.fget(coord)
+        assert result is True
+
+    def test_solar_is_not_safety_handler(self) -> None:
+        """SOLAR must return False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = self._make_coord_with_result(ControlMethod.SOLAR)
+        result = AdaptiveDataUpdateCoordinator._pipeline_is_safety_handler.fget(coord)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
 # Trace and decision trace content
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Custom position covers were sending `set_cover_position` on every sun update (every few seconds), causing audible relay clicks. The regression landed in v2.18.3 when `CustomPositionHandler` gained `bypass_auto_control=True` — this flag cascaded to `force=True` in the position context, bypassing the same-position short-circuit in `CoverCommandService`.

The fix has two parts:
- Added `_pipeline_is_safety_handler` property to `coordinator.py` that returns `True` only for FORCE and WEATHER control methods. `async_handle_state_change` and `async_handle_first_refresh` now use it instead of `_pipeline_bypasses_auto_control` for `is_safety`, so custom positions no longer trigger `force=True`.
- Lifted the same-position guard in `apply_position` (`cover_command.py`) to a top-level check that applies to all callers including `force=True` — defence in depth.

## Testing
- ✅ 2493 tests passing
- New tests: `TestCustomPositionNoRedundantCommands`, `TestSamePositionBypassesForceGate`, `TestPipelineIsSafetyHandlerProperty`

## Related Issues
Refs #290