### PR TITLE
fix: add set_position service to services.yaml (#372)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -43,6 +43,29 @@ export_config:
         config_entry:
           integration: adaptive_cover_pro
 
+set_position:
+  name: Set position
+  description: >-
+    Move the targeted covers to an explicit position. Clamps up to the highest
+    active custom-position minimum-mode floor across all slots, and sends with
+    force=True so manual override does not block the command. Tilt is not
+    affected; on venetian instances only the primary axis is moved.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    position:
+      name: Position
+      description: "Target position (0–100%)."
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+
 set_position_limits:
   name: Set position limits
   description: >-

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -41,3 +41,64 @@ def test_set_blind_spot_service_description_mentions_fov_frame():
     svc = _load()["set_blind_spot"]
     desc = svc["description"].lower()
     assert "fov" in desc or "field of view" in desc
+
+
+def test_set_position_service_exists_in_yaml():
+    svc = _load()
+    assert (
+        "set_position" in svc
+    ), "set_position service is registered in Python but has no entry in services.yaml"
+
+
+def test_set_position_has_target_block():
+    svc = _load()["set_position"]
+    assert "target" in svc
+    assert svc["target"]["entity"]["integration"] == "adaptive_cover_pro"
+
+
+def test_set_position_has_position_field_with_correct_range():
+    fields = _load()["set_position"]["fields"]
+    assert "position" in fields
+    sel = fields["position"]["selector"]["number"]
+    assert sel["min"] == 0
+    assert sel["max"] == 100
+    assert sel["step"] == 1
+    assert sel["mode"] == "slider"
+    assert sel["unit_of_measurement"] == "%"
+
+
+# Names wired with hass.services.async_register in services/__init__.py.
+# Add here when registering a new service; remove when deregistering.
+REGISTERED_SERVICES = {
+    "export_config",
+    "get_diagnostics",
+    "integration_enable",
+    "integration_disable",
+    "emergency_stop",
+    "set_position",
+    # Options services (registered via register_options_services / OPTIONS_SERVICE_NAMES)
+    "set_position_limits",
+    "set_sunset_sunrise",
+    "set_automation_timing",
+    "set_manual_override",
+    "set_force_override",
+    "set_custom_position",
+    "set_motion",
+    "set_light_cloud",
+    "set_climate",
+    "set_weather_safety",
+    "set_sun_tracking",
+    "set_blind_spot",
+    "set_interpolation",
+    "set_geometry",
+    "set_venetian",
+    "set_option",
+}
+
+
+def test_all_registered_services_have_yaml_entry():
+    documented = set(_load().keys())
+    missing = REGISTERED_SERVICES - documented
+    assert (
+        not missing
+    ), f"Service(s) registered in Python but missing from services.yaml: {sorted(missing)}"


### PR DESCRIPTION
## Summary
The `adaptive_cover_pro.set_position` service shipped in v2.21.0 was registered in Python but never added to `services.yaml`. Without that descriptor, Home Assistant's UI has no target picker, no `position` field selector, and no description text for the service. Added the full YAML entry matching the sibling-service pattern, plus a broader structural guard that prevents the same class of bug for any future service.

## Testing
- ✅ 3060 tests passing (4 net-new: 3 set_position assertions + 1 structural guard covering all 22 registered services)

## Related Issues
Refs #372