### PR TITLE
fix: retain forecast tasks on the config entry so 5-min refresh actually runs

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -540,9 +540,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return  # already scheduled
 
         # Fire the initial compute as a background task so the rest of
-        # entry setup doesn't wait on the executor.
-        self.hass.async_create_background_task(
-            self.async_recompute_forecast(), name="acp_initial_forecast"
+        # entry setup doesn't wait on the executor.  Use the config-entry
+        # task helper (not hass.async_create_background_task): it ties the
+        # task to the entry, which keeps a hard reference until the
+        # coroutine completes.  hass.async_create_background_task can race
+        # with the GC when called from a sync timer callback — tasks were
+        # being destroyed before reaching their first await, surfacing as
+        # "Task was destroyed but it is pending!" in the HA log.
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self.async_recompute_forecast(),
+            name="acp_initial_forecast",
         )
 
         # Periodic recompute on a slow cadence — the forecast is a 12-hour
@@ -550,8 +558,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # information.  The timer fires a background task each tick to keep
         # the event loop free.
         def _tick(_now: dt.datetime) -> None:
-            self.hass.async_create_background_task(
-                self.async_recompute_forecast(), name="acp_periodic_forecast"
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self.async_recompute_forecast(),
+                name="acp_periodic_forecast",
             )
 
         self._forecast_unsub = async_track_time_interval(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -420,16 +420,17 @@ async def test_start_forecast_scheduler_kicks_off_initial_background_task(monkey
 
     coord = MagicMock(spec=coord_mod.AdaptiveDataUpdateCoordinator)
     coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
     coord._forecast_unsub = None
 
     # Capture background tasks instead of running them.  Close the coroutine
     # passed in to avoid "coroutine was never awaited" warnings — we're
     # asserting on call_count, not on coroutine completion.
-    def _capture_bg(coro, name=None):  # noqa: ARG001
+    def _capture_bg(_hass, coro, name=None):  # noqa: ARG001
         coro.close()
         return MagicMock(name="task")
 
-    coord.hass.async_create_background_task = MagicMock(side_effect=_capture_bg)
+    coord.config_entry.async_create_background_task = MagicMock(side_effect=_capture_bg)
 
     # Capture the time-interval registration.
     track_calls: list = []
@@ -445,8 +446,9 @@ async def test_start_forecast_scheduler_kicks_off_initial_background_task(monkey
 
     coord_mod.AdaptiveDataUpdateCoordinator._start_forecast_scheduler(coord)
 
-    # One initial background task fired.
-    assert coord.hass.async_create_background_task.call_count == 1
+    # One initial background task fired via the config-entry helper (NOT
+    # hass.async_create_background_task — see coordinator.py for why).
+    assert coord.config_entry.async_create_background_task.call_count == 1
     # One time-interval timer registered.
     assert len(track_calls) == 1
     # Interval matches the constant (5 minutes).
@@ -472,13 +474,14 @@ async def test_start_forecast_scheduler_is_idempotent(monkeypatch):
 
     coord = MagicMock(spec=coord_mod.AdaptiveDataUpdateCoordinator)
     coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
     coord._forecast_unsub = MagicMock(name="existing_unsub")
 
-    def _capture_bg(coro, name=None):  # noqa: ARG001
+    def _capture_bg(_hass, coro, name=None):  # noqa: ARG001
         coro.close()
         return MagicMock(name="task")
 
-    coord.hass.async_create_background_task = MagicMock(side_effect=_capture_bg)
+    coord.config_entry.async_create_background_task = MagicMock(side_effect=_capture_bg)
 
     track_mock = MagicMock(return_value=MagicMock(name="new_unsub"))
     monkeypatch.setattr(
@@ -488,7 +491,7 @@ async def test_start_forecast_scheduler_is_idempotent(monkeypatch):
     coord_mod.AdaptiveDataUpdateCoordinator._start_forecast_scheduler(coord)
 
     # Nothing scheduled — early return on existing handle.
-    assert coord.hass.async_create_background_task.call_count == 0
+    assert coord.config_entry.async_create_background_task.call_count == 0
     assert track_mock.call_count == 0
 
 
@@ -500,13 +503,14 @@ async def test_forecast_scheduler_tick_fires_background_task(monkeypatch):
 
     coord = MagicMock(spec=coord_mod.AdaptiveDataUpdateCoordinator)
     coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
     coord._forecast_unsub = None
 
-    def _capture_bg(coro, name=None):  # noqa: ARG001
+    def _capture_bg(_hass, coro, name=None):  # noqa: ARG001
         coro.close()
         return MagicMock(name="task")
 
-    coord.hass.async_create_background_task = MagicMock(side_effect=_capture_bg)
+    coord.config_entry.async_create_background_task = MagicMock(side_effect=_capture_bg)
 
     captured_cb: list = []
 
@@ -523,11 +527,64 @@ async def test_forecast_scheduler_tick_fires_background_task(monkeypatch):
     assert len(captured_cb) == 1
 
     # Initial schedule already created one background task.
-    initial_count = coord.hass.async_create_background_task.call_count
+    initial_count = coord.config_entry.async_create_background_task.call_count
     # Fire two ticks.
     captured_cb[0](datetime.now(UTC))
     captured_cb[0](datetime.now(UTC))
-    assert coord.hass.async_create_background_task.call_count == initial_count + 2
+    assert (
+        coord.config_entry.async_create_background_task.call_count == initial_count + 2
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_forecast_scheduler_uses_entry_task_helper_not_hass(monkeypatch):
+    """Regression: must use `config_entry.async_create_background_task`.
+
+    The hass-level helper let tasks be destroyed before reaching their
+    first await when scheduled from a sync timer callback, producing
+    "Task was destroyed but it is pending!" in the log and silently
+    skipping the 5-min forecast refresh.  The entry-level helper holds
+    a hard reference for the lifetime of the entry, which fixes it.
+    """
+    from custom_components.adaptive_cover_pro import coordinator as coord_mod
+
+    coord = MagicMock(spec=coord_mod.AdaptiveDataUpdateCoordinator)
+    coord.hass = MagicMock()
+    coord.config_entry = MagicMock()
+    coord._forecast_unsub = None
+
+    def _capture_bg(_hass, coro, name=None):  # noqa: ARG001
+        coro.close()
+        return MagicMock(name="task")
+
+    coord.config_entry.async_create_background_task = MagicMock(side_effect=_capture_bg)
+    # Mark the hass helper so we can assert it is NOT used.
+    coord.hass.async_create_background_task = MagicMock(name="hass_helper")
+
+    captured_cb: list = []
+
+    def _fake_track_time_interval(_hass, cb, _interval):
+        captured_cb.append(cb)
+        return MagicMock(name="unsub")
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.event.async_track_time_interval",
+        _fake_track_time_interval,
+    )
+
+    coord_mod.AdaptiveDataUpdateCoordinator._start_forecast_scheduler(coord)
+    captured_cb[0](datetime.now(UTC))
+
+    # Initial + one tick = 2 calls, all on the entry helper.
+    assert coord.config_entry.async_create_background_task.call_count == 2
+    coord.hass.async_create_background_task.assert_not_called()
+
+    # First positional arg passed to the entry helper is hass, per the HA
+    # `ConfigEntry.async_create_background_task(hass, target, name=...)` signature.
+    for call in coord.config_entry.async_create_background_task.call_args_list:
+        args, _kwargs = call
+        assert args[0] is coord.hass
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The 5-min `async_track_time_interval` for the `position_forecast` sensor was firing, but each scheduled `acp_periodic_forecast` task was being destroyed before reaching its first `await` — surfacing as repeated `Task was destroyed but it is pending!` warnings in the HA log and freezing the forecast attribute at boot-time values.
- Root cause: `hass.async_create_background_task` was being called from inside a synchronous `async_track_time_interval` callback. The hass-level background-task set lost the reference race with the GC before the loop got a chance to schedule the coroutine.
- Fix is one-character-ish in spirit: switch both the initial-compute kick and the periodic tick over to `config_entry.async_create_background_task`, which is HA's recommended pattern for entry-scoped background work and holds a hard reference for the lifetime of the entry. Same call shape, just the right helper.

## Discovery
Confirmed in the live instance via the HA MCP server: all eight `*_position_forecast` sensors had `last_updated == last_reported == last_changed` frozen at the integration's last load time, despite the c41c27e `async_update_listeners` fix being deployed. System log showed 29 occurrences of:

```
Task was destroyed but it is pending!
(task: <Task pending name='acp_periodic_forecast'
coro=<AdaptiveDataUpdateCoordinator.async_recompute_forecast()>>)
```

The `running at coordinator.py:561` line pointed at the function definition — meaning the coroutine never even reached its first await. Classic lost-reference GC race.

## Testing
- ✅ 40 forecast tests passing (`venv/bin/python -m pytest tests/test_forecast.py`)
- New regression test `test_forecast_scheduler_uses_entry_task_helper_not_hass` asserts the entry helper is used (and the hass helper is not) — this is what prevents the symptom recurring.
- Three existing scheduler tests adjusted to mock `config_entry.async_create_background_task` and the new `(hass, coro, name=...)` signature.

## Related Issues
None filed — caught while debugging why the forecast sensor wasn't refreshing on a live instance.