### PR TITLE
refactor: clean up legacy climate step and optional-key duplication

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -793,14 +793,6 @@ TEMPERATURE_CLIMATE_SCHEMA = vol.Schema(
     }
 )
 
-# Combined schema for backward compatibility (used by SYNC_CATEGORIES)
-CLIMATE_SCHEMA = vol.Schema(
-    {
-        **dict(LIGHT_CLOUD_SCHEMA.schema.items()),
-        **dict(TEMPERATURE_CLIMATE_SCHEMA.schema.items()),
-    }
-)
-
 WEATHER_OPTIONS = vol.Schema(
     {
         vol.Optional(
@@ -2603,41 +2595,6 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_climate(self, user_input: dict[str, Any] | None = None):
-        """Manage climate options (combined, for backward compat with options flow)."""
-        if user_input is not None:
-            entities = [
-                CONF_TEMP_ENTITY,
-                CONF_OUTSIDETEMP_ENTITY,
-                CONF_WEATHER_ENTITY,
-                CONF_PRESENCE_ENTITY,
-                CONF_LUX_ENTITY,
-                CONF_IRRADIANCE_ENTITY,
-            ]
-            self.optional_entities(entities, user_input)
-            if user_input.get(CONF_CLIMATE_MODE) and not user_input.get(
-                CONF_TEMP_ENTITY
-            ):
-                return self.async_show_form(
-                    step_id="climate",
-                    data_schema=CLIMATE_SCHEMA,
-                    errors={CONF_TEMP_ENTITY: "Required when climate mode is enabled"},
-                    description_placeholders={
-                        "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Climate"
-                    },
-                )
-            self.config.update(user_input)
-            if self.config.get(CONF_WEATHER_ENTITY):
-                return await self.async_step_weather()
-            return await self.async_step_summary()
-        return self.async_show_form(
-            step_id="climate",
-            data_schema=CLIMATE_SCHEMA,
-            description_placeholders={
-                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Climate"
-            },
-        )
-
     async def async_step_weather(self, user_input: dict[str, Any] | None = None):
         """Manage weather conditions."""
         if user_input is not None:
@@ -3470,43 +3427,6 @@ class OptionsFlowHandler(OptionsFlow):
             ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Climate-Mode"
-            },
-        )
-
-    async def async_step_climate(self, user_input: dict[str, Any] | None = None):
-        """Manage climate options (legacy combined step, kept for backward compat)."""
-        if user_input is not None:
-            entities = [
-                CONF_TEMP_ENTITY,
-                CONF_OUTSIDETEMP_ENTITY,
-                CONF_WEATHER_ENTITY,
-                CONF_PRESENCE_ENTITY,
-                CONF_LUX_ENTITY,
-                CONF_IRRADIANCE_ENTITY,
-            ]
-            self.optional_entities(entities, user_input)
-            if user_input.get(CONF_CLIMATE_MODE) and not user_input.get(
-                CONF_TEMP_ENTITY
-            ):
-                return self.async_show_form(
-                    step_id="climate",
-                    data_schema=self.add_suggested_values_to_schema(
-                        CLIMATE_SCHEMA, user_input or self.options
-                    ),
-                    errors={CONF_TEMP_ENTITY: "Required when climate mode is enabled"},
-                    description_placeholders={
-                        "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Climate"
-                    },
-                )
-            self.options.update(user_input)
-            return await self.async_step_init()
-        return self.async_show_form(
-            step_id="climate",
-            data_schema=self.add_suggested_values_to_schema(
-                CLIMATE_SCHEMA, user_input or self.options
-            ),
-            description_placeholders={
-                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Climate"
             },
         )
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -671,6 +671,18 @@ WEATHER_OVERRIDE_SCHEMA = vol.Schema(
     }
 )
 
+# Keys in WEATHER_OVERRIDE_SCHEMA with default=vol.UNDEFINED. Voluptuous omits
+# them from user_input when cleared, so both flow handlers must call
+# optional_entities() with this list before dict.update() -- otherwise the prior
+# value survives a clear (issue #323).
+_WEATHER_OVERRIDE_OPTIONAL_KEYS: list[str] = [
+    CONF_WEATHER_WIND_SPEED_SENSOR,
+    CONF_WEATHER_WIND_DIRECTION_SENSOR,
+    CONF_WEATHER_RAIN_SENSOR,
+    CONF_WEATHER_IS_RAINING_SENSOR,
+    CONF_WEATHER_IS_WINDY_SENSOR,
+]
+
 # --- Light & Cloud (works without climate mode) ---
 LIGHT_CLOUD_SCHEMA = vol.Schema(
     {
@@ -747,6 +759,19 @@ LIGHT_CLOUD_SCHEMA = vol.Schema(
     }
 )
 
+# Keys in LIGHT_CLOUD_SCHEMA with default=vol.UNDEFINED (entity fields use
+# explicit UNDEFINED; CONF_CLOUDY_POSITION uses bare vol.Optional which also
+# produces default=vol.UNDEFINED). Both flow handlers must call
+# optional_entities() with this list before dict.update() -- see #323 and #392.
+_LIGHT_CLOUD_OPTIONAL_KEYS: list[str] = [
+    CONF_CLOUDY_POSITION,
+    CONF_WEATHER_ENTITY,
+    CONF_IS_SUNNY_SENSOR,
+    CONF_LUX_ENTITY,
+    CONF_IRRADIANCE_ENTITY,
+    CONF_CLOUD_COVERAGE_ENTITY,
+]
+
 # --- Temperature Climate Mode ---
 TEMPERATURE_CLIMATE_SCHEMA = vol.Schema(
     {
@@ -792,6 +817,15 @@ TEMPERATURE_CLIMATE_SCHEMA = vol.Schema(
         ): selector.BooleanSelector(),
     }
 )
+
+# Keys in TEMPERATURE_CLIMATE_SCHEMA with default=vol.UNDEFINED (CONF_TEMP_ENTITY
+# is a bare vol.Optional). Both flow handlers must call optional_entities() with
+# this list before dict.update() -- see #323.
+_TEMPERATURE_CLIMATE_OPTIONAL_KEYS: list[str] = [
+    CONF_TEMP_ENTITY,
+    CONF_OUTSIDETEMP_ENTITY,
+    CONF_PRESENCE_ENTITY,
+]
 
 WEATHER_OPTIONS = vol.Schema(
     {
@@ -2520,16 +2554,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     ):
         """Configure weather-based safety overrides."""
         if user_input is not None:
-            self.optional_entities(
-                [
-                    CONF_WEATHER_WIND_SPEED_SENSOR,
-                    CONF_WEATHER_WIND_DIRECTION_SENSOR,
-                    CONF_WEATHER_RAIN_SENSOR,
-                    CONF_WEATHER_IS_RAINING_SENSOR,
-                    CONF_WEATHER_IS_WINDY_SENSOR,
-                ],
-                user_input,
-            )
+            self.optional_entities(_WEATHER_OVERRIDE_OPTIONAL_KEYS, user_input)
             self.config.update(user_input)
             return await self.async_step_light_cloud()
         return self.async_show_form(
@@ -2543,16 +2568,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_light_cloud(self, user_input: dict[str, Any] | None = None):
         """Configure light sensors, weather conditions, and cloud suppression."""
         if user_input is not None:
-            self.optional_entities(
-                [
-                    CONF_WEATHER_ENTITY,
-                    CONF_LUX_ENTITY,
-                    CONF_IRRADIANCE_ENTITY,
-                    CONF_CLOUD_COVERAGE_ENTITY,
-                    CONF_IS_SUNNY_SENSOR,
-                ],
-                user_input,
-            )
+            self.optional_entities(_LIGHT_CLOUD_OPTIONAL_KEYS, user_input)
             self.config.update(user_input)
             return await self.async_step_temperature_climate()
         return self.async_show_form(
@@ -2568,12 +2584,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     ):
         """Configure temperature-based climate mode."""
         if user_input is not None:
-            entities = [
-                CONF_TEMP_ENTITY,
-                CONF_OUTSIDETEMP_ENTITY,
-                CONF_PRESENCE_ENTITY,
-            ]
-            self.optional_entities(entities, user_input)
+            self.optional_entities(_TEMPERATURE_CLIMATE_OPTIONAL_KEYS, user_input)
             if user_input.get(CONF_CLIMATE_MODE) and not user_input.get(
                 CONF_TEMP_ENTITY
             ):
@@ -3126,16 +3137,7 @@ class OptionsFlowHandler(OptionsFlow):
     ):
         """Manage weather-based safety overrides."""
         if user_input is not None:
-            self.optional_entities(
-                [
-                    CONF_WEATHER_WIND_SPEED_SENSOR,
-                    CONF_WEATHER_WIND_DIRECTION_SENSOR,
-                    CONF_WEATHER_RAIN_SENSOR,
-                    CONF_WEATHER_IS_RAINING_SENSOR,
-                    CONF_WEATHER_IS_WINDY_SENSOR,
-                ],
-                user_input,
-            )
+            self.optional_entities(_WEATHER_OVERRIDE_OPTIONAL_KEYS, user_input)
             self.options.update(user_input)
             return await self.async_step_init()
         return self.async_show_form(
@@ -3372,16 +3374,7 @@ class OptionsFlowHandler(OptionsFlow):
     async def async_step_light_cloud(self, user_input: dict[str, Any] | None = None):
         """Manage light sensors, weather conditions, and cloud suppression."""
         if user_input is not None:
-            self.optional_entities(
-                [
-                    CONF_WEATHER_ENTITY,
-                    CONF_LUX_ENTITY,
-                    CONF_IRRADIANCE_ENTITY,
-                    CONF_CLOUD_COVERAGE_ENTITY,
-                    CONF_IS_SUNNY_SENSOR,
-                ],
-                user_input,
-            )
+            self.optional_entities(_LIGHT_CLOUD_OPTIONAL_KEYS, user_input)
             self.options.update(user_input)
             return await self.async_step_init()
         return self.async_show_form(
@@ -3399,12 +3392,7 @@ class OptionsFlowHandler(OptionsFlow):
     ):
         """Manage temperature-based climate mode."""
         if user_input is not None:
-            entities = [
-                CONF_TEMP_ENTITY,
-                CONF_OUTSIDETEMP_ENTITY,
-                CONF_PRESENCE_ENTITY,
-            ]
-            self.optional_entities(entities, user_input)
+            self.optional_entities(_TEMPERATURE_CLIMATE_OPTIONAL_KEYS, user_input)
             if user_input.get(CONF_CLIMATE_MODE) and not user_input.get(
                 CONF_TEMP_ENTITY
             ):

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -289,48 +289,6 @@
           "weather_timeout": "Sekunden zu warten, nachdem ALLE Bedingungen geklärt sind, bevor normale Kontrolle fortgesetzt wird. Verhindert schnelles Umschalten bei böigem oder unterbrochenem Wetter. Auf 0 setzen für sofortige Fortsetzung."
         }
       },
-      "climate": {
-        "data": {
-          "weather_entity": "Wetter-Entität (optional)",
-          "lux_entity": "Luxsensor (optional)",
-          "lux_threshold": "Luxschwellwert",
-          "irradiance_entity": "Strahlungssensor (optional)",
-          "irradiance_threshold": "Strahlungsschwellwert",
-          "cloud_coverage_entity": "Wolkendecken-Sensor (optional)",
-          "cloud_coverage_threshold": "Wolkendecken-Schwellwert",
-          "cloud_suppression": "Blendungssteuerung bei schwachem Licht unterdrücken",
-          "climate_mode": "Klimamodus aktivieren",
-          "temp_entity": "Innere Temperaturentität",
-          "temp_low": "Unterer Temperaturschwellwert",
-          "temp_high": "Oberer Temperaturschwellwert",
-          "outside_temp": "Außentemperatursensor (optional)",
-          "presence_entity": "Anwesenheitsentität (optional)",
-          "transparent_blind": "Transparente Jalousie",
-          "winter_close_insulation": "Winterisolationsmodus",
-          "cloudy_position": "Bewölkungsposition (optional)"
-        },
-        "data_description": {
-          "weather_entity": "Optionale Wetter-Integration für wolkenkalibrierte Steuerung. Wenn Wetter = bewölkt/regnerisch: Überspringt Winterwärmeerwerb (keine Sonne zum Erfassen), Kehrt zur Standardposition zurück (keine Überhitzungsgefahr). Wenn Wetter = sonnig/klar: Wendet vollständige Klimastrategien an. Lassen Sie leer, um immer sonnig anzunehmen (einfacher). Empfohlen, wenn Sie Wetter-Integration haben – vermeidet unnötige Schließungen.",
-          "lux_entity": "Optionaler Lichtsensor zur präzisen Sonnenerkennung (innen oder außen). Misst sichtbares Licht in Lux-Einheiten. Legen Sie Schwellwert für „sonnig“-Bedingung fest. Typisch: 5000–10000 Lux für direkte Sonne. Wenn unter Schwellwert: Behandeln Sie als bewölkt, überspringen Sie Klimastrategien. Lassen Sie leer, wenn Sie diesen Sensor nicht haben. Fortgeschrittenes Feature – die meisten Benutzer benötigen dies nicht.",
-          "lux_threshold": "Lux-Schwellwert (wann als „sonnig“ betrachten). Wenn Sensor über diesem Wert abliest: Sonne ist vorhanden, wenden Sie Klimastrategien an. Wenn darunter: Behandeln Sie als bewölkt, verwenden Sie Standardposition. Typische Werte: 5000–10000 Lux für direkte Sonneneinstrahlung, 2000–3000 Lux für helles indirektes Licht. Passen Sie basierend auf Sensorplatzierung und Empfindlichkeit an.",
-          "irradiance_entity": "Optionaler Solarstrahlungssensor für präzise Sonnenerkennung (außen). Misst Sonnenleistung in W/m²-Einheiten. Legen Sie Schwellwert für „sonnig“-Bedingung fest. Typisch: 300–500 W/m² für direkte Sonne. Wenn unter Schwellwert: Behandeln Sie als bewölkt, überspringen Sie Klimastrategien. Lassen Sie leer, wenn Sie diesen Sensor nicht haben. Fortgeschrittenes Feature – die meisten Benutzer benötigen dies nicht.",
-          "irradiance_threshold": "Bestrahlungs-Schwellwert (wann als „sonnig“ betrachten). Wenn Sensor über diesem Wert abliest (W/m²): Sonne ist vorhanden, wenden Sie Klimastrategien an. Wenn darunter: Behandeln Sie als bewölkt, verwenden Sie Standardposition. Typische Werte: 300–500 W/m² für direkte Sonneneinstrahlung, 100–200 W/m² für bewölkten Tag. Passen Sie basierend auf Ihrem Klima und Vorlieben an.",
-          "cloud_coverage_entity": "Optionaler Wolkenbedeckungssensor, der 0–100% meldet. Verfügbar von Integrationen wie Google Wetter. Wenn auf oder über dem Schwellwert: Blendungsschutz wird unterdrückt und die Beschattung kehrt zur Standardposition zurück. Lassen Sie leer, wenn Sie diesen Sensor nicht haben.",
-          "cloud_coverage_threshold": "Wolkenbedeckungsprozentsatz, bei dem oder darüber der Blendungsschutz unterdrückt wird (z. B. 75 bedeutet 75% Wolkenbedeckung = bedeckt). Standard: 75%.",
-          "cloud_suppression": "Wenn aktiviert, unterdrückt Blendungsschutz, wenn Wetter, Lux-, Bestrahlungs- oder Wolkenbedeckungsbedingungen anzeigen, dass keine echte direkte Sonne vorhanden ist – die Beschattung kehrt stattdessen zur Standardposition zurück anstatt der Sonne zu folgen. Erfordert NICHT, dass der Klimamodus aktiviert ist: Konfigurieren Sie eine Wetherentität, einen Luxsensor, einen Bestrahlungssensor oder einen Wolkenbedeckungssensor oben und diese Schaltfläche funktioniert eigenständig. Nützlich, wenn Sie lichtkalibriertes Blendungsunterdrückung ohne vollständige temperaturgesteuerte Klimakontrolle möchten.",
-          "climate_mode": "Temperaturbasierte Beschattungsstrategien aktivieren. Wenn AN: Beschattungsverhalten passt sich basierend auf Raumtemperatur an – öffnet sich vollständig im Winter zur Erfassung von Sonnenwärme, schließt sich vollständig im Sommer um Überhitzung zu verhindern. Erfordert einen Raumtemperatursensor. Lassen Sie AUS wenn Sie nur Blendungsschutz (Sonnenverfolgung) ohne temperaturgesteuerte Verhalten möchten.",
-          "temp_entity": "Temperatursensor für den Klimamodus (innen oder außen). Wird zur Bestimmung von Winter-/Sommerstrategien verwendet. Raumtemperatursensor empfohlen (misst Raumkomfort). Außentemperatursensor als Alternative (verfolgt Außenwetter). Thermostat: Kann current_temperature-Attribut verwenden. Stellen Sie sicher, dass Sensoreinheiten Ihrem Home Assistant-Einheitensystem entsprechen (°C oder °F).",
-          "temp_low": "Temperaturschwellwert für WINTERMODUS (in Ihren Systemeinheiten). Wenn Temperatur < dieser Wert: Beschattung öffnet sich vollständig an sonnigen Tagen um Wärme zu gewinnen. Empfohlene Werte: °C: 18–20°C (65–68°F), °F: 65–68°F. Passen Sie basierend auf Ihrer Komfortvorliebe an. Niedrigerer Wert = Wintermodus seltener (nur wenn sehr kalt). Höherer Wert = Wintermodus häufiger (priorisieren Sie Solarertrag).",
-          "temp_high": "Temperaturschwellwert für SOMMERMODUS (in Ihren Systemeinheiten). Wenn Temperatur > dieser Wert: Beschattung schließt sich vollständig, um Überhitzung zu verhindern. Empfohlene Werte: °C: 23–25°C (73–77°F), °F: 73–77°F. Passen Sie basierend auf Ihrer Kühlungsvorliebe an. Niedrigerer Wert = Sommermodus früher (aggressive Kühlung). Höherer Wert = Sommermodus später (tolerate mehr Wärme).",
-          "outside_temp": "Optionaler Außentemperatursensor für bessere Sommererkennung. Wenn eingestellt, erfordert der Sommermodus BEIDE: Raumtemperatur > hoher Schwellwert UND Außentemperatur > Außenschwellwert. Verhindert Schließen der Beschattung, wenn es draußen kühl ist (offen für Brise). Lassen Sie leer, um nur Raumtemperatur zu verwenden. Empfohlen, wenn Sie Außensensor haben – verbessert den Komfort.",
-          "presence_entity": "Optionaler Anwesenheitssensor (Home/Away-Erkennung). Unterstützte Typen: device_tracker, person, zone, binary_sensor. Wenn WEG: Sommer schließt vollständig (sparen auf AC), Winter öffnet sich an sonnigen Tagen (passive Solarheizung). Wenn ZUHAUSE: Verwenden Sie normale Klimastrategien mit Wetterkennung. Lassen Sie leer, um immer anzunehmen, dass jemand zuhause ist. Spart Energie wenn weg, behält Komfort bei wenn zuhause.",
-          "transparent_blind": "Aktivieren Sie dies, wenn Ihre Jalousie lichtdurchlässig ist (Voile/leichter Stoff). Ändert Sommerverhalten: Transparent AN schließt auf 0% im Sommer (blockiere Wärme, behalte Licht). Transparent AUS nutzt berechnete Position. Lichtdurchlässige Jalousien reduzieren Wärme, lassen aber Licht durch. Lassen Sie deaktiviert für undurchsichtige/Verdunkelungs-Jalousien.",
-          "winter_close_insulation": "Schließen Sie die Beschattung im Winter, wenn die Sonne nicht das Fenster trifft. Bietet Isolierung durch Abhalten kalter Luft und Bewahrung von Wärme. Wenn die Sonne in das Sichtfeld des Fensters eintritt, öffnet sich die Beschattung wie normal zur Solarheizung.",
-          "cloudy_position": "Position (0-100%), zu der Beschattungen verschoben werden, wenn Wolkenunterdrückung aktiv ist (bewölkt / niedriges Licht). 0% = geschlossen (Jalousien heruntergelassen / Markise eingezogen), 100% = offen (Jalousien hochgezogen / Markise ausgefahren). Leer lassen, um die Standardposition zu verwenden."
-        },
-        "description": "Aktivieren Sie klimabewusste Beschattungselemente-Steuerung. Wenn aktiv, öffnet die Integration Beschattungselemente im Winter, um Solarwärme zu nutzen, und schließt sie im Sommer, um die Kühlast zu reduzieren. Dieser Bildschirm konfiguriert, welche Licht- und Wolkensensoren bestimmen, ob die Sonne derzeit aktiv ist.\n\nTemperaturgrenzen, Anwesenheitseinstellungen und saisonale Verhaltensregeln befinden sich auf dem nächsten Bildschirm. Wetterbedingungsmappings folgen danach. Alle Klima-Untereinstellungen werden ignoriert, wenn der Klimamodus deaktiviert ist.\n\n[Weitere Informationen]({learn_more})",
-        "title": "Klimakonfiguration"
-      },
       "weather": {
         "data": {
           "weather_state": "Wetterbedingungen"
@@ -515,7 +473,6 @@
           "glare_zones": "🔆 Blendungszonen",
           "interp": "📊 Positionskalibrierung",
           "automation": "⏱️ Zeitplan und Timing",
-          "climate": "Klimakonfiguration",
           "weather": "Wetterbedingungen",
           "manual_override": "✋ Manuelle Übersteuerung",
           "force_override": "🚨 Zwangsübersteuerung",
@@ -804,48 +761,6 @@
           "weather_override_min_mode": "Wenn aktiviert, fungiert die Übersteuerungsposition als Mindestgrenze – der Behang wird nicht unter diese Position schließen, aber höhere Positionen von Sonnenverfolgung oder anderen Berechnungen sind erlaubt. Wenn deaktiviert (Standard), wird der Behang auf die genaue Übersteuerungsposition gesetzt.",
           "weather_timeout": "Sekunden zu warten, nachdem ALLE Bedingungen gelöst sind, bevor normale Steuerung fortgesetzt wird. Verhindert schnelles Umschalten bei böigen oder zeitweiligen Bedingungen. Auf 0 setzen für sofortige Fortführung."
         }
-      },
-      "climate": {
-        "data": {
-          "weather_entity": "Wetter-Entität (optional)",
-          "lux_entity": "Luxsensor (optional)",
-          "lux_threshold": "Luxschwellwert",
-          "irradiance_entity": "Strahlungssensor (optional)",
-          "irradiance_threshold": "Strahlungsschwellwert",
-          "cloud_coverage_entity": "Wolkendecken-Sensor (optional)",
-          "cloud_coverage_threshold": "Wolkendecken-Schwellwert",
-          "cloud_suppression": "Blendungssteuerung bei schwachem Licht unterdrücken",
-          "climate_mode": "Klimamodus aktivieren",
-          "temp_entity": "Innere Temperaturentität",
-          "temp_low": "Unterer Temperaturschwellwert",
-          "temp_high": "Oberer Temperaturschwellwert",
-          "outside_temp": "Außentemperatursensor (optional)",
-          "presence_entity": "Anwesenheitsentität (optional)",
-          "transparent_blind": "Transparente Jalousie",
-          "winter_close_insulation": "Winterisolationsmodus",
-          "cloudy_position": "Bewölkungsposition (optional)"
-        },
-        "data_description": {
-          "weather_entity": "Optionale Wetter-Integration für bewölkungsbewusste Kontrolle. Wenn Wetter = bewölkt/regnerisch: Überspringt Wintersolareintrag (keine Sonne zum Nutzen), Kehrt zur Standardposition zurück (keine Überhitzungsgefahr). Wenn Wetter = sonnig/klar: Wendet vollständige Klimastrategien an. Lassen Sie leer, um immer sonnig anzunehmen (einfacher). Empfohlen, wenn Sie eine Wetter-Integration haben - vermeidet unnötige Schließvorgänge.",
-          "lux_entity": "Optionaler Lichtstärkensensor zur genauen Sonnenerfassung (innen oder außen). Misst das sichtbare Licht in Luxeinheiten. Legen Sie den Schwellwert für die Bedingung „sonnig“ fest. Typisch: 5000-10000 Lux für direkte Sonne. Wenn unter Schwellwert: Als bewölkt behandeln, Klimastrategien überspringen. Lassen Sie leer, wenn Sie nicht über diesen Sensor verfügen. Fortgeschrittene Funktion - die meisten Benutzer brauchen dies nicht.",
-          "lux_threshold": "Luxschwellwert (wann als „sonnig“ zu betrachten). Wenn der Sensor über diesem Wert liest: Sonne ist vorhanden, Klimastrategien anwenden. Wenn darunter: Als bewölkt behandeln, Standardposition verwenden. Typische Werte: 5000-10000 Lux für direkte Sonneneinstrahlung, 2000-3000 Lux für helles indirektes Licht. Passen Sie basierend auf Platzierung und Empfindlichkeit des Sensors an.",
-          "irradiance_entity": "Optionaler Solarstrahlungssensor zur genauen Sonnenerfassung (außen). Misst die Solarleistung in W/m²-Einheiten. Legen Sie den Schwellwert für die Bedingung „sonnig“ fest. Typisch: 300-500 W/m² für direkte Sonne. Wenn unter Schwellwert: Als bewölkt behandeln, Klimastrategien überspringen. Lassen Sie leer, wenn Sie nicht über diesen Sensor verfügen. Fortgeschrittene Funktion - die meisten Benutzer brauchen dies nicht.",
-          "irradiance_threshold": "Bestrahlungsschwellwert (wann als „sonnig“ zu betrachten). Wenn der Sensor über diesem Wert (W/m²) liest: Sonne ist vorhanden, Klimastrategien anwenden. Wenn darunter: Als bewölkt behandeln, Standardposition verwenden. Typische Werte: 300-500 W/m² für direkte Sonneneinstrahlung, 100-200 W/m² für bewölkten Tag. Passen Sie basierend auf Ihrem Klima und Ihren Vorlieben an.",
-          "cloud_coverage_entity": "Optionaler Bewölkungssensor, der 0-100% anzeigt. Verfügbar aus Integrationen wie Google Weather. Bei oder über dem Schwellwert wird die Blendkontrolle unterdrückt und die Beschattung kehrt zur Standardposition zurück. Lassen Sie leer, wenn Sie nicht über diesen Sensor verfügen.",
-          "cloud_coverage_threshold": "Bewölkungsprozentsatz bei oder über dem die Blendkontrolle unterdrückt wird (z.B. 75 bedeutet 75% Bewölkung = bedeckt). Standard: 75%.",
-          "cloud_suppression": "Bei Aktivierung wird die Blendkontrolle unterdrückt, wenn Wetter-, Lux-, Bestrahlungs- oder Bewölkungsbedingungen anzeigen, dass keine echte direkte Sonne vorhanden ist — die Beschattung kehrt stattdessen zur Standardposition zurück. Erfordert NICHT, dass der Klimamodus aktiviert ist: Konfigurieren Sie eine Wetterentität, einen Luxsensor, einen Bestrahlungssensor oder einen Bewölkungssensor oben, und dieser Umschalter funktioniert alleine. Nützlich, wenn Sie lichtalergie Blendkontrolle ohne vollständige temperaturgesteuerte Klimatisierung möchten.",
-          "climate_mode": "Temperaturbasierte Cover-Strategien aktivieren. Bei AN: Das Verhalten der Beschattung passt sich der Innentemperatur an — öffnet sich im Winter vollständig, um Sonnenwärme zu nutzen, schließt sich im Sommer vollständig, um Überhitzung zu vermeiden. Erfordert einen Raumtemperatursensor. Lassen Sie AUS, wenn Sie nur Blendkontrolle (Sonnenverfolgung) ohne temperaturgesteuerte Verhaltensweise möchten.",
-          "temp_entity": "Temperatursensor für den Klimamodus (innen oder außen). Wird zur Bestimmung von Winter-/Sommersstrategien verwendet. Raumtemperatursensor empfohlen (misst Raumkomfort). Außentemperatursensor als Alternative (verfolgt das Außenwetter). Thermostat: Kann das current_temperature-Attribut verwenden. Stellen Sie sicher, dass die Sensoreinheiten Ihrem Home Assistant-Einheitensystem entsprechen (°C oder °F).",
-          "temp_low": "Temperaturschwellwert für WINTERMODUS (in Ihren Systemeinheiten). Wenn Temperatur < dieser Wert: Die Beschattung öffnet sich an sonnigen Tagen, um Wärme zu gewinnen. Empfohlene Werte: °C: 18-20°C (65-68°F), °F: 65-68°F. Passen Sie basierend auf Ihren Komfortvorlieben an. Niedrigerer Wert = Wintermodus weniger häufig (nur bei sehr kaltem Wetter). Höherer Wert = Wintermodus häufiger (priorisieren Sie Solargewinne).",
-          "temp_high": "Temperaturschwellwert für SOMMERMODUS (in Ihren Systemeinheiten). Wenn Temperatur > dieser Wert: Die Beschattung schließt sich vollständig, um Überhitzung zu vermeiden. Empfohlene Werte: °C: 23-25°C (73-77°F), °F: 73-77°F. Passen Sie basierend auf Ihren Kühlungsvorlieben an. Niedrigerer Wert = Sommermodus früher (aggressive Kühlung). Höherer Wert = Sommermodus später (toleriere mehr Wärme).",
-          "outside_temp": "Optionaler Außentemperatursensor für bessere Sommererkennung. Bei Einstellung erfordert der Sommermodus BEIDES: Innentemperatur > hoher Schwellwert UND Außentemperatur > außerer Schwellwert. Verhindert das Schließen von Beschattung, wenn es außen kühl ist (öffnen Sie für Luftzug). Lassen Sie leer, um nur die Innentemperatur zu verwenden. Empfohlen, wenn Sie einen Außensensor haben - verbessert Komfort.",
-          "presence_entity": "Optionaler Anwesenheitssensor (Zuhause/Weg-Erkennung). Unterstützte Typen: device_tracker, person, zone, binary_sensor. Bei WEG: Sommer schließt vollständig (Klimaanlage sparen), Winter öffnet an sonnigen Tagen (passive Solarheizung). Bei ZUHAUSE: Verwenden Sie normale Klimastrategien mit Wetteralertness. Lassen Sie leer, um immer davon auszugehen, dass jemand zuhause ist. Spart Energie, wenn weg, erhält Komfort, wenn zuhause.",
-          "transparent_blind": "Aktivieren Sie dies, wenn Ihre Jalousie durchsichtig ist (Seidenstoff/Leichtgewebe). Ändert das Sommerverhalten: Transparent AN schließt im Sommer auf 0% (Wärme blockieren, Licht bewahren). Transparent AUS verwendet berechnete Position. Durchsichtige Jalousien reduzieren Wärme, aber lassen Licht durch. Lassen Sie deaktiviert für undurchsichtige/Verdunkelungsjaloussen.",
-          "winter_close_insulation": "Schließen Sie die Beschattung im Winter, wenn die Sonne das Fenster nicht trifft. Bietet Isolierung, indem kalte Luft draußen und Wärme drinnen bleibt. Wenn die Sonne das Sichtfeld des Fensters erreicht, öffnet sich die Beschattung für Solarheizung wie gewohnt.",
-          "cloudy_position": "Position (0-100%), zu der Beschattungen verschoben werden, wenn Wolkenunterdrückung aktiv ist (bewölkt / niedriges Licht). 0% = geschlossen (Jalousien heruntergelassen / Markise eingezogen), 100% = offen (Jalousien hochgezogen / Markise ausgefahren). Leer lassen, um die Standardposition zu verwenden."
-        },
-        "description": "Aktivieren Sie klimabewusste Beschattungselemente-Steuerung. Wenn aktiv, öffnet die Integration Beschattungselemente im Winter, um Solarwärme zu nutzen, und schließt sie im Sommer, um die Kühlast zu reduzieren. Dieser Bildschirm konfiguriert, welche Licht- und Wolkensensoren bestimmen, ob die Sonne derzeit aktiv ist.\n\nTemperaturgrenzen, Anwesenheitseinstellungen und saisonale Verhaltensregeln befinden sich auf dem nächsten Bildschirm. Wetterbedingungsmappings folgen danach. Alle Klima-Untereinstellungen werden ignoriert, wenn der Klimamodus deaktiviert ist.\n\n[Weitere Informationen]({learn_more})",
-        "title": "Klimakonfiguration"
       },
       "weather": {
         "data": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -289,48 +289,6 @@
           "weather_timeout": "Seconds to wait after ALL conditions clear before resuming normal control. Prevents rapid toggling during gusty or intermittent conditions. Set to 0 for instant resume."
         }
       },
-      "climate": {
-        "data": {
-          "weather_entity": "Weather entity (optional)",
-          "lux_entity": "Lux sensor (optional)",
-          "lux_threshold": "Lux threshold",
-          "irradiance_entity": "Irradiance sensor (optional)",
-          "irradiance_threshold": "Irradiance threshold",
-          "cloud_coverage_entity": "Cloud coverage sensor (optional)",
-          "cloud_coverage_threshold": "Cloud coverage threshold",
-          "cloud_suppression": "Suppress glare control in low light",
-          "cloudy_position": "Cloudy position (optional)",
-          "climate_mode": "Enable climate mode",
-          "temp_entity": "Inside temperature entity",
-          "temp_low": "Low temperature threshold",
-          "temp_high": "High temperature threshold",
-          "outside_temp": "Outside temperature sensor (optional)",
-          "presence_entity": "Presence entity (optional)",
-          "transparent_blind": "Transparent blind",
-          "winter_close_insulation": "Winter insulation mode"
-        },
-        "data_description": {
-          "weather_entity": "Optional weather integration for cloud-aware control. When weather = cloudy/rainy: Skips winter solar gain (no sun to capture), Returns to default position (no overheating risk). When weather = sunny/clear: Applies full climate strategies. Leave empty to assume always sunny (simpler). Recommended if you have weather integration - avoids unnecessary closes.",
-          "lux_entity": "Optional light intensity sensor for precise sun detection (indoor or outdoor). Measures visible light in lux units. Set threshold value for 'sunny' condition. Typical: 5000-10000 lux for direct sun. When below threshold: Treat as cloudy, skip climate strategies. Leave empty if you don't have this sensor. Advanced feature - most users don't need this.",
-          "lux_threshold": "Lux level threshold (when to consider 'sunny'). When sensor reads above this value: Sun is present, apply climate strategies. When below: Treat as cloudy, use default position. Typical values: 5000-10000 lux for direct sunlight, 2000-3000 lux for bright indirect light. Adjust based on sensor placement and sensitivity.",
-          "irradiance_entity": "Optional solar radiation sensor for precise sun detection (outdoor). Measures solar power in W/m² units. Set threshold value for 'sunny' condition. Typical: 300-500 W/m² for direct sun. When below threshold: Treat as cloudy, skip climate strategies. Leave empty if you don't have this sensor. Advanced feature - most users don't need this.",
-          "irradiance_threshold": "Irradiance level threshold (when to consider 'sunny'). When sensor reads above this value (W/m²): Sun is present, apply climate strategies. When below: Treat as cloudy, use default position. Typical values: 300-500 W/m² for direct sunlight, 100-200 W/m² for cloudy day. Adjust based on your climate and preference.",
-          "cloud_coverage_entity": "Optional cloud coverage sensor reporting 0-100%. Available from integrations like Google Weather. When at or above the threshold, glare control is suppressed and covers return to their default position. Leave empty if you don't have this sensor.",
-          "cloud_coverage_threshold": "Cloud coverage percentage at or above which glare control is suppressed (e.g., 75 means 75% cloud cover = overcast). Default: 75%.",
-          "cloud_suppression": "When enabled, suppresses glare control when weather, lux, irradiance, or cloud coverage conditions indicate no real direct sun — covers return to their default position instead of tracking the sun. Does NOT require climate mode to be enabled: configure a weather entity, lux sensor, irradiance sensor, or cloud coverage sensor above and this toggle will work on its own. Useful if you want light-aware glare suppression without full temperature-based climate control.",
-          "cloudy_position": "Position (0-100%) to move covers to when cloud suppression fires (cloudy / low-light conditions). 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Leave blank to use the default position.",
-          "climate_mode": "Enable temperature-based cover strategies. When ON: cover behavior adapts based on indoor temperature — opens fully in winter to capture solar heat, closes fully in summer to block overheating. Requires an inside temperature sensor. Leave OFF if you only want glare control (sun tracking) without temperature-driven behavior.",
-          "temp_entity": "Temperature sensor for climate mode (indoor or outdoor). Used to determine winter/summer strategies. Indoor sensor recommended (measures room comfort). Outdoor sensor alternative (tracks outside weather). Thermostat: Can use current_temperature attribute. Make sure sensor units match your Home Assistant unit system (°C or °F).",
-          "temp_low": "Temperature threshold for WINTER mode (in your system units). When temperature < this value: Cover opens fully on sunny days to gain heat. Recommended values: °C: 18-20°C (65-68°F), °F: 65-68°F. Adjust based on your comfort preference. Lower value = winter mode less often (only when very cold). Higher value = winter mode more often (prioritize solar gain).",
-          "temp_high": "Temperature threshold for SUMMER mode (in your system units). When temperature > this value: Cover closes fully to prevent overheating. Recommended values: °C: 23-25°C (73-77°F), °F: 73-77°F. Adjust based on your cooling preference. Lower value = summer mode sooner (aggressive cooling). Higher value = summer mode later (tolerate more heat).",
-          "outside_temp": "Optional outdoor temperature sensor for better summer detection. When set, summer mode requires BOTH: Indoor temperature > high threshold AND Outdoor temperature > outside threshold. Prevents closing covers when it's cool outside (open for breeze). Leave empty to use only indoor temperature. Recommended if you have outdoor sensor - improves comfort.",
-          "presence_entity": "Optional presence sensor (home/away detection). Supported types: device_tracker, person, zone, binary_sensor. When AWAY: Summer closes fully (save on AC), Winter opens on sunny days (passive solar heating). When HOME: Use normal climate strategies with weather awareness. Leave empty to always assume someone is home. Saves energy when away, maintains comfort when home.",
-          "transparent_blind": "Check this if your blind is see-through (sheer/light fabric). Changes summer behavior: Transparent ON closes to 0% in summer (block heat, keep light). Transparent OFF uses calculated position. Transparent blinds reduce heat but allow light through. Leave unchecked for opaque/blackout blinds.",
-          "winter_close_insulation": "Close covers in winter when the sun is not hitting the window. Provides insulation by keeping cold air out and warmth in. When the sun enters the window's field of view, covers will open for solar heating as normal."
-        },
-        "description": "Enable climate-aware cover control. When active, the integration opens covers in winter to capture solar heat and closes them in summer to reduce cooling load. This screen configures which light and cloud sensors determine whether the sun is currently active.\n\nTemperature thresholds, presence settings, and seasonal behaviour rules are on the next screen. Weather condition mappings follow after that. All climate sub-settings are ignored when climate mode is disabled.\n\n[Learn more]({learn_more})",
-        "title": "Climate Configuration"
-      },
       "weather": {
         "data": {
           "weather_state": "Weather Conditions"
@@ -516,7 +474,6 @@
           "glare_zones": "🔆 Glare Zones",
           "interp": "📊 Position Calibration",
           "automation": "⏱️ Schedule & Timing",
-          "climate": "Climate Configuration",
           "weather": "Weather Conditions",
           "manual_override": "✋ Manual Override",
           "force_override": "🚨 Force Override",
@@ -804,48 +761,6 @@
           "weather_override_min_mode": "When enabled, the override position acts as a minimum floor — the cover will not close below this position, but higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact override position.",
           "weather_timeout": "Seconds to wait after ALL conditions clear before resuming normal control. Prevents rapid toggling during gusty or intermittent conditions. Set to 0 for instant resume."
         }
-      },
-      "climate": {
-        "data": {
-          "weather_entity": "Weather entity (optional)",
-          "lux_entity": "Lux sensor (optional)",
-          "lux_threshold": "Lux threshold",
-          "irradiance_entity": "Irradiance sensor (optional)",
-          "irradiance_threshold": "Irradiance threshold",
-          "cloud_coverage_entity": "Cloud coverage sensor (optional)",
-          "cloud_coverage_threshold": "Cloud coverage threshold",
-          "cloud_suppression": "Suppress glare control in low light",
-          "cloudy_position": "Cloudy position (optional)",
-          "climate_mode": "Enable climate mode",
-          "temp_entity": "Inside temperature entity",
-          "temp_low": "Low temperature threshold",
-          "temp_high": "High temperature threshold",
-          "outside_temp": "Outside temperature sensor (optional)",
-          "presence_entity": "Presence entity (optional)",
-          "transparent_blind": "Transparent blind",
-          "winter_close_insulation": "Winter insulation mode"
-        },
-        "data_description": {
-          "weather_entity": "Optional weather integration for cloud-aware control. When weather = cloudy/rainy: Skips winter solar gain (no sun to capture), Returns to default position (no overheating risk). When weather = sunny/clear: Applies full climate strategies. Leave empty to assume always sunny (simpler). Recommended if you have weather integration - avoids unnecessary closes.",
-          "lux_entity": "Optional light intensity sensor for precise sun detection (indoor or outdoor). Measures visible light in lux units. Set threshold value for 'sunny' condition. Typical: 5000-10000 lux for direct sun. When below threshold: Treat as cloudy, skip climate strategies. Leave empty if you don't have this sensor. Advanced feature - most users don't need this.",
-          "lux_threshold": "Lux level threshold (when to consider 'sunny'). When sensor reads above this value: Sun is present, apply climate strategies. When below: Treat as cloudy, use default position. Typical values: 5000-10000 lux for direct sunlight, 2000-3000 lux for bright indirect light. Adjust based on sensor placement and sensitivity.",
-          "irradiance_entity": "Optional solar radiation sensor for precise sun detection (outdoor). Measures solar power in W/m² units. Set threshold value for 'sunny' condition. Typical: 300-500 W/m² for direct sun. When below threshold: Treat as cloudy, skip climate strategies. Leave empty if you don't have this sensor. Advanced feature - most users don't need this.",
-          "irradiance_threshold": "Irradiance level threshold (when to consider 'sunny'). When sensor reads above this value (W/m²): Sun is present, apply climate strategies. When below: Treat as cloudy, use default position. Typical values: 300-500 W/m² for direct sunlight, 100-200 W/m² for cloudy day. Adjust based on your climate and preference.",
-          "cloud_coverage_entity": "Optional cloud coverage sensor reporting 0-100%. Available from integrations like Google Weather. When at or above the threshold, glare control is suppressed and covers return to their default position. Leave empty if you don't have this sensor.",
-          "cloud_coverage_threshold": "Cloud coverage percentage at or above which glare control is suppressed (e.g., 75 means 75% cloud cover = overcast). Default: 75%.",
-          "cloud_suppression": "When enabled, suppresses glare control when weather, lux, irradiance, or cloud coverage conditions indicate no real direct sun — covers return to their default position instead of tracking the sun. Does NOT require climate mode to be enabled: configure a weather entity, lux sensor, irradiance sensor, or cloud coverage sensor above and this toggle will work on its own. Useful if you want light-aware glare suppression without full temperature-based climate control.",
-          "cloudy_position": "Position (0-100%) to move covers to when cloud suppression fires (cloudy / low-light conditions). 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Leave blank to use the default position.",
-          "climate_mode": "Enable temperature-based cover strategies. When ON: cover behavior adapts based on indoor temperature — opens fully in winter to capture solar heat, closes fully in summer to block overheating. Requires an inside temperature sensor. Leave OFF if you only want glare control (sun tracking) without temperature-driven behavior.",
-          "temp_entity": "Temperature sensor for climate mode (indoor or outdoor). Used to determine winter/summer strategies. Indoor sensor recommended (measures room comfort). Outdoor sensor alternative (tracks outside weather). Thermostat: Can use current_temperature attribute. Make sure sensor units match your Home Assistant unit system (°C or °F).",
-          "temp_low": "Temperature threshold for WINTER mode (in your system units). When temperature < this value: Cover opens fully on sunny days to gain heat. Recommended values: °C: 18-20°C (65-68°F), °F: 65-68°F. Adjust based on your comfort preference. Lower value = winter mode less often (only when very cold). Higher value = winter mode more often (prioritize solar gain).",
-          "temp_high": "Temperature threshold for SUMMER mode (in your system units). When temperature > this value: Cover closes fully to prevent overheating. Recommended values: °C: 23-25°C (73-77°F), °F: 73-77°F. Adjust based on your cooling preference. Lower value = summer mode sooner (aggressive cooling). Higher value = summer mode later (tolerate more heat).",
-          "outside_temp": "Optional outdoor temperature sensor for better summer detection. When set, summer mode requires BOTH: Indoor temperature > high threshold AND Outdoor temperature > outside threshold. Prevents closing covers when it's cool outside (open for breeze). Leave empty to use only indoor temperature. Recommended if you have outdoor sensor - improves comfort.",
-          "presence_entity": "Optional presence sensor (home/away detection). Supported types: device_tracker, person, zone, binary_sensor. When AWAY: Summer closes fully (save on AC), Winter opens on sunny days (passive solar heating). When HOME: Use normal climate strategies with weather awareness. Leave empty to always assume someone is home. Saves energy when away, maintains comfort when home.",
-          "transparent_blind": "Check this if your blind is see-through (sheer/light fabric). Changes summer behavior: Transparent ON closes to 0% in summer (block heat, keep light). Transparent OFF uses calculated position. Transparent blinds reduce heat but allow light through. Leave unchecked for opaque/blackout blinds.",
-          "winter_close_insulation": "Close covers in winter when the sun is not hitting the window. Provides insulation by keeping cold air out and warmth in. When the sun enters the window's field of view, covers will open for solar heating as normal."
-        },
-        "description": "Enable climate-aware cover control. When active, the integration opens covers in winter to capture solar heat and closes them in summer to reduce cooling load. This screen configures which light and cloud sensors determine whether the sun is currently active.\n\nTemperature thresholds, presence settings, and seasonal behaviour rules are on the next screen. Weather condition mappings follow after that. All climate sub-settings are ignored when climate mode is disabled.\n\n[Learn more]({learn_more})",
-        "title": "Climate Configuration"
       },
       "weather": {
         "data": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -289,48 +289,6 @@
           "weather_timeout": "Secondes à attendre après que TOUTES les conditions se clairent avant de reprendre le contrôle normal. Empêche le basculement rapide pendant les conditions de rafales ou intermittentes. Réglez sur 0 pour une reprise instantanée."
         }
       },
-      "climate": {
-        "data": {
-          "weather_entity": "Entité météo (optionnelle)",
-          "lux_entity": "Capteur de lux (optionnel)",
-          "lux_threshold": "Seuil de lux",
-          "irradiance_entity": "Capteur d'irradiance (optionnel)",
-          "irradiance_threshold": "Seuil d'irradiance",
-          "cloud_coverage_entity": "Capteur de couverture nuageuse (optionnel)",
-          "cloud_coverage_threshold": "Seuil de couverture nuageuse",
-          "cloud_suppression": "Supprimer le contrôle d'éblouissement en faible lumière",
-          "climate_mode": "Activer le mode climatique",
-          "temp_entity": "Entité de température intérieure",
-          "temp_low": "Seuil de température basse",
-          "temp_high": "Seuil de température haute",
-          "outside_temp": "Capteur de température extérieure (optionnel)",
-          "presence_entity": "Entité de présence (optionnelle)",
-          "transparent_blind": "Store transparent",
-          "winter_close_insulation": "Mode isolation hivernale",
-          "cloudy_position": "Position nuageux (optionnel)"
-        },
-        "data_description": {
-          "weather_entity": "Intégration météo optionnelle pour un contrôle adapté aux nuages. Quand la météo est nuageuse/pluvieuse : l'apport solaire hivernal est ignoré (pas de soleil à capter) et le store revient à sa position par défaut (aucun risque de surchauffe). Quand la météo est ensoleillée/dégagée : les stratégies climatiques complètes s'appliquent. Laissez vide pour supposer qu'il fait toujours soleil (mode simplifié). Recommandé si vous disposez d'une intégration météo — évite les fermetures inutiles.",
-          "lux_entity": "Capteur d'intensité lumineuse optionnel pour une détection précise du soleil (intérieur ou extérieur). Mesure la lumière visible en lux. Définissez la valeur de seuil pour la condition « ensoleillé ». Valeurs typiques : 5 000-10 000 lux pour le soleil direct. Quand la valeur est inférieure au seuil : le ciel est traité comme nuageux et les stratégies climatiques sont ignorées. Laissez vide si vous ne disposez pas de ce capteur. Fonction avancée — la plupart des utilisateurs n'en ont pas besoin.",
-          "lux_threshold": "Seuil de niveau d'éclairement (à partir duquel le ciel est considéré comme « ensoleillé »). Quand le capteur dépasse cette valeur : le soleil est présent, les stratégies climatiques s'appliquent. Quand la valeur est inférieure : le ciel est traité comme nuageux et la position par défaut est utilisée. Valeurs typiques : 5 000-10 000 lux pour le soleil direct, 2 000-3 000 lux pour une lumière indirecte vive. Ajustez selon le placement du capteur et sa sensibilité.",
-          "irradiance_entity": "Capteur de rayonnement solaire optionnel pour une détection précise du soleil (extérieur). Mesure la puissance solaire en W/m². Définissez la valeur de seuil pour la condition « ensoleillé ». Valeurs typiques : 300-500 W/m² pour le soleil direct. Quand la valeur est inférieure au seuil : le ciel est traité comme nuageux et les stratégies climatiques sont ignorées. Laissez vide si vous ne disposez pas de ce capteur. Fonction avancée — la plupart des utilisateurs n'en ont pas besoin.",
-          "irradiance_threshold": "Seuil de niveau d'irradiance (à partir duquel le ciel est considéré comme « ensoleillé »). Quand le capteur dépasse cette valeur (W/m²) : le soleil est présent, les stratégies climatiques s'appliquent. Quand la valeur est inférieure : le ciel est traité comme nuageux et la position par défaut est utilisée. Valeurs typiques : 300-500 W/m² pour le soleil direct, 100-200 W/m² pour un jour nuageux. Ajustez selon votre climat et vos préférences.",
-          "cloud_coverage_entity": "Capteur de couverture nuageuse optionnel indiquant une valeur de 0 à 100 %. Disponible via des intégrations comme Google Weather. Quand la valeur atteint ou dépasse le seuil, le contrôle de l'éblouissement est supprimé et les stores reviennent à leur position par défaut. Laissez vide si vous ne disposez pas de ce capteur.",
-          "cloud_coverage_threshold": "Pourcentage de couverture nuageuse à partir duquel le contrôle de l'éblouissement est supprimé (par ex., 75 signifie 75 % de nuages = ciel couvert). Par défaut : 75 %.",
-          "cloud_suppression": "Quand cette option est activée, le contrôle de l'éblouissement est supprimé lorsque les conditions météo, lux, irradiance ou couverture nuageuse indiquent l'absence de soleil direct — les stores reviennent à leur position par défaut au lieu de suivre le soleil. NE REQUIERT PAS l'activation du mode climatique : configurez une entité météo, un capteur de lux, d'irradiance ou de couverture nuageuse ci-dessus et cette option fonctionnera de manière autonome. Utile si vous souhaitez une suppression de l'éblouissement adaptée à la lumière sans contrôle climatique complet basé sur la température.",
-          "climate_mode": "Activer les stratégies de store basées sur la température. Quand ACTIVÉ : le comportement du store s'adapte à la température intérieure — s'ouvre complètement en hiver pour capter la chaleur solaire, se ferme complètement en été pour éviter la surchauffe. Nécessite un capteur de température intérieure. Laissez DÉSACTIVÉ si vous souhaitez uniquement le contrôle de l'éblouissement (suivi du soleil) sans comportement piloté par la température.",
-          "temp_entity": "Capteur de température pour le mode climatique (intérieur ou extérieur). Utilisé pour déterminer les stratégies hiver/été. Capteur intérieur recommandé (mesure le confort de la pièce). Capteur extérieur comme alternative (suit la météo extérieure). Thermostat : peut utiliser l'attribut current_temperature. Assurez-vous que les unités du capteur correspondent aux unités de votre système Home Assistant (°C ou °F).",
-          "temp_low": "Seuil de température pour le mode HIVER (dans vos unités système). Quand la température est inférieure à cette valeur : le store s'ouvre complètement par temps ensoleillé pour gagner de la chaleur. Valeurs recommandées : °C : 18-20 °C (65-68 °F), °F : 65-68 °F. Ajustez selon vos préférences de confort. Valeur plus basse = mode hiver moins souvent (uniquement par grand froid). Valeur plus haute = mode hiver plus souvent (privilégie l'apport solaire).",
-          "temp_high": "Seuil de température pour le mode ÉTÉ (dans vos unités système). Quand la température est supérieure à cette valeur : le store se ferme complètement pour éviter la surchauffe. Valeurs recommandées : °C : 23-25 °C (73-77 °F), °F : 73-77 °F. Ajustez selon vos préférences de rafraîchissement. Valeur plus basse = mode été plus tôt (refroidissement agressif). Valeur plus haute = mode été plus tard (tolère plus de chaleur).",
-          "outside_temp": "Capteur de température extérieure optionnel pour une meilleure détection du mode été. Quand configuré, le mode été nécessite que BOTH : la température intérieure soit supérieure au seuil haut ET la température extérieure soit supérieure au seuil extérieur. Évite de fermer les stores quand il fait frais dehors (laissez entrer la brise). Laissez vide pour n'utiliser que la température intérieure. Recommandé si vous disposez d'un capteur extérieur — améliore le confort.",
-          "presence_entity": "Capteur de présence optionnel (détection présent/absent). Types pris en charge : device_tracker, person, zone, binary_sensor. Quand ABSENT : l'été, le store se ferme complètement (économie de climatisation) ; l'hiver, il s'ouvre par temps ensoleillé (chauffage solaire passif). Quand PRÉSENT : utilise les stratégies climatiques normales avec prise en compte de la météo. Laissez vide pour supposer qu'une personne est toujours présente. Économise de l'énergie en cas d'absence, maintient le confort quand quelqu'un est là.",
-          "transparent_blind": "Cochez cette case si votre store est transparent (tissu léger ou voile). Modifie le comportement estival : Transparent ACTIVÉ ferme à 0 % en été (bloque la chaleur, laisse passer la lumière). Transparent DÉSACTIVÉ utilise la position calculée. Les stores transparents réduisent la chaleur tout en laissant passer la lumière. Laissez décoché pour les stores opaques ou occultants.",
-          "winter_close_insulation": "Ferme les stores en hiver lorsque le soleil n'est pas en face de la fenêtre. Assure l'isolation en empêchant l'air froid d'entrer et en retenant la chaleur. Lorsque le soleil entre dans le champ de vision de la fenêtre, les stores s'ouvrent pour le chauffage solaire comme d'habitude.",
-          "cloudy_position": "Position (0-100%) pour déplacer les protections lorsque la suppression nuageuse se déclenche (conditions nuageuses / faible luminosité). 0% = fermé (stores baissés / store banne rétracté), 100% = ouvert (stores levés / store banne déployé). Laissez vide pour utiliser la position par défaut."
-        },
-        "description": "Activez le contrôle de protection conscient du climat. Lorsqu'actif, l'intégration ouvre les protections en hiver pour capturer la chaleur solaire et les ferme en été pour réduire la charge de refroidissement. Cet écran configure quels capteurs de lumière et de nuage déterminent si le soleil est actuellement actif.\n\nLes seuils de température, les paramètres de présence et les règles de comportement saisonnier se trouvent sur l'écran suivant. Les mappages de conditions météorologiques suivent ensuite. Tous les paramètres secondaires du climat sont ignorés lorsque le mode climat est désactivé.\n\n[Learn more]({learn_more})",
-        "title": "Configuration climatique"
-      },
       "weather": {
         "data": {
           "weather_state": "Conditions météorologiques"
@@ -515,7 +473,6 @@
           "glare_zones": "🔆 Zones d'éblouissement",
           "interp": "📊 Étalonnage de position",
           "automation": "⏱️ Horaires et synchronisation",
-          "climate": "Configuration climatique",
           "weather": "Conditions météorologiques",
           "manual_override": "✋ Dérogation manuelle",
           "force_override": "🚨 Dérogation forcée",
@@ -804,48 +761,6 @@
           "weather_override_min_mode": "Quand activé, la position de dérogation agit comme un plancher minimum — le store ne se fermera pas en dessous de cette position, mais les positions plus élevées du suivi du soleil ou d'autres calculs sont autorisées à passer. Quand désactivé (par défaut), le store est toujours défini à la position de dérogation exacte.",
           "weather_timeout": "Secondes à attendre après que TOUTES les conditions se clairent avant de reprendre le contrôle normal. Empêche le basculement rapide pendant les conditions de rafales ou intermittentes. Réglez sur 0 pour une reprise instantanée."
         }
-      },
-      "climate": {
-        "data": {
-          "weather_entity": "Entité météo (optionnelle)",
-          "lux_entity": "Capteur de lux (optionnel)",
-          "lux_threshold": "Seuil de lux",
-          "irradiance_entity": "Capteur d'irradiance (optionnel)",
-          "irradiance_threshold": "Seuil d'irradiance",
-          "cloud_coverage_entity": "Capteur de couverture nuageuse (optionnel)",
-          "cloud_coverage_threshold": "Seuil de couverture nuageuse",
-          "cloud_suppression": "Supprimer le contrôle d'éblouissement en faible lumière",
-          "climate_mode": "Activer le mode climatique",
-          "temp_entity": "Entité de température intérieure",
-          "temp_low": "Seuil de température basse",
-          "temp_high": "Seuil de température haute",
-          "outside_temp": "Capteur de température extérieure (optionnel)",
-          "presence_entity": "Entité de présence (optionnelle)",
-          "transparent_blind": "Store transparent",
-          "winter_close_insulation": "Mode isolation hivernale",
-          "cloudy_position": "Position nuageux (optionnel)"
-        },
-        "data_description": {
-          "weather_entity": "Intégration météo optionnelle pour un contrôle adapté aux nuages. Quand la météo est nuageuse/pluvieuse : l'apport solaire hivernal est ignoré (pas de soleil à capter) et le store revient à sa position par défaut (aucun risque de surchauffe). Quand la météo est ensoleillée/dégagée : les stratégies climatiques complètes s'appliquent. Laissez vide pour supposer qu'il fait toujours soleil (mode simplifié). Recommandé si vous disposez d'une intégration météo — évite les fermetures inutiles.",
-          "lux_entity": "Capteur d'intensité lumineuse optionnel pour une détection précise du soleil (intérieur ou extérieur). Mesure la lumière visible en lux. Définissez la valeur de seuil pour la condition « ensoleillé ». Valeurs typiques : 5 000-10 000 lux pour le soleil direct. Quand la valeur est inférieure au seuil : le ciel est traité comme nuageux et les stratégies climatiques sont ignorées. Laissez vide si vous ne disposez pas de ce capteur. Fonction avancée — la plupart des utilisateurs n'en ont pas besoin.",
-          "lux_threshold": "Seuil de niveau d'éclairement (à partir duquel le ciel est considéré comme « ensoleillé »). Quand le capteur dépasse cette valeur : le soleil est présent, les stratégies climatiques s'appliquent. Quand la valeur est inférieure : le ciel est traité comme nuageux et la position par défaut est utilisée. Valeurs typiques : 5 000-10 000 lux pour le soleil direct, 2 000-3 000 lux pour une lumière indirecte vive. Ajustez selon le placement du capteur et sa sensibilité.",
-          "irradiance_entity": "Capteur de rayonnement solaire optionnel pour une détection précise du soleil (extérieur). Mesure la puissance solaire en W/m². Définissez la valeur de seuil pour la condition « ensoleillé ». Valeurs typiques : 300-500 W/m² pour le soleil direct. Quand la valeur est inférieure au seuil : le ciel est traité comme nuageux et les stratégies climatiques sont ignorées. Laissez vide si vous ne disposez pas de ce capteur. Fonction avancée — la plupart des utilisateurs n'en ont pas besoin.",
-          "irradiance_threshold": "Seuil de niveau d'irradiance (à partir duquel le ciel est considéré comme « ensoleillé »). Quand le capteur dépasse cette valeur (W/m²) : le soleil est présent, les stratégies climatiques s'appliquent. Quand la valeur est inférieure : le ciel est traité comme nuageux et la position par défaut est utilisée. Valeurs typiques : 300-500 W/m² pour le soleil direct, 100-200 W/m² pour un jour nuageux. Ajustez selon votre climat et vos préférences.",
-          "cloud_coverage_entity": "Capteur de couverture nuageuse optionnel indiquant une valeur de 0 à 100 %. Disponible via des intégrations comme Google Weather. Quand la valeur atteint ou dépasse le seuil, le contrôle de l'éblouissement est supprimé et les stores reviennent à leur position par défaut. Laissez vide si vous ne disposez pas de ce capteur.",
-          "cloud_coverage_threshold": "Pourcentage de couverture nuageuse à partir duquel le contrôle de l'éblouissement est supprimé (par ex., 75 signifie 75 % de nuages = ciel couvert). Par défaut : 75 %.",
-          "cloud_suppression": "Quand cette option est activée, le contrôle de l'éblouissement est supprimé lorsque les conditions météo, lux, irradiance ou couverture nuageuse indiquent l'absence de soleil direct — les stores reviennent à leur position par défaut au lieu de suivre le soleil. NE REQUIERT PAS l'activation du mode climatique : configurez une entité météo, un capteur de lux, d'irradiance ou de couverture nuageuse ci-dessus et cette option fonctionnera de manière autonome. Utile si vous souhaitez une suppression de l'éblouissement adaptée à la lumière sans contrôle climatique complet basé sur la température.",
-          "climate_mode": "Activer les stratégies de store basées sur la température. Quand ACTIVÉ : le comportement du store s'adapte à la température intérieure — s'ouvre complètement en hiver pour capter la chaleur solaire, se ferme complètement en été pour éviter la surchauffe. Nécessite un capteur de température intérieure. Laissez DÉSACTIVÉ si vous souhaitez uniquement le contrôle de l'éblouissement (suivi du soleil) sans comportement piloté par la température.",
-          "temp_entity": "Capteur de température pour le mode climatique (intérieur ou extérieur). Utilisé pour déterminer les stratégies hiver/été. Capteur intérieur recommandé (mesure le confort de la pièce). Capteur extérieur comme alternative (suit la météo extérieure). Thermostat : peut utiliser l'attribut current_temperature. Assurez-vous que les unités du capteur correspondent aux unités de votre système Home Assistant (°C ou °F).",
-          "temp_low": "Seuil de température pour le mode HIVER (dans vos unités système). Quand la température est inférieure à cette valeur : le store s'ouvre complètement par temps ensoleillé pour gagner de la chaleur. Valeurs recommandées : °C : 18-20 °C (65-68 °F), °F : 65-68 °F. Ajustez selon vos préférences de confort. Valeur plus basse = mode hiver moins souvent (uniquement par grand froid). Valeur plus haute = mode hiver plus souvent (privilégie l'apport solaire).",
-          "temp_high": "Seuil de température pour le mode ÉTÉ (dans vos unités système). Quand la température est supérieure à cette valeur : le store se ferme complètement pour éviter la surchauffe. Valeurs recommandées : °C : 23-25 °C (73-77 °F), °F : 73-77 °F. Ajustez selon vos préférences de rafraîchissement. Valeur plus basse = mode été plus tôt (refroidissement agressif). Valeur plus haute = mode été plus tard (tolère plus de chaleur).",
-          "outside_temp": "Capteur de température extérieure optionnel pour une meilleure détection du mode été. Quand configuré, le mode été nécessite que BOTH : la température intérieure soit supérieure au seuil haut ET la température extérieure soit supérieure au seuil extérieur. Évite de fermer les stores quand il fait frais dehors (laissez entrer la brise). Laissez vide pour n'utiliser que la température intérieure. Recommandé si vous disposez d'un capteur extérieur — améliore le confort.",
-          "presence_entity": "Capteur de présence optionnel (détection présent/absent). Types pris en charge : device_tracker, person, zone, binary_sensor. Quand ABSENT : l'été, le store se ferme complètement (économie de climatisation) ; l'hiver, il s'ouvre par temps ensoleillé (chauffage solaire passif). Quand PRÉSENT : utilise les stratégies climatiques normales avec prise en compte de la météo. Laissez vide pour supposer qu'une personne est toujours présente. Économise de l'énergie en cas d'absence, maintient le confort quand quelqu'un est là.",
-          "transparent_blind": "Cochez cette case si votre store est transparent (tissu léger ou voile). Modifie le comportement estival : Transparent ACTIVÉ ferme à 0 % en été (bloque la chaleur, laisse passer la lumière). Transparent DÉSACTIVÉ utilise la position calculée. Les stores transparents réduisent la chaleur tout en laissant passer la lumière. Laissez décoché pour les stores opaques ou occultants.",
-          "winter_close_insulation": "Ferme les stores en hiver lorsque le soleil n'est pas en face de la fenêtre. Assure l'isolation en empêchant l'air froid d'entrer et en retenant la chaleur. Lorsque le soleil entre dans le champ de vision de la fenêtre, les stores s'ouvrent pour le chauffage solaire comme d'habitude.",
-          "cloudy_position": "Position (0-100%) pour déplacer les protections lorsque la suppression nuageuse se déclenche (conditions nuageuses / faible luminosité). 0% = fermé (stores baissés / store banne rétracté), 100% = ouvert (stores levés / store banne déployé). Laissez vide pour utiliser la position par défaut."
-        },
-        "description": "Activez le contrôle de protection conscient du climat. Lorsqu'actif, l'intégration ouvre les protections en hiver pour capturer la chaleur solaire et les ferme en été pour réduire la charge de refroidissement. Cet écran configure quels capteurs de lumière et de nuage déterminent si le soleil est actuellement actif.\n\nLes seuils de température, les paramètres de présence et les règles de comportement saisonnier se trouvent sur l'écran suivant. Les mappages de conditions météorologiques suivent ensuite. Tous les paramètres secondaires du climat sont ignorés lorsque le mode climat est désactivé.\n\n[Learn more]({learn_more})",
-        "title": "Configuration climatique"
       },
       "weather": {
         "data": {

--- a/tests/test_config_ux_simplification.py
+++ b/tests/test_config_ux_simplification.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock
 
 
 from custom_components.adaptive_cover_pro.config_flow import (
-    CLIMATE_SCHEMA,
     ConfigFlowHandler,
     LIGHT_CLOUD_SCHEMA,
     SYNC_CATEGORIES,
@@ -168,15 +167,6 @@ class TestSplitSchemas:
         """TEMPERATURE_CLIMATE_SCHEMA should NOT contain lux settings."""
         keys = [str(k) for k in TEMPERATURE_CLIMATE_SCHEMA.schema]
         assert "lux_entity" not in keys
-
-    def test_combined_climate_schema_has_all_keys(self):
-        """Combined CLIMATE_SCHEMA should have all keys from both split schemas."""
-        combined_keys = {str(k) for k in CLIMATE_SCHEMA.schema}
-        light_keys = {str(k) for k in LIGHT_CLOUD_SCHEMA.schema}
-        temp_keys = {str(k) for k in TEMPERATURE_CLIMATE_SCHEMA.schema}
-        # Combined should be superset (may differ on weather_state)
-        assert light_keys - {"weather_state"} <= combined_keys
-        assert temp_keys <= combined_keys
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_ux_simplification.py
+++ b/tests/test_config_ux_simplification.py
@@ -15,14 +15,23 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 
+import pytest
+import voluptuous as vol
+
 from custom_components.adaptive_cover_pro.config_flow import (
     ConfigFlowHandler,
     LIGHT_CLOUD_SCHEMA,
     SYNC_CATEGORIES,
     TEMPERATURE_CLIMATE_SCHEMA,
+    WEATHER_OVERRIDE_SCHEMA,
     _build_config_summary,
+    _build_custom_position_schema_dict,
+    _CUSTOM_POSITION_OPTIONAL_KEYS,
     _extract_shared_options,
+    _LIGHT_CLOUD_OPTIONAL_KEYS,
     _SYNC_UI_CATEGORIES,
+    _TEMPERATURE_CLIMATE_OPTIONAL_KEYS,
+    _WEATHER_OVERRIDE_OPTIONAL_KEYS,
 )
 from custom_components.adaptive_cover_pro.const import (
     CONF_AZIMUTH,
@@ -562,4 +571,63 @@ class TestSelectorDomains:
         """outside_temp (outsidetemp_entity) accepts numeric domains."""
         assert (
             _domain_for(TEMPERATURE_CLIMATE_SCHEMA, "outside_temp") == _NUMERIC_EXPECTED
+        )
+
+
+# ---------------------------------------------------------------------------
+# Schema-walking guard: _*_OPTIONAL_KEYS must exactly match the vol.Optional
+# keys with default=vol.UNDEFINED in their paired schema. Catches the #323 /
+# #377 bug class (key added to schema with no default but not added to the
+# constant — value silently survives a user clear).
+# ---------------------------------------------------------------------------
+
+
+_SCHEMA_OPTIONAL_KEY_PAIRS = [
+    ("WEATHER_OVERRIDE", WEATHER_OVERRIDE_SCHEMA, _WEATHER_OVERRIDE_OPTIONAL_KEYS),
+    ("LIGHT_CLOUD", LIGHT_CLOUD_SCHEMA, _LIGHT_CLOUD_OPTIONAL_KEYS),
+    ("TEMPERATURE_CLIMATE", TEMPERATURE_CLIMATE_SCHEMA, _TEMPERATURE_CLIMATE_OPTIONAL_KEYS),
+    # CUSTOM_POSITION's constant covers the venetian-augmented variant (with
+    # tilt fields), not the bare module-level schema — build that variant for
+    # the guard.
+    (
+        "CUSTOM_POSITION",
+        vol.Schema(_build_custom_position_schema_dict(sensor_type="cover_venetian")),
+        _CUSTOM_POSITION_OPTIONAL_KEYS,
+    ),
+]
+
+
+def _schema_undefined_optional_keys(schema: vol.Schema) -> set[str]:
+    """Return string keys of every vol.Optional marker whose default is vol.UNDEFINED.
+
+    Covers both vol.Optional(KEY, default=vol.UNDEFINED) and bare
+    vol.Optional(KEY) — the latter's default is also vol.UNDEFINED.
+    """
+    return {
+        str(key)
+        for key in schema.schema
+        if isinstance(key, vol.Optional) and key.default is vol.UNDEFINED
+    }
+
+
+class TestOptionalKeyConstants:
+    """_*_OPTIONAL_KEYS must exactly equal the set of vol.Optional keys whose
+    default is vol.UNDEFINED in the paired schema.
+    """
+
+    @pytest.mark.parametrize(
+        "label,schema,constant", _SCHEMA_OPTIONAL_KEY_PAIRS
+    )
+    def test_optional_keys_match_schema(self, label, schema, constant):
+        from_schema = _schema_undefined_optional_keys(schema)
+        from_constant = set(constant)
+        missing = from_schema - from_constant
+        extra = from_constant - from_schema
+        assert not missing, (
+            f"{label}: schema has UNDEFINED-default keys missing from constant: "
+            f"{sorted(missing)}"
+        )
+        assert not extra, (
+            f"{label}: constant has keys that are not UNDEFINED in schema "
+            f"(stale): {sorted(extra)}"
         )


### PR DESCRIPTION
## Summary

Two related config-flow cleanups on a single branch.

**#391 — Remove legacy combined climate step** (commit `c4e997d`)
The `async_step_climate` handler on both `ConfigFlowHandler` and `OptionsFlowHandler` was unreachable — the wizard chain and options menu route directly to the split `light_cloud` + `temperature_climate` steps. Removed both handlers, `CLIMATE_SCHEMA`, the orphan `config.step.climate` / `options.step.climate` / `menu_options.climate` translation entries in `en.json`/`de.json`/`fr.json`, and the no-longer-meaningful `test_combined_climate_schema_has_all_keys` test. `SYNC_CATEGORIES["climate"]` is intentionally kept — it's a separate concept (legacy programmatic-sync alias).

**#392 — Co-locate `_*_OPTIONAL_KEYS` with their schemas** (commit `7d2c5ac`)
Inline `optional_entities([...])` lists for `WEATHER_OVERRIDE`, `LIGHT_CLOUD`, and `TEMPERATURE_CLIMATE` were duplicated across the two flow handlers — the same drift surface that produced #323 and #377. Extracted three module-level constants adjacent to their schemas, matching the existing `_CUSTOM_POSITION_OPTIONAL_KEYS` pattern, and rewired the four remaining call sites.

Also fixes a latent #377-class omission: `CONF_CLOUDY_POSITION` is a bare `vol.Optional` in `LIGHT_CLOUD_SCHEMA` (implicit `default=vol.UNDEFINED`) but was missing from both inline lists, so clearing the field in the UI silently kept the prior value. `_LIGHT_CLOUD_OPTIONAL_KEYS` now includes it.

Adds a parametrized `TestOptionalKeyConstants` guard that walks each schema and asserts every `vol.Optional` key with `default=vol.UNDEFINED` is in the matching constant — exactly, no missing and no stale entries. Covers all four schemas (CUSTOM_POSITION built with `sensor_type="cover_venetian"` so the guard sees the tilt-augmented variant the constant covers).

The CODING_GUIDELINES "Testing Rules" section was amended in the same arc (separate dotfiles-managed file, committed via the usual sync) to record that pure-deletion / no-behavior-change refactors don't require new tests — verification is the existing suite staying green.

## Testing

- ✅ 3384 tests passing (up from 3380 baseline; +4 from the new schema-walking guard)
- ✅ `./scripts/validate_translations.py --ci` passes
- ✅ `ruff check` clean on touched files

## Related Issues

Refs #391
Refs #392