### PR TITLE
feat: share SunData cache across entries at same location

### DIFF
--- a/custom_components/adaptive_cover_pro/sun.py
+++ b/custom_components/adaptive_cover_pro/sun.py
@@ -3,8 +3,8 @@
 `SunData` caches the day's solar timeline (`pd.date_range` plus the
 per-tick azimuth/elevation lists from astral) so a single property read
 doesn't pay the full ~289-call astral walk every time. The cache is
-keyed on `date.today()` — it self-invalidates at midnight without any
-explicit refresh.
+keyed on `(timezone, lat, lon, elevation, date.today())` — it
+self-invalidates at midnight without any explicit refresh.
 
 This shape exists because `position_forecast` (and any future
 forecast-style consumer) reads ``solar_azimuth`` / ``solar_elevation``
@@ -12,13 +12,45 @@ in a tight loop. The plain `@property` form recomputed everything on
 every access, with a nested ``for _i in self.times`` clause that
 re-evaluated ``self.times`` on every iteration — pathological inside
 a 49-step forecast walker. See issue #437.
+
+The module-level ``_DAY_CACHE`` shares one fill across all ``SunData``
+instances at the same location (e.g. 10 covers at the same address).
+The fill runs inside ``hass.async_add_executor_job`` (off the event
+loop), so the cache is guarded by a ``threading.Lock``. See issue #441.
 """
 
 from __future__ import annotations
 
+import threading
+from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 
 import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Module-level day cache — shared across all SunData instances
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class _SunDayData:
+    """Module-cache value: one day's computed times/azimuth/elevation for a location."""
+
+    times: pd.DatetimeIndex
+    azi: list[float]
+    ele: list[float]
+
+
+_CACHE_LOCK: threading.Lock = threading.Lock()
+_DAY_CACHE: dict[tuple, _SunDayData] = {}
+
+
+def _cache_key(
+    timezone: str, location, elevation: float
+) -> tuple[str, float, float, float, date]:
+    """Module-level cache key — date.today() component self-invalidates at midnight."""
+    return (timezone, location.latitude, location.longitude, elevation, date.today())
 
 
 class SunData:
@@ -44,23 +76,58 @@ class SunData:
     def _ensure_today(self) -> None:
         """Refresh the cached timeline + solar angles when the day rolls over.
 
-        Builds the 5-minute timeline once and walks it a single time per
-        accessor (`solar_azimuth`, `solar_elevation`) — the previous
-        implementation re-ran `pd.date_range` once per loop iteration.
+        Three-tier lookup:
+        1. Fast path — instance fields already populated for today.
+        2. Module lookup — dict GET (no lock); assign from cached _SunDayData.
+        3. Miss — acquire lock, double-check, build timeline, purge stale
+           entries, store, release; then assign from the new entry.
         """
         today = date.today()
+        # Tier 1: instance fast path.
         if self._cache_day == today and self._cache_times is not None:
             return
-        end_date = today + timedelta(days=1)
-        times = pd.date_range(
-            start=today, end=end_date, freq="5min", tz=self.timezone, name="time"
-        )
-        azi_list = [self.location.solar_azimuth(t, self.elevation) for t in times]
-        ele_list = [self.location.solar_elevation(t, self.elevation) for t in times]
+
+        key = _cache_key(self.timezone, self.location, self.elevation)
+
+        # Tier 2: module cache hit (no lock — CPython GIL + immutable value safe).
+        cached = _DAY_CACHE.get(key)
+        if cached is not None:
+            self._cache_day = today
+            self._cache_times = cached.times
+            self._cache_azi = cached.azi
+            self._cache_ele = cached.ele
+            return
+
+        # Tier 3: fill under lock.
+        with _CACHE_LOCK:
+            # Double-checked locking: another thread may have filled while we waited.
+            cached = _DAY_CACHE.get(key)
+            if cached is None:
+                end_date = today + timedelta(days=1)
+                times = pd.date_range(
+                    start=today,
+                    end=end_date,
+                    freq="5min",
+                    tz=self.timezone,
+                    name="time",
+                )
+                azi_list = [
+                    self.location.solar_azimuth(t, self.elevation) for t in times
+                ]
+                ele_list = [
+                    self.location.solar_elevation(t, self.elevation) for t in times
+                ]
+                cached = _SunDayData(times=times, azi=azi_list, ele=ele_list)
+                # Purge stale (non-today) entries to keep memory bounded.
+                stale = [k for k in _DAY_CACHE if k[4] != today]
+                for k in stale:
+                    del _DAY_CACHE[k]
+                _DAY_CACHE[key] = cached
+
         self._cache_day = today
-        self._cache_times = times
-        self._cache_azi = azi_list
-        self._cache_ele = ele_list
+        self._cache_times = cached.times
+        self._cache_azi = cached.azi
+        self._cache_ele = cached.ele
 
     @property
     def times(self) -> pd.DatetimeIndex:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import threading
 from datetime import datetime, timedelta, UTC
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+import custom_components.adaptive_cover_pro.sun as _sun_mod
 
 from custom_components.adaptive_cover_pro.forecast import (
     EVENT_FOV_ENTER,
@@ -571,3 +574,155 @@ async def test_async_recompute_forecast_handles_missing_data(monkeypatch):
 
     await coord_mod.AdaptiveDataUpdateCoordinator.async_recompute_forecast(coord)
     assert coord._position_forecast is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Module-level SunData cache (issue #441 — Part 1)
+#
+# These tests pin the cross-entry shared-cache contract introduced in #441.
+# Two SunData instances at the same (timezone, lat, lon, elevation) must
+# share a single pd.date_range+astral walk per day; instances at different
+# keys must remain independent; the cache self-invalidates at midnight via
+# date.today() in the key; and concurrent fills are guarded by a lock.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_sun_day_cache():
+    """Wipe module-level SunData cache before/after each test."""
+    _sun_mod._DAY_CACHE.clear()
+    yield
+    _sun_mod._DAY_CACHE.clear()
+
+
+def _make_real_sun_data(
+    *, latitude: float = 37.0, longitude: float = -122.0, elevation: float = 0.0
+):
+    """Build a real SunData instance backed by a mock astral Location."""
+    from custom_components.adaptive_cover_pro.sun import SunData
+
+    location = MagicMock()
+    location.latitude = latitude
+    location.longitude = longitude
+    location.solar_azimuth = MagicMock(return_value=180.0)
+    location.solar_elevation = MagicMock(return_value=45.0)
+    return SunData(timezone="UTC", location=location, elevation=elevation)
+
+
+class TestSunDataModuleCache:
+    """Module-level day-keyed cache shares astral computation across SunData instances."""
+
+    def test_two_instances_same_location_share_one_fill(self):
+        """Two SunData at the same key trigger pd.date_range at most once."""
+        import pandas as pd
+
+        sd1 = _make_real_sun_data()
+        sd2 = _make_real_sun_data()
+
+        with patch(
+            "custom_components.adaptive_cover_pro.sun.pd.date_range",
+            wraps=pd.date_range,
+        ) as spy:
+            _ = sd1.times
+            _ = sd2.times
+
+        assert spy.call_count <= 1, (
+            f"pd.date_range called {spy.call_count}× for two instances at the same "
+            "location — expected ≤ 1 (module cache should prevent the second fill)"
+        )
+
+    def test_instances_different_elevation_get_independent_fills(self):
+        """Two SunData at different elevations each trigger their own fill."""
+        import pandas as pd
+
+        sd1 = _make_real_sun_data(elevation=0.0)
+        sd2 = _make_real_sun_data(elevation=500.0)
+
+        with patch(
+            "custom_components.adaptive_cover_pro.sun.pd.date_range",
+            wraps=pd.date_range,
+        ) as spy:
+            _ = sd1.times
+            _ = sd2.times
+
+        assert spy.call_count == 2, (
+            f"pd.date_range called {spy.call_count}× — expected exactly 2 for "
+            "instances at different elevations (independent cache entries)"
+        )
+
+    def test_cache_invalidates_at_midnight(self):
+        """After a simulated day-rollover the cache fills again on the new date."""
+        import pandas as pd
+
+        sd = _make_real_sun_data()
+
+        with patch(
+            "custom_components.adaptive_cover_pro.sun.pd.date_range",
+            wraps=pd.date_range,
+        ) as spy:
+            _ = sd.times  # fills the cache for today
+
+            # Simulate midnight: clear the module cache as a new day would.
+            _sun_mod._DAY_CACHE.clear()
+            # Reset instance fields so _ensure_today doesn't short-circuit.
+            sd._cache_day = None
+            sd._cache_times = None
+            sd._cache_azi = None
+            sd._cache_ele = None
+
+            _ = sd.times  # must fill again
+
+        assert (
+            spy.call_count == 2
+        ), f"pd.date_range called {spy.call_count}× — expected 2 (one per day)"
+
+    def test_cache_key_helper_exists_and_is_deterministic(self):
+        """_cache_key is importable and returns the same tuple on repeated calls."""
+        from custom_components.adaptive_cover_pro.sun import _cache_key
+
+        location = MagicMock()
+        location.latitude = 37.0
+        location.longitude = -122.0
+
+        key1 = _cache_key("UTC", location, 0.0)
+        key2 = _cache_key("UTC", location, 0.0)
+
+        assert key1 == key2
+        # Key is a tuple with at least 5 elements: tz, lat, lon, elevation, date.
+        assert isinstance(key1, tuple)
+        assert len(key1) >= 5
+
+    def test_concurrent_fills_produce_single_result(self):
+        """Two threads racing on the same key trigger pd.date_range at most once."""
+        import pandas as pd
+
+        # We need two SunData with the same key but separate instances so
+        # neither has a warm instance cache.
+        sd1 = _make_real_sun_data()
+        sd2 = _make_real_sun_data()
+
+        results: list[int] = []
+        barrier = threading.Barrier(2)
+
+        with patch(
+            "custom_components.adaptive_cover_pro.sun.pd.date_range",
+            wraps=pd.date_range,
+        ) as spy:
+
+            def _fill(sd):
+                barrier.wait()  # both threads start at the same moment
+                _ = sd.times
+                results.append(1)
+
+            t1 = threading.Thread(target=_fill, args=(sd1,))
+            t2 = threading.Thread(target=_fill, args=(sd2,))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+        assert len(results) == 2  # both threads completed
+        assert spy.call_count <= 1, (
+            f"pd.date_range called {spy.call_count}× under concurrent access — "
+            "expected ≤ 1 (lock should prevent duplicate fills)"
+        )


### PR DESCRIPTION
## Summary
Replaces the per-instance day-cache in `SunData._ensure_today()` with a module-level `_DAY_CACHE` dict keyed on `(timezone, lat, lon, elevation, date.today())`. For N entries at the same physical location, daily astral computation drops from N fills to 1.

Three-tier lookup: per-instance fast path, module-level dict GET, fill-under-lock with double-checked locking. Cache values are a `_SunDayData` frozen dataclass. `threading.Lock` guards fill because `build_forecast_for_coord` runs in an executor thread. Stale (non-today) entries are purged at fill time. The `SunData.__init__` API and all `@property` bodies are unchanged.

The original issue also proposed gating `_start_forecast_scheduler` behind an opt-out toggle. Dropped: the `adaptive-cover-pro-card` companion depends on the forecast sensor being populated, so the scheduler must always run.

## Testing
- ✅ 25 tests passing in `tests/test_forecast.py` (20 existing + 5 new in `TestSunDataModuleCache`)
- ✅ `sun.py` coverage 100% in full suite
- ✅ `./scripts/lint` clean

## Related Issues
Refs #441
Refs #437