### PR TITLE
fix: skip cover commands when entity unloaded/unavailable (#342)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -469,7 +469,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.logger.debug("Cover state change")
         data = event.data
         if data["old_state"] is None:
-            self.logger.debug("Old state is None")
+            # Issue #342: a cover transitioning from "not registered yet" to a
+            # real state is the cue that the platform finished loading. The
+            # initial first_refresh likely skipped this entity with
+            # cover_unavailable; recompute now that it's reachable.
+            new_state = data["new_state"]
+            if new_state is not None and new_state.state not in (
+                "unavailable",
+                "unknown",
+            ):
+                self.logger.debug(
+                    "Cover %s came online (%s); requesting refresh",
+                    data["entity_id"],
+                    new_state.state,
+                )
+                await self.async_request_refresh()
+            else:
+                self.logger.debug("Old state is None")
             return
         self.state_change_data = StateChangedData(
             data["entity_id"], data["old_state"], data["new_state"]

--- a/custom_components/adaptive_cover_pro/managers/cover_command.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -878,6 +879,25 @@ class CoverCommandService:
         #     auto_control (issue #293)
         _trigger = reason
         _inverse = context.inverse_state
+
+        # Cover-loaded boundary check (issue #342). HA may register the
+        # integration before the underlying cover platform finishes loading
+        # (e.g. Homematic IP) — issuing set_cover_position before the entity
+        # exists triggers a HA warning and, on platforms that queue commands,
+        # replays the wrong target once the entity comes online. Bypasses none
+        # of the other gates: even is_safety / force=True must wait for the
+        # entity to register.
+        state_obj = self._hass.states.get(entity_id)
+        if state_obj is None or state_obj.state == STATE_UNAVAILABLE:
+            return self._skip(
+                entity_id,
+                "cover_unavailable",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=None,
+            )
+
         _current = self._get_current_position(entity_id)
 
         # Hard kill switch — blocks ALL commands, including safety overrides and
@@ -1516,6 +1536,10 @@ class CoverCommandService:
         """Send command directly, bypassing gate checks (reconciliation use only).
 
         Does NOT reset the retry count — the caller (_reconcile) owns that.
+
+        NB: callers are responsible for entity-loaded-ness. Reconciliation only
+        runs for entities that already passed the cover_unavailable gate in
+        ``apply_position`` (issue #342), so no duplicate gate is needed here.
         """
         service, service_data, _ = self._prepare_service_call(
             entity_id, target, reset_retries=False

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -368,6 +368,52 @@ class TestFirstRefreshSendsStartupCommands:
         assert coordinator.first_refresh is False
 
     @pytest.mark.asyncio
+    async def test_first_refresh_skips_unloaded_cover_entity(self):
+        """Issue #342: first refresh must not call set_cover_position on unloaded covers.
+
+        On HA restart, the cover platform may not finish loading before the
+        integration's first refresh runs. The cover_unavailable gate in
+        apply_position must short-circuit so HA never sees the service call
+        (which would otherwise emit a "missing or not currently available"
+        warning and, on platforms that queue commands, replay it later).
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+        from custom_components.adaptive_cover_pro.managers.cover_command import (
+            CoverCommandService,
+        )
+
+        coordinator = _make_coordinator(entities=["cover.unloaded"])
+        coordinator.first_refresh = True
+
+        real_hass = MagicMock()
+        real_hass.states.get.return_value = None
+        real_hass.services.async_call = AsyncMock()
+
+        real_svc = CoverCommandService(
+            hass=real_hass,
+            logger=MagicMock(),
+            cover_type="cover_blind",
+            grace_mgr=MagicMock(),
+            open_close_threshold=50,
+        )
+        coordinator._cmd_svc = real_svc
+
+        async def _delegate(cover, state, reason, ctx):
+            return await real_svc.apply_position(cover, state, reason, ctx)
+
+        coordinator._dispatch_to_cover = AsyncMock(side_effect=_delegate)
+
+        await AdaptiveDataUpdateCoordinator.async_handle_first_refresh(
+            coordinator, state=100, options={}
+        )
+
+        real_hass.services.async_call.assert_not_called()
+        assert real_svc.last_skipped_action["reason"] == "cover_unavailable"
+        assert real_svc.last_skipped_action["entity_id"] == "cover.unloaded"
+
+    @pytest.mark.asyncio
     async def test_reload_during_time_window_does_not_move_covers(self):
         """On config-entry reload, first-refresh must NOT move non-safety covers.
 
@@ -910,3 +956,79 @@ class TestTargetJustReachedSkipsManualOverride:
 
         # "cover.other" is NOT in _target_just_reached → detection runs normally
         coordinator.manager.handle_state_change.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Step 8: Cover-online transition retriggers refresh (issue #342)
+# ---------------------------------------------------------------------------
+
+
+class TestCoverOnlineTransitionRetrigger:
+    """When a tracked cover transitions from unavailable to a real state, the
+    coordinator must run another refresh so the correct position is recomputed
+    and dispatched (the original startup pass was skipped via cover_unavailable).
+    """
+
+    def _make_event(self, entity_id: str, new_state_value):
+        event = MagicMock()
+        new_state = (
+            MagicMock(state=new_state_value) if new_state_value is not None else None
+        )
+        event.data = {
+            "entity_id": entity_id,
+            "old_state": None,
+            "new_state": new_state,
+        }
+        return event
+
+    @pytest.mark.asyncio
+    async def test_cover_online_transition_triggers_refresh(self):
+        """old_state=None + new_state has a real value → schedule a refresh."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = _make_coordinator(entities=["cover.late"])
+        coordinator.async_request_refresh = AsyncMock()
+
+        await AdaptiveDataUpdateCoordinator.async_check_cover_state_change(
+            coordinator, self._make_event("cover.late", "open")
+        )
+
+        coordinator.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cover_online_to_unavailable_does_not_retrigger(self):
+        """old_state=None + new_state.state=='unavailable' must NOT refresh.
+
+        Cover platform registered the entity but it's still not reachable —
+        another refresh now would just re-skip with cover_unavailable.
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = _make_coordinator(entities=["cover.late"])
+        coordinator.async_request_refresh = AsyncMock()
+
+        await AdaptiveDataUpdateCoordinator.async_check_cover_state_change(
+            coordinator, self._make_event("cover.late", "unavailable")
+        )
+
+        coordinator.async_request_refresh.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cover_online_to_unknown_does_not_retrigger(self):
+        """old_state=None + new_state.state=='unknown' must NOT refresh."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = _make_coordinator(entities=["cover.late"])
+        coordinator.async_request_refresh = AsyncMock()
+
+        await AdaptiveDataUpdateCoordinator.async_check_cover_state_change(
+            coordinator, self._make_event("cover.late", "unknown")
+        )
+
+        coordinator.async_request_refresh.assert_not_awaited()

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import datetime as dt
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.adaptive_cover_pro.managers.cover_command import (
     CoverCommandService,
+    PositionContext,
     build_special_positions,
 )
 
@@ -182,7 +183,12 @@ def test_check_position_delta_from_special_bypass(cmd_svc):
 
 
 def test_check_position_delta_none_position(cmd_svc):
-    """Returns True (send command) when position is unavailable."""
+    """Returns True for the loaded-but-unknown-position case (e.g. Z-Wave covers).
+
+    The unloaded-entity case is gated upstream in apply_position via the
+    cover_unavailable skip code, so a None here means the entity IS registered
+    but its current_position attribute is unknown.
+    """
     with patch.object(cmd_svc, "_get_current_position", return_value=None):
         assert cmd_svc._check_position_delta("cover.test", 50, 20, [0, 100]) is True
 
@@ -528,3 +534,91 @@ def test_read_position_tilt_only_under_cover_blind(mock_hass, logger, grace_mgr)
         "cover.tilt_only_blind", caps, state_obj
     )
     assert result == 60
+
+
+# --- apply_position cover_unavailable gate (issue #342) ---
+
+
+def _ctx() -> PositionContext:
+    """Build a PositionContext that passes every gate downstream of cover_unavailable."""
+    return PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=5,
+        time_threshold=0,
+        special_positions=[0, 100],
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_position_skips_when_entity_state_missing(cmd_svc, mock_hass):
+    """Issue #342: skip with cover_unavailable when hass.states.get returns None.
+
+    On HA restart, cover entities may not yet be registered in the state machine.
+    Issuing a service call against an unregistered entity emits a HA warning
+    and (on platforms that queue commands) executes once the entity loads,
+    moving the cover to the wrong position.
+    """
+    mock_hass.states.get.return_value = None
+    mock_hass.services.async_call = AsyncMock()
+
+    outcome, reason = await cmd_svc.apply_position(
+        "cover.unloaded", 100, "startup", _ctx()
+    )
+
+    assert (outcome, reason) == ("skipped", "cover_unavailable")
+    mock_hass.services.async_call.assert_not_called()
+    assert cmd_svc.last_skipped_action["reason"] == "cover_unavailable"
+    assert cmd_svc.last_skipped_action["entity_id"] == "cover.unloaded"
+
+
+@pytest.mark.asyncio
+async def test_apply_position_skips_when_entity_state_unavailable(cmd_svc, mock_hass):
+    """Issue #342: skip with cover_unavailable when state.state == 'unavailable'.
+
+    Some platforms (e.g. Homematic IP) register the entity early but report
+    unavailable until the device is reachable; commands against it are queued
+    and replayed once available, producing the same wrong-position symptom.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="unavailable", attributes={})
+    mock_hass.services.async_call = AsyncMock()
+
+    outcome, reason = await cmd_svc.apply_position(
+        "cover.unavailable", 100, "startup", _ctx()
+    )
+
+    assert (outcome, reason) == ("skipped", "cover_unavailable")
+    mock_hass.services.async_call.assert_not_called()
+    assert cmd_svc.last_skipped_action["reason"] == "cover_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_apply_position_proceeds_when_state_loaded_with_unknown_position(
+    cmd_svc, mock_hass
+):
+    """Loaded entity with current_position=None must NOT trigger cover_unavailable.
+
+    Z-Wave covers commonly report a real state (open/closed) without a numeric
+    current_position attribute. The new gate must only short-circuit when the
+    entity itself is unloaded or marked unavailable — not for unknown position.
+    """
+    mock_hass.states.get.return_value = MagicMock(
+        state="open",
+        attributes={"current_position": None, "supported_features": 15},
+    )
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=None),
+        patch.object(cmd_svc, "_check_position_delta", return_value=True),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch.object(
+            cmd_svc,
+            "_prepare_service_call",
+            return_value=("set_cover_position", {"entity_id": "cover.zw"}, True),
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position("cover.zw", 50, "solar", _ctx())
+
+    assert reason != "cover_unavailable"

--- a/tests/test_skip_reason_guard.py
+++ b/tests/test_skip_reason_guard.py
@@ -40,6 +40,7 @@ _EXPECTED_SKIP_CODES: frozenset[str] = frozenset(
         "no_capable_service",
         "dry_run",
         "service_call_failed",
+        "cover_unavailable",
     }
 )
 


### PR DESCRIPTION
## Summary
- On HA restart, the cover platform sometimes registers entities late (Homematic IP is the report in #342). The integration's first refresh would call `set_cover_position` before the entity existed, producing a "missing or not currently available" warning and — on platforms that queue commands — replaying the wrong target once the entity came online, moving the cover.
- Adds a `cover_unavailable` skip code in `CoverCommandService.apply_position` that short-circuits when `hass.states.get(entity_id)` returns `None` or the state is `unavailable`. No other gate is bypassed (even safety/force still defers).
- Coordinator now requests a refresh when a tracked cover transitions from `old_state=None` to a real (non-`unavailable`/`unknown`) state, so the originally-skipped position is recomputed and dispatched once the entity is reachable.

## Testing
- ✅ 2647 tests passing (8 new — gate behavior in `test_managers/test_cover_command.py`, first-refresh skip + online-transition retrigger in `test_coordinator_integration.py`, registry update in `test_skip_reason_guard.py`)
- ✅ Ruff clean

## Docs
- Wiki Troubleshooting page updated with the new `cover_unavailable` skip reason.

## Related Issues
Refs #342