### PR TITLE
fix: anchor venetian publish-lag to settle transition + startup grace (#33)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -521,6 +521,36 @@ VENETIAN_BACKROTATE_MAX_DELTA_PERCENT = 30
 # so the cap must stay suspended until the HA state machine has fully drained.
 VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS = 5.0
 
+# Bypass the back-rotate cap for this many seconds after the sequencer observes
+# the cover transition out of the moving state (i.e. anchored to the actual
+# moving→settled boundary inside ``_wait_for_position_settle``, NOT to
+# ``stamp_position_command``). Somfy IO actuators in issue #33 publish their
+# back-rotate tilt burst ~27 s after settle; 45 s leaves ~18 s headroom for
+# slower bus republish on KNX/Z2M while staying well under
+# VENETIAN_TILT_SUPPRESSION_SECONDS=90.0. Anchored to the real settle
+# transition (not stamp_position_command), so a premature-stall on a slow-start
+# actuator cannot start this clock early.
+#
+# Behavioural-impact note: fast actuators (KNX sub-second publish, Shelly 2PM)
+# settle and publish back-rotate inside VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS=5.0
+# today, so extending publish-lag to 45 s does change behaviour: a user
+# twisting slats by hand at +10 s post-settle would, under the new code, be
+# classed as motor back-drive and not trip override — if their delta exceeds
+# 30 (the cap). Risk bounded by physics: real motor back-drive is
+# single-digit-percent (VENETIAN_REBASE_MAX_DRIFT_PERCENT=15), so a delta of
+# 30-95% during the 5-45 s window is implausible on any actuator. A user
+# twisting slats during the window almost always lands within the existing cap
+# (delta ≤ 30) which has always suppressed regardless of actuator speed.
+VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS = 45.0
+
+# Refuse to count unchanged-position samples as a "stall" during the first N
+# seconds of _wait_for_position_settle UNLESS the cover has been observed in
+# opening/closing at least once. Justification: Somfy IO motors take 3-5 s to
+# begin physical travel after the service call; 6 s covers observed delay with
+# 1 s headroom. VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS=60.0 still hard-caps
+# so a dead motor doesn't block the rest of the update cycle.
+VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS = 6.0
+
 # After set_cover_tilt_position returns, real motors keep back-driving the
 # vertical axis briefly. Wait this many seconds before reading current_position
 # for the post-tilt rebase so the rebase captures the actual settled position

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -37,8 +37,10 @@ from ...const import (
     ATTR_TILT_POSITION,
     DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
     VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
+    VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
     VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES,
     VENETIAN_POSITION_SETTLE_POLL_SECONDS,
+    VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS,
     VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
     VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS,
     VENETIAN_POST_TILT_REBASE_DELAY_SECONDS,
@@ -113,6 +115,13 @@ class DualAxisSequencer:
         # CoverCommandService.PerEntityState) so non-venetian covers carry no
         # dual-axis state at all.
         self._suppression_at: dict[str, dt.datetime] = {}
+        # Per-entity ``moving → settled`` transition timestamp. Anchors the
+        # publish-lag window (issue #33 Track A) to the actual settle event
+        # observed by the sequencer, not to ``stamp_position_command``.
+        # Written by ``run_sequence`` after ``_wait_for_position_settle``
+        # returns, and lazy-written from ``is_in_suppression_with_cap`` when
+        # the cap query observes a settled state with no stamp yet.
+        self._settled_at: dict[str, dt.datetime] = {}
         self._tilt_targets: dict[str, int] = {}
         # Entities whose last stored target has been verified against the
         # actuator. Dedup at _send_tilt_command only fires when the target
@@ -162,37 +171,62 @@ class DualAxisSequencer:
     # -- suppression window ------------------------------------------------ #
 
     def stamp_position_command(self, entity_id: str) -> None:
-        """Record that a ``set_cover_position`` was just emitted."""
+        """Record that a ``set_cover_position`` was just emitted.
+
+        Also clears any prior ``moving → settled`` stamp for this entity so
+        the publish-lag window starts fresh for the new cycle. Without this
+        reset an old settle stamp from the previous cycle would leak its
+        publish-lag tail into a new command, letting a user touch on the
+        next cycle get swallowed as motor drift.
+        """
         self._suppression_at[entity_id] = dt.datetime.now(dt.UTC)
+        self._settled_at.pop(entity_id, None)
+
+    def _stamp_settled(self, entity_id: str) -> None:
+        """Record that the sequencer observed ``moving → settled`` for this entity.
+
+        Single dict-access site shared by the deterministic write in
+        ``run_sequence`` (after ``_wait_for_position_settle`` returns) and
+        the opportunistic lazy-write in ``is_in_suppression_with_cap``. Keep
+        callers from poking ``_settled_at`` directly so the publish-lag
+        anchor stays a single source of truth.
+        """
+        self._settled_at[entity_id] = dt.datetime.now(dt.UTC)
 
     def is_in_suppression(self, entity_id: str) -> bool:
         """Return whether the back-rotate window is still open for this cover."""
         ts = self._suppression_at.get(entity_id)
         if ts is None:
             return False
-        elapsed = (dt.datetime.now(dt.UTC) - ts).total_seconds()
-        return elapsed < VENETIAN_TILT_SUPPRESSION_SECONDS
+        return self._seconds_since(ts) < VENETIAN_TILT_SUPPRESSION_SECONDS
 
     def is_in_suppression_with_cap(self, entity_id: str, delta: float) -> bool:
         """Suppress back-rotate drift only when the delta is plausibly motor drift.
 
-        Slat geometry bounds back-rotation magnitude post-settle; a large delta
-        once the carriage has stopped is a user move, not motor drift, so the
-        manual-override path runs and the user's command is recorded (issue #33
-        follow-on).
+        Three-tier suppression on the tilt axis after a position command:
 
-        While the carriage is still mid-travel (HA cover state ``opening`` or
-        ``closing``) the cap is bypassed: real-world venetian actuators (KNX,
-        Shelly 2PM, FGR223) back-retract the slats by well over the cap during
-        carriage motion, so an arbitrarily large delta is still motor drift
-        until ``cover.state`` settles. The cap reasserts once state leaves the
-        moving set.
+        (a) **Carriage still mid-travel** (``cover.state`` in
+            ``opening``/``closing``): any delta is motor drift while the
+            motor runs. The cap is fully bypassed.
 
-        A post-settle grace tail (``VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS``)
-        also bypasses the cap: KNX/Shelly actuators publish their tilt-walk
-        burst after ``cover.state`` already reads ``open``/``closed``, so the
-        cap would reject legitimate motor drift as a user move without this
-        window (issue #33).
+        (b) **Post-stamp command-grace tail**
+            (``VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS``, 5 s): for a brief
+            tail after ``stamp_position_command``, even a large delta
+            (>cap) is still motor drift. Catches fast actuators (KNX,
+            Shelly 2PM) whose back-rotate burst lands microseconds after
+            ``cover.state`` reports settled.
+
+        (c) **Post-settle publish-lag window**
+            (``VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS``, 45 s): anchored
+            to the ``moving → settled`` transition the sequencer observed
+            in ``_wait_for_position_settle`` (or lazy-stamped here on the
+            first non-moving query). Catches slow-bus republish on Somfy
+            IO via Tahoma and KNX/Z2M where the back-rotate tilt value
+            lands tens of seconds after the cover physically stops.
+
+        Outside all three tiers the legacy slat-geometry cap applies: a
+        delta above ``VENETIAN_BACKROTATE_MAX_DELTA_PERCENT`` is a user
+        move and the manual-override path runs.
         """
         if not self.is_in_suppression(entity_id):
             return False
@@ -200,11 +234,23 @@ class DualAxisSequencer:
             state = self._get_state(entity_id)
             if state in _COVER_MOVING_STATES:
                 return True
+        # (b) Command-grace tail anchored to stamp_position_command.
         stamp = self._suppression_at.get(entity_id)
-        if stamp is not None:
-            elapsed = (dt.datetime.now(dt.UTC) - stamp).total_seconds()
-            if elapsed < VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS:
-                return True
+        if stamp is not None and (
+            self._seconds_since(stamp) < VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS
+        ):
+            return True
+        # (c) Publish-lag window anchored to moving → settled.
+        # Lazy-write: if the cap query observes a non-moving state and a
+        # live suppression stamp but no settle stamp yet, treat this query
+        # itself as the first non-moving observation and stamp now.
+        if entity_id not in self._settled_at and stamp is not None:
+            self._stamp_settled(entity_id)
+        settled_at = self._settled_at.get(entity_id)
+        if settled_at is not None and (
+            self._seconds_since(settled_at) < VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS
+        ):
+            return True
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
 
     # -- tilt sequence ----------------------------------------------------- #
@@ -219,10 +265,14 @@ class DualAxisSequencer:
         Defense-in-depth hook for Auto Control off→on transitions (issue #33).
         Suppression timestamps are intentionally untouched — the back-rotate
         window is a time-based safeguard, independent of the stored-target
-        cache.
+        cache. The ``moving → settled`` stamps used by the publish-lag
+        window are also cleared so a stale prior-cycle settle can't leak its
+        suppression tail into the next command after Auto Control is
+        re-enabled.
         """
         self._tilt_targets.clear()
         self._tilt_targets_verified.clear()
+        self._settled_at.clear()
 
     async def run_sequence(
         self,
@@ -241,6 +291,13 @@ class DualAxisSequencer:
         # Only the position-sequence path owns this stamp; tilt-only sends from
         # update_tilt_only must not extend it (issue #33 follow-on).
         self.stamp_position_command(entity_id)
+        # Anchor the publish-lag window to the moving → settled transition
+        # we just observed (issue #33 Track A). Must come AFTER
+        # stamp_position_command because that call clears ``_settled_at`` for
+        # a fresh cycle — we want the publish-lag clock to start now, not
+        # leak from a prior cycle. ``stamp_position_command`` pops; this
+        # write puts the fresh settle stamp back.
+        self._stamp_settled(entity_id)
         await self._send_tilt_command(
             entity_id,
             tilt_target=tilt_target,
@@ -510,12 +567,24 @@ class DualAxisSequencer:
         prevents a Shelly 2PM (or similar hardware) that publishes position at
         ~1 s intervals from triggering a false stall while the motor is still
         mid-travel.
+
+        Startup grace (``VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS``):
+        some actuators (Somfy IO via Tahoma in issue #33) take 3-5 s to begin
+        physical travel after the service call. During that pre-motion window
+        ``cover.state`` still reads ``open``/``closed`` and ``current_position``
+        is unchanged, which would otherwise trip the 3-sample stall counter
+        and declare settle 20-30 s before the cover actually stops moving.
+        The startup grace blocks stall declaration until either the cover has
+        been observed in a moving state at least once, or the wall-clock
+        grace window has elapsed since the loop began.
         """
-        deadline = dt.datetime.now(dt.UTC) + dt.timedelta(
+        loop_started = dt.datetime.now(dt.UTC)
+        deadline = loop_started + dt.timedelta(
             seconds=VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
         )
         last_position: int | None = None
         unchanged_samples = 0
+        motion_observed = False
 
         while dt.datetime.now(dt.UTC) < deadline:
             current = self._get_current_position(entity_id)
@@ -526,6 +595,8 @@ class DualAxisSequencer:
             # the no-progress stall counter use the same snapshot.
             state = self._get_state(entity_id) if self._get_state else None
             is_moving = state in _COVER_MOVING_STATES
+            if is_moving:
+                motion_observed = True
 
             if abs(current - target) <= self._position_tolerance:
                 # When a get_state callback is provided, also require that
@@ -541,7 +612,14 @@ class DualAxisSequencer:
                     unchanged_samples = 0
                 else:
                     unchanged_samples += 1
-                    if unchanged_samples >= VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES:
+                    startup_grace_elapsed = (
+                        self._seconds_since(loop_started)
+                        >= VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS
+                    )
+                    if (
+                        unchanged_samples >= VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES
+                        and (motion_observed or startup_grace_elapsed)
+                    ):
                         self._logger.debug(
                             "Venetian settle: %s stalled at %s%% (target %s%%) "
                             "after %d unchanged samples",
@@ -565,6 +643,17 @@ class DualAxisSequencer:
             VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
         )
         return False, last_position
+
+    @staticmethod
+    def _seconds_since(stamp: dt.datetime) -> float:
+        """Return wall-clock seconds since ``stamp`` (UTC).
+
+        Single source of truth for elapsed-since-timestamp arithmetic.
+        Used by both the settle-loop startup grace and the suppression
+        cap-grace / publish-lag checks so the formula isn't duplicated
+        across the file.
+        """
+        return (dt.datetime.now(dt.UTC) - stamp).total_seconds()
 
     # -- diagnostics helpers ----------------------------------------------- #
 

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
     VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS,
     VENETIAN_TILT_SUPPRESSION_SECONDS,
 )
@@ -127,6 +128,13 @@ class TestSuppressionDeltaCap:
         assert seq.is_in_suppression_with_cap("cover.x", delta=10.0) is True
 
     def test_suppressed_large_delta_past_grace_returns_false(self):
+        """Past both the cap-grace and publish-lag windows, the cap reasserts.
+
+        The publish-lag window (issue #33 Track A) was added in front of the
+        legacy cap path. To reach the cap-reasserts behavior the test
+        backdates both ``_suppression_at`` past the cap grace and
+        ``_settled_at`` past the publish lag.
+        """
         from custom_components.adaptive_cover_pro.const import (
             VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
         )
@@ -135,6 +143,9 @@ class TestSuppressionDeltaCap:
         seq.stamp_position_command("cover.x")
         seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
             seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        seq._settled_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 1.0
         )
         big = VENETIAN_BACKROTATE_MAX_DELTA_PERCENT + 1
         assert seq.is_in_suppression_with_cap("cover.x", delta=float(big)) is False
@@ -182,11 +193,20 @@ class TestSuppressionDeltaCap:
     def test_suppressed_large_delta_with_settled_state_past_grace_returns_false(
         self,
     ) -> None:
-        """Once the post-settle grace tail expires, the cap reasserts."""
+        """Once both the cap-grace and publish-lag windows expire, the cap reasserts.
+
+        The publish-lag window (issue #33 Track A) was added in front of the
+        legacy cap path. Both ``_suppression_at`` (cap-grace anchor) and
+        ``_settled_at`` (publish-lag anchor) must be backdated for the cap
+        path to run.
+        """
         _, seq = _build_sequencer(get_state=lambda _eid: "open")
         seq.stamp_position_command("cover.x")
         seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
             seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        seq._settled_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 1.0
         )
         assert seq.is_in_suppression_with_cap("cover.x", delta=100.0) is False
 
@@ -204,6 +224,68 @@ class TestSuppressionDeltaCap:
             seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
         )
         assert seq.is_in_suppression_with_cap("cover.x", delta=10.0) is True
+
+    def test_large_delta_inside_publish_lag_after_settled_returns_true(self) -> None:
+        """Inside the post-settle publish-lag window, any delta is motor drift.
+
+        Track A in issue #33: Somfy IO actuators republish their back-rotate
+        tilt burst tens of seconds after ``cover.state`` reports settled —
+        well past the small (5 s) post-settle cap grace. Anchoring a longer
+        publish-lag window to the ``moving → settled`` transition the
+        sequencer observed in its settle loop bypasses the back-rotate cap
+        for that full window, so the late burst doesn't latch false manual
+        override.
+        """
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq.stamp_position_command("cover.x")
+        # Backdate the stamp past the existing cap-grace so only the new
+        # publish-lag window can save us.
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        # The sequencer just observed moving→settled.
+        seq._settled_at["cover.x"] = dt.datetime.now(dt.UTC)
+        assert seq.is_in_suppression_with_cap("cover.x", delta=95.0) is True
+
+    def test_large_delta_past_publish_lag_after_settled_returns_false(self) -> None:
+        """Once the publish-lag window elapses, the cap reasserts.
+
+        Counterpart to ``test_large_delta_inside_publish_lag_after_settled_returns_true``:
+        backdating ``_settled_at`` past the publish-lag window puts a large
+        delta firmly in user-touch territory. A sub-cap delta still passes
+        the legacy cap path.
+        """
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq.stamp_position_command("cover.x")
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        seq._settled_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 1.0
+        )
+        assert seq.is_in_suppression_with_cap("cover.x", delta=95.0) is False
+        # Sub-cap delta still suppressed via the cap path.
+        assert seq.is_in_suppression_with_cap("cover.x", delta=10.0) is True
+
+    def test_publish_lag_clears_on_next_position_command(self) -> None:
+        """``stamp_position_command`` clears ``_settled_at`` for a fresh cycle.
+
+        Without the clear, an old settle stamp from a previous cycle would
+        leak its publish-lag window into a new command — letting a true
+        user touch on the next cycle get swallowed as motor drift.
+        """
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq.stamp_position_command("cover.x")
+        seq._suppression_at["cover.x"] = dt.datetime.now(dt.UTC) - dt.timedelta(
+            seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0
+        )
+        # Lazy-write path: the cap query stamps _settled_at opportunistically.
+        seq.is_in_suppression_with_cap("cover.x", delta=10.0)
+        assert "cover.x" in seq._settled_at
+        # A new position command starts a fresh cycle; the prior settle
+        # stamp must be forgotten.
+        seq.stamp_position_command("cover.x")
+        assert "cover.x" not in seq._settled_at
 
 
 @pytest.mark.asyncio
@@ -249,6 +331,137 @@ class TestSettleAndTilt:
             "cover.x", position_target=60, tilt_target=80, reason="solar"
         )
         assert hass.services.async_call.call_count == 0
+
+    async def test_run_sequence_stamps_settled_at_after_wait_returns(self):
+        """``run_sequence`` deterministically stamps the moving→settled anchor.
+
+        After ``_wait_for_position_settle`` returns, the sequencer must
+        stamp ``_settled_at`` to anchor the publish-lag window (issue #33
+        Track A). Without this deterministic stamp the window would rely
+        solely on the lazy-write in ``is_in_suppression_with_cap``, which
+        only fires if/when a manual-override query happens to land at the
+        right moment.
+        """
+        _, seq = _build_sequencer()
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 60))
+        assert "cover.x" not in seq._settled_at
+        before = dt.datetime.now(dt.UTC)
+        await seq.run_sequence(
+            "cover.x", position_target=60, tilt_target=80, reason="solar"
+        )
+        after = dt.datetime.now(dt.UTC)
+        assert "cover.x" in seq._settled_at
+        assert before <= seq._settled_at["cover.x"] <= after
+
+    async def test_settle_does_not_stall_during_startup_grace_when_state_never_moves(
+        self, monkeypatch
+    ):
+        """Startup grace must block stall declaration before motor begins to travel.
+
+        Somfy IO motors take 3-5 s to begin physical travel after the service
+        call. During that window cover.state still reads "open" and
+        current_position is unchanged. Without the startup grace, the
+        no-progress counter trips after 3 samples and the loop declares stall
+        20-30 s before the cover actually stops moving — starting the
+        publish-lag clock far too early (issue #33 Track B).
+        """
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS",
+            0.05,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS",
+            0.2,
+        )
+        _, seq = _build_sequencer(get_state=lambda _eid: "open")
+        seq._get_current_position = MagicMock(return_value=100)
+
+        reached, last = await seq._wait_for_position_settle("cover.x", target=9)
+
+        assert reached is False
+        # Pre-fix returns after 4 samples (poll 1 sets last=100, polls 2-4
+        # each tick unchanged_samples up to 3 → stall). With the startup
+        # grace the loop must keep polling past the unchanged-sample
+        # threshold until the wall-clock grace elapses (0.05 s) or the
+        # timeout fires (0.2 s). Either way that's strictly more than 4
+        # samples.
+        assert seq._get_current_position.call_count > 4
+
+    async def test_settle_does_not_stall_after_motion_observed(self, monkeypatch):
+        """Once motion is observed, the unchanged-sample stall counter is active again.
+
+        State cycles ``open → closing → closing → open → open → open``; the
+        gate must let the post-motion 3-unchanged-sample stall fire. Without
+        a motion-observed flag, the same gate that protects pre-motion startup
+        would suppress all post-motion stalls and the loop would only ever
+        bail on the 60 s timeout.
+        """
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS",
+            0,
+        )
+        state_seq = iter(["open", "closing", "closing", "open", "open", "open"])
+        _, seq = _build_sequencer(
+            get_state=lambda _eid: next(state_seq, "open"),
+        )
+        seq._get_current_position = MagicMock(side_effect=[100, 100, 95, 95, 95, 95])
+
+        reached, last = await seq._wait_for_position_settle("cover.x", target=9)
+
+        assert reached is False
+        assert last == 95
+        # poll 1 (open, 100, last=None reset), poll 2 (closing, 100, moving
+        # reset), poll 3 (closing, 95, moving reset), poll 4 (open, 95,
+        # unchanged=1), poll 5 (open, 95, unchanged=2), poll 6 (open, 95,
+        # unchanged=3 → stall).
+        assert seq._get_current_position.call_count >= 6
+
+    async def test_settle_does_not_stall_during_startup_grace_no_state_callback(
+        self, monkeypatch
+    ):
+        """No ``get_state`` callback: startup grace still gates on wall-clock elapsed.
+
+        Backwards-compat path used by tests and non-venetian callers that
+        construct DualAxisSequencer without a state callback. The startup
+        grace must still apply, anchored purely on wall-clock time since the
+        loop began — otherwise a slow-starting motor's pre-motion samples
+        would prematurely declare stall.
+        """
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS",
+            0.05,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS",
+            0.2,
+        )
+        _, seq = _build_sequencer()  # no get_state
+        seq._get_current_position = MagicMock(return_value=60)
+
+        reached, last = await seq._wait_for_position_settle("cover.x", target=9)
+
+        assert reached is False
+        assert seq._get_current_position.call_count > 4
 
 
 @pytest.mark.asyncio
@@ -702,10 +915,22 @@ class TestSettleStateAware:
     async def test_settle_unchanged_samples_only_count_when_stationary(
         self, monkeypatch
     ):
-        """When state is always open, the existing 3-sample stall still fires."""
+        """When state is always open AND startup grace has elapsed, the 3-sample stall fires.
+
+        The startup grace (Track B fix in issue #33) is intentionally
+        bypassed here so we exercise the post-grace stall path. The
+        production grace prevents a slow-starting motor's pre-motion samples
+        from being misclassified as stall; once grace expires, the legacy
+        3-unchanged-sample counter still terminates the wait.
+        """
         monkeypatch.setattr(
             "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS",
             0,
         )
         state_seq = iter(["open", "open", "open", "open", "open"])
@@ -815,10 +1040,21 @@ class TestSettleStateAware:
         assert pos_calls[0] == 2
 
     async def test_settle_falls_back_when_no_get_state(self, monkeypatch):
-        """No get_state injected → behaves identically to pre-fix code (stall at 3)."""
+        """No get_state injected + startup grace bypassed → stalls at 4 polls.
+
+        Equivalent of the pre-Track-B fall-back path: with no state callback
+        and the startup grace patched to zero, the legacy 3-unchanged-sample
+        counter terminates the loop at poll 4 (poll 1 sets last_position,
+        polls 2-4 each increment unchanged_samples to 3).
+        """
         monkeypatch.setattr(
             "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
             ".VENETIAN_POSITION_SETTLE_POLL_SECONDS",
+            0,
+        )
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+            ".VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS",
             0,
         )
         calls = [0]

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -70,7 +70,12 @@ def _tilt_check(*, expected: int = 70, suppressed: bool) -> SecondaryAxisCheck:
 
 
 def _make_sequencer_suppression(
-    *, entity_id: str, state: str, stamp_age_seconds: float = 0.0
+    *,
+    entity_id: str,
+    state: str,
+    stamp_age_seconds: float = 0.0,
+    settled_now: bool = False,
+    settled_age_seconds: float = 0.0,
 ) -> Callable[[str, float], bool]:
     """Build a real ``DualAxisSequencer`` and return its bound delta-cap gate.
 
@@ -83,6 +88,13 @@ def _make_sequencer_suppression(
     ``stamp_age_seconds`` backdates the suppression stamp so callers can land
     outside the post-settle cap-grace tail while still inside the overall
     suppression window.
+
+    ``settled_now`` calls the sequencer's ``_stamp_settled`` writer to
+    deterministically anchor the publish-lag window to "now" — modelling the
+    state immediately after ``run_sequence`` observes the carriage transition
+    to settled (issue #33 Track A). ``settled_age_seconds`` then backdates
+    that anchor so a test can land outside the publish-lag window while
+    keeping the legacy cap path intact.
     """
     hass = MagicMock()
     seq = DualAxisSequencer(
@@ -98,6 +110,10 @@ def _make_sequencer_suppression(
     seq.stamp_position_command(entity_id)
     if stamp_age_seconds > 0:
         seq._suppression_at[entity_id] -= dt.timedelta(seconds=stamp_age_seconds)
+    if settled_now:
+        seq._stamp_settled(entity_id)
+        if settled_age_seconds > 0:
+            seq._settled_at[entity_id] -= dt.timedelta(seconds=settled_age_seconds)
     return seq.is_in_suppression_with_cap
 
 
@@ -350,17 +366,31 @@ def test_tilt_drift_inside_post_settle_grace_is_ignored() -> None:
 
 
 def test_tilt_drift_after_settle_grace_with_large_delta_trips_override() -> None:
-    """Once the 5s grace tail elapses, the geometry-bounded cap reasserts.
+    """Once both the 5s cap-grace AND 45s publish-lag windows elapse, the cap reasserts.
 
-    A delta > 30% with state=``stopped`` and stamp older than the grace tail
-    is a user grabbing the slats, not motor drift, and must still trip
-    manual override even inside the 90s suppression window.
+    A delta > 30% with state=``stopped`` and both ``_suppression_at`` and
+    ``_settled_at`` aged past their respective windows is a user grabbing
+    the slats, not motor drift, and must still trip manual override even
+    inside the 90s overall suppression window.
+
+    The publish-lag window (issue #33 Track A) extends the original
+    cap-grace behaviour: pre-Track-A this test backdated only the
+    suppression stamp by 10 s; post-Track-A the settled anchor must also
+    be backdated past 45 s.
     """
+    from custom_components.adaptive_cover_pro.const import (
+        VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
+    )
+
     entity_id = "cover.venetian_post_settle_user_move"
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
     suppression = _make_sequencer_suppression(
-        entity_id=entity_id, state="stopped", stamp_age_seconds=10.0
+        entity_id=entity_id,
+        state="stopped",
+        stamp_age_seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 5.0,
+        settled_now=True,
+        settled_age_seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 1.0,
     )
 
     mgr.handle_state_change(
@@ -398,6 +428,167 @@ def test_non_venetian_cover_with_no_check_runs_position_axis_only() -> None:
     )
 
     assert not mgr.is_cover_manual(entity_id)
+
+
+# ---------------------------------------------------------------------------
+# Issue #33 Track A: publish-lag window anchored to moving → settled
+# ---------------------------------------------------------------------------
+
+
+def test_late_publish_burst_after_real_settle_does_not_trip_override() -> None:
+    """Somfy IO publish-lag scenario end-to-end (issue #33 Track A).
+
+    Reproduces the user's diagnostic: position command stamped, motor
+    physically settles, sequencer observes moving→settled (``_stamp_settled``
+    fires), 20-40 s later the actuator republishes the back-rotate tilt
+    burst with a delta > 30%. The new publish-lag window must suppress the
+    burst even though the legacy cap-grace (5 s) has long expired.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS,
+    )
+
+    entity_id = "cover.venetian_publish_lag"
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    suppression = _make_sequencer_suppression(
+        entity_id=entity_id,
+        state="stopped",
+        stamp_age_seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0,
+        settled_now=True,
+    )
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=100, tilt=5),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=100,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=suppression,
+        ),
+    )
+
+    assert not mgr.is_cover_manual(entity_id)
+    events = mgr.get_event_buffer()
+    assert any(
+        evt.get("event") == "manual_override_rejected_tilt_suppression"
+        for evt in events
+    ), f"expected rejected_tilt_suppression event, got {events}"
+
+
+def test_real_user_twist_after_publish_lag_still_trips_override() -> None:
+    """After the publish-lag window expires, a large tilt delta is a user touch.
+
+    Counterpart to ``test_late_publish_burst_after_real_settle_does_not_trip_override``:
+    same setup, but ``_settled_at`` is backdated past the publish-lag window
+    so the cap reasserts. A delta=95 is a real wand-twist and must trip
+    manual override.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
+        VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS,
+    )
+
+    entity_id = "cover.venetian_real_user_twist"
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    suppression = _make_sequencer_suppression(
+        entity_id=entity_id,
+        state="stopped",
+        stamp_age_seconds=VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS + 1.0,
+        settled_now=True,
+        settled_age_seconds=VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS + 1.0,
+    )
+
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=100, tilt=5),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=100,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=suppression,
+        ),
+    )
+
+    assert mgr.is_cover_manual(entity_id)
+    events = mgr.get_event_buffer()
+    assert any(
+        evt.get("event") == "manual_override_set" for evt in events
+    ), f"expected manual_override_set event, got {events}"
+
+
+async def test_premature_stall_does_not_start_publish_lag_clock_early() -> None:
+    """End-to-end Track B + Track A: stall declaration is anchored to real settle.
+
+    A slow-starting actuator publishes the same position for the first few
+    samples (motor hasn't begun travel), then ramps down. Without the
+    Track B startup-grace fix the settle loop would declare stall on the
+    third pre-motion sample and ``run_sequence`` would stamp
+    ``_settled_at`` 20-30 s before the cover actually stops — starting
+    the publish-lag clock at the wrong moment.
+
+    This integration test drives ``run_sequence`` against that hardware
+    profile and asserts the stamp lands AFTER the startup-grace window
+    has elapsed.
+    """
+    import datetime as _dt
+
+    from custom_components.adaptive_cover_pro.cover_types.venetian.sequencer import (
+        DualAxisSequencer,
+    )
+
+    # Slow-start profile: 100 % for 5 samples (pre-motion), then ramps to 9.
+    pos_seq = iter([100, 100, 100, 100, 100, 80, 60, 9, 9, 9])
+    state_seq = iter(["open"] * 5 + ["closing"] * 3 + ["open"] * 2)
+
+    from unittest.mock import AsyncMock
+
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    seq = DualAxisSequencer(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=lambda _eid: next(pos_seq, 9),
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_state=lambda _eid: next(state_seq, "open"),
+        post_settle_hold_seconds=0,
+    )
+
+    # Drive the settle loop fast and force a short startup grace so the test
+    # completes quickly, while still proving the grace gates the stall.
+    import custom_components.adaptive_cover_pro.cover_types.venetian.sequencer as seq_mod
+
+    orig_poll = seq_mod.VENETIAN_POSITION_SETTLE_POLL_SECONDS
+    orig_grace = seq_mod.VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS
+    seq_mod.VENETIAN_POSITION_SETTLE_POLL_SECONDS = 0.01
+    seq_mod.VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS = 0.05
+    try:
+        t0 = _dt.datetime.now(_dt.UTC)
+        await seq.run_sequence(
+            "cover.x", position_target=9, tilt_target=60, reason="solar"
+        )
+    finally:
+        seq_mod.VENETIAN_POSITION_SETTLE_POLL_SECONDS = orig_poll
+        seq_mod.VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS = orig_grace
+
+    assert "cover.x" in seq._settled_at
+    elapsed = (seq._settled_at["cover.x"] - t0).total_seconds()
+    # Must land at or after the startup-grace boundary (0.05 s here). The
+    # pre-fix code would stamp within microseconds of t0.
+    assert elapsed >= 0.05, f"settled_at stamped too early: {elapsed:.4f} s"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Anchors the venetian back-rotate publish-lag window to the actual `moving → settled` state transition rather than to `stamp_position_command`. New constant `VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS = 45.0` covers the 27 s post-settle back-rotate burst observed on Somfy IO in issue #33.
- Adds a startup-grace in `_wait_for_position_settle` (`VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS = 6.0`) so the settle detector doesn't mistake pre-motion same-position samples for a stall on slow-start motors.
- Adds 10 regression tests covering the suppression boundary post-settle and the premature-stall scenario.

## Behavioural impact
Fast actuators (KNX sub-second publish, Shelly 2PM) settle within `VENETIAN_POST_SETTLE_CAP_GRACE_SECONDS=5.0` today, so extending publish-lag to 45 s changes behaviour: a user twisting slats by hand at +10 s post-settle would, under the new code, be classed as motor back-drive and not trip override — *if* delta exceeds 30 (the cap). Risk bounded by physics: real motor back-drive is single-digit-percent (`VENETIAN_REBASE_MAX_DRIFT_PERCENT=15`), so a delta of 30-95% during the 5-45 s window is implausible on any actuator. A user twisting slats during the window almost always lands within the existing cap.

## Testing
- ✅ 238 venetian + manual-override tests passing (10 new)
- ✅ 3407 full project suite passing, 0 failures
- ✅ Lint clean

## Related Issues
Refs #33