### PR TITLE
feat: add adaptive_cover_pro.stop service

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2038,6 +2038,22 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         return await self._cmd_svc.apply_position(entity_id, clamped, trigger, ctx)
 
+    async def async_apply_user_stop(
+        self,
+        entity_id: str,
+        *,
+        trigger: str,
+    ) -> tuple[str, str]:
+        """Apply a user-initiated stop to a single cover.
+
+        Engages manual override (so the next cycle does not immediately
+        counter-command the cover) then dispatches an ACP-context-stamped
+        ``cover.stop_cover`` via :meth:`CoverCommandService.apply_user_stop`.
+        Stop is unconditional — no pipeline preemption check.
+        """
+        self.manager.mark_user_command(entity_id, reason=trigger)
+        return await self._cmd_svc.apply_user_stop(entity_id)
+
     def build_diagnostic_data(self) -> dict:
         """Build diagnostic data from current coordinator state."""
         result = self._pipeline_result

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -552,6 +552,16 @@ class CoverCommandService:
         """
         return self._transit_elapsed_without_progress(entity_id, now)
 
+    async def apply_user_stop(self, entity_id: str) -> tuple[str, str]:
+        """Send an ACP-context-stamped ``cover.stop_cover`` for a user-initiated stop.
+
+        Routes through ``_stop_tracker.call_stop_cover`` so the resulting
+        EVENT_CALL_SERVICE is recognised as ACP-originated and ignored by
+        the coordinator's service-call listener.
+        """
+        await self._stop_tracker.call_stop_cover(entity_id)
+        return "sent", "stop_cover"
+
     def was_acp_stop_context(self, context_id: str) -> bool:
         """Whether ``context_id`` belongs to an ACP-originated cover.stop_cover call.
 

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1,3 +1,15 @@
+stop:
+  name: Stop cover
+  description: >-
+    Sends stop_cover to the targeted covers via the ACP proxy so the command
+    is recognised as ACP-originated. Engages manual override so the next
+    automatic cycle does not immediately counter-command the cover. Compatible
+    with manual_ignore_external mode — the Lovelace card stop button should
+    call this service instead of cover.stop_cover directly.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+
 integration_enable:
   name: Enable integration
   description: >-

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -16,6 +16,7 @@ from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagno
 from .export_service import EXPORT_CONFIG_SCHEMA, async_handle_export
 from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
+from .stop_service import async_handle_stop
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,6 +160,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, "set_position", async_handle_set_position, schema=SET_POSITION_SCHEMA
     )
+    hass.services.async_register(DOMAIN, "stop", async_handle_stop)
 
     register_options_services(hass)
 
@@ -173,5 +175,6 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "integration_disable")
     hass.services.async_remove(DOMAIN, "emergency_stop")
     hass.services.async_remove(DOMAIN, "set_position")
+    hass.services.async_remove(DOMAIN, "stop")
     for name in OPTIONS_SERVICE_NAMES:
         hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/stop_service.py
+++ b/custom_components/adaptive_cover_pro/services/stop_service.py
@@ -1,0 +1,41 @@
+"""stop service — sends stop_cover via the ACP-stamped context.
+
+Thin target-resolution layer over ``Coordinator.async_apply_user_stop``,
+which owns the manual-override engagement and stop dispatch logic.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _resolve_targets(hass, call):
+    """Thin re-export so tests can patch the local name."""
+    from . import _resolve_targets as _rt  # noqa: PLC0415
+
+    return _rt(hass, call)
+
+
+async def async_handle_stop(call: ServiceCall) -> None:
+    """Handle the stop service call.
+
+    Resolves the target block to one or more coordinators (each with an
+    optional entity filter), then delegates each stop command to
+    ``coord.async_apply_user_stop`` — the single delegation point for
+    manual-override engagement and ACP-context-stamped stop dispatch.
+    """
+    hass = call.hass
+    targets = _resolve_targets(hass, call)
+
+    for coord, entity_filter in targets.items():
+        entity_ids: list[str] = (
+            list(entity_filter) if entity_filter is not None else list(coord.entities)
+        )
+        for entity_id in entity_ids:
+            await coord.async_apply_user_stop(entity_id, trigger="stop")

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1670,6 +1670,10 @@
       },
       "name": "Position setzen (mit Mindestwert-Erzwingung)",
       "description": "Bewegt die Beschattung zur angeforderten Position und begrenzt sie auf den höchsten aktiven Mindestwert der benutzerdefinierten Position. Verwenden Sie dies statt cover.set_cover_position, wenn Sie ACP's Mindestwerte aus Automationen berücksichtigen möchten. Die Neigung wird nicht beeinflusst."
+    },
+    "stop": {
+      "name": "Beschattung stoppen",
+      "description": "Sendet stop_cover an die gewählten Beschattungen über den ACP-Proxy. Aktiviert Manuelle Übersteuerung, sodass der nächste automatische Zyklus die Beschattung nicht gegen die Bedienung aussteuert. Verwenden Sie dies statt cover.stop_cover, wenn manual_ignore_external aktiviert ist."
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1137,6 +1137,10 @@
     }
   },
   "services": {
+    "stop": {
+      "name": "Stop cover",
+      "description": "Sends stop_cover to the targeted covers via the ACP proxy. Engages manual override so the next automatic cycle does not counter-command the cover. Use this instead of cover.stop_cover when manual_ignore_external is enabled."
+    },
     "integration_enable": {
       "name": "Enable integration",
       "description": "Re-enables Adaptive Cover Pro on the targeted instances. Covers stay where they are; positioning resumes on the next natural update cycle."

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1670,6 +1670,10 @@
       },
       "name": "Définir la position (avec plancher appliqué)",
       "description": "Déplace la protection vers la position demandée, en la limitant au plancher minimum le plus élevé de la position personnalisée active en mode minimum. Utilisez ceci au lieu de cover.set_cover_position quand vous avez besoin que les planchers de mode minimum d'ACP soient respectés à partir des automatisations. L'inclinaison n'est pas affectée."
+    },
+    "stop": {
+      "name": "Arrêter la protection",
+      "description": "Envoie stop_cover aux protections ciblées via le proxy ACP. Active la dérogation manuelle afin que le prochain cycle automatique ne contre-commande pas la protection. Utilisez ce service à la place de cover.stop_cover quand manual_ignore_external est activé."
     }
   }
 }

--- a/tests/services/test_stop_service.py
+++ b/tests/services/test_stop_service.py
@@ -1,0 +1,151 @@
+"""Unit tests for the stop_service module.
+
+Tests the thin target-resolution layer over
+``Coordinator.async_apply_user_stop``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_coord(*, entities: list[str] | None = None, apply_user_stop_result=None):
+    """Build a minimal mock coordinator."""
+    coord = MagicMock()
+    coord.entities = entities or ["cover.test_blind"]
+    coord.async_apply_user_stop = AsyncMock(
+        return_value=apply_user_stop_result or ("sent", "stop_cover")
+    )
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Step 2: _resolve_targets wrapper delegates to services._resolve_targets
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_targets_wrapper_delegates_to_services_module() -> None:
+    """The local _resolve_targets wrapper forwards args to services._resolve_targets."""
+    from custom_components.adaptive_cover_pro.services.stop_service import (
+        _resolve_targets as wrapper,
+    )
+
+    sentinel_hass = MagicMock(name="hass")
+    sentinel_call = MagicMock(name="call")
+    expected = {"coord_x": None}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services._resolve_targets",
+        return_value=expected,
+    ) as real:
+        result = wrapper(sentinel_hass, sentinel_call)
+
+    real.assert_called_once_with(sentinel_hass, sentinel_call)
+    assert result is expected
+
+
+# ---------------------------------------------------------------------------
+# Step 3: mark_user_command is called via async_apply_user_stop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_handle_stop_calls_apply_user_stop() -> None:
+    """async_handle_stop calls coord.async_apply_user_stop for each entity."""
+    from custom_components.adaptive_cover_pro.services.stop_service import (
+        async_handle_stop,
+    )
+
+    coord = _make_coord()
+    call = MagicMock()
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.stop_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_stop(call)
+
+    coord.async_apply_user_stop.assert_awaited_once_with(
+        "cover.test_blind", trigger="stop"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 6: Entity filter limits which entities are commanded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entity_filter_limits_commands() -> None:
+    """When entity_filter is a set, only those entities get commanded."""
+    from custom_components.adaptive_cover_pro.services.stop_service import (
+        async_handle_stop,
+    )
+
+    coord = _make_coord(entities=["cover.blind_a", "cover.blind_b"])
+    call = MagicMock()
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.stop_service._resolve_targets",
+        return_value={coord: {"cover.blind_a"}},
+    ):
+        await async_handle_stop(call)
+
+    calls = coord.async_apply_user_stop.await_args_list
+    entity_ids_commanded = [c.args[0] for c in calls]
+    assert entity_ids_commanded == ["cover.blind_a"]
+
+
+# ---------------------------------------------------------------------------
+# Step 7: No target → all coordinators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_filter_commands_all_entities() -> None:
+    """When entity_filter is None, all coordinator entities are commanded."""
+    from custom_components.adaptive_cover_pro.services.stop_service import (
+        async_handle_stop,
+    )
+
+    coord = _make_coord(entities=["cover.blind_a", "cover.blind_b"])
+    call = MagicMock()
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.stop_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_stop(call)
+
+    calls = coord.async_apply_user_stop.await_args_list
+    entity_ids_commanded = sorted(c.args[0] for c in calls)
+    assert entity_ids_commanded == ["cover.blind_a", "cover.blind_b"]
+
+
+# ---------------------------------------------------------------------------
+# Step 8: Unknown entity → silently skipped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_entity_silently_skipped() -> None:
+    """Empty resolve → no coordinator → no async_apply_user_stop call."""
+    from custom_components.adaptive_cover_pro.services.stop_service import (
+        async_handle_stop,
+    )
+
+    call = MagicMock()
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.stop_service._resolve_targets",
+        return_value={},
+    ):
+        await async_handle_stop(call)
+    # No assertion needed — just must not raise

--- a/tests/test_services_stop.py
+++ b/tests/test_services_stop.py
@@ -1,0 +1,248 @@
+"""Integration and unit tests for the adaptive_cover_pro.stop service.
+
+Steps 1, 4, 5, 9, 10, 11 of the TDD plan.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from tests.ha_helpers import (
+    VERTICAL_OPTIONS,
+    _patch_coordinator_refresh,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _setup(hass, entry_id: str = "stop_01", name: str = "Stop Cover"):
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": name, CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id=entry_id,
+        title=name,
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _make_coord(*, entities: list[str] | None = None):
+    """Minimal mock coordinator for unit-level stop tests."""
+    coord = MagicMock()
+    coord.entities = entities or ["cover.test_blind"]
+    coord.async_apply_user_stop = AsyncMock(return_value=("sent", "stop_cover"))
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Step 1: Service is registered and unregistered
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_stop_service_registered_after_setup(hass) -> None:
+    """adaptive_cover_pro.stop is registered after async_setup_services."""
+    await _setup(hass, entry_id="stop_reg_01")
+    assert hass.services.has_service(
+        DOMAIN, "stop"
+    ), "stop service should be registered after setup"
+
+
+@pytest.mark.integration
+async def test_stop_service_removed_after_all_entries_unloaded(hass) -> None:
+    """Stop service is removed when the last entry is unloaded."""
+    entry = await _setup(hass, entry_id="stop_unload_01")
+    assert hass.services.has_service(DOMAIN, "stop")
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.services.has_service(
+        DOMAIN, "stop"
+    ), "stop service should be removed when last entry is unloaded"
+
+
+# ---------------------------------------------------------------------------
+# Step 4: cover.stop_cover is forwarded (via async_apply_user_stop → _cmd_svc)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_stop_calls_mark_user_command_and_stop() -> None:
+    """async_apply_user_stop calls mark_user_command then apply_user_stop."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock()
+    coord.manager = MagicMock()
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.apply_user_stop = AsyncMock(return_value=("sent", "stop_cover"))
+
+    # Bind the real method
+    coord.async_apply_user_stop = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_stop.__get__(coord)
+    )
+
+    await coord.async_apply_user_stop("cover.test_blind", trigger="stop")
+
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.test_blind", reason="stop"
+    )
+    coord._cmd_svc.apply_user_stop.assert_awaited_once_with("cover.test_blind")
+
+
+# ---------------------------------------------------------------------------
+# Step 5: ACP context stamped → was_acp_stop_context returns True
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_user_stop_public_method_wraps_stop_tracker() -> None:
+    """CoverCommandService.apply_user_stop delegates to _stop_tracker.call_stop_cover."""
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+    )
+
+    cmd_svc = MagicMock(spec=CoverCommandService)
+    cmd_svc._stop_tracker = MagicMock()
+    cmd_svc._stop_tracker.call_stop_cover = AsyncMock()
+
+    # Bind the real method
+    cmd_svc.apply_user_stop = CoverCommandService.apply_user_stop.__get__(cmd_svc)
+
+    await cmd_svc.apply_user_stop("cover.test_blind")
+
+    cmd_svc._stop_tracker.call_stop_cover.assert_awaited_once_with("cover.test_blind")
+
+
+# ---------------------------------------------------------------------------
+# Step 9: ACP service path bypasses the manual_ignore_external gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_acp_stop_service_bypasses_manual_ignore_external_gate() -> None:
+    """When async_apply_user_stop stamps ACP context, async_check_cover_service_call
+    sees was_acp_stop_context=True and ignores the external event.
+
+    This verifies the end-to-end bypass: ACP stop → context stamped → gate passes.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from homeassistant.core import Context, Event
+
+    entity_id = "cover.test_blind"
+
+    # Build a minimal coordinator mock with was_acp_stop_context=True
+    coordinator = MagicMock()
+    coordinator.manual_toggle = True
+    coordinator.automatic_control = True
+    coordinator.manual_ignore_external = True
+    coordinator.entities = [entity_id]
+    coordinator.logger = MagicMock()
+    coordinator._manual_gate_closed_log = MagicMock()
+
+    cmd_svc = MagicMock()
+    # Simulate ACP context — was_acp_stop_context returns True
+    cmd_svc.was_acp_stop_context = MagicMock(return_value=True)
+    cmd_svc.is_waiting_for_target = MagicMock(return_value=False)
+    cmd_svc.set_target = MagicMock()
+    cmd_svc.discard_target = MagicMock()
+    coordinator._cmd_svc = cmd_svc
+    coordinator.manager = MagicMock()
+    coordinator.manager.is_cover_manual = MagicMock(return_value=False)
+    coordinator.manager.handle_stop_service_call = MagicMock()
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {}
+
+    ctx = Context()
+    event = Event(
+        "call_service",
+        {
+            "domain": "cover",
+            "service": "stop_cover",
+            "service_data": {"entity_id": entity_id},
+            "context": ctx,
+        },
+        context=ctx,
+    )
+
+    await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+        coordinator, event
+    )
+
+    # Gate should have passed the ACP context check and returned early
+    coordinator.manager.handle_stop_service_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Step 10: services.yaml documents the stop service
+# ---------------------------------------------------------------------------
+
+
+def test_services_yaml_has_stop_entry() -> None:
+    """services.yaml contains a top-level 'stop' key."""
+    import yaml
+    from pathlib import Path
+
+    services_yaml = (
+        Path(__file__).parent.parent
+        / "custom_components"
+        / "adaptive_cover_pro"
+        / "services.yaml"
+    )
+    data = yaml.safe_load(services_yaml.read_text())
+    assert (
+        "stop" in data
+    ), f"'stop' key missing from services.yaml; found: {list(data.keys())}"
+    entry = data["stop"]
+    assert "name" in entry
+    assert "description" in entry
+    assert "target" in entry
+
+
+# ---------------------------------------------------------------------------
+# Step 11: translations/en.json has stop entry
+# ---------------------------------------------------------------------------
+
+
+def test_en_json_has_stop_service_entry() -> None:
+    """translations/en.json has a services.stop entry."""
+    import json
+    from pathlib import Path
+
+    en_json = (
+        Path(__file__).parent.parent
+        / "custom_components"
+        / "adaptive_cover_pro"
+        / "translations"
+        / "en.json"
+    )
+    data = json.loads(en_json.read_text())
+    services = data.get("services", {})
+    assert (
+        "stop" in services
+    ), f"'stop' key missing from en.json services; found: {list(services.keys())}"
+    stop = services["stop"]
+    assert "name" in stop
+    assert "description" in stop


### PR DESCRIPTION
## Summary
Adds `adaptive_cover_pro.stop` service mirroring `set_position`: routes `cover.stop_cover` through ACP's command stack so the call stamps an ACP-originated HA context AND engages manual override via `mark_user_command`. With `manual_ignore_external` enabled, the resulting state-change event is recognized as ACP-originated, and the next automatic cycle does not counter-command the cover.

The Lovelace card can switch its stop handler from `cover.stop_cover` to `adaptive_cover_pro.stop` once this lands (jrhubott/adaptive-cover-pro-card#67). Until then, the card's direct `cover.stop_cover` call will silently fail when `manual_ignore_external` is on.

## Testing
- ✅ 3670+ tests passing (12 new tests for the stop service path)

## Related Issues
Refs #456