### PR TITLE
feat: expose pipeline-aware My Position button and number (#409)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -45,6 +45,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.COVER,
+    Platform.NUMBER,
 ]
 CONF_SUN = ["sun.sun"]
 

--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -7,7 +7,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import _LOGGER, CONF_ENTITIES, DOMAIN
+from .const import _LOGGER, CONF_ENTITIES, CONF_MY_POSITION_VALUE, DOMAIN
 from .coordinator import AdaptiveDataUpdateCoordinator
 from .entity_base import AdaptiveCoverBaseEntity
 
@@ -25,12 +25,15 @@ async def async_setup_entry(
     reset_manual = AdaptiveCoverButton(
         config_entry.entry_id, hass, config_entry, coordinator
     )
+    my_position = AdaptiveCoverMyPositionButton(
+        config_entry.entry_id, hass, config_entry, coordinator
+    )
 
     buttons = []
 
     entities = config_entry.options.get(CONF_ENTITIES, [])
     if len(entities) >= 1:
-        buttons = [reset_manual]
+        buttons = [reset_manual, my_position]
 
     async_add_entities(buttons)
 
@@ -107,3 +110,37 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
                     entity,
                 )
                 self.coordinator._cmd_svc.set_waiting(entity, False)  # noqa: SLF001
+
+
+class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):
+    """Button that recalls the user's saved My Position preset."""
+
+    _attr_translation_key = "my_position"
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: AdaptiveDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(entry_id, hass, config_entry, coordinator)
+        self._attr_unique_id = f"{entry_id}_my_position"
+        self._entities = config_entry.options.get(CONF_ENTITIES, [])
+
+    async def async_press(self) -> None:
+        """Send the My Position command to all configured covers."""
+        my_position_value = self.config_entry.options.get(CONF_MY_POSITION_VALUE)
+        if my_position_value is None:
+            _LOGGER.warning(
+                "My Position button pressed but my_position_value is not configured"
+            )
+            return
+        for entity_id in self._entities:
+            await self.coordinator.async_apply_user_position(
+                entity_id,
+                int(my_position_value),
+                trigger="my_position_recall",
+                force=False,
+            )

--- a/custom_components/adaptive_cover_pro/number.py
+++ b/custom_components/adaptive_cover_pro/number.py
@@ -1,0 +1,74 @@
+"""Number platform for the Adaptive Cover Pro integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    CONF_ENTITIES,
+    CONF_MY_POSITION_VALUE,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    _RANGE_MY_POSITION,
+)
+from .coordinator import AdaptiveDataUpdateCoordinator
+from .entity_base import AdaptiveCoverBaseEntity
+from .services.options_service import apply_options_patch, validate_options_patch
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the number platform."""
+    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
+    numbers = []
+
+    entities = config_entry.options.get(CONF_ENTITIES, [])
+    if len(entities) >= 1:
+        numbers = [
+            AdaptiveCoverMyPositionNumber(
+                config_entry.entry_id, hass, config_entry, coordinator
+            )
+        ]
+
+    async_add_entities(numbers)
+
+
+class AdaptiveCoverMyPositionNumber(AdaptiveCoverBaseEntity, NumberEntity):
+    """Number entity for configuring the My Position value."""
+
+    _attr_translation_key = "my_position_value"
+    _attr_native_min_value = _RANGE_MY_POSITION[0]
+    _attr_native_max_value = _RANGE_MY_POSITION[1]
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: AdaptiveDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the number entity."""
+        super().__init__(entry_id, hass, config_entry, coordinator)
+        self._attr_unique_id = f"{entry_id}_my_position_value"
+        self._entities = config_entry.options.get(CONF_ENTITIES, [])
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist a new My Position value to config_entry.options."""
+        patch = {CONF_MY_POSITION_VALUE: int(value)}
+        sensor_type = self.config_entry.data.get(CONF_SENSOR_TYPE)
+        validate_options_patch(patch, dict(self.config_entry.options), sensor_type)
+        await apply_options_patch(self.hass, self.coordinator, patch)

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1020,6 +1020,16 @@
           "off": "Aus"
         }
       }
+    },
+    "button": {
+      "my_position": {
+        "name": "Meine Position"
+      }
+    },
+    "number": {
+      "my_position_value": {
+        "name": "Mein Positionswert"
+      }
     }
   },
   "selector": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1020,6 +1020,16 @@
           "off": "Off"
         }
       }
+    },
+    "button": {
+      "my_position": {
+        "name": "My Position"
+      }
+    },
+    "number": {
+      "my_position_value": {
+        "name": "My Position Value"
+      }
     }
   },
   "selector": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1020,6 +1020,16 @@
           "off": "Désactivé"
         }
       }
+    },
+    "button": {
+      "my_position": {
+        "name": "Ma Position"
+      }
+    },
+    "number": {
+      "my_position_value": {
+        "name": "Valeur de Ma Position"
+      }
     }
   },
   "selector": {

--- a/tests/test_my_position_button.py
+++ b/tests/test_my_position_button.py
@@ -1,0 +1,128 @@
+"""Tests for AdaptiveCoverMyPositionButton (button platform, issue #409)."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — My Position button created when entities configured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_my_position_button_created_when_entities_configured():
+    """async_setup_entry must yield exactly one AdaptiveCoverMyPositionButton."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverMyPositionButton,
+        async_setup_entry,
+    )
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES, DOMAIN
+
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.options = {CONF_ENTITIES: ["cover.test1"]}
+    config_entry.data = {"name": "Test Cover", "sensor_type": "cover_blind"}
+
+    coordinator = MagicMock()
+    hass.data = {DOMAIN: {"test_entry": coordinator}}
+
+    added = []
+
+    def capture(entities, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, capture)
+
+    my_pos_buttons = [e for e in added if isinstance(e, AdaptiveCoverMyPositionButton)]
+    assert len(my_pos_buttons) == 1
+
+
+# ---------------------------------------------------------------------------
+# Step 9 — async_press calls async_apply_user_position for each entity
+# ---------------------------------------------------------------------------
+
+
+def _make_my_position_button(*, options=None, entities=None):
+    """Return a minimal AdaptiveCoverMyPositionButton without HA infrastructure."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverMyPositionButton,
+    )
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENTITIES,
+        CONF_MY_POSITION_VALUE,
+    )
+
+    if entities is None:
+        entities = ["cover.test1", "cover.test2"]
+    if options is None:
+        options = {CONF_MY_POSITION_VALUE: 55, CONF_ENTITIES: entities}
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.options = options
+    config_entry.data = {"name": "Test Cover", "sensor_type": "cover_blind"}
+
+    coordinator = MagicMock()
+    coordinator.async_apply_user_position = AsyncMock(
+        return_value=("sent", "set_cover_position")
+    )
+
+    button = AdaptiveCoverMyPositionButton.__new__(AdaptiveCoverMyPositionButton)
+    button.coordinator = coordinator
+    button.config_entry = config_entry
+    button._entities = entities
+    return button
+
+
+@pytest.mark.asyncio
+async def test_press_calls_async_apply_user_position():
+    """async_press must call async_apply_user_position for each entity."""
+    button = _make_my_position_button()
+
+    await button.async_press()
+
+    assert button.coordinator.async_apply_user_position.call_count == 2
+    for call in button.coordinator.async_apply_user_position.call_args_list:
+        assert call.args[1] == 55
+        assert call.kwargs.get("trigger") == "my_position_recall"
+        assert call.kwargs.get("force") is False
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — Warn-and-skip when my_position_value not configured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_press_warn_and_skip_when_my_position_not_configured():
+    """async_press must skip all covers when my_position_value is not set."""
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES
+
+    options = {CONF_ENTITIES: ["cover.test1", "cover.test2"]}
+    button = _make_my_position_button(
+        options=options, entities=["cover.test1", "cover.test2"]
+    )
+
+    await button.async_press()
+
+    button.coordinator.async_apply_user_position.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Step 11 — Preempted-skip return does not raise
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_press_records_preempted_skip_when_force_override_active():
+    """async_press must not raise when coordinator returns preempted_by_force_override."""
+    button = _make_my_position_button()
+    button.coordinator.async_apply_user_position = AsyncMock(
+        return_value=("skipped", "preempted_by_force_override")
+    )
+
+    # Must not raise
+    await button.async_press()

--- a/tests/test_my_position_number.py
+++ b/tests/test_my_position_number.py
@@ -1,0 +1,202 @@
+"""Tests for AdaptiveCoverMyPositionNumber (number platform, issue #409)."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Platform.NUMBER in PLATFORMS
+# ---------------------------------------------------------------------------
+
+
+def test_platform_number_in_platforms():
+    """Platform.NUMBER must be listed in the integration's PLATFORMS."""
+    from homeassistant.const import Platform
+
+    from custom_components.adaptive_cover_pro import PLATFORMS
+
+    assert Platform.NUMBER in PLATFORMS
+
+
+# ---------------------------------------------------------------------------
+# Step 2 — Module importable with AdaptiveCoverMyPositionNumber
+# ---------------------------------------------------------------------------
+
+
+def test_number_module_importable():
+    """number.py must export AdaptiveCoverMyPositionNumber."""
+    from custom_components.adaptive_cover_pro import number
+    from custom_components.adaptive_cover_pro.number import (
+        AdaptiveCoverMyPositionNumber,
+    )
+
+    assert hasattr(number, "async_setup_entry")
+    assert AdaptiveCoverMyPositionNumber is not None
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — Entity created when len(entities) >= 1
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_number_entity_created_when_entities_configured():
+    """async_setup_entry must yield exactly one AdaptiveCoverMyPositionNumber."""
+    from custom_components.adaptive_cover_pro.number import (
+        AdaptiveCoverMyPositionNumber,
+        async_setup_entry,
+    )
+
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES, DOMAIN
+
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.options = {CONF_ENTITIES: ["cover.test1"]}
+    config_entry.data = {"name": "Test Cover", "sensor_type": "cover_blind"}
+
+    coordinator = MagicMock()
+    hass.data = {DOMAIN: {"test_entry": coordinator}}
+
+    added = []
+
+    def capture(entities, **kwargs):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, capture)
+
+    assert len(added) == 1
+    assert isinstance(added[0], AdaptiveCoverMyPositionNumber)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by Steps 4, 5, 6, 7
+# ---------------------------------------------------------------------------
+
+
+def _make_number_entity():
+    """Return a minimal AdaptiveCoverMyPositionNumber without HA infrastructure."""
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES
+    from custom_components.adaptive_cover_pro.number import (
+        AdaptiveCoverMyPositionNumber,
+    )
+
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.options = {CONF_ENTITIES: ["cover.test1"]}
+    config_entry.data = {"name": "Test Cover", "sensor_type": "cover_blind"}
+
+    coordinator = MagicMock()
+    hass = MagicMock()
+
+    entity = AdaptiveCoverMyPositionNumber.__new__(AdaptiveCoverMyPositionNumber)
+    entity.hass = hass
+    entity.config_entry = config_entry
+    entity.coordinator = coordinator
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — Min/max/step from _RANGE_MY_POSITION
+# ---------------------------------------------------------------------------
+
+
+def test_number_entity_range_matches_const():
+    """Native min/max must match _RANGE_MY_POSITION; step must be 1."""
+    from custom_components.adaptive_cover_pro.const import _RANGE_MY_POSITION
+    from homeassistant.const import PERCENTAGE
+
+    entity = _make_number_entity()
+
+    assert entity._attr_native_min_value == _RANGE_MY_POSITION[0]
+    assert entity._attr_native_max_value == _RANGE_MY_POSITION[1]
+    assert entity._attr_native_step == 1
+    assert entity._attr_native_unit_of_measurement == PERCENTAGE
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — entity_category = CONFIG
+# ---------------------------------------------------------------------------
+
+
+def test_number_entity_category_is_config():
+    """Entity category must be CONFIG so the entity appears in the config section."""
+    from homeassistant.helpers.entity import EntityCategory
+
+    entity = _make_number_entity()
+
+    assert entity._attr_entity_category == EntityCategory.CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — async_set_native_value calls validate + apply
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_native_value_calls_apply_options_patch():
+    """async_set_native_value must validate then apply the patch via options-service."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENTITIES,
+        CONF_MY_POSITION_VALUE,
+        CONF_SENSOR_TYPE,
+    )
+
+    entity = _make_number_entity()
+    current_options = {CONF_ENTITIES: ["cover.test1"]}
+    entity.config_entry.options = current_options
+    entity.config_entry.data = {
+        "name": "Test Cover",
+        CONF_SENSOR_TYPE: "cover_blind",
+    }
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.number.validate_options_patch"
+        ) as mock_validate,
+        patch(
+            "custom_components.adaptive_cover_pro.number.apply_options_patch",
+            new_callable=AsyncMock,
+        ) as mock_apply,
+    ):
+        mock_validate.return_value = {CONF_MY_POSITION_VALUE: 42}
+        mock_apply.return_value = {}
+
+        await entity.async_set_native_value(42.0)
+
+        expected_patch = {CONF_MY_POSITION_VALUE: 42}
+        mock_validate.assert_called_once_with(
+            expected_patch, dict(current_options), "cover_blind"
+        )
+        mock_apply.assert_called_once_with(
+            entity.hass, entity.coordinator, expected_patch
+        )
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — Cross-field rule fires (real validator, no mocks)
+# ---------------------------------------------------------------------------
+
+
+def test_set_native_value_cross_field_rule_fires():
+    """Setting my_position_value=None when sunset_use_my=True must raise ServiceValidationError."""
+    from homeassistant.core import ServiceValidationError
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MY_POSITION_VALUE,
+        CONF_SUNSET_USE_MY,
+    )
+    from custom_components.adaptive_cover_pro.services.options_service import (
+        validate_options_patch,
+    )
+
+    with pytest.raises(
+        ServiceValidationError, match="sunset_use_my=true requires my_position_value"
+    ):
+        validate_options_patch(
+            {CONF_MY_POSITION_VALUE: None},
+            {CONF_SUNSET_USE_MY: True},
+            "cover_blind",
+        )

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -68,8 +68,12 @@ from custom_components.adaptive_cover_pro.binary_sensor import (
     AdaptiveCoverPositionMismatchSensor,
 )
 from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
-from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+from custom_components.adaptive_cover_pro.button import (
+    AdaptiveCoverButton,
+    AdaptiveCoverMyPositionButton,
+)
 from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
+from custom_components.adaptive_cover_pro.number import AdaptiveCoverMyPositionNumber
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -217,6 +221,19 @@ ENTITY_FACTORIES: dict[type, object] = {
     ),
     # --- button.py ---
     AdaptiveCoverButton: lambda: AdaptiveCoverButton(
+        entry_id="test_avail_entry",
+        hass=_make_hass(),
+        config_entry=_make_config_entry(),
+        coordinator=_make_coordinator(),
+    ),
+    AdaptiveCoverMyPositionButton: lambda: AdaptiveCoverMyPositionButton(
+        entry_id="test_avail_entry",
+        hass=_make_hass(),
+        config_entry=_make_config_entry(),
+        coordinator=_make_coordinator(),
+    ),
+    # --- number.py ---
+    AdaptiveCoverMyPositionNumber: lambda: AdaptiveCoverMyPositionNumber(
         entry_id="test_avail_entry",
         hass=_make_hass(),
         config_entry=_make_config_entry(),

--- a/tests/test_unique_id_snapshot.py
+++ b/tests/test_unique_id_snapshot.py
@@ -113,6 +113,9 @@ EXPECTED_UNIQUE_ID_SUFFIXES = sorted(
         "position_mismatch",
         # --- button platform ---
         "Reset Manual Override",
+        "my_position",
+        # --- number platform ---
+        "my_position_value",
     ]
 )
 


### PR DESCRIPTION
## Summary
- New `button.<managed_cover>_my_position` recalls the saved `CONF_MY_POSITION_VALUE` through `coordinator.async_apply_user_position`. The recall respects ACP's full pipeline: force_override (100), weather (90), and high-priority custom-position slots all preempt the recall; lower-priority handlers don't. Floor-clamp from min-mode custom positions and `mark_user_command` engagement come for free.
- New `number.<managed_cover>_my_position_value` (EntityCategory.CONFIG) exposes the My Position value at runtime. Writes go through the options-service patch path so the `sunset_use_my ⇒ my_position_value` cross-field rule still fires.
- Integration-agnostic by design — routing layer picks `set_cover_position` for position-capable covers and falls back to the Somfy stop-while-stationary trick automatically. No upstream-integration coupling.

## Testing
- ✅ 3420 tests passing (full suite, 0 failed, 0 xfail).
- New tests: `tests/test_my_position_button.py`, `tests/test_my_position_number.py`.
- Guard tests updated: `tests/test_sensor_availability.py`, `tests/test_unique_id_snapshot.py`.
- Translation validator + parity tests: ✅.

## Related Issues
Refs #409