### PR TITLE
fix: gate cloud suppression on direct_sun_valid (#417)

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -36,6 +36,8 @@ class CloudSuppressionHandler(OverrideHandler):
             return None
         if not snapshot.climate_options.cloud_suppression_enabled:
             return None
+        if not snapshot.cover.direct_sun_valid:
+            return None
 
         r = snapshot.climate_readings
         triggers = []
@@ -74,4 +76,6 @@ class CloudSuppressionHandler(OverrideHandler):
         """Reason when cloud suppression is not active."""
         if not snapshot.in_time_window:
             return "outside time window"
+        if not snapshot.cover.direct_sun_valid:
+            return "cloud suppression skipped (sun outside window FOV)"
         return "cloud suppression inactive (direct sun present or feature disabled)"

--- a/tests/test_cloud_suppression.py
+++ b/tests/test_cloud_suppression.py
@@ -55,7 +55,7 @@ def _is_cloud_suppression_active(
     cloud_suppression_enabled: bool,
     weather_readings: ClimateReadings | None,
 ) -> bool:
-    """Replicate coordinator._is_cloud_suppression_active() logic for unit testing."""
+    """Check if cloud suppression is active based on conditions."""
     if not cloud_suppression_enabled:
         return False
     if weather_readings is None:
@@ -361,10 +361,37 @@ class TestCloudSuppressionPipelineIntegration:
         result = registry.evaluate(snapshot)
         assert result.control_method == ControlMethod.MANUAL
 
+    def test_default_wins_when_cloud_trigger_active_but_sun_outside_fov(self) -> None:
+        """DefaultHandler wins when cloud trigger fires but sun is outside the FOV.
+
+        Regression for issue #417: CloudSuppressionHandler used to ignore
+        direct_sun_valid and send the cover to cloudy_position / default_position
+        even when the sun was geometrically outside the window's field of view.
+        """
+        registry = self._make_registry()
+        snapshot = make_snapshot(
+            direct_sun_valid=False,
+            default_position=60,
+            climate_readings=make_weather_readings(is_sunny=False),
+            climate_options=ClimateOptions(
+                temp_low=None,
+                temp_high=None,
+                temp_switch=True,
+                transparent_blind=False,
+                temp_summer_outside=None,
+                cloud_suppression_enabled=True,
+                winter_close_insulation=False,
+            ),
+        )
+        result = registry.evaluate(snapshot)
+        assert result.control_method == ControlMethod.DEFAULT
+        assert result.position == 60
+
     def test_cloud_suppression_overrides_climate(self) -> None:
         """Cloud suppression (priority 60) fires before climate handler (priority 50)."""
         registry = self._make_registry()
         snapshot = make_snapshot(
+            direct_sun_valid=True,
             climate_mode_enabled=True,
             default_position=70,
             climate_readings=make_weather_readings(is_sunny=False),
@@ -408,8 +435,9 @@ class TestCloudyPosition:
         return CloudSuppressionHandler()
 
     def test_returns_cloudy_position_when_configured(self) -> None:
-        """Handler returns cloudy_position when set and cloud triggers fire."""
+        """Handler returns cloudy_position when set and cloud triggers fire (sun in FOV)."""
         snapshot = make_snapshot(
+            direct_sun_valid=True,
             default_position=60,
             is_sunset_active=False,
             climate_readings=make_weather_readings(is_sunny=False),
@@ -423,8 +451,9 @@ class TestCloudyPosition:
         assert "85%" in result.reason
 
     def test_falls_back_to_default_when_cloudy_position_none(self) -> None:
-        """Handler falls back to default_position when cloudy_position is None."""
+        """Handler falls back to default_position when cloudy_position is None (sun in FOV)."""
         snapshot = make_snapshot(
+            direct_sun_valid=True,
             default_position=60,
             is_sunset_active=False,
             climate_readings=make_weather_readings(is_sunny=False),
@@ -446,8 +475,9 @@ class TestCloudyPosition:
         assert self._handler().evaluate(snapshot) is None
 
     def test_sunset_active_overrides_cloudy_position(self) -> None:
-        """Sunset position wins over cloudy_position when sunset window is active."""
+        """Sunset position wins over cloudy_position when sunset window is active (sun in FOV)."""
         snapshot = make_snapshot(
+            direct_sun_valid=True,
             default_position=10,
             is_sunset_active=True,
             climate_readings=make_weather_readings(is_sunny=False),
@@ -460,7 +490,7 @@ class TestCloudyPosition:
         assert "cloudy position" not in result.reason
 
     def test_cloudy_position_respects_max_position_limit(self) -> None:
-        """Max position limit clamps cloudy_position."""
+        """Max position limit clamps cloudy_position (sun in FOV)."""
         from unittest.mock import MagicMock
 
         cfg = MagicMock()
@@ -468,7 +498,7 @@ class TestCloudyPosition:
         cfg.max_pos = 70
         cfg.min_pos_sun_only = False
         cfg.max_pos_sun_only = False
-        cover = _make_mock_cover(config=cfg)
+        cover = _make_mock_cover(direct_sun_valid=True, config=cfg)
         snapshot = make_snapshot(
             cover=cover,
             default_position=60,
@@ -481,7 +511,7 @@ class TestCloudyPosition:
         assert result.position == 70
 
     def test_cloudy_position_respects_min_position_limit(self) -> None:
-        """Min position limit clamps cloudy_position."""
+        """Min position limit clamps cloudy_position (sun in FOV)."""
         from unittest.mock import MagicMock
 
         cfg = MagicMock()
@@ -489,7 +519,7 @@ class TestCloudyPosition:
         cfg.max_pos = None
         cfg.min_pos_sun_only = False
         cfg.max_pos_sun_only = False
-        cover = _make_mock_cover(config=cfg)
+        cover = _make_mock_cover(direct_sun_valid=True, config=cfg)
         snapshot = make_snapshot(
             cover=cover,
             default_position=60,

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -81,8 +81,9 @@ class TestCloudSuppressionHandler:
         assert self.handler.evaluate(snap) is None
 
     def test_activates_when_not_sunny(self) -> None:
-        """Activate when weather state is not sunny."""
+        """Activate when weather state is not sunny and sun is within FOV."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=False),
             climate_options=_make_options(enabled=True),
             default_position=30,
@@ -93,8 +94,9 @@ class TestCloudSuppressionHandler:
         assert result.position == 30
 
     def test_activates_when_lux_below_threshold(self) -> None:
-        """Activate when lux is below the configured threshold."""
+        """Activate when lux is below the configured threshold and sun is within FOV."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=True, lux_below_threshold=True),
             climate_options=_make_options(enabled=True),
         )
@@ -103,8 +105,9 @@ class TestCloudSuppressionHandler:
         assert result.control_method == ControlMethod.CLOUD
 
     def test_activates_when_irradiance_below_threshold(self) -> None:
-        """Activate when solar irradiance is below threshold."""
+        """Activate when solar irradiance is below threshold and sun is within FOV."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(
                 is_sunny=True, irradiance_below_threshold=True
             ),
@@ -115,8 +118,9 @@ class TestCloudSuppressionHandler:
         assert result.control_method == ControlMethod.CLOUD
 
     def test_activates_when_cloud_coverage_above_threshold(self) -> None:
-        """Activate when cloud coverage sensor exceeds threshold."""
+        """Activate when cloud coverage sensor exceeds threshold and sun is within FOV."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(cloud_coverage_above_threshold=True),
             climate_options=_make_options(enabled=True),
         )
@@ -125,8 +129,9 @@ class TestCloudSuppressionHandler:
         assert result.control_method == ControlMethod.CLOUD
 
     def test_returns_default_position(self) -> None:
-        """Return snapshot.default_position when suppressing."""
+        """Return snapshot.default_position when suppressing (sun within FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=False),
             climate_options=_make_options(enabled=True),
             default_position=55,
@@ -204,8 +209,9 @@ class TestCloudHandlerTimeWindow:
         )
 
     def test_returns_result_inside_time_window(self) -> None:
-        """Cloud suppression should activate when inside the time window."""
+        """Cloud suppression should activate when inside the time window and sun in FOV."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=False),
             climate_options=_make_options(enabled=True),
             default_position=30,
@@ -248,8 +254,9 @@ class TestCloudHandlerReasonString:
     handler = CloudSuppressionHandler()
 
     def test_reason_includes_weather_not_sunny(self) -> None:
-        """Reason must mention 'weather not sunny' when is_sunny is False."""
+        """Reason must mention 'weather not sunny' when is_sunny is False (sun in FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=False),
             climate_options=_make_options(enabled=True),
         )
@@ -258,8 +265,9 @@ class TestCloudHandlerReasonString:
         assert "weather not sunny" in result.reason
 
     def test_reason_includes_lux_below_threshold(self) -> None:
-        """Reason must mention 'lux below threshold' when lux fires."""
+        """Reason must mention 'lux below threshold' when lux fires (sun in FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=True, lux_below_threshold=True),
             climate_options=_make_options(enabled=True),
         )
@@ -268,8 +276,9 @@ class TestCloudHandlerReasonString:
         assert "lux below threshold" in result.reason
 
     def test_reason_includes_irradiance_below_threshold(self) -> None:
-        """Reason must mention 'irradiance below threshold' when irradiance fires."""
+        """Reason must mention 'irradiance below threshold' when irradiance fires (sun in FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(
                 is_sunny=True, irradiance_below_threshold=True
             ),
@@ -280,8 +289,9 @@ class TestCloudHandlerReasonString:
         assert "irradiance below threshold" in result.reason
 
     def test_reason_includes_cloud_coverage_above_threshold(self) -> None:
-        """Reason must mention 'cloud coverage above threshold' when cloud fires."""
+        """Reason must mention 'cloud coverage above threshold' when cloud fires (sun in FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(
                 is_sunny=True, cloud_coverage_above_threshold=True
             ),
@@ -292,8 +302,9 @@ class TestCloudHandlerReasonString:
         assert "cloud coverage above threshold" in result.reason
 
     def test_reason_lists_multiple_triggers(self) -> None:
-        """When multiple conditions fire, all should appear in the reason string."""
+        """When multiple conditions fire, all should appear in the reason string (sun in FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(
                 is_sunny=False,
                 lux_below_threshold=True,
@@ -308,11 +319,82 @@ class TestCloudHandlerReasonString:
         assert "cloud coverage above threshold" in result.reason
 
     def test_reason_does_not_say_no_direct_sun_detected(self) -> None:
-        """Old generic phrase 'no direct sun detected' must not appear (Issue #222)."""
+        """Old generic phrase 'no direct sun detected' must not appear (Issue #222, sun in FOV)."""
         snap = make_snapshot(
+            direct_sun_valid=True,
             climate_readings=_make_readings(is_sunny=False),
             climate_options=_make_options(enabled=True),
         )
         result = self.handler.evaluate(snap)
         assert result is not None
         assert "no direct sun detected" not in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Issue #417 — CloudSuppressionHandler must respect direct_sun_valid (FOV gate)
+# ---------------------------------------------------------------------------
+
+
+class TestCloudHandlerFOVGate:
+    """CloudSuppressionHandler must return None when sun is outside the window FOV.
+
+    Before the fix, CloudSuppressionHandler ignored ``snapshot.cover.direct_sun_valid``
+    and would override normal pipeline behaviour (sending the cover to default/cloudy
+    position) even when the sun was geometrically outside the window's field of view.
+    In that scenario, the cloud trigger is irrelevant — the solar handler would already
+    have passed, so cloud suppression firing causes incorrect behaviour.
+    """
+
+    handler = CloudSuppressionHandler()
+
+    def test_returns_none_when_cloud_trigger_active_but_sun_outside_fov(self) -> None:
+        """Cloud-based trigger must not fire when sun is outside the window FOV.
+
+        Regression for issue #417: weather 'not sunny' triggered cloud suppression
+        even when direct_sun_valid=False (sun geometrically outside the FOV).
+        """
+        snap = make_snapshot(
+            direct_sun_valid=False,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            default_position=80,
+        )
+        assert self.handler.evaluate(snap) is None
+
+    def test_returns_none_when_lux_trigger_active_but_sun_outside_fov(self) -> None:
+        """Lux-based trigger must not fire when sun is outside the window FOV.
+
+        Regression for issue #417: lux below threshold triggered cloud suppression
+        even when direct_sun_valid=False (sun geometrically outside the FOV).
+        """
+        snap = make_snapshot(
+            direct_sun_valid=False,
+            climate_readings=_make_readings(is_sunny=True, lux_below_threshold=True),
+            climate_options=_make_options(enabled=True),
+        )
+        assert self.handler.evaluate(snap) is None
+
+    def test_still_activates_when_cloud_trigger_active_and_sun_in_fov(self) -> None:
+        """Cloud suppression fires normally when sun IS within the window FOV."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            default_position=80,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.CLOUD
+
+    def test_describe_skip_mentions_fov_when_sun_outside_fov(self) -> None:
+        """describe_skip() must mention FOV when sun is outside the window FOV."""
+        snap = make_snapshot(
+            direct_sun_valid=False,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            in_time_window=True,
+        )
+        reason = self.handler.describe_skip(snap)
+        assert (
+            "fov" in reason.lower()
+        ), f"Expected 'fov' in describe_skip reason but got: {reason!r}"


### PR DESCRIPTION
## Summary
CloudSuppressionHandler was firing even when the sun was outside the window's field of view, sending the cover to cloudy_position or the default_position when the pipeline should have fallen through to DefaultHandler. The most damaging case: with a configured `cloudy_position` (e.g., 80%), the cover physically moved to 80% at dusk when the sun was already behind the building.

Added `if not snapshot.cover.direct_sun_valid: return None` to `CloudSuppressionHandler.evaluate()` — mirroring the gate already used by `solar.py`, `glare_zone.py`, `motion_timeout.py`, and `climate.py`. Updated `describe_skip()` to return a distinct reason ("cloud suppression skipped (sun outside window FOV)") so the decision trace is accurate.

## Testing
- ✅ 531 tests passing (-k "cloud_suppression or pipeline")
- New `TestCloudHandlerFOVGate` covers both branches of the guard plus the new describe_skip reason
- New `test_default_wins_when_cloud_trigger_active_but_sun_outside_fov` integration regression in `TestCloudSuppressionPipelineIntegration` confirms DefaultHandler wins end-to-end

## Related Issues
Refs #417