### PR TITLE
fix: surface my_position_value + preserve Somfy "My" brand (#409)

### DIFF
--- a/custom_components/adaptive_cover_pro/number.py
+++ b/custom_components/adaptive_cover_pro/number.py
@@ -66,6 +66,12 @@ class AdaptiveCoverMyPositionNumber(AdaptiveCoverBaseEntity, NumberEntity):
         self._attr_unique_id = f"{entry_id}_my_position_value"
         self._entities = config_entry.options.get(CONF_ENTITIES, [])
 
+    @property
+    def native_value(self) -> float | None:
+        """Return the current My Position value from config entry options."""
+        value = self.config_entry.options.get(CONF_MY_POSITION_VALUE)
+        return float(value) if value is not None else None
+
     async def async_set_native_value(self, value: float) -> None:
         """Persist a new My Position value to config_entry.options."""
         patch = {CONF_MY_POSITION_VALUE: int(value)}

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1023,12 +1023,12 @@
     },
     "button": {
       "my_position": {
-        "name": "Meine Position"
+        "name": "Verwaltete My-Position"
       }
     },
     "number": {
       "my_position_value": {
-        "name": "Mein Positionswert"
+        "name": "Verwalteter My-Positionswert"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1023,12 +1023,12 @@
     },
     "button": {
       "my_position": {
-        "name": "My Position"
+        "name": "Managed My Position"
       }
     },
     "number": {
       "my_position_value": {
-        "name": "My Position Value"
+        "name": "Managed My Position Value"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1023,12 +1023,12 @@
     },
     "button": {
       "my_position": {
-        "name": "Ma Position"
+        "name": "Position My gérée"
       }
     },
     "number": {
       "my_position_value": {
-        "name": "Valeur de Ma Position"
+        "name": "Valeur de position My gérée"
       }
     }
   },

--- a/tests/test_my_position_number.py
+++ b/tests/test_my_position_number.py
@@ -200,3 +200,34 @@ def test_set_native_value_cross_field_rule_fires():
             {CONF_SUNSET_USE_MY: True},
             "cover_blind",
         )
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — native_value reads CONF_MY_POSITION_VALUE from options (issue #409)
+# ---------------------------------------------------------------------------
+
+
+def test_native_value_returns_option_value():
+    """native_value must return float(CONF_MY_POSITION_VALUE) from config_entry.options."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENTITIES,
+        CONF_MY_POSITION_VALUE,
+    )
+
+    entity = _make_number_entity()
+    entity.config_entry.options = {
+        CONF_ENTITIES: ["cover.test1"],
+        CONF_MY_POSITION_VALUE: 35,
+    }
+
+    assert entity.native_value == 35.0
+
+
+def test_native_value_returns_none_when_not_set():
+    """native_value must be None when CONF_MY_POSITION_VALUE is absent from options."""
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES
+
+    entity = _make_number_entity()
+    entity.config_entry.options = {CONF_ENTITIES: ["cover.test1"]}
+
+    assert entity.native_value is None


### PR DESCRIPTION
## Summary
Two follow-up fixes against the My Position entities shipped in PR #410 (v2.22.0-beta.6), reported by @environ314 in #409:

- **Bug:** `number.<managed>_my_position_value` showed `unknown` after every options-form save. Root cause: `AdaptiveCoverMyPositionNumber` defined `async_set_native_value` (write path) but no `native_value` property, so HA's base class returned the class-level `_attr_native_value = None`. Every options submit triggers a full config-entry reload, so the entity was recreated with no memory of the persisted value. Fixed by adding a `native_value` property that reads `CONF_MY_POSITION_VALUE` from `config_entry.options` — mirrors the live-read pattern the button already uses.
- **Naming / i18n:** EN names were identical ("My Position" / "My Position Value"), so the button/number pair was visually ambiguous. FR and DE translated the Somfy brand name "My" as the French possessive "Ma" / German "Meine" — the physical button on French- and German-market Somfy RTS remotes is labeled "my" verbatim. Renamed EN to "Managed My Position" / "Managed My Position Value", then synced DE ("Verwaltete My-Position" / "Verwalteter My-Positionswert") and FR ("Position My gérée" / "Valeur de position My gérée") keeping "My" as a verbatim brand-name token.

## Testing
- ✅ 2 new regression tests in `tests/test_my_position_number.py` (Step 8) — assert `native_value` reads from options
- ✅ 87 passing across `pytest -k "my_position or number or translation"`
- ✅ `./scripts/validate_translations.py --ci` exits 0
- ✅ `number.py` at 100% line coverage

## Related Issues
Refs #409