### PR TITLE
refactor: rename proxy cover suffix from _slider to _managed (#374)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1613,7 +1613,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         if not _any_min_mode:
             lines.append(
                 "⚠️ Proxy cover is enabled but no custom-position slot has "
-                "Use as minimum on — the slider will not clamp."
+                "Use as minimum on — the managed cover will not clamp."
             )
 
     # =========================================================================

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -108,6 +108,10 @@ CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
 CONF_ENTITIES = "group"  # list of HA cover entity_ids controlled
 CONF_ENABLE_PROXY_COVER = "enable_proxy_cover"  # opt-in proxy cover platform
 DEFAULT_ENABLE_PROXY_COVER = False
+TRIGGER_PROXY_POSITION = "proxy_managed"
+TRIGGER_PROXY_OPEN = "proxy_open"
+TRIGGER_PROXY_CLOSE = "proxy_close"
+TRIGGER_PROXY_TILT = "proxy_tilt"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -27,6 +27,10 @@ from .const import (
     CONF_ENTITIES,
     DEFAULT_ENABLE_PROXY_COVER,
     DOMAIN,
+    TRIGGER_PROXY_CLOSE,
+    TRIGGER_PROXY_OPEN,
+    TRIGGER_PROXY_POSITION,
+    TRIGGER_PROXY_TILT,
 )
 from .cover_types.base import (
     CAP_HAS_SET_TILT_POSITION,
@@ -114,9 +118,9 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         title = config_entry.title or config_entry.data.get("name") or "Adaptive"
         if multi:
             label = _source_friendly_label(hass, source_entity_id)
-            self._attr_name = f"{title} Slider ({label})"
+            self._attr_name = f"{title} Managed ({label})"
         else:
-            self._attr_name = f"{title} Slider"
+            self._attr_name = f"{title} Managed"
 
     # ---- availability + mirroring -------------------------------------- #
 
@@ -206,7 +210,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
             return
         position = int(kwargs["position"])
         await self.coordinator.async_apply_user_position(
-            self._source_entity_id, position, trigger="proxy_slider"
+            self._source_entity_id, position, trigger=TRIGGER_PROXY_POSITION
         )
 
     async def async_open_cover(self, **kwargs: Any) -> None:
@@ -214,7 +218,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         if not self._source_available():
             return
         await self.coordinator.async_apply_user_position(
-            self._source_entity_id, 100, trigger="proxy_open"
+            self._source_entity_id, 100, trigger=TRIGGER_PROXY_OPEN
         )
 
     async def async_close_cover(self, **kwargs: Any) -> None:
@@ -222,7 +226,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         if not self._source_available():
             return
         await self.coordinator.async_apply_user_position(
-            self._source_entity_id, 0, trigger="proxy_close"
+            self._source_entity_id, 0, trigger=TRIGGER_PROXY_CLOSE
         )
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
@@ -233,7 +237,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
             return
         position = int(kwargs["tilt_position"])
         await self.coordinator.async_apply_user_position(
-            self._source_entity_id, position, trigger="proxy_tilt"
+            self._source_entity_id, position, trigger=TRIGGER_PROXY_TILT
         )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1272,8 +1272,8 @@ class CoverCommandService:
 
         Surfaces a "preempted_by_handler" skip in ``last_skipped_action`` so
         the existing Skipped Action diagnostic sensor labels the reason
-        (e.g. "Proxy slider to 30 preempted by weather override"). Used by
-        :meth:`Coordinator.async_apply_user_position` when the proxy slider
+        (e.g. "Proxy managed to 30 preempted by weather override"). Used by
+        :meth:`Coordinator.async_apply_user_position` when the proxy cover
         or ``set_position`` service is overruled by force_override / weather
         / a custom-position slot with priority > 80.
         """

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -507,7 +507,7 @@ class AdaptiveCoverManager:
         Args:
             entity_id: Cover entity ID to mark as manually overridden.
             reason: Short label recorded into the diagnostic event buffer
-                (e.g. ``"proxy_slider"``, ``"set_position"``).
+                (e.g. ``"proxy_managed"``, ``"set_position"``).
 
         """
         self.manual_control[entity_id] = True

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -26,7 +26,7 @@
         "data_description": {
           "group": "Wählen Sie die Beschattungsentitäten, die diese Integrationsinstanz steuern soll. Sie können mehrere Beschattungen auswählen, um sie als Gruppe zu steuern (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Beschattungen aus, die diesem bestimmten Fenster dienen – erstellen Sie separate Integrationsinstanzen für verschiedene Fenster.",
           "linked_device_id": "Wählen Sie ein physisches Gerät, in das die Entitäten dieser Integration zusammengeführt werden. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um zu einem separaten virtuellen Adaptive Cover-Gerät zurückzukehren. Es werden nur Geräte angezeigt, die die ausgewählten Beschattungsentitäten besitzen.",
-          "enable_proxy_cover": "Geben Sie eine Proxy-Beschattungsentität pro physischer Beschattung frei. Verwenden Sie diese auf Dashboards statt der physischen Beschattung, damit der Schieberegler Mindeststellungen respektiert. Standard: aus."
+          "enable_proxy_cover": "Geben Sie eine Proxy-Beschattungsentität pro physischer Beschattung frei. Verwenden Sie diese auf Dashboards statt der physischen Beschattung, damit manuelle Befehle die Mindestpositionen respektieren. Standard: aus."
         }
       },
       "geometry": {
@@ -552,7 +552,7 @@
         "data_description": {
           "group": "Wählen Sie die Cover-Entitäten aus, die von dieser Integrationsinstanz gesteuert werden sollen. Sie können mehrere Abdeckungen auswählen, um sie als Gruppe zu steuern (alle erhalten dieselben Positionsbefehle). Wählen Sie nur Abdeckungen aus, die diesem bestimmten Fenster dienen - erstellen Sie separate Integrationsinstanzen für verschiedene Fenster.",
           "linked_device_id": "Wählen Sie ein physisches Gerät aus, um die Entitäten dieser Integration zusammenzuführen. Die Sensoren, Schalter und Schaltflächen der Integration werden direkt unter diesem Gerät in Home Assistant angezeigt. Wählen Sie „Keine (eigenständiges Gerät)“, um auf ein separates virtuelles Adaptive Cover-Gerät zurückzukehren. Nur Geräte, die die ausgewählten Cover-Entitäten besitzen, werden angezeigt.",
-          "enable_proxy_cover": "Geben Sie eine Proxy-Beschattungsentität pro physischer Beschattung frei. Verwenden Sie diese auf Dashboards statt der physischen Beschattung, damit der Schieberegler Mindeststellungen respektiert. Standard: aus."
+          "enable_proxy_cover": "Geben Sie eine Proxy-Beschattungsentität pro physischer Beschattung frei. Verwenden Sie diese auf Dashboards statt der physischen Beschattung, damit manuelle Befehle die Mindestpositionen respektieren. Standard: aus."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -26,7 +26,7 @@
         "data_description": {
           "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
           "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown.",
-          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so manual commands respect min-mode floors. Default: off."
         }
       },
       "geometry": {
@@ -552,7 +552,7 @@
         "data_description": {
           "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
           "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown.",
-          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so the slider respects min-mode floors. Default: off."
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so manual commands respect min-mode floors. Default: off."
         }
       },
       "geometry": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -26,7 +26,7 @@
         "data_description": {
           "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores pour les contrôler ensemble (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores qui servent cette fenêtre particulière - créez des instances d'intégration séparées pour différentes fenêtres.",
           "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés.",
-          "enable_proxy_cover": "Expose une entité de couverture proxy par protection physique. Utilisez ceci sur les tableaux de bord à la place de la protection physique afin que le curseur respecte les seuils minimum. Par défaut : désactivé."
+          "enable_proxy_cover": "Expose une entité de couverture proxy par protection physique. Utilisez ceci sur les tableaux de bord à la place de la protection physique afin que les commandes manuelles respectent les positions minimales. Par défaut : désactivé."
         }
       },
       "geometry": {
@@ -552,7 +552,7 @@
         "data_description": {
           "group": "Sélectionnez les entités de store à contrôler via cette instance d'intégration. Vous pouvez sélectionner plusieurs stores pour les contrôler ensemble (tous recevront les mêmes commandes de position). Ne sélectionnez que les stores qui servent cette fenêtre particulière - créez des instances d'intégration séparées pour différentes fenêtres.",
           "linked_device_id": "Sélectionnez un appareil physique pour fusionner les entités de cette intégration. Les capteurs, commutateurs et boutons de l'intégration apparaîtront directement sous cet appareil dans Home Assistant. Sélectionnez « Aucun (appareil autonome) » pour revenir à un appareil Adaptive Cover virtuel séparé. Seuls les appareils qui possèdent les entités de store sélectionnées sont affichés.",
-          "enable_proxy_cover": "Expose une entité de couverture proxy par protection physique. Utilisez ceci sur les tableaux de bord à la place de la protection physique afin que le curseur respecte les seuils minimum. Par défaut : désactivé."
+          "enable_proxy_cover": "Expose une entité de couverture proxy par protection physique. Utilisez ceci sur les tableaux de bord à la place de la protection physique afin que les commandes manuelles respectent les positions minimales. Par défaut : désactivé."
         }
       },
       "geometry": {

--- a/tests/cover/test_proxy_cover_commands.py
+++ b/tests/cover/test_proxy_cover_commands.py
@@ -89,12 +89,12 @@ async def test_set_cover_position_routes_through_async_apply_user_position(
         blocking=True,
     )
     coord.async_apply_user_position.assert_awaited_once_with(
-        "cover.living_room", 42, trigger="proxy_slider"
+        "cover.living_room", 42, trigger="proxy_managed"
     )
 
 
-async def test_set_cover_position_uses_proxy_slider_trigger(hass) -> None:
-    """The trigger label for a slider command is ``proxy_slider``."""
+async def test_set_cover_position_uses_proxy_managed_trigger(hass) -> None:
+    """The trigger label for a managed cover command is ``proxy_managed``."""
     entry, coord, proxy_eid = await _setup_proxy(hass, entry_id="proxy_cmd_trig")
     coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
 
@@ -105,7 +105,7 @@ async def test_set_cover_position_uses_proxy_slider_trigger(hass) -> None:
         blocking=True,
     )
     args, kwargs = coord.async_apply_user_position.await_args
-    assert kwargs.get("trigger") == "proxy_slider"
+    assert kwargs.get("trigger") == "proxy_managed"
 
 
 async def test_open_cover_calls_apply_user_position_with_100(hass) -> None:

--- a/tests/cover/test_proxy_cover_setup.py
+++ b/tests/cover/test_proxy_cover_setup.py
@@ -101,7 +101,7 @@ async def test_proxy_unique_id_format(hass) -> None:
 
 
 async def test_proxy_name_single_cover(hass) -> None:
-    """Single-cover proxy name is ``f'{title} Slider'``."""
+    """Single-cover proxy name is ``f'{title} Managed'``."""
     sources = ["cover.living_room"]
     entry = await _setup_with_proxy(
         hass,
@@ -113,7 +113,7 @@ async def test_proxy_name_single_cover(hass) -> None:
     proxies = _proxy_states(hass, entry.entry_id)
     assert len(proxies) == 1
     # Friendly name is on the state object
-    assert proxies[0].attributes.get("friendly_name") == "Living Blinds Slider"
+    assert proxies[0].attributes.get("friendly_name") == "Living Blinds Managed"
 
 
 async def test_proxy_name_multiple_covers_includes_friendly_name(hass) -> None:
@@ -131,7 +131,7 @@ async def test_proxy_name_multiple_covers_includes_friendly_name(hass) -> None:
     assert len(proxies) == 2
     names = {p.attributes.get("friendly_name") for p in proxies}
     # Each name starts with the base title and includes the source label
-    assert all(n.startswith("Whole House Slider (") for n in names), names
+    assert all(n.startswith("Whole House Managed (") for n in names), names
     # Both source segments are present
     joined = " | ".join(names)
     assert "living_room" in joined.replace(" ", "_") or "Living" in joined

--- a/tests/cover/test_proxy_preemption_integration.py
+++ b/tests/cover/test_proxy_preemption_integration.py
@@ -1,7 +1,7 @@
 """Proxy cover preemption + manual-override engagement (integration).
 
 Covers the contract added to ``Coordinator.async_apply_user_position`` when
-the proxy slider is moved:
+the proxy managed cover is moved:
 
 - A higher-priority pipeline winner (force_override, weather) silently
   drops the move and records into ``last_skipped_action``.
@@ -69,7 +69,7 @@ async def _setup_proxy(hass, *, source: str = "cover.living_room"):
     return entry, coordinator, proxy_eid
 
 
-async def test_proxy_slider_blocked_when_force_override_active(hass) -> None:
+async def test_proxy_managed_blocked_when_force_override_active(hass) -> None:
     """force_override (priority 100) wins → no cover command, no manual override."""
     _, coord, proxy_eid = await _setup_proxy(hass)
 
@@ -108,8 +108,8 @@ async def test_proxy_slider_blocked_when_force_override_active(hass) -> None:
     assert coord._cmd_svc.last_skipped_action.get("winner") == "force_override"
 
 
-async def test_proxy_slider_engages_manual_override_on_success(hass) -> None:
-    """A successful proxy slider move marks the source cover as manually overridden."""
+async def test_proxy_managed_engages_manual_override_on_success(hass) -> None:
+    """A successful proxy managed cover move marks the source cover as manually overridden."""
     _, coord, proxy_eid = await _setup_proxy(hass)
 
     # Pipeline winner: solar (priority 40 < ManualOverride priority 80).

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -126,10 +126,10 @@ async def test_async_apply_user_position_passes_above_floor_unchanged() -> None:
     """Requested > floor → passes through unchanged."""
     coord, ctx = _make_coord([_slot(40, is_on=True, min_mode=True)])
 
-    await coord.async_apply_user_position("cover.test", 80, trigger="proxy_slider")
+    await coord.async_apply_user_position("cover.test", 80, trigger="proxy_managed")
 
     coord._cmd_svc.apply_position.assert_awaited_once_with(
-        "cover.test", 80, "proxy_slider", ctx
+        "cover.test", 80, "proxy_managed", ctx
     )
 
 
@@ -199,14 +199,14 @@ async def test_default_engages_manual_override_when_no_preemption() -> None:
     coord, ctx = _make_coord([], winner_name="solar", winner_priority=40)
 
     outcome = await coord.async_apply_user_position(
-        "cover.test", 50, trigger="proxy_slider"
+        "cover.test", 50, trigger="proxy_managed"
     )
 
     coord.manager.mark_user_command.assert_called_once_with(
-        "cover.test", reason="proxy_slider"
+        "cover.test", reason="proxy_managed"
     )
     coord._cmd_svc.apply_position.assert_awaited_once_with(
-        "cover.test", 50, "proxy_slider", ctx
+        "cover.test", 50, "proxy_managed", ctx
     )
     assert outcome == ("sent", "set_cover_position")
 
@@ -217,14 +217,14 @@ async def test_default_skipped_when_force_override_active() -> None:
     coord, _ctx = _make_coord([], winner_name="force_override", winner_priority=100)
 
     outcome = await coord.async_apply_user_position(
-        "cover.test", 50, trigger="proxy_slider"
+        "cover.test", 50, trigger="proxy_managed"
     )
 
     assert outcome == ("skipped", "preempted_by_force_override")
     coord._cmd_svc.apply_position.assert_not_awaited()
     coord.manager.mark_user_command.assert_not_called()
     coord._cmd_svc.record_preempted_skip.assert_called_once_with(
-        "cover.test", 50, trigger="proxy_slider", winner_name="force_override"
+        "cover.test", 50, trigger="proxy_managed", winner_name="force_override"
     )
 
 
@@ -250,13 +250,13 @@ async def test_default_not_blocked_by_cloud_suppression() -> None:
     """cloud_suppression (60) does NOT preempt — command dispatched + manual override engaged."""
     coord, ctx = _make_coord([], winner_name="cloud_suppression", winner_priority=60)
 
-    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_slider")
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_managed")
 
     coord.manager.mark_user_command.assert_called_once_with(
-        "cover.test", reason="proxy_slider"
+        "cover.test", reason="proxy_managed"
     )
     coord._cmd_svc.apply_position.assert_awaited_once_with(
-        "cover.test", 50, "proxy_slider", ctx
+        "cover.test", 50, "proxy_managed", ctx
     )
 
 
@@ -265,13 +265,13 @@ async def test_default_not_blocked_by_solar() -> None:
     """Solar (40) does NOT preempt — command dispatched + manual override engaged."""
     coord, ctx = _make_coord([], winner_name="solar", winner_priority=40)
 
-    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_slider")
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_managed")
 
     coord.manager.mark_user_command.assert_called_once_with(
-        "cover.test", reason="proxy_slider"
+        "cover.test", reason="proxy_managed"
     )
     coord._cmd_svc.apply_position.assert_awaited_once_with(
-        "cover.test", 50, "proxy_slider", ctx
+        "cover.test", 50, "proxy_managed", ctx
     )
 
 
@@ -315,7 +315,7 @@ async def test_snapshot_passed_to_pipeline_has_manual_override_false() -> None:
     coord, _ctx = _make_coord([], winner_name="solar", winner_priority=40)
     coord.manager.binary_cover_manual = True  # stale flag set
 
-    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_slider")
+    await coord.async_apply_user_position("cover.test", 50, trigger="proxy_managed")
 
     coord._build_pipeline_snapshot.assert_called_once()
     _, kwargs = coord._build_pipeline_snapshot.call_args
@@ -327,10 +327,10 @@ async def test_preempted_skip_recorded_in_last_skipped_action() -> None:
     """When preempted, record_preempted_skip is called with the winner name."""
     coord, _ctx = _make_coord([], winner_name="force_override", winner_priority=100)
 
-    await coord.async_apply_user_position("cover.test", 42, trigger="proxy_slider")
+    await coord.async_apply_user_position("cover.test", 42, trigger="proxy_managed")
 
     coord._cmd_svc.record_preempted_skip.assert_called_once_with(
-        "cover.test", 42, trigger="proxy_slider", winner_name="force_override"
+        "cover.test", 42, trigger="proxy_managed", winner_name="force_override"
     )
 
 

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -434,7 +434,7 @@ def test_mark_user_command_sets_flag_and_timestamp():
     )
     manager.add_covers(["cover.test"])
 
-    manager.mark_user_command("cover.test", reason="proxy_slider")
+    manager.mark_user_command("cover.test", reason="proxy_managed")
 
     assert manager.is_cover_manual("cover.test")
     assert "cover.test" in manager.manual_control_time
@@ -478,7 +478,7 @@ def test_mark_user_command_works_for_entity_not_in_covers():
     )
     # Intentionally not calling add_covers(["cover.test"])
 
-    manager.mark_user_command("cover.test", reason="proxy_slider")
+    manager.mark_user_command("cover.test", reason="proxy_managed")
 
     assert manager.is_cover_manual("cover.test")
 


### PR DESCRIPTION
## Summary
Renames the opt-in proxy cover entity from `cover.*_slider` / "<title> Slider" to `cover.*_managed` / "<title> Managed" per @environ314's feedback in #374. The `_slider` suffix was UI jargon and misrepresented the proxy's scope — it intercepts open, close, and tilt commands too, not just slider moves. Same change extracts the four trigger strings (`proxy_managed`, `proxy_open`, `proxy_close`, `proxy_tilt`) into named constants in `const.py` to satisfy the no-magic-strings rule.

`unique_id` is unchanged (`{entry_id}_proxy_{slug}` was already neutral), so the underlying registry row survives. Early v2.21.2 adopters keep their existing `cover.*_slider` entity_id; the display name updates to "Managed". To pick up the new entity_id they go to Settings → Entities and rename manually.

## Testing
- ✅ 3169 tests passing
- ✅ Translation parity check green (en/de/fr)

## Related Issues
Refs #374