### PR TITLE
fix: apply tilt_skip_above guard to tilt-only path (#33)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -313,6 +313,21 @@ class VenetianPolicy(CoverTypePolicy):
             return False
         return self._sequencer.is_in_suppression(entity_id)
 
+    def _resolve_skip_above_tilt(
+        self, position: int | None, fallback_tilt: int | None
+    ) -> int | None:
+        """Apply the ``tilt_skip_above`` guard to a tilt decision.
+
+        Returns ``POSITION_OPEN`` (neutral) when the carriage is commanded
+        above the skip threshold so the actuator's tilt cache is overwritten
+        with a benign value rather than the prior solar-cycle tilt; returns
+        ``fallback_tilt`` otherwise. Shared by ``after_position_command`` and
+        ``maybe_update_tilt_only`` so the threshold rule lives in one place.
+        """
+        if position is not None and position > self._tilt_skip_above:
+            return POSITION_OPEN
+        return fallback_tilt
+
     async def maybe_update_tilt_only(
         self,
         entity_id: str,
@@ -328,9 +343,10 @@ class VenetianPolicy(CoverTypePolicy):
             return
         if self._sequencer.is_in_suppression(entity_id):
             return
+        tilt_target = self._resolve_skip_above_tilt(current_position, self._last_tilt)
         await self._sequencer.update_tilt_only(
             entity_id,
-            tilt_target=self._last_tilt,
+            tilt_target=tilt_target,
             current_position=current_position,
             reason=reason,
         )
@@ -379,12 +395,11 @@ class VenetianPolicy(CoverTypePolicy):
         seq = self._sequencer
         if seq is None:
             return
-        if position > self._tilt_skip_above:
-            tilt_target = POSITION_OPEN
-        else:
-            tilt_target = getattr(context, "tilt", None)
-            if tilt_target is None:
-                return
+        tilt_target = self._resolve_skip_above_tilt(
+            position, getattr(context, "tilt", None)
+        )
+        if tilt_target is None:
+            return
         # Open suppression early — covers position-axis settle events that
         # fire before _send_tilt_command runs (which itself stamps again).
         seq.stamp_position_command(entity_id)

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -305,6 +305,53 @@ class TestVenetianMaybeUpdateTiltOnly:
             "cover.x", current_position=0, context=MagicMock(), reason="solar"
         )
 
+    async def test_routes_tilt_to_position_open_when_above_skip_threshold(self):
+        """When current_position > tilt_skip_above, the sequencer receives POSITION_OPEN.
+
+        Mirrors the guard in after_position_command — without this, fully-retracted
+        carriages storm the actuator with redundant tilt commands every solar
+        recompute (issue #33, geryyyyyy's beta.10 diagnostics).
+        """
+        policy = self._policy_with_last_tilt(tilt_value=40)
+        policy._tilt_skip_above = 95
+
+        await policy.maybe_update_tilt_only(
+            "cover.x", current_position=98, context=MagicMock(), reason="solar"
+        )
+
+        policy._sequencer.update_tilt_only.assert_awaited_once()
+        kwargs = policy._sequencer.update_tilt_only.await_args.kwargs
+        assert kwargs["tilt_target"] == POSITION_OPEN
+
+    async def test_uses_last_tilt_when_at_skip_threshold(self):
+        """current_position == tilt_skip_above is NOT above the threshold.
+
+        The guard is strict `>`, matching after_position_command semantics.
+        """
+        policy = self._policy_with_last_tilt(tilt_value=40)
+        policy._tilt_skip_above = 95
+
+        await policy.maybe_update_tilt_only(
+            "cover.x", current_position=95, context=MagicMock(), reason="solar"
+        )
+
+        policy._sequencer.update_tilt_only.assert_awaited_once()
+        kwargs = policy._sequencer.update_tilt_only.await_args.kwargs
+        assert kwargs["tilt_target"] == 40
+
+    async def test_uses_last_tilt_when_current_position_is_none(self):
+        """current_position=None falls back to _last_tilt — we can't evaluate the guard."""
+        policy = self._policy_with_last_tilt(tilt_value=55)
+        policy._tilt_skip_above = 95
+
+        await policy.maybe_update_tilt_only(
+            "cover.x", current_position=None, context=MagicMock(), reason="solar"
+        )
+
+        policy._sequencer.update_tilt_only.assert_awaited_once()
+        kwargs = policy._sequencer.update_tilt_only.await_args.kwargs
+        assert kwargs["tilt_target"] == 55
+
 
 @pytest.mark.asyncio
 async def test_after_position_command_fires_tilt_at_position_zero() -> None:


### PR DESCRIPTION
## Summary
- `maybe_update_tilt_only` now applies the same `tilt_skip_above` guard that `after_position_command` already enforces, routing tilt to `POSITION_OPEN` when the carriage is above the threshold (default 95).
- Extracted the threshold rule into a private `_resolve_skip_above_tilt` helper shared by both call sites — no more mirrored guard blocks.
- Closes the test gap in `TestVenetianMaybeUpdateTiltOnly` with three new cases (above threshold, at boundary, None position).

## Testing
- ✅ 2985 tests passing

## Related Issues
Refs #33