### PR TITLE
feat: card #60 support — slot snapshot, slot enable, position forecast

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -305,7 +305,7 @@ CUSTOM_POSITION_SLOT_NUMBERS: tuple[int, ...] = (1, 2, 3, 4)  # supported indice
 
 
 def _custom_position_slot_keys(n: int) -> dict[str, str]:
-    """Return the six wire-format option keys for slot *n*."""
+    """Return the seven wire-format option keys for slot *n*."""
     return {
         "sensor": f"custom_position_sensor_{n}",
         "position": f"custom_position_{n}",
@@ -313,7 +313,16 @@ def _custom_position_slot_keys(n: int) -> dict[str, str]:
         "min_mode": f"custom_position_min_mode_{n}",
         "use_my": f"custom_position_use_my_{n}",
         "tilt": f"custom_position_tilt_{n}",
+        # `enabled` is opt-out: existing entries lack the key and behave as
+        # enabled. Set to False to silence a slot without clearing its
+        # configuration — used by the companion card's slot toggle UI.
+        "enabled": f"custom_position_enabled_{n}",
     }
+
+
+# Default for an absent custom_position_enabled_<N> option — backwards-compatible
+# with entries configured before the enabled key existed.
+DEFAULT_CUSTOM_POSITION_ENABLED = True
 
 
 # {slot_number: {sub_key: wire_key}}

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -153,6 +153,9 @@ CONF_ENABLE_MAX_POSITION = "enable_max_position"
 CONF_ENABLE_MIN_POSITION = "enable_min_position"
 # Fallback position when no override applies, % (range 0-100).
 CONF_DEFAULT_HEIGHT = "default_percentage"
+# Effective default position when no `default_percentage` is configured.
+# 0 % = closed; matches the historical fallback in coordinator.get_blind_data.
+DEFAULT_DEFAULT_HEIGHT = 0
 CONF_INVERSE_STATE = "inverse_state"  # True if cover reports 0=open, 100=closed
 CONF_INVERSE_TILT = "inverse_tilt"  # True if tilt reports 0=open, 100=closed
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -71,6 +71,7 @@ from .const import (
     CONF_SUNSET_TIME_ENTITY,
     CONF_TRANSIT_TIMEOUT,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_ENABLED,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
@@ -1617,7 +1618,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
             sensor = options.get(slot_keys["sensor"])
             position = options.get(slot_keys["position"])
-            if sensor and position is not None:
+            enabled = bool(
+                options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED)
+            )
+            if sensor and position is not None and enabled:
                 priority = int(
                     options.get(slot_keys["priority"])
                     or DEFAULT_CUSTOM_POSITION_PRIORITY

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -1,0 +1,245 @@
+"""Forecast helpers: today's sun-vs-window timeline for the companion card.
+
+Walks the per-coordinator solar position table that ``SunData`` already
+computes for the current day and emits a coarse-grained series of
+(timestamp, position) samples plus the boundary events the dashboard
+needs (sunrise, sunset, FOV entry, FOV exit).
+
+Only solar tracking is projected forward — the other handlers in the
+pipeline (manual override, motion, weather safety, custom positions)
+depend on inherently real-time inputs and would mislead a forecast if
+naively held at their current state. Holding the geometry constant and
+walking the sun gives the user the answer to the question that matters
+most for a tile dashboard: *when will this window get direct sun next,
+and roughly where will the cover sit through the rest of the day?*
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+from collections.abc import Callable
+
+from .const import CONF_DEFAULT_HEIGHT, DEFAULT_DEFAULT_HEIGHT
+
+if TYPE_CHECKING:
+    from .coordinator import AdaptiveDataUpdateCoordinator
+    from .engine.covers.base import AdaptiveGeneralCover
+    from .sun import SunData
+
+
+# Forecast sampling cadence. 15-minute steps over a 12-hour window is dense
+# enough for the dashboard strip to read smoothly and cheap enough that the
+# computation finishes in well under a second on a Pi 4.
+FORECAST_STEP_MINUTES = 15
+FORECAST_WINDOW_HOURS = 12
+
+# Event kinds emitted on the forecast.
+EVENT_SUNRISE = "sunrise"
+EVENT_SUNSET = "sunset"
+EVENT_FOV_ENTER = "fov_enter"
+EVENT_FOV_EXIT = "fov_exit"
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastSample:
+    """One (time, position) pair on the forecast strip."""
+
+    t: datetime
+    position: int
+    handler: str  # "solar" when direct sun is valid at t, else "default"
+
+
+@dataclass(frozen=True, slots=True)
+class ForecastEvent:
+    """A boundary event on the forecast timeline."""
+
+    t: datetime
+    kind: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class Forecast:
+    """Result of :func:`build_forecast` — samples + events for one cover."""
+
+    samples: tuple[ForecastSample, ...]
+    events: tuple[ForecastEvent, ...]
+
+    def to_attrs(self) -> dict[str, list[dict]]:
+        """Serialize to the wire format the diagnostic sensor exposes.
+
+        Times become ISO 8601 strings so the Lovelace card can parse them
+        without a special date type.
+        """
+        return {
+            "forecast": [
+                {"t": s.t.isoformat(), "position": s.position, "handler": s.handler}
+                for s in self.samples
+            ],
+            "events": [
+                {"t": e.t.isoformat(), "kind": e.kind, "label": e.label}
+                for e in self.events
+            ],
+        }
+
+
+def build_forecast(
+    *,
+    sun_data: SunData,
+    cover_factory: Callable[[float, float], AdaptiveGeneralCover],
+    default_position: int,
+    now: datetime,
+    step_minutes: int = FORECAST_STEP_MINUTES,
+    window_hours: int = FORECAST_WINDOW_HOURS,
+) -> Forecast:
+    """Compute the forecast for one cover.
+
+    ``cover_factory`` is a closure that builds a cover engine for an
+    arbitrary (sol_azi, sol_elev) pair; the caller is responsible for
+    passing the same configuration / sun_data the live cover uses.
+    Decoupling the factory from this helper keeps the function pure and
+    trivially testable with a stub cover.
+    """
+    samples = _build_samples(
+        sun_data=sun_data,
+        cover_factory=cover_factory,
+        default_position=default_position,
+        now=now,
+        step_minutes=step_minutes,
+        window_hours=window_hours,
+    )
+    events = _build_events(sun_data=sun_data, samples=samples)
+    return Forecast(samples=tuple(samples), events=tuple(events))
+
+
+def _build_samples(
+    *,
+    sun_data: SunData,
+    cover_factory: Callable[[float, float], AdaptiveGeneralCover],
+    default_position: int,
+    now: datetime,
+    step_minutes: int,
+    window_hours: int,
+) -> list[ForecastSample]:
+    """Walk the sun_data table at *step_minutes* cadence for *window_hours*."""
+    times = list(sun_data.times)
+    azis = list(sun_data.solar_azimuth)
+    eles = list(sun_data.solar_elevation)
+    if not times:
+        return []
+    horizon = now + timedelta(hours=window_hours)
+    step = timedelta(minutes=step_minutes)
+
+    samples: list[ForecastSample] = []
+    t = now
+    while t <= horizon:
+        idx = _nearest_index(times, t)
+        if idx is None:
+            t += step
+            continue
+        azi = float(azis[idx])
+        ele = float(eles[idx])
+        cover = cover_factory(azi, ele)
+        if cover.direct_sun_valid:
+            samples.append(
+                ForecastSample(
+                    t=t, position=int(cover.calculate_percentage()), handler="solar"
+                )
+            )
+        else:
+            samples.append(
+                ForecastSample(t=t, position=int(default_position), handler="default")
+            )
+        t += step
+    return samples
+
+
+def _build_events(
+    *, sun_data: SunData, samples: list[ForecastSample]
+) -> list[ForecastEvent]:
+    """Sunrise/sunset come from SunData; FOV transitions come from the samples."""
+    events: list[ForecastEvent] = []
+    sunrise = sun_data.sunrise()
+    sunset = sun_data.sunset()
+    if sunrise is not None:
+        events.append(ForecastEvent(t=sunrise, kind=EVENT_SUNRISE, label="Sunrise"))
+    if sunset is not None:
+        events.append(ForecastEvent(t=sunset, kind=EVENT_SUNSET, label="Sunset"))
+
+    # FOV transitions: walk samples, emit an event when handler switches.
+    prev_handler: str | None = None
+    for sample in samples:
+        if prev_handler is None:
+            prev_handler = sample.handler
+            continue
+        if sample.handler == prev_handler:
+            continue
+        if sample.handler == "solar":
+            events.append(
+                ForecastEvent(t=sample.t, kind=EVENT_FOV_ENTER, label="Sun enters FOV")
+            )
+        else:
+            events.append(
+                ForecastEvent(t=sample.t, kind=EVENT_FOV_EXIT, label="Sun exits FOV")
+            )
+        prev_handler = sample.handler
+
+    return sorted(events, key=lambda e: e.t)
+
+
+def _nearest_index(times: list[datetime], target: datetime) -> int | None:
+    """Index of the time in *times* closest to *target* (linear scan, ~250 items).
+
+    Returns None when *times* is empty. The caller has already short-circuited
+    in that case, but the guard keeps this helper safe in isolation.
+    """
+    if not times:
+        return None
+    # Pandas DatetimeIndex entries are timezone-aware; convert target to match.
+    target_tz = target.tzinfo
+    if target_tz is None and times[0].tzinfo is not None:
+        target = target.replace(tzinfo=times[0].tzinfo)
+    best_idx = 0
+    best_delta = abs((times[0] - target).total_seconds())
+    for i, ts in enumerate(times):
+        delta = abs((ts - target).total_seconds())
+        if delta < best_delta:
+            best_idx = i
+            best_delta = delta
+    return best_idx
+
+
+def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
+    """Coordinator shim around :func:`build_forecast`.
+
+    Reads the coordinator's policy, sun provider, config service, and options
+    to drive the pure helper. Kept thin so unit tests can exercise the pure
+    function directly with stubs.
+    """
+    from homeassistant.util import dt as dt_util
+
+    options = coord.config_entry.options
+    sun_data = coord._sun_provider.create_sun_data(  # noqa: SLF001
+        coord.hass.config.time_zone
+    )
+    config = coord._config_service.get_common_data(options)  # noqa: SLF001
+
+    def make_cover(azi: float, ele: float) -> AdaptiveGeneralCover:
+        return coord._policy.build_calc_engine(  # noqa: SLF001
+            logger=coord.logger,
+            sol_azi=azi,
+            sol_elev=ele,
+            sun_data=sun_data,
+            config=config,
+            config_service=coord._config_service,  # noqa: SLF001
+            options=options,
+        )
+
+    return build_forecast(
+        sun_data=sun_data,
+        cover_factory=make_cover,
+        default_position=int(options.get(CONF_DEFAULT_HEIGHT, DEFAULT_DEFAULT_HEIGHT)),
+        now=dt_util.now(),
+    )

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.22.1-beta.2"
+  "version": "2.22.1-beta.3"
 }

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -85,6 +85,7 @@ class CustomPositionHandler(OverrideHandler):
                             raw_calculated_position=raw,
                             custom_position_active_slot=self._slot,
                             custom_position_minimum_mode=None,
+                            custom_position_active_slot_name=state.sensor_name,
                         )
                     pos, mode_note = apply_minimum_mode(
                         self._position, raw, enabled=state.min_mode
@@ -104,6 +105,7 @@ class CustomPositionHandler(OverrideHandler):
                         custom_position_minimum_mode=(
                             (raw < self._position) if state.min_mode else None
                         ),
+                        custom_position_active_slot_name=state.sensor_name,
                     )
                 # Sensor found but not active — pass through
                 return None

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -64,6 +64,7 @@ from ..const import (
     CONF_WEATHER_STATE,
     CONF_WINTER_CLOSE_INSULATION,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_ENABLED,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_MOTION_TIMEOUT_MODE,
 )
@@ -176,7 +177,10 @@ class PipelineSnapshotBuilder:
         for slot_keys in CUSTOM_POSITION_SLOTS.values():
             sensor = options.get(slot_keys["sensor"])
             position = options.get(slot_keys["position"])
-            if sensor and position is not None:
+            enabled = bool(
+                options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED)
+            )
+            if sensor and position is not None and enabled:
                 state = self._hass.states.get(sensor)
                 is_on = bool(state and state.state == "on")
                 sensor_name = (

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from collections.abc import Callable
 
+from homeassistant.const import ATTR_FRIENDLY_NAME
+
 from ..const import (
     CONF_CLOUD_COVERAGE_ENTITY,
     CONF_CLOUD_COVERAGE_THRESHOLD,
@@ -175,8 +177,10 @@ class PipelineSnapshotBuilder:
             sensor = options.get(slot_keys["sensor"])
             position = options.get(slot_keys["position"])
             if sensor and position is not None:
-                is_on = bool(
-                    (state := self._hass.states.get(sensor)) and state.state == "on"
+                state = self._hass.states.get(sensor)
+                is_on = bool(state and state.state == "on")
+                sensor_name = (
+                    state.attributes.get(ATTR_FRIENDLY_NAME) if state else None
                 )
                 priority = int(
                     options.get(slot_keys["priority"])
@@ -195,6 +199,7 @@ class PipelineSnapshotBuilder:
                         min_mode=min_mode,
                         use_my=use_my,
                         tilt=tilt,
+                        sensor_name=sensor_name,
                     )
                 )
         return result

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -49,6 +49,10 @@ class CustomPositionSensorState:
     min_mode: bool
     use_my: bool
     tilt: int | None = None
+    # Human label of the bound sensor (its friendly_name attribute), surfaced so
+    # downstream diagnostics can show e.g. "Custom · Table extension" instead of
+    # just "Custom #1". None when the sensor isn't loaded or has no friendly_name.
+    sensor_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -261,3 +265,7 @@ class PipelineResult:
     #   non-custom handler wins.
     custom_position_active_slot: int | None = None
     custom_position_minimum_mode: bool | None = None
+    # Human label of the winning slot's bound sensor (its friendly_name).
+    # None when the sensor isn't loaded, has no friendly_name, or when any
+    # non-custom handler wins.
+    custom_position_active_slot_name: str | None = None

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import ATTR_FRIENDLY_NAME, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -35,6 +35,8 @@ from .const import (
     CONF_WEATHER_SEVERE_SENSORS,
     CONF_WEATHER_WIND_SPEED_SENSOR,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_ENABLED,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEGREES_IN_CIRCLE,
     DOMAIN,
 )
@@ -767,6 +769,59 @@ def _configured_handlers(opts: Mapping[str, Any]) -> list[str]:
     return enabled
 
 
+def _build_custom_position_slots_snapshot(
+    options: Mapping[str, Any], hass: Any
+) -> list[dict[str, Any]]:
+    """Build a per-slot snapshot for the companion card's slot UI.
+
+    Always returns one row per slot (1-4) so the consumer can render a stable
+    grid. Rows for unconfigured slots have ``enabled=False`` with the other
+    fields nulled out — the card uses ``sensor is not None`` to tell
+    "configured but disabled" apart from "never configured".
+    """
+    snapshot: list[dict[str, Any]] = []
+    for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
+        sensor = options.get(slot_keys["sensor"])
+        position = options.get(slot_keys["position"])
+        configured = bool(sensor) and position is not None
+        sensor_name: str | None = None
+        if configured:
+            state = hass.states.get(sensor) if sensor else None
+            if state is not None:
+                sensor_name = state.attributes.get(ATTR_FRIENDLY_NAME)
+        snapshot.append(
+            {
+                "slot": slot,
+                "enabled": (
+                    bool(
+                        options.get(
+                            slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED
+                        )
+                    )
+                    if configured
+                    else False
+                ),
+                "sensor": sensor if configured else None,
+                "sensor_name": sensor_name,
+                "position": int(position) if configured else None,
+                "priority": (
+                    int(
+                        options.get(slot_keys["priority"])
+                        or DEFAULT_CUSTOM_POSITION_PRIORITY
+                    )
+                    if configured
+                    else None
+                ),
+                "min_mode": (
+                    bool(options.get(slot_keys["min_mode"], False))
+                    if configured
+                    else None
+                ),
+            }
+        )
+    return snapshot
+
+
 def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
     attrs: dict[str, Any] = {}
     result = s.coordinator._pipeline_result  # noqa: SLF001
@@ -804,6 +859,9 @@ def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
 
     attrs["in_time_window"] = s.coordinator.check_adaptive_time
     attrs["enabled_handlers"] = _configured_handlers(s.config_entry.options)
+    attrs["custom_position_slots"] = _build_custom_position_slots_snapshot(
+        s.config_entry.options, s.coordinator.hass
+    )
 
     diagnostics = s.coordinator.data.diagnostics if s.coordinator.data else {}
     if diagnostics:

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -793,6 +793,10 @@ def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
             attrs["custom_position_active_slot"] = result.custom_position_active_slot
         if result.custom_position_minimum_mode is not None:
             attrs["custom_position_minimum_mode"] = result.custom_position_minimum_mode
+        if result.custom_position_active_slot_name is not None:
+            attrs["custom_position_active_slot_name"] = (
+                result.custom_position_active_slot_name
+            )
         if result.control_method == ControlMethod.WEATHER:
             weather_mgr = s.coordinator._weather_mgr  # noqa: SLF001
             attrs["weather_active_conditions"] = weather_mgr.active_conditions

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -43,6 +43,7 @@ from .const import (
 from .coordinator import AdaptiveDataUpdateCoordinator
 from .entity_base import AdaptiveCoverDiagnosticSensorBase, AdaptiveCoverSensorBase
 from .enums import ControlMethod
+from .forecast import build_forecast_for_coord
 from .unit_system import length_display_unit, to_display_length
 
 
@@ -769,6 +770,43 @@ def _configured_handlers(opts: Mapping[str, Any]) -> list[str]:
     return enabled
 
 
+def _safe_forecast(coord: AdaptiveDataUpdateCoordinator):
+    """Compute the forecast or return None on any setup-time failure.
+
+    The coordinator may not yet have a sun provider / config service hooked up
+    during the brief first-refresh window; falling through gracefully here
+    keeps the sensor available rather than throwing.
+    """
+    try:
+        return build_forecast_for_coord(coord)
+    except Exception:  # noqa: BLE001 — defensive degradation, not silencing a bug
+        return None
+
+
+def _position_forecast_value(s: _ACPDiagnosticSensor) -> dt.datetime | None:
+    """Return the timestamp of the next forecast event (sunrise, FOV enter, ...).
+
+    None when no events are scheduled or the forecast cannot be computed.
+    Used by the timestamp-typed Position Forecast sensor; the full series
+    lives in extra_state_attributes.
+    """
+    forecast = _safe_forecast(s.coordinator)
+    if forecast is None:
+        return None
+    now = dt_util.now()
+    upcoming = [e for e in forecast.events if e.t >= now]
+    return upcoming[0].t if upcoming else None
+
+
+def _position_forecast_attrs(
+    s: _ACPDiagnosticSensor,
+) -> Mapping[str, Any] | None:
+    forecast = _safe_forecast(s.coordinator)
+    if forecast is None:
+        return None
+    return forecast.to_attrs()
+
+
 def _build_custom_position_slots_snapshot(
     options: Mapping[str, Any], hass: Any
 ) -> list[dict[str, Any]]:
@@ -997,6 +1035,15 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         options=tuple(m.value for m in ControlMethod) + ("unknown",),
         value_fn=_decision_trace_value,
         attrs_fn=_decision_trace_attrs,
+    ),
+    _SensorSpec(
+        suffix="position_forecast",
+        display_name="Position Forecast",
+        icon="mdi:chart-line",
+        translation_key="position_forecast",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        value_fn=_position_forecast_value,
+        attrs_fn=_position_forecast_attrs,
     ),
     _SensorSpec(
         suffix="last_skipped_action",

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -277,6 +277,7 @@ FIELD_VALIDATORS: dict[str, Any] = {
         slot_keys["tilt"]: _range(slot_keys["tilt"])
         for slot_keys in CUSTOM_POSITION_SLOTS.values()
     },
+    **{slot_keys["enabled"]: _bool_v() for slot_keys in CUSTOM_POSITION_SLOTS.values()},
     # Glare zones 1–4 — name is free-form text; x/y/radius/z pull ranges from
     # OPTION_RANGES (bounds mirror config_flow._build_glare_zones_schema).
     **{
@@ -738,6 +739,7 @@ async def _handle_set_custom_position(hass: HomeAssistant, call: ServiceCall) ->
         "priority": slot_keys["priority"],
         "min_mode": slot_keys["min_mode"],
         "use_my": slot_keys["use_my"],
+        "enabled": slot_keys["enabled"],
     }
 
     # Build patch: only include fields that were supplied in the call

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1001,6 +1001,9 @@
           "weather_override": "Wetter-Übersteuerung",
           "cloud_suppression": "Wolkenunterdrückung"
         }
+      },
+      "position_forecast": {
+        "name": "Positionsvorhersage"
       }
     },
     "switch": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1001,6 +1001,9 @@
           "weather_override": "Weather Override",
           "cloud_suppression": "Cloud Suppression"
         }
+      },
+      "position_forecast": {
+        "name": "Position Forecast"
       }
     },
     "switch": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1001,6 +1001,9 @@
           "weather_override": "Dérogation météo",
           "cloud_suppression": "Suppression de nuages"
         }
+      },
+      "position_forecast": {
+        "name": "Prévision de position"
       }
     },
     "switch": {

--- a/release_notes/v2.22.1-beta.3.md
+++ b/release_notes/v2.22.1-beta.3.md
@@ -1,0 +1,112 @@
+# v2.22.1-beta.3
+
+beta.3 ships the companion card's slot-management and position-forecast surface: per-slot enable/disable, a `custom_position_slots` snapshot on the decision trace, a new `sensor.<cover>_position_forecast` diagnostic, and the sensor friendly-name that lets card badges read "Custom · Table extension" instead of just "Custom #1". It also fixes two bugs found since beta.2 (My Position button ignoring the auto-control gate and routing non-positional covers incorrectly), adds HA unit-system support across the config UI and sensors, and allows a shaded distance of 0 m and a per-glare-zone Z height.
+
+## 🎯 Should I install this?
+
+- **If you are helping shape the companion Lovelace card's slot UI or position-forecast strip**, this is the build to grab. beta.3 is cut from the `feature/card-issue-60-support` branch (3 commits ahead of main); the three branch-only changes (`bee0b8a`, `58a6c9a`, `b1322e7`) exist precisely to support [adaptive-cover-pro-card#60](https://github.com/jrhubott/adaptive-cover-pro-card/issues/60).
+- **If you use the My Position button and have automatic control turned off**, install this — beta.2 silently dropped every button press when `auto_control` was off. The fix routes the button call with `bypass_auto_control=True` so it behaves the same whether or not automatic control is enabled.
+- **If you're on a US-customary HA instance**, beta.3 displays geometry lengths in inches and labels weather thresholds with the configured sensor's unit. Storage stays in metres/centimetres so no migration runs.
+- **If you have glare zones configured**, you can now add a `z` height (0–3 m) per zone to protect a point above the floor — eye level, a TV screen, a tabletop — rather than just a floor disk.
+- **If you are on v2.22.0 or beta.2 and it's working**, all other changes are additive. No existing state or attributes change beyond the items above.
+
+## ✨ Added
+
+### Custom-position slot enable/disable + decision-trace slot snapshot (`58a6c9a`)
+
+Each custom-position slot gains a new opt-out config key `custom_position_enabled_<N>` (default `True` when absent, so existing entries behave unchanged). Setting it `False` silences a slot without losing its sensor, position, or priority configuration — the companion card uses this for its per-slot toggle UI. Both `PipelineSnapshotBuilder.read_custom_position_sensors` and `_build_pipeline()` in the coordinator honor the flag; a disabled slot is excluded from the snapshot and never instantiated as a `CustomPositionHandler`.
+
+The `set_custom_position` service gains an `enabled` field that writes `custom_position_enabled_<N>` so card and automation callers can toggle a slot without touching the options flow.
+
+`sensor.<cover>_decision_trace` gains a new attribute `custom_position_slots` — a stable 4-row list (one per slot, configured or not) with the shape `{slot, enabled, sensor, sensor_name, position, priority, min_mode}`. Unconfigured slots appear with `enabled=False` and other fields null so the card can render a fixed grid. The card uses `sensor != None` to distinguish "configured but disabled" from "never configured".
+
+### Custom-position sensor friendly name on decision trace (`bee0b8a`)
+
+`sensor.<cover>_decision_trace` gains `custom_position_active_slot_name` when a `CustomPositionHandler` wins the pipeline. The value is the winning slot's bound binary sensor's `friendly_name` attribute (e.g. `"Table extension"`), pulled via `ATTR_FRIENDLY_NAME` from `hass.states`. Falls back to `None` when the sensor isn't loaded or has no friendly name, in which case the attribute is omitted entirely to keep the trace clean.
+
+The field is threaded through `CustomPositionSensorState.sensor_name`, `PipelineResult.custom_position_active_slot_name`, `CustomPositionHandler`, and `_decision_trace_attrs` in `sensor.py`.
+
+### Position Forecast diagnostic sensor (`b1322e7`)
+
+A new `sensor.<cover>_position_forecast` diagnostic sensor (device class `timestamp`) projects today's solar-tracking behavior as a coarse timeline. Its state is the ISO 8601 timestamp of the next upcoming forecast event (sunrise, sunset, FOV entry, FOV exit), and its `forecast` attribute carries a list of `{t, position, handler}` samples at 15-minute steps over a 12-hour window. The `events` attribute lists `{t, kind, label}` boundary events.
+
+The new `forecast.py` module exposes `build_forecast()` as a pure function parameterized over a `cover_factory` closure (solar azimuth + elevation → `AdaptiveGeneralCover`), and `build_forecast_for_coord()` as a thin shim that wires it to the coordinator's sun provider, policy, and config service. Only solar tracking is projected — manual override, motion, weather safety, and custom positions depend on real-time inputs that would mislead a forecast if naively held at their current state.
+
+The sensor degrades gracefully to `None` on any setup-time exception via `_safe_forecast`, so it stays available during the first-refresh window. Translations added to `en.json`, `de.json`, and `fr.json`.
+
+### HA unit system in config UI and sensors (`33154eb`)
+
+Geometry and sun-tracking configuration now displays in the user's HA unit system. When HA is configured as US-customary, length fields (blind height, awning length, slat dimensions, shaded distance) show in inches rather than decimal metres. The `weather_override_schema` and related weather-step schemas now label wind-speed and rain thresholds with the configured sensor's `unit_of_measurement` when available, falling back to HA's locale unit.
+
+Storage remains canonical (metres, centimetres, sensor-unit) — no migration needed for existing entries.
+
+The `sensor.<cover>_target_position` sensor gains three new attributes: `target_distance`, `actual_distances`, and `distance_unit`. These translate the 0–100% position into a physical travel distance using the cover's lift-axis dimension (window height for blinds/venetian, awning length for awnings). Tilt-only covers skip these attributes. The cover-type dispatch lives behind a new `lift_travel_metres` hook on `CoverTypePolicy` so `sensor.py` stays free of cover-type branching.
+
+The `sensor.<cover>_climate_status` sensor gains a `ha_temperature_unit` attribute alongside the existing `temperature_unit`.
+
+The `sun_tracking_schema` module-level constant is preserved as a metric alias; callers that need the hass-aware version call `sun_tracking_schema(hass)`.
+
+### Default new entry title to source device name (`6ea10ed`)
+
+When a user leaves the name field blank in the create flow and the first selected cover entity has an attached HA device, the entry title now defaults to the device's `name_by_user` or `name` verbatim — no "Vertical/Horizontal/Tilt" prefix, no "Adaptive" word. A Zigbee device named "Patio Stairs Shade" produces the entry title "Patio Stairs Shade" and a proxy entity `cover.patio_stairs_shade_managed`. Falls back to the existing `Adaptive {entity_name}` behavior when no device is attached, and respects a user-typed name as before.
+
+The lookup lives in the new `_get_device_name_for_entity` function in `config_flow.py`.
+
+### Shaded distance 0 m and glare zone Z height (`fdcdf99`)
+
+**Distance 0 m:** `_RANGE_DISTANCE` is lowered from `(0.1, 50.0)` to `(0.0, 50.0)` and the `length_selector` floor matches. The calculation engine multiplies by distance and never divides, so distance = 0 yields position = 0 (fully closed at the glass plane) with no NaN or inf.
+
+**Glare zone Z height:** `GlareZone` gains a `z: float = 0.0` field. When `z > 0`, `glare_zone_effective_distance` in `engine/covers/vertical.py` offsets the effective distance by `z / tan(sol_elev)` using the shared `_elevation_offset` helper (the same trigonometric construction as the sill-height offset). Default `z = 0` reproduces existing behaviour byte-for-byte. The `glare_zone_<N>_z` key is added to `OPTION_RANGES` and `FIELD_VALIDATORS` so the options service validates it. The `_GLARE_ZONE_DIMENSION_KEYS` cm-to-m migration list in `__init__.py` is extended to include `z` (no-op for existing configs whose defaults are zero). The glare-zone reason string appends `" (Z-adjusted)"` when at least one contributing zone has `z > 0`.
+
+## 🐛 Fixed
+
+### My Position button bypasses auto-control gate and routes hardware My correctly (`20ad30c`)
+
+`AdaptiveCoverMyPositionButton.async_press` was calling `coordinator.async_apply_user_position` without `bypass_auto_control=True`. When the automatic-control switch was off, the `auto_control_off` gate in `_cmd_svc.apply_position` silently dropped the command. The fix passes `bypass_auto_control=True` and `use_my_position=True` from the button to `async_apply_user_position`, which threads them into `_build_position_context`. `use_my_position` is OR-composed with the pipeline result's value so either source can enable the hardware-My routing path.
+
+## ⚠️ Field additions (decision_trace)
+
+Card template authors should pick up these new attributes on `sensor.<cover>_decision_trace`:
+
+| Key                                | Type                  | Present when                                                              |
+| ---------------------------------- | --------------------- | ------------------------------------------------------------------------- |
+| `custom_position_active_slot_name` | `str \| None`         | A `CustomPositionHandler` wins and its bound sensor has a `friendly_name` |
+| `custom_position_slots`            | `list[dict]` (4 rows) | Always — one row per slot regardless of configuration                     |
+
+`custom_position_slots` row shape: `{slot: int, enabled: bool, sensor: str|None, sensor_name: str|None, position: int|None, priority: int|None, min_mode: bool|None}`
+
+The new `sensor.<cover>_position_forecast` sensor attributes:
+
+| Key        | Type                           | Notes                                                                 |
+| ---------- | ------------------------------ | --------------------------------------------------------------------- |
+| `forecast` | `list[{t, position, handler}]` | ISO 8601 timestamps; `handler` is `"solar"` or `"default"`            |
+| `events`   | `list[{t, kind, label}]`       | `kind` is one of `"sunrise"`, `"sunset"`, `"fov_enter"`, `"fov_exit"` |
+
+## 🧪 Tests
+
+- ✅ 3583 tests passing (up from 3475 in beta.2)
+
+New in beta.3:
+
+- `tests/test_forecast.py` (266 lines): pure-function coverage of `build_forecast` — sample cadence, solar vs. default handler, FOV transitions, sunrise/sunset event detection, wire-format serialization.
+- `tests/test_config_flow_integration.py`: 3 new integration tests for device-name derivation (`test_create_flow_title_uses_device_name_when_attached`, `test_create_flow_title_falls_back_to_adaptive_prefix_without_device`, `test_create_flow_user_typed_name_overrides_device_name`).
+- `tests/test_my_position_button.py`: 2 new regression tests for issue #430 (`test_my_position_button_bypasses_auto_control`, `test_my_position_button_passes_bypass_kwargs`).
+- `tests/test_diagnostics/test_decision_trace_custom_position.py`: extended for `custom_position_active_slot_name` propagation and the `custom_position_slots` snapshot (enabled/disabled/unconfigured rows).
+- `tests/test_pipeline/test_snapshot_builder.py`: new unit tests for friendly-name propagation and `custom_position_enabled_<N>` filtering.
+- `tests/test_pipeline/test_custom_position_handler.py`: `TestCustomPositionActiveSlotName` class covering normal path, `use_my` path, and None fallback.
+- `tests/test_services_options.py`: `enabled` field routing tests for `set_custom_position`.
+
+## Compatibility
+
+- Home Assistant 2026.3.0+
+- Python 3.11+
+- No breaking changes
+
+## References
+
+[#404]: https://github.com/jrhubott/adaptive-cover-pro/issues/404
+[#427]: https://github.com/jrhubott/adaptive-cover-pro/issues/427
+[#428]: https://github.com/jrhubott/adaptive-cover-pro/pull/428
+[#429]: https://github.com/jrhubott/adaptive-cover-pro/pull/429
+[#430]: https://github.com/jrhubott/adaptive-cover-pro/issues/430
+[#431]: https://github.com/jrhubott/adaptive-cover-pro/pull/431

--- a/tests/test_diagnostics/test_decision_trace_custom_position.py
+++ b/tests/test_diagnostics/test_decision_trace_custom_position.py
@@ -153,3 +153,87 @@ def test_custom_position_active_slot_name_absent_when_none() -> None:
     attrs = sensor.extra_state_attributes or {}
 
     assert "custom_position_active_slot_name" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# custom_position_slots snapshot
+# ---------------------------------------------------------------------------
+
+
+def _make_sensor_with_options(options: dict, states: dict | None = None):
+    """Build a sensor whose config entry has the given options + hass.states map."""
+    hass = _make_hass()
+    if states:
+        hass.states.get.side_effect = lambda eid, _states=states: _states.get(eid)
+
+    coord = MagicMock()
+    coord.data = None
+    coord._pipeline_result = None
+    coord.logger = MagicMock()
+    coord.hass = hass
+    coord.check_adaptive_time = True
+
+    entry = MagicMock()
+    entry.entry_id = "snapshot_entry"
+    entry.data = {"name": "Test", CONF_SENSOR_TYPE: SensorType.BLIND}
+    entry.options = options
+
+    from custom_components.adaptive_cover_pro.sensor import (
+        AdaptiveCoverDecisionTraceSensor,
+    )
+
+    return AdaptiveCoverDecisionTraceSensor(
+        "snapshot_entry", hass, entry, "Test", coord
+    )
+
+
+def test_custom_position_slots_snapshot_lists_configured_slots() -> None:
+    """Each configured slot appears in custom_position_slots with its full config."""
+    bound = MagicMock()
+    bound.attributes = {"friendly_name": "Table extension"}
+    options = {
+        "custom_position_sensor_1": "binary_sensor.table",
+        "custom_position_1": 60,
+        "custom_position_priority_1": 80,
+        "custom_position_min_mode_1": True,
+    }
+    sensor = _make_sensor_with_options(options, states={"binary_sensor.table": bound})
+    attrs = sensor.extra_state_attributes or {}
+
+    slots = attrs.get("custom_position_slots")
+    assert isinstance(slots, list)
+    # Snapshot must include all 4 slots so the card can render an even row.
+    assert len(slots) == 4
+
+    slot1 = next(s for s in slots if s["slot"] == 1)
+    assert slot1["enabled"] is True  # default when key absent
+    assert slot1["position"] == 60
+    assert slot1["priority"] == 80
+    assert slot1["min_mode"] is True
+    assert slot1["sensor_name"] == "Table extension"
+
+
+def test_custom_position_slots_snapshot_reflects_enabled_false() -> None:
+    """A slot with custom_position_enabled_N=False reads enabled=False."""
+    options = {
+        "custom_position_sensor_2": "binary_sensor.x",
+        "custom_position_2": 40,
+        "custom_position_enabled_2": False,
+    }
+    sensor = _make_sensor_with_options(options)
+    attrs = sensor.extra_state_attributes or {}
+
+    slot2 = next(s for s in attrs["custom_position_slots"] if s["slot"] == 2)
+    assert slot2["enabled"] is False
+
+
+def test_custom_position_slots_snapshot_unconfigured_slot_is_inactive() -> None:
+    """Unconfigured slots still appear, marked enabled=False with null sensor."""
+    sensor = _make_sensor_with_options({})  # no slots configured
+    attrs = sensor.extra_state_attributes or {}
+
+    for s in attrs["custom_position_slots"]:
+        assert s["enabled"] is False
+        assert s["position"] is None
+        assert s["sensor"] is None
+        assert s["sensor_name"] is None

--- a/tests/test_diagnostics/test_decision_trace_custom_position.py
+++ b/tests/test_diagnostics/test_decision_trace_custom_position.py
@@ -60,6 +60,7 @@ def _make_custom_result(
     *,
     custom_position_active_slot: int | None = None,
     custom_position_minimum_mode: bool | None = None,
+    custom_position_active_slot_name: str | None = None,
 ) -> PipelineResult:
     """Build a CUSTOM_POSITION PipelineResult with the given diagnostic fields."""
     return PipelineResult(
@@ -68,6 +69,7 @@ def _make_custom_result(
         reason="custom position #1 active [bypasses automatic control]",
         custom_position_active_slot=custom_position_active_slot,
         custom_position_minimum_mode=custom_position_minimum_mode,
+        custom_position_active_slot_name=custom_position_active_slot_name,
     )
 
 
@@ -120,3 +122,34 @@ def test_custom_position_fields_absent_when_non_custom_wins() -> None:
 
     assert "custom_position_active_slot" not in attrs
     assert "custom_position_minimum_mode" not in attrs
+    assert "custom_position_active_slot_name" not in attrs
+
+
+def test_custom_position_active_slot_name_present_when_set() -> None:
+    """Custom wins with sensor friendly_name 'Table extension' → attr emitted verbatim.
+
+    Surfaces the human label so the companion card can render
+    "Custom · Table extension" instead of just "Custom #1".
+    """
+    result = _make_custom_result(
+        custom_position_active_slot=1,
+        custom_position_minimum_mode=True,
+        custom_position_active_slot_name="Table extension",
+    )
+    sensor = _make_sensor(result)
+    attrs = sensor.extra_state_attributes or {}
+
+    assert attrs.get("custom_position_active_slot_name") == "Table extension"
+
+
+def test_custom_position_active_slot_name_absent_when_none() -> None:
+    """Custom wins but no friendly_name resolved → attr not emitted (avoids noise)."""
+    result = _make_custom_result(
+        custom_position_active_slot=2,
+        custom_position_minimum_mode=False,
+        custom_position_active_slot_name=None,
+    )
+    sensor = _make_sensor(result)
+    attrs = sensor.extra_state_attributes or {}
+
+    assert "custom_position_active_slot_name" not in attrs

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,266 @@
+"""Tests for forecast.build_forecast — pure pure-function level coverage."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, UTC
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.forecast import (
+    EVENT_FOV_ENTER,
+    EVENT_FOV_EXIT,
+    EVENT_SUNRISE,
+    EVENT_SUNSET,
+    FORECAST_STEP_MINUTES,
+    FORECAST_WINDOW_HOURS,
+    Forecast,
+    ForecastEvent,
+    ForecastSample,
+    build_forecast,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 6, 1, 6, 0, tzinfo=UTC)
+
+
+def _make_sun_data(
+    *,
+    n_samples: int = 96,
+    step_minutes: int = 5,
+    azi_at: float = 180.0,
+    ele_at: float = 30.0,
+    sunrise: datetime | None = None,
+    sunset: datetime | None = None,
+):
+    """Build a minimal SunData stand-in for forecast tests.
+
+    Produces a constant-sun timeline for *n_samples* steps of *step_minutes*
+    starting at _NOW.  Tests that need a varying sun pattern can patch the
+    azimuth/elevation lists after construction.
+    """
+    times = [_NOW + timedelta(minutes=i * step_minutes) for i in range(n_samples)]
+    sd = MagicMock()
+    sd.times = times
+    sd.solar_azimuth = [azi_at] * n_samples
+    sd.solar_elevation = [ele_at] * n_samples
+    sd.sunrise = MagicMock(return_value=sunrise)
+    sd.sunset = MagicMock(return_value=sunset)
+    return sd
+
+
+def _make_cover_factory(*, solar_valid: bool, percentage: int = 40):
+    """Build a cover_factory closure used by build_forecast.
+
+    The returned cover's direct_sun_valid always returns *solar_valid*; its
+    calculate_percentage() always returns *percentage*.  Tests that want
+    per-timestamp variation pass a custom factory.
+    """
+
+    def factory(azi: float, ele: float):  # noqa: ARG001
+        cover = MagicMock()
+        cover.direct_sun_valid = solar_valid
+        cover.calculate_percentage = MagicMock(return_value=percentage)
+        return cover
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Sample series shape
+# ---------------------------------------------------------------------------
+
+
+class TestBuildForecastSamples:
+    """build_forecast emits one sample per tick over the configured window."""
+
+    def test_default_cadence_emits_step_per_15_minutes_for_12_hours(self):
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=10,
+            now=_NOW,
+        )
+        # 12 hours of 15-minute steps inclusive at both ends = 12 * 60 / 15 + 1.
+        expected = (FORECAST_WINDOW_HOURS * 60 // FORECAST_STEP_MINUTES) + 1
+        assert len(f.samples) == expected
+        # All samples carry the configured default since solar isn't valid.
+        assert all(s.position == 10 and s.handler == "default" for s in f.samples)
+
+    def test_solar_valid_samples_use_calculated_percentage(self):
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=True, percentage=55),
+            default_position=10,
+            now=_NOW,
+        )
+        assert all(s.position == 55 and s.handler == "solar" for s in f.samples)
+
+    def test_custom_step_and_window_produce_proportional_sample_count(self):
+        sd = _make_sun_data(n_samples=200, step_minutes=5)
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+            step_minutes=30,
+            window_hours=4,
+        )
+        assert len(f.samples) == (4 * 60 // 30) + 1
+
+    def test_empty_sun_data_returns_empty_samples_and_events(self):
+        sd = _make_sun_data(n_samples=0)
+        sd.times = []
+        sd.solar_azimuth = []
+        sd.solar_elevation = []
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+        )
+        assert f.samples == ()
+        assert f.events == ()
+
+
+# ---------------------------------------------------------------------------
+# Event detection
+# ---------------------------------------------------------------------------
+
+
+class TestBuildForecastEvents:
+    """Sunrise / sunset / FOV transitions land in the events list."""
+
+    def test_sunrise_and_sunset_emitted_when_present(self):
+        sunrise = _NOW + timedelta(hours=2)
+        sunset = _NOW + timedelta(hours=10)
+        sd = _make_sun_data(sunrise=sunrise, sunset=sunset)
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+        )
+        kinds = [e.kind for e in f.events]
+        assert EVENT_SUNRISE in kinds
+        assert EVENT_SUNSET in kinds
+
+    def test_sunrise_sunset_skipped_when_none_returned(self):
+        sd = _make_sun_data(sunrise=None, sunset=None)
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+        )
+        assert EVENT_SUNRISE not in [e.kind for e in f.events]
+        assert EVENT_SUNSET not in [e.kind for e in f.events]
+
+    def test_handler_switch_emits_fov_enter_and_exit(self):
+        """Cover-factory swings direct_sun_valid mid-window → enter + exit events."""
+        sd = _make_sun_data()
+        # solar valid during minutes 30-90 (i.e. samples 2-6 at 15-min step).
+        valid_window_start = _NOW + timedelta(minutes=30)
+        valid_window_end = _NOW + timedelta(minutes=90)
+
+        def factory(_azi, _ele):
+            cover = MagicMock()
+            cover.calculate_percentage = MagicMock(return_value=50)
+            # Mutated per call via closure to time-of-call check is awkward; the
+            # forecast walker passes (azi, ele) at *target* time, so we need a
+            # different signal — use a counter tracking call index.
+            return cover
+
+        # Simpler: drive the switch by providing per-tick solar validity via a
+        # cover_factory that toggles based on the call counter.
+        call_state = {"calls": 0}
+        toggle_points = [2, 6]  # sample indices where direct_sun_valid flips
+
+        def toggling_factory(_azi, _ele):
+            idx = call_state["calls"]
+            call_state["calls"] += 1
+            cover = MagicMock()
+            cover.direct_sun_valid = toggle_points[0] <= idx < toggle_points[1]
+            cover.calculate_percentage = MagicMock(return_value=50)
+            return cover
+
+        # Silence linters: factory + tick variables are intentionally unused.
+        _ = factory
+        _ = valid_window_start
+        _ = valid_window_end
+
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=toggling_factory,
+            default_position=0,
+            now=_NOW,
+        )
+        kinds = [e.kind for e in f.events]
+        assert EVENT_FOV_ENTER in kinds
+        assert EVENT_FOV_EXIT in kinds
+
+    def test_events_returned_sorted_by_time(self):
+        sd = _make_sun_data(
+            sunrise=_NOW + timedelta(hours=4),
+            sunset=_NOW + timedelta(hours=10),
+        )
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+        )
+        times = [e.t for e in f.events]
+        assert times == sorted(times)
+
+
+# ---------------------------------------------------------------------------
+# Wire-format serialization
+# ---------------------------------------------------------------------------
+
+
+class TestForecastToAttrs:
+    """to_attrs() produces a stable wire shape for the diagnostic sensor."""
+
+    def test_samples_serialise_with_iso_timestamps(self):
+        f = Forecast(
+            samples=(ForecastSample(t=_NOW, position=42, handler="solar"),),
+            events=(),
+        )
+        attrs = f.to_attrs()
+        assert attrs["forecast"] == [
+            {"t": _NOW.isoformat(), "position": 42, "handler": "solar"}
+        ]
+
+    def test_events_serialise_with_iso_timestamps(self):
+        f = Forecast(
+            samples=(),
+            events=(ForecastEvent(t=_NOW, kind=EVENT_SUNRISE, label="Sunrise"),),
+        )
+        attrs = f.to_attrs()
+        assert attrs["events"] == [
+            {"t": _NOW.isoformat(), "kind": "sunrise", "label": "Sunrise"}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("default", [0, 50, 100])
+def test_default_position_round_trips_through_samples(default: int):
+    """Whatever default_position we pass appears verbatim in non-solar samples."""
+    sd = _make_sun_data()
+    f = build_forecast(
+        sun_data=sd,
+        cover_factory=_make_cover_factory(solar_valid=False),
+        default_position=default,
+        now=_NOW,
+    )
+    assert {s.position for s in f.samples} == {default}

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -662,3 +662,71 @@ class TestCustomPositionMinimumMode:
         )
         assert result.custom_position_active_slot is None
         assert result.custom_position_minimum_mode is None
+
+
+# ---------------------------------------------------------------------------
+# custom_position_active_slot_name — sensor friendly-name propagation
+# ---------------------------------------------------------------------------
+
+
+class TestCustomPositionActiveSlotName:
+    """The handler propagates the bound sensor's friendly_name onto the result.
+
+    Lets downstream diagnostics (decision_trace, companion card badge) show
+    "Custom · Table extension" instead of just "Custom #1".
+    """
+
+    @staticmethod
+    def _state_with_name(name: str | None) -> CustomPositionSensorState:
+        return CustomPositionSensorState(
+            entity_id=_ENTITY,
+            is_on=True,
+            position=50,
+            priority=_DEFAULT_PRIORITY,
+            min_mode=False,
+            use_my=False,
+            sensor_name=name,
+        )
+
+    def test_name_propagates_on_normal_path(self) -> None:
+        snap = make_snapshot(
+            custom_position_sensors=[self._state_with_name("Table extension")]
+        )
+        result = _handler(entity_id=_ENTITY, position=50).evaluate(snap)
+        assert result is not None
+        assert result.custom_position_active_slot_name == "Table extension"
+
+    def test_name_propagates_on_use_my_path(self) -> None:
+        state = CustomPositionSensorState(
+            entity_id=_ENTITY,
+            is_on=True,
+            position=50,
+            priority=_DEFAULT_PRIORITY,
+            min_mode=False,
+            use_my=True,
+            sensor_name="My preset",
+        )
+        snap = make_snapshot(
+            custom_position_sensors=[state],
+            my_position_value=30,
+        )
+        result = _handler(entity_id=_ENTITY, position=50).evaluate(snap)
+        assert result is not None
+        assert result.use_my_position is True
+        assert result.custom_position_active_slot_name == "My preset"
+
+    def test_name_is_none_when_sensor_name_unset(self) -> None:
+        snap = make_snapshot(custom_position_sensors=[self._state_with_name(None)])
+        result = _handler(entity_id=_ENTITY, position=50).evaluate(snap)
+        assert result is not None
+        assert result.custom_position_active_slot_name is None
+
+    def test_field_defaults_to_none_on_plain_result(self) -> None:
+        """A non-custom PipelineResult has custom_position_active_slot_name=None."""
+        from custom_components.adaptive_cover_pro.enums import ControlMethod
+        from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+        result = PipelineResult(
+            position=50, control_method=ControlMethod.SOLAR, reason="solar"
+        )
+        assert result.custom_position_active_slot_name is None

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -250,6 +250,43 @@ def test_read_custom_position_sensors_sensor_name_none_when_no_friendly_name_att
 
 
 @pytest.mark.unit
+def test_read_custom_position_sensors_skips_slots_with_enabled_false():
+    """Disabled slots are omitted from the snapshot entirely.
+
+    A slot with sensor + position configured but `enabled=False` must not
+    appear in the snapshot, so its CustomPositionHandler can never claim
+    position even if the bound sensor goes on.
+    """
+    on_state = MagicMock()
+    on_state.state = "on"
+    builder, _, _ = _make_builder(states={"binary_sensor.guest": on_state})
+
+    first_slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        first_slot_keys["sensor"]: "binary_sensor.guest",
+        first_slot_keys["position"]: 42,
+        first_slot_keys["enabled"]: False,
+    }
+    assert builder.read_custom_position_sensors(opts) == []
+
+
+@pytest.mark.unit
+def test_read_custom_position_sensors_defaults_enabled_true_when_key_absent():
+    """A slot configured before the enabled key existed behaves as enabled."""
+    on_state = MagicMock()
+    on_state.state = "on"
+    builder, _, _ = _make_builder(states={"binary_sensor.guest": on_state})
+
+    first_slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        first_slot_keys["sensor"]: "binary_sensor.guest",
+        first_slot_keys["position"]: 42,
+        # no `enabled` key — pre-feature options
+    }
+    assert len(builder.read_custom_position_sensors(opts)) == 1
+
+
+@pytest.mark.unit
 def test_build_recomputes_effective_default_when_omitted():
     builder, _, _ = _make_builder()
     cover_data = MagicMock()

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -197,6 +197,59 @@ def test_read_custom_position_sensors_unconfigured_returns_empty():
 
 
 @pytest.mark.unit
+def test_read_custom_position_sensors_carries_friendly_name():
+    """sensor_name is populated from the bound sensor's friendly_name attribute.
+
+    Surfaces the human label of the sensor that triggered a slot so that
+    downstream diagnostics (decision_trace, companion card badge) can show
+    "Custom · Table extension" instead of just "Custom #1".
+    """
+    on_state = MagicMock()
+    on_state.state = "on"
+    on_state.attributes = {"friendly_name": "Table extension"}
+    builder, _, _ = _make_builder(states={"binary_sensor.guest": on_state})
+
+    first_slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        first_slot_keys["sensor"]: "binary_sensor.guest",
+        first_slot_keys["position"]: 42,
+    }
+    out = builder.read_custom_position_sensors(opts)
+    assert out[0].sensor_name == "Table extension"
+
+
+@pytest.mark.unit
+def test_read_custom_position_sensors_sensor_name_none_when_state_missing():
+    """sensor_name is None when the bound sensor isn't in hass.states."""
+    builder, _, _ = _make_builder()  # no states map → hass.states.get returns None
+
+    first_slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        first_slot_keys["sensor"]: "binary_sensor.guest",
+        first_slot_keys["position"]: 42,
+    }
+    out = builder.read_custom_position_sensors(opts)
+    assert out[0].sensor_name is None
+
+
+@pytest.mark.unit
+def test_read_custom_position_sensors_sensor_name_none_when_no_friendly_name_attr():
+    """sensor_name is None when the bound sensor has no friendly_name attribute."""
+    on_state = MagicMock()
+    on_state.state = "on"
+    on_state.attributes = {}  # no friendly_name key
+    builder, _, _ = _make_builder(states={"binary_sensor.guest": on_state})
+
+    first_slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        first_slot_keys["sensor"]: "binary_sensor.guest",
+        first_slot_keys["position"]: 42,
+    }
+    out = builder.read_custom_position_sensors(opts)
+    assert out[0].sensor_name is None
+
+
+@pytest.mark.unit
 def test_build_recomputes_effective_default_when_omitted():
     builder, _, _ = _make_builder()
     cover_data = MagicMock()

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -872,6 +872,37 @@ class TestSetCustomPosition:
 
         new_opts = mock_update.call_args[1]["options"]
         assert "custom_position_sensor_1" not in new_opts
+
+    async def test_enabled_field_routing(self, hass: HomeAssistant):
+        """`enabled: false` on slot N updates `custom_position_enabled_N` only."""
+        opts = {
+            **VERTICAL_OPTIONS,
+            "custom_position_sensor_2": "binary_sensor.scene",
+            "custom_position_2": 50,
+        }
+        await _setup(hass, entry_id="cp_en_02", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_custom_position", {"slot": 2, "enabled": False})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_enabled_2"] is False
+        # Other slot fields untouched
+        assert new_opts["custom_position_sensor_2"] == "binary_sensor.scene"
+        assert new_opts["custom_position_2"] == 50
+
+    async def test_enabled_field_round_trip_true(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="cp_en_03")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_custom_position", {"slot": 3, "enabled": True})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_enabled_3"] is True
         assert "custom_position_1" not in new_opts
 
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -40,7 +40,7 @@ _EN_JSON: dict = json.loads(
 # Canary: lock the expected set of sensor translation_keys. Update here when a
 # new sensor spec with translation_key is added.
 _EXPECTED_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
-    {"control_status", "decision_trace", "motion_status"}
+    {"control_status", "decision_trace", "motion_status", "position_forecast"}
 )
 
 # Switch keys that appear in en.json under entity.switch but are generated

--- a/tests/test_unique_id_snapshot.py
+++ b/tests/test_unique_id_snapshot.py
@@ -94,6 +94,7 @@ EXPECTED_UNIQUE_ID_SUFFIXES = sorted(
         "motion_status",
         "force_override_triggers",
         "climate_status",
+        "position_forecast",
         # --- switch platform (uses display switch_name, not translation key) ---
         "Integration Enabled",
         "Automatic Control",


### PR DESCRIPTION
## Summary
Surfaces the data and config the companion card's [issue #60](https://github.com/jrhubott/adaptive-cover-pro-card/issues/60) more-info dialog needs:

- **Slot friendly_name on decision_trace** — `custom_position_active_slot_name` lets the card render "Custom · Table extension" instead of "Custom #1".
- **Custom-position slot enable + slot snapshot** — new `custom_position_enabled_<N>` opt-out option (defaults True), a stable 4-row `custom_position_slots` snapshot on `decision_trace`, and an `enabled` route on the `set_custom_position` service so the card can toggle slots without touching the options flow.
- **`position_forecast` diagnostic sensor** — new `forecast.py` helper walks the per-coordinator `SunData` table to emit a 15-min / 12-hour position series plus boundary events (sunrise, sunset, FOV entry/exit). Solar-only projection; other handlers depend on real-time inputs and would mislead a forecast if held at current state.

Translations for de/fr synced via `acp-translate`.

## Testing
- ✅ New tests: `tests/test_forecast.py`, `tests/test_decision_trace_custom_position.py`, `tests/test_pipeline/test_custom_position_handler.py`, `tests/test_pipeline/test_snapshot_builder.py`, `tests/test_services_options.py` additions
- ✅ Canary lists in `test_spec_translation_keys.py` and `test_unique_id_snapshot.py` updated for the new translation_key / unique_id suffix

## Related Issues
Refs jrhubott/adaptive-cover-pro-card#60