### PR TITLE
feat: add hold_position mode to motion timeout

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -73,6 +73,10 @@ from .const import (
     CONF_MODE,
     CONF_MOTION_SENSORS,
     CONF_MOTION_TIMEOUT,
+    CONF_MOTION_TIMEOUT_MODE,
+    DEFAULT_MOTION_TIMEOUT_MODE,
+    MOTION_TIMEOUT_MODE_HOLD,
+    MOTION_TIMEOUT_MODE_RETURN,
     CONF_OPEN_CLOSE_THRESHOLD,
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
@@ -602,6 +606,15 @@ MOTION_OVERRIDE_SCHEMA = vol.Schema(
                 unit_of_measurement="seconds",
             )
         ),
+        vol.Optional(
+            CONF_MOTION_TIMEOUT_MODE, default=DEFAULT_MOTION_TIMEOUT_MODE
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[MOTION_TIMEOUT_MODE_RETURN, MOTION_TIMEOUT_MODE_HOLD],
+                mode=selector.SelectSelectorMode.LIST,
+                translation_key="motion_timeout_mode",
+            )
+        ),
     }
 )
 
@@ -931,7 +944,7 @@ def _format_duration(dur: dict | int | float | None) -> str:
     """
     if dur is None:
         return ""
-    if isinstance(dur, (int, float)):
+    if isinstance(dur, int | float):
         return f"{int(dur)} min"
     h = int(dur.get("hours", 0) or 0)
     m = int(dur.get("minutes", 0) or 0)
@@ -1397,13 +1410,25 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             )
 
     # Motion timeout (75)
+    timeout_mode = config.get(CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE)
     if has_motion:
         n = len(config.get(CONF_MOTION_SENSORS) or [])
         sensor_word = "sensor" if n == 1 else "sensors"
+        if timeout_mode == MOTION_TIMEOUT_MODE_HOLD:
+            action = (
+                "covers hold current position (return to default when sun leaves FOV)"
+            )
+        else:
+            action = f"covers return to default ({default_pos}%)"
         lines.append(
             f"🚶 Motion-based: if no occupancy for {motion_timeout}s "
-            f"({n} {sensor_word}) → covers return to default ({default_pos}%)"
+            f"({n} {sensor_word}) → {action}"
             f"{_badge(75)}"
+        )
+    elif timeout_mode == MOTION_TIMEOUT_MODE_HOLD:
+        lines.append(
+            "⚠️ hold_position mode is set but no motion sensors are configured "
+            "— the setting has no effect until sensors are added"
         )
 
     # Cloud suppression (60)
@@ -1850,6 +1875,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
     "motion_override_values": frozenset(
         {
             CONF_MOTION_TIMEOUT,
+            CONF_MOTION_TIMEOUT_MODE,
         }
     ),
     "motion_override_sensors": frozenset(
@@ -1862,6 +1888,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
         {
             CONF_MOTION_SENSORS,
             CONF_MOTION_TIMEOUT,
+            CONF_MOTION_TIMEOUT_MODE,
         }
     ),
     "weather_override_values": frozenset(

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -205,6 +205,10 @@ MAX_TRANSIT_TIMEOUT = 600
 
 # Motion control constants
 DEFAULT_MOTION_TIMEOUT = 300  # 5 minutes default timeout for no-motion detection
+CONF_MOTION_TIMEOUT_MODE = "motion_timeout_mode"
+MOTION_TIMEOUT_MODE_RETURN = "return_to_default"
+MOTION_TIMEOUT_MODE_HOLD = "hold_position"
+DEFAULT_MOTION_TIMEOUT_MODE = MOTION_TIMEOUT_MODE_RETURN
 
 # Weather override constants
 DEFAULT_WEATHER_WIND_SPEED_THRESHOLD = (

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -55,6 +55,8 @@ from .const import (
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_MOTION_SENSORS,
     CONF_MOTION_TIMEOUT,
+    CONF_MOTION_TIMEOUT_MODE,
+    DEFAULT_MOTION_TIMEOUT_MODE,
     CONF_WEATHER_WIND_SPEED_SENSOR,
     CONF_WEATHER_WIND_DIRECTION_SENSOR,
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
@@ -1103,6 +1105,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             my_position_value=options.get(CONF_MY_POSITION_VALUE),
             sunset_use_my=bool(options.get(CONF_SUNSET_USE_MY, False)),
             enable_sun_tracking=bool(options.get(CONF_ENABLE_SUN_TRACKING, True)),
+            motion_timeout_mode=options.get(
+                CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE
+            ),
+            current_cover_position=self._compute_mean_cover_position(),
         )
         self._pipeline_result = self._pipeline.evaluate(snapshot)
 
@@ -1299,6 +1305,24 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             diagnostics=diagnostics,
         )
 
+    def _compute_mean_cover_position(self) -> int | None:
+        """Return integer mean of current entity positions, or None if none are available.
+
+        Used to populate PipelineSnapshot.current_cover_position so the
+        MotionTimeoutHandler can hold covers at their current physical position
+        in hold_position mode.
+        """
+        if self._snapshot is None:
+            return None
+        positions = [
+            p
+            for p in self._snapshot.cover_positions.values()
+            if isinstance(p, int | float)
+        ]
+        if not positions:
+            return None
+        return int(round(sum(positions) / len(positions)))
+
     def _build_position_context(
         self,
         entity: str,
@@ -1356,6 +1380,38 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 else False
             ),
         )
+
+    async def _dispatch_to_cover(
+        self,
+        cover: str,
+        state: int,
+        reason: str,
+        ctx,
+    ) -> tuple[str, str] | None:
+        """Send a position command or record a hold-mode skip.
+
+        When the active pipeline result has skip_command=True (hold_position
+        mode during motion timeout), no command is issued. A motion_hold skip
+        record is written instead so diagnostics show why the cover didn't move.
+        All other callers (forced transitions, override clears, window events)
+        bypass this helper and call apply_position directly so they are never
+        blocked by hold mode.
+        """
+        if self._pipeline_result is not None and self._pipeline_result.skip_command:
+            self._cmd_svc.record_skipped_action(
+                cover,
+                "motion_hold",
+                state,
+                trigger=reason,
+                inverse_state=self._inverse_state,
+                extras={
+                    "held_position": self._pipeline_result.position,
+                    "would_be_position": state,
+                    "motion_timeout_mode": "hold_position",
+                },
+            )
+            return None
+        return await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
 
     async def _async_send_after_override_clear(
         self,
@@ -1492,7 +1548,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 is_safety=is_safety,
                 sun_just_appeared=sun_just_appeared,
             )
-            await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
+            await self._dispatch_to_cover(cover, state, reason, ctx)
         self.state_change = False
         self.logger.debug("State change handled")
 
@@ -1611,7 +1667,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 is_safety=is_safety,
                 sun_just_appeared=sun_just_appeared,
             )
-            await self._cmd_svc.apply_position(cover, state, "startup", context=ctx)
+            await self._dispatch_to_cover(cover, state, "startup", ctx)
         self.first_refresh = False
         self._is_reload = False
         self.logger.debug("First refresh handled")
@@ -2001,6 +2057,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             config_options=dict(self.config_entry.options),
             motion_detected=self.is_motion_detected,
             motion_timeout_active=self._motion_mgr._motion_timeout_active,
+            motion_hold_active=(
+                self._pipeline_result is not None
+                and self._pipeline_result.skip_command
+                and self._pipeline_result.control_method == ControlMethod.MOTION
+            ),
             force_override_sensors=self.config_entry.options.get(
                 CONF_FORCE_OVERRIDE_SENSORS, []
             ),

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -63,6 +63,7 @@ class DiagnosticContext:
     # Motion manager state
     motion_detected: bool = True
     motion_timeout_active: bool = False
+    motion_hold_active: bool = False
 
     # Force override config
     force_override_sensors: list = field(default_factory=list)
@@ -386,7 +387,7 @@ class DiagnosticsBuilder:
             # Round temperatures to 1 decimal — presentation boundary.
             raw_temp = climate_data.get_current_temperature
             diagnostics["active_temperature"] = (
-                round(raw_temp, 1) if isinstance(raw_temp, (int, float)) else raw_temp
+                round(raw_temp, 1) if isinstance(raw_temp, int | float) else raw_temp
             )
 
             def _round_temp(val: object) -> object:
@@ -557,6 +558,7 @@ class DiagnosticsBuilder:
                 ),
                 "motion_detected": ctx.motion_detected,
                 "motion_timeout_active": ctx.motion_timeout_active,
+                "motion_hold_active": ctx.motion_hold_active,
                 "manual_toggle": ctx.manual_toggle,
                 "enabled_toggle": ctx.enabled_toggle,
                 "cloud_suppression_enabled": options.get(CONF_CLOUD_SUPPRESSION, False),

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -1,9 +1,7 @@
 {
   "domain": "adaptive_cover_pro",
   "name": "Adaptive Cover Pro",
-  "codeowners": [
-    "@jrhubott"
-  ],
+  "codeowners": ["@jrhubott"],
   "config_flow": true,
   "dependencies": [
     "sun",
@@ -16,9 +14,6 @@
   "documentation": "https://github.com/jrhubott/adaptive-cover-pro",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
-  "requirements": [
-    "astral",
-    "pandas"
-  ],
+  "requirements": ["astral", "pandas"],
   "version": "2.19.0-beta.2"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.19.0-beta.2"
+  "version": "2.19.0-beta.3"
 }

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -25,6 +25,26 @@ class MotionTimeoutHandler(OverrideHandler):
             return None
         if not snapshot.motion_timeout_active:
             return None
+
+        # Hold-position mode: freeze the cover at its current physical position
+        # while the sun is actively in the FOV. When the sun leaves (or the time
+        # window closes), fall through to the return_to_default branch below so
+        # the cover returns to default without requiring motion re-detection.
+        if (
+            snapshot.motion_timeout_mode == "hold_position"
+            and snapshot.in_time_window
+            and snapshot.cover.direct_sun_valid
+            and snapshot.current_cover_position is not None
+        ):
+            held = snapshot.current_cover_position
+            return PipelineResult(
+                position=held,
+                control_method=ControlMethod.MOTION,
+                reason=f"motion timeout — holding position {held}% (sun in FOV)",
+                skip_command=True,
+                raw_calculated_position=compute_raw_calculated_position(snapshot),
+            )
+
         position = compute_default_position(snapshot)
         pos_label = (
             "sunset position" if snapshot.is_sunset_active else "default position"

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -153,6 +153,16 @@ class PipelineSnapshot:
     my_position_value: int | None = None
     sunset_use_my: bool = False
 
+    # Motion timeout mode:
+    #   "return_to_default" (default) — handler sends the configured default position
+    #   "hold_position" — handler emits skip_command=True so the cover stays put while
+    #     the sun is active; falls through to default when sun leaves FOV or window closes.
+    motion_timeout_mode: str = "return_to_default"
+
+    # Mean of current entity positions (int-rounded). None when no entity reports a
+    # numeric position. Read by MotionTimeoutHandler in hold_position mode only.
+    current_cover_position: int | None = None
+
 
 # ---------------------------------------------------------------------------
 # Output types
@@ -212,3 +222,8 @@ class PipelineResult:
     # (cover.stop_cover while stationary → triggers the Somfy "My" hardware preset).
     # Position-capable covers gracefully fall through to set_cover_position(position).
     use_my_position: bool = False
+
+    # When True, the coordinator must NOT issue a cover command this cycle.
+    # Used by hold-mode handlers (e.g. MotionTimeoutHandler with hold_position) to
+    # record the decision in diagnostics while leaving the cover physically untouched.
+    skip_command: bool = False

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -541,6 +541,9 @@ def _motion_status_value(s: _ACPDiagnosticSensor) -> str:
         return "not_configured"
     mgr = s.coordinator._motion_mgr  # noqa: SLF001
     if mgr._motion_timeout_active:  # noqa: SLF001
+        pr = getattr(s.coordinator, "_pipeline_result", None)
+        if pr is not None and pr.skip_command and pr.control_method.value == "motion":
+            return "holding"
         return "no_motion"
     if mgr.last_motion_time is None:
         return "waiting_for_data"

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -220,11 +220,13 @@
         "description": "Aktivieren Sie anwesenheitsbasierte Steuerung. Wenn alle konfigurierten Sensoren keine Bewegung melden, stoppt die Integration die Sonnenverfolgung und bewegt Beschattungselemente nach Ablauf des Timeouts in ihre Standardposition. Wenn ein Sensor Bewegung erkennt, wird die automatische Positionierung fortgesetzt.\n\nJede Mischung aus Bewegungs-, Anwesenheits- oder Binär-Präsenzsensoren kann verwendet werden. Die Logik ist ODER — jeder einzelne aktive Sensor zählt als anwesend. Dies ist nützlich für Räume, in denen Sie nicht möchten, dass sich Beschattungselemente anpassen, wenn niemand anwesend ist.\n\n[Weitere Informationen]({learn_more})",
         "data": {
           "motion_sensors": "Bewegungs-/Belegungssensoren für belegungsbasierte Steuerung",
-          "motion_timeout": "Bewegungs-Timeout-Dauer"
+          "motion_timeout": "Bewegungs-Timeout-Dauer",
+          "motion_timeout_mode": "Wenn die Bewegung zeitlich abläuft"
         },
         "data_description": {
           "motion_sensors": "Binärsensoren, die die automatische Sonnenposititionierung aktivieren/deaktivieren, basierend auf Belegung. Wenn EIN Sensor Bewegung erkennt, verwenden Beschattungen automatische sonnenbasierte Positionierung. Wenn ALLE Sensoren für die Timeout-Dauer keine Bewegung anzeigen, kehren Beschattungen zur Standardposition zurück. Leer lassen, um diese Funktion zu deaktivieren.",
-          "motion_timeout": "Dauer (in Sekunden), die gewartet werden soll, nachdem die letzte Bewegung erkannt wurde, bevor Beschattungen zur Standardposition zurückkehren. Verhindert schnelle Positionsänderungen, wenn Bewegungssensoren häufig wechseln. Bereich: 30-3600 Sekunden (0,5-60 Minuten). Standardwert: 300 Sekunden (5 Minuten)."
+          "motion_timeout": "Dauer (in Sekunden), die gewartet werden soll, nachdem die letzte Bewegung erkannt wurde, bevor Beschattungen zur Standardposition zurückkehren. Verhindert schnelle Positionsänderungen, wenn Bewegungssensoren häufig wechseln. Bereich: 30-3600 Sekunden (0,5-60 Minuten). Standardwert: 300 Sekunden (5 Minuten).",
+          "motion_timeout_mode": "Aktion, wenn keine Bewegung für die eingestellte Dauer erkannt wird. „Standardposition zurückkehren\" fährt die Jalousien in die Standardposition. „Position halten\" behält die aktuelle Position bei, während die Sonne im Sichtfeld ist (damit eine zurückkehrende Person die Jalousien so findet, wie sie sie hinterlassen hat). Die Jalousien kehren trotzdem zur Standardposition zurück, wenn die Sonne das Sichtfeld verlässt oder das Zeitfenster endet."
         }
       },
       "weather_override": {
@@ -706,11 +708,13 @@
         "description": "Aktivieren Sie anwesenheitsbasierte Steuerung. Wenn alle konfigurierten Sensoren keine Bewegung melden, stoppt die Integration die Sonnenverfolgung und bewegt Beschattungselemente nach Ablauf des Timeouts in ihre Standardposition. Wenn ein Sensor Bewegung erkennt, wird die automatische Positionierung fortgesetzt.\n\nJede Mischung aus Bewegungs-, Anwesenheits- oder Binär-Präsenzsensoren kann verwendet werden. Die Logik ist ODER — jeder einzelne aktive Sensor zählt als anwesend. Dies ist nützlich für Räume, in denen Sie nicht möchten, dass sich Beschattungselemente anpassen, wenn niemand anwesend ist.\n\n[Weitere Informationen]({learn_more})",
         "data": {
           "motion_sensors": "Bewegungs-/Belegungssensoren für belegungsbasierte Steuerung",
-          "motion_timeout": "Bewegungs-Timeout-Dauer"
+          "motion_timeout": "Bewegungs-Timeout-Dauer",
+          "motion_timeout_mode": "Wenn die Bewegung zeitlich abläuft"
         },
         "data_description": {
           "motion_sensors": "Binärsensoren, die die automatische Sonnenverfolgung basierend auf Anwesenheit aktivieren/deaktivieren. Wenn EIN Sensor Bewegung erkennt, verwenden Behänge automatische sonnengesteuerte Positionierung. Wenn ALLE Sensoren zeigen, dass keine Bewegung für die Timeout-Dauer vorhanden ist, kehren Behänge zu Standardposition zurück. Leer lassen, um diese Funktion zu deaktivieren.",
-          "motion_timeout": "Dauer (in Sekunden), um nach der letzten Bewegung zu warten, bevor Behänge zur Standardposition zurückkehren. Verhindert schnelle Positionsänderungen, wenn Bewegungssensoren häufig umschalten. Bereich: 30–3600 Sekunden (0,5–60 Minuten). Standard: 300 Sekunden (5 Minuten)."
+          "motion_timeout": "Dauer (in Sekunden), um nach der letzten Bewegung zu warten, bevor Behänge zur Standardposition zurückkehren. Verhindert schnelle Positionsänderungen, wenn Bewegungssensoren häufig umschalten. Bereich: 30–3600 Sekunden (0,5–60 Minuten). Standard: 300 Sekunden (5 Minuten).",
+          "motion_timeout_mode": "Aktion, wenn keine Bewegung für die eingestellte Dauer erkannt wird. „Standardposition zurückkehren\" fährt die Jalousien in die Standardposition. „Position halten\" behält die aktuelle Position bei, während die Sonne im Sichtfeld ist (damit eine zurückkehrende Person die Jalousien so findet, wie sie sie hinterlassen hat). Die Jalousien kehren trotzdem zur Standardposition zurück, wenn die Sonne das Sichtfeld verlässt oder das Zeitfenster endet."
         }
       },
       "weather_override": {
@@ -983,7 +987,8 @@
           "motion_detected": "Bewegung erkannt",
           "timeout_pending": "Timeout ausstehend",
           "no_motion": "Keine Bewegung",
-          "waiting_for_data": "Warten auf Daten"
+          "waiting_for_data": "Warten auf Daten",
+          "holding": "Position wird gehalten"
         }
       },
       "decision_trace": {
@@ -1098,6 +1103,12 @@
         "custom_position": "Benutzerdefinierte Positionen",
         "motion_override": "Bewegungsübersteuerung",
         "weather_override": "Wetter-Übersteuerung"
+      }
+    },
+    "motion_timeout_mode": {
+      "options": {
+        "return_to_default": "Standardposition zurückkehren",
+        "hold_position": "Aktuelle Position halten"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -220,11 +220,13 @@
         "description": "Enable occupancy-based control. When all configured sensors report no motion, the integration stops sun tracking and moves covers to their default position after the timeout expires. When any sensor detects motion, automatic positioning resumes.\n\nAny mix of motion, occupancy, or binary presence sensors can be used. The logic is OR — any single active sensor counts as occupied. This is useful for rooms where you don't want covers adjusting when nobody is present.\n\n[Learn more]({learn_more})",
         "data": {
           "motion_sensors": "Motion/occupancy sensors for occupancy-based control",
-          "motion_timeout": "Motion timeout duration"
+          "motion_timeout": "Motion timeout duration",
+          "motion_timeout_mode": "When motion times out"
         },
         "data_description": {
           "motion_sensors": "Binary sensors that enable/disable automatic sun positioning based on occupancy. When ANY sensor detects motion, covers use automatic sun-based positioning. When ALL sensors show no motion for the timeout duration, covers return to default position. Leave empty to disable this feature.",
-          "motion_timeout": "Duration (in seconds) to wait after last motion before returning covers to default position. Prevents rapid position changes when motion sensors toggle frequently. Range: 30-3600 seconds (0.5-60 minutes). Default: 300 seconds (5 minutes)."
+          "motion_timeout": "Duration (in seconds) to wait after last motion before returning covers to default position. Prevents rapid position changes when motion sensors toggle frequently. Range: 30-3600 seconds (0.5-60 minutes). Default: 300 seconds (5 minutes).",
+          "motion_timeout_mode": "What to do when motion has been absent for the timeout duration. 'Return to default' moves covers to the default position. 'Hold position' leaves covers where they are while the sun is in the FOV (so an occupant who returns finds them how they left them); covers still return to default once the sun leaves the FOV or the time window closes."
         }
       },
       "weather_override": {
@@ -706,11 +708,13 @@
         "description": "Enable occupancy-based control. When all configured sensors report no motion, the integration stops sun tracking and moves covers to their default position after the timeout expires. When any sensor detects motion, automatic positioning resumes.\n\nAny mix of motion, occupancy, or binary presence sensors can be used. The logic is OR — any single active sensor counts as occupied. This is useful for rooms where you don't want covers adjusting when nobody is present.\n\n[Learn more]({learn_more})",
         "data": {
           "motion_sensors": "Motion/occupancy sensors for occupancy-based control",
-          "motion_timeout": "Motion timeout duration"
+          "motion_timeout": "Motion timeout duration",
+          "motion_timeout_mode": "When motion times out"
         },
         "data_description": {
           "motion_sensors": "Binary sensors that enable/disable automatic sun positioning based on occupancy. When ANY sensor detects motion, covers use automatic sun-based positioning. When ALL sensors show no motion for the timeout duration, covers return to default position. Leave empty to disable this feature.",
-          "motion_timeout": "Duration (in seconds) to wait after last motion before returning covers to default position. Prevents rapid position changes when motion sensors toggle frequently. Range: 30-3600 seconds (0.5-60 minutes). Default: 300 seconds (5 minutes)."
+          "motion_timeout": "Duration (in seconds) to wait after last motion before returning covers to default position. Prevents rapid position changes when motion sensors toggle frequently. Range: 30-3600 seconds (0.5-60 minutes). Default: 300 seconds (5 minutes).",
+          "motion_timeout_mode": "What to do when motion has been absent for the timeout duration. 'Return to default' moves covers to the default position. 'Hold position' leaves covers where they are while the sun is in the FOV (so an occupant who returns finds them how they left them); covers still return to default once the sun leaves the FOV or the time window closes."
         }
       },
       "weather_override": {
@@ -983,6 +987,7 @@
           "motion_detected": "Motion Detected",
           "timeout_pending": "Timeout Pending",
           "no_motion": "No Motion",
+          "holding": "Holding Position",
           "waiting_for_data": "Waiting for Data"
         }
       },
@@ -1098,6 +1103,12 @@
         "custom_position": "Custom Positions",
         "motion_override": "Motion Override",
         "weather_override": "Weather Override"
+      }
+    },
+    "motion_timeout_mode": {
+      "options": {
+        "return_to_default": "Return to default position",
+        "hold_position": "Hold current position"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -220,11 +220,13 @@
         "description": "Activez le contrôle basé sur l'occupance. Lorsque tous les capteurs configurés signalent l'absence de mouvement, l'intégration arrête le suivi du soleil et déplace les protections à leur position par défaut après l'expiration du délai d'attente. Lorsqu'un capteur détecte un mouvement, le positionnement automatique reprend.\n\nN'importe quel mélange de capteurs de mouvement, d'occupance ou de présence binaire peut être utilisé. La logique est OU — n'importe quel capteur actif compte comme occupé. Ceci est utile pour les pièces où vous ne voulez pas que les protections s'ajustent lorsque personne n'est présent.\n\n[Learn more]({learn_more})",
         "data": {
           "motion_sensors": "Capteurs de mouvement/occupation pour le contrôle basé sur l'occupation",
-          "motion_timeout": "Durée du délai d'inactivité du mouvement"
+          "motion_timeout": "Durée du délai d'inactivité du mouvement",
+          "motion_timeout_mode": "Lors de l'expiration du délai de mouvement"
         },
         "data_description": {
           "motion_sensors": "Capteurs binaires qui activent/désactivent le positionnement solaire automatique en fonction de l'occupation. Quand N'IMPORTE QUEL capteur détecte le mouvement, les stores utilisent le positionnement automatique basé sur le soleil. Quand TOUS les capteurs n'indiquent aucun mouvement pendant la durée du délai, les stores retournent à la position par défaut. Laissez vide pour désactiver cette fonction.",
-          "motion_timeout": "Durée (en secondes) à attendre après le dernier mouvement avant de retourner les stores à la position par défaut. Empêche les changements rapides de position quand les capteurs de mouvement basculent fréquemment. Plage : 30-3600 secondes (0,5-60 minutes). Par défaut : 300 secondes (5 minutes)."
+          "motion_timeout": "Durée (en secondes) à attendre après le dernier mouvement avant de retourner les stores à la position par défaut. Empêche les changements rapides de position quand les capteurs de mouvement basculent fréquemment. Plage : 30-3600 secondes (0,5-60 minutes). Par défaut : 300 secondes (5 minutes).",
+          "motion_timeout_mode": "Action à effectuer lorsqu'aucun mouvement n'a été détecté pendant la durée du délai. « Retourner à la position par défaut » déplace les stores à la position par défaut. « Maintenir la position » laisse les stores où ils sont tandis que le soleil est dans le champ de vision (de sorte qu'un occupant qui revient les trouve comme il les a laissés) ; les stores retournent néanmoins à la position par défaut une fois que le soleil quitte le champ de vision ou que la fenêtre de temps se ferme."
         }
       },
       "weather_override": {
@@ -706,11 +708,13 @@
         "description": "Activez le contrôle basé sur l'occupance. Lorsque tous les capteurs configurés signalent l'absence de mouvement, l'intégration arrête le suivi du soleil et déplace les protections à leur position par défaut après l'expiration du délai d'attente. Lorsqu'un capteur détecte un mouvement, le positionnement automatique reprend.\n\nN'importe quel mélange de capteurs de mouvement, d'occupance ou de présence binaire peut être utilisé. La logique est OU — n'importe quel capteur actif compte comme occupé. Ceci est utile pour les pièces où vous ne voulez pas que les protections s'ajustent lorsque personne n'est présent.\n\n[Learn more]({learn_more})",
         "data": {
           "motion_sensors": "Capteurs de mouvement/occupation pour le contrôle basé sur l'occupation",
-          "motion_timeout": "Durée du délai d'inactivité du mouvement"
+          "motion_timeout": "Durée du délai d'inactivité du mouvement",
+          "motion_timeout_mode": "Lors de l'expiration du délai de mouvement"
         },
         "data_description": {
           "motion_sensors": "Capteurs binaires qui activent/désactivent le positionnement solaire automatique en fonction de l'occupation. Quand N'IMPORTE QUEL capteur détecte le mouvement, les stores utilisent le positionnement automatique basé sur le soleil. Quand TOUS les capteurs n'indiquent aucun mouvement pendant la durée du délai, les stores retournent à la position par défaut. Laissez vide pour désactiver cette fonction.",
-          "motion_timeout": "Durée (en secondes) à attendre après le dernier mouvement avant de retourner les stores à la position par défaut. Empêche les changements rapides de position quand les capteurs de mouvement basculent fréquemment. Plage : 30-3600 secondes (0,5-60 minutes). Par défaut : 300 secondes (5 minutes)."
+          "motion_timeout": "Durée (en secondes) à attendre après le dernier mouvement avant de retourner les stores à la position par défaut. Empêche les changements rapides de position quand les capteurs de mouvement basculent fréquemment. Plage : 30-3600 secondes (0,5-60 minutes). Par défaut : 300 secondes (5 minutes).",
+          "motion_timeout_mode": "Action à effectuer lorsqu'aucun mouvement n'a été détecté pendant la durée du délai. « Retourner à la position par défaut » déplace les stores à la position par défaut. « Maintenir la position » laisse les stores où ils sont tandis que le soleil est dans le champ de vision (de sorte qu'un occupant qui revient les trouve comme il les a laissés) ; les stores retournent néanmoins à la position par défaut une fois que le soleil quitte le champ de vision ou que la fenêtre de temps se ferme."
         }
       },
       "weather_override": {
@@ -983,7 +987,8 @@
           "motion_detected": "Mouvement détecté",
           "timeout_pending": "Délai en cours",
           "no_motion": "Aucun mouvement",
-          "waiting_for_data": "En attente de données"
+          "waiting_for_data": "En attente de données",
+          "holding": "Maintien de la position"
         }
       },
       "decision_trace": {
@@ -1098,6 +1103,12 @@
         "custom_position": "Positions personnalisées",
         "motion_override": "Dérogation mouvement",
         "weather_override": "Dérogation météo"
+      }
+    },
+    "motion_timeout_mode": {
+      "options": {
+        "return_to_default": "Retourner à la position par défaut",
+        "hold_position": "Maintenir la position actuelle"
       }
     }
   },

--- a/release_notes/v2.19.0-beta.3.md
+++ b/release_notes/v2.19.0-beta.3.md
@@ -1,0 +1,128 @@
+## 🎯 Config Flow UX Overhaul, Hold Position on Vacancy, and Bug Fixes
+
+Beta.3 adds a `hold_position` mode to motion control: when occupancy is lost, the
+cover freezes at its current physical position instead of returning to default. Control
+resumes and snaps to the calculated position when occupancy is re-detected (#333).
+
+### 🔑 Highlights
+
+- Every setup and options screen now shows a contextual description with a [Learn more] link to the correct wiki page, reducing the need to leave HA to understand each setting.
+- The options flow now shows the instance name at the top so you always know which cover you're configuring.
+- Motion, on/off, and numeric entity selectors now accept a wider range of domains (`device_tracker`, `person`, `zone`, `switch`, `schedule`, `input_number`) so non-standard setups require fewer workarounds (#319).
+- Clearing a custom position slot's sensor, position, or priority in the UI now actually clears it — previously the old value was silently kept (#323).
+- Transit timeout is now included when syncing Manual Override settings to other covers.
+- Covers with `sill_height` configured no longer close fully when the sill blocks all sun penetration at low elevations — they raise to 100% (open) instead (#304).
+- New `hold_position` mode for motion timeout: covers freeze at their current physical position when occupancy is lost, then resume when occupancy is re-detected (#333).
+
+### ✨ Features
+
+- **Hold position on vacancy (`hold_position` motion timeout mode) (#333):**
+  A new `motion_timeout_mode` option in the Motion Override config step controls what
+  happens when the motion timeout expires. `return_to_default` (the existing behavior)
+  sends the cover to its default position. `hold_position` (new) leaves the cover
+  exactly where it is — no move is issued. When occupancy is re-detected, control
+  resumes and the cover moves to the currently calculated position. The hold exits
+  naturally when the active time window closes or the sun leaves the window's field of
+  view. A new `"holding"` state on the `motion_status` sensor shows when hold is active,
+  and `motion_hold_active` is included in the diagnostics download for troubleshooting.
+
+- **Widen entity selector domains for on/off, numeric, and motion inputs (#319):**
+  Config flow selectors for on/off fields (force override, weather, presence, custom
+  position, and motion) previously accepted only `binary_sensor` and `input_boolean`.
+  They now also accept `device_tracker`, `person`, `zone`, `switch`, and `schedule`.
+  Numeric fields (lux, irradiance, temperature) now accept `sensor` and `input_number`
+  across the board. Motion detection is backed by a shared `is_entity_active()` helper
+  extracted from `ClimateProvider`, so all entity types are evaluated consistently
+  across the pipeline.
+
+- **Instance name in options flow menu:**
+  The options flow main menu now displays the config entry title (cover name) as a
+  subtitle so you can immediately confirm which cover you're editing when multiple
+  instances are configured.
+
+- **Contextual descriptions and wiki links on every config/options screen:**
+  Every step in both the initial setup wizard and the options flow now includes a
+  description explaining the purpose of the screen and its key fields. Each screen
+  carries a {learn_more} link that resolves to the correct wiki page at runtime —
+  type-specific pages (Vertical / Horizontal / Tilt) for the Geometry screen.
+  All descriptions are translated into DE and FR.
+
+### 🐛 Bug Fixes
+
+- **Sill height causes cover to fully close at low sun elevations (#304):**
+  When `sill_height` is configured and the sill alone intercepts all sun penetration
+  into the protected zone (common at low sun elevations, ~45° and below), the engine
+  previously clamped `effective_distance` to zero, producing `position=0%` (fully
+  closed). The correct geometric answer is `100%` (fully raised/open) — the sill
+  handles all blocking, so the blind is not needed. The fix short-circuits to `h_win`
+  (fully raised) when `sill_height > 0` and `effective_distance ≤ 0`. Behavior is
+  unchanged when `sill_height=0`. Awnings inherit the fix via `super()`, returning
+  `length=0` (retracted), which is also correct.
+
+  ⚠️ **If you enabled `inverse_state=True` as a workaround for this bug, disable it
+  after updating.** The `inverse_state` option remains valid only for covers where HA
+  itself reports position in reverse (0=open, 100=closed).
+
+- **Custom position slot fields not cleared when user empties them (#323):**
+  Clearing a slot's sensor, target position, or priority in the UI silently kept the
+  previous value because `dict.update()` was called without first coercing
+  Voluptuous-optional keys to `None`. A shared `_CUSTOM_POSITION_OPTIONAL_KEYS` list
+  now ensures both the initial setup and options flows zero out omitted fields.
+
+- **Transit timeout dropped when syncing Manual Override settings:**
+  `CONF_TRANSIT_TIMEOUT` was part of `MANUAL_OVERRIDE_SCHEMA` but absent from the
+  `manual_override` frozenset in `SYNC_CATEGORIES`. Copying Manual Override settings
+  to other covers silently omitted the transit timeout. It is now included.
+
+- **Last action sensor showed UTC time instead of local time:**
+  The last cover action timestamp was formatted from a UTC-aware datetime without
+  converting to the HA local timezone first, so users in non-UTC zones saw the wrong
+  time. The sensor now converts to local time before formatting.
+
+- **HASSFEST rejects literal URLs in translation strings:**
+  Wiki links added as `[Learn more](URL)` in translation strings were rejected by
+  `hassfest`. All URLs are now injected at runtime via `description_placeholders`
+  (`{learn_more}`), keeping translation files URL-free.
+
+### 🧹 Chores
+
+- **Tier 1 cleanup (#320):** Typo fixes, dead-code removal, type-hint tightening, and
+  enum-lookup simplification across `coordinator.py`, helpers, and the pipeline. Pure
+  hygiene — no runtime behavior change.
+
+- **Tier 2 DRY extractions (#321):** Pulls duplicated logic into shared helpers in
+  `pipeline/helpers.py` (notably `apply_minimum_mode()`, used by force, weather, and
+  custom-position handlers). Override handlers now route min-mode floor/reason through
+  one canonical path instead of three near-identical inline blocks.
+
+- **Tier 3 — deduplicate custom-position 4-slot scaffolding (#322):** Centralizes the
+  on-disk wire-format key names for the four custom-position slots into a single
+  `CUSTOM_POSITION_SLOTS` map in `const.py`. Coordinator, config flow, options
+  service, sensor enablement, and `__init__.py` all iterate the map instead of
+  unpacking parallel 20-line tuple tables. Existing config_entry option keys are
+  unchanged, so no migration is needed.
+
+- **Standardize MotionManager timestamps:** All five timestamp call sites in
+  `MotionManager` now route through a single `_now()` UTC-aware helper, replacing a
+  mix of naive `datetime.now().timestamp()` floats and aware `datetime.now(dt.UTC)`
+  calls. Behavior is identical; the manager now has one timestamp source.
+
+- **Typed `CustomPositionSensorState` replaces the 6-tuple in `PipelineSnapshot`:**
+  The per-slot sensor reading carried in `PipelineSnapshot` was a positional
+  `tuple[str, bool, bool, int, int, bool, bool]` that became brittle as fields accumulated.
+  It is now a frozen `CustomPositionSensorState` dataclass with named fields, matching
+  the snapshot's existing `ClimateOptions` style.
+
+- **Dict-driven spec/factory for sensor, switch, and binary_sensor platforms:**
+  Entity construction is now driven by a central spec dictionary instead of inline
+  conditionals, making it easier to add new entity types without touching multiple
+  callsites.
+
+- **Collapse `CoverCommandService` per-entity dicts into `PerEntityState`:**
+  Per-entity mutable state (last command time, last position, retry counters) is now
+  grouped in a `PerEntityState` dataclass instead of spread across three parallel
+  dicts. Behavior is unchanged.
+
+### 🧪 Testing
+
+- 2607 tests passing

--- a/scripts/release
+++ b/scripts/release
@@ -534,10 +534,13 @@ update_manifest_version() {
         return 0
     fi
 
-    # Update version using jq (preserves formatting)
+    # Update version using jq, then re-format with prettier so pre-commit is a no-op
     local tmp_file="${MANIFEST_FILE}.tmp"
     jq --arg version "$new_version" '.version = $version' "$MANIFEST_FILE" > "$tmp_file"
     mv "$tmp_file" "$MANIFEST_FILE"
+    if command -v npx &> /dev/null; then
+        npx prettier --write "$MANIFEST_FILE" &> /dev/null || true
+    fi
 
     log_success "Updated $MANIFEST_FILE to version $new_version"
 }

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1892,3 +1892,51 @@ def test_cloudy_position_no_warning_when_suppression_on():
         (ln for ln in summary.splitlines() if "Cloud suppression" in ln), ""
     )
     assert "⚠️" not in cloud_line
+
+
+# ---------------------------------------------------------------------------
+# Motion timeout mode (issue #333)
+# ---------------------------------------------------------------------------
+
+
+def test_motion_summary_default_mode_says_return_to_default():
+    """Default mode shows 'return to default' in motion bullet."""
+    cfg = {
+        CONF_MOTION_SENSORS: ["binary_sensor.motion"],
+        CONF_MOTION_TIMEOUT: 120,
+        CONF_DEFAULT_HEIGHT: 45,
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    motion_line = next((ln for ln in summary.splitlines() if "Motion-based" in ln), "")
+    assert "return to default" in motion_line.lower()
+
+
+def test_motion_summary_hold_mode_says_hold_position():
+    """hold_position mode shows a hold description in motion bullet."""
+    from custom_components.adaptive_cover_pro.const import CONF_MOTION_TIMEOUT_MODE
+
+    cfg = {
+        CONF_MOTION_SENSORS: ["binary_sensor.motion"],
+        CONF_MOTION_TIMEOUT: 120,
+        CONF_DEFAULT_HEIGHT: 45,
+        CONF_MOTION_TIMEOUT_MODE: "hold_position",
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    motion_line = next((ln for ln in summary.splitlines() if "Motion-based" in ln), "")
+    assert "hold" in motion_line.lower()
+
+
+def test_motion_summary_hold_mode_no_sensors_shows_warning():
+    """hold_position mode with no sensors shows a ⚠️ warning."""
+    from custom_components.adaptive_cover_pro.const import CONF_MOTION_TIMEOUT_MODE
+
+    cfg = {
+        CONF_MOTION_SENSORS: [],
+        CONF_MOTION_TIMEOUT_MODE: "hold_position",
+    }
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert (
+        "⚠️" in summary
+        and "hold_position" in summary.lower()
+        or ("hold_position" in summary or "hold position" in summary.lower())
+    )

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -73,6 +73,15 @@ def _make_coordinator(
     coordinator._cmd_svc.apply_position = AsyncMock(
         return_value=("sent", "set_cover_position")
     )
+
+    # _dispatch_to_cover wraps apply_position; mock it to delegate so tests that
+    # assert on apply_position continue to work unchanged.
+    async def _dispatch_side_effect(cover, state, reason, ctx):
+        return await coordinator._cmd_svc.apply_position(
+            cover, state, reason, context=ctx
+        )
+
+    coordinator._dispatch_to_cover = AsyncMock(side_effect=_dispatch_side_effect)
     # Default: cold-start (not a reload).  Tests that want reload behaviour
     # must set coordinator._is_reload = True explicitly.
     coordinator._is_reload = False

--- a/tests/test_debug_diagnostics.py
+++ b/tests/test_debug_diagnostics.py
@@ -15,6 +15,7 @@ from custom_components.adaptive_cover_pro.diagnostics.builder import (
     DiagnosticContext,
     DiagnosticsBuilder,
 )
+from custom_components.adaptive_cover_pro.pipeline.types import DecisionStep
 from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
 from custom_components.adaptive_cover_pro.managers.manual_override import (
     AdaptiveCoverManager,
@@ -774,3 +775,56 @@ class TestTrackActionEnrichment:
         )
         svc._track_action("cover.test", "set_cover_position", 50, True)
         assert svc.last_cover_action["timestamp"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Motion hold diagnostics (issue #333)
+# ---------------------------------------------------------------------------
+
+
+class TestMotionHoldDiagnostics:
+    """DiagnosticContext and builder correctly surface hold_position mode state."""
+
+    def test_motion_hold_active_defaults_false(self):
+        """motion_hold_active defaults to False on DiagnosticContext."""
+        ctx = _base_ctx()
+        assert ctx.motion_hold_active is False
+
+    def test_motion_hold_active_can_be_set_true(self):
+        """motion_hold_active can be set True when pipeline is in hold mode."""
+        ctx = _base_ctx(motion_hold_active=True)
+        assert ctx.motion_hold_active is True
+
+    def test_build_configuration_emits_motion_hold_active_false(self):
+        """_build_configuration includes motion_hold_active=False by default."""
+        ctx = _base_ctx(motion_hold_active=False)
+        result, _ = DiagnosticsBuilder().build(ctx)
+        assert result["configuration"]["motion_hold_active"] is False
+
+    def test_build_configuration_emits_motion_hold_active_true(self):
+        """_build_configuration includes motion_hold_active=True when hold is active."""
+        ctx = _base_ctx(motion_hold_active=True)
+        result, _ = DiagnosticsBuilder().build(ctx)
+        assert result["configuration"]["motion_hold_active"] is True
+
+    def test_decision_trace_captures_hold_reason(self):
+        """Decision trace reason string is preserved verbatim from PipelineResult."""
+        hold_pr = PipelineResult(
+            position=42,
+            control_method=ControlMethod.MOTION,
+            reason="motion timeout — holding position 42% (sun in FOV)",
+            skip_command=True,
+            decision_trace=[
+                DecisionStep(
+                    handler="motion_timeout",
+                    matched=True,
+                    reason="motion timeout — holding position 42% (sun in FOV)",
+                    position=42,
+                )
+            ],
+        )
+        ctx = _base_ctx(pipeline_result=hold_pr)
+        result, _ = DiagnosticsBuilder().build(ctx)
+        trace = result["decision_trace"]
+        motion_step = next(s for s in trace if s["handler"] == "motion_timeout")
+        assert "holding" in motion_step["reason"].lower()

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -719,6 +719,7 @@ class TestConfigurationDiagnostics:
             "motion_timeout",
             "motion_detected",
             "motion_timeout_active",
+            "motion_hold_active",
             "manual_toggle",
             "enabled_toggle",
             "cloud_suppression_enabled",

--- a/tests/test_manual_override_persistence.py
+++ b/tests/test_manual_override_persistence.py
@@ -203,8 +203,16 @@ async def test_first_refresh_skips_apply_position_for_manual_cover():
 
     coordinator._cmd_svc = MagicMock()
     coordinator._cmd_svc.apply_position = _fake_apply
+    coordinator._pipeline_result = None
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
     coordinator.logger = MagicMock()
+
+    # _dispatch_to_cover delegates to apply_position; wire it up so the
+    # manual-cover skip logic is exercised through the real dispatch path.
+    async def _fake_dispatch(cover, state, reason, ctx):
+        await _fake_apply(cover, state, reason, context=ctx)
+
+    coordinator._dispatch_to_cover = _fake_dispatch
 
     # Call the real method with our mock coordinator as self
     await AdaptiveDataUpdateCoordinator.async_handle_first_refresh(

--- a/tests/test_motion_hold_skip.py
+++ b/tests/test_motion_hold_skip.py
@@ -1,0 +1,67 @@
+"""Tests for coordinator skip path when pipeline result has skip_command=True."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+
+def _make_coordinator_with_skip_command(*, skip_command: bool, position: int = 42):
+    """Build a minimal coordinator whose _pipeline_result has skip_command set."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._inverse_state = False
+
+    coord._pipeline_result = PipelineResult(
+        position=position,
+        control_method=ControlMethod.MOTION,
+        reason="motion timeout — holding position 42% (sun in FOV)",
+        skip_command=skip_command,
+    )
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", None))
+    cmd_svc.record_skipped_action = MagicMock()
+    coord._cmd_svc = cmd_svc
+
+    return coord
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_to_cover_calls_record_skipped_when_skip_command_true():
+    """_dispatch_to_cover records motion_hold skip and does not call apply_position."""
+    coord = _make_coordinator_with_skip_command(skip_command=True, position=42)
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.test", 42, "solar", ctx)
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    coord._cmd_svc.record_skipped_action.assert_called_once()
+    args, kwargs = coord._cmd_svc.record_skipped_action.call_args
+    assert args[1] == "motion_hold"
+    extras = kwargs.get("extras", {})
+    assert "held_position" in extras
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_to_cover_calls_apply_position_when_skip_command_false():
+    """_dispatch_to_cover calls apply_position normally when skip_command is False."""
+    coord = _make_coordinator_with_skip_command(skip_command=False, position=42)
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.test", 42, "solar", ctx)
+
+    coord._cmd_svc.apply_position.assert_called_once_with(
+        "cover.test", 42, "solar", context=ctx
+    )
+    coord._cmd_svc.record_skipped_action.assert_not_called()

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -341,8 +341,16 @@ def _make_state_change_coordinator(
     coordinator._pipeline_bypasses_auto_control = bypass_auto_control
     coordinator._pipeline_is_safety_handler = bypass_auto_control
     coordinator._pipeline_result = MagicMock()
+    coordinator._pipeline_result.skip_command = False
     coordinator._pipeline_result.control_method.value = "force"
     coordinator.state_change = True
+
+    async def _dispatch_side_effect(cover, state, reason, ctx):
+        return await coordinator._cmd_svc.apply_position(
+            cover, state, reason, context=ctx
+        )
+
+    coordinator._dispatch_to_cover = AsyncMock(side_effect=_dispatch_side_effect)
     return coordinator
 
 

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -82,6 +82,8 @@ def make_snapshot(
     my_position_value: int | None = None,
     sunset_use_my: bool = False,
     enable_sun_tracking: bool = True,
+    motion_timeout_mode: str = "return_to_default",
+    current_cover_position: int | None = None,
     # Convenience: configure mock cover
     direct_sun_valid: bool = False,
     calculate_percentage_return: float = 50.0,
@@ -126,4 +128,6 @@ def make_snapshot(
         my_position_value=my_position_value,
         sunset_use_my=sunset_use_my,
         enable_sun_tracking=enable_sun_tracking,
+        motion_timeout_mode=motion_timeout_mode,
+        current_cover_position=current_cover_position,
     )

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -19,9 +19,65 @@ from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position impo
 )
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
+    PipelineResult,
 )
 
 from tests.test_pipeline.conftest import make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# PipelineResult.skip_command
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineResultSkipCommand:
+    """PipelineResult carries a skip_command flag for hold-mode handlers."""
+
+    def test_skip_command_defaults_false(self) -> None:
+        """skip_command is False by default — no behavior change for existing results."""
+        from custom_components.adaptive_cover_pro.enums import ControlMethod
+
+        r = PipelineResult(
+            position=42, control_method=ControlMethod.DEFAULT, reason="x"
+        )
+        assert r.skip_command is False
+
+    def test_skip_command_can_be_set_true(self) -> None:
+        """skip_command=True can be constructed for hold-mode results."""
+        from custom_components.adaptive_cover_pro.enums import ControlMethod
+
+        r = PipelineResult(
+            position=42,
+            control_method=ControlMethod.MOTION,
+            reason="hold",
+            skip_command=True,
+        )
+        assert r.skip_command is True
+
+
+# ---------------------------------------------------------------------------
+# PipelineSnapshot new fields — motion_timeout_mode / current_cover_position
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineSnapshotNewFields:
+    """PipelineSnapshot carries motion_timeout_mode and current_cover_position."""
+
+    def test_motion_timeout_mode_defaults_return_to_default(self) -> None:
+        snap = make_snapshot()
+        assert snap.motion_timeout_mode == "return_to_default"
+
+    def test_motion_timeout_mode_accepts_hold_position(self) -> None:
+        snap = make_snapshot(motion_timeout_mode="hold_position")
+        assert snap.motion_timeout_mode == "hold_position"
+
+    def test_current_cover_position_defaults_none(self) -> None:
+        snap = make_snapshot()
+        assert snap.current_cover_position is None
+
+    def test_current_cover_position_accepts_integer(self) -> None:
+        snap = make_snapshot(current_cover_position=42)
+        assert snap.current_cover_position == 42
 
 
 def test_pipeline_snapshot_is_importable() -> None:
@@ -410,6 +466,90 @@ class TestMotionTimeoutHandler:
     def test_name(self) -> None:
         """MotionTimeoutHandler name is 'motion_timeout'."""
         assert MotionTimeoutHandler.name == "motion_timeout"
+
+
+class TestMotionTimeoutHandlerHoldMode:
+    """Tests for MotionTimeoutHandler hold_position mode."""
+
+    handler = MotionTimeoutHandler()
+
+    def test_hold_fires_when_sun_active(self) -> None:
+        """hold_position + in_time_window + direct_sun_valid → skip_command=True at current pos."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=True,
+            direct_sun_valid=True,
+            current_cover_position=42,
+            default_position=10,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.skip_command is True
+        assert result.position == 42
+        assert result.control_method == ControlMethod.MOTION
+        assert "hold" in result.reason.lower()
+
+    def test_hold_exits_when_sun_not_valid(self) -> None:
+        """hold_position + direct_sun_valid=False → fall through to default position."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=True,
+            direct_sun_valid=False,
+            current_cover_position=42,
+            default_position=10,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.skip_command is False
+        assert result.position == 10
+
+    def test_hold_exits_outside_time_window(self) -> None:
+        """hold_position + in_time_window=False → fall through to default position."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=False,
+            direct_sun_valid=True,
+            current_cover_position=42,
+            default_position=10,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.skip_command is False
+        assert result.position == 10
+
+    def test_hold_falls_back_when_position_unknown(self) -> None:
+        """hold_position + current_cover_position=None → fall through to default (safe fallback)."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=True,
+            direct_sun_valid=True,
+            current_cover_position=None,
+            default_position=10,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.skip_command is False
+        assert result.position == 10
+
+    def test_return_to_default_mode_unchanged(self) -> None:
+        """return_to_default mode is completely unchanged (regression guard)."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="return_to_default",
+            in_time_window=True,
+            direct_sun_valid=True,
+            current_cover_position=42,
+            default_position=20,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.skip_command is False
+        assert result.position == 20
+        assert result.control_method == ControlMethod.MOTION
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds a `hold_position` mode to the motion timeout config option. When motion times out in this mode, the cover freezes at its current physical position rather than returning to the default. The hold exits naturally when the sun leaves the window's field of view or the active time window closes.

Key implementation details:
- `PipelineResult.skip_command` sentinel: when True, `_dispatch_to_cover()` records a skip action instead of issuing a cover command
- `MotionTimeoutHandler` returns current physical position with `skip_command=True` when hold conditions are met
- New `_dispatch_to_cover()` coordinator helper replaces direct `apply_position` calls in regular update loops
- `motion_status` sensor gains a `"holding"` state for visibility
- `motion_hold_active` added to the diagnostics configuration section for troubleshooting
- DE/FR translations synced for all 7 new keys

## Testing
- ✅ 2607 tests passing
- `pipeline/handlers/motion_timeout.py` at 100% coverage
- New test files: `tests/test_motion_hold_skip.py`, updated handler tests

## Related Issues
Refs #333