### PR TITLE
fix: bypass time-delta gate when custom-position sensor edge-triggers

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -222,6 +222,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.state_change = False
         self.cover_state_change = False
         self.first_refresh = False
+        self._last_state_change_entity: str | None = None
         # Set to True when the coordinator is created during a config-entry reload
         # (HA already running) vs. a cold HA boot.  On reload, first-refresh dispatch
         # is suppressed for non-safety handlers to avoid disturbing covers that the
@@ -459,6 +460,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.logger.debug(
             "Entity state change: %s (%s → %s)", entity_id, old_val, new_val
         )
+        self._last_state_change_entity = entity_id
         self.state_change = True
         await self.async_refresh()
 
@@ -1533,16 +1535,22 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # (solar, climate, cloud, default) must not reposition covers before
         # the user's start time or after the end time.  The pipeline still
         # evaluates so diagnostics/sensor state remain correct.
+        custom_position_sensor_triggered = self._is_custom_position_sensor_trigger()
+
         if (
             not self.check_adaptive_time
             and not is_safety
             and not force_override_released
+            and not custom_position_sensor_triggered
         ):
             self.state_change = False
+            self._last_state_change_entity = None
             self.logger.debug("Outside time window — skipping position update")
             return
 
-        use_force = is_safety or force_override_released
+        use_force = (
+            is_safety or force_override_released or custom_position_sensor_triggered
+        )
         if force_override_released:
             reason = "force_override_cleared"
             self.logger.debug(
@@ -1566,6 +1574,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             await self._dispatch_to_cover(cover, state, reason, ctx)
         self.state_change = False
+        self._last_state_change_entity = None
         self.logger.debug("State change handled")
 
     async def async_handle_cover_state_change(self, state: int):
@@ -2236,6 +2245,28 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         return self._pipeline_result.control_method in (
             ControlMethod.FORCE,
             ControlMethod.WEATHER,
+        )
+
+    def _is_custom_position_sensor_trigger(self) -> bool:
+        """Return True when this refresh was edge-triggered by a custom-position slot's own sensor.
+
+        When a sensor toggles, the cover may be at a completely different position
+        (e.g. solar tracking just moved it).  Passing force=True lets the command
+        bypass the time-delta gate so the slot's position is actually applied.
+        The same-position short-circuit (PR #300) still suppresses redundant
+        re-sends when the sensor stays active across subsequent solar refreshes.
+        """
+        if self._pipeline_result is None:
+            return False
+        if self._pipeline_result.control_method is not ControlMethod.CUSTOM_POSITION:
+            return False
+        trigger = self._last_state_change_entity
+        if trigger is None:
+            return False
+        options = self.config_entry.options
+        return any(
+            options.get(slot_keys["sensor"]) == trigger
+            for slot_keys in CUSTOM_POSITION_SLOTS.values()
         )
 
     @property

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -68,6 +68,7 @@ def _make_coordinator(
     )
 
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
+    coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
     coordinator._cmd_svc = MagicMock()
     coordinator._cmd_svc.apply_position = AsyncMock(
@@ -285,6 +286,111 @@ class TestCustomPositionNoRedundantCommands:
             is_safety=False,
             sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
         )
+
+
+# ---------------------------------------------------------------------------
+# Step 5: Custom-position sensor edge-trigger bypasses time-delta gate
+# ---------------------------------------------------------------------------
+
+
+class TestCustomPositionSensorEdgeTriggerBypassesGate:
+    """Sensor toggle triggers force=True; solar refresh keeps force=False.
+
+    Issue #348: a custom-position sensor toggling within delta_time of the last
+    cover move must NOT be throttled.  The same-position short-circuit (PR #300)
+    still prevents redundant re-sends when the sensor stays active across solar
+    refreshes.
+    """
+
+    @pytest.mark.asyncio
+    async def test_custom_position_sensor_edge_trigger_uses_force_context(self):
+        """Sensor-triggered custom position must call _build_position_context with force=True."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=60,
+            control_method=ControlMethod.CUSTOM_POSITION,
+            bypass_auto_control=True,
+        )
+        coordinator = _make_coordinator(
+            entities=["cover.blind"],
+            pipeline_result=result,
+        )
+        coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=True)
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator, state=60, options={}
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.blind",
+            {},
+            force=True,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_position_sun_driven_refresh_does_not_use_force_context(self):
+        """Solar-cycle refresh with active custom position keeps force=False (PR #300 invariant)."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=60,
+            control_method=ControlMethod.CUSTOM_POSITION,
+            bypass_auto_control=True,
+        )
+        coordinator = _make_coordinator(
+            entities=["cover.blind"],
+            pipeline_result=result,
+        )
+        coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator, state=60, options={}
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.blind",
+            {},
+            force=False,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+
+class TestCustomPositionTriggerEntityRecording:
+    """async_check_entity_state_change records the triggering entity_id."""
+
+    @pytest.mark.asyncio
+    async def test_async_check_entity_state_change_records_trigger_entity(self):
+        """Trigger entity_id is stored as _last_state_change_entity for use in async_handle_state_change."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = MagicMock()
+        coordinator.async_refresh = AsyncMock()
+        coordinator.state_change = False
+        coordinator._last_state_change_entity = None
+        coordinator.logger = MagicMock()
+
+        event = MagicMock()
+        event.data = {
+            "entity_id": "binary_sensor.movie_time",
+            "old_state": MagicMock(state="off"),
+            "new_state": MagicMock(state="on"),
+        }
+
+        await AdaptiveDataUpdateCoordinator.async_check_entity_state_change(
+            coordinator, event
+        )
+
+        assert coordinator._last_state_change_entity == "binary_sensor.movie_time"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -37,6 +37,7 @@ def _make_coordinator(*, check_adaptive_time: bool, automatic_control: bool = Tr
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
+    coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
     coordinator._cmd_svc = MagicMock()
     coordinator._cmd_svc.apply_position = AsyncMock(
@@ -333,6 +334,7 @@ def _make_state_change_coordinator(
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
+    coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
     coordinator._cmd_svc = MagicMock()
     coordinator._cmd_svc.apply_position = AsyncMock(

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -126,6 +126,46 @@ async def test_apply_skips_time_delta_too_small(svc):
 
 
 @pytest.mark.asyncio
+async def test_apply_force_bypasses_time_delta_for_custom_position(svc, mock_hass):
+    """Issue #348: force=True bypasses the time-delta gate for custom-position edge-triggers."""
+    _patch_position(svc, 30)
+    recent = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=10)
+    with (
+        _patch_caps(),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+            return_value=recent,
+        ),
+    ):
+        outcome, _ = await svc.apply_position(
+            "cover.test",
+            60,
+            "custom_position",
+            context=_ctx(time_threshold=5, force=True, auto_control=True),
+        )
+    assert outcome == "sent"
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_force_same_position_still_skipped_for_custom_position(
+    svc, mock_hass
+):
+    """PR #300 invariant: force=True with same position is still skipped."""
+    _patch_position(svc, 60)
+    with _patch_caps():
+        outcome, detail = await svc.apply_position(
+            "cover.test",
+            60,
+            "custom_position",
+            context=_ctx(force=True, auto_control=True),
+        )
+    assert outcome == "skipped"
+    assert detail == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_apply_skips_manual_override(svc):
     _patch_position(svc, 30)
     with patch(


### PR DESCRIPTION
## Summary
When a custom-position binary sensor toggles within `delta_time` minutes of a previous cover movement, the resulting command was silently dropped by the time-delta gate in `apply_position()`. The same-position short-circuit added in PR #300 suppresses redundant re-sends when the cover is already at the target, but doesn't protect the edge-triggered case where the cover is at a different position.

Fixed by recording the triggering entity in `async_check_entity_state_change` and checking in `async_handle_state_change` whether it matches a configured custom-position sensor. When it does, `force=True` is passed to bypass the time-delta gate. Solar-driven refreshes with an active sensor keep `force=False`, preserving the PR #300 invariant.

## Testing
- ✅ 2652 tests passing

## Related Issues
Refs #348