### PR TITLE
refactor: phased coordinator/policy cleanup (phases A-I)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -487,11 +487,16 @@ def _priority_slider() -> selector.NumberSelector:
 def _build_custom_position_schema_dict(sensor_type: str | None = None) -> dict:
     """Compose the full custom-position schema by iterating CUSTOM_POSITION_SLOTS.
 
-    When sensor_type is ``SensorType.VENETIAN``, per-slot tilt sliders and
-    global default/sunset tilt sliders are added.  All other cover types omit
-    them since tilt is not applicable.
+    Per-slot tilt sliders and global default/sunset tilt sliders are added
+    for cover types whose policy declares ``custom_position_includes_tilt``
+    (venetian today). All other cover types omit them since tilt is not
+    applicable. A fifth cover type opts in by flipping that ClassVar — not by
+    editing this function.
     """
-    is_venetian = sensor_type == SensorType.VENETIAN
+    include_tilt = (
+        sensor_type in POLICY_REGISTRY
+        and get_policy(sensor_type).custom_position_includes_tilt
+    )
     schema: dict = {}
     for slot_keys in CUSTOM_POSITION_SLOTS.values():
         schema[vol.Optional(slot_keys["sensor"])] = _binary_on_selector()
@@ -503,9 +508,9 @@ def _build_custom_position_schema_dict(sensor_type: str | None = None) -> dict:
         schema[vol.Optional(slot_keys["use_my"], default=False)] = (
             selector.BooleanSelector()
         )
-        if is_venetian:
+        if include_tilt:
             schema[vol.Optional(slot_keys["tilt"])] = _position_slider()
-    if is_venetian:
+    if include_tilt:
         schema[vol.Optional(CONF_DEFAULT_TILT)] = _position_slider()
         schema[vol.Optional(CONF_SUNSET_TILT)] = _position_slider()
     return schema

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -152,20 +152,22 @@ SENSOR_TYPE_MENU = [
 
 _STANDALONE_SENTINEL = "__standalone__"
 
-_GEOMETRY_WIKI_URL: dict[str, str] = {
-    SensorType.BLIND: "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Vertical",
-    SensorType.AWNING: "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Horizontal",
-    SensorType.TILT: "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Tilt",
-    SensorType.VENETIAN: "https://github.com/jrhubott/adaptive-cover-pro/wiki/Venetian-Blinds",
-}
+_WIKI_BASE_URL = "https://github.com/jrhubott/adaptive-cover-pro/wiki"
 
 
 def _geometry_wiki_link(sensor_type: str | None) -> str:
-    url = _GEOMETRY_WIKI_URL.get(
-        sensor_type,
-        "https://github.com/jrhubott/adaptive-cover-pro/wiki/Cover-Types",
+    """Build the per-type wiki "Learn more" link from the policy's anchor.
+
+    A fifth cover type opts in by overriding ``CoverTypePolicy.wiki_anchor()``
+    on its subclass — no edit here is required.
+    """
+    # Avoid POLICY_REGISTRY lookup before its module-level import below.
+    from .cover_types import POLICY_REGISTRY as _registry, get_policy as _get
+
+    anchor = (
+        _get(sensor_type).wiki_anchor() if sensor_type in _registry else "Cover-Types"
     )
-    return f"[Learn more]({url})"
+    return f"[Learn more]({_WIKI_BASE_URL}/{anchor})"
 
 
 CONFIG_SCHEMA = vol.Schema(
@@ -1111,13 +1113,11 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
       4. Decision Priority — compact chain showing active/inactive handlers
     """
     # ---- Gather all values up front ----------------------------------------
-    type_labels = {
-        SensorType.BLIND: "Vertical Blind",
-        SensorType.AWNING: "Horizontal Awning",
-        SensorType.TILT: "Venetian / Tilt Blind",
-        SensorType.VENETIAN: "Venetian Blind (Dual-Axis)",
-    }
-    type_label = type_labels.get(sensor_type, "Cover") if sensor_type else "Cover"
+    type_label = (
+        get_policy(sensor_type).display_label()
+        if sensor_type in POLICY_REGISTRY
+        else "Cover"
+    )
 
     entities: list[str] = config.get(CONF_ENTITIES) or []
     default_pos = config.get(CONF_DEFAULT_HEIGHT, 0)

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2557,6 +2557,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                     CONF_LUX_ENTITY,
                     CONF_IRRADIANCE_ENTITY,
                     CONF_CLOUD_COVERAGE_ENTITY,
+                    CONF_IS_SUNNY_SENSOR,
                 ],
                 user_input,
             )
@@ -3420,6 +3421,7 @@ class OptionsFlowHandler(OptionsFlow):
                     CONF_LUX_ENTITY,
                     CONF_IRRADIANCE_ENTITY,
                     CONF_CLOUD_COVERAGE_ENTITY,
+                    CONF_IS_SUNNY_SENSOR,
                 ],
                 user_input,
             )

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -506,6 +506,12 @@ VENETIAN_REBASE_MAX_DRIFT_PERCENT = 15
 # so the manual-override path runs even inside the suppression window.
 VENETIAN_BACKROTATE_MAX_DELTA_PERCENT = 30
 
+# Grace tail after stamp_position_command: even when cover.state has already
+# settled to "open"/"closed", bypass the backrotate cap for this many seconds.
+# Real actuators publish their tilt-walk burst AFTER the carriage reports open,
+# so the cap must stay suspended until the HA state machine has fully drained.
+VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS = 5.0
+
 # After set_cover_tilt_position returns, real motors keep back-driving the
 # vertical axis briefly. Wait this many seconds before reading current_position
 # for the post-tilt rebase so the rebase captures the actual settled position

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -478,7 +478,7 @@ MAX_POSITION_RETRIES = 3  # maximum re-send attempts before giving up
 # 21. Venetian Dual-Axis Sequencing
 # =============================================================================
 # Venetian covers move both vertical position AND tilt. The dual-axis sequencer
-# (managers/dual_axis_sequencer.py) issues the position command, waits for the
+# (cover_types/venetian/sequencer.py) issues the position command, waits for the
 # carriage to settle, then issues the tilt command. Constants in this section
 # govern that handshake and the venetian-specific mode/clamp options.
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -592,7 +592,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         is_now_active = self._weather_mgr.is_any_condition_active
 
         if is_now_active:
-            if not self._weather_mgr._override_active:
+            if not self._weather_mgr.is_weather_override_active:
                 self.logger.info(
                     "Weather conditions active (%s) — retracting covers", entity_id
                 )
@@ -2312,7 +2312,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             final_state=self.state,
             config_options=dict(self.config_entry.options),
             motion_detected=self.is_motion_detected,
-            motion_timeout_active=self._motion_mgr._motion_timeout_active,
+            motion_timeout_active=self._motion_mgr.is_motion_timeout_active,
             motion_hold_active=(
                 self._pipeline_result is not None
                 and self._pipeline_result.skip_command

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -311,6 +311,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             or DEFAULT_TRANSIT_TIMEOUT_SECONDS,
             on_tick=self._check_time_window_transition,
             event_buffer=self._event_buffer,
+            # Routes manual-override classifier debug lines through the
+            # coordinator's debug-categories gate (INFO when debug_mode +
+            # category enabled, otherwise DEBUG).
+            debug_log=self._debug_log,
         )
 
         # Late-bind cover-type policy dependencies (e.g. VenetianPolicy
@@ -644,261 +648,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
 
     def process_entity_state_change(self):
-        """Check if cover position change was user-initiated (manual override detection)."""
-        event = self.state_change_data
-        self.logger.debug("Processing state change event: %s", event)
-        entity_id = event.entity_id
-        if self.ignore_intermediate_states and event.new_state.state in [
-            "opening",
-            "closing",
-        ]:
-            self.logger.debug("Ignoring intermediate state change for %s", entity_id)
-            return
-        if self._cmd_svc.is_waiting_for_target(entity_id):
-            # Check if still in grace period
-            if self._is_in_grace_period(entity_id):
-                self.logger.debug(
-                    "Position change for %s ignored (in grace period)", entity_id
-                )
-                return  # Ignore ALL position changes during grace period
+        """Check if cover position change was user-initiated (manual override detection).
 
-            # Grace period expired — check if cover reached target (tolerance-based)
-            caps = self._cmd_svc.get_cover_capabilities(entity_id)
-            position = self._cmd_svc.read_position_with_capabilities(
-                entity_id, caps, event.new_state
-            )
-            reached = self._cmd_svc.check_target_reached(entity_id, position)
-            if reached:
-                # Mark this entity so async_handle_cover_state_change() skips the
-                # manual override comparison for this event.  The cover has just
-                # settled at its commanded position (within position tolerance) —
-                # any small positional difference is motor rounding, not a user
-                # action.  The set is cleared at the end of that handler.
-                self._target_just_reached.add(entity_id)
-                self._debug_log(
-                    "manual_override",
-                    "Target just reached for %s — skipping manual override check for this event",
-                    entity_id,
-                )
-            else:
-                # Grace period expired but the cover is not at the commanded target.
-                # Determine whether the cover is still actively moving toward the
-                # target (integration-initiated transit) or has stopped / moved away
-                # (user action — Issue #147).
-                #
-                # HA covers report transitional states ("opening"/"closing") while
-                # moving, then a final state ("stopped"/"open"/"closed") when done.
-                # If ignore_intermediate_states is True, those transitional events
-                # are already filtered out above, so we only reach here with final
-                # states and always clear wait_for_target.
-                #
-                # However, some covers (French volet-roulant, some Zigbee rolling
-                # shutters) never emit transitional states at all — they stay "open"
-                # or "closed" throughout transit and simply update current_position.
-                # The direction/progress check therefore runs for ALL covers based
-                # on position delta, regardless of the HA state string (Issue #285).
-                cover_is_transitioning = event.new_state.state in (
-                    "opening",
-                    "closing",
-                )
-
-                old_position = (
-                    self._cmd_svc.read_position_with_capabilities(  # noqa: SLF001
-                        entity_id, caps, event.old_state
-                    )
-                )
-                target = self._cmd_svc.get_target(entity_id)
-
-                # Step-motor pause (Issue #186) takes highest priority: some covers
-                # briefly report "open"/"closed" at an intermediate position between
-                # motor pulses before resuming transit.  If the *new* state is
-                # non-transitional and the *old* state was transitional, the cover
-                # just paused mid-transit — restart grace period to let the motor
-                # resume.  This must be checked before the direction/progress block
-                # so that forward-progress detection (Issue #285) does not short-
-                # circuit the grace-period restart.
-                was_transitioning = (
-                    event.old_state is not None
-                    and event.old_state.state in ("opening", "closing")
-                )
-                if (
-                    not cover_is_transitioning
-                    and was_transitioning
-                    and target is not None
-                    and position is not None
-                    and position != target
-                ):
-                    self._start_grace_period(entity_id)
-                    self._debug_log(
-                        "manual_override",
-                        "Cover %s paused mid-transit at %s (target %s) "
-                        "— restarting grace period",
-                        entity_id,
-                        position,
-                        target,
-                    )
-                    self.logger.debug(
-                        "Wait for target: %s", self._cmd_svc.waiting_entities()
-                    )
-                    return
-
-                # Direction/progress check: runs for all covers where positions and
-                # target are known, EXCEPT when HA explicitly reports "stopped" (an
-                # unambiguous halt signal).  This extends the progress-aware backstop
-                # from Issue #271 to covers that never emit "opening"/"closing".
-                if (
-                    old_position is not None
-                    and position is not None
-                    and target is not None
-                    and event.new_state.state != "stopped"
-                ):
-                    old_distance = abs(old_position - target)
-                    new_distance = abs(position - target)
-
-                    if new_distance < old_distance:
-                        # Unambiguously moving toward target — still in transit.
-                        # Reset the progress clock so the backstop window extends.
-                        now = dt.datetime.now(dt.UTC)
-                        self._cmd_svc.record_progress(entity_id, now)  # noqa: SLF001
-                        self._debug_log(
-                            "manual_override",
-                            "Grace expired but %s still in transit toward "
-                            "target %s (was %s, now %s, state=%s) "
-                            "— keeping wait_for_target",
-                            entity_id,
-                            target,
-                            old_position,
-                            position,
-                            event.new_state.state,
-                        )
-                        self._event_buffer.record(
-                            {
-                                "ts": now.isoformat(),
-                                "event": "transit_progress_forward",
-                                "entity_id": entity_id,
-                                "old_position": old_position,
-                                "new_position": position,
-                                "target": target,
-                                "old_distance": old_distance,
-                                "new_distance": new_distance,
-                                "cover_state": event.new_state.state,
-                            }
-                        )
-                        self.logger.debug(
-                            "Wait for target: %s", self._cmd_svc.waiting_entities()
-                        )
-                        return
-
-                    # Progress-aware backstop: if no forward progress has been
-                    # observed for longer than the configured transit timeout,
-                    # the cover is stuck or stalled — clear wait_for_target so
-                    # manual override detection can run.  The clock resets each
-                    # time record_progress() is called (when new_distance <
-                    # old_distance above), so slow-but-moving covers are not
-                    # prematurely cleared.  Covers that never report intermediate
-                    # positions fall back to measuring from _sent_at.
-                    now = dt.datetime.now(dt.UTC)
-                    elapsed = self._cmd_svc.transit_elapsed_without_progress(
-                        entity_id, now
-                    )
-                    if elapsed is not None:
-                        timeout = self._cmd_svc.transit_timeout_seconds
-                        if elapsed > timeout:
-                            self._cmd_svc.set_waiting(entity_id, False)
-                            self._debug_log(
-                                "manual_override",
-                                "Transit timeout for %s (%.0fs > %ds without progress) "
-                                "— clearing wait_for_target",
-                                entity_id,
-                                elapsed,
-                                timeout,
-                            )
-                            self._event_buffer.record(
-                                {
-                                    "ts": now.isoformat(),
-                                    "event": "transit_timeout_cleared",
-                                    "entity_id": entity_id,
-                                    "elapsed_seconds": round(elapsed, 1),
-                                    "timeout_seconds": timeout,
-                                    "position": position,
-                                    "target": target,
-                                    "cover_state": event.new_state.state,
-                                }
-                            )
-                            self.logger.debug(
-                                "Wait for target: %s", self._cmd_svc.waiting_entities()
-                            )
-                            return
-
-                    if new_distance == old_distance:
-                        # Positions equal — could be startup delay or stall.
-                        # Startup delay: motor just engaged; state transitions from
-                        # non-transitional (e.g. "closed") to something else.
-                        # Stall: state didn't change and cover was already in transit;
-                        # fall through to clear (e.g. opening→opening same position).
-                        # open→open same position with no state change is also a
-                        # genuine stop — fall through (Issue #172 regression guard).
-                        old_state_str = (
-                            event.old_state.state
-                            if event.old_state is not None
-                            else None
-                        )
-                        new_state_str = event.new_state.state
-                        state_changed = old_state_str != new_state_str
-                        if (
-                            old_state_str not in ("opening", "closing")
-                            and state_changed
-                        ):
-                            self._debug_log(
-                                "manual_override",
-                                "Grace expired but %s position unchanged at %s "
-                                "(startup delay — old state was %s) "
-                                "— keeping wait_for_target",
-                                entity_id,
-                                position,
-                                old_state_str,
-                            )
-                            self._event_buffer.record(
-                                {
-                                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                                    "event": "transit_startup_delay",
-                                    "entity_id": entity_id,
-                                    "position": position,
-                                    "old_state": old_state_str,
-                                    "new_state": new_state_str,
-                                    "target": target,
-                                }
-                            )
-                            self.logger.debug(
-                                "Wait for target: %s", self._cmd_svc.waiting_entities()
-                            )
-                            return
-
-                # Clear wait_for_target to allow manual override detection.
-                self._cmd_svc.set_waiting(entity_id, False)
-                self._debug_log(
-                    "manual_override",
-                    "Grace period expired, cover %s not in transit "
-                    "— clearing wait_for_target "
-                    "(position=%s, state=%s)",
-                    entity_id,
-                    position,
-                    event.new_state.state,
-                )
-                self._event_buffer.record(
-                    {
-                        "ts": dt.datetime.now(dt.UTC).isoformat(),
-                        "event": "transit_cleared",
-                        "entity_id": entity_id,
-                        "position": position,
-                        "cover_state": event.new_state.state,
-                        "old_position": old_position,
-                        "target": target,
-                    }
-                )
-            self.logger.debug("Wait for target: %s", self._cmd_svc.waiting_entities())
-        else:
-            self.logger.debug("No wait for target call for %s", entity_id)
+        Thin shim over :meth:`CoverCommandService.classify_state_change` —
+        Phase F relocated the body into ``managers/cover_command/state_classifier.py``.
+        The ``_target_just_reached`` set is passed by reference so the
+        classifier mutates the same object that
+        :meth:`async_handle_cover_state_change` reads and clears later in
+        the same event lifecycle.
+        """
+        self._cmd_svc.classify_state_change(
+            self.state_change_data,
+            ignore_intermediate_states=self.ignore_intermediate_states,
+            target_just_reached=self._target_just_reached,
+            grace_mgr=self._grace_mgr,
+        )
 
     def _is_in_grace_period(self, entity_id: str) -> bool:
         """Check if entity is in command grace period."""

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -105,6 +105,7 @@ from .state.climate_provider import ClimateProvider, ClimateReadings
 from .state.cover_provider import CoverProvider
 from .state.snapshot import CoverStateSnapshot, SunSnapshot
 from .state.sun_provider import SunProvider
+from .state.window_transition_tracker import WindowTransitionTracker
 
 _MANIFEST_VERSION: str = json.loads(
     (pathlib.Path(__file__).parent / "manifest.json").read_text()
@@ -341,12 +342,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
         )
 
-        # Track sun validity transitions (for responsive sun in-front detection)
-        self._last_sun_validity_state: bool | None = None
-
-        # Track sunset-window transitions so covers reposition when the
-        # astronomical sunset window opens after the user's end_time (issue #266).
-        self._prev_sunset_active: bool | None = None
+        # Window-transition tracker — owns sun-visibility and astronomical
+        # sunset-window transition state (extracted from coordinator in Phase E).
+        self._window_tracker = WindowTransitionTracker(
+            hass=self.hass,
+            logger=self.logger,
+            event_buffer=self._event_buffer,
+            effective_default_fn=self._compute_current_effective_default,
+        )
 
         # Time of the last successful _async_update_data() completion.
         # HA's DataUpdateCoordinator only exposes last_update_success (bool);
@@ -2448,114 +2451,30 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
 
     async def _check_sunset_window_transition(self) -> None:
-        """Dispatch sunset_pos when the astronomical sunset window opens after end_time.
+        """Delegate astronomical-sunset-window transition handling to the tracker.
 
-        Handles the case where end_time fires before sunset+offset: _on_window_closed
-        sends the daytime default (is_sunset_active=False at that moment). When the
-        sunset window later opens, this detects the False→True transition and sends
-        the sunset position (issue #266).
-
-        Mirrors the _last_sun_validity_state pattern: _prev_sunset_active=None on
-        startup prevents spurious dispatch when HA restarts mid-sunset.
+        See :meth:`WindowTransitionTracker.check_sunset_window` for the
+        full contract (issue #266).
         """
-        if not self._track_end_time:
-            return
-        if not self.automatic_control:
-            self.logger.debug(
-                "Sunset window opened but automatic control is OFF — skipping reposition"
-            )
-            return
         options = self.config_entry.options
-        sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-        if sunset_pos_cfg is None:
-            return
-
-        _effective_pos, is_sunset = self._compute_current_effective_default(options)
-
-        if self._prev_sunset_active is None:
-            self._prev_sunset_active = is_sunset
-            return
-
-        just_opened = (not self._prev_sunset_active) and is_sunset
-        self._prev_sunset_active = is_sunset
-
-        if not just_opened:
-            return
-
-        pos_to_send = (
-            inverse_state(int(sunset_pos_cfg))
-            if self._inverse_state
-            else int(sunset_pos_cfg)
+        await self._window_tracker.check_sunset_window(
+            track_end_time=self._track_end_time,
+            automatic_control=self.automatic_control,
+            sunset_pos_cfg=options.get(CONF_SUNSET_POS),
+            options=options,
+            inverse_state_enabled=self._inverse_state,
+            entities=self.entities,
+            is_cover_manual=self.manager.is_cover_manual,
+            build_position_context=lambda c, o: self._build_position_context(
+                c, o, force=False
+            ),
+            apply_position=self._cmd_svc.apply_position,
+            refresh=self.async_refresh,
         )
-        self.logger.info(
-            "Sunset window opened after end_time — dispatching sunset position %s%% "
-            "to %s cover(s) (issue #266)",
-            pos_to_send,
-            len(self.entities),
-        )
-        self._event_buffer.record(
-            {
-                "ts": dt.datetime.now(dt.UTC).isoformat(),
-                "event": "sunset_window_opened",
-                "position": pos_to_send,
-                "cover_count": len(self.entities),
-            }
-        )
-        for cover_entity in self.entities:
-            if self.manager.is_cover_manual(cover_entity):
-                continue
-            ctx = self._build_position_context(cover_entity, options, force=False)
-            await self._cmd_svc.apply_position(
-                cover_entity, pos_to_send, "sunset_window_opened", context=ctx
-            )
-        await self.async_refresh()
 
     def _check_sun_validity_transition(self) -> bool:
-        """Check if sun validity state has changed from False to True.
-
-        Returns True if sun just came into field of view, indicating
-        covers should immediately reposition regardless of delta checks.
-        """
-        # Need cover data to check sun validity
-        if self._cover_data is None:
-            return False
-
-        current_sun_valid = self._cover_data.direct_sun_valid
-
-        # Initialize tracking on first call
-        if self._last_sun_validity_state is None:
-            self._last_sun_validity_state = current_sun_valid
-            return False
-
-        # Detect transitions
-        sun_just_appeared = (not self._last_sun_validity_state) and current_sun_valid
-        sun_just_left = self._last_sun_validity_state and (not current_sun_valid)
-
-        # Update tracking
-        self._last_sun_validity_state = current_sun_valid
-
-        if sun_just_appeared:
-            self.logger.info(
-                "Sun visibility transition detected: OFF → ON (sun came into field of view)"
-            )
-            self._event_buffer.record(
-                {
-                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                    "event": "sun_entered_fov",
-                }
-            )
-        elif sun_just_left:
-            self.logger.debug(
-                "Sun visibility transition detected: ON → OFF (sun left field of view)"
-            )
-            self._event_buffer.record(
-                {
-                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                    "event": "sun_left_fov",
-                }
-            )
-
-        return sun_just_appeared
+        """Delegate sun-visibility transition detection to the tracker."""
+        return self._window_tracker.sun_just_appeared(self._cover_data)
 
     async def async_shutdown(self) -> None:
         """Clean up resources on shutdown.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -37,24 +37,16 @@ from .const import (
     CONF_AZIMUTH,
     CONF_BLIND_SPOT_ELEVATION,
     CONF_CLIMATE_MODE,
+    CONF_CLOUDY_POSITION,
+    CONF_DEBUG_CATEGORIES,
+    CONF_DEBUG_EVENT_BUFFER_SIZE,
+    CONF_DEBUG_MODE,
     CONF_DEFAULT_HEIGHT,
-    CONF_DEFAULT_TILT,
+    CONF_DRY_RUN,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_ENTITIES,
-    CONF_MY_POSITION_VALUE,
-    CONF_SUNSET_TILT,
-    CONF_SUNSET_USE_MY,
-    CUSTOM_POSITION_SLOTS,
-    DEFAULT_CUSTOM_POSITION_PRIORITY,
-    CONF_FORCE_OVERRIDE_MIN_MODE,
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
-    CONF_MOTION_SENSORS,
-    CONF_MOTION_TIMEOUT_MODE,
-    DEFAULT_MOTION_TIMEOUT_MODE,
-    CONF_WEATHER_OVERRIDE_MIN_MODE,
-    CONF_WEATHER_OVERRIDE_POSITION,
-    CONF_WEATHER_BYPASS_AUTO_CONTROL,
-    CONF_ENABLE_SUN_TRACKING,
     CONF_FOV_LEFT,
     CONF_FOV_RIGHT,
     CONF_INTERP,
@@ -63,40 +55,21 @@ from .const import (
     CONF_MANUAL_IGNORE_INTERMEDIATE,
     CONF_MANUAL_OVERRIDE_DURATION,
     CONF_MANUAL_OVERRIDE_RESET,
+    CONF_MOTION_SENSORS,
+    CONF_MY_POSITION_VALUE,
     CONF_OPEN_CLOSE_THRESHOLD,
     CONF_RETURN_SUNSET,
     CONF_SUNRISE_OFFSET,
     CONF_SUNSET_OFFSET,
     CONF_SUNSET_POS,
-    CONF_TEMP_ENTITY,
-    CONF_TEMP_LOW,
-    CONF_TEMP_HIGH,
-    CONF_OUTSIDETEMP_ENTITY,
-    CONF_PRESENCE_ENTITY,
-    CONF_WEATHER_ENTITY,
-    CONF_WEATHER_STATE,
-    CONF_OUTSIDE_THRESHOLD,
-    CONF_TRANSPARENT_BLIND,
-    CONF_WINTER_CLOSE_INSULATION,
-    CONF_CLOUD_SUPPRESSION,
-    CONF_CLOUDY_POSITION,
-    CONF_CLOUD_COVERAGE_ENTITY,
-    CONF_CLOUD_COVERAGE_THRESHOLD,
-    CONF_IS_SUNNY_SENSOR,
-    CONF_LUX_ENTITY,
-    CONF_IRRADIANCE_ENTITY,
-    CONF_LUX_THRESHOLD,
-    CONF_IRRADIANCE_THRESHOLD,
-    CONF_DEBUG_CATEGORIES,
-    CONF_DEBUG_EVENT_BUFFER_SIZE,
-    CONF_DEBUG_MODE,
-    CONF_DRY_RUN,
     CONF_TRANSIT_TIMEOUT,
+    CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
-    POSITION_TOLERANCE_PERCENT,
     DOMAIN,
     LOGGER,
+    POSITION_TOLERANCE_PERCENT,
     STARTUP_GRACE_PERIOD_SECONDS,
 )
 from .diagnostics.builder import DiagnosticContext, DiagnosticsBuilder
@@ -126,11 +99,7 @@ from .pipeline.handlers import (
     WeatherOverrideHandler,
 )
 from .pipeline.registry import PipelineRegistry
-from .pipeline.types import (
-    ClimateOptions,
-    CustomPositionSensorState,
-    PipelineSnapshot,
-)
+from .pipeline.snapshot_builder import PipelineSnapshotBuilder
 from .enums import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
 from .state.cover_provider import CoverProvider
@@ -293,6 +262,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Cover entity state provider
         self._cover_provider = CoverProvider(hass=self.hass, logger=self.logger)
 
+        # Pipeline snapshot builder — owns the HA reads + assembly for each
+        # PipelineSnapshot.  Coordinator drives it once per cycle in
+        # _calculate_cover_state and again from async_apply_user_position for
+        # the preemption check.
+        self._snapshot_builder = PipelineSnapshotBuilder(
+            hass=self.hass,
+            logger=self.logger,
+            climate_provider=self._climate_provider,
+            toggles=self._toggles,
+            policy=self._policy,
+            config_service=self._config_service,
+        )
+
         # Current state snapshot (built at start of each update cycle)
         self._snapshot: CoverStateSnapshot | None = None
 
@@ -391,7 +373,20 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             True if any configured force override sensor is in "on" state
 
         """
-        return any(self._read_force_sensor_states(self.config_entry.options).values())
+        return any(
+            self._snapshot_builder.read_force_sensors(
+                self.config_entry.options
+            ).values()
+        )
+
+    def _is_glare_zone_enabled(self, idx: int) -> bool:
+        """Return the per-instance glare-zone switch for ``zone idx``.
+
+        The coordinator owns the dynamic ``glare_zone_N`` attributes the
+        switch platform writes to.  Exposed as a callable so the snapshot
+        builder can read them without reaching back into ``self``.
+        """
+        return getattr(self, f"glare_zone_{idx}", True)
 
     @property
     def is_motion_detected(self) -> bool:
@@ -1037,7 +1032,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Read all climate-related entities (temp, presence, weather, lux, irradiance, cloud).
         # The result is stored in self._weather_readings and passed to PipelineSnapshot
         # so ClimateHandler and CloudSuppressionHandler can self-evaluate.
-        self._read_climate_state(options)
+        self._weather_readings = self._snapshot_builder.read_climate(options)
 
         # Compute the effective default position from astronomical sunset/sunrise.
         # This is the single source of truth — all pipeline handlers use it via
@@ -1068,9 +1063,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Store cover engine object for use by diagnostics/sensors
         self._cover_data = cover_data
 
-        snapshot = self._build_pipeline_snapshot(
+        snapshot = self._snapshot_builder.build(
             options,
             cover_data=cover_data,
+            cover_type=self._cover_type,
+            climate_readings=self._weather_readings,
+            manual_override_active=self.manager.binary_cover_manual,
+            motion_timeout_active=self.is_motion_timeout_active,
+            weather_override_active=self.is_weather_override_active,
+            in_time_window=self.check_adaptive_time,
+            current_cover_position=self._compute_mean_cover_position(),
+            is_glare_zone_enabled=self._is_glare_zone_enabled,
             effective_default=effective_default,
             is_sunset_active=is_sunset_active,
         )
@@ -1226,7 +1229,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # next cycle can detect the on → off transition for the release edge.
         current_custom_position_sensors_active = {
             s.entity_id: s.is_on
-            for s in self._read_custom_position_sensor_states(options)
+            for s in self._snapshot_builder.read_custom_position_sensors(options)
         }
         self._prev_custom_position_sensors_active = (
             current_custom_position_sensors_active
@@ -1952,221 +1955,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             state_attr(self.hass, "sun.sun", "elevation"),
         ]
 
-    def _read_climate_state(self, options) -> None:
-        """Read all climate-related entities into self._weather_readings.
-
-        This is the single call to ClimateProvider.read() for each update cycle.
-        It reads temperature sensors, presence, weather, lux, irradiance, and
-        cloud coverage.  All pipeline handlers (ClimateHandler, CloudSuppressionHandler)
-        consume the result via snapshot.climate_readings.
-
-        NOTE: If ClimateProvider.read() gains new keyword parameters, they MUST
-        also be wired here from the corresponding options key.  The coordinator
-        wiring test (test_coordinator_climate_wiring.py) will catch any mismatch.
-        """
-        cloud_suppression_enabled = bool(options.get(CONF_CLOUD_SUPPRESSION, False))
-        lux_entity = options.get(CONF_LUX_ENTITY)
-        irradiance_entity = options.get(CONF_IRRADIANCE_ENTITY)
-        # Cloud suppression is documented as independent of Climate Mode, so let
-        # it read lux/irradiance even when the climate-mode toggles are off.
-        use_lux = bool(self._toggles.lux_toggle) or (
-            cloud_suppression_enabled and lux_entity is not None
-        )
-        use_irradiance = bool(self._toggles.irradiance_toggle) or (
-            cloud_suppression_enabled and irradiance_entity is not None
-        )
-        self._weather_readings = self._climate_provider.read(
-            temp_entity=options.get(CONF_TEMP_ENTITY),
-            outside_entity=options.get(CONF_OUTSIDETEMP_ENTITY),
-            presence_entity=options.get(CONF_PRESENCE_ENTITY),
-            weather_entity=options.get(CONF_WEATHER_ENTITY),
-            weather_condition=options.get(CONF_WEATHER_STATE),
-            use_lux=use_lux,
-            lux_entity=lux_entity,
-            lux_threshold=options.get(CONF_LUX_THRESHOLD),
-            use_irradiance=use_irradiance,
-            irradiance_entity=irradiance_entity,
-            irradiance_threshold=options.get(CONF_IRRADIANCE_THRESHOLD),
-            use_cloud_coverage=cloud_suppression_enabled,
-            cloud_coverage_entity=options.get(CONF_CLOUD_COVERAGE_ENTITY),
-            cloud_coverage_threshold=options.get(CONF_CLOUD_COVERAGE_THRESHOLD),
-            is_sunny_sensor=options.get(CONF_IS_SUNNY_SENSOR),
-        )
-
-    def _build_climate_options(self, options) -> ClimateOptions:
-        """Build ClimateOptions from config entry options."""
-        return ClimateOptions(
-            temp_low=options.get(CONF_TEMP_LOW),
-            temp_high=options.get(CONF_TEMP_HIGH),
-            temp_switch=bool(self._toggles.temp_toggle),
-            transparent_blind=options.get(CONF_TRANSPARENT_BLIND, False),
-            temp_summer_outside=options.get(CONF_OUTSIDE_THRESHOLD),
-            cloud_suppression_enabled=bool(options.get(CONF_CLOUD_SUPPRESSION, False)),
-            winter_close_insulation=bool(
-                options.get(CONF_WINTER_CLOSE_INSULATION, False)
-            ),
-            cloudy_position=options.get(CONF_CLOUDY_POSITION),
-        )
-
-    def _read_force_sensor_states(self, options) -> dict[str, bool]:
-        """Read force override sensor states from HA into a plain dict."""
-        sensors = options.get(CONF_FORCE_OVERRIDE_SENSORS, [])
-        return {
-            sensor: bool(
-                (state := self.hass.states.get(sensor)) and state.state == "on"
-            )
-            for sensor in sensors
-        }
-
-    def _read_custom_position_sensor_states(
-        self, options
-    ) -> list[CustomPositionSensorState]:
-        """Read custom position sensor states from HA into an ordered list.
-
-        Returns one CustomPositionSensorState per configured slot (sensor and
-        position both set).  Priority defaults to DEFAULT_CUSTOM_POSITION_PRIORITY
-        (77) when not set so existing installations behave identically.  min_mode
-        defaults to False; use_my defaults to False (when True the slot triggers
-        the cover's hardware "My" preset via stop_cover instead of the slot's
-        numeric position).
-        """
-        result = []
-        for slot_keys in CUSTOM_POSITION_SLOTS.values():
-            sensor = options.get(slot_keys["sensor"])
-            position = options.get(slot_keys["position"])
-            if sensor and position is not None:
-                is_on = bool(
-                    (state := self.hass.states.get(sensor)) and state.state == "on"
-                )
-                priority = int(
-                    options.get(slot_keys["priority"])
-                    or DEFAULT_CUSTOM_POSITION_PRIORITY
-                )
-                min_mode = bool(options.get(slot_keys["min_mode"], False))
-                use_my = bool(options.get(slot_keys["use_my"], False))
-                raw_tilt = options.get(slot_keys["tilt"])
-                tilt = int(raw_tilt) if raw_tilt is not None else None
-                result.append(
-                    CustomPositionSensorState(
-                        entity_id=sensor,
-                        is_on=is_on,
-                        position=int(position),
-                        priority=priority,
-                        min_mode=min_mode,
-                        use_my=use_my,
-                        tilt=tilt,
-                    )
-                )
-        return result
-
-    def _build_pipeline_snapshot(
-        self,
-        options: dict,
-        *,
-        cover_data=None,
-        effective_default: int | None = None,
-        is_sunset_active: bool | None = None,
-        manual_override_active: bool | None = None,
-    ) -> PipelineSnapshot:
-        """Build a ``PipelineSnapshot`` for evaluation.
-
-        Single source of truth used by both the per-cycle update loop (which
-        passes the freshly-computed ``cover_data`` / ``effective_default`` /
-        ``is_sunset_active``) and ``async_apply_user_position`` (which falls
-        back to the most-recent stored values to evaluate a preemption check
-        outside the update cycle).
-
-        Args:
-            options: Config entry options dict.
-            cover_data: AdaptiveGeneralCover for this cycle. Defaults to
-                ``self._cover_data`` when omitted.
-            effective_default: Pre-computed effective default position.
-                Recomputed from options when omitted.
-            is_sunset_active: Pre-computed sunset-window flag. Recomputed
-                from options when omitted.
-            manual_override_active: When ``None`` (default) uses
-                ``self.manager.binary_cover_manual``. Pass ``False`` from the
-                preemption-check path so a stale manual-override flag does
-                not self-claim priority 80 and let the cover move anyway.
-
-        """
-        if cover_data is None:
-            cover_data = self._cover_data
-        if effective_default is None or is_sunset_active is None:
-            h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
-            sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-            sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
-            sunrise_off = int(
-                options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
-            )
-            effective_default, is_sunset_active = compute_effective_default(
-                h_def=h_def,
-                sunset_pos=sunset_pos_cfg,
-                sun_data=cover_data.sun_data,
-                sunset_off=sunset_off,
-                sunrise_off=sunrise_off,
-            )
-
-        glare_zones_cfg = self._policy.glare_zones_config(
-            self._config_service, self.config_entry.options
-        )
-        active_zone_names: set[str] = set()
-        if glare_zones_cfg is not None:
-            for idx, zone in enumerate(glare_zones_cfg.zones):
-                if getattr(self, f"glare_zone_{idx}", True):
-                    active_zone_names.add(zone.name)
-
-        manual_active = (
-            self.manager.binary_cover_manual
-            if manual_override_active is None
-            else manual_override_active
-        )
-
-        return PipelineSnapshot(
-            cover=cover_data,
-            config=cover_data.config,
-            cover_type=self._cover_type,
-            default_position=effective_default,
-            is_sunset_active=is_sunset_active,
-            # NOTE: configured_default and configured_sunset_pos are deliberately
-            # absent from PipelineSnapshot.  They are annotated onto PipelineResult
-            # by the coordinator after evaluation so the raw config values are
-            # never accessible to pipeline handler logic.
-            climate_readings=self._weather_readings,
-            climate_mode_enabled=self._toggles.switch_mode,
-            climate_options=self._build_climate_options(options),
-            force_override_sensors=self._read_force_sensor_states(options),
-            force_override_position=options.get(CONF_FORCE_OVERRIDE_POSITION, 0),
-            force_override_min_mode=bool(
-                options.get(CONF_FORCE_OVERRIDE_MIN_MODE, False)
-            ),
-            manual_override_active=manual_active,
-            motion_timeout_active=self.is_motion_timeout_active,
-            weather_override_active=self.is_weather_override_active,
-            weather_override_position=options.get(CONF_WEATHER_OVERRIDE_POSITION, 0),
-            weather_override_min_mode=bool(
-                options.get(CONF_WEATHER_OVERRIDE_MIN_MODE, False)
-            ),
-            weather_bypass_auto_control=options.get(
-                CONF_WEATHER_BYPASS_AUTO_CONTROL, True
-            ),
-            glare_zones=glare_zones_cfg,
-            active_zone_names=frozenset(active_zone_names),
-            in_time_window=self.check_adaptive_time,
-            motion_control_enabled=self._toggles.motion_control,
-            custom_position_sensors=self._read_custom_position_sensor_states(options),
-            my_position_value=options.get(CONF_MY_POSITION_VALUE),
-            sunset_use_my=bool(options.get(CONF_SUNSET_USE_MY, False)),
-            enable_sun_tracking=bool(options.get(CONF_ENABLE_SUN_TRACKING, True)),
-            motion_timeout_mode=options.get(
-                CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE
-            ),
-            current_cover_position=self._compute_mean_cover_position(),
-            policy=self._policy,
-            default_tilt=options.get(CONF_DEFAULT_TILT),
-            sunset_tilt=options.get(CONF_SUNSET_TILT),
-        )
-
     async def async_apply_user_position(
         self,
         entity_id: str,
@@ -2196,7 +1984,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         opt in.
         """
         opts = options if options is not None else self.config_entry.options
-        states = self._read_custom_position_sensor_states(opts)
+        states = self._snapshot_builder.read_custom_position_sensors(opts)
         floors = [s.position for s in states if s.is_on and s.min_mode]
         effective_floor = max(floors) if floors else 0
         clamped = max(int(requested), effective_floor)
@@ -2216,7 +2004,18 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
 
         if not force:
-            snapshot = self._build_pipeline_snapshot(opts, manual_override_active=False)
+            snapshot = self._snapshot_builder.build(
+                opts,
+                cover_data=self._cover_data,
+                cover_type=self._cover_type,
+                climate_readings=self._weather_readings,
+                manual_override_active=False,
+                motion_timeout_active=self.is_motion_timeout_active,
+                weather_override_active=self.is_weather_override_active,
+                in_time_window=self.check_adaptive_time,
+                current_cover_position=self._compute_mean_cover_position(),
+                is_glare_zone_enabled=self._is_glare_zone_enabled,
+            )
             result = self._pipeline.evaluate(snapshot)
             winner_step = next((s for s in result.decision_trace if s.matched), None)
             if winner_step is not None:

--- a/custom_components/adaptive_cover_pro/cover_types/awning.py
+++ b/custom_components/adaptive_cover_pro/cover_types/awning.py
@@ -76,6 +76,14 @@ class AwningPolicy(CoverTypePolicy):
     axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS_OPEN_BLOCKS_SUN,)
     supports_return_to_default_switch = True
 
+    def wiki_anchor(self) -> str:
+        """Horizontal-awning geometry page."""
+        return "Configuration-Horizontal"
+
+    def display_label(self) -> str:
+        """User-facing label for horizontal awnings."""
+        return "Horizontal Awning"
+
     def disallowed_geometry_fields(
         self,
         *,

--- a/custom_components/adaptive_cover_pro/cover_types/awning.py
+++ b/custom_components/adaptive_cover_pro/cover_types/awning.py
@@ -74,6 +74,7 @@ class AwningPolicy(CoverTypePolicy):
     # ``position_for_intent`` falls out of the base implementation without any
     # subclass override.
     axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS_OPEN_BLOCKS_SUN,)
+    supports_return_to_default_switch = True
 
     def disallowed_geometry_fields(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -154,6 +154,20 @@ class CoverTypePolicy(ABC):
     # ``switch.py`` that hardcoded ``("cover_blind", "cover_awning")``.
     supports_return_to_default_switch: ClassVar[bool] = False
 
+    # Whether the diagnostic surface exposes a dual-axis target sensor (the
+    # "Target Tilt" sensor in ``sensor.py``). Only meaningful for cover types
+    # that drive both position and tilt on a single HA entity — venetian today.
+    # Replaces the literal ``SensorType.VENETIAN ==`` lambda gate that used to
+    # live on ``sensor.py:807``.
+    exposes_dual_axis_sensor: ClassVar[bool] = False
+
+    # Whether the custom-position config-flow UI surfaces per-slot tilt sliders
+    # and the global default/sunset tilt sliders. Only meaningful for cover
+    # types whose policy can act on tilt independently — venetian today.
+    # Replaces the ``is_venetian = sensor_type == SensorType.VENETIAN`` branch
+    # in ``config_flow._build_custom_position_schema_dict``.
+    custom_position_includes_tilt: ClassVar[bool] = False
+
     @abstractmethod
     def build_calc_engine(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -17,10 +17,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import voluptuous as vol
 from homeassistant.const import (
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
+from homeassistant.helpers import selector
 
 from ..const import ATTR_POSITION, ATTR_TILT_POSITION, POSITION_CLOSED, POSITION_OPEN
 from ..helpers import get_open_close_state, should_use_tilt, state_attr
@@ -144,6 +146,14 @@ class CoverTypePolicy(ABC):
     # without touching every gate site.
     supports_glare_zones: ClassVar[bool] = False
 
+    # Whether the "Return to default when disabled" switch is exposed for this
+    # cover type. Currently only single-axis position covers (blind, awning)
+    # have a meaningful "default height" semantic; tilt-only covers don't, and
+    # venetian's default is driven through the dual-axis sequencer rather than
+    # a fire-and-forget position. Replaces the legacy string list at
+    # ``switch.py`` that hardcoded ``("cover_blind", "cover_awning")``.
+    supports_return_to_default_switch: ClassVar[bool] = False
+
     @abstractmethod
     def build_calc_engine(
         self,
@@ -191,10 +201,21 @@ class CoverTypePolicy(ABC):
         """
         return
 
-    def is_in_tilt_suppression(self, entity_id: str) -> bool:  # noqa: ARG002
+    def is_in_tilt_suppression(
+        self,
+        entity_id: str,  # noqa: ARG002
+        delta: float = 0.0,  # noqa: ARG002
+    ) -> bool:
         """Return whether the tilt-axis suppression window is open.
 
-        Default ``False`` for cover types without a back-rotating tilt axis.
+        ``delta`` is the magnitude of the observed change on the suppressed
+        axis; ``VenetianPolicy`` uses it to gate small motor-drift values
+        while letting larger user moves fall through. Cover types without a
+        back-rotating tilt axis ignore the argument and return ``False``.
+
+        The signature matches the ``Callable[[str, float], bool]`` contract
+        consumed by ``SecondaryAxisCheck.suppression`` so the method can be
+        passed as that callback directly without an adapter lambda.
         """
         return False
 
@@ -340,5 +361,33 @@ class CoverTypePolicy(ABC):
         cross-type geometry fields to reject. Default returns nothing — the
         caller must use this method to opt in (each registered policy
         implements it explicitly so we don't silently fail open).
+        """
+        return []
+
+    def entity_selector_filter(self) -> selector.EntityFilterSelectorConfig:
+        """Return the config-flow entity-selector filter for this cover type.
+
+        Default: the plain ``cover`` domain with no capability requirement.
+        Override only when the cover type needs to require a specific feature
+        flag at selection time (e.g. ``TiltPolicy`` filters to tilt-capable
+        entities).
+        """
+        return selector.EntityFilterSelectorConfig(domain="cover")
+
+    def geometry_schema(self) -> vol.Schema:
+        """Return the config-flow geometry sub-schema for this cover type.
+
+        Default: empty schema. Override to surface cover-type-specific
+        geometry inputs (window dimensions, awning angle, slat depth, etc.).
+        """
+        return vol.Schema({})
+
+    def summary_geometry_lines(
+        self, config: dict[str, Any]
+    ) -> list[str]:  # noqa: ARG002
+        """Return the user-facing geometry summary lines for the config flow.
+
+        Default: no geometry summary. Override to render the
+        cover-type-specific geometry block in ``_build_config_summary``.
         """
         return []

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -405,3 +405,25 @@ class CoverTypePolicy(ABC):
         cover-type-specific geometry block in ``_build_config_summary``.
         """
         return []
+
+    def wiki_anchor(self) -> str:
+        """Return the wiki page anchor for this cover type's geometry docs.
+
+        ``config_flow._geometry_wiki_link`` composes the full URL by
+        appending this fragment to the wiki base. Default is the generic
+        cover-types overview — every concrete policy overrides to its own
+        page. Replaces the legacy ``_GEOMETRY_WIKI_URL`` dict in
+        ``config_flow.py`` that mapped ``SensorType`` literals to URLs.
+        """
+        return "Cover-Types"
+
+    def display_label(self) -> str:
+        """Return the human-readable label for this cover type.
+
+        Used by ``config_flow._build_config_summary`` and any other UI
+        surface that names the cover type. Default falls back to the
+        ``cover_type`` slug for stub policies; every concrete policy
+        overrides to its user-facing name. Replaces the legacy
+        ``type_labels`` dict in ``config_flow.py``.
+        """
+        return self.cover_type.removeprefix("cover_").replace("_", " ").title()

--- a/custom_components/adaptive_cover_pro/cover_types/blind.py
+++ b/custom_components/adaptive_cover_pro/cover_types/blind.py
@@ -81,6 +81,7 @@ class BlindPolicy(CoverTypePolicy):
     cover_type = "cover_blind"
     axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
     supports_glare_zones = True
+    supports_return_to_default_switch = True
 
     def disallowed_geometry_fields(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/blind.py
+++ b/custom_components/adaptive_cover_pro/cover_types/blind.py
@@ -83,6 +83,14 @@ class BlindPolicy(CoverTypePolicy):
     supports_glare_zones = True
     supports_return_to_default_switch = True
 
+    def wiki_anchor(self) -> str:
+        """Vertical-blind geometry page."""
+        return "Configuration-Vertical"
+
+    def display_label(self) -> str:
+        """User-facing label for vertical blinds."""
+        return "Vertical Blind"
+
     def disallowed_geometry_fields(
         self,
         *,

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -67,6 +67,14 @@ class TiltPolicy(CoverTypePolicy):
     cover_type = "cover_tilt"
     axes: ClassVar[tuple[CoverAxis, ...]] = (TILT_AXIS,)
 
+    def wiki_anchor(self) -> str:
+        """Slat-tilt geometry page."""
+        return "Configuration-Tilt"
+
+    def display_label(self) -> str:
+        """User-facing label for tilt-only covers."""
+        return "Venetian / Tilt Blind"
+
     def disallowed_geometry_fields(
         self,
         *,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian.py
@@ -376,12 +376,15 @@ class VenetianPolicy(CoverTypePolicy):
         """Expose the sequencer for diagnostics / tests."""
         return self._sequencer
 
-    def is_in_tilt_suppression(self, entity_id: str, delta: float) -> bool:
+    def is_in_tilt_suppression(self, entity_id: str, delta: float = 0.0) -> bool:
         """Suppress back-rotate drift only when ``delta`` is plausibly motor drift.
 
         Delegates to the sequencer's delta-aware gate. Large deltas inside the
         window are user moves, not motor drift, and fall through to the
-        manual-override numeric path (issue #33 follow-on).
+        manual-override numeric path (issue #33 follow-on). The ``delta``
+        default matches the base signature so the method is interchangeable
+        with other policies when passed as a ``SecondaryAxisCheck.suppression``
+        callback.
         """
         if self._sequencer is None:
             return False

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/__init__.py
@@ -1,0 +1,19 @@
+"""Venetian cover-type package — policy + dual-axis sequencer.
+
+Re-exports the public surface so existing imports
+(``from cover_types.venetian import VenetianPolicy``) continue to work
+after the venetian.py → venetian/ package conversion. The legacy
+``managers.dual_axis_sequencer`` import path has been retired —
+import ``DualAxisSequencer`` from this package instead.
+"""
+
+from __future__ import annotations
+
+from .policy import GEOMETRY_VENETIAN_SCHEMA, VenetianPolicy
+from .sequencer import DualAxisSequencer
+
+__all__ = [
+    "DualAxisSequencer",
+    "GEOMETRY_VENETIAN_SCHEMA",
+    "VenetianPolicy",
+]

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -106,6 +106,14 @@ class VenetianPolicy(CoverTypePolicy):
     exposes_dual_axis_sensor: ClassVar[bool] = True
     custom_position_includes_tilt: ClassVar[bool] = True
 
+    def wiki_anchor(self) -> str:
+        """Dual-axis venetian wiki page."""
+        return "Venetian-Blinds"
+
+    def display_label(self) -> str:
+        """User-facing label for dual-axis venetians."""
+        return "Venetian Blind (Dual-Axis)"
+
     def __init__(self) -> None:
         """Initialise without a sequencer; ``attach()`` wires one up later."""
         self._sequencer: DualAxisSequencer | None = None

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -103,6 +103,8 @@ class VenetianPolicy(CoverTypePolicy):
     # the position axis. The tilt axis is filled in by ``post_pipeline_resolve``
     # and dispatched separately by the ``DualAxisSequencer``.
     axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS, TILT_AXIS)
+    exposes_dual_axis_sensor: ClassVar[bool] = True
+    custom_position_includes_tilt: ClassVar[bool] = True
 
     def __init__(self) -> None:
         """Initialise without a sequencer; ``attach()`` wires one up later."""

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -5,6 +5,11 @@ on a single HA entity. Position is resolved by the same pipeline handlers as
 ``cover_blind`` (using a vertical calculation engine); tilt is filled
 post-pipeline by ``VenetianCoverCalculation`` and threaded through the
 position-context so ``CoverCommandService`` can run the dual-axis sequence.
+
+The sibling ``sequencer.py`` owns the per-entity dual-axis state and the
+position-settle / tilt-verify polling. This module owns the policy decisions
+(when to send a pre-position tilt, what tilt to compute, how to thread it
+into the pipeline result).
 """
 
 from __future__ import annotations
@@ -16,7 +21,7 @@ import voluptuous as vol
 from homeassistant.const import SERVICE_SET_COVER_POSITION
 from homeassistant.helpers import selector
 
-from ..const import (
+from ...const import (
     CONF_INVERSE_TILT,
     CONF_MAX_TILT,
     CONF_MIN_TILT,
@@ -36,12 +41,11 @@ from ..const import (
     VENETIAN_MODE_TILT_ONLY,
     VENETIAN_MODES,
 )
-from ..engine.covers import AdaptiveVerticalCover, VenetianCoverCalculation
-from ..managers.dual_axis_sequencer import DualAxisSequencer
-from ..managers.manual_override import SecondaryAxisCheck
-from ..pipeline.types import DecisionStep
-from ._helpers import window_dimensions_lines
-from .base import (
+from ...engine.covers import AdaptiveVerticalCover, VenetianCoverCalculation
+from ...managers.manual_override import SecondaryAxisCheck
+from ...pipeline.types import DecisionStep
+from .._helpers import window_dimensions_lines
+from ..base import (
     CAP_HAS_SET_POSITION,
     CAP_HAS_SET_TILT_POSITION,
     POSITION_AXIS,
@@ -50,13 +54,14 @@ from .base import (
     CoverTypePolicy,
     caps_get,
 )
-from .blind import GEOMETRY_VERTICAL_SCHEMA
-from .tilt import GEOMETRY_TILT_SCHEMA, TILT_CAPABLE_ENTITY_FILTER
+from ..blind import GEOMETRY_VERTICAL_SCHEMA
+from ..tilt import GEOMETRY_TILT_SCHEMA, TILT_CAPABLE_ENTITY_FILTER
+from .sequencer import DualAxisSequencer
 
 if TYPE_CHECKING:
-    from ..engine.covers import AdaptiveGeneralCover
-    from ..pipeline.types import PipelineResult
-    from ..services.configuration_service import ConfigurationService
+    from ...engine.covers import AdaptiveGeneralCover
+    from ...pipeline.types import PipelineResult
+    from ...services.configuration_service import ConfigurationService
 
 
 GEOMETRY_VENETIAN_SCHEMA = GEOMETRY_VERTICAL_SCHEMA.extend(
@@ -131,7 +136,7 @@ class VenetianPolicy(CoverTypePolicy):
 
     def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
         """Render window dimensions plus the slat-config block."""
-        from ..const import CONF_TILT_DEPTH, CONF_TILT_DISTANCE, CONF_TILT_MODE
+        from ...const import CONF_TILT_DEPTH, CONF_TILT_DISTANCE, CONF_TILT_MODE
 
         tilt_parts: list[str] = []
         if (v := config.get(CONF_TILT_DEPTH)) is not None:
@@ -233,7 +238,7 @@ class VenetianPolicy(CoverTypePolicy):
         branch even when the sun is below the horizon (issue #33), so
         direct_sun_valid is the authoritative signal.
         """
-        from ..enums import ControlMethod
+        from ...enums import ControlMethod
 
         if result.control_method != ControlMethod.SOLAR:
             return True

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -10,6 +10,13 @@ once, after vertical motion has finished.
 
 Owned by ``VenetianPolicy``; constructed when the policy is attached to
 the coordinator. Other cover-type policies have no sequencer at all.
+
+Co-located with ``policy.py`` under ``cover_types/venetian/`` so the
+venetian-only state (back-rotate window, tilt targets, verify cache)
+lives alongside the policy that owns it. Per CODING_GUIDELINES.md
+"Managers Hold State, Policies Hold Behavior", cover-type-bound
+machinery belongs next to its policy, not in the cover-type-agnostic
+``managers/`` package.
 """
 
 from __future__ import annotations
@@ -26,7 +33,7 @@ from homeassistant.const import (
 )
 from homeassistant.exceptions import HomeAssistantError
 
-from ..const import (
+from ...const import (
     ATTR_TILT_POSITION,
     DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
     VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
@@ -40,13 +47,13 @@ from ..const import (
     VENETIAN_TILT_VERIFY_POLL_SECONDS,
     VENETIAN_TILT_VERIFY_TOLERANCE,
 )
-from .cover_command.gates import check_position_delta
-from .manual_override import inverse_state
+from ...managers.cover_command.gates import check_position_delta
+from ...managers.manual_override import inverse_state
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
-    from ..diagnostics.event_buffer import EventBuffer
+    from ...diagnostics.event_buffer import EventBuffer
 
 # HA cover states that indicate the motor is still mid-travel.
 _COVER_MOVING_STATES = frozenset({"opening", "closing"})
@@ -101,7 +108,7 @@ class DualAxisSequencer:
         self._invert_tilt = invert_tilt
         self._get_min_change = get_min_change
         self._post_settle_hold_seconds = post_settle_hold_seconds
-        # Per-entity timestamps. Keep these in the sequencer (rather than on
+        # Per-entity timestamps. Keep these on the sequencer (rather than on
         # CoverCommandService.PerEntityState) so non-venetian covers carry no
         # dual-axis state at all.
         self._suppression_at: dict[str, dt.datetime] = {}

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -40,6 +40,7 @@ from ...const import (
     VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES,
     VENETIAN_POSITION_SETTLE_POLL_SECONDS,
     VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
+    VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS,
     VENETIAN_POST_TILT_REBASE_DELAY_SECONDS,
     VENETIAN_REBASE_MAX_DRIFT_PERCENT,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
@@ -186,12 +187,23 @@ class DualAxisSequencer:
         carriage motion, so an arbitrarily large delta is still motor drift
         until ``cover.state`` settles. The cap reasserts once state leaves the
         moving set.
+
+        A post-settle grace tail (``VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS``)
+        also bypasses the cap: KNX/Shelly actuators publish their tilt-walk
+        burst after ``cover.state`` already reads ``open``/``closed``, so the
+        cap would reject legitimate motor drift as a user move without this
+        window (issue #33).
         """
         if not self.is_in_suppression(entity_id):
             return False
         if self._get_state is not None:
             state = self._get_state(entity_id)
             if state in _COVER_MOVING_STATES:
+                return True
+        stamp = self._suppression_at.get(entity_id)
+        if stamp is not None:
+            elapsed = (dt.datetime.now(dt.UTC) - stamp).total_seconds()
+            if elapsed < VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS:
                 return True
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
 

--- a/custom_components/adaptive_cover_pro/managers/common/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/common/__init__.py
@@ -1,0 +1,7 @@
+"""Shared helpers used by multiple manager modules."""
+
+from __future__ import annotations
+
+from .timeout_controller import TimeoutController
+
+__all__ = ["TimeoutController"]

--- a/custom_components/adaptive_cover_pro/managers/common/timeout_controller.py
+++ b/custom_components/adaptive_cover_pro/managers/common/timeout_controller.py
@@ -1,0 +1,116 @@
+"""Single-task asyncio timeout helper.
+
+``MotionManager``, ``WeatherManager`` and ``GracePeriodManager`` all
+implement the same "spawn task → asyncio.sleep → check / set flag /
+record event → null out the task handle" pattern. The pattern is small
+but the hand-rolled copies in each manager have drifted (different log
+messages, different event names, different cancel-safety) and the
+"forgot to null the handle" footgun has bitten the repo before.
+
+This helper owns the lifecycle in one place. It is a concrete class —
+no ABC, no Protocol. Managers compose it; they do not inherit from it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+
+class TimeoutController:
+    """Manage a single in-flight asyncio task for a fire-once timer.
+
+    Each instance owns at most one task. Calling :meth:`start` while a
+    timer is in flight cancels the existing one first, then spawns the
+    new one — the helper never has two parallel timers. On expiry, the
+    handle is nulled out automatically (even if the on-expire callback
+    raises), closing the "stale task handle" bug class.
+
+    The helper makes one explicit promise and one explicit non-promise:
+
+    * **Promised:** if :meth:`cancel` is called *before* the sleep
+      completes, ``on_expire`` will not run.
+    * **Not promised:** if :meth:`cancel` is called *after* the sleep
+      completes (i.e. during the on-expire callback's own awaits), the
+      callback is not interrupted at the controller boundary — the
+      cancel becomes a no-op there. Cancellation reaching into a
+      half-run callback is a footgun, so this helper draws the line at
+      "sleep done = callback committed". Callers that need finer
+      control should add their own guard inside ``on_expire``.
+
+    The ``label`` argument is a short identifier (e.g. ``"motion
+    timeout"``) used in debug logs only — not user-facing.
+    """
+
+    def __init__(self, logger, *, label: str = "timeout") -> None:
+        """Initialize with the manager's logger and a short label.
+
+        Args:
+            logger: Used for debug-level cancel/start messages. The same
+                logger every consuming manager already uses, so log
+                output stays attributable to the owning manager.
+            label: Short identifier for log messages. Convention is
+                ``"<feature> timeout"`` (e.g. ``"motion timeout"``).
+
+        """
+        self._logger = logger
+        self._label = label
+        self._task: asyncio.Task | None = None
+
+    @property
+    def is_running(self) -> bool:
+        """Return True iff a timer task is in flight (not done, not cancelled)."""
+        return self._task is not None and not self._task.done()
+
+    def start(
+        self,
+        seconds: float,
+        on_expire: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Cancel any in-flight timer and spawn a new one.
+
+        The new task sleeps for ``seconds`` and then awaits
+        ``on_expire()``. Exceptions raised by ``on_expire`` propagate
+        out of the asyncio task (so they surface in logs) — the
+        controller does not swallow them.
+
+        Args:
+            seconds: How long to sleep before invoking ``on_expire``.
+            on_expire: Async callable run once after the sleep completes.
+
+        """
+        self.cancel()
+        self._task = asyncio.create_task(self._run(seconds, on_expire))
+
+    async def _run(
+        self,
+        seconds: float,
+        on_expire: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Inner coroutine — sleep, then run ``on_expire``.
+
+        The task object running this coroutine is captured at entry and
+        only clears ``self._task`` if it still matches at exit. This
+        lets ``on_expire`` start a new timer on the same controller
+        without the prior task's ``finally`` clobbering the new handle.
+        """
+        own = asyncio.current_task()
+        try:
+            await asyncio.sleep(seconds)
+        except asyncio.CancelledError:
+            return
+
+        try:
+            await on_expire()
+        finally:
+            # Identity check protects against on_expire starting a new
+            # timer (which would have replaced self._task by now).
+            if self._task is own:
+                self._task = None
+
+    def cancel(self) -> None:
+        """Cancel the in-flight task, if any. Safe no-op when idle."""
+        if self.is_running:
+            self._logger.debug("%s canceled", self._label)
+            self._task.cancel()
+        self._task = None

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -31,6 +31,7 @@ from . import gates
 from .diagnostics import DiagnosticsRecorder
 from .position_context import PositionContextTracker
 from .routing import ServiceCallPlan, build_special_positions, route_service_call
+from .state_classifier import StateClassifier
 from .state_store import PerEntityState, PositionContext
 from .stop import StopTracker
 
@@ -86,6 +87,7 @@ class CoverCommandService:
         on_tick=None,
         *,
         event_buffer=None,
+        debug_log=None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -107,6 +109,10 @@ class CoverCommandService:
                 interval without an extra timer.
             event_buffer: Shared diagnostic ring buffer (optional). When provided,
                 cover_command_sent and cover_command_skipped events are appended.
+            debug_log: Optional ``(category, msg, *args) -> None`` callable used
+                by the manual-override classifier so its diagnostic lines respect
+                the coordinator's debug-categories gate.  Defaults to plain
+                ``logger.debug`` when omitted.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -191,6 +197,23 @@ class CoverCommandService:
         # events into the shared event buffer.
         self._event_buffer: EventBuffer | None = event_buffer
         self._diag = DiagnosticsRecorder(event_buffer=event_buffer)
+
+        # Manual-override state classifier — the per-event "is this our own
+        # transit or a user move" decision (issues #147, #172, #186, #271,
+        # #285).  Body was extracted verbatim from the coordinator in Phase F.
+        # ``debug_log`` defaults to a plain logger.debug; the coordinator
+        # passes its own _debug_log so debug_mode + debug_categories still
+        # gate INFO-level emission.
+        if debug_log is None:
+
+            def debug_log(_category, msg, *args):
+                logger.debug(msg, *args)
+
+        self._state_classifier = StateClassifier(
+            self,
+            event_buffer=event_buffer,
+            debug_log=debug_log,
+        )
 
         # Reconciliation timer handle (async_track_time_interval unsubscribe fn)
         self._reconcile_unsub = None
@@ -683,6 +706,35 @@ class CoverCommandService:
 
         """
         self._open_close_threshold = threshold
+
+    # ------------------------------------------------------------------ #
+    # State classification (manual-override detection)
+    # ------------------------------------------------------------------ #
+
+    def classify_state_change(
+        self,
+        event,
+        *,
+        ignore_intermediate_states: bool,
+        target_just_reached: set[str],
+        grace_mgr,
+    ) -> None:
+        """Classify a post-command cover state change.
+
+        Delegates to :class:`StateClassifier`.  Mutates
+        ``target_just_reached`` in place when the cover reaches its
+        commanded position; clears ``wait_for_target`` (via
+        :meth:`set_waiting`) when the cover has settled or stalled long
+        enough that manual-override detection should run on the next
+        event.  See the classifier's docstring for the full decision
+        tree and the issue numbers each branch closes.
+        """
+        self._state_classifier.classify(
+            event,
+            ignore_intermediate_states=ignore_intermediate_states,
+            target_just_reached=target_just_reached,
+            grace_mgr=grace_mgr,
+        )
 
     # ------------------------------------------------------------------ #
     # Capability detection

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -109,11 +109,12 @@ class CoverCommandService:
                 cover_command_sent and cover_command_skipped events are appended.
 
         """
-        # Local import: ``cover_types`` re-exports ``VenetianPolicy`` which
-        # imports ``DualAxisSequencer`` from this manager package, so a
-        # module-level import here would close the loop and ImportError on
-        # first load. The policy is only consulted at construction time and
-        # afterwards through ``self._policy``.
+        # Local import: ``cover_types.venetian.sequencer`` imports
+        # ``managers.cover_command.gates`` (a sibling module) for the tilt
+        # min-delta check, so a module-level ``from ...cover_types import
+        # get_policy`` here can still close a partial-init loop on first
+        # load. The policy is only consulted at construction time and
+        # afterwards through ``self._policy``, so the local import is cheap.
         from ...cover_types import get_policy
 
         self._hass = hass

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_classifier.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_classifier.py
@@ -1,0 +1,353 @@
+"""Cover-state-change classification for manual-override detection.
+
+`StateClassifier` is the single piece of code that decides whether a
+post-command cover state change represents the integration's own transit
+(grace period, mid-transit pause, forward progress, settle) or genuine
+user activity (manual override).  The logic stays *byte-for-byte
+equivalent* to the body that lived inline on the coordinator before this
+extraction — every issue-fix comment is preserved verbatim.  Refactoring
+this code is not in scope; relocating it is.
+
+Background — the inline implementation accumulated five issue-numbered
+behaviour fixes over its lifetime:
+
+- **#147** — clearing wait_for_target on intermediate states caused
+  user-initiated moves to be mis-attributed to ACP.
+- **#172** — startup motor-engagement delay must keep wait_for_target so
+  ACP-commanded covers aren't false-flagged before they move.
+- **#186** — step-motor covers briefly report a non-transitional state
+  between pulses; restart the grace period instead of clearing.
+- **#271** — progress-aware backstop: clear wait_for_target only after
+  *transit_timeout* seconds without forward progress, so slow-but-moving
+  covers are not prematurely cleared.
+- **#285** — direction/progress check runs for covers that never emit
+  "opening"/"closing", based purely on position delta.
+
+The classifier is composed by :class:`CoverCommandService` and accessed
+through its public :meth:`classify_state_change` wrapper.  External state
+flows in as keyword arguments:
+
+- ``target_just_reached`` is a ``set[str]`` owned by the coordinator and
+  *mutated in place* — the coordinator reads it from another handler
+  inside the same event lifecycle, and changing that contract is out of
+  scope for this phase.
+- ``grace_mgr`` is the same :class:`GracePeriodManager` the cover
+  command service already composes; it is passed by argument here so the
+  classifier never reaches back into the service for it.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+
+if TYPE_CHECKING:
+    from homeassistant.core import Event
+
+    from ...diagnostics.event_buffer import EventBuffer
+    from ...managers.grace_period import GracePeriodManager
+
+
+DebugLogFn = Callable[..., None]
+
+
+class StateClassifier:
+    """Classify post-command cover state changes for manual-override detection."""
+
+    def __init__(
+        self,
+        service: Any,
+        *,
+        event_buffer: EventBuffer | None,
+        debug_log: DebugLogFn,
+    ) -> None:
+        """Bind the classifier to its long-lived collaborators.
+
+        ``service`` is the :class:`CoverCommandService` instance — the
+        classifier reads waiting / target / capability / progress state
+        through its public surface.
+        """
+        self._service = service
+        self._event_buffer = event_buffer
+        self._debug_log = debug_log
+        self._logger = getattr(service, "_logger", None)
+
+    def classify(
+        self,
+        event: Event,
+        *,
+        ignore_intermediate_states: bool,
+        target_just_reached: set[str],
+        grace_mgr: GracePeriodManager,
+    ) -> None:
+        """Decide whether ``event`` is ACP-driven transit or a manual move.
+
+        Mutates ``target_just_reached`` and (via the bound service) clears
+        ``wait_for_target`` when the cover has settled at the commanded
+        position, runs out of progress, or otherwise enters a state where
+        the manual-override detector should run on the next event.
+        """
+        svc = self._service
+        cmd_svc = svc  # legacy name from inline body
+        logger = self._logger
+        entity_id = event.entity_id
+        if logger is not None:
+            logger.debug("Processing state change event: %s", event)
+        if ignore_intermediate_states and event.new_state.state in [
+            "opening",
+            "closing",
+        ]:
+            if logger is not None:
+                logger.debug("Ignoring intermediate state change for %s", entity_id)
+            return
+        if cmd_svc.is_waiting_for_target(entity_id):
+            # Check if still in grace period
+            if grace_mgr.is_in_command_grace_period(entity_id):
+                if logger is not None:
+                    logger.debug(
+                        "Position change for %s ignored (in grace period)", entity_id
+                    )
+                return  # Ignore ALL position changes during grace period
+
+            # Grace period expired — check if cover reached target (tolerance-based)
+            caps = cmd_svc.get_cover_capabilities(entity_id)
+            position = cmd_svc.read_position_with_capabilities(
+                entity_id, caps, event.new_state
+            )
+            reached = cmd_svc.check_target_reached(entity_id, position)
+            if reached:
+                # Mark this entity so async_handle_cover_state_change() skips the
+                # manual override comparison for this event.  The cover has just
+                # settled at its commanded position (within position tolerance) —
+                # any small positional difference is motor rounding, not a user
+                # action.  The set is cleared at the end of that handler.
+                target_just_reached.add(entity_id)
+                self._debug_log(
+                    "manual_override",
+                    "Target just reached for %s — skipping manual override check for this event",
+                    entity_id,
+                )
+            else:
+                # Grace period expired but the cover is not at the commanded target.
+                # Determine whether the cover is still actively moving toward the
+                # target (integration-initiated transit) or has stopped / moved away
+                # (user action — Issue #147).
+                #
+                # HA covers report transitional states ("opening"/"closing") while
+                # moving, then a final state ("stopped"/"open"/"closed") when done.
+                # If ignore_intermediate_states is True, those transitional events
+                # are already filtered out above, so we only reach here with final
+                # states and always clear wait_for_target.
+                #
+                # However, some covers (French volet-roulant, some Zigbee rolling
+                # shutters) never emit transitional states at all — they stay "open"
+                # or "closed" throughout transit and simply update current_position.
+                # The direction/progress check therefore runs for ALL covers based
+                # on position delta, regardless of the HA state string (Issue #285).
+                cover_is_transitioning = event.new_state.state in (
+                    "opening",
+                    "closing",
+                )
+
+                old_position = cmd_svc.read_position_with_capabilities(  # noqa: SLF001
+                    entity_id, caps, event.old_state
+                )
+                target = cmd_svc.get_target(entity_id)
+
+                # Step-motor pause (Issue #186) takes highest priority: some covers
+                # briefly report "open"/"closed" at an intermediate position between
+                # motor pulses before resuming transit.  If the *new* state is
+                # non-transitional and the *old* state was transitional, the cover
+                # just paused mid-transit — restart grace period to let the motor
+                # resume.  This must be checked before the direction/progress block
+                # so that forward-progress detection (Issue #285) does not short-
+                # circuit the grace-period restart.
+                was_transitioning = (
+                    event.old_state is not None
+                    and event.old_state.state in ("opening", "closing")
+                )
+                if (
+                    not cover_is_transitioning
+                    and was_transitioning
+                    and target is not None
+                    and position is not None
+                    and position != target
+                ):
+                    grace_mgr.start_command_grace_period(entity_id)
+                    self._debug_log(
+                        "manual_override",
+                        "Cover %s paused mid-transit at %s (target %s) "
+                        "— restarting grace period",
+                        entity_id,
+                        position,
+                        target,
+                    )
+                    if logger is not None:
+                        logger.debug("Wait for target: %s", cmd_svc.waiting_entities())
+                    return
+
+                # Direction/progress check: runs for all covers where positions and
+                # target are known, EXCEPT when HA explicitly reports "stopped" (an
+                # unambiguous halt signal).  This extends the progress-aware backstop
+                # from Issue #271 to covers that never emit "opening"/"closing".
+                if (
+                    old_position is not None
+                    and position is not None
+                    and target is not None
+                    and event.new_state.state != "stopped"
+                ):
+                    old_distance = abs(old_position - target)
+                    new_distance = abs(position - target)
+
+                    if new_distance < old_distance:
+                        # Unambiguously moving toward target — still in transit.
+                        # Reset the progress clock so the backstop window extends.
+                        now = dt.datetime.now(dt.UTC)
+                        cmd_svc.record_progress(entity_id, now)  # noqa: SLF001
+                        self._debug_log(
+                            "manual_override",
+                            "Grace expired but %s still in transit toward "
+                            "target %s (was %s, now %s, state=%s) "
+                            "— keeping wait_for_target",
+                            entity_id,
+                            target,
+                            old_position,
+                            position,
+                            event.new_state.state,
+                        )
+                        if self._event_buffer is not None:
+                            self._event_buffer.record(
+                                {
+                                    "ts": now.isoformat(),
+                                    "event": "transit_progress_forward",
+                                    "entity_id": entity_id,
+                                    "old_position": old_position,
+                                    "new_position": position,
+                                    "target": target,
+                                    "old_distance": old_distance,
+                                    "new_distance": new_distance,
+                                    "cover_state": event.new_state.state,
+                                }
+                            )
+                        if logger is not None:
+                            logger.debug(
+                                "Wait for target: %s", cmd_svc.waiting_entities()
+                            )
+                        return
+
+                    # Progress-aware backstop: if no forward progress has been
+                    # observed for longer than the configured transit timeout,
+                    # the cover is stuck or stalled — clear wait_for_target so
+                    # manual override detection can run.  The clock resets each
+                    # time record_progress() is called (when new_distance <
+                    # old_distance above), so slow-but-moving covers are not
+                    # prematurely cleared.  Covers that never report intermediate
+                    # positions fall back to measuring from _sent_at.
+                    now = dt.datetime.now(dt.UTC)
+                    elapsed = cmd_svc.transit_elapsed_without_progress(entity_id, now)
+                    if elapsed is not None:
+                        timeout = cmd_svc.transit_timeout_seconds
+                        if elapsed > timeout:
+                            cmd_svc.set_waiting(entity_id, False)
+                            self._debug_log(
+                                "manual_override",
+                                "Transit timeout for %s (%.0fs > %ds without progress) "
+                                "— clearing wait_for_target",
+                                entity_id,
+                                elapsed,
+                                timeout,
+                            )
+                            if self._event_buffer is not None:
+                                self._event_buffer.record(
+                                    {
+                                        "ts": now.isoformat(),
+                                        "event": "transit_timeout_cleared",
+                                        "entity_id": entity_id,
+                                        "elapsed_seconds": round(elapsed, 1),
+                                        "timeout_seconds": timeout,
+                                        "position": position,
+                                        "target": target,
+                                        "cover_state": event.new_state.state,
+                                    }
+                                )
+                            if logger is not None:
+                                logger.debug(
+                                    "Wait for target: %s", cmd_svc.waiting_entities()
+                                )
+                            return
+
+                    if new_distance == old_distance:
+                        # Positions equal — could be startup delay or stall.
+                        # Startup delay: motor just engaged; state transitions from
+                        # non-transitional (e.g. "closed") to something else.
+                        # Stall: state didn't change and cover was already in transit;
+                        # fall through to clear (e.g. opening→opening same position).
+                        # open→open same position with no state change is also a
+                        # genuine stop — fall through (Issue #172 regression guard).
+                        old_state_str = (
+                            event.old_state.state
+                            if event.old_state is not None
+                            else None
+                        )
+                        new_state_str = event.new_state.state
+                        state_changed = old_state_str != new_state_str
+                        if (
+                            old_state_str not in ("opening", "closing")
+                            and state_changed
+                        ):
+                            self._debug_log(
+                                "manual_override",
+                                "Grace expired but %s position unchanged at %s "
+                                "(startup delay — old state was %s) "
+                                "— keeping wait_for_target",
+                                entity_id,
+                                position,
+                                old_state_str,
+                            )
+                            if self._event_buffer is not None:
+                                self._event_buffer.record(
+                                    {
+                                        "ts": dt.datetime.now(dt.UTC).isoformat(),
+                                        "event": "transit_startup_delay",
+                                        "entity_id": entity_id,
+                                        "position": position,
+                                        "old_state": old_state_str,
+                                        "new_state": new_state_str,
+                                        "target": target,
+                                    }
+                                )
+                            if logger is not None:
+                                logger.debug(
+                                    "Wait for target: %s", cmd_svc.waiting_entities()
+                                )
+                            return
+
+                # Clear wait_for_target to allow manual override detection.
+                cmd_svc.set_waiting(entity_id, False)
+                self._debug_log(
+                    "manual_override",
+                    "Grace period expired, cover %s not in transit "
+                    "— clearing wait_for_target "
+                    "(position=%s, state=%s)",
+                    entity_id,
+                    position,
+                    event.new_state.state,
+                )
+                if self._event_buffer is not None:
+                    self._event_buffer.record(
+                        {
+                            "ts": dt.datetime.now(dt.UTC).isoformat(),
+                            "event": "transit_cleared",
+                            "entity_id": entity_id,
+                            "position": position,
+                            "cover_state": event.new_state.state,
+                            "old_position": old_position,
+                            "target": target,
+                        }
+                    )
+            if logger is not None:
+                logger.debug("Wait for target: %s", cmd_svc.waiting_entities())
+        else:
+            if logger is not None:
+                logger.debug("No wait for target call for %s", entity_id)

--- a/custom_components/adaptive_cover_pro/managers/grace_period.py
+++ b/custom_components/adaptive_cover_pro/managers/grace_period.py
@@ -7,6 +7,7 @@ import datetime as dt
 from typing import TYPE_CHECKING
 
 from ..const import COMMAND_GRACE_PERIOD_SECONDS, STARTUP_GRACE_PERIOD_SECONDS
+from .common import TimeoutController
 
 if TYPE_CHECKING:
     from ..diagnostics.event_buffer import EventBuffer
@@ -42,10 +43,14 @@ class GracePeriodManager:
         self._command_grace_seconds = command_grace_seconds
         self._startup_grace_seconds = startup_grace_seconds
 
+        # Per-entity command grace: raw dict-keyed tasks. The per-entity
+        # nature doesn't fit a single-task TimeoutController; keeping it
+        # bespoke avoids per-entity controller bookkeeping for ~5s timers.
         self._command_timestamps: dict[str, float] = {}
         self._grace_period_tasks: dict[str, asyncio.Task] = {}
+        # Startup grace: single timer, fits the controller cleanly.
         self._startup_timestamp: float | None = None
-        self._startup_grace_period_task: asyncio.Task | None = None
+        self._startup_timer = TimeoutController(logger, label="startup grace")
 
     # --- Command grace period ---
 
@@ -152,16 +157,9 @@ class GracePeriodManager:
         respond slowly due to system initialization.
 
         """
-        if (
-            self._startup_grace_period_task
-            and not self._startup_grace_period_task.done()
-        ):
-            self._startup_grace_period_task.cancel()
-
         self._startup_timestamp = dt.datetime.now().timestamp()
-
-        self._startup_grace_period_task = asyncio.create_task(
-            self._startup_grace_period_timeout()
+        self._startup_timer.start(
+            self._startup_grace_seconds, self._on_startup_grace_expired
         )
 
         self._logger.info(
@@ -169,15 +167,9 @@ class GracePeriodManager:
             self._startup_grace_seconds,
         )
 
-    async def _startup_grace_period_timeout(self) -> None:
-        """Clear startup grace period after timeout."""
-        try:
-            await asyncio.sleep(self._startup_grace_seconds)
-        except asyncio.CancelledError:
-            return
-
+    async def _on_startup_grace_expired(self) -> None:
+        """Body that runs after the startup grace sleep completes."""
         self._startup_timestamp = None
-        self._startup_grace_period_task = None
 
         self._logger.debug("Startup grace period expired")
         if self._event_buffer is not None:
@@ -200,10 +192,5 @@ class GracePeriodManager:
         for entity_id in list(self._grace_period_tasks.keys()):
             self.cancel_command_grace_period(entity_id)
 
-        if (
-            self._startup_grace_period_task
-            and not self._startup_grace_period_task.done()
-        ):
-            self._startup_grace_period_task.cancel()
-            self._startup_grace_period_task = None
-            self._startup_timestamp = None
+        self._startup_timer.cancel()
+        self._startup_timestamp = None

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -14,6 +14,22 @@ from ..diagnostics.event_buffer import EventBuffer
 from ..helpers import check_cover_features
 
 
+def effective_manual_threshold(user_threshold: int | None) -> int:
+    """Resolve the effective manual-override threshold for a delta comparison.
+
+    Floored at ``POSITION_TOLERANCE_PERCENT`` so motor rounding and reporting
+    imprecision can't trip false positives even when the user configures
+    ``manual_threshold = 0`` or leaves it unset. Both the primary-axis check
+    in ``handle_state_change`` and the secondary-axis check in
+    ``SecondaryAxisCheck.evaluate`` delegate here; keeping the two in sync
+    via a single helper prevents the formula from drifting (e.g. the day
+    ``POSITION_TOLERANCE_PERCENT`` changes).
+    """
+    return max(
+        user_threshold if user_threshold is not None else 0, POSITION_TOLERANCE_PERCENT
+    )
+
+
 @dataclasses.dataclass(frozen=True, slots=True)
 class SecondaryAxisResult:
     """Outcome of evaluating a non-primary axis for manual-override drift.
@@ -59,10 +75,7 @@ class SecondaryAxisCheck:
         if new_value is None:
             return SecondaryAxisResult()
 
-        effective_threshold = max(
-            manual_threshold if manual_threshold is not None else 0,
-            POSITION_TOLERANCE_PERCENT,
-        )
+        effective_threshold = effective_manual_threshold(manual_threshold)
         delta = abs(self.expected - new_value)
 
         # Check suppression BEFORE the on-target short-circuit. When the motor
@@ -307,15 +320,11 @@ class AdaptiveCoverManager:
             return
 
         if new_position != our_state:
-            # Use the larger of the user-configured threshold and the position
-            # tolerance constant as the minimum detectable change.  This prevents
-            # motor rounding and position-reporting imprecision (up to
-            # POSITION_TOLERANCE_PERCENT) from triggering false manual overrides
-            # even when the user has not configured an explicit threshold.
-            effective_threshold = max(
-                manual_threshold if manual_threshold is not None else 0,
-                POSITION_TOLERANCE_PERCENT,
-            )
+            # Floor the threshold at POSITION_TOLERANCE_PERCENT so motor rounding
+            # / position-reporting imprecision can't trip false positives even
+            # when the user leaves manual_threshold unset. See
+            # ``effective_manual_threshold`` for the single-source-of-truth.
+            effective_threshold = effective_manual_threshold(manual_threshold)
             if abs(our_state - new_position) <= effective_threshold:
                 self.logger.debug(
                     "Position change %s%% is less than effective threshold %s%% for %s (user threshold=%s, tolerance floor=%s)",

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -111,8 +111,7 @@ class SecondaryAxisCheck:
                     "new_position": new_value,
                     "effective_threshold": effective_threshold,
                     "reason": (
-                        f"{self.label} delta {delta:.1f}% >= threshold "
-                        f"{effective_threshold}% (no recent position cmd)"
+                        f"{self.label} delta {delta:.1f}% >= threshold {effective_threshold}%"
                     ),
                 },
             )

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import datetime as dt
 from typing import TYPE_CHECKING
 from collections.abc import Callable
@@ -12,6 +11,7 @@ if TYPE_CHECKING:
 
 from ..const import DEFAULT_MOTION_TIMEOUT
 from ..helpers import is_entity_active
+from .common import TimeoutController
 
 
 class MotionManager:
@@ -44,7 +44,7 @@ class MotionManager:
         self._sensors: list[str] = []
         self._timeout_seconds: int = DEFAULT_MOTION_TIMEOUT
 
-        self._motion_timeout_task: asyncio.Task | None = None
+        self._timer = TimeoutController(logger, label="motion timeout")
         self._last_motion_time: float | None = None
         self._motion_timeout_active: bool = False
 
@@ -106,6 +106,16 @@ class MotionManager:
         return self._motion_timeout_active
 
     @property
+    def has_pending_timeout(self) -> bool:
+        """Return True iff a no-motion timer is in flight (sleeping, not yet expired).
+
+        Public observation point so tests don't have to reach into the
+        ``TimeoutController`` instance. Distinguishes "timer running"
+        from "timeout already expired" (``is_motion_timeout_active``).
+        """
+        return self._timer.is_running
+
+    @property
     def last_motion_time(self) -> float | None:
         """Return UNIX timestamp of the most recent motion detection, or None."""
         return self._last_motion_time
@@ -134,10 +144,7 @@ class MotionManager:
             already the current state (no refresh needed).
 
         """
-        had_pending = (
-            self._motion_timeout_task is not None
-            and not self._motion_timeout_task.done()
-        )
+        had_pending = self._timer.is_running
         had_active = self._motion_timeout_active
         self.cancel_motion_timeout()
         self._last_motion_time = self._now().timestamp()
@@ -158,42 +165,45 @@ class MotionManager:
                 ``coordinator.async_refresh``.
 
         """
-        self.cancel_motion_timeout()
+        # Record the "cancelled" event before the controller swaps timers
+        # so the diagnostic ring still shows the cancel-on-restart edge.
+        if self._timer.is_running and self._event_buffer is not None:
+            self._event_buffer.record(
+                {
+                    "ts": self._now().isoformat(),
+                    "event": "motion_timeout_canceled",
+                }
+            )
 
+        timeout_seconds = self._timeout_seconds
         self._logger.info(
             "No motion detected - starting %s second timeout before using default position",
-            self._timeout_seconds,
+            timeout_seconds,
         )
         if self._event_buffer is not None:
             self._event_buffer.record(
                 {
                     "ts": self._now().isoformat(),
                     "event": "motion_timeout_started",
-                    "timeout_seconds": self._timeout_seconds,
+                    "timeout_seconds": timeout_seconds,
                 }
             )
 
-        task = asyncio.create_task(
-            self._motion_timeout_handler(self._timeout_seconds, refresh_callback)
-        )
-        self._motion_timeout_task = task
+        async def _on_expire() -> None:
+            await self._on_motion_timeout_expired(timeout_seconds, refresh_callback)
 
-    async def _motion_timeout_handler(
+        self._timer.start(timeout_seconds, _on_expire)
+
+    async def _on_motion_timeout_expired(
         self, timeout_seconds: int, refresh_callback: Callable
     ) -> None:
-        """Handle timeout expiration after no motion is detected.
+        """Body that runs after the no-motion sleep completes.
 
-        Args:
-            timeout_seconds: How long to wait before activating default position
-            refresh_callback: Called after timeout expires if motion is still absent
-
+        Re-checks the motion state — sensors may have flipped on during
+        the sleep, in which case the default-position fallback should
+        not fire. Otherwise sets the active flag, emits the expiry
+        event, and delegates to the caller's refresh callback.
         """
-        try:
-            await asyncio.sleep(timeout_seconds)
-        except asyncio.CancelledError:
-            return
-
-        # Double-check: motion may have re-appeared during the sleep
         if self.is_motion_detected:
             self._logger.debug(
                 "Motion detected during timeout - canceling default position"
@@ -225,14 +235,11 @@ class MotionManager:
 
     def cancel_motion_timeout(self) -> None:
         """Cancel the running timeout task, if any."""
-        if self._motion_timeout_task and not self._motion_timeout_task.done():
-            self._logger.debug("Motion timeout canceled")
-            self._motion_timeout_task.cancel()
-            if self._event_buffer is not None:
-                self._event_buffer.record(
-                    {
-                        "ts": self._now().isoformat(),
-                        "event": "motion_timeout_canceled",
-                    }
-                )
-        self._motion_timeout_task = None
+        if self._timer.is_running and self._event_buffer is not None:
+            self._event_buffer.record(
+                {
+                    "ts": self._now().isoformat(),
+                    "event": "motion_timeout_canceled",
+                }
+            )
+        self._timer.cancel()

--- a/custom_components/adaptive_cover_pro/managers/weather.py
+++ b/custom_components/adaptive_cover_pro/managers/weather.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -14,6 +13,7 @@ from ..const import (
     DEFAULT_WINDOW_AZIMUTH,
     DEGREES_IN_CIRCLE,
 )
+from .common import TimeoutController
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -77,7 +77,7 @@ class WeatherManager:
         self._timeout_seconds: int = DEFAULT_WEATHER_TIMEOUT
 
         # Runtime state
-        self._timeout_task: asyncio.Task | None = None
+        self._timer = TimeoutController(logger, label="weather clear-delay")
         self._override_active: bool = False
 
     # --- Configuration ---
@@ -163,7 +163,7 @@ class WeatherManager:
     @property
     def is_timeout_running(self) -> bool:
         """Return True when a clear-delay timeout task is pending."""
-        return self._timeout_task is not None and not self._timeout_task.done()
+        return self._timer.is_running
 
     @property
     def in_clear_delay(self) -> bool:
@@ -301,34 +301,26 @@ class WeatherManager:
                 normal control should resume.
 
         """
-        self.cancel_weather_timeout()
-
+        timeout_seconds = self._timeout_seconds
         self._logger.info(
             "Weather conditions cleared — starting %s second delay before resuming normal control",
-            self._timeout_seconds,
+            timeout_seconds,
         )
 
-        task = asyncio.create_task(
-            self._weather_timeout_handler(self._timeout_seconds, refresh_callback)
-        )
-        self._timeout_task = task
+        async def _on_expire() -> None:
+            await self._on_weather_timeout_expired(timeout_seconds, refresh_callback)
 
-    async def _weather_timeout_handler(
+        self._timer.start(timeout_seconds, _on_expire)
+
+    async def _on_weather_timeout_expired(
         self, timeout_seconds: int, refresh_callback: Callable
     ) -> None:
-        """Handle timeout expiration after weather conditions clear.
+        """Body that runs after the clear-delay sleep completes.
 
-        Args:
-            timeout_seconds: How long to wait before deactivating the override
-            refresh_callback: Called after timeout expires if conditions still clear
-
+        Re-checks whether weather conditions have returned during the
+        sleep — if so, the override is kept active and the refresh
+        callback is suppressed.
         """
-        try:
-            await asyncio.sleep(timeout_seconds)
-        except asyncio.CancelledError:
-            return
-
-        # Double-check: conditions may have returned during the sleep
         if self.is_any_condition_active:
             self._logger.debug(
                 "Weather conditions returned during clear-delay — keeping override active"
@@ -359,7 +351,4 @@ class WeatherManager:
 
     def cancel_weather_timeout(self) -> None:
         """Cancel the running clear-delay timeout task, if any."""
-        if self._timeout_task and not self._timeout_task.done():
-            self._logger.debug("Weather clear-delay timeout canceled")
-            self._timeout_task.cancel()
-        self._timeout_task = None
+        self._timer.cancel()

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.21.5"
+  "version": "2.22.0-beta.1"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.22.0-beta.1"
+  "version": "2.22.0-beta.2"
 }

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
@@ -8,7 +8,7 @@ Thanks to @ZamenWolk for identifying this in GitHub issue #213.
 
 from __future__ import annotations
 
-from typing import cast
+import logging
 
 from ...cover_types import get_policy
 from ...engine.covers.vertical import (
@@ -19,6 +19,8 @@ from ...enums import ControlMethod
 from ..handler import OverrideHandler
 from ..helpers import apply_snapshot_limits, compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class GlareZoneHandler(OverrideHandler):
@@ -58,7 +60,18 @@ class GlareZoneHandler(OverrideHandler):
         if not snapshot.cover.direct_sun_valid:
             return None
 
-        cover = cast(AdaptiveVerticalCover, snapshot.cover)
+        # Belt-and-braces: ``supports_glare_zones`` is the public gate, but a
+        # future policy that flips the flag without binding a vertical engine
+        # would silently type-confuse here. Verify at runtime; skip + warn so
+        # the pipeline doesn't crash on the next attribute access.
+        if not isinstance(snapshot.cover, AdaptiveVerticalCover):
+            _LOGGER.warning(
+                "GlareZoneHandler gated on supports_glare_zones=True but cover "
+                "is %s, not AdaptiveVerticalCover — skipping",
+                type(snapshot.cover).__name__,
+            )
+            return None
+        cover = snapshot.cover
         window_half_width = snapshot.glare_zones.window_width / 2.0
         base_distance = cover.distance
 

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -1,0 +1,315 @@
+"""Pipeline snapshot construction.
+
+`PipelineSnapshotBuilder` aggregates HA entity reads, options, manager state,
+and policy-derived glare-zone configuration into a single
+:class:`PipelineSnapshot` for the pipeline registry to evaluate.
+
+It is composed by the coordinator and constructed once at coordinator
+initialisation.  The builder holds no per-cycle state: every value that
+changes per cycle (manual-override flag, motion-timeout flag, weather flag,
+time-window flag, current cover position, the cover engine, etc.) flows in
+as a method argument.  The coordinator remains the single owner of
+``_weather_readings`` — the builder returns ``ClimateReadings`` from
+:meth:`read_climate` and the coordinator stores it.
+
+Background: this code lived inline on the coordinator as five private
+methods (``_read_climate_state``, ``_build_climate_options``,
+``_read_force_sensor_states``, ``_read_custom_position_sensor_states``,
+``_build_pipeline_snapshot``) totalling ~213 LOC.  Extracting them follows
+the same composed-class pattern that Phase B established with
+:class:`TimeoutController`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from collections.abc import Callable
+
+from ..const import (
+    CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_CLOUD_COVERAGE_THRESHOLD,
+    CONF_CLOUD_SUPPRESSION,
+    CONF_CLOUDY_POSITION,
+    CONF_DEFAULT_HEIGHT,
+    CONF_DEFAULT_TILT,
+    CONF_ENABLE_SUN_TRACKING,
+    CONF_FORCE_OVERRIDE_MIN_MODE,
+    CONF_FORCE_OVERRIDE_POSITION,
+    CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_IRRADIANCE_ENTITY,
+    CONF_IRRADIANCE_THRESHOLD,
+    CONF_IS_SUNNY_SENSOR,
+    CONF_LUX_ENTITY,
+    CONF_LUX_THRESHOLD,
+    CONF_MOTION_TIMEOUT_MODE,
+    CONF_MY_POSITION_VALUE,
+    CONF_OUTSIDE_THRESHOLD,
+    CONF_OUTSIDETEMP_ENTITY,
+    CONF_PRESENCE_ENTITY,
+    CONF_SUNRISE_OFFSET,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_POS,
+    CONF_SUNSET_TILT,
+    CONF_SUNSET_USE_MY,
+    CONF_TEMP_ENTITY,
+    CONF_TEMP_HIGH,
+    CONF_TEMP_LOW,
+    CONF_TRANSPARENT_BLIND,
+    CONF_WEATHER_BYPASS_AUTO_CONTROL,
+    CONF_WEATHER_ENTITY,
+    CONF_WEATHER_OVERRIDE_MIN_MODE,
+    CONF_WEATHER_OVERRIDE_POSITION,
+    CONF_WEATHER_STATE,
+    CONF_WINTER_CLOSE_INSULATION,
+    CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+    DEFAULT_MOTION_TIMEOUT_MODE,
+)
+from ..helpers import compute_effective_default
+from .types import (
+    ClimateOptions,
+    CustomPositionSensorState,
+    PipelineSnapshot,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from ..config_types import ConfigContextAdapter
+    from ..cover_types.base import CoverTypePolicy
+    from ..engine.covers.base import AdaptiveGeneralCover
+    from ..managers.toggles import ToggleManager
+    from ..services.configuration_service import ConfigurationService
+    from ..state.climate_provider import ClimateProvider, ClimateReadings
+
+
+class PipelineSnapshotBuilder:
+    """Aggregate HA reads + manager state into a :class:`PipelineSnapshot`."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        *,
+        climate_provider: ClimateProvider,
+        toggles: ToggleManager,
+        policy: CoverTypePolicy,
+        config_service: ConfigurationService,
+    ) -> None:
+        """Bind the builder to its long-lived collaborators."""
+        self._hass = hass
+        self._logger = logger
+        self._climate_provider = climate_provider
+        self._toggles = toggles
+        self._policy = policy
+        self._config_service = config_service
+
+    # ---- HA reads ---------------------------------------------------------
+
+    def read_climate(self, options: dict) -> ClimateReadings:
+        """Read all climate-related entities into a fresh ``ClimateReadings``.
+
+        Single call to :meth:`ClimateProvider.read` for each update cycle.
+        Reads temperature sensors, presence, weather, lux, irradiance, and
+        cloud coverage.  All pipeline handlers (ClimateHandler,
+        CloudSuppressionHandler) consume the result via
+        ``snapshot.climate_readings``.
+
+        Cloud suppression is documented as independent of Climate Mode, so
+        lux/irradiance are read whenever cloud suppression is enabled and the
+        corresponding entity is configured — even if the climate-mode toggles
+        are off.
+        """
+        cloud_suppression_enabled = bool(options.get(CONF_CLOUD_SUPPRESSION, False))
+        lux_entity = options.get(CONF_LUX_ENTITY)
+        irradiance_entity = options.get(CONF_IRRADIANCE_ENTITY)
+        use_lux = bool(self._toggles.lux_toggle) or (
+            cloud_suppression_enabled and lux_entity is not None
+        )
+        use_irradiance = bool(self._toggles.irradiance_toggle) or (
+            cloud_suppression_enabled and irradiance_entity is not None
+        )
+        return self._climate_provider.read(
+            temp_entity=options.get(CONF_TEMP_ENTITY),
+            outside_entity=options.get(CONF_OUTSIDETEMP_ENTITY),
+            presence_entity=options.get(CONF_PRESENCE_ENTITY),
+            weather_entity=options.get(CONF_WEATHER_ENTITY),
+            weather_condition=options.get(CONF_WEATHER_STATE),
+            use_lux=use_lux,
+            lux_entity=lux_entity,
+            lux_threshold=options.get(CONF_LUX_THRESHOLD),
+            use_irradiance=use_irradiance,
+            irradiance_entity=irradiance_entity,
+            irradiance_threshold=options.get(CONF_IRRADIANCE_THRESHOLD),
+            use_cloud_coverage=cloud_suppression_enabled,
+            cloud_coverage_entity=options.get(CONF_CLOUD_COVERAGE_ENTITY),
+            cloud_coverage_threshold=options.get(CONF_CLOUD_COVERAGE_THRESHOLD),
+            is_sunny_sensor=options.get(CONF_IS_SUNNY_SENSOR),
+        )
+
+    def read_force_sensors(self, options: dict) -> dict[str, bool]:
+        """Read force override sensor states from HA into a plain dict."""
+        sensors = options.get(CONF_FORCE_OVERRIDE_SENSORS, [])
+        return {
+            sensor: bool(
+                (state := self._hass.states.get(sensor)) and state.state == "on"
+            )
+            for sensor in sensors
+        }
+
+    def read_custom_position_sensors(
+        self, options: dict
+    ) -> list[CustomPositionSensorState]:
+        """Read custom position sensor states from HA into an ordered list.
+
+        Returns one :class:`CustomPositionSensorState` per configured slot
+        (sensor and position both set).  Priority defaults to
+        ``DEFAULT_CUSTOM_POSITION_PRIORITY`` (77) when not set so existing
+        installations behave identically.  ``min_mode`` defaults to False;
+        ``use_my`` defaults to False (when True the slot triggers the cover's
+        hardware "My" preset via ``stop_cover`` instead of the slot's numeric
+        position).
+        """
+        result: list[CustomPositionSensorState] = []
+        for slot_keys in CUSTOM_POSITION_SLOTS.values():
+            sensor = options.get(slot_keys["sensor"])
+            position = options.get(slot_keys["position"])
+            if sensor and position is not None:
+                is_on = bool(
+                    (state := self._hass.states.get(sensor)) and state.state == "on"
+                )
+                priority = int(
+                    options.get(slot_keys["priority"])
+                    or DEFAULT_CUSTOM_POSITION_PRIORITY
+                )
+                min_mode = bool(options.get(slot_keys["min_mode"], False))
+                use_my = bool(options.get(slot_keys["use_my"], False))
+                raw_tilt = options.get(slot_keys["tilt"])
+                tilt = int(raw_tilt) if raw_tilt is not None else None
+                result.append(
+                    CustomPositionSensorState(
+                        entity_id=sensor,
+                        is_on=is_on,
+                        position=int(position),
+                        priority=priority,
+                        min_mode=min_mode,
+                        use_my=use_my,
+                        tilt=tilt,
+                    )
+                )
+        return result
+
+    # ---- Pure assembly ----------------------------------------------------
+
+    def build_climate_options(self, options: dict) -> ClimateOptions:
+        """Build a :class:`ClimateOptions` from config entry options."""
+        return ClimateOptions(
+            temp_low=options.get(CONF_TEMP_LOW),
+            temp_high=options.get(CONF_TEMP_HIGH),
+            temp_switch=bool(self._toggles.temp_toggle),
+            transparent_blind=options.get(CONF_TRANSPARENT_BLIND, False),
+            temp_summer_outside=options.get(CONF_OUTSIDE_THRESHOLD),
+            cloud_suppression_enabled=bool(options.get(CONF_CLOUD_SUPPRESSION, False)),
+            winter_close_insulation=bool(
+                options.get(CONF_WINTER_CLOSE_INSULATION, False)
+            ),
+            cloudy_position=options.get(CONF_CLOUDY_POSITION),
+        )
+
+    def build(
+        self,
+        options: dict,
+        *,
+        cover_data: AdaptiveGeneralCover,
+        cover_type: str,
+        climate_readings: ClimateReadings | None,
+        manual_override_active: bool,
+        motion_timeout_active: bool,
+        weather_override_active: bool,
+        in_time_window: bool,
+        current_cover_position: int | None,
+        is_glare_zone_enabled: Callable[[int], bool],
+        effective_default: int | None = None,
+        is_sunset_active: bool | None = None,
+    ) -> PipelineSnapshot:
+        """Assemble the per-cycle :class:`PipelineSnapshot`.
+
+        ``effective_default`` / ``is_sunset_active`` are recomputed from
+        ``options`` and ``cover_data.sun_data`` when omitted — preserving the
+        fallback the original ``_build_pipeline_snapshot`` used so that
+        ``async_apply_user_position`` (which evaluates a preemption check
+        outside the update cycle) can still build a valid snapshot without
+        knowing those values.
+
+        ``is_glare_zone_enabled(idx)`` returns the current state of the
+        per-instance glare-zone master switch for zone ``idx``.  The coordinator
+        owns those switch attributes (``glare_zone_0``, ``glare_zone_1`` …);
+        the builder reads them through this callable so it never reaches back
+        into ``coordinator.self``.
+        """
+        if effective_default is None or is_sunset_active is None:
+            h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
+            sunset_pos_cfg = options.get(CONF_SUNSET_POS)
+            sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
+            sunrise_off = int(
+                options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
+            )
+            effective_default, is_sunset_active = compute_effective_default(
+                h_def=h_def,
+                sunset_pos=sunset_pos_cfg,
+                sun_data=cover_data.sun_data,
+                sunset_off=sunset_off,
+                sunrise_off=sunrise_off,
+            )
+
+        glare_zones_cfg = self._policy.glare_zones_config(self._config_service, options)
+        active_zone_names: set[str] = set()
+        if glare_zones_cfg is not None:
+            for idx, zone in enumerate(glare_zones_cfg.zones):
+                if is_glare_zone_enabled(idx):
+                    active_zone_names.add(zone.name)
+
+        return PipelineSnapshot(
+            cover=cover_data,
+            config=cover_data.config,
+            cover_type=cover_type,
+            default_position=effective_default,
+            is_sunset_active=is_sunset_active,
+            # NOTE: configured_default and configured_sunset_pos are deliberately
+            # absent from PipelineSnapshot.  They are annotated onto PipelineResult
+            # by the coordinator after evaluation so the raw config values are
+            # never accessible to pipeline handler logic.
+            climate_readings=climate_readings,
+            climate_mode_enabled=self._toggles.switch_mode,
+            climate_options=self.build_climate_options(options),
+            force_override_sensors=self.read_force_sensors(options),
+            force_override_position=options.get(CONF_FORCE_OVERRIDE_POSITION, 0),
+            force_override_min_mode=bool(
+                options.get(CONF_FORCE_OVERRIDE_MIN_MODE, False)
+            ),
+            manual_override_active=manual_override_active,
+            motion_timeout_active=motion_timeout_active,
+            weather_override_active=weather_override_active,
+            weather_override_position=options.get(CONF_WEATHER_OVERRIDE_POSITION, 0),
+            weather_override_min_mode=bool(
+                options.get(CONF_WEATHER_OVERRIDE_MIN_MODE, False)
+            ),
+            weather_bypass_auto_control=options.get(
+                CONF_WEATHER_BYPASS_AUTO_CONTROL, True
+            ),
+            glare_zones=glare_zones_cfg,
+            active_zone_names=frozenset(active_zone_names),
+            in_time_window=in_time_window,
+            motion_control_enabled=self._toggles.motion_control,
+            custom_position_sensors=self.read_custom_position_sensors(options),
+            my_position_value=options.get(CONF_MY_POSITION_VALUE),
+            sunset_use_my=bool(options.get(CONF_SUNSET_USE_MY, False)),
+            enable_sun_tracking=bool(options.get(CONF_ENABLE_SUN_TRACKING, True)),
+            motion_timeout_mode=options.get(
+                CONF_MOTION_TIMEOUT_MODE, DEFAULT_MOTION_TIMEOUT_MODE
+            ),
+            current_cover_position=current_cover_position,
+            policy=self._policy,
+            default_tilt=options.get(CONF_DEFAULT_TILT),
+            sunset_tilt=options.get(CONF_SUNSET_TILT),
+        )

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -551,7 +551,7 @@ def _motion_status_value(s: _ACPDiagnosticSensor) -> str:
     if not s.config_entry.options.get(CONF_MOTION_SENSORS):
         return "not_configured"
     mgr = s.coordinator._motion_mgr  # noqa: SLF001
-    if mgr._motion_timeout_active:  # noqa: SLF001
+    if mgr.is_motion_timeout_active:
         pr = getattr(s.coordinator, "_pipeline_result", None)
         if pr is not None and pr.skip_command and pr.control_method.value == "motion":
             return "holding"
@@ -560,8 +560,7 @@ def _motion_status_value(s: _ACPDiagnosticSensor) -> str:
         return "waiting_for_data"
     if s.coordinator.is_motion_detected:
         return "motion_detected"
-    task = mgr._motion_timeout_task  # noqa: SLF001
-    if task is not None and not task.done():
+    if mgr.has_pending_timeout:
         return "timeout_pending"
     return "waiting_for_data"
 
@@ -575,9 +574,7 @@ def _motion_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
     }  # noqa: SLF001
 
     if mgr.last_motion_time is not None:
-        task = mgr._motion_timeout_task  # noqa: SLF001
-        timeout_pending = task is not None and not task.done()
-        if timeout_pending or mgr._motion_timeout_active:  # noqa: SLF001
+        if mgr.has_pending_timeout or mgr.is_motion_timeout_active:
             end_ts = mgr.last_motion_time + mgr._timeout_seconds  # noqa: SLF001
             attrs["motion_timeout_end_time"] = dt_util.utc_from_timestamp(
                 end_ts

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -37,7 +37,6 @@ from .const import (
     CUSTOM_POSITION_SLOTS,
     DEGREES_IN_CIRCLE,
     DOMAIN,
-    SensorType,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
 from .entity_base import AdaptiveCoverDiagnosticSensorBase, AdaptiveCoverSensorBase
@@ -77,6 +76,21 @@ class _SensorSpec:
     diagnostic: bool = (
         True  # False → uses AdaptiveCoverSensorBase (Cover_Position et al.)
     )
+
+
+def _exposes_dual_axis_sensor(entry: ConfigEntry) -> bool:
+    """Gate the dual-axis Target Tilt sensor on the cover-type policy.
+
+    Modelled on ``binary_sensor._glare_zones_enabled_for_blind`` so a new
+    cover type opts in by flipping ``CoverTypePolicy.exposes_dual_axis_sensor``
+    on its subclass — not by editing sensor.py.
+    """
+    from .cover_types import POLICY_REGISTRY, get_policy
+
+    sensor_type = entry.data.get(CONF_SENSOR_TYPE)
+    if sensor_type not in POLICY_REGISTRY:
+        return False
+    return get_policy(sensor_type).exposes_dual_axis_sensor
 
 
 # ---------------------------------------------------------------------------
@@ -804,7 +818,7 @@ _STANDARD_SPECS: tuple[_SensorSpec, ...] = (
         suggested_display_precision=0,
         value_fn=_cover_tilt_value,
         diagnostic=False,
-        enabled_when=lambda e: e.data.get(CONF_SENSOR_TYPE) == SensorType.VENETIAN,
+        enabled_when=_exposes_dual_axis_sensor,
     ),
     _SensorSpec(
         suffix="Start Sun",

--- a/custom_components/adaptive_cover_pro/state/__init__.py
+++ b/custom_components/adaptive_cover_pro/state/__init__.py
@@ -4,6 +4,7 @@ from .climate_provider import ClimateProvider, ClimateReadings
 from .cover_provider import CoverProvider
 from .snapshot import CoverCapabilities, CoverStateSnapshot, SunSnapshot
 from .sun_provider import SunProvider
+from .window_transition_tracker import WindowTransitionTracker
 
 __all__ = [
     "ClimateProvider",
@@ -13,4 +14,5 @@ __all__ = [
     "CoverStateSnapshot",
     "SunProvider",
     "SunSnapshot",
+    "WindowTransitionTracker",
 ]

--- a/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
+++ b/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
@@ -1,0 +1,195 @@
+"""Window-transition tracking for sun visibility and astronomical sunset.
+
+`WindowTransitionTracker` owns two correlated bits of stateful transition
+detection that previously lived inline on the coordinator:
+
+- **Sun visibility transition.** `sun_just_appeared()` returns True when the
+  cover's direct-sun-valid flag flips from False to True between calls,
+  signalling that covers should immediately reposition regardless of the
+  per-update delta gates.  False→True records ``sun_entered_fov`` and
+  True→False records ``sun_left_fov`` in the diagnostic event buffer.
+
+- **Astronomical sunset window.** `check_sunset_window()` detects the
+  False→True transition of the astronomical sunset window (sun crosses the
+  configured offset after sunset) and dispatches the configured sunset
+  position to all non-manually-controlled covers.  Covers issue #266 —
+  where the user's configured end_time fires before the astronomical
+  sunset offset elapses, so the daytime default is sent at end_time and
+  the sunset position is sent later when the window finally opens.
+
+Both pieces of state initialise to ``None`` so a coordinator restart
+mid-sunset does not spuriously dispatch — the first call seeds the prior
+state and returns without acting, matching the behaviour before extraction.
+
+The tracker is framework-light: it never imports the coordinator.
+Per-cycle collaborators (entities list, manager, command service,
+position-context builder, refresh callback) flow in by parameter at each
+call.  Long-lived collaborators (hass, logger, event buffer, and a
+closure that returns the current effective default + sunset flag) are
+constructor-injected.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from ..managers.manual_override import inverse_state
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from ..config_types import ConfigContextAdapter
+    from ..diagnostics.event_buffer import EventBuffer
+    from ..managers.cover_command import PositionContext
+
+
+# Type aliases for readability of the public surface.
+EffectiveDefaultFn = Callable[[dict], tuple[int, bool]]
+BuildContextFn = Callable[[str, dict], "PositionContext"]
+ApplyPositionFn = Callable[..., Awaitable[Any]]
+RefreshFn = Callable[[], Awaitable[Any]]
+IsCoverManualFn = Callable[[str], bool]
+
+
+class WindowTransitionTracker:
+    """Track sun-visibility and astronomical-sunset-window transitions."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        *,
+        event_buffer: EventBuffer,
+        effective_default_fn: EffectiveDefaultFn,
+    ) -> None:
+        """Bind collaborators and reset transition state to ``None``."""
+        self._hass = hass
+        self._logger = logger
+        self._event_buffer = event_buffer
+        self._effective_default_fn = effective_default_fn
+        # ``None`` on first call prevents spurious dispatch when the
+        # integration starts mid-transition (issue #266 / sun FoV).
+        self._last_sun_validity_state: bool | None = None
+        self._prev_sunset_active: bool | None = None
+
+    # ---- Sun visibility --------------------------------------------------
+
+    def sun_just_appeared(self, cover_data) -> bool:
+        """Return True when ``direct_sun_valid`` just flipped False→True.
+
+        Records ``sun_entered_fov`` / ``sun_left_fov`` events on every
+        observed transition.  Returns False until the first call has seeded
+        the prior state.
+        """
+        if cover_data is None:
+            return False
+
+        current_sun_valid = cover_data.direct_sun_valid
+
+        if self._last_sun_validity_state is None:
+            self._last_sun_validity_state = current_sun_valid
+            return False
+
+        sun_just_appeared = (not self._last_sun_validity_state) and current_sun_valid
+        sun_just_left = self._last_sun_validity_state and (not current_sun_valid)
+
+        self._last_sun_validity_state = current_sun_valid
+
+        if sun_just_appeared:
+            self._logger.info(
+                "Sun visibility transition detected: OFF → ON (sun came into field of view)"
+            )
+            self._event_buffer.record(
+                {
+                    "ts": dt.datetime.now(dt.UTC).isoformat(),
+                    "event": "sun_entered_fov",
+                }
+            )
+        elif sun_just_left:
+            self._logger.debug(
+                "Sun visibility transition detected: ON → OFF (sun left field of view)"
+            )
+            self._event_buffer.record(
+                {
+                    "ts": dt.datetime.now(dt.UTC).isoformat(),
+                    "event": "sun_left_fov",
+                }
+            )
+
+        return sun_just_appeared
+
+    # ---- Astronomical sunset window -------------------------------------
+
+    async def check_sunset_window(
+        self,
+        *,
+        track_end_time: bool,
+        automatic_control: bool,
+        sunset_pos_cfg: int | None,
+        options: dict,
+        inverse_state_enabled: bool,
+        entities: list[str],
+        is_cover_manual: IsCoverManualFn,
+        build_position_context: BuildContextFn,
+        apply_position: ApplyPositionFn,
+        refresh: RefreshFn,
+    ) -> None:
+        """Detect False→True transition of the astronomical sunset window.
+
+        On opening transition, dispatches ``sunset_pos_cfg`` (inverted when
+        the cover uses inverse state) to every non-manual cover.  No-ops
+        when the user has not opted in to ``return_sunset`` tracking, when
+        automatic control is disabled, when no sunset position is
+        configured, or on the seeding call.
+        """
+        if not track_end_time:
+            return
+        if not automatic_control:
+            self._logger.debug(
+                "Sunset window opened but automatic control is OFF — skipping reposition"
+            )
+            return
+        if sunset_pos_cfg is None:
+            return
+
+        _effective_pos, is_sunset = self._effective_default_fn(options)
+
+        if self._prev_sunset_active is None:
+            self._prev_sunset_active = is_sunset
+            return
+
+        just_opened = (not self._prev_sunset_active) and is_sunset
+        self._prev_sunset_active = is_sunset
+
+        if not just_opened:
+            return
+
+        pos_to_send = (
+            inverse_state(int(sunset_pos_cfg))
+            if inverse_state_enabled
+            else int(sunset_pos_cfg)
+        )
+        self._logger.info(
+            "Sunset window opened after end_time — dispatching sunset position %s%% "
+            "to %s cover(s) (issue #266)",
+            pos_to_send,
+            len(entities),
+        )
+        self._event_buffer.record(
+            {
+                "ts": dt.datetime.now(dt.UTC).isoformat(),
+                "event": "sunset_window_opened",
+                "position": pos_to_send,
+                "cover_count": len(entities),
+            }
+        )
+        for cover_entity in entities:
+            if is_cover_manual(cover_entity):
+                continue
+            ctx = build_position_context(cover_entity, options)
+            await apply_position(
+                cover_entity, pos_to_send, "sunset_window_opened", context=ctx
+            )
+        await refresh()

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -26,6 +26,7 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
+from .cover_types import get_policy
 from .entity_base import AdaptiveCoverBaseEntity
 
 
@@ -70,8 +71,14 @@ def _has_climate_irradiance(entry: ConfigEntry) -> bool:
     return _has_climate_mode(entry) and bool(entry.options.get(CONF_IRRADIANCE_ENTITY))
 
 
-def _is_vertical_or_horizontal(entry: ConfigEntry) -> bool:
-    return entry.data.get(CONF_SENSOR_TYPE) in ("cover_awning", "cover_blind")
+def _supports_return_to_default_switch(entry: ConfigEntry) -> bool:
+    """Whether the "Return to default when disabled" switch applies to this cover.
+
+    The answer is a per-cover-type semantic, owned by the ``CoverTypePolicy``.
+    """
+    return get_policy(
+        entry.data.get(CONF_SENSOR_TYPE)
+    ).supports_return_to_default_switch
 
 
 def _has_motion_sensors(entry: ConfigEntry) -> bool:
@@ -102,7 +109,7 @@ _SWITCH_SPECS: tuple[_SwitchSpec, ...] = (
         switch_name="Return to default when disabled",
         key="return_to_default_toggle",
         initial_state=False,
-        enabled_when=_is_vertical_or_horizontal,
+        enabled_when=_supports_return_to_default_switch,
     ),
     _SwitchSpec(
         switch_name="Motion Control",

--- a/release_notes/v2.22.0-beta.1.md
+++ b/release_notes/v2.22.0-beta.1.md
@@ -1,0 +1,48 @@
+# v2.22.0-beta.1
+
+## 🎯 v2.22.0-beta.1 — Internal Refactor (Developer Beta)
+
+Nine-phase internal refactor that restructures `cover_types/`, `managers/`, `state/`, and `pipeline/` to make adding new cover types tractable without forking coordinator logic. No user-visible changes, no config changes, no bug fixes.
+
+## ⚠️ Should I install this?
+
+**Only install this beta if you are currently experiencing a bug** and have been asked to test it, or if you are a developer working on the integration.
+
+If you are on **v2.21.5 and it is working correctly, stay there.** This release exists to validate that the refactor introduced no regressions, not to deliver new capabilities. There is nothing here for users who are not hitting an active problem.
+
+### 🔑 Highlights
+
+- Coordinator shrunk by ~640 lines of code; responsibility distributed into `managers/`, `state/`, `pipeline/`, and `cover_types/` where it belongs.
+- Manual-override detection extracted from `coordinator.process_entity_state_change` into `managers/cover_command/state_classifier.py`; all five prior issue-specific fixes (#147, #172, #186, #271, #285) preserved verbatim.
+- Cover-type-specific behaviour consolidated onto `CoverTypePolicy` subclasses; the coordinator and pipeline handlers no longer branch on cover-type strings or hardcoded capability keys.
+- `StubSingleAxisPolicy` and `StubDualAxisPolicy` added as canary types; ~60 regression tests now run across all real and stub policies to catch future regressions early.
+- Net diff: 62 files changed, +3,682 / −1,251 lines.
+
+### 🧹 Chores
+
+- **Phase A — latent-defect cleanup at the policy boundary:** Six surgical fixes around `CoverTypePolicy`: `GlareZoneHandler` downcast guarded; `VenetianPolicy.is_in_tilt_suppression` signature harmonised; return-to-default switch gate moved to a policy `ClassVar`; manual-override threshold deduped; custom-position priority default unified; `CoverTypePolicy` safe-defaults added.
+
+- **Phase B — `TimeoutController` for the manager timeout pattern:** Consolidates the timeout-spawn/await/expiry/nullify pattern shared by `MotionManager`, `WeatherManager`, and `GracePeriodManager` into `managers/common/timeout_controller.py`. Removes ~80 lines of duplication.
+
+- **Phase C — `DualAxisSequencer` relocated to `cover_types/venetian/`:** Moves `managers/dual_axis_sequencer.py` and the flat `cover_types/venetian.py` into a new `cover_types/venetian/` package (`policy.py` + `sequencer.py`). Zero behavior change; the sequencer now lives alongside the policy that owns it.
+
+- **Phase D — `PipelineSnapshotBuilder` extracted from coordinator:** Five coordinator methods (~213 LOC) move into `pipeline/snapshot_builder.py`. Climate, force-sensor, and custom-position reads, plus snapshot assembly, are no longer inline in the coordinator.
+
+- **Phase E — `WindowTransitionTracker` extracted from coordinator:** ~130 lines of transition tracking move into `state/window_transition_tracker.py`. Removes `_last_sun_validity_state` and `_prev_sunset_active` as coordinator instance attributes.
+
+- **Phase F — `StateClassifier` extracted from coordinator:** Moves a 256-line manual-override detection block into `managers/cover_command/state_classifier.py`. Issue-specific logic for #147, #172, #186, #271, and #285 is preserved exactly.
+
+- **Phase G — eliminate last cover-type literals, harden guard:** Replaces remaining `SensorType.VENETIAN ==` checks with `ClassVar` flags (`exposes_dual_axis_sensor`, `custom_position_includes_tilt`). Adds a regression guard that scans for banned literal patterns to prevent the pattern from re-entering.
+
+- **Phase H — stub policies + parametrised cross-type invariants:** Introduces `StubSingleAxisPolicy` and `StubDualAxisPolicy`; production code must tolerate an unknown policy. Parametrises ~60 regression tests across all real and stub policies.
+
+- **Phase I — wiki anchor + display label onto the policy:** Consolidates per-type label and wiki-URL mappings onto `CoverTypePolicy.wiki_anchor()` and `display_label()` hooks. Removes hardcoded mappings from `config_flow.py`.
+
+### 🧪 Testing
+
+- 3375 tests passing (up from 3367 in v2.21.5).
+
+## Compatibility
+
+- Home Assistant 2026.3.0+
+- Python 3.11+

--- a/release_notes/v2.22.0-beta.2.md
+++ b/release_notes/v2.22.0-beta.2.md
@@ -1,0 +1,57 @@
+# v2.22.0-beta.2
+
+## 🎯 v2.22.0-beta.2 — Refactor + Post-Settle Cap Grace (Developer + Issue-33 Beta)
+
+This beta carries everything from v2.22.0-beta.1 (the nine-phase internal refactor) plus a targeted fix for a venetian false-override bug discovered after beta.1: on KNX, Shelly 2PM, and other real-motor actuators, `cover.state` can settle to `open`/`closed` before the tilt-walk burst finishes publishing, causing `DualAxisSequencer.is_in_suppression_with_cap` to reject legitimate motor drift as a user move. If you are running real venetian hardware that was tripping false manual-override after a position command, please install this beta and report back on issue [#33].
+
+## ⚠️ Should I install this?
+
+- If you ran v2.22.0-beta.1 and it worked, install this — it adds the post-settle cap grace fix on top.
+- If you are on v2.21.5 and seeing false manual-override on venetian blinds after a position command (issue [#33]), please install this beta and report back.
+- If you are on v2.21.5 and not hitting any issue, you may want to stay there.
+
+### 🔑 Highlights
+
+- **NEW in beta.2:** A 5-second post-settle cap grace in `DualAxisSequencer.is_in_suppression_with_cap` eliminates false venetian manual-override on KNX, Shelly 2PM, FGR223, and similar actuators that publish their tilt-walk burst after `cover.state` has already reported `open`/`closed` (issue [#33]).
+- Coordinator shrunk by ~640 lines of code; responsibility distributed into `managers/`, `state/`, `pipeline/`, and `cover_types/` where it belongs.
+- Manual-override detection extracted from `coordinator.process_entity_state_change` into `managers/cover_command/state_classifier.py`; all five prior issue-specific fixes (#147, #172, #186, #271, #285) preserved verbatim.
+- Cover-type-specific behaviour consolidated onto `CoverTypePolicy` subclasses; the coordinator and pipeline handlers no longer branch on cover-type strings or hardcoded capability keys.
+- `StubSingleAxisPolicy` and `StubDualAxisPolicy` added as canary types; ~60 regression tests now run across all real and stub policies to catch future regressions early.
+- Net diff (beta.1 refactor): 62 files changed, +3,682 / −1,251 lines.
+
+### 🐛 Bug Fixes (new in beta.2)
+
+- **Post-settle cap grace prevents false venetian override ([#33], commit 8c911d3):** `DualAxisSequencer.is_in_suppression_with_cap` guards against false manual-override by bypassing the geometry-bounded backrotate cap while `cover.state` is in a moving set. On real KNX, Shelly 2PM, and FGR223 actuators, however, the carriage reports `open` or `closed` before the full tilt-walk burst has drained from the HA state machine, so the cap would reassert mid-burst and flag the trailing delta as a user grab — latching manual override immediately after a programmatic position command. The fix adds a `VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS = 5.0` constant and checks the elapsed time since `stamp_position_command` was called inside `is_in_suppression_with_cap`: for 5 seconds after the stamp, the cap bypass stays active even when `cover.state` has already settled. Once the grace tail expires, the geometry-bounded cap reasserts normally and will still detect a genuine user move. Also tightened the manual-override reason string in `managers/manual_override.py` — the redundant "(no recent position cmd)" suffix was removed.
+
+### 🧹 Chores
+
+- **Phase A — latent-defect cleanup at the policy boundary:** Six surgical fixes around `CoverTypePolicy`: `GlareZoneHandler` downcast guarded; `VenetianPolicy.is_in_tilt_suppression` signature harmonised; return-to-default switch gate moved to a policy `ClassVar`; manual-override threshold deduped; custom-position priority default unified; `CoverTypePolicy` safe-defaults added.
+
+- **Phase B — `TimeoutController` for the manager timeout pattern:** Consolidates the timeout-spawn/await/expiry/nullify pattern shared by `MotionManager`, `WeatherManager`, and `GracePeriodManager` into `managers/common/timeout_controller.py`. Removes ~80 lines of duplication.
+
+- **Phase C — `DualAxisSequencer` relocated to `cover_types/venetian/`:** Moves `managers/dual_axis_sequencer.py` and the flat `cover_types/venetian.py` into a new `cover_types/venetian/` package (`policy.py` + `sequencer.py`). Zero behavior change; the sequencer now lives alongside the policy that owns it.
+
+- **Phase D — `PipelineSnapshotBuilder` extracted from coordinator:** Five coordinator methods (~213 LOC) move into `pipeline/snapshot_builder.py`. Climate, force-sensor, and custom-position reads, plus snapshot assembly, are no longer inline in the coordinator.
+
+- **Phase E — `WindowTransitionTracker` extracted from coordinator:** ~130 lines of transition tracking move into `state/window_transition_tracker.py`. Removes `_last_sun_validity_state` and `_prev_sunset_active` as coordinator instance attributes.
+
+- **Phase F — `StateClassifier` extracted from coordinator:** Moves a 256-line manual-override detection block into `managers/cover_command/state_classifier.py`. Issue-specific logic for #147, #172, #186, #271, and #285 is preserved exactly.
+
+- **Phase G — eliminate last cover-type literals, harden guard:** Replaces remaining `SensorType.VENETIAN ==` checks with `ClassVar` flags (`exposes_dual_axis_sensor`, `custom_position_includes_tilt`). Adds a regression guard that scans for banned literal patterns to prevent the pattern from re-entering.
+
+- **Phase H — stub policies + parametrised cross-type invariants:** Introduces `StubSingleAxisPolicy` and `StubDualAxisPolicy`; production code must tolerate an unknown policy. Parametrises ~60 regression tests across all real and stub policies.
+
+- **Phase I — wiki anchor + display label onto the policy:** Consolidates per-type label and wiki-URL mappings onto `CoverTypePolicy.wiki_anchor()` and `display_label()` hooks. Removes hardcoded mappings from `config_flow.py`.
+
+### 🧪 Testing
+
+- 3380 tests passing (up from 3375 in v2.22.0-beta.1).
+- New tests in `tests/test_manual_override_venetian.py` cover the inside-grace and post-grace cases for the post-settle cap-grace tail, including a `stamp_age_seconds` backdating helper that lands stamps outside the 5s window while staying inside the overall suppression window.
+- New tests in `tests/test_cover_types/test_venetian_sequencer.py` cover the cap grace: large delta inside grace returns true with settled state, large delta past grace returns false, small delta past grace still suppresses, and in-motion bypass still passes any delta.
+
+## Compatibility
+
+- Home Assistant 2026.3.0+
+- Python 3.11+
+
+[#33]: https://github.com/jrhubott/adaptive-cover-pro/issues/33

--- a/tests/services/test_set_position_service.py
+++ b/tests/services/test_set_position_service.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
 )
@@ -22,7 +23,7 @@ def _slot(position: int, *, is_on: bool, min_mode: bool) -> CustomPositionSensor
         entity_id=f"binary_sensor.slot_p{position}",
         is_on=is_on,
         position=position,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=min_mode,
         use_my=False,
     )

--- a/tests/services/test_set_position_service.py
+++ b/tests/services/test_set_position_service.py
@@ -38,7 +38,8 @@ def _make_coord(custom_states):
     coord.entities = ["cover.living_room"]
     coord.config_entry = MagicMock()
     coord.config_entry.options = {}
-    coord._read_custom_position_sensor_states.return_value = custom_states
+    coord._snapshot_builder = MagicMock()
+    coord._snapshot_builder.read_custom_position_sensors.return_value = custom_states
     ctx = MagicMock(name="position_context")
     coord._build_position_context.return_value = ctx
     coord._cmd_svc = MagicMock()

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -239,7 +239,33 @@ async def _trigger_first_refresh_safety(coord):
 
 
 async def _trigger_window_close_return_sunset(coord):
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
     coord._track_end_time = True
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord._inverse_state = False
+    coord.entities = []
+    coord.manager = MagicMock()
+    coord._build_position_context = MagicMock()
+    event_buffer = getattr(coord, "_event_buffer", None) or EventBuffer(maxlen=10)
+    coord._event_buffer = event_buffer
+    # Phase E: _check_time_window_transition awaits the sunset-window tracker
+    # after running the closed-window callback.  Seed prev_sunset_active=True
+    # so it no-ops without redispatching.
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
+    tracker._prev_sunset_active = True
+    coord._window_tracker = tracker
 
     async def _invoke(track_end_time, refresh_callback, on_window_open=None):
         await refresh_callback()
@@ -256,13 +282,29 @@ async def _trigger_sunset_window_opened(coord):
     gated by automatic_control=False.  The method must return early without
     dispatching (non-bypass, gated path).
     """
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
     coord._track_end_time = True
-    coord._prev_sunset_active = False
     coord.config_entry = MagicMock()
     coord.config_entry.options = {"sunset_position": 0}
     coord._inverse_state = False
     coord._compute_current_effective_default = MagicMock(return_value=(0, True))
     coord.async_refresh = AsyncMock()
+    event_buffer = getattr(coord, "_event_buffer", None) or EventBuffer(maxlen=10)
+    coord._event_buffer = event_buffer
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=event_buffer,
+        effective_default_fn=coord._compute_current_effective_default,
+    )
+    tracker._prev_sunset_active = False
+    coord._window_tracker = tracker
     await coord._check_sunset_window_transition()
 
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -325,7 +325,8 @@ async def _trigger_async_apply_user_position(coord):
     """
     coord.config_entry = MagicMock()
     coord.config_entry.options = {}
-    coord._read_custom_position_sensor_states = MagicMock(return_value=[])
+    coord._snapshot_builder = MagicMock()
+    coord._snapshot_builder.read_custom_position_sensors = MagicMock(return_value=[])
     await coord.async_apply_user_position(
         "cover.test", 42, trigger="set_position", force=True
     )

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -52,6 +52,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_SUNRISE_OFFSET,
     CONF_SUNSET_OFFSET,
     CONF_INVERSE_STATE,
+    CONF_IS_SUNNY_SENSOR,
     CONF_WINDOW_DEPTH,
     CUSTOM_POSITION_SLOTS,
     DOMAIN,
@@ -1286,6 +1287,60 @@ async def test_options_flow_custom_position_clears_sensor_position_and_priority(
         assert (
             saved.get(slot["priority"]) is None
         ), f"{slot['priority']} should be None after clearing"
+
+
+# ---------------------------------------------------------------------------
+# Regression: clearing Is Sunny sensor in light_cloud step (issue #377)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_options_flow_light_cloud_clears_is_sunny_sensor(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing the Is Sunny binary sensor in options flow must set the key to None.
+
+    Regression for issue #377: submitting an empty light_cloud form while a
+    previously-saved CONF_IS_SUNNY_SENSOR exists must overwrite it with None, not
+    leave the old entity_id in place. Same class of bug as #323 — the
+    `optional_entities()` call site omitted the key.
+    """
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    pre_options = dict(VERTICAL_OPTIONS)
+    pre_options[CONF_IS_SUNNY_SENSOR] = "binary_sensor.sunny"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Is Sunny Clear", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=pre_options,
+        entry_id="is_sunny_clear_01",
+        title="Is Sunny Clear",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "light_cloud"}
+    )
+    assert result["step_id"] == "light_cloud"
+
+    result = await hass.config_entries.options.async_configure(result["flow_id"], {})
+    assert result["type"] in ("form", "menu")
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    assert result["type"] == "create_entry"
+
+    assert (
+        result["data"].get(CONF_IS_SUNNY_SENSOR) is None
+    ), "CONF_IS_SUNNY_SENSOR should be None after clearing, not 'binary_sensor.sunny'"
 
 
 @pytest.mark.integration

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -75,7 +75,19 @@ def _make_coord(
     coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
     coord.config_entry = MagicMock()
     coord.config_entry.options = default_options if default_options is not None else {}
-    coord._read_custom_position_sensor_states.return_value = custom_states
+    # PipelineSnapshotBuilder mock — Phase D moved HA reads + snapshot
+    # assembly onto this collaborator.  Both call-sites of
+    # async_apply_user_position route through it.
+    coord._snapshot_builder = MagicMock()
+    coord._snapshot_builder.read_custom_position_sensors.return_value = custom_states
+    snapshot_sentinel = MagicMock(name="pipeline_snapshot")
+    coord._snapshot_builder.build = MagicMock(return_value=snapshot_sentinel)
+    # Coordinator state that the builder call needs as keyword args.  These
+    # are instance attributes (set in __init__) so they aren't on the spec'd
+    # MagicMock by default — preset them explicitly.
+    coord._cover_data = MagicMock(name="cover_data")
+    coord._cover_type = "cover_blind"
+    coord._weather_readings = None
     ctx = MagicMock(name="position_context")
     coord._build_position_context.return_value = ctx
     coord._cmd_svc = MagicMock()
@@ -89,10 +101,6 @@ def _make_coord(
     coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
         winner_name, winner_priority
     )
-
-    # _build_pipeline_snapshot is stubbed — preemption check just needs an object.
-    snapshot_sentinel = MagicMock(name="pipeline_snapshot")
-    coord._build_pipeline_snapshot = MagicMock(return_value=snapshot_sentinel)
 
     # Handler lookup so the helper can resolve priority from the winner step.
     handler = MagicMock()
@@ -182,7 +190,9 @@ async def test_async_apply_user_position_uses_passed_options_when_provided() -> 
         "cover.test", 10, trigger="set_position", options=custom_options
     )
 
-    coord._read_custom_position_sensor_states.assert_called_once_with(custom_options)
+    coord._snapshot_builder.read_custom_position_sensors.assert_called_once_with(
+        custom_options
+    )
     # And the override flowed into _build_position_context too
     args, kwargs = coord._build_position_context.call_args
     # signature: (entity, options, *, force=...)
@@ -318,8 +328,8 @@ async def test_snapshot_passed_to_pipeline_has_manual_override_false() -> None:
 
     await coord.async_apply_user_position("cover.test", 50, trigger="proxy_managed")
 
-    coord._build_pipeline_snapshot.assert_called_once()
-    _, kwargs = coord._build_pipeline_snapshot.call_args
+    coord._snapshot_builder.build.assert_called_once()
+    _, kwargs = coord._snapshot_builder.build.call_args
     assert kwargs.get("manual_override_active") is False
 
 

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.pipeline.handlers.manual_override import (
     ManualOverrideHandler,
 )
@@ -28,7 +29,7 @@ def _slot(pos: int, *, is_on: bool, min_mode: bool) -> CustomPositionSensorState
         entity_id=f"binary_sensor.slot_{pos}",
         is_on=is_on,
         position=pos,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=min_mode,
         use_my=False,
     )

--- a/tests/test_coordinator_climate_wiring.py
+++ b/tests/test_coordinator_climate_wiring.py
@@ -1,13 +1,14 @@
-"""Coordinator → ClimateProvider wiring tests.
+"""PipelineSnapshotBuilder → ClimateProvider wiring tests.
 
 These tests guard against the regression introduced in v2.12.0 (Issue #134) where
-the refactor from climate_mode_data() to _read_climate_state() silently dropped
-temp_entity, outside_entity, and presence_entity from the ClimateProvider.read()
-call — causing inside_temperature, outside_temperature, and is_presence to always
-be None/True regardless of configuration.
+the refactor from climate_mode_data() to the per-cycle climate-read step silently
+dropped temp_entity, outside_entity, and presence_entity from the
+``ClimateProvider.read()`` call — causing inside_temperature, outside_temperature,
+and is_presence to always be None/True regardless of configuration.
 
-The tests here verify the coordinator passes every config key to ClimateProvider.read()
-and will fail immediately if a future refactor drops a parameter.
+Phase D moved the climate-read step onto :class:`PipelineSnapshotBuilder`; these
+tests now drive the builder directly via its public surface.  The wiring contract
+(every option key reaches ``ClimateProvider.read``) is unchanged.
 """
 
 from __future__ import annotations
@@ -33,6 +34,9 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_ENTITY,
     CONF_WEATHER_STATE,
 )
+from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+    PipelineSnapshotBuilder,
+)
 from custom_components.adaptive_cover_pro.state.climate_provider import (
     ClimateProvider,
     ClimateReadings,
@@ -53,29 +57,53 @@ _DUMMY_READINGS = ClimateReadings(
 )
 
 
-def _make_coordinator():
-    """Build a minimal AdaptiveDataUpdateCoordinator with mocked dependencies.
+def _make_builder(
+    *,
+    lux_toggle: bool | None = False,
+    irradiance_toggle: bool | None = False,
+    temp_toggle: bool = False,
+):
+    """Build a :class:`PipelineSnapshotBuilder` with mocked collaborators."""
+    climate_provider = MagicMock(spec=ClimateProvider)
+    climate_provider.read.return_value = _DUMMY_READINGS
 
-    We only need the pieces used by _read_climate_state():
-      - self._climate_provider  (ClimateProvider mock)
-      - self._toggles           (toggles mock)
-    """
-    from custom_components.adaptive_cover_pro.coordinator import (
-        AdaptiveDataUpdateCoordinator,
-    )
-
-    coord = object.__new__(AdaptiveDataUpdateCoordinator)
-    coord._climate_provider = MagicMock(spec=ClimateProvider)
-    coord._climate_provider.read.return_value = _DUMMY_READINGS
-    coord._weather_readings = None
-
-    # Toggles: all feature flags off by default
     toggles = MagicMock()
-    toggles.lux_toggle = False
-    toggles.irradiance_toggle = False
-    coord._toggles = toggles
+    toggles.lux_toggle = lux_toggle
+    toggles.irradiance_toggle = irradiance_toggle
+    toggles.temp_toggle = temp_toggle
 
-    return coord
+    builder = PipelineSnapshotBuilder(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        climate_provider=climate_provider,
+        toggles=toggles,
+        policy=MagicMock(),
+        config_service=MagicMock(),
+    )
+    return builder, climate_provider
+
+
+def _make_coordinator():
+    """Backward-compat shim used by the original test bodies.
+
+    Returns an object exposing ``_climate_provider`` and ``_read_climate_state``
+    so the call-sites below stay readable.  The implementation routes through
+    the builder under test.
+    """
+
+    class _Shim:
+        def __init__(self):
+            self._builder, self._climate_provider = _make_builder()
+            self._weather_readings = None
+
+        def _read_climate_state(self, options):
+            self._weather_readings = self._builder.read_climate(options)
+
+        @property
+        def _toggles(self):
+            return self._builder._toggles  # noqa: SLF001 — internal mock view
+
+    return _Shim()
 
 
 # ---------------------------------------------------------------------------
@@ -458,16 +486,17 @@ class TestCloudSuppressionWiring:
 
 
 def _make_coordinator_with_toggles():
-    """Build a coordinator with temp_toggle for _build_climate_options tests."""
-    from custom_components.adaptive_cover_pro.coordinator import (
-        AdaptiveDataUpdateCoordinator,
-    )
+    """Shim for the cloudy-position tests: exposes ``_build_climate_options``."""
+    builder, _ = _make_builder()
 
-    coord = object.__new__(AdaptiveDataUpdateCoordinator)
-    toggles = MagicMock()
-    toggles.temp_toggle = False
-    coord._toggles = toggles
-    return coord
+    class _Shim:
+        def __init__(self):
+            self._builder = builder
+
+        def _build_climate_options(self, options):
+            return self._builder.build_climate_options(options)
+
+    return _Shim()
 
 
 class TestCloudyPositionWiring:

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -25,6 +25,27 @@ def _make_coordinator():
     return coord
 
 
+def _make_snapshot_builder(coord):
+    """Build a :class:`PipelineSnapshotBuilder` bound to ``coord.hass`` / toggles.
+
+    Phase D moved the custom-position sensor reads off the coordinator and
+    into this builder.  Existing tests that drove the old private method
+    construct the builder here and call its public surface.
+    """
+    from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+        PipelineSnapshotBuilder,
+    )
+
+    return PipelineSnapshotBuilder(
+        hass=coord.hass,
+        logger=coord.logger,
+        climate_provider=MagicMock(),
+        toggles=coord._toggles,
+        policy=MagicMock(),
+        config_service=MagicMock(),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Toggle property getters and setters
 # ---------------------------------------------------------------------------
@@ -245,7 +266,7 @@ def test_read_custom_position_sensor_states_reads_entity_state():
         CONF_CUSTOM_POSITION_PRIORITY_1: 77,
     }
 
-    result = coord._read_custom_position_sensor_states(options)
+    result = _make_snapshot_builder(coord).read_custom_position_sensors(options)
 
     assert len(result) == 1
     state = result[0]
@@ -286,7 +307,7 @@ def test_read_custom_position_sensor_states_with_priority_fallback():
         CONF_CUSTOM_POSITION_PRIORITY_1: None,  # None → use default
     }
 
-    result = coord._read_custom_position_sensor_states(options)
+    result = _make_snapshot_builder(coord).read_custom_position_sensors(options)
 
     assert len(result) == 1
     state = result[0]
@@ -584,7 +605,7 @@ def test_read_custom_position_sensor_states_tilt_threaded():
         tilt_key: 65,
     }
 
-    result = coord._read_custom_position_sensor_states(options)
+    result = _make_snapshot_builder(coord).read_custom_position_sensors(options)
 
     assert len(result) == 1
     assert result[0].tilt == 65
@@ -617,7 +638,7 @@ def test_read_custom_position_sensor_states_tilt_none_when_absent():
         # no tilt
     }
 
-    result = coord._read_custom_position_sensor_states(options)
+    result = _make_snapshot_builder(coord).read_custom_position_sensors(options)
 
     assert len(result) == 1
     assert result[0].tilt is None

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -110,8 +110,24 @@ def test_manual_toggle_getter_setter():
 
 
 # ---------------------------------------------------------------------------
-# _check_sun_validity_transition
+# _check_sun_validity_transition — Phase E delegated to WindowTransitionTracker
 # ---------------------------------------------------------------------------
+
+
+def _attach_window_tracker(coord, *, prev_state: bool | None) -> None:
+    """Wire a fresh WindowTransitionTracker onto ``coord`` with seeded state."""
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
+    tracker._last_sun_validity_state = prev_state
+    coord._window_tracker = tracker
 
 
 @pytest.mark.unit
@@ -119,7 +135,7 @@ def test_sun_validity_transition_returns_false_when_no_cover_data():
     """_check_sun_validity_transition returns False when _cover_data is None."""
     coord = _make_coordinator()
     coord._cover_data = None
-    coord._last_sun_validity_state = None
+    _attach_window_tracker(coord, prev_state=None)
 
     result = coord._check_sun_validity_transition()
     assert result is False
@@ -127,17 +143,17 @@ def test_sun_validity_transition_returns_false_when_no_cover_data():
 
 @pytest.mark.unit
 def test_sun_validity_transition_initializes_on_first_call():
-    """First call initializes _last_sun_validity_state, returns False."""
+    """First call seeds the tracker state and returns False."""
     coord = _make_coordinator()
     cover_data = MagicMock()
     cover_data.direct_sun_valid = True
     coord._cover_data = cover_data
-    coord._last_sun_validity_state = None
+    _attach_window_tracker(coord, prev_state=None)
 
     result = coord._check_sun_validity_transition()
 
     assert result is False
-    assert coord._last_sun_validity_state is True
+    assert coord._window_tracker._last_sun_validity_state is True
 
 
 @pytest.mark.unit
@@ -147,7 +163,7 @@ def test_sun_validity_transition_detects_sun_appeared():
     cover_data = MagicMock()
     cover_data.direct_sun_valid = True
     coord._cover_data = cover_data
-    coord._last_sun_validity_state = False  # was False, now True
+    _attach_window_tracker(coord, prev_state=False)
 
     result = coord._check_sun_validity_transition()
 
@@ -162,7 +178,7 @@ def test_sun_validity_transition_detects_sun_left():
     cover_data = MagicMock()
     cover_data.direct_sun_valid = False
     coord._cover_data = cover_data
-    coord._last_sun_validity_state = True  # was True, now False
+    _attach_window_tracker(coord, prev_state=True)
 
     result = coord._check_sun_validity_transition()
 
@@ -410,6 +426,30 @@ async def test_window_close_skips_reposition_when_auto_control_off():
     coord._toggles = ToggleManager()
     coord.automatic_control = False
     coord._track_end_time = True
+    # Window-close path now awaits the sunset-window tracker; seed one that
+    # short-circuits via track_end_time=False (no dispatch, no state change).
+    config_entry = MagicMock()
+    config_entry.options = {}
+    coord.config_entry = config_entry
+    coord.entities = []
+    coord._inverse_state = False
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    coord._event_buffer = EventBuffer(maxlen=10)
+    coord.manager = MagicMock()
+    coord.async_refresh = AsyncMock()
+    coord._build_position_context = MagicMock()
+    coord._window_tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
 
     cmd_svc = MagicMock()
     cmd_svc.apply_position = AsyncMock()
@@ -478,6 +518,23 @@ async def test_window_close_sends_reposition_when_auto_control_on():
     cover_data.sun_data = MagicMock()
     coord.get_blind_data = MagicMock(return_value=cover_data)
     coord._build_position_context = MagicMock(return_value=MagicMock(force=True))
+    coord.manager = MagicMock()
+
+    # Window-tracker no-ops (track_end_time stays True at the coord level for
+    # _on_window_closed, but the tracker is seeded with prev_sunset_active=True
+    # so the post-close sunset-window check skips redispatch).
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
+    tracker._prev_sunset_active = True
+    coord._window_tracker = tracker
 
     with patch(
         "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",

--- a/tests/test_coordinator_logging.py
+++ b/tests/test_coordinator_logging.py
@@ -204,40 +204,45 @@ class TestCancelMotionTimeoutLogging:
         )
         return coord
 
-    def test_logs_when_task_active(self):
+    @pytest.mark.asyncio
+    async def test_logs_when_task_active(self):
         """Logs 'Motion timeout canceled' when an active task is canceled."""
+        from unittest.mock import AsyncMock
+
         coord = self._make_coordinator()
-        mock_task = MagicMock()
-        mock_task.done.return_value = False
-        coord._motion_mgr._motion_timeout_task = mock_task
+        # Real pending timer via the public API.
+        coord._motion_mgr.update_config(
+            sensors=["binary_sensor.motion"], timeout_seconds=300
+        )
+        coord._motion_mgr.start_motion_timeout(AsyncMock())
+        assert coord._motion_mgr.has_pending_timeout is True
+        coord.logger.debug.reset_mock()
 
         coord._cancel_motion_timeout()
 
-        mock_task.cancel.assert_called_once()
-        assert coord._motion_mgr._motion_timeout_task is None
-        calls = [str(c) for c in coord.logger.debug.call_args_list]
-        assert any("Motion timeout canceled" in c for c in calls)
+        assert coord._motion_mgr.has_pending_timeout is False
+        # The TimeoutController uses lazy %-format logging; check both the
+        # format string and the label argument made it through.
+        matched = any(
+            call.args
+            and "canceled" in str(call.args[0])
+            and any("motion timeout" in str(a) for a in call.args[1:])
+            for call in coord.logger.debug.call_args_list
+        )
+        assert (
+            matched
+        ), f"expected a 'motion timeout canceled' log; got {coord.logger.debug.call_args_list}"
 
     def test_no_log_when_no_task(self):
         """Does not log when no task is active."""
         coord = self._make_coordinator()
-        coord._motion_mgr._motion_timeout_task = None
+        # Manager starts idle — no pending timer.
+        assert coord._motion_mgr.has_pending_timeout is False
 
         coord._cancel_motion_timeout()
 
         coord.logger.debug.assert_not_called()
-        assert coord._motion_mgr._motion_timeout_task is None
-
-    def test_no_log_when_task_already_done(self):
-        """Does not log when task is already done."""
-        coord = self._make_coordinator()
-        mock_task = MagicMock()
-        mock_task.done.return_value = True
-        coord._motion_mgr._motion_timeout_task = mock_task
-
-        coord._cancel_motion_timeout()
-
-        mock_task.cancel.assert_not_called()
+        assert coord._motion_mgr.has_pending_timeout is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -33,7 +33,7 @@ from custom_components.adaptive_cover_pro.managers.cover_command import (
 def _zero_post_tilt_delay(monkeypatch):
     """Skip the 1.5s real-motor settle delay in unit tests."""
     monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
         "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
         0,
     )

--- a/tests/test_cover_types/stub_policy.py
+++ b/tests/test_cover_types/stub_policy.py
@@ -1,0 +1,92 @@
+"""Shared synthetic cover-type policies used as parametrize fodder.
+
+These are hypothetical "fifth cover types" — they satisfy the
+``CoverTypePolicy`` ABC with only the abstract method overridden, and serve
+as canaries for the invariant: code outside ``cover_types/`` must tolerate
+a registered policy it has never heard of.
+
+If a future change to coordinator / managers / pipeline / config_flow /
+sensor / switch / binary_sensor introduces an assumption that crashes for
+an unknown cover type, the tests parametrising over ``ALL_POLICIES_WITH_STUBS``
+catch it before the real fifth cover type lands.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.cover_types import POLICY_REGISTRY
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    POSITION_AXIS,
+    TILT_AXIS,
+    CoverAxis,
+    CoverTypePolicy,
+)
+
+
+class StubSingleAxisPolicy(CoverTypePolicy):
+    """The smallest legal single-axis policy — one axis, no extra hooks.
+
+    Models a fifth cover type added later that overrides only the abstract
+    ``build_calc_engine`` and leaves every config-flow / pipeline hook on
+    its base-class default. Verifies the base defaults don't crash when a
+    partial implementation lands.
+    """
+
+    cover_type: ClassVar[str] = "cover_stub"
+    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+        return MagicMock()
+
+
+class StubDualAxisPolicy(CoverTypePolicy):
+    """The smallest legal dual-axis policy — position + tilt, no extra hooks.
+
+    Models a fifth cover type that happens to be dual-axis but doesn't
+    inherit any of ``VenetianPolicy``'s machinery. Verifies dual-axis-aware
+    code paths don't assume ``isinstance(policy, VenetianPolicy)`` — they
+    must rely on ``len(policy.axes) == 2`` or capability flags instead.
+    """
+
+    cover_type: ClassVar[str] = "cover_stub_dual"
+    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS, TILT_AXIS)
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+        return MagicMock()
+
+
+@contextmanager
+def register_stub_policy(policy_cls: type[CoverTypePolicy]):
+    """Temporarily insert a stub policy into ``POLICY_REGISTRY`` for one test.
+
+    Used by tests that exercise registry-based dispatch (``get_policy()`` and
+    its consumers). Method-level invariants don't need this — they
+    instantiate the stub class directly.
+
+    Usage::
+
+        with register_stub_policy(StubSingleAxisPolicy):
+            assert get_policy("cover_stub") is not None
+    """
+    key = policy_cls.cover_type
+    assert (
+        key not in POLICY_REGISTRY
+    ), f"{key} already registered — pick a unique stub cover_type"
+    POLICY_REGISTRY[key] = policy_cls
+    try:
+        yield policy_cls
+    finally:
+        POLICY_REGISTRY.pop(key, None)
+
+
+# The four real policies plus both stubs. Most invariant tests parametrise
+# over this list so adding a fifth real cover type automatically extends
+# coverage without further edits.
+ALL_POLICIES_WITH_STUBS: tuple[type[CoverTypePolicy], ...] = (
+    *POLICY_REGISTRY.values(),
+    StubSingleAxisPolicy,
+    StubDualAxisPolicy,
+)

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -340,6 +340,48 @@ class TestReadAxisValue:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Per-cover-type feature flags — replace string-list gates outside cover_types/
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("cover_type", ALL_COVER_TYPES)
+def test_is_in_tilt_suppression_uniform_signature(cover_type: str) -> None:
+    """Every policy must accept ``is_in_tilt_suppression(entity_id, delta)``.
+
+    Pins the Liskov-safe signature reconciliation. Calling with both
+    positional and keyword forms must work for every registered policy so
+    the method can be passed as a ``SecondaryAxisCheck.suppression``
+    callback without per-type adapters.
+    """
+    policy = get_policy(cover_type)
+    # Positional form.
+    assert policy.is_in_tilt_suppression("cover.x", 0.0) is False
+    # Keyword form.
+    assert policy.is_in_tilt_suppression("cover.x", delta=10.0) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cover_type", "expected"),
+    [
+        ("cover_blind", True),
+        ("cover_awning", True),
+        ("cover_tilt", False),
+        ("cover_venetian", False),
+    ],
+)
+def test_supports_return_to_default_switch(cover_type: str, expected: bool) -> None:
+    """The Return-to-default switch is exposed for position-axis covers only.
+
+    Pins the ClassVar that replaced the legacy ``switch.py`` string-list gate.
+    Adding a fifth cover type must add a row here, not branch on the type
+    string in ``switch.py``.
+    """
+    assert get_policy(cover_type).supports_return_to_default_switch is expected
+
+
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 _PRODUCTION_ROOT = _REPO_ROOT / "custom_components" / "adaptive_cover_pro"
 

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -416,3 +416,105 @@ def test_no_hardcoded_caps_get_strings_in_production() -> None:
         "Hardcoded caps.get('has_*') strings found — replace with "
         "caps_get(caps, CAP_HAS_*):\n  " + "\n  ".join(offenders)
     )
+
+
+# ---------------------------------------------------------------------------
+# Cover-type-literal comparison guard
+# ---------------------------------------------------------------------------
+# Production code outside ``cover_types/`` must dispatch through
+# ``get_policy(sensor_type).<flag>`` rather than comparing the sensor type to
+# a ``SensorType.<NAME>`` enum or hardcoded ``"cover_<name>"`` string. Adding
+# a fifth cover type must not require parallel edits at every call site that
+# branched on the previous four — the policy ClassVars exist for exactly that.
+
+# Compares ``something == SensorType.X`` or ``SensorType.X == something``
+# (and ``!=``). Variable-to-variable compares (``== current_type``) don't
+# match because the right-hand side must be a literal ``SensorType.<NAME>``.
+_BANNED_SENSORTYPE_COMPARE_RE = re.compile(
+    r"SensorType\.[A-Z_]+\s*(==|!=)|(==|!=)\s*SensorType\.[A-Z_]+"
+)
+# Compares ``cover_type == "cover_blind"`` and friends — the pre-policy
+# string-comparison form that ``caps_get`` and ``get_policy`` replaced.
+_BANNED_COVER_TYPE_LITERAL_RE = re.compile(
+    r'cover_type\s*(==|!=)\s*["\']cover_[a-z_]+["\']'
+)
+# Files inside cover_types/ are the boundary the guard enforces — the policy
+# layer is allowed (and required) to know about its own concrete types.
+_TYPE_BOUNDARY = _PRODUCTION_ROOT / "cover_types"
+
+
+@pytest.mark.unit
+def test_no_cover_type_literals_outside_cover_types() -> None:
+    """Fail if any production module outside cover_types/ compares to a SensorType literal.
+
+    The "fifth cover type" punch list grows every time code branches on
+    ``SensorType.X`` directly. Add a ClassVar on ``CoverTypePolicy`` (see
+    ``exposes_dual_axis_sensor`` and ``custom_position_includes_tilt`` for
+    worked examples) and call it through ``get_policy(sensor_type)``
+    instead — see CODING_GUIDELINES.md "Cover Type Abstraction".
+    """
+    offenders: list[str] = []
+    for path in _PRODUCTION_ROOT.rglob("*.py"):
+        # cover_types/ legitimately knows about concrete types — the guard
+        # enforces the boundary, not internal policy code.
+        if _TYPE_BOUNDARY in path.parents:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if not (
+                _BANNED_SENSORTYPE_COMPARE_RE.search(line)
+                or _BANNED_COVER_TYPE_LITERAL_RE.search(line)
+            ):
+                continue
+            stripped = line.strip()
+            # Skip lines that are clearly comment/docstring — same heuristic
+            # as the sibling caps.get scan above.
+            if stripped.startswith(("#", '"', "'")):
+                continue
+            rel = path.relative_to(_REPO_ROOT)
+            offenders.append(f"{rel}:{lineno}: {stripped}")
+    assert not offenders, (
+        "Cover-type-literal comparisons found outside cover_types/ — "
+        "dispatch through get_policy(sensor_type).<flag> instead:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cover_type", "expected"),
+    [
+        ("cover_blind", False),
+        ("cover_awning", False),
+        ("cover_tilt", False),
+        ("cover_venetian", True),
+    ],
+)
+def test_exposes_dual_axis_sensor(cover_type: str, expected: bool) -> None:
+    """The dual-axis Target Tilt sensor is enabled only for venetian today.
+
+    Pins the ClassVar that replaced the literal ``SensorType.VENETIAN ==``
+    lambda gate on ``sensor.py``. Adding a fifth cover type must add a row
+    here, not edit sensor.py.
+    """
+    assert get_policy(cover_type).exposes_dual_axis_sensor is expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cover_type", "expected"),
+    [
+        ("cover_blind", False),
+        ("cover_awning", False),
+        ("cover_tilt", False),
+        ("cover_venetian", True),
+    ],
+)
+def test_custom_position_includes_tilt(cover_type: str, expected: bool) -> None:
+    """The custom-position UI surfaces tilt sliders only for venetian today.
+
+    Pins the ClassVar that replaced the ``is_venetian`` schema branch in
+    ``config_flow._build_custom_position_schema_dict``. Adding a fifth cover
+    type must add a row here, not edit config_flow.py.
+    """
+    assert get_policy(cover_type).custom_position_includes_tilt is expected

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -518,3 +518,42 @@ def test_custom_position_includes_tilt(cover_type: str, expected: bool) -> None:
     type must add a row here, not edit config_flow.py.
     """
     assert get_policy(cover_type).custom_position_includes_tilt is expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cover_type", "anchor"),
+    [
+        ("cover_blind", "Configuration-Vertical"),
+        ("cover_awning", "Configuration-Horizontal"),
+        ("cover_tilt", "Configuration-Tilt"),
+        ("cover_venetian", "Venetian-Blinds"),
+    ],
+)
+def test_wiki_anchor(cover_type: str, anchor: str) -> None:
+    """Each policy points ``_geometry_wiki_link`` at its own wiki page.
+
+    Pins the per-policy override that replaced the
+    ``_GEOMETRY_WIKI_URL`` dict on ``config_flow.py``.
+    """
+    assert get_policy(cover_type).wiki_anchor() == anchor
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cover_type", "label"),
+    [
+        ("cover_blind", "Vertical Blind"),
+        ("cover_awning", "Horizontal Awning"),
+        ("cover_tilt", "Venetian / Tilt Blind"),
+        ("cover_venetian", "Venetian Blind (Dual-Axis)"),
+    ],
+)
+def test_display_label(cover_type: str, label: str) -> None:
+    """Each policy carries its own user-facing label for ``_build_config_summary``.
+
+    Pins the per-policy override that replaced the ``type_labels`` dict on
+    ``config_flow.py``. The exact strings remain byte-identical to the
+    pre-refactor labels so existing UI tests / screenshots still match.
+    """
+    assert get_policy(cover_type).display_label() == label

--- a/tests/test_cover_types/test_base_policy.py
+++ b/tests/test_cover_types/test_base_policy.py
@@ -2,18 +2,14 @@
 
 from __future__ import annotations
 
-from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
 import voluptuous as vol
 
-from custom_components.adaptive_cover_pro.cover_types.base import (
-    POSITION_AXIS,
-    CoverAxis,
-    CoverTypePolicy,
-)
 from custom_components.adaptive_cover_pro.cover_types.blind import BlindPolicy
+
+from .stub_policy import StubSingleAxisPolicy
 
 
 @pytest.mark.asyncio
@@ -29,25 +25,9 @@ async def test_maybe_update_tilt_only_default_is_noop() -> None:
     assert result is None
 
 
-class _MinimalStubPolicy(CoverTypePolicy):
-    """The smallest legal CoverTypePolicy — only implements the abstract hook.
-
-    Models a fifth cover type added later that forgets to override the
-    config-flow hooks. The defaults on the base class must keep the flow
-    functional without that override, so the config flow can't crash
-    silently for a partial implementation.
-    """
-
-    cover_type = "cover_stub"
-    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
-
-    def build_calc_engine(self, **kwargs):  # type: ignore[override]
-        return MagicMock()
-
-
 def test_entity_selector_filter_default_is_plain_cover_domain() -> None:
     """The base default returns a plain cover-domain selector config."""
-    flt = _MinimalStubPolicy().entity_selector_filter()
+    flt = StubSingleAxisPolicy().entity_selector_filter()
     assert flt["domain"] == "cover"
     # No capability requirement should be advertised by the default.
     assert "supported_features" not in flt
@@ -55,11 +35,11 @@ def test_entity_selector_filter_default_is_plain_cover_domain() -> None:
 
 def test_geometry_schema_default_is_empty() -> None:
     """The base default returns an empty vol.Schema, not None."""
-    schema = _MinimalStubPolicy().geometry_schema()
+    schema = StubSingleAxisPolicy().geometry_schema()
     assert isinstance(schema, vol.Schema)
     assert schema({}) == {}
 
 
 def test_summary_geometry_lines_default_is_empty_list() -> None:
     """The base default returns ``[]`` so summary builders can extend unconditionally."""
-    assert _MinimalStubPolicy().summary_geometry_lines({}) == []
+    assert StubSingleAxisPolicy().summary_geometry_lines({}) == []

--- a/tests/test_cover_types/test_base_policy.py
+++ b/tests/test_cover_types/test_base_policy.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
+import voluptuous as vol
 
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    POSITION_AXIS,
+    CoverAxis,
+    CoverTypePolicy,
+)
 from custom_components.adaptive_cover_pro.cover_types.blind import BlindPolicy
 
 
@@ -20,3 +27,39 @@ async def test_maybe_update_tilt_only_default_is_noop() -> None:
         reason="solar",
     )
     assert result is None
+
+
+class _MinimalStubPolicy(CoverTypePolicy):
+    """The smallest legal CoverTypePolicy — only implements the abstract hook.
+
+    Models a fifth cover type added later that forgets to override the
+    config-flow hooks. The defaults on the base class must keep the flow
+    functional without that override, so the config flow can't crash
+    silently for a partial implementation.
+    """
+
+    cover_type = "cover_stub"
+    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]
+        return MagicMock()
+
+
+def test_entity_selector_filter_default_is_plain_cover_domain() -> None:
+    """The base default returns a plain cover-domain selector config."""
+    flt = _MinimalStubPolicy().entity_selector_filter()
+    assert flt["domain"] == "cover"
+    # No capability requirement should be advertised by the default.
+    assert "supported_features" not in flt
+
+
+def test_geometry_schema_default_is_empty() -> None:
+    """The base default returns an empty vol.Schema, not None."""
+    schema = _MinimalStubPolicy().geometry_schema()
+    assert isinstance(schema, vol.Schema)
+    assert schema({}) == {}
+
+
+def test_summary_geometry_lines_default_is_empty_list() -> None:
+    """The base default returns ``[]`` so summary builders can extend unconditionally."""
+    assert _MinimalStubPolicy().summary_geometry_lines({}) == []

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -1,0 +1,169 @@
+"""Method-level invariants every CoverTypePolicy — including a stub fifth cover type — must honour.
+
+These tests parametrise over the four registered policies plus the synthetic
+stubs in :mod:`stub_policy`. They catch the class of bug where adding a
+fifth cover type breaks a default-hook contract that previously held only
+by coincidence (e.g. ``cover_capability_warnings`` returning ``None``
+instead of ``[]`` because the only callers happened to handle ``None``).
+
+Two flavours of stub are exercised:
+
+* ``StubSingleAxisPolicy`` — minimal one-axis policy. Catches assumptions
+  that a fifth cover type would need any of the venetian-specific hooks.
+* ``StubDualAxisPolicy`` — minimal two-axis policy. Catches assumptions
+  that "dual-axis" implies ``isinstance(policy, VenetianPolicy)`` rather
+  than ``len(policy.axes) == 2``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import voluptuous as vol
+
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    CAP_HAS_SET_POSITION,
+    CAP_HAS_SET_TILT_POSITION,
+    CoverAxis,
+    CoverTypePolicy,
+)
+
+from .stub_policy import (
+    ALL_POLICIES_WITH_STUBS,
+    StubDualAxisPolicy,
+    StubSingleAxisPolicy,
+    register_stub_policy,
+)
+
+
+@pytest.fixture(params=ALL_POLICIES_WITH_STUBS, ids=lambda p: p.cover_type)
+def policy(request) -> CoverTypePolicy:
+    """One policy instance per registered type + each stub."""
+    return request.param()
+
+
+# ---- Default-hook return-type contracts ---------------------------------- #
+
+
+@pytest.mark.unit
+def test_cover_capability_warnings_returns_list(policy: CoverTypePolicy) -> None:
+    """Warnings is always a list — config flow extends it unconditionally."""
+    assert isinstance(policy.cover_capability_warnings(known={}), list)
+
+
+@pytest.mark.unit
+def test_disallowed_geometry_fields_returns_list(policy: CoverTypePolicy) -> None:
+    """``options_service.validate_options_patch`` iterates this — never None."""
+    result = policy.disallowed_geometry_fields(
+        vertical_only=set(),
+        awning_only=set(),
+        tilt_only=set(),
+    )
+    assert isinstance(result, list)
+
+
+@pytest.mark.unit
+def test_glare_zones_config_safe_default(policy: CoverTypePolicy) -> None:
+    """Default returns None; only BlindPolicy may return a GlareZonesConfig."""
+    result = policy.glare_zones_config(MagicMock(), {})
+    assert result is None or hasattr(result, "zones")
+
+
+@pytest.mark.unit
+def test_entity_selector_filter_targets_cover_domain(
+    policy: CoverTypePolicy,
+) -> None:
+    """Every policy targets HA cover entities — the selector must say so."""
+    flt = policy.entity_selector_filter()
+    assert flt.get("domain") == "cover"
+
+
+@pytest.mark.unit
+def test_geometry_schema_is_voluptuous_schema(policy: CoverTypePolicy) -> None:
+    """Geometry schema is always a ``vol.Schema``, never None or a raw dict."""
+    schema = policy.geometry_schema()
+    assert isinstance(schema, vol.Schema)
+
+
+@pytest.mark.unit
+def test_summary_geometry_lines_returns_list(policy: CoverTypePolicy) -> None:
+    """Summary geometry block is always a list of strings."""
+    lines = policy.summary_geometry_lines({})
+    assert isinstance(lines, list)
+    assert all(isinstance(line, str) for line in lines)
+
+
+# ---- Hook signatures ----------------------------------------------------- #
+
+
+@pytest.mark.unit
+def test_is_in_tilt_suppression_returns_bool(policy: CoverTypePolicy) -> None:
+    """Both positional and keyword forms return a bool — pinned for callbacks."""
+    assert isinstance(policy.is_in_tilt_suppression("cover.x", 0.0), bool)
+    assert isinstance(policy.is_in_tilt_suppression("cover.x", delta=10.0), bool)
+
+
+@pytest.mark.unit
+def test_position_for_intent_returns_open_or_closed(policy: CoverTypePolicy) -> None:
+    """``position_for_intent`` returns 0 or 100, and the two intents differ."""
+    pos_through = policy.position_for_intent(sun_through=True)
+    pos_block = policy.position_for_intent(sun_through=False)
+    assert pos_through in (0, 100)
+    assert pos_block in (0, 100)
+    # Otherwise the policy can't distinguish sun-through from block-sun.
+    assert pos_through != pos_block
+
+
+@pytest.mark.unit
+def test_select_default_axis_returns_cover_axis(policy: CoverTypePolicy) -> None:
+    """``select_default_axis`` always returns a ``CoverAxis``, never None."""
+    # Empty caps → fallback through ``should_use_tilt``.
+    axis = policy.select_default_axis(caps={})
+    assert isinstance(axis, CoverAxis)
+    # Full caps → primary axis wins.
+    full_caps = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: True}
+    axis = policy.select_default_axis(caps=full_caps)
+    assert isinstance(axis, CoverAxis)
+
+
+@pytest.mark.unit
+def test_axes_tuple_non_empty(policy: CoverTypePolicy) -> None:
+    """Every policy declares at least one axis — selecting one must be safe."""
+    assert len(policy.axes) >= 1
+
+
+# ---- Registry-level invariants ------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("policy_cls", [StubSingleAxisPolicy, StubDualAxisPolicy])
+def test_register_stub_policy_round_trip(policy_cls) -> None:
+    """A stub policy registers and unregisters via the context manager.
+
+    Pins the invariant that ``POLICY_REGISTRY`` is mutable enough to accept
+    a fifth cover type at test time — i.e. no hidden global state assumes
+    only the four registered types.
+    """
+    with register_stub_policy(policy_cls):
+        retrieved = get_policy(policy_cls.cover_type)
+        assert isinstance(retrieved, policy_cls)
+
+    # After the context exits, the stub is gone — the registry was restored.
+    with pytest.raises(ValueError, match="Unsupported cover type"):
+        get_policy(policy_cls.cover_type)
+
+
+@pytest.mark.unit
+def test_stub_policy_passes_capability_warning_with_stub_registered() -> None:
+    """Registered stub policy can answer ``cover_capability_warnings`` cleanly.
+
+    A real consumer of the registry is config_flow's capability-warning
+    builder; this test asserts it doesn't crash for an unknown-to-it
+    cover type. The check itself stays inside the policy layer (no
+    config_flow import) to keep this an isolated invariant.
+    """
+    with register_stub_policy(StubSingleAxisPolicy):
+        policy = get_policy("cover_stub")
+        assert policy.cover_capability_warnings(known={}) == []

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -577,7 +577,7 @@ def test_attach_forwards_post_settle_hold_to_sequencer() -> None:
     hass = MagicMock()
 
     with patch(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.DualAxisSequencer"
+        "custom_components.adaptive_cover_pro.cover_types.venetian.policy.DualAxisSequencer"
     ) as MockSeq:
         MockSeq.return_value = MagicMock()
         policy.attach(

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
 )
 from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
@@ -125,13 +126,16 @@ class TestSuppressionDeltaCap:
         seq.stamp_position_command("cover.x")
         assert seq.is_in_suppression_with_cap("cover.x", delta=10.0) is True
 
-    def test_suppressed_large_delta_returns_false(self):
+    def test_suppressed_large_delta_past_grace_returns_false(self):
         from custom_components.adaptive_cover_pro.const import (
             VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
         )
 
         _, seq = _build_sequencer()
         seq.stamp_position_command("cover.x")
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
         big = VENETIAN_BACKROTATE_MAX_DELTA_PERCENT + 1
         assert seq.is_in_suppression_with_cap("cover.x", delta=float(big)) is False
 
@@ -160,6 +164,46 @@ class TestSuppressionDeltaCap:
             seconds=VENETIAN_TILT_SUPPRESSION_SECONDS + 1
         )
         assert seq.is_in_suppression_with_cap("cover.x", delta=1.0) is False
+
+    def test_suppressed_large_delta_with_settled_state_inside_grace_returns_true(
+        self,
+    ) -> None:
+        """Large delta inside the post-settle grace window should suppress.
+
+        Regression for issue #33: real KNX/Shelly actuators publish tilt-walk
+        bursts AFTER ``cover.state`` has already settled to "open". Without a
+        grace tail, the cap rejects deltas >30 even microseconds after the
+        carriage settles, latching false manual override.
+        """
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq.stamp_position_command("cover.x")
+        assert seq.is_in_suppression_with_cap("cover.x", delta=100.0) is True
+
+    def test_suppressed_large_delta_with_settled_state_past_grace_returns_false(
+        self,
+    ) -> None:
+        """Once the post-settle grace tail expires, the cap reasserts."""
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq.stamp_position_command("cover.x")
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        assert seq.is_in_suppression_with_cap("cover.x", delta=100.0) is False
+
+    def test_suppressed_large_delta_while_cover_moving_returns_true(self) -> None:
+        """In-motion bypass: any delta is motor drift while cover.state is moving."""
+        _, seq = _build_sequencer(get_state=lambda _eid: "closing")
+        seq.stamp_position_command("cover.x")
+        assert seq.is_in_suppression_with_cap("cover.x", delta=100.0) is True
+
+    def test_suppressed_small_delta_settled_state_past_grace_returns_true(self) -> None:
+        """Cap path still suppresses sub-cap deltas after grace expires."""
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq.stamp_position_command("cover.x")
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        assert seq.is_in_suppression_with_cap("cover.x", delta=10.0) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -22,7 +22,7 @@ from custom_components.adaptive_cover_pro.const import (
     VENETIAN_TILT_SUPPRESSION_SECONDS,
 )
 from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
-from custom_components.adaptive_cover_pro.managers.dual_axis_sequencer import (
+from custom_components.adaptive_cover_pro.cover_types.venetian.sequencer import (
     DualAxisSequencer,
 )
 
@@ -40,12 +40,12 @@ def _zero_post_tilt_delay(monkeypatch):
     because it is the behaviour under test.
     """
     monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
         "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
         0,
     )
     monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
         "VENETIAN_TILT_VERIFY_POLL_SECONDS",
         0,
     )
@@ -264,7 +264,7 @@ class TestPostTiltRebase:
             sleep_calls.append(delay)
 
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer.asyncio.sleep",
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer.asyncio.sleep",
             _capture_sleep,
         )
 
@@ -302,7 +302,7 @@ class TestPostTiltRebase:
             service_call_count[0] += 1
 
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer.asyncio.sleep",
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer.asyncio.sleep",
             _capture_sleep,
         )
 
@@ -349,7 +349,7 @@ class TestPostTiltRebase:
         )
 
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer."
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
             "VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -563,7 +563,7 @@ class TestSettleStateAware:
     async def test_settle_does_not_fire_while_state_is_closing(self, monkeypatch):
         """Stall counter must stay at zero while state=closing, regardless of position."""
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -599,7 +599,7 @@ class TestSettleStateAware:
     async def test_settle_does_not_fire_while_state_is_opening(self, monkeypatch):
         """Same as closing test — opening state must also suppress the stall counter."""
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -634,7 +634,7 @@ class TestSettleStateAware:
     ):
         """Stall counter must reset if state becomes moving mid-sequence."""
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -660,7 +660,7 @@ class TestSettleStateAware:
     ):
         """When state is always open, the existing 3-sample stall still fires."""
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -691,7 +691,7 @@ class TestSettleStateAware:
         until the state is no longer moving, then return True.
         """
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -725,7 +725,7 @@ class TestSettleStateAware:
         with last position == 52.
         """
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -750,7 +750,7 @@ class TestSettleStateAware:
         waiting for any state transition.
         """
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -773,7 +773,7 @@ class TestSettleStateAware:
     async def test_settle_falls_back_when_no_get_state(self, monkeypatch):
         """No get_state injected → behaves identically to pre-fix code (stall at 3)."""
         monkeypatch.setattr(
-            "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer"
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
         )
@@ -1602,7 +1602,7 @@ async def test_run_sequence_uses_configured_post_settle_hold() -> None:
     import unittest.mock
 
     with unittest.mock.patch(
-        "custom_components.adaptive_cover_pro.managers.dual_axis_sequencer.asyncio.sleep",
+        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer.asyncio.sleep",
         side_effect=_capture_sleep,
     ):
         _, seq = _build_sequencer(post_settle_hold_seconds=5.0)

--- a/tests/test_event_buffer_recording.py
+++ b/tests/test_event_buffer_recording.py
@@ -111,11 +111,36 @@ def _make_transit_coordinator(
     cmd_svc.record_progress = MagicMock(side_effect=_record_prog)
     cmd_svc.check_target_reached = MagicMock(return_value=False)
     cmd_svc.get_cover_capabilities = MagicMock(return_value={"has_set_position": True})
+    cmd_svc.set_waiting = MagicMock()
+    cmd_svc.waiting_entities = MagicMock(return_value=[])
 
     def _read_pos(eid, caps, state_obj):
         return new_pos if state_obj is coord.state_change_data.new_state else old_pos
 
     cmd_svc.read_position_with_capabilities = MagicMock(side_effect=_read_pos)
+
+    # Phase F: process_entity_state_change is now a thin shim that calls
+    # cmd_svc.classify_state_change.  Wire a real StateClassifier onto the
+    # mock service so its public method drives the same body the test
+    # previously exercised through the inline coordinator.
+    from custom_components.adaptive_cover_pro.managers.cover_command.state_classifier import (
+        StateClassifier,
+    )
+
+    cmd_svc._logger = MagicMock()
+    classifier = StateClassifier(
+        cmd_svc, event_buffer=buf, debug_log=lambda *_a, **_kw: None
+    )
+    cmd_svc.classify_state_change = (
+        lambda event, *, ignore_intermediate_states, target_just_reached, grace_mgr: (
+            classifier.classify(
+                event,
+                ignore_intermediate_states=ignore_intermediate_states,
+                target_just_reached=target_just_reached,
+                grace_mgr=grace_mgr,
+            )
+        )
+    )
     coord._cmd_svc = cmd_svc
 
     coord._is_in_grace_period = (

--- a/tests/test_event_buffer_recording.py
+++ b/tests/test_event_buffer_recording.py
@@ -292,6 +292,9 @@ class TestSunFOVEvents:
         from custom_components.adaptive_cover_pro.coordinator import (
             AdaptiveDataUpdateCoordinator,
         )
+        from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+            WindowTransitionTracker,
+        )
 
         buf = EventBuffer(maxlen=50)
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
@@ -301,7 +304,15 @@ class TestSunFOVEvents:
         cover_data = MagicMock()
         cover_data.direct_sun_valid = direct_sun_valid
         coord._cover_data = cover_data
-        coord._last_sun_validity_state = prev_state
+        # Phase E: sun-validity state lives on the WindowTransitionTracker.
+        tracker = WindowTransitionTracker(
+            hass=MagicMock(),
+            logger=coord.logger,
+            event_buffer=buf,
+            effective_default_fn=lambda _opts: (0, False),
+        )
+        tracker._last_sun_validity_state = prev_state
+        coord._window_tracker = tracker
         return coord
 
     def test_sun_entered_fov_records_event(self) -> None:
@@ -382,6 +393,23 @@ class TestEndTimeDefaultSentEvent:
         time_mgr = MagicMock()
         time_mgr.check_transition = _invoke_close
         coord._time_mgr = time_mgr
+        coord.manager = MagicMock()
+
+        # Phase E: _check_time_window_transition awaits the sunset-window
+        # tracker after running the closed-window callback.  Seed a tracker
+        # with prev_sunset_active=True so it no-ops without redispatching.
+        from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+            WindowTransitionTracker,
+        )
+
+        tracker = WindowTransitionTracker(
+            hass=MagicMock(),
+            logger=coord.logger,
+            event_buffer=buf,
+            effective_default_fn=coord._compute_current_effective_default,
+        )
+        tracker._prev_sunset_active = True
+        coord._window_tracker = tracker
 
         return coord
 
@@ -432,6 +460,9 @@ class TestSunsetWindowOpenedEvent:
         from custom_components.adaptive_cover_pro.managers.cover_command import (
             PositionContext,
         )
+        from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+            WindowTransitionTracker,
+        )
 
         buf = EventBuffer(maxlen=50)
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
@@ -441,7 +472,6 @@ class TestSunsetWindowOpenedEvent:
         coord.automatic_control = True
         coord._track_end_time = True
         coord._inverse_state = False
-        coord._prev_sunset_active = False
 
         entities = [MagicMock()]
         coord.entities = entities
@@ -471,6 +501,15 @@ class TestSunsetWindowOpenedEvent:
             )
         )
         coord._compute_current_effective_default = MagicMock(return_value=(0, True))
+        # Phase E: sunset-window state lives on the WindowTransitionTracker.
+        tracker = WindowTransitionTracker(
+            hass=MagicMock(),
+            logger=coord.logger,
+            event_buffer=buf,
+            effective_default_fn=coord._compute_current_effective_default,
+        )
+        tracker._prev_sunset_active = False
+        coord._window_tracker = tracker
         return coord
 
     @pytest.mark.asyncio
@@ -507,7 +546,7 @@ class TestSunsetWindowOpenedEvent:
         )
 
         coord = self._make_coord()
-        coord._prev_sunset_active = True  # already open — no transition
+        coord._window_tracker._prev_sunset_active = True  # already open — no transition
         await AdaptiveDataUpdateCoordinator._check_sunset_window_transition(coord)
         assert "sunset_window_opened" not in _event_types(coord._event_buffer)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.cover_types import get_policy
 from tests.conftest import make_snapshot_for_cover
 from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
@@ -844,7 +845,7 @@ class TestCustomPositionEndToEnd:
                         slot=1,
                         entity_id="binary_sensor.scene",
                         position=33,
-                        priority=77,
+                        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     ),
                     SolarHandler(),
                     DefaultHandler(),
@@ -872,7 +873,7 @@ class TestCustomPositionEndToEnd:
                         entity_id="binary_sensor.scene",
                         is_on=True,
                         position=33,
-                        priority=77,
+                        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                         min_mode=False,
                         use_my=False,
                     )

--- a/tests/test_issue_266_sunset_transition.py
+++ b/tests/test_issue_266_sunset_transition.py
@@ -39,7 +39,6 @@ def _make_coord(
     coord.automatic_control = automatic_control
     coord._track_end_time = track_end_time
     coord._inverse_state = inverse_state
-    coord._prev_sunset_active: bool | None = None
 
     entities = [MagicMock() for _ in range(n_entities)]
     coord.entities = entities
@@ -78,8 +77,20 @@ def _make_coord(
     from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
         EventBuffer,
     )
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
 
     coord._event_buffer = EventBuffer(maxlen=50)
+    # Phase E: sunset-window state lives on the WindowTransitionTracker.  Each
+    # test reseeds via _seed_sunset_state below.
+    coord._compute_current_effective_default = MagicMock(return_value=(0, False))
+    coord._window_tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=coord._compute_current_effective_default,
+    )
 
     return coord
 
@@ -87,10 +98,13 @@ def _make_coord(
 def _seed_sunset_state(
     coord, *, prev: bool | None, current_is_sunset: bool, pos: int = 0
 ):
-    """Seed _prev_sunset_active and mock _compute_current_effective_default."""
-    coord._prev_sunset_active = prev
+    """Seed the tracker's prior-sunset state and what the next effective-default lookup returns."""
+    coord._window_tracker._prev_sunset_active = prev
     coord._compute_current_effective_default = MagicMock(
         return_value=(pos, current_is_sunset)
+    )
+    coord._window_tracker._effective_default_fn = (
+        coord._compute_current_effective_default
     )
 
 
@@ -159,7 +173,7 @@ async def test_no_dispatch_when_sunset_pos_not_configured():
     """No dispatch when sunset_pos is not configured (None)."""
     coord = _make_coord(sunset_pos=None)
     # _compute_current_effective_default won't be called because we return early
-    coord._prev_sunset_active = False
+    coord._window_tracker._prev_sunset_active = False
     # No sunset_pos in options → return early before checking transition
 
     await coord._check_sunset_window_transition()
@@ -212,14 +226,17 @@ async def test_prev_sunset_active_initial_none_does_not_dispatch():
     """
     coord = _make_coord(sunset_pos=0)
     # _prev_sunset_active starts as None (fresh coordinator)
-    assert coord._prev_sunset_active is None
+    assert coord._window_tracker._prev_sunset_active is None
     coord._compute_current_effective_default = MagicMock(return_value=(0, True))
+    coord._window_tracker._effective_default_fn = (
+        coord._compute_current_effective_default
+    )
 
     await coord._check_sunset_window_transition()
 
     coord._cmd_svc.apply_position.assert_not_called()
     # State should be initialized
-    assert coord._prev_sunset_active is True
+    assert coord._window_tracker._prev_sunset_active is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_managers/test_motion.py
+++ b/tests/test_managers/test_motion.py
@@ -102,10 +102,10 @@ def test_is_motion_timeout_active_no_sensors(mgr):
 
 
 def test_is_motion_timeout_active_when_set(mock_hass, logger):
-    """Returns True when _motion_timeout_active flag is True and sensors configured."""
+    """Returns True after a no-motion event has activated the fallback state."""
     mgr = MotionManager(hass=mock_hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion_room"], timeout_seconds=300)
-    mgr._motion_timeout_active = True
+    mgr.set_no_motion()  # public path that flips the active flag without waiting
 
     assert mgr.is_motion_timeout_active is True
 
@@ -152,104 +152,92 @@ def test_last_motion_time_tracking(mgr):
 
 
 def test_record_motion_detected_clears_active_flag(mock_hass, logger):
-    """record_motion_detected() clears _motion_timeout_active."""
+    """record_motion_detected() returns the manager to the "motion present" state."""
     mgr = MotionManager(hass=mock_hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion_room"], timeout_seconds=300)
-    mgr._motion_timeout_active = True
+    mgr.set_no_motion()
+    assert mgr.is_motion_timeout_active is True
 
     mgr.record_motion_detected()
 
-    assert mgr._motion_timeout_active is False
+    assert mgr.is_motion_timeout_active is False
 
 
-def test_record_motion_detected_cancels_task(mock_hass, logger):
-    """record_motion_detected() cancels a running timeout task."""
+@pytest.mark.asyncio
+async def test_record_motion_detected_cancels_pending_timer(mock_hass, logger):
+    """A pending no-motion timer is cancelled when motion returns."""
     mgr = MotionManager(hass=mock_hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion_room"], timeout_seconds=300)
+    mgr.start_motion_timeout(AsyncMock())
+    assert mgr.has_pending_timeout is True
 
-    task = MagicMock()
-    task.done.return_value = False
-    mgr._motion_timeout_task = task
+    refreshed_needed = mgr.record_motion_detected()
 
-    mgr.record_motion_detected()
-
-    task.cancel.assert_called_once()
-    assert mgr._motion_timeout_task is None
+    assert mgr.has_pending_timeout is False
+    assert refreshed_needed is True  # caller should refresh — timer was in flight
 
 
 # --- cancel_motion_timeout ---
 
 
-def test_cancel_motion_timeout(mock_hass, logger):
-    """Cancels mock task and sets _motion_timeout_task to None."""
+@pytest.mark.asyncio
+async def test_cancel_motion_timeout_clears_pending(mock_hass, logger):
+    """cancel_motion_timeout idempotently clears any pending timer."""
     mgr = MotionManager(hass=mock_hass, logger=logger)
-
-    task = MagicMock()
-    task.done.return_value = False
-    mgr._motion_timeout_task = task
-
-    mgr.cancel_motion_timeout()
-
-    task.cancel.assert_called_once()
-    assert mgr._motion_timeout_task is None
-
-
-def test_cancel_motion_timeout_no_task(mgr):
-    """Does not raise when no task exists."""
-    mgr.cancel_motion_timeout()
-    assert mgr._motion_timeout_task is None
-
-
-def test_cancel_motion_timeout_already_done(mock_hass, logger):
-    """Does not call cancel when task is already done."""
-    mgr = MotionManager(hass=mock_hass, logger=logger)
-
-    task = MagicMock()
-    task.done.return_value = True
-    mgr._motion_timeout_task = task
+    mgr.update_config(sensors=["binary_sensor.motion_room"], timeout_seconds=300)
+    mgr.start_motion_timeout(AsyncMock())
+    assert mgr.has_pending_timeout is True
 
     mgr.cancel_motion_timeout()
 
-    task.cancel.assert_not_called()
-    assert mgr._motion_timeout_task is None
+    assert mgr.has_pending_timeout is False
 
 
-# --- _motion_timeout_handler ---
+def test_cancel_motion_timeout_when_idle_is_noop(mgr):
+    """Cancel is safe to call when no timer is pending."""
+    mgr.cancel_motion_timeout()  # must not raise
+    assert mgr.has_pending_timeout is False
+
+
+# --- timeout expiry body ---
 
 
 @pytest.mark.asyncio
-async def test_motion_timeout_handler_sets_active(mock_hass, logger):
-    """Timeout handler sets active flag and calls refresh when motion absent."""
+async def test_timeout_expiry_sets_active_and_refreshes_when_motion_absent(
+    mock_hass, logger
+):
+    """When the timer expires with motion still absent, fallback state activates."""
     mgr = MotionManager(hass=mock_hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion_room"], timeout_seconds=300)
 
-    # Patch is_motion_detected to return False (no motion after timeout)
     original_prop = MotionManager.is_motion_detected
     MotionManager.is_motion_detected = property(lambda self: False)
     try:
         callback = AsyncMock()
-        await mgr._motion_timeout_handler(0.01, callback)
+        # Drive the on-expire body directly with a known elapsed value; the
+        # body is the unit under test, not the asyncio plumbing (covered by
+        # TimeoutController tests).
+        await mgr._on_motion_timeout_expired(0, callback)
 
-        assert mgr._motion_timeout_active is True
+        assert mgr.is_motion_timeout_active is True
         callback.assert_called_once()
     finally:
         MotionManager.is_motion_detected = original_prop
 
 
 @pytest.mark.asyncio
-async def test_motion_timeout_handler_skips_if_motion(mock_hass, logger):
-    """Timeout handler does not set active flag if motion was re-detected."""
+async def test_timeout_expiry_skips_when_motion_returned(mock_hass, logger):
+    """If motion returned during the sleep, fallback must not activate."""
     mgr = MotionManager(hass=mock_hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion_room"], timeout_seconds=300)
 
-    # Patch is_motion_detected to return True (motion during timeout)
     original_prop = MotionManager.is_motion_detected
     MotionManager.is_motion_detected = property(lambda self: True)
     try:
         callback = AsyncMock()
-        await mgr._motion_timeout_handler(0.01, callback)
+        await mgr._on_motion_timeout_expired(0, callback)
 
-        assert mgr._motion_timeout_active is False
+        assert mgr.is_motion_timeout_active is False
         callback.assert_not_called()
     finally:
         MotionManager.is_motion_detected = original_prop

--- a/tests/test_managers/test_secondary_axis_check.py
+++ b/tests/test_managers/test_secondary_axis_check.py
@@ -11,9 +11,45 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import POSITION_TOLERANCE_PERCENT
 from custom_components.adaptive_cover_pro.managers.manual_override import (
     SecondaryAxisCheck,
+    effective_manual_threshold,
 )
+
+
+@pytest.mark.unit
+class TestEffectiveManualThreshold:
+    """Single-source-of-truth for the manual-override threshold floor.
+
+    Two callers (``handle_state_change`` and ``SecondaryAxisCheck.evaluate``)
+    delegate here; pinning the contract prevents the formula from drifting
+    across the two sites the next time the floor changes.
+    """
+
+    def test_none_returns_floor(self):
+        assert effective_manual_threshold(None) == POSITION_TOLERANCE_PERCENT
+
+    def test_zero_returns_floor(self):
+        assert effective_manual_threshold(0) == POSITION_TOLERANCE_PERCENT
+
+    def test_below_floor_returns_floor(self):
+        assert (
+            effective_manual_threshold(POSITION_TOLERANCE_PERCENT - 1)
+            == POSITION_TOLERANCE_PERCENT
+        )
+
+    def test_at_floor_returns_floor(self):
+        assert (
+            effective_manual_threshold(POSITION_TOLERANCE_PERCENT)
+            == POSITION_TOLERANCE_PERCENT
+        )
+
+    def test_above_floor_returns_user_value(self):
+        assert (
+            effective_manual_threshold(POSITION_TOLERANCE_PERCENT + 7)
+            == POSITION_TOLERANCE_PERCENT + 7
+        )
 
 
 def _state(attrs: dict):

--- a/tests/test_managers/test_state_classifier.py
+++ b/tests/test_managers/test_state_classifier.py
@@ -1,0 +1,234 @@
+"""Direct tests for :class:`StateClassifier`.
+
+The existing manual-override tests (issue #147, #172, #186, #271, #285)
+exercise the same body through the coordinator's
+:meth:`process_entity_state_change` shim and remain the contract guard
+for behavioural correctness.  These tests cover the new public surface:
+``CoverCommandService.classify_state_change`` and the classifier's
+direct ``classify()`` method, with the smallest cases needed to prove the
+relocation is wired correctly.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
+from custom_components.adaptive_cover_pro.managers.cover_command.state_classifier import (
+    StateClassifier,
+)
+from custom_components.adaptive_cover_pro.managers.grace_period import (
+    GracePeriodManager,
+)
+
+
+def _make_event(
+    entity_id: str, new_pos: int, old_pos: int, new_state="open", old_state="open"
+):
+    event = MagicMock()
+    event.entity_id = entity_id
+    event.new_state = MagicMock()
+    event.new_state.state = new_state
+    event.new_state.attributes = {"current_position": new_pos}
+    event.old_state = MagicMock()
+    event.old_state.state = old_state
+    event.old_state.attributes = {"current_position": old_pos}
+    return event
+
+
+def _make_service(
+    *,
+    target: int,
+    new_pos: int,
+    old_pos: int,
+    waiting: bool = True,
+    transit_timeout: int = 45,
+    sent_seconds_ago: float = 10.0,
+    last_progress_seconds_ago: float | None = None,
+    reached: bool = False,
+):
+    """Return a MagicMock service exposing the public surface the classifier uses."""
+    svc = MagicMock()
+    svc._logger = MagicMock()
+    svc.is_waiting_for_target = MagicMock(return_value=waiting)
+    svc.get_cover_capabilities = MagicMock(return_value={"has_set_position": True})
+
+    def _read_pos(_eid, _caps, state_obj):
+        return (
+            new_pos
+            if state_obj.attributes.get("current_position") == new_pos
+            else old_pos
+        )
+
+    svc.read_position_with_capabilities = MagicMock(side_effect=_read_pos)
+    svc.check_target_reached = MagicMock(return_value=reached)
+    svc.get_target = MagicMock(return_value=target)
+    svc.record_progress = MagicMock()
+    svc.set_waiting = MagicMock()
+    svc.waiting_entities = MagicMock(return_value=[])
+    svc.transit_timeout_seconds = transit_timeout
+
+    now = dt.datetime.now(dt.UTC)
+    ref_age = (
+        last_progress_seconds_ago
+        if last_progress_seconds_ago is not None
+        else sent_seconds_ago
+    )
+
+    def _elapsed(_eid, now_arg):
+        ref = now - dt.timedelta(seconds=ref_age)
+        return (now_arg - ref).total_seconds()
+
+    svc.transit_elapsed_without_progress = MagicMock(side_effect=_elapsed)
+    return svc
+
+
+@pytest.fixture
+def classifier_setup():
+    buf = EventBuffer(maxlen=20)
+    grace = GracePeriodManager(logger=MagicMock(), command_grace_seconds=5.0)
+    debug_log = MagicMock()
+
+    def _build(svc):
+        classifier = StateClassifier(svc, event_buffer=buf, debug_log=debug_log)
+        return classifier, buf, grace, debug_log
+
+    return _build
+
+
+@pytest.mark.unit
+def test_classify_returns_early_when_not_waiting(classifier_setup):
+    svc = _make_service(target=0, new_pos=10, old_pos=10, waiting=False)
+    classifier, _buf, grace, _debug_log = classifier_setup(svc)
+    target_just_reached: set[str] = set()
+    classifier.classify(
+        _make_event("cover.x", new_pos=10, old_pos=10),
+        ignore_intermediate_states=False,
+        target_just_reached=target_just_reached,
+        grace_mgr=grace,
+    )
+    svc.set_waiting.assert_not_called()
+    assert target_just_reached == set()
+
+
+@pytest.mark.unit
+def test_classify_skips_intermediate_states_when_configured(classifier_setup):
+    svc = _make_service(target=0, new_pos=50, old_pos=60)
+    classifier, _buf, grace, _debug_log = classifier_setup(svc)
+    classifier.classify(
+        _make_event("cover.x", new_pos=50, old_pos=60, new_state="opening"),
+        ignore_intermediate_states=True,
+        target_just_reached=set(),
+        grace_mgr=grace,
+    )
+    svc.is_waiting_for_target.assert_not_called()
+
+
+@pytest.mark.unit
+def test_classify_marks_target_just_reached_within_tolerance(classifier_setup):
+    svc = _make_service(target=0, new_pos=1, old_pos=60, reached=True)
+    classifier, _buf, grace, _debug_log = classifier_setup(svc)
+    target_just_reached: set[str] = set()
+    classifier.classify(
+        _make_event("cover.x", new_pos=1, old_pos=60),
+        ignore_intermediate_states=False,
+        target_just_reached=target_just_reached,
+        grace_mgr=grace,
+    )
+    assert "cover.x" in target_just_reached
+
+
+@pytest.mark.unit
+def test_classify_records_forward_progress(classifier_setup):
+    svc = _make_service(target=0, new_pos=50, old_pos=60)
+    classifier, buf, grace, _debug_log = classifier_setup(svc)
+    classifier.classify(
+        _make_event("cover.x", new_pos=50, old_pos=60),
+        ignore_intermediate_states=False,
+        target_just_reached=set(),
+        grace_mgr=grace,
+    )
+    types = [e["event"] for e in buf.snapshot()]
+    assert "transit_progress_forward" in types
+    svc.record_progress.assert_called_once()
+    svc.set_waiting.assert_not_called()
+
+
+@pytest.mark.unit
+def test_classify_clears_wait_after_transit_timeout(classifier_setup):
+    svc = _make_service(
+        target=0,
+        new_pos=80,
+        old_pos=80,
+        sent_seconds_ago=50.0,
+        transit_timeout=45,
+    )
+    classifier, buf, grace, _debug_log = classifier_setup(svc)
+    classifier.classify(
+        _make_event("cover.x", new_pos=80, old_pos=80),
+        ignore_intermediate_states=False,
+        target_just_reached=set(),
+        grace_mgr=grace,
+    )
+    types = [e["event"] for e in buf.snapshot()]
+    assert "transit_timeout_cleared" in types
+    svc.set_waiting.assert_called_once_with("cover.x", False)
+
+
+@pytest.mark.unit
+def test_classify_restarts_grace_on_step_motor_pause(classifier_setup):
+    svc = _make_service(target=10, new_pos=50, old_pos=60)
+    classifier, _buf, grace, _debug_log = classifier_setup(svc)
+    grace.start_command_grace_period = MagicMock()
+    event = _make_event(
+        "cover.x", new_pos=50, old_pos=60, new_state="open", old_state="opening"
+    )
+    classifier.classify(
+        event,
+        ignore_intermediate_states=False,
+        target_just_reached=set(),
+        grace_mgr=grace,
+    )
+    grace.start_command_grace_period.assert_called_once_with("cover.x")
+    # Step-motor pause must short-circuit BEFORE the forward-progress block.
+    svc.record_progress.assert_not_called()
+
+
+@pytest.mark.unit
+def test_classify_records_startup_delay(classifier_setup):
+    svc = _make_service(target=100, new_pos=0, old_pos=0)
+    classifier, buf, grace, _debug_log = classifier_setup(svc)
+    event = _make_event(
+        "cover.x", new_pos=0, old_pos=0, new_state="open", old_state="closed"
+    )
+    classifier.classify(
+        event,
+        ignore_intermediate_states=False,
+        target_just_reached=set(),
+        grace_mgr=grace,
+    )
+    types = [e["event"] for e in buf.snapshot()]
+    assert "transit_startup_delay" in types
+    # Startup-delay branch must NOT clear wait_for_target.
+    svc.set_waiting.assert_not_called()
+
+
+@pytest.mark.unit
+def test_classify_clears_wait_when_cover_moves_away_from_target(classifier_setup):
+    svc = _make_service(target=0, new_pos=70, old_pos=60)
+    classifier, buf, grace, _debug_log = classifier_setup(svc)
+    event = _make_event(
+        "cover.x", new_pos=70, old_pos=60, new_state="open", old_state="open"
+    )
+    classifier.classify(
+        event,
+        ignore_intermediate_states=False,
+        target_just_reached=set(),
+        grace_mgr=grace,
+    )
+    types = [e["event"] for e in buf.snapshot()]
+    assert "transit_cleared" in types
+    svc.set_waiting.assert_called_once_with("cover.x", False)

--- a/tests/test_managers/test_timeout_controller.py
+++ b/tests/test_managers/test_timeout_controller.py
@@ -1,0 +1,181 @@
+"""Unit tests for ``TimeoutController``.
+
+Pins the four contract guarantees that the three timeout-owning managers
+rely on:
+
+  1. ``start`` cancels an existing timer before spawning a new one.
+  2. ``cancel`` before expiry suppresses the callback.
+  3. The handle nulls out after expiry so the controller is reusable.
+  4. ``on_expire`` raising does not leave a dangling task handle.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.common import TimeoutController
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test.timeout_controller")
+
+
+def _zero_sleep_controller(logger) -> TimeoutController:
+    """Build a controller with a label that keeps assertions readable."""
+    return TimeoutController(logger, label="test timer")
+
+
+class TestLifecycle:
+    """Idle → running → expired transitions."""
+
+    async def test_idle_at_construction(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+        assert ctrl.is_running is False
+
+    async def test_start_marks_running(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+
+        async def _noop() -> None:
+            await asyncio.sleep(0)
+
+        # A long sleep so the timer stays in flight long enough to inspect.
+        ctrl.start(seconds=100, on_expire=_noop)
+        assert ctrl.is_running is True
+        ctrl.cancel()
+
+    async def test_callback_runs_after_sleep(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+        fired = asyncio.Event()
+
+        async def _on_expire() -> None:
+            fired.set()
+
+        ctrl.start(seconds=0, on_expire=_on_expire)
+        # Yield twice — first to let the create_task task run, second for sleep(0)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert fired.is_set()
+
+    async def test_handle_nulled_after_expiry(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+
+        async def _on_expire() -> None:
+            return
+
+        ctrl.start(seconds=0, on_expire=_on_expire)
+        # Drain the event loop until the controller is idle again.
+        for _ in range(5):
+            if not ctrl.is_running:
+                break
+            await asyncio.sleep(0)
+        assert ctrl.is_running is False
+
+
+class TestCancel:
+    """Cancellation semantics."""
+
+    async def test_cancel_before_expiry_suppresses_callback(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+        fired = asyncio.Event()
+
+        async def _on_expire() -> None:
+            fired.set()
+
+        ctrl.start(seconds=100, on_expire=_on_expire)
+        ctrl.cancel()
+        # Give the cancelled task a chance to settle.
+        await asyncio.sleep(0)
+        assert ctrl.is_running is False
+        assert fired.is_set() is False
+
+    async def test_cancel_when_idle_is_noop(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+        ctrl.cancel()  # must not raise
+        assert ctrl.is_running is False
+
+    async def test_double_cancel_is_safe(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+
+        async def _on_expire() -> None:
+            return
+
+        ctrl.start(seconds=100, on_expire=_on_expire)
+        ctrl.cancel()
+        ctrl.cancel()  # second cancel must not raise
+
+
+class TestStartReplaces:
+    """Calling ``start`` twice cancels the first timer."""
+
+    async def test_second_start_cancels_first(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+        first_fired = asyncio.Event()
+        second_fired = asyncio.Event()
+
+        async def _first() -> None:
+            first_fired.set()
+
+        async def _second() -> None:
+            second_fired.set()
+
+        ctrl.start(seconds=100, on_expire=_first)
+        ctrl.start(seconds=0, on_expire=_second)
+        # Drain
+        for _ in range(5):
+            if second_fired.is_set():
+                break
+            await asyncio.sleep(0)
+        assert first_fired.is_set() is False
+        assert second_fired.is_set() is True
+
+
+class TestCallbackErrors:
+    """A callback that raises must not leave a stale handle behind."""
+
+    async def test_handle_cleared_when_callback_raises(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+
+        async def _explode() -> None:
+            raise RuntimeError("boom")
+
+        ctrl.start(seconds=0, on_expire=_explode)
+        # Drain. The task will end with an exception; asyncio will log it,
+        # but we only care that the controller is idle again.
+        for _ in range(5):
+            if not ctrl.is_running:
+                break
+            await asyncio.sleep(0)
+        assert ctrl.is_running is False
+
+
+class TestCallbackMayRestart:
+    """``on_expire`` is free to start a new timer on the same controller."""
+
+    async def test_callback_starting_new_timer_is_not_clobbered(self, logger) -> None:
+        ctrl = _zero_sleep_controller(logger)
+        first_fired = asyncio.Event()
+        second_fired = asyncio.Event()
+
+        async def _second() -> None:
+            second_fired.set()
+
+        async def _first() -> None:
+            first_fired.set()
+            ctrl.start(seconds=0, on_expire=_second)
+
+        ctrl.start(seconds=0, on_expire=_first)
+        # Drain enough turns for both timers to fire.
+        for _ in range(8):
+            if second_fired.is_set():
+                break
+            await asyncio.sleep(0)
+        assert first_fired.is_set()
+        assert second_fired.is_set()
+        # Final state must be idle, not stuck with the first task's handle.
+        assert ctrl.is_running is False

--- a/tests/test_managers/test_weather.py
+++ b/tests/test_managers/test_weather.py
@@ -94,12 +94,15 @@ def test_configured_sensors_includes_all(mock_hass, logger):
 
 def test_not_active_when_no_sensors(mgr):
     """Feature disabled when no sensors configured."""
-    mgr._override_active = True  # Even if flag set, no sensors → False
+    # Even if the underlying flag would otherwise be set, the property gates
+    # off when no sensors are configured. We drive the public path
+    # (record_conditions_active) and check the gate still wins.
+    mgr.record_conditions_active()
     assert mgr.is_weather_override_active is False
 
 
 def test_active_when_flag_set_and_sensors_configured(mock_hass, logger):
-    """Returns True when _override_active is True and sensors configured."""
+    """Returns True after record_conditions_active when sensors are configured."""
     m = WeatherManager(hass=mock_hass, logger=logger)
     m.update_config(
         wind_speed_sensor="sensor.wind",
@@ -114,7 +117,7 @@ def test_active_when_flag_set_and_sensors_configured(mock_hass, logger):
         severe_sensors=[],
         timeout_seconds=300,
     )
-    m._override_active = True
+    m.record_conditions_active()
     assert m.is_weather_override_active is True
 
 
@@ -505,7 +508,7 @@ def test_or_logic_single_condition_sufficient(mock_hass, logger):
 
 
 def test_record_conditions_active_sets_flag(mock_hass, logger):
-    """record_conditions_active sets _override_active to True."""
+    """record_conditions_active flips the override-active state to True."""
     m = WeatherManager(hass=mock_hass, logger=logger)
     m.update_config(
         wind_speed_sensor="sensor.wind",
@@ -521,10 +524,11 @@ def test_record_conditions_active_sets_flag(mock_hass, logger):
         timeout_seconds=300,
     )
     m.record_conditions_active()
-    assert m._override_active is True
+    assert m.is_weather_override_active is True
 
 
-def test_record_conditions_active_cancels_timeout(mock_hass, logger):
+@pytest.mark.asyncio
+async def test_record_conditions_active_cancels_timeout(mock_hass, logger):
     """record_conditions_active cancels a running clear-delay timeout."""
     m = WeatherManager(hass=mock_hass, logger=logger)
     m.update_config(
@@ -540,57 +544,20 @@ def test_record_conditions_active_cancels_timeout(mock_hass, logger):
         severe_sensors=[],
         timeout_seconds=300,
     )
-    task = MagicMock()
-    task.done.return_value = False
-    m._timeout_task = task
+    m.start_weather_timeout(AsyncMock())
+    assert m.is_timeout_running is True
 
     m.record_conditions_active()
 
-    task.cancel.assert_called_once()
-    assert m._timeout_task is None
+    assert m.is_timeout_running is False
 
 
 # --- cancel_weather_timeout ---
 
 
-def test_cancel_timeout_cancels_task(mock_hass, logger):
-    """cancel_weather_timeout cancels running task and clears reference."""
-    m = WeatherManager(hass=mock_hass, logger=logger)
-    task = MagicMock()
-    task.done.return_value = False
-    m._timeout_task = task
-
-    m.cancel_weather_timeout()
-
-    task.cancel.assert_called_once()
-    assert m._timeout_task is None
-
-
-def test_cancel_timeout_no_task_safe(mgr):
-    """cancel_weather_timeout does not raise when no task."""
-    mgr.cancel_weather_timeout()
-    assert mgr._timeout_task is None
-
-
-def test_cancel_timeout_already_done(mock_hass, logger):
-    """Does not call cancel on an already-done task."""
-    m = WeatherManager(hass=mock_hass, logger=logger)
-    task = MagicMock()
-    task.done.return_value = True
-    m._timeout_task = task
-
-    m.cancel_weather_timeout()
-
-    task.cancel.assert_not_called()
-    assert m._timeout_task is None
-
-
-# --- _weather_timeout_handler ---
-
-
 @pytest.mark.asyncio
-async def test_timeout_handler_deactivates_when_clear(mock_hass, logger):
-    """Timeout handler deactivates override and calls refresh when conditions clear."""
+async def test_cancel_timeout_cancels_task(mock_hass, logger):
+    """cancel_weather_timeout cancels a running task."""
     m = WeatherManager(hass=mock_hass, logger=logger)
     m.update_config(
         wind_speed_sensor="sensor.wind",
@@ -605,16 +572,50 @@ async def test_timeout_handler_deactivates_when_clear(mock_hass, logger):
         severe_sensors=[],
         timeout_seconds=300,
     )
-    m._override_active = True
+    m.start_weather_timeout(AsyncMock())
+    assert m.is_timeout_running is True
+
+    m.cancel_weather_timeout()
+
+    assert m.is_timeout_running is False
+
+
+def test_cancel_timeout_no_task_safe(mgr):
+    """cancel_weather_timeout does not raise when no task is pending."""
+    mgr.cancel_weather_timeout()
+    assert mgr.is_timeout_running is False
+
+
+# --- timeout expiry body ---
+
+
+@pytest.mark.asyncio
+async def test_timeout_handler_deactivates_when_clear(mock_hass, logger):
+    """On-expire body deactivates override and calls refresh when conditions clear."""
+    m = WeatherManager(hass=mock_hass, logger=logger)
+    m.update_config(
+        wind_speed_sensor="sensor.wind",
+        wind_direction_sensor=None,
+        wind_speed_threshold=50.0,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor=None,
+        rain_threshold=1.0,
+        is_raining_sensor=None,
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=300,
+    )
+    m.record_conditions_active()  # override is currently active
 
     # Patch is_any_condition_active to return False (conditions cleared)
     original_prop = WeatherManager.is_any_condition_active
     WeatherManager.is_any_condition_active = property(lambda self: False)
     try:
         callback = AsyncMock()
-        await m._weather_timeout_handler(0.01, callback)
+        await m._on_weather_timeout_expired(0, callback)
 
-        assert m._override_active is False
+        assert m.is_weather_override_active is False
         callback.assert_called_once()
     finally:
         WeatherManager.is_any_condition_active = original_prop
@@ -622,7 +623,7 @@ async def test_timeout_handler_deactivates_when_clear(mock_hass, logger):
 
 @pytest.mark.asyncio
 async def test_timeout_handler_stays_active_if_conditions_return(mock_hass, logger):
-    """Timeout handler keeps override active if conditions return during sleep."""
+    """On-expire body keeps override active when conditions returned during the sleep."""
     m = WeatherManager(hass=mock_hass, logger=logger)
     m.update_config(
         wind_speed_sensor="sensor.wind",
@@ -637,16 +638,16 @@ async def test_timeout_handler_stays_active_if_conditions_return(mock_hass, logg
         severe_sensors=[],
         timeout_seconds=300,
     )
-    m._override_active = True
+    m.record_conditions_active()
 
     # Patch is_any_condition_active to return True (conditions returned)
     original_prop = WeatherManager.is_any_condition_active
     WeatherManager.is_any_condition_active = property(lambda self: True)
     try:
         callback = AsyncMock()
-        await m._weather_timeout_handler(0.01, callback)
+        await m._on_weather_timeout_expired(0, callback)
 
-        assert m._override_active is True
+        assert m.is_weather_override_active is True
         callback.assert_not_called()
     finally:
         WeatherManager.is_any_condition_active = original_prop
@@ -692,30 +693,39 @@ def test_is_timeout_running_false_when_no_task(mgr):
 
 @pytest.mark.asyncio
 async def test_is_timeout_running_true_when_task_pending(mgr):
-    import asyncio
-
-    async def _long_sleep():
-        await asyncio.sleep(9999)
-
-    task = asyncio.create_task(_long_sleep())
-    mgr._timeout_task = task
+    mgr.start_weather_timeout(AsyncMock())
     try:
         assert mgr.is_timeout_running is True
     finally:
-        task.cancel()
+        mgr.cancel_weather_timeout()
 
 
 @pytest.mark.asyncio
-async def test_is_timeout_running_false_when_task_done(mgr):
+async def test_is_timeout_running_false_when_task_done(mock_hass, logger):
+    """The handle nulls automatically when the timer expires."""
     import asyncio
 
-    async def _noop():
-        pass
-
-    task = asyncio.create_task(_noop())
-    await task
-    mgr._timeout_task = task
-    assert mgr.is_timeout_running is False
+    m = WeatherManager(hass=mock_hass, logger=logger)
+    m.update_config(
+        wind_speed_sensor="sensor.wind",
+        wind_direction_sensor=None,
+        wind_speed_threshold=50.0,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor=None,
+        rain_threshold=1.0,
+        is_raining_sensor=None,
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=0,  # expire immediately
+    )
+    m.start_weather_timeout(AsyncMock())
+    # Drain the loop until the controller settles.
+    for _ in range(5):
+        if not m.is_timeout_running:
+            break
+        await asyncio.sleep(0)
+    assert m.is_timeout_running is False
 
 
 # --- reconcile ---
@@ -746,41 +756,34 @@ def _make_simple_wind_mgr(
 def test_reconcile_signals_start_when_flag_stuck_and_clear(mock_hass, logger):
     """G1: override flag True, conditions clear, no timer → should_start_timeout."""
     m = _make_simple_wind_mgr(mock_hass, logger, speed="10.0")
-    m._override_active = True
+    m.record_conditions_active()
     assert m.reconcile() == "should_start_timeout"
 
 
 def test_reconcile_noop_when_conditions_still_active(mock_hass, logger):
     """G2: override flag True, conditions active → None."""
     m = _make_simple_wind_mgr(mock_hass, logger, speed="75.0")
-    m._override_active = True
+    m.record_conditions_active()
     assert m.reconcile() is None
 
 
 def test_reconcile_noop_when_flag_not_set(mock_hass, logger):
     """G3: override flag False, conditions clear → None."""
     m = _make_simple_wind_mgr(mock_hass, logger, speed="10.0")
-    m._override_active = False
+    # Fresh manager — no record_conditions_active call.
     assert m.reconcile() is None
 
 
 @pytest.mark.asyncio
 async def test_reconcile_noop_when_timer_already_running(mock_hass, logger):
     """G4: override flag True, conditions clear, timer pending → None."""
-    import asyncio
-
     m = _make_simple_wind_mgr(mock_hass, logger, speed="10.0")
-    m._override_active = True
-
-    async def _long_sleep():
-        await asyncio.sleep(9999)
-
-    task = asyncio.create_task(_long_sleep())
-    m._timeout_task = task
+    m.record_conditions_active()
+    m.start_weather_timeout(AsyncMock())
     try:
         assert m.reconcile() is None
     finally:
-        task.cancel()
+        m.cancel_weather_timeout()
 
 
 def test_reconcile_noop_when_no_sensors_configured(mock_hass, logger):
@@ -799,7 +802,7 @@ def test_reconcile_noop_when_no_sensors_configured(mock_hass, logger):
         severe_sensors=[],
         timeout_seconds=300,
     )
-    m._override_active = True
+    m.record_conditions_active()
     assert m.reconcile() is None
 
 
@@ -871,16 +874,22 @@ def test_in_clear_delay_false_when_no_task(mgr):
     assert mgr.in_clear_delay is False
 
 
-def test_in_clear_delay_true_when_timeout_running(mgr):
+@pytest.mark.asyncio
+async def test_in_clear_delay_true_when_timeout_running(mgr):
     """Returns True when a pending timeout task exists."""
-    mgr._timeout_task = MagicMock()
-    mgr._timeout_task.done.return_value = False
-    assert mgr.in_clear_delay is True
+    mgr.start_weather_timeout(AsyncMock())
+    try:
+        assert mgr.in_clear_delay is True
+    finally:
+        mgr.cancel_weather_timeout()
 
 
-def test_active_conditions_empty_but_in_clear_delay(mgr):
+@pytest.mark.asyncio
+async def test_active_conditions_empty_but_in_clear_delay(mgr):
     """No live conditions + pending timeout → active_conditions empty, in_clear_delay True."""
-    mgr._timeout_task = MagicMock()
-    mgr._timeout_task.done.return_value = False
-    assert mgr.active_conditions == []
-    assert mgr.in_clear_delay is True
+    mgr.start_weather_timeout(AsyncMock())
+    try:
+        assert mgr.active_conditions == []
+        assert mgr.in_clear_delay is True
+    finally:
+        mgr.cancel_weather_timeout()

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from unittest.mock import MagicMock
 
 from custom_components.adaptive_cover_pro.cover_types import get_policy
-from custom_components.adaptive_cover_pro.managers.dual_axis_sequencer import (
+from custom_components.adaptive_cover_pro.cover_types.venetian import (
     DualAxisSequencer,
 )
 from custom_components.adaptive_cover_pro.managers.manual_override import (

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -62,7 +62,7 @@ def _tilt_check(*, expected: int = 70, suppressed: bool) -> SecondaryAxisCheck:
 
 
 def _make_sequencer_suppression(
-    *, entity_id: str, state: str
+    *, entity_id: str, state: str, stamp_age_seconds: float = 0.0
 ) -> Callable[[str, float], bool]:
     """Build a real ``DualAxisSequencer`` and return its bound delta-cap gate.
 
@@ -71,6 +71,10 @@ def _make_sequencer_suppression(
     callback together so the cap behaves exactly as ``VenetianPolicy.is_in_tilt_suppression``
     does in production. ``state`` should be ``"opening"``/``"closing"`` to
     model an in-transit cycle, or ``"stopped"`` to model a settled cycle.
+
+    ``stamp_age_seconds`` backdates the suppression stamp so callers can land
+    outside the post-settle cap-grace tail while still inside the overall
+    suppression window.
     """
     hass = MagicMock()
     seq = DualAxisSequencer(
@@ -84,6 +88,8 @@ def _make_sequencer_suppression(
         get_state=lambda _eid: state,
     )
     seq.stamp_position_command(entity_id)
+    if stamp_age_seconds > 0:
+        seq._suppression_at[entity_id] -= dt.timedelta(seconds=stamp_age_seconds)
     return seq.is_in_suppression_with_cap
 
 
@@ -304,18 +310,50 @@ def test_tilt_drift_during_in_transit_open_is_ignored_regardless_of_delta() -> N
     assert not mgr.is_cover_manual(entity_id)
 
 
-def test_tilt_drift_after_settle_with_large_delta_still_trips_override() -> None:
-    """The in-transit cap bypass must NOT swallow a genuine post-settle user move.
+def test_tilt_drift_inside_post_settle_grace_is_ignored() -> None:
+    """Within the 5s grace tail after settle, even a large delta is motor drift.
 
-    Once ``cover.state`` leaves the moving set, the geometry-bounded cap
-    reasserts: a delta > 30% with state=``stopped`` is a user grabbing the
-    slats, not motor drift, and must still trip manual override even inside
-    the 90s suppression window.
+    KNX/Shelly actuators publish their tilt-walk burst AFTER ``cover.state``
+    has already settled to ``open``/``closed``. The post-settle cap grace
+    keeps suppression on for this brief tail so the burst isn't misread as a
+    user grab (issue #33).
+    """
+    entity_id = "cover.venetian_post_settle_grace"
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    suppression = _make_sequencer_suppression(entity_id=entity_id, state="stopped")
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=80,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=suppression,
+        ),
+    )
+
+    assert not mgr.is_cover_manual(entity_id)
+
+
+def test_tilt_drift_after_settle_grace_with_large_delta_trips_override() -> None:
+    """Once the 5s grace tail elapses, the geometry-bounded cap reasserts.
+
+    A delta > 30% with state=``stopped`` and stamp older than the grace tail
+    is a user grabbing the slats, not motor drift, and must still trip
+    manual override even inside the 90s suppression window.
     """
     entity_id = "cover.venetian_post_settle_user_move"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
-    suppression = _make_sequencer_suppression(entity_id=entity_id, state="stopped")
+    suppression = _make_sequencer_suppression(
+        entity_id=entity_id, state="stopped", stamp_age_seconds=10.0
+    )
 
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=50, tilt=0),

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1,5 +1,6 @@
 """Tests for motion-based automatic control feature."""
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -162,7 +163,7 @@ def test_is_motion_timeout_active_with_sensors():
     coordinator, _ = _make_coordinator_with_motion_mgr(
         sensors=["binary_sensor.motion_living_room"]
     )
-    coordinator._motion_mgr._motion_timeout_active = True
+    coordinator._motion_mgr.set_no_motion()  # flip active flag via public path
 
     result = AdaptiveDataUpdateCoordinator.is_motion_timeout_active.fget(coordinator)
     assert result is True
@@ -170,7 +171,7 @@ def test_is_motion_timeout_active_with_sensors():
 
 @pytest.mark.asyncio
 async def test_motion_timeout_handler_sets_active_flag():
-    """Test that motion timeout handler sets the active flag."""
+    """Test that the on-expire body sets the active flag and runs the refresh."""
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
@@ -181,9 +182,9 @@ async def test_motion_timeout_handler_sets_active_flag():
     MotionManager.is_motion_detected = property(lambda self: False)
     try:
         refresh = AsyncMock()
-        await mgr._motion_timeout_handler(0.01, refresh)
+        await mgr._on_motion_timeout_expired(0, refresh)
 
-        assert mgr._motion_timeout_active is True
+        assert mgr.is_motion_timeout_active is True
         refresh.assert_called_once()
     finally:
         MotionManager.is_motion_detected = original_prop
@@ -191,7 +192,7 @@ async def test_motion_timeout_handler_sets_active_flag():
 
 @pytest.mark.asyncio
 async def test_motion_timeout_handler_cancels_if_motion_detected():
-    """Test that motion timeout handler cancels if motion detected during timeout."""
+    """Test that the on-expire body short-circuits when motion returned."""
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
@@ -202,33 +203,32 @@ async def test_motion_timeout_handler_cancels_if_motion_detected():
     MotionManager.is_motion_detected = property(lambda self: True)
     try:
         refresh = AsyncMock()
-        await mgr._motion_timeout_handler(0.01, refresh)
+        await mgr._on_motion_timeout_expired(0, refresh)
 
-        assert mgr._motion_timeout_active is False
+        assert mgr.is_motion_timeout_active is False
         refresh.assert_not_called()
     finally:
         MotionManager.is_motion_detected = original_prop
 
 
-def test_cancel_motion_timeout():
-    """Test canceling motion timeout task."""
+@pytest.mark.asyncio
+async def test_cancel_motion_timeout():
+    """Test canceling a pending motion timeout via coordinator delegate."""
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
 
-    coordinator, _ = _make_coordinator_with_motion_mgr()
+    coordinator, _ = _make_coordinator_with_motion_mgr(
+        sensors=["binary_sensor.motion_living_room"]
+    )
 
-    # Create a mock task on the manager
-    task = MagicMock()
-    task.done.return_value = False
-    coordinator._motion_mgr._motion_timeout_task = task
+    # Spin up a real (long) pending timer via the public API.
+    coordinator._motion_mgr.start_motion_timeout(AsyncMock())
+    assert coordinator._motion_mgr.has_pending_timeout is True
 
-    # Cancel timeout via coordinator delegate
     AdaptiveDataUpdateCoordinator._cancel_motion_timeout(coordinator)
 
-    # Verify task was canceled and cleared
-    task.cancel.assert_called_once()
-    assert coordinator._motion_mgr._motion_timeout_task is None
+    assert coordinator._motion_mgr.has_pending_timeout is False
 
 
 def test_cancel_motion_timeout_no_task():
@@ -238,32 +238,40 @@ def test_cancel_motion_timeout_no_task():
     )
 
     coordinator, _ = _make_coordinator_with_motion_mgr()
-    coordinator._motion_mgr._motion_timeout_task = None
+    # No timer running.
+    assert coordinator._motion_mgr.has_pending_timeout is False
 
-    # Should not raise an error
+    # Should not raise an error.
     AdaptiveDataUpdateCoordinator._cancel_motion_timeout(coordinator)
-    assert coordinator._motion_mgr._motion_timeout_task is None
+    assert coordinator._motion_mgr.has_pending_timeout is False
 
 
-def test_cancel_motion_timeout_task_done():
-    """Test canceling motion timeout when task is already done."""
+@pytest.mark.asyncio
+async def test_cancel_motion_timeout_task_done():
+    """A completed-but-not-cleared timer must still cancel cleanly via the delegate."""
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
 
-    coordinator, _ = _make_coordinator_with_motion_mgr()
+    coordinator, _ = _make_coordinator_with_motion_mgr(
+        sensors=["binary_sensor.motion_living_room"]
+    )
 
-    # Create a mock task that's done
-    task = MagicMock()
-    task.done.return_value = True
-    coordinator._motion_mgr._motion_timeout_task = task
+    # Drive a real timer to completion so the controller sees a done task.
+    original_prop = MotionManager.is_motion_detected
+    MotionManager.is_motion_detected = property(lambda self: True)
+    try:
+        coordinator._motion_mgr.start_motion_timeout(AsyncMock())
+        for _ in range(5):
+            if not coordinator._motion_mgr.has_pending_timeout:
+                break
+            await asyncio.sleep(0)
+    finally:
+        MotionManager.is_motion_detected = original_prop
 
-    # Cancel timeout
+    # Cancel must be a no-op now that the timer has settled.
     AdaptiveDataUpdateCoordinator._cancel_motion_timeout(coordinator)
-
-    # Task should not be canceled (already done), but should be cleared
-    task.cancel.assert_not_called()
-    assert coordinator._motion_mgr._motion_timeout_task is None
+    assert coordinator._motion_mgr.has_pending_timeout is False
 
 
 @pytest.mark.asyncio
@@ -276,7 +284,7 @@ async def test_async_check_motion_state_change_on():
     coordinator, _ = _make_coordinator_with_motion_mgr(
         sensors=["binary_sensor.motion_living_room"]
     )
-    coordinator._motion_mgr._motion_timeout_active = True
+    coordinator._motion_mgr.set_no_motion()  # active flag on, no timer pending
     coordinator.state_change = False
     coordinator.async_refresh = AsyncMock()
 
@@ -296,7 +304,7 @@ async def test_async_check_motion_state_change_on():
     assert coordinator._motion_mgr.last_motion_time is not None
 
     # Verify motion timeout was deactivated and refresh was called
-    assert coordinator._motion_mgr._motion_timeout_active is False
+    assert coordinator._motion_mgr.is_motion_timeout_active is False
     assert coordinator.state_change is True
     coordinator.async_refresh.assert_called_once()
 
@@ -316,11 +324,10 @@ async def test_async_check_motion_state_change_on_during_timeout_pending():
     coordinator, _ = _make_coordinator_with_motion_mgr(
         sensors=["binary_sensor.motion_living_room"]
     )
-    # Timeout is PENDING: task is running but has NOT expired yet
-    coordinator._motion_mgr._motion_timeout_active = False
-    pending_task = MagicMock()
-    pending_task.done.return_value = False
-    coordinator._motion_mgr._motion_timeout_task = pending_task
+    # Timer is PENDING: started but has NOT expired yet (long timeout).
+    coordinator._motion_mgr.start_motion_timeout(AsyncMock())
+    assert coordinator._motion_mgr.has_pending_timeout is True
+    assert coordinator._motion_mgr.is_motion_timeout_active is False
 
     coordinator.state_change = False
     coordinator.async_refresh = AsyncMock()
@@ -335,16 +342,15 @@ async def test_async_check_motion_state_change_on_during_timeout_pending():
         coordinator, event
     )
 
-    # Timeout task must be cancelled
-    pending_task.cancel.assert_called_once()
-    assert coordinator._motion_mgr._motion_timeout_task is None
+    # Timer must have been cancelled.
+    assert coordinator._motion_mgr.has_pending_timeout is False
 
-    # Refresh must be triggered even though _motion_timeout_active was False
+    # Refresh must be triggered even though the timer never expired.
     assert coordinator.state_change is True
     coordinator.async_refresh.assert_called_once()
 
-    # Active flag must remain False (timeout never expired)
-    assert coordinator._motion_mgr._motion_timeout_active is False
+    # Active flag must remain False (timer never expired).
+    assert coordinator._motion_mgr.is_motion_timeout_active is False
 
 
 @pytest.mark.asyncio
@@ -361,9 +367,9 @@ async def test_async_check_motion_state_change_on_no_timeout_no_refresh():
     coordinator, _ = _make_coordinator_with_motion_mgr(
         sensors=["binary_sensor.motion_living_room"]
     )
-    # Neither timeout active nor pending — already in motion_detected state
-    coordinator._motion_mgr._motion_timeout_active = False
-    coordinator._motion_mgr._motion_timeout_task = None
+    # Neither timer pending nor fallback active — already in motion_detected state.
+    assert coordinator._motion_mgr.has_pending_timeout is False
+    assert coordinator._motion_mgr.is_motion_timeout_active is False
     coordinator._motion_mgr._last_motion_time = 1700000000.0  # prior motion recorded
 
     coordinator.state_change = False
@@ -393,64 +399,44 @@ def test_record_motion_detected_returns_true_when_timeout_active():
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
-    mgr._motion_timeout_active = True
-    mgr._motion_timeout_task = None
+    mgr.set_no_motion()  # fallback state activated, no pending timer
 
     result = mgr.record_motion_detected()
 
     assert result is True
-    assert mgr._motion_timeout_active is False
+    assert mgr.is_motion_timeout_active is False
 
 
-def test_record_motion_detected_returns_true_when_task_pending():
-    """record_motion_detected returns True when timeout task was still running."""
+@pytest.mark.asyncio
+async def test_record_motion_detected_returns_true_when_task_pending():
+    """record_motion_detected returns True when a timer is in flight."""
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
-    mgr._motion_timeout_active = False
-    task = MagicMock()
-    task.done.return_value = False
-    mgr._motion_timeout_task = task
+    mgr.start_motion_timeout(AsyncMock())
+    assert mgr.has_pending_timeout is True
+    assert mgr.is_motion_timeout_active is False
 
     result = mgr.record_motion_detected()
 
     assert result is True
-    assert mgr._motion_timeout_active is False
-    assert mgr._motion_timeout_task is None
-    task.cancel.assert_called_once()
+    assert mgr.is_motion_timeout_active is False
+    assert mgr.has_pending_timeout is False
 
 
 def test_record_motion_detected_returns_false_when_no_timeout():
-    """record_motion_detected returns False when no timeout was pending or active."""
+    """record_motion_detected returns False when no timer or fallback is active."""
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
-    mgr._motion_timeout_active = False
-    mgr._motion_timeout_task = None
+    # Fresh manager — neither flag nor pending timer.
 
     result = mgr.record_motion_detected()
 
     assert result is False
     assert mgr.last_motion_time is not None
-
-
-def test_record_motion_detected_returns_false_when_task_done():
-    """record_motion_detected returns False when timeout task had already completed."""
-    hass = MagicMock()
-    logger = MagicMock()
-    mgr = MotionManager(hass=hass, logger=logger)
-    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
-    mgr._motion_timeout_active = False
-    task = MagicMock()
-    task.done.return_value = True  # task completed but flag somehow not set
-    mgr._motion_timeout_task = task
-
-    result = mgr.record_motion_detected()
-
-    # done() task is treated the same as no task — not pending
-    assert result is False
 
 
 @pytest.mark.asyncio
@@ -727,16 +713,32 @@ async def test_async_shutdown_cancels_motion_timeout():
 
 
 def _make_motion_mgr(
-    last_motion_time=None, timeout_active=False, timeout_task=None, timeout_seconds=300
+    last_motion_time=None,
+    timeout_active=False,
+    timeout_pending=False,
+    timeout_seconds=300,
 ):
-    """Create a MotionManager with pre-set internal state."""
+    """Create a MotionManager configured for a specific state combination.
+
+    Drives all observable state through the public API: ``set_no_motion``
+    for the fallback-active flag, ``start_motion_timeout`` (long timeout)
+    for the "timer in flight" case. A sentinel sensor is always
+    registered so ``is_motion_timeout_active`` is not gated off by the
+    "no sensors → feature disabled" guard. Internal field assignment is
+    reserved for ``last_motion_time`` (no public setter; diagnostic).
+
+    Note: ``timeout_pending=True`` requires an active asyncio loop —
+    callers must be marked ``@pytest.mark.asyncio``.
+    """
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
-    mgr.update_config(sensors=[], timeout_seconds=timeout_seconds)
+    mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=timeout_seconds)
     mgr._last_motion_time = last_motion_time
-    mgr._motion_timeout_active = timeout_active
-    mgr._motion_timeout_task = timeout_task
+    if timeout_active:
+        mgr.set_no_motion()
+    if timeout_pending:
+        mgr.start_motion_timeout(AsyncMock())
     return mgr
 
 
@@ -788,7 +790,6 @@ def test_motion_status_sensor_motion_detected():
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1700000000.0,
         timeout_active=False,
-        timeout_task=None,
     )
     type(coordinator).is_motion_detected = property(lambda self: True)
 
@@ -796,16 +797,14 @@ def test_motion_status_sensor_motion_detected():
     assert sensor.native_value == "motion_detected"
 
 
-def test_motion_status_sensor_timeout_pending():
+@pytest.mark.asyncio
+async def test_motion_status_sensor_timeout_pending():
     """Sensor returns timeout_pending when countdown task is running."""
-    task = MagicMock()
-    task.done.return_value = False
-
     coordinator = MagicMock()
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1700000000.0,
         timeout_active=False,
-        timeout_task=task,
+        timeout_pending=True,
     )
     type(coordinator).is_motion_detected = property(lambda self: False)
 
@@ -819,7 +818,6 @@ def test_motion_status_sensor_no_motion():
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1700000000.0,
         timeout_active=True,
-        timeout_task=None,
     )
     type(coordinator).is_motion_detected = property(lambda self: False)
 
@@ -828,15 +826,16 @@ def test_motion_status_sensor_no_motion():
 
 
 def test_motion_status_sensor_waiting_for_data_fallback():
-    """Sensor returns waiting_for_data when no state matches (e.g. after task completes but flag not set)."""
-    task = MagicMock()
-    task.done.return_value = True
+    """Sensor returns waiting_for_data when neither active nor pending.
 
+    Post-TimeoutController the "stale completed task" state can't occur
+    (the handle auto-nulls), so the genuine fallback is "no flags set".
+    """
     coordinator = MagicMock()
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1700000000.0,
         timeout_active=False,
-        timeout_task=task,
+        timeout_pending=False,
     )
     type(coordinator).is_motion_detected = property(lambda self: False)
 
@@ -844,16 +843,14 @@ def test_motion_status_sensor_waiting_for_data_fallback():
     assert sensor.native_value == "waiting_for_data"
 
 
-def test_motion_status_sensor_attributes_with_timeout():
+@pytest.mark.asyncio
+async def test_motion_status_sensor_attributes_with_timeout():
     """Attributes include motion_timeout_end_time when timeout is pending."""
-    task = MagicMock()
-    task.done.return_value = False
-
     coordinator = MagicMock()
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1700000000.0,
         timeout_active=False,
-        timeout_task=task,
+        timeout_pending=True,
         timeout_seconds=300,
     )
 
@@ -871,7 +868,6 @@ def test_motion_status_sensor_attributes_no_timeout():
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1700000000.0,
         timeout_active=False,
-        timeout_task=None,
         timeout_seconds=300,
     )
 
@@ -917,7 +913,7 @@ def test_motion_status_sensor_no_timestamp_device_class():
 
 
 def test_set_no_motion_activates_immediately():
-    """set_no_motion() sets _motion_timeout_active without starting a task."""
+    """set_no_motion() activates the fallback state without starting a timer."""
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
@@ -925,25 +921,24 @@ def test_set_no_motion_activates_immediately():
 
     mgr.set_no_motion()
 
-    assert mgr._motion_timeout_active is True
-    assert mgr._motion_timeout_task is None
+    assert mgr.is_motion_timeout_active is True
+    assert mgr.has_pending_timeout is False
 
 
-def test_set_no_motion_cancels_pending_timeout():
+@pytest.mark.asyncio
+async def test_set_no_motion_cancels_pending_timeout():
     """set_no_motion() cancels any running timeout task."""
     hass = MagicMock()
     logger = MagicMock()
     mgr = MotionManager(hass=hass, logger=logger)
     mgr.update_config(sensors=["binary_sensor.motion"], timeout_seconds=300)
-
-    task = MagicMock()
-    task.done.return_value = False
-    mgr._motion_timeout_task = task
+    mgr.start_motion_timeout(AsyncMock())
+    assert mgr.has_pending_timeout is True
 
     mgr.set_no_motion()
 
-    task.cancel.assert_called_once()
-    assert mgr._motion_timeout_active is True
+    assert mgr.has_pending_timeout is False
+    assert mgr.is_motion_timeout_active is True
 
 
 def test_check_initial_motion_state_all_off_sets_no_motion():
@@ -1016,7 +1011,7 @@ def test_check_initial_motion_state_sensor_on_sets_last_motion_time():
     mgr.record_motion_detected()
 
     assert mgr.last_motion_time is not None
-    assert mgr._motion_timeout_active is False
+    assert mgr.is_motion_timeout_active is False
     assert mgr.is_motion_detected is True  # still reads live sensor
 
 
@@ -1031,7 +1026,6 @@ def test_motion_status_sensor_shows_motion_detected_after_reload():
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=1000.0,
         timeout_active=False,
-        timeout_task=None,
     )
     type(coordinator).is_motion_detected = property(lambda self: True)
 
@@ -1042,15 +1036,14 @@ def test_motion_status_sensor_shows_motion_detected_after_reload():
 def test_motion_status_sensor_startup_no_motion():
     """Sensor shows no_motion at startup when sensors are configured but all off.
 
-    set_no_motion() sets _motion_timeout_active=True without last_motion_time.
-    The sensor must check _motion_timeout_active before last_motion_time so it
-    shows no_motion rather than waiting_for_data.
+    set_no_motion() sets the fallback-active flag without last_motion_time.
+    The sensor must check is_motion_timeout_active before last_motion_time
+    so it shows no_motion rather than waiting_for_data.
     """
     coordinator = MagicMock()
     coordinator._motion_mgr = _make_motion_mgr(
         last_motion_time=None,
         timeout_active=True,
-        timeout_task=None,
     )
     type(coordinator).is_motion_detected = property(lambda self: False)
 

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -810,6 +810,7 @@ async def test_motion_status_sensor_timeout_pending():
 
     sensor = _make_motion_status_sensor(coordinator)
     assert sensor.native_value == "timeout_pending"
+    coordinator._motion_mgr.cancel_motion_timeout()
 
 
 def test_motion_status_sensor_no_motion():
@@ -860,6 +861,7 @@ async def test_motion_status_sensor_attributes_with_timeout():
     assert attrs["motion_timeout_seconds"] == 300
     assert "motion_timeout_end_time" in attrs
     assert "last_motion_time" in attrs
+    coordinator._motion_mgr.cancel_motion_timeout()
 
 
 def test_motion_status_sensor_attributes_no_timeout():

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
 )
@@ -232,7 +233,7 @@ def test_pipeline_1000_evaluations_under_500ms() -> None:
             entity_id=f"binary_sensor.cp_perf_{i}",
             is_on=False,
             position=0,
-            priority=77,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             min_mode=False,
             use_my=False,
         )

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
@@ -18,7 +19,7 @@ from .conftest import make_snapshot
 # ---------------------------------------------------------------------------
 
 _ENTITY = "binary_sensor.scene_a"
-_DEFAULT_PRIORITY = 77
+_DEFAULT_PRIORITY = DEFAULT_CUSTOM_POSITION_PRIORITY
 
 
 def _handler(
@@ -443,7 +444,7 @@ class TestCustomPositionSensorStateTilt:
             entity_id=_ENTITY,
             is_on=True,
             position=50,
-            priority=77,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             min_mode=False,
             use_my=False,
         )
@@ -455,7 +456,7 @@ class TestCustomPositionSensorStateTilt:
             entity_id=_ENTITY,
             is_on=True,
             position=50,
-            priority=77,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             min_mode=False,
             use_my=False,
             tilt=35,
@@ -468,7 +469,7 @@ class TestCustomPositionSensorStateTilt:
             entity_id=_ENTITY,
             is_on=True,
             position=50,
-            priority=77,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             min_mode=False,
             use_my=False,
             tilt=0,
@@ -481,7 +482,7 @@ class TestCustomPositionSensorStateTilt:
             entity_id=_ENTITY,
             is_on=True,
             position=50,
-            priority=77,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             min_mode=False,
             use_my=False,
             tilt=100,

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -13,6 +13,9 @@ from custom_components.adaptive_cover_pro.config_types import (
     GlareZone,
     GlareZonesConfig,
 )
+from custom_components.adaptive_cover_pro.engine.covers.vertical import (
+    AdaptiveVerticalCover,
+)
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.glare_zone import (
     GlareZoneHandler,
@@ -31,8 +34,12 @@ def _make_vertical_cover(
     direct_sun_valid: bool = True,
     calculate_percentage_return: float = 60.0,
 ):
-    """Build a mock AdaptiveVerticalCover for GlareZoneHandler tests."""
-    cover = MagicMock()
+    """Build a mock AdaptiveVerticalCover for GlareZoneHandler tests.
+
+    ``spec=AdaptiveVerticalCover`` makes ``isinstance`` return True so the
+    handler's runtime type guard (the post-cast safety net) accepts the mock.
+    """
+    cover = MagicMock(spec=AdaptiveVerticalCover)
     cover.direct_sun_valid = direct_sun_valid
     cover.distance = distance
     cover.gamma = gamma
@@ -138,6 +145,34 @@ class TestGlareZoneHandlerGating:
             active_zone_names={"desk"},
         )
         assert self.handler.evaluate(snap) is None
+
+    def test_skips_with_warning_when_cover_is_not_vertical(self, caplog) -> None:
+        """Runtime guard: a non-vertical cover paired with supports_glare_zones must skip.
+
+        Replaces the pre-A.5 unchecked ``cast(AdaptiveVerticalCover, …)``.
+        Simulates a future policy that flips ``supports_glare_zones`` without
+        binding a vertical engine — the handler must not crash on the next
+        attribute access, and must surface a warning so the misconfiguration
+        is debuggable from the logs.
+        """
+        import logging
+
+        # Plain MagicMock — no spec — so isinstance(.., AdaptiveVerticalCover) is False.
+        bogus_cover = MagicMock()
+        bogus_cover.direct_sun_valid = True
+        snap = make_snapshot(
+            cover=bogus_cover,
+            cover_type="cover_blind",
+            glare_zones=_make_glare_config(),
+            active_zone_names={"desk"},
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert self.handler.evaluate(snap) is None
+
+        assert any(
+            "not AdaptiveVerticalCover" in record.message for record in caplog.records
+        ), "expected the safety-net warning to be emitted"
 
 
 class TestGlareZoneHandlerLogic:

--- a/tests/test_pipeline/test_glare_zone_handler_fix.py
+++ b/tests/test_pipeline/test_glare_zone_handler_fix.py
@@ -25,6 +25,9 @@ from custom_components.adaptive_cover_pro.config_types import (
     GlareZone,
     GlareZonesConfig,
 )
+from custom_components.adaptive_cover_pro.engine.covers.vertical import (
+    AdaptiveVerticalCover,
+)
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.glare_zone import (
     GlareZoneHandler,
@@ -39,7 +42,7 @@ def _make_vertical_cover(
     calculate_percentage_return: float = 60.0,
 ):
     """Build a mock AdaptiveVerticalCover for GlareZoneHandler tests."""
-    cover = MagicMock()
+    cover = MagicMock(spec=AdaptiveVerticalCover)
     cover.direct_sun_valid = direct_sun_valid
     cover.distance = distance
     cover.gamma = gamma

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     ClimateHandler,
@@ -350,7 +351,10 @@ class TestCustomPositionHandlerMinModeWithSunTrackingOff:
 
     def _make_handler(self) -> CustomPositionHandler:
         return CustomPositionHandler(
-            slot=1, entity_id="binary_sensor.cp1", position=80, priority=77
+            slot=1,
+            entity_id="binary_sensor.cp1",
+            position=80,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         )
 
     def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
@@ -362,7 +366,7 @@ class TestCustomPositionHandlerMinModeWithSunTrackingOff:
                     entity_id="binary_sensor.cp1",
                     is_on=True,
                     position=80,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=True,
                     use_my=False,
                 )
@@ -385,7 +389,7 @@ class TestCustomPositionHandlerMinModeWithSunTrackingOff:
                     entity_id="binary_sensor.cp1",
                     is_on=True,
                     position=80,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=True,
                     use_my=False,
                 )

--- a/tests/test_pipeline/test_pipeline_integration.py
+++ b/tests/test_pipeline/test_pipeline_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
     ClimateCoverData,
@@ -527,7 +528,10 @@ class TestCustomPositionConfigurablePriority:
             [
                 ManualOverrideHandler(),
                 CustomPositionHandler(
-                    slot=1, entity_id="binary_sensor.scene", position=45, priority=77
+                    slot=1,
+                    entity_id="binary_sensor.scene",
+                    position=45,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                 ),
                 MotionTimeoutHandler(),
                 SolarHandler(),
@@ -1035,8 +1039,16 @@ def _climate_options_intermediate() -> ClimateOptions:
 
 
 def _make_glare_climate_cover(calculate_percentage_return: float = 91.0):
-    """Mock vertical cover satisfying both GlareZoneHandler and ClimateHandler."""
-    cover = MagicMock()
+    """Mock vertical cover satisfying both GlareZoneHandler and ClimateHandler.
+
+    Specced against ``AdaptiveVerticalCover`` so the post-A.5 isinstance guard
+    in ``GlareZoneHandler.evaluate`` accepts the mock.
+    """
+    from custom_components.adaptive_cover_pro.engine.covers.vertical import (
+        AdaptiveVerticalCover,
+    )
+
+    cover = MagicMock(spec=AdaptiveVerticalCover)
     cover.direct_sun_valid = True
     cover.valid = True
     cover.distance = 3.0

--- a/tests/test_pipeline/test_registry.py
+++ b/tests/test_pipeline/test_registry.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     ClimateHandler,
@@ -313,7 +314,7 @@ def _make_custom_position_handler() -> CustomPositionHandler:
         slot=1,
         entity_id="binary_sensor.custom",
         position=50,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
     )
 
 
@@ -338,7 +339,7 @@ def test_climate_data_populated_when_custom_position_wins() -> None:
                 entity_id="binary_sensor.custom",
                 is_on=True,
                 position=50,
-                priority=77,
+                priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                 min_mode=False,
                 use_my=False,
             ),
@@ -419,7 +420,7 @@ def test_outprioritized_handler_trace_has_descriptive_reason() -> None:
                 entity_id="binary_sensor.custom",
                 is_on=True,
                 position=50,
-                priority=77,
+                priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                 min_mode=False,
                 use_my=False,
             ),

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -1,0 +1,313 @@
+"""Direct tests for :class:`PipelineSnapshotBuilder`.
+
+The pre-existing climate-wiring tests (``tests/test_coordinator_climate_wiring``)
+also exercise the builder through coordinator shims to preserve their original
+intent.  These tests are the public-API contract tests that don't pretend to
+involve a coordinator at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_CLOUD_SUPPRESSION,
+    CONF_CLOUDY_POSITION,
+    CONF_DEFAULT_HEIGHT,
+    CONF_DEFAULT_TILT,
+    CONF_FORCE_OVERRIDE_POSITION,
+    CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_LUX_ENTITY,
+    CONF_OUTSIDE_THRESHOLD,
+    CONF_TEMP_HIGH,
+    CONF_TEMP_LOW,
+    CONF_TRANSPARENT_BLIND,
+    CONF_WEATHER_BYPASS_AUTO_CONTROL,
+    CONF_WEATHER_OVERRIDE_POSITION,
+    CONF_WINTER_CLOSE_INSULATION,
+    CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+)
+from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+    PipelineSnapshotBuilder,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    ClimateOptions,
+    CustomPositionSensorState,
+)
+from custom_components.adaptive_cover_pro.state.climate_provider import (
+    ClimateProvider,
+    ClimateReadings,
+)
+
+
+def _dummy_readings() -> ClimateReadings:
+    return ClimateReadings(
+        outside_temperature=None,
+        inside_temperature=None,
+        is_presence=True,
+        is_sunny=True,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+
+
+def _make_builder(
+    *,
+    lux_toggle: bool | None = False,
+    irradiance_toggle: bool | None = False,
+    temp_toggle: bool = False,
+    switch_mode: bool = False,
+    motion_control: bool = False,
+    states: dict | None = None,
+):
+    hass = MagicMock()
+    states_map = states or {}
+
+    def _states_get(eid):
+        return states_map.get(eid)
+
+    hass.states.get.side_effect = _states_get
+
+    climate_provider = MagicMock(spec=ClimateProvider)
+    climate_provider.read.return_value = _dummy_readings()
+
+    toggles = MagicMock()
+    toggles.lux_toggle = lux_toggle
+    toggles.irradiance_toggle = irradiance_toggle
+    toggles.temp_toggle = temp_toggle
+    toggles.switch_mode = switch_mode
+    toggles.motion_control = motion_control
+
+    policy = MagicMock()
+    policy.glare_zones_config.return_value = None
+
+    builder = PipelineSnapshotBuilder(
+        hass=hass,
+        logger=MagicMock(),
+        climate_provider=climate_provider,
+        toggles=toggles,
+        policy=policy,
+        config_service=MagicMock(),
+    )
+    return builder, climate_provider, hass
+
+
+@pytest.mark.unit
+def test_read_force_sensors_returns_on_off_dict():
+    on_state = MagicMock()
+    on_state.state = "on"
+    off_state = MagicMock()
+    off_state.state = "off"
+    builder, _, _ = _make_builder(
+        states={
+            "binary_sensor.alarm": on_state,
+            "binary_sensor.calm": off_state,
+        }
+    )
+    out = builder.read_force_sensors(
+        {CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.alarm", "binary_sensor.calm"]}
+    )
+    assert out == {"binary_sensor.alarm": True, "binary_sensor.calm": False}
+
+
+@pytest.mark.unit
+def test_read_force_sensors_missing_entity_treated_as_off():
+    builder, _, _ = _make_builder(states={})
+    out = builder.read_force_sensors(
+        {CONF_FORCE_OVERRIDE_SENSORS: ["binary_sensor.ghost"]}
+    )
+    assert out == {"binary_sensor.ghost": False}
+
+
+@pytest.mark.unit
+def test_read_force_sensors_no_config_returns_empty():
+    builder, _, _ = _make_builder()
+    assert builder.read_force_sensors({}) == {}
+
+
+@pytest.mark.unit
+def test_build_climate_options_full_mapping():
+    builder, _, _ = _make_builder(temp_toggle=True)
+    opts = {
+        CONF_TEMP_LOW: 18.0,
+        CONF_TEMP_HIGH: 24.0,
+        CONF_TRANSPARENT_BLIND: True,
+        CONF_OUTSIDE_THRESHOLD: 28.0,
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_WINTER_CLOSE_INSULATION: True,
+        CONF_CLOUDY_POSITION: 30,
+    }
+    out = builder.build_climate_options(opts)
+    assert isinstance(out, ClimateOptions)
+    assert out.temp_low == 18.0
+    assert out.temp_high == 24.0
+    assert out.temp_switch is True
+    assert out.transparent_blind is True
+    assert out.temp_summer_outside == 28.0
+    assert out.cloud_suppression_enabled is True
+    assert out.winter_close_insulation is True
+    assert out.cloudy_position == 30
+
+
+@pytest.mark.unit
+def test_build_climate_options_minimal_defaults_to_none_or_false():
+    builder, _, _ = _make_builder()
+    out = builder.build_climate_options({})
+    assert out.temp_low is None
+    assert out.temp_high is None
+    assert out.temp_switch is False
+    assert out.transparent_blind is False
+    assert out.cloud_suppression_enabled is False
+    assert out.winter_close_insulation is False
+    assert out.cloudy_position is None
+
+
+@pytest.mark.unit
+def test_read_custom_position_sensors_emits_one_state_per_configured_slot():
+    on_state = MagicMock()
+    on_state.state = "on"
+    builder, _, _ = _make_builder(states={"binary_sensor.guest": on_state})
+
+    first_slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        first_slot_keys["sensor"]: "binary_sensor.guest",
+        first_slot_keys["position"]: 42,
+    }
+    out = builder.read_custom_position_sensors(opts)
+    assert len(out) == 1
+    state = out[0]
+    assert isinstance(state, CustomPositionSensorState)
+    assert state.entity_id == "binary_sensor.guest"
+    assert state.is_on is True
+    assert state.position == 42
+    assert state.priority == DEFAULT_CUSTOM_POSITION_PRIORITY
+    assert state.min_mode is False
+    assert state.use_my is False
+    assert state.tilt is None
+
+
+@pytest.mark.unit
+def test_read_custom_position_sensors_unconfigured_returns_empty():
+    builder, _, _ = _make_builder()
+    assert builder.read_custom_position_sensors({}) == []
+
+
+@pytest.mark.unit
+def test_build_recomputes_effective_default_when_omitted():
+    builder, _, _ = _make_builder()
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    cover_data.sun_data.astral_sunset = None
+    cover_data.sun_data.astral_sunrise = None
+    cover_data.sun_data.now = None
+    opts = {CONF_DEFAULT_HEIGHT: 55}
+
+    snapshot = builder.build(
+        opts,
+        cover_data=cover_data,
+        cover_type="cover_blind",
+        climate_readings=None,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda idx: True,
+    )
+    assert snapshot.default_position == 55
+    assert snapshot.is_sunset_active is False
+
+
+@pytest.mark.unit
+def test_build_forwards_explicit_effective_default():
+    builder, _, _ = _make_builder(switch_mode=True, motion_control=True)
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    opts = {
+        CONF_FORCE_OVERRIDE_POSITION: 95,
+        CONF_WEATHER_OVERRIDE_POSITION: 5,
+        CONF_DEFAULT_TILT: 50,
+        CONF_WEATHER_BYPASS_AUTO_CONTROL: False,
+    }
+
+    snapshot = builder.build(
+        opts,
+        cover_data=cover_data,
+        cover_type="cover_tilt",
+        climate_readings=None,
+        manual_override_active=True,
+        motion_timeout_active=True,
+        weather_override_active=True,
+        in_time_window=False,
+        current_cover_position=37,
+        is_glare_zone_enabled=lambda idx: False,
+        effective_default=10,
+        is_sunset_active=True,
+    )
+    assert snapshot.default_position == 10
+    assert snapshot.is_sunset_active is True
+    assert snapshot.force_override_position == 95
+    assert snapshot.weather_override_position == 5
+    assert snapshot.weather_bypass_auto_control is False
+    assert snapshot.manual_override_active is True
+    assert snapshot.motion_timeout_active is True
+    assert snapshot.weather_override_active is True
+    assert snapshot.in_time_window is False
+    assert snapshot.current_cover_position == 37
+    assert snapshot.climate_mode_enabled is True
+    assert snapshot.motion_control_enabled is True
+    assert snapshot.default_tilt == 50
+    assert snapshot.cover_type == "cover_tilt"
+
+
+@pytest.mark.unit
+def test_build_consults_is_glare_zone_enabled_callable():
+    """Per-zone master switch is read via the callable, not via getattr on coord."""
+    builder, _, _ = _make_builder()
+
+    zone_a = MagicMock()
+    zone_a.name = "zone_a"
+    zone_b = MagicMock()
+    zone_b.name = "zone_b"
+    glare_cfg = MagicMock()
+    glare_cfg.zones = [zone_a, zone_b]
+    builder._policy.glare_zones_config.return_value = glare_cfg
+
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+
+    snapshot = builder.build(
+        {},
+        cover_data=cover_data,
+        cover_type="cover_blind",
+        climate_readings=None,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda idx: idx == 0,
+        effective_default=0,
+        is_sunset_active=False,
+    )
+    assert snapshot.active_zone_names == frozenset({"zone_a"})
+
+
+@pytest.mark.unit
+def test_read_climate_use_lux_inferred_from_cloud_suppression():
+    """Phase D preserves the Issue #268 cloud-suppression override."""
+    builder, climate_provider, _ = _make_builder(lux_toggle=None)
+    opts = {
+        CONF_CLOUD_SUPPRESSION: True,
+        CONF_LUX_ENTITY: "sensor.lux",
+    }
+    builder.read_climate(opts)
+    _, kwargs = climate_provider.read.call_args
+    assert kwargs["use_lux"] is True

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
@@ -65,7 +66,7 @@ def _registry_with_custom_tilt(tilt: int | None = None) -> PipelineRegistry:
                 entity_id="binary_sensor.scene",
                 position=60,
                 tilt=tilt,
-                priority=77,
+                priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             ),
             SolarHandler(),
             DefaultHandler(),

--- a/tests/test_safety_override_bypass.py
+++ b/tests/test_safety_override_bypass.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     DefaultHandler,
@@ -515,7 +516,10 @@ class TestCustomPositionBypass:
 
     def _handler(self, position: int = 50) -> CustomPositionHandler:
         return CustomPositionHandler(
-            slot=1, entity_id=_CP_ENTITY, position=position, priority=77
+            slot=1,
+            entity_id=_CP_ENTITY,
+            position=position,
+            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         )
 
     def _snapshot_on(self, position: int = 50) -> object:
@@ -525,7 +529,7 @@ class TestCustomPositionBypass:
                     entity_id=_CP_ENTITY,
                     is_on=True,
                     position=position,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=False,
                     use_my=False,
                 )
@@ -552,7 +556,7 @@ class TestCustomPositionBypass:
                     entity_id=_CP_ENTITY,
                     is_on=False,
                     position=50,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=False,
                     use_my=False,
                 )

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -69,8 +69,12 @@ def _make_coord(
     coord.config_entry = MagicMock()
     coord.config_entry.options = options or {}
 
-    # _read_custom_position_sensor_states
-    coord._read_custom_position_sensor_states.return_value = custom_states or []
+    # Snapshot builder — async_apply_user_position routes its custom-position
+    # read through this collaborator after Phase D.
+    coord._snapshot_builder = MagicMock()
+    coord._snapshot_builder.read_custom_position_sensors.return_value = (
+        custom_states or []
+    )
 
     # _build_position_context
     ctx = MagicMock()

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_SENSOR_TYPE,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
     DOMAIN,
     SensorType,
 )
@@ -260,7 +261,7 @@ async def test_min_mode_slot_off_no_clamping() -> None:
         entity_id="binary_sensor.slot1",
         is_on=False,
         position=60,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -298,7 +299,7 @@ async def test_min_mode_slot_on_clamps_up() -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=50,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -336,7 +337,7 @@ async def test_request_equals_floor_no_extra_clamping() -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=50,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -369,7 +370,7 @@ async def test_request_above_floor_no_clamping() -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=50,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -407,7 +408,7 @@ async def test_two_floors_request_below_highest_clamped() -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=40,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -415,7 +416,7 @@ async def test_two_floors_request_below_highest_clamped() -> None:
         entity_id="binary_sensor.slot2",
         is_on=True,
         position=65,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -448,7 +449,7 @@ async def test_two_floors_request_above_highest_not_clamped() -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=40,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -456,7 +457,7 @@ async def test_two_floors_request_above_highest_not_clamped() -> None:
         entity_id="binary_sensor.slot2",
         is_on=True,
         position=65,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -551,7 +552,7 @@ async def test_clamp_emits_info_log(caplog) -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=50,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=True,
         use_my=False,
     )
@@ -675,7 +676,7 @@ async def test_non_min_mode_slot_on_does_not_clamp() -> None:
         entity_id="binary_sensor.slot1",
         is_on=True,
         position=80,
-        priority=77,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         min_mode=False,
         use_my=False,
     )

--- a/tests/test_startup_grace_period.py
+++ b/tests/test_startup_grace_period.py
@@ -91,17 +91,16 @@ async def test_startup_grace_period_timeout_clears_tracking():
         GracePeriodManager,
     )
 
-    # Test the GracePeriodManager timeout directly (the coordinator delegates to it)
+    # Test the GracePeriodManager timeout body directly (the coordinator delegates to it)
     mock_logger = MagicMock()
     mgr = GracePeriodManager(logger=mock_logger, startup_grace_seconds=0.1)
     mgr._startup_timestamp = dt.datetime.now().timestamp()
-    mgr._startup_grace_period_task = None
 
-    await mgr._startup_grace_period_timeout()
+    await mgr._on_startup_grace_expired()
 
     # Verify tracking was cleared
     assert mgr._startup_timestamp is None
-    assert mgr._startup_grace_period_task is None
+    assert mgr.is_in_startup_grace_period() is False
 
     # Verify debug log was called for expiration
     mock_logger.debug.assert_called_once()
@@ -157,41 +156,31 @@ async def test_start_startup_grace_period_sets_timestamp():
 
 @pytest.mark.asyncio
 async def test_start_startup_grace_period_cancels_existing_task():
-    """Test that _start_startup_grace_period cancels existing task."""
-    from unittest.mock import patch
+    """A second start cancels the previous startup grace timer (no double-fire)."""
     from custom_components.adaptive_cover_pro.const import STARTUP_GRACE_PERIOD_SECONDS
     from custom_components.adaptive_cover_pro.managers.grace_period import (
         GracePeriodManager,
     )
 
-    # Create mock task
-    mock_task = MagicMock()
-    mock_task.done.return_value = False
-
-    # Create minimal mock coordinator backed by a real GracePeriodManager
+    # Real GracePeriodManager so the controller behaviour is exercised end-to-end.
     coordinator = MagicMock()
     coordinator._grace_mgr = GracePeriodManager(
         logger=MagicMock(),
         startup_grace_seconds=STARTUP_GRACE_PERIOD_SECONDS,
     )
-    coordinator._grace_mgr._startup_grace_period_task = mock_task
 
-    # Import the method
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
 
-    # Mock asyncio.create_task to avoid creating actual task
-    def _close_coro(coro):
-        coro.close()
-        return MagicMock()
+    AdaptiveDataUpdateCoordinator._start_startup_grace_period(coordinator)
+    assert coordinator._grace_mgr._startup_timer.is_running is True
 
-    with patch("asyncio.create_task", side_effect=_close_coro):
-        # Call the method
-        AdaptiveDataUpdateCoordinator._start_startup_grace_period(coordinator)
+    AdaptiveDataUpdateCoordinator._start_startup_grace_period(coordinator)
+    # A new timer must be running (the prior one was cancelled by start()).
+    assert coordinator._grace_mgr._startup_timer.is_running is True
 
-    # Verify old task was cancelled
-    mock_task.cancel.assert_called_once()
+    coordinator._grace_mgr.cancel_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_state/test_window_transition_tracker.py
+++ b/tests/test_state/test_window_transition_tracker.py
@@ -1,0 +1,207 @@
+"""Direct tests for :class:`WindowTransitionTracker`.
+
+The pre-existing tests in test_coordinator_coverage, test_issue_266_sunset_transition,
+test_event_buffer_recording, and test_auto_control_gate_matrix continue to exercise
+the tracker through the coordinator's delegating methods.  These tests drive the
+tracker's public surface directly without involving a coordinator.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
+from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+    WindowTransitionTracker,
+)
+
+
+def _make_tracker(effective_default=(0, False)) -> WindowTransitionTracker:
+    return WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        event_buffer=EventBuffer(maxlen=10),
+        effective_default_fn=lambda _opts: effective_default,
+    )
+
+
+def _event_types(buf: EventBuffer) -> list[str]:
+    return [e["event"] for e in buf.snapshot()]
+
+
+# ---------------------------------------------------------------------------
+# sun_just_appeared — state machine + event recording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sun_just_appeared_returns_false_when_cover_data_is_none():
+    tracker = _make_tracker()
+    assert tracker.sun_just_appeared(None) is False
+
+
+@pytest.mark.unit
+def test_sun_just_appeared_first_call_seeds_state_and_returns_false():
+    tracker = _make_tracker()
+    cover_data = MagicMock()
+    cover_data.direct_sun_valid = True
+    assert tracker.sun_just_appeared(cover_data) is False
+    assert tracker._last_sun_validity_state is True
+    # No transition event recorded on seeding.
+    assert _event_types(tracker._event_buffer) == []
+
+
+@pytest.mark.unit
+def test_sun_just_appeared_returns_true_on_false_to_true_transition():
+    tracker = _make_tracker()
+    tracker._last_sun_validity_state = False
+    cover_data = MagicMock()
+    cover_data.direct_sun_valid = True
+    assert tracker.sun_just_appeared(cover_data) is True
+    assert "sun_entered_fov" in _event_types(tracker._event_buffer)
+
+
+@pytest.mark.unit
+def test_sun_just_appeared_returns_false_on_true_to_false_transition():
+    tracker = _make_tracker()
+    tracker._last_sun_validity_state = True
+    cover_data = MagicMock()
+    cover_data.direct_sun_valid = False
+    assert tracker.sun_just_appeared(cover_data) is False
+    assert "sun_left_fov" in _event_types(tracker._event_buffer)
+
+
+@pytest.mark.unit
+def test_sun_just_appeared_no_event_when_state_unchanged():
+    tracker = _make_tracker()
+    tracker._last_sun_validity_state = True
+    cover_data = MagicMock()
+    cover_data.direct_sun_valid = True
+    assert tracker.sun_just_appeared(cover_data) is False
+    assert _event_types(tracker._event_buffer) == []
+
+
+# ---------------------------------------------------------------------------
+# check_sunset_window — gates + dispatch
+# ---------------------------------------------------------------------------
+
+
+def _common_kwargs(
+    *, automatic_control=True, sunset_pos_cfg=25, inverse=False, entities=None
+):
+    """Build the per-call kwargs the tracker needs."""
+    apply_position = AsyncMock(return_value=("sent", ""))
+    refresh = AsyncMock()
+    build_ctx = MagicMock(return_value=MagicMock(name="position_context"))
+    return (
+        {
+            "track_end_time": True,
+            "automatic_control": automatic_control,
+            "sunset_pos_cfg": sunset_pos_cfg,
+            "options": {},
+            "inverse_state_enabled": inverse,
+            "entities": entities if entities is not None else ["cover.a"],
+            "is_cover_manual": lambda _e: False,
+            "build_position_context": build_ctx,
+            "apply_position": apply_position,
+            "refresh": refresh,
+        },
+        apply_position,
+        refresh,
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_skips_when_track_end_time_off():
+    tracker = _make_tracker(effective_default=(0, True))
+    kwargs, apply_position, refresh = _common_kwargs()
+    kwargs["track_end_time"] = False
+    await tracker.check_sunset_window(**kwargs)
+    apply_position.assert_not_called()
+    refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_skips_when_automatic_control_off():
+    tracker = _make_tracker(effective_default=(0, True))
+    kwargs, apply_position, _ = _common_kwargs(automatic_control=False)
+    await tracker.check_sunset_window(**kwargs)
+    apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_skips_when_sunset_pos_not_configured():
+    tracker = _make_tracker(effective_default=(0, True))
+    kwargs, apply_position, _ = _common_kwargs(sunset_pos_cfg=None)
+    await tracker.check_sunset_window(**kwargs)
+    apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_first_call_seeds_state_without_dispatch():
+    """Mirrors the _last_sun_validity_state=None pattern (no spurious restart dispatch)."""
+    tracker = _make_tracker(effective_default=(0, True))
+    kwargs, apply_position, _ = _common_kwargs()
+    await tracker.check_sunset_window(**kwargs)
+    apply_position.assert_not_called()
+    assert tracker._prev_sunset_active is True
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_dispatches_on_false_to_true_transition():
+    tracker = _make_tracker(effective_default=(0, True))
+    tracker._prev_sunset_active = False
+    kwargs, apply_position, refresh = _common_kwargs(
+        sunset_pos_cfg=25, entities=["cover.a", "cover.b"]
+    )
+    await tracker.check_sunset_window(**kwargs)
+    assert apply_position.call_count == 2
+    # Position is the raw sunset_pos when inverse_state is off.
+    for call in apply_position.call_args_list:
+        assert call.args[1] == 25
+    refresh.assert_awaited()
+    assert tracker._prev_sunset_active is True
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_inverse_state_inverts_position():
+    tracker = _make_tracker(effective_default=(0, True))
+    tracker._prev_sunset_active = False
+    kwargs, apply_position, _ = _common_kwargs(sunset_pos_cfg=0, inverse=True)
+    await tracker.check_sunset_window(**kwargs)
+    apply_position.assert_called_once()
+    assert apply_position.call_args.args[1] == 100
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_skips_manual_covers():
+    tracker = _make_tracker(effective_default=(0, True))
+    tracker._prev_sunset_active = False
+    kwargs, apply_position, _ = _common_kwargs(entities=["cover.manual", "cover.auto"])
+    kwargs["is_cover_manual"] = lambda eid: eid == "cover.manual"
+    await tracker.check_sunset_window(**kwargs)
+    assert apply_position.call_count == 1
+    assert apply_position.call_args.args[0] == "cover.auto"
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_no_double_dispatch_when_already_true():
+    tracker = _make_tracker(effective_default=(0, True))
+    tracker._prev_sunset_active = True  # already in the sunset window
+    kwargs, apply_position, _ = _common_kwargs()
+    await tracker.check_sunset_window(**kwargs)
+    apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_sunset_window_records_sunset_window_opened_event():
+    tracker = _make_tracker(effective_default=(0, True))
+    tracker._prev_sunset_active = False
+    kwargs, _, _ = _common_kwargs(sunset_pos_cfg=25, entities=["a", "b", "c"])
+    await tracker.check_sunset_window(**kwargs)
+    events = tracker._event_buffer.snapshot()
+    sunset = next(e for e in events if e["event"] == "sunset_window_opened")
+    assert sunset["position"] == 25
+    assert sunset["cover_count"] == 3

--- a/tests/test_weather_motion_interaction.py
+++ b/tests/test_weather_motion_interaction.py
@@ -14,6 +14,7 @@ Covers:
 
 from __future__ import annotations
 
+from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
 from custom_components.adaptive_cover_pro.enums import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
     CloudSuppressionHandler,
@@ -62,7 +63,10 @@ def _full_registry() -> PipelineRegistry:
             WeatherOverrideHandler(),
             ManualOverrideHandler(),
             CustomPositionHandler(
-                slot=1, entity_id="binary_sensor.scene", position=55, priority=77
+                slot=1,
+                entity_id="binary_sensor.scene",
+                position=55,
+                priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
             ),
             MotionTimeoutHandler(),
             CloudSuppressionHandler(),
@@ -353,7 +357,7 @@ class TestCustomPositionPriorityInteractions:
                     entity_id="binary_sensor.scene",
                     is_on=True,
                     position=55,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=False,
                     use_my=False,
                 )
@@ -376,7 +380,7 @@ class TestCustomPositionPriorityInteractions:
                     entity_id="binary_sensor.scene",
                     is_on=True,
                     position=55,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=False,
                     use_my=False,
                 )
@@ -395,7 +399,7 @@ class TestCustomPositionPriorityInteractions:
                     entity_id="binary_sensor.scene",
                     is_on=False,
                     position=55,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=False,
                     use_my=False,
                 )
@@ -417,7 +421,7 @@ class TestCustomPositionPriorityInteractions:
                     entity_id="binary_sensor.scene",
                     is_on=True,
                     position=55,
-                    priority=77,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
                     min_mode=False,
                     use_my=False,
                 )

--- a/tests/test_weather_override.py
+++ b/tests/test_weather_override.py
@@ -63,7 +63,7 @@ def test_is_weather_override_active_delegates_to_manager():
     )
 
     coordinator, _ = _make_coordinator_with_weather_mgr(wind_speed_sensor="sensor.wind")
-    coordinator._weather_mgr._override_active = True
+    coordinator._weather_mgr.record_conditions_active()
 
     result = AdaptiveDataUpdateCoordinator.is_weather_override_active.fget(coordinator)
     assert result is True
@@ -76,7 +76,7 @@ def test_is_weather_override_active_false_when_flag_not_set():
     )
 
     coordinator, _ = _make_coordinator_with_weather_mgr(wind_speed_sensor="sensor.wind")
-    coordinator._weather_mgr._override_active = False
+    # Fresh manager — override-active flag defaults to False.
 
     result = AdaptiveDataUpdateCoordinator.is_weather_override_active.fget(coordinator)
     assert result is False
@@ -113,7 +113,7 @@ async def test_weather_state_change_activates_on_condition_met():
         coordinator, event
     )
 
-    assert coordinator._weather_mgr._override_active is True
+    assert coordinator._weather_mgr.is_weather_override_active is True
     assert coordinator.state_change is True
     coordinator.async_refresh.assert_called_once()
 
@@ -131,7 +131,7 @@ async def test_weather_state_change_starts_timeout_when_cleared():
 
     # Wind speed dropped below threshold — conditions cleared
     hass.states.get.return_value = MagicMock(state="10.0")
-    coordinator._weather_mgr._override_active = True  # Was active
+    coordinator._weather_mgr.record_conditions_active()  # was active
 
     coordinator.async_refresh = AsyncMock()
     coordinator.state_change = False
@@ -192,7 +192,7 @@ def test_reconcile_weather_override_starts_timer_when_flag_stuck(hass=None):
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="10.0")  # below threshold
-    coordinator._weather_mgr._override_active = True
+    coordinator._weather_mgr.record_conditions_active()
     coordinator._start_weather_timeout = MagicMock()
 
     AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
@@ -210,7 +210,7 @@ def test_reconcile_weather_override_noop_when_conditions_active():
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="75.0")  # above threshold
-    coordinator._weather_mgr._override_active = True
+    coordinator._weather_mgr.record_conditions_active()
     coordinator._start_weather_timeout = MagicMock()
 
     AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
@@ -228,7 +228,7 @@ def test_reconcile_weather_override_noop_when_flag_false():
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="10.0")
-    coordinator._weather_mgr._override_active = False
+    # Fresh manager — override-active defaults to False.
     coordinator._start_weather_timeout = MagicMock()
 
     AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
@@ -239,8 +239,6 @@ def test_reconcile_weather_override_noop_when_flag_false():
 @pytest.mark.asyncio
 async def test_reconcile_weather_override_noop_when_timer_running():
     """G4: override active, conditions clear, timer already running → no second timer."""
-    import asyncio
-
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
@@ -249,26 +247,21 @@ async def test_reconcile_weather_override_noop_when_timer_running():
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="10.0")
-    coordinator._weather_mgr._override_active = True
+    coordinator._weather_mgr.record_conditions_active()
+    coordinator._weather_mgr.start_weather_timeout(AsyncMock())
     coordinator._start_weather_timeout = MagicMock()
-
-    async def _long_sleep():
-        await asyncio.sleep(9999)
-
-    task = asyncio.create_task(_long_sleep())
-    coordinator._weather_mgr._timeout_task = task
     try:
         AdaptiveDataUpdateCoordinator._reconcile_weather_override(coordinator)
         coordinator._start_weather_timeout.assert_not_called()
     finally:
-        task.cancel()
+        coordinator._weather_mgr.cancel_weather_timeout()
 
 
 # --- _recover_weather_override_on_restart ---
 
 
 def test_recover_on_restart_sets_flag_when_conditions_active():
-    """G5: on first refresh, conditions active → restores _override_active=True."""
+    """G5: on first refresh, conditions active → restores override-active state."""
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
@@ -277,11 +270,11 @@ def test_recover_on_restart_sets_flag_when_conditions_active():
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="75.0")  # above threshold
-    coordinator._weather_mgr._override_active = False  # simulates post-restart reset
+    # Fresh manager — post-restart state is "flag reset to False".
 
     AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
 
-    assert coordinator._weather_mgr._override_active is True
+    assert coordinator._weather_mgr.is_weather_override_active is True
 
 
 def test_recover_on_restart_noop_when_conditions_clear():
@@ -294,11 +287,10 @@ def test_recover_on_restart_noop_when_conditions_clear():
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="10.0")  # below threshold
-    coordinator._weather_mgr._override_active = False
 
     AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
 
-    assert coordinator._weather_mgr._override_active is False
+    assert coordinator._weather_mgr.is_weather_override_active is False
 
 
 def test_recover_on_restart_noop_when_no_sensors_configured():
@@ -308,11 +300,10 @@ def test_recover_on_restart_noop_when_no_sensors_configured():
     )
 
     coordinator, hass = _make_coordinator_with_weather_mgr()  # no wind sensor
-    coordinator._weather_mgr._override_active = False
 
     AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
 
-    assert coordinator._weather_mgr._override_active is False
+    assert coordinator._weather_mgr.is_weather_override_active is False
     hass.states.get.assert_not_called()
 
 
@@ -333,10 +324,12 @@ async def test_restart_race_then_conditions_clear_starts_timer():
     )
     # 1. Conditions active on startup (simulates HA restart with wind still up)
     hass.states.get.return_value = MagicMock(state="75.0")
-    coordinator._weather_mgr._override_active = False
+    # Fresh manager — post-restart state is "flag reset to False".
 
     AdaptiveDataUpdateCoordinator._recover_weather_override_on_restart(coordinator)
-    assert coordinator._weather_mgr._override_active is True  # recovery worked
+    assert (
+        coordinator._weather_mgr.is_weather_override_active is True
+    )  # recovery worked
 
     # 2. Wind drops; state-change event fires
     hass.states.get.return_value = MagicMock(state="10.0")
@@ -355,16 +348,14 @@ async def test_restart_race_then_conditions_clear_starts_timer():
         coordinator, event
     )
 
-    # Without the restart recovery fix, _override_active would be False here
-    # and the else-branch would short-circuit without starting the timer.
+    # Without the restart recovery fix, the override-active flag would be False
+    # here and the else-branch would short-circuit without starting the timer.
     coordinator._start_weather_timeout.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_weather_state_change_cleared_does_not_restart_running_timer():
     """Regression: a cleared event does not restart a timer that's already running."""
-    import asyncio
-
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
@@ -374,16 +365,12 @@ async def test_weather_state_change_cleared_does_not_restart_running_timer():
         wind_speed_sensor="sensor.wind"
     )
     hass.states.get.return_value = MagicMock(state="10.0")  # conditions clear
-    coordinator._weather_mgr._override_active = True
+    coordinator._weather_mgr.record_conditions_active()
+    coordinator._weather_mgr.start_weather_timeout(AsyncMock())
     coordinator._start_weather_timeout = MagicMock()
     coordinator.async_refresh = AsyncMock()
     coordinator.state_change = False
 
-    async def _long_sleep():
-        await asyncio.sleep(9999)
-
-    task = asyncio.create_task(_long_sleep())
-    coordinator._weather_mgr._timeout_task = task
     try:
         event = MagicMock(spec=Event)
         event.data = {
@@ -395,7 +382,7 @@ async def test_weather_state_change_cleared_does_not_restart_running_timer():
         )
         coordinator._start_weather_timeout.assert_not_called()
     finally:
-        task.cancel()
+        coordinator._weather_mgr.cancel_weather_timeout()
 
 
 # --- first-refresh ordering: recovery before pipeline ---


### PR DESCRIPTION
## Summary

A nine-commit chain that pushes cover-type-specific behaviour onto the `CoverTypePolicy` hierarchy and extracts controller-shaped state off the coordinator into focused helpers. No behaviour change for end users — every phase is mechanical, byte-preserving where possible, and gated by new or migrated tests at each step.

Test count moves **3239 → 3375 (+136 tests)** across the chain. Lint clean throughout. The tip also carries the `v2.22.0-beta.1` version bump + release notes for the beta I already cut from this branch.

## Phase-by-phase

| Phase | What | Why |
|-------|------|-----|
| **A** — latent-defect cleanup | Six surgical fixes around the policy boundary: isinstance guard on the glare-zone downcast, Liskov fix on `is_in_tilt_suppression`, `supports_return_to_default_switch` ClassVar replacing a hardcoded `(\"cover_awning\", \"cover_blind\")` tuple in `switch.py`, dedup'd manual-override threshold formula, replaced 33 hardcoded `priority=77` test fixtures with `DEFAULT_CUSTOM_POSITION_PRIORITY`, safe defaults on three `CoverTypePolicy` methods | Closes defect surfaces the abstraction already promised but didn't enforce; a fifth cover type that forgets one is now harmless. |
| **B** — `TimeoutController` | Single owner of the spawn-task / sleep / check / null-the-handle cycle previously copy-pasted across `MotionManager`, `WeatherManager`, and the startup-grace path on `GracePeriodManager`. Manager tests migrated off private state to the public surface per CODING_GUIDELINES § Testing Rules. | Three drifted copies of the same loop. Closes the stale-task-handle footgun. |
| **C** — relocate `DualAxisSequencer` | Moved from `managers/` into `cover_types/venetian/` as a sibling to `policy.py`. Public import path preserved via `__init__.py` re-exports; tests relocated to `tests/test_cover_types/`. | The sequencer was structurally venetian-only (hardcoded `ATTR_TILT_POSITION`, tilt inversion, back-rotate window) but lived in the cover-type-agnostic manager layer. |
| **D** — `PipelineSnapshotBuilder` | Extracted five coordinator methods (~213 LOC) that assembled `PipelineSnapshot` from HA reads + manager state + policy-derived glare-zone config into a composed builder. `_weather_readings` ownership stays on the coordinator; glare-zone master switches flow in as an `is_glare_zone_enabled(idx)` callable. | Construction had no dependency on coordinator lifecycle — every input flowed in by argument or through stable collaborators. |
| **E** — `WindowTransitionTracker` | Extracted two correlated transition detectors (sun-validity False→True, sunset-window False→True per issue #266) and their `_last_sun_validity_state` / `_prev_sunset_active` state onto a framework-light tracker in `state/`. Per-cycle collaborators flow in by keyword; long-lived ones are constructor-injected. | ~130 LOC of stateful detection that didn't depend on coordinator internals beyond the `_compute_current_effective_default` closure (which stays on the coordinator and is injected at construction). |
| **F** — `StateClassifier` | Moved the 256-line `process_entity_state_change` body — the integration's source of truth for ACP-transit vs. genuine-user-activity — off the coordinator and into `managers/cover_command/state_classifier.py`, composed by `CoverCommandService` alongside its existing siblings. All five issue-numbered behaviours (#147, #172, #186, #271, #285) preserved verbatim. Coordinator side is now a 6-line shim. | All five inputs the body consumed already lived on `CoverCommandService`. Keeping it on the coordinator was purely accidental. |
| **G** — eliminate last cover-type literals | Two ClassVar flags (`exposes_dual_axis_sensor`, `custom_position_includes_tilt`) absorb the last `SensorType.X ==` literals outside `cover_types/` — in `sensor.py` (Target Tilt diagnostic) and `config_flow._build_custom_position_schema_dict`. New regression guard in `tests/test_cover_types/test_axes.py` scans every production module outside `cover_types/` for cover-type-string branching and fails CI if any reappear. | The abstraction rule from CODING_GUIDELINES is now enforced, not aspirational. |
| **H** — stub policies + cross-type invariants | Two synthetic fifth-cover-type policies (single- and dual-axis) plus a `register_stub_policy` context manager, exercised against ten method-level contracts × six policies = 60 parametrised cases. Three registry round-trip tests. Removed the now-redundant inline `_MinimalStubPolicy`. | Production code outside `cover_types/` must tolerate a registered policy it has never heard of. This now has teeth. |
| **I** — wiki anchor + display label | Two new `CoverTypePolicy` hooks (`wiki_anchor()`, `display_label()`) consolidate the last per-type dicts in `config_flow.py`. Geometry-wiki URL composed from `_WIKI_BASE_URL` + anchor instead of a four-entry lookup table. Summary builder reads the label off the policy. Existing UI strings remain byte-identical. | The two dicts had to be edited in lockstep with the policy hierarchy. Now a new cover type carries its own. |

## Testing
- 3375 tests passing on the tip (3239 on main)
- New test surfaces:
  - `tests/test_managers/test_timeout_controller.py`
  - `tests/test_managers/test_state_classifier.py`
  - `tests/test_pipeline/test_snapshot_builder.py`
  - `tests/test_state/test_window_transition_tracker.py`
  - `tests/test_cover_types/{stub_policy,test_axes,test_invariants}.py`
- Migrations off private state: motion / weather / grace-period manager tests, climate-wiring regression guard (issue #134), apply-user-position service tests, custom-position state tests
- Lint clean across all phases

## Notes for review
- Each phase is a single, focused commit — easiest to review one at a time.
- The tip carries the `v2.22.0-beta.1` version bump + release notes for the beta that already shipped from this branch.
- No production-side migrations required: managers, providers, and pipeline handlers all retain their existing public surfaces.