### PR TITLE
feat: improve FR wording for cloud_suppression decision trace

### DIFF
--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1007,7 +1007,7 @@
           "force_override": "Dérogation forcée",
           "custom_position": "Position personnalisée",
           "weather_override": "Dérogation météo",
-          "cloud_suppression": "Suppression de nuages"
+          "cloud_suppression": "Désactivation par temps nuageux"
         }
       },
       "position_forecast": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -290,3 +290,21 @@ def test_venetian_mode_in_en_geometry_translations() -> None:
     assert "venetian_mode" in opt_geom.get(
         "data_description", {}
     ), "venetian_mode description missing from options.step.geometry.data_description"
+
+
+# ---------------------------------------------------------------------------
+# Issue #457 — FR cloud_suppression decision trace label must use action-oriented phrasing
+# ---------------------------------------------------------------------------
+
+
+def test_fr_cloud_suppression_decision_trace_state() -> None:
+    """FR decision_trace.state.cloud_suppression must use action-oriented phrasing, not 'Suppression de nuages'."""
+    fr = _load(TRANSLATIONS_DIR / "fr.json")
+    value = fr["entity"]["sensor"]["decision_trace"]["state"]["cloud_suppression"]
+    assert value != "Suppression de nuages", (
+        "Reverted to misleading phrasing — must say 'Désactivation par temps nuageux' "
+        "(reads as 'removing the clouds' to a French native speaker; see issue #457)"
+    )
+    assert (
+        "nuageux" in value.lower()
+    ), f"FR cloud_suppression state label should reference cloudy weather; got: {value!r}"


### PR DESCRIPTION
## Summary
The French translation for `decision_trace.state.cloud_suppression` read as "Suppression de nuages", which a native speaker flagged as semantically wrong ("removing the clouds themselves"). I changed it to "Désactivation par temps nuageux" to match the wording the companion Lovelace card just adopted in its own FR dictionary. Scope is the single value at `fr.json:1010`; `en.json` and `de.json` are unchanged.

A regression guard in `tests/test_translations.py` pins the new wording so a future `acp-translate` sync can't silently revert it.

## Testing
- ✅ 25 tests passing in `tests/test_translations.py` (24 baseline + 1 new regression guard)
- ✅ `scripts/validate_translations.py` reports 1063/1063 parity, 0 missing/extra

## Related Issues
Refs #457
Refs jrhubott/adaptive-cover-pro-card#64