### PR TITLE
feat: opt-in proxy cover for floor-aware dashboard sliders (#374)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -39,7 +39,13 @@ from .coordinator import AdaptiveDataUpdateCoordinator
 from .migrations import async_prune_legacy_entities, async_prune_legacy_sensor_entities
 from .services import async_setup_services, async_unload_services
 
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.BINARY_SENSOR, Platform.BUTTON]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.COVER,
+]
 CONF_SUN = ["sun.sun"]
 
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_ENABLE_GLARE_ZONES,
     CONF_ENABLE_MAX_POSITION,
     CONF_ENABLE_MIN_POSITION,
+    CONF_ENABLE_PROXY_COVER,
     CONF_ENABLE_SUN_TRACKING,
     CONF_END_ENTITY,
     CONF_END_TIME,
@@ -43,6 +44,7 @@ from .const import (
     CONF_SUNSET_USE_MY,
     CUSTOM_POSITION_SLOTS,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
+    DEFAULT_ENABLE_PROXY_COVER,
     CONF_FORCE_OVERRIDE_MIN_MODE,
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
@@ -1600,6 +1602,20 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             "My Preset Value is not set — falls back to configured %."
         )
 
+    # Proxy cover toggle (system-wide; not part of the decision chain)
+    proxy_enabled = bool(config.get(CONF_ENABLE_PROXY_COVER))
+    lines.append("")
+    lines.append(f"**Proxy cover**: {'enabled' if proxy_enabled else 'disabled'}")
+    if proxy_enabled:
+        _any_min_mode = any(
+            bool(config.get(f"custom_position_min_mode_{_i}")) for _i in range(1, 5)
+        )
+        if not _any_min_mode:
+            lines.append(
+                "⚠️ Proxy cover is enabled but no custom-position slot has "
+                "Use as minimum on — the slider will not clamp."
+            )
+
     # =========================================================================
     # Section 4: Decision Priority (compact reference)
     # =========================================================================
@@ -2024,6 +2040,9 @@ def _build_cover_entity_schema(
                 )
             )
         )
+    schema_dict[
+        vol.Optional(CONF_ENABLE_PROXY_COVER, default=DEFAULT_ENABLE_PROXY_COVER)
+    ] = selector.BooleanSelector()
     return vol.Schema(schema_dict)
 
 

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -106,6 +106,8 @@ CONF_DISTANCE = "distance_shaded_area"  # blind→shaded distance, m (0.1-50.0)
 CONF_FOV_LEFT = "fov_left"  # left half-FOV from azimuth, degrees 0-180
 CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
 CONF_ENTITIES = "group"  # list of HA cover entity_ids controlled
+CONF_ENABLE_PROXY_COVER = "enable_proxy_cover"  # opt-in proxy cover platform
+DEFAULT_ENABLE_PROXY_COVER = False
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2098,6 +2098,43 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
         return result
 
+    async def async_apply_user_position(
+        self,
+        entity_id: str,
+        requested: int,
+        *,
+        trigger: str,
+        options: dict | None = None,
+    ) -> tuple[str, str]:
+        """Apply a user-initiated position to a single cover.
+
+        Single delegation point for any user-facing command (the
+        ``set_position`` service, the opt-in proxy cover entity, future
+        external triggers). Owns the min-mode floor clamp, builds a
+        force-context, and forwards to ``CoverCommandService.apply_position``.
+        """
+        opts = options if options is not None else self.config_entry.options
+        states = self._read_custom_position_sensor_states(opts)
+        floors = [s.position for s in states if s.is_on and s.min_mode]
+        effective_floor = max(floors) if floors else 0
+        clamped = max(int(requested), effective_floor)
+        if clamped != requested:
+            _LOGGER.info(
+                "%s: requested %d clamped to %d (active min-mode floor)",
+                trigger,
+                requested,
+                clamped,
+            )
+        else:
+            _LOGGER.debug(
+                "%s: requested %d, floor %d — no clamping needed",
+                trigger,
+                requested,
+                effective_floor,
+            )
+        ctx = self._build_position_context(entity_id, opts, force=True)
+        return await self._cmd_svc.apply_position(entity_id, clamped, trigger, ctx)
+
     def build_diagnostic_data(self) -> dict:
         """Build diagnostic data from current coordinator state."""
         result = self._pipeline_result

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1066,57 +1066,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Store cover engine object for use by diagnostics/sensors
         self._cover_data = cover_data
 
-        # Build snapshot with raw state — handlers evaluate their own conditions
-        glare_zones_cfg = self._policy.glare_zones_config(
-            self._config_service, self.config_entry.options
-        )
-        active_zone_names: set[str] = set()
-        if glare_zones_cfg is not None:
-            for idx, zone in enumerate(glare_zones_cfg.zones):
-                if getattr(self, f"glare_zone_{idx}", True):
-                    active_zone_names.add(zone.name)
-
-        snapshot = PipelineSnapshot(
-            cover=cover_data,
-            config=cover_data.config,
-            cover_type=self._cover_type,
-            default_position=effective_default,
+        snapshot = self._build_pipeline_snapshot(
+            options,
+            cover_data=cover_data,
+            effective_default=effective_default,
             is_sunset_active=is_sunset_active,
-            # NOTE: configured_default and configured_sunset_pos are deliberately
-            # absent from PipelineSnapshot.  They are annotated onto PipelineResult
-            # by the coordinator after evaluation (see below) so the raw config
-            # values are never accessible to pipeline handler logic.
-            climate_readings=self._weather_readings,
-            climate_mode_enabled=self._toggles.switch_mode,
-            climate_options=self._build_climate_options(options),
-            force_override_sensors=self._read_force_sensor_states(options),
-            force_override_position=options.get(CONF_FORCE_OVERRIDE_POSITION, 0),
-            force_override_min_mode=bool(
-                options.get(CONF_FORCE_OVERRIDE_MIN_MODE, False)
-            ),
-            manual_override_active=self.manager.binary_cover_manual,
-            motion_timeout_active=self.is_motion_timeout_active,
-            weather_override_active=self.is_weather_override_active,
-            weather_override_position=options.get(CONF_WEATHER_OVERRIDE_POSITION, 0),
-            weather_override_min_mode=bool(
-                options.get(CONF_WEATHER_OVERRIDE_MIN_MODE, False)
-            ),
-            weather_bypass_auto_control=options.get(
-                CONF_WEATHER_BYPASS_AUTO_CONTROL, True
-            ),
-            glare_zones=glare_zones_cfg,
-            active_zone_names=frozenset(active_zone_names),
-            in_time_window=self.check_adaptive_time,
-            motion_control_enabled=self._toggles.motion_control,
-            custom_position_sensors=self._read_custom_position_sensor_states(options),
-            my_position_value=options.get(CONF_MY_POSITION_VALUE),
-            sunset_use_my=bool(options.get(CONF_SUNSET_USE_MY, False)),
-            enable_sun_tracking=bool(options.get(CONF_ENABLE_SUN_TRACKING, True)),
-            motion_timeout_mode=options.get(
-                CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE
-            ),
-            current_cover_position=self._compute_mean_cover_position(),
-            policy=self._policy,
         )
         self._pipeline_result = self._pipeline.evaluate(snapshot)
 
@@ -1861,6 +1815,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             [(h.name, h.priority) for h in custom_handlers],
             sun_tracking_enabled,
         )
+        self._handler_by_name = {h.name: h for h in handlers}
         return PipelineRegistry(
             handlers, event_buffer=getattr(self, "_event_buffer", None)
         )
@@ -2098,6 +2053,112 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
         return result
 
+    def _build_pipeline_snapshot(
+        self,
+        options: dict,
+        *,
+        cover_data=None,
+        effective_default: int | None = None,
+        is_sunset_active: bool | None = None,
+        manual_override_active: bool | None = None,
+    ) -> PipelineSnapshot:
+        """Build a ``PipelineSnapshot`` for evaluation.
+
+        Single source of truth used by both the per-cycle update loop (which
+        passes the freshly-computed ``cover_data`` / ``effective_default`` /
+        ``is_sunset_active``) and ``async_apply_user_position`` (which falls
+        back to the most-recent stored values to evaluate a preemption check
+        outside the update cycle).
+
+        Args:
+            options: Config entry options dict.
+            cover_data: AdaptiveGeneralCover for this cycle. Defaults to
+                ``self._cover_data`` when omitted.
+            effective_default: Pre-computed effective default position.
+                Recomputed from options when omitted.
+            is_sunset_active: Pre-computed sunset-window flag. Recomputed
+                from options when omitted.
+            manual_override_active: When ``None`` (default) uses
+                ``self.manager.binary_cover_manual``. Pass ``False`` from the
+                preemption-check path so a stale manual-override flag does
+                not self-claim priority 80 and let the cover move anyway.
+
+        """
+        if cover_data is None:
+            cover_data = self._cover_data
+        if effective_default is None or is_sunset_active is None:
+            h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
+            sunset_pos_cfg = options.get(CONF_SUNSET_POS)
+            sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
+            sunrise_off = int(
+                options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
+            )
+            effective_default, is_sunset_active = compute_effective_default(
+                h_def=h_def,
+                sunset_pos=sunset_pos_cfg,
+                sun_data=cover_data.sun_data,
+                sunset_off=sunset_off,
+                sunrise_off=sunrise_off,
+            )
+
+        glare_zones_cfg = self._policy.glare_zones_config(
+            self._config_service, self.config_entry.options
+        )
+        active_zone_names: set[str] = set()
+        if glare_zones_cfg is not None:
+            for idx, zone in enumerate(glare_zones_cfg.zones):
+                if getattr(self, f"glare_zone_{idx}", True):
+                    active_zone_names.add(zone.name)
+
+        manual_active = (
+            self.manager.binary_cover_manual
+            if manual_override_active is None
+            else manual_override_active
+        )
+
+        return PipelineSnapshot(
+            cover=cover_data,
+            config=cover_data.config,
+            cover_type=self._cover_type,
+            default_position=effective_default,
+            is_sunset_active=is_sunset_active,
+            # NOTE: configured_default and configured_sunset_pos are deliberately
+            # absent from PipelineSnapshot.  They are annotated onto PipelineResult
+            # by the coordinator after evaluation so the raw config values are
+            # never accessible to pipeline handler logic.
+            climate_readings=self._weather_readings,
+            climate_mode_enabled=self._toggles.switch_mode,
+            climate_options=self._build_climate_options(options),
+            force_override_sensors=self._read_force_sensor_states(options),
+            force_override_position=options.get(CONF_FORCE_OVERRIDE_POSITION, 0),
+            force_override_min_mode=bool(
+                options.get(CONF_FORCE_OVERRIDE_MIN_MODE, False)
+            ),
+            manual_override_active=manual_active,
+            motion_timeout_active=self.is_motion_timeout_active,
+            weather_override_active=self.is_weather_override_active,
+            weather_override_position=options.get(CONF_WEATHER_OVERRIDE_POSITION, 0),
+            weather_override_min_mode=bool(
+                options.get(CONF_WEATHER_OVERRIDE_MIN_MODE, False)
+            ),
+            weather_bypass_auto_control=options.get(
+                CONF_WEATHER_BYPASS_AUTO_CONTROL, True
+            ),
+            glare_zones=glare_zones_cfg,
+            active_zone_names=frozenset(active_zone_names),
+            in_time_window=self.check_adaptive_time,
+            motion_control_enabled=self._toggles.motion_control,
+            custom_position_sensors=self._read_custom_position_sensor_states(options),
+            my_position_value=options.get(CONF_MY_POSITION_VALUE),
+            sunset_use_my=bool(options.get(CONF_SUNSET_USE_MY, False)),
+            enable_sun_tracking=bool(options.get(CONF_ENABLE_SUN_TRACKING, True)),
+            motion_timeout_mode=options.get(
+                CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE
+            ),
+            current_cover_position=self._compute_mean_cover_position(),
+            policy=self._policy,
+        )
+
     async def async_apply_user_position(
         self,
         entity_id: str,
@@ -2105,13 +2166,26 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         *,
         trigger: str,
         options: dict | None = None,
+        force: bool = False,
     ) -> tuple[str, str]:
         """Apply a user-initiated position to a single cover.
 
         Single delegation point for any user-facing command (the
         ``set_position`` service, the opt-in proxy cover entity, future
-        external triggers). Owns the min-mode floor clamp, builds a
-        force-context, and forwards to ``CoverCommandService.apply_position``.
+        external triggers). Owns the min-mode floor clamp, the pipeline
+        preemption check, manual-override engagement, and dispatch to
+        ``CoverCommandService.apply_position``.
+
+        Default behavior (``force=False``): engages manual override and
+        consults the pipeline. When a handler with priority strictly greater
+        than :class:`ManualOverrideHandler` priority (force_override 100,
+        weather 90, custom-position slots configured > 80) wins, the move is
+        dropped and recorded via ``CoverCommandService.record_preempted_skip``.
+
+        ``force=True``: legacy programmatic behavior — skip the pipeline
+        preemption check and skip manual-override engagement. Used by the
+        ``adaptive_cover_pro.set_position`` service when callers explicitly
+        opt in.
         """
         opts = options if options is not None else self.config_entry.options
         states = self._read_custom_position_sensor_states(opts)
@@ -2132,6 +2206,34 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 requested,
                 effective_floor,
             )
+
+        if not force:
+            snapshot = self._build_pipeline_snapshot(opts, manual_override_active=False)
+            result = self._pipeline.evaluate(snapshot)
+            winner_step = next((s for s in result.decision_trace if s.matched), None)
+            if winner_step is not None:
+                winner_name = winner_step.handler
+                winner_handler = self._handler_by_name.get(winner_name)
+                winner_priority = (
+                    winner_handler.priority if winner_handler is not None else 0
+                )
+                if winner_priority > ManualOverrideHandler.priority:
+                    _LOGGER.info(
+                        "user move on %s preempted by %s (priority %d > %d)",
+                        entity_id,
+                        winner_name,
+                        winner_priority,
+                        ManualOverrideHandler.priority,
+                    )
+                    self._cmd_svc.record_preempted_skip(
+                        entity_id,
+                        clamped,
+                        trigger=trigger,
+                        winner_name=winner_name,
+                    )
+                    return "skipped", f"preempted_by_{winner_name}"
+            self.manager.mark_user_command(entity_id, reason=trigger)
+
         ctx = self._build_position_context(entity_id, opts, force=True)
         return await self._cmd_svc.apply_position(entity_id, clamped, trigger, ctx)
 

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -1,0 +1,248 @@
+"""Opt-in proxy cover platform for Adaptive Cover Pro.
+
+When ``CONF_ENABLE_PROXY_COVER`` is True, one ``AdaptiveProxyCover`` entity is
+created per source cover in ``CONF_ENTITIES``. The proxy mirrors source state
+verbatim (no inverse-state transform) and routes user commands through
+``Coordinator.async_apply_user_position`` so min-mode custom-position floors
+are honoured. ``stop_cover`` forwards directly to the source.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.cover import (
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.util import slugify
+
+from .const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    DEFAULT_ENABLE_PROXY_COVER,
+    DOMAIN,
+)
+from .cover_types.base import (
+    CAP_HAS_SET_TILT_POSITION,
+    STATE_ATTR_POSITION,
+    STATE_ATTR_TILT_POSITION,
+    caps_get,
+)
+from .entity_base import AdaptiveCoverBaseEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import Event, HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import AdaptiveDataUpdateCoordinator
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up proxy cover entities for an ACP config entry."""
+    if not entry.options.get(CONF_ENABLE_PROXY_COVER, DEFAULT_ENABLE_PROXY_COVER):
+        return
+
+    sources: list[str] = list(entry.options.get(CONF_ENTITIES) or [])
+    if not sources:
+        return
+
+    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    multi = len(sources) > 1
+
+    entities: list[AdaptiveProxyCover] = [
+        AdaptiveProxyCover(
+            entry_id=entry.entry_id,
+            hass=hass,
+            config_entry=entry,
+            coordinator=coordinator,
+            source_entity_id=src,
+            multi=multi,
+        )
+        for src in sources
+    ]
+    async_add_entities(entities)
+
+
+def _source_friendly_label(hass: HomeAssistant, entity_id: str) -> str:
+    """Return a human label for a source entity_id (registry > object_id)."""
+    reg = er.async_get(hass)
+    entry = reg.async_get(entity_id)
+    if entry and (entry.original_name or entry.name):
+        return entry.name or entry.original_name
+    state = hass.states.get(entity_id)
+    if state is not None:
+        friendly = state.attributes.get("friendly_name")
+        if friendly:
+            return friendly
+    return entity_id.split(".", 1)[-1].replace("_", " ").title()
+
+
+class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
+    """Proxy cover that mirrors a source and routes commands through ACP."""
+
+    _attr_has_entity_name = False
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        *,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: AdaptiveDataUpdateCoordinator,
+        source_entity_id: str,
+        multi: bool,
+    ) -> None:
+        """Initialise a proxy cover bound to ``source_entity_id``."""
+        super().__init__(entry_id, hass, config_entry, coordinator)
+        self._source_entity_id = source_entity_id
+        self._attr_unique_id = f"{entry_id}_proxy_{slugify(source_entity_id)}"
+        title = config_entry.title or config_entry.data.get("name") or "Adaptive"
+        if multi:
+            label = _source_friendly_label(hass, source_entity_id)
+            self._attr_name = f"{title} Slider ({label})"
+        else:
+            self._attr_name = f"{title} Slider"
+
+    # ---- availability + mirroring -------------------------------------- #
+
+    @property
+    def available(self) -> bool:
+        """Mirror source availability."""
+        state = self.hass.states.get(self._source_entity_id)
+        if state is None:
+            return False
+        return state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Mirror source current_position verbatim (no inverse transform)."""
+        state = self.hass.states.get(self._source_entity_id)
+        if state is None:
+            return None
+        value = state.attributes.get(STATE_ATTR_POSITION)
+        return int(value) if value is not None else None
+
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Mirror source current_tilt_position verbatim."""
+        state = self.hass.states.get(self._source_entity_id)
+        if state is None:
+            return None
+        value = state.attributes.get(STATE_ATTR_TILT_POSITION)
+        return int(value) if value is not None else None
+
+    @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Mirror source supported_features."""
+        state = self.hass.states.get(self._source_entity_id)
+        if state is None:
+            return CoverEntityFeature(0)
+        return CoverEntityFeature(int(state.attributes.get("supported_features", 0)))
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Derived from mirrored current_position (0 = closed)."""
+        pos = self.current_cover_position
+        if pos is None:
+            return None
+        return pos == 0
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to source state changes once mounted."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                [self._source_entity_id],
+                self._handle_source_event,
+            )
+        )
+
+    @callback
+    def _handle_source_event(self, event: Event) -> None:
+        self.async_write_ha_state()
+
+    # ---- command routing ---------------------------------------------- #
+
+    def _source_available(self) -> bool:
+        state = self.hass.states.get(self._source_entity_id)
+        if state is None or state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            _LOGGER.debug(
+                "proxy %s: source %s unavailable — dropping command",
+                self.entity_id,
+                self._source_entity_id,
+            )
+            return False
+        return True
+
+    def _source_caps(self) -> dict[str, bool]:
+        feats = int(self.supported_features)
+        return {
+            "has_set_position": bool(feats & CoverEntityFeature.SET_POSITION),
+            "has_set_tilt_position": bool(feats & CoverEntityFeature.SET_TILT_POSITION),
+            "has_open": bool(feats & CoverEntityFeature.OPEN),
+            "has_close": bool(feats & CoverEntityFeature.CLOSE),
+            "has_stop": bool(feats & CoverEntityFeature.STOP),
+        }
+
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
+        """Route slider position via the floor-clamping helper."""
+        if not self._source_available():
+            return
+        position = int(kwargs["position"])
+        await self.coordinator.async_apply_user_position(
+            self._source_entity_id, position, trigger="proxy_slider"
+        )
+
+    async def async_open_cover(self, **kwargs: Any) -> None:
+        """Open command routed through the helper as position=100."""
+        if not self._source_available():
+            return
+        await self.coordinator.async_apply_user_position(
+            self._source_entity_id, 100, trigger="proxy_open"
+        )
+
+    async def async_close_cover(self, **kwargs: Any) -> None:
+        """Close command routed through the helper (clamp applies intentionally)."""
+        if not self._source_available():
+            return
+        await self.coordinator.async_apply_user_position(
+            self._source_entity_id, 0, trigger="proxy_close"
+        )
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Route tilt position via the helper when the source supports tilt."""
+        if not self._source_available():
+            return
+        if not caps_get(self._source_caps(), CAP_HAS_SET_TILT_POSITION):
+            return
+        position = int(kwargs["tilt_position"])
+        await self.coordinator.async_apply_user_position(
+            self._source_entity_id, position, trigger="proxy_tilt"
+        )
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop forwards directly to the source (no clamp)."""
+        if not self._source_available():
+            return
+        await self.hass.services.async_call(
+            "cover",
+            "stop_cover",
+            {ATTR_ENTITY_ID: self._source_entity_id},
+            blocking=False,
+        )

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1246,6 +1246,43 @@ class CoverCommandService:
             "wait_for_target": s.waiting,
         }
 
+    def record_preempted_skip(
+        self,
+        entity_id: str,
+        position: int,
+        *,
+        trigger: str,
+        winner_name: str,
+    ) -> None:
+        """Record a user move preempted by a higher-priority pipeline handler.
+
+        Surfaces a "preempted_by_handler" skip in ``last_skipped_action`` so
+        the existing Skipped Action diagnostic sensor labels the reason
+        (e.g. "Proxy slider to 30 preempted by weather override"). Used by
+        :meth:`Coordinator.async_apply_user_position` when the proxy slider
+        or ``set_position`` service is overruled by force_override / weather
+        / a custom-position slot with priority > 80.
+        """
+        current_position = self._get_current_position(entity_id)
+        self._diag.record_skipped_action(
+            entity_id,
+            "preempted_by_handler",
+            position,
+            trigger=trigger,
+            current_position=current_position,
+            inverse_state=False,
+            extras={"winner": winner_name},
+        )
+        self._diag.record_skip_event(
+            entity_id,
+            "preempted_by_handler",
+            position,
+            trigger=trigger,
+            inverse_state=False,
+            current_position=current_position,
+            extras={"winner": winner_name},
+        )
+
     def record_skipped_action(
         self,
         entity: str,

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -490,6 +490,36 @@ class AdaptiveCoverManager:
         """
         self.manual_control[cover] = True
 
+    def mark_user_command(self, entity_id: str, *, reason: str) -> None:
+        """Engage manual override pre-emptively from an ACP-owned surface.
+
+        Pre-emptive analog of :meth:`handle_user_initiated_state_change` which
+        is post-facto: called from the proxy cover entity and the
+        ``adaptive_cover_pro.set_position`` service before the cover even
+        moves so the next coordinator cycle does not yank the cover off the
+        user's set point.
+
+        Uses ``setdefault`` for ``manual_control_time`` so successive drags
+        do not extend the override window (matches ``allow_reset=False``
+        semantics).  Does not require the entity to be in ``self.covers`` —
+        the proxy may dispatch before ``add_covers`` runs.
+
+        Args:
+            entity_id: Cover entity ID to mark as manually overridden.
+            reason: Short label recorded into the diagnostic event buffer
+                (e.g. ``"proxy_slider"``, ``"set_position"``).
+
+        """
+        self.manual_control[entity_id] = True
+        self.manual_control_time.setdefault(entity_id, dt.datetime.now(dt.UTC))
+        self._record_event(
+            entity_id,
+            "manual_override_set",
+            our_state=None,
+            new_position=None,
+            reason=reason,
+        )
+
     async def reset_if_needed(self) -> set[str]:
         """Reset expired manual overrides.
 

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -47,9 +47,10 @@ set_position:
   name: Set position
   description: >-
     Move the targeted covers to an explicit position. Clamps up to the highest
-    active custom-position minimum-mode floor across all slots, and sends with
-    force=True so manual override does not block the command. Tilt is not
-    affected; on venetian instances only the primary axis is moved.
+    active custom-position minimum-mode floor across all slots. By default the
+    call engages manual override and respects the priority pipeline (so an
+    active force_override or weather override still wins); set force=true to
+    bypass the pipeline check and skip manual-override engagement.
   target:
     entity:
       integration: adaptive_cover_pro
@@ -65,6 +66,16 @@ set_position:
           step: 1
           mode: slider
           unit_of_measurement: "%"
+    force:
+      name: Force
+      description: >-
+        When true, bypass the priority pipeline check and skip manual-override
+        engagement. Default false — service calls respect force_override /
+        weather and engage manual override like a dashboard slider.
+      required: false
+      default: false
+      selector:
+        boolean:
 
 set_position_limits:
   name: Set position limits

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 SET_POSITION_SCHEMA = vol.Schema(
     {
         vol.Required("position"): vol.All(Coerce(int), Range(min=0, max=100)),
+        vol.Optional("force", default=False): bool,
     },
     extra=vol.PREVENT_EXTRA,
 )
@@ -38,10 +39,16 @@ async def async_handle_set_position(call: ServiceCall) -> None:
     Resolves the target block to one or more coordinators (each with an
     optional entity filter), then delegates each command to
     ``coord.async_apply_user_position`` — the single source of truth for
-    floor clamping and force-context construction.
+    floor clamping, pipeline preemption, and dispatch.
+
+    ``force`` (default ``False``) propagates through: when ``False`` the
+    service respects force_override / weather and engages manual override
+    like a dashboard slider; when ``True`` it bypasses the pipeline check
+    and skips manual-override engagement (legacy programmatic behavior).
     """
     hass = call.hass
     requested: int = call.data["position"]
+    force: bool = call.data.get("force", False)
     targets = _resolve_targets(hass, call)
 
     for coord, entity_filter in targets.items():
@@ -50,5 +57,5 @@ async def async_handle_set_position(call: ServiceCall) -> None:
         )
         for entity_id in entity_ids:
             await coord.async_apply_user_position(
-                entity_id, requested, trigger="set_position"
+                entity_id, requested, trigger="set_position", force=force
             )

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -1,4 +1,8 @@
-"""set_position service — moves a cover to a position, clamping to min-mode floors."""
+"""set_position service — moves a cover to a position, clamping to min-mode floors.
+
+Thin target-resolution layer over ``Coordinator.async_apply_user_position``,
+which owns the floor-clamp + force-context + dispatch logic.
+"""
 
 from __future__ import annotations
 
@@ -31,49 +35,20 @@ def _resolve_targets(hass, call):
 async def async_handle_set_position(call: ServiceCall) -> None:
     """Handle the set_position service call.
 
-    For each targeted coordinator:
-    1. Read active min-mode custom-position floors.
-    2. Clamp requested position to the highest active floor (if any).
-    3. Build context with force=True to bypass the manual-override gate.
-    4. Call apply_position for each targeted entity.
+    Resolves the target block to one or more coordinators (each with an
+    optional entity filter), then delegates each command to
+    ``coord.async_apply_user_position`` — the single source of truth for
+    floor clamping and force-context construction.
     """
     hass = call.hass
     requested: int = call.data["position"]
-
     targets = _resolve_targets(hass, call)
 
     for coord, entity_filter in targets.items():
-        options = coord.config_entry.options
-
-        # Collect active min-mode floors
-        states = coord._read_custom_position_sensor_states(options)  # noqa: SLF001
-        floors = [s.position for s in states if s.is_on and s.min_mode]
-        effective_floor = max(floors) if floors else 0
-
-        clamped = max(requested, effective_floor)
-
-        if clamped != requested:
-            _LOGGER.info(
-                "set_position: requested %d clamped to %d (active min-mode floor)",
-                requested,
-                clamped,
-            )
-        else:
-            _LOGGER.debug(
-                "set_position: requested %d, floor %d — no clamping needed",
-                requested,
-                effective_floor,
-            )
-
-        # Determine which entities to command
         entity_ids: list[str] = (
             list(entity_filter) if entity_filter is not None else list(coord.entities)
         )
-
         for entity_id in entity_ids:
-            ctx = coord._build_position_context(  # noqa: SLF001
-                entity_id, options, force=True
-            )
-            await coord._cmd_svc.apply_position(  # noqa: SLF001
-                entity_id, clamped, "set_position", ctx
+            await coord.async_apply_user_position(
+                entity_id, requested, trigger="set_position"
             )

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -20,11 +20,13 @@
         "description": "Wählen Sie die Beschattungselemente aus, die diese Instanz steuert, und ordnen Sie sie optional einem physischen Gerät in HA zu. Mehrere Beschattungselemente können eine Instanz teilen — sie verwenden die gleichen Einstellungen und bewegen sich unabhängig. Um Beschattungselemente mit unterschiedlichen Fensterorientierungen zu steuern, erstellen Sie eine separate Instanz für jedes.\n\n[Weitere Informationen]({learn_more})",
         "data": {
           "group": "Beschattungsentitäten",
-          "linked_device_id": "An Gerät anhängen"
+          "linked_device_id": "An Gerät anhängen",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
         },
         "data_description": {
           "group": "Wählen Sie die Beschattungsentitäten, die diese Integrationsinstanz steuern soll. Sie können mehrere Beschattungen auswählen, um sie als Gruppe zu steuern (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Beschattungen aus, die diesem bestimmten Fenster dienen – erstellen Sie separate Integrationsinstanzen für verschiedene Fenster.",
-          "linked_device_id": "Wählen Sie ein physisches Gerät, in das die Entitäten dieser Integration zusammengeführt werden. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um zu einem separaten virtuellen Adaptive Cover-Gerät zurückzukehren. Es werden nur Geräte angezeigt, die die ausgewählten Beschattungsentitäten besitzen."
+          "linked_device_id": "Wählen Sie ein physisches Gerät, in das die Entitäten dieser Integration zusammengeführt werden. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um zu einem separaten virtuellen Adaptive Cover-Gerät zurückzukehren. Es werden nur Geräte angezeigt, die die ausgewählten Beschattungsentitäten besitzen.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
         }
       },
       "geometry": {
@@ -544,11 +546,13 @@
         "description": "Wählen Sie die Beschattungselemente aus, die diese Instanz steuert, und ordnen Sie sie optional einem physischen Gerät in HA zu. Mehrere Beschattungselemente können eine Instanz teilen — sie verwenden die gleichen Einstellungen und bewegen sich unabhängig. Um Beschattungselemente mit unterschiedlichen Fensterorientierungen zu steuern, erstellen Sie eine separate Instanz für jedes.\n\n[Weitere Informationen]({learn_more})",
         "data": {
           "group": "Beschattungsentitäten",
-          "linked_device_id": "An Gerät anhängen"
+          "linked_device_id": "An Gerät anhängen",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
         },
         "data_description": {
           "group": "Wählen Sie die Cover-Entitäten aus, die von dieser Integrationsinstanz gesteuert werden sollen. Sie können mehrere Abdeckungen auswählen, um sie als Gruppe zu steuern (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Abdeckungen aus, die diesem bestimmten Fenster dienen - erstellen Sie separate Integrationsinstanzen für verschiedene Fenster.",
-          "linked_device_id": "Wählen Sie ein physisches Gerät aus, um die Entitäten dieser Integration zusammenzuführen. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um auf ein separates virtuelles Adaptive Cover-Gerät zurückzukehren. Nur Geräte, die die ausgewählten Cover-Entitäten besitzen, werden angezeigt."
+          "linked_device_id": "Wählen Sie ein physisches Gerät aus, um die Entitäten dieser Integration zusammenzuführen. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um auf ein separates virtuelles Adaptive Cover-Gerät zurückzukehren. Nur Geräte, die die ausgewählten Cover-Entitäten besitzen, werden angezeigt.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -21,12 +21,12 @@
         "data": {
           "group": "Beschattungsentitäten",
           "linked_device_id": "An Gerät anhängen",
-          "enable_proxy_cover": "Expose Proxy Cover Entity"
+          "enable_proxy_cover": "Proxy-Beschattungsentität freigeben"
         },
         "data_description": {
           "group": "Wählen Sie die Beschattungsentitäten, die diese Integrationsinstanz steuern soll. Sie können mehrere Beschattungen auswählen, um sie als Gruppe zu steuern (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Beschattungen aus, die diesem bestimmten Fenster dienen – erstellen Sie separate Integrationsinstanzen für verschiedene Fenster.",
           "linked_device_id": "Wählen Sie ein physisches Gerät, in das die Entitäten dieser Integration zusammengeführt werden. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um zu einem separaten virtuellen Adaptive Cover-Gerät zurückzukehren. Es werden nur Geräte angezeigt, die die ausgewählten Beschattungsentitäten besitzen.",
-          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
+          "enable_proxy_cover": "Geben Sie eine Proxy-Beschattungsentität pro physischer Beschattung frei. Verwenden Sie diese auf Dashboards statt der physischen Beschattung, damit der Schieberegler Mindeststellungen respektiert. Standard: aus."
         }
       },
       "geometry": {
@@ -547,12 +547,12 @@
         "data": {
           "group": "Beschattungsentitäten",
           "linked_device_id": "An Gerät anhängen",
-          "enable_proxy_cover": "Expose Proxy Cover Entity"
+          "enable_proxy_cover": "Proxy-Beschattungsentität freigeben"
         },
         "data_description": {
           "group": "Wählen Sie die Cover-Entitäten aus, die von dieser Integrationsinstanz gesteuert werden sollen. Sie können mehrere Abdeckungen auswählen, um sie als Gruppe zu steuern (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Abdeckungen aus, die diesem bestimmten Fenster dienen - erstellen Sie separate Integrationsinstanzen für verschiedene Fenster.",
           "linked_device_id": "Wählen Sie ein physisches Gerät aus, um die Entitäten dieser Integration zusammenzuführen. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um auf ein separates virtuelles Adaptive Cover-Gerät zurückzukehren. Nur Geräte, die die ausgewählten Cover-Entitäten besitzen, werden angezeigt.",
-          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
+          "enable_proxy_cover": "Geben Sie eine Proxy-Beschattungsentität pro physischer Beschattung frei. Verwenden Sie diese auf Dashboards statt der physischen Beschattung, damit der Schieberegler Mindeststellungen respektiert. Standard: aus."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1667,6 +1667,10 @@
         "position": {
           "name": "Position",
           "description": "Zielposition der Beschattung (0–100%). Wird bis zur aktiven Mindestwertstufe begrenzt, falls eine konfiguriert ist und deren Sensor aktiviert ist."
+        },
+        "force": {
+          "name": "Erzwingen",
+          "description": "Wenn aktiviert, umgeht die Prioritäts-Pipeline-Prüfung und überspringt die Manuelle-Übersteuerung-Aktivierung. Standard: deaktiviert — Dienstaufrufe beachten force_override / weather und aktivieren manuelle Übersteuerung wie ein Dashboard-Schieberegler."
         }
       },
       "name": "Position setzen (mit Mindestwert-Erzwingung)",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1664,11 +1664,15 @@
     },
     "set_position": {
       "name": "Set position (floor-enforced)",
-      "description": "Moves the cover to the requested position, clamping to the highest active custom-position minimum-mode floor. Use this instead of cover.set_cover_position when you need ACP's min-mode floors respected from automations. Tilt is not affected.",
+      "description": "Moves the cover to the requested position, clamping to the highest active custom-position minimum-mode floor. By default the call engages manual override and respects the priority pipeline (force_override / weather still win); set force=true to bypass the pipeline check and skip manual-override engagement. Tilt is not affected.",
       "fields": {
         "position": {
           "name": "Position",
           "description": "Target cover position (0–100%). Clamped up to the active minimum-mode floor if one is configured and its sensor is on."
+        },
+        "force": {
+          "name": "Force",
+          "description": "When true, bypass the priority pipeline check and skip manual-override engagement. Default false — service calls respect force_override / weather and engage manual override like a dashboard slider."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -20,11 +20,13 @@
         "description": "Select the covers this instance controls and optionally attach them to a physical device in HA. Multiple covers can share one instance — they use the same settings and move independently. To control covers with different window orientations, create a separate instance for each.\n\n[Learn more]({learn_more})",
         "data": {
           "group": "Cover Entities",
-          "linked_device_id": "Attach to Device"
+          "linked_device_id": "Attach to Device",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
         },
         "data_description": {
           "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
         }
       },
       "geometry": {
@@ -544,11 +546,13 @@
         "description": "Select the covers this instance controls and optionally attach them to a physical device in HA. Multiple covers can share one instance — they use the same settings and move independently. To control covers with different window orientations, create a separate instance for each.\n\n[Learn more]({learn_more})",
         "data": {
           "group": "Cover Entities",
-          "linked_device_id": "Attach to Device"
+          "linked_device_id": "Attach to Device",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
         },
         "data_description": {
           "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
-          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown."
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -20,11 +20,13 @@
         "description": "Sélectionnez les protections que cette instance contrôle et connectez-les optionnellement à un appareil physique dans HA. Plusieurs protections peuvent partager une instance – elles utilisent les mêmes paramètres et se déplacent indépendamment. Pour contrôler des protections avec des orientations de fenêtre différentes, créez une instance séparée pour chacune.\n\n[Learn more]({learn_more})",
         "data": {
           "group": "Entités de store",
-          "linked_device_id": "Attacher à un appareil"
+          "linked_device_id": "Attacher à un appareil",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
         },
         "data_description": {
           "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores pour les contrôler ensemble (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores qui servent cette fenêtre particulière - créez des instances d'intégration séparées pour différentes fenêtres.",
-          "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés."
+          "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
         }
       },
       "geometry": {
@@ -544,11 +546,13 @@
         "description": "Sélectionnez les protections que cette instance contrôle et connectez-les optionnellement à un appareil physique dans HA. Plusieurs protections peuvent partager une instance – elles utilisent les mêmes paramètres et se déplacent indépendamment. Pour contrôler des protections avec des orientations de fenêtre différentes, créez une instance séparée pour chacune.\n\n[Learn more]({learn_more})",
         "data": {
           "group": "Entités de store",
-          "linked_device_id": "Attacher à un appareil"
+          "linked_device_id": "Attacher à un appareil",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
         },
         "data_description": {
           "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores pour les contrôler ensemble (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores qui servent cette fenêtre particulière - créez des instances d'intégration séparées pour différentes fenêtres.",
-          "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés."
+          "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -21,12 +21,12 @@
         "data": {
           "group": "Entités de store",
           "linked_device_id": "Attacher à un appareil",
-          "enable_proxy_cover": "Expose Proxy Cover Entity"
+          "enable_proxy_cover": "Exposer l'entité de couverture proxy"
         },
         "data_description": {
           "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores pour les contrôler ensemble (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores qui servent cette fenêtre particulière - créez des instances d'intégration séparées pour différentes fenêtres.",
           "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés.",
-          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
+          "enable_proxy_cover": "Expose une entité de couverture proxy par protection physique. Utilisez ceci sur les tableaux de bord à la place de la protection physique afin que le curseur respecte les seuils minimum. Par défaut : désactivé."
         }
       },
       "geometry": {
@@ -547,12 +547,12 @@
         "data": {
           "group": "Entités de store",
           "linked_device_id": "Attacher à un appareil",
-          "enable_proxy_cover": "Expose Proxy Cover Entity"
+          "enable_proxy_cover": "Exposer l'entité de couverture proxy"
         },
         "data_description": {
           "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores pour les contrôler ensemble (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores qui servent cette fenêtre particulière - créez des instances d'intégration séparées pour différentes fenêtres.",
           "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés.",
-          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
+          "enable_proxy_cover": "Expose une entité de couverture proxy par protection physique. Utilisez ceci sur les tableaux de bord à la place de la protection physique afin que le curseur respecte les seuils minimum. Par défaut : désactivé."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1667,6 +1667,10 @@
         "position": {
           "name": "Position",
           "description": "Position cible de la protection (0–100%). Limitée jusqu'au plancher minimum actif si l'un est configuré et que son capteur est activé."
+        },
+        "force": {
+          "name": "Forcer",
+          "description": "Lorsque cette option est activée, contourne la vérification de la pipeline de priorité et ignore l'engagement de dérogation manuelle. Par défaut false — les appels de service respectent force_override / weather et engagent la dérogation manuelle comme un curseur du tableau de bord."
         }
       },
       "name": "Définir la position (avec plancher appliqué)",

--- a/tests/cover/__init__.py
+++ b/tests/cover/__init__.py
@@ -1,0 +1,1 @@
+"""Cover platform tests."""

--- a/tests/cover/test_proxy_cover_commands.py
+++ b/tests/cover/test_proxy_cover_commands.py
@@ -1,0 +1,210 @@
+"""Proxy cover command routing tests (Phase D Step 16)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, TILT_OPTIONS, _patch_coordinator_refresh
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _setup_proxy(
+    hass,
+    *,
+    source: str = "cover.living_room",
+    cover_type: str = SensorType.BLIND,
+    entry_id: str = "proxy_cmd",
+    options: dict | None = None,
+    state: str = "open",
+    attrs: dict | None = None,
+):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+
+    base = (
+        dict(options)
+        if options is not None
+        else (
+            dict(TILT_OPTIONS)
+            if cover_type == SensorType.TILT
+            else dict(VERTICAL_OPTIONS)
+        )
+    )
+    base[CONF_ENTITIES] = [source]
+    base[CONF_ENABLE_PROXY_COVER] = True
+
+    hass.states.async_set(
+        source,
+        state,
+        attrs or {"current_position": 50, "supported_features": 143},
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Proxy Cmd", CONF_SENSOR_TYPE: cover_type},
+        options=base,
+        entry_id=entry_id,
+        title="Proxy Cmd",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+    return entry, coordinator, proxy_eid
+
+
+async def test_set_cover_position_routes_through_async_apply_user_position(
+    hass,
+) -> None:
+    """A ``cover.set_cover_position`` service call delegates to the helper."""
+    entry, coord, proxy_eid = await _setup_proxy(hass, entry_id="proxy_cmd_set")
+    coord.async_apply_user_position = AsyncMock(
+        return_value=("sent", "set_cover_position")
+    )
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": proxy_eid, "position": 42},
+        blocking=True,
+    )
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.living_room", 42, trigger="proxy_slider"
+    )
+
+
+async def test_set_cover_position_uses_proxy_slider_trigger(hass) -> None:
+    """The trigger label for a slider command is ``proxy_slider``."""
+    entry, coord, proxy_eid = await _setup_proxy(hass, entry_id="proxy_cmd_trig")
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": proxy_eid, "position": 10},
+        blocking=True,
+    )
+    args, kwargs = coord.async_apply_user_position.await_args
+    assert kwargs.get("trigger") == "proxy_slider"
+
+
+async def test_open_cover_calls_apply_user_position_with_100(hass) -> None:
+    """``cover.open_cover`` sends 100 with trigger ``proxy_open``."""
+    entry, coord, proxy_eid = await _setup_proxy(hass, entry_id="proxy_cmd_open")
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+
+    await hass.services.async_call(
+        "cover", "open_cover", {"entity_id": proxy_eid}, blocking=True
+    )
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.living_room", 100, trigger="proxy_open"
+    )
+
+
+async def test_close_cover_calls_apply_user_position_with_0(hass) -> None:
+    """``cover.close_cover`` sends 0 with trigger ``proxy_close`` (clamp applies)."""
+    entry, coord, proxy_eid = await _setup_proxy(hass, entry_id="proxy_cmd_close")
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+
+    await hass.services.async_call(
+        "cover", "close_cover", {"entity_id": proxy_eid}, blocking=True
+    )
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.living_room", 0, trigger="proxy_close"
+    )
+
+
+async def test_set_cover_tilt_position_routes_through_apply_user_position(hass) -> None:
+    """Tilt-capable cover: ``cover.set_cover_tilt_position`` routes through the helper."""
+    entry, coord, proxy_eid = await _setup_proxy(
+        hass,
+        cover_type=SensorType.TILT,
+        source="cover.venetian",
+        entry_id="proxy_cmd_tilt",
+        attrs={
+            "current_position": 50,
+            "current_tilt_position": 50,
+            "supported_features": 143 | 128,
+        },
+    )
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_tilt_position",
+        {"entity_id": proxy_eid, "tilt_position": 75},
+        blocking=True,
+    )
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.venetian", 75, trigger="proxy_tilt"
+    )
+
+
+async def test_stop_cover_forwards_directly_no_clamp(hass) -> None:
+    """``cover.stop_cover`` forwards to the source service, not through the helper."""
+    from homeassistant.const import EVENT_CALL_SERVICE
+
+    entry, coord, proxy_eid = await _setup_proxy(hass, entry_id="proxy_cmd_stop")
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+
+    # Track every cover.stop_cover service call via the event bus.
+    calls: list[dict] = []
+
+    def _on_event(event):
+        if (
+            event.data.get("domain") == "cover"
+            and event.data.get("service") == "stop_cover"
+        ):
+            calls.append(dict(event.data.get("service_data") or {}))
+
+    hass.bus.async_listen(EVENT_CALL_SERVICE, _on_event)
+
+    await hass.services.async_call(
+        "cover", "stop_cover", {"entity_id": proxy_eid}, blocking=True
+    )
+    await hass.async_block_till_done()
+    # The helper must NOT have been called
+    coord.async_apply_user_position.assert_not_called()
+    # A forwarded stop_cover targets the source entity
+    targeted = [c for c in calls if c.get("entity_id") == "cover.living_room"]
+    assert targeted, f"no forwarded stop_cover; captured={calls}"
+
+
+async def test_commands_dropped_when_source_unavailable(hass) -> None:
+    """Source unavailable → helper never called, no exception raised."""
+    entry, coord, proxy_eid = await _setup_proxy(
+        hass,
+        entry_id="proxy_cmd_unavail",
+        state="unavailable",
+        attrs={},
+    )
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+
+    # set_position
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": proxy_eid, "position": 50},
+        blocking=True,
+    )
+    coord.async_apply_user_position.assert_not_called()

--- a/tests/cover/test_proxy_cover_coverage.py
+++ b/tests/cover/test_proxy_cover_coverage.py
@@ -1,0 +1,278 @@
+"""Targeted coverage tests for proxy cover branches not hit by feature tests."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _setup_no_sources(hass) -> None:
+    """Proxy enabled, but ``CONF_ENTITIES`` is empty — no proxies are created."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = []
+    opts[CONF_ENABLE_PROXY_COVER] = True
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Empty Sources", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id="proxy_cov_empty",
+        title="Empty Sources",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+
+async def test_setup_returns_when_sources_empty(hass) -> None:
+    """``async_setup_entry`` with enabled flag + empty entities returns cleanly."""
+    from homeassistant.helpers import entity_registry as er
+
+    await _setup_no_sources(hass)
+    reg = er.async_get(hass)
+    proxies = [
+        e
+        for e in reg.entities.values()
+        if e.unique_id.startswith("proxy_cov_empty_proxy_")
+    ]
+    assert proxies == []
+
+
+# ---------------------------------------------------------------------------
+# Source-unavailable command guards (exercises every command's early-return)
+# ---------------------------------------------------------------------------
+
+
+async def _setup_unavail_proxy(hass):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = ["cover.dead_blind"]
+    opts[CONF_ENABLE_PROXY_COVER] = True
+
+    hass.states.async_set(
+        "cover.dead_blind",
+        "open",
+        {"current_position": 50, "supported_features": 143 | 128},
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Dead", CONF_SENSOR_TYPE: SensorType.TILT},
+        options=opts,
+        entry_id="proxy_cov_unavail",
+        title="Dead",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coord = hass.data[DOMAIN][entry.entry_id]
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+
+    # Flip the source to unavailable AFTER setup so the proxy is alive but blind.
+    hass.states.async_set("cover.dead_blind", "unavailable", {})
+    await hass.async_block_till_done()
+    return coord, proxy_eid
+
+
+async def test_open_close_tilt_stop_dropped_when_source_unavailable(
+    hass, caplog
+) -> None:
+    """Every command early-returns when the source is unavailable.
+
+    Call the proxy's command methods directly so HA's "skip unavailable entity"
+    framework guard doesn't short-circuit the early-return branch we're trying
+    to cover.
+    """
+    coord, proxy_eid = await _setup_unavail_proxy(hass)
+    caplog.set_level(logging.DEBUG, logger="custom_components.adaptive_cover_pro.cover")
+
+    proxy = next(
+        e
+        for e in hass.data["entity_components"]["cover"].entities
+        if e.entity_id == proxy_eid
+    )
+    await proxy.async_set_cover_position(position=50)
+    await proxy.async_open_cover()
+    await proxy.async_close_cover()
+    await proxy.async_set_cover_tilt_position(tilt_position=40)
+    await proxy.async_stop_cover()
+    coord.async_apply_user_position.assert_not_called()
+    # Debug log must mention "unavailable — dropping"
+    assert any(
+        "unavailable" in r.getMessage() for r in caplog.records
+    ), "expected debug log mentioning unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Tilt-incapable source: set_cover_tilt_position no-ops
+# ---------------------------------------------------------------------------
+
+
+async def test_tilt_command_dropped_when_source_lacks_tilt_capability(hass) -> None:
+    """Source supports position but not tilt → set_cover_tilt_position no-ops."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = ["cover.no_tilt"]
+    opts[CONF_ENABLE_PROXY_COVER] = True
+    # supported_features = 15 → no SET_TILT_POSITION (128) bit
+    hass.states.async_set(
+        "cover.no_tilt",
+        "open",
+        {"current_position": 50, "supported_features": 15},
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "No Tilt", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id="proxy_cov_no_tilt",
+        title="No Tilt",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coord = hass.data[DOMAIN][entry.entry_id]
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+
+    # Use the proxy's own method directly — HA's framework would reject the
+    # service call up-front because supported_features doesn't include tilt,
+    # but the in-class guard still needs coverage for defence-in-depth.
+    proxy = next(
+        e
+        for e in hass.data["entity_components"]["cover"].entities
+        if e.entity_id == proxy_eid
+    )
+    await proxy.async_set_cover_tilt_position(tilt_position=80)
+    coord.async_apply_user_position.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Property null-paths: state missing entirely from HA
+# ---------------------------------------------------------------------------
+
+
+async def test_properties_when_source_state_object_missing(hass) -> None:
+    """When ``hass.states.get`` returns None, properties degrade safely."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = ["cover.transient"]
+    opts[CONF_ENABLE_PROXY_COVER] = True
+    hass.states.async_set(
+        "cover.transient",
+        "open",
+        {"current_position": 50, "supported_features": 143},
+    )
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Transient", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id="proxy_cov_missing",
+        title="Transient",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+    proxy = next(
+        e
+        for e in hass.data["entity_components"]["cover"].entities
+        if e.entity_id == proxy_eid
+    )
+    # Remove the source state object entirely
+    hass.states.async_remove("cover.transient")
+    await hass.async_block_till_done()
+
+    assert proxy.available is False
+    assert proxy.current_cover_position is None
+    assert proxy.current_cover_tilt_position is None
+    assert int(proxy.supported_features) == 0
+    assert proxy.is_closed is None
+
+
+# ---------------------------------------------------------------------------
+# Source friendly-label resolution branches
+# ---------------------------------------------------------------------------
+
+
+def test_source_friendly_label_state_friendly_name(hass) -> None:
+    """When no registry entry exists but state has friendly_name, use it."""
+    from custom_components.adaptive_cover_pro.cover import _source_friendly_label
+
+    hass.states.async_set(
+        "cover.unregistered_blind",
+        "open",
+        {"friendly_name": "Pretty Name"},
+    )
+    assert _source_friendly_label(hass, "cover.unregistered_blind") == "Pretty Name"
+
+
+def test_source_friendly_label_falls_back_to_object_id(hass) -> None:
+    """No registry, no friendly_name → titlecased object_id."""
+    from custom_components.adaptive_cover_pro.cover import _source_friendly_label
+
+    # No state, no entry
+    label = _source_friendly_label(hass, "cover.no_such_thing")
+    assert label == "No Such Thing"
+
+
+def test_source_friendly_label_uses_registry_name(hass) -> None:
+    """Registry entry with name takes priority over state friendly_name."""
+    from custom_components.adaptive_cover_pro.cover import _source_friendly_label
+    from homeassistant.helpers import entity_registry as er
+
+    reg = er.async_get(hass)
+    reg.async_get_or_create(
+        "cover", "test_platform", "uid_xyz", suggested_object_id="reg_blind"
+    )
+    reg.async_update_entity("cover.reg_blind", name="Registry Name")
+    hass.states.async_set(
+        "cover.reg_blind", "open", {"friendly_name": "Ignored State Name"}
+    )
+    assert _source_friendly_label(hass, "cover.reg_blind") == "Registry Name"

--- a/tests/cover/test_proxy_cover_mirror.py
+++ b/tests/cover/test_proxy_cover_mirror.py
@@ -1,0 +1,160 @@
+"""Proxy cover mirroring tests (Phase D Step 14)."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_INVERSE_STATE,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _setup_single(
+    hass,
+    *,
+    source: str = "cover.living_room",
+    entry_id: str = "proxy_mirror_01",
+    state: str = "open",
+    attrs: dict | None = None,
+    extra_options: dict | None = None,
+):
+    """Set up a single-source proxy and return ``(entry, proxy_entity_id)``."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = [source]
+    opts[CONF_ENABLE_PROXY_COVER] = True
+    if extra_options:
+        opts.update(extra_options)
+
+    hass.states.async_set(
+        source,
+        state,
+        attrs or {"current_position": 60, "supported_features": 143},
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Mirror Cover", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title="Mirror Cover",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+    return entry, proxy_eid
+
+
+async def test_proxy_mirrors_source_current_position(hass) -> None:
+    """``current_position`` from source state appears on the proxy state."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        attrs={"current_position": 42, "supported_features": 143},
+        entry_id="proxy_mirror_pos",
+    )
+    state = hass.states.get(proxy_eid)
+    assert state.attributes.get("current_position") == 42
+
+
+async def test_proxy_mirrors_source_current_tilt_position(hass) -> None:
+    """``current_tilt_position`` from source state appears on the proxy state."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        attrs={
+            "current_position": 60,
+            "current_tilt_position": 30,
+            "supported_features": 143 | 128,
+        },
+        entry_id="proxy_mirror_tilt",
+    )
+    state = hass.states.get(proxy_eid)
+    assert state.attributes.get("current_tilt_position") == 30
+
+
+async def test_proxy_mirrors_source_supported_features(hass) -> None:
+    """``supported_features`` from source state appears on the proxy state."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        attrs={"current_position": 0, "supported_features": 15},
+        entry_id="proxy_mirror_feats",
+    )
+    state = hass.states.get(proxy_eid)
+    assert state.attributes.get("supported_features") == 15
+
+
+async def test_proxy_unavailable_when_source_unavailable(hass) -> None:
+    """``state == unavailable`` on source → proxy state is unavailable."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state="unavailable",
+        attrs={},
+        entry_id="proxy_mirror_unavail",
+    )
+    state = hass.states.get(proxy_eid)
+    assert state.state == "unavailable"
+
+
+async def test_proxy_unavailable_when_source_unknown(hass) -> None:
+    """``state == unknown`` on source → proxy state is unavailable."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state="unknown",
+        attrs={},
+        entry_id="proxy_mirror_unknown",
+    )
+    state = hass.states.get(proxy_eid)
+    assert state.state == "unavailable"
+
+
+async def test_proxy_state_updates_on_source_state_change(hass) -> None:
+    """Updating source state propagates to proxy state attribute."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        attrs={"current_position": 50, "supported_features": 143},
+        entry_id="proxy_mirror_changes",
+    )
+    # Change source position
+    hass.states.async_set(
+        "cover.living_room",
+        "open",
+        {"current_position": 25, "supported_features": 143},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(proxy_eid)
+    assert state.attributes.get("current_position") == 25
+
+
+async def test_proxy_does_not_double_invert_position(hass) -> None:
+    """Even with ``CONF_INVERSE_STATE=True``, the proxy mirrors the source value verbatim.
+
+    The integration's set_position path inverts internally; the proxy must
+    not invert on the read side too. If source reports 30%, proxy shows 30%.
+    """
+    _, proxy_eid = await _setup_single(
+        hass,
+        attrs={"current_position": 30, "supported_features": 143},
+        entry_id="proxy_mirror_no_double_inv",
+        extra_options={CONF_INVERSE_STATE: True},
+    )
+    state = hass.states.get(proxy_eid)
+    assert state.attributes.get("current_position") == 30

--- a/tests/cover/test_proxy_cover_reload.py
+++ b/tests/cover/test_proxy_cover_reload.py
@@ -1,0 +1,105 @@
+"""Proxy cover dynamic reload tests (Phase E Step 19)."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _setup(
+    hass,
+    *,
+    proxy_enabled: bool,
+    entry_id: str,
+):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    opts = dict(VERTICAL_OPTIONS)
+    opts[CONF_ENTITIES] = ["cover.living_room"]
+    opts[CONF_ENABLE_PROXY_COVER] = proxy_enabled
+
+    hass.states.async_set(
+        "cover.living_room",
+        "open",
+        {"current_position": 50, "supported_features": 143},
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Reload Cover", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title="Reload Cover",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _proxy_states(hass, entry_id: str) -> list[str]:
+    from homeassistant.helpers import entity_registry as er
+
+    reg = er.async_get(hass)
+    return [
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry_id
+        and e.unique_id.startswith(f"{entry_id}_proxy_")
+        and hass.states.get(e.entity_id) is not None
+    ]
+
+
+async def test_enabling_proxy_via_options_creates_entities_on_reload(hass) -> None:
+    """Flipping the option on then reloading creates the proxy entity."""
+    entry = await _setup(hass, proxy_enabled=False, entry_id="proxy_reload_on")
+    assert _proxy_states(hass, entry.entry_id) == []
+
+    # Flip the option on; the update-listener triggers reload.
+    new_options = dict(entry.options)
+    new_options[CONF_ENABLE_PROXY_COVER] = True
+    with _patch_coordinator_refresh():
+        hass.config_entries.async_update_entry(entry, options=new_options)
+        await hass.async_block_till_done()
+
+    proxies = _proxy_states(hass, entry.entry_id)
+    assert len(proxies) == 1
+
+
+async def test_disabling_proxy_via_options_removes_entities_on_reload(hass) -> None:
+    """Flipping the option off then reloading retires the proxy state.
+
+    Per HA convention, the entity-registry entry is intentionally left
+    behind. The platform reload causes the live state to flip to
+    ``unavailable`` (the platform no longer publishes it).
+    """
+    entry = await _setup(hass, proxy_enabled=True, entry_id="proxy_reload_off")
+    proxies = _proxy_states(hass, entry.entry_id)
+    assert proxies, "proxy missing before disable"
+    proxy_eid = proxies[0]
+    # Live state is published before disable
+    assert hass.states.get(proxy_eid).state != "unavailable"
+
+    new_options = dict(entry.options)
+    new_options[CONF_ENABLE_PROXY_COVER] = False
+    with _patch_coordinator_refresh():
+        hass.config_entries.async_update_entry(entry, options=new_options)
+        await hass.async_block_till_done()
+
+    # After reload with proxy off, the platform no longer publishes the entity.
+    state = hass.states.get(proxy_eid)
+    assert (
+        state is None or state.state == "unavailable"
+    ), f"expected proxy retired (None/unavailable); got {state}"

--- a/tests/cover/test_proxy_cover_setup.py
+++ b/tests/cover/test_proxy_cover_setup.py
@@ -1,0 +1,162 @@
+"""Proxy cover entity setup tests (Phase D Step 12)."""
+
+from __future__ import annotations
+
+
+import pytest
+from homeassistant.util import slugify
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+
+pytestmark = pytest.mark.integration
+
+
+async def _setup_with_proxy(
+    hass,
+    *,
+    enabled: bool,
+    sources: list[str] | None = None,
+    entry_id: str = "proxy_setup_01",
+    name: str = "Adaptive Cover",
+):
+    """Set up an ACP entry with proxy toggle in a known state."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    opts = dict(VERTICAL_OPTIONS)
+    if sources is not None:
+        opts[CONF_ENTITIES] = sources
+    opts[CONF_ENABLE_PROXY_COVER] = enabled
+
+    # Seed the source cover state(s)
+    for src in opts[CONF_ENTITIES]:
+        hass.states.async_set(
+            src, "open", {"current_position": 100, "supported_features": 143}
+        )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": name, CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title=name,
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _proxy_states(hass, entry_id: str):
+    """Find all proxy cover state objects belonging to ``entry_id``."""
+    from homeassistant.helpers import entity_registry as er
+
+    reg = er.async_get(hass)
+    proxy_eids = {
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry_id
+        and e.unique_id.startswith(f"{entry_id}_proxy_")
+    }
+    return [hass.states.get(eid) for eid in proxy_eids if hass.states.get(eid)]
+
+
+async def test_no_proxy_entities_when_flag_disabled(hass) -> None:
+    """No proxy entity is created while CONF_ENABLE_PROXY_COVER is False."""
+    entry = await _setup_with_proxy(hass, enabled=False, entry_id="proxy_off")
+    assert _proxy_states(hass, entry.entry_id) == []
+
+
+async def test_one_proxy_entity_per_physical_cover_when_enabled(hass) -> None:
+    """One proxy is created per source in CONF_ENTITIES."""
+    sources = ["cover.living_room", "cover.bedroom"]
+    entry = await _setup_with_proxy(
+        hass, enabled=True, sources=sources, entry_id="proxy_two"
+    )
+    proxies = _proxy_states(hass, entry.entry_id)
+    assert len(proxies) == 2
+
+
+async def test_proxy_unique_id_format(hass) -> None:
+    """Unique ID follows ``{entry_id}_proxy_{slugify(source)}``."""
+    from homeassistant.helpers import entity_registry as er
+
+    sources = ["cover.living_room"]
+    entry = await _setup_with_proxy(
+        hass, enabled=True, sources=sources, entry_id="proxy_uid_01"
+    )
+    reg = er.async_get(hass)
+    expected = f"{entry.entry_id}_proxy_{slugify('cover.living_room')}"
+    matches = [e for e in reg.entities.values() if e.unique_id == expected]
+    assert matches, f"unique_id {expected!r} not found in registry"
+    assert matches[0].entity_id.startswith("cover.")
+
+
+async def test_proxy_name_single_cover(hass) -> None:
+    """Single-cover proxy name is ``f'{title} Slider'``."""
+    sources = ["cover.living_room"]
+    entry = await _setup_with_proxy(
+        hass,
+        enabled=True,
+        sources=sources,
+        entry_id="proxy_name_single",
+        name="Living Blinds",
+    )
+    proxies = _proxy_states(hass, entry.entry_id)
+    assert len(proxies) == 1
+    # Friendly name is on the state object
+    assert proxies[0].attributes.get("friendly_name") == "Living Blinds Slider"
+
+
+async def test_proxy_name_multiple_covers_includes_friendly_name(hass) -> None:
+    """Multi-cover proxy name includes the source friendly name."""
+    sources = ["cover.living_room", "cover.bedroom"]
+    # Source friendly names are inferred from entity_id when no friendly_name attr is set
+    entry = await _setup_with_proxy(
+        hass,
+        enabled=True,
+        sources=sources,
+        entry_id="proxy_name_multi",
+        name="Whole House",
+    )
+    proxies = _proxy_states(hass, entry.entry_id)
+    assert len(proxies) == 2
+    names = {p.attributes.get("friendly_name") for p in proxies}
+    # Each name starts with the base title and includes the source label
+    assert all(n.startswith("Whole House Slider (") for n in names), names
+    # Both source segments are present
+    joined = " | ".join(names)
+    assert "living_room" in joined.replace(" ", "_") or "Living" in joined
+    assert "bedroom" in joined.replace(" ", "_") or "Bedroom" in joined
+
+
+async def test_proxy_device_info_matches_acp_entry_device(hass) -> None:
+    """DeviceInfo identifier ``(DOMAIN, entry.entry_id)`` matches the entry's virtual device."""
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+
+    sources = ["cover.living_room"]
+    entry = await _setup_with_proxy(
+        hass, enabled=True, sources=sources, entry_id="proxy_dev_01"
+    )
+    e_reg = er.async_get(hass)
+    d_reg = dr.async_get(hass)
+    # Look up an ACP sensor created by the same entry to find the virtual device
+    own_entities = [
+        ent for ent in e_reg.entities.values() if ent.config_entry_id == entry.entry_id
+    ]
+    assert own_entities, "no entities registered for entry"
+    devices = {ent.device_id for ent in own_entities if ent.device_id}
+    assert (
+        len(devices) == 1
+    ), f"expected a single virtual device shared by all ACP entities; got {devices}"
+    device = d_reg.async_get(next(iter(devices)))
+    assert (DOMAIN, entry.entry_id) in device.identifiers

--- a/tests/cover/test_proxy_preemption_integration.py
+++ b/tests/cover/test_proxy_preemption_integration.py
@@ -1,0 +1,136 @@
+"""Proxy cover preemption + manual-override engagement (integration).
+
+Covers the contract added to ``Coordinator.async_apply_user_position`` when
+the proxy slider is moved:
+
+- A higher-priority pipeline winner (force_override, weather) silently
+  drops the move and records into ``last_skipped_action``.
+- An allowed move engages manual override pre-emptively so the next
+  coordinator cycle does not yank the cover off the user's set point.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    SensorType,
+)
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    DecisionStep,
+    PipelineResult,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+pytestmark = pytest.mark.integration
+
+
+async def _setup_proxy(hass, *, source: str = "cover.living_room"):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from homeassistant.helpers import entity_registry as er
+
+    base = dict(VERTICAL_OPTIONS)
+    base[CONF_ENTITIES] = [source]
+    base[CONF_ENABLE_PROXY_COVER] = True
+
+    hass.states.async_set(
+        source,
+        "open",
+        {"current_position": 50, "supported_features": 143},
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Proxy Pre", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=base,
+        entry_id="proxy_pre",
+        title="Proxy Pre",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    reg = er.async_get(hass)
+    proxy_eid = next(
+        e.entity_id
+        for e in reg.entities.values()
+        if e.config_entry_id == entry.entry_id
+        and e.unique_id.startswith(f"{entry.entry_id}_proxy_")
+    )
+    return entry, coordinator, proxy_eid
+
+
+async def test_proxy_slider_blocked_when_force_override_active(hass) -> None:
+    """force_override (priority 100) wins → no cover command, no manual override."""
+    _, coord, proxy_eid = await _setup_proxy(hass)
+
+    coord._pipeline = MagicMock()
+    coord._pipeline.evaluate.return_value = PipelineResult(
+        position=10,
+        control_method=ControlMethod.FORCE,
+        reason="force_override active",
+        decision_trace=[
+            DecisionStep(
+                handler="force_override",
+                matched=True,
+                reason="force",
+                position=10,
+            )
+        ],
+    )
+    fo = MagicMock()
+    fo.priority = 100
+    coord._handler_by_name = {"force_override": fo}
+    coord._cmd_svc.apply_position = MagicMock()
+    coord._cmd_svc.apply_position.side_effect = AssertionError(
+        "apply_position must not be called when force_override preempts"
+    )
+    coord.manager.mark_user_command = MagicMock()
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": proxy_eid, "position": 30},
+        blocking=True,
+    )
+
+    coord.manager.mark_user_command.assert_not_called()
+    assert coord._cmd_svc.last_skipped_action.get("reason") == "preempted_by_handler"
+    assert coord._cmd_svc.last_skipped_action.get("winner") == "force_override"
+
+
+async def test_proxy_slider_engages_manual_override_on_success(hass) -> None:
+    """A successful proxy slider move marks the source cover as manually overridden."""
+    _, coord, proxy_eid = await _setup_proxy(hass)
+
+    # Pipeline winner: solar (priority 40 < ManualOverride priority 80).
+    coord._pipeline = MagicMock()
+    coord._pipeline.evaluate.return_value = PipelineResult(
+        position=80,
+        control_method=ControlMethod.SOLAR,
+        reason="solar",
+        decision_trace=[
+            DecisionStep(handler="solar", matched=True, reason="solar", position=80)
+        ],
+    )
+    handler = MagicMock()
+    handler.priority = 40
+    coord._handler_by_name = {"solar": handler}
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_position",
+        {"entity_id": proxy_eid, "position": 30},
+        blocking=True,
+    )
+
+    assert coord.manager.is_cover_manual("cover.living_room")

--- a/tests/services/__init__.py
+++ b/tests/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service-layer tests."""

--- a/tests/services/test_set_position_service.py
+++ b/tests/services/test_set_position_service.py
@@ -1,0 +1,110 @@
+"""Regression test for set_position service min-mode floor clamp.
+
+This test locks in the floor-clamping contract BEFORE the helper extraction
+refactor (Phase B). The same clamp behaviour must continue to hold after
+``async_handle_set_position`` is rewritten to delegate to
+``Coordinator.async_apply_user_position``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+)
+
+
+def _slot(position: int, *, is_on: bool, min_mode: bool) -> CustomPositionSensorState:
+    return CustomPositionSensorState(
+        entity_id=f"binary_sensor.slot_p{position}",
+        is_on=is_on,
+        position=position,
+        priority=77,
+        min_mode=min_mode,
+        use_my=False,
+    )
+
+
+def _make_coord(custom_states):
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock()
+    coord.entities = ["cover.living_room"]
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord._read_custom_position_sensor_states.return_value = custom_states
+    ctx = MagicMock(name="position_context")
+    coord._build_position_context.return_value = ctx
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.apply_position = AsyncMock(
+        return_value=("sent", "set_cover_position")
+    )
+    coord.async_apply_user_position = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_position.__get__(coord)
+    )
+    return coord, ctx
+
+
+@pytest.mark.asyncio
+async def test_set_position_clamps_requested_below_min_mode_floor() -> None:
+    """Two slots: slot 1 (min_mode, on, pos=30); slot 2 (not-min, off, pos=80).
+
+    Verifies the documented contract of the existing service:
+      - position=10 (below floor)  → clamped up to 30, force=True
+      - position=50 (above floor)  → passes through unchanged, force=True
+      - no min-mode active         → passes through unchanged
+    """
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    slot1 = _slot(30, is_on=True, min_mode=True)
+    slot2 = _slot(80, is_on=False, min_mode=False)
+
+    # Case 1: below floor → clamps to 30
+    coord, ctx = _make_coord([slot1, slot2])
+    call = MagicMock()
+    call.data = {"position": 10}
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.living_room", 30, "set_position", ctx
+    )
+    # force=True passed to _build_position_context
+    _, kwargs = coord._build_position_context.call_args
+    assert kwargs.get("force") is True
+
+    # Case 2: above floor → unchanged at 50
+    coord, ctx = _make_coord([slot1, slot2])
+    call = MagicMock()
+    call.data = {"position": 50}
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.living_room", 50, "set_position", ctx
+    )
+
+    # Case 3: no min-mode floor active → passes through
+    slot_off = _slot(30, is_on=False, min_mode=True)
+    coord, ctx = _make_coord([slot_off])
+    call = MagicMock()
+    call.data = {"position": 10}
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.living_room", 10, "set_position", ctx
+    )

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -314,6 +314,19 @@ async def _trigger_switch_auto_control_off_return(coord):
     await switch.async_turn_off()
 
 
+async def _trigger_async_apply_user_position(coord):
+    """Trigger: user-initiated position (set_position service / proxy slider).
+
+    ``async_apply_user_position`` builds a force=True context so the slider
+    move bypasses delta/time/manual_override gates. Not a safety target —
+    the move should not persist across window boundaries.
+    """
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord._read_custom_position_sensor_states = MagicMock(return_value=[])
+    await coord.async_apply_user_position("cover.test", 42, trigger="set_position")
+
+
 CONTROL_GATE_MATRIX: list[MatrixCase] = [
     MatrixCase(
         id="manual_override_expiry",
@@ -376,6 +389,16 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
         is_safety_target=False,
         setup=lambda _: None,
         trigger=_trigger_switch_auto_control_off_return,
+    ),
+    MatrixCase(
+        # User-initiated single entry point (set_position service + opt-in
+        # proxy cover entity). Bypasses gates via force=True so the slider
+        # move lands immediately, but the target is NOT persisted.
+        id="async_apply_user_position",
+        is_safety_bypass=True,
+        is_safety_target=False,
+        setup=lambda _: None,
+        trigger=_trigger_async_apply_user_position,
     ),
 ]
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -315,16 +315,20 @@ async def _trigger_switch_auto_control_off_return(coord):
 
 
 async def _trigger_async_apply_user_position(coord):
-    """Trigger: user-initiated position (set_position service / proxy slider).
+    """Trigger: ``set_position`` service called with ``force=True``.
 
-    ``async_apply_user_position`` builds a force=True context so the slider
-    move bypasses delta/time/manual_override gates. Not a safety target —
-    the move should not persist across window boundaries.
+    ``async_apply_user_position(force=True)`` builds a force=True context so
+    the slider move bypasses delta/time/manual_override gates. Not a safety
+    target — the move should not persist across window boundaries. The new
+    ``force=False`` default contract (pipeline preemption + manual-override
+    engagement) is covered in ``test_coordinator_apply_user_position.py``.
     """
     coord.config_entry = MagicMock()
     coord.config_entry.options = {}
     coord._read_custom_position_sensor_states = MagicMock(return_value=[])
-    await coord.async_apply_user_position("cover.test", 42, trigger="set_position")
+    await coord.async_apply_user_position(
+        "cover.test", 42, trigger="set_position", force=True
+    )
 
 
 CONTROL_GATE_MATRIX: list[MatrixCase] = [

--- a/tests/test_config_flow_proxy_cover.py
+++ b/tests/test_config_flow_proxy_cover.py
@@ -1,0 +1,49 @@
+"""Config-flow plumbing for the opt-in proxy cover toggle."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from custom_components.adaptive_cover_pro.config_flow import _build_cover_entity_schema
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_PROXY_COVER,
+    CONF_ENTITIES,
+    DEFAULT_ENABLE_PROXY_COVER,
+    SensorType,
+)
+
+
+def _schema_defaults(schema: vol.Schema) -> dict[str, Any]:
+    """Return {key_name: default_value} for every Optional key in ``schema``."""
+    out: dict[str, Any] = {}
+    for key in schema.schema:
+        if isinstance(key, vol.Optional):
+            default = key.default
+            value = default() if callable(default) else default
+            out[str(key)] = value
+    return out
+
+
+def test_cover_entity_schema_contains_enable_proxy_cover_field() -> None:
+    """``_build_cover_entity_schema`` exposes the new toggle."""
+    schema = _build_cover_entity_schema(SensorType.BLIND)
+    names = [str(k) for k in schema.schema]
+    assert CONF_ENABLE_PROXY_COVER in names
+
+
+def test_proxy_cover_defaults_to_false() -> None:
+    """The toggle defaults to the DEFAULT_ENABLE_PROXY_COVER value (False)."""
+    schema = _build_cover_entity_schema(SensorType.BLIND)
+    defaults = _schema_defaults(schema)
+    assert (
+        defaults.get(CONF_ENABLE_PROXY_COVER) is DEFAULT_ENABLE_PROXY_COVER
+    ), f"expected default False; got {defaults!r}"
+
+
+def test_proxy_cover_schema_validates_boolean_round_trip() -> None:
+    """User input of ``True`` round-trips through the schema."""
+    schema = _build_cover_entity_schema(SensorType.BLIND)
+    out = schema({CONF_ENTITIES: [], CONF_ENABLE_PROXY_COVER: True})
+    assert out[CONF_ENABLE_PROXY_COVER] is True

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -2024,3 +2024,52 @@ def test_motion_summary_hold_mode_no_sensors_shows_warning():
         and "hold_position" in summary.lower()
         or ("hold_position" in summary or "hold position" in summary.lower())
     )
+
+
+# ---------------------------------------------------------------------------
+# Proxy cover summary line + min-mode warning
+# ---------------------------------------------------------------------------
+
+
+def test_config_summary_shows_proxy_cover_disabled_by_default():
+    """Default-off proxy cover is reflected in the summary."""
+    from custom_components.adaptive_cover_pro.const import CONF_ENABLE_PROXY_COVER
+
+    cfg = _minimal_vertical()
+    cfg[CONF_ENABLE_PROXY_COVER] = False
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    assert "Proxy cover" in summary
+    proxy_line = next(ln for ln in summary.splitlines() if "Proxy cover" in ln)
+    assert "disabled" in proxy_line.lower()
+
+
+def test_config_summary_shows_proxy_cover_enabled():
+    """Enabled proxy cover is reflected in the summary."""
+    from custom_components.adaptive_cover_pro.const import CONF_ENABLE_PROXY_COVER
+
+    cfg = _minimal_vertical()
+    cfg[CONF_ENABLE_PROXY_COVER] = True
+    # A min-mode slot is configured so no warning fires.
+    cfg["custom_position_sensor_1"] = "binary_sensor.evening"
+    cfg["custom_position_1"] = 60
+    cfg["custom_position_min_mode_1"] = True
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    proxy_line = next(ln for ln in summary.splitlines() if "Proxy cover" in ln)
+    assert "enabled" in proxy_line.lower()
+
+
+def test_config_summary_warns_when_proxy_enabled_without_min_mode_slot():
+    """Proxy enabled with no min-mode slots → ⚠ warning line."""
+    from custom_components.adaptive_cover_pro.const import CONF_ENABLE_PROXY_COVER
+
+    cfg = _minimal_vertical()
+    cfg[CONF_ENABLE_PROXY_COVER] = True
+    # A custom slot is configured but min_mode=False.
+    cfg["custom_position_sensor_1"] = "binary_sensor.evening"
+    cfg["custom_position_1"] = 60
+    cfg["custom_position_min_mode_1"] = False
+    summary = _build_config_summary(cfg, SensorType.BLIND)
+    proxy_block = [ln for ln in summary.splitlines() if "proxy" in ln.lower()]
+    assert any(
+        "⚠" in ln for ln in proxy_block
+    ), f"expected ⚠ warning near proxy line; got: {proxy_block}"

--- a/tests/test_const_proxy_cover.py
+++ b/tests/test_const_proxy_cover.py
@@ -1,0 +1,14 @@
+"""Constants for the opt-in proxy cover feature."""
+
+from __future__ import annotations
+
+
+def test_proxy_cover_constants_exist() -> None:
+    """CONF_ENABLE_PROXY_COVER and DEFAULT_ENABLE_PROXY_COVER are defined."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENABLE_PROXY_COVER,
+        DEFAULT_ENABLE_PROXY_COVER,
+    )
+
+    assert CONF_ENABLE_PROXY_COVER == "enable_proxy_cover"
+    assert DEFAULT_ENABLE_PROXY_COVER is False

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -1,0 +1,135 @@
+"""Tests for ``Coordinator.async_apply_user_position`` shared helper.
+
+This helper is the single delegation point for any user-initiated cover
+position command (the ``set_position`` integration service, the opt-in
+proxy cover entity, future external triggers). It owns the min-mode floor
+clamp + force-context build + ``apply_position`` dispatch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+)
+
+
+def _slot(pos: int, *, is_on: bool, min_mode: bool) -> CustomPositionSensorState:
+    return CustomPositionSensorState(
+        entity_id=f"binary_sensor.slot_{pos}",
+        is_on=is_on,
+        position=pos,
+        priority=77,
+        min_mode=min_mode,
+        use_my=False,
+    )
+
+
+def _make_coord(custom_states, *, default_options=None):
+    """Build a coordinator-shaped mock that exposes async_apply_user_position.
+
+    We import the *real* method off the Coordinator class and bind it onto a
+    MagicMock so we can drive it without a full HA setup.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = default_options if default_options is not None else {}
+    coord._read_custom_position_sensor_states.return_value = custom_states
+    ctx = MagicMock(name="position_context")
+    coord._build_position_context.return_value = ctx
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.apply_position = AsyncMock(
+        return_value=("sent", "set_cover_position")
+    )
+
+    # Bind the real method
+    coord.async_apply_user_position = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_position.__get__(coord)
+    )
+    return coord, ctx
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_position_clamps_to_min_mode_floor() -> None:
+    """Requested < highest active min-mode floor → clamped up to floor."""
+    coord, ctx = _make_coord([_slot(40, is_on=True, min_mode=True)])
+
+    await coord.async_apply_user_position("cover.test", 10, trigger="set_position")
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 40, "set_position", ctx
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_position_passes_above_floor_unchanged() -> None:
+    """Requested > floor → passes through unchanged."""
+    coord, ctx = _make_coord([_slot(40, is_on=True, min_mode=True)])
+
+    await coord.async_apply_user_position("cover.test", 80, trigger="proxy_slider")
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 80, "proxy_slider", ctx
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_position_no_floors_uses_requested() -> None:
+    """No active min-mode slots → requested value passes through."""
+    coord, ctx = _make_coord(
+        [_slot(80, is_on=True, min_mode=False), _slot(20, is_on=False, min_mode=True)]
+    )
+
+    await coord.async_apply_user_position("cover.test", 5, trigger="set_position")
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 5, "set_position", ctx
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_position_uses_force_context() -> None:
+    """_build_position_context must be called with force=True."""
+    coord, _ctx = _make_coord([])
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_open")
+
+    coord._build_position_context.assert_called_once()
+    _, kwargs = coord._build_position_context.call_args
+    assert kwargs.get("force") is True
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_position_accepts_trigger_label() -> None:
+    """The trigger label is forwarded verbatim to ``apply_position``."""
+    coord, ctx = _make_coord([])
+    await coord.async_apply_user_position("cover.test", 33, trigger="proxy_tilt")
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 33, "proxy_tilt", ctx
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_position_uses_passed_options_when_provided() -> None:
+    """When ``options`` is passed, it overrides ``self.config_entry.options``."""
+    entry_options = {"from": "entry"}
+    coord, _ctx = _make_coord(
+        [_slot(70, is_on=True, min_mode=True)], default_options=entry_options
+    )
+    custom_options = {"from": "override"}
+
+    await coord.async_apply_user_position(
+        "cover.test", 10, trigger="set_position", options=custom_options
+    )
+
+    coord._read_custom_position_sensor_states.assert_called_once_with(custom_options)
+    # And the override flowed into _build_position_context too
+    args, kwargs = coord._build_position_context.call_args
+    # signature: (entity, options, *, force=...)
+    assert args[1] is custom_options or kwargs.get("options") is custom_options

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -3,7 +3,8 @@
 This helper is the single delegation point for any user-initiated cover
 position command (the ``set_position`` integration service, the opt-in
 proxy cover entity, future external triggers). It owns the min-mode floor
-clamp + force-context build + ``apply_position`` dispatch.
+clamp, the pipeline preemption check, manual-override engagement, and the
+``apply_position`` dispatch.
 """
 
 from __future__ import annotations
@@ -12,8 +13,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.pipeline.handlers.manual_override import (
+    ManualOverrideHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
+    DecisionStep,
+    PipelineResult,
 )
 
 
@@ -28,11 +34,38 @@ def _slot(pos: int, *, is_on: bool, min_mode: bool) -> CustomPositionSensorState
     )
 
 
-def _make_coord(custom_states, *, default_options=None):
+def _pipeline_result_with_winner(
+    handler_name: str, priority: int, position: int = 50
+) -> PipelineResult:
+    """Build a synthetic ``PipelineResult`` whose decision_trace flags ``handler_name`` as the matched winner."""
+    from custom_components.adaptive_cover_pro.enums import ControlMethod
+
+    return PipelineResult(
+        position=position,
+        control_method=ControlMethod.SOLAR,
+        reason="test",
+        decision_trace=[
+            DecisionStep(
+                handler=handler_name, matched=True, reason="test", position=position
+            )
+        ],
+    )
+
+
+def _make_coord(
+    custom_states,
+    *,
+    default_options=None,
+    winner_name: str = "solar",
+    winner_priority: int = 40,
+):
     """Build a coordinator-shaped mock that exposes async_apply_user_position.
 
     We import the *real* method off the Coordinator class and bind it onto a
-    MagicMock so we can drive it without a full HA setup.
+    MagicMock so we can drive it without a full HA setup. By default the
+    pipeline mock returns ``solar`` (priority 40) as the winner — strictly
+    less than ``ManualOverrideHandler.priority`` (80), so the preemption
+    check passes through to dispatch.
     """
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
@@ -48,6 +81,26 @@ def _make_coord(custom_states, *, default_options=None):
     coord._cmd_svc.apply_position = AsyncMock(
         return_value=("sent", "set_cover_position")
     )
+    coord._cmd_svc.record_preempted_skip = MagicMock()
+
+    # Pipeline mock: returns a synthetic result with the named handler as winner.
+    coord._pipeline = MagicMock()
+    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
+        winner_name, winner_priority
+    )
+
+    # _build_pipeline_snapshot is stubbed — preemption check just needs an object.
+    snapshot_sentinel = MagicMock(name="pipeline_snapshot")
+    coord._build_pipeline_snapshot = MagicMock(return_value=snapshot_sentinel)
+
+    # Handler lookup so the helper can resolve priority from the winner step.
+    handler = MagicMock()
+    handler.priority = winner_priority
+    coord._handler_by_name = {winner_name: handler}
+
+    # Manager for manual-override engagement.
+    coord.manager = MagicMock()
+    coord.manager.mark_user_command = MagicMock()
 
     # Bind the real method
     coord.async_apply_user_position = (
@@ -133,3 +186,154 @@ async def test_async_apply_user_position_uses_passed_options_when_provided() -> 
     args, kwargs = coord._build_position_context.call_args
     # signature: (entity, options, *, force=...)
     assert args[1] is custom_options or kwargs.get("options") is custom_options
+
+
+# ---------------------------------------------------------------------------
+# New contract: pipeline preemption check + manual-override engagement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_engages_manual_override_when_no_preemption() -> None:
+    """Default path: solar winner (40) < ManualOverride priority → command dispatched and manual override engaged."""
+    coord, ctx = _make_coord([], winner_name="solar", winner_priority=40)
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 50, trigger="proxy_slider"
+    )
+
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.test", reason="proxy_slider"
+    )
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 50, "proxy_slider", ctx
+    )
+    assert outcome == ("sent", "set_cover_position")
+
+
+@pytest.mark.asyncio
+async def test_default_skipped_when_force_override_active() -> None:
+    """force_override (100) wins → command dropped, manual override not engaged."""
+    coord, _ctx = _make_coord([], winner_name="force_override", winner_priority=100)
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 50, trigger="proxy_slider"
+    )
+
+    assert outcome == ("skipped", "preempted_by_force_override")
+    coord._cmd_svc.apply_position.assert_not_awaited()
+    coord.manager.mark_user_command.assert_not_called()
+    coord._cmd_svc.record_preempted_skip.assert_called_once_with(
+        "cover.test", 50, trigger="proxy_slider", winner_name="force_override"
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_skipped_when_weather_active() -> None:
+    """Weather (90) wins → command dropped, manual override not engaged."""
+    coord, _ctx = _make_coord([], winner_name="weather", winner_priority=90)
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 30, trigger="set_position"
+    )
+
+    assert outcome == ("skipped", "preempted_by_weather")
+    coord._cmd_svc.apply_position.assert_not_awaited()
+    coord.manager.mark_user_command.assert_not_called()
+    coord._cmd_svc.record_preempted_skip.assert_called_once_with(
+        "cover.test", 30, trigger="set_position", winner_name="weather"
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_not_blocked_by_cloud_suppression() -> None:
+    """cloud_suppression (60) does NOT preempt — command dispatched + manual override engaged."""
+    coord, ctx = _make_coord([], winner_name="cloud_suppression", winner_priority=60)
+
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_slider")
+
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.test", reason="proxy_slider"
+    )
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 50, "proxy_slider", ctx
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_not_blocked_by_solar() -> None:
+    """Solar (40) does NOT preempt — command dispatched + manual override engaged."""
+    coord, ctx = _make_coord([], winner_name="solar", winner_priority=40)
+
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_slider")
+
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.test", reason="proxy_slider"
+    )
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 50, "proxy_slider", ctx
+    )
+
+
+@pytest.mark.asyncio
+async def test_force_true_bypasses_pipeline_check() -> None:
+    """force=True with force_override winner → command still dispatches."""
+    coord, ctx = _make_coord([], winner_name="force_override", winner_priority=100)
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 50, trigger="set_position", force=True
+    )
+
+    assert outcome == ("sent", "set_cover_position")
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 50, "set_position", ctx
+    )
+    # Pipeline must NOT have been consulted on the force=True path
+    coord._pipeline.evaluate.assert_not_called()
+    coord._cmd_svc.record_preempted_skip.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_true_does_not_engage_manual_override() -> None:
+    """force=True must NOT call mark_user_command, regardless of pipeline winner."""
+    coord, _ctx = _make_coord([], winner_name="solar", winner_priority=40)
+
+    await coord.async_apply_user_position(
+        "cover.test", 50, trigger="set_position", force=True
+    )
+
+    coord.manager.mark_user_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_passed_to_pipeline_has_manual_override_false() -> None:
+    """Meta-bug guard: preemption snapshot must force manual_override_active=False.
+
+    Otherwise a stale manual_control flag would self-claim priority 80 and
+    let the cover move anyway.
+    """
+    coord, _ctx = _make_coord([], winner_name="solar", winner_priority=40)
+    coord.manager.binary_cover_manual = True  # stale flag set
+
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_slider")
+
+    coord._build_pipeline_snapshot.assert_called_once()
+    _, kwargs = coord._build_pipeline_snapshot.call_args
+    assert kwargs.get("manual_override_active") is False
+
+
+@pytest.mark.asyncio
+async def test_preempted_skip_recorded_in_last_skipped_action() -> None:
+    """When preempted, record_preempted_skip is called with the winner name."""
+    coord, _ctx = _make_coord([], winner_name="force_override", winner_priority=100)
+
+    await coord.async_apply_user_position("cover.test", 42, trigger="proxy_slider")
+
+    coord._cmd_svc.record_preempted_skip.assert_called_once_with(
+        "cover.test", 42, trigger="proxy_slider", winner_name="force_override"
+    )
+
+
+def test_manual_override_priority_constant_unchanged() -> None:
+    """Locks in ManualOverrideHandler.priority=80 so the preemption cutoff stays correct."""
+    assert ManualOverrideHandler.priority == 80

--- a/tests/test_force_apply_allowlist.py
+++ b/tests/test_force_apply_allowlist.py
@@ -74,6 +74,10 @@ ALLOWED_LITERAL_FORCE_TRUE_SITES: frozenset[str] = frozenset(
         "_async_send_after_override_clear",
         # _on_window_closed removed: it now uses force=False so the end-time
         # target is not safety-tagged.  See issue #215/#216 fix.
+        # User-initiated single entry point (set_position service + opt-in
+        # proxy cover entity). Bypasses delta/time/manual_override gates so
+        # an explicit slider move always lands.
+        "async_apply_user_position",
     }
 )
 
@@ -105,7 +109,7 @@ def _enclosing_function(node: ast.AST, tree: ast.Module) -> str | None:
     current = parent.get(id(node))
     innermost = None
     while current is not None:
-        if isinstance(current, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef):
             innermost = current.name
             break
         current = parent.get(id(current))

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -415,3 +415,98 @@ async def test_reset_button_sends_correct_position_with_climate_mode():
     sent_position = call[0][0]
     assert sent_position == CLIMATE_POSITION
     assert sent_position != SOLAR_POSITION
+
+
+# ---------------------------------------------------------------------------
+# mark_user_command — pre-emptive manual-override entry point used by the
+# proxy cover and the set_position service.
+# ---------------------------------------------------------------------------
+
+
+def test_mark_user_command_sets_flag_and_timestamp():
+    """mark_user_command flips manual_control and records a timestamp."""
+    from custom_components.adaptive_cover_pro.managers.manual_override import (
+        AdaptiveCoverManager,
+    )
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(), reset_duration={"minutes": 15}, logger=MagicMock()
+    )
+    manager.add_covers(["cover.test"])
+
+    manager.mark_user_command("cover.test", reason="proxy_slider")
+
+    assert manager.is_cover_manual("cover.test")
+    assert "cover.test" in manager.manual_control_time
+    assert isinstance(manager.manual_control_time["cover.test"], dt.datetime)
+
+
+def test_mark_user_command_records_diagnostic_event():
+    """mark_user_command pushes a manual_override_set event into the ring buffer."""
+    from custom_components.adaptive_cover_pro.managers.manual_override import (
+        AdaptiveCoverManager,
+    )
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(), reset_duration={"minutes": 15}, logger=MagicMock()
+    )
+
+    manager.mark_user_command("cover.test", reason="set_position")
+
+    events = manager.get_event_buffer()
+    matching = [
+        e
+        for e in events
+        if e.get("event") == "manual_override_set"
+        and e.get("entity_id") == "cover.test"
+        and e.get("reason") == "set_position"
+    ]
+    assert matching, f"expected manual_override_set event, got {events}"
+
+
+def test_mark_user_command_works_for_entity_not_in_covers():
+    """mark_user_command must not require entity_id ∈ self.covers.
+
+    The proxy may dispatch before add_covers() runs during integration setup.
+    """
+    from custom_components.adaptive_cover_pro.managers.manual_override import (
+        AdaptiveCoverManager,
+    )
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(), reset_duration={"minutes": 15}, logger=MagicMock()
+    )
+    # Intentionally not calling add_covers(["cover.test"])
+
+    manager.mark_user_command("cover.test", reason="proxy_slider")
+
+    assert manager.is_cover_manual("cover.test")
+
+
+def test_mark_user_command_setdefault_does_not_extend_timestamp():
+    """Calling mark_user_command twice preserves the first timestamp.
+
+    Matches allow_reset=False semantics so successive drags do not extend
+    the override window.
+    """
+    from custom_components.adaptive_cover_pro.managers.manual_override import (
+        AdaptiveCoverManager,
+    )
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(), reset_duration={"minutes": 15}, logger=MagicMock()
+    )
+
+    manager.mark_user_command("cover.test", reason="first")
+    first_ts = manager.manual_control_time["cover.test"]
+
+    # Move the clock forward slightly between calls
+    import time
+
+    time.sleep(0.01)
+    manager.mark_user_command("cover.test", reason="second")
+    second_ts = manager.manual_control_time["cover.test"]
+
+    assert (
+        second_ts == first_ts
+    ), f"timestamp must not be extended: first={first_ts}, second={second_ts}"

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -47,6 +47,7 @@ import custom_components.adaptive_cover_pro.sensor  # noqa: F401
 import custom_components.adaptive_cover_pro.binary_sensor  # noqa: F401
 import custom_components.adaptive_cover_pro.switch  # noqa: F401
 import custom_components.adaptive_cover_pro.button  # noqa: F401
+import custom_components.adaptive_cover_pro.cover  # noqa: F401
 
 from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverClimateStatusSensor,
@@ -68,6 +69,7 @@ from custom_components.adaptive_cover_pro.binary_sensor import (
 )
 from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
 from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -77,6 +79,13 @@ from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
 def _make_hass():
     hass = MagicMock()
     hass.config.units.temperature_unit = "°C"
+    return hass
+
+
+def _make_hass_no_states():
+    """Hass mock whose states.get() returns None — proxy/source-mirroring entities."""
+    hass = _make_hass()
+    hass.states.get = MagicMock(return_value=None)
     return hass
 
 
@@ -212,6 +221,17 @@ ENTITY_FACTORIES: dict[type, object] = {
         hass=_make_hass(),
         config_entry=_make_config_entry(),
         coordinator=_make_coordinator(),
+    ),
+    # --- cover.py ---
+    # Proxy mirrors source-cover availability via hass.states.get(); a hass
+    # mock that returns None for states.get yields available=False naturally.
+    AdaptiveProxyCover: lambda: AdaptiveProxyCover(
+        entry_id="test_avail_entry",
+        hass=_make_hass_no_states(),
+        config_entry=_make_config_entry(),
+        coordinator=_make_coordinator(),
+        source_entity_id="cover.test_source",
+        multi=False,
     ),
 }
 

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -695,3 +695,127 @@ async def test_non_min_mode_slot_on_does_not_clamp() -> None:
         "set_position",
         coord._build_position_context.return_value,
     )
+
+
+# ---------------------------------------------------------------------------
+# New contract: ``force`` parameter and pipeline preemption
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_default_engages_manual_override() -> None:
+    """Calling the service without ``force`` engages manual override."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(custom_states=[])
+    call = MagicMock()
+    call.data = {"position": 50}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    # mark_user_command must have been called (via the bound real method).
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.test_blind", reason="set_position"
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_force_true_bypasses_pipeline() -> None:
+    """With ``force=True`` even an active weather override does not block.
+
+    Default pipeline mock auto-yields no winner step (iterating a MagicMock
+    returns empty), so the legacy bypass path is exercised directly: the
+    command dispatches and manual override is NOT engaged.
+    """
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(custom_states=[])
+    call = MagicMock()
+    call.data = {"position": 50, "force": True}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_awaited_once()
+    coord.manager.mark_user_command.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_service_force_default_preempted_by_force_override() -> None:
+    """With force=False (default) and force_override winning, the call is rejected."""
+    from custom_components.adaptive_cover_pro.pipeline.types import (
+        DecisionStep,
+        PipelineResult,
+    )
+    from custom_components.adaptive_cover_pro.enums import ControlMethod
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = _make_coord(custom_states=[])
+    # Wire up the pipeline mock and handler lookup explicitly so the
+    # preemption branch resolves a real priority value.
+    coord._pipeline.evaluate.return_value = PipelineResult(
+        position=10,
+        control_method=ControlMethod.FORCE,
+        reason="force",
+        decision_trace=[
+            DecisionStep(
+                handler="force_override", matched=True, reason="force", position=10
+            )
+        ],
+    )
+    handler = MagicMock()
+    handler.priority = 100
+    coord._handler_by_name = {"force_override": handler}
+    coord._cmd_svc.record_preempted_skip = MagicMock()
+
+    call = MagicMock()
+    call.data = {"position": 50}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord._cmd_svc.apply_position.assert_not_awaited()
+    coord.manager.mark_user_command.assert_not_called()
+    coord._cmd_svc.record_preempted_skip.assert_called_once_with(
+        "cover.test_blind",
+        50,
+        trigger="set_position",
+        winner_name="force_override",
+    )
+
+
+def test_schema_accepts_force_parameter() -> None:
+    """SET_POSITION_SCHEMA accepts the new optional ``force`` field."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    result = SET_POSITION_SCHEMA({"position": 50, "force": True})
+    assert result["position"] == 50
+    assert result["force"] is True
+
+
+def test_schema_defaults_force_to_false() -> None:
+    """SET_POSITION_SCHEMA defaults ``force`` to False when omitted."""
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        SET_POSITION_SCHEMA,
+    )
+
+    result = SET_POSITION_SCHEMA({"position": 50})
+    assert result.get("force") is False

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -83,6 +83,15 @@ def _make_coord(
     coord._cmd_svc = MagicMock()
     coord._cmd_svc.apply_position = AsyncMock(return_value=apply_position_result)
 
+    # Bind the real coordinator helper so the service exercises it.
+    from custom_components.adaptive_cover_pro.coordinator import (  # noqa: PLC0415
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord.async_apply_user_position = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_position.__get__(coord)
+    )
+
     return coord
 
 


### PR DESCRIPTION
## Summary
- Adds an opt-in `Expose Proxy Cover Entity` toggle on the Covers & Device step. When enabled, ACP creates one `cover.*_slider` proxy per physical cover.
- The proxy intercepts `cover.set_cover_position` / `open_cover` / `close_cover` / `set_cover_tilt_position` and routes them through the same min-mode floor clamp the `set_position` service already uses, so dashboard sliders (HA core, mushroom-cover-card, etc.) respect the floor.
- Floor-clamp logic extracted from `set_position_service` into a new shared `Coordinator.async_apply_user_position` helper — one code path, two callers.
- `stop_cover` passes through unclamped; commands while the source cover is unavailable are dropped.

## Testing
- ✅ 3118 tests passing (baseline 3074 + 44 new)
- ✅ 100% patch coverage on `cover.py`
- ✅ DE/FR translations synced for the new toggle label and description

## Related Issues
Refs #374