### PR TITLE
fix: venetian tilt suppression cap + verify dedup (#33)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
+++ b/custom_components/adaptive_cover_pro/managers/dual_axis_sequencer.py
@@ -106,6 +106,12 @@ class DualAxisSequencer:
         # dual-axis state at all.
         self._suppression_at: dict[str, dt.datetime] = {}
         self._tilt_targets: dict[str, int] = {}
+        # Entities whose last stored target has been verified against the
+        # actuator. Dedup at _send_tilt_command only fires when the target
+        # matches AND the entity is in this set — a verify=False fire-and-
+        # forget send stores the target but does not mark verified, so the
+        # subsequent verifying send still runs (issue #33).
+        self._tilt_targets_verified: set[str] = set()
         self._tilt_sent_at: dict[str, dt.datetime] = {}
 
     # -- tilt inversion ---------------------------------------------------- #
@@ -162,12 +168,24 @@ class DualAxisSequencer:
     def is_in_suppression_with_cap(self, entity_id: str, delta: float) -> bool:
         """Suppress back-rotate drift only when the delta is plausibly motor drift.
 
-        Slat geometry bounds back-rotation magnitude; a large delta inside the
-        window is a user move, not motor drift, so the manual-override path
-        runs and the user's command is recorded (issue #33 follow-on).
+        Slat geometry bounds back-rotation magnitude post-settle; a large delta
+        once the carriage has stopped is a user move, not motor drift, so the
+        manual-override path runs and the user's command is recorded (issue #33
+        follow-on).
+
+        While the carriage is still mid-travel (HA cover state ``opening`` or
+        ``closing``) the cap is bypassed: real-world venetian actuators (KNX,
+        Shelly 2PM, FGR223) back-retract the slats by well over the cap during
+        carriage motion, so an arbitrarily large delta is still motor drift
+        until ``cover.state`` settles. The cap reasserts once state leaves the
+        moving set.
         """
         if not self.is_in_suppression(entity_id):
             return False
+        if self._get_state is not None:
+            state = self._get_state(entity_id)
+            if state in _COVER_MOVING_STATES:
+                return True
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
 
     # -- tilt sequence ----------------------------------------------------- #
@@ -185,6 +203,7 @@ class DualAxisSequencer:
         cache.
         """
         self._tilt_targets.clear()
+        self._tilt_targets_verified.clear()
 
     async def run_sequence(
         self,
@@ -236,7 +255,16 @@ class DualAxisSequencer:
         matches and the caller didn't pass ``force=True``, no service call
         fires. That keeps ``run_sequence``'s post-settle tilt from re-sending
         a tilt that ``before_position_command`` already sent for the same
-        opening transition (issue #33 tilt-first path).
+        opening transition — total service-call count for an opening
+        transition remains 2 (tilt + position).
+
+        But the dedup branch still runs the verify step when the stored
+        target hasn't yet been confirmed against the actuator (issue #33
+        tilt-first path). Otherwise a misbehaving actuator that lands at
+        the wrong tilt during the carriage travel is never noticed: no
+        drift event, no ``_tilt_targets`` pop, no retry on the next cycle.
+        ``_tilt_targets_verified`` tracks which stored targets have already
+        been confirmed so the verify only fires once per target.
 
         ``verify=False`` is the fire-and-forget mode used by
         ``before_position_command``: the service call dispatches and the
@@ -254,6 +282,9 @@ class DualAxisSequencer:
                 position_target=position_target,
                 trigger=reason,
             )
+            if verify and entity_id not in self._tilt_targets_verified:
+                await asyncio.sleep(VENETIAN_POST_TILT_REBASE_DELAY_SECONDS)
+                await self._verify_and_record_tilt(entity_id, tilt_target)
             return
 
         if not force and self._get_min_change is not None:
@@ -298,6 +329,10 @@ class DualAxisSequencer:
             return
 
         self._tilt_targets[entity_id] = tilt_target  # store logical value
+        # A freshly-sent target is unverified until _verify_and_record_tilt
+        # confirms it lands on the actuator (issue #33). Discard preemptively
+        # in case a prior cycle marked the entity verified.
+        self._tilt_targets_verified.discard(entity_id)
         self._tilt_sent_at[entity_id] = dt.datetime.now(dt.UTC)
         # Restart the grace window so the tilt-axis change isn't read as a
         # user touch by manual_override detection.
@@ -547,6 +582,10 @@ class DualAxisSequencer:
             actual = self._to_wire(actual_wire)
             delta = abs(actual - tilt_target)
             if delta <= VENETIAN_TILT_VERIFY_TOLERANCE:
+                # Stored target now matches the actuator — mark verified so
+                # the dedup gate in _send_tilt_command can safely skip a
+                # subsequent send for the same target (issue #33).
+                self._tilt_targets_verified.add(entity_id)
                 self._record_event(
                     "tilt_command_verified",
                     entity_id=entity_id,
@@ -576,3 +615,4 @@ class DualAxisSequencer:
             tolerance=VENETIAN_TILT_VERIFY_TOLERANCE,
         )
         self._tilt_targets.pop(entity_id, None)
+        self._tilt_targets_verified.discard(entity_id)

--- a/tests/test_managers/test_dual_axis_sequencer.py
+++ b/tests/test_managers/test_dual_axis_sequencer.py
@@ -970,6 +970,106 @@ class TestSendTiltCommandDedup:
         )
         assert hass.services.async_call.call_count == 2
 
+    async def test_dedup_after_unverified_send_still_runs_verify(self):
+        """Issue #33: dedup must not silence drift detection on an unverified target.
+
+        ``before_position_command`` sends tilt pre-position with ``verify=False,
+        force=True``; the post-settle ``run_sequence`` reaches the dedup gate
+        with the same target stored. The service-call dedup is preserved
+        (count stays at 1), but verify still runs against the actuator —
+        otherwise a wrong landing is never noticed and ``_tilt_targets``
+        is never popped to re-arm the next cycle's retry.
+        """
+        buf = EventBuffer(maxlen=16)
+        hass, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 0, event_buffer=buf
+        )
+        await seq._send_tilt_command(
+            "cover.x",
+            tilt_target=60,
+            position_target=17,
+            reason="auto_control_on",
+            force=True,
+            verify=False,
+        )
+        assert hass.services.async_call.call_count == 1
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=60, position_target=17, reason="solar"
+        )
+        # Second send dedups (preserves opening-cycle service-call count) but
+        # the verify path runs because the prior send was unverified.
+        assert hass.services.async_call.call_count == 1
+        drift = [e for e in buf.snapshot() if e["event"] == "tilt_command_drift"]
+        assert len(drift) == 1
+        # Drift clears the stored target so the next update_tilt_only retries.
+        assert seq.last_tilt_target("cover.x") is None
+
+
+@pytest.mark.asyncio
+class TestTiltFirstThenSequenceVerify:
+    """Integration-shaped guard for the tilt-first opening path (issue #33).
+
+    Report 2 timeline: ``before_position_command`` fires tilt=60 pre-position
+    (``verify=False, force=True``); the carriage opens; ``run_sequence`` waits
+    for settle, then re-enters ``_send_tilt_command(verify=True)`` with the
+    same target. Service-call dedup is preserved (cycle stays at 2 tilt+pos
+    calls) but verify MUST run on the deduped branch — otherwise a wrong
+    landing is never noticed and the cover sits at the wrong tilt forever.
+    """
+
+    async def test_run_sequence_after_tilt_first_runs_verify_on_dedup(self):
+        """End-to-end: tilt-first then run_sequence with divergent actuator.
+
+        Produces a single tilt service call AND a tilt_command_drift event.
+        """
+        buf = EventBuffer(maxlen=32)
+        # Actuator reports the wrong tilt (0) for every verify sample — the
+        # fix's verify path should observe this and emit tilt_command_drift.
+        hass, seq = _build_sequencer(
+            get_current_tilt_position=lambda _eid: 0,
+            event_buffer=buf,
+        )
+        # Stub the settle loop so run_sequence completes synchronously.
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 17))
+
+        # Step 1: before_position_command fires tilt pre-position.
+        await seq._send_tilt_command(
+            "cover.x",
+            tilt_target=60,
+            position_target=17,
+            reason="auto_control_on",
+            force=True,
+            verify=False,
+        )
+        # Step 2: position command would fire here; we skip it (separate path).
+        # Step 3: after_position_command runs run_sequence which re-enters
+        # _send_tilt_command with the default verify=True.
+        await seq.run_sequence(
+            "cover.x",
+            position_target=17,
+            tilt_target=60,
+            reason="solar",
+        )
+
+        # Service-call dedup preserved: still just the pre-tilt call.
+        assert hass.services.async_call.call_count == 1
+
+        events = buf.snapshot()
+        # The dedup branch DID run verify, and verify saw the wrong landing.
+        # Pre-fix: no verify event at all (verify was wholly skipped).
+        drift = [e for e in events if e["event"] == "tilt_command_drift"]
+        assert len(drift) == 1
+        # Dedup itself was recorded.
+        skipped = [
+            e
+            for e in events
+            if e["event"] == "tilt_command_skipped"
+            and e.get("reason") == "target_unchanged"
+        ]
+        assert len(skipped) == 1
+        # Drift cleared the stored target so update_tilt_only re-fires next cycle.
+        assert seq.last_tilt_target("cover.x") is None
+
 
 @pytest.mark.asyncio
 class TestTiltVerifyWithRetry:

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -13,9 +13,13 @@ Wired through ``SecondaryAxisCheck`` — a per-cover-type plug supplied by
 from __future__ import annotations
 
 import datetime as dt
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.managers.dual_axis_sequencer import (
+    DualAxisSequencer,
+)
 from custom_components.adaptive_cover_pro.managers.manual_override import (
     AdaptiveCoverManager,
     SecondaryAxisCheck,
@@ -55,6 +59,32 @@ def _tilt_check(*, expected: int = 70, suppressed: bool) -> SecondaryAxisCheck:
         label="tilt",
         suppression=lambda _eid, _delta: suppressed,
     )
+
+
+def _make_sequencer_suppression(
+    *, entity_id: str, state: str
+) -> Callable[[str, float], bool]:
+    """Build a real ``DualAxisSequencer`` and return its bound delta-cap gate.
+
+    Closes the integration gap the lambda-stub helpers leave open (issue #33
+    follow-on): wires ``stamp_position_command`` and the ``_get_state``
+    callback together so the cap behaves exactly as ``VenetianPolicy.is_in_tilt_suppression``
+    does in production. ``state`` should be ``"opening"``/``"closing"`` to
+    model an in-transit cycle, or ``"stopped"`` to model a settled cycle.
+    """
+    hass = MagicMock()
+    seq = DualAxisSequencer(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=lambda _eid: None,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_state=lambda _eid: state,
+    )
+    seq.stamp_position_command(entity_id)
+    return seq.is_in_suppression_with_cap
 
 
 def test_tilt_drift_inside_suppression_window_is_ignored() -> None:
@@ -204,6 +234,102 @@ def test_position_drift_outside_tilt_suppression_trips_override() -> None:
         is_waiting=lambda _eid: False,
         manual_threshold=5,
         secondary_axis_check=_tilt_check(suppressed=False),
+    )
+
+    assert mgr.is_cover_manual(entity_id)
+
+
+def test_tilt_drift_during_in_transit_close_is_ignored_regardless_of_delta() -> None:
+    """Issue #33: motor back-rotate during a closing carriage can exceed the cap.
+
+    Report 1 timeline: ``set_cover_position(86)`` stamps suppression at T+0;
+    while ``cover.state == "closing"`` the actuator reports
+    ``current_tilt_position=0`` against ``our_state=100`` — a 100% delta that
+    blows past the 30% ``VENETIAN_BACKROTATE_MAX_DELTA_PERCENT`` cap. The cap
+    must NOT defeat suppression while the carriage is still mid-travel; this
+    is real motor drift, not a user move.
+    """
+    entity_id = "cover.venetian_kitchen_close"
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    suppression = _make_sequencer_suppression(entity_id=entity_id, state="closing")
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=86, tilt=0),
+        our_state=100,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=100,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=suppression,
+        ),
+    )
+
+    assert not mgr.is_cover_manual(entity_id)
+
+
+def test_tilt_drift_during_in_transit_open_is_ignored_regardless_of_delta() -> None:
+    """Issue #33: same fault on the opening side (Report 2, fnep).
+
+    Diagnostic timeline: at T+0 ``set_cover_position(17)`` stamps suppression;
+    while ``cover.state == "opening"`` the actuator reports
+    ``current_tilt_position=100`` against ``our_state=60`` — a 40% delta past
+    the 30% cap. Suppression must hold; the 60→100 mismatch is the actuator
+    landing wrong during travel, not a user touch.
+    """
+    entity_id = "cover.venetian_office_open"
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    suppression = _make_sequencer_suppression(entity_id=entity_id, state="opening")
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=17, tilt=100),
+        our_state=60,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=60,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=suppression,
+        ),
+    )
+
+    assert not mgr.is_cover_manual(entity_id)
+
+
+def test_tilt_drift_after_settle_with_large_delta_still_trips_override() -> None:
+    """The in-transit cap bypass must NOT swallow a genuine post-settle user move.
+
+    Once ``cover.state`` leaves the moving set, the geometry-bounded cap
+    reasserts: a delta > 30% with state=``stopped`` is a user grabbing the
+    slats, not motor drift, and must still trip manual override even inside
+    the 90s suppression window.
+    """
+    entity_id = "cover.venetian_post_settle_user_move"
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    suppression = _make_sequencer_suppression(entity_id=entity_id, state="stopped")
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=80,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=suppression,
+        ),
     )
 
     assert mgr.is_cover_manual(entity_id)


### PR DESCRIPTION
## Summary
Fixes two related venetian bugs reported on v2.21.3:

- **In-transit cap defeat** — `is_in_suppression_with_cap` returned False as soon as the actuator's tilt delta exceeded the 30% back-rotate cap, even while the carriage was mid-travel. Real-world actuators (KNX, Shelly 2PM, FGR223) back-retract slats by far more than 30% during motion, so the cap fired against pure motor drift and the manual-override path latched onto it. Both `geryyyyyy` (closing, delta=100%) and `fnep` (opening, delta=40%) hit this.
- **Verify-skipping dedup** — `_send_tilt_command`'s target-unchanged dedup short-circuited the post-settle verify step on the venetian tilt-first opening path. A misbehaving actuator that landed at the wrong tilt was never noticed; drift never popped the stored target, and the cover sat at the wrong angle indefinitely while compounding with the cap bug to fire a false manual override.

## Fix
Both in `managers/dual_axis_sequencer.py`:

1. **State-aware cap.** Bypass the 30% cap when `cover.state` is `opening`/`closing`; cap reasserts post-settle so genuine user moves still trip override.
2. **Verify-on-dedup.** The dedup branch now runs verify when the prior send was an unverified fire-and-forget. New `_tilt_targets_verified` set ensures verify only fires once per target. Preserves the published 2-service-call-per-cycle invariant for opening transitions.

No changes to `cover_types/venetian.py`, `managers/manual_override.py`, or `const.py` — fix stays inside the venetian-owned `DualAxisSequencer`.

## Testing
- ✅ 3226 tests passing (was 3225 baseline; +5 new regression tests, 0 failures)
- New tests:
  - `test_tilt_drift_during_in_transit_close_is_ignored_regardless_of_delta`
  - `test_tilt_drift_during_in_transit_open_is_ignored_regardless_of_delta`
  - `test_tilt_drift_after_settle_with_large_delta_still_trips_override`
  - `test_dedup_after_unverified_send_still_runs_verify`
  - `test_run_sequence_after_tilt_first_runs_verify_on_dedup`
- Lint clean.

## Related Issues
Refs #33