### PR TITLE
fix: sunset_position bugs — wrong fallback during morning + cannot clear stored 0 (backport to v2.22)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -354,6 +354,17 @@ POSITION_SCHEMA = vol.Schema(
     }
 )
 
+# Keys in POSITION_SCHEMA with default=vol.UNDEFINED that voluptuous omits when
+# cleared by the user. Both flow handlers must call optional_entities() with this
+# list before dict.update() — otherwise the prior value survives a clear
+# (issue #439; same class as #323).
+_POSITION_OPTIONAL_KEYS: list[str] = [
+    CONF_SUNSET_POS,
+    CONF_MY_POSITION_VALUE,
+    CONF_SUNSET_TIME_ENTITY,
+    CONF_SUNRISE_TIME_ENTITY,
+]
+
 AUTOMATION_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DELTA_POSITION, default=2): selector.NumberSelector(
@@ -2406,6 +2417,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_position(self, user_input: dict[str, Any] | None = None):
         """Configure position settings."""
         if user_input is not None:
+            self.optional_entities(_POSITION_OPTIONAL_KEYS, user_input)
             self.config.update(user_input)
             # Quick setup: skip optional screens, go straight to summary
             if self.setup_mode == "quick":
@@ -3078,6 +3090,7 @@ class OptionsFlowHandler(OptionsFlow):
     async def async_step_position(self, user_input: dict[str, Any] | None = None):
         """Adjust position settings."""
         if user_input is not None:
+            self.optional_entities(_POSITION_OPTIONAL_KEYS, user_input)
             self.options.update(user_input)
             return await self.async_step_init()
         return self.async_show_form(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -874,6 +874,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             sunrise_off=sunrise_off,
             sunset_time=sunset_time,
             sunrise_time=sunrise_time,
+            after_start_time=self.after_start_time,
         )
         self.logger.debug(
             "Effective default: %s (sunset_active=%s, h_def=%s, sunset_pos=%s)",
@@ -2277,6 +2278,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             sunrise_off=sunrise_off,
             sunset_time=sunset_time,
             sunrise_time=sunrise_time,
+            after_start_time=self.after_start_time,
         )
 
     async def _check_sunset_window_transition(self) -> None:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -202,6 +202,7 @@ def compute_effective_default(
     *,
     sunset_time: dt.datetime | None = None,
     sunrise_time: dt.datetime | None = None,
+    after_start_time: bool = False,
 ) -> tuple[int, bool]:
     """Return the effective default cover position based on astronomical sunset/sunrise.
 
@@ -227,6 +228,12 @@ def compute_effective_default(
         sunrise_time: Optional override for the sunrise boundary (naive-local datetime).
             When provided, replaces the astral-computed sunrise. ``sunrise_off`` still
             applies on top. Falls back to astral when ``None``.
+        after_start_time: When ``True``, the user's operational window has already
+            started. In that case the ``before_sunrise`` branch is suppressed so that
+            a start_time earlier than astronomical sunrise (a valid config on short
+            winter days) does not incorrectly apply the sunset/night position.
+            Defaults to ``False`` for backward-compatibility with call sites that do
+            not have start_time context.
 
     Returns:
         A ``(effective_default, is_sunset_active)`` tuple where
@@ -250,7 +257,10 @@ def compute_effective_default(
 
     after_sunset = now_naive > (sunset + timedelta(minutes=sunset_off))
     before_sunrise = now_naive < (sunrise + timedelta(minutes=sunrise_off))
-    is_sunset_active = after_sunset or before_sunrise
+    # Suppress before_sunrise when the operational window has already started:
+    # start_time < astronomical_sunrise is a valid user config (e.g. start at 08:00,
+    # sunrise at 08:15 in winter). Once the user's window opens, nighttime rules end.
+    is_sunset_active = after_sunset or (before_sunrise and not after_start_time)
 
     effective = int(sunset_pos) if is_sunset_active else int(h_def)
     return effective, is_sunset_active

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -1400,3 +1400,72 @@ async def test_options_flow_venetian_geometry_saves_mode(hass: HomeAssistant) ->
 
     if result["type"] == "create_entry":
         assert result["data"].get(CONF_VENETIAN_MODE) == VENETIAN_MODE_TILT_ONLY
+
+
+@pytest.mark.integration
+async def test_options_flow_position_step_clears_sunset_pos_when_omitted(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing sunset_position in options flow must write None, not keep old 0.
+
+    Regression for issue #439: submitting the position form without
+    CONF_SUNSET_POS while a prior value of 0 is stored must overwrite it
+    with None, not leave 0 in place.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_SUNSET_POS,
+        CONF_SUNSET_USE_MY,
+    )
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    pre_options = dict(VERTICAL_OPTIONS)
+    pre_options[CONF_SUNSET_POS] = 0  # seed the bug scenario
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Sunset Clear Test", CONF_SENSOR_TYPE: SensorType.BLIND},
+        options=pre_options,
+        entry_id="sunset_clear_01",
+        title="Sunset Clear Test",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "position"}
+    )
+    assert result["step_id"] == "position"
+
+    # Submit position form WITHOUT CONF_SUNSET_POS (user cleared the field)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_DEFAULT_HEIGHT: 60,
+            CONF_MIN_POSITION: 0,
+            CONF_ENABLE_MIN_POSITION: False,
+            CONF_MAX_POSITION: 100,
+            CONF_ENABLE_MAX_POSITION: False,
+            CONF_SUNSET_OFFSET: 0,
+            CONF_SUNRISE_OFFSET: 0,
+            CONF_INVERSE_STATE: False,
+            "interp": False,
+            "open_close_threshold": 50,
+            CONF_SUNSET_USE_MY: False,
+            # CONF_SUNSET_POS deliberately omitted — simulates user clearing the field
+        },
+    )
+    # Navigate to done
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    assert result["type"] == "create_entry"
+
+    saved = result["data"]
+    assert (
+        saved.get(CONF_SUNSET_POS) is None
+    ), "sunset_position must be None after clearing, not retain previous value 0"

--- a/tests/test_config_ux_simplification.py
+++ b/tests/test_config_ux_simplification.py
@@ -21,6 +21,7 @@ import voluptuous as vol
 from custom_components.adaptive_cover_pro.config_flow import (
     ConfigFlowHandler,
     LIGHT_CLOUD_SCHEMA,
+    POSITION_SCHEMA,
     SYNC_CATEGORIES,
     TEMPERATURE_CLIMATE_SCHEMA,
     WEATHER_OVERRIDE_SCHEMA,
@@ -29,6 +30,7 @@ from custom_components.adaptive_cover_pro.config_flow import (
     _CUSTOM_POSITION_OPTIONAL_KEYS,
     _extract_shared_options,
     _LIGHT_CLOUD_OPTIONAL_KEYS,
+    _POSITION_OPTIONAL_KEYS,
     _SYNC_UI_CATEGORIES,
     _TEMPERATURE_CLIMATE_OPTIONAL_KEYS,
     _WEATHER_OVERRIDE_OPTIONAL_KEYS,
@@ -583,6 +585,7 @@ class TestSelectorDomains:
 
 
 _SCHEMA_OPTIONAL_KEY_PAIRS = [
+    ("POSITION", POSITION_SCHEMA, _POSITION_OPTIONAL_KEYS),
     ("WEATHER_OVERRIDE", WEATHER_OVERRIDE_SCHEMA, _WEATHER_OVERRIDE_OPTIONAL_KEYS),
     ("LIGHT_CLOUD", LIGHT_CLOUD_SCHEMA, _LIGHT_CLOUD_OPTIONAL_KEYS),
     (

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -777,6 +777,8 @@ def test_compute_current_effective_default_passes_sunset_entity_time():
     cover_data.sun_data = MagicMock()
     coord.get_blind_data = MagicMock(return_value=cover_data)
     coord.hass = MagicMock()
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.after_start_time = False
 
     fake_sunset_dt = dt.datetime(2026, 5, 22, 22, 0, 0)
     options = {
@@ -824,6 +826,8 @@ def test_compute_current_effective_default_passes_sunrise_entity_time():
     cover_data.sun_data = MagicMock()
     coord.get_blind_data = MagicMock(return_value=cover_data)
     coord.hass = MagicMock()
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.after_start_time = False
 
     fake_sunrise_dt = dt.datetime(2026, 5, 22, 8, 0, 0)
     options = {

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -507,3 +507,88 @@ class TestEntityOverride:
             )
         assert active is True
         assert result == 80
+
+
+# ---------------------------------------------------------------------------
+# Start-time suppression of before-sunrise branch (issue #438)
+# ---------------------------------------------------------------------------
+
+
+class TestStartTimeSuppressesBeforeSunrise:
+    """When after_start_time=True the before-sunrise branch must not activate sunset_pos.
+
+    Regression for issue #438: start_time < astronomical_sunrise caused
+    sunset_pos (0%) to be used instead of default_pos (100%) in the morning.
+    """
+
+    def test_before_sunrise_but_after_start_time_returns_h_def(self):
+        """Regression: at 08:05 UTC, before sunrise at 08:10, but after start_time=08:00."""
+        sun = _make_sun_data(sunrise_hour=8, sunrise_minute=10, sunset_hour=18)
+        today = dt.date.today()
+        now = dt.datetime(today.year, today.month, today.day, 8, 5, 0)
+        with _freeze_now(now):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                after_start_time=True,
+            )
+        # Operational window is open → sunset_pos must NOT apply
+        assert result == 100
+        assert active is False
+
+    def test_before_sunrise_without_start_time_still_returns_sunset_pos(self):
+        """Existing behaviour preserved when after_start_time=False (default)."""
+        sun = _make_sun_data(sunrise_hour=8, sunrise_minute=10, sunset_hour=18)
+        today = dt.date.today()
+        now = dt.datetime(today.year, today.month, today.day, 8, 5, 0)
+        with _freeze_now(now):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                after_start_time=False,
+            )
+        # No start_time context → classic before-sunrise behaviour
+        assert result == 0
+        assert active is True
+
+    def test_before_sunrise_after_start_time_with_positive_sunrise_offset(self):
+        """after_start_time=True also suppresses when sunrise_off extends the window."""
+        sun = _make_sun_data(sunrise_hour=6, sunset_hour=18)
+        today = dt.date.today()
+        # sunrise=06:00, offset=120 → window would close at 08:00 without start_time fix
+        now = dt.datetime(today.year, today.month, today.day, 7, 30, 0)
+        with _freeze_now(now):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=120,
+                after_start_time=True,
+            )
+        assert result == 100
+        assert active is False
+
+    def test_after_sunset_not_affected_by_after_start_time(self):
+        """after_start_time=True must NOT suppress the after-sunset branch."""
+        sun = _make_sun_data(sunrise_hour=6, sunset_hour=18)
+        today = dt.date.today()
+        now = dt.datetime(today.year, today.month, today.day, 19, 0, 0)  # after sunset
+        with _freeze_now(now):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                after_start_time=True,
+            )
+        # after sunset → sunset_pos still applies regardless of start_time
+        assert result == 0
+        assert active is True

--- a/tests/test_effective_default_integration.py
+++ b/tests/test_effective_default_integration.py
@@ -398,3 +398,50 @@ class TestPipelineDefaultPropagationContract:
 
         assert day_result.position == 60
         assert sunset_result.position == 10
+
+
+# ---------------------------------------------------------------------------
+# Issue #438 regression: start_time < astronomical_sunrise (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestStartTimeSuppressesSunsetDuringOperationalWindow:
+    """When operational window is open, before-sunrise branch must not apply sunset_pos.
+
+    Integration test: exercises compute_effective_default + DefaultHandler pipeline
+    together to confirm the fix flows end-to-end from the helper into the pipeline
+    result (regression for issue #438).
+    """
+
+    def test_pipeline_uses_h_def_when_before_sunrise_but_after_start_time(self):
+        """Regression #438: DefaultHandler must return h_def, not sunset_pos, when
+        the operational window is open even if before astronomical sunrise.
+
+        Scenario: sunrise=08:00, sunrise_off=10 → window closes at 08:10.
+        now=08:05 → before_sunrise normally True, but after_start_time suppresses it.
+        """
+        sun_data = _make_sun_data(sunset_hour=18, sunrise_hour=8)
+        # sunrise=08:00, offset=10 → boundary at 08:10; now=08:05 → before_sunrise
+        # without fix; suppressed with after_start_time=True.
+        with _freeze_now(_today(8, 5)):
+            effective, is_sunset_active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun_data,
+                sunset_off=0,
+                sunrise_off=10,
+                after_start_time=True,
+            )
+
+        assert is_sunset_active is False
+        assert effective == 100
+
+        registry = _registry(DefaultHandler())
+        snap = make_snapshot(
+            direct_sun_valid=False,
+            default_position=effective,
+            is_sunset_active=is_sunset_active,
+        )
+        result = registry.evaluate(snap)
+        assert result.control_method == ControlMethod.DEFAULT
+        assert result.position == 100  # h_def, NOT sunset_pos=0


### PR DESCRIPTION
Backport of #450 to `release/v2.22`.

## Summary
See #450 for the full bug description and rationale.

- **#438** — `compute_effective_default()` applied the sunset fallback whenever `now < astronomical_sunrise + offset`, even when the user's configured `start_time` had already passed. Covers sat at `sunset_position` during morning operational windows on short winter days. Cherry-picked clean.
- **#439** — `POSITION_SCHEMA.merge(...)` re-applied a stored `sunset_position=0`, so users couldn't clear the field once set. Production fix cherry-picked clean; the regression test needed two small adaptations for the v2.22 codebase (see below).

**Conflict resolution notes.** The cherry-pick required hand-resolution in `tests/test_config_flow_integration.py`:
- The new test referenced `CoverType.BLIND` (v2.23 name) — renamed to `SensorType.BLIND` for v2.22.
- The new test passed `CONF_ENABLE_MY_POSITION_ENTITIES: False` in the form data — that constant is part of the My-preset feature that hasn't shipped on v2.22 yet. Removed both the import and the form-data entry; the rest of the test still exercises the actual fix (clearing `sunset_position` to None).

The production-code change (`config_flow.py`) auto-merged cleanly; no semantic drift.

## Testing
- ✅ Full suite: 3456 passed
- ✅ Touched test files (focused): 175 passed
- Touched files: `tests/test_config_flow_integration.py`, `tests/test_config_ux_simplification.py`, `tests/test_coordinator_coverage.py`, `tests/test_effective_default.py`, `tests/test_effective_default_integration.py`

## Related Issues
Refs #438
Refs #439