### PR TITLE
feat: O(1) arithmetic lookup for forecast _nearest_index

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -462,6 +462,9 @@ STARTUP_GRACE_PERIOD_SECONDS = 30.0  # disable manual-override after HA startup
 # transitions promptly, cheap enough that even on a Pi 4 the executor job
 # completes in well under a second.
 FORECAST_RECOMPUTE_INTERVAL_MIN = 5
+# Physical step between consecutive SunData timeline entries (seconds).
+# Matches the "5min" freq passed to pd.date_range in sun.py.
+SUN_DATA_STEP_SECONDS: int = 300
 
 # Maximum time (seconds) to suppress manual override detection after sending a
 # position command.  Once this threshold is crossed, wait_for_target is cleared

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from collections.abc import Callable
 
-from .const import CONF_DEFAULT_HEIGHT, DEFAULT_DEFAULT_HEIGHT
+from .const import CONF_DEFAULT_HEIGHT, DEFAULT_DEFAULT_HEIGHT, SUN_DATA_STEP_SECONDS
 
 if TYPE_CHECKING:
     from .coordinator import AdaptiveDataUpdateCoordinator
@@ -189,26 +189,21 @@ def _build_events(
     return sorted(events, key=lambda e: e.t)
 
 
-def _nearest_index(times: list[datetime], target: datetime) -> int | None:
-    """Index of the time in *times* closest to *target* (linear scan, ~250 items).
+def _nearest_index(
+    times: list[datetime], target: datetime, step_seconds: int = SUN_DATA_STEP_SECONDS
+) -> int | None:
+    """Index of the time in *times* closest to *target* (O(1) arithmetic lookup).
 
-    Returns None when *times* is empty. The caller has already short-circuited
-    in that case, but the guard keeps this helper safe in isolation.
+    ``times`` is expected to be the fixed 5-minute grid from ``SunData.times``.
+    ``step_seconds`` is parameterised so this stays correct if the cadence changes.
+    Returns None when *times* is empty.
     """
     if not times:
         return None
-    # Pandas DatetimeIndex entries are timezone-aware; convert target to match.
-    target_tz = target.tzinfo
-    if target_tz is None and times[0].tzinfo is not None:
+    if target.tzinfo is None and times[0].tzinfo is not None:
         target = target.replace(tzinfo=times[0].tzinfo)
-    best_idx = 0
-    best_delta = abs((times[0] - target).total_seconds())
-    for i, ts in enumerate(times):
-        delta = abs((ts - target).total_seconds())
-        if delta < best_delta:
-            best_idx = i
-            best_delta = delta
-    return best_idx
+    delta = (target - times[0]).total_seconds()
+    return max(0, min(len(times) - 1, round(delta / step_seconds)))
 
 
 def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -587,6 +587,66 @@ async def test_async_recompute_forecast_handles_missing_data(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+class TestNearestIndex:
+    """_nearest_index returns correct O(1) arithmetic result for all real SunData grid points."""
+
+    def test_exact_grid_points_match_linear_scan(self):
+        """Every 5-min mark in the sun_data timeline gives the same index as the linear scan."""
+        from custom_components.adaptive_cover_pro.forecast import _nearest_index
+        from datetime import UTC, datetime, timedelta
+
+        origin = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+        times = [origin + timedelta(minutes=5 * i) for i in range(289)]
+
+        for expected_idx, t in enumerate(times):
+            result = _nearest_index(times, t)
+            assert result == expected_idx, f"idx {expected_idx}: got {result}"
+
+    def test_target_before_start_clamps_to_zero(self):
+        from custom_components.adaptive_cover_pro.forecast import _nearest_index
+        from datetime import UTC, datetime, timedelta
+
+        origin = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+        times = [origin + timedelta(minutes=5 * i) for i in range(10)]
+        assert _nearest_index(times, origin - timedelta(hours=2)) == 0
+
+    def test_target_after_end_clamps_to_last(self):
+        from custom_components.adaptive_cover_pro.forecast import _nearest_index
+        from datetime import UTC, datetime, timedelta
+
+        origin = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+        times = [origin + timedelta(minutes=5 * i) for i in range(10)]
+        assert _nearest_index(times, origin + timedelta(days=1)) == 9
+
+    def test_tz_naive_target_coerces_to_match_tz_aware_list(self):
+        from custom_components.adaptive_cover_pro.forecast import _nearest_index
+        from datetime import UTC, datetime, timedelta
+
+        origin = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+        times = [origin + timedelta(minutes=5 * i) for i in range(10)]
+        naive = datetime(2026, 6, 1, 0, 0)
+        result = _nearest_index(times, naive)
+        assert result is not None
+
+    def test_empty_times_returns_none(self):
+        from custom_components.adaptive_cover_pro.forecast import _nearest_index
+        from datetime import UTC, datetime
+
+        assert _nearest_index([], datetime(2026, 6, 1, tzinfo=UTC)) is None
+
+    @pytest.mark.parametrize("offset_minutes", [0, 1, 2, 4, 5, 10, 600, 1440])
+    def test_midpoint_rounds_to_nearest(self, offset_minutes):
+        from custom_components.adaptive_cover_pro.forecast import _nearest_index
+        from datetime import UTC, datetime, timedelta
+
+        origin = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
+        times = [origin + timedelta(minutes=5 * i) for i in range(289)]
+        target = origin + timedelta(minutes=offset_minutes)
+        result = _nearest_index(times, target)
+        expected = max(0, min(288, round(offset_minutes / 5)))
+        assert result == expected
+
+
 @pytest.fixture(autouse=True)
 def _clear_sun_day_cache():
     """Wipe module-level SunData cache before/after each test."""


### PR DESCRIPTION
## Summary
`forecast.py:_nearest_index` walked the ~289-entry `SunData.times` list linearly for each of 49 forecast samples — about 14k timestamp comparisons per `build_forecast` call. Since `SunData.times` is a fixed 5-minute grid built from `pd.date_range`, the lookup reduces to integer arithmetic: `round((target - times[0]).total_seconds() / step_seconds)` clamped to `[0, len-1]`.

- Added `SUN_DATA_STEP_SECONDS = 300` constant in `const.py`.
- Replaced the linear scan in `_nearest_index` with the arithmetic form; tz-naive targets are coerced to match the tz-aware grid as before.
- Added `TestNearestIndex` (13 tests) covering the exact-grid property, before/after-end clamps, tz-naive coercion, empty input, and parametric midpoint rounding.

## Testing
- ✅ 3641 tests passing
- ✅ `tests/test_forecast.py` 25 → 38

## Related Issues
Refs #442