### PR TITLE
fix: honor handler-supplied tilt for non-SOLAR venetian paths (#369)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -220,14 +220,18 @@ class VenetianPolicy(CoverTypePolicy):
             vert_config=config_service.get_vertical_data(options),
         )
 
-    def _tilt_suppressed(self, result: PipelineResult, cover) -> bool:
-        """Return True when tilt synthesis must be skipped this cycle.
+    def _engine_tilt_suppressed(self, result: PipelineResult, cover) -> bool:
+        """Return True when the solar engine should NOT compute a tilt.
 
-        Tilt is meaningful only when (a) the pipeline emitted ControlMethod.SOLAR
-        AND (b) the cover engine confirms direct sun is hitting the window. The
-        climate handler can emit SOLAR on its low-light branch even when the sun
-        is below the horizon (issue #33), so direct_sun_valid is the authoritative
-        signal.
+        Applies only to the engine-fallback path; handler-supplied tilts
+        (``result.tilt is not None`` on entry to ``post_pipeline_resolve``)
+        bypass this gate entirely.
+
+        Engine tilt is meaningful only when (a) the pipeline emitted
+        ControlMethod.SOLAR AND (b) the cover engine confirms direct sun is
+        hitting the window. The climate handler can emit SOLAR on its low-light
+        branch even when the sun is below the horizon (issue #33), so
+        direct_sun_valid is the authoritative signal.
         """
         from ..enums import ControlMethod
 
@@ -259,11 +263,7 @@ class VenetianPolicy(CoverTypePolicy):
         if result is None:
             return result
 
-        if self._tilt_suppressed(result, cover):
-            self._clear_last_tilt()
-            return replace(result, tilt=None)
-
-        # If a handler already set an explicit tilt, honor it — skip the engine.
+        # Handler-supplied tilt is explicit user intent — honor it unconditionally.
         if result.tilt is not None:
             handler_tilt = result.tilt
             position = result.position
@@ -295,6 +295,11 @@ class VenetianPolicy(CoverTypePolicy):
             return replace(
                 result, position=position, tilt=handler_tilt, decision_trace=trace
             )
+
+        # No handler tilt: engine fallback runs only when SOLAR + direct sun.
+        if self._engine_tilt_suppressed(result, cover):
+            self._clear_last_tilt()
+            return replace(result, tilt=None)
 
         venetian_calc = VenetianCoverCalculation(
             config=config,

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -305,8 +305,48 @@ class TestPostPipelineResolveHandlerTilt:
         handler_names = [s.handler for s in out.decision_trace]
         assert "venetian_handler_tilt" in handler_names
 
-    def test_suppression_clears_handler_tilt_for_non_solar(self):
-        """Non-SOLAR: suppression fires first → handler tilt is cleared to None."""
+    def test_handler_tilt_honored_for_custom_position(self):
+        """Handler-supplied tilt on CUSTOM_POSITION must survive (issue #369 regression)."""
+        policy = _make_policy()
+        for handler_tilt in (42, 0):
+            result = PipelineResult(
+                position=50,
+                control_method=ControlMethod.CUSTOM_POSITION,
+                reason="test",
+                tilt=handler_tilt,
+            )
+            out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+            assert out.tilt == handler_tilt
+
+    def test_handler_tilt_honored_for_default_path(self):
+        """Handler-supplied tilt on DEFAULT (default_tilt / sunset_tilt) must survive."""
+        policy = _make_policy()
+        result = PipelineResult(
+            position=50,
+            control_method=ControlMethod.DEFAULT,
+            reason="test",
+            tilt=30,
+        )
+        out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+        assert out.tilt == 30
+
+    def test_handler_tilt_honored_when_direct_sun_invalid(self):
+        """Explicit handler tilt bypasses the direct_sun_valid gate."""
+        policy = _make_policy()
+        cover = _make_cover(direct_sun_valid=False)
+        kwargs = _solar_kwargs()
+        kwargs["cover"] = cover
+        result = PipelineResult(
+            position=50,
+            control_method=ControlMethod.SOLAR,
+            reason="test",
+            tilt=50,
+        )
+        out = policy.post_pipeline_resolve(result, **kwargs)
+        assert out.tilt == 50
+
+    def test_handler_tilt_survives_non_solar_suppression(self):
+        """Non-SOLAR with handler-supplied tilt must honor it (was the bug in #369)."""
         policy = _make_policy()
         result = PipelineResult(
             position=50,
@@ -315,7 +355,7 @@ class TestPostPipelineResolveHandlerTilt:
             tilt=35,
         )
         out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
-        assert out.tilt is None
+        assert out.tilt == 35
 
     def test_engine_tilt_used_when_result_tilt_is_none_on_solar(self):
         """SOLAR + direct_sun_valid + result.tilt=None → engine computes tilt (not None)."""

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -151,12 +151,12 @@ class TestCustomPositionTiltEndToEnd:
         result = registry.evaluate(snap)
         assert result.tilt == 0
 
-    def test_custom_handler_tilt_suppressed_by_venetian_for_non_solar(self):
-        """VenetianPolicy suppresses handler tilt for CUSTOM_POSITION control method.
+    def test_custom_handler_tilt_honored_by_venetian_for_non_solar(self):
+        """VenetianPolicy honors handler tilt for CUSTOM_POSITION (issue #369).
 
-        The suppression check (non-SOLAR → clear tilt) runs before the
-        handler-tilt honor path, so the resolved tilt is None even when the
-        pipeline result carries tilt=40.
+        The handler-tilt honor path runs before engine suppression, so a
+        custom-position handler that supplies tilt=40 survives end-to-end even
+        when ControlMethod is non-SOLAR.
         """
         from custom_components.adaptive_cover_pro.cover_types.venetian import (
             VenetianPolicy,
@@ -169,12 +169,11 @@ class TestCustomPositionTiltEndToEnd:
         )
         pipeline_result = registry.evaluate(snap)
         assert pipeline_result.control_method == ControlMethod.CUSTOM_POSITION
-        assert pipeline_result.tilt == 40  # raw pipeline carries the handler tilt
+        assert pipeline_result.tilt == 40
 
         policy = VenetianPolicy()
         resolved = policy.post_pipeline_resolve(pipeline_result, **_solar_kwargs())
-        # CUSTOM_POSITION is not SOLAR — suppression clears tilt
-        assert resolved.tilt is None
+        assert resolved.tilt == 40
 
     def test_solar_handler_tilt_honored_by_venetian(self):
         """A PipelineResult with SOLAR control_method + tilt → venetian honors it.
@@ -197,8 +196,8 @@ class TestCustomPositionTiltEndToEnd:
         resolved = policy.post_pipeline_resolve(result, **_solar_kwargs())
         assert resolved.tilt == 42
 
-    def test_default_handler_tilt_suppressed_by_venetian(self):
-        """DEFAULT control method → venetian suppresses, tilt becomes None."""
+    def test_default_handler_tilt_honored_by_venetian(self):
+        """DEFAULT control method with handler tilt → venetian honors it (issue #369)."""
         from custom_components.adaptive_cover_pro.cover_types.venetian import (
             VenetianPolicy,
         )
@@ -211,7 +210,7 @@ class TestCustomPositionTiltEndToEnd:
         )
         policy = VenetianPolicy()
         resolved = policy.post_pipeline_resolve(result, **_solar_kwargs())
-        assert resolved.tilt is None
+        assert resolved.tilt == 70
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reorders `VenetianPolicy.post_pipeline_resolve` to honor handler-supplied tilt before the engine-suppression check, so custom-position and default/sunset handlers no longer have their configured tilt wiped on non-SOLAR `ControlMethod` values.
- Renames `_tilt_suppressed` → `_engine_tilt_suppressed` with an updated docstring clarifying it gates only the engine-fallback path.
- Adds regression tests for `CUSTOM_POSITION` + `tilt=0`, `DEFAULT` path, and the `direct_sun_valid=False` + handler tilt case; inverts three previously-passing tests that encoded the bug behavior.

## Testing
- ✅ 3232 tests passing (95% coverage)

## Related Issues
Refs #369