### PR TITLE
fix: custom-position sensor release edge forces return to calculated position (#365)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -302,6 +302,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # the release transition and bypass time/position delta gates.
         self._prev_force_override_active: bool = False
 
+        # Per-sensor on/off state from last cycle.  Mirrors
+        # _prev_force_override_active so a custom-position sensor that flips
+        # off can also force a return to the calculated position regardless of
+        # which lower-priority handler now wins.  Keyed by sensor entity_id.
+        self._prev_custom_position_sensors_active: dict[str, bool] = {}
+
         # Diagnostics builder (extracted from coordinator)
         self._diagnostics_builder = DiagnosticsBuilder()
 
@@ -1215,6 +1221,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # the release transition in async_handle_state_change().
         prev_force_override = self._prev_force_override_active
 
+        # Capture last cycle's per-sensor active map so we can detect a custom
+        # position sensor flipping off (release edge of #365).
+        prev_custom_position_sensors_active = dict(
+            self._prev_custom_position_sensors_active
+        )
+
         # Build unified state snapshot for this update cycle
         _sun_azimuth = state_attr(self.hass, "sun.sun", "azimuth")
         _sun_elevation = state_attr(self.hass, "sun.sun", "elevation")
@@ -1259,9 +1271,33 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # captured in the snapshot we just built).
         self._prev_force_override_active = self.is_force_override_active
 
+        # Same for custom-position sensors: stamp this cycle's on/off map so
+        # next cycle can detect the on → off transition for the release edge.
+        current_custom_position_sensors_active = {
+            s.entity_id: s.is_on
+            for s in self._read_custom_position_sensor_states(options)
+        }
+        self._prev_custom_position_sensors_active = (
+            current_custom_position_sensors_active
+        )
+
+        # Set of sensors that transitioned on → off this cycle.  When the
+        # triggering entity is one of these, force=True bypasses time/position
+        # delta gates so covers return to the calculated position promptly.
+        custom_position_released_entities = {
+            eid
+            for eid, was_on in prev_custom_position_sensors_active.items()
+            if was_on and not current_custom_position_sensors_active.get(eid, False)
+        }
+
         # Handle types of changes
         if self.state_change:
-            await self.async_handle_state_change(state, options, prev_force_override)
+            await self.async_handle_state_change(
+                state,
+                options,
+                prev_force_override,
+                custom_position_released_entities,
+            )
         elif auto_expired:
             # One or more manual overrides just timed out.  Proactively send
             # the fresh pipeline position so covers don't linger at the
@@ -1516,7 +1552,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         return sent
 
     async def async_handle_state_change(
-        self, state: int, options, prev_force_override: bool = False
+        self,
+        state: int,
+        options,
+        prev_force_override: bool = False,
+        custom_position_released_entities: set[str] | None = None,
     ):
         """Send position commands to all covers when a tracked entity changes.
 
@@ -1530,12 +1570,33 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         now inactive), force=True is also passed so the time delta check cannot
         block the return to the calculated position.  The force override's own
         position change should not count against the time threshold.
+
+        ``custom_position_released_entities`` holds the set of custom-position
+        sensors that flipped on → off this cycle.  When the triggering entity
+        for this refresh is one of them, force=True is also passed so the
+        return to the calculated position is not throttled (#365).
         """
         sun_just_appeared = self._check_sun_validity_transition()
         is_safety = self._pipeline_is_safety_handler
         force_override_released = (
             prev_force_override and not self.is_force_override_active
         )
+
+        # Custom-position sensor release edge: the entity that triggered this
+        # refresh just flipped off and a lower-priority handler (solar/default)
+        # now wins, so _is_custom_position_sensor_trigger() returns False.
+        # Mirrors force_override_released for the same reason: the time-delta
+        # gate would otherwise drop the return-to-calculated command.  Short-
+        # circuit when the set is empty so callers that bypass __init__ (e.g.
+        # gate-matrix fixtures) don't need to wire _last_state_change_entity.
+        trigger_entity: str | None = None
+        custom_position_released = False
+        if custom_position_released_entities:
+            trigger_entity = self._last_state_change_entity
+            custom_position_released = (
+                trigger_entity is not None
+                and trigger_entity in custom_position_released_entities
+            )
 
         # Outside the configured time window, only safety handlers (force
         # override, weather) are allowed to move covers.  All other handlers
@@ -1549,6 +1610,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             and not is_safety
             and not force_override_released
             and not custom_position_sensor_triggered
+            and not custom_position_released
         ):
             self.state_change = False
             self._last_state_change_entity = None
@@ -1556,13 +1618,24 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return
 
         use_force = (
-            is_safety or force_override_released or custom_position_sensor_triggered
+            is_safety
+            or force_override_released
+            or custom_position_sensor_triggered
+            or custom_position_released
         )
         if force_override_released:
             reason = "force_override_cleared"
             self.logger.debug(
                 "Force override released — bypassing time/position delta gates "
                 "to return to calculated position %s",
+                state,
+            )
+        elif custom_position_released:
+            reason = "custom_position_released"
+            self.logger.debug(
+                "Custom-position sensor %s released — bypassing time/position "
+                "delta gates to return to calculated position %s",
+                trigger_entity,
                 state,
             )
         else:

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -363,6 +363,173 @@ class TestCustomPositionSensorEdgeTriggerBypassesGate:
         )
 
 
+class TestCustomPositionSensorReleaseEdgeBypassesGate:
+    """Custom-position sensor release-edge mirrors force-override release (#365).
+
+    When a custom-position sensor toggles off, the CustomPositionHandler returns
+    None and a lower-priority handler (SOLAR / DEFAULT) wins, so the pipeline's
+    control_method is no longer CUSTOM_POSITION.  Without explicit release
+    handling, force=True is never threaded, and CoverCommandService drops the
+    return-to-solar command on the time-delta gate.
+
+    The fix mirrors the existing _prev_force_override_active pattern: the
+    coordinator captures last cycle's per-sensor active state and computes a
+    set of sensors that flipped from on to off this cycle.  When the released
+    sensor IS the entity that triggered this refresh, force=True is passed.
+    """
+
+    def _make_release_coordinator(
+        self,
+        *,
+        last_state_change_entity: str = "binary_sensor.movie_time",
+    ):
+        """Coordinator where a custom-position sensor just transitioned on → off.
+
+        Pipeline result is SOLAR because the sensor is off this cycle —
+        CustomPositionHandler returned None at custom_position.py:92.
+        """
+        result = _make_pipeline_result(
+            position=55,
+            control_method=ControlMethod.SOLAR,
+            bypass_auto_control=False,
+        )
+        coordinator = _make_coordinator(entities=["cover.test"], pipeline_result=result)
+        coordinator.check_adaptive_time = True
+        coordinator.is_force_override_active = False
+        coordinator._last_state_change_entity = last_state_change_entity
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_custom_position_release_passes_force_true(self):
+        """When the triggering sensor flipped on → off, force=True bypasses gates."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = self._make_release_coordinator()
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator,
+            state=55,
+            options={},
+            prev_force_override=False,
+            custom_position_released_entities={"binary_sensor.movie_time"},
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.test",
+            {},
+            force=True,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_custom_position_release_uses_released_reason(self):
+        """Reason string on release is 'custom_position_released'."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = self._make_release_coordinator()
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator,
+            state=55,
+            options={},
+            prev_force_override=False,
+            custom_position_released_entities={"binary_sensor.movie_time"},
+        )
+
+        call = coordinator._cmd_svc.apply_position.call_args
+        reason = call.args[2]
+        assert reason == "custom_position_released"
+
+    @pytest.mark.asyncio
+    async def test_no_release_with_empty_released_set(self):
+        """Empty released set: no release detected, force stays False."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = self._make_release_coordinator()
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator,
+            state=55,
+            options={},
+            prev_force_override=False,
+            custom_position_released_entities=set(),
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.test",
+            {},
+            force=False,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_release_only_when_triggering_entity_matches(self):
+        """A sensor in the released set but NOT the trigger entity does not force."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = self._make_release_coordinator(
+            last_state_change_entity="cover.test"
+        )
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator,
+            state=55,
+            options={},
+            prev_force_override=False,
+            custom_position_released_entities={"binary_sensor.movie_time"},
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.test",
+            {},
+            force=False,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_release_bypasses_time_window_gate(self):
+        """Release fires even when outside the configured time window.
+
+        Symmetric to force_override_released, which already overrides the
+        time-window gate at coordinator.py:1547-1552.  Otherwise a sensor that
+        flips off after end_time would leave covers stuck at the slot's
+        position with no way to return to the calculated value.
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coordinator = self._make_release_coordinator()
+        coordinator.check_adaptive_time = False  # outside time window
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator,
+            state=55,
+            options={},
+            prev_force_override=False,
+            custom_position_released_entities={"binary_sensor.movie_time"},
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.test",
+            {},
+            force=True,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+
 class TestCustomPositionTriggerEntityRecording:
     """async_check_entity_state_change records the triggering entity_id."""
 


### PR DESCRIPTION
## Summary
- A custom-position sensor flipping off used to leave the cover stuck at the slot's position because the time-delta gate dropped the return-to-calculated command. The ON edge was fixed in #348/#349; the OFF edge was missed.
- Mirrored the force-override release pattern: coordinator now tracks per-sensor on/off state across cycles, computes the released set each cycle in `_async_update_data`, and threads it into `async_handle_state_change`. When the released sensor is the triggering entity, `force=True` is passed and the reason is `custom_position_released`.

## Testing
- New `TestCustomPositionSensorReleaseEdgeBypassesGate` class with 5 tests covering release-passes-force, released-reason, no-release-with-empty-set, release-only-when-triggering-entity-matches, and release-bypasses-time-window-gate.
- Full suite: 2982 passed.

## Related Issues
Refs #365