### PR TITLE
fix: honor in-transit guard during reconciliation (#418)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1535,6 +1535,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self.manual_threshold,
                 secondary_axis_check=secondary_axis_check,
                 is_in_command_grace=self._grace_mgr.is_in_command_grace_period,
+                is_in_transit=self._cmd_svc._is_cover_in_transit,
             )
             # When a cover transitions into manual override, discard any
             # pre-existing integration target (including safety-tagged

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -153,7 +153,12 @@ class CoverCommandService:
         # try_stop_one orchestration. The EVENT_CALL_SERVICE listener in the
         # coordinator uses ``was_acp_stop_context`` to distinguish our own stop
         # commands from user-initiated stops.
-        self._stop_tracker = StopTracker(hass, logger, dry_run_fn=lambda: self._dry_run)
+        self._stop_tracker = StopTracker(
+            hass,
+            logger,
+            dry_run_fn=lambda: self._dry_run,
+            is_in_transit_fn=self._is_cover_in_transit,
+        )
 
         # Position-context tracker mirrors the stop tracker for the
         # set_cover_position / open_cover / close_cover service calls. The
@@ -780,6 +785,17 @@ class CoverCommandService:
         """
         return self._get_current_position(entity)
 
+    def _is_cover_in_transit(self, entity_id: str) -> bool:
+        """Return True when HA reports the cover as actively opening or closing.
+
+        Used as a shared predicate by the reconciliation pass and delegated to
+        by StopTracker.is_cover_in_motion, keeping the in-transit definition in
+        a single place. Callers that need to guard against stale position reads
+        during a transit move delegate here rather than inlining the state check.
+        """
+        state_obj = self._hass.states.get(entity_id)
+        return state_obj is not None and state_obj.state in ("opening", "closing")
+
     # ------------------------------------------------------------------ #
     # Gate checks (used internally by apply_position)
     # ------------------------------------------------------------------ #
@@ -1216,7 +1232,33 @@ class CoverCommandService:
                 )
                 continue
 
-            # 5. Read actual position
+            # 5. Skip entities that are actively moving — HA's reported position
+            # can lag the physical position during a transit, so a retry sent
+            # now would race the in-flight command and produce a double-move.
+            # The cover will emit another state-change event when it stops;
+            # that tick runs the full reconciliation path.
+            if self._is_cover_in_transit(entity_id):
+                cover_state = getattr(
+                    self._hass.states.get(entity_id), "state", "unknown"
+                )
+                self._logger.debug(
+                    "Reconcile: %s in transit (state=%s) — skipping resend",
+                    entity_id,
+                    cover_state,
+                )
+                if self._event_buffer is not None:
+                    self._event_buffer.record(
+                        {
+                            "ts": dt.datetime.now(dt.UTC).isoformat(),
+                            "event": "reconcile_skipped_in_transit",
+                            "entity_id": entity_id,
+                            "target_position": target,
+                            "cover_state": cover_state,
+                        }
+                    )
+                continue
+
+            # 6. Read actual position
             actual = self._get_current_position(entity_id)
             if actual is None:
                 self._logger.debug(
@@ -1224,7 +1266,7 @@ class CoverCommandService:
                 )
                 continue
 
-            # 6. Check match
+            # 7. Check match
             if abs(actual - target) <= self._position_tolerance:
                 s.retry_count = 0
                 self._logger.debug(
@@ -1235,7 +1277,7 @@ class CoverCommandService:
                 )
                 continue
 
-            # 7. Mismatch — retry up to max_retries
+            # 8. Mismatch — retry up to max_retries
             if s.retry_count >= self._max_retries:
                 if not s.gave_up:
                     # Log warning exactly once; subsequent ticks are silent

--- a/custom_components/adaptive_cover_pro/managers/cover_command/stop.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/stop.py
@@ -37,6 +37,7 @@ class StopTracker:
         logger,
         *,
         dry_run_fn: Callable[[], bool],
+        is_in_transit_fn: Callable[[str], bool] | None = None,
     ) -> None:
         """Initialize the StopTracker.
 
@@ -46,12 +47,27 @@ class StopTracker:
             dry_run_fn: Zero-arg callable returning the current dry-run flag.
                 Captured as a callable rather than a snapshot so the
                 tracker always reflects the orchestrator's live setting.
+            is_in_transit_fn: Optional callable ``(entity_id) -> bool`` that
+                returns True when HA reports the cover as opening or closing.
+                Defaults to an inline check when omitted (standalone use).
+                ``CoverCommandService`` supplies ``self._is_cover_in_transit``
+                so the transit predicate lives in exactly one place.
 
         """
         self._hass = hass
         self._logger = logger
         self._dry_run_fn = dry_run_fn
+        self._is_in_transit_fn: Callable[[str], bool] = (
+            is_in_transit_fn
+            if is_in_transit_fn is not None
+            else self._default_in_transit
+        )
         self._acp_stop_contexts: deque[str] = deque(maxlen=self._CONTEXT_HISTORY_SIZE)
+
+    def _default_in_transit(self, entity_id: str) -> bool:
+        """Inline fallback when no external predicate is injected."""
+        state_obj = self._hass.states.get(entity_id)
+        return state_obj is not None and state_obj.state in ("opening", "closing")
 
     # ------------------------------------------------------------------ #
     # Context tracking
@@ -85,11 +101,12 @@ class StopTracker:
         Note: ``send_my_position`` intentionally does NOT call this method —
         it deliberately sends stop_cover to a stationary cover (that is what
         triggers the My preset). This gate applies to shutdown paths only.
+
+        Delegates to the injected ``is_in_transit_fn`` (supplied by
+        ``CoverCommandService`` as ``self._is_cover_in_transit``) so the
+        transit predicate lives in one place.
         """
-        state_obj = self._hass.states.get(entity_id)
-        if state_obj is None:
-            return False
-        return state_obj.state in ("opening", "closing")
+        return self._is_in_transit_fn(entity_id)
 
     async def call_stop_cover(self, entity_id: str) -> None:
         """Issue cover.stop_cover and record the call context as ACP-originated.

--- a/custom_components/adaptive_cover_pro/managers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override.py
@@ -216,6 +216,7 @@ class AdaptiveCoverManager:
         *,
         secondary_axis_check: SecondaryAxisCheck | None = None,
         is_in_command_grace: Callable[[str], bool] | None = None,
+        is_in_transit: Callable[[str], bool] | None = None,
     ):
         """Process state change for manual override.
 
@@ -244,6 +245,13 @@ class AdaptiveCoverManager:
                 suppressed — the position change is the cover responding to
                 the ACP command, not a user touch.  Supplied by the coordinator
                 via ``GracePeriodManager.is_in_command_grace_period``.
+            is_in_transit: Optional callable ``(entity_id) -> bool`` returning
+                True when HA reports the cover state as ``opening`` or
+                ``closing``.  When True, the position-axis check is skipped
+                because ``current_position`` lags the physical position during
+                travel (issue #271).  Supplied by the coordinator via
+                ``CoverCommandService._is_cover_in_transit`` so the predicate
+                lives in one place.
 
         """
         event = states_data
@@ -323,8 +331,8 @@ class AdaptiveCoverManager:
         # look like a stale-position event with state=closing/opening.
         # Wait for the next event when the cover stops; that event runs
         # the full position-math path.
-        new_state_str = getattr(new_state, "state", None)
-        if new_state_str in ("opening", "closing"):
+        if is_in_transit is not None and is_in_transit(entity_id):
+            new_state_str = getattr(new_state, "state", "unknown")
             self._record_event(
                 entity_id,
                 "manual_override_rejected_in_transit",

--- a/tests/test_issue_271_slow_cover_transit_false_override.py
+++ b/tests/test_issue_271_slow_cover_transit_false_override.py
@@ -538,15 +538,29 @@ class TestInTransitGuard:
         event.new_state.last_updated = dt.datetime.now(dt.UTC)
         return event
 
-    def _make_manager(self, entity_id: str):
+    def _make_manager(self, entity_id: str, initial_state_str: str = "open"):
         from custom_components.adaptive_cover_pro.managers.manual_override import (
             AdaptiveCoverManager,
         )
 
+        # Provide a mutable state holder so tests can configure what
+        # hass.states.get(entity_id) returns. The transit predicate the
+        # coordinator passes to handle_state_change reads from hass.states;
+        # tests build the same predicate and pass it as a per-call kwarg.
+        hass = MagicMock()
+        state_holder = MagicMock()
+        state_holder.state = initial_state_str
+        hass.states.get.return_value = state_holder
+
         manager = AdaptiveCoverManager(
-            hass=MagicMock(),
+            hass=hass,
             reset_duration={"hours": 1},
             logger=MagicMock(),
+        )
+        manager._hass_state_holder = state_holder  # expose for per-test updates
+        manager._test_is_in_transit = lambda eid: (
+            hass.states.get(eid) is not None
+            and hass.states.get(eid).state in ("opening", "closing")
         )
         manager.add_covers([entity_id])
         return manager
@@ -562,7 +576,7 @@ class TestInTransitGuard:
         from custom_components.adaptive_cover_pro.cover_types import get_policy
 
         entity_id = "cover.patio_right_tv_shade"
-        manager = self._make_manager(entity_id)
+        manager = self._make_manager(entity_id, initial_state_str="closing")
         event = self._make_event(entity_id, current_position=100, state_str="closing")
 
         manager.handle_state_change(
@@ -572,6 +586,7 @@ class TestInTransitGuard:
             allow_reset=True,
             is_waiting=lambda _eid: False,
             manual_threshold=0,
+            is_in_transit=manager._test_is_in_transit,
         )
 
         assert not manager.is_cover_manual(entity_id), (
@@ -592,7 +607,7 @@ class TestInTransitGuard:
         from custom_components.adaptive_cover_pro.cover_types import get_policy
 
         entity_id = "cover.slow_open"
-        manager = self._make_manager(entity_id)
+        manager = self._make_manager(entity_id, initial_state_str="opening")
         event = self._make_event(entity_id, current_position=0, state_str="opening")
 
         manager.handle_state_change(
@@ -602,6 +617,7 @@ class TestInTransitGuard:
             allow_reset=True,
             is_waiting=lambda _eid: False,
             manual_threshold=0,
+            is_in_transit=manager._test_is_in_transit,
         )
 
         assert not manager.is_cover_manual(entity_id)
@@ -616,7 +632,7 @@ class TestInTransitGuard:
         from custom_components.adaptive_cover_pro.cover_types import get_policy
 
         entity_id = "cover.bedroom"
-        manager = self._make_manager(entity_id)
+        manager = self._make_manager(entity_id, initial_state_str="closing")
         policy = get_policy("cover_blind")
 
         in_transit = self._make_event(
@@ -629,11 +645,14 @@ class TestInTransitGuard:
             allow_reset=True,
             is_waiting=lambda _eid: False,
             manual_threshold=5,
+            is_in_transit=manager._test_is_in_transit,
         )
         assert not manager.is_cover_manual(
             entity_id
         ), "In-transit event must not have marked manual override"
 
+        # Advance the mocked HA state to reflect the cover settling
+        manager._hass_state_holder.state = "open"
         settled = self._make_event(entity_id, current_position=95, state_str="open")
         manager.handle_state_change(
             states_data=settled,
@@ -642,6 +661,7 @@ class TestInTransitGuard:
             allow_reset=True,
             is_waiting=lambda _eid: False,
             manual_threshold=5,
+            is_in_transit=manager._test_is_in_transit,
         )
         assert manager.is_cover_manual(entity_id), (
             "Settled event with current_position far from target must still "
@@ -665,6 +685,7 @@ class TestInTransitGuard:
             allow_reset=True,
             is_waiting=lambda _eid: False,
             manual_threshold=0,
+            is_in_transit=manager._test_is_in_transit,
         )
 
         assert not manager.is_cover_manual(entity_id)

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -928,6 +928,92 @@ def test_clear_non_safety_targets(svc):
     assert svc.is_safety_target("cover.safety")
 
 
+# ------------------------------------------------------------------ #
+# _reconcile — in-transit guard (issue #418)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_while_cover_opening(svc, mock_hass):
+    """Reconciliation must not resend a target while the cover reports state=opening.
+
+    Regression for issue #418: the reconcile pass did not honour the
+    in-transit guard that apply_position and manual_override already
+    respected. A cover that just received a command and is actively
+    opening would be incorrectly retried before it reached its target.
+    """
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    buf = EventBuffer(maxlen=20)
+    svc._event_buffer = buf
+
+    svc.set_target("cover.test", 50)
+    svc.set_waiting("cover.test", False)
+    _patch_position(svc, 30)  # Off target — would normally trigger retry
+
+    # Cover is actively moving toward the target
+    state_obj = MagicMock()
+    state_obj.state = "opening"
+    mock_hass.states.get.return_value = state_obj
+
+    await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_not_called()
+    event_names = [e["event"] for e in buf.snapshot()]
+    assert "reconcile_skipped_in_transit" in event_names
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_while_cover_closing(svc, mock_hass):
+    """Reconciliation must not resend a target while the cover reports state=closing."""
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    buf = EventBuffer(maxlen=20)
+    svc._event_buffer = buf
+
+    svc.set_target("cover.test", 10)
+    svc.set_waiting("cover.test", False)
+    _patch_position(svc, 70)  # Off target — would normally trigger retry
+
+    # Cover is actively closing toward the target
+    state_obj = MagicMock()
+    state_obj.state = "closing"
+    mock_hass.states.get.return_value = state_obj
+
+    await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_not_called()
+    event_names = [e["event"] for e in buf.snapshot()]
+    assert "reconcile_skipped_in_transit" in event_names
+
+
+@pytest.mark.asyncio
+async def test_reconcile_retries_stationary_off_target(svc, mock_hass):
+    """Reconciliation does retry a stationary cover that is off target.
+
+    Regression guard: the in-transit guard must not block retries for covers
+    that have stopped but not reached their target (state=stopped or similar).
+    """
+    svc.set_target("cover.test", 50)
+    svc.set_waiting("cover.test", False)
+    _patch_position(svc, 30)  # Off target
+
+    # Cover is stationary — not in transit
+    state_obj = MagicMock()
+    state_obj.state = "stopped"
+    mock_hass.states.get.return_value = state_obj
+
+    with _patch_caps():
+        await svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    mock_hass.services.async_call.assert_called_once()
+    assert svc.state("cover.test").retry_count == 1
+
+
 @pytest.mark.asyncio
 async def test_force_apply_bypasses_time_delta_gate(svc, mock_hass):
     """force=True must bypass time_delta_too_small so safety commands always get sent.


### PR DESCRIPTION
## Summary
- Extracts `CoverCommandService._is_cover_in_transit` as the single source of truth for the `state in ("opening","closing")` predicate that was previously inlined in three places.
- Adds an early-continue in `run_reconciliation_pass` that records a `reconcile_skipped_in_transit` event instead of re-sending `set_cover_position` mid-travel. Closes the race where an RF-remote press during a reconcile tick would be overridden by the integration.
- `StopTracker.is_cover_in_motion` and `AdaptiveCoverManager.handle_state_change` now delegate to the SSOT predicate; `handle_state_change` takes `is_in_transit` as a per-call kwarg matching the existing `is_in_command_grace` injection pattern.

## Testing
- ✅ 3469 tests passing (full suite)
- ✅ 3 new regression tests in `tests/test_position_reconciliation.py` (opening, closing, stationary off-target)
- ✅ `tests/test_issue_271_slow_cover_transit_false_override.py` updated for the new kwarg pattern; still green

## Related Issues
Refs #418