### PR TITLE
feat: mirror source opening/closing state on managed cover

### DIFF
--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
+    CoverState,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import callback
@@ -124,18 +125,34 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
 
     # ---- availability + mirroring -------------------------------------- #
 
+    def _source_state(self) -> Any:
+        """Return the current HA state object for the source entity, or None."""
+        return self.hass.states.get(self._source_entity_id)
+
     @property
     def available(self) -> bool:
         """Mirror source availability."""
-        state = self.hass.states.get(self._source_entity_id)
+        state = self._source_state()
         if state is None:
             return False
         return state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
 
     @property
+    def is_opening(self) -> bool:
+        """True when the source cover reports it is opening."""
+        state = self._source_state()
+        return state is not None and state.state == CoverState.OPENING
+
+    @property
+    def is_closing(self) -> bool:
+        """True when the source cover reports it is closing."""
+        state = self._source_state()
+        return state is not None and state.state == CoverState.CLOSING
+
+    @property
     def current_cover_position(self) -> int | None:
         """Mirror source current_position verbatim (no inverse transform)."""
-        state = self.hass.states.get(self._source_entity_id)
+        state = self._source_state()
         if state is None:
             return None
         value = state.attributes.get(STATE_ATTR_POSITION)
@@ -144,7 +161,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
     @property
     def current_cover_tilt_position(self) -> int | None:
         """Mirror source current_tilt_position verbatim."""
-        state = self.hass.states.get(self._source_entity_id)
+        state = self._source_state()
         if state is None:
             return None
         value = state.attributes.get(STATE_ATTR_TILT_POSITION)
@@ -153,7 +170,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
     @property
     def supported_features(self) -> CoverEntityFeature:
         """Mirror source supported_features."""
-        state = self.hass.states.get(self._source_entity_id)
+        state = self._source_state()
         if state is None:
             return CoverEntityFeature(0)
         return CoverEntityFeature(int(state.attributes.get("supported_features", 0)))

--- a/tests/cover/test_proxy_cover_mirror.py
+++ b/tests/cover/test_proxy_cover_mirror.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import pytest
 
+from homeassistant.components.cover import CoverState
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENABLE_PROXY_COVER,
     CONF_ENTITIES,
@@ -158,3 +161,131 @@ async def test_proxy_does_not_double_invert_position(hass) -> None:
     )
     state = hass.states.get(proxy_eid)
     assert state.attributes.get("current_position") == 30
+
+
+# ---- transient-state tests (is_opening / is_closing) ------------------- #
+
+
+def _get_proxy_entity(hass, proxy_eid):
+    """Return the AdaptiveProxyCover entity object for the given entity_id."""
+    cover_component = hass.data.get("entity_components", {}).get("cover")
+    if cover_component is not None:
+        return cover_component.get_entity(proxy_eid)
+    return None
+
+
+async def test_proxy_is_opening_when_source_is_opening(hass) -> None:
+    """``is_opening`` is True and ``is_closing`` is False when source is opening."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state=CoverState.OPENING,
+        attrs={"current_position": 50, "supported_features": 143},
+        entry_id="proxy_opening_test",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert entity_obj.is_opening is True
+    assert entity_obj.is_closing is False
+
+
+async def test_proxy_is_closing_when_source_is_closing(hass) -> None:
+    """``is_closing`` is True and ``is_opening`` is False when source is closing."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state=CoverState.CLOSING,
+        attrs={"current_position": 50, "supported_features": 143},
+        entry_id="proxy_closing_test",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert entity_obj.is_closing is True
+    assert entity_obj.is_opening is False
+
+
+async def test_proxy_is_not_opening_or_closing_when_source_is_open(hass) -> None:
+    """Both transient properties are False when source is open (steady state)."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state=CoverState.OPEN,
+        attrs={"current_position": 100, "supported_features": 143},
+        entry_id="proxy_open_not_transient",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert entity_obj.is_opening is False
+    assert entity_obj.is_closing is False
+
+
+async def test_proxy_is_not_opening_or_closing_when_source_is_closed(hass) -> None:
+    """Both transient properties are False when source is closed (steady state)."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state=CoverState.CLOSED,
+        attrs={"current_position": 0, "supported_features": 143},
+        entry_id="proxy_closed_not_transient",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert entity_obj.is_opening is False
+    assert entity_obj.is_closing is False
+
+
+async def test_proxy_state_transitions_through_opening(hass) -> None:
+    """Proxy state string tracks source through closed → opening → open."""
+    source_id = "cover.transition_source"
+    _, proxy_eid = await _setup_single(
+        hass,
+        source=source_id,
+        state=CoverState.CLOSED,
+        attrs={"current_position": 0, "supported_features": 143},
+        entry_id="proxy_transition_test",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert hass.states.get(proxy_eid).state == CoverState.CLOSED
+
+    # Transition to opening
+    hass.states.async_set(
+        source_id,
+        CoverState.OPENING,
+        {"current_position": 50, "supported_features": 143},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(proxy_eid).state == CoverState.OPENING
+
+    # Transition to open
+    hass.states.async_set(
+        source_id,
+        CoverState.OPEN,
+        {"current_position": 100, "supported_features": 143},
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(proxy_eid).state == CoverState.OPEN
+
+
+async def test_proxy_is_opening_false_when_source_unavailable(hass) -> None:
+    """Both transient properties are False when source is unavailable."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state=STATE_UNAVAILABLE,
+        attrs={},
+        entry_id="proxy_unavail_transient",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert entity_obj.is_opening is False
+    assert entity_obj.is_closing is False
+
+
+async def test_proxy_is_opening_false_when_source_unknown(hass) -> None:
+    """Both transient properties are False when source is unknown."""
+    _, proxy_eid = await _setup_single(
+        hass,
+        state=STATE_UNKNOWN,
+        attrs={},
+        entry_id="proxy_unknown_transient",
+    )
+    entity_obj = _get_proxy_entity(hass, proxy_eid)
+    assert entity_obj is not None
+    assert entity_obj.is_opening is False
+    assert entity_obj.is_closing is False


### PR DESCRIPTION
## Summary
- Add `is_opening` / `is_closing` properties to `AdaptiveProxyCover` so the managed cover entity reports HA's transient `opening`/`closing` states while the source cover is moving. Without these properties, HA's `@final` `state` property falls through to `is_closed`, so the managed entity was stuck reporting `open`/`closed` during movement.
- Extract a `_source_state()` helper that the six `hass.states.get(self._source_entity_id)` call sites now share (no-duplication rule).

## Testing
- ✅ 3239 tests passing (+7 new mirror tests covering opening/closing, stable open/closed, closed→opening→open transition, and unavailable/unknown source).

## Related Issues
Refs #388