### PR TITLE
fix(config_flow): preserve user-supplied name in cover entity step

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2316,7 +2316,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 first_entity_id = user_input[CONF_ENTITIES][0]
                 entity_reg = er.async_get(self.hass)
                 entity_entry = entity_reg.async_get(first_entity_id)
-                if entity_entry:
+                if entity_entry and not self.config.get("name"):
                     entity_name = (
                         entity_entry.original_name
                         or entity_entry.name


### PR DESCRIPTION
## Summary

Preserve the user-supplied ACP name when the cover-entity step runs.

## Problem

`async_step_cover_entities` currently overwrites `self.config["name"]` even when the user already supplied a name in the earlier `create_new` step.

In setups where multiple source covers expose the same entity-registry `original_name` (for example many Tuya covers reporting `Curtain`), this can collapse distinct ACP entries toward the same generated title.

## Change

Only auto-generate a name from the first selected cover if the flow does not already have a name.

## Behavior impact

- Existing auto-generated naming still works when no name was provided.
- Explicit user-entered names are no longer overwritten.
- No runtime cover-control behavior changes.

## Manual test

Created a new ACP entry with an explicit name, selected a source cover with a generic `original_name`, and verified the explicit name is preserved.
