### PR TITLE
fix: let user commands above custom-position floor pass through

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -107,6 +107,7 @@ from .pipeline.handlers import (
 )
 from .pipeline.registry import PipelineRegistry
 from .pipeline.snapshot_builder import PipelineSnapshotBuilder
+from .pipeline.types import CustomPositionSensorState
 from .enums import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
 from .state.cover_provider import CoverProvider
@@ -158,6 +159,26 @@ class AdaptiveCoverData:
     states: dict
     attributes: dict
     diagnostics: dict | None = None
+
+
+def _winner_is_satisfied_custom_floor(
+    winner_handler: object,
+    states: list[CustomPositionSensorState],
+    clamped: int,
+) -> bool:
+    """Return True when the winning handler is a min-mode custom-position floor that the user's clamped request already satisfies."""
+    if not isinstance(winner_handler, CustomPositionHandler):
+        return False
+    matching = next(
+        (s for s in states if s.entity_id == winner_handler._entity_id),
+        None,
+    )
+    return (
+        matching is not None
+        and matching.is_on
+        and matching.min_mode
+        and clamped >= matching.position
+    )
 
 
 class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
@@ -1827,7 +1848,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 winner_priority = (
                     winner_handler.priority if winner_handler is not None else 0
                 )
-                if winner_priority > ManualOverrideHandler.priority:
+                if _winner_is_satisfied_custom_floor(winner_handler, states, clamped):
+                    pass  # fall through to mark_user_command + dispatch
+                elif winner_priority > ManualOverrideHandler.priority:
                     _LOGGER.info(
                         "user move on %s preempted by %s (priority %d > %d)",
                         entity_id,

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -14,6 +14,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.manual_override import (
     ManualOverrideHandler,
 )
@@ -59,6 +62,7 @@ def _make_coord(
     default_options=None,
     winner_name: str = "solar",
     winner_priority: int = 40,
+    winner_handler_instance=None,
 ):
     """Build a coordinator-shaped mock that exposes async_apply_user_position.
 
@@ -103,9 +107,12 @@ def _make_coord(
     )
 
     # Handler lookup so the helper can resolve priority from the winner step.
-    handler = MagicMock()
-    handler.priority = winner_priority
-    coord._handler_by_name = {winner_name: handler}
+    if winner_handler_instance is not None:
+        coord._handler_by_name = {winner_name: winner_handler_instance}
+    else:
+        handler = MagicMock()
+        handler.priority = winner_priority
+        coord._handler_by_name = {winner_name: handler}
 
     # Manager for manual-override engagement.
     coord.manager = MagicMock()
@@ -348,3 +355,158 @@ async def test_preempted_skip_recorded_in_last_skipped_action() -> None:
 def test_manual_override_priority_constant_unchanged() -> None:
     """Locks in ManualOverrideHandler.priority=80 so the preemption cutoff stays correct."""
     assert ManualOverrideHandler.priority == 80
+
+
+# ---------------------------------------------------------------------------
+# Custom-position min-mode floor interaction with async_apply_user_position
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_custom_position_min_mode_does_not_preempt_request_above_floor() -> None:
+    """When the winning custom-position handler is a min-mode floor and the user
+    requests a position at or above that floor, the command must NOT be preempted.
+    """
+    handler = CustomPositionHandler(
+        slot=1, entity_id="binary_sensor.cp1", position=60, priority=95
+    )
+    state = CustomPositionSensorState(
+        entity_id="binary_sensor.cp1",
+        is_on=True,
+        position=60,
+        priority=95,
+        min_mode=True,
+        use_my=False,
+    )
+    coord, ctx = _make_coord(
+        [state],
+        winner_name="custom_position_1",
+        winner_priority=95,
+        winner_handler_instance=handler,
+    )
+    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
+        "custom_position_1", 95, position=60
+    )
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 90, trigger="set_position"
+    )
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 90, "set_position", ctx
+    )
+    coord._cmd_svc.record_preempted_skip.assert_not_called()
+    assert outcome == ("sent", "set_cover_position")
+
+
+@pytest.mark.asyncio
+async def test_custom_position_min_mode_clamps_and_dispatches_request_below_floor() -> (
+    None
+):
+    """When the winning custom-position handler is a min-mode floor and the user
+    requests below that floor, the command is clamped to the floor and dispatched
+    (NOT preempted).
+    """
+    handler = CustomPositionHandler(
+        slot=1, entity_id="binary_sensor.cp1", position=60, priority=95
+    )
+    state = CustomPositionSensorState(
+        entity_id="binary_sensor.cp1",
+        is_on=True,
+        position=60,
+        priority=95,
+        min_mode=True,
+        use_my=False,
+    )
+    coord, ctx = _make_coord(
+        [state],
+        winner_name="custom_position_1",
+        winner_priority=95,
+        winner_handler_instance=handler,
+    )
+    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
+        "custom_position_1", 95, position=60
+    )
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 40, trigger="set_position"
+    )
+
+    coord._cmd_svc.apply_position.assert_awaited_once_with(
+        "cover.test", 60, "set_position", ctx
+    )
+    coord._cmd_svc.record_preempted_skip.assert_not_called()
+    assert outcome == ("sent", "set_cover_position")
+
+
+@pytest.mark.asyncio
+async def test_custom_position_exact_mode_still_preempts() -> None:
+    """When the winning custom-position handler is NOT in min-mode, it preempts
+    as before — the new exception must not fire.
+    """
+    handler = CustomPositionHandler(
+        slot=1, entity_id="binary_sensor.cp1", position=60, priority=95
+    )
+    state = CustomPositionSensorState(
+        entity_id="binary_sensor.cp1",
+        is_on=True,
+        position=60,
+        priority=95,
+        min_mode=False,
+        use_my=False,
+    )
+    coord, _ctx = _make_coord(
+        [state],
+        winner_name="custom_position_1",
+        winner_priority=95,
+        winner_handler_instance=handler,
+    )
+    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
+        "custom_position_1", 95, position=60
+    )
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 70, trigger="set_position"
+    )
+
+    assert outcome == ("skipped", "preempted_by_custom_position_1")
+    coord._cmd_svc.record_preempted_skip.assert_called_once()
+    coord._cmd_svc.apply_position.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_custom_position_min_mode_preempts_when_request_below_floor_and_handler_is_different_slot() -> (
+    None
+):
+    """When the winning handler is a different slot than the active min-mode
+    sensor state, the handler is not satisfied — preemption applies as normal.
+    """
+    handler = CustomPositionHandler(
+        slot=2, entity_id="binary_sensor.cp2", position=60, priority=95
+    )
+    # Only slot 1 is in the state list — slot 2's entity_id is absent
+    state = CustomPositionSensorState(
+        entity_id="binary_sensor.cp1",
+        is_on=True,
+        position=60,
+        priority=95,
+        min_mode=True,
+        use_my=False,
+    )
+    coord, _ctx = _make_coord(
+        [state],
+        winner_name="custom_position_2",
+        winner_priority=95,
+        winner_handler_instance=handler,
+    )
+    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
+        "custom_position_2", 95, position=60
+    )
+
+    outcome = await coord.async_apply_user_position(
+        "cover.test", 90, trigger="set_position"
+    )
+
+    assert outcome == ("skipped", "preempted_by_custom_position_2")
+    coord._cmd_svc.record_preempted_skip.assert_called_once()
+    coord._cmd_svc.apply_position.assert_not_awaited()


### PR DESCRIPTION
## Summary
- `async_apply_user_position` previously dropped any user command when a custom-position handler with priority > `ManualOverrideHandler.priority` (80) won the pipeline — including min-mode handlers where the requested position already respected the floor.
- The coordinator now checks whether the winning handler is a `CustomPositionHandler` with `min_mode=True` and `clamped >= state.position`. If so, the user command falls through to dispatch rather than being preempted.
- Min-mode now matches the UI description: it acts as a permissive floor, not a forced-exact target.

## Testing
- ✅ 4 new tests in `tests/test_coordinator_apply_user_position.py` covering: request above floor (now passes), request below floor (clamped + dispatched), exact-mode preservation, slot-mismatch boundary.
- ✅ Scoped suite (`test_coordinator_apply_user_position` + `test_pipeline/test_custom_position_handler` + `cover/test_proxy_preemption_integration`): 65 passing.
- ✅ Full suite: 3444 passing, 0 failed.

## Related Issues
Refs #416