### PR TITLE
feat: translate climate_status state values via slugs (#453)

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -681,10 +681,10 @@ def _climate_status_value(s: _ACPDiagnosticSensor) -> str | None:
     if data is None:
         return None
     if data.get("is_summer"):
-        return "Summer Mode"
+        return "summer_mode"
     if data.get("is_winter"):
-        return "Winter Mode"
-    return "Intermediate"
+        return "winter_mode"
+    return "intermediate"
 
 
 def _climate_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
@@ -1111,6 +1111,9 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         suffix="climate_status",
         display_name="Climate Status",
         icon="mdi:weather-partly-cloudy",
+        translation_key="climate_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=("summer_mode", "winter_mode", "intermediate"),
         value_fn=_climate_status_value,
         attrs_fn=_climate_status_attrs,
         enabled_when=lambda e: bool(e.options.get(CONF_CLIMATE_MODE, False)),

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1008,6 +1008,13 @@
       },
       "position_forecast": {
         "name": "Positionsvorhersage"
+      },
+      "climate_status": {
+        "state": {
+          "summer_mode": "Sommermodus",
+          "winter_mode": "Wintermodus",
+          "intermediate": "Übergang"
+        }
       }
     },
     "switch": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -990,6 +990,13 @@
           "waiting_for_data": "Waiting for Data"
         }
       },
+      "climate_status": {
+        "state": {
+          "summer_mode": "Summer Mode",
+          "winter_mode": "Winter Mode",
+          "intermediate": "Intermediate"
+        }
+      },
       "decision_trace": {
         "name": "Decision Trace",
         "state": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1008,6 +1008,13 @@
       },
       "position_forecast": {
         "name": "Prévision de position"
+      },
+      "climate_status": {
+        "state": {
+          "summer_mode": "Mode été",
+          "winter_mode": "Mode hiver",
+          "intermediate": "Intermédiaire"
+        }
       }
     },
     "switch": {

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -6,12 +6,15 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.components.sensor import SensorDeviceClass
+
 from custom_components.adaptive_cover_pro.const import CONF_SENSOR_TYPE, CoverType
 from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverClimateStatusSensor,
     AdaptiveCoverControlStatusSensor,
     AdaptiveCoverLastActionSensor,
     AdaptiveCoverSunPositionSensor,
+    _DIAGNOSTIC_SPECS,
 )
 
 
@@ -46,7 +49,7 @@ def _make_hass():
 
 @pytest.mark.unit
 def test_climate_status_native_value_summer_mode():
-    """Returns 'Summer Mode' when is_summer is True."""
+    """Returns 'summer_mode' slug when is_summer is True."""
     coord = _make_coordinator(
         diagnostics={"climate_conditions": {"is_summer": True, "is_winter": False}}
     )
@@ -59,12 +62,12 @@ def test_climate_status_native_value_summer_mode():
         coordinator=coord,
         hass_ref=_make_hass(),
     )
-    assert sensor.native_value == "Summer Mode"
+    assert sensor.native_value == "summer_mode"
 
 
 @pytest.mark.unit
 def test_climate_status_native_value_winter_mode():
-    """Returns 'Winter Mode' when is_winter is True."""
+    """Returns 'winter_mode' slug when is_winter is True."""
     coord = _make_coordinator(
         diagnostics={"climate_conditions": {"is_summer": False, "is_winter": True}}
     )
@@ -77,12 +80,12 @@ def test_climate_status_native_value_winter_mode():
         coordinator=coord,
         hass_ref=_make_hass(),
     )
-    assert sensor.native_value == "Winter Mode"
+    assert sensor.native_value == "winter_mode"
 
 
 @pytest.mark.unit
 def test_climate_status_native_value_intermediate():
-    """Returns 'Intermediate' when neither summer nor winter."""
+    """Returns 'intermediate' slug when neither summer nor winter."""
     coord = _make_coordinator(
         diagnostics={"climate_conditions": {"is_summer": False, "is_winter": False}}
     )
@@ -95,7 +98,7 @@ def test_climate_status_native_value_intermediate():
         coordinator=coord,
         hass_ref=_make_hass(),
     )
-    assert sensor.native_value == "Intermediate"
+    assert sensor.native_value == "intermediate"
 
 
 @pytest.mark.unit
@@ -370,3 +373,17 @@ def test_control_status_attrs_expose_cover_type(sensor_type):
     attrs = sensor.extra_state_attributes
     assert attrs is not None
     assert attrs.get("cover_type") == sensor_type
+
+
+# ---------------------------------------------------------------------------
+# climate_status _SensorSpec — translation_key, device_class, options
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_climate_status_spec_properties():
+    """climate_status spec must declare translation_key, ENUM device_class, and all three slugs."""
+    spec = next(s for s in _DIAGNOSTIC_SPECS if s.suffix == "climate_status")
+    assert spec.translation_key == "climate_status"
+    assert spec.device_class == SensorDeviceClass.ENUM
+    assert set(spec.options) == {"summer_mode", "winter_mode", "intermediate"}

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -40,7 +40,13 @@ _EN_JSON: dict = json.loads(
 # Canary: lock the expected set of sensor translation_keys. Update here when a
 # new sensor spec with translation_key is added.
 _EXPECTED_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
-    {"control_status", "decision_trace", "motion_status", "position_forecast"}
+    {
+        "climate_status",
+        "control_status",
+        "decision_trace",
+        "motion_status",
+        "position_forecast",
+    }
 )
 
 # Switch keys that appear in en.json under entity.switch but are generated


### PR DESCRIPTION
## Summary
Switches `climate_status` from raw English strings (`"Summer Mode"`, etc.) to slugs (`summer_mode`, `winter_mode`, `intermediate`) and wires up `translation_key`, `device_class=ENUM`, and `options` on the `_SensorSpec` so HA renders the per-language label from a state block.

Added the `entity.sensor.climate_status.state` block to `en.json`; synced `fr.json` and `de.json` via the `acp-translate` skill. Locked the new spec fields and the slug set across all three languages in tests.

This is a breaking change for any user automation or template that compares against the previous English state values — the release notes for the next version will call this out explicitly.

Pairs with the card-side i18n work in jrhubott/adaptive-cover-pro-card#64.

## Testing
- ✅ 3652 tests passing (full suite)
- New: `test_climate_status_spec_properties` locks `translation_key`, `device_class=ENUM`, and `options`
- Updated: three `test_climate_status_native_value_*` assertions
- Updated: `_EXPECTED_SENSOR_TRANSLATION_KEYS` canary in `test_spec_translation_keys.py`

## Related Issues
Refs #453