### PR TITLE
perf: exclude heavy sensor attributes from the recorder

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -79,6 +79,7 @@ class _SensorSpec:
     diagnostic: bool = (
         True  # False → uses AdaptiveCoverSensorBase (Cover_Position et al.)
     )
+    unrecorded_attributes: frozenset[str] = frozenset()
 
 
 def _exposes_dual_axis_sensor(entry: ConfigEntry) -> bool:
@@ -966,6 +967,9 @@ _STANDARD_SPECS: tuple[_SensorSpec, ...] = (
         value_fn=_cover_position_value,
         attrs_fn=_cover_position_attrs,
         diagnostic=False,
+        unrecorded_attributes=frozenset(
+            {"actual_positions", "actual_distances", "position_explanation"}
+        ),
     ),
     _SensorSpec(
         suffix="Cover_Tilt",
@@ -1017,6 +1021,7 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         translation_key="control_status",
         value_fn=_control_status_value,
         attrs_fn=_control_status_attrs,
+        unrecorded_attributes=frozenset({"manual_covers"}),
     ),
     _SensorSpec(
         suffix="decision_trace",
@@ -1027,6 +1032,9 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         options=tuple(m.value for m in ControlMethod) + ("unknown",),
         value_fn=_decision_trace_value,
         attrs_fn=_decision_trace_attrs,
+        unrecorded_attributes=frozenset(
+            {"trace", "custom_position_slots", "enabled_handlers"}
+        ),
     ),
     _SensorSpec(
         suffix="position_forecast",
@@ -1036,6 +1044,7 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         device_class=SensorDeviceClass.TIMESTAMP,
         value_fn=_position_forecast_value,
         attrs_fn=_position_forecast_attrs,
+        unrecorded_attributes=frozenset({"forecast", "events"}),
     ),
     _SensorSpec(
         suffix="last_skipped_action",
@@ -1069,6 +1078,7 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         should_poll=False,
         value_fn=_position_verification_value,
         attrs_fn=_position_verification_attrs,
+        unrecorded_attributes=frozenset({"per_entity"}),
     ),
     _SensorSpec(
         suffix="motion_status",
@@ -1114,6 +1124,31 @@ _SPEC_OVERRIDES: dict[str, type[_ACPDiagnosticSensor]] = {
 }
 
 
+def _resolve_cls(default_base: type, spec: _SensorSpec) -> type:
+    """Pick the concrete class for ``spec``.
+
+    _SPEC_OVERRIDES wins for the base (RestoreEntity etc.); _unrecorded_attributes,
+    when set, is layered on via a one-shot subclass — HA reads that attribute at
+    class init, so it must live on a class, not an instance.
+    """
+    base = _SPEC_OVERRIDES.get(spec.suffix, default_base)
+    if not spec.unrecorded_attributes:
+        return base
+    return type(
+        f"_ACPSensor_{spec.suffix}",
+        (base,),
+        {"_unrecorded_attributes": spec.unrecorded_attributes},
+    )
+
+
+_STANDARD_CLASSES: dict[str, type] = {
+    s.suffix: _resolve_cls(_ACPSensor, s) for s in _STANDARD_SPECS
+}
+_DIAGNOSTIC_CLASSES: dict[str, type] = {
+    s.suffix: _resolve_cls(_ACPDiagnosticSensor, s) for s in _DIAGNOSTIC_SPECS
+}
+
+
 # ---------------------------------------------------------------------------
 # Platform setup
 # ---------------------------------------------------------------------------
@@ -1134,14 +1169,15 @@ async def async_setup_entry(
     for spec in _STANDARD_SPECS:
         if not spec.enabled_when(config_entry):
             continue
+        cls = _STANDARD_CLASSES[spec.suffix]
         entities.append(
-            _ACPSensor(config_entry.entry_id, hass, config_entry, coordinator, spec)
+            cls(config_entry.entry_id, hass, config_entry, coordinator, spec)
         )
 
     for spec in _DIAGNOSTIC_SPECS:
         if not spec.enabled_when(config_entry):
             continue
-        cls = _SPEC_OVERRIDES.get(spec.suffix, _ACPDiagnosticSensor)
+        cls = _DIAGNOSTIC_CLASSES[spec.suffix]
         entities.append(
             cls(config_entry.entry_id, hass, config_entry, coordinator, spec)
         )

--- a/tests/test_sensor_unrecorded_attributes.py
+++ b/tests/test_sensor_unrecorded_attributes.py
@@ -1,0 +1,73 @@
+"""Regression guard for recorder exclusion of heavy sensor attributes.
+
+The listed attribute keys are consumed live by the companion Lovelace card
+and the live state UI — they have no recorder-history use case. HA reads
+``_unrecorded_attributes`` at class init, so the spec-driven class composition
+in ``sensor.py`` must surface each spec's frozenset on its resolved class.
+"""
+
+import pytest
+
+from custom_components.adaptive_cover_pro.sensor import (
+    _DIAGNOSTIC_CLASSES,
+    _DIAGNOSTIC_SPECS,
+    _STANDARD_CLASSES,
+    _STANDARD_SPECS,
+)
+
+
+EXPECTED: dict[str, set[str]] = {
+    "Cover_Position": {
+        "actual_positions",
+        "actual_distances",
+        "position_explanation",
+    },
+    "control_status": {"manual_covers"},
+    "decision_trace": {"trace", "custom_position_slots", "enabled_handlers"},
+    "position_forecast": {"forecast", "events"},
+    "position_verification": {"per_entity"},
+}
+
+
+def _resolved_cls(suffix: str) -> type:
+    return _STANDARD_CLASSES.get(suffix) or _DIAGNOSTIC_CLASSES[suffix]
+
+
+@pytest.mark.parametrize(("suffix", "keys"), list(EXPECTED.items()))
+def test_unrecorded_attributes_present(suffix: str, keys: set[str]) -> None:
+    cls = _resolved_cls(suffix)
+    assert keys.issubset(
+        cls._unrecorded_attributes
+    ), f"{suffix}: expected {keys} ⊆ {set(cls._unrecorded_attributes)}"
+
+
+def test_specs_with_unrecorded_attrs_propagate_to_classes() -> None:
+    for spec in (*_STANDARD_SPECS, *_DIAGNOSTIC_SPECS):
+        if not spec.unrecorded_attributes:
+            continue
+        cls = _resolved_cls(spec.suffix)
+        assert spec.unrecorded_attributes.issubset(cls._unrecorded_attributes)
+
+
+def test_specs_without_unrecorded_attrs_reuse_default_class() -> None:
+    """Specs that don't opt in must still resolve to the original base class.
+
+    Prevents the resolver from accidentally allocating fresh subclasses for
+    every spec — that would defeat HA's class-cached state_info packing.
+    """
+    from custom_components.adaptive_cover_pro.sensor import (
+        _ACPDiagnosticSensor,
+        _ACPSensor,
+        _SPEC_OVERRIDES,
+    )
+
+    for spec in _STANDARD_SPECS:
+        if spec.unrecorded_attributes:
+            continue
+        assert _STANDARD_CLASSES[spec.suffix] is _ACPSensor
+
+    for spec in _DIAGNOSTIC_SPECS:
+        if spec.unrecorded_attributes:
+            continue
+        expected = _SPEC_OVERRIDES.get(spec.suffix, _ACPDiagnosticSensor)
+        assert _DIAGNOSTIC_CLASSES[spec.suffix] is expected


### PR DESCRIPTION
## Summary
- Five sensors were writing bulky `extra_state_attributes` (arrays/dicts) to the recorder on every coordinator cycle, dominating DB volume with data nobody queries from history. The companion Lovelace card and the live state UI read these attributes live, not from history.
- Added an `unrecorded_attributes: frozenset[str]` field to `_SensorSpec` plus a `_resolve_cls` helper that composes per-spec subclasses so HA reads `_unrecorded_attributes` at class init (HA ignores per-instance assignment). Composes cleanly with the existing `_SPEC_OVERRIDES` mechanism so `manual_override_end_time`'s RestoreEntity wiring keeps working.
- Live state, templates, automation triggers, and the Lovelace card all keep seeing every attribute — only the recorder DB stops persisting these keys. Existing rows are untouched and age out under normal retention.

### Sensors and excluded attribute keys
| Sensor | Excluded keys |
|---|---|
| `Cover_Position` | `actual_positions`, `actual_distances`, `position_explanation` |
| `control_status` | `manual_covers` |
| `decision_trace` | `trace`, `custom_position_slots`, `enabled_handlers` |
| `position_forecast` | `forecast`, `events` |
| `position_verification` | `per_entity` |

`climate_status` was considered but its `attrs_fn` already unpacks the internal `temperature_details` dict into flat scalars — nothing heavy to exclude.

### Trade-off note
On `Cover_Position`, `position_explanation` is the human-readable "why did it move?" line. Excluding it from history means that forensic value is only available live, not from recorder queries. Accepted as a deliberate trade for maximum DB savings on the highest-volume sensor.

## Testing
- ✅ 3,629 tests passing (added `tests/test_sensor_unrecorded_attributes.py` with 7 cases — covers per-spec exclusion, propagation through the resolver, and verifies non-excluded specs still reuse the original base class)
- ✅ Ruff + Black clean
- ✅ Manual verification path documented in the plan: SQL spot-check against `state_attributes` after a few cycles confirms new rows no longer contain the excluded keys.