### PR TITLE
feat: dual-axis venetian blind support — v2.20.0 (#33)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -135,6 +135,16 @@ class TiltConfig:
 # Operational runtime config — read once per coordinator update cycle.
 # ---------------------------------------------------------------------------
 
+
+@dataclass(frozen=True, slots=True)
+class VenetianSlice:
+    """Venetian-specific runtime options."""
+
+    post_settle_hold_seconds: float
+    tilt_skip_above: int
+    venetian_mode: str
+
+
 # Sub-dataclasses group fields by manager so each manager's ``update_config``
 # can take a typed slice instead of a fan of kwargs. The slices live below;
 # the top-level ``RuntimeConfig`` aggregates them plus the bare flags the
@@ -215,6 +225,7 @@ class RuntimeConfig:
     time_window: TimeWindowSlice
     motion: MotionSlice
     weather: WeatherSlice
+    venetian: VenetianSlice
 
     @classmethod
     def from_options(cls, options: dict) -> RuntimeConfig:
@@ -244,6 +255,9 @@ class RuntimeConfig:
             CONF_OPEN_CLOSE_THRESHOLD,
             CONF_START_ENTITY,
             CONF_START_TIME,
+            CONF_VENETIAN_MODE,
+            CONF_VENETIAN_POST_SETTLE_HOLD,
+            CONF_VENETIAN_TILT_SKIP_ABOVE,
             CONF_WEATHER_IS_RAINING_SENSOR,
             CONF_WEATHER_IS_WINDY_SENSOR,
             CONF_WEATHER_RAIN_SENSOR,
@@ -256,6 +270,9 @@ class RuntimeConfig:
             CONF_WEATHER_WIND_SPEED_THRESHOLD,
             DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
             DEFAULT_MOTION_TIMEOUT,
+            DEFAULT_VENETIAN_MODE,
+            DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+            DEFAULT_VENETIAN_TILT_SKIP_ABOVE,
             DEFAULT_WEATHER_RAIN_THRESHOLD,
             DEFAULT_WEATHER_TIMEOUT,
             DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE,
@@ -315,5 +332,15 @@ class RuntimeConfig:
                 timeout_seconds=options.get(
                     CONF_WEATHER_TIMEOUT, DEFAULT_WEATHER_TIMEOUT
                 ),
+            ),
+            venetian=VenetianSlice(
+                post_settle_hold_seconds=options.get(
+                    CONF_VENETIAN_POST_SETTLE_HOLD,
+                    DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+                ),
+                tilt_skip_above=options.get(
+                    CONF_VENETIAN_TILT_SKIP_ABOVE, DEFAULT_VENETIAN_TILT_SKIP_ABOVE
+                ),
+                venetian_mode=options.get(CONF_VENETIAN_MODE, DEFAULT_VENETIAN_MODE),
             ),
         )

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -197,6 +197,10 @@ VENETIAN_TILT_SUPPRESSION_SECONDS = 90.0
 # for the post-tilt rebase so the rebase captures the actual settled position
 # rather than the pre-back-drive snapshot.
 VENETIAN_POST_TILT_REBASE_DELAY_SECONDS = 1.5
+# Hold delay between position settle and the tilt command. Some actuators
+# perform a firmware tilt-reassert after the carriage reports closed/open
+# (e.g. FGR223): firing the tilt command immediately races that reassert.
+VENETIAN_POST_SETTLE_HOLD_SECONDS = 2.0
 # Drift tolerance for tilt verification: if actual tilt differs from the sent
 # target by more than this many percent after the post-tilt delay, the recorded
 # target is cleared so the next update_tilt_only cycle retries the command.

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1,61 +1,284 @@
-"""Constants for integration_blueprint."""
+"""Constants for the Adaptive Cover Pro integration.
+
+Every public symbol the rest of the package depends on lives here. The file is
+organized into named sections (banner-style headers below) and every constant
+carries an inline comment with its unit, range, default, or role.
+
+Conventions
+-----------
+* ``CONF_*`` constants hold the wire-format key under which an option is
+  persisted in ``config_entry.options``. These strings are stored in the user's
+  Home Assistant config and **must stay byte-stable** across releases — renaming
+  the Python name is fine, renaming the string value is not.
+* ``DEFAULT_*`` constants are the value applied when the corresponding option is
+  unset.
+* Private ``_RANGE_*`` tuples are ``(min, max)`` bounds used only inside this
+  module to build ``OPTION_RANGES`` — the single source of truth that
+  ``config_flow.py`` selectors and ``services/options_service.py`` validators
+  both consume.
+* ``ATTR_*`` constants are HA service-call attribute keys.
+
+Section index
+-------------
+ 1. Module Identity & Logging
+ 2. Cover Type & Device
+ 3. Window / Vertical-Blind Geometry
+ 4. Awning Geometry
+ 5. Tilt / Venetian Slat Geometry
+ 6. Position Limits & Inverse State
+ 7. Sun Tracking
+ 8. Sunset & Sunrise Behavior
+ 9. Blind Spot
+10. Glare Zones
+11. Climate Strategy
+12. Light & Cloud Sensing
+13. Force Override
+14. Custom Position Slots
+15. Weather Override (Safety)
+16. Automation Timing & Gating
+17. Interpolation
+18. Manual Override & Transit
+19. Motion Control
+20. Position Verification
+21. Venetian Dual-Axis Sequencing
+22. Debug & Diagnostics
+23. Control Status (diagnostic enum)
+24. Geometric Accuracy (calc engine)
+25. UI Defaults & Validation Caps
+26. Numeric Option Ranges (single source of truth)
+"""
 
 import logging
 
-DOMAIN = "adaptive_cover_pro"
-LOGGER = logging.getLogger(__package__)
-_LOGGER = logging.getLogger(__name__)
+# =============================================================================
+# 1. Module Identity & Logging
+# =============================================================================
+# Domain string, package-level loggers, and HA service-call attribute keys.
 
-ATTR_POSITION = "position"
-ATTR_TILT_POSITION = "tilt_position"
+DOMAIN = "adaptive_cover_pro"  # HA integration domain; must match manifest.json
+LOGGER = logging.getLogger(__package__)  # package-scoped logger
+_LOGGER = logging.getLogger(__name__)  # module-scoped; also imported by button.py
 
-CONF_AZIMUTH = "set_azimuth"
+ATTR_POSITION = "position"  # HA cover service attr: vertical position (0-100)
+ATTR_TILT_POSITION = "tilt_position"  # HA cover service attr: slat tilt (0-100)
+
+# Legacy carryover from the integration_blueprint template; kept for symbol
+# stability (unused at runtime).
 CONF_BLUEPRINT = "blueprint"
-CONF_HEIGHT_WIN = "window_height"
-CONF_DISTANCE = "distance_shaded_area"
-CONF_WINDOW_DEPTH = "window_depth"
-CONF_SILL_HEIGHT = "sill_height"
-CONF_DEFAULT_HEIGHT = "default_percentage"
-CONF_FOV_LEFT = "fov_left"
-CONF_FOV_RIGHT = "fov_right"
-CONF_ENTITIES = "group"
-CONF_HEIGHT_AWNING = "height_awning"
-CONF_LENGTH_AWNING = "length_awning"
-CONF_AWNING_ANGLE = "angle"
-CONF_SENSOR_TYPE = "sensor_type"
-CONF_INVERSE_STATE = "inverse_state"
-CONF_INVERSE_TILT = "inverse_tilt"
-CONF_SUNSET_POS = "sunset_position"
-CONF_SUNSET_OFFSET = "sunset_offset"
-CONF_TILT_DEPTH = "slat_depth"
-CONF_TILT_DISTANCE = "slat_distance"
-CONF_TILT_MODE = "tilt_mode"
-CONF_SUNRISE_OFFSET = "sunrise_offset"
-CONF_TEMP_ENTITY = "temp_entity"
-CONF_PRESENCE_ENTITY = "presence_entity"
-CONF_WEATHER_ENTITY = "weather_entity"
-CONF_TEMP_LOW = "temp_low"
-CONF_TEMP_HIGH = "temp_high"
-CONF_MODE = "mode"
-CONF_CLIMATE_MODE = "climate_mode"
-CONF_WEATHER_STATE = "weather_state"
-CONF_MAX_POSITION = "max_position"
-CONF_MIN_POSITION = "min_position"
+
+
+# =============================================================================
+# 2. Cover Type & Device
+# =============================================================================
+# Identifies which cover type a config entry models and which HA device, if
+# any, the entities should be linked to.
+
+CONF_SENSOR_TYPE = "sensor_type"  # one of SensorType.* below
+CONF_DEVICE_ID = "linked_device_id"  # HA device_id to link this instance to
+
+
+class SensorType:
+    """Cover-type identifiers stored in ``config_entry.data[CONF_SENSOR_TYPE]``.
+
+    These values drive which ``CoverTypePolicy`` (under ``cover_types/``) is
+    instantiated, which config-flow geometry step is shown, and which calc-engine
+    cover module under ``engine/covers/`` is used.
+    """
+
+    BLIND = "cover_blind"  # vertical blind — up/down movement
+    AWNING = "cover_awning"  # horizontal awning — in/out extension
+    TILT = "cover_tilt"  # tilt-only — slat rotation, no carriage movement
+    VENETIAN = "cover_venetian"  # dual-axis — position AND tilt
+
+
+# =============================================================================
+# 3. Window / Vertical-Blind Geometry
+# =============================================================================
+# Window-frame dimensions and sun-tracking field-of-view. Consumed by
+# `engine/sun_geometry.py` and the vertical-blind calc path.
+
+CONF_AZIMUTH = "set_azimuth"  # window azimuth, degrees 0-359 (south=180)
+CONF_HEIGHT_WIN = "window_height"  # window height, metres (0.1-50.0)
+CONF_WINDOW_WIDTH = "window_width"  # window width, metres (0.1-50.0)
+CONF_WINDOW_DEPTH = "window_depth"  # window recess depth, metres (0.0-5.0)
+CONF_SILL_HEIGHT = "sill_height"  # sill height above floor, metres (0.0-50.0)
+CONF_DISTANCE = "distance_shaded_area"  # blind→shaded distance, m (0.1-50.0)
+CONF_FOV_LEFT = "fov_left"  # left half-FOV from azimuth, degrees 0-180
+CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
+CONF_ENTITIES = "group"  # list of HA cover entity_ids controlled
+
+
+# =============================================================================
+# 4. Awning Geometry
+# =============================================================================
+# Horizontal awning dimensions (extension length and tilt).
+
+CONF_HEIGHT_AWNING = "height_awning"  # mount height above ground, metres
+CONF_LENGTH_AWNING = "length_awning"  # extension length, metres (0.3-6.0)
+CONF_AWNING_ANGLE = "angle"  # tilt from horizontal, degrees (0-45)
+
+
+# =============================================================================
+# 5. Tilt / Venetian Slat Geometry
+# =============================================================================
+# Slat dimensions used to compute tilt angle, plus min/max tilt clamps.
+
+CONF_TILT_DEPTH = "slat_depth"  # slat depth, cm (range 0.1-15.0)
+CONF_TILT_DISTANCE = "slat_distance"  # vertical slat spacing, cm (0.1-15.0)
+CONF_TILT_MODE = "tilt_mode"  # tilt strategy identifier
+CONF_MAX_TILT = "max_tilt"  # cap on sun-derived tilt %, 0-100
+DEFAULT_MAX_TILT = 100  # default: no upper cap
+CONF_MIN_TILT = "min_tilt"  # floor on sun-derived tilt %, 0-100
+DEFAULT_MIN_TILT = 0  # default: no lower floor
+
+
+# =============================================================================
+# 6. Position Limits & Inverse State
+# =============================================================================
+# Hard min/max position clamps, default-when-not-tracking, the inverse-state
+# flags (some covers report 0=open instead of 0=closed), and the two named
+# fixed points POSITION_CLOSED / POSITION_OPEN used widely in calc code.
+
+CONF_MAX_POSITION = "max_position"  # upper clamp on commanded position (1-100)
+CONF_MIN_POSITION = "min_position"  # lower clamp on commanded position (0-99)
+# If True, max_position is only enforced during active sun tracking.
 CONF_ENABLE_MAX_POSITION = "enable_max_position"
+# If True, min_position is only enforced during active sun tracking.
 CONF_ENABLE_MIN_POSITION = "enable_min_position"
+# Fallback position when no override applies, % (range 0-100).
+CONF_DEFAULT_HEIGHT = "default_percentage"
+CONF_INVERSE_STATE = "inverse_state"  # True if cover reports 0=open, 100=closed
+CONF_INVERSE_TILT = "inverse_tilt"  # True if tilt reports 0=open, 100=closed
+
+POSITION_CLOSED = 0  # canonical fully-closed position
+POSITION_OPEN = 100  # canonical fully-open position
+
+
+# =============================================================================
+# 7. Sun Tracking
+# =============================================================================
+# Master enable flag and the elevation window outside of which sun tracking is
+# suppressed (handlers fall through to the default position).
+
+# Master switch — disable to run on overrides only.
 CONF_ENABLE_SUN_TRACKING = "enable_sun_tracking"
-CONF_OUTSIDETEMP_ENTITY = "outside_temp"
-CONF_FORCE_OVERRIDE_SENSORS = "force_override_sensors"
-CONF_FORCE_OVERRIDE_POSITION = "force_override_position"
+CONF_MIN_ELEVATION = "min_elevation"  # sun must be at least this high, deg 0-90
+CONF_MAX_ELEVATION = "max_elevation"  # tracking off above this elevation, 0-90
+# True if blind passes some light even when closed (used by glare/climate).
+CONF_TRANSPARENT_BLIND = "transparent_blind"
+
+
+# =============================================================================
+# 8. Sunset & Sunrise Behavior
+# =============================================================================
+# What position to take after sunset / before sunrise, plus offset windows that
+# shift the activation moment.
+
+CONF_SUNSET_POS = "sunset_position"  # post-sunset position 0-100; None=default
+CONF_SUNSET_OFFSET = "sunset_offset"  # minutes ±120 from sunset to switch
+CONF_SUNRISE_OFFSET = "sunrise_offset"  # minutes ±120 from sunrise to resume
+CONF_RETURN_SUNSET = "return_sunset"  # True: force-send default at end_time
+# If True, sunset position uses CONF_MY_POSITION_VALUE instead of CONF_SUNSET_POS.
+CONF_SUNSET_USE_MY = "sunset_use_my"
+
+
+# =============================================================================
+# 9. Blind Spot
+# =============================================================================
+# Azimuth wedge inside which the sun is treated as "blocked" (e.g. by a tree),
+# so direct-sun handling switches off even if geometry says otherwise.
+
+CONF_ENABLE_BLIND_SPOT = "blind_spot"  # master enable
+CONF_BLIND_SPOT_LEFT = "blind_spot_left"  # left edge, azimuth deg 0-359
+CONF_BLIND_SPOT_RIGHT = "blind_spot_right"  # right edge, azimuth deg 0-360
+# Sun elevation below which the blind-spot wedge applies, degrees 0-90.
+CONF_BLIND_SPOT_ELEVATION = "blind_spot_elevation"
+
+
+# =============================================================================
+# 10. Glare Zones
+# =============================================================================
+# Optional glare-zone handler (priority 45 in the override pipeline).
+
+CONF_ENABLE_GLARE_ZONES = "enable_glare_zones"  # activate glare-zone handler
+
+
+# =============================================================================
+# 11. Climate Strategy
+# =============================================================================
+# Climate-aware operation: temperature thresholds, presence, weather entity,
+# winter-insulation override, and the strategy mode enum.
+
+CONF_MODE = "mode"  # legacy strategy mode key (back-compat)
+CONF_CLIMATE_MODE = "climate_mode"  # enable climate handler (priority 50)
+CONF_TEMP_ENTITY = "temp_entity"  # indoor temp sensor entity_id
+CONF_TEMP_LOW = "temp_low"  # "cold" threshold, sensor unit (0-90)
+CONF_TEMP_HIGH = "temp_high"  # "hot" threshold, sensor unit (0-90)
+CONF_OUTSIDETEMP_ENTITY = "outside_temp"  # outdoor temp sensor entity_id
+# Outdoor temp threshold for summer/winter mode switch (range 0-100).
+CONF_OUTSIDE_THRESHOLD = "outside_threshold"
+CONF_PRESENCE_ENTITY = "presence_entity"  # presence/occupancy sensor entity_id
+CONF_WEATHER_ENTITY = "weather_entity"  # weather. integration entity_id
+CONF_WEATHER_STATE = "weather_state"  # states that trigger climate handler
+# True to close covers at night in winter for added insulation.
+CONF_WINTER_CLOSE_INSULATION = "winter_close_insulation"
+
+STRATEGY_MODE_BASIC = "basic"  # geometry only, no climate inputs
+STRATEGY_MODE_CLIMATE = "climate"  # climate-aware (temps/presence/weather)
+STRATEGY_MODES = [
+    STRATEGY_MODE_BASIC,
+    STRATEGY_MODE_CLIMATE,
+]  # ordered list used by config_flow selectors
+
+CLIMATE_SUMMER_TILT_ANGLE = 45  # degrees — slat tilt under summer cooling
+CLIMATE_DEFAULT_TILT_ANGLE = 80  # degrees — tilt when no climate signal
+
+
+# =============================================================================
+# 12. Light & Cloud Sensing
+# =============================================================================
+# Optional inputs for the cloud-suppression handler (priority 60): direct
+# illuminance/irradiance sensors, a precomputed "is sunny" boolean, and cloud-
+# coverage suppression that switches to CONF_CLOUDY_POSITION when overcast.
+
+CONF_LUX_ENTITY = "lux_entity"  # illuminance sensor entity_id, lx
+# Below this lux value the sun is treated as too weak to track.
+CONF_LUX_THRESHOLD = "lux_threshold"
+CONF_IRRADIANCE_ENTITY = "irradiance_entity"  # irradiance sensor, W/m²
+# Below this irradiance the sun is treated as too weak to track.
+CONF_IRRADIANCE_THRESHOLD = "irradiance_threshold"
+CONF_IS_SUNNY_SENSOR = "is_sunny_sensor"  # precomputed binary "is sunny"
+CONF_CLOUD_COVERAGE_ENTITY = "cloud_coverage_entity"  # cloud-cover % sensor
+# % cloud cover above which the suppression handler activates.
+CONF_CLOUD_COVERAGE_THRESHOLD = "cloud_coverage_threshold"
+CONF_CLOUD_SUPPRESSION = "cloud_suppression"  # master enable
+CONF_CLOUDY_POSITION = "cloudy_position"  # position while suppressed (0-100)
+
+DEFAULT_CLOUD_COVERAGE_THRESHOLD = 75  # default: 75% cover = overcast
+
+
+# =============================================================================
+# 13. Force Override
+# =============================================================================
+# Highest-priority handler (100). When any of the listed binary sensors is on,
+# command the configured position.
+
+CONF_FORCE_OVERRIDE_SENSORS = "force_override_sensors"  # binary_sensor list
+CONF_FORCE_OVERRIDE_POSITION = "force_override_position"  # position 0-100
+# If True, force-override is only enforced as a min position (won't close more).
 CONF_FORCE_OVERRIDE_MIN_MODE = "force_override_min_mode"
 
-# --- Custom position slots ---------------------------------------------------
-# Each slot exposes the same five config keys (sensor / position / priority /
-# min_mode / use_my). The wire-format names ("custom_position_sensor_3" etc.)
-# are stored in user config_entry.options, so they MUST stay stable; the helper
-# below derives them programmatically and the per-slot CONF_* aliases below are
-# kept for callers that prefer the named constant.
-CUSTOM_POSITION_SLOT_NUMBERS: tuple[int, ...] = (1, 2, 3, 4)
+
+# =============================================================================
+# 14. Custom Position Slots
+# =============================================================================
+# Up to four independently-configurable position slots, each with its own
+# trigger sensor, position, priority (1-99), min-mode flag, and "use my
+# position" flag. Each slot has five wire-format keys; they are generated
+# below to keep them DRY. The numbered per-slot CONF_* aliases are retained
+# for callers that prefer named constants over dict lookup.
+
+CUSTOM_POSITION_SLOT_NUMBERS: tuple[int, ...] = (1, 2, 3, 4)  # supported indices
 
 
 def _custom_position_slot_keys(n: int) -> dict[str, str]:
@@ -69,184 +292,126 @@ def _custom_position_slot_keys(n: int) -> dict[str, str]:
     }
 
 
+# {slot_number: {sub_key: wire_key}}
 CUSTOM_POSITION_SLOTS: dict[int, dict[str, str]] = {
     n: _custom_position_slot_keys(n) for n in CUSTOM_POSITION_SLOT_NUMBERS
 }
 
-CONF_CUSTOM_POSITION_SENSOR_1 = CUSTOM_POSITION_SLOTS[1]["sensor"]
-CONF_CUSTOM_POSITION_1 = CUSTOM_POSITION_SLOTS[1]["position"]
-CONF_CUSTOM_POSITION_PRIORITY_1 = CUSTOM_POSITION_SLOTS[1]["priority"]
-CONF_CUSTOM_POSITION_MIN_MODE_1 = CUSTOM_POSITION_SLOTS[1]["min_mode"]
-CONF_CUSTOM_POSITION_USE_MY_1 = CUSTOM_POSITION_SLOTS[1]["use_my"]
+# Slot 1 — named aliases for each of the five sub-keys.
+CONF_CUSTOM_POSITION_SENSOR_1 = CUSTOM_POSITION_SLOTS[1]["sensor"]  # trigger
+CONF_CUSTOM_POSITION_1 = CUSTOM_POSITION_SLOTS[1]["position"]  # 0-100
+CONF_CUSTOM_POSITION_PRIORITY_1 = CUSTOM_POSITION_SLOTS[1]["priority"]  # 1-99
+CONF_CUSTOM_POSITION_MIN_MODE_1 = CUSTOM_POSITION_SLOTS[1]["min_mode"]  # min-only
+CONF_CUSTOM_POSITION_USE_MY_1 = CUSTOM_POSITION_SLOTS[1]["use_my"]  # use my-pos
+
+# Slot 2.
 CONF_CUSTOM_POSITION_SENSOR_2 = CUSTOM_POSITION_SLOTS[2]["sensor"]
 CONF_CUSTOM_POSITION_2 = CUSTOM_POSITION_SLOTS[2]["position"]
 CONF_CUSTOM_POSITION_PRIORITY_2 = CUSTOM_POSITION_SLOTS[2]["priority"]
 CONF_CUSTOM_POSITION_MIN_MODE_2 = CUSTOM_POSITION_SLOTS[2]["min_mode"]
 CONF_CUSTOM_POSITION_USE_MY_2 = CUSTOM_POSITION_SLOTS[2]["use_my"]
+
+# Slot 3.
 CONF_CUSTOM_POSITION_SENSOR_3 = CUSTOM_POSITION_SLOTS[3]["sensor"]
 CONF_CUSTOM_POSITION_3 = CUSTOM_POSITION_SLOTS[3]["position"]
 CONF_CUSTOM_POSITION_PRIORITY_3 = CUSTOM_POSITION_SLOTS[3]["priority"]
 CONF_CUSTOM_POSITION_MIN_MODE_3 = CUSTOM_POSITION_SLOTS[3]["min_mode"]
 CONF_CUSTOM_POSITION_USE_MY_3 = CUSTOM_POSITION_SLOTS[3]["use_my"]
+
+# Slot 4.
 CONF_CUSTOM_POSITION_SENSOR_4 = CUSTOM_POSITION_SLOTS[4]["sensor"]
 CONF_CUSTOM_POSITION_4 = CUSTOM_POSITION_SLOTS[4]["position"]
 CONF_CUSTOM_POSITION_PRIORITY_4 = CUSTOM_POSITION_SLOTS[4]["priority"]
 CONF_CUSTOM_POSITION_MIN_MODE_4 = CUSTOM_POSITION_SLOTS[4]["min_mode"]
 CONF_CUSTOM_POSITION_USE_MY_4 = CUSTOM_POSITION_SLOTS[4]["use_my"]
-CONF_MY_POSITION_VALUE = "my_position_value"
-CONF_SUNSET_USE_MY = "sunset_use_my"
-DEFAULT_CUSTOM_POSITION_PRIORITY = 77
-CONF_MOTION_SENSORS = "motion_sensors"
-CONF_MOTION_TIMEOUT = "motion_timeout"
-CONF_ENABLE_BLIND_SPOT = "blind_spot"
-CONF_BLIND_SPOT_RIGHT = "blind_spot_right"
-CONF_BLIND_SPOT_LEFT = "blind_spot_left"
-CONF_BLIND_SPOT_ELEVATION = "blind_spot_elevation"
-CONF_MIN_ELEVATION = "min_elevation"
-CONF_MAX_ELEVATION = "max_elevation"
-CONF_TRANSPARENT_BLIND = "transparent_blind"
-CONF_WINTER_CLOSE_INSULATION = "winter_close_insulation"
-CONF_CLOUD_SUPPRESSION = "cloud_suppression"
-CONF_CLOUDY_POSITION = "cloudy_position"
-CONF_INTERP_START = "interp_start"
-CONF_INTERP_END = "interp_end"
-CONF_INTERP_LIST = "interp_list"
-CONF_INTERP_LIST_NEW = "interp_list_new"
-CONF_INTERP = "interp"
-CONF_LUX_ENTITY = "lux_entity"
-CONF_LUX_THRESHOLD = "lux_threshold"
-CONF_IRRADIANCE_ENTITY = "irradiance_entity"
-CONF_IRRADIANCE_THRESHOLD = "irradiance_threshold"
-CONF_CLOUD_COVERAGE_ENTITY = "cloud_coverage_entity"
-CONF_CLOUD_COVERAGE_THRESHOLD = "cloud_coverage_threshold"
-CONF_IS_SUNNY_SENSOR = "is_sunny_sensor"
-CONF_OUTSIDE_THRESHOLD = "outside_threshold"
-CONF_DEVICE_ID = "linked_device_id"
-CONF_ENABLE_GLARE_ZONES = "enable_glare_zones"
-CONF_WINDOW_WIDTH = "window_width"
 
-# Weather override
-CONF_WEATHER_WIND_SPEED_SENSOR = "weather_wind_speed_sensor"
-CONF_WEATHER_WIND_DIRECTION_SENSOR = "weather_wind_direction_sensor"
+CONF_MY_POSITION_VALUE = "my_position_value"  # user's "my" position, 1-99
+DEFAULT_CUSTOM_POSITION_PRIORITY = 77  # default priority for a new slot
+
+
+# =============================================================================
+# 15. Weather Override (Safety)
+# =============================================================================
+# Weather-priority safety handler (priority 90). Retracts/closes covers when
+# wind, rain, or other severe conditions warrant it. Threshold units must
+# match the configured sensor unit — no conversion is applied.
+
+CONF_WEATHER_WIND_SPEED_SENSOR = "weather_wind_speed_sensor"  # wind-speed entity
+CONF_WEATHER_WIND_DIRECTION_SENSOR = "weather_wind_direction_sensor"  # deg entity
+# Wind speed above which override fires (range 0-200, in the sensor's unit).
 CONF_WEATHER_WIND_SPEED_THRESHOLD = "weather_wind_speed_threshold"
+# ± degrees from window azimuth that counts as on-axis wind (range 5-180).
 CONF_WEATHER_WIND_DIRECTION_TOLERANCE = "weather_wind_direction_tolerance"
-CONF_WEATHER_RAIN_SENSOR = "weather_rain_sensor"
+CONF_WEATHER_RAIN_SENSOR = "weather_rain_sensor"  # rain-rate sensor entity_id
+# Rain rate above which override fires (range 0-100, in the sensor's unit).
 CONF_WEATHER_RAIN_THRESHOLD = "weather_rain_threshold"
-CONF_WEATHER_IS_RAINING_SENSOR = "weather_is_raining_sensor"
-CONF_WEATHER_IS_WINDY_SENSOR = "weather_is_windy_sensor"
-CONF_WEATHER_SEVERE_SENSORS = "weather_severe_sensors"
+CONF_WEATHER_IS_RAINING_SENSOR = "weather_is_raining_sensor"  # binary entity_id
+CONF_WEATHER_IS_WINDY_SENSOR = "weather_is_windy_sensor"  # binary entity_id
+CONF_WEATHER_SEVERE_SENSORS = "weather_severe_sensors"  # severe-weather list
+# Position commanded during weather override (range 0-100).
 CONF_WEATHER_OVERRIDE_POSITION = "weather_override_position"
+# If True, weather override is only enforced as a min position.
 CONF_WEATHER_OVERRIDE_MIN_MODE = "weather_override_min_mode"
-CONF_WEATHER_TIMEOUT = "weather_timeout"
+CONF_WEATHER_TIMEOUT = "weather_timeout"  # resume delay after clear, s (0-3600)
+# If True, weather override fires even when auto control is off.
 CONF_WEATHER_BYPASS_AUTO_CONTROL = "weather_bypass_auto_control"
 
+# Threshold unit must match the sensor (no conversion applied).
+DEFAULT_WEATHER_WIND_SPEED_THRESHOLD = 50.0
+# Degrees each side of window azimuth that counts as on-axis wind.
+DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE = 45
+# Threshold unit must match the sensor (no conversion applied).
+DEFAULT_WEATHER_RAIN_THRESHOLD = 1.0
+DEFAULT_WEATHER_TIMEOUT = 300  # seconds before resuming after clear
 
-CONF_DELTA_POSITION = "delta_position"
-CONF_DELTA_TIME = "delta_time"
-CONF_START_TIME = "start_time"
-CONF_START_ENTITY = "start_entity"
-CONF_END_TIME = "end_time"
-CONF_END_ENTITY = "end_entity"
-CONF_RETURN_SUNSET = "return_sunset"
+
+# =============================================================================
+# 16. Automation Timing & Gating
+# =============================================================================
+# Delta thresholds (position / time) that gate command emission, plus the
+# active time-of-day window.
+
+CONF_DELTA_POSITION = "delta_position"  # min % change to emit, range 1-90
+CONF_DELTA_TIME = "delta_time"  # min seconds between commands, range 2-60
+CONF_START_TIME = "start_time"  # active-window start "HH:MM:SS"
+CONF_START_ENTITY = "start_entity"  # input_datetime overriding start_time
+CONF_END_TIME = "end_time"  # active-window end "HH:MM:SS"
+CONF_END_ENTITY = "end_entity"  # input_datetime overriding end_time
+
+
+# =============================================================================
+# 17. Interpolation
+# =============================================================================
+# Maps the calc-engine raw position output through a user-defined interpolation
+# curve before commanding the cover.
+
+CONF_INTERP = "interp"  # master enable for interpolation
+CONF_INTERP_START = "interp_start"  # start of interp domain, % (0-100)
+CONF_INTERP_END = "interp_end"  # end of interp domain, % (0-100)
+CONF_INTERP_LIST = "interp_list"  # legacy list of control points
+CONF_INTERP_LIST_NEW = "interp_list_new"  # new-format control points
+
+
+# =============================================================================
+# 18. Manual Override & Transit
+# =============================================================================
+# How the integration detects, ignores, and recovers from manual user input on
+# the cover. Includes the in-flight transit timeout that suppresses false
+# manual-override detection during normal motor travel.
+
+# How long a manual override stays active before automation resumes.
 CONF_MANUAL_OVERRIDE_DURATION = "manual_override_duration"
+# If True, the manual override is reset when end_time is reached.
 CONF_MANUAL_OVERRIDE_RESET = "manual_override_reset"
-CONF_MANUAL_THRESHOLD = "manual_threshold"
+CONF_MANUAL_THRESHOLD = "manual_threshold"  # % delta = manual touch, 0-99
+# If True, intermediate positions don't count as manual touches.
 CONF_MANUAL_IGNORE_INTERMEDIATE = "manual_ignore_intermediate"
+# Position threshold separating "open" vs "closed" classification, % (1-99).
 CONF_OPEN_CLOSE_THRESHOLD = "open_close_threshold"
 
-# Debug & Diagnostics
-CONF_DEBUG_MODE = "debug_mode"
-CONF_DEBUG_CATEGORIES = "debug_categories"
-CONF_DEBUG_EVENT_BUFFER_SIZE = "debug_event_buffer_size"
-CONF_DRY_RUN = "dry_run"
-
-DEBUG_CATEGORY_MANUAL_OVERRIDE = "manual_override"
-DEBUG_CATEGORY_RECONCILIATION = "reconciliation"
-DEBUG_CATEGORY_PIPELINE = "pipeline"
-DEBUG_CATEGORY_MOTION = "motion"
-DEBUG_CATEGORIES_ALL = [
-    DEBUG_CATEGORY_MANUAL_OVERRIDE,
-    DEBUG_CATEGORY_RECONCILIATION,
-    DEBUG_CATEGORY_PIPELINE,
-    DEBUG_CATEGORY_MOTION,
-]
-
-DEFAULT_DEBUG_EVENT_BUFFER_SIZE = 250
-MAX_DEBUG_EVENT_BUFFER_SIZE = 1000
-
-# Position verification constants (fixed values, not configurable)
-POSITION_CHECK_INTERVAL_MINUTES = 1  # Fixed interval for position verification
-POSITION_TOLERANCE_PERCENT = 3  # Fixed tolerance for position matching
-MAX_POSITION_RETRIES = 3  # Maximum retry attempts before giving up
-
-# Dual-axis venetian sequencing (Issue #33). After a position command lands,
-# the service polls current_position every poll-interval seconds, declares
-# the cover "settled" when the position matches the target within the standard
-# tolerance OR has not changed for three consecutive samples, and proceeds to
-# the tilt command.  Hard cap at the timeout so a stuck cover does not block
-# the rest of the update cycle indefinitely.
-VENETIAN_POSITION_SETTLE_POLL_SECONDS = 0.5
-VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS = 60.0
-VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES = 3
-# Suppress tilt-axis manual override detection for this many seconds after a
-# venetian position command. Real motors back-rotate the slats while moving
-# vertically, and that drift would otherwise read as a user touch.
-VENETIAN_TILT_SUPPRESSION_SECONDS = 90.0
-# After set_cover_tilt_position returns, real motors keep back-driving the
-# vertical axis briefly. Wait this many seconds before reading current_position
-# for the post-tilt rebase so the rebase captures the actual settled position
-# rather than the pre-back-drive snapshot.
-VENETIAN_POST_TILT_REBASE_DELAY_SECONDS = 1.5
-# Hold delay between position settle and the tilt command. Some actuators
-# perform a firmware tilt-reassert after the carriage reports closed/open
-# (e.g. FGR223): firing the tilt command immediately races that reassert.
-# The value is now configurable per-instance; this module-level constant
-# remains as the hard-coded default consumed only when no instance config is
-# available (e.g. unit tests that don't inject the kwarg).
-CONF_VENETIAN_POST_SETTLE_HOLD = "venetian_post_settle_hold"
-DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS = 2.0
-_RANGE_VENETIAN_POST_SETTLE_HOLD = (0.0, 10.0)
-# Drift tolerance for tilt verification: if actual tilt differs from the sent
-# target by more than this many percent after the post-tilt delay, the recorded
-# target is cleared so the next update_tilt_only cycle retries the command.
-VENETIAN_TILT_VERIFY_TOLERANCE = 5  # percent
-# Skip the tilt command when the commanded position exceeds this threshold —
-# at high positions the slats are retracted into the housing and tilting is
-# physically meaningless. The value is configurable per-instance.
-CONF_VENETIAN_TILT_SKIP_ABOVE = "venetian_tilt_skip_above"
-DEFAULT_VENETIAN_TILT_SKIP_ABOVE = 95  # percent
-MIN_VENETIAN_TILT_SKIP_ABOVE = 50
-MAX_VENETIAN_TILT_SKIP_ABOVE = 100
-_RANGE_VENETIAN_TILT_SKIP_ABOVE = (
-    MIN_VENETIAN_TILT_SKIP_ABOVE,
-    MAX_VENETIAN_TILT_SKIP_ABOVE,
-)
-
-# Venetian cover operating mode.  position_and_tilt tracks both axes with solar
-# geometry; tilt_only closes the cover to 0% and tracks only the slat angle.
-CONF_VENETIAN_MODE = "venetian_mode"
-VENETIAN_MODE_POSITION_AND_TILT = "position_and_tilt"
-VENETIAN_MODE_TILT_ONLY = "tilt_only"
-DEFAULT_VENETIAN_MODE = VENETIAN_MODE_POSITION_AND_TILT
-VENETIAN_MODES = (VENETIAN_MODE_POSITION_AND_TILT, VENETIAN_MODE_TILT_ONLY)
-
-# Maximum slat tilt percentage (0–100). Caps the sun-derived slat angle so
-# slats never reach angles that can reflect direct sun into the room.
-CONF_MAX_TILT = "max_tilt"
-DEFAULT_MAX_TILT = 100
-_RANGE_MAX_TILT = (0, 100)
-
-# Minimum slat tilt percentage (0–100). Floors the sun-derived slat angle so
-# slats never close fully — useful for blinds that block all light at 0%.
-CONF_MIN_TILT = "min_tilt"
-DEFAULT_MIN_TILT = 0
-_RANGE_MIN_TILT = (0, 100)
-
-# Manual override detection grace period (fixed values, not configurable)
-COMMAND_GRACE_PERIOD_SECONDS = 5.0  # Time to ignore position changes after command
-STARTUP_GRACE_PERIOD_SECONDS = (
-    30.0  # Time to disable manual override detection on startup
-)
+# Manual override detection grace periods (fixed values, not configurable).
+COMMAND_GRACE_PERIOD_SECONDS = 5.0  # ignore position changes after a command
+STARTUP_GRACE_PERIOD_SECONDS = 30.0  # disable manual-override after HA startup
 
 # Maximum time (seconds) to suppress manual override detection after sending a
 # position command.  Once this threshold is crossed, wait_for_target is cleared
@@ -260,164 +425,272 @@ STARTUP_GRACE_PERIOD_SECONDS = (
 # typically complete a full traverse in 20–40 seconds.  The timeout resets
 # whenever the cover makes forward progress toward target, so slow-but-moving
 # covers get an extended window proportional to when they last moved.
-DEFAULT_TRANSIT_TIMEOUT_SECONDS = 45
-TRANSIT_TIMEOUT_SECONDS = DEFAULT_TRANSIT_TIMEOUT_SECONDS  # backward-compat alias
+DEFAULT_TRANSIT_TIMEOUT_SECONDS = 45  # seconds — module-level default
+TRANSIT_TIMEOUT_SECONDS = DEFAULT_TRANSIT_TIMEOUT_SECONDS  # back-compat alias
 
-# User-configurable transit timeout (exposed in the manual override config step)
-CONF_TRANSIT_TIMEOUT = "transit_timeout"
-MIN_TRANSIT_TIMEOUT = 15
-MAX_TRANSIT_TIMEOUT = 600
+# User-configurable transit timeout (exposed in manual-override config step).
+CONF_TRANSIT_TIMEOUT = "transit_timeout"  # per-instance override, seconds
+MIN_TRANSIT_TIMEOUT = 15  # seconds — UI lower bound
+MAX_TRANSIT_TIMEOUT = 600  # seconds — UI upper bound
 
-# Motion control constants
-DEFAULT_MOTION_TIMEOUT = 300  # 5 minutes default timeout for no-motion detection
-CONF_MOTION_TIMEOUT_MODE = "motion_timeout_mode"
-MOTION_TIMEOUT_MODE_RETURN = "return_to_default"
-MOTION_TIMEOUT_MODE_HOLD = "hold_position"
-DEFAULT_MOTION_TIMEOUT_MODE = MOTION_TIMEOUT_MODE_RETURN
 
-# Weather override constants
-DEFAULT_WEATHER_WIND_SPEED_THRESHOLD = (
-    50.0  # threshold unit must match sensor (no conversion applied)
-)
-DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE = 45  # degrees each side of window azimuth
-DEFAULT_WEATHER_RAIN_THRESHOLD = (
-    1.0  # threshold unit must match sensor (no conversion applied)
-)
-DEFAULT_WEATHER_TIMEOUT = 300  # seconds before resuming after conditions clear
+# =============================================================================
+# 19. Motion Control
+# =============================================================================
+# Optional motion-triggered handler (priority 75). After motion ceases for
+# CONF_MOTION_TIMEOUT seconds, behavior depends on CONF_MOTION_TIMEOUT_MODE.
 
-# Cloud coverage constants
-DEFAULT_CLOUD_COVERAGE_THRESHOLD = 75  # 75% cloud coverage = overcast
+CONF_MOTION_SENSORS = "motion_sensors"  # binary_sensor list; empty=disabled
+CONF_MOTION_TIMEOUT = "motion_timeout"  # no-motion window, s (30-3600)
+CONF_MOTION_TIMEOUT_MODE = "motion_timeout_mode"  # one of MOTION_TIMEOUT_MODE_*
 
-# Window/awning geometry defaults (UI defaults and validation caps)
-DEFAULT_WINDOW_HEIGHT = 2.1  # metres
-DEFAULT_AWNING_LENGTH = 2.1  # metres — awning extension length
-DEFAULT_WINDOW_AZIMUTH = 180  # degrees, south-facing
+MOTION_TIMEOUT_MODE_RETURN = "return_to_default"  # return to default height
+MOTION_TIMEOUT_MODE_HOLD = "hold_position"  # hold current position
+
+DEFAULT_MOTION_TIMEOUT = 300  # 5 minutes — default no-motion window
+DEFAULT_MOTION_TIMEOUT_MODE = MOTION_TIMEOUT_MODE_RETURN  # default mode
+
+
+# =============================================================================
+# 20. Position Verification
+# =============================================================================
+# Fixed (non-configurable) constants that drive the periodic check ensuring
+# the cover actually reached the commanded position.
+
+POSITION_CHECK_INTERVAL_MINUTES = 1  # minutes — recheck cadence
+POSITION_TOLERANCE_PERCENT = 3  # % — "position matches" tolerance
+MAX_POSITION_RETRIES = 3  # maximum re-send attempts before giving up
+
+
+# =============================================================================
+# 21. Venetian Dual-Axis Sequencing
+# =============================================================================
+# Venetian covers move both vertical position AND tilt. The dual-axis sequencer
+# (managers/dual_axis_sequencer.py) issues the position command, waits for the
+# carriage to settle, then issues the tilt command. Constants in this section
+# govern that handshake and the venetian-specific mode/clamp options.
+
+# After a position command lands, the service polls current_position every
+# poll-interval seconds, declares the cover "settled" when the position matches
+# the target within the standard tolerance OR has not changed for three
+# consecutive samples, and proceeds to the tilt command.  Hard cap at the
+# timeout so a stuck cover does not block the rest of the update cycle.
+VENETIAN_POSITION_SETTLE_POLL_SECONDS = 0.5  # poll interval while settling
+VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS = 60.0  # hard cap on settle wait
+VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES = 3  # samples → "settled"
+
+# Suppress tilt-axis manual override detection for this many seconds after a
+# venetian position command. Real motors back-rotate the slats while moving
+# vertically, and that drift would otherwise read as a user touch.
+VENETIAN_TILT_SUPPRESSION_SECONDS = 90.0  # tilt-axis override-suppression window
+
+# After set_cover_tilt_position returns, real motors keep back-driving the
+# vertical axis briefly. Wait this many seconds before reading current_position
+# for the post-tilt rebase so the rebase captures the actual settled position
+# rather than the pre-back-drive snapshot.
+VENETIAN_POST_TILT_REBASE_DELAY_SECONDS = 1.5  # wait before post-tilt rebase
+
+# Drift tolerance for tilt verification: if actual tilt differs from the sent
+# target by more than this many percent after the post-tilt delay, the recorded
+# target is cleared so the next update_tilt_only cycle retries the command.
+VENETIAN_TILT_VERIFY_TOLERANCE = 5  # percent — tilt-verification tolerance
+
+# Hold delay between position settle and the tilt command. Some actuators
+# perform a firmware tilt-reassert after the carriage reports closed/open
+# (e.g. FGR223): firing the tilt command immediately races that reassert.
+# The value is configurable per-instance; the module-level default is consumed
+# only when no instance config is available (e.g. unit tests).
+CONF_VENETIAN_POST_SETTLE_HOLD = "venetian_post_settle_hold"  # s, 0.0-10.0
+DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS = 2.0  # default post-settle hold
+
+# Skip the tilt command when the commanded position exceeds this threshold —
+# at high positions the slats are retracted into the housing and tilting is
+# physically meaningless. The value is configurable per-instance.
+CONF_VENETIAN_TILT_SKIP_ABOVE = "venetian_tilt_skip_above"  # %, 50-100
+DEFAULT_VENETIAN_TILT_SKIP_ABOVE = 95  # percent — default skip-tilt threshold
+MIN_VENETIAN_TILT_SKIP_ABOVE = 50  # UI lower bound
+MAX_VENETIAN_TILT_SKIP_ABOVE = 100  # UI upper bound
+
+# Venetian cover operating mode.  position_and_tilt tracks both axes with solar
+# geometry; tilt_only closes the cover to 0% and tracks only the slat angle.
+CONF_VENETIAN_MODE = "venetian_mode"  # one of VENETIAN_MODES
+VENETIAN_MODE_POSITION_AND_TILT = "position_and_tilt"  # track position AND tilt
+VENETIAN_MODE_TILT_ONLY = "tilt_only"  # hold at 0%, track tilt only
+DEFAULT_VENETIAN_MODE = VENETIAN_MODE_POSITION_AND_TILT  # default mode
+VENETIAN_MODES = (VENETIAN_MODE_POSITION_AND_TILT, VENETIAN_MODE_TILT_ONLY)
+
+
+# =============================================================================
+# 22. Debug & Diagnostics
+# =============================================================================
+# Debug-mode toggle, per-category logging filters, the rolling event buffer,
+# and dry-run mode (suppresses outgoing cover commands).
+
+CONF_DEBUG_MODE = "debug_mode"  # master debug switch
+CONF_DEBUG_CATEGORIES = "debug_categories"  # list of DEBUG_CATEGORY_* strings
+CONF_DEBUG_EVENT_BUFFER_SIZE = "debug_event_buffer_size"  # see MAX_ below
+CONF_DRY_RUN = "dry_run"  # log commands without sending them
+
+DEBUG_CATEGORY_MANUAL_OVERRIDE = "manual_override"  # manual-override events
+DEBUG_CATEGORY_RECONCILIATION = "reconciliation"  # reconciliation logic
+DEBUG_CATEGORY_PIPELINE = "pipeline"  # pipeline handler trace
+DEBUG_CATEGORY_MOTION = "motion"  # motion handler events
+DEBUG_CATEGORIES_ALL = [
+    DEBUG_CATEGORY_MANUAL_OVERRIDE,
+    DEBUG_CATEGORY_RECONCILIATION,
+    DEBUG_CATEGORY_PIPELINE,
+    DEBUG_CATEGORY_MOTION,
+]  # full set of categories, used as the config_flow selector source
+
+DEFAULT_DEBUG_EVENT_BUFFER_SIZE = 250  # default rolling-buffer size
+MAX_DEBUG_EVENT_BUFFER_SIZE = 1000  # hard upper bound on rolling buffer
+
+
+# =============================================================================
+# 23. Control Status (diagnostic enum)
+# =============================================================================
+# String identifiers exposed by the diagnostic "control_status" sensor so
+# users can see which pipeline branch is currently active.
+
+
+class ControlStatus:
+    """Control-status values reported by the diagnostic sensor.
+
+    Each value reflects the reason the integration is (or is not) currently
+    commanding the cover. Surfaced verbatim in diagnostics and the Lovelace
+    card; do not rename without updating downstream consumers.
+    """
+
+    ACTIVE = "active"  # actively tracking the sun / running automation
+    OUTSIDE_TIME_WINDOW = "outside_time_window"  # outside start/end window
+    POSITION_DELTA_TOO_SMALL = "position_delta_too_small"  # < CONF_DELTA_POSITION
+    TIME_DELTA_TOO_SMALL = "time_delta_too_small"  # < CONF_DELTA_TIME
+    MANUAL_OVERRIDE = "manual_override"  # manual override active
+    AUTOMATIC_CONTROL_OFF = "automatic_control_off"  # auto-control toggled off
+    SUN_NOT_VISIBLE = "sun_not_visible"  # sun outside elevation/FOV
+    FORCE_OVERRIDE_ACTIVE = "force_override_active"  # priority-100 handler
+    WEATHER_OVERRIDE_ACTIVE = "weather_override_active"  # priority-90 handler
+    MOTION_TIMEOUT = "motion_timeout"  # priority-75 handler fired
+
+
+# =============================================================================
+# 24. Geometric Accuracy (calc engine)
+# =============================================================================
+# Edge-case thresholds and safety-margin multipliers used in calculation.py
+# and engine/sun_geometry.py. Tuning these affects how aggressively the
+# integration retreats from extreme sun geometries.
+
+# Edge-case thresholds for extreme sun positions.
+EDGE_CASE_LOW_ELEVATION = 2.0  # deg — below this, use low-elev path
+EDGE_CASE_HIGH_ELEVATION = 88.0  # deg — above this, use high-elev path
+EDGE_CASE_EXTREME_GAMMA = 85  # deg — max horizontal angle considered
+
+# Safety margin thresholds and multipliers.
+SAFETY_MARGIN_GAMMA_THRESHOLD = 45  # deg — angle where gamma margins start
+SAFETY_MARGIN_GAMMA_MAX = 0.2  # +20% at extreme horizontal angles (>45°)
+SAFETY_MARGIN_LOW_ELEV_THRESHOLD = 10  # deg — low-angle margin threshold
+SAFETY_MARGIN_LOW_ELEV_MAX = 0.15  # +15% at low sun elevation (<10°)
+SAFETY_MARGIN_HIGH_ELEV_THRESHOLD = 75  # deg — high-angle margin threshold
+SAFETY_MARGIN_HIGH_ELEV_MAX = 0.1  # +10% at high sun elevation (>75°)
+
+# Window depth calculation threshold.
+WINDOW_DEPTH_GAMMA_THRESHOLD = 10  # deg — min gamma for depth contribution
+
+
+# =============================================================================
+# 25. UI Defaults & Validation Caps
+# =============================================================================
+# Default values shown in the config-flow UI and hard caps not derived from
+# OPTION_RANGES (used for legacy schema validation).
+
+DEFAULT_WINDOW_HEIGHT = 2.1  # metres — config-flow default
+DEFAULT_AWNING_LENGTH = 2.1  # metres — config-flow default
+DEFAULT_WINDOW_AZIMUTH = 180  # degrees — config-flow default (south-facing)
 MAX_WINDOW_DEPTH = 5.0  # metres — UI cap for window depth
 MAX_AWNING_ANGLE = 45  # degrees — UI cap for awning tilt
 DEGREES_IN_CIRCLE = 360  # used for azimuth/wind-direction wrap-around math
 
-STRATEGY_MODE_BASIC = "basic"
-STRATEGY_MODE_CLIMATE = "climate"
-STRATEGY_MODES = [
-    STRATEGY_MODE_BASIC,
-    STRATEGY_MODE_CLIMATE,
-]
 
+# =============================================================================
+# 26. Numeric Option Ranges (single source of truth)
+# =============================================================================
+# Each ``_RANGE_*`` tuple is ``(min, max)`` for the named CONF_* option.
+# ``OPTION_RANGES`` (built at module import) is the dict consumed by both
+# ``config_flow.py`` selectors and ``services/options_service.FIELD_VALIDATORS``
+# — keep ranges defined here, not duplicated at the call sites.
 
-class SensorType:
-    """Possible modes for a number selector."""
+# Geometry — vertical blind.
+_RANGE_HEIGHT_WIN = (0.1, 50.0)  # CONF_HEIGHT_WIN, metres
+_RANGE_WINDOW_WIDTH = (0.1, 50.0)  # CONF_WINDOW_WIDTH, metres
+_RANGE_WINDOW_DEPTH = (0.0, 5.0)  # CONF_WINDOW_DEPTH, metres
+_RANGE_SILL_HEIGHT = (0.0, 50.0)  # CONF_SILL_HEIGHT, metres
 
-    BLIND = "cover_blind"
-    AWNING = "cover_awning"
-    TILT = "cover_tilt"
-    VENETIAN = "cover_venetian"
+# Geometry — awning.
+_RANGE_LENGTH_AWNING = (0.3, 6.0)  # CONF_LENGTH_AWNING, metres
+_RANGE_AWNING_ANGLE = (0, 45)  # CONF_AWNING_ANGLE, degrees
 
+# Geometry — tilt / venetian slats.
+_RANGE_TILT_DEPTH = (0.1, 15.0)  # CONF_TILT_DEPTH, cm
+_RANGE_TILT_DISTANCE = (0.1, 15.0)  # CONF_TILT_DISTANCE, cm
+_RANGE_MAX_TILT = (0, 100)  # CONF_MAX_TILT, percent
+_RANGE_MIN_TILT = (0, 100)  # CONF_MIN_TILT, percent
 
-class ControlStatus:
-    """Control status options for diagnostic sensor."""
+# Sun tracking.
+_RANGE_AZIMUTH = (0, 359)  # CONF_AZIMUTH, degrees
+_RANGE_FOV = (0, 180)  # CONF_FOV_LEFT / CONF_FOV_RIGHT, degrees
+_RANGE_ELEVATION = (0, 90)  # min/max elevation, degrees
+_RANGE_DISTANCE = (0.1, 50.0)  # CONF_DISTANCE, metres
 
-    ACTIVE = "active"
-    OUTSIDE_TIME_WINDOW = "outside_time_window"
-    POSITION_DELTA_TOO_SMALL = "position_delta_too_small"
-    TIME_DELTA_TOO_SMALL = "time_delta_too_small"
-    MANUAL_OVERRIDE = "manual_override"
-    AUTOMATIC_CONTROL_OFF = "automatic_control_off"
-    SUN_NOT_VISIBLE = "sun_not_visible"
-    FORCE_OVERRIDE_ACTIVE = "force_override_active"
-    WEATHER_OVERRIDE_ACTIVE = "weather_override_active"
-    MOTION_TIMEOUT = "motion_timeout"
+# Blind spot.
+# Asymmetric LEFT vs RIGHT bounds are a historical quirk; preserved for compat.
+_RANGE_BLIND_SPOT_LEFT = (0, 359)  # CONF_BLIND_SPOT_LEFT, degrees
+_RANGE_BLIND_SPOT_RIGHT = (0, 360)  # CONF_BLIND_SPOT_RIGHT, degrees
+_RANGE_BLIND_SPOT_ELEVATION = (0, 90)  # CONF_BLIND_SPOT_ELEVATION, degrees
 
+# Position limits & sunset.
+_RANGE_DEFAULT_HEIGHT = (0, 100)  # CONF_DEFAULT_HEIGHT, percent
+_RANGE_MAX_POSITION = (1, 100)  # CONF_MAX_POSITION, percent
+_RANGE_MIN_POSITION = (0, 99)  # CONF_MIN_POSITION, percent
+_RANGE_SUNSET_POS = (0, 100)  # CONF_SUNSET_POS, percent
+_RANGE_MY_POSITION = (1, 99)  # CONF_MY_POSITION_VALUE, percent
+_RANGE_OFFSET_MINUTES = (-120, 120)  # sunset/sunrise offsets, minutes
+_RANGE_OPEN_CLOSE_THRESHOLD = (1, 99)  # CONF_OPEN_CLOSE_THRESHOLD, percent
 
-# Geometric accuracy constants (used in calculation.py for safety margins and edge cases)
-# Edge case thresholds for extreme sun positions
-EDGE_CASE_LOW_ELEVATION = 2.0  # degrees - minimum elevation for normal calculation
-EDGE_CASE_HIGH_ELEVATION = (
-    88.0  # degrees - maximum elevation before using simplified calculation
-)
-EDGE_CASE_EXTREME_GAMMA = 85  # degrees - maximum horizontal angle deviation
+# Interpolation.
+_RANGE_INTERP_VALUE = (0, 100)  # interp start/end, percent
 
-# Safety margin thresholds and multipliers
-SAFETY_MARGIN_GAMMA_THRESHOLD = 45  # degrees - angle where gamma-based margins start
-SAFETY_MARGIN_GAMMA_MAX = 0.2  # 20% increase at extreme horizontal angles (>45°)
-SAFETY_MARGIN_LOW_ELEV_THRESHOLD = (
-    10  # degrees - elevation where low-angle margins apply
-)
-SAFETY_MARGIN_LOW_ELEV_MAX = 0.15  # 15% increase at low sun elevation (<10°)
-SAFETY_MARGIN_HIGH_ELEV_THRESHOLD = (
-    75  # degrees - elevation where high-angle margins apply
-)
-SAFETY_MARGIN_HIGH_ELEV_MAX = 0.1  # 10% increase at high sun elevation (>75°)
+# Automation timing.
+_RANGE_DELTA_POSITION = (1, 90)  # CONF_DELTA_POSITION, percent
+_RANGE_DELTA_TIME = (2, 60)  # CONF_DELTA_TIME, seconds
 
-# Window depth calculation threshold
-WINDOW_DEPTH_GAMMA_THRESHOLD = (
-    10  # degrees - minimum gamma for window depth contribution
-)
+# Manual override.
+_RANGE_MANUAL_THRESHOLD = (0, 99)  # CONF_MANUAL_THRESHOLD, percent
 
-# Climate mode constants
-CLIMATE_SUMMER_TILT_ANGLE = 45  # degrees - tilt angle for summer cooling strategy
-CLIMATE_DEFAULT_TILT_ANGLE = 80  # degrees - default tilt angle when not present
+# Force override / custom positions.
+_RANGE_FORCE_POSITION = (0, 100)  # CONF_FORCE_OVERRIDE_POSITION, percent
+_RANGE_CUSTOM_POSITION = (0, 100)  # per-slot custom position, percent
+_RANGE_CUSTOM_PRIORITY = (1, 99)  # per-slot custom priority
 
-# Cover position constants
-POSITION_CLOSED = 0  # Fully closed position
-POSITION_OPEN = 100  # Fully open position
+# Motion.
+_RANGE_MOTION_TIMEOUT = (30, 3600)  # CONF_MOTION_TIMEOUT, seconds
 
+# Climate.
+_RANGE_TEMPERATURE = (0, 90)  # temp_low / temp_high (sensor unit)
+_RANGE_OUTSIDE_THRESHOLD = (0, 100)  # CONF_OUTSIDE_THRESHOLD (sensor unit)
 
-# ---------------------------------------------------------------------------
-# Numeric option ranges — single source of truth shared by config_flow.py
-# (UI selectors) and services/options_service.py (programmatic validators).
-# Each tuple is ``(min, max)`` for the named ``CONF_*`` option.
-# ---------------------------------------------------------------------------
+# Weather safety.
+_RANGE_WEATHER_WIND_SPEED = (0, 200)  # wind-speed threshold (sensor unit)
+_RANGE_WEATHER_WIND_DIRECTION_TOLERANCE = (5, 180)  # wind-direction tol, deg
+_RANGE_WEATHER_RAIN = (0, 100)  # rain threshold (sensor unit)
+_RANGE_WEATHER_OVERRIDE_POSITION = (0, 100)  # weather-override pos, percent
+_RANGE_WEATHER_TIMEOUT = (0, 3600)  # weather-resume timeout, seconds
 
-# Geometry — vertical blind
-_RANGE_HEIGHT_WIN = (0.1, 50.0)
-_RANGE_WINDOW_WIDTH = (0.1, 50.0)
-_RANGE_WINDOW_DEPTH = (0.0, 5.0)
-_RANGE_SILL_HEIGHT = (0.0, 50.0)
-# Geometry — awning
-_RANGE_LENGTH_AWNING = (0.3, 6.0)
-_RANGE_AWNING_ANGLE = (0, 45)
-# Geometry — tilt/venetian
-_RANGE_TILT_DEPTH = (0.1, 15.0)
-_RANGE_TILT_DISTANCE = (0.1, 15.0)
-# Sun tracking
-_RANGE_AZIMUTH = (0, 359)
-_RANGE_FOV = (0, 180)
-_RANGE_ELEVATION = (0, 90)
-_RANGE_DISTANCE = (0.1, 50.0)
-# Blind spot
-_RANGE_BLIND_SPOT_LEFT = (0, 359)
-_RANGE_BLIND_SPOT_RIGHT = (0, 360)
-_RANGE_BLIND_SPOT_ELEVATION = (0, 90)
-# Position limits & sunset
-_RANGE_DEFAULT_HEIGHT = (0, 100)
-_RANGE_MAX_POSITION = (1, 100)
-_RANGE_MIN_POSITION = (0, 99)
-_RANGE_SUNSET_POS = (0, 100)
-_RANGE_MY_POSITION = (1, 99)
-_RANGE_OFFSET_MINUTES = (-120, 120)
-_RANGE_OPEN_CLOSE_THRESHOLD = (1, 99)
-# Interpolation
-_RANGE_INTERP_VALUE = (0, 100)
-# Automation timing
-_RANGE_DELTA_POSITION = (1, 90)
-_RANGE_DELTA_TIME = (2, 60)
-# Manual override
-_RANGE_MANUAL_THRESHOLD = (0, 99)
-# Force override / custom positions
-_RANGE_FORCE_POSITION = (0, 100)
-_RANGE_CUSTOM_POSITION = (0, 100)
-_RANGE_CUSTOM_PRIORITY = (1, 99)
-# Motion
-_RANGE_MOTION_TIMEOUT = (30, 3600)
-# Climate
-_RANGE_TEMPERATURE = (0, 90)
-_RANGE_OUTSIDE_THRESHOLD = (0, 100)
-# Weather safety
-_RANGE_WEATHER_WIND_SPEED = (0, 200)
-_RANGE_WEATHER_WIND_DIRECTION_TOLERANCE = (5, 180)
-_RANGE_WEATHER_RAIN = (0, 100)
-_RANGE_WEATHER_OVERRIDE_POSITION = (0, 100)
-_RANGE_WEATHER_TIMEOUT = (0, 3600)
+# Venetian sequencing.
+_RANGE_VENETIAN_POST_SETTLE_HOLD = (0.0, 10.0)  # post-settle hold, seconds
+_RANGE_VENETIAN_TILT_SKIP_ABOVE = (
+    MIN_VENETIAN_TILT_SKIP_ABOVE,
+    MAX_VENETIAN_TILT_SKIP_ABOVE,
+)  # CONF_VENETIAN_TILT_SKIP_ABOVE, percent
 
 
 def _build_option_ranges() -> dict[str, tuple[float, float]]:
@@ -480,4 +753,5 @@ def _build_option_ranges() -> dict[str, tuple[float, float]]:
     return ranges
 
 
+# Exported single source of truth — built at module import.
 OPTION_RANGES: dict[str, tuple[float, float]] = _build_option_ranges()

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -200,7 +200,12 @@ VENETIAN_POST_TILT_REBASE_DELAY_SECONDS = 1.5
 # Hold delay between position settle and the tilt command. Some actuators
 # perform a firmware tilt-reassert after the carriage reports closed/open
 # (e.g. FGR223): firing the tilt command immediately races that reassert.
-VENETIAN_POST_SETTLE_HOLD_SECONDS = 2.0
+# The value is now configurable per-instance; this module-level constant
+# remains as the hard-coded default consumed only when no instance config is
+# available (e.g. unit tests that don't inject the kwarg).
+CONF_VENETIAN_POST_SETTLE_HOLD = "venetian_post_settle_hold"
+DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS = 2.0
+_RANGE_VENETIAN_POST_SETTLE_HOLD = (0.0, 10.0)
 # Drift tolerance for tilt verification: if actual tilt differs from the sent
 # target by more than this many percent after the post-tilt delay, the recorded
 # target is cleared so the next update_tilt_only cycle retries the command.
@@ -212,6 +217,10 @@ CONF_VENETIAN_TILT_SKIP_ABOVE = "venetian_tilt_skip_above"
 DEFAULT_VENETIAN_TILT_SKIP_ABOVE = 95  # percent
 MIN_VENETIAN_TILT_SKIP_ABOVE = 50
 MAX_VENETIAN_TILT_SKIP_ABOVE = 100
+_RANGE_VENETIAN_TILT_SKIP_ABOVE = (
+    MIN_VENETIAN_TILT_SKIP_ABOVE,
+    MAX_VENETIAN_TILT_SKIP_ABOVE,
+)
 
 # Venetian cover operating mode.  position_and_tilt tracks both axes with solar
 # geometry; tilt_only closes the cover to 0% and tracks only the slat angle.
@@ -461,6 +470,8 @@ def _build_option_ranges() -> dict[str, tuple[float, float]]:
         CONF_WEATHER_TIMEOUT: _RANGE_WEATHER_TIMEOUT,
         CONF_MAX_TILT: _RANGE_MAX_TILT,
         CONF_MIN_TILT: _RANGE_MIN_TILT,
+        CONF_VENETIAN_POST_SETTLE_HOLD: _RANGE_VENETIAN_POST_SETTLE_HOLD,
+        CONF_VENETIAN_TILT_SKIP_ABOVE: _RANGE_VENETIAN_TILT_SKIP_ABOVE,
     }
     # Custom-position slots: per-slot position (0–100) and priority (1–99).
     for slot_keys in CUSTOM_POSITION_SLOTS.values():

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -96,10 +96,6 @@ from .const import (
     DOMAIN,
     LOGGER,
     STARTUP_GRACE_PERIOD_SECONDS,
-    CONF_VENETIAN_MODE,
-    CONF_VENETIAN_TILT_SKIP_ABOVE,
-    DEFAULT_VENETIAN_MODE,
-    DEFAULT_VENETIAN_TILT_SKIP_ABOVE,
 )
 from .diagnostics.builder import DiagnosticContext, DiagnosticsBuilder
 from .diagnostics.event_buffer import EventBuffer
@@ -335,6 +331,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Late-bind cover-type policy dependencies (e.g. VenetianPolicy
         # constructs its DualAxisSequencer here once cmd_svc + grace_mgr are
         # available).  Default policies have a no-op attach.
+        _rc_attach = RuntimeConfig.from_options(self.config_entry.options)
         self._policy.attach(
             hass=self.hass,
             logger=self.logger,
@@ -348,12 +345,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self.hass, eid, "current_tilt_position"
             ),
             event_buffer=self._event_buffer,
-            tilt_skip_above=self.config_entry.options.get(
-                CONF_VENETIAN_TILT_SKIP_ABOVE, DEFAULT_VENETIAN_TILT_SKIP_ABOVE
-            ),
-            venetian_mode=self.config_entry.options.get(
-                CONF_VENETIAN_MODE, DEFAULT_VENETIAN_MODE
-            ),
+            tilt_skip_above=_rc_attach.venetian.tilt_skip_above,
+            venetian_mode=_rc_attach.venetian.venetian_mode,
+            post_settle_hold_seconds=_rc_attach.venetian.post_settle_hold_seconds,
             invert_tilt=lambda: self._inverse_tilt,
             get_min_change=lambda: self.min_change,
         )

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1151,6 +1151,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             config=cover_data.config,
             config_service=self._config_service,
             options=options,
+            cover=cover_data,
         )
 
         self.logger.debug(

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -169,6 +169,7 @@ class CoverTypePolicy(ABC):
         config,
         config_service: ConfigurationService,
         options: dict,
+        cover: AdaptiveGeneralCover | None = None,
     ) -> PipelineResult:
         """Enrich the pipeline result. Default: identity."""
         return result

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -313,6 +313,21 @@ class VenetianPolicy(CoverTypePolicy):
             return False
         return self._sequencer.is_in_suppression(entity_id)
 
+    def _resolve_skip_above_tilt(
+        self, position: int | None, fallback_tilt: int | None
+    ) -> int | None:
+        """Apply the ``tilt_skip_above`` guard to a tilt decision.
+
+        Returns ``POSITION_OPEN`` (neutral) when the carriage is commanded
+        above the skip threshold so the actuator's tilt cache is overwritten
+        with a benign value rather than the prior solar-cycle tilt; returns
+        ``fallback_tilt`` otherwise. Shared by ``after_position_command`` and
+        ``maybe_update_tilt_only`` so the threshold rule lives in one place.
+        """
+        if position is not None and position > self._tilt_skip_above:
+            return POSITION_OPEN
+        return fallback_tilt
+
     async def maybe_update_tilt_only(
         self,
         entity_id: str,
@@ -328,9 +343,10 @@ class VenetianPolicy(CoverTypePolicy):
             return
         if self._sequencer.is_in_suppression(entity_id):
             return
+        tilt_target = self._resolve_skip_above_tilt(current_position, self._last_tilt)
         await self._sequencer.update_tilt_only(
             entity_id,
-            tilt_target=self._last_tilt,
+            tilt_target=tilt_target,
             current_position=current_position,
             reason=reason,
         )
@@ -379,12 +395,11 @@ class VenetianPolicy(CoverTypePolicy):
         seq = self._sequencer
         if seq is None:
             return
-        if position > self._tilt_skip_above:
-            tilt_target = POSITION_OPEN
-        else:
-            tilt_target = getattr(context, "tilt", None)
-            if tilt_target is None:
-                return
+        tilt_target = self._resolve_skip_above_tilt(
+            position, getattr(context, "tilt", None)
+        )
+        if tilt_target is None:
+            return
         # Open suppression early — covers position-axis settle events that
         # fire before _send_tilt_command runs (which itself stamps again).
         seq.stamp_position_command(entity_id)

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -209,6 +209,21 @@ class VenetianPolicy(CoverTypePolicy):
             vert_config=config_service.get_vertical_data(options),
         )
 
+    def _tilt_suppressed(self, result: PipelineResult, cover) -> bool:
+        """Return True when tilt synthesis must be skipped this cycle.
+
+        Tilt is meaningful only when (a) the pipeline emitted ControlMethod.SOLAR
+        AND (b) the cover engine confirms direct sun is hitting the window. The
+        climate handler can emit SOLAR on its low-light branch even when the sun
+        is below the horizon (issue #33), so direct_sun_valid is the authoritative
+        signal.
+        """
+        from ..enums import ControlMethod
+
+        if result.control_method != ControlMethod.SOLAR:
+            return True
+        return cover is None or not cover.direct_sun_valid
+
     def post_pipeline_resolve(
         self,
         result: PipelineResult,
@@ -220,6 +235,7 @@ class VenetianPolicy(CoverTypePolicy):
         config,
         config_service: ConfigurationService,
         options: dict,
+        cover: AdaptiveGeneralCover | None = None,
     ) -> PipelineResult:
         """Fill the tilt that pairs with the pipeline-resolved position.
 
@@ -231,9 +247,8 @@ class VenetianPolicy(CoverTypePolicy):
         """
         if result is None:
             return result
-        from ..enums import ControlMethod
 
-        if result.control_method != ControlMethod.SOLAR:
+        if self._tilt_suppressed(result, cover):
             return replace(result, tilt=None)
         venetian_calc = VenetianCoverCalculation(
             config=config,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -21,10 +21,12 @@ from ..const import (
     CONF_MAX_TILT,
     CONF_MIN_TILT,
     CONF_VENETIAN_MODE,
+    CONF_VENETIAN_POST_SETTLE_HOLD,
     CONF_VENETIAN_TILT_SKIP_ABOVE,
     DEFAULT_MAX_TILT,
     DEFAULT_MIN_TILT,
     DEFAULT_VENETIAN_MODE,
+    DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
     DEFAULT_VENETIAN_TILT_SKIP_ABOVE,
     MAX_VENETIAN_TILT_SKIP_ABOVE,
     MIN_VENETIAN_TILT_SKIP_ABOVE,
@@ -71,6 +73,10 @@ GEOMETRY_VENETIAN_SCHEMA = GEOMETRY_VERTICAL_SCHEMA.extend(
         vol.Optional(CONF_VENETIAN_MODE, default=DEFAULT_VENETIAN_MODE): vol.In(
             VENETIAN_MODES
         ),
+        vol.Optional(
+            CONF_VENETIAN_POST_SETTLE_HOLD,
+            default=DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+        ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
         vol.Optional(CONF_INVERSE_TILT, default=False): bool,
         vol.Optional(CONF_MAX_TILT, default=DEFAULT_MAX_TILT): vol.All(
             vol.Coerce(int), vol.Range(min=0, max=100)
@@ -150,6 +156,10 @@ class VenetianPolicy(CoverTypePolicy):
         max_tilt_line = [f"max tilt {max_tilt}%"]
         min_tilt = config.get(CONF_MIN_TILT, DEFAULT_MIN_TILT)
         min_tilt_line = [f"min tilt {min_tilt}%"]
+        hold = config.get(
+            CONF_VENETIAN_POST_SETTLE_HOLD, DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
+        )
+        post_settle_line = [f"post-settle hold {round(hold, 1)}s"]
         return (
             window_dimensions_lines(config)
             + slat_line
@@ -158,6 +168,7 @@ class VenetianPolicy(CoverTypePolicy):
             + inverse_tilt_line
             + min_tilt_line
             + max_tilt_line
+            + post_settle_line
         )
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:
@@ -311,6 +322,9 @@ class VenetianPolicy(CoverTypePolicy):
             event_buffer=kwargs.get("event_buffer"),
             invert_tilt=kwargs.get("invert_tilt"),
             get_min_change=kwargs.get("get_min_change"),
+            post_settle_hold_seconds=kwargs.get(
+                "post_settle_hold_seconds", DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
+            ),
         )
         if "tilt_skip_above" in kwargs:
             self._tilt_skip_above = int(kwargs["tilt_skip_above"])

--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -31,6 +31,7 @@ from ..const import (
     VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES,
     VENETIAN_POSITION_SETTLE_POLL_SECONDS,
     VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
+    VENETIAN_POST_SETTLE_HOLD_SECONDS,
     VENETIAN_POST_TILT_REBASE_DELAY_SECONDS,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
     VENETIAN_TILT_VERIFY_TOLERANCE,
@@ -130,6 +131,7 @@ class DualAxisSequencer:
     ) -> None:
         """Wait for vertical motion to settle, then send the tilt command."""
         await self._wait_for_position_settle(entity_id, position_target)
+        await asyncio.sleep(VENETIAN_POST_SETTLE_HOLD_SECONDS)
         await self._send_tilt_command(
             entity_id,
             tilt_target=tilt_target,
@@ -336,11 +338,18 @@ class DualAxisSequencer:
             if current is None:
                 return False, last_position
 
-            if abs(current - target) <= self._position_tolerance:
-                return True, current
-
+            # Read state once per iteration so both the in-tolerance gate and
+            # the no-progress stall counter use the same snapshot.
             state = self._get_state(entity_id) if self._get_state else None
             is_moving = state in _COVER_MOVING_STATES
+
+            if abs(current - target) <= self._position_tolerance:
+                # When a get_state callback is provided, also require that
+                # the cover has actually stopped before declaring settle —
+                # some actuators briefly transit through the target position
+                # while still in a "closing"/"opening" state.
+                if self._get_state is None or not is_moving:
+                    return True, current
 
             if last_position is not None and current == last_position:
                 if is_moving:

--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -28,10 +28,10 @@ from homeassistant.exceptions import HomeAssistantError
 
 from ..const import (
     ATTR_TILT_POSITION,
+    DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
     VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES,
     VENETIAN_POSITION_SETTLE_POLL_SECONDS,
     VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
-    VENETIAN_POST_SETTLE_HOLD_SECONDS,
     VENETIAN_POST_TILT_REBASE_DELAY_SECONDS,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
     VENETIAN_TILT_VERIFY_TOLERANCE,
@@ -78,6 +78,7 @@ class DualAxisSequencer:
         event_buffer: EventBuffer | None = None,
         invert_tilt: Callable[[], bool] | None = None,
         get_min_change: Callable[[], int] | None = None,
+        post_settle_hold_seconds: float = DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
     ) -> None:
         """Bind HA + cmd_svc dependencies; per-entity timestamps start empty."""
         self._hass = hass
@@ -92,6 +93,7 @@ class DualAxisSequencer:
         self._event_buffer = event_buffer
         self._invert_tilt = invert_tilt
         self._get_min_change = get_min_change
+        self._post_settle_hold_seconds = post_settle_hold_seconds
         # Per-entity timestamps. Keep these in the sequencer (rather than on
         # CoverCommandService.PerEntityState) so non-venetian covers carry no
         # dual-axis state at all.
@@ -176,7 +178,7 @@ class DualAxisSequencer:
     ) -> None:
         """Wait for vertical motion to settle, then send the tilt command."""
         await self._wait_for_position_settle(entity_id, position_target)
-        await asyncio.sleep(VENETIAN_POST_SETTLE_HOLD_SECONDS)
+        await asyncio.sleep(self._post_settle_hold_seconds)
         await self._send_tilt_command(
             entity_id,
             tilt_target=tilt_target,

--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -53,6 +53,12 @@ _TILT_SKIP_TARGET_UNCHANGED = "target_unchanged"
 _TILT_SKIP_SERVICE_FAILED = "service_call_failed"
 _TILT_SKIP_DELTA_TOO_SMALL = "delta_too_small"
 
+# Anchor sources for the tilt min-delta gate (issue #33). The gate compares
+# the new target against either the live actuator reading (preferred) or the
+# previously-stored target (fallback when the actuator can't be read).
+_ANCHOR_SOURCE_ACTUAL = "actual"
+_ANCHOR_SOURCE_TARGET_FALLBACK = "target_fallback"
+
 
 class DualAxisSequencer:
     """Position→settle→tilt sequencer + tilt-axis suppression window."""
@@ -96,10 +102,39 @@ class DualAxisSequencer:
     # -- tilt inversion ---------------------------------------------------- #
 
     def _to_wire(self, tilt: int) -> int:
-        """Convert logical tilt to wire value, applying inversion if configured."""
+        """Convert logical tilt to wire value, applying inversion if configured.
+
+        Symmetric: applied to a logical value yields wire; applied to a wire
+        value yields logical. Both directions go through the same inversion
+        check, so callers reading the actuator can use this to compare
+        against a logical target.
+        """
         if self._invert_tilt is not None and self._invert_tilt():
             return inverse_state(tilt)
         return tilt
+
+    def _resolve_tilt_anchor(self, entity_id: str) -> tuple[int | None, str]:
+        """Return ``(anchor, source)`` for the tilt min-delta gate.
+
+        Issue #33: the gate must anchor on the actuator's live tilt to avoid
+        comparing against a stale stored target (the motor auto-tilts on
+        close, leaving ``_tilt_targets`` out of sync with reality).
+
+        Returns
+        -------
+        ``(value, source)`` where:
+          * ``value`` is a logical tilt position (``0..100``) or ``None`` if
+            neither the actuator nor a stored target is available.
+          * ``source`` is :data:`_ANCHOR_SOURCE_ACTUAL` when the live read
+            succeeded, or :data:`_ANCHOR_SOURCE_TARGET_FALLBACK` when we fell
+            back to the stored target.
+
+        """
+        if self._get_current_tilt_position is not None:
+            wire = self._get_current_tilt_position(entity_id)
+            if wire is not None:
+                return self._to_wire(wire), _ANCHOR_SOURCE_ACTUAL
+        return self._tilt_targets.get(entity_id), _ANCHOR_SOURCE_TARGET_FALLBACK
 
     # -- suppression window ------------------------------------------------ #
 
@@ -120,6 +155,16 @@ class DualAxisSequencer:
     def last_tilt_target(self, entity_id: str) -> int | None:
         """Return the last tilt target sent (for diagnostics / tests)."""
         return self._tilt_targets.get(entity_id)
+
+    def clear_tilt_targets(self) -> None:
+        """Forget every stored tilt target — anchor falls back to live actuator reads.
+
+        Defense-in-depth hook for Auto Control off→on transitions (issue #33).
+        Suppression timestamps are intentionally untouched — the back-rotate
+        window is a time-based safeguard, independent of the stored-target
+        cache.
+        """
+        self._tilt_targets.clear()
 
     async def run_sequence(
         self,
@@ -152,15 +197,20 @@ class DualAxisSequencer:
 
         Shared by ``run_sequence`` (post-settle chase) and ``update_tilt_only``
         (tilt-only update when position hasn't changed).
+
+        The min-delta gate is anchored on the live actuator reading (issue
+        #33) with fallback to the stored target when current tilt is
+        unavailable — without this, a stale stored target (e.g. set before
+        the motor auto-tilted on close) skips legitimate moves.
         """
         if not force and self._get_min_change is not None:
-            prior = self._tilt_targets.get(entity_id)
-            if prior is not None and not check_position_delta(
+            anchor, anchor_source = self._resolve_tilt_anchor(entity_id)
+            if anchor is not None and not check_position_delta(
                 entity_id,
                 tilt_target,
                 self._get_min_change(),
                 None,
-                position=prior,
+                position=anchor,
                 logger=self._logger,
                 axis_label="tilt",
             ):
@@ -171,7 +221,9 @@ class DualAxisSequencer:
                     tilt_position=tilt_target,
                     position_target=position_target,
                     trigger=reason,
-                    prior_tilt_target=prior,
+                    prior_tilt_target=self._tilt_targets.get(entity_id),
+                    anchor_value=anchor,
+                    anchor_source=anchor_source,
                     min_delta_required=self._get_min_change(),
                 )
                 return

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.21.0-beta.1"
+  "version": "2.21.0-beta.2"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.20.1"
+  "version": "2.21.0-beta.1"
 }

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -237,6 +237,8 @@ class ClimateCoverState:
                 return self._solar_position()
             elif self.climate_data.is_summer:
                 self.climate_strategy = ClimateStrategy.SUMMER_COOLING
+                if degrees == TiltMode.MODE2.max_degrees:
+                    return round((degrees - CLIMATE_SUMMER_TILT_ANGLE) / degrees * 100)
                 return round((CLIMATE_SUMMER_TILT_ANGLE / degrees) * 100)
         # Close for insulation when in winter and sun not hitting window.
         if self.climate_data.is_winter and self.climate_data.winter_close_insulation:

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -363,6 +363,13 @@ class ClimateHandler(OverrideHandler):
         elif climate_data.is_winter:
             method = ControlMethod.WINTER
             season = "winter"
+        elif climate_cover_state.climate_strategy == ClimateStrategy.LOW_LIGHT:
+            # Low-light / no-sun branch — the cover returns to its default
+            # position rather than tracking the sun.  Emitting SOLAR here
+            # would cause VenetianPolicy to synthesise a tilt from the
+            # still-drifting azimuth even when the sun has set (issue #33).
+            method = ControlMethod.DEFAULT
+            season = "glare control (low light)"
         else:
             method = ControlMethod.SOLAR
             season = "glare control"

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -902,6 +902,44 @@ set_geometry:
             - mode1
             - mode2
 
+set_venetian:
+  name: Set venetian options
+  description: >-
+    Update venetian-blind specific options: operating mode, tilt skip threshold,
+    and post-settle hold. Applicable to venetian cover types only.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    venetian_mode:
+      name: Venetian mode
+      description: "Operating mode: 'position_and_tilt' (move carriage then tilt) or 'tilt_only' (tilt only, no carriage movement)."
+      selector:
+        select:
+          options:
+            - position_and_tilt
+            - tilt_only
+    venetian_tilt_skip_above:
+      name: Tilt skip above (%)
+      description: "Skip tilt commands when carriage position exceeds this value (0–100%). Set to 100 to always tilt."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    venetian_post_settle_hold:
+      name: Post-settle hold (s)
+      description: "Seconds to wait after carriage stops before sending the tilt command (0.0–10.0 s). Raise to 4–6 s for KNX FGR223 firmware."
+      selector:
+        number:
+          min: 0.0
+          max: 10.0
+          step: 0.1
+          mode: slider
+          unit_of_measurement: s
+
 set_option:
   name: Set option (generic)
   description: >-

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -15,6 +15,7 @@ from ..const import DOMAIN
 from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagnostics
 from .export_service import EXPORT_CONFIG_SCHEMA, async_handle_export
 from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
+from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -155,6 +156,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN, "integration_disable", handle_integration_disable
     )
     hass.services.async_register(DOMAIN, "emergency_stop", handle_emergency_stop)
+    hass.services.async_register(
+        DOMAIN, "set_position", async_handle_set_position, schema=SET_POSITION_SCHEMA
+    )
 
     register_options_services(hass)
 
@@ -168,5 +172,6 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "integration_enable")
     hass.services.async_remove(DOMAIN, "integration_disable")
     hass.services.async_remove(DOMAIN, "emergency_stop")
+    hass.services.async_remove(DOMAIN, "set_position")
     for name in OPTIONS_SERVICE_NAMES:
         hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -89,6 +89,10 @@ from ..const import (
     CONF_TILT_DEPTH,
     CONF_TILT_DISTANCE,
     CONF_TILT_MODE,
+    CONF_VENETIAN_MODE,
+    CONF_VENETIAN_POST_SETTLE_HOLD,
+    CONF_VENETIAN_TILT_SKIP_ABOVE,
+    VENETIAN_MODES,
     CONF_TRANSPARENT_BLIND,
     CONF_WEATHER_BYPASS_AUTO_CONTROL,
     CONF_WEATHER_ENTITY,
@@ -194,6 +198,10 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_TILT_MODE: _select_v("mode1", "mode2"),
     CONF_MAX_TILT: _range(CONF_MAX_TILT),
     CONF_MIN_TILT: _range(CONF_MIN_TILT),
+    # Venetian-specific options
+    CONF_VENETIAN_POST_SETTLE_HOLD: _range(CONF_VENETIAN_POST_SETTLE_HOLD),
+    CONF_VENETIAN_TILT_SKIP_ABOVE: _range(CONF_VENETIAN_TILT_SKIP_ABOVE),
+    CONF_VENETIAN_MODE: _select_v(*VENETIAN_MODES),
     # Sun tracking
     CONF_ENABLE_SUN_TRACKING: _bool_v(),
     CONF_AZIMUTH: _range(CONF_AZIMUTH),
@@ -450,6 +458,14 @@ _SECTION_GEOMETRY_ALL = (
     _SECTION_GEOMETRY_VERTICAL | _SECTION_GEOMETRY_AWNING | _SECTION_GEOMETRY_TILT
 )
 
+_SECTION_VENETIAN = frozenset(
+    {
+        CONF_VENETIAN_POST_SETTLE_HOLD,
+        CONF_VENETIAN_TILT_SKIP_ABOVE,
+        CONF_VENETIAN_MODE,
+    }
+)
+
 # All settable keys (union of all sections)
 ALL_SETTABLE_KEYS: frozenset[str] = (
     _SECTION_POSITION_LIMITS
@@ -465,6 +481,7 @@ ALL_SETTABLE_KEYS: frozenset[str] = (
     | _SECTION_BLIND_SPOT
     | _SECTION_INTERPOLATION
     | _SECTION_GEOMETRY_ALL
+    | _SECTION_VENETIAN
     | frozenset(v for keys in CUSTOM_POSITION_SLOTS.values() for v in keys.values())
 )
 
@@ -814,6 +831,9 @@ def register_options_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, "set_geometry", _section_handler(_SECTION_GEOMETRY_ALL)
     )
+    hass.services.async_register(
+        DOMAIN, "set_venetian", _section_handler(_SECTION_VENETIAN)
+    )
 
     async def _custom_pos_handler(call: ServiceCall) -> None:
         await _handle_set_custom_position(hass, call)
@@ -842,5 +862,6 @@ OPTIONS_SERVICE_NAMES: tuple[str, ...] = (
     "set_blind_spot",
     "set_interpolation",
     "set_geometry",
+    "set_venetian",
     "set_option",
 )

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -1,0 +1,79 @@
+"""set_position service — moves a cover to a position, clamping to min-mode floors."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from voluptuous.validators import Coerce, Range
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+_LOGGER = logging.getLogger(__name__)
+
+SET_POSITION_SCHEMA = vol.Schema(
+    {
+        vol.Required("position"): vol.All(Coerce(int), Range(min=0, max=100)),
+    },
+    extra=vol.PREVENT_EXTRA,
+)
+
+
+def _resolve_targets(hass, call):
+    """Thin re-export so tests can patch the local name."""
+    from . import _resolve_targets as _rt  # noqa: PLC0415
+
+    return _rt(hass, call)
+
+
+async def async_handle_set_position(call: ServiceCall) -> None:
+    """Handle the set_position service call.
+
+    For each targeted coordinator:
+    1. Read active min-mode custom-position floors.
+    2. Clamp requested position to the highest active floor (if any).
+    3. Build context with force=True to bypass the manual-override gate.
+    4. Call apply_position for each targeted entity.
+    """
+    hass = call.hass
+    requested: int = call.data["position"]
+
+    targets = _resolve_targets(hass, call)
+
+    for coord, entity_filter in targets.items():
+        options = coord.config_entry.options
+
+        # Collect active min-mode floors
+        states = coord._read_custom_position_sensor_states(options)  # noqa: SLF001
+        floors = [s.position for s in states if s.is_on and s.min_mode]
+        effective_floor = max(floors) if floors else 0
+
+        clamped = max(requested, effective_floor)
+
+        if clamped != requested:
+            _LOGGER.info(
+                "set_position: requested %d clamped to %d (active min-mode floor)",
+                requested,
+                clamped,
+            )
+        else:
+            _LOGGER.debug(
+                "set_position: requested %d, floor %d — no clamping needed",
+                requested,
+                effective_floor,
+            )
+
+        # Determine which entities to command
+        entity_ids: list[str] = (
+            list(entity_filter) if entity_filter is not None else list(coord.entities)
+        )
+
+        for entity_id in entity_ids:
+            ctx = coord._build_position_context(  # noqa: SLF001
+                entity_id, options, force=True
+            )
+            await coord._cmd_svc.apply_position(  # noqa: SLF001
+                entity_id, clamped, "set_position", ctx
+            )

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -248,6 +248,14 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         self._attr_is_on = True
         setattr(self.coordinator, self._key, True)
         if self._key == "automatic_control" and kwargs.get("added") is not True:
+            # Issue #33 defense-in-depth: invalidate the venetian sequencer's
+            # stored tilt targets so the very next cycle resolves the
+            # min-delta gate's anchor from live actuator state rather than a
+            # potentially stale cached target. No-op on non-venetian policies
+            # (their _policy has no sequencer attribute or it's None).
+            sequencer = getattr(self.coordinator._policy, "sequencer", None)
+            if sequencer is not None:
+                sequencer.clear_tilt_targets()
             options = self.coordinator.config_entry.options
             for entity in self.coordinator.entities:
                 if (

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -44,7 +44,8 @@
           "venetian_mode": "Betriebsmodus",
           "inverse_tilt": "Neigung invertieren",
           "max_tilt": "Maximale Lamellennneigung (%)",
-          "min_tilt": "Minimale Lamellenneigung (%)"
+          "min_tilt": "Minimale Lamellenneigung (%)",
+          "venetian_post_settle_hold": "Wartezeit nach Fahrt (s)"
         },
         "data_description": {
           "window_height": "Höhe Ihres Fensters in Metern (von unten bis oben des Glasbereichs). Beispiele: Standard-Tür = 2,0m, Kleines Fenster = 1,5m, Vom Boden bis zur Decke = 2,5m. Messen Sie von dort, wo die Beschattung beginnt, bis zu der Stelle, wo sie endet, wenn vollständig ausgefahren. Wird verwendet, um optimale Beschattungsposition zum Blockieren direkter Sonneneinstrahlung zu berechnen. Hinweis: 1 Meter ≈ 3,3 Fuß.",
@@ -60,7 +61,8 @@
           "venetian_mode": "Wie die Jalousie mit Lamellen beide Achsen nutzt, wenn die Sonne im Verfolgungsfenster ist. **Position und Neigung** (Standard): Die Beschattung wird auf die berechnete Position abgesenkt und die Lamellen neigen sich zum optimalen Winkel — am besten für kombinierte Beschattung und Privatsphäre. **Nur Neigung**: Die Beschattung bleibt geschlossen (Position 0 %) und nur der Lamellenwinkel folgt der Sonne — am besten, wenn Sie immer vollständige Abdeckung wünschen und Blendung kontinuierlich über die Neigung kontrollieren möchten.",
           "inverse_tilt": "Invertiert nur die Neigungsachse. Aktivieren Sie diese Option, wenn Ihre Hardware den Wert 0 für \"Lamellen offen\" und 100 für \"Lamellen geschlossen\" sendet, was dem Erwartungswert der Integration entspricht. Dies gilt nur für die Neigungsachse (Lamellen) — die Positionsachse wird separat durch \"Zustand invertieren\" gesteuert. Die meisten Beschattungen benötigen dies nicht. Nützlich für KNX- oder Somfy-Hardware, bei der die Neigungsrichtung der HA-Konvention entgegengesetzt verdrahtet ist.",
           "max_tilt": "Obergrenze für den maximalen Neigungswinkel der Lamellen (0–100). Niedrigere Werte verhindern, dass Lamellen Winkelpositionen erreichen, die direktes Sonnenlicht ins Zimmer reflektieren. Standard: 100 (keine Obergrenze). Beispiel: Stellen Sie 70 ein, wenn vollständig geöffnete Lamellen zu Spitzensonnenzeiten Blendungen verursachen.",
-          "min_tilt": "Untergrenze für die minimale Neigungswinkel der Lamellen (0–100). Höhere Werte verhindern, dass Lamellen vollständig schließen – nützlich für Jalousien, die bei 0% das gesamte Licht blockieren. Standard: 0 (keine Untergrenze). Beispiel: Stellen Sie 10 ein, wenn Ihre Jalousien bei 0% vollständig dunkel werden und Sie immer etwas Licht durchlassen möchten."
+          "min_tilt": "Untergrenze für die minimale Neigungswinkel der Lamellen (0–100). Höhere Werte verhindern, dass Lamellen vollständig schließen – nützlich für Jalousien, die bei 0% das gesamte Licht blockieren. Standard: 0 (keine Untergrenze). Beispiel: Stellen Sie 10 ein, wenn Ihre Jalousien bei 0% vollständig dunkel werden und Sie immer etwas Licht durchlassen möchten.",
+          "venetian_post_settle_hold": "Wie lange (in Sekunden) nach dem Anhalten des Antriebs gewartet wird, bevor der Neigungsbefehl gesendet wird. Standardmäßig 2,0 s, was für die meisten Aktoren geeignet ist. Erhöhen Sie den Wert auf 4–6 s für KNX FGR223 oder andere Firmware, die kurz nach dem Anhalten des Antriebs eine Neigung-zu-Offen-Bewegung erneut auslöst — ohne die zusätzliche Wartezeit konkurriert der Neigungsbefehl mit dieser Auslösung und verliert. Bereich 0,0–10,0 s."
         }
       },
       "sun_tracking": {
@@ -566,7 +568,8 @@
           "venetian_mode": "Betriebsmodus",
           "inverse_tilt": "Neigung invertieren",
           "max_tilt": "Maximale Lamellennneigung (%)",
-          "min_tilt": "Minimale Lamellenneigung (%)"
+          "min_tilt": "Minimale Lamellenneigung (%)",
+          "venetian_post_settle_hold": "Wartezeit nach Fahrt (s)"
         },
         "data_description": {
           "window_height": "Höhe Ihres Fensters in Metern (von unten bis oben des Glasbereichs). Beispiele: Standard-Tür = 2,0m, Kleines Fenster = 1,5m, Vom Boden bis Decke = 2,5m. Messen Sie von wo die Abdeckung beginnt bis wo sie endet, wenn vollständig ausgefahren. Wird verwendet, um die optimale Abdeckungsposition zu berechnen, um direkte Sonneneinstrahlung zu blockieren. Hinweis: 1 Meter ≈ 3,3 Fuß.",
@@ -582,7 +585,8 @@
           "venetian_mode": "Wie die Jalousie mit Lamellen beide Achsen nutzt, wenn die Sonne im Verfolgungsfenster ist. **Position und Neigung** (Standard): Die Beschattung wird auf die berechnete Position abgesenkt und die Lamellen neigen sich zum optimalen Winkel — am besten für kombinierte Beschattung und Privatsphäre. **Nur Neigung**: Die Beschattung bleibt geschlossen (Position 0 %) und nur der Lamellenwinkel folgt der Sonne — am besten, wenn Sie immer vollständige Abdeckung wünschen und Blendung kontinuierlich über die Neigung kontrollieren möchten.",
           "inverse_tilt": "Invertiert nur die Neigungsachse. Aktivieren Sie diese Option, wenn Ihre Hardware den Wert 0 für \"Lamellen offen\" und 100 für \"Lamellen geschlossen\" sendet, was dem Erwartungswert der Integration entspricht. Dies gilt nur für die Neigungsachse (Lamellen) — die Positionsachse wird separat durch \"Zustand invertieren\" gesteuert. Die meisten Beschattungen benötigen dies nicht. Nützlich für KNX- oder Somfy-Hardware, bei der die Neigungsrichtung der HA-Konvention entgegengesetzt verdrahtet ist.",
           "max_tilt": "Obergrenze für den maximalen Neigungswinkel der Lamellen (0–100). Niedrigere Werte verhindern, dass Lamellen Winkelpositionen erreichen, die direktes Sonnenlicht ins Zimmer reflektieren. Standard: 100 (keine Obergrenze). Beispiel: Stellen Sie 70 ein, wenn vollständig geöffnete Lamellen zu Spitzensonnenzeiten Blendungen verursachen.",
-          "min_tilt": "Untergrenze für die minimale Neigungswinkel der Lamellen (0–100). Höhere Werte verhindern, dass Lamellen vollständig schließen – nützlich für Jalousien, die bei 0% das gesamte Licht blockieren. Standard: 0 (keine Untergrenze). Beispiel: Stellen Sie 10 ein, wenn Ihre Jalousien bei 0% vollständig dunkel werden und Sie immer etwas Licht durchlassen möchten."
+          "min_tilt": "Untergrenze für die minimale Neigungswinkel der Lamellen (0–100). Höhere Werte verhindern, dass Lamellen vollständig schließen – nützlich für Jalousien, die bei 0% das gesamte Licht blockieren. Standard: 0 (keine Untergrenze). Beispiel: Stellen Sie 10 ein, wenn Ihre Jalousien bei 0% vollständig dunkel werden und Sie immer etwas Licht durchlassen möchten.",
+          "venetian_post_settle_hold": "Wie lange (in Sekunden) nach dem Anhalten des Antriebs gewartet wird, bevor der Neigungsbefehl gesendet wird. Standardmäßig 2,0 s, was für die meisten Aktoren geeignet ist. Erhöhen Sie den Wert auf 4–6 s für KNX FGR223 oder andere Firmware, die kurz nach dem Anhalten des Antriebs eine Neigung-zu-Offen-Bewegung erneut auslöst — ohne die zusätzliche Wartezeit konkurriert der Neigungsbefehl mit dieser Auslösung und verliert. Bereich 0,0–10,0 s."
         }
       },
       "sun_tracking": {
@@ -1633,6 +1637,24 @@
         "config_entry_id": {
           "name": "Konfigurationseintrag",
           "description": "Explizite Konfigurations-Eintrags-IDs zum Abfragen. Wenn weggelassen, gilt die standardmäßige Zielauswahl. Kein Ziel gibt alle ACP-Instanzen zurück."
+        }
+      }
+    },
+    "set_venetian": {
+      "name": "Jalousie-Optionen setzen",
+      "description": "Jalousie-spezifische Optionen aktualisieren: Betriebsmodus, Neigungsschwellenwert und Wartezeit nach Fahrt.",
+      "fields": {
+        "venetian_mode": {
+          "name": "Jalousie-Modus",
+          "description": "Betriebsmodus: 'position_and_tilt' (Antrieb fahren, dann neigen) oder 'tilt_only' (nur neigen, kein Fahren)."
+        },
+        "venetian_tilt_skip_above": {
+          "name": "Neigung überspringen ab (%)",
+          "description": "Neigungsbefehle überspringen, wenn die Position des Antriebs diesen Wert überschreitet (0–100 %). Auf 100 setzen, um immer zu neigen."
+        },
+        "venetian_post_settle_hold": {
+          "name": "Wartezeit nach Fahrt (s)",
+          "description": "Wartezeit in Sekunden nach dem Anhalten des Antriebs, bevor der Neigungsbefehl gesendet wird (0,0–10,0 s). Auf 4–6 s erhöhen für KNX FGR223-Firmware."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1657,6 +1657,16 @@
           "description": "Wartezeit in Sekunden nach dem Anhalten des Antriebs, bevor der Neigungsbefehl gesendet wird (0,0–10,0 s). Auf 4–6 s erhöhen für KNX FGR223-Firmware."
         }
       }
+    },
+    "set_position": {
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Zielposition der Beschattung (0–100%). Wird bis zur aktiven Mindestwertstufe begrenzt, falls eine konfiguriert ist und deren Sensor aktiviert ist."
+        }
+      },
+      "name": "Position setzen (mit Mindestwert-Erzwingung)",
+      "description": "Bewegt die Beschattung zur angeforderten Position und begrenzt sie auf den höchsten aktiven Mindestwert der benutzerdefinierten Position. Verwenden Sie dies statt cover.set_cover_position, wenn Sie ACP's Mindestwerte aus Automationen berücksichtigen möchten. Die Neigung wird nicht beeinflusst."
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1657,6 +1657,16 @@
           "description": "Seconds to wait after carriage stops before sending the tilt command (0.0–10.0 s). Raise to 4–6 s for KNX FGR223 firmware."
         }
       }
+    },
+    "set_position": {
+      "name": "Set position (floor-enforced)",
+      "description": "Moves the cover to the requested position, clamping to the highest active custom-position minimum-mode floor. Use this instead of cover.set_cover_position when you need ACP's min-mode floors respected from automations. Tilt is not affected.",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Target cover position (0–100%). Clamped up to the active minimum-mode floor if one is configured and its sensor is on."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -42,6 +42,7 @@
           "slat_distance": "Slat Spacing",
           "venetian_tilt_skip_above": "Skip Tilt Above Position (%)",
           "venetian_mode": "Operating Mode",
+          "venetian_post_settle_hold": "Post-settle Hold (s)",
           "inverse_tilt": "Inverse Tilt",
           "max_tilt": "Maximum Slat Tilt (%)",
           "min_tilt": "Minimum Slat Tilt (%)"
@@ -58,6 +59,7 @@
           "slat_distance": "Vertical spacing between slat centers. Measure from the middle of one slat to the middle of the next slat (vertically). Usually slightly more than slat depth to allow overlap when closed. Common: 3-8cm depending on blind type. Used to calculate optimal tilt angle.",
           "venetian_tilt_skip_above": "When the cover is commanded above this position (0–100%), the tilt command is skipped. At high positions the slats retract into the housing and tilting is physically meaningless. Default 95%. Increase if your blind tilts correctly near the top; decrease if it tries to tilt when fully raised.",
           "venetian_mode": "How the venetian blind uses both axes when the sun is in the tracking window. **Position and tilt** (default): the cover lowers to the calculated position and the slats tilt to the optimal angle — best for combined shading and privacy. **Tilt only**: the cover stays closed (position 0%) and only the slat angle tracks the sun — best when you always want full coverage and want continuous glare control via tilt.",
+          "venetian_post_settle_hold": "How long (in seconds) to wait after the carriage settles before sending the tilt command. Default 2.0 s suits most actuators. Raise to 4–6 s for KNX FGR223 or other firmware that re-asserts a tilt-to-open shortly after the carriage stops — without the extra hold the tilt command races that re-assert and loses. Range 0.0–10.0 s.",
           "inverse_tilt": "Inverts the tilt axis only. Enable when your hardware sends tilt 0 for slats-open and 100 for slats-closed, which is the opposite of what the integration expects. This applies only to the tilt (slat) axis — the position axis is controlled separately by 'Inverse state'. Most covers do not need this. Useful for KNX or Somfy hardware where the tilt direction is wired opposite to the HA convention.",
           "max_tilt": "Cap on the maximum slat tilt percentage (0–100). Lower values prevent slats from reaching angles that reflect direct sun into the room. Default: 100 (no cap). Example: set to 70 if fully-open slats cause glare at peak sun angles.",
           "min_tilt": "Floor on the minimum slat tilt percentage (0–100). Higher values prevent slats from closing fully — useful for blinds that block all light at 0%. Default: 0 (no floor). Example: set to 10 if your blinds become fully dark at 0% and you always want some light through."
@@ -564,6 +566,7 @@
           "slat_distance": "Slat Spacing",
           "venetian_tilt_skip_above": "Skip Tilt Above Position (%)",
           "venetian_mode": "Operating Mode",
+          "venetian_post_settle_hold": "Post-settle Hold (s)",
           "inverse_tilt": "Inverse Tilt",
           "max_tilt": "Maximum Slat Tilt (%)",
           "min_tilt": "Minimum Slat Tilt (%)"
@@ -580,6 +583,7 @@
           "slat_distance": "Vertical spacing between slat centers. Measure from the middle of one slat to the middle of the next slat (vertically). Usually slightly more than slat depth to allow overlap when closed. Common: 3-8cm depending on blind type. Used to calculate optimal tilt angle.",
           "venetian_tilt_skip_above": "When the cover is commanded above this position (0–100%), the tilt command is skipped. At high positions the slats retract into the housing and tilting is physically meaningless. Default 95%. Increase if your blind tilts correctly near the top; decrease if it tries to tilt when fully raised.",
           "venetian_mode": "How the venetian blind uses both axes when the sun is in the tracking window. **Position and tilt** (default): the cover lowers to the calculated position and the slats tilt to the optimal angle — best for combined shading and privacy. **Tilt only**: the cover stays closed (position 0%) and only the slat angle tracks the sun — best when you always want full coverage and want continuous glare control via tilt.",
+          "venetian_post_settle_hold": "How long (in seconds) to wait after the carriage settles before sending the tilt command. Default 2.0 s suits most actuators. Raise to 4–6 s for KNX FGR223 or other firmware that re-asserts a tilt-to-open shortly after the carriage stops — without the extra hold the tilt command races that re-assert and loses. Range 0.0–10.0 s.",
           "inverse_tilt": "Inverts the tilt axis only. Enable when your hardware sends tilt 0 for slats-open and 100 for slats-closed, which is the opposite of what the integration expects. This applies only to the tilt (slat) axis — the position axis is controlled separately by 'Inverse state'. Most covers do not need this. Useful for KNX or Somfy hardware where the tilt direction is wired opposite to the HA convention.",
           "max_tilt": "Cap on the maximum slat tilt percentage (0–100). Lower values prevent slats from reaching angles that reflect direct sun into the room. Default: 100 (no cap). Example: set to 70 if fully-open slats cause glare at peak sun angles.",
           "min_tilt": "Floor on the minimum slat tilt percentage (0–100). Higher values prevent slats from closing fully — useful for blinds that block all light at 0%. Default: 0 (no floor). Example: set to 10 if your blinds become fully dark at 0% and you always want some light through."
@@ -1633,6 +1637,24 @@
         "value": {
           "name": "Value",
           "description": "New value for the option. Pass null to clear an optional field."
+        }
+      }
+    },
+    "set_venetian": {
+      "name": "Set venetian options",
+      "description": "Update venetian-blind specific options: operating mode, tilt skip threshold, and post-settle hold.",
+      "fields": {
+        "venetian_mode": {
+          "name": "Venetian mode",
+          "description": "Operating mode: 'position_and_tilt' (move carriage then tilt) or 'tilt_only' (tilt only, no carriage movement)."
+        },
+        "venetian_tilt_skip_above": {
+          "name": "Tilt skip above (%)",
+          "description": "Skip tilt commands when carriage position exceeds this value (0–100%). Set to 100 to always tilt."
+        },
+        "venetian_post_settle_hold": {
+          "name": "Post-settle hold (s)",
+          "description": "Seconds to wait after carriage stops before sending the tilt command (0.0–10.0 s). Raise to 4–6 s for KNX FGR223 firmware."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -44,7 +44,8 @@
           "venetian_mode": "Mode de fonctionnement",
           "inverse_tilt": "Inverser l'inclinaison",
           "max_tilt": "Inclinaison Maximale des Lamelles (%)",
-          "min_tilt": "Inclinaison Minimale des Lamelles (%)"
+          "min_tilt": "Inclinaison Minimale des Lamelles (%)",
+          "venetian_post_settle_hold": "Délai post-arrêt (s)"
         },
         "data_description": {
           "window_height": "Hauteur de votre fenêtre en mètres (du bas au haut de la zone vitrée). Exemples : porte standard = 2,0 m, petite fenêtre = 1,5 m, du sol au plafond = 2,5 m. Mesurez du point de départ du store à son point d'arrivée lorsqu'il est complètement étendu. Utilisé pour calculer la position optimale du store pour bloquer la lumière directe du soleil. Remarque : 1 mètre ≈ 3,3 pieds.",
@@ -60,7 +61,8 @@
           "venetian_mode": "Comment le store vénitien utilise les deux axes lorsque le soleil se trouve dans la fenêtre de suivi. **Position et inclinaison** (par défaut) : le store descend à la position calculée et les lamelles s'inclinent à l'angle optimal — idéal pour une protection combinée et l'intimité. **Inclinaison uniquement** : le store reste fermé (position 0%) et seul l'angle des lamelles suit le soleil — idéal lorsque vous souhaitez une couverture complète et un contrôle continu de l'éblouissement par inclinaison.",
           "inverse_tilt": "Inverse l'axe d'inclinaison uniquement. Activez si votre matériel envoie une inclinaison 0 pour lamelles ouvertes et 100 pour lamelles fermées, ce qui est l'opposé de ce que l'intégration attend. Cela s'applique uniquement à l'axe d'inclinaison (lamelles) — l'axe de position est contrôlé séparément par « Inverser l'état ». La plupart des protections n'ont pas besoin de ceci. Utile pour le matériel KNX ou Somfy où la direction d'inclinaison est câblée à l'opposé de la convention HA.",
           "max_tilt": "Limite de l'angle d'inclinaison maximal des lamelles (0–100 %). Les valeurs plus basses empêchent les lamelles d'atteindre des angles qui réfléchissent la lumière directe du soleil dans la pièce. Défaut : 100 (pas de limite). Exemple : réglez à 70 si les lamelles complètement ouvertes causent des reflets à des angles de soleil maximum.",
-          "min_tilt": "Limite inférieure de l'angle d'inclinaison des lamelles (0–100 %). Les valeurs plus élevées empêchent les lamelles de se fermer complètement — utile pour les stores qui bloquent toute la lumière à 0 %. Défaut : 0 (pas de limite). Exemple : réglez à 10 si vos stores deviennent complètement opaques à 0 % et vous voulez toujours un peu de lumière."
+          "min_tilt": "Limite inférieure de l'angle d'inclinaison des lamelles (0–100 %). Les valeurs plus élevées empêchent les lamelles de se fermer complètement — utile pour les stores qui bloquent toute la lumière à 0 %. Défaut : 0 (pas de limite). Exemple : réglez à 10 si vos stores deviennent complètement opaques à 0 % et vous voulez toujours un peu de lumière.",
+          "venetian_post_settle_hold": "Durée d'attente (en secondes) après l'arrêt du mécanisme avant l'envoi de la commande d'inclinaison. La valeur par défaut de 2,0 s convient à la plupart des actionneurs. Augmentez à 4–6 s pour le KNX FGR223 ou tout autre firmware qui réenclenche une inclinaison-vers-ouvert peu après l'arrêt du mécanisme — sans ce délai supplémentaire, la commande d'inclinaison entre en conflit avec ce réenclenchement et perd. Plage : 0,0–10,0 s."
         }
       },
       "sun_tracking": {
@@ -566,7 +568,8 @@
           "venetian_mode": "Mode de fonctionnement",
           "inverse_tilt": "Inverser l'inclinaison",
           "max_tilt": "Inclinaison Maximale des Lamelles (%)",
-          "min_tilt": "Inclinaison Minimale des Lamelles (%)"
+          "min_tilt": "Inclinaison Minimale des Lamelles (%)",
+          "venetian_post_settle_hold": "Délai post-arrêt (s)"
         },
         "data_description": {
           "window_height": "Hauteur de votre fenêtre en mètres (du bas au haut de la zone vitrée). Exemples : porte standard = 2,0 m, petite fenêtre = 1,5 m, du sol au plafond = 2,5 m. Mesurez du point de départ du store à son point d'arrivée lorsqu'il est complètement étendu. Utilisé pour calculer la position optimale du store pour bloquer la lumière directe du soleil. Remarque : 1 mètre ≈ 3,3 pieds.",
@@ -582,7 +585,8 @@
           "venetian_mode": "Comment le store vénitien utilise les deux axes lorsque le soleil se trouve dans la fenêtre de suivi. **Position et inclinaison** (par défaut) : le store descend à la position calculée et les lamelles s'inclinent à l'angle optimal — idéal pour une protection combinée et l'intimité. **Inclinaison uniquement** : le store reste fermé (position 0%) et seul l'angle des lamelles suit le soleil — idéal lorsque vous souhaitez une couverture complète et un contrôle continu de l'éblouissement par inclinaison.",
           "inverse_tilt": "Inverse l'axe d'inclinaison uniquement. Activez si votre matériel envoie une inclinaison 0 pour lamelles ouvertes et 100 pour lamelles fermées, ce qui est l'opposé de ce que l'intégration attend. Cela s'applique uniquement à l'axe d'inclinaison (lamelles) — l'axe de position est contrôlé séparément par « Inverser l'état ». La plupart des protections n'ont pas besoin de ceci. Utile pour le matériel KNX ou Somfy où la direction d'inclinaison est câblée à l'opposé de la convention HA.",
           "max_tilt": "Limite de l'angle d'inclinaison maximal des lamelles (0–100 %). Les valeurs plus basses empêchent les lamelles d'atteindre des angles qui réfléchissent la lumière directe du soleil dans la pièce. Défaut : 100 (pas de limite). Exemple : réglez à 70 si les lamelles complètement ouvertes causent des reflets à des angles de soleil maximum.",
-          "min_tilt": "Limite inférieure de l'angle d'inclinaison des lamelles (0–100 %). Les valeurs plus élevées empêchent les lamelles de se fermer complètement — utile pour les stores qui bloquent toute la lumière à 0 %. Défaut : 0 (pas de limite). Exemple : réglez à 10 si vos stores deviennent complètement opaques à 0 % et vous voulez toujours un peu de lumière."
+          "min_tilt": "Limite inférieure de l'angle d'inclinaison des lamelles (0–100 %). Les valeurs plus élevées empêchent les lamelles de se fermer complètement — utile pour les stores qui bloquent toute la lumière à 0 %. Défaut : 0 (pas de limite). Exemple : réglez à 10 si vos stores deviennent complètement opaques à 0 % et vous voulez toujours un peu de lumière.",
+          "venetian_post_settle_hold": "Durée d'attente (en secondes) après l'arrêt du mécanisme avant l'envoi de la commande d'inclinaison. La valeur par défaut de 2,0 s convient à la plupart des actionneurs. Augmentez à 4–6 s pour le KNX FGR223 ou tout autre firmware qui réenclenche une inclinaison-vers-ouvert peu après l'arrêt du mécanisme — sans ce délai supplémentaire, la commande d'inclinaison entre en conflit avec ce réenclenchement et perd. Plage : 0,0–10,0 s."
         }
       },
       "sun_tracking": {
@@ -1633,6 +1637,24 @@
         "config_entry_id": {
           "name": "Entrée de configuration",
           "description": "ID(s) d'entrée de configuration explicite(s) à interroger. Lorsqu'omis, la sélection de cible standard s'applique. Aucune cible retourne toutes les instances ACP."
+        }
+      }
+    },
+    "set_venetian": {
+      "name": "Définir les options store vénitien",
+      "description": "Mettre à jour les options spécifiques au store vénitien : mode de fonctionnement, seuil d'inclinaison et délai post-arrêt.",
+      "fields": {
+        "venetian_mode": {
+          "name": "Mode store vénitien",
+          "description": "Mode de fonctionnement : 'position_and_tilt' (déplacer le mécanisme puis incliner) ou 'tilt_only' (incliner uniquement, sans déplacement)."
+        },
+        "venetian_tilt_skip_above": {
+          "name": "Ignorer inclinaison au-dessus de (%)",
+          "description": "Ignorer les commandes d'inclinaison lorsque la position du mécanisme dépasse cette valeur (0–100 %). Régler à 100 pour toujours incliner."
+        },
+        "venetian_post_settle_hold": {
+          "name": "Délai post-arrêt (s)",
+          "description": "Secondes d'attente après l'arrêt du mécanisme avant l'envoi de la commande d'inclinaison (0,0–10,0 s). Augmenter à 4–6 s pour le firmware KNX FGR223."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1657,6 +1657,16 @@
           "description": "Secondes d'attente après l'arrêt du mécanisme avant l'envoi de la commande d'inclinaison (0,0–10,0 s). Augmenter à 4–6 s pour le firmware KNX FGR223."
         }
       }
+    },
+    "set_position": {
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position cible de la protection (0–100%). Limitée jusqu'au plancher minimum actif si l'un est configuré et que son capteur est activé."
+        }
+      },
+      "name": "Définir la position (avec plancher appliqué)",
+      "description": "Déplace la protection vers la position demandée, en la limitant au plancher minimum le plus élevé de la position personnalisée active en mode minimum. Utilisez ceci au lieu de cover.set_cover_position quand vous avez besoin que les planchers de mode minimum d'ACP soient respectés à partir des automatisations. L'inclinaison n'est pas affectée."
     }
   }
 }

--- a/release_notes/v2.21.0-beta.1.md
+++ b/release_notes/v2.21.0-beta.1.md
@@ -1,0 +1,88 @@
+## 🪟 v2.21.0-beta.1 — Venetian Sequencer Stability
+
+First beta of the 2.21.0 series. This beta focuses on hardening the venetian
+dual-axis sequencer introduced in v2.20.0. Testers running venetian blind
+configurations — particularly on KNX, Somfy IO/Tahoma, Shelly 2PM, or FGR223
+actuators — should exercise tilt sequencing across solar cycles, tilt-skip-above
+thresholds, and climate-mode interactions and report any unexpected behavior.
+
+### Highlights
+
+Three targeted fixes close the remaining sequencer edge cases identified after
+v2.20.1 shipped. The tilt delta gate now anchors on the actuator's live tilt
+reading rather than a stored target that goes stale when the motor auto-tilts on
+close; this prevents the gate from suppressing legitimate tilt corrections after
+a close cycle or after Auto Control is toggled back on. The tilt-only update
+path (`maybe_update_tilt_only`) now applies the same `tilt_skip_above` retraction
+guard that `after_position_command` already enforced, eliminating the redundant
+tilt commands that fired on every solar recompute while the carriage sat above the
+threshold. A 2.0-second post-settle hold between position settle and the tilt
+command reduces the race against firmware tilt-reassert on actuators like the
+FGR223 that reapply their internal tilt cache shortly after the carriage stops.
+
+### Features
+
+- **Post-settle hold and state gate for venetian sequencer (#33):**
+  `_wait_for_position_settle` now requires the cover to have left `opening` or
+  `closing` state before declaring settle, when a `get_state` callback is provided
+  — position within tolerance alone is no longer sufficient. After settle returns,
+  the sequencer holds `VENETIAN_POST_SETTLE_HOLD_SECONDS` (2.0 s) before
+  dispatching `set_cover_tilt_position`. This eliminates a race where the tilt
+  command landed while the actuator was mid firmware tilt-reassert. The no-callback
+  path is preserved for backwards compatibility with non-state-aware callers.
+
+### Bug Fixes
+
+- **Anchor venetian tilt min-delta gate on live actuator reading (#33):**
+  The delta gate in `DualAxisSequencer` was comparing a new tilt target against
+  `_tilt_targets[entity_id]` — the value the integration last commanded — rather
+  than the actuator's current reported tilt. After a close, the motor
+  mechanically auto-tilts to 100 regardless of the value the integration last sent,
+  leaving the stored anchor out of sync with reality. The gate then suppressed
+  correct tilt commands because the stale anchor looked like the cover was already
+  at the target. The same stale anchor persisted through Auto Control off→on
+  transitions. The fix introduces `_resolve_tilt_anchor`, which reads the live
+  `current_tilt_position` via the existing callback and converts it to logical space
+  through `_to_wire`, falling back to the stored target only when the actuator value
+  is unavailable. As a defense-in-depth measure, `clear_tilt_targets` is now called
+  on the sequencer when Auto Control is turned on by the user (but not during
+  startup restore), so the first cycle after re-enable resolves from actuator state.
+  The `tilt_command_skipped` diagnostic event gains `anchor_value` and
+  `anchor_source` fields (`actual` or `target_fallback`) for future debugging;
+  `prior_tilt_target` is preserved for backwards compatibility.
+
+- **Apply `tilt_skip_above` guard to tilt-only path (#33):**
+  `VenetianPolicy.maybe_update_tilt_only` was passing `_last_tilt` directly to
+  `DualAxisSequencer.update_tilt_only` without checking whether the carriage was
+  above the `tilt_skip_above` threshold. `after_position_command` already enforced
+  this guard, but the tilt-only path bypassed it entirely. The result was a
+  redundant `set_cover_tilt_position` call on every solar recompute while the
+  carriage sat retracted above the threshold. The fix extracts the threshold logic
+  into a shared `_resolve_skip_above_tilt` helper used by both call sites, returning
+  `POSITION_OPEN` when the carriage is above the threshold and the original tilt
+  otherwise. No behavior change when the carriage is below the threshold.
+
+### Chores
+
+- **CI issue-confirmation respects pinned label:** The issue-confirmation workflow
+  now skips auto-close for issues marked with the `pinned` label, preventing
+  false-positive closures on tracked issues that are deliberately held open.
+
+### Compatibility
+
+- Home Assistant 2026.3.0+
+
+### Feedback
+
+File reports as comments on [issue #33] or open a new issue. Priority scenarios
+for this beta: venetian tilt sequencing across close/open cycles, tilt-skip-above
+behavior at and above the threshold, and climate-mode interactions on venetian
+covers where Auto Control is toggled mid-session.
+
+### All-betas highlights (2.21.0 series)
+
+- Venetian tilt delta gate anchored on live actuator reading
+- Post-settle state gate and 2.0 s hold before tilt dispatch
+- `tilt_skip_above` guard applied consistently to both sequencer paths
+
+[issue #33]: https://github.com/jrhubott/adaptive-cover-pro/issues/33

--- a/release_notes/v2.21.0-beta.2.md
+++ b/release_notes/v2.21.0-beta.2.md
@@ -1,0 +1,91 @@
+# v2.21.0-beta.2 — Venetian Tilt Strip on Invalid Sun
+
+## 🎯 Highlights
+
+This is the second beta in the 2.21.0 series, building on beta.1's sequencer
+stability fixes. If you are testing venetian blinds, beta.2 closes a gap that
+caused tilt commands to fire overnight: the climate handler's low-light branch
+was emitting a solar control method even when the sun was below the horizon,
+and the tilt synthesis step had no guard against that case. Beta.2 adds two
+layers of defense — the climate handler now emits the correct control method on
+the low-light branch, and the venetian policy checks the engine's
+`direct_sun_valid` flag before synthesising a tilt at all. Beta.1's three fixes
+(live-anchor delta gate, post-settle hold, `tilt_skip_above` guard on the
+tilt-only path) are included unchanged.
+
+## 🐛 What's new in beta.2
+
+**Strip venetian tilt when direct sun is invalid (#33):** When the climate
+handler evaluated an intermediate-temperature, low-light scenario (sun below
+the horizon or lux below threshold), it fell through to the generic
+`ControlMethod.SOLAR` branch. The venetian policy's tilt synthesis step treats
+`SOLAR` as a green light to compute a tilt from the current sun azimuth — even
+at midnight, when that azimuth is still drifting. The result was a tilt command
+roughly every four minutes overnight, observed by testers on FGR223 and similar
+actuators.
+
+The fix closes both ends of the path:
+
+- The climate handler now emits `ControlMethod.DEFAULT` on the low-light
+  branch rather than `SOLAR`, so the pipeline result already carries the
+  correct intent before the venetian policy sees it.
+
+- The venetian policy adds a `direct_sun_valid` check as a second guard.
+  Even if another handler path produces `SOLAR` while the sun is not
+  actually striking the window, `direct_sun_valid=False` causes tilt
+  synthesis to be skipped and the tilt field on the pipeline result is
+  set to `None`.
+
+## ✨ Cumulative beta-series changes (since v2.20.1)
+
+- 🐛 **Venetian tilt emitted overnight on low-light branch (#33):** Climate
+  handler's low-light path now emits `ControlMethod.DEFAULT`; venetian policy
+  additionally gates tilt synthesis on `direct_sun_valid`.
+
+- 🐛 **Venetian tilt delta gate used stale stored target (#33):** Delta gate now
+  anchors on the actuator's live reported tilt, falling back to the stored target
+  only when the actuator value is unavailable. Prevents the gate from suppressing
+  correct tilt commands after a close cycle or an Auto Control off→on transition.
+
+- 🐛 **`tilt_skip_above` guard missing from tilt-only update path (#33):**
+  When the carriage sat at or above the threshold, the tilt-only path bypassed
+  the retraction guard, firing a redundant tilt command on every solar recompute.
+  Both call sites now share a single threshold helper.
+
+- ✨ **Post-settle state gate and hold before tilt dispatch (#33):**
+  Position-within-tolerance alone no longer declares settle; the cover must also
+  have left `opening`/`closing` state. A 2.0-second hold after settle finishes
+  reduces races against firmware tilt-reassert on actuators like the FGR223.
+
+- 🧹 **CI issue-confirmation respects `pinned` label:** Auto-close skips issues
+  marked `pinned`, preventing false-positive closures on deliberately held-open
+  tracked issues.
+
+## 🧪 What we'd like you to test
+
+- **Overnight tilt behavior:** With climate mode enabled on a venetian cover,
+  confirm no tilt commands fire after sunset or before sunrise.
+- **Low-light transitions:** As the sun sets through the climate mode lux or
+  `is_sunny` threshold, verify the cover returns to its default position without
+  triggering a tilt command.
+- **Post-close tilt on FGR223 / firmware tilt-reassert actuators:** After a
+  full close-and-tilt cycle, confirm the tilt command lands cleanly and is not
+  overwritten by the actuator's reassert behavior.
+- **Auto Control off→on:** Toggle Auto Control off, wait for a solar recompute,
+  toggle back on — confirm the first tilt command after re-enable reflects the
+  actuator's current reported tilt, not a stale stored value.
+- **Carriage above `tilt_skip_above` threshold:** Retract the blind above the
+  threshold and confirm no tilt commands appear in the logs.
+
+## 📝 Feedback
+
+Report results on [issue #33] or open a new issue if you hit something
+unrelated to the venetian sequencer. General questions and setup help belong
+in [GitHub Discussions].
+
+## Compatibility
+
+- Home Assistant 2026.3.0+
+
+[issue #33]: https://github.com/jrhubott/adaptive-cover-pro/issues/33
+[GitHub Discussions]: https://github.com/jrhubott/adaptive-cover-pro/discussions

--- a/tests/test_climate_cover_state.py
+++ b/tests/test_climate_cover_state.py
@@ -11,6 +11,7 @@ from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
     ClimateCoverState,
 )
 from tests.conftest import make_snapshot_for_cover
+from tests.cover_helpers import build_tilt_cover
 
 
 def _make_climate(**overrides):
@@ -1163,3 +1164,186 @@ class TestIssue71IrradianceSummerFix:
 
             assert result == POSITION_CLOSED
             assert state_handler.climate_strategy.name == "SUMMER_COOLING"
+
+
+class TestIssue373Mode2SummerTiltHemisphere:
+    """Regression tests for Issue #373.
+
+    MODE2 tilt blinds use a 0–180° range where >50% means the slat is tilted
+    toward the upper/blocking hemisphere.  The summer cooling angle (45°) must
+    be mapped to the far side of horizontal (135° equivalent = 75%) for MODE2,
+    not to 25% (which is on the open/wrong hemisphere).
+    """
+
+    # ------------------------------------------------------------------
+    # 1a — MODE2 summer with presence must land on blocking hemisphere
+    # ------------------------------------------------------------------
+
+    @pytest.mark.unit
+    def test_tilt_summer_mode2_with_presence_correct_hemisphere(
+        self, tilt_cover_instance, mock_logger
+    ):
+        """MODE2 summer cooling must produce >50% (blocking hemisphere), not 25%."""
+        tilt_cover_instance.mode = "mode2"
+
+        with (
+            patch.object(
+                type(tilt_cover_instance), "valid", new_callable=PropertyMock
+            ) as mock_valid,
+            patch.object(
+                type(tilt_cover_instance), "direct_sun_valid", new_callable=PropertyMock
+            ) as mock_dsv,
+        ):
+            mock_valid.return_value = True
+            mock_dsv.return_value = True
+
+            climate_data = _make_climate(
+                inside_temperature="27.0",
+                outside_temperature="30.0",
+                temp_high=25.0,
+                temp_summer_outside=22.0,
+                policy=get_policy("cover_tilt"),
+                is_presence=True,
+                is_sunny=True,
+                irradiance_below_threshold=False,
+                lux_below_threshold=False,
+                winter_close_insulation=False,
+            )
+
+            state_handler = ClimateCoverState(
+                make_snapshot_for_cover(
+                    tilt_cover_instance, tilt_cover_instance.config.h_def
+                ),
+                climate_data,
+            )
+            result = state_handler.tilt_with_presence(180)
+
+            assert result > 50, f"Expected >50 (blocking hemisphere) but got {result}"
+            assert result >= 75, f"Expected >=75 but got {result}"
+            assert state_handler.climate_strategy.name == "SUMMER_COOLING"
+
+    # ------------------------------------------------------------------
+    # 1b — MODE1 summer with presence baseline unchanged (canary)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.unit
+    def test_tilt_summer_mode1_with_presence_baseline_unchanged(
+        self, tilt_cover_instance, mock_logger
+    ):
+        """MODE1 summer cooling formula must be unchanged after the MODE2 fix."""
+        # tilt_cover_instance fixture defaults to mode1 — verify and keep it
+        assert tilt_cover_instance.mode == "mode1"
+
+        with (
+            patch.object(
+                type(tilt_cover_instance), "valid", new_callable=PropertyMock
+            ) as mock_valid,
+            patch.object(
+                type(tilt_cover_instance), "direct_sun_valid", new_callable=PropertyMock
+            ) as mock_dsv,
+        ):
+            mock_valid.return_value = True
+            mock_dsv.return_value = True
+
+            climate_data = _make_climate(
+                inside_temperature="27.0",
+                outside_temperature="30.0",
+                temp_high=25.0,
+                temp_summer_outside=22.0,
+                policy=get_policy("cover_tilt"),
+                is_presence=True,
+                is_sunny=True,
+                irradiance_below_threshold=False,
+                lux_below_threshold=False,
+                winter_close_insulation=False,
+            )
+
+            state_handler = ClimateCoverState(
+                make_snapshot_for_cover(
+                    tilt_cover_instance, tilt_cover_instance.config.h_def
+                ),
+                climate_data,
+            )
+            result = state_handler.tilt_with_presence(90)
+
+            from custom_components.adaptive_cover_pro.const import (
+                CLIMATE_SUMMER_TILT_ANGLE,
+            )
+
+            expected_mode1 = round((CLIMATE_SUMMER_TILT_ANGLE / 90) * 100)
+            assert result == expected_mode1
+            assert state_handler.climate_strategy.name == "SUMMER_COOLING"
+
+    # ------------------------------------------------------------------
+    # 1c — MODE2 summer with presence + min_pos=50 must not clamp to 50
+    # ------------------------------------------------------------------
+
+    @pytest.mark.unit
+    def test_tilt_summer_mode2_with_presence_min_pos_clamp(
+        self, mock_logger, mock_sun_data
+    ):
+        """MODE2 summer result (75%) must survive min_pos=50 without clamping to 50.
+
+        Mirrors the exact user symptom: min_position=50, enable_min_position=false
+        (always enforce).  Pre-fix the raw result was 25 → clamped to 50 (horizontal).
+        Post-fix the raw result is 75 → 75 > 50 so no clamp, stays at 75.
+        """
+        tilt = build_tilt_cover(
+            logger=mock_logger,
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sunset_pos=0,
+            sunset_off=0,
+            sunrise_off=0,
+            sun_data=mock_sun_data,
+            fov_left=45,
+            fov_right=45,
+            win_azi=180,
+            h_def=50,
+            max_pos=100,
+            min_pos=50,
+            max_pos_bool=False,
+            min_pos_bool=False,  # always enforce (not sun-only)
+            blind_spot_left=None,
+            blind_spot_right=None,
+            blind_spot_elevation=None,
+            blind_spot_on=False,
+            min_elevation=None,
+            max_elevation=None,
+            slat_distance=0.03,
+            depth=0.02,
+            mode="mode2",
+        )
+
+        with (
+            patch.object(type(tilt), "valid", new_callable=PropertyMock) as mock_valid,
+            patch.object(
+                type(tilt), "direct_sun_valid", new_callable=PropertyMock
+            ) as mock_dsv,
+        ):
+            mock_valid.return_value = True
+            mock_dsv.return_value = True
+
+            climate_data = _make_climate(
+                inside_temperature="27.0",
+                outside_temperature="30.0",
+                temp_high=25.0,
+                temp_summer_outside=22.0,
+                policy=get_policy("cover_tilt"),
+                is_presence=True,
+                is_sunny=True,
+                irradiance_below_threshold=False,
+                lux_below_threshold=False,
+                winter_close_insulation=False,
+            )
+
+            state_handler = ClimateCoverState(
+                make_snapshot_for_cover(tilt, tilt.config.h_def),
+                climate_data,
+            )
+            result = state_handler.tilt_state()
+
+            assert (
+                result > 50
+            ), f"Expected result >50 (not clamped to horizontal) but got {result}"
+            assert result == 75, f"Expected 75 but got {result}"

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -317,6 +317,23 @@ def test_geometry_venetian_shows_min_tilt_custom():
     assert "min tilt 15%" in summary
 
 
+def test_geometry_venetian_shows_post_settle_hold_default():
+    """Venetian summary includes post-settle hold at the default value (2.0 s)."""
+    summary = _build_config_summary({}, SensorType.VENETIAN)
+    assert "post-settle hold 2.0s" in summary
+
+
+def test_geometry_venetian_shows_post_settle_hold_custom():
+    """Venetian summary reflects a custom post_settle_hold value."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_VENETIAN_POST_SETTLE_HOLD,
+    )
+
+    cfg = {CONF_VENETIAN_POST_SETTLE_HOLD: 5.5}
+    summary = _build_config_summary(cfg, SensorType.VENETIAN)
+    assert "post-settle hold 5.5s" in summary
+
+
 # ---------------------------------------------------------------------------
 # Section 2: How It Decides — Sun Tracking
 # ---------------------------------------------------------------------------

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -266,3 +266,48 @@ async def test_coordinator_wires_venetian_mode_into_policy(hass: HomeAssistant) 
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
     assert coordinator._policy._venetian_mode == VENETIAN_MODE_TILT_ONLY
+
+
+@pytest.mark.integration
+async def test_coordinator_wires_post_settle_hold_into_sequencer(
+    hass: HomeAssistant,
+) -> None:
+    """Coordinator passes post_settle_hold_seconds from options to the DualAxisSequencer.
+
+    Regression guard: if the coordinator forgets to forward the hold, the
+    sequencer silently uses the module default (2.0 s) regardless of the
+    user's configured value, making the option a no-op.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_VENETIAN_POST_SETTLE_HOLD,
+    )
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_VENETIAN_POST_SETTLE_HOLD] = 7.5
+
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {
+            "current_position": 100,
+            "current_tilt_position": 50,
+            "supported_features": 143,
+        },
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Venetian Hold Test", CONF_SENSOR_TYPE: SensorType.VENETIAN},
+        options=opts,
+        entry_id="venetian_hold_01",
+        title="Venetian Hold Test",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    seq = coordinator._policy.sequencer
+    assert seq is not None
+    assert seq._post_settle_hold_seconds == 7.5

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -589,6 +589,10 @@ async def test_tilt_below_delta_threshold_skipped_in_full_pipeline(svc, hass):
         is_dry_run=lambda: False,
         event_buffer=buf,
         get_min_change=lambda: 8,
+        # Issue #33: anchor on live actuator. Stub returns the same logical value
+        # as the stored target so the gate-logic assertion is isolated from
+        # anchor source.
+        get_current_tilt_position=lambda _eid: 50,
     )
     policy._sequencer._wait_for_position_settle = AsyncMock(return_value=(True, 60))
 
@@ -603,7 +607,13 @@ async def test_tilt_below_delta_threshold_skipped_in_full_pipeline(svc, hass):
         # simulate what post_pipeline_resolve would have computed.
         policy._sequencer._suppression_at.clear()
         policy._last_tilt = 53
-        hass.states.get.return_value = _state_with_position(60)
+        # State now reflects post-first-cycle: position=60, tilt=50 (matches
+        # what we stored on cycle 1). The actuator anchor is 50; the new target
+        # is 53; delta=3 < min_change=8 → skip.
+        state = MagicMock()
+        state.state = "open"
+        state.attributes = {"current_position": 60, "current_tilt_position": 50}
+        hass.states.get.return_value = state
         await svc.apply_position(entity_id, 60, "solar", ctx2)
 
     # Second cycle: same position (no position command) + tilt below threshold → only 0 new calls

--- a/tests/test_cover_types/test_config_flow_dispatch.py
+++ b/tests/test_cover_types/test_config_flow_dispatch.py
@@ -118,6 +118,7 @@ class TestSummaryGeometryLines:
             "mode: position and tilt",
             "min tilt 0%",
             "max tilt 100%",
+            "post-settle hold 2.0s",
         ]
 
     def test_empty_config_renders_nothing(self):
@@ -131,6 +132,7 @@ class TestSummaryGeometryLines:
             "mode: position and tilt",
             "min tilt 0%",
             "max tilt 100%",
+            "post-settle hold 2.0s",
         ]
 
     def test_venetian_summary_shows_inverse_tilt_when_set(self):

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -305,6 +305,53 @@ class TestVenetianMaybeUpdateTiltOnly:
             "cover.x", current_position=0, context=MagicMock(), reason="solar"
         )
 
+    async def test_routes_tilt_to_position_open_when_above_skip_threshold(self):
+        """When current_position > tilt_skip_above, the sequencer receives POSITION_OPEN.
+
+        Mirrors the guard in after_position_command — without this, fully-retracted
+        carriages storm the actuator with redundant tilt commands every solar
+        recompute (issue #33, geryyyyyy's beta.10 diagnostics).
+        """
+        policy = self._policy_with_last_tilt(tilt_value=40)
+        policy._tilt_skip_above = 95
+
+        await policy.maybe_update_tilt_only(
+            "cover.x", current_position=98, context=MagicMock(), reason="solar"
+        )
+
+        policy._sequencer.update_tilt_only.assert_awaited_once()
+        kwargs = policy._sequencer.update_tilt_only.await_args.kwargs
+        assert kwargs["tilt_target"] == POSITION_OPEN
+
+    async def test_uses_last_tilt_when_at_skip_threshold(self):
+        """current_position == tilt_skip_above is NOT above the threshold.
+
+        The guard is strict `>`, matching after_position_command semantics.
+        """
+        policy = self._policy_with_last_tilt(tilt_value=40)
+        policy._tilt_skip_above = 95
+
+        await policy.maybe_update_tilt_only(
+            "cover.x", current_position=95, context=MagicMock(), reason="solar"
+        )
+
+        policy._sequencer.update_tilt_only.assert_awaited_once()
+        kwargs = policy._sequencer.update_tilt_only.await_args.kwargs
+        assert kwargs["tilt_target"] == 40
+
+    async def test_uses_last_tilt_when_current_position_is_none(self):
+        """current_position=None falls back to _last_tilt — we can't evaluate the guard."""
+        policy = self._policy_with_last_tilt(tilt_value=55)
+        policy._tilt_skip_above = 95
+
+        await policy.maybe_update_tilt_only(
+            "cover.x", current_position=None, context=MagicMock(), reason="solar"
+        )
+
+        policy._sequencer.update_tilt_only.assert_awaited_once()
+        kwargs = policy._sequencer.update_tilt_only.await_args.kwargs
+        assert kwargs["tilt_target"] == 55
+
 
 @pytest.mark.asyncio
 async def test_after_position_command_fires_tilt_at_position_zero() -> None:

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -28,6 +28,49 @@ def test_retract_threshold_constants_exist() -> None:
     assert DEFAULT_VENETIAN_TILT_SKIP_ABOVE == 95
 
 
+def test_geometry_schema_accepts_post_settle_hold() -> None:
+    """GEOMETRY_VENETIAN_SCHEMA accepts venetian_post_settle_hold in range [0.0, 10.0]."""
+    import voluptuous as vol
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_VENETIAN_POST_SETTLE_HOLD,
+        DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+    )
+    from custom_components.adaptive_cover_pro.cover_types.venetian import (
+        GEOMETRY_VENETIAN_SCHEMA,
+    )
+
+    # Empty dict → default 2.0
+    result_default = GEOMETRY_VENETIAN_SCHEMA({})
+    assert (
+        result_default[CONF_VENETIAN_POST_SETTLE_HOLD]
+        == DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
+    )
+
+    # Custom value round-trips
+    result_custom = GEOMETRY_VENETIAN_SCHEMA({CONF_VENETIAN_POST_SETTLE_HOLD: 5.0})
+    assert result_custom[CONF_VENETIAN_POST_SETTLE_HOLD] == 5.0
+
+    # Out-of-range raises
+    with pytest.raises(vol.Invalid):
+        GEOMETRY_VENETIAN_SCHEMA({CONF_VENETIAN_POST_SETTLE_HOLD: 10.1})
+    with pytest.raises(vol.Invalid):
+        GEOMETRY_VENETIAN_SCHEMA({CONF_VENETIAN_POST_SETTLE_HOLD: -0.1})
+
+
+def test_post_settle_hold_constants_exist() -> None:
+    """CONF, DEFAULT, and OPTION_RANGES for post-settle hold must be exported."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_VENETIAN_POST_SETTLE_HOLD,
+        DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+        OPTION_RANGES,
+    )
+
+    assert CONF_VENETIAN_POST_SETTLE_HOLD == "venetian_post_settle_hold"
+    assert DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS == 2.0
+    assert OPTION_RANGES[CONF_VENETIAN_POST_SETTLE_HOLD] == (0.0, 10.0)
+
+
 def test_max_tilt_constants_exist() -> None:
     """CONF_MAX_TILT, DEFAULT_MAX_TILT, and OPTION_RANGES entry must be exported."""
     from custom_components.adaptive_cover_pro.const import (
@@ -522,6 +565,31 @@ def test_secondary_axis_check_returns_none_without_tilt() -> None:
     result.tilt = None
     assert policy.secondary_axis_check(result, cmd_svc=MagicMock()) is None
     assert policy.secondary_axis_check(None, cmd_svc=MagicMock()) is None
+
+
+def test_attach_forwards_post_settle_hold_to_sequencer() -> None:
+    """attach() with post_settle_hold_seconds=7.0 wires that value into DualAxisSequencer."""
+    from unittest.mock import MagicMock, patch
+
+    policy = VenetianPolicy()
+    hass = MagicMock()
+
+    with patch(
+        "custom_components.adaptive_cover_pro.cover_types.venetian.DualAxisSequencer"
+    ) as MockSeq:
+        MockSeq.return_value = MagicMock()
+        policy.attach(
+            hass=hass,
+            logger=MagicMock(),
+            grace_mgr=MagicMock(),
+            get_current_position=lambda _: None,
+            set_commanded_position=lambda *_: None,
+            position_tolerance=5,
+            is_dry_run=lambda: False,
+            post_settle_hold_seconds=7.0,
+        )
+        _, kwargs = MockSeq.call_args
+        assert kwargs.get("post_settle_hold_seconds") == 7.0
 
 
 def test_attach_threads_invert_tilt_callable_into_sequencer() -> None:

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -23,6 +23,13 @@ def _make_policy() -> VenetianPolicy:
     return VenetianPolicy()
 
 
+def _make_cover(*, direct_sun_valid: bool = True):
+    """Build a minimal cover mock for post_pipeline_resolve tests."""
+    cover = MagicMock()
+    cover.direct_sun_valid = direct_sun_valid
+    return cover
+
+
 def _config_service_stub():
     """Minimal config_service stub that returns objects the engine can use."""
     from tests.cover_helpers import make_tilt_config, make_vertical_config
@@ -34,12 +41,13 @@ def _config_service_stub():
 
 
 def _solar_kwargs():
-    """Kwargs suitable for a SOLAR post_pipeline_resolve call."""
+    """Kwargs suitable for a SOLAR post_pipeline_resolve call (direct sun valid)."""
     from tests.cover_helpers import make_cover_config
 
     sun_data = MagicMock()
     sun_data.timezone = "UTC"
     return {
+        "cover": _make_cover(direct_sun_valid=True),
         "logger": MagicMock(),
         "sol_azi": 180.0,
         "sol_elev": 45.0,
@@ -151,3 +159,63 @@ class TestPostPipelineResolveTiltOnlyMode:
             _make_result(ControlMethod.SOLAR, position=50), **_solar_kwargs()
         )
         assert out.position == 50
+
+
+class TestPostPipelineResolveNoSunStrip:
+    """Tilt must be stripped when SOLAR is emitted but direct sun is not hitting the window.
+
+    Issue #33: the climate handler emits ControlMethod.SOLAR on its LOW_LIGHT
+    branch even when cover.direct_sun_valid=False (post-sunset). Without a
+    direct_sun_valid guard, post_pipeline_resolve synthesises a tilt from the
+    still-drifting sun azimuth and the DualAxisSequencer sends tilt commands
+    every ~4 minutes overnight.
+    """
+
+    def test_tilt_stripped_when_solar_but_direct_sun_invalid(self):
+        """ControlMethod.SOLAR + direct_sun_valid=False → tilt must be None."""
+        policy = _make_policy()
+        cover = _make_cover(direct_sun_valid=False)
+        kwargs = _solar_kwargs()
+        kwargs["cover"] = cover
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SOLAR),
+            **kwargs,
+        )
+        assert out.tilt is None
+
+    def test_tilt_stripped_when_solar_and_sunset_valid(self):
+        """SOLAR + direct_sun_valid=False + sunset_valid=True → tilt still None.
+
+        sunset_valid does not grant a direct-sun exemption; only direct_sun_valid does.
+        """
+        policy = _make_policy()
+        cover = _make_cover(direct_sun_valid=False)
+        cover.sunset_valid = True
+        kwargs = _solar_kwargs()
+        kwargs["cover"] = cover
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SOLAR),
+            **kwargs,
+        )
+        assert out.tilt is None
+
+    def test_tilt_computed_when_solar_and_direct_sun_valid(self):
+        """Regression guard: SOLAR + direct_sun_valid=True → tilt must still be computed."""
+        policy = _make_policy()
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SOLAR),
+            **_solar_kwargs(),
+        )
+        assert out.tilt is not None
+
+    def test_last_tilt_not_updated_when_sun_invalid(self):
+        """When tilt is stripped due to invalid sun, _last_tilt must remain None."""
+        policy = _make_policy()
+        cover = _make_cover(direct_sun_valid=False)
+        kwargs = _solar_kwargs()
+        kwargs["cover"] = cover
+        policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SOLAR),
+            **kwargs,
+        )
+        assert policy._last_tilt is None

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -29,10 +29,19 @@ from custom_components.adaptive_cover_pro.managers.dual_axis_sequencer import (
 
 @pytest.fixture(autouse=True)
 def _zero_post_tilt_delay(monkeypatch):
-    """Skip the 1.5s real-motor settle delay in unit tests."""
+    """Skip real-motor delays in unit tests.
+
+    Zeroes both the post-tilt rebase delay (1.5 s) and the post-settle hold
+    (2.0 s) so the test suite doesn't spend real time waiting on asyncio.sleep.
+    """
     monkeypatch.setattr(
         "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
         "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
+        0,
+    )
+    monkeypatch.setattr(
+        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+        "VENETIAN_POST_SETTLE_HOLD_SECONDS",
         0,
     )
 
@@ -214,6 +223,61 @@ class TestPostTiltRebase:
             "asyncio.sleep was not called after the tilt service call — "
             "post-tilt rebase delay is missing"
         )
+
+    async def test_post_settle_hold_delay_observed_before_tilt_command(
+        self, monkeypatch
+    ):
+        """A post-settle hold sleep must occur BEFORE the tilt service call in run_sequence.
+
+        Without this hold, the tilt command races mechanical vibration left over
+        from the position motor on real hardware (Somfy IO, KNX, Shelly 2PM).
+        The test verifies that asyncio.sleep is called with the hold duration
+        before the first tilt service call, NOT only after it.
+        """
+        sleep_calls: list[float] = []
+        service_call_count = [0]
+
+        async def _capture_sleep(delay):
+            sleep_calls.append(delay)
+
+        async def _record_service_call(*args, **kwargs):
+            service_call_count[0] += 1
+
+        # Override the post-settle hold constant to a non-zero sentinel so the
+        # autouse fixture zero won't suppress the assertion.
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+            "VENETIAN_POST_SETTLE_HOLD_SECONDS",
+            0.5,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer.asyncio.sleep",
+            _capture_sleep,
+        )
+
+        set_cmd_pos = MagicMock()
+        hass, seq = _build_sequencer(set_commanded_position=set_cmd_pos)
+        hass.services.async_call = AsyncMock(side_effect=_record_service_call)
+        seq._get_current_position = lambda _eid: 60
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 60))
+
+        await seq.run_sequence(
+            "cover.x", position_target=60, tilt_target=80, reason="solar"
+        )
+
+        # The 0.5 s post-settle hold must appear in sleep_calls BEFORE the first
+        # tilt service call. We check this by verifying 0.5 is present and that
+        # the service call was actually made (i.e. this isn't a dry-run test).
+        assert service_call_count[0] == 1, "tilt service call was never made"
+        assert (
+            0.5 in sleep_calls
+        ), "asyncio.sleep(0.5) was not called — post-settle hold is missing from run_sequence"
+        # The 0.5 s hold must come BEFORE the first service call, so it must be
+        # the first element in sleep_calls (the post-tilt rebase delay is zeroed
+        # by the autouse fixture but the hold override above sets it to 0.5).
+        assert (
+            sleep_calls[0] == 0.5
+        ), f"Expected post-settle hold (0.5 s) to be first sleep, got {sleep_calls}"
 
     async def test_does_not_rebase_when_tilt_service_fails(self):
         """If the tilt service call raises, rebase must not run."""
@@ -429,6 +493,96 @@ class TestSettleStateAware:
         assert reached is False
         # poll 1: last=None → reset; poll 2-4: unchanged 1-3 → stall at poll 4.
         assert calls[0] == 4
+
+    async def test_settle_waits_when_in_tolerance_but_state_is_closing(
+        self, monkeypatch
+    ):
+        """Settle must NOT short-circuit on position alone while cover.state is moving.
+
+        The cover reports position 52, which is within tolerance of target 50.
+        But cover.state is still "closing" for the first two polls and only
+        transitions to "closed" on poll three. The loop must keep iterating
+        until the state is no longer moving, then return True.
+        """
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        # All positions are in-tolerance (target=50, value=52, tol=5).
+        # State: closing × 2, then closed.
+        pos_calls = [0]
+
+        def get_pos(_eid):
+            pos_calls[0] += 1
+            return 52
+
+        state_seq = iter(["closing", "closing", "closed"])
+        _, seq = _build_sequencer(get_state=lambda _eid: next(state_seq, "closed"))
+        seq._get_current_position = get_pos
+
+        reached, last = await seq._wait_for_position_settle("cover.x", target=50)
+
+        assert reached is True
+        # The loop must NOT have short-circuited on poll 1 (position in-tolerance but
+        # still closing). It must have polled at least 3 times.
+        assert pos_calls[0] >= 3
+
+    async def test_settle_returns_true_when_state_becomes_closed_while_in_tolerance(
+        self, monkeypatch
+    ):
+        """Settle returns True once state leaves moving, even when position was always in-tolerance.
+
+        Positions are all within tolerance (target=50, value=52, tol=5). The
+        state transitions closing→closing→closed. The loop must continue past
+        polls 1-2 (state=closing) and return True on poll 3 (state=closed),
+        with last position == 52.
+        """
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        state_seq = iter(["closing", "closing", "closed"])
+        _, seq = _build_sequencer(get_state=lambda _eid: next(state_seq, "closed"))
+        seq._get_current_position = lambda _eid: 52
+
+        reached, last = await seq._wait_for_position_settle("cover.x", target=50)
+
+        assert reached is True
+        assert last == 52
+
+    async def test_settle_returns_true_on_position_alone_when_no_get_state(
+        self, monkeypatch
+    ):
+        """When no get_state callback is provided, position tolerance is sufficient to return True.
+
+        This is the backwards-compat path for non-venetian callers and tests
+        that construct DualAxisSequencer without a get_state argument. Positions
+        [80, 52] with target=50 (tol=5): poll 1 is out-of-tolerance, poll 2 is
+        in-tolerance → the loop returns True immediately on poll 2, without
+        waiting for any state transition.
+        """
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        pos_calls = [0]
+        pos_seq = iter([80, 52])
+
+        def get_pos(_eid):
+            pos_calls[0] += 1
+            return next(pos_seq, 52)
+
+        _, seq = _build_sequencer()  # no get_state
+        seq._get_current_position = get_pos
+
+        reached, last = await seq._wait_for_position_settle("cover.x", target=50)
+
+        assert reached is True
+        assert last == 52
+        assert pos_calls[0] == 2
 
     async def test_settle_falls_back_when_no_get_state(self, monkeypatch):
         """No get_state injected → behaves identically to pre-fix code (stall at 3)."""

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -31,17 +31,14 @@ from custom_components.adaptive_cover_pro.managers.dual_axis_sequencer import (
 def _zero_post_tilt_delay(monkeypatch):
     """Skip real-motor delays in unit tests.
 
-    Zeroes both the post-tilt rebase delay (1.5 s) and the post-settle hold
-    (2.0 s) so the test suite doesn't spend real time waiting on asyncio.sleep.
+    Zeroes the post-tilt rebase delay (1.5 s) so the test suite doesn't spend
+    real time waiting on asyncio.sleep.  The post-settle hold is now a
+    per-instance parameter (``post_settle_hold_seconds``) defaulting to 0 in
+    ``_build_sequencer`` — no monkeypatching needed for that delay.
     """
     monkeypatch.setattr(
         "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
         "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
-        0,
-    )
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
-        "VENETIAN_POST_SETTLE_HOLD_SECONDS",
         0,
     )
 
@@ -56,6 +53,7 @@ def _build_sequencer(
     event_buffer=None,
     invert_tilt=None,
     get_min_change=None,
+    post_settle_hold_seconds: float = 0,
 ):
     hass = MagicMock()
     hass.services.async_call = AsyncMock()
@@ -79,6 +77,7 @@ def _build_sequencer(
             event_buffer=event_buffer,
             invert_tilt=invert_tilt,
             get_min_change=get_min_change,
+            post_settle_hold_seconds=post_settle_hold_seconds,
         ),
     )
 
@@ -243,20 +242,17 @@ class TestPostTiltRebase:
         async def _record_service_call(*args, **kwargs):
             service_call_count[0] += 1
 
-        # Override the post-settle hold constant to a non-zero sentinel so the
-        # autouse fixture zero won't suppress the assertion.
-        monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
-            "VENETIAN_POST_SETTLE_HOLD_SECONDS",
-            0.5,
-        )
         monkeypatch.setattr(
             "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer.asyncio.sleep",
             _capture_sleep,
         )
 
         set_cmd_pos = MagicMock()
-        hass, seq = _build_sequencer(set_commanded_position=set_cmd_pos)
+        # post_settle_hold_seconds=0.5 is injected via the per-instance kwarg — the
+        # autouse fixture no longer needs to monkeypatch a module constant.
+        hass, seq = _build_sequencer(
+            set_commanded_position=set_cmd_pos, post_settle_hold_seconds=0.5
+        )
         hass.services.async_call = AsyncMock(side_effect=_record_service_call)
         seq._get_current_position = lambda _eid: 60
         seq._wait_for_position_settle = AsyncMock(return_value=(True, 60))
@@ -274,7 +270,7 @@ class TestPostTiltRebase:
         ), "asyncio.sleep(0.5) was not called — post-settle hold is missing from run_sequence"
         # The 0.5 s hold must come BEFORE the first service call, so it must be
         # the first element in sleep_calls (the post-tilt rebase delay is zeroed
-        # by the autouse fixture but the hold override above sets it to 0.5).
+        # by the autouse fixture, leaving only the 0.5 hold).
         assert (
             sleep_calls[0] == 0.5
         ), f"Expected post-settle hold (0.5 s) to be first sleep, got {sleep_calls}"
@@ -1079,6 +1075,32 @@ class TestTiltDeltaAnchorIsActualTilt:
         assert events[0]["reason"] == "delta_too_small"
         assert events[0]["anchor_source"] == "actual"
         assert events[0]["anchor_value"] == 72
+
+
+@pytest.mark.asyncio
+async def test_run_sequence_uses_configured_post_settle_hold() -> None:
+    """DualAxisSequencer built with post_settle_hold_seconds=5.0 sleeps 5.0 s, not 2.0."""
+    sleep_calls: list[float] = []
+
+    async def _capture_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    import unittest.mock
+
+    with unittest.mock.patch(
+        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer.asyncio.sleep",
+        side_effect=_capture_sleep,
+    ):
+        _, seq = _build_sequencer(post_settle_hold_seconds=5.0)
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 60))
+        await seq.run_sequence(
+            "cover.x", position_target=60, tilt_target=80, reason="solar"
+        )
+
+    assert 5.0 in sleep_calls, f"Expected 5.0 in sleep_calls, got {sleep_calls}"
+    assert (
+        2.0 not in sleep_calls
+    ), f"2.0 (module default) must not appear, got {sleep_calls}"
 
 
 class TestClearTiltTargets:

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -839,13 +839,21 @@ class TestTiltDeltaGate:
     """Tilt commands must respect the configured min-change threshold."""
 
     async def test_below_min_change_skips_service_call(self):
-        """When tilt delta is below min_change, no service call is made and a skip event is emitted."""
+        """When tilt delta is below min_change, no service call is made and a skip event is emitted.
+
+        Stored target and actuator agree at 50 — gate skips because delta < min_change
+        regardless of anchor source (issue #33).
+        """
         from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
             EventBuffer,
         )
 
         buf = EventBuffer(maxlen=20)
-        hass, seq = _build_sequencer(get_min_change=lambda: 8, event_buffer=buf)
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 8,
+            event_buffer=buf,
+            get_current_tilt_position=lambda _eid: 50,
+        )
         seq._tilt_targets["cover.x"] = 50
 
         await seq._send_tilt_command(
@@ -859,8 +867,15 @@ class TestTiltDeltaGate:
         assert events[0]["reason"] == "delta_too_small"
 
     async def test_at_or_above_min_change_emits_service_call(self):
-        """When tilt delta meets min_change, the tilt service call fires."""
-        hass, seq = _build_sequencer(get_min_change=lambda: 8)
+        """When tilt delta meets min_change, the tilt service call fires.
+
+        Stored target and actuator agree at 50 — gate fires because delta >= min_change
+        regardless of anchor source (issue #33).
+        """
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 8,
+            get_current_tilt_position=lambda _eid: 50,
+        )
         seq._tilt_targets["cover.x"] = 50
 
         await seq._send_tilt_command(
@@ -892,8 +907,14 @@ class TestTiltDeltaGate:
         assert hass.services.async_call.call_count == 1
 
     async def test_default_min_change_one_is_permissive(self):
-        """Without get_min_change, any delta ≥ 1 sends — gate is permissive by default."""
-        hass, seq = _build_sequencer()  # no get_min_change
+        """Without get_min_change, any delta ≥ 1 sends — gate is permissive by default.
+
+        Stored target and actuator agree at 50 — gate is permissive regardless of
+        anchor source (issue #33).
+        """
+        hass, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 50,
+        )  # no get_min_change
         seq._tilt_targets["cover.x"] = 50
 
         await seq._send_tilt_command(
@@ -901,3 +922,200 @@ class TestTiltDeltaGate:
         )
 
         assert hass.services.async_call.call_count == 1
+
+
+class TestResolveTiltAnchor:
+    """``_resolve_tilt_anchor`` returns the right (value, source) for each branch.
+
+    Issue #33: covers the three call paths into the helper — live actuator read,
+    actuator-returns-None fallback, and no-callback fallback.
+    """
+
+    def test_returns_actual_when_callback_provided_and_returns_value(self):
+        """Live actuator read short-circuits the stored target."""
+        _, seq = _build_sequencer(get_current_tilt_position=lambda _eid: 72)
+        seq._tilt_targets["cover.x"] = 99  # stored target is stale
+        value, source = seq._resolve_tilt_anchor("cover.x")
+        assert value == 72
+        assert source == "actual"
+
+    def test_falls_back_to_stored_when_actuator_returns_none(self):
+        """When the callback returns None, fall back to stored target."""
+        _, seq = _build_sequencer(get_current_tilt_position=lambda _eid: None)
+        seq._tilt_targets["cover.x"] = 50
+        value, source = seq._resolve_tilt_anchor("cover.x")
+        assert value == 50
+        assert source == "target_fallback"
+
+    def test_falls_back_to_stored_when_callback_not_wired(self):
+        """When no callback is configured at all, fall back to stored target."""
+        _, seq = _build_sequencer()  # no get_current_tilt_position
+        seq._tilt_targets["cover.x"] = 40
+        value, source = seq._resolve_tilt_anchor("cover.x")
+        assert value == 40
+        assert source == "target_fallback"
+
+    def test_actual_inverted_when_invert_tilt_set(self):
+        """Wire reading is converted to logical space when inversion is configured."""
+        _, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 80,
+            invert_tilt=lambda: True,
+        )
+        value, source = seq._resolve_tilt_anchor("cover.x")
+        # inverse_state(80) == 20
+        assert value == 20
+        assert source == "actual"
+
+    def test_returns_none_value_when_actuator_none_and_no_stored_target(self):
+        """No actuator + no stored target → (None, target_fallback)."""
+        _, seq = _build_sequencer(get_current_tilt_position=lambda _eid: None)
+        value, source = seq._resolve_tilt_anchor("cover.x")
+        assert value is None
+        assert source == "target_fallback"
+
+
+@pytest.mark.asyncio
+class TestTiltDeltaAnchorIsActualTilt:
+    """Issue #33: the tilt min-delta gate must anchor on live actuator state.
+
+    The stored ``_tilt_targets`` value can drift from reality whenever the
+    motor auto-tilts mechanically (e.g. on close, on slat back-rotate) — comparing
+    a new target against the *stored target* skips legitimate motion while the
+    cover is far from where ACP thinks it is. The fix anchors on the actuator's
+    actual tilt (with fallback to the stored target when unavailable).
+    """
+
+    async def test_stale_anchor_after_close_does_not_skip_legitimate_move(self):
+        """Stored=74 (fiction), actual=100 (closed), target=72 → command must fire.
+
+        Reproduces issue #33 comment 81 failure mode 1: motor auto-tilted to 100
+        on close, but our stored target is the pre-close 74. New target 72 has
+        |72−74|=2 against stored (would skip), but |72−100|=28 against actual
+        (must fire).
+        """
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 8,
+            get_current_tilt_position=lambda _eid: 100,
+        )
+        seq._tilt_targets["cover.x"] = 74
+
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=72, position_target=60, reason="solar"
+        )
+
+        assert hass.services.async_call.call_count == 1
+
+    async def test_slow_drift_past_stale_anchor_fires_each_cycle(self):
+        """Stored=74, actual=100. Targets 70, 69, 68 each delta against stored
+        is 4-6 (would skip), but against actual is 30-32 (must fire).
+
+        Reproduces issue #33 comment 81 failure mode 2: solar drift across
+        multiple cycles below the legacy stored-target min_change but well
+        above the gate threshold relative to actual tilt.
+        """
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 8,
+            get_current_tilt_position=lambda _eid: 100,
+        )
+        seq._tilt_targets["cover.x"] = 74
+
+        for target in (70, 69, 68):
+            await seq._send_tilt_command(
+                "cover.x", tilt_target=target, position_target=60, reason="solar"
+            )
+
+        assert hass.services.async_call.call_count == 3
+
+    async def test_anchor_falls_back_to_stored_target_when_actuator_returns_none(self):
+        """When ``get_current_tilt_position`` returns None, anchor falls back
+        to the stored target and the gate still skips when delta is small.
+
+        The diagnostic event must record ``anchor_source='target_fallback'``
+        and ``anchor_value=<stored>`` so operators can see why a skip happened.
+        """
+        buf = EventBuffer(maxlen=20)
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 8,
+            get_current_tilt_position=lambda _eid: None,
+            event_buffer=buf,
+        )
+        seq._tilt_targets["cover.x"] = 50
+
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=53, position_target=60, reason="solar"
+        )
+
+        assert hass.services.async_call.call_count == 0
+        events = buf.snapshot()
+        assert len(events) == 1
+        assert events[0]["event"] == "tilt_command_skipped"
+        assert events[0]["reason"] == "delta_too_small"
+        assert events[0]["anchor_source"] == "target_fallback"
+        assert events[0]["anchor_value"] == 50
+
+    async def test_skip_event_records_actual_anchor_when_available(self):
+        """When actuator reports a current tilt, skip events record it as the anchor.
+
+        Stored=99 (stale), actual=72, target=74, min_change=8: delta vs stored
+        is 25 (would fire under old logic), delta vs actual is 2 → skip with
+        ``anchor_source='actual'`` and ``anchor_value=72``.
+        """
+        buf = EventBuffer(maxlen=20)
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 8,
+            get_current_tilt_position=lambda _eid: 72,
+            event_buffer=buf,
+        )
+        seq._tilt_targets["cover.x"] = 99
+
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=74, position_target=60, reason="solar"
+        )
+
+        assert hass.services.async_call.call_count == 0
+        events = buf.snapshot()
+        assert len(events) == 1
+        assert events[0]["event"] == "tilt_command_skipped"
+        assert events[0]["reason"] == "delta_too_small"
+        assert events[0]["anchor_source"] == "actual"
+        assert events[0]["anchor_value"] == 72
+
+
+class TestClearTiltTargets:
+    """``clear_tilt_targets`` invalidates the stored-target cache (issue #33).
+
+    Defense-in-depth hook called from Auto Control off→on transitions, so the
+    very next cycle resolves the anchor from the live actuator instead of an
+    arbitrarily old stored target.
+    """
+
+    def test_clears_all_stored_tilt_targets(self):
+        _, seq = _build_sequencer()
+        seq._tilt_targets["cover.a"] = 50
+        seq._tilt_targets["cover.b"] = 75
+
+        seq.clear_tilt_targets()
+
+        assert seq._tilt_targets == {}
+
+    def test_last_tilt_target_returns_none_after_clear(self):
+        _, seq = _build_sequencer()
+        seq._tilt_targets["cover.a"] = 50
+
+        seq.clear_tilt_targets()
+
+        assert seq.last_tilt_target("cover.a") is None
+
+    def test_does_not_touch_suppression_timestamps(self):
+        """Back-rotate suppression is a time-based safeguard, independent of the
+        stored-target cache — clearing tilt targets must not reopen the suppression
+        window early.
+        """
+        _, seq = _build_sequencer()
+        seq.stamp_position_command("cover.a")
+        before = dict(seq._suppression_at)
+        assert before  # sanity: there's something to preserve
+
+        seq.clear_tilt_targets()
+
+        assert seq._suppression_at == before

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -790,3 +790,79 @@ class TestClimateHandlerAwningSemantics:
         assert (
             result.position == 100
         ), f"Blind winter heating must still raise (100%) after awning fix; got {result.position}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #33 — ClimateHandler must not emit ControlMethod.SOLAR on low-light branch
+# ---------------------------------------------------------------------------
+
+
+class TestClimateHandlerControlMethodOnLowLightBranch:
+    """Low-light / no-sun branch of the climate handler must emit ControlMethod.DEFAULT.
+
+    Before the fix, the else-branch in ClimateHandler.evaluate() unconditionally
+    set method=ControlMethod.SOLAR even when the strategy was LOW_LIGHT. This
+    caused VenetianPolicy.post_pipeline_resolve to synthesise a tilt from the
+    still-drifting sun azimuth, triggering tilt commands every ~4 minutes
+    overnight (issue #33).
+    """
+
+    handler = ClimateHandler()
+
+    def test_low_light_emits_default_not_solar(self) -> None:
+        """Presence + intermediate temp + is_sunny=False → ControlMethod.DEFAULT."""
+        cover = _make_blind_cover(direct_sun_valid=False)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=22.0,
+                is_presence=True,
+                is_sunny=False,
+            ),
+            climate_options=_make_options(temp_low=18.0, temp_high=26.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.DEFAULT, (
+            f"Low-light branch must emit DEFAULT, not {result.control_method}"
+        )
+
+    def test_no_presence_low_light_emits_default_not_solar(self) -> None:
+        """No presence + intermediate temp + is_sunny=False → ControlMethod.DEFAULT."""
+        cover = _make_blind_cover(direct_sun_valid=False)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=22.0,
+                is_presence=False,
+                is_sunny=False,
+            ),
+            climate_options=_make_options(temp_low=18.0, temp_high=26.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.DEFAULT, (
+            f"Low-light (no presence) branch must emit DEFAULT, not {result.control_method}"
+        )
+
+    def test_lux_below_threshold_emits_default_not_solar(self) -> None:
+        """Presence + intermediate temp + lux_below_threshold=True → ControlMethod.DEFAULT."""
+        cover = _make_blind_cover(direct_sun_valid=False)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(
+                inside_temperature=22.0,
+                is_presence=True,
+                is_sunny=True,
+                lux_below_threshold=True,
+            ),
+            climate_options=_make_options(temp_low=18.0, temp_high=26.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.DEFAULT, (
+            f"Lux-below-threshold branch must emit DEFAULT, not {result.control_method}"
+        )

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -824,9 +824,9 @@ class TestClimateHandlerControlMethodOnLowLightBranch:
         )
         result = self.handler.evaluate(snap)
         assert result is not None
-        assert result.control_method == ControlMethod.DEFAULT, (
-            f"Low-light branch must emit DEFAULT, not {result.control_method}"
-        )
+        assert (
+            result.control_method == ControlMethod.DEFAULT
+        ), f"Low-light branch must emit DEFAULT, not {result.control_method}"
 
     def test_no_presence_low_light_emits_default_not_solar(self) -> None:
         """No presence + intermediate temp + is_sunny=False → ControlMethod.DEFAULT."""
@@ -843,9 +843,9 @@ class TestClimateHandlerControlMethodOnLowLightBranch:
         )
         result = self.handler.evaluate(snap)
         assert result is not None
-        assert result.control_method == ControlMethod.DEFAULT, (
-            f"Low-light (no presence) branch must emit DEFAULT, not {result.control_method}"
-        )
+        assert (
+            result.control_method == ControlMethod.DEFAULT
+        ), f"Low-light (no presence) branch must emit DEFAULT, not {result.control_method}"
 
     def test_lux_below_threshold_emits_default_not_solar(self) -> None:
         """Presence + intermediate temp + lux_below_threshold=True → ControlMethod.DEFAULT."""
@@ -863,6 +863,6 @@ class TestClimateHandlerControlMethodOnLowLightBranch:
         )
         result = self.handler.evaluate(snap)
         assert result is not None
-        assert result.control_method == ControlMethod.DEFAULT, (
-            f"Lux-below-threshold branch must emit DEFAULT, not {result.control_method}"
-        )
+        assert (
+            result.control_method == ControlMethod.DEFAULT
+        ), f"Lux-below-threshold branch must emit DEFAULT, not {result.control_method}"

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -167,3 +167,46 @@ def test_runtime_config_is_frozen() -> None:
     rc = RuntimeConfig.from_options({})
     with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
         rc.entities = ["cover.never"]  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_runtime_config_venetian_slice_defaults() -> None:
+    """Empty options dict → VenetianSlice uses DEFAULT_* constants from const.py."""
+    from custom_components.adaptive_cover_pro.const import (
+        DEFAULT_VENETIAN_MODE,
+        DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+        DEFAULT_VENETIAN_TILT_SKIP_ABOVE,
+        VENETIAN_MODE_POSITION_AND_TILT,
+    )
+
+    rc = RuntimeConfig.from_options({})
+    assert (
+        rc.venetian.post_settle_hold_seconds
+        == DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
+    )
+    assert rc.venetian.post_settle_hold_seconds == 2.0
+    assert rc.venetian.tilt_skip_above == DEFAULT_VENETIAN_TILT_SKIP_ABOVE
+    assert rc.venetian.tilt_skip_above == 95
+    assert rc.venetian.venetian_mode == DEFAULT_VENETIAN_MODE
+    assert rc.venetian.venetian_mode == VENETIAN_MODE_POSITION_AND_TILT
+
+
+@pytest.mark.unit
+def test_runtime_config_venetian_slice_reads_options() -> None:
+    """Custom values round-trip through VenetianSlice correctly."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_VENETIAN_MODE,
+        CONF_VENETIAN_POST_SETTLE_HOLD,
+        CONF_VENETIAN_TILT_SKIP_ABOVE,
+        VENETIAN_MODE_TILT_ONLY,
+    )
+
+    options = {
+        CONF_VENETIAN_POST_SETTLE_HOLD: 5.5,
+        CONF_VENETIAN_TILT_SKIP_ABOVE: 80,
+        CONF_VENETIAN_MODE: VENETIAN_MODE_TILT_ONLY,
+    }
+    rc = RuntimeConfig.from_options(options)
+    assert rc.venetian.post_settle_hold_seconds == 5.5
+    assert rc.venetian.tilt_skip_above == 80
+    assert rc.venetian.venetian_mode == VENETIAN_MODE_TILT_ONLY

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -61,6 +61,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_SUNSET_USE_MY,
     CONF_TEMP_HIGH,
     CONF_TEMP_LOW,
+    CONF_VENETIAN_MODE,
+    CONF_VENETIAN_POST_SETTLE_HOLD,
     CONF_WEATHER_BYPASS_AUTO_CONTROL,
     CONF_WEATHER_OVERRIDE_POSITION,
     CONF_WEATHER_SEVERE_SENSORS,
@@ -68,11 +70,13 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
     DOMAIN,
     SensorType,
+    VENETIAN_MODE_POSITION_AND_TILT,
 )
 from custom_components.adaptive_cover_pro.services.options_service import (
     ALL_SETTABLE_KEYS,
     FIELD_VALIDATORS,
     IDENTITY_KEYS,
+    OPTIONS_SERVICE_NAMES,
     _cross_field_validate,
     apply_options_patch,
     validate_options_patch,
@@ -290,6 +294,35 @@ class TestFieldValidators:
         with pytest.raises(Exception):
             FIELD_VALIDATORS[CONF_DISTANCE](50.01)
 
+    def test_field_validators_post_settle_hold_range(self):
+        """venetian_post_settle_hold accepts 0.0/2.0/10.0/None; rejects out-of-range."""
+        import voluptuous as vol
+
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_VENETIAN_POST_SETTLE_HOLD,
+        )
+
+        v = FIELD_VALIDATORS[CONF_VENETIAN_POST_SETTLE_HOLD]
+        v(0.0)  # min
+        v(2.0)  # default
+        v(10.0)  # max
+        v(None)  # optional clear
+
+        with pytest.raises(vol.Invalid):
+            v(10.1)
+        with pytest.raises(vol.Invalid):
+            v(-0.1)
+
+    def test_field_validators_venetian_mode_and_skip_above_present(self):
+        """venetian_mode and venetian_tilt_skip_above must be in FIELD_VALIDATORS."""
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_VENETIAN_MODE,
+            CONF_VENETIAN_TILT_SKIP_ABOVE,
+        )
+
+        assert CONF_VENETIAN_MODE in FIELD_VALIDATORS
+        assert CONF_VENETIAN_TILT_SKIP_ABOVE in FIELD_VALIDATORS
+
 
 class TestCrossFieldValidate:
     """Unit tests for _cross_field_validate."""
@@ -470,6 +503,7 @@ class TestServiceRegistration:
             "set_blind_spot",
             "set_interpolation",
             "set_geometry",
+            "set_venetian",
             "set_option",
         ]:
             assert hass.services.has_service(
@@ -1231,3 +1265,105 @@ class TestReloadPropagation:
             )
 
         mock_update.assert_not_called()
+
+
+class TestSetVenetian:
+    """Tests for set_venetian service (Phase 5 Step 10)."""
+
+    def test_set_venetian_in_options_service_names(self):
+        """set_venetian must be listed in OPTIONS_SERVICE_NAMES for proper unload."""
+        assert "set_venetian" in OPTIONS_SERVICE_NAMES
+
+    async def test_set_venetian_service_registered(self, hass: HomeAssistant):
+        """set_venetian service is registered after integration setup."""
+        await _setup(hass, entry_id="ven_reg_01")
+        assert hass.services.has_service(
+            DOMAIN, "set_venetian"
+        ), "Service 'set_venetian' not registered"
+
+    async def test_set_venetian_updates_post_settle_hold(self, hass: HomeAssistant):
+        """set_venetian updates venetian_post_settle_hold in options."""
+        await _setup(hass, entry_id="ven_hold_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_venetian",
+                {CONF_VENETIAN_POST_SETTLE_HOLD: 5.0},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_VENETIAN_POST_SETTLE_HOLD] == 5.0
+
+    async def test_set_venetian_updates_mode(self, hass: HomeAssistant):
+        """set_venetian updates venetian_mode in options."""
+        await _setup(hass, entry_id="ven_mode_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_venetian",
+                {CONF_VENETIAN_MODE: VENETIAN_MODE_POSITION_AND_TILT},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_VENETIAN_MODE] == VENETIAN_MODE_POSITION_AND_TILT
+
+    async def test_set_venetian_rejects_out_of_range_hold(self, hass: HomeAssistant):
+        """set_venetian rejects venetian_post_settle_hold out of range."""
+        await _setup(hass, entry_id="ven_range_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_venetian",
+                {CONF_VENETIAN_POST_SETTLE_HOLD: 99.0},
+            )
+
+    async def test_set_venetian_rejects_invalid_mode(self, hass: HomeAssistant):
+        """set_venetian rejects an unknown venetian_mode string."""
+        await _setup(hass, entry_id="ven_mode_invalid_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(
+                hass,
+                "set_venetian",
+                {CONF_VENETIAN_MODE: "invalid_mode_xyz"},
+            )
+
+    async def test_set_venetian_uses_default_hold_when_cleared(
+        self, hass: HomeAssistant
+    ):
+        """Clearing venetian_post_settle_hold (None) removes it from options."""
+        opts = dict(VERTICAL_OPTIONS)
+        opts[CONF_VENETIAN_POST_SETTLE_HOLD] = 5.0
+        await _setup(hass, entry_id="ven_clear_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_venetian",
+                {CONF_VENETIAN_POST_SETTLE_HOLD: None},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        # Key removed (None = clear); coordinator will use DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
+        assert CONF_VENETIAN_POST_SETTLE_HOLD not in new_opts
+
+    def test_section_venetian_has_three_keys(self):
+        """_SECTION_VENETIAN must contain all three venetian option keys."""
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            _SECTION_VENETIAN,
+        )
+
+        assert CONF_VENETIAN_POST_SETTLE_HOLD in _SECTION_VENETIAN
+        assert CONF_VENETIAN_MODE in _SECTION_VENETIAN
+        # Skip CONF_VENETIAN_TILT_SKIP_ABOVE import — use length check
+        assert len(_SECTION_VENETIAN) == 3

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -1,0 +1,688 @@
+"""Tests for the set_position service.
+
+Strict red-green-refactor: each section corresponds to a TDD plan step.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+)
+from tests.ha_helpers import (
+    VERTICAL_OPTIONS,
+    _patch_coordinator_refresh,
+)
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _setup(
+    hass,
+    entry_id: str = "sp_01",
+    options: dict | None = None,
+    name: str = "SP Cover",
+):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    opts = dict(VERTICAL_OPTIONS) if options is None else options
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": name, CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title=name,
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _make_coord(
+    *,
+    entities: list[str] | None = None,
+    options: dict | None = None,
+    custom_states: list[CustomPositionSensorState] | None = None,
+    is_manual: bool = False,
+    apply_position_result=("sent", "set_cover_position"),
+):
+    """Build a minimal mock coordinator for unit-level tests."""
+    coord = MagicMock()
+    coord.entities = entities or ["cover.test_blind"]
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = options or {}
+
+    # _read_custom_position_sensor_states
+    coord._read_custom_position_sensor_states.return_value = custom_states or []
+
+    # _build_position_context
+    ctx = MagicMock()
+    coord._build_position_context.return_value = ctx
+
+    # manager
+    coord.manager = MagicMock()
+    coord.manager.is_cover_manual.return_value = is_manual
+
+    # _cmd_svc.apply_position
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.apply_position = AsyncMock(return_value=apply_position_result)
+
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Step 1 (Red → Green): Service registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_set_position_service_registered_after_setup(hass) -> None:
+    """set_position service is registered after async_setup_services."""
+    await _setup(hass, entry_id="sp_reg_01")
+    assert hass.services.has_service(
+        DOMAIN, "set_position"
+    ), "set_position service should be registered after setup"
+
+
+@pytest.mark.integration
+async def test_set_position_service_removed_after_all_entries_unloaded(hass) -> None:
+    """set_position service is removed when the last entry is unloaded."""
+    entry = await _setup(hass, entry_id="sp_unload_01")
+    assert hass.services.has_service(DOMAIN, "set_position")
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.services.has_service(
+        DOMAIN, "set_position"
+    ), "set_position service should be removed when last entry is unloaded"
+
+
+# ---------------------------------------------------------------------------
+# Wrapper coverage: thin _resolve_targets re-export
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_targets_wrapper_delegates_to_services_module() -> None:
+    """The local _resolve_targets wrapper forwards args to services._resolve_targets."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        _resolve_targets as wrapper,
+    )
+
+    sentinel_hass = MagicMock(name="hass")
+    sentinel_call = MagicMock(name="call")
+    expected = {"coord_x": None}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services._resolve_targets",
+        return_value=expected,
+    ) as real:
+        result = wrapper(sentinel_hass, sentinel_call)
+
+    real.assert_called_once_with(sentinel_hass, sentinel_call)
+    assert result is expected
+
+
+# ---------------------------------------------------------------------------
+# Steps 3 & 14 (Red → Green): Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_rejects_missing_position() -> None:
+    """Schema raises when position is absent."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_POSITION_SCHEMA({})
+
+
+def test_schema_rejects_position_out_of_range() -> None:
+    """Schema raises when position=150 (> 100)."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_POSITION_SCHEMA({"position": 150})
+
+
+def test_schema_rejects_negative_position() -> None:
+    """Schema raises when position=-1 (< 0)."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_POSITION_SCHEMA({"position": -1})
+
+
+def test_schema_accepts_boundary_values() -> None:
+    """Schema accepts position=0 and position=100."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    assert SET_POSITION_SCHEMA({"position": 0})["position"] == 0
+    assert SET_POSITION_SCHEMA({"position": 100})["position"] == 100
+
+
+def test_schema_rejects_extra_key_tilt() -> None:
+    """Schema rejects extra key 'tilt' (PREVENT_EXTRA)."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_POSITION_SCHEMA({"position": 50, "tilt": 30})
+
+
+def test_schema_coerces_string_to_int() -> None:
+    """Schema coerces string '40' to int 40."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    result = SET_POSITION_SCHEMA({"position": "40"})
+    assert result["position"] == 40
+    assert isinstance(result["position"], int)
+
+
+# ---------------------------------------------------------------------------
+# Step 5 (Red → Green): No floor active — position passes through unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_floor_active_position_passes_through() -> None:
+    """No active min_mode slots → apply_position called with requested position."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(custom_states=[])
+    call = MagicMock()
+    call.data = {"position": 40}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        40,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 6 (Red → Green): min_mode slot off — no clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_min_mode_slot_off_no_clamping() -> None:
+    """Slot with min_mode=True but is_on=False does NOT act as a floor."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=False,
+        position=60,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot])
+    call = MagicMock()
+    call.data = {"position": 30}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        30,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 7 (Red → Green): min_mode slot on — clamps up
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_min_mode_slot_on_clamps_up() -> None:
+    """Slot with min_mode=True, is_on=True, position=50, request 20 → clamped to 50."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=50,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot])
+    call = MagicMock()
+    call.data = {"position": 20}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        50,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 8 (Red → Green): at floor and above floor — no clamping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_request_equals_floor_no_extra_clamping() -> None:
+    """Request exactly at floor (50) → apply_position called with 50."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=50,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot])
+    call = MagicMock()
+    call.data = {"position": 50}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        50,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_above_floor_no_clamping() -> None:
+    """Request (70) above floor (50) → apply_position called with 70."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=50,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot])
+    call = MagicMock()
+    call.data = {"position": 70}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        70,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Steps 10–11 (Red → Green): Multiple min_mode floors — highest wins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_floors_request_below_highest_clamped() -> None:
+    """Two active min_mode slots (40, 65); request 50 → clamped to 65."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot_a = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=40,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    slot_b = CustomPositionSensorState(
+        entity_id="binary_sensor.slot2",
+        is_on=True,
+        position=65,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot_a, slot_b])
+    call = MagicMock()
+    call.data = {"position": 50}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        65,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+@pytest.mark.asyncio
+async def test_two_floors_request_above_highest_not_clamped() -> None:
+    """Two active min_mode slots (40, 65); request 70 → not clamped."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot_a = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=40,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    slot_b = CustomPositionSensorState(
+        entity_id="binary_sensor.slot2",
+        is_on=True,
+        position=65,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot_a, slot_b])
+    call = MagicMock()
+    call.data = {"position": 70}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        70,
+        "set_position",
+        coord._build_position_context.return_value,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 12 (Red → Green): Manual override — force=True bypasses gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_override_active_force_bypasses_gate() -> None:
+    """is_cover_manual=True but force=True → apply_position still invoked."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(custom_states=[], is_manual=True)
+    call = MagicMock()
+    call.data = {"position": 40}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    # _build_position_context should be called with force=True
+    coord._build_position_context.assert_called_once()
+    call_kwargs = coord._build_position_context.call_args
+    assert call_kwargs.kwargs.get("force") is True or (
+        len(call_kwargs.args) >= 3 and call_kwargs.args[2] is True
+    ), f"force=True expected in _build_position_context call, got {call_kwargs}"
+
+    # apply_position must still be called (not blocked)
+    coord._cmd_svc.apply_position.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Step 13 (Red → Green): Unknown entity_id — silently skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_entity_id_silently_skipped() -> None:
+    """entity_id not owned by any ACP coord → apply_position never called, no exception."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    call = MagicMock()
+    call.data = {"entity_id": ["cover.unknown"], "position": 40}
+
+    # _resolve_targets returns empty dict → no coordinator to act on
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={},
+    ):
+        # Must not raise
+        await async_handle_set_position(call)
+
+
+# ---------------------------------------------------------------------------
+# Steps 16–17 (Red → Green): INFO log when clamped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clamp_emits_info_log(caplog) -> None:
+    """Clamping 20→50 emits an INFO log containing 'clamped' and '50'."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=50,
+        priority=77,
+        min_mode=True,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot])
+    call = MagicMock()
+    call.data = {"position": 20}
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+            return_value={coord: None},
+        ),
+        caplog.at_level(logging.INFO, logger="custom_components.adaptive_cover_pro"),
+    ):
+        await async_handle_set_position(call)
+
+    log_text = caplog.text
+    assert "clamped" in log_text.lower(), f"Expected 'clamped' in log, got: {log_text}"
+    assert "50" in log_text, f"Expected '50' in log, got: {log_text}"
+
+
+@pytest.mark.asyncio
+async def test_no_clamp_emits_debug_log(caplog) -> None:
+    """No clamping → no INFO log (DEBUG-only)."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(custom_states=[])
+    call = MagicMock()
+    call.data = {"position": 40}
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+            return_value={coord: None},
+        ),
+        caplog.at_level(logging.INFO, logger="custom_components.adaptive_cover_pro"),
+    ):
+        await async_handle_set_position(call)
+
+    # INFO log should NOT contain "clamped"
+    info_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "clamped" in r.getMessage().lower()
+    ]
+    assert not info_records, f"Unexpected INFO clamp log: {info_records}"
+
+
+# ---------------------------------------------------------------------------
+# Entity filter: only targeted entities within coordinator are commanded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entity_filter_limits_commands() -> None:
+    """When entity_filter is a set, only those entities get commanded."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(
+        entities=["cover.blind_a", "cover.blind_b"],
+        custom_states=[],
+    )
+    call = MagicMock()
+    call.data = {"position": 60}
+
+    # Simulate _resolve_targets returning a filter of only blind_a
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: {"cover.blind_a"}},
+    ):
+        await async_handle_set_position(call)
+
+    # Only blind_a should be commanded
+    calls = coord._cmd_svc.apply_position.await_args_list
+    entity_ids_commanded = [c.args[0] for c in calls]
+    assert entity_ids_commanded == ["cover.blind_a"]
+
+
+@pytest.mark.asyncio
+async def test_no_filter_commands_all_entities() -> None:
+    """When entity_filter is None, all coordinator entities are commanded."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(
+        entities=["cover.blind_a", "cover.blind_b"],
+        custom_states=[],
+    )
+    call = MagicMock()
+    call.data = {"position": 60}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    calls = coord._cmd_svc.apply_position.await_args_list
+    entity_ids_commanded = sorted(c.args[0] for c in calls)
+    assert entity_ids_commanded == ["cover.blind_a", "cover.blind_b"]
+
+
+# ---------------------------------------------------------------------------
+# Non-min_mode slot (is_on=True) does NOT act as floor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_min_mode_slot_on_does_not_clamp() -> None:
+    """Slot is_on=True but min_mode=False — no floor effect."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot = CustomPositionSensorState(
+        entity_id="binary_sensor.slot1",
+        is_on=True,
+        position=80,
+        priority=77,
+        min_mode=False,
+        use_my=False,
+    )
+    coord = _make_coord(custom_states=[slot])
+    call = MagicMock()
+    call.data = {"position": 30}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test_blind",
+        30,
+        "set_position",
+        coord._build_position_context.return_value,
+    )

--- a/tests/test_switch_actions.py
+++ b/tests/test_switch_actions.py
@@ -125,6 +125,70 @@ async def test_turn_on_non_automatic_control_key_no_position_send():
     coord.async_refresh.assert_called_once()
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_turn_on_automatic_control_clears_venetian_tilt_targets():
+    """Auto Control off→on must clear the venetian sequencer's stored tilt targets.
+
+    Issue #33 defense-in-depth: the min-delta gate now anchors on live actuator
+    reads, but a stale ``_tilt_targets`` cache could still mislead diagnostics
+    or fallback logic. Clearing on auto-on lets the very next cycle resolve
+    cleanly from actuator state.
+    """
+    coord = _make_coordinator()
+    coord.entities = ["cover.test_1"]
+    # Wire a venetian-style policy with a sequencer attribute we can spy on.
+    sequencer = MagicMock()
+    sequencer.clear_tilt_targets = MagicMock()
+    coord._policy = MagicMock()
+    coord._policy.sequencer = sequencer
+
+    switch = _make_switch(key="automatic_control", coordinator=coord)
+    await switch.async_turn_on()  # off→on transition (no added kwarg)
+
+    sequencer.clear_tilt_targets.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_turn_on_automatic_control_no_sequencer_is_noop():
+    """Non-venetian policies have ``sequencer is None`` — must not raise.
+
+    Vertical / horizontal / tilt-only policies don't own a sequencer; the
+    clear-tilt-targets hook must short-circuit cleanly without AttributeError.
+    """
+    coord = _make_coordinator()
+    coord.entities = ["cover.test_1"]
+    coord._policy = MagicMock()
+    coord._policy.sequencer = None
+
+    switch = _make_switch(key="automatic_control", coordinator=coord)
+    # Should not raise even though there's no sequencer to clear.
+    await switch.async_turn_on()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_turn_on_automatic_control_with_added_kwarg_does_not_clear():
+    """Restore-from-state (added=True) must not invalidate stored tilt targets.
+
+    The clear-tilt-targets hook is meant for *real* user toggles; startup
+    restore reconstructs auto_control's last state and should not perturb the
+    sequencer.
+    """
+    coord = _make_coordinator()
+    coord.entities = ["cover.test_1"]
+    sequencer = MagicMock()
+    sequencer.clear_tilt_targets = MagicMock()
+    coord._policy = MagicMock()
+    coord._policy.sequencer = sequencer
+
+    switch = _make_switch(key="automatic_control", coordinator=coord)
+    await switch.async_turn_on(added=True)
+
+    sequencer.clear_tilt_targets.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # async_turn_off: automatic_control key
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR is the full **v2.20.0 dual-axis venetian blind feature train**, closing
[#33]. It introduces a new `cover_venetian` sensor type that owns BOTH
`set_cover_position` and `set_cover_tilt_position` on a single Home Assistant
entity, replacing the prior workaround of pairing two instances (one
`cover_blind` + one `cover_tilt`) against the same physical blind. It also
includes the architectural lift that made the new cover type clean to add:
`CoverTypePolicy` now owns every cover-type decision, so control code
(coordinator, command service, pipeline handlers, state providers, managers)
no longer branches on cover-type strings.

The branch shipped as a 7-beta series (`v2.20.0-beta.1` → `v2.20.0-beta.7`)
to volunteer testers from #33 (KNX, Somfy IO/Tahoma, Shelly 2PM); each beta
addressed a concrete failure mode reported during the prior round.

Refs #33

## Highlights

### New cover type

- **`cover_venetian` sensor type** — pick "Venetian Blind (Dual-Axis)" in setup.
  One config entry captures both window dimensions and slat geometry.
- **Position-then-tilt sequencing** (`DualAxisSequencer`) — sends
  `set_cover_position`, polls `current_position` until the motor settles
  (within tolerance, or three consecutive no-progress samples while not
  `opening`/`closing`, hard-capped at 60s), then sends
  `set_cover_tilt_position`. Eliminates the ping-pong between paired blind +
  tilt instances.
- **Per-axis manual override with back-rotate suppression** — tilt drift
  inside a 90s window after a position command is treated as motor
  back-rotate and ignored. Tilt deltas outside that window (user grabs the
  wand) still trip manual override on the tilt axis.
- **Decision-trace tilt** — the Decision Trace sensor and diagnostics
  download show the engine-derived slat angle alongside the resolved
  position. New synthetic terminal step `venetian_engine` records the
  computation; `venetian_mode` step records tilt-only override.
- **Target Tilt sensor** — diagnostic sensor exposing the engine's target
  slat angle (degrees) without needing the diagnostics bundle.

### Configurable tilt guards

- **Skip Tilt Above Position (%)** — guards against firing
  `set_cover_tilt_position` when the cover is retracted into its housing
  and slats are physically hidden (default: 95%).
- **Venetian Mode** — `position_and_tilt` (default) or `tilt_only`. In
  `tilt_only` the position command is suppressed and the integration drives
  only the slat axis — useful for hardware like Shelly 2PM that prefers
  tilt-first operation, or when vertical position is held fixed by another
  automation.
- **Solar-only tilt gate** — tilt commands only fire when the pipeline's
  control method is `SOLAR`. Outside sun-tracking windows (overrides,
  manual holds, non-solar paths) tilt is suppressed at the source rather
  than caught by per-cycle skip logic.
- **Continuous tilt tracking** — when the position axis won't change but
  the slat angle should (sun moves, cover already at target),
  `update_tilt_only` re-issues `set_cover_tilt_position` alone with the
  same suppression window.

### Reliability fixes (beta evolution)

The beta series fixed seven distinct failure modes reported by testers:

- **Post-tilt reconciliation loop (beta.2):** coordinator was treating each
  `current_tilt_position` state-change after a tilt command as a fresh
  deviation and re-sending the command. Now the back-rotate window
  swallows post-command drift on both axes.
- **Skip tilt when retracted (beta.3):** `tilt_skip_above` guard added.
- **Two-bug manual-override fix (beta.4):** `SecondaryAxisCheck.evaluate`
  was bypassing suppression on `new_value == expected`, and
  `_rebase_commanded_position` was sampling `current_position` before the
  motor finished its back-drive. Together they produced false override
  trips on covers behaving correctly.
- **Tolerance-boundary drift fix (beta.4):** position drift exactly at the
  tolerance boundary was rounded inconsistently across the rebase and the
  manual-override check, leaving them disagreeing about whether drift had
  occurred.
- **Skip tilt when at/below lower bound (beta.5, later removed in beta.6):**
  near-closed venetians with pinched slats produced motor loops; replaced
  by the cleaner solar-gate approach in beta.6.
- **Two-layer tilt loss for Shelly 2PM (beta.6):**
  - *False settle:* `_wait_for_position_settle` now respects `cover.state`
    — while `opening`/`closing`, the stall counter resets, preventing
    Shelly's ~1Hz position publishes from triggering a premature settle.
  - *No recovery:* `_send_tilt_command` reads back `current_tilt_position`
    after the call. If tilt drifts beyond `VENETIAN_TILT_VERIFY_TOLERANCE`
    (5%), the recorded target is cleared so the next cycle retries instead
    of short-circuiting forever.
- **False override on tilt-only path (beta.7):** `update_tilt_only` was
  sending `set_cover_tilt_position` without stamping the back-rotate
  suppression window, producing spurious `manual_override_set` events
  during slat settle. Suppression is now stamped inside
  `_send_tilt_command` so both `run_sequence` and `update_tilt_only` open
  the window whenever a tilt command fires.

### Diagnostics

All tilt command outcomes emit `EventBuffer` events
(`tilt_command_sent`, `tilt_command_skipped`, `tilt_command_verified`,
`tilt_command_drift`) at the same richness as the existing position-command
events — visible in the diagnostics download for triage.

## Architecture: `CoverTypePolicy` re-axis

Cover-type-specific knowledge now lives behind `CoverTypePolicy` and the
`CoverAxis` descriptors it declares. Code outside `cover_types/` never
branches on the cover-type string. The new venetian dropped in cleanly
because of this work; future cover types (shutters, dual-roller) won't need
control-flow surgery either.

What was pushed onto the policy:

- **HA service / state attribute / capability key** for each axis
  (`POSITION_AXIS`, `TILT_AXIS`, etc.) — `CoverCommandService`,
  `CoverProvider`, and the manual-override state-change path read these
  through `policy.select_default_axis(caps)` and
  `policy.read_axis_value(...)`.
- **"Open blocks sun" semantics** — exposed via
  `policy.position_for_intent(sun_through=...)`, consumed by climate
  strategy.
- **Glare zones / dual-axis / type-only features** — gated by
  `ClassVar` flags (`supports_glare_zones`, etc.).
- **Post-position settle/sequence** —
  `policy.after_position_command(...)` runs the venetian back-rotate
  sequence after a successful `set_cover_position`.
- **Geometry schema and entity-selector filter** — `policy.geometry_schema()`
  and `policy.entity_selector_filter()` drive the config flow.

The new convention is documented in `CODING_GUIDELINES.md` under
"Cover Type Abstraction — No String Branches Outside `cover_types/`",
with banned patterns, a decision-location table, and a checklist for
adding a new cover type.

## Testing

- ✅ **2,883 tests passing** (was ~2,560 on `main`).
- New test files added for the dual-axis surface:
  `tests/test_cover_types/test_axes.py`,
  `tests/test_cover_types/test_calc_engine_dispatch.py`,
  `tests/test_cover_types/test_config_flow_dispatch.py`,
  `tests/test_cover_types/test_venetian.py`,
  `tests/test_cover_types/test_venetian_post_pipeline.py`,
  `tests/test_managers/test_dual_axis_sequencer.py` (~600 lines covering
  settle behaviour, drift recovery, suppression windows, tilt-only path,
  and all four diagnostic event types),
  `tests/test_managers/test_secondary_axis_check.py`,
  `tests/test_manual_override_venetian.py`,
  `tests/test_pipeline_types_venetian.py`,
  `tests/test_sensor_venetian_tilt.py`,
  `tests/test_cover_command_venetian.py`.
- `cover_types/venetian.py` at **100% line coverage**.
- Codecov gates configured via new `codecov.yml`: patch ≥ 95%, project
  drop ≤ 0.5pp. PR clears both.

## Files

`+6,370 / −560` across 69 files.

Production code touched: `coordinator.py`, `config_flow.py`, `sensor.py`,
`switch.py`, `binary_sensor.py`, `cover.py`, `entity_base.py`, `const.py`,
`enums.py`, the entire `cover_types/` package (new), `engine/covers/`,
`managers/cover_command.py`, new `managers/dual_axis_sequencer.py`,
`managers/manual_override.py`, `pipeline/types.py`,
`state/cover_provider.py`, `diagnostics/builder.py`, translations
(`en.json`, `de.json`, `fr.json`).

## Release notes

Per-beta detail lives under `release_notes/v2.20.0-beta.{1..7}.md`.

## Related

- Closes #33 — Dual-axis venetian blind support.