### PR TITLE
fix: dispatch fresh solar position when auto-control re-enabled

### DIFF
--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -263,18 +263,16 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
             sequencer = getattr(self.coordinator._policy, "sequencer", None)
             if sequencer is not None:
                 sequencer.clear_tilt_targets()
-            options = self.coordinator.config_entry.options
-            for entity in self.coordinator.entities:
-                if (
-                    not self.coordinator.manager.is_cover_manual(entity)
-                    and self.coordinator.check_adaptive_time
-                ):
-                    ctx = self.coordinator._build_position_context(
-                        entity, options, force=True
-                    )
-                    await self.coordinator._cmd_svc.apply_position(
-                        entity, self.coordinator.state, "auto_control_on", context=ctx
-                    )
+            # Issue #352: signal state_change so the upcoming refresh routes
+            # through async_handle_state_change with the post-pipeline result.
+            # The previous design dispatched coordinator.state BEFORE refresh,
+            # sending the stale prior-cycle DefaultHandler value (e.g. 100 from
+            # an out-of-window cycle) and then waiting up to a minute for the
+            # periodic window-open transition to dispatch the correct solar
+            # value. Routing through state_change keeps dispatch in one place
+            # (the coordinator), aligned with weather/motion/window-open
+            # callers that already use this idiom.
+            self.coordinator.state_change = True
         await self.coordinator.async_refresh()
         self.schedule_update_ha_state()
 

--- a/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
+++ b/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
@@ -1,0 +1,257 @@
+"""Issue #352: Auto Control OFF→ON must dispatch the post-refresh solar value.
+
+Before the fix, ``switch.async_turn_on`` for ``automatic_control`` dispatched
+``coordinator.state`` BEFORE calling ``async_refresh()``. That cached state was
+the previous pipeline cycle's result — and when the previous cycle ran outside
+the time window (or with auto-control off), it was the DefaultHandler position
+(typically "open"=100). The subsequent refresh did NOT set ``state_change=True``,
+so the freshly-computed solar position was never dispatched until the next
+periodic window-transition tick (up to ~1 min later). The blind opened fully,
+then closed to the solar position seconds later.
+
+The fix funnels through the coordinator's normal state-change dispatch:
+``switch.async_turn_on`` sets ``coordinator.state_change = True`` and lets
+``async_refresh`` → ``async_handle_state_change`` own dispatch, so the value
+sent reflects the post-refresh pipeline result, not the stale pre-refresh
+snapshot.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.enums import ControlMethod
+from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
+from custom_components.adaptive_cover_pro.managers.toggles import ToggleManager
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
+
+
+SOLAR_POSITION = 30
+CACHED_DEFAULT_POSITION = 100  # previous cycle's DefaultHandler win (open)
+
+
+def _make_coord_with_stale_default():
+    """Coordinator whose pre-refresh ``state`` is the DefaultHandler position from
+    a previous out-of-window cycle, and whose next refresh will produce the
+    SOLAR_POSITION via ``async_handle_state_change``.
+    """
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._toggles = ToggleManager()
+    coord.automatic_control = False
+    coord.entities = ["cover.test_1"]
+    coord._policy = MagicMock()
+    coord._policy.sequencer = None
+    coord._inverse_state = False
+    coord._use_interpolation = False  # ``coord.state`` post-processing
+    coord._pending_cover_events = []
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
+    cmd_svc.record_skipped_action = MagicMock()
+    coord._cmd_svc = cmd_svc
+
+    # Pre-refresh: stale state from previous out-of-window cycle. ``coord.state``
+    # is a derived property that reads ``_pipeline_result.position`` and applies
+    # interpolation/inverse_state, so setting the pipeline result is enough.
+    coord._pipeline_result = PipelineResult(
+        position=CACHED_DEFAULT_POSITION,
+        control_method=ControlMethod.DEFAULT,
+        reason="default",
+        bypass_auto_control=False,
+    )
+    coord.state_change = False
+
+    manager = MagicMock()
+    manager.is_cover_manual.return_value = False
+    manager.manual_controlled = []
+    coord.manager = manager
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.is_active = True  # check_adaptive_time delegates here
+    coord._check_sun_validity_transition = MagicMock(return_value=False)
+    coord._is_custom_position_sensor_trigger = MagicMock(return_value=False)
+    coord._last_state_change_entity = None
+
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+
+    coord.min_change = 2
+    coord.time_threshold = 0
+
+    def _fake_build_ctx(
+        entity,
+        options,
+        *,
+        force=False,
+        is_safety=False,
+        bypass_auto_control=False,
+        sun_just_appeared=False,
+    ):
+        return PositionContext(
+            auto_control=True,  # automatic_control has been flipped True
+            manual_override=False,
+            sun_just_appeared=sun_just_appeared,
+            min_change=2,
+            time_threshold=0,
+            special_positions=[0, 100],
+            force=force,
+            is_safety=is_safety,
+            bypass_auto_control=bypass_auto_control,
+        )
+
+    coord._build_position_context = _fake_build_ctx
+
+    return coord
+
+
+def _wire_solar_refresh(coord):
+    """Make ``coord.async_refresh`` simulate a pipeline tick that computes
+    SOLAR_POSITION and routes through ``async_handle_state_change`` when
+    ``coord.state_change`` is set.
+    """
+
+    async def _fake_refresh():
+        # ``coord.state`` derives from ``_pipeline_result.position``; setting
+        # the pipeline result is enough to flip the state from 100 (default) to
+        # SOLAR_POSITION.
+        coord._pipeline_result = PipelineResult(
+            position=SOLAR_POSITION,
+            control_method=ControlMethod.SOLAR,
+            reason="solar",
+            bypass_auto_control=False,
+        )
+        if coord.state_change:
+            with patch.object(
+                type(coord),
+                "is_force_override_active",
+                new_callable=PropertyMock,
+                return_value=False,
+            ):
+                await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+                    coord,
+                    coord.state,
+                    coord.config_entry.options,
+                    prev_force_override=False,
+                    custom_position_released_entities=set(),
+                )
+
+    coord.async_refresh = AsyncMock(side_effect=_fake_refresh)
+
+
+def _make_switch(coord):
+    switch = object.__new__(AdaptiveCoverSwitch)
+    switch.coordinator = coord
+    switch._key = "automatic_control"
+    switch._switch_name = "Automatic Control"
+    switch._initial_state = True
+    switch._attr_is_on = False
+    switch.schedule_update_ha_state = MagicMock()
+    return switch
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_auto_control_on_dispatches_post_refresh_solar_not_cached_default():
+    """Turn on auto-control must dispatch the FRESH solar value, not the cached default.
+
+    Pre-refresh ``coord.state == 100`` (DefaultHandler win from a previous
+    out-of-window cycle). After the fix, the only dispatch happens inside
+    ``async_handle_state_change`` (driven by the refresh) and the value is
+    ``SOLAR_POSITION``. Before the fix, the switch dispatches ``100`` directly
+    from the loop in ``async_turn_on`` and never re-dispatches the fresh
+    solar value because ``state_change`` was never set.
+    """
+    coord = _make_coord_with_stale_default()
+    _wire_solar_refresh(coord)
+
+    switch = _make_switch(coord)
+    await switch.async_turn_on()
+
+    assert coord._cmd_svc.apply_position.await_count >= 1
+    dispatched_positions = [
+        c.args[1] for c in coord._cmd_svc.apply_position.await_args_list
+    ]
+    assert SOLAR_POSITION in dispatched_positions, (
+        f"expected fresh solar {SOLAR_POSITION} to be dispatched, got "
+        f"{dispatched_positions}"
+    )
+    assert CACHED_DEFAULT_POSITION not in dispatched_positions, (
+        f"stale pre-refresh default {CACHED_DEFAULT_POSITION} must NOT be "
+        f"dispatched; got {dispatched_positions}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_auto_control_on_signals_state_change_and_refresh_owns_dispatch():
+    """Structural guard: the switch must signal state_change and refresh owns dispatch.
+
+    Asserts:
+    1. ``coord.state_change is True`` at the moment ``async_refresh`` is invoked
+       (so the refresh's ``async_handle_state_change`` step actually runs).
+    2. NO ``apply_position`` calls happen BEFORE ``async_refresh`` is invoked
+       (BINDING_GUIDELINES #1/#5: switch is signal-only, coordinator owns dispatch).
+    """
+    coord = _make_coord_with_stale_default()
+    _wire_solar_refresh(coord)
+
+    refresh_observed_state_change: dict[str, bool] = {}
+    dispatches_before_refresh: list[int] = []
+    refresh_started = {"value": False}
+
+    original_apply = coord._cmd_svc.apply_position
+
+    async def _record_dispatch(*args, **kwargs):
+        if not refresh_started["value"]:
+            dispatches_before_refresh.append(args[1])
+        return await original_apply(*args, **kwargs)
+
+    coord._cmd_svc.apply_position = AsyncMock(side_effect=_record_dispatch)
+
+    original_refresh_fn = coord.async_refresh.side_effect
+
+    async def _refresh_with_capture():
+        refresh_observed_state_change["was_true"] = coord.state_change
+        refresh_started["value"] = True
+        await original_refresh_fn()
+
+    coord.async_refresh = AsyncMock(side_effect=_refresh_with_capture)
+
+    switch = _make_switch(coord)
+    await switch.async_turn_on()
+
+    assert refresh_observed_state_change.get("was_true") is True, (
+        "switch.async_turn_on must set coordinator.state_change=True before "
+        "calling async_refresh() so async_handle_state_change runs"
+    )
+    assert dispatches_before_refresh == [], (
+        "switch.async_turn_on must NOT dispatch positions before "
+        "async_refresh() — the coordinator's normal state-change path owns "
+        f"dispatch. Saw pre-refresh dispatches: {dispatches_before_refresh}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_auto_control_on_outside_time_window_does_not_dispatch():
+    """Outside the time window the coordinator's normal gate still blocks dispatch.
+
+    With ``check_adaptive_time=False``, ``async_handle_state_change`` returns
+    early at the non-safety guard (coordinator.py:1329-1337). After the fix,
+    the switch flips ``state_change=True`` and lets the refresh decide — and
+    the refresh correctly skips dispatch outside the window.
+    """
+    coord = _make_coord_with_stale_default()
+    coord._time_mgr.is_active = False  # outside time window
+    _wire_solar_refresh(coord)
+
+    switch = _make_switch(coord)
+    await switch.async_turn_on()
+
+    coord._cmd_svc.apply_position.assert_not_awaited()

--- a/tests/test_switch_actions.py
+++ b/tests/test_switch_actions.py
@@ -65,49 +65,69 @@ def _make_switch(key: str = "automatic_control", coordinator=None, config_entry=
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_turn_on_automatic_control_sends_position_to_non_manual_covers():
-    """Turn on automatic_control sends position to non-manual covers in window."""
+async def test_turn_on_automatic_control_signals_state_change_and_refreshes():
+    """Turn on automatic_control signals state_change; coordinator owns dispatch.
+
+    Issue #352: the switch must NOT dispatch positions itself — that would
+    send the stale pre-refresh ``coordinator.state``. Instead it sets
+    ``state_change=True`` and lets ``async_refresh`` route through
+    ``async_handle_state_change``, which dispatches the post-pipeline value.
+    """
     coord = _make_coordinator()
     coord.entities = ["cover.test_1", "cover.test_2"]
     coord.manager.is_cover_manual.side_effect = lambda e: e == "cover.test_2"
-
-    switch = _make_switch(key="automatic_control", coordinator=coord)
-    await switch.async_turn_on()
-
-    # apply_position called once — for cover.test_1 (cover.test_2 is manual)
-    assert coord._cmd_svc.apply_position.call_count == 1
-    call_args = coord._cmd_svc.apply_position.call_args
-    assert call_args[0][0] == "cover.test_1"
-    coord.async_refresh.assert_called_once()
-
-
-@pytest.mark.asyncio
-@pytest.mark.unit
-async def test_turn_on_automatic_control_skips_outside_time_window():
-    """Turn on automatic_control skips apply when not in time window."""
-    coord = _make_coordinator()
-    coord.entities = ["cover.test_1"]
-    coord.manager.is_cover_manual.return_value = False
-    coord.check_adaptive_time = False  # outside window
+    coord.state_change = False
 
     switch = _make_switch(key="automatic_control", coordinator=coord)
     await switch.async_turn_on()
 
     coord._cmd_svc.apply_position.assert_not_called()
+    assert coord.state_change is True
+    coord.async_refresh.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_turn_on_automatic_control_outside_time_window_still_signals():
+    """Outside the time window the switch still signals; the gate lives downstream.
+
+    Issue #352: the time-window skip now lives in ``async_handle_state_change``
+    (coordinator.py:1329-1337), not in the switch. The switch unconditionally
+    sets ``state_change=True`` so the coordinator gets a chance to evaluate
+    and decide whether to dispatch.
+    """
+    coord = _make_coordinator()
+    coord.entities = ["cover.test_1"]
+    coord.manager.is_cover_manual.return_value = False
+    coord.check_adaptive_time = False  # gate enforced inside the refresh
+    coord.state_change = False
+
+    switch = _make_switch(key="automatic_control", coordinator=coord)
+    await switch.async_turn_on()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    assert coord.state_change is True
     coord.async_refresh.assert_called_once()
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_turn_on_with_added_kwarg_skips_position_send():
-    """Turn on with added=True does not send positions (startup init path)."""
+    """Restore-from-state (added=True) must NOT signal state_change.
+
+    Startup-restore reconstructs auto_control's last state and must not
+    perturb the coordinator's dispatch flag — the first refresh has its own
+    path (``async_handle_first_refresh``).
+    """
     coord = _make_coordinator()
     coord.entities = ["cover.test_1"]
+    coord.state_change = False
 
     switch = _make_switch(key="automatic_control", coordinator=coord)
     await switch.async_turn_on(added=True)
 
     coord._cmd_svc.apply_position.assert_not_called()
+    assert coord.state_change is False
     coord.async_refresh.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
When the `automatic_control` switch flipped OFF→ON, the switch dispatched the cached `coordinator.state` (a stale out-of-window DefaultHandler position, typically open=100) before `async_refresh()`. The refresh did not set `state_change=True`, so the freshly computed solar position was never dispatched — it had to wait for the next periodic window-transition tick. The user saw the blind open fully at the start of the time window, then close to the correct solar position seconds later.

The fix sets `coordinator.state_change = True` before `async_refresh()`, routing dispatch through the coordinator's existing `async_handle_state_change` path. This is the same idiom the weather, motion, and window-open callers already use (`coordinator.py:602, 637, 2187`).

## Testing
- ✅ 3425 tests passing
- ✅ 3 new regression tests in `tests/test_issue_352_auto_control_on_uses_fresh_solar.py` cover the post-refresh dispatch, the signal-only switch contract, and the outside-time-window gate
- ✅ Re-Red checkpoint: stashing the switch.py change makes the regression tests fail with the exact bug signature

## Related Issues
Refs #352