### PR TITLE
fix: floor-clamped position skips post-pipeline interp/inverse (#469)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2169,9 +2169,20 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         bypass_auto_control=True on their result, which causes their position
         to be returned directly — bypassing interpolation and inverse_state —
         even when automatic_control is OFF or outside the time window.
+
+        Floor-clamped winners (issue #469): when the registry raises a
+        non-bypass winner's position to a user-configured floor, the
+        resulting value is already in cover-position space.  Interpolation
+        and inverse_state would re-map a user-typed floor through the
+        calibration curve and silently dispatch a different position, so
+        the same short-circuit applies.
         """
-        # Safety overrides take full precedence — skip post-processing transforms.
-        if self._pipeline_bypasses_auto_control:
+        # Safety overrides and floor-clamped winners both produce positions
+        # already in cover-position space — skip post-processing transforms.
+        if (
+            self._pipeline_bypasses_auto_control
+            or self._pipeline_result.floor_clamp_applied
+        ):
             return self._pipeline_result.position
 
         state = self._pipeline_result.position

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -170,7 +170,11 @@ class PipelineRegistry:
         # after evaluation so they never appear in the snapshot
         # that handlers can read.
         if clamped_position != winner.position:
-            winner = dataclasses.replace(winner, position=clamped_position)
+            winner = dataclasses.replace(
+                winner,
+                position=clamped_position,
+                floor_clamp_applied=True,
+            )
         result = dataclasses.replace(
             winner,
             decision_trace=trace,
@@ -194,6 +198,7 @@ class PipelineRegistry:
                     "position": result.position,
                     "reason": result.reason,
                     "bypass_auto_control": result.bypass_auto_control,
+                    "floor_clamp_applied": result.floor_clamp_applied,
                     "is_sunset_active": result.is_sunset_active,
                 }
             )

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -237,6 +237,12 @@ class PipelineResult:
     # normal sun-tracking automation.
     bypass_auto_control: bool = False
 
+    # When True, the registry's floor-clamp composition pass raised this
+    # winner's position to a user-configured floor. The coordinator's `state`
+    # property treats the position as already in cover-position space and
+    # skips interpolation / inverse-state remapping (issue #469).
+    floor_clamp_applied: bool = False
+
     # When True, the coordinator should route this command through
     # CoverCommandService.send_my_position() on non-position-capable covers
     # (cover.stop_cover while stationary → triggers the Somfy "My" hardware preset).

--- a/tests/test_display_rounding.py
+++ b/tests/test_display_rounding.py
@@ -37,7 +37,11 @@ class TestCoordinatorStateIntCoercion:
         )
 
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        pr = SimpleNamespace(position=pipeline_position, bypass_auto_control=False)
+        pr = SimpleNamespace(
+            position=pipeline_position,
+            bypass_auto_control=False,
+            floor_clamp_applied=False,
+        )
         coord._pipeline_result = pr
         coord._use_interpolation = True
         coord._inverse_state = False
@@ -76,7 +80,9 @@ class TestCoordinatorStateIntCoercion:
         )
 
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        pr = SimpleNamespace(position=55, bypass_auto_control=False)
+        pr = SimpleNamespace(
+            position=55, bypass_auto_control=False, floor_clamp_applied=False
+        )
         coord._pipeline_result = pr
         coord._use_interpolation = False
         coord._inverse_state = False

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -423,6 +423,81 @@ def test_floor_inactive_when_sensor_off() -> None:
     assert not any(s.handler == "floor_clamp" for s in result.decision_trace)
 
 
+def test_floor_clamp_sets_floor_clamp_applied_flag() -> None:
+    """Active floor that raises the winner sets ``floor_clamp_applied=True`` (issue #469)."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [_cp_handler(1, "binary_sensor.cp1", 60)]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.floor_clamp_applied is True
+
+
+def test_no_clamp_keeps_floor_clamp_applied_false() -> None:
+    """With no active floors, ``floor_clamp_applied`` stays False (issue #469)."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+    )
+    registry = _registry_with_custom([])
+    result = registry.evaluate(snap)
+    assert result.floor_clamp_applied is False
+
+
+def test_inactive_floor_below_winner_keeps_flag_false() -> None:
+    """Floor present but below winner — clamp not applied, flag stays False (issue #469)."""
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=ClimateReadings(
+            outside_temperature=None,
+            inside_temperature=22.0,  # not summer/winter → LOW_LIGHT → default_position
+            is_presence=False,
+            is_sunny=False,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            cloud_coverage_above_threshold=False,
+        ),
+        climate_options=_summer_options(),
+        default_position=80,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [_cp_handler(1, "binary_sensor.cp1", 60)]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    assert result.position == 80
+    assert result.floor_clamp_applied is False
+
+
 def test_decision_trace_does_not_mislabel_winner() -> None:
     """Only the underlying handler is marked as the non-clamp winner (no double-winner)."""
     cover = _climate_cover(direct_sun_valid=False)

--- a/tests/test_pipeline/test_floor_dispatch_integration.py
+++ b/tests/test_pipeline/test_floor_dispatch_integration.py
@@ -1,0 +1,170 @@
+"""Integration tests for floor-clamp short-circuit in coordinator dispatch.
+
+Regression coverage for issue #469: when the pipeline registry's floor-clamp
+composition raises a non-bypass winner's position to a user-configured floor,
+the coordinator's ``state`` property must treat the resulting position as
+already in cover-position space and skip interpolation / inverse-state.
+
+Pre-#469 behaviour applied interpolation and inverse_state to the
+floor-clamped position, so the dispatched cover command diverged from the
+``pipeline_evaluated`` event's reported position.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+
+def _make_pipeline_result(
+    *,
+    position: int,
+    control_method: ControlMethod = ControlMethod.DEFAULT,
+    bypass_auto_control: bool = False,
+    floor_clamp_applied: bool = False,
+) -> PipelineResult:
+    return PipelineResult(
+        position=position,
+        control_method=control_method,
+        reason="test",
+        bypass_auto_control=bypass_auto_control,
+        floor_clamp_applied=floor_clamp_applied,
+    )
+
+
+def _make_coordinator(
+    *,
+    pipeline_result: PipelineResult,
+    inverse_state_enabled: bool = False,
+    use_interpolation: bool = False,
+    start_value=None,
+    end_value=None,
+    normal_list=None,
+    new_list=None,
+) -> MagicMock:
+    coordinator = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+    coordinator._pipeline_result = pipeline_result
+    coordinator._pipeline_bypasses_auto_control = pipeline_result.bypass_auto_control
+    coordinator._use_interpolation = use_interpolation
+    coordinator._inverse_state = inverse_state_enabled
+    coordinator.start_value = start_value
+    coordinator.end_value = end_value
+    coordinator.normal_list = normal_list
+    coordinator.new_list = new_list
+    coordinator.logger = MagicMock()
+    return coordinator
+
+
+# ---------------------------------------------------------------------------
+# Floor-clamp short-circuit (issue #469)
+# ---------------------------------------------------------------------------
+
+
+def test_floor_clamped_non_bypass_winner_skips_interpolation():
+    """Floor-clamped position must not be remapped through interpolation."""
+    result = _make_pipeline_result(
+        position=25,
+        control_method=ControlMethod.DEFAULT,
+        bypass_auto_control=False,
+        floor_clamp_applied=True,
+    )
+    coord = _make_coordinator(
+        pipeline_result=result,
+        use_interpolation=True,
+        normal_list=[0, 25, 58, 100],
+        new_list=[0, 45, 58, 100],
+        start_value=0,
+        end_value=100,
+    )
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 25
+
+
+def test_floor_clamped_non_bypass_winner_skips_inverse_state():
+    """Floor-clamped position must not be inverted (100 - 25 = 75)."""
+    result = _make_pipeline_result(
+        position=25,
+        control_method=ControlMethod.DEFAULT,
+        bypass_auto_control=False,
+        floor_clamp_applied=True,
+    )
+    coord = _make_coordinator(
+        pipeline_result=result,
+        inverse_state_enabled=True,
+        use_interpolation=False,
+    )
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 25
+
+
+def test_non_floor_winner_still_runs_interpolation():
+    """Anti-regression: ordinary (non floor-clamped) winners still get interp."""
+    result = _make_pipeline_result(
+        position=25,
+        control_method=ControlMethod.DEFAULT,
+        bypass_auto_control=False,
+        floor_clamp_applied=False,
+    )
+    coord = _make_coordinator(
+        pipeline_result=result,
+        use_interpolation=True,
+        normal_list=[0, 25, 58, 100],
+        new_list=[0, 45, 58, 100],
+        start_value=0,
+        end_value=100,
+    )
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 45
+
+
+def test_non_floor_winner_still_runs_inverse_state():
+    """Anti-regression: ordinary winners still get inverse_state applied."""
+    result = _make_pipeline_result(
+        position=25,
+        control_method=ControlMethod.DEFAULT,
+        bypass_auto_control=False,
+        floor_clamp_applied=False,
+    )
+    coord = _make_coordinator(
+        pipeline_result=result,
+        inverse_state_enabled=True,
+        use_interpolation=False,
+    )
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 75
+
+
+def test_bypass_auto_control_still_short_circuits_independently_of_floor_flag():
+    """bypass_auto_control short-circuit works regardless of floor flag value."""
+    result = _make_pipeline_result(
+        position=42,
+        control_method=ControlMethod.FORCE,
+        bypass_auto_control=True,
+        floor_clamp_applied=False,
+    )
+    coord = _make_coordinator(
+        pipeline_result=result,
+        use_interpolation=True,
+        inverse_state_enabled=True,
+        normal_list=[0, 25, 58, 100],
+        new_list=[0, 45, 58, 100],
+        start_value=0,
+        end_value=100,
+    )
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 42


### PR DESCRIPTION
## Summary

Adds a `floor_clamp_applied: bool` flag to `PipelineResult`. The registry sets it when its floor-composition pass clamps the winner's position; the coordinator's `state` property uses it as a second short-circuit gate (alongside `bypass_auto_control`) so floor-clamped values skip post-pipeline interpolation and `inverse_state` transforms. Restores the pre-#465 semantic that floor values are in cover-position space, without altering the meaning of `bypass_auto_control`.

Symmetric across both interpolation and inverse_state — an inverted cover with floor=25 would otherwise have dispatched 75 (same defect class).

## Testing
- ✅ 3697 tests passing (3689 baseline + 8 new)
- ✅ 5 integration-boundary tests (`tests/test_pipeline/test_floor_dispatch_integration.py`) drive the regression at the `coordinator.state` boundary, including the reporter's exact interp scenario (interp_list_new=[0,45,58,100], position=25 → dispatched=25 not 45)
- ✅ 3 registry-level tests confirm the flag is set when and only when the floor clamp fires
- ✅ Lint + black clean

## Related Issues
Refs #469