### PR TITLE
fix: preserve shaded distance of 0 through config service

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -721,6 +721,7 @@ WINDOW_DEPTH_GAMMA_THRESHOLD = 10  # deg — min gamma for depth contribution
 # OPTION_RANGES (used for legacy schema validation).
 
 DEFAULT_WINDOW_HEIGHT = 2.1  # metres — config-flow default
+DEFAULT_DISTANCE = 1.0  # metres — shaded distance default for vertical blinds
 DEFAULT_AWNING_LENGTH = 2.1  # metres — config-flow default
 DEFAULT_WINDOW_AZIMUTH = 180  # degrees — config-flow default (south-facing)
 MAX_WINDOW_DEPTH = 5.0  # metres — UI cap for window depth

--- a/custom_components/adaptive_cover_pro/services/configuration_service.py
+++ b/custom_components/adaptive_cover_pro/services/configuration_service.py
@@ -32,9 +32,11 @@ from ..const import (
     CONF_TILT_MODE,
     CONF_WINDOW_DEPTH,
     CONF_WINDOW_WIDTH,
+    DEFAULT_DISTANCE,
     DEFAULT_GLARE_ZONE_Z,
     DEFAULT_MAX_TILT,
     DEFAULT_MIN_TILT,
+    DEFAULT_WINDOW_HEIGHT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -78,9 +80,11 @@ class ConfigurationService:
             VerticalConfig with distance, window_height, window_depth, sill_height
 
         """
+        _raw_distance = options.get(CONF_DISTANCE)
+        _raw_h_win = options.get(CONF_HEIGHT_WIN)
         return VerticalConfig(
-            distance=options.get(CONF_DISTANCE) or 1.0,
-            h_win=options.get(CONF_HEIGHT_WIN) or 2.1,
+            distance=_raw_distance if _raw_distance is not None else DEFAULT_DISTANCE,
+            h_win=_raw_h_win if _raw_h_win is not None else DEFAULT_WINDOW_HEIGHT,
             window_depth=options.get(CONF_WINDOW_DEPTH)
             or 0.0,  # Default 0.0; handle None for non-vertical covers
             sill_height=options.get(CONF_SILL_HEIGHT)

--- a/tests/test_glare_zones_config_service.py
+++ b/tests/test_glare_zones_config_service.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 from custom_components.adaptive_cover_pro.config_types import GlareZonesConfig
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DISTANCE,
     CONF_ENABLE_GLARE_ZONES,
     CONF_WINDOW_DEPTH,
     CONF_WINDOW_WIDTH,
@@ -182,3 +183,37 @@ class TestGetVerticalData:
         svc = _make_service()
         result = svc.get_vertical_data({CONF_WINDOW_DEPTH: 0.3})
         assert result.window_depth == 0.3
+
+    def test_distance_zero_is_preserved(self):
+        """CONF_DISTANCE=0.0 must not be treated as falsy and silently replaced with 1.0.
+
+        Regression for issue #464: distance=0 sets shaded area at the glass plane;
+        the cover must close fully (0%), not stay open because distance=1.0 was substituted.
+        """
+        svc = _make_service()
+        result = svc.get_vertical_data({CONF_DISTANCE: 0.0})
+        assert result.distance == 0.0
+
+    def test_distance_zero_int_is_preserved(self):
+        """CONF_DISTANCE=0 (integer) must also be preserved, not treated as falsy."""
+        svc = _make_service()
+        result = svc.get_vertical_data({CONF_DISTANCE: 0})
+        assert result.distance == 0
+
+    def test_distance_none_defaults_to_1m(self):
+        """CONF_DISTANCE=None (unset key or explicitly None) falls back to DEFAULT_DISTANCE (1.0m)."""
+        svc = _make_service()
+        result = svc.get_vertical_data({CONF_DISTANCE: None})
+        assert result.distance == 1.0
+
+    def test_distance_absent_defaults_to_1m(self):
+        """Missing CONF_DISTANCE key falls back to DEFAULT_DISTANCE (1.0m)."""
+        svc = _make_service()
+        result = svc.get_vertical_data({})
+        assert result.distance == 1.0
+
+    def test_distance_nonzero_preserved(self):
+        """Non-zero CONF_DISTANCE is passed through unchanged."""
+        svc = _make_service()
+        result = svc.get_vertical_data({CONF_DISTANCE: 2.5})
+        assert result.distance == 2.5


### PR DESCRIPTION
## Summary
- `ConfigurationService.get_vertical_data` used `options.get(CONF_DISTANCE) or 1.0`, which treats the valid user value `0` as falsy and silently substitutes the default. The calculation engine handles `distance=0` correctly — it just never received it.
- Replaced the two `or`-falsy-zero patterns (distance and h_win) with explicit `is not None` guards against named defaults (`DEFAULT_DISTANCE`, `DEFAULT_WINDOW_HEIGHT`).

## Testing
- ✅ 3677 tests passing, 0 failing
- Added 5 regression tests to `TestGetVerticalData` covering `distance=0.0`, `distance=0` (int), `None`, absent, and nonzero values.

## Related Issues
Refs #464