### PR TITLE
fix: venetian tilt-sync and tilt-first on opens (#33)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -505,6 +505,15 @@ VENETIAN_POST_TILT_REBASE_DELAY_SECONDS = 1.5  # wait before post-tilt rebase
 # target is cleared so the next update_tilt_only cycle retries the command.
 VENETIAN_TILT_VERIFY_TOLERANCE = 5  # percent — tilt-verification tolerance
 
+# Verify-with-retry budget. _verify_and_record_tilt reads current_tilt_position
+# up to MAX_SAMPLES times, POLL_SECONDS apart, accepting on the first
+# in-tolerance sample. KNX/Shelly actuators publish post-tilt state via state
+# updates that can lag 1–3 s past VENETIAN_POST_TILT_REBASE_DELAY_SECONDS; a
+# single-shot read misreads that lag as drift and triggers a phantom retry
+# next cycle (issue #33).
+VENETIAN_TILT_VERIFY_MAX_SAMPLES = 4  # total reads (1 immediate + 3 retries)
+VENETIAN_TILT_VERIFY_POLL_SECONDS = 1.0  # sleep between retry reads
+
 # Hold delay between position settle and the tilt command. Some actuators
 # perform a firmware tilt-reassert after the carriage reports closed/open
 # (e.g. FGR223): firing the tilt command immediately races that reassert.

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -213,6 +213,24 @@ class CoverTypePolicy(ABC):
         """
         return
 
+    async def before_position_command(
+        self,
+        cmd_svc,  # noqa: ARG002
+        entity_id: str,  # noqa: ARG002
+        *,
+        service: str,  # noqa: ARG002
+        position: int,  # noqa: ARG002
+        context,  # noqa: ARG002
+        reason: str,  # noqa: ARG002
+    ) -> None:
+        """Run any pre-command work before the position service fires.
+
+        Default: no-op. ``VenetianPolicy`` overrides this to send tilt-first
+        on opening transitions (issue #33) so the actuator's slats reach the
+        target angle before the carriage starts moving.
+        """
+        return
+
     async def after_position_command(
         self,
         cmd_svc,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -415,6 +415,53 @@ class VenetianPolicy(CoverTypePolicy):
             suppression=self.is_in_tilt_suppression,
         )
 
+    async def before_position_command(
+        self,
+        cmd_svc,  # noqa: ARG002
+        entity_id: str,
+        *,
+        service: str,
+        position: int,
+        context,
+        reason: str,
+    ) -> None:
+        """Send tilt FIRST on opening transitions, before set_cover_position fires.
+
+        KNX/Shelly venetian actuators briefly reassert their cached tilt
+        against partially-closed slats during open travel — a visible "slats
+        close then open" flicker. Sending the new tilt before the carriage
+        starts moving lets the open absorb any back-rotation into the
+        already-targeted angle (issue #33).
+
+        Closing transitions keep the existing position-then-tilt order in
+        ``after_position_command`` (slats must close after the carriage has
+        finished travelling). The post-settle tilt resend in
+        ``run_sequence`` short-circuits on the target-unchanged dedup added
+        to ``_send_tilt_command``, so total service-call count for an
+        opening transition remains 2 (tilt + position).
+        """
+        if service != SERVICE_SET_COVER_POSITION:
+            return
+        seq = self._sequencer
+        if seq is None:
+            return
+        tilt_target = self._resolve_skip_above_tilt(
+            position, getattr(context, "tilt", None)
+        )
+        if tilt_target is None:
+            return
+        current = seq._get_current_position(entity_id)
+        if current is None or position <= current:
+            return
+        await seq._send_tilt_command(
+            entity_id,
+            tilt_target=tilt_target,
+            position_target=position,
+            reason=reason,
+            force=True,
+            verify=False,
+        )
+
     async def after_position_command(
         self,
         cmd_svc,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -260,6 +260,7 @@ class VenetianPolicy(CoverTypePolicy):
             return result
 
         if self._tilt_suppressed(result, cover):
+            self._clear_last_tilt()
             return replace(result, tilt=None)
         venetian_calc = VenetianCoverCalculation(
             config=config,
@@ -346,6 +347,17 @@ class VenetianPolicy(CoverTypePolicy):
         if self._sequencer is None:
             return False
         return self._sequencer.is_in_suppression_with_cap(entity_id, delta)
+
+    def _clear_last_tilt(self) -> None:
+        """Forget the last resolved tilt so tilt-only cycles don't replay it.
+
+        Called on every suppressed branch of ``post_pipeline_resolve``
+        (non-SOLAR control method, or SOLAR with no direct sun). Without this
+        reset, ``maybe_update_tilt_only`` keeps re-firing the prior solar
+        tilt against an actuator that the user thinks should be neutral —
+        producing the chronic position/tilt state divergence in issue #33.
+        """
+        self._last_tilt = None
 
     def _resolve_skip_above_tilt(
         self, position: int | None, fallback_tilt: int | None

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -969,6 +969,20 @@ class CoverCommandService:
             position,
         )
 
+        # Cover-type policy hook: dual-axis covers (venetian) pre-send tilt
+        # on opening transitions so the actuator's slats are at the target
+        # angle before the carriage starts moving (issue #33). Default
+        # policies are no-ops.
+        if context.policy is not None:
+            await context.policy.before_position_command(
+                self,
+                entity_id,
+                service=service,
+                position=position,
+                context=context,
+                reason=reason,
+            )
+
         ctx = Context()
         self._position_context_tracker.record(ctx.id)
         try:

--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -220,6 +220,7 @@ class DualAxisSequencer:
         reason: str,
         force: bool = False,
         position_settled: bool = True,
+        verify: bool = True,
     ) -> None:
         """Emit ``set_cover_tilt_position`` and rebase the commanded position.
 
@@ -230,7 +231,31 @@ class DualAxisSequencer:
         #33) with fallback to the stored target when current tilt is
         unavailable — without this, a stale stored target (e.g. set before
         the motor auto-tilted on close) skips legitimate moves.
+
+        A target-unchanged dedup runs first: if the stored target already
+        matches and the caller didn't pass ``force=True``, no service call
+        fires. That keeps ``run_sequence``'s post-settle tilt from re-sending
+        a tilt that ``before_position_command`` already sent for the same
+        opening transition (issue #33 tilt-first path).
+
+        ``verify=False`` is the fire-and-forget mode used by
+        ``before_position_command``: the service call dispatches and the
+        target is recorded, but the post-tilt sleep, verify, and rebase are
+        all skipped. Verifying the pre-position tilt is pointless because
+        the actuator hasn't published yet AND the position command is about
+        to move the carriage; verification would race both signals.
         """
+        if not force and tilt_target == self._tilt_targets.get(entity_id):
+            self._record_event(
+                "tilt_command_skipped",
+                reason=_TILT_SKIP_TARGET_UNCHANGED,
+                entity_id=entity_id,
+                tilt_position=tilt_target,
+                position_target=position_target,
+                trigger=reason,
+            )
+            return
+
         if not force and self._get_min_change is not None:
             anchor, anchor_source = self._resolve_tilt_anchor(entity_id)
             if anchor is not None and not check_position_delta(
@@ -319,6 +344,9 @@ class DualAxisSequencer:
             position_target=position_target,
             trigger=reason,
         )
+
+        if not verify:
+            return
 
         # Wait for the motor's mechanical back-drive on the vertical axis to
         # settle before reading current_position for the rebase. Without this

--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -36,6 +36,8 @@ from ..const import (
     VENETIAN_POST_TILT_REBASE_DELAY_SECONDS,
     VENETIAN_REBASE_MAX_DRIFT_PERCENT,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
+    VENETIAN_TILT_VERIFY_MAX_SAMPLES,
+    VENETIAN_TILT_VERIFY_POLL_SECONDS,
     VENETIAN_TILT_VERIFY_TOLERANCE,
 )
 from .cover_command.gates import check_position_delta
@@ -328,7 +330,7 @@ class DualAxisSequencer:
         # may back-rotate the slats during position movement, leaving the cover
         # at tilt=0 even though we sent tilt=N. If we detect drift, clear the
         # recorded target so the next update_tilt_only cycle retries.
-        self._verify_and_record_tilt(entity_id, tilt_target)
+        await self._verify_and_record_tilt(entity_id, tilt_target)
 
         if position_settled:
             self._rebase_commanded_position(entity_id, position_target)
@@ -492,46 +494,57 @@ class DualAxisSequencer:
             {"ts": dt.datetime.now(dt.UTC).isoformat(), "event": event_name, **fields}
         )
 
-    def _verify_and_record_tilt(self, entity_id: str, tilt_target: int) -> None:
-        """Read actual tilt position and emit a verified/drift diagnostic event.
+    async def _verify_and_record_tilt(self, entity_id: str, tilt_target: int) -> None:
+        """Poll actual tilt up to N samples; accept on the first in-tolerance read.
 
-        If the actual tilt differs from the target beyond ``VENETIAN_TILT_VERIFY_TOLERANCE``,
-        clears the recorded target so the next ``update_tilt_only`` cycle retries.
+        Attempt 0 reads immediately (the caller has already slept
+        ``VENETIAN_POST_TILT_REBASE_DELAY_SECONDS``); attempts 1..N-1 sleep
+        ``VENETIAN_TILT_VERIFY_POLL_SECONDS`` before reading. Only when every
+        sample is out of tolerance do we emit ``tilt_command_drift`` and
+        clear the recorded target. Real-actuator publish lag (KNX, Shelly)
+        can land the slats correctly but report the pre-update value for
+        1–3 s afterwards — a single-shot read misreads that lag as drift
+        and triggers a phantom retry next cycle (issue #33).
         """
         if self._get_current_tilt_position is None:
             return
-        actual_wire = self._get_current_tilt_position(entity_id)
-        if actual_wire is None:
-            return
-        # Convert wire reading back to logical space so comparison is consistent
-        # with the logical tilt_target regardless of inversion setting.
-        actual = self._to_wire(actual_wire)
-        delta = abs(actual - tilt_target)
-        if delta <= VENETIAN_TILT_VERIFY_TOLERANCE:
-            self._record_event(
-                "tilt_command_verified",
-                entity_id=entity_id,
-                tilt_target=tilt_target,
-                actual_tilt_position=actual,
-                delta=delta,
-                tolerance=VENETIAN_TILT_VERIFY_TOLERANCE,
-            )
-        else:
-            self._logger.warning(
-                "Venetian tilt drift detected for %s: sent %s%% but actual is %s%% "
-                "(delta=%s%% > tolerance=%s%%) — clearing recorded target for retry",
-                entity_id,
-                tilt_target,
-                actual,
-                delta,
-                VENETIAN_TILT_VERIFY_TOLERANCE,
-            )
-            self._record_event(
-                "tilt_command_drift",
-                entity_id=entity_id,
-                tilt_target=tilt_target,
-                actual_tilt_position=actual,
-                delta=delta,
-                tolerance=VENETIAN_TILT_VERIFY_TOLERANCE,
-            )
-            self._tilt_targets.pop(entity_id, None)
+        actual: int | None = None
+        delta: int | None = None
+        for attempt in range(VENETIAN_TILT_VERIFY_MAX_SAMPLES):
+            if attempt > 0:
+                await asyncio.sleep(VENETIAN_TILT_VERIFY_POLL_SECONDS)
+            actual_wire = self._get_current_tilt_position(entity_id)
+            if actual_wire is None:
+                return
+            actual = self._to_wire(actual_wire)
+            delta = abs(actual - tilt_target)
+            if delta <= VENETIAN_TILT_VERIFY_TOLERANCE:
+                self._record_event(
+                    "tilt_command_verified",
+                    entity_id=entity_id,
+                    tilt_target=tilt_target,
+                    actual_tilt_position=actual,
+                    delta=delta,
+                    tolerance=VENETIAN_TILT_VERIFY_TOLERANCE,
+                )
+                return
+        self._logger.warning(
+            "Venetian tilt drift detected for %s after %d samples: "
+            "sent %s%% but actual is %s%% (delta=%s%% > tolerance=%s%%) "
+            "— clearing recorded target for retry",
+            entity_id,
+            VENETIAN_TILT_VERIFY_MAX_SAMPLES,
+            tilt_target,
+            actual,
+            delta,
+            VENETIAN_TILT_VERIFY_TOLERANCE,
+        )
+        self._record_event(
+            "tilt_command_drift",
+            entity_id=entity_id,
+            tilt_target=tilt_target,
+            actual_tilt_position=actual,
+            delta=delta,
+            tolerance=VENETIAN_TILT_VERIFY_TOLERANCE,
+        )
+        self._tilt_targets.pop(entity_id, None)

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.21.1"
+  "version": "2.21.2-beta.1"
 }

--- a/release_notes/v2.21.2-beta.1.md
+++ b/release_notes/v2.21.2-beta.1.md
@@ -1,0 +1,34 @@
+# v2.21.2-beta.1
+
+## 🎯 v2.21.2-beta.1 — Venetian Tilt/Move Sequencing Polish (Beta)
+
+This beta refines how the venetian dual-axis sequencer handles tilt-and-move transitions, fixing edge cases where the slats lagged behind the position move or where suppressed cycles left stale tilt state. Please test against your real venetian blinds and report results on issue #33.
+
+### 🔑 Highlights
+
+- Tilt-first on opening transitions — slats now tilt to target before the position move starts, eliminating the "slats close then open" flicker on KNX and Shelly actuators.
+- Tilt verification now polls with retry, tolerating slow actuators that publish state updates 1–3 s after the move completes.
+- Suppressed venetian cycles correctly clear cached tilt state, preventing stale `_last_tilt` from replaying through the tilt-only refresh path.
+
+### ✨ Features
+
+- **Tilt-first hook on opening transitions (#33):** A new `CoverTypePolicy.before_position_command` hook (default no-op) is invoked by `CoverCommandService.apply_position` before `set_cover_position` fires. `VenetianPolicy.before_position_command` implements the hook: on opening transitions (target > current position), it sends tilt via `_send_tilt_command(force=True, verify=False)` before the carriage moves. Closing transitions keep the existing position-then-tilt order in `after_position_command` — slats must close after the carriage has finished travelling. A target-unchanged dedup added to `_send_tilt_command` short-circuits the post-settle tilt resend in `run_sequence` when nothing changed, keeping total service-call count for an opening transition at 2 (tilt + position).
+
+### 🐛 Bug Fixes
+
+- **Tilt verification falsely declares drift on lagging actuators (#33):** The single-shot `_verify_and_record_tilt` read `current_tilt_position` exactly 1.5 s after the tilt command and immediately declared drift if the reading didn't match. KNX and Shelly venetian actuators can publish their post-tilt state update 1–3 s after that window, so the verify routinely read the pre-update value, falsely flagged drift, cleared `_tilt_targets`, and re-armed `update_tilt_only` to fire the same tilt command again next cycle — sometimes twice. `_verify_and_record_tilt` is now async and polls up to `VENETIAN_TILT_VERIFY_MAX_SAMPLES` (4) times, `VENETIAN_TILT_VERIFY_POLL_SECONDS` (1.0 s) apart. The method accepts on the first in-tolerance sample; `tilt_command_drift` is emitted and the recorded target cleared only when every sample is out of tolerance. Healthy hardware still completes in roughly 1.5 s; lagging actuators get up to ~4.5 s to publish before drift is declared.
+
+- **Suppressed venetian cycle leaves `_last_tilt` armed, replaying stale tilt (#33):** `post_pipeline_resolve`'s suppressed branch — reached when the control method is non-SOLAR or when SOLAR is active but `direct_sun_valid` is false — returned early without resetting `_last_tilt`. The prior solar tilt therefore kept replaying through `maybe_update_tilt_only` on every subsequent cycle, producing chronic position/tilt state divergence: the blind sat physically at 100/100 while HA kept reporting 100/55. A new `_clear_last_tilt()` method is called before the early-return so the tilt-only refresh stops at the correct time.
+
+### 🧪 Testing
+
+- 3094 tests passing.
+- New tests in `tests/test_cover_types/test_venetian.py` cover the `before_position_command` hook: opening vs. closing transition branching, `None` tilt target short-circuit, and interaction with `_resolve_skip_above_tilt`.
+- New tests in `tests/test_managers/test_dual_axis_sequencer.py` cover poll-retry behavior: immediate acceptance on the first in-tolerance sample, acceptance on a later sample after initial lag, and drift declaration only after all samples are out of tolerance.
+- New tests in `tests/test_cover_types/test_venetian_post_pipeline.py` cover the `_clear_last_tilt` path: non-SOLAR control method clears a primed `_last_tilt`, SOLAR with `direct_sun_valid=False` clears it, and the `result is None` early-return leaves it untouched.
+
+## Compatibility
+
+- Home Assistant 2026.3.0+
+
+[#33]: https://github.com/jrhubott/adaptive-cover-pro/issues/33

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -133,10 +133,17 @@ def _state_with_position(pos: int):
 
 
 @pytest.mark.asyncio
-async def test_apply_position_emits_position_then_tilt(svc, hass, attached_policy):
-    """Both services fire on a venetian apply_position with tilt set."""
+async def test_apply_position_emits_tilt_then_position_on_open(
+    svc, hass, attached_policy
+):
+    """On opening transitions, tilt fires BEFORE position (issue #33 tilt-first).
+
+    Total service-call count stays at 2: the post-settle tilt resend from
+    ``run_sequence`` short-circuits on the target-unchanged dedup added to
+    ``_send_tilt_command``.
+    """
     entity_id = "cover.venetian_kitchen"
-    hass.states.get.return_value = _state_with_position(0)
+    hass.states.get.return_value = _state_with_position(0)  # opening 0 → 60
 
     with _patch_caps_dual_axis():
         outcome, _ = await svc.apply_position(
@@ -146,9 +153,9 @@ async def test_apply_position_emits_position_then_tilt(svc, hass, attached_polic
     assert outcome == "sent"
     assert hass.services.async_call.call_count == 2
     services_called = [call.args[1] for call in hass.services.async_call.call_args_list]
-    assert services_called == ["set_cover_position", "set_cover_tilt_position"]
-    last_data = hass.services.async_call.call_args_list[-1].args[2]
-    assert last_data["tilt_position"] == 80
+    assert services_called == ["set_cover_tilt_position", "set_cover_position"]
+    tilt_data = hass.services.async_call.call_args_list[0].args[2]
+    assert tilt_data["tilt_position"] == 80
 
 
 @pytest.mark.asyncio
@@ -179,7 +186,7 @@ async def test_apply_position_sends_neutral_tilt_when_position_above_threshold(
     from custom_components.adaptive_cover_pro.const import POSITION_OPEN
 
     entity_id = "cover.venetian_retracted"
-    hass.states.get.return_value = _state_with_position(90)
+    hass.states.get.return_value = _state_with_position(90)  # opening 90 → 96
 
     with _patch_caps_dual_axis():
         outcome, _ = await svc.apply_position(
@@ -188,10 +195,12 @@ async def test_apply_position_sends_neutral_tilt_when_position_above_threshold(
 
     assert outcome == "sent"
     assert hass.services.async_call.call_count == 2
-    assert hass.services.async_call.call_args_list[0].args[1] == "set_cover_position"
-    tilt_call = hass.services.async_call.call_args_list[1]
+    # Opening transition: tilt-first (issue #33). The retract path overrides
+    # context.tilt with POSITION_OPEN regardless of which command fires first.
+    tilt_call = hass.services.async_call.call_args_list[0]
     assert tilt_call.args[1] == "set_cover_tilt_position"
     assert tilt_call.args[2]["tilt_position"] == POSITION_OPEN
+    assert hass.services.async_call.call_args_list[1].args[1] == "set_cover_position"
 
 
 @pytest.mark.asyncio

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -646,3 +646,135 @@ def test_secondary_axis_check_carries_expected_tilt() -> None:
     assert check.label == "tilt"
     assert check.suppression.__func__ is VenetianPolicy.is_in_tilt_suppression
     assert check.suppression.__self__ is policy
+
+
+@pytest.mark.asyncio
+class TestBeforePositionCommandTiltFirstOnOpen:
+    """Issue #33: ``before_position_command`` sends tilt FIRST on opening
+    transitions so the actuator's slats reach the target angle before the
+    carriage starts moving.
+
+    Without this, KNX/Shelly actuators briefly reassert their cached tilt
+    against partially-closed slats during travel — visible as a "slats close
+    then open" flicker. On closing transitions the existing
+    position-then-tilt order is correct (slats must close after the carriage
+    has finished travelling), so the tilt-first branch is opening-only.
+
+    The dedup added in ``_send_tilt_command`` keeps total service-call count
+    at 2 (position + tilt) by short-circuiting the post-settle tilt resend
+    that ``after_position_command`` → ``run_sequence`` would otherwise fire.
+    """
+
+    def _make_policy_with_send_mock(
+        self, *, current_position: int | None
+    ) -> VenetianPolicy:
+        policy = _make_policy(tilt_skip_above=95)
+        policy._sequencer._send_tilt_command = AsyncMock()
+        policy._sequencer._get_current_position = MagicMock(
+            return_value=current_position
+        )
+        return policy
+
+    async def test_open_transition_sends_tilt_with_force(self) -> None:
+        """current=20 → target=80 (opening) must send tilt with force=True."""
+        policy = self._make_policy_with_send_mock(current_position=20)
+
+        await policy.before_position_command(
+            cmd_svc=MagicMock(),
+            entity_id="cover.venetian_x",
+            service=SERVICE_SET_COVER_POSITION,
+            position=80,
+            context=_ctx(policy, tilt=POSITION_OPEN),
+            reason="solar",
+        )
+
+        policy._sequencer._send_tilt_command.assert_awaited_once()
+        kwargs = policy._sequencer._send_tilt_command.await_args.kwargs
+        assert kwargs["tilt_target"] == POSITION_OPEN
+        assert kwargs["position_target"] == 80
+        assert kwargs["force"] is True
+
+    async def test_closing_transition_does_not_send_tilt(self) -> None:
+        """current=80 → target=20 (closing) must NOT pre-send tilt."""
+        policy = self._make_policy_with_send_mock(current_position=80)
+
+        await policy.before_position_command(
+            cmd_svc=MagicMock(),
+            entity_id="cover.venetian_x",
+            service=SERVICE_SET_COVER_POSITION,
+            position=20,
+            context=_ctx(policy, tilt=40),
+            reason="solar",
+        )
+
+        policy._sequencer._send_tilt_command.assert_not_awaited()
+
+    async def test_unknown_current_position_does_not_send_tilt(self) -> None:
+        """When current position is unreadable, fall back to the existing order."""
+        policy = self._make_policy_with_send_mock(current_position=None)
+
+        await policy.before_position_command(
+            cmd_svc=MagicMock(),
+            entity_id="cover.venetian_x",
+            service=SERVICE_SET_COVER_POSITION,
+            position=80,
+            context=_ctx(policy, tilt=POSITION_OPEN),
+            reason="solar",
+        )
+
+        policy._sequencer._send_tilt_command.assert_not_awaited()
+
+    async def test_non_position_service_does_not_send_tilt(self) -> None:
+        """The hook only acts on set_cover_position, not on open/close/stop."""
+        policy = self._make_policy_with_send_mock(current_position=20)
+
+        await policy.before_position_command(
+            cmd_svc=MagicMock(),
+            entity_id="cover.venetian_x",
+            service="open_cover",
+            position=80,
+            context=_ctx(policy, tilt=POSITION_OPEN),
+            reason="solar",
+        )
+
+        policy._sequencer._send_tilt_command.assert_not_awaited()
+
+    async def test_no_tilt_in_context_does_not_send_tilt(self) -> None:
+        """Without a tilt target in context, there's nothing to pre-send."""
+        policy = self._make_policy_with_send_mock(current_position=20)
+        ctx = PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=1,
+            time_threshold=0,
+            special_positions=[0, 100],
+            force=True,
+            tilt=None,
+            policy=policy,
+        )
+
+        await policy.before_position_command(
+            cmd_svc=MagicMock(),
+            entity_id="cover.venetian_x",
+            service=SERVICE_SET_COVER_POSITION,
+            position=80,
+            context=ctx,
+            reason="solar",
+        )
+
+        policy._sequencer._send_tilt_command.assert_not_awaited()
+
+    async def test_no_sequencer_is_safe(self) -> None:
+        """A detached policy (no sequencer) must not crash."""
+        policy = VenetianPolicy()  # not attached
+        assert policy._sequencer is None
+
+        await policy.before_position_command(
+            cmd_svc=MagicMock(),
+            entity_id="cover.venetian_x",
+            service=SERVICE_SET_COVER_POSITION,
+            position=80,
+            context=_ctx(policy, tilt=POSITION_OPEN),
+            reason="solar",
+        )

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -219,3 +219,45 @@ class TestPostPipelineResolveNoSunStrip:
             **kwargs,
         )
         assert policy._last_tilt is None
+
+
+class TestPostPipelineResolveClearsLastTilt:
+    """Issue #33: a suppressed cycle must reset ``_last_tilt`` so the next
+    ``maybe_update_tilt_only`` cycle doesn't replay the prior solar tilt.
+
+    Without this, a solar cycle (which sets ``_last_tilt = N``) followed by a
+    non-SOLAR / no-direct-sun cycle leaves ``_last_tilt`` armed, and the
+    tilt-only refresh keeps firing the stale solar tilt against an actuator
+    that should be neutral. The user sees HA reporting e.g. 100/55 forever.
+    """
+
+    def test_suppressed_call_clears_prior_solar_last_tilt(self):
+        """Non-SOLAR control method must clear a primed ``_last_tilt``."""
+        policy = _make_policy()
+        policy._last_tilt = 70  # simulate prior solar cycle's resolved tilt
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.WEATHER), **_non_solar_kwargs()
+        )
+        assert policy._last_tilt is None
+        assert out.tilt is None
+
+    def test_solar_with_no_direct_sun_clears_prior_last_tilt(self):
+        """SOLAR with ``direct_sun_valid=False`` must clear a primed ``_last_tilt``.
+
+        This is the climate-handler low-light branch — pipeline emits SOLAR
+        but the cover engine reports the sun isn't on the window.
+        """
+        policy = _make_policy()
+        policy._last_tilt = 55
+        kwargs = _solar_kwargs()
+        kwargs["cover"] = _make_cover(direct_sun_valid=False)
+        out = policy.post_pipeline_resolve(_make_result(ControlMethod.SOLAR), **kwargs)
+        assert policy._last_tilt is None
+        assert out.tilt is None
+
+    def test_none_result_does_not_clobber_last_tilt(self):
+        """The ``result is None`` early-return must not touch ``_last_tilt``."""
+        policy = _make_policy()
+        policy._last_tilt = 42
+        policy.post_pipeline_resolve(None, **_non_solar_kwargs())
+        assert policy._last_tilt == 42

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -31,14 +31,22 @@ from custom_components.adaptive_cover_pro.managers.dual_axis_sequencer import (
 def _zero_post_tilt_delay(monkeypatch):
     """Skip real-motor delays in unit tests.
 
-    Zeroes the post-tilt rebase delay (1.5 s) so the test suite doesn't spend
-    real time waiting on asyncio.sleep.  The post-settle hold is now a
-    per-instance parameter (``post_settle_hold_seconds``) defaulting to 0 in
-    ``_build_sequencer`` — no monkeypatching needed for that delay.
+    Zeroes the post-tilt rebase delay (1.5 s) and the verify-retry poll
+    interval (1.0 s) so the test suite doesn't spend real time waiting on
+    asyncio.sleep. The post-settle hold is a per-instance parameter
+    (``post_settle_hold_seconds``) defaulting to 0 in ``_build_sequencer``
+    — no monkeypatching needed for that delay. The retry sample COUNT
+    (``VENETIAN_TILT_VERIFY_MAX_SAMPLES``) is left at its production value
+    because it is the behaviour under test.
     """
     monkeypatch.setattr(
         "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
         "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
+        0,
+    )
+    monkeypatch.setattr(
+        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+        "VENETIAN_TILT_VERIFY_POLL_SECONDS",
         0,
     )
 
@@ -828,6 +836,85 @@ class TestTiltVerification:
             "cover.x", tilt_target=80, current_position=60, reason="solar"
         )
         assert hass.services.async_call.call_count == 2
+
+
+@pytest.mark.asyncio
+class TestTiltVerifyWithRetry:
+    """Issue #33: verify must tolerate actuator publish lag.
+
+    KNX/Shelly venetian actuators publish ``current_tilt_position`` via state
+    updates that can lag the service call by 1–3 s past the existing
+    ``VENETIAN_POST_TILT_REBASE_DELAY_SECONDS`` (1.5 s) wait. A single-shot
+    verify reads the pre-update value, declares drift, and clears
+    ``_tilt_targets`` — which then re-arms the next ``update_tilt_only`` cycle
+    to fire a second (and third) tilt command for the same logical target.
+    The verify must poll up to ``VENETIAN_TILT_VERIFY_MAX_SAMPLES`` times,
+    ``VENETIAN_TILT_VERIFY_POLL_SECONDS`` apart, and only declare drift when
+    every sample is out of tolerance.
+    """
+
+    async def test_verify_accepts_on_late_sample_and_keeps_target(self):
+        """Stale read first, then a matching read → target preserved, no drift event."""
+        tilt_readings = iter([0, 0, 80])
+        buf = EventBuffer(maxlen=16)
+        _, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: next(tilt_readings, 80),
+            event_buffer=buf,
+        )
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        assert seq.last_tilt_target("cover.x") == 80
+        drift_events = [e for e in buf.snapshot() if e["event"] == "tilt_command_drift"]
+        verified_events = [
+            e for e in buf.snapshot() if e["event"] == "tilt_command_verified"
+        ]
+        assert drift_events == []
+        assert len(verified_events) == 1
+
+    async def test_verify_clears_target_when_all_samples_drift(self):
+        """Constantly stale read → target cleared, drift event records final sample."""
+        buf = EventBuffer(maxlen=16)
+        _, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 0,
+            event_buffer=buf,
+        )
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        assert seq.last_tilt_target("cover.x") is None
+        drift_events = [e for e in buf.snapshot() if e["event"] == "tilt_command_drift"]
+        assert len(drift_events) == 1
+        assert drift_events[0]["actual_tilt_position"] == 0
+        assert drift_events[0]["delta"] == 80
+
+    async def test_verify_stops_polling_after_first_in_tolerance_sample(self):
+        """In-tolerance first read must short-circuit — no extra polls."""
+        tilt_mock = MagicMock(side_effect=[78])
+        _, seq = _build_sequencer(get_current_tilt_position=tilt_mock)
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        assert tilt_mock.call_count == 1
+        assert seq.last_tilt_target("cover.x") == 80
+
+    async def test_verify_skipped_when_get_current_tilt_position_unwired(self):
+        """No tilt-read callback → preserve target, emit no verify/drift events."""
+        buf = EventBuffer(maxlen=16)
+        _, seq = _build_sequencer(
+            get_current_tilt_position=None,
+            event_buffer=buf,
+        )
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        assert seq.last_tilt_target("cover.x") == 80
+        verify_events = [
+            e
+            for e in buf.snapshot()
+            if e["event"] in ("tilt_command_verified", "tilt_command_drift")
+        ]
+        assert verify_events == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -839,6 +839,139 @@ class TestTiltVerification:
 
 
 @pytest.mark.asyncio
+class TestSendTiltCommandVerifyFlag:
+    """``verify=False`` lets ``before_position_command`` fire-and-forget.
+
+    Before sending a position command on an opening transition (issue #33),
+    the policy pre-sends the tilt so slats are at the target angle before
+    the carriage moves. Verifying that pre-tilt is wrong: the actuator
+    hasn't published the new tilt yet, and the position command is about to
+    move the carriage anyway. With ``verify=False``, the service call fires,
+    the target is recorded into ``_tilt_targets`` (so the post-settle resend
+    dedups), and no sleep/verify/rebase runs.
+    """
+
+    async def test_verify_false_skips_drift_event_and_preserves_target(self):
+        """No drift event is emitted; stored target survives even when actuator reads stale."""
+        buf = EventBuffer(maxlen=16)
+        _, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 0,  # would normally drift
+            event_buffer=buf,
+        )
+        await seq._send_tilt_command(
+            "cover.x",
+            tilt_target=80,
+            position_target=60,
+            reason="solar",
+            verify=False,
+        )
+        assert seq.last_tilt_target("cover.x") == 80
+        verify_events = [
+            e
+            for e in buf.snapshot()
+            if e["event"] in ("tilt_command_verified", "tilt_command_drift")
+        ]
+        assert verify_events == []
+
+    async def test_verify_false_does_not_rebase_position(self):
+        """``_rebase_commanded_position`` must not fire when verify=False."""
+        recorded: list[tuple[str, int]] = []
+
+        def _record(eid: str, pos: int) -> None:
+            recorded.append((eid, pos))
+
+        _, seq = _build_sequencer(
+            current_positions=[55],  # would rebase 60 → 55 under default verify=True
+            set_commanded_position=_record,
+            get_current_tilt_position=lambda _eid: 80,  # in-tolerance: would verify ok
+        )
+        await seq._send_tilt_command(
+            "cover.x",
+            tilt_target=80,
+            position_target=60,
+            reason="solar",
+            verify=False,
+        )
+        assert recorded == []
+
+    async def test_verify_true_default_still_runs_verify(self):
+        """Default behaviour (verify=True) must remain unchanged."""
+        buf = EventBuffer(maxlen=16)
+        _, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 78,
+            event_buffer=buf,
+        )
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        verified = [e for e in buf.snapshot() if e["event"] == "tilt_command_verified"]
+        assert len(verified) == 1
+
+
+@pytest.mark.asyncio
+class TestSendTiltCommandDedup:
+    """``_send_tilt_command`` short-circuits when the stored target already matches.
+
+    Issue #33 follow-on: when ``before_position_command`` sends tilt-first on
+    an opening transition, the subsequent ``run_sequence`` reaches its own
+    ``_send_tilt_command`` step with the same target already stored.  Without
+    a top-level dedup, the second send fires a redundant
+    ``set_cover_tilt_position`` service call. The dedup keeps the total
+    venetian-open service-call count at 2 (position + tilt) instead of 3.
+    """
+
+    async def test_second_send_with_same_target_skips_service_call(self):
+        hass, seq = _build_sequencer()
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        assert hass.services.async_call.call_count == 1
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        assert hass.services.async_call.call_count == 1
+
+    async def test_second_send_with_same_target_records_skipped_event(self):
+        buf = EventBuffer(maxlen=16)
+        _, seq = _build_sequencer(event_buffer=buf)
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        buf2 = EventBuffer(maxlen=16)
+        seq._event_buffer = buf2
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        skipped = [e for e in buf2.snapshot() if e["event"] == "tilt_command_skipped"]
+        assert len(skipped) == 1
+        assert skipped[0]["reason"] == "target_unchanged"
+
+    async def test_force_bypasses_dedup(self):
+        hass, seq = _build_sequencer()
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        await seq._send_tilt_command(
+            "cover.x",
+            tilt_target=80,
+            position_target=60,
+            reason="solar",
+            force=True,
+        )
+        assert hass.services.async_call.call_count == 2
+
+    async def test_different_target_does_not_dedup(self):
+        hass, seq = _build_sequencer()
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=80, position_target=60, reason="solar"
+        )
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=40, position_target=60, reason="solar"
+        )
+        assert hass.services.async_call.call_count == 2
+
+
+@pytest.mark.asyncio
 class TestTiltVerifyWithRetry:
     """Issue #33: verify must tolerate actuator publish lag.
 
@@ -1056,11 +1189,19 @@ class TestTiltInversion:
         assert seq.last_tilt_target("cover.x") == 80
 
     async def test_invert_tilt_callable_evaluated_per_call(self):
-        """Callable must be evaluated on each send so runtime option changes take effect."""
+        """Callable must be evaluated on each send so runtime option changes take effect.
+
+        ``force=True`` bypasses the target-unchanged dedup so both sends
+        actually fire the service call (the dedup is unrelated to inversion).
+        """
         inverted = [True]
         hass, seq = _build_sequencer(invert_tilt=lambda: inverted[0])
         await seq._send_tilt_command(
-            "cover.x", tilt_target=80, position_target=60, reason="solar"
+            "cover.x",
+            tilt_target=80,
+            position_target=60,
+            reason="solar",
+            force=True,
         )
         first_wire = hass.services.async_call.call_args_list[-1].args[2][
             "tilt_position"
@@ -1069,7 +1210,11 @@ class TestTiltInversion:
 
         inverted[0] = False
         await seq._send_tilt_command(
-            "cover.x", tilt_target=80, position_target=60, reason="solar"
+            "cover.x",
+            tilt_target=80,
+            position_target=60,
+            reason="solar",
+            force=True,
         )
         second_wire = hass.services.async_call.call_args_list[-1].args[2][
             "tilt_position"


### PR DESCRIPTION
## Summary

Three changes to the venetian dual-axis sequencer addressing the report in issue #33 (comment from x4N70pHyLL after v2.21.1 shipped).

1. **`_last_tilt` reset on suppressed cycles** (`cover_types/venetian.py`). The `_tilt_suppressed` branch of `post_pipeline_resolve` returned early without clearing `self._last_tilt`, so the prior solar tilt kept replaying through `maybe_update_tilt_only` every cycle once the sun left the FOV. This was the chronic 100/55 state divergence the reporter described.

2. **Verify-with-retry on `_send_tilt_command`** (`managers/dual_axis_sequencer.py`). The single-shot verify read `current_tilt_position` exactly 1.5s after the tilt command, then declared drift and cleared `_tilt_targets` if the reading didn't match. KNX/Shelly actuators publish state with 1–3s lag past that, so the verify routinely false-flagged drift and re-armed `update_tilt_only` to fire the same tilt again next cycle. New constants `VENETIAN_TILT_VERIFY_MAX_SAMPLES=4` and `VENETIAN_TILT_VERIFY_POLL_SECONDS=1.0` give lagging actuators up to ~4.5s to publish before drift is declared; healthy hardware still completes in 1.5s.

3. **Tilt-first on opening transitions** (new `CoverTypePolicy.before_position_command` hook + venetian override). On opens, KNX/Shelly actuators briefly reassert their cached tilt against partially-closed slats during travel. Sending the new tilt before the carriage starts moving avoids this. Implementation: new policy hook invoked before the `set_cover_position` service dispatch; venetian sends tilt via `_send_tilt_command(force=True, verify=False)`. A target-unchanged dedup added at the top of `_send_tilt_command` keeps total service-call count for an opening transition at 2 (no redundant post-settle resend).

## Testing

- ✅ 3094 tests passing (+13 since baseline)
- ✅ Per-commit pytest scope green at each step
- ✅ Pre-commit (ruff + black + prettier + translations) clean

## Related Issues

Refs #33