### PR TITLE
feat: surface active weather conditions on decision trace sensor

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/weather.py
+++ b/custom_components/adaptive_cover_pro/managers/weather.py
@@ -18,6 +18,13 @@ from ..const import (
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
+# Condition label constants — used in active_conditions list
+_COND_WIND_SPEED = "wind_speed"
+_COND_RAIN_RATE = "rain_rate"
+_COND_IS_RAINING = "is_raining"
+_COND_IS_WINDY = "is_windy"
+_COND_SEVERE = "severe_weather"
+
 
 class WeatherManager:
     """Manage weather-based safety overrides for cover control.
@@ -157,6 +164,27 @@ class WeatherManager:
     def is_timeout_running(self) -> bool:
         """Return True when a clear-delay timeout task is pending."""
         return self._timeout_task is not None and not self._timeout_task.done()
+
+    @property
+    def in_clear_delay(self) -> bool:
+        """Return True when override is held active by the clear-delay timer."""
+        return self.is_timeout_running
+
+    @property
+    def active_conditions(self) -> list[str]:
+        """Return labels of currently active weather conditions."""
+        result = []
+        if self._is_wind_active():
+            result.append(_COND_WIND_SPEED)
+        if self._is_rain_active():
+            result.append(_COND_RAIN_RATE)
+        if self._is_binary_on(self._is_raining_sensor):
+            result.append(_COND_IS_RAINING)
+        if self._is_binary_on(self._is_windy_sensor):
+            result.append(_COND_IS_WINDY)
+        if self._is_any_severe_active():
+            result.append(_COND_SEVERE)
+        return result
 
     # --- Condition evaluation helpers ---
 

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -716,6 +716,10 @@ def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
         attrs["configured_sunset_pos"] = result.configured_sunset_pos
         if result.tilt is not None:
             attrs["tilt"] = result.tilt
+        if result.control_method == ControlMethod.WEATHER:
+            weather_mgr = s.coordinator._weather_mgr  # noqa: SLF001
+            attrs["weather_active_conditions"] = weather_mgr.active_conditions
+            attrs["weather_in_clear_delay"] = weather_mgr.in_clear_delay
 
     attrs["in_time_window"] = s.coordinator.check_adaptive_time
     attrs["enabled_handlers"] = _configured_handlers(s.config_entry.options)

--- a/tests/test_decision_trace_enabled_handlers.py
+++ b/tests/test_decision_trace_enabled_handlers.py
@@ -25,6 +25,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_ENTITY,
     SensorType,
 )
+from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.sensor import AdaptiveCoverDecisionTraceSensor
 
 
@@ -231,6 +232,84 @@ def test_full_configuration_enables_everything():
 def test_minimal_configuration_enables_only_always_on():
     enabled = _enabled({CONF_ENABLE_SUN_TRACKING: False})
     assert enabled == {"manual", "default"}
+
+
+# ---------------------------------------------------------------------------
+# weather_active_conditions / weather_in_clear_delay attrs
+# ---------------------------------------------------------------------------
+
+
+def _make_pipeline_result(control_method: ControlMethod):
+    """Return a minimal mock pipeline result with the given control_method."""
+    result = MagicMock()
+    result.control_method = control_method
+    result.decision_trace = []
+    result.reason = "test"
+    result.bypass_auto_control = False
+    result.default_position = 0
+    result.is_sunset_active = False
+    result.configured_default = 0
+    result.configured_sunset_pos = None
+    result.tilt = None
+    return result
+
+
+def test_weather_active_conditions_present_when_weather_override():
+    """weather_active_conditions and weather_in_clear_delay present when WEATHER."""
+    coordinator = _make_coordinator()
+    coordinator._pipeline_result = _make_pipeline_result(ControlMethod.WEATHER)
+    coordinator._weather_mgr = MagicMock()
+    coordinator._weather_mgr.active_conditions = ["wind_speed"]
+    coordinator._weather_mgr.in_clear_delay = False
+
+    sensor = AdaptiveCoverDecisionTraceSensor(
+        "test_enabled_handlers_entry",
+        _make_hass(),
+        _make_config_entry(),
+        "Test",
+        coordinator,
+    )
+    attrs = sensor.extra_state_attributes or {}
+    assert attrs["weather_active_conditions"] == ["wind_speed"]
+    assert attrs["weather_in_clear_delay"] is False
+
+
+def test_weather_in_clear_delay_true_when_timeout_running():
+    """weather_in_clear_delay is True when timeout task pending."""
+    coordinator = _make_coordinator()
+    coordinator._pipeline_result = _make_pipeline_result(ControlMethod.WEATHER)
+    coordinator._weather_mgr = MagicMock()
+    coordinator._weather_mgr.active_conditions = []
+    coordinator._weather_mgr.in_clear_delay = True
+
+    sensor = AdaptiveCoverDecisionTraceSensor(
+        "test_enabled_handlers_entry",
+        _make_hass(),
+        _make_config_entry(),
+        "Test",
+        coordinator,
+    )
+    attrs = sensor.extra_state_attributes or {}
+    assert attrs["weather_active_conditions"] == []
+    assert attrs["weather_in_clear_delay"] is True
+
+
+def test_weather_keys_absent_when_not_weather_override():
+    """weather_active_conditions and weather_in_clear_delay absent for non-WEATHER override."""
+    coordinator = _make_coordinator()
+    coordinator._pipeline_result = _make_pipeline_result(ControlMethod.SOLAR)
+    coordinator._weather_mgr = MagicMock()
+
+    sensor = AdaptiveCoverDecisionTraceSensor(
+        "test_enabled_handlers_entry",
+        _make_hass(),
+        _make_config_entry(),
+        "Test",
+        coordinator,
+    )
+    attrs = sensor.extra_state_attributes or {}
+    assert "weather_active_conditions" not in attrs
+    assert "weather_in_clear_delay" not in attrs
 
 
 def test_handler_names_match_card_normalized_form():

--- a/tests/test_managers/test_weather.py
+++ b/tests/test_managers/test_weather.py
@@ -6,7 +6,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.adaptive_cover_pro.managers.weather import WeatherManager
+from custom_components.adaptive_cover_pro.managers.weather import (
+    WeatherManager,
+    _COND_IS_RAINING,
+    _COND_RAIN_RATE,
+    _COND_SEVERE,
+    _COND_WIND_SPEED,
+)
 
 
 @pytest.fixture
@@ -795,3 +801,86 @@ def test_reconcile_noop_when_no_sensors_configured(mock_hass, logger):
     )
     m._override_active = True
     assert m.reconcile() is None
+
+
+# --- active_conditions ---
+
+
+def test_active_conditions_wind_speed_only(mock_hass, logger):
+    """Returns ['wind_speed'] when only wind speed sensor is active."""
+    m = WeatherManager(hass=mock_hass, logger=logger)
+    m.update_config(
+        wind_speed_sensor="sensor.wind",
+        wind_direction_sensor=None,
+        wind_speed_threshold=50.0,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor=None,
+        rain_threshold=1.0,
+        is_raining_sensor=None,
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=300,
+    )
+    mock_hass.states.get.return_value = _make_state("75.0")
+    assert m.active_conditions == [_COND_WIND_SPEED]
+
+
+def test_active_conditions_rain_and_is_raining(mock_hass, logger):
+    """Returns rain_rate and is_raining labels; wind_speed and severe absent."""
+    m = WeatherManager(hass=mock_hass, logger=logger)
+    m.update_config(
+        wind_speed_sensor=None,
+        wind_direction_sensor=None,
+        wind_speed_threshold=50.0,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor="sensor.rain",
+        rain_threshold=1.0,
+        is_raining_sensor="binary_sensor.raining",
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=300,
+    )
+
+    def get_state(entity_id):
+        if entity_id == "sensor.rain":
+            return _make_state("5.0")
+        if entity_id == "binary_sensor.raining":
+            return _make_state("on")
+        return None
+
+    mock_hass.states.get.side_effect = get_state
+    conditions = m.active_conditions
+    assert _COND_RAIN_RATE in conditions
+    assert _COND_IS_RAINING in conditions
+    assert _COND_WIND_SPEED not in conditions
+    assert _COND_SEVERE not in conditions
+
+
+def test_active_conditions_empty_when_no_conditions(mgr):
+    """Returns empty list when no conditions active."""
+    assert mgr.active_conditions == []
+
+
+# --- in_clear_delay ---
+
+
+def test_in_clear_delay_false_when_no_task(mgr):
+    """Returns False when no timeout task is running."""
+    assert mgr.in_clear_delay is False
+
+
+def test_in_clear_delay_true_when_timeout_running(mgr):
+    """Returns True when a pending timeout task exists."""
+    mgr._timeout_task = MagicMock()
+    mgr._timeout_task.done.return_value = False
+    assert mgr.in_clear_delay is True
+
+
+def test_active_conditions_empty_but_in_clear_delay(mgr):
+    """No live conditions + pending timeout → active_conditions empty, in_clear_delay True."""
+    mgr._timeout_task = MagicMock()
+    mgr._timeout_task.done.return_value = False
+    assert mgr.active_conditions == []
+    assert mgr.in_clear_delay is True


### PR DESCRIPTION
## Summary
- `WeatherManager` gains two properties: `active_conditions: list[str]` (currently-active condition labels — `wind_speed`, `rain_rate`, `is_raining`, `is_windy`, `severe_weather`) and `in_clear_delay: bool` (alias for the post-clearance timer).
- Decision Trace sensor's `extra_state_attributes` now includes `weather_active_conditions` and `weather_in_clear_delay` when `control_method == ControlMethod.WEATHER`. Keys are absent for any other control method.
- Now you can tell which weather condition closed a cover, and whether the override is still being held by the cool-down timer after conditions cleared.

## Testing
- ✅ 515 tests passing across pipeline, weather manager, decision trace, sensor, and diagnostics suites
- 9 new tests added: 6 for the manager properties, 3 for the sensor attrs