### PR TITLE
fix: suppress override during command grace on venetian tilt

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1478,6 +1478,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self._cmd_svc.is_waiting_for_target,
                 self.manual_threshold,
                 secondary_axis_check=secondary_axis_check,
+                is_in_command_grace=self._grace_mgr.is_in_command_grace_period,
             )
             # When a cover transitions into manual override, discard any
             # pre-existing integration target (including safety-tagged

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -117,6 +117,7 @@ class VenetianPolicy(CoverTypePolicy):
     def __init__(self) -> None:
         """Initialise without a sequencer; ``attach()`` wires one up later."""
         self._sequencer: DualAxisSequencer | None = None
+        self._grace_mgr = None
         self._tilt_skip_above: int = DEFAULT_VENETIAN_TILT_SKIP_ABOVE
         self._venetian_mode: str = DEFAULT_VENETIAN_MODE
         self._last_tilt: int | None = None
@@ -364,6 +365,7 @@ class VenetianPolicy(CoverTypePolicy):
 
     def attach(self, **kwargs: Any) -> None:  # noqa: D401
         """Construct the dual-axis sequencer once cmd_svc is available."""
+        self._grace_mgr = kwargs.get("grace_mgr")
         self._sequencer = DualAxisSequencer(
             hass=kwargs["hass"],
             logger=kwargs["logger"],
@@ -454,6 +456,22 @@ class VenetianPolicy(CoverTypePolicy):
             reason=reason,
         )
 
+    def _is_in_tilt_command_grace(self, entity_id: str, delta: float = 0.0) -> bool:
+        """Return True when the entity is inside the command-grace window.
+
+        Delegates to the coordinator-supplied ``GracePeriodManager``; returns
+        False when no manager is available (non-attached policy, tests that
+        construct the policy without attach()).
+
+        The ``delta`` parameter is accepted to match the
+        ``Callable[[str, float], bool]`` signature expected by
+        ``SecondaryAxisCheck.suppression`` — it is not used here because the
+        grace period is time-based, not delta-based.
+        """
+        if self._grace_mgr is None:
+            return False
+        return self._grace_mgr.is_in_command_grace_period(entity_id)
+
     def secondary_axis_check(
         self, result: PipelineResult, cmd_svc
     ) -> SecondaryAxisCheck | None:
@@ -462,14 +480,25 @@ class VenetianPolicy(CoverTypePolicy):
         Returns ``None`` when no tilt has been resolved (e.g. on a refresh
         where the engine couldn't compute one); otherwise carries the
         expected tilt and the suppression callback into manual_override.
+
+        The suppression callback is an OR-composition of the motor back-rotate
+        suppression window (``is_in_tilt_suppression``) and the command-grace
+        period (``_is_in_tilt_command_grace``).  Either condition is sufficient
+        to suppress the tilt-axis check and prevent a false override.
         """
         if result is None or result.tilt is None:
             return None
+
+        def _suppression(entity_id: str, delta: float = 0.0) -> bool:
+            return self.is_in_tilt_suppression(
+                entity_id, delta
+            ) or self._is_in_tilt_command_grace(entity_id, delta)
+
         return SecondaryAxisCheck(
             expected=result.tilt,
             attribute="current_tilt_position",
             label="tilt",
-            suppression=self.is_in_tilt_suppression,
+            suppression=_suppression,
         )
 
     async def before_position_command(

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -215,6 +215,7 @@ class AdaptiveCoverManager:
         manual_threshold,
         *,
         secondary_axis_check: SecondaryAxisCheck | None = None,
+        is_in_command_grace: Callable[[str], bool] | None = None,
     ):
         """Process state change for manual override.
 
@@ -237,6 +238,12 @@ class AdaptiveCoverManager:
                 the cover-type policy (see ``CoverTypePolicy.secondary_axis_check``).
                 When provided, the secondary axis is evaluated up front and a
                 manual-override match short-circuits the position-axis check.
+            is_in_command_grace: Optional callable ``(entity_id) -> bool`` that
+                returns True while the integration's command-grace window is
+                active for this entity.  When True, all override detection is
+                suppressed — the position change is the cover responding to
+                the ACP command, not a user touch.  Supplied by the coordinator
+                via ``GracePeriodManager.is_in_command_grace_period``.
 
         """
         event = states_data
@@ -252,6 +259,15 @@ class AdaptiveCoverManager:
                 our_state=our_state,
                 new_position=None,
                 reason="wait_for_target active",
+            )
+            return
+        if is_in_command_grace is not None and is_in_command_grace(entity_id):
+            self._record_event(
+                entity_id,
+                "manual_override_rejected_command_grace",
+                our_state=our_state,
+                new_position=None,
+                reason="command grace period active",
             )
             return
 

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -635,7 +635,13 @@ def test_attach_invert_tilt_defaults_to_none() -> None:
 
 
 def test_secondary_axis_check_carries_expected_tilt() -> None:
-    """With a resolved tilt, the check exposes the expected slat angle and label."""
+    """With a resolved tilt, the check exposes the expected slat angle and label.
+
+    The suppression callback is an OR-composition of the tilt-suppression
+    window and the command-grace period. When neither is active (unattached
+    policy, no grace manager) it returns False.
+    """
+    entity_id = "cover.venetian_test"
     policy = VenetianPolicy()
     result = MagicMock()
     result.tilt = 75
@@ -644,8 +650,10 @@ def test_secondary_axis_check_carries_expected_tilt() -> None:
     assert check.expected == 75
     assert check.attribute == "current_tilt_position"
     assert check.label == "tilt"
-    assert check.suppression.__func__ is VenetianPolicy.is_in_tilt_suppression
-    assert check.suppression.__self__ is policy
+    # Suppression must be callable with the standard (entity_id, delta) signature.
+    assert callable(check.suppression)
+    # With no sequencer and no grace manager, suppression must return False.
+    assert check.suppression(entity_id, 0.0) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_false_manual_override_on_automation.py
+++ b/tests/test_false_manual_override_on_automation.py
@@ -441,6 +441,79 @@ def test_wait_for_target_prevents_override_regardless_of_tolerance():
     ), "wait_for_target=True must block all override detection"
 
 
+def test_position_change_inside_command_grace_is_not_override():
+    """Position change inside the command-grace window must NOT trip manual override.
+
+    Grace is active for the entity (timestamp just stamped). Even though the
+    position delta exceeds the threshold, the grace gate must suppress it.
+    """
+    from custom_components.adaptive_cover_pro.managers.grace_period import (
+        GracePeriodManager,
+    )
+    import datetime as _dt
+
+    entity_id = "cover.test"
+    grace_mgr = GracePeriodManager(logger=MagicMock())
+    # Stamp grace directly to avoid asyncio.create_task in unit-test context.
+    grace_mgr._command_timestamps[entity_id] = _dt.datetime.now().timestamp()
+
+    manager = _make_manager()
+    state_data = _make_state_change_data(
+        entity_id, position=52
+    )  # delta=20 > threshold=5
+
+    manager.handle_state_change(
+        state_data,
+        our_state=72,
+        policy=get_policy("cover_blind"),
+        allow_reset=False,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        is_in_command_grace=grace_mgr.is_in_command_grace_period,
+    )
+
+    assert not manager.is_cover_manual(
+        entity_id
+    ), "Position change inside command grace should NOT trigger manual override"
+
+
+def test_position_change_after_grace_expired_trips_override():
+    """Position change after command-grace has expired must still trip override.
+
+    Grace window is 5 s. Stamping a timestamp 10 s in the past means the
+    grace period has already elapsed, so the position-delta check must run
+    and detect the manual override normally.
+    """
+    from custom_components.adaptive_cover_pro.managers.grace_period import (
+        GracePeriodManager,
+    )
+    import datetime as _dt
+
+    entity_id = "cover.test"
+    grace_mgr = GracePeriodManager(logger=MagicMock())
+    # Backdate the timestamp so grace has already expired (10 s > 5 s window).
+    grace_mgr._command_timestamps[entity_id] = _dt.datetime.now().timestamp() - 10
+
+    manager = _make_manager()
+    state_data = _make_state_change_data(
+        entity_id, position=52
+    )  # delta=20 > threshold=5
+
+    manager.handle_state_change(
+        state_data,
+        our_state=72,
+        policy=get_policy("cover_blind"),
+        allow_reset=False,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        is_in_command_grace=grace_mgr.is_in_command_grace_period,
+    )
+
+    assert (
+        manager.is_cover_manual(entity_id) is True
+    ), "Position change after grace expired should trigger manual override"
+
+
 def test_tolerance_floor_applies_to_tilt_cover():
     """The tolerance floor applies equally to tilt covers (cover_tilt type)."""
     from custom_components.adaptive_cover_pro.managers.manual_override import (

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -20,10 +20,18 @@ from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.cover_types.venetian import (
     DualAxisSequencer,
 )
+from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
+    VenetianPolicy,
+)
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.managers.grace_period import (
+    GracePeriodManager,
+)
 from custom_components.adaptive_cover_pro.managers.manual_override import (
     AdaptiveCoverManager,
     SecondaryAxisCheck,
 )
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
 
 def _make_event(entity_id: str, *, position: int | None, tilt: int | None):
@@ -390,3 +398,116 @@ def test_non_venetian_cover_with_no_check_runs_position_axis_only() -> None:
     )
 
     assert not mgr.is_cover_manual(entity_id)
+
+
+# ---------------------------------------------------------------------------
+# Issue #33 follow-on: command-grace guard for tilt-axis manual-override
+# ---------------------------------------------------------------------------
+
+
+def _make_policy_with_grace(
+    entity_id: str, *, venetian_mode: str = "tilt_only"
+) -> tuple[VenetianPolicy, GracePeriodManager]:
+    """Build a VenetianPolicy attached with a real GracePeriodManager in active grace.
+
+    Stamps ``entity_id`` in the grace manager so
+    ``grace_mgr.is_in_command_grace_period(entity_id)`` returns True.
+    The sequencer is wired for real via attach() so the suppression path
+    runs exactly as it does in production.
+    """
+    import datetime as _dt
+
+    grace_mgr = GracePeriodManager(logger=MagicMock())
+    # Stamp the entity directly — avoids asyncio.create_task() in unit-test context.
+    grace_mgr._command_timestamps[entity_id] = _dt.datetime.now().timestamp()
+
+    policy = VenetianPolicy()
+    policy.attach(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        grace_mgr=grace_mgr,
+        get_current_position=lambda _: None,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        venetian_mode=venetian_mode,
+    )
+    return policy, grace_mgr
+
+
+def _make_pipeline_result(*, tilt: int = 60) -> PipelineResult:
+    """Build a minimal PipelineResult with a resolved tilt."""
+    return PipelineResult(
+        position=50,
+        control_method=ControlMethod.SOLAR,
+        reason="solar",
+        tilt=tilt,
+    )
+
+
+def test_tilt_axis_change_inside_command_grace_is_not_override() -> None:
+    """Tilt state change inside the command-grace window must NOT trip manual override.
+
+    User1's diagnostic: ``tilt_command_sent`` → 4.5 s → ``tilt_command_drift``
+    → ``manual_override_set``, all inside the 5 s command-grace tail.
+
+    In tilt_only mode ``update_tilt_only`` never stamps ``_suppression_at``, so
+    ``is_in_tilt_suppression`` returns False. Without the new grace gate the
+    delta=17 tilt change trips a false override.
+    """
+    entity_id = "cover.venetian_grace_tilt_only"
+    mgr = _make_manager(entity_id)
+    policy, grace_mgr = _make_policy_with_grace(entity_id, venetian_mode="tilt_only")
+
+    result = _make_pipeline_result(tilt=60)
+    check = policy.secondary_axis_check(result, MagicMock())
+    # delta = |60 - 43| = 17, threshold = 3 → would normally trip override
+    assert check is not None
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=None, tilt=43),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=3,
+        secondary_axis_check=check,
+    )
+
+    assert not mgr.is_cover_manual(
+        entity_id
+    ), "Tilt change inside command grace should NOT trigger manual override"
+
+
+def test_tilt_only_update_inside_grace_position_and_tilt_mode_not_override() -> None:
+    """Same grace guard applies in position_and_tilt mode.
+
+    User2's path: update_tilt_only fires in position_and_tilt mode, similarly
+    never stamps _suppression_at. A tilt state-change inside grace must be
+    suppressed regardless of mode.
+    """
+    entity_id = "cover.venetian_grace_pos_and_tilt"
+    mgr = _make_manager(entity_id)
+    policy, grace_mgr = _make_policy_with_grace(
+        entity_id, venetian_mode="position_and_tilt"
+    )
+
+    result = _make_pipeline_result(tilt=60)
+    check = policy.secondary_axis_check(result, MagicMock())
+    # delta = |60 - 43| = 17, threshold = 3 → would normally trip override
+    assert check is not None
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=None, tilt=43),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=3,
+        secondary_axis_check=check,
+    )
+
+    assert not mgr.is_cover_manual(entity_id), (
+        "Tilt change inside command grace (position_and_tilt mode) "
+        "should NOT trigger manual override"
+    )


### PR DESCRIPTION
## Summary
Two reporters on #33 (2026-05-20) hit false manual override on v2.22.0-beta.2. User1's diagnostic captured the smoking gun: `tilt_command_sent` → 4.5 s later `tilt_command_drift` (actual=17 vs target=0) → `manual_override_set` 200 µs after the drift → grace expired 503 ms after the trip. The trip landed inside the 5 s command grace.

Root cause: `VenetianPolicy.secondary_axis_check` built its `suppression` callback from `is_in_tilt_suppression`, which keys on `_suppression_at` — only stamped by the position-axis `run_sequence`, never by `update_tilt_only`. The tilt-only path armed the per-entity grace via `_send_tilt_command` but the override path never consulted it. The primary-axis early-return at `manual_override.py:248` also only gated on `is_waiting_for_target`, not on grace.

Fix: a single shared predicate `grace_mgr.is_in_command_grace_period(entity_id)` is consumed by both axes.
- `VenetianPolicy.secondary_axis_check` OR-composes the back-rotate window with the grace predicate (venetian-specific behaviour stays on the policy).
- `handle_state_change` accepts an optional `is_in_command_grace` callable from the coordinator; an early-return emits the new `manual_override_rejected_command_grace` event for diagnostic clarity.

## Testing
- ✅ 313 tests passing in the override/venetian/sequencer baseline (309 prior + 4 new), 0 failed
- ✅ Full suite: 3397 passed, 0 failed
- ✅ Lint clean

New regression tests:
- `test_tilt_axis_change_inside_command_grace_is_not_override` (user1's `tilt_only` path)
- `test_tilt_only_update_inside_grace_position_and_tilt_mode_not_override` (user2's likely path)
- `test_position_change_inside_command_grace_is_not_override` (primary axis symmetry)
- `test_position_change_after_grace_expired_trips_override` (negative case — grace doesn't over-suppress)

## Related Issues
Refs #33