### PR TITLE
fix: restore presence entity selector domains (#313)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -836,7 +836,13 @@ TEMPERATURE_CLIMATE_SCHEMA = vol.Schema(
             CONF_PRESENCE_ENTITY, default=vol.UNDEFINED
         ): selector.EntitySelector(
             selector.EntityFilterSelectorConfig(
-                domain=["binary_sensor", "input_boolean"]
+                domain=[
+                    "device_tracker",
+                    "person",
+                    "zone",
+                    "binary_sensor",
+                    "input_boolean",
+                ]
             )
         ),
         vol.Optional(CONF_TRANSPARENT_BLIND, default=False): selector.BooleanSelector(),

--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -104,7 +104,7 @@ class ClimateProvider:
         if presence is None:
             return True
         domain = get_domain(presence_entity)
-        if domain == "device_tracker":
+        if domain in ("device_tracker", "person"):
             return presence == "home"
         if domain == "zone":
             return int(presence) > 0

--- a/tests/test_config_ux_simplification.py
+++ b/tests/test_config_ux_simplification.py
@@ -131,6 +131,27 @@ class TestSplitSchemas:
         keys = [str(k) for k in TEMPERATURE_CLIMATE_SCHEMA.schema]
         assert "presence_entity" in keys
 
+    def test_presence_entity_selector_allows_five_domains(self):
+        """Presence entity selector must accept the five supported domains.
+
+        Regression guard for #313 — PR #287 silently narrowed this list to
+        just binary_sensor/input_boolean, blocking zone/device_tracker users
+        even though the runtime consumer still routes by domain.
+        """
+        for key, value in TEMPERATURE_CLIMATE_SCHEMA.schema.items():
+            if str(key) == "presence_entity":
+                domain = value.config["domain"]
+                assert set(domain) == {
+                    "device_tracker",
+                    "person",
+                    "zone",
+                    "binary_sensor",
+                    "input_boolean",
+                }
+                assert len(domain) == 5
+                return
+        raise AssertionError("presence_entity not found in schema")
+
     def test_temperature_climate_no_lux(self):
         """TEMPERATURE_CLIMATE_SCHEMA should NOT contain lux settings."""
         keys = [str(k) for k in TEMPERATURE_CLIMATE_SCHEMA.schema]

--- a/tests/test_state/test_climate_provider.py
+++ b/tests/test_state/test_climate_provider.py
@@ -160,6 +160,20 @@ class TestPresence:
         assert readings.is_presence is False
 
     @pytest.mark.unit
+    def test_person_home(self, provider, mock_hass):
+        """person 'home' → True (regression guard for #313)."""
+        mock_hass.states.get.return_value = _mock_state("person.alice", "home")
+        readings = provider.read(presence_entity="person.alice")
+        assert readings.is_presence is True
+
+    @pytest.mark.unit
+    def test_person_away(self, provider, mock_hass):
+        """person 'not_home' → False (regression guard for #313)."""
+        mock_hass.states.get.return_value = _mock_state("person.alice", "not_home")
+        readings = provider.read(presence_entity="person.alice")
+        assert readings.is_presence is False
+
+    @pytest.mark.unit
     def test_input_boolean_on(self, provider, mock_hass):
         """input_boolean 'on' → True."""
         mock_hass.states.get.return_value = _mock_state("input_boolean.presence", "on")


### PR DESCRIPTION
## Summary
PR #287 had silently narrowed the presence entity selector from five domains (device_tracker, person, zone, binary_sensor, input_boolean) down to just two (binary_sensor, input_boolean). I've restored the original five-domain set and added support for the `person` entity type in the presence reader, which treats home/not_home states like device_tracker.

## Testing
- ✅ 2514 tests passing

## Related Issues
Refs #313