### PR TITLE
fix: enforce min_position_sun_tracking floor when stored as float (#475)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -97,7 +97,11 @@ class CoverConfig:
             min_pos=options.get(CONF_MIN_POSITION) or 0,
             max_pos_sun_only=options.get(CONF_ENABLE_MAX_POSITION, False),
             min_pos_sun_only=options.get(CONF_ENABLE_MIN_POSITION, False),
-            min_pos_sun_tracking=options.get(CONF_MIN_POSITION_SUN_TRACKING),  # no `or` — preserves None vs 0
+            min_pos_sun_tracking=(  # no `or` — preserves None vs 0; int() coerces HA float from NumberSelector
+                int(options[CONF_MIN_POSITION_SUN_TRACKING])
+                if options.get(CONF_MIN_POSITION_SUN_TRACKING) is not None
+                else None
+            ),
             blind_spot_left=options.get(CONF_BLIND_SPOT_LEFT),
             blind_spot_right=options.get(CONF_BLIND_SPOT_RIGHT),
             blind_spot_elevation=options.get(CONF_BLIND_SPOT_ELEVATION),

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -102,11 +102,12 @@ class PositionConverter:
         # Sun-tracking floor: when sun_tracking_min_pos is set and sun is valid,
         # use it as the effective min floor instead of min_pos.
         # None means "fall back to min_pos" — preserves existing behavior exactly.
-        # Guard: only use if it's an int (not None or any non-numeric sentinel).
-        _use_sun_tracking = (
-            isinstance(sun_tracking_min_pos, int) and sun_valid
-        )
-        effective_min = sun_tracking_min_pos if _use_sun_tracking else min_pos
+        # Guard: isinstance(x, (int, float)) accepts both int and float so the floor
+        # fires when HA's NumberSelector stores a float (e.g. 25.0) — issue #475.
+        # Using (int, float) rather than is-not-None avoids false-positives from
+        # unspecified MagicMock attributes in tests.
+        _use_sun_tracking = isinstance(sun_tracking_min_pos, (int, float)) and sun_valid
+        effective_min = int(sun_tracking_min_pos) if _use_sun_tracking else min_pos
 
         # Apply min position limit
         if effective_min is not None and effective_min != 0:

--- a/tests/test_position_limits_integration.py
+++ b/tests/test_position_limits_integration.py
@@ -15,7 +15,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.config_types import CoverConfig
+from custom_components.adaptive_cover_pro.const import (
+    CONF_MIN_POSITION_SUN_TRACKING,
+    ControlMethod,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
     ClimateHandler,
 )
@@ -467,3 +471,37 @@ class TestSunTrackingMinPosition:
 
         assert result.control_method == ControlMethod.SOLAR
         assert result.position == 20  # falls back to regular min_pos
+
+    def test_config_from_options_float_coerced_to_int(self):
+        """CoverConfig.from_options coerces a float min_pos_sun_tracking to int.
+
+        HA's NumberSelector always stores float (e.g. 25.0); the dataclass field
+        is typed int | None.  The boundary read in from_options must coerce.
+        Regression test for issue #475.
+        """
+        config = CoverConfig.from_options(
+            {
+                CONF_MIN_POSITION_SUN_TRACKING: 25.0,  # float — as HA stores it
+            }
+        )
+        assert isinstance(config.min_pos_sun_tracking, int)
+        assert config.min_pos_sun_tracking == 25
+
+    def test_solar_handler_uses_sun_tracking_min_floor_float_value(self):
+        """SolarHandler floors at sun_tracking_min_pos even when stored as float.
+
+        HA stores NumberSelector values as float (e.g. 25.0); the isinstance(x, int)
+        guard in apply_limits silently skips the floor for floats.
+        Regression test for issue #475.
+        """
+        snap = _snap_with_solar(
+            calculate_return=0.0,
+            min_pos=0,
+            min_pos_sun_tracking=25.0,  # float — as HA stores it; bug: floor not applied
+            direct_sun_valid=True,
+        )
+        registry = PipelineRegistry([SolarHandler(), DefaultHandler()])
+        result = registry.evaluate(snap)
+
+        assert result.control_method == ControlMethod.SOLAR
+        assert result.position == 25  # must be floored at 25, not 1


### PR DESCRIPTION
## Summary
- `PositionConverter.apply_limits()` used `isinstance(sun_tracking_min_pos, int)` to guard whether to apply the sun-tracking floor. HA's `NumberSelector` stores values as float (e.g. `25.0`), so the guard silently skipped — users saw the `max(state, 1)` baseline floor of 1% instead of their configured floor (e.g. 25%).
- Fix: coerce `CONF_MIN_POSITION_SUN_TRACKING` to int at the HA boundary in `CoverConfig.from_options()`. Defense-in-depth: widen the consumer-side guard to `(int, float)` and inline-coerce, so the floor still fires if a float slips past the boundary.

## Testing
- ✅ 3699 tests passing
- Two new regression tests in `tests/test_position_limits_integration.py::TestSunTrackingMinPosition`:
  - `test_config_from_options_float_coerced_to_int`
  - `test_solar_handler_uses_sun_tracking_min_floor_float_value`

## Related Issues
Refs #475