### PR TITLE
fix: compose floor-mode rules as post-pipeline clamp (#463)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -113,9 +113,9 @@ from .pipeline.handlers import (
     SolarHandler,
     WeatherOverrideHandler,
 )
+from .pipeline.floors import effective_floor, gather_active_floors
 from .pipeline.registry import PipelineRegistry
 from .pipeline.snapshot_builder import PipelineSnapshotBuilder
-from .pipeline.types import CustomPositionSensorState
 from .const import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
 from .state.cover_provider import CoverProvider
@@ -174,26 +174,6 @@ class AdaptiveCoverData:
     attributes: dict
     diagnostics: dict | None = None
     position_forecast: Forecast | None = None
-
-
-def _winner_is_satisfied_custom_floor(
-    winner_handler: object,
-    states: list[CustomPositionSensorState],
-    clamped: int,
-) -> bool:
-    """Return True when the winning handler is a min-mode custom-position floor that the user's clamped request already satisfies."""
-    if not isinstance(winner_handler, CustomPositionHandler):
-        return False
-    matching = next(
-        (s for s in states if s.entity_id == winner_handler._entity_id),
-        None,
-    )
-    return (
-        matching is not None
-        and matching.is_on
-        and matching.min_mode
-        and clamped >= matching.position
-    )
 
 
 class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
@@ -1970,10 +1950,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         opt in.
         """
         opts = options if options is not None else self.config_entry.options
-        states = self._snapshot_builder.read_custom_position_sensors(opts)
-        floors = [s.position for s in states if s.is_on and s.min_mode]
-        effective_floor = max(floors) if floors else 0
-        clamped = max(int(requested), effective_floor)
+        snapshot = self._snapshot_builder.build(
+            opts,
+            cover_data=self._cover_data,
+            cover_type=self._cover_type,
+            climate_readings=self._weather_readings,
+            manual_override_active=False,
+            motion_timeout_active=self.is_motion_timeout_active,
+            weather_override_active=self.is_weather_override_active,
+            in_time_window=self.check_adaptive_time,
+            current_cover_position=self._compute_mean_cover_position(),
+            is_glare_zone_enabled=self._is_glare_zone_enabled,
+        )
+        floors = gather_active_floors(snapshot)
+        effective_floor_pos, _ = effective_floor(floors)
+        clamped = max(int(requested), effective_floor_pos)
         if clamped != requested:
             _LOGGER.info(
                 "%s: requested %d clamped to %d (active min-mode floor)",
@@ -1986,33 +1977,26 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 "%s: requested %d, floor %d — no clamping needed",
                 trigger,
                 requested,
-                effective_floor,
+                effective_floor_pos,
             )
 
         if not force:
-            snapshot = self._snapshot_builder.build(
-                opts,
-                cover_data=self._cover_data,
-                cover_type=self._cover_type,
-                climate_readings=self._weather_readings,
-                manual_override_active=False,
-                motion_timeout_active=self.is_motion_timeout_active,
-                weather_override_active=self.is_weather_override_active,
-                in_time_window=self.check_adaptive_time,
-                current_cover_position=self._compute_mean_cover_position(),
-                is_glare_zone_enabled=self._is_glare_zone_enabled,
-            )
             result = self._pipeline.evaluate(snapshot)
-            winner_step = next((s for s in result.decision_trace if s.matched), None)
+            winner_step = next(
+                (
+                    s
+                    for s in result.decision_trace
+                    if s.matched and s.handler != "floor_clamp"
+                ),
+                None,
+            )
             if winner_step is not None:
                 winner_name = winner_step.handler
                 winner_handler = self._handler_by_name.get(winner_name)
                 winner_priority = (
                     winner_handler.priority if winner_handler is not None else 0
                 )
-                if _winner_is_satisfied_custom_floor(winner_handler, states, clamped):
-                    pass  # fall through to mark_user_command + dispatch
-                elif winner_priority > ManualOverrideHandler.priority:
+                if winner_priority > ManualOverrideHandler.priority:
                     _LOGGER.info(
                         "user move on %s preempted by %s (priority %d > %d)",
                         entity_id,

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -485,7 +485,12 @@ class DiagnosticsBuilder:
 
     @staticmethod
     def _build_decision_trace(ctx: DiagnosticContext) -> dict:
-        """Build per-handler decision trace from pipeline result."""
+        """Build per-handler decision trace from pipeline result.
+
+        Note: the trace may include a synthetic ``floor_clamp`` step that is
+        not backed by a registered handler — it represents the post-decision
+        floor-composition pass in :class:`PipelineRegistry` (issue #463).
+        """
         result = ctx.pipeline_result
         if result is None or not result.decision_trace:
             return {"decision_trace": []}

--- a/custom_components/adaptive_cover_pro/pipeline/floors.py
+++ b/custom_components/adaptive_cover_pro/pipeline/floors.py
@@ -1,0 +1,105 @@
+"""Floor-mode composition helpers (issue #463).
+
+A "floor" is a minimum-position clamp contributed by an *active* override —
+custom-position slot with ``min_mode``, weather override with ``min_mode``,
+or force override with ``min_mode`` — that must raise whichever handler
+ultimately wins the pipeline, regardless of priority.
+
+These helpers are pure: they read a :class:`PipelineSnapshot` and return
+plain data. The registry composes the active floors after picking a winner;
+the coordinator's user-move clamp consumes the same helpers so the
+``max(active_floors)`` arithmetic exists in exactly one place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from .types import PipelineSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class FloorClampInfo:
+    """One active floor contributed to the pipeline composition pass.
+
+    Attributes:
+        source: Stable identifier used as the ``handler`` field in the
+                decision trace — e.g. ``"custom_position_1"``,
+                ``"weather"``, ``"force_override"``.
+        label:  Human-readable name used in the clamp reason string —
+                the bound sensor's friendly name, or a fixed string for
+                weather / force overrides.
+        position: The floor position (0–100) in pre-inversion canonical
+                space (0 = closed, 100 = open).
+
+    """
+
+    source: str
+    label: str
+    position: int
+
+
+def gather_active_floors(snapshot: PipelineSnapshot) -> list[FloorClampInfo]:
+    """Collect every active min-mode floor contributed by the snapshot.
+
+    Order of returned floors:
+      1. Custom-position slots, in the order they appear in
+         ``snapshot.custom_position_sensors`` (matches ``_build_pipeline``
+         registration order).
+      2. The weather override floor, if any.
+      3. The force override floor, if any.
+
+    A custom-position floor is active when its sensor is ``is_on`` and
+    ``min_mode`` is True. ``use_my`` floors are excluded — the "Use My"
+    path is hardware-pinned and never participates in floor semantics.
+    """
+    floors: list[FloorClampInfo] = []
+    for index, state in enumerate(snapshot.custom_position_sensors, start=1):
+        if state.is_on and state.min_mode and not state.use_my:
+            label = state.sensor_name or state.entity_id
+            floors.append(
+                FloorClampInfo(
+                    source=f"custom_position_{index}",
+                    label=label,
+                    position=state.position,
+                )
+            )
+    if snapshot.weather_override_active and snapshot.weather_override_min_mode:
+        floors.append(
+            FloorClampInfo(
+                source="weather",
+                label="weather override",
+                position=snapshot.weather_override_position,
+            )
+        )
+    if (
+        snapshot.force_override_sensors
+        and any(snapshot.force_override_sensors.values())
+        and snapshot.force_override_min_mode
+    ):
+        floors.append(
+            FloorClampInfo(
+                source="force_override",
+                label="force override",
+                position=snapshot.force_override_position,
+            )
+        )
+    return floors
+
+
+def effective_floor(
+    floors: Iterable[FloorClampInfo],
+) -> tuple[int, FloorClampInfo | None]:
+    """Return the highest active floor and the FloorClampInfo it came from.
+
+    When ``floors`` is empty, returns ``(0, None)`` — the coordinator and
+    registry both treat 0 as "no clamp applied".
+    """
+    winner: FloorClampInfo | None = None
+    for info in floors:
+        if winner is None or info.position > winner.position:
+            winner = info
+    if winner is None:
+        return 0, None
+    return winner.position, winner

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...const import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import apply_minimum_mode, compute_raw_calculated_position
+from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -60,11 +60,21 @@ class CustomPositionHandler(OverrideHandler):
         return f"custom_position_{self._slot}"
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
-        """Return the configured position when this slot's sensor is active."""
+        """Return the configured position when this slot's sensor is active.
+
+        In ``min_mode`` (and not on the ``use_my`` path), the handler defers
+        by returning ``None``. The registry then composes the configured
+        position as a post-decision floor clamp on whichever lower-priority
+        handler wins (issue #463).
+        """
         # Find our sensor in the snapshot's sensor list by entity_id.
         for state in snapshot.custom_position_sensors:
             if state.entity_id == self._entity_id:
                 if state.is_on:
+                    # Floor mode (without use_my) defers to the floor-clamp
+                    # composition pass — see pipeline/floors.py.
+                    if state.min_mode and not state.use_my:
+                        return None
                     raw = compute_raw_calculated_position(snapshot)
                     # "Use My" path: route through the cover's hardware-stored My preset.
                     # my_position_value acts as both the target and the reason annotation.
@@ -87,9 +97,9 @@ class CustomPositionHandler(OverrideHandler):
                             custom_position_minimum_mode=None,
                             custom_position_active_slot_name=state.sensor_name,
                         )
-                    pos, mode_note = apply_minimum_mode(
-                        self._position, raw, enabled=state.min_mode
-                    )
+                    # Exact-position branch (state.min_mode is False here —
+                    # floor mode defers above).
+                    pos = self._position
                     return PipelineResult(
                         position=pos,
                         tilt=self._tilt,
@@ -97,14 +107,12 @@ class CustomPositionHandler(OverrideHandler):
                         control_method=ControlMethod.CUSTOM_POSITION,
                         reason=(
                             f"custom position #{self._slot} active ({self._entity_id})"
-                            f" — position {pos}%{mode_note}"
+                            f" — position {pos}%"
                             " [bypasses automatic control]"
                         ),
                         raw_calculated_position=raw,
                         custom_position_active_slot=self._slot,
-                        custom_position_minimum_mode=(
-                            (raw < self._position) if state.min_mode else None
-                        ),
+                        custom_position_minimum_mode=None,
                         custom_position_active_slot_name=state.sensor_name,
                     )
                 # Sensor found but not active — pass through

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/force_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/force_override.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...const import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import apply_minimum_mode, compute_raw_calculated_position
+from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -20,21 +20,26 @@ class ForceOverrideHandler(OverrideHandler):
     priority = 100
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
-        """Return override position when any force override sensor is on."""
+        """Return override position when any force override sensor is on.
+
+        When ``force_override_min_mode`` is True, the handler defers
+        (returns ``None``) so the registry can compose the configured
+        position as a post-decision floor clamp on whichever lower-priority
+        handler wins (issue #463).
+        """
         if not snapshot.force_override_sensors:
             return None
         if not any(snapshot.force_override_sensors.values()):
             return None
+        if snapshot.force_override_min_mode:
+            return None
         active = [e for e, on in snapshot.force_override_sensors.items() if on]
-        configured = snapshot.force_override_position
+        pos = snapshot.force_override_position
         raw = compute_raw_calculated_position(snapshot)
-        pos, mode_note = apply_minimum_mode(
-            configured, raw, enabled=snapshot.force_override_min_mode
-        )
         return PipelineResult(
             position=pos,
             control_method=ControlMethod.FORCE,
-            reason=f"force override active ({', '.join(active)}) — position {pos}%{mode_note} [bypasses automatic control]",
+            reason=f"force override active ({', '.join(active)}) — position {pos}% [bypasses automatic control]",
             bypass_auto_control=True,
             raw_calculated_position=raw,
         )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/weather.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/weather.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...const import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import apply_minimum_mode, compute_raw_calculated_position
+from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -28,16 +28,21 @@ class WeatherOverrideHandler(OverrideHandler):
     priority = 90
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
-        """Return override position when weather conditions are active."""
+        """Return override position when weather conditions are active.
+
+        When ``weather_override_min_mode`` is True, the handler defers
+        (returns ``None``) so the registry can compose the configured
+        position as a post-decision floor clamp on whichever lower-priority
+        handler wins (issue #463).
+        """
         if not snapshot.weather_override_active:
             return None
-        configured = snapshot.weather_override_position
+        if snapshot.weather_override_min_mode:
+            return None
+        pos = snapshot.weather_override_position
         bypass = snapshot.weather_bypass_auto_control
         raw = compute_raw_calculated_position(snapshot)
-        pos, mode_note = apply_minimum_mode(
-            configured, raw, enabled=snapshot.weather_override_min_mode
-        )
-        reason = f"weather override active — position {pos}%{mode_note}"
+        reason = f"weather override active — position {pos}%"
         if bypass:
             reason += " [bypasses automatic control]"
         return PipelineResult(

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -6,9 +6,10 @@ patterns across pipeline handlers:
 - ``apply_snapshot_limits``    — apply position limits using config from the snapshot
 - ``compute_solar_position``   — calculate_percentage() + floor-at-1 + limits
 - ``compute_default_position`` — default_position + limits (sun not in FOV)
-- ``apply_minimum_mode``       — pick max(configured, raw) when min-mode is on,
-                                 else just the configured value, plus a
-                                 reason-string suffix for diagnostics
+
+Floor-mode composition (the former ``apply_minimum_mode`` semantic) now
+lives in :mod:`pipeline.floors` and runs as a post-decision pass in the
+registry — see issue #463.
 """
 
 from __future__ import annotations
@@ -95,39 +96,6 @@ def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
         snapshot.default_position,
         sun_valid=False,
     )
-
-
-def apply_minimum_mode(
-    configured: int,
-    raw: int,
-    *,
-    enabled: bool,
-) -> tuple[int, str]:
-    """Pick a position from the configured/raw pair under min-mode rules.
-
-    Several override handlers (force, weather, custom-position) support a
-    "minimum-mode" toggle: when on, the override acts as a *floor* under the
-    sun-tracked position rather than a hard target — covers go to whichever
-    is more closed (the configured override, or what solar tracking would do
-    anyway).  When off, the configured override is used as-is.
-
-    Args:
-        configured: User-configured override position (0–100).
-        raw:        The sun-tracked position the handler would otherwise yield.
-        enabled:    Whether minimum-mode is active for this handler instance.
-
-    Returns:
-        ``(position, reason_suffix)`` — the position to send and a short
-        diagnostic suffix to append to the handler's reason string. Suffix is
-        empty when minimum-mode is off so the reason reads cleanly.
-
-    """
-    if enabled:
-        return (
-            max(configured, raw),
-            f" [minimum mode — floor {configured}%, calculated {raw}%]",
-        )
-    return configured, ""
 
 
 def compute_default_position(snapshot: PipelineSnapshot) -> int:

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -6,6 +6,7 @@ import dataclasses
 import datetime as dt
 
 from ..diagnostics.event_buffer import EventBuffer
+from .floors import effective_floor, gather_active_floors
 from .handler import OverrideHandler
 from .types import DecisionStep, PipelineResult, PipelineSnapshot
 
@@ -115,12 +116,61 @@ class PipelineRegistry:
                             merged[field_name] = val
                             break
 
+        # Floor-mode composition (issue #463).  Custom-position slots,
+        # weather override, and force override in min_mode each contribute
+        # a "floor" — a minimum position that must clamp the winner regardless
+        # of priority.  The handlers themselves defer (return None) in floor
+        # mode; the registry composes the effective floor here so the
+        # arithmetic lives in exactly one place (pipeline/floors.py).
+        active_floors = gather_active_floors(snapshot)
+        floor_pos, floor_info = effective_floor(active_floors)
+        clamped_position = winner.position
+        if floor_info is not None and floor_pos > winner.position:
+            clamped_position = floor_pos
+            trace.append(
+                DecisionStep(
+                    handler="floor_clamp",
+                    matched=True,
+                    reason=(
+                        f"floor raised winner from {winner.position}% to "
+                        f"{floor_pos}% by {floor_info.label}"
+                    ),
+                    position=floor_pos,
+                )
+            )
+        # Replace any existing trace step whose handler matches an active
+        # floor's source — those steps came from the deferral path and
+        # carry an unhelpful describe_skip reason.  We give them a fresh
+        # entry that explains the floor was active but did not win.
+        floor_sources = {info.source for info in active_floors}
+        trace = [step for step in trace if step.handler not in floor_sources]
+        for info in active_floors:
+            if (
+                floor_info is not None
+                and info is floor_info
+                and floor_pos > winner.position
+            ):
+                continue  # this floor *did* win — already emitted as floor_clamp
+            trace.append(
+                DecisionStep(
+                    handler=info.source,
+                    matched=False,
+                    reason=(
+                        f"floor {info.position}% inactive "
+                        f"(winner {winner.position}% above floor)"
+                    ),
+                    position=info.position,
+                )
+            )
+
         # Propagate sunset-window flags from the snapshot.
         # NOTE: configured_default and configured_sunset_pos are
         # intentionally left at their defaults (0 / None) here.
         # The coordinator annotates them via dataclasses.replace()
         # after evaluation so they never appear in the snapshot
         # that handlers can read.
+        if clamped_position != winner.position:
+            winner = dataclasses.replace(winner, position=clamped_position)
         result = dataclasses.replace(
             winner,
             decision_trace=trace,

--- a/tests/services/test_set_position_service.py
+++ b/tests/services/test_set_position_service.py
@@ -40,6 +40,12 @@ def _make_coord(custom_states):
     coord.config_entry.options = {}
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors.return_value = custom_states
+    # Floor composition reads custom_position_sensors from a real PipelineSnapshot
+    # (issue #463) — return a populated snapshot from build().
+    from tests.test_pipeline.conftest import make_snapshot  # noqa: PLC0415
+
+    snapshot = make_snapshot(custom_position_sensors=custom_states or [])
+    coord._snapshot_builder.build = MagicMock(return_value=snapshot)
     ctx = MagicMock(name="position_context")
     coord._build_position_context.return_value = ctx
     coord._cmd_svc = MagicMock()

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -371,9 +371,46 @@ async def _trigger_async_apply_user_position(coord):
     coord.config_entry.options = {}
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors = MagicMock(return_value=[])
-    await coord.async_apply_user_position(
-        "cover.test", 42, trigger="set_position", force=True
-    )
+    # Floor composition reads from a real PipelineSnapshot (#463).
+    from tests.test_pipeline.conftest import make_snapshot  # noqa: PLC0415
+    from unittest.mock import patch as _patch  # noqa: PLC0415
+
+    snapshot = make_snapshot()
+    coord._snapshot_builder.build = MagicMock(return_value=snapshot)
+    # Snapshot builder consumes these coordinator attrs via kwargs — present
+    # them as plain mocks so the call signature resolves.  The mock returns
+    # the pre-built snapshot regardless of inputs.
+    coord._cover_data = MagicMock()
+    coord._cover_type = "cover_blind"
+    coord._weather_readings = None
+    coord._compute_mean_cover_position = MagicMock(return_value=None)
+    # is_motion_timeout_active / is_weather_override_active / check_adaptive_time
+    # are properties — patch them at the class level for this call.
+    with (
+        _patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "is_motion_timeout_active",
+            new_callable=lambda: False,
+        ),
+        _patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "is_weather_override_active",
+            new_callable=lambda: False,
+        ),
+        _patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "check_adaptive_time",
+            new_callable=lambda: True,
+        ),
+        _patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "_is_glare_zone_enabled",
+            new=MagicMock(return_value=False),
+        ),
+    ):
+        await coord.async_apply_user_position(
+            "cover.test", 42, trigger="set_position", force=True
+        )
 
 
 CONTROL_GATE_MATRIX: list[MatrixCase] = [

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -63,6 +63,12 @@ def _make_coord(
     winner_name: str = "solar",
     winner_priority: int = 40,
     winner_handler_instance=None,
+    weather_override_active: bool = False,
+    weather_override_position: int = 0,
+    weather_override_min_mode: bool = False,
+    force_override_sensors: dict[str, bool] | None = None,
+    force_override_position: int = 0,
+    force_override_min_mode: bool = False,
 ):
     """Build a coordinator-shaped mock that exposes async_apply_user_position.
 
@@ -75,6 +81,7 @@ def _make_coord(
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
+    from tests.test_pipeline.conftest import make_snapshot
 
     coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
     coord.config_entry = MagicMock()
@@ -84,8 +91,16 @@ def _make_coord(
     # async_apply_user_position route through it.
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors.return_value = custom_states
-    snapshot_sentinel = MagicMock(name="pipeline_snapshot")
-    coord._snapshot_builder.build = MagicMock(return_value=snapshot_sentinel)
+    snapshot = make_snapshot(
+        custom_position_sensors=custom_states or [],
+        weather_override_active=weather_override_active,
+        weather_override_position=weather_override_position,
+        weather_override_min_mode=weather_override_min_mode,
+        force_override_sensors=force_override_sensors or {},
+        force_override_position=force_override_position,
+        force_override_min_mode=force_override_min_mode,
+    )
+    coord._snapshot_builder.build = MagicMock(return_value=snapshot)
     # Coordinator state that the builder call needs as keyword args.  These
     # are instance attributes (set in __init__) so they aren't on the spec'd
     # MagicMock by default — preset them explicitly.
@@ -197,9 +212,10 @@ async def test_async_apply_user_position_uses_passed_options_when_provided() -> 
         "cover.test", 10, trigger="set_position", options=custom_options
     )
 
-    coord._snapshot_builder.read_custom_position_sensors.assert_called_once_with(
-        custom_options
-    )
+    coord._snapshot_builder.build.assert_called_once()
+    args, kwargs = coord._snapshot_builder.build.call_args
+    # First positional arg of build() is the options dict.
+    assert args[0] is custom_options or kwargs.get("opts") is custom_options
     # And the override flowed into _build_position_context too
     args, kwargs = coord._build_position_context.call_args
     # signature: (entity, options, *, force=...)
@@ -364,12 +380,10 @@ def test_manual_override_priority_constant_unchanged() -> None:
 
 @pytest.mark.asyncio
 async def test_custom_position_min_mode_does_not_preempt_request_above_floor() -> None:
-    """When the winning custom-position handler is a min-mode floor and the user
-    requests a position at or above that floor, the command must NOT be preempted.
+    """When a min-mode floor is active and the user requests a position at or
+    above the floor, the command must NOT be preempted — floors defer to the
+    floor-clamp composition pass (#463), they no longer act as priority winners.
     """
-    handler = CustomPositionHandler(
-        slot=1, entity_id="binary_sensor.cp1", position=60, priority=95
-    )
     state = CustomPositionSensorState(
         entity_id="binary_sensor.cp1",
         is_on=True,
@@ -380,12 +394,8 @@ async def test_custom_position_min_mode_does_not_preempt_request_above_floor() -
     )
     coord, ctx = _make_coord(
         [state],
-        winner_name="custom_position_1",
-        winner_priority=95,
-        winner_handler_instance=handler,
-    )
-    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
-        "custom_position_1", 95, position=60
+        winner_name="solar",
+        winner_priority=40,
     )
 
     outcome = await coord.async_apply_user_position(
@@ -403,13 +413,9 @@ async def test_custom_position_min_mode_does_not_preempt_request_above_floor() -
 async def test_custom_position_min_mode_clamps_and_dispatches_request_below_floor() -> (
     None
 ):
-    """When the winning custom-position handler is a min-mode floor and the user
-    requests below that floor, the command is clamped to the floor and dispatched
-    (NOT preempted).
+    """When a min-mode floor is active and the user requests below the floor,
+    the command is clamped to the floor and dispatched — NOT preempted.
     """
-    handler = CustomPositionHandler(
-        slot=1, entity_id="binary_sensor.cp1", position=60, priority=95
-    )
     state = CustomPositionSensorState(
         entity_id="binary_sensor.cp1",
         is_on=True,
@@ -420,12 +426,8 @@ async def test_custom_position_min_mode_clamps_and_dispatches_request_below_floo
     )
     coord, ctx = _make_coord(
         [state],
-        winner_name="custom_position_1",
-        winner_priority=95,
-        winner_handler_instance=handler,
-    )
-    coord._pipeline.evaluate.return_value = _pipeline_result_with_winner(
-        "custom_position_1", 95, position=60
+        winner_name="solar",
+        winner_priority=40,
     )
 
     outcome = await coord.async_apply_user_position(
@@ -478,13 +480,14 @@ async def test_custom_position_exact_mode_still_preempts() -> None:
 async def test_custom_position_min_mode_preempts_when_request_below_floor_and_handler_is_different_slot() -> (
     None
 ):
-    """When the winning handler is a different slot than the active min-mode
-    sensor state, the handler is not satisfied — preemption applies as normal.
+    """A real-position custom-position handler (different slot) wins with
+    priority 95 > 80 → preempts. The floor clamp on the requested value
+    is irrelevant once preemption fires.
     """
     handler = CustomPositionHandler(
         slot=2, entity_id="binary_sensor.cp2", position=60, priority=95
     )
-    # Only slot 1 is in the state list — slot 2's entity_id is absent
+    # Only slot 1 is the min-mode floor — slot 2 is the priority-95 winner.
     state = CustomPositionSensorState(
         entity_id="binary_sensor.cp1",
         is_on=True,

--- a/tests/test_my_position_button.py
+++ b/tests/test_my_position_button.py
@@ -160,7 +160,10 @@ def _make_my_position_coord():
     coord.config_entry.options = {}
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors.return_value = []
-    coord._snapshot_builder.build = MagicMock(return_value=MagicMock())
+    # Floor composition reads from a real PipelineSnapshot (#463).
+    from tests.test_pipeline.conftest import make_snapshot  # noqa: PLC0415
+
+    coord._snapshot_builder.build = MagicMock(return_value=make_snapshot())
     coord._cover_data = MagicMock()
     coord._cover_type = "cover_blind"
     coord._weather_readings = None

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -224,8 +224,13 @@ def test_pipeline_1000_evaluations_under_500ms() -> None:
     snapshot.motion_control_enabled = True
     snapshot.force_override_active = False
     snapshot.force_override_position = 0
+    snapshot.force_override_sensors = {}
+    snapshot.force_override_min_mode = False
     snapshot.is_weather_active = False
     snapshot.weather_position = 0
+    snapshot.weather_override_active = False
+    snapshot.weather_override_position = 0
+    snapshot.weather_override_min_mode = False
     snapshot.weather_bypass_auto_control = False
     snapshot.manual_override_active = False
     snapshot.custom_position_sensors = [

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -279,7 +279,13 @@ class TestRawCalculatedPosition:
 
 
 class TestMinimumPositionMode:
-    """Tests for CustomPositionHandler minimum position mode."""
+    """Tests for CustomPositionHandler minimum position mode.
+
+    Floor-mode composition lives in the registry post-decision pass (see
+    ``tests/test_pipeline/test_floor_composition.py``). At the handler
+    level, all min_mode does is *defer* — evaluate() returns None so the
+    pipeline can pick a genuine lower-priority winner.
+    """
 
     def _snapshot_min_mode(
         self,
@@ -310,41 +316,15 @@ class TestMinimumPositionMode:
         assert result is not None
         assert result.position == 30
 
-    def test_min_mode_on_calculated_higher_uses_calculated(self) -> None:
-        """With min_mode on, if calculated position > floor, use calculated."""
+    def test_min_mode_on_defers(self) -> None:
+        """With min_mode on, the handler defers (returns None) — the floor is
+        composed by the registry, not produced by the handler.
+        """
         snap = self._snapshot_min_mode(
             position=30, min_mode=True, calculate_percentage_return=50.0
         )
         result = _handler(entity_id=_ENTITY, position=30).evaluate(snap)
-        assert result is not None
-        assert result.position == 50
-
-    def test_min_mode_on_calculated_lower_uses_floor(self) -> None:
-        """With min_mode on, if calculated position < floor, use the floor."""
-        snap = self._snapshot_min_mode(
-            position=30, min_mode=True, calculate_percentage_return=10.0
-        )
-        result = _handler(entity_id=_ENTITY, position=30).evaluate(snap)
-        assert result is not None
-        assert result.position == 30
-
-    def test_min_mode_on_calculated_equal_uses_floor(self) -> None:
-        """With min_mode on, if calculated equals floor, position equals floor."""
-        snap = self._snapshot_min_mode(
-            position=30, min_mode=True, calculate_percentage_return=30.0
-        )
-        result = _handler(entity_id=_ENTITY, position=30).evaluate(snap)
-        assert result is not None
-        assert result.position == 30
-
-    def test_min_mode_on_reason_mentions_minimum_mode(self) -> None:
-        """With min_mode on, reason string mentions minimum mode."""
-        snap = self._snapshot_min_mode(
-            position=30, min_mode=True, calculate_percentage_return=50.0
-        )
-        result = _handler(entity_id=_ENTITY, position=30).evaluate(snap)
-        assert result is not None
-        assert "minimum mode" in result.reason
+        assert result is None
 
     def test_min_mode_off_reason_no_minimum_mode_mention(self) -> None:
         """With min_mode off, reason string does not mention minimum mode."""
@@ -354,15 +334,6 @@ class TestMinimumPositionMode:
         result = _handler(entity_id=_ENTITY, position=30).evaluate(snap)
         assert result is not None
         assert "minimum mode" not in result.reason
-
-    def test_min_mode_control_method_still_custom_position(self) -> None:
-        """ControlMethod remains CUSTOM_POSITION regardless of min_mode."""
-        snap = self._snapshot_min_mode(
-            position=30, min_mode=True, calculate_percentage_return=70.0
-        )
-        result = _handler(entity_id=_ENTITY, position=30).evaluate(snap)
-        assert result is not None
-        assert result.control_method == ControlMethod.CUSTOM_POSITION
 
 
 # ---------------------------------------------------------------------------
@@ -382,15 +353,17 @@ class TestBypassAutoControl:
         assert result is not None
         assert result.bypass_auto_control is True
 
-    def test_bypass_flag_set_min_mode_path(self) -> None:
-        """Min-mode path sets bypass_auto_control=True."""
+    def test_bypass_flag_min_mode_defers(self) -> None:
+        """Min-mode handler defers (returns None) — bypass is moot since no
+        result is produced. The floor-clamp composition pass in the registry
+        carries the bypass forward via the lower-priority winner.
+        """
         snapshot = make_snapshot(
             custom_position_sensors=[_make_state(_ENTITY, True, 30, 77, True, False)],
             calculate_percentage_return=50.0,
         )
         result = _handler(entity_id=_ENTITY, position=30).evaluate(snapshot)
-        assert result is not None
-        assert result.bypass_auto_control is True
+        assert result is None
 
     def test_bypass_flag_set_use_my_path(self) -> None:
         """Use-My path sets bypass_auto_control=True."""
@@ -546,15 +519,16 @@ class TestHandlerTilt:
         assert result is not None
         assert result.tilt is None
 
-    def test_tilt_stamped_on_min_mode_path(self) -> None:
-        """Handler with tilt=60 stamps result.tilt=60 on min-mode path."""
+    def test_min_mode_defers_so_no_tilt_emitted(self) -> None:
+        """Min-mode handler defers — tilt would be applied by the lower-priority
+        winner; this handler emits no result of its own.
+        """
         snapshot = make_snapshot(
             custom_position_sensors=[_make_state(_ENTITY, True, 30, 77, True, False)],
             calculate_percentage_return=50.0,
         )
         result = _handler(entity_id=_ENTITY, position=30, tilt=60).evaluate(snapshot)
-        assert result is not None
-        assert result.tilt == 60
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -594,7 +568,13 @@ class TestCustomPositionActiveSlot:
 
 
 class TestCustomPositionMinimumMode:
-    """custom_position_minimum_mode reflects whether the floor constraint is actively raising position."""
+    """custom_position_minimum_mode field on PipelineResult.
+
+    With floor-mode composition moved to the registry, the handler no longer
+    emits a PipelineResult when min_mode is active — it defers. The remaining
+    on-handler invariants: the field is None on exact-position results, on the
+    use-My path, and on non-custom results.
+    """
 
     def _snap(
         self,
@@ -616,21 +596,11 @@ class TestCustomPositionMinimumMode:
             my_position_value=my_position_value,
         )
 
-    def test_custom_position_minimum_mode_true_when_floor_constrains(self) -> None:
-        """min_mode=True and raw < floor → custom_position_minimum_mode is True."""
+    def test_min_mode_defers(self) -> None:
+        """min_mode=True (without use_my) → evaluate() returns None."""
         snap = self._snap(position=50, min_mode=True, calculate_percentage_return=20.0)
         result = _handler(entity_id=_ENTITY, position=50).evaluate(snap)
-        assert result is not None
-        assert result.position == 50
-        assert result.custom_position_minimum_mode is True
-
-    def test_custom_position_minimum_mode_false_when_floor_is_noop(self) -> None:
-        """min_mode=True and raw >= floor → custom_position_minimum_mode is False (motivating case)."""
-        snap = self._snap(position=50, min_mode=True, calculate_percentage_return=70.0)
-        result = _handler(entity_id=_ENTITY, position=50).evaluate(snap)
-        assert result is not None
-        assert result.position == 70
-        assert result.custom_position_minimum_mode is False
+        assert result is None
 
     def test_custom_position_minimum_mode_none_when_exact_mode(self) -> None:
         """min_mode=False → custom_position_minimum_mode is None."""

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -1,0 +1,453 @@
+"""Tests for cross-handler floor-mode composition (issue #463).
+
+The pipeline registry composes floor (min-mode) clamps from custom-position,
+weather-override, and force-override sources as a post-decision pass. A floor
+no longer wins the priority chain — it raises the winner's position when the
+winner is below the highest active floor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.const import (
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers import (
+    ClimateHandler,
+    DefaultHandler,
+    ForceOverrideHandler,
+    SolarHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.weather import (
+    WeatherOverrideHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    ClimateOptions,
+    CustomPositionSensorState,
+)
+from custom_components.adaptive_cover_pro.state.climate_provider import (
+    ClimateReadings,
+)
+
+from tests.test_pipeline.conftest import make_snapshot
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _climate_cover(
+    *, direct_sun_valid: bool = True, calculate_percentage_return: float = 50.0
+) -> MagicMock:
+    """Build a mock cover usable by ClimateHandler (needs valid, logger)."""
+    cover = MagicMock()
+    cover.direct_sun_valid = direct_sun_valid
+    cover.valid = direct_sun_valid
+    cover.calculate_percentage = MagicMock(return_value=calculate_percentage_return)
+    cover.logger = MagicMock()
+    config = MagicMock()
+    config.min_pos = None
+    config.max_pos = None
+    config.min_pos_sun_only = False
+    config.max_pos_sun_only = False
+    cover.config = config
+    return cover
+
+
+def _summer_readings(inside: float = 30.0) -> ClimateReadings:
+    return ClimateReadings(
+        outside_temperature=None,
+        inside_temperature=inside,
+        is_presence=False,  # no presence -> normal_without_presence -> SUMMER closes
+        is_sunny=True,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        cloud_coverage_above_threshold=False,
+    )
+
+
+def _summer_options() -> ClimateOptions:
+    return ClimateOptions(
+        temp_low=18.0,
+        temp_high=26.0,
+        temp_switch=False,  # use inside temp
+        transparent_blind=True,
+        temp_summer_outside=None,
+        cloud_suppression_enabled=False,
+        winter_close_insulation=False,
+    )
+
+
+def _cp_state(
+    entity_id: str,
+    *,
+    is_on: bool,
+    position: int,
+    min_mode: bool,
+    sensor_name: str | None = None,
+    use_my: bool = False,
+    priority: int = DEFAULT_CUSTOM_POSITION_PRIORITY,
+) -> CustomPositionSensorState:
+    return CustomPositionSensorState(
+        entity_id=entity_id,
+        is_on=is_on,
+        position=position,
+        priority=priority,
+        min_mode=min_mode,
+        use_my=use_my,
+        sensor_name=sensor_name,
+    )
+
+
+def _cp_handler(
+    slot: int,
+    entity_id: str,
+    position: int,
+    *,
+    priority: int = DEFAULT_CUSTOM_POSITION_PRIORITY,
+) -> CustomPositionHandler:
+    return CustomPositionHandler(
+        slot=slot,
+        entity_id=entity_id,
+        position=position,
+        priority=priority,
+    )
+
+
+def _registry_with_custom(handlers: list) -> PipelineRegistry:
+    return PipelineRegistry(
+        [*handlers, ClimateHandler(), SolarHandler(), DefaultHandler()]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Composition tests
+# ---------------------------------------------------------------------------
+
+
+def test_custom_position_floor_clamps_climate_winner() -> None:
+    """Climate winner at 30% is raised to 60% by an active custom floor."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [_cp_handler(1, "binary_sensor.cp1", 60)]
+    registry = _registry_with_custom(handlers)
+    # ClimateHandler in summer-without-presence returns position_for_intent
+    # (sun_through=False) — for a blind that's 0; but with config min_pos=None
+    # we get 0. Override calculate_percentage so SolarHandler isn't relevant
+    # here: we explicitly check climate is the winner.
+    result = registry.evaluate(snap)
+    assert result.position == 60
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "climate"
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+
+
+def test_custom_position_floor_above_climate_is_inert() -> None:
+    """Climate at 80% above floor of 60% — no clamp applied."""
+    # We need climate to compute 80%. Easiest path: climate is GLARE_CONTROL
+    # (defers) or LOW_LIGHT (returns default). Instead, use a Winter heating
+    # path: position_for_intent(sun_through=True) -> 100 for blind. We pick
+    # a configuration where the climate handler returns 80 directly via
+    # is_sunny=False low-light path with default_position=80.
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=ClimateReadings(
+            outside_temperature=None,
+            inside_temperature=22.0,  # between low/high → not summer/winter
+            is_presence=False,
+            is_sunny=False,  # forces LOW_LIGHT → default_position
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            cloud_coverage_above_threshold=False,
+        ),
+        climate_options=_summer_options(),
+        default_position=80,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [_cp_handler(1, "binary_sensor.cp1", 60)]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.position == 80
+    assert not any(
+        s.handler == "floor_clamp" and s.matched for s in result.decision_trace
+    )
+    cp_step = next(s for s in result.decision_trace if s.handler == "custom_position_1")
+    assert cp_step.matched is False
+
+
+def test_two_custom_floors_pick_highest() -> None:
+    """Two active floors at 40 and 60 — winner clamped to max (60)."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=40,
+                min_mode=True,
+                sensor_name="Floor40",
+            ),
+            _cp_state(
+                "binary_sensor.cp2",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Floor60",
+            ),
+        ],
+    )
+    handlers = [
+        _cp_handler(1, "binary_sensor.cp1", 40),
+        _cp_handler(2, "binary_sensor.cp2", 60),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.position == 60
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+    assert "Floor60" in clamp_steps[0].reason
+
+
+def test_real_position_custom_slot_clamped_by_floor_slot() -> None:
+    """A real-position custom slot (30) is clamped by another slot's floor (60)."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=30,
+                min_mode=False,  # real position
+                sensor_name="Real",
+            ),
+            _cp_state(
+                "binary_sensor.cp2",
+                is_on=True,
+                position=60,
+                min_mode=True,  # floor
+                sensor_name="Floor",
+            ),
+        ],
+    )
+    handlers = [
+        _cp_handler(1, "binary_sensor.cp1", 30),
+        _cp_handler(2, "binary_sensor.cp2", 60),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.position == 60
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "custom_position_1"
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+    assert "Floor" in clamp_steps[0].reason
+
+
+def test_weather_override_min_mode_clamps_climate() -> None:
+    """Weather override floor 60% clamps climate winner at 30%."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        weather_override_active=True,
+        weather_override_position=60,
+        weather_override_min_mode=True,
+    )
+    registry = _registry_with_custom([WeatherOverrideHandler()])
+    result = registry.evaluate(snap)
+    assert result.position == 60
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "climate"
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+    assert "weather override" in clamp_steps[0].reason
+
+
+def test_force_override_min_mode_clamps_solar() -> None:
+    """Force-override floor 60% clamps a Solar winner at 25%."""
+    cover = _climate_cover(direct_sun_valid=True, calculate_percentage_return=25.0)
+    snap = make_snapshot(
+        cover=cover,
+        direct_sun_valid=True,
+        calculate_percentage_return=25.0,
+        force_override_sensors={"binary_sensor.s": True},
+        force_override_position=60,
+        force_override_min_mode=True,
+    )
+    registry = _registry_with_custom([ForceOverrideHandler()])
+    result = registry.evaluate(snap)
+    assert result.position == 60
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "solar"
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+    assert "force override" in clamp_steps[0].reason
+
+
+def test_floor_sources_combined_picks_max() -> None:
+    """Custom floor 50 + weather floor 60 + climate 20 → result=60, labelled 'weather override'."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=50,
+                min_mode=True,
+                sensor_name="CustomFloor",
+            )
+        ],
+        weather_override_active=True,
+        weather_override_position=60,
+        weather_override_min_mode=True,
+    )
+    handlers = [
+        _cp_handler(1, "binary_sensor.cp1", 50),
+        WeatherOverrideHandler(),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.position == 60
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+    assert "weather override" in clamp_steps[0].reason
+
+
+def test_no_active_floors_unchanged() -> None:
+    """No min-mode handler active — climate winner emerges untouched."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+    )
+    registry = _registry_with_custom([])
+    result = registry.evaluate(snap)
+    # In summer without presence, transparent_blind=True, the policy returns
+    # position_for_intent(sun_through=False)=0 for a blind. We just verify
+    # no clamp step appears, and result.position is whatever climate yields.
+    assert not any(s.handler == "floor_clamp" for s in result.decision_trace)
+
+
+def test_floor_inactive_when_sensor_off() -> None:
+    """A min_mode slot whose sensor is off must not contribute a floor."""
+    cover = _climate_cover(direct_sun_valid=True, calculate_percentage_return=30.0)
+    snap = make_snapshot(
+        cover=cover,
+        direct_sun_valid=True,
+        calculate_percentage_return=30.0,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=False,
+                position=60,
+                min_mode=True,
+                sensor_name="Off",
+            )
+        ],
+    )
+    handlers = [_cp_handler(1, "binary_sensor.cp1", 60)]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.position == 30  # solar
+    assert not any(s.handler == "floor_clamp" for s in result.decision_trace)
+
+
+def test_decision_trace_does_not_mislabel_winner() -> None:
+    """Only the underlying handler is marked as the non-clamp winner (no double-winner)."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [_cp_handler(1, "binary_sensor.cp1", 60)]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    # Exactly one matched=True step that isn't floor_clamp.
+    non_clamp_matched = [
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    ]
+    assert len(non_clamp_matched) == 1
+    assert non_clamp_matched[0].handler == "climate"

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -167,7 +167,11 @@ class TestForceOverrideHandler:
 
 
 class TestForceOverrideHandlerMinMode:
-    """Tests for ForceOverrideHandler minimum position mode."""
+    """ForceOverrideHandler defers in min_mode; the registry composes the floor.
+
+    See ``tests/test_pipeline/test_floor_composition.py`` for the end-to-end
+    floor-clamp composition tests.
+    """
 
     handler = ForceOverrideHandler()
 
@@ -184,8 +188,10 @@ class TestForceOverrideHandlerMinMode:
         assert result is not None
         assert result.position == 30
 
-    def test_min_mode_on_calculated_higher_uses_calculated(self) -> None:
-        """With min_mode on, if calculated position > floor, use calculated."""
+    def test_min_mode_on_defers(self) -> None:
+        """With min_mode on, evaluate() returns None — the registry composes
+        the floor as a post-decision clamp.
+        """
         snap = make_snapshot(
             force_override_sensors={"binary_sensor.s": True},
             force_override_position=30,
@@ -194,60 +200,7 @@ class TestForceOverrideHandlerMinMode:
             calculate_percentage_return=50.0,
         )
         result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 50
-
-    def test_min_mode_on_calculated_lower_uses_floor(self) -> None:
-        """With min_mode on, if calculated position < floor, use the floor."""
-        snap = make_snapshot(
-            force_override_sensors={"binary_sensor.s": True},
-            force_override_position=30,
-            force_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=10.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 30
-
-    def test_min_mode_on_calculated_equal_uses_floor(self) -> None:
-        """With min_mode on, if calculated equals floor, position equals floor."""
-        snap = make_snapshot(
-            force_override_sensors={"binary_sensor.s": True},
-            force_override_position=30,
-            force_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=30.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 30
-
-    def test_min_mode_on_reason_mentions_minimum_mode(self) -> None:
-        """With min_mode on, reason string mentions minimum mode."""
-        snap = make_snapshot(
-            force_override_sensors={"binary_sensor.s": True},
-            force_override_position=30,
-            force_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=50.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert "minimum mode" in result.reason
-
-    def test_min_mode_control_method_still_force(self) -> None:
-        """ControlMethod remains FORCE regardless of min_mode."""
-        snap = make_snapshot(
-            force_override_sensors={"binary_sensor.s": True},
-            force_override_position=30,
-            force_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=70.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.control_method == ControlMethod.FORCE
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -256,16 +209,17 @@ class TestForceOverrideHandlerMinMode:
 
 
 class TestForceOverrideHandlerMinModeWithSunTrackingOff:
-    """Force override min-mode floors correctly when sun tracking is disabled.
+    """ForceOverrideHandler defers in min_mode regardless of sun-tracking toggle.
 
-    Regression tests for #264: with tracking off and default=100, a
-    configured floor of 80 must yield max(80, 100)=100, not max(80, 29)=80.
+    Issue #264 (floor measured against default rather than solar when tracking
+    off) is now handled by the registry's floor-composition pass, which clamps
+    whichever lower-priority handler actually wins — including the default
+    fallback when tracking is off.
     """
 
     handler = ForceOverrideHandler()
 
-    def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
-        """Min-mode floor measured against default position, not solar, when tracking off."""
+    def test_min_mode_defers_when_tracking_off(self) -> None:
         snap = make_snapshot(
             force_override_sensors={"binary_sensor.s": True},
             force_override_position=80,
@@ -276,26 +230,9 @@ class TestForceOverrideHandlerMinModeWithSunTrackingOff:
             enable_sun_tracking=False,
         )
         result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 100
+        assert result is None
 
-    def test_min_mode_floor_still_enforced_when_default_below_floor(self) -> None:
-        """Floor is enforced when default position is below the configured floor."""
-        snap = make_snapshot(
-            force_override_sensors={"binary_sensor.s": True},
-            force_override_position=80,
-            force_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=29.0,
-            default_position=50,
-            enable_sun_tracking=False,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 80
-
-    def test_min_mode_sun_tracking_enabled_unchanged_regression(self) -> None:
-        """Regression guard: solar floor semantics unchanged when tracking is on."""
+    def test_min_mode_defers_when_tracking_on(self) -> None:
         snap = make_snapshot(
             force_override_sensors={"binary_sensor.s": True},
             force_override_position=80,
@@ -306,17 +243,15 @@ class TestForceOverrideHandlerMinModeWithSunTrackingOff:
             enable_sun_tracking=True,
         )
         result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 80  # max(80, 29) = 80 — solar floor applies
+        assert result is None
 
 
 class TestWeatherOverrideHandlerMinModeWithSunTrackingOff:
-    """Weather override min-mode floors correctly when sun tracking is disabled."""
+    """WeatherOverrideHandler defers in min_mode regardless of sun-tracking toggle."""
 
     handler = WeatherOverrideHandler()
 
-    def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
-        """Min-mode floor measured against default position, not solar, when tracking off."""
+    def test_min_mode_defers_when_tracking_off(self) -> None:
         snap = make_snapshot(
             weather_override_active=True,
             weather_override_position=80,
@@ -327,11 +262,9 @@ class TestWeatherOverrideHandlerMinModeWithSunTrackingOff:
             enable_sun_tracking=False,
         )
         result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 100
+        assert result is None
 
-    def test_min_mode_sun_tracking_enabled_unchanged_regression(self) -> None:
-        """Regression guard: solar floor semantics unchanged when tracking is on."""
+    def test_min_mode_defers_when_tracking_on(self) -> None:
         snap = make_snapshot(
             weather_override_active=True,
             weather_override_position=80,
@@ -342,12 +275,11 @@ class TestWeatherOverrideHandlerMinModeWithSunTrackingOff:
             enable_sun_tracking=True,
         )
         result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 80  # max(80, 29) = 80 — solar floor applies
+        assert result is None
 
 
 class TestCustomPositionHandlerMinModeWithSunTrackingOff:
-    """Custom position min-mode floors correctly when sun tracking is disabled."""
+    """CustomPositionHandler defers in min_mode regardless of sun-tracking toggle."""
 
     def _make_handler(self) -> CustomPositionHandler:
         return CustomPositionHandler(
@@ -357,8 +289,7 @@ class TestCustomPositionHandlerMinModeWithSunTrackingOff:
             priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
         )
 
-    def test_min_mode_uses_default_not_solar_when_tracking_off(self) -> None:
-        """Min-mode floor measured against default position, not solar, when tracking off."""
+    def test_min_mode_defers_when_tracking_off(self) -> None:
         handler = self._make_handler()
         snap = make_snapshot(
             custom_position_sensors=[
@@ -377,11 +308,9 @@ class TestCustomPositionHandlerMinModeWithSunTrackingOff:
             enable_sun_tracking=False,
         )
         result = handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 100
+        assert result is None
 
-    def test_min_mode_sun_tracking_enabled_unchanged_regression(self) -> None:
-        """Regression guard: solar floor semantics unchanged when tracking is on."""
+    def test_min_mode_defers_when_tracking_on(self) -> None:
         handler = self._make_handler()
         snap = make_snapshot(
             custom_position_sensors=[
@@ -400,8 +329,7 @@ class TestCustomPositionHandlerMinModeWithSunTrackingOff:
             enable_sun_tracking=True,
         )
         result = handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 80  # max(80, 29) = 80 — solar floor applies
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_pipeline_integration.py
+++ b/tests/test_pipeline/test_pipeline_integration.py
@@ -592,43 +592,12 @@ class TestFieldPropagationThroughRegistry:
         assert result.control_method == ControlMethod.CUSTOM_POSITION
         assert result.custom_position_active_slot == 2
 
-    def test_custom_position_minimum_mode_false_when_raw_above_floor(self) -> None:
-        """Regression guard for issue #421: registry must not strip PipelineResult fields
-        added after the original whitelist.
-
-        custom_position_minimum_mode=False (floor is a no-op) must survive registry.
-        This is the motivating case: floor=50, raw=80 → floor does not constrain.
-        """
-        registry = PipelineRegistry(
-            [
-                CustomPositionHandler(
-                    slot=1,
-                    entity_id="binary_sensor.slot1",
-                    position=50,
-                    priority=77,
-                ),
-                SolarHandler(),
-                DefaultHandler(),
-            ]
-        )
-        snap = make_snapshot(
-            custom_position_sensors=[
-                _cps("binary_sensor.slot1", True, 50, 77, min_mode=True)
-            ],
-            direct_sun_valid=True,
-            calculate_percentage_return=80.0,
-        )
-        result = registry.evaluate(snap)
-        assert result.control_method == ControlMethod.CUSTOM_POSITION
-        # raw=80 > floor=50 → floor is a no-op → custom_position_minimum_mode is False
-        assert result.custom_position_minimum_mode is False
-
-    def test_custom_position_minimum_mode_true_when_floor_constrains(self) -> None:
-        """Regression guard for issue #421: registry must not strip PipelineResult fields
-        added after the original whitelist.
-
-        custom_position_minimum_mode=True (floor raises position) must survive registry.
-        floor=50, raw=10 → floor actively constrains.
+    def test_custom_position_min_mode_floor_above_solar_clamps_via_registry(
+        self,
+    ) -> None:
+        """floor=50, solar=10 → registry composes a floor_clamp step and clamps
+        the SolarHandler winner to 50%. CustomPositionHandler itself defers in
+        min_mode (issue #463).
         """
         registry = PipelineRegistry(
             [
@@ -650,9 +619,40 @@ class TestFieldPropagationThroughRegistry:
             calculate_percentage_return=10.0,
         )
         result = registry.evaluate(snap)
-        assert result.control_method == ControlMethod.CUSTOM_POSITION
-        # raw=10 < floor=50 → floor actively constrains → custom_position_minimum_mode is True
-        assert result.custom_position_minimum_mode is True
+        assert result.position == 50
+        assert result.control_method == ControlMethod.SOLAR
+        # The floor-clamp synthetic step is in the trace.
+        assert any(
+            s.handler == "floor_clamp" and s.matched for s in result.decision_trace
+        )
+
+    def test_custom_position_min_mode_no_clamp_when_solar_above_floor(self) -> None:
+        """floor=50, solar=80 → floor is inert, no clamp, no floor_clamp step."""
+        registry = PipelineRegistry(
+            [
+                CustomPositionHandler(
+                    slot=1,
+                    entity_id="binary_sensor.slot1",
+                    position=50,
+                    priority=77,
+                ),
+                SolarHandler(),
+                DefaultHandler(),
+            ]
+        )
+        snap = make_snapshot(
+            custom_position_sensors=[
+                _cps("binary_sensor.slot1", True, 50, 77, min_mode=True)
+            ],
+            direct_sun_valid=True,
+            calculate_percentage_return=80.0,
+        )
+        result = registry.evaluate(snap)
+        assert result.position == 80
+        assert result.control_method == ControlMethod.SOLAR
+        assert not any(
+            s.handler == "floor_clamp" and s.matched for s in result.decision_trace
+        )
 
     def test_use_my_position_survives_registry(self) -> None:
         """Regression guard for issue #421: registry must not strip PipelineResult fields

--- a/tests/test_pipeline/test_sun_tracking_toggle.py
+++ b/tests/test_pipeline/test_sun_tracking_toggle.py
@@ -128,11 +128,9 @@ def test_sun_tracking_disabled_pipeline_falls_through_to_default():
 
 @pytest.mark.unit
 def test_force_override_min_mode_with_sun_tracking_off_uses_default():
-    """Force override min-mode floors against default position when sun tracking is off.
-
-    End-to-end regression test for #264: with tracking off (default=100) and
-    a geometrically valid sun (solar=29), the min-mode floor of 80 must resolve
-    to max(80, 100)=100, not max(80, 29)=80.
+    """Force override defers in min_mode; with sun tracking off, the winner
+    is DefaultHandler (position=100). The floor of 80 is below the default,
+    so no clamp is applied. End-to-end regression test for #264 + #463.
     """
     from custom_components.adaptive_cover_pro.const import ControlMethod
     from tests.test_pipeline.conftest import make_snapshot
@@ -152,5 +150,9 @@ def test_force_override_min_mode_with_sun_tracking_off_uses_default():
     result = registry.evaluate(snap)
 
     assert result is not None
-    assert result.control_method == ControlMethod.FORCE
-    assert result.position == 100  # max(80, default=100) = 100
+    assert result.control_method == ControlMethod.DEFAULT
+    assert result.position == 100  # default beats the floor 80
+    # No clamp step because the floor is below the winner.
+    assert not any(
+        s.handler == "floor_clamp" and s.matched for s in result.decision_trace
+    )

--- a/tests/test_pipeline/test_weather_handler.py
+++ b/tests/test_pipeline/test_weather_handler.py
@@ -82,7 +82,11 @@ class TestWeatherOverrideHandler:
 
 
 class TestWeatherOverrideHandlerMinMode:
-    """Tests for WeatherOverrideHandler minimum position mode."""
+    """WeatherOverrideHandler defers in min_mode; the registry composes the floor.
+
+    See ``tests/test_pipeline/test_floor_composition.py`` for the end-to-end
+    floor-clamp composition tests.
+    """
 
     handler = WeatherOverrideHandler()
 
@@ -99,8 +103,10 @@ class TestWeatherOverrideHandlerMinMode:
         assert result is not None
         assert result.position == 30
 
-    def test_min_mode_on_calculated_higher_uses_calculated(self) -> None:
-        """With min_mode on, if calculated position > floor, use calculated."""
+    def test_min_mode_on_defers(self) -> None:
+        """With min_mode on, evaluate() returns None — the registry composes
+        the floor as a post-decision clamp.
+        """
         snap = make_snapshot(
             weather_override_active=True,
             weather_override_position=30,
@@ -109,57 +115,4 @@ class TestWeatherOverrideHandlerMinMode:
             calculate_percentage_return=50.0,
         )
         result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 50
-
-    def test_min_mode_on_calculated_lower_uses_floor(self) -> None:
-        """With min_mode on, if calculated position < floor, use the floor."""
-        snap = make_snapshot(
-            weather_override_active=True,
-            weather_override_position=30,
-            weather_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=10.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 30
-
-    def test_min_mode_on_calculated_equal_uses_floor(self) -> None:
-        """With min_mode on, if calculated equals floor, position equals floor."""
-        snap = make_snapshot(
-            weather_override_active=True,
-            weather_override_position=30,
-            weather_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=30.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.position == 30
-
-    def test_min_mode_on_reason_mentions_minimum_mode(self) -> None:
-        """With min_mode on, reason string mentions minimum mode."""
-        snap = make_snapshot(
-            weather_override_active=True,
-            weather_override_position=30,
-            weather_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=50.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert "minimum mode" in result.reason
-
-    def test_min_mode_control_method_still_weather(self) -> None:
-        """ControlMethod remains WEATHER regardless of min_mode."""
-        snap = make_snapshot(
-            weather_override_active=True,
-            weather_override_position=30,
-            weather_override_min_mode=True,
-            direct_sun_valid=True,
-            calculate_percentage_return=70.0,
-        )
-        result = self.handler.evaluate(snap)
-        assert result is not None
-        assert result.control_method == ControlMethod.WEATHER
+        assert result is None

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -70,11 +70,17 @@ def _make_coord(
     coord.config_entry.options = options or {}
 
     # Snapshot builder — async_apply_user_position routes its custom-position
-    # read through this collaborator after Phase D.
+    # read through this collaborator after Phase D.  Floor composition now
+    # consumes the full PipelineSnapshot (issue #463), so we hand back a real
+    # snapshot pre-populated with the requested custom-position states.
+    from tests.test_pipeline.conftest import make_snapshot  # noqa: PLC0415
+
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors.return_value = (
         custom_states or []
     )
+    snapshot = make_snapshot(custom_position_sensors=custom_states or [])
+    coord._snapshot_builder.build = MagicMock(return_value=snapshot)
 
     # _build_position_context
     ctx = MagicMock()


### PR DESCRIPTION
## Summary
Floor-mode custom positions previously won the priority chain and outprioritized lower-priority real-position rules instead of clamping them. Min-mode handlers (`custom_position`, `weather` override, `force_override`) now defer from `evaluate()`. A new `pipeline/floors.py` helper plus a post-decision pass in `PipelineRegistry.evaluate` raises the winner's position by `max(active_floors)` and surfaces the clamp as a distinct `floor_clamp` step in the decision trace. The coordinator's user-move clamp delegates to the same helper, so `max(active_floors)` lives in exactly one place. `apply_minimum_mode` and `_winner_is_satisfied_custom_floor` are removed.

Generic across all three min-mode code paths per the reporter's combined `max(real_position, floor)` semantics.

## Testing
- ✅ 3672 tests passing
- ✅ 10 new cross-handler composition tests in `tests/test_pipeline/test_floor_composition.py` covering custom-position floors clamping climate / solar / each other, weather and force-override min-mode clamping, multi-source floor max, inert floor cases, and decision-trace correctness.

## Related Issues
Refs #463