### PR TITLE
fix: venetian dual-axis loop after v2.21.0 release (#33)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -484,6 +484,16 @@ VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES = 3  # samples → "settled"
 # vertically, and that drift would otherwise read as a user touch.
 VENETIAN_TILT_SUPPRESSION_SECONDS = 90.0  # tilt-axis override-suppression window
 
+# Refuse to absorb post-tilt drift larger than this many percent. Real-motor
+# back-drive is single-digit percent; a large delta (e.g. user opened the blind
+# during settle) must not be silently adopted as the new commanded target.
+VENETIAN_REBASE_MAX_DRIFT_PERCENT = 15
+
+# Cap the tilt delta the back-rotate suppression window will swallow. Slat
+# geometry bounds mechanical back-rotation; a delta above this is a user move,
+# so the manual-override path runs even inside the suppression window.
+VENETIAN_BACKROTATE_MAX_DELTA_PERCENT = 30
+
 # After set_cover_tilt_position returns, real motors keep back-driving the
 # vertical axis briefly. Wait this many seconds before reading current_position
 # for the post-tilt rebase so the rebase captures the actual settled position
@@ -501,7 +511,7 @@ VENETIAN_TILT_VERIFY_TOLERANCE = 5  # percent — tilt-verification tolerance
 # The value is configurable per-instance; the module-level default is consumed
 # only when no instance config is available (e.g. unit tests).
 CONF_VENETIAN_POST_SETTLE_HOLD = "venetian_post_settle_hold"  # s, 0.0-10.0
-DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS = 2.0  # default post-settle hold
+DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS = 3.0  # default post-settle hold
 
 # Skip the tilt command when the commanded position exceeds this threshold —
 # at high positions the slats are retracted into the housing and tilting is

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -336,11 +336,16 @@ class VenetianPolicy(CoverTypePolicy):
         """Expose the sequencer for diagnostics / tests."""
         return self._sequencer
 
-    def is_in_tilt_suppression(self, entity_id: str) -> bool:
-        """Return whether the venetian back-rotate suppression window is open."""
+    def is_in_tilt_suppression(self, entity_id: str, delta: float) -> bool:
+        """Suppress back-rotate drift only when ``delta`` is plausibly motor drift.
+
+        Delegates to the sequencer's delta-aware gate. Large deltas inside the
+        window are user moves, not motor drift, and fall through to the
+        manual-override numeric path (issue #33 follow-on).
+        """
         if self._sequencer is None:
             return False
-        return self._sequencer.is_in_suppression(entity_id)
+        return self._sequencer.is_in_suppression_with_cap(entity_id, delta)
 
     def _resolve_skip_above_tilt(
         self, position: int | None, fallback_tilt: int | None

--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -29,10 +29,12 @@ from homeassistant.exceptions import HomeAssistantError
 from ..const import (
     ATTR_TILT_POSITION,
     DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+    VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
     VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES,
     VENETIAN_POSITION_SETTLE_POLL_SECONDS,
     VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
     VENETIAN_POST_TILT_REBASE_DELAY_SECONDS,
+    VENETIAN_REBASE_MAX_DRIFT_PERCENT,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
     VENETIAN_TILT_VERIFY_TOLERANCE,
 )
@@ -52,6 +54,9 @@ _TILT_SKIP_DRY_RUN = "dry_run"
 _TILT_SKIP_TARGET_UNCHANGED = "target_unchanged"
 _TILT_SKIP_SERVICE_FAILED = "service_call_failed"
 _TILT_SKIP_DELTA_TOO_SMALL = "delta_too_small"
+
+# Reason codes for rebase_skipped events.
+_REBASE_SKIP_SETTLE_FAILED = "settle_failed"
 
 # Anchor sources for the tilt min-delta gate (issue #33). The gate compares
 # the new target against either the live actuator reading (preferred) or the
@@ -152,6 +157,17 @@ class DualAxisSequencer:
         elapsed = (dt.datetime.now(dt.UTC) - ts).total_seconds()
         return elapsed < VENETIAN_TILT_SUPPRESSION_SECONDS
 
+    def is_in_suppression_with_cap(self, entity_id: str, delta: float) -> bool:
+        """Suppress back-rotate drift only when the delta is plausibly motor drift.
+
+        Slat geometry bounds back-rotation magnitude; a large delta inside the
+        window is a user move, not motor drift, so the manual-override path
+        runs and the user's command is recorded (issue #33 follow-on).
+        """
+        if not self.is_in_suppression(entity_id):
+            return False
+        return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
+
     # -- tilt sequence ----------------------------------------------------- #
 
     def last_tilt_target(self, entity_id: str) -> int | None:
@@ -177,13 +193,20 @@ class DualAxisSequencer:
         reason: str,
     ) -> None:
         """Wait for vertical motion to settle, then send the tilt command."""
-        await self._wait_for_position_settle(entity_id, position_target)
+        settled, _last = await self._wait_for_position_settle(
+            entity_id, position_target
+        )
         await asyncio.sleep(self._post_settle_hold_seconds)
+        # The window protects the position-axis settle + tilt-induced back-drive.
+        # Only the position-sequence path owns this stamp; tilt-only sends from
+        # update_tilt_only must not extend it (issue #33 follow-on).
+        self.stamp_position_command(entity_id)
         await self._send_tilt_command(
             entity_id,
             tilt_target=tilt_target,
             position_target=position_target,
             reason=reason,
+            position_settled=settled,
         )
 
     async def _send_tilt_command(
@@ -194,6 +217,7 @@ class DualAxisSequencer:
         position_target: int,
         reason: str,
         force: bool = False,
+        position_settled: bool = True,
     ) -> None:
         """Emit ``set_cover_tilt_position`` and rebase the commanded position.
 
@@ -262,13 +286,6 @@ class DualAxisSequencer:
             position_target,
         )
 
-        # Open the back-rotate suppression window so tilt-axis state events
-        # produced by slat settle aren't read as user-initiated manual override.
-        # Both run_sequence and update_tilt_only paths need this stamp here;
-        # the early stamp in VenetianPolicy.after_position_command only covers
-        # state events that fire during the position-axis settle wait.
-        self.stamp_position_command(entity_id)
-
         try:
             await self._hass.services.async_call(
                 COVER_DOMAIN,
@@ -313,7 +330,16 @@ class DualAxisSequencer:
         # recorded target so the next update_tilt_only cycle retries.
         self._verify_and_record_tilt(entity_id, tilt_target)
 
-        self._rebase_commanded_position(entity_id, position_target)
+        if position_settled:
+            self._rebase_commanded_position(entity_id, position_target)
+        else:
+            self._record_event(
+                "rebase_skipped",
+                reason=_REBASE_SKIP_SETTLE_FAILED,
+                entity_id=entity_id,
+                position_target=position_target,
+                trigger=reason,
+            )
 
     async def update_tilt_only(
         self,
@@ -359,7 +385,27 @@ class DualAxisSequencer:
         actual = self._get_current_position(entity_id)
         if actual is None:
             return
-        if abs(actual - position_target) <= self._position_tolerance:
+        drift = abs(actual - position_target)
+        if drift <= self._position_tolerance:
+            return
+        if drift > VENETIAN_REBASE_MAX_DRIFT_PERCENT:
+            self._logger.warning(
+                "Venetian rebase refused for %s: drift %s%% exceeds max %s%% "
+                "(commanded %s%%, actual %s%%)",
+                entity_id,
+                drift,
+                VENETIAN_REBASE_MAX_DRIFT_PERCENT,
+                position_target,
+                actual,
+            )
+            self._record_event(
+                "rebase_refused_drift_too_large",
+                entity_id=entity_id,
+                position_target=position_target,
+                actual_position=actual,
+                drift=drift,
+                max_drift=VENETIAN_REBASE_MAX_DRIFT_PERCENT,
+            )
             return
         self._logger.debug(
             "Venetian post-tilt rebase: %s commanded %s%% → actual %s%% "

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -46,7 +46,7 @@ class SecondaryAxisCheck:
     expected: int
     attribute: str  # e.g. "current_tilt_position"
     label: str  # e.g. "tilt" — flavours the rejection-reason text
-    suppression: Callable[[str], bool] | None = None
+    suppression: Callable[[str, float], bool] | None = None
 
     def evaluate(
         self,
@@ -70,7 +70,7 @@ class SecondaryAxisCheck:
         # exactly on target while the position axis still shows back-drive drift.
         # Returning consumed=False here would let the position-axis check run and
         # falsely trip manual override on that drift.
-        if self.suppression is not None and self.suppression(entity_id):
+        if self.suppression is not None and self.suppression(entity_id, delta):
             return SecondaryAxisResult(
                 consumed=True,
                 event_name="manual_override_rejected_tilt_suppression",

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -318,9 +318,9 @@ def test_geometry_venetian_shows_min_tilt_custom():
 
 
 def test_geometry_venetian_shows_post_settle_hold_default():
-    """Venetian summary includes post-settle hold at the default value (2.0 s)."""
+    """Venetian summary includes post-settle hold at the default value (3.0 s)."""
     summary = _build_config_summary({}, SensorType.VENETIAN)
-    assert "post-settle hold 2.0s" in summary
+    assert "post-settle hold 3.0s" in summary
 
 
 def test_geometry_venetian_shows_post_settle_hold_custom():

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -162,7 +162,7 @@ async def test_apply_position_stamps_suppression_window(svc, hass, attached_poli
             entity_id, 40, "solar", _ctx_venetian(attached_policy, tilt=70)
         )
 
-    assert attached_policy.is_in_tilt_suppression(entity_id) is True
+    assert attached_policy.is_in_tilt_suppression(entity_id, delta=0.0) is True
 
 
 @pytest.mark.asyncio
@@ -368,7 +368,7 @@ async def test_tilt_on_target_plus_position_back_drive_does_not_trip_manual_over
         )
 
     # Suppression window must be open immediately after apply_position.
-    assert attached_policy.is_in_tilt_suppression(entity_id)
+    assert attached_policy.is_in_tilt_suppression(entity_id, delta=0.0)
 
     mgr = AdaptiveCoverManager(
         hass=MagicMock(),
@@ -403,17 +403,41 @@ async def test_tilt_on_target_plus_position_back_drive_does_not_trip_manual_over
 
 
 @pytest.mark.asyncio
-async def test_tilt_only_update_then_tilt_settle_event_does_not_trip_manual_override(
+async def test_tilt_only_update_does_not_stamp_suppression_window(
     svc, hass, attached_policy
 ):
-    """Regression for issue #33: tilt-only path must stamp suppression so settle events don't trip override.
+    """Issue #33 follow-on: tilt-only updates must NOT extend the back-rotate window.
 
-    Sequence:
-      1. maybe_update_tilt_only fires (no prior apply_position — cover already at target position).
-      2. HA fires state-change: tilt drifts mid-settle (motor back-rotate).
+    The window protects the *position-axis* settle and the tilt-induced back-drive
+    that follows. A tilt-only send from ``maybe_update_tilt_only`` doesn't move
+    the carriage, so it must not refresh the window — otherwise a user opening
+    the blind during the (now extended) window is silently consumed as motor
+    drift, stranding reconciliation at the user-driven position.
+    """
+    entity_id = "cover.venetian_morning"
+    hass.states.get.return_value = _state_with_position(50)
 
-    Bug (fixed): _send_tilt_command on the tilt-only path never stamped _suppression_at,
-    so SecondaryAxisCheck saw the drift as user-initiated and set manual override.
+    # Seed _last_tilt so maybe_update_tilt_only doesn't short-circuit on None.
+    attached_policy._last_tilt = 70
+
+    await attached_policy.maybe_update_tilt_only(
+        entity_id, current_position=50, context=None, reason="solar"
+    )
+
+    # New contract: tilt-only path leaves the window untouched.
+    assert attached_policy.is_in_tilt_suppression(entity_id, delta=0.0) is False
+
+
+@pytest.mark.asyncio
+async def test_tilt_only_small_mid_settle_drift_does_not_trip_manual_override(
+    svc, hass, attached_policy
+):
+    """Tilt-only path: small mid-settle drift falls below manual_threshold and is silent.
+
+    Replaces the pre-fix protection (which stamped the window from the tilt-only
+    path and absorbed arbitrarily large drifts). The realistic case for mid-settle
+    drift is single-digit percent — covered by the manual_threshold floor — not
+    the 50-pt swing the prior bug silently allowed.
     """
     import datetime as dt
 
@@ -424,16 +448,11 @@ async def test_tilt_only_update_then_tilt_settle_event_does_not_trip_manual_over
 
     entity_id = "cover.venetian_morning"
     hass.states.get.return_value = _state_with_position(50)
-
-    # Seed _last_tilt so maybe_update_tilt_only doesn't short-circuit on None check.
     attached_policy._last_tilt = 70
 
     await attached_policy.maybe_update_tilt_only(
         entity_id, current_position=50, context=None, reason="solar"
     )
-
-    # Suppression window must be open after a tilt-only update.
-    assert attached_policy.is_in_tilt_suppression(entity_id)
 
     mgr = AdaptiveCoverManager(
         hass=MagicMock(),
@@ -446,7 +465,7 @@ async def test_tilt_only_update_then_tilt_settle_event_does_not_trip_manual_over
     event.entity_id = entity_id
     event.new_state = MagicMock()
     event.new_state.state = "stopped"
-    event.new_state.attributes = {"current_position": 50, "current_tilt_position": 20}
+    event.new_state.attributes = {"current_position": 50, "current_tilt_position": 72}
     event.new_state.last_updated = dt.datetime.now(dt.UTC)
 
     mgr.handle_state_change(
@@ -455,7 +474,7 @@ async def test_tilt_only_update_then_tilt_settle_event_does_not_trip_manual_over
         policy=get_policy("cover_venetian"),
         allow_reset=True,
         is_waiting=lambda _eid: False,
-        manual_threshold=3,
+        manual_threshold=5,
         secondary_axis_check=SecondaryAxisCheck(
             expected=70,
             attribute="current_tilt_position",

--- a/tests/test_cover_types/test_config_flow_dispatch.py
+++ b/tests/test_cover_types/test_config_flow_dispatch.py
@@ -118,7 +118,7 @@ class TestSummaryGeometryLines:
             "mode: position and tilt",
             "min tilt 0%",
             "max tilt 100%",
-            "post-settle hold 2.0s",
+            "post-settle hold 3.0s",
         ]
 
     def test_empty_config_renders_nothing(self):
@@ -132,7 +132,7 @@ class TestSummaryGeometryLines:
             "mode: position and tilt",
             "min tilt 0%",
             "max tilt 100%",
-            "post-settle hold 2.0s",
+            "post-settle hold 3.0s",
         ]
 
     def test_venetian_summary_shows_inverse_tilt_when_set(self):

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -40,7 +40,7 @@ def test_geometry_schema_accepts_post_settle_hold() -> None:
         GEOMETRY_VENETIAN_SCHEMA,
     )
 
-    # Empty dict → default 2.0
+    # Empty dict → default DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
     result_default = GEOMETRY_VENETIAN_SCHEMA({})
     assert (
         result_default[CONF_VENETIAN_POST_SETTLE_HOLD]
@@ -67,7 +67,7 @@ def test_post_settle_hold_constants_exist() -> None:
     )
 
     assert CONF_VENETIAN_POST_SETTLE_HOLD == "venetian_post_settle_hold"
-    assert DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS == 2.0
+    assert DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS == 3.0
     assert OPTION_RANGES[CONF_VENETIAN_POST_SETTLE_HOLD] == (0.0, 10.0)
 
 
@@ -547,15 +547,17 @@ def test_sequencer_property_exposes_attached_sequencer() -> None:
 def test_is_in_tilt_suppression_false_without_sequencer() -> None:
     """No sequencer attached → suppression check short-circuits to False."""
     policy = VenetianPolicy()
-    assert policy.is_in_tilt_suppression("cover.any") is False
+    assert policy.is_in_tilt_suppression("cover.any", delta=10.0) is False
 
 
 def test_is_in_tilt_suppression_delegates_to_sequencer() -> None:
-    """With a sequencer, is_in_tilt_suppression delegates to it."""
+    """With a sequencer, is_in_tilt_suppression delegates to the delta-aware gate."""
     policy = _make_policy()
-    policy._sequencer.is_in_suppression = MagicMock(return_value=True)
-    assert policy.is_in_tilt_suppression("cover.x") is True
-    policy._sequencer.is_in_suppression.assert_called_once_with("cover.x")
+    policy._sequencer.is_in_suppression_with_cap = MagicMock(return_value=True)
+    assert policy.is_in_tilt_suppression("cover.x", delta=10.0) is True
+    policy._sequencer.is_in_suppression_with_cap.assert_called_once_with(
+        "cover.x", 10.0
+    )
 
 
 def test_secondary_axis_check_returns_none_without_tilt() -> None:

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -103,6 +103,57 @@ class TestSuppressionWindow:
         assert seq.is_in_suppression("cover.x") is False
 
 
+@pytest.mark.unit
+class TestSuppressionDeltaCap:
+    """``is_in_suppression_with_cap`` adds a delta gate on top of the window.
+
+    The cap is the venetian-side policy that protects against user moves
+    inside the back-rotate window from being silently swallowed as motor drift
+    (issue #33 follow-on).
+    """
+
+    def test_suppressed_small_delta_returns_true(self):
+        _, seq = _build_sequencer()
+        seq.stamp_position_command("cover.x")
+        assert seq.is_in_suppression_with_cap("cover.x", delta=10.0) is True
+
+    def test_suppressed_large_delta_returns_false(self):
+        from custom_components.adaptive_cover_pro.const import (
+            VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
+        )
+
+        _, seq = _build_sequencer()
+        seq.stamp_position_command("cover.x")
+        big = VENETIAN_BACKROTATE_MAX_DELTA_PERCENT + 1
+        assert seq.is_in_suppression_with_cap("cover.x", delta=float(big)) is False
+
+    def test_suppressed_delta_at_cap_boundary_returns_true(self):
+        from custom_components.adaptive_cover_pro.const import (
+            VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
+        )
+
+        _, seq = _build_sequencer()
+        seq.stamp_position_command("cover.x")
+        # Cap is inclusive — delta == cap is still motor back-drive.
+        assert (
+            seq.is_in_suppression_with_cap(
+                "cover.x", delta=float(VENETIAN_BACKROTATE_MAX_DELTA_PERCENT)
+            )
+            is True
+        )
+
+    def test_no_stamp_means_not_suppressed_regardless_of_delta(self):
+        _, seq = _build_sequencer()
+        assert seq.is_in_suppression_with_cap("cover.x", delta=1.0) is False
+
+    def test_stale_stamp_expires_regardless_of_delta(self):
+        _, seq = _build_sequencer()
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_TILT_SUPPRESSION_SECONDS + 1
+        )
+        assert seq.is_in_suppression_with_cap("cover.x", delta=1.0) is False
+
+
 @pytest.mark.asyncio
 class TestSettleAndTilt:
     """Settle-loop and tilt-service-call branches of ``run_sequence``."""
@@ -275,6 +326,46 @@ class TestPostTiltRebase:
             sleep_calls[0] == 0.5
         ), f"Expected post-settle hold (0.5 s) to be first sleep, got {sleep_calls}"
 
+    async def test_settle_timeout_with_user_open_does_not_rebase(self, monkeypatch):
+        """Issue #33 follow-on regression seal: settle timeout + user-open does not strand the target.
+
+        Reproduces the diagnostic timeline from
+        ``/tmp/issue33-last-diag.json`` in miniature: pipeline wants
+        position=0, but the cover is at 100 because the user opened it during
+        the back-rotate suppression window. The real settle loop hits the
+        stall budget without progress, and the rebase MUST refuse to absorb
+        the 100-pt drift.
+        """
+        from custom_components.adaptive_cover_pro.const import (
+            VENETIAN_REBASE_MAX_DRIFT_PERCENT,
+        )
+
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+            "VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+
+        set_cmd_pos = MagicMock()
+        hass, seq = _build_sequencer(
+            set_commanded_position=set_cmd_pos,
+            get_state=lambda _eid: "open",  # not moving → stall path fires
+        )
+        seq._get_current_position = lambda _eid: 100
+
+        await seq.run_sequence(
+            "cover.x", position_target=0, tilt_target=80, reason="solar"
+        )
+
+        # The seal: target_call NOT mutated to the user's 100.
+        set_cmd_pos.assert_not_called()
+        # Belt-and-braces: even if the settle gate slipped, the drift cap
+        # would catch this drift.
+        assert abs(100 - 0) > VENETIAN_REBASE_MAX_DRIFT_PERCENT
+        # Tilt is still attempted on settle failure — the fix scope is rebase,
+        # not tilt delivery. Real motors that stall briefly still get tilt.
+        assert hass.services.async_call.call_count == 1
+
     async def test_does_not_rebase_when_tilt_service_fails(self):
         """If the tilt service call raises, rebase must not run."""
         from homeassistant.exceptions import HomeAssistantError
@@ -289,6 +380,74 @@ class TestPostTiltRebase:
             "cover.x", position_target=50, tilt_target=80, reason="solar"
         )
         set_cmd_pos.assert_not_called()
+
+    async def test_does_not_rebase_when_drift_exceeds_max_cap(self):
+        """Drift > VENETIAN_REBASE_MAX_DRIFT_PERCENT must NOT be absorbed.
+
+        Belt-and-braces guard: even if settle reports success (intentionally
+        mocked True here), the cap stands on its own. Real motor back-drive is
+        single-digit percent; a 100 % delta is the user opening the blind.
+        """
+        from custom_components.adaptive_cover_pro.const import (
+            VENETIAN_REBASE_MAX_DRIFT_PERCENT,
+        )
+
+        set_cmd_pos = MagicMock()
+        _, seq = _build_sequencer(set_commanded_position=set_cmd_pos)
+        seq._get_current_position = lambda _eid: 100
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 100))
+        await seq.run_sequence(
+            "cover.x", position_target=0, tilt_target=80, reason="solar"
+        )
+        set_cmd_pos.assert_not_called()
+        # The cap MUST be smaller than the drift we just refused to absorb.
+        assert abs(100 - 0) > VENETIAN_REBASE_MAX_DRIFT_PERCENT
+
+    async def test_rebases_when_drift_between_tolerance_and_cap(self):
+        """Drift in the small-back-drive band (tolerance < d ≤ cap) still rebases."""
+        set_cmd_pos = MagicMock()
+        _, seq = _build_sequencer(set_commanded_position=set_cmd_pos)
+        # target=50, actual=60 → drift=10 > tolerance(5) and ≤ cap(15).
+        seq._get_current_position = lambda _eid: 60
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 50))
+        await seq.run_sequence(
+            "cover.x", position_target=50, tilt_target=80, reason="solar"
+        )
+        set_cmd_pos.assert_called_once_with("cover.x", 60)
+
+    async def test_run_sequence_stamps_suppression_window(self):
+        """The position-axis path must still stamp — the window protects
+        post-position back-drive state events.
+        """
+        set_cmd_pos = MagicMock()
+        _, seq = _build_sequencer(set_commanded_position=set_cmd_pos)
+        seq._get_current_position = lambda _eid: 60
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 60))
+        assert seq.is_in_suppression("cover.x") is False
+        await seq.run_sequence(
+            "cover.x", position_target=60, tilt_target=80, reason="solar"
+        )
+        assert seq.is_in_suppression("cover.x") is True
+
+    async def test_does_not_rebase_when_settle_returns_false(self):
+        """Settle timeout / stall must NOT rebase the commanded position.
+
+        Reproduces the issue-33 trail: pipeline wants position=0 but the user
+        has opened the blind to 100. The settle loop times out without progress
+        and the unbounded rebase silently absorbs 100 as the new target,
+        stranding the cover.
+        """
+        set_cmd_pos = MagicMock()
+        hass, seq = _build_sequencer(set_commanded_position=set_cmd_pos)
+        seq._get_current_position = lambda _eid: 100
+        seq._wait_for_position_settle = AsyncMock(return_value=(False, 100))
+        await seq.run_sequence(
+            "cover.x", position_target=0, tilt_target=80, reason="solar"
+        )
+        set_cmd_pos.assert_not_called()
+        # Tilt is still attempted — fix scope is rebase only.
+        assert seq.last_tilt_target("cover.x") == 80
+        assert hass.services.async_call.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -336,12 +495,35 @@ class TestUpdateTiltOnly:
         assert hass.services.async_call.call_count == 1
         assert hass.services.async_call.call_args.args[1] == "set_cover_tilt_position"
 
-    async def test_stamps_suppression_after_send(self):
+    async def test_does_not_stamp_suppression_after_send(self):
+        """Tilt-only sends must NOT (re)stamp the back-rotate window.
+
+        The window covers a position command's mechanical back-drive. A tilt-only
+        update from ``maybe_update_tilt_only`` / ``auto_control_on`` doesn't move
+        the carriage and shouldn't reset the timer (issue #33 follow-on: the
+        re-stamp kept the suppression window open long enough to silently
+        consume the user's manual open).
+        """
         _, seq = _build_sequencer()
         await seq.update_tilt_only(
             "cover.x", tilt_target=70, current_position=40, reason="solar"
         )
-        assert seq.is_in_suppression("cover.x") is True
+        assert seq.is_in_suppression("cover.x") is False
+
+    async def test_update_tilt_only_does_not_extend_existing_suppression_window(self):
+        """A tilt-only send must NOT push the existing stamp forward.
+
+        Reproduces the diagnostic: a position command from 60s ago has 30s of
+        window remaining. A tilt-only update at this point must preserve the
+        original stamp, not refresh it to "now" and grant another 90 seconds.
+        """
+        _, seq = _build_sequencer()
+        past = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=60)
+        seq._suppression_at["cover.x"] = past
+        await seq.update_tilt_only(
+            "cover.x", tilt_target=70, current_position=40, reason="solar"
+        )
+        assert seq._suppression_at["cover.x"] == past
 
     async def test_short_circuits_when_target_unchanged(self):
         hass, seq = _build_sequencer()

--- a/tests/test_managers/test_secondary_axis_check.py
+++ b/tests/test_managers/test_secondary_axis_check.py
@@ -27,7 +27,9 @@ def _check(*, expected: int = 70, suppressed: bool = False) -> SecondaryAxisChec
         expected=expected,
         attribute="current_tilt_position",
         label="tilt",
-        suppression=(lambda _eid: suppressed) if suppressed is not None else None,
+        suppression=(
+            (lambda _eid, _delta: suppressed) if suppressed is not None else None
+        ),
     )
 
 
@@ -61,19 +63,59 @@ class TestNoOpPaths:
 
 @pytest.mark.unit
 class TestSuppressed:
-    """Suppressed drift records a rejection event and falls through."""
+    """Suppression predicate decides whether back-rotate drift is consumed.
+
+    The predicate is the venetian-side seam — it knows both the back-rotate
+    window and the delta cap. Small deltas inside the window return True
+    (consumed). Large deltas during the window return False (fall through to
+    the numeric path which records the user's move).
+    """
 
     def test_suppressed_consumes_both_axes(self):
-        # Suppression window is open: both tilt AND position axes are blocked so
-        # the motor's back-drive cannot trigger a false manual override.
+        # Predicate returns True (small delta inside window) — back-drive is
+        # suppressed; both tilt AND position checks are short-circuited.
         res = _check(expected=70, suppressed=True).evaluate(
-            "cover.x", _state({"current_tilt_position": 20}), manual_threshold=5
+            "cover.x", _state({"current_tilt_position": 68}), manual_threshold=5
         )
         assert res.consumed is True  # blocks position-axis fall-through
         assert res.is_manual is False
         assert res.event_name == "manual_override_rejected_tilt_suppression"
         assert res.event_kwargs["our_state"] == 70
+        assert res.event_kwargs["new_position"] == 68
+
+    def test_predicate_rejects_falls_through_to_numeric_path(self):
+        # Predicate returns False (delta cap exceeded inside window). The common
+        # manager must continue past the suppression branch and the existing
+        # numeric path records the user's move as `manual_override_set`.
+        res = _check(expected=70, suppressed=False).evaluate(
+            "cover.x", _state({"current_tilt_position": 20}), manual_threshold=5
+        )
+        assert res.consumed is True
+        assert res.is_manual is True
+        assert res.event_name == "manual_override_set"
+        assert res.event_kwargs["our_state"] == 70
         assert res.event_kwargs["new_position"] == 20
+        # The numeric path's reason text wins — no "back-rotate" wording.
+        assert res.event_kwargs["reason"].startswith("tilt delta 50.0% >= threshold")
+
+    def test_predicate_called_with_entity_and_delta(self):
+        # Verify the widened signature is actually used.
+        seen: list[tuple[str, float]] = []
+
+        def _predicate(entity_id: str, delta: float) -> bool:
+            seen.append((entity_id, delta))
+            return False
+
+        check = SecondaryAxisCheck(
+            expected=70,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=_predicate,
+        )
+        check.evaluate(
+            "cover.kitchen", _state({"current_tilt_position": 30}), manual_threshold=5
+        )
+        assert seen == [("cover.kitchen", 40.0)]
 
 
 @pytest.mark.unit

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -53,7 +53,7 @@ def _tilt_check(*, expected: int = 70, suppressed: bool) -> SecondaryAxisCheck:
         expected=expected,
         attribute="current_tilt_position",
         label="tilt",
-        suppression=lambda _eid: suppressed,
+        suppression=lambda _eid, _delta: suppressed,
     )
 
 

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -184,7 +184,7 @@ def test_runtime_config_venetian_slice_defaults() -> None:
         rc.venetian.post_settle_hold_seconds
         == DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
     )
-    assert rc.venetian.post_settle_hold_seconds == 2.0
+    assert rc.venetian.post_settle_hold_seconds == 3.0
     assert rc.venetian.tilt_skip_above == DEFAULT_VENETIAN_TILT_SKIP_ABOVE
     assert rc.venetian.tilt_skip_above == 95
     assert rc.venetian.venetian_mode == DEFAULT_VENETIAN_MODE


### PR DESCRIPTION
## Summary
- Four interacting fixes in the venetian dual-axis sequencer eliminate a loop where the user opening the blind during the 90s back-rotate window was silently absorbed as the new target (reported as a v2.21.0 follow-on in https://github.com/jrhubott/adaptive-cover-pro/issues/33).
- Specifically: rebase now requires settle success AND drift ≤ 15%; suppression now ignores tilt deltas > 30% (treated as user action, not motor drift); `update_tilt_only` no longer extends the suppression window.
- Bumps `DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS` 2.0 → 3.0 per reporter's own observation that 3s tested well.
- `managers/manual_override.py` change is exactly ±2 lines (widened `SecondaryAxisCheck.suppression` to `Callable[[str, float], bool]`); non-venetian cover types unaffected.

## Testing
- ✅ 3074 tests passing, 0 failing
- New: drift-cap, settle-gate, delta-cap, stamp-re-homing red→green tests
- New: integration regression seal `test_settle_timeout_with_user_open_does_not_rebase` that reproduces the diagnostic timeline in miniature
- Existing `TestSuppressed` and `TestUpdateTiltOnly` assertions rewritten where they encoded the buggy contract

## Related Issues
Refs #33