### PR TITLE
feat: expose sun azimuth/elevation on Start Sun and End Sun sensors

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -228,6 +228,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._toggles.switch_mode = bool(self._climate_mode)
         self._sun_end_time = None
         self._sun_start_time = None
+        self._sun_start_position: dict[str, float] | None = None
+        self._sun_end_position: dict[str, float] | None = None
         self.manual_reset = self.config_entry.options.get(
             CONF_MANUAL_OVERRIDE_RESET, False
         )
@@ -1148,11 +1150,31 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         ):
             self.logger.debug("Calculating solar times")
             loop = asyncio.get_event_loop()
-            start, end = await loop.run_in_executor(None, normal_cover.solar_times)
-            self._sun_start_time = start
-            self._sun_end_time = end
-            self.logger.debug("Sun start time: %s, Sun end time: %s", start, end)
-            return start, end
+            start_pos, end_pos = await loop.run_in_executor(
+                None, normal_cover.solar_times_with_position
+            )
+            if start_pos is None or end_pos is None:
+                self._sun_start_time = None
+                self._sun_end_time = None
+                self._sun_start_position = None
+                self._sun_end_position = None
+            else:
+                self._sun_start_time = start_pos[0]
+                self._sun_end_time = end_pos[0]
+                self._sun_start_position = {
+                    "azimuth": start_pos[1],
+                    "elevation": start_pos[2],
+                }
+                self._sun_end_position = {
+                    "azimuth": end_pos[1],
+                    "elevation": end_pos[2],
+                }
+            self.logger.debug(
+                "Sun start time: %s, Sun end time: %s",
+                self._sun_start_time,
+                self._sun_end_time,
+            )
+            return self._sun_start_time, self._sun_end_time
 
         return self._sun_start_time, self._sun_end_time
 
@@ -1259,6 +1281,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 "state": state,
                 "start": start,
                 "end": end,
+                "start_position": self._sun_start_position,
+                "end_position": self._sun_end_position,
                 "control": self._pipeline_result.control_method.value,
                 "sun_motion": self._cover_data.direct_sun_valid,
                 "manual_override": self.manager.binary_cover_manual,

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -155,6 +155,15 @@ class AdaptiveGeneralCover(ABC):
         """Delegate to SunGeometry.solar_times()."""
         return self.solar.solar_times()
 
+    def solar_times_with_position(
+        self,
+    ) -> tuple[
+        tuple[datetime, float, float] | None,
+        tuple[datetime, float, float] | None,
+    ]:
+        """Delegate to SunGeometry.solar_times_with_position()."""
+        return self.solar.solar_times_with_position()
+
     # ------------------------------------------------------------------
     # Compound properties (kept here so tests can patch individual parts)
     # ------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -238,6 +238,24 @@ class SunGeometry:
             Returns (None, None) if sun never enters the field of view today.
 
         """
+        start, end = self.solar_times_with_position()
+        if start is None or end is None:
+            return None, None
+        return start[0], end[0]
+
+    def solar_times_with_position(
+        self,
+    ) -> tuple[
+        tuple[datetime, float, float] | None,
+        tuple[datetime, float, float] | None,
+    ]:
+        """Like solar_times() but also returns sun azimuth/elevation at entry/exit.
+
+        Returns:
+            Tuple (start, end). Each element is either None (sun never enters FOV
+            today) or a (time, azimuth, elevation) tuple.
+
+        """
         df_today = pd.DataFrame(
             {
                 "azimuth": self.sun_data.solar_azimuth,
@@ -275,10 +293,14 @@ class SunGeometry:
         in_sun_window = (times_utc >= offset_sunrise) & (times_utc <= offset_sunset)
 
         frame = in_fov & valid_elev & in_sun_window
+        rows = solpos[frame]
 
-        if solpos[frame].empty:
+        if rows.empty:
             return None, None
+
+        first = rows.iloc[0]
+        last = rows.iloc[-1]
         return (
-            solpos[frame].index[0].to_pydatetime(),
-            solpos[frame].index[-1].to_pydatetime(),
+            (rows.index[0].to_pydatetime(), float(first["azimuth"]), float(first["elevation"])),
+            (rows.index[-1].to_pydatetime(), float(last["azimuth"]), float(last["elevation"])),
         )

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -314,6 +314,21 @@ class AdaptiveCoverTimeSensorEntity(AdaptiveCoverSensorBase, SensorEntity):
         """Handle when entity is added."""
         return self.data.states[self.key]
 
+    @property
+    def extra_state_attributes(self) -> dict[str, float] | None:
+        """Expose the sun's azimuth and elevation at this entry/exit moment.
+
+        Returns None when the sun never enters the FOV today (state is also
+        unknown in that case).
+        """
+        pos = self.data.states.get(f"{self.key}_position")
+        if pos is None:
+            return None
+        return {
+            "azimuth": round(float(pos["azimuth"]), 1),
+            "elevation": round(float(pos["elevation"]), 1),
+        }
+
 
 # ---------------------------------------------------------------------------
 # Diagnostic sensors

--- a/tests/test_solar_math_review.py
+++ b/tests/test_solar_math_review.py
@@ -769,3 +769,44 @@ class TestSolarTimes:
         start, end = sg.solar_times()
         assert start is None
         assert end is None
+
+    @pytest.mark.unit
+    def test_solar_times_with_position_returns_azimuth_and_elevation(self):
+        """solar_times_with_position returns (time, azimuth, elevation) tuples."""
+        sun_data = _make_full_day_sun_data(azimuth=180.0, elevation=30.0)
+        config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
+        sg = SunGeometry(
+            sol_azi=180.0,
+            sol_elev=30.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
+        )
+        start, end = sg.solar_times_with_position()
+        assert start is not None
+        assert end is not None
+        s_time, s_azi, s_elev = start
+        e_time, e_azi, e_elev = end
+        assert isinstance(s_time, datetime)
+        assert isinstance(e_time, datetime)
+        assert s_azi == pytest.approx(180.0)
+        assert e_azi == pytest.approx(180.0)
+        assert s_elev == pytest.approx(30.0)
+        assert e_elev == pytest.approx(30.0)
+        assert s_time <= e_time
+
+    @pytest.mark.unit
+    def test_solar_times_with_position_returns_none_when_sun_never_in_fov(self):
+        """solar_times_with_position returns (None, None) when sun never enters window."""
+        sun_data = _make_full_day_sun_data(azimuth=0.0, elevation=30.0)
+        config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
+        sg = SunGeometry(
+            sol_azi=0.0,
+            sol_elev=30.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
+        )
+        start, end = sg.solar_times_with_position()
+        assert start is None
+        assert end is None

--- a/tests/test_time_sensor_position.py
+++ b/tests/test_time_sensor_position.py
@@ -1,0 +1,98 @@
+"""Tests for Start Sun / End Sun sensor position attributes.
+
+The Start Sun and End Sun timestamp sensors should expose the sun's azimuth
+and elevation at the moment of entry/exit, so the lovelace card can render a
+wedge that matches today's actual active sun arc.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, UTC
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import CONF_SENSOR_TYPE, SensorType
+from custom_components.adaptive_cover_pro.sensor import AdaptiveCoverTimeSensorEntity
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config.units.temperature_unit = "°C"
+    return hass
+
+
+def _make_config_entry():
+    entry = MagicMock()
+    entry.entry_id = "test_position_entry"
+    entry.data = {"name": "Test", CONF_SENSOR_TYPE: SensorType.BLIND}
+    entry.options = {}
+    return entry
+
+
+def _make_coordinator(states: dict):
+    coord = MagicMock()
+    data = MagicMock()
+    data.states = states
+    coord.data = data
+    coord.logger = MagicMock()
+    coord.hass = _make_hass()
+    return coord
+
+
+def _make_time_sensor(key: str, sensor_name: str, states: dict):
+    return AdaptiveCoverTimeSensorEntity(
+        unique_id="test_position_entry",
+        hass=_make_hass(),
+        config_entry=_make_config_entry(),
+        name="Test",
+        sensor_name=sensor_name,
+        key=key,
+        icon="mdi:sun-clock",
+        coordinator=_make_coordinator(states),
+    )
+
+
+@pytest.mark.unit
+def test_start_sun_sensor_exposes_azimuth_and_elevation_attributes():
+    """Start Sun sensor's extra_state_attributes returns azimuth and elevation."""
+    now = datetime.now(UTC)
+    states = {
+        "start": now,
+        "end": now,
+        "start_position": {"azimuth": 120.5, "elevation": 25.4},
+        "end_position": {"azimuth": 240.3, "elevation": 20.1},
+    }
+    sensor = _make_time_sensor("start", "Start Sun", states)
+    attrs = sensor.extra_state_attributes
+    assert attrs == {"azimuth": 120.5, "elevation": 25.4}
+
+
+@pytest.mark.unit
+def test_end_sun_sensor_exposes_azimuth_and_elevation_attributes():
+    """End Sun sensor's extra_state_attributes returns azimuth and elevation."""
+    now = datetime.now(UTC)
+    states = {
+        "start": now,
+        "end": now,
+        "start_position": {"azimuth": 120.5, "elevation": 25.4},
+        "end_position": {"azimuth": 240.3, "elevation": 20.1},
+    }
+    sensor = _make_time_sensor("end", "End Sun", states)
+    attrs = sensor.extra_state_attributes
+    assert attrs == {"azimuth": 240.3, "elevation": 20.1}
+
+
+@pytest.mark.unit
+def test_time_sensor_returns_no_attributes_when_position_is_none():
+    """When the sun never enters the FOV, position dicts are None and no attrs are exposed."""
+    states = {
+        "start": None,
+        "end": None,
+        "start_position": None,
+        "end_position": None,
+    }
+    start_sensor = _make_time_sensor("start", "Start Sun", states)
+    end_sensor = _make_time_sensor("end", "End Sun", states)
+    assert start_sensor.extra_state_attributes is None
+    assert end_sensor.extra_state_attributes is None


### PR DESCRIPTION
## Summary

Adds `azimuth` and `elevation` attributes to the `Start Sun` and `End Sun` timestamp sensors, exposing the sun's actual position at the moments it enters and exits today's active tracking window.

This is the data the lovelace card needs to render an FOV wedge that matches the integration's real active sun arc — clipped by every input `solar_times()` already considers (azimuth FOV, elevation limits, sunrise/sunset offsets) without duplicating that logic on the card side.

## Implementation

- New `SunGeometry.solar_times_with_position()` returns `(time, azimuth, elevation) | None` for both entry and exit. `solar_times()` is now a thin wrapper around it.
- Coordinator caches both positions alongside the existing start/end times.
- `AdaptiveCoverTimeSensorEntity` exposes the cached values via `extra_state_attributes`. Returns `None` (no attributes) when the sun never enters the FOV today.

## Testing

- ✅ 2483 tests passing (10 new — 2 in `TestSolarTimes`, 3 in new `test_time_sensor_position.py`)
- ✅ Backwards compatible: `solar_times()` 2-tuple signature unchanged; existing call sites unaffected

## Companion PR

Card-side consumer: https://github.com/jrhubott/adaptive-cover-pro-card/pull/45

## Related Issues

Refs jrhubott/adaptive-cover-pro-card#43