### PR TITLE
chore: tier 2 DRY extractions (helpers, no behavior changes)

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -253,9 +253,18 @@ class DiagnosticsBuilder:
 
     @classmethod
     def _build_position(cls, ctx: DiagnosticContext) -> dict:
-        """Build position diagnostics."""
+        """Build position diagnostics by composing the smaller per-section helpers."""
         diagnostics: dict = {}
+        diagnostics.update(cls._build_position_base(ctx))
+        diagnostics.update(cls._build_position_delta_time(ctx))
+        diagnostics.update(cls._build_position_calc_details(ctx))
+        diagnostics["last_updated"] = dt.datetime.now(dt.UTC).isoformat()
+        return diagnostics
 
+    @classmethod
+    def _build_position_base(cls, ctx: DiagnosticContext) -> dict:
+        """Build calculated position, control status/reason, optional flags, and explanation."""
+        diagnostics: dict = {}
         result = ctx.pipeline_result
         raw_pos = result.raw_calculated_position if result is not None else 0
         diagnostics["calculated_position"] = raw_pos
@@ -272,25 +281,31 @@ class DiagnosticsBuilder:
         if result is not None and result.tilt is not None:
             diagnostics["tilt"] = result.tilt
 
-        explanation = cls._build_position_explanation(ctx)
-        diagnostics["position_explanation"] = explanation
+        diagnostics["position_explanation"] = cls._build_position_explanation(ctx)
+        return diagnostics
 
-        # Delta thresholds
-        diagnostics["delta_position_threshold"] = ctx.min_change
-        diagnostics["delta_time_threshold_minutes"] = ctx.time_threshold
-
-        # Position delta from last action
+    @staticmethod
+    def _build_position_delta_time(ctx: DiagnosticContext) -> dict:
+        """Threshold values plus delta-from-last-action and time-since-last-action."""
+        diagnostics: dict = {
+            "delta_position_threshold": ctx.min_change,
+            "delta_time_threshold_minutes": ctx.time_threshold,
+        }
+        result = ctx.pipeline_result
+        raw_pos = result.raw_calculated_position if result is not None else 0
         last_action = ctx.last_cover_action
+
         if last_action.get("position") is not None:
             diagnostics["position_delta_from_last_action"] = abs(
                 raw_pos - last_action["position"]
             )
 
-        # Time since last action
         if last_action.get("timestamp"):
             try:
                 last_ts = dt.datetime.fromisoformat(last_action["timestamp"])
                 if last_ts.tzinfo is None:
+                    # ISO timestamps without offset are stored as UTC by the
+                    # coordinator; treat them that way for the elapsed-time math.
                     last_ts = last_ts.replace(tzinfo=dt.UTC)
                 now_utc = dt.datetime.now(dt.UTC)
                 elapsed = (now_utc - last_ts).total_seconds()
@@ -298,15 +313,17 @@ class DiagnosticsBuilder:
             except (ValueError, AttributeError):
                 pass
 
-        # Vertical cover calculation details
-        if ctx.cover:
-            calc_details = getattr(ctx.cover, "_last_calc_details", None)
-            if calc_details is not None:
-                diagnostics["calculation_details"] = calc_details
-
-        diagnostics["last_updated"] = dt.datetime.now(dt.UTC).isoformat()
-
         return diagnostics
+
+    @staticmethod
+    def _build_position_calc_details(ctx: DiagnosticContext) -> dict:
+        """Surface the cover's per-cycle calc trace when one was recorded."""
+        if not ctx.cover:
+            return {}
+        calc_details = getattr(ctx.cover, "_last_calc_details", None)
+        if calc_details is None:
+            return {}
+        return {"calculation_details": calc_details}
 
     @staticmethod
     def _build_time_window(ctx: DiagnosticContext) -> dict:

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -75,6 +75,24 @@ class SunGeometry:
     # Validity checks
     # ------------------------------------------------------------------
 
+    def _elevation_within_bounds(self, elev):
+        """Return whether *elev* is within the configured min/max bounds.
+
+        Works for scalar floats and pandas Series alike (uses bitwise ``&`` and
+        comparison operators that both support).
+
+        **Caller** must handle the "neither bound configured" case separately —
+        the scalar property defaults to ``elev >= 0`` while the Series-based
+        ``solar_times_with_position`` defaults to ``elev > 0``. That ½°
+        difference at the horizon is intentional and predates this helper.
+        """
+        min_e, max_e = self.config.min_elevation, self.config.max_elevation
+        if min_e is None:
+            return elev <= max_e
+        if max_e is None:
+            return elev >= min_e
+        return (elev >= min_e) & (elev <= max_e)
+
     @property
     def valid_elevation(self) -> bool:
         """Check if sun elevation is within configured limits.
@@ -86,13 +104,7 @@ class SunGeometry:
         """
         if self.config.min_elevation is None and self.config.max_elevation is None:
             return self.sol_elev >= 0
-        if self.config.min_elevation is None:
-            return self.sol_elev <= self.config.max_elevation
-        if self.config.max_elevation is None:
-            return self.sol_elev >= self.config.min_elevation
-        within_range = (
-            self.config.min_elevation <= self.sol_elev <= self.config.max_elevation
-        )
+        within_range = bool(self._elevation_within_bounds(self.sol_elev))
         self.logger.debug("elevation within range? %s", within_range)
         return within_range
 
@@ -272,17 +284,13 @@ class SunGeometry:
             self.azi_max_abs - self.azi_min_abs
         ) % 360
 
-        # Elevation check — matches valid_elevation property logic
+        # Elevation check — matches valid_elevation property logic, except the
+        # "no bounds set" default here is `elev > 0` (strictly above horizon)
+        # while the scalar property uses `>= 0` to include the horizon line.
         if self.config.min_elevation is None and self.config.max_elevation is None:
             valid_elev = elev > 0
-        elif self.config.min_elevation is None:
-            valid_elev = elev <= self.config.max_elevation
-        elif self.config.max_elevation is None:
-            valid_elev = elev >= self.config.min_elevation
         else:
-            valid_elev = (elev >= self.config.min_elevation) & (
-                elev <= self.config.max_elevation
-            )
+            valid_elev = self._elevation_within_bounds(elev)
 
         # Sunset/sunrise offset — exclude times within the offset windows.
         sunset_utc = self.sun_data.sunset().replace(tzinfo=None)

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 from dateutil import parser
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.util import dt as dt_util
 
@@ -15,11 +16,15 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Entity states that mean "no usable value" — used by the safe-read helpers
+# below so the same set is checked everywhere instead of inline literals.
+_INVALID_STATES: frozenset[str] = frozenset({STATE_UNKNOWN, STATE_UNAVAILABLE})
+
 
 def get_safe_state(hass: HomeAssistant, entity_id: str):
     """Get a safe state value if not available."""
     state = hass.states.get(entity_id)
-    if not state or state.state in ["unknown", "unavailable"]:
+    if not state or state.state in _INVALID_STATES:
         return None
     return state.state
 
@@ -238,7 +243,7 @@ def get_open_close_state(hass: HomeAssistant, entity_id: str) -> int | None:
 
     """
     state = hass.states.get(entity_id)
-    if not state or state.state in ["unknown", "unavailable"]:
+    if not state or state.state in _INVALID_STATES:
         return None
 
     if state.state == "closed":

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...enums import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import compute_raw_calculated_position
+from ..helpers import apply_minimum_mode, compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -81,12 +81,9 @@ class CustomPositionHandler(OverrideHandler):
                             ),
                             raw_calculated_position=raw,
                         )
-                    if min_mode:
-                        pos = max(self._position, raw)
-                        mode_note = f" [minimum mode — floor {self._position}%, calculated {raw}%]"
-                    else:
-                        pos = self._position
-                        mode_note = ""
+                    pos, mode_note = apply_minimum_mode(
+                        self._position, raw, enabled=min_mode
+                    )
                     return PipelineResult(
                         position=pos,
                         bypass_auto_control=True,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/force_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/force_override.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...enums import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import compute_raw_calculated_position
+from ..helpers import apply_minimum_mode, compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -28,12 +28,9 @@ class ForceOverrideHandler(OverrideHandler):
         active = [e for e, on in snapshot.force_override_sensors.items() if on]
         configured = snapshot.force_override_position
         raw = compute_raw_calculated_position(snapshot)
-        if snapshot.force_override_min_mode:
-            pos = max(configured, raw)
-            mode_note = f" [minimum mode — floor {configured}%, calculated {raw}%]"
-        else:
-            pos = configured
-            mode_note = ""
+        pos, mode_note = apply_minimum_mode(
+            configured, raw, enabled=snapshot.force_override_min_mode
+        )
         return PipelineResult(
             position=pos,
             control_method=ControlMethod.FORCE,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/weather.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/weather.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...enums import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import compute_raw_calculated_position
+from ..helpers import apply_minimum_mode, compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -34,12 +34,9 @@ class WeatherOverrideHandler(OverrideHandler):
         configured = snapshot.weather_override_position
         bypass = snapshot.weather_bypass_auto_control
         raw = compute_raw_calculated_position(snapshot)
-        if snapshot.weather_override_min_mode:
-            pos = max(configured, raw)
-            mode_note = f" [minimum mode — floor {configured}%, calculated {raw}%]"
-        else:
-            pos = configured
-            mode_note = ""
+        pos, mode_note = apply_minimum_mode(
+            configured, raw, enabled=snapshot.weather_override_min_mode
+        )
         reason = f"weather override active — position {pos}%{mode_note}"
         if bypass:
             reason += " [bypasses automatic control]"

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -1,11 +1,14 @@
 """Shared pipeline computation helpers.
 
-These module-level functions eliminate copy-paste of the three most repeated
+These module-level functions eliminate copy-paste of the most repeated
 patterns across pipeline handlers:
 
-- ``apply_snapshot_limits`` — apply position limits using config from the snapshot
-- ``compute_solar_position``  — calculate_percentage() + floor-at-1 + limits
+- ``apply_snapshot_limits``    — apply position limits using config from the snapshot
+- ``compute_solar_position``   — calculate_percentage() + floor-at-1 + limits
 - ``compute_default_position`` — default_position + limits (sun not in FOV)
+- ``apply_minimum_mode``       — pick max(configured, raw) when min-mode is on,
+                                 else just the configured value, plus a
+                                 reason-string suffix for diagnostics
 """
 
 from __future__ import annotations
@@ -92,6 +95,39 @@ def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
         snapshot.default_position,
         sun_valid=False,
     )
+
+
+def apply_minimum_mode(
+    configured: int,
+    raw: int,
+    *,
+    enabled: bool,
+) -> tuple[int, str]:
+    """Pick a position from the configured/raw pair under min-mode rules.
+
+    Several override handlers (force, weather, custom-position) support a
+    "minimum-mode" toggle: when on, the override acts as a *floor* under the
+    sun-tracked position rather than a hard target — covers go to whichever
+    is more closed (the configured override, or what solar tracking would do
+    anyway).  When off, the configured override is used as-is.
+
+    Args:
+        configured: User-configured override position (0–100).
+        raw:        The sun-tracked position the handler would otherwise yield.
+        enabled:    Whether minimum-mode is active for this handler instance.
+
+    Returns:
+        ``(position, reason_suffix)`` — the position to send and a short
+        diagnostic suffix to append to the handler's reason string. Suffix is
+        empty when minimum-mode is off so the reason reads cleanly.
+
+    """
+    if enabled:
+        return (
+            max(configured, raw),
+            f" [minimum mode — floor {configured}%, calculated {raw}%]",
+        )
+    return configured, ""
 
 
 def compute_default_position(snapshot: PipelineSnapshot) -> int:

--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from operator import ge, le
 from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 from ..helpers import get_domain, get_safe_state, state_attr
 
@@ -132,6 +134,35 @@ class ClimateProvider:
         self._logger.debug("is_sunny(): No weather condition defined")
         return True
 
+    def _read_numeric_threshold(
+        self,
+        *,
+        enabled: bool,
+        entity: str | None,
+        threshold: int | None,
+        comparison: Callable[[float, float], bool],
+        label: str,
+    ) -> bool:
+        """Compare an entity's numeric state to a threshold.
+
+        Shared shape used by lux / irradiance / cloud-coverage readings:
+        feature-flag gate, then read the entity, coerce to float, and compare
+        against the configured threshold. Non-numeric or unavailable values
+        return False so the climate snapshot stays bool-typed.
+        """
+        if not enabled or entity is None or threshold is None:
+            return False
+        value = get_safe_state(self._hass, entity)
+        if value is None:
+            return False
+        try:
+            return comparison(float(value), threshold)
+        except (ValueError, TypeError):
+            self._logger.debug(
+                "%s entity %s returned non-numeric value: %r", label, entity, value
+            )
+            return False
+
     def _read_lux(
         self,
         use_lux: bool,
@@ -139,20 +170,13 @@ class ClimateProvider:
         lux_threshold: int | None,
     ) -> bool:
         """Check if lux is at or below threshold (low light)."""
-        if not use_lux:
-            return False
-        if lux_entity is not None and lux_threshold is not None:
-            value = get_safe_state(self._hass, lux_entity)
-            if value is None:
-                return False
-            try:
-                return float(value) <= lux_threshold
-            except (ValueError, TypeError):
-                self._logger.debug(
-                    "Lux entity %s returned non-numeric value: %r", lux_entity, value
-                )
-                return False
-        return False
+        return self._read_numeric_threshold(
+            enabled=use_lux,
+            entity=lux_entity,
+            threshold=lux_threshold,
+            comparison=le,
+            label="Lux",
+        )
 
     def _read_irradiance(
         self,
@@ -161,22 +185,13 @@ class ClimateProvider:
         irradiance_threshold: int | None,
     ) -> bool:
         """Check if irradiance is at or below threshold (low radiation)."""
-        if not use_irradiance:
-            return False
-        if irradiance_entity is not None and irradiance_threshold is not None:
-            value = get_safe_state(self._hass, irradiance_entity)
-            if value is None:
-                return False
-            try:
-                return float(value) <= irradiance_threshold
-            except (ValueError, TypeError):
-                self._logger.debug(
-                    "Irradiance entity %s returned non-numeric value: %r",
-                    irradiance_entity,
-                    value,
-                )
-                return False
-        return False
+        return self._read_numeric_threshold(
+            enabled=use_irradiance,
+            entity=irradiance_entity,
+            threshold=irradiance_threshold,
+            comparison=le,
+            label="Irradiance",
+        )
 
     def _read_cloud_coverage(
         self,
@@ -185,19 +200,10 @@ class ClimateProvider:
         cloud_coverage_threshold: int | None,
     ) -> bool:
         """Check if cloud coverage is at or above threshold (overcast)."""
-        if not use_cloud_coverage:
-            return False
-        if cloud_coverage_entity is not None and cloud_coverage_threshold is not None:
-            value = get_safe_state(self._hass, cloud_coverage_entity)
-            if value is None:
-                return False
-            try:
-                return float(value) >= cloud_coverage_threshold
-            except (ValueError, TypeError):
-                self._logger.debug(
-                    "Cloud coverage entity %s returned non-numeric value: %r",
-                    cloud_coverage_entity,
-                    value,
-                )
-                return False
-        return False
+        return self._read_numeric_threshold(
+            enabled=use_cloud_coverage,
+            entity=cloud_coverage_entity,
+            threshold=cloud_coverage_threshold,
+            comparison=ge,
+            label="Cloud coverage",
+        )

--- a/tests/test_state/test_climate_provider.py
+++ b/tests/test_state/test_climate_provider.py
@@ -161,14 +161,14 @@ class TestPresence:
 
     @pytest.mark.unit
     def test_person_home(self, provider, mock_hass):
-        """person 'home' → True (regression guard for #313)."""
+        """Person 'home' → True (regression guard for #313)."""
         mock_hass.states.get.return_value = _mock_state("person.alice", "home")
         readings = provider.read(presence_entity="person.alice")
         assert readings.is_presence is True
 
     @pytest.mark.unit
     def test_person_away(self, provider, mock_hass):
-        """person 'not_home' → False (regression guard for #313)."""
+        """Person 'not_home' → False (regression guard for #313)."""
         mock_hass.states.get.return_value = _mock_state("person.alice", "not_home")
         readings = provider.read(presence_entity="person.alice")
         assert readings.is_presence is False


### PR DESCRIPTION
## Summary

Second tier of the code-review cleanup. Five small extractions, each replacing a copy-paste block with a single named helper. No public API or behavior changes.

- **pipeline/helpers.py — `apply_minimum_mode()`**: shared helper for the floor-vs-configured selection. Used by `force_override`, `weather`, and `custom_position` handlers (drops three near-identical 4-line if/else blocks).
- **helpers.py — `_INVALID_STATES`**: `frozenset({STATE_UNKNOWN, STATE_UNAVAILABLE})` constant in place of inline `["unknown", "unavailable"]` list literals across `get_safe_state` and `get_open_close_state`.
- **state/climate_provider.py — `_read_numeric_threshold()`**: shared shape for lux / irradiance / cloud-coverage. Three public methods are now thin wrappers parametrised by `operator.le` / `operator.ge`.
- **engine/sun_geometry.py — `_elevation_within_bounds()`**: extracts the bounded-case branch logic shared between scalar `valid_elevation` and Series-based `solar_times_with_position`. The "no bounds set" fallback stays inline at each callsite to preserve the intentional `>= 0` vs `> 0` horizon-line difference.
- **diagnostics/builder.py — split `_build_position`**: 55-line composite is now three focused helpers (`_build_position_base`, `_build_position_delta_time`, `_build_position_calc_details`) composed by the original method.

## Testing

- ✅ 2,536 tests passing
- ✅ `./scripts/lint` clean

## Note

Branches off `main`, not off `chore/tier1-cleanup` — files don't overlap, so this can land independently in either order.