### PR TITLE
feat: standardize options flow field ordering

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -308,6 +308,9 @@ POSITION_SCHEMA = vol.Schema(
                 unit_of_measurement="%",
             )
         ),
+        vol.Optional(
+            CONF_ENABLE_MAX_POSITION, default=False
+        ): selector.BooleanSelector(),
         vol.Optional(CONF_MAX_POSITION, default=100): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=1,
@@ -318,7 +321,7 @@ POSITION_SCHEMA = vol.Schema(
             )
         ),
         vol.Optional(
-            CONF_ENABLE_MAX_POSITION, default=False
+            CONF_ENABLE_MIN_POSITION, default=False
         ): selector.BooleanSelector(),
         vol.Optional(CONF_MIN_POSITION, default=0): selector.NumberSelector(
             selector.NumberSelectorConfig(
@@ -329,9 +332,6 @@ POSITION_SCHEMA = vol.Schema(
                 unit_of_measurement="%",
             )
         ),
-        vol.Optional(
-            CONF_ENABLE_MIN_POSITION, default=False
-        ): selector.BooleanSelector(),
         vol.Optional(CONF_MIN_POSITION_SUN_TRACKING): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
@@ -340,6 +340,12 @@ POSITION_SCHEMA = vol.Schema(
                 mode=selector.NumberSelectorMode.SLIDER,
                 unit_of_measurement="%",
             )
+        ),
+        vol.Optional(CONF_SUNSET_TIME_ENTITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
+        ),
+        vol.Optional(CONF_SUNRISE_TIME_ENTITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
         ),
         vol.Optional(CONF_SUNSET_POS): selector.NumberSelector(
             selector.NumberSelectorConfig(
@@ -350,19 +356,6 @@ POSITION_SCHEMA = vol.Schema(
                 unit_of_measurement="%",
             )
         ),
-        vol.Optional(
-            CONF_ENABLE_MY_POSITION_ENTITIES,
-            default=DEFAULT_ENABLE_MY_POSITION_ENTITIES,
-        ): selector.BooleanSelector(),
-        vol.Optional(CONF_MY_POSITION_VALUE): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=1,
-                max=99,
-                mode=selector.NumberSelectorMode.SLIDER,
-                unit_of_measurement="%",
-            )
-        ),
-        vol.Optional(CONF_SUNSET_USE_MY, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_SUNSET_OFFSET, default=0): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=-120,
@@ -379,12 +372,20 @@ POSITION_SCHEMA = vol.Schema(
                 unit_of_measurement="minutes",
             )
         ),
-        vol.Optional(CONF_SUNSET_TIME_ENTITY): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
+        vol.Optional(CONF_RETURN_SUNSET, default=False): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_ENABLE_MY_POSITION_ENTITIES,
+            default=DEFAULT_ENABLE_MY_POSITION_ENTITIES,
+        ): selector.BooleanSelector(),
+        vol.Optional(CONF_MY_POSITION_VALUE): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=1,
+                max=99,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="%",
+            )
         ),
-        vol.Optional(CONF_SUNRISE_TIME_ENTITY): selector.EntitySelector(
-            selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
-        ),
+        vol.Optional(CONF_SUNSET_USE_MY, default=False): selector.BooleanSelector(),
         vol.Optional(CONF_OPEN_CLOSE_THRESHOLD, default=50): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=1,
@@ -430,15 +431,14 @@ AUTOMATION_SCHEMA = vol.Schema(
                 unit_of_measurement="minutes",
             )
         ),
-        vol.Optional(CONF_START_TIME, default="00:00:00"): selector.TimeSelector(),
         vol.Optional(CONF_START_ENTITY): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
         ),
-        vol.Optional(CONF_END_TIME, default="00:00:00"): selector.TimeSelector(),
+        vol.Optional(CONF_START_TIME, default="00:00:00"): selector.TimeSelector(),
         vol.Optional(CONF_END_ENTITY): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
         ),
-        vol.Optional(CONF_RETURN_SUNSET, default=False): selector.BooleanSelector(),
+        vol.Optional(CONF_END_TIME, default="00:00:00"): selector.TimeSelector(),
     }
 )
 
@@ -696,6 +696,18 @@ def weather_override_schema(
                 CONF_WEATHER_WIND_DIRECTION_SENSOR, default=vol.UNDEFINED
             ): _numeric_selector(),
             vol.Optional(
+                CONF_WEATHER_RAIN_SENSOR, default=vol.UNDEFINED
+            ): _numeric_selector(),
+            vol.Optional(
+                CONF_WEATHER_IS_RAINING_SENSOR, default=vol.UNDEFINED
+            ): _binary_on_selector(),
+            vol.Optional(
+                CONF_WEATHER_IS_WINDY_SENSOR, default=vol.UNDEFINED
+            ): _binary_on_selector(),
+            vol.Optional(CONF_WEATHER_SEVERE_SENSORS, default=[]): _binary_on_selector(
+                multiple=True
+            ),
+            vol.Optional(
                 CONF_WEATHER_WIND_SPEED_THRESHOLD,
                 default=DEFAULT_WEATHER_WIND_SPEED_THRESHOLD,
             ): selector.NumberSelector(
@@ -720,9 +732,6 @@ def weather_override_schema(
                 )
             ),
             vol.Optional(
-                CONF_WEATHER_RAIN_SENSOR, default=vol.UNDEFINED
-            ): _numeric_selector(),
-            vol.Optional(
                 CONF_WEATHER_RAIN_THRESHOLD, default=DEFAULT_WEATHER_RAIN_THRESHOLD
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
@@ -732,15 +741,6 @@ def weather_override_schema(
                     mode=selector.NumberSelectorMode.SLIDER,
                     unit_of_measurement=rain_unit,
                 )
-            ),
-            vol.Optional(
-                CONF_WEATHER_IS_RAINING_SENSOR, default=vol.UNDEFINED
-            ): _binary_on_selector(),
-            vol.Optional(
-                CONF_WEATHER_IS_WINDY_SENSOR, default=vol.UNDEFINED
-            ): _binary_on_selector(),
-            vol.Optional(CONF_WEATHER_SEVERE_SENSORS, default=[]): _binary_on_selector(
-                multiple=True
             ),
             vol.Optional(
                 CONF_WEATHER_OVERRIDE_POSITION, default=0
@@ -820,6 +820,18 @@ def light_cloud_schema(
                 selector.EntityFilterSelectorConfig(domain="weather")
             ),
             vol.Optional(
+                CONF_IS_SUNNY_SENSOR, default=vol.UNDEFINED
+            ): _binary_on_selector(),
+            vol.Optional(CONF_LUX_ENTITY, default=vol.UNDEFINED): _numeric_selector(
+                device_class="illuminance"
+            ),
+            vol.Optional(
+                CONF_IRRADIANCE_ENTITY, default=vol.UNDEFINED
+            ): _numeric_selector(device_class="irradiance"),
+            vol.Optional(
+                CONF_CLOUD_COVERAGE_ENTITY, default=vol.UNDEFINED
+            ): _numeric_selector(),
+            vol.Optional(
                 CONF_WEATHER_STATE, default=["sunny", "partlycloudy", "cloudy", "clear"]
             ): selector.SelectSelector(
                 selector.SelectSelectorConfig(
@@ -845,20 +857,11 @@ def light_cloud_schema(
                     ],
                 )
             ),
-            vol.Optional(
-                CONF_IS_SUNNY_SENSOR, default=vol.UNDEFINED
-            ): _binary_on_selector(),
-            vol.Optional(CONF_LUX_ENTITY, default=vol.UNDEFINED): _numeric_selector(
-                device_class="illuminance"
-            ),
             vol.Optional(CONF_LUX_THRESHOLD, default=1000): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     mode=selector.NumberSelectorMode.BOX, unit_of_measurement=lux_unit
                 )
             ),
-            vol.Optional(
-                CONF_IRRADIANCE_ENTITY, default=vol.UNDEFINED
-            ): _numeric_selector(device_class="irradiance"),
             vol.Optional(
                 CONF_IRRADIANCE_THRESHOLD, default=300
             ): selector.NumberSelector(
@@ -866,9 +869,6 @@ def light_cloud_schema(
                     mode=selector.NumberSelectorMode.BOX, unit_of_measurement=irr_unit
                 )
             ),
-            vol.Optional(
-                CONF_CLOUD_COVERAGE_ENTITY, default=vol.UNDEFINED
-            ): _numeric_selector(),
             vol.Optional(
                 CONF_CLOUD_COVERAGE_THRESHOLD, default=DEFAULT_CLOUD_COVERAGE_THRESHOLD
             ): selector.NumberSelector(
@@ -925,6 +925,12 @@ def temperature_climate_schema(
             vol.Optional(CONF_TEMP_ENTITY): selector.EntitySelector(
                 selector.EntityFilterSelectorConfig(domain=["climate", "sensor"])
             ),
+            vol.Optional(
+                CONF_OUTSIDETEMP_ENTITY, default=vol.UNDEFINED
+            ): _numeric_selector(),
+            vol.Optional(
+                CONF_PRESENCE_ENTITY, default=vol.UNDEFINED
+            ): _presence_like_selector(),
             vol.Optional(CONF_TEMP_LOW, default=21): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=_TEMP_RANGE_MIN,
@@ -943,9 +949,6 @@ def temperature_climate_schema(
                     unit_of_measurement=inside_unit,
                 )
             ),
-            vol.Optional(
-                CONF_OUTSIDETEMP_ENTITY, default=vol.UNDEFINED
-            ): _numeric_selector(),
             vol.Optional(CONF_OUTSIDE_THRESHOLD, default=25): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=_TEMP_RANGE_MIN,
@@ -954,9 +957,6 @@ def temperature_climate_schema(
                     unit_of_measurement=outside_unit,
                 )
             ),
-            vol.Optional(
-                CONF_PRESENCE_ENTITY, default=vol.UNDEFINED
-            ): _presence_like_selector(),
             vol.Optional(
                 CONF_TRANSPARENT_BLIND, default=False
             ): selector.BooleanSelector(),
@@ -2015,6 +2015,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_OPEN_CLOSE_THRESHOLD,
             CONF_INVERSE_STATE,
             CONF_INTERP,
+            CONF_RETURN_SUNSET,
         }
     ),
     "interp": frozenset(
@@ -2033,7 +2034,6 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_START_ENTITY,
             CONF_END_TIME,
             CONF_END_ENTITY,
-            CONF_RETURN_SUNSET,
         }
     ),
     "manual_override": frozenset(

--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -56,7 +56,9 @@ class CoverConfig:
     blind_spot_on: bool
     min_elevation: int | None
     max_elevation: int | None
-    min_pos_sun_tracking: int | None = None  # separate floor for sun-tracking only; None = use min_pos
+    min_pos_sun_tracking: int | None = (
+        None  # separate floor for sun-tracking only; None = use min_pos
+    )
 
     @classmethod
     def from_options(cls, options: dict) -> CoverConfig:

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -565,7 +565,9 @@ class DiagnosticsBuilder:
                 "blind_spot_left": options.get(CONF_BLIND_SPOT_LEFT),
                 "blind_spot_right": options.get(CONF_BLIND_SPOT_RIGHT),
                 "min_position": options.get(CONF_MIN_POSITION),
-                "min_position_sun_tracking": options.get(CONF_MIN_POSITION_SUN_TRACKING),
+                "min_position_sun_tracking": options.get(
+                    CONF_MIN_POSITION_SUN_TRACKING
+                ),
                 "max_position": options.get(CONF_MAX_POSITION),
                 "enable_min_position": options.get(CONF_ENABLE_MIN_POSITION, False),
                 "enable_max_position": options.get(CONF_ENABLE_MAX_POSITION, False),

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -113,7 +113,8 @@
           "inverse_state": "Zustand umkehren (erforderlich für Beschattungen, die nicht HA-Richtlinien folgen)",
           "interp": "Positionskalibrierung aktivieren (benutzerdefinierte Öffnungs-/Schließungspositionszuordnung)",
           "sunrise_time_entity": "Sonnenaufgangs-Zeit-Entität",
-          "sunset_time_entity": "Sonnenuntergangs-Zeit-Entität"
+          "sunset_time_entity": "Sonnenuntergangs-Zeit-Entität",
+          "return_sunset": "Beschattungen zur aktuellen Standardposition verschieben, wenn die Endzeit erreicht wird"
         },
         "data_description": {
           "default_percentage": "Beschattungsposition, wenn die Sonne nicht vor dem Fenster steht (0-100 %). 0 % = geschlossen (Jalousien gesenkt / Markise eingezogen), 50 % = halb offen (ausgewogenes Licht und Datenschutz), 100 % = offen (Jalousien angehoben / Markise ausgefahren). Dies ist die ‚Ruheposition', die verwendet wird, wenn die Sonnenverfolgung nicht aktiv ist (Sonne ist hinter dem Fenster, blockiert durch Hindernisse oder außerhalb der Verfolgungszeiten).",
@@ -132,7 +133,8 @@
           "inverse_state": "Aktivieren Sie für Beschattungen, bei denen die Positionslogik umgekehrt ist. Standard: 0 = geschlossen/gesenkt, 100 = offen/angehoben. Invertiert: 0 = offen/angehoben, 100 = geschlossen/gesenkt. Aktivieren Sie dies NUR, wenn Ihre Beschattung das entgegengesetzte Verhalten zeigt, 100 % schließt anstatt zu öffnen, oder die Dokumentation sagt ‚invertiert' oder ‚umgekehrt'. Testen Sie Ihre Beschattung zunächst manuell. Die meisten Beschattungen benötigen dies nicht.",
           "interp": "Aktivieren Sie die benutzerdefinierte Positionszuordnung zur Kalibrierung von Beschattungen, die nicht linear auf 0–100 %-Befehle reagieren. Wenn aktiviert, wird ein Abschnitt ‚Positionskalibrierung' im Optionsmenü angezeigt (unter Positionseinstellungen), in dem Sie die Zuordnungswerte konfigurieren können. Anwendungsfälle: Beschattung bewegt sich nicht linear, bevorzugte Bereiche (mehr geschlossen oder mehr offen), Kalibrierung für ungewöhnliches Beschattungsverhalten. Deaktiviert für Normalbetrieb lassen.",
           "sunrise_time_entity": "Optionale Entität, deren Zustand eine Datum/Uhrzeit ist (z. B. Sun2 'Sonnenaufgang bei -4° Elevation'). Bei Einstellung ersetzt sie die durch astral berechnete Sonnenaufgangszeit als Grenze zum Schließen des Fensters morgens. Akzeptiert Sensor- oder input_datetime-Entitäten. Der Sonnenaufgang-Offset wird zusätzlich angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist.",
-          "sunset_time_entity": "Optionale Entität, deren Zustand eine Datum/Uhrzeit ist (z. B. Sun2 'Sonnenuntergang bei -4° Elevation'). Bei Einstellung ersetzt sie die durch astral berechnete Sonnenuntergangszeit als Fenstergrenze. Akzeptiert Sensor- oder input_datetime-Entitäten, die eine ISO-8601-Datum/Uhrzeit melden. Der Sonnenuntergang-Offset wird zusätzlich angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist."
+          "sunset_time_entity": "Optionale Entität, deren Zustand eine Datum/Uhrzeit ist (z. B. Sun2 'Sonnenuntergang bei -4° Elevation'). Bei Einstellung ersetzt sie die durch astral berechnete Sonnenuntergangszeit als Fenstergrenze. Akzeptiert Sensor- oder input_datetime-Entitäten, die eine ISO-8601-Datum/Uhrzeit melden. Der Sonnenuntergang-Offset wird zusätzlich angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist.",
+          "return_sunset": "Wenn der Betriebsendzeitpunkt erreicht ist, verschieben Sie die Beschattung auf die aktuelle wirksame Standardposition (die bei bereits eingetretenem astronomischem Sonnenuntergang die Sonnenuntergangsposition ist, andernfalls die normale Standardposition). Nützlich, wenn Ihr Endzeitpunkt vor Sonnenuntergang liegt und Sie die Beschattung korrekt für den Abend positionieren möchten. Diese Bewegung erfolgt nur, wenn die automatische Steuerung AN ist – wenn die automatische Steuerung deaktiviert ist, bleibt die Beschattung dort, wo sie sich zum Endzeitpunkt befindet."
         }
       },
       "automation": {
@@ -144,8 +146,7 @@
           "start_time": "Startzeit",
           "start_entity": "Entität, die die Startzeit angibt",
           "end_time": "Endzeit",
-          "end_entity": "Entität, die die Endzeit angibt",
-          "return_sunset": "Beschattungen zur aktuellen Standardposition verschieben, wenn die Endzeit erreicht wird"
+          "end_entity": "Entität, die die Endzeit angibt"
         },
         "data_description": {
           "delta_position": "Minimale Positionsänderung (%) erforderlich, bevor die Beschattung angepasst wird. Verhindert winzige Anpassungen bei langsamer Sonnenbewegung. Typische Werte: 1–2% (sehr responsiv, häufige Anpassungen), 5% (ausgewogen, für die meisten empfohlen), 10% (seltener, größere Bewegungen). Beispiel: Wenn die Beschattung bei 30% ist und die Sonne sich leicht bewegt, nur anpassen, wenn die neue Position 35% oder mehr beträgt (mit 5%-Schwellwert). Reduziert Verschleiß und Geräusche durch ständige winzige Anpassungen.",
@@ -153,8 +154,7 @@
           "start_time": "Automatische Steuerung nicht vor dieser Uhrzeit starten (24-Stunden-Format). Nutzen Sie dies, um morgens länger zu schlafen ohne Jalousien (auf 08:00 oder später einstellen), Ihre Routine abzugleichen (auf Ihre Aufwachzeit einstellen) oder lassen Sie es leer, um bei Sonnenaufgang zu starten. Beispiel: „07:30“ bedeutet, dass die automatische Steuerung um 07:30 Uhr beginnt. Manuelle Steuerung funktioniert davor weiterhin.",
           "start_entity": "Entität, die den Startzeitpunkt darstellt und die oben eingestellte feste Startzeit außer Kraft setzt. Nützlich zur Automatisierung der Startzeit mit einer Entität (z. B. Sensor, der die Aufwachzeit basierend auf Kalender oder Schlafverfolgung bereitstellt).",
           "end_time": "Automatische Steuerung nach dieser Uhrzeit beenden (24-Stunden-Format). Nutzen Sie dies für Abendprivatsphäre (auf 18:00 oder 19:00 einstellen), Rückkehr zum Standard vor dem Schlafengehen oder lassen Sie es leer, um bis zum Sonnenuntergang weiterzumachen. Beispiel: „20:00“ bedeutet, dass die automatische Steuerung um 20:00 Uhr endet. Manuelle Steuerung funktioniert nach dieser Zeit weiterhin.",
-          "end_entity": "Entität, die den Endzeitpunkt darstellt und die oben eingestellte feste Endzeit außer Kraft setzt. Nützlich zur Automatisierung der Endzeit mit einer Entität (z. B. Sensor, der die Schlafenszeit basierend auf Kalender oder täglicher Routine bereitstellt).",
-          "return_sunset": "Wenn der Betriebsendzeitpunkt erreicht ist, verschieben Sie die Beschattung auf die aktuelle wirksame Standardposition (die bei bereits eingetretenem astronomischem Sonnenuntergang die Sonnenuntergangsposition ist, andernfalls die normale Standardposition). Nützlich, wenn Ihr Endzeitpunkt vor Sonnenuntergang liegt und Sie die Beschattung korrekt für den Abend positionieren möchten. Diese Bewegung erfolgt nur, wenn die automatische Steuerung AN ist – wenn die automatische Steuerung deaktiviert ist, bleibt die Beschattung dort, wo sie sich zum Endzeitpunkt befindet."
+          "end_entity": "Entität, die den Endzeitpunkt darstellt und die oben eingestellte feste Endzeit außer Kraft setzt. Nützlich zur Automatisierung der Endzeit mit einer Entität (z. B. Sensor, der die Schlafenszeit basierend auf Kalender oder täglicher Routine bereitstellt)."
         }
       },
       "manual_override": {
@@ -515,8 +515,7 @@
           "start_time": "Startzeit",
           "start_entity": "Entität, die die Startzeit angibt",
           "end_time": "Endzeit",
-          "end_entity": "Entität, die die Endzeit angibt",
-          "return_sunset": "Beschattungen zur aktuellen Standardposition verschieben, wenn die Endzeit erreicht wird"
+          "end_entity": "Entität, die die Endzeit angibt"
         },
         "data_description": {
           "delta_position": "Minimale Positionsänderung (%) erforderlich, bevor die Beschattung angepasst wird. Verhindert kleine Anpassungen, während sich die Sonne langsam bewegt. Typische Werte: 1-2 % (sehr reaktiv, kann häufig anpassen), 5 % (ausgewogen, empfohlen für die meisten), 10 % (weniger häufig, größere Bewegungen). Beispiel: Wenn die Beschattung bei 30 % ist und die Sonne sich leicht bewegt, passen Sie nur an, wenn die neue Position 35 % oder höher ist (mit 5 % Schwelle). Reduziert Motorverschleiß und Lärm von konstanten kleinen Anpassungen.",
@@ -524,8 +523,7 @@
           "start_time": "Starten Sie nicht die automatische Kontrolle vor dieser Zeit (24-Stunden-Format). Verwenden Sie dies, um länger zu schlafen ohne Morgenblindheit (auf 08:00 oder später setzen), Ihrer Routine zu entsprechen (auf Aufwachzeit setzen), oder leer lassen, um bei Sonnenaufgang zu starten. Beispiel: ‚07:30' bedeutet, dass die automatische Kontrolle um 07:30 Uhr beginnt. Manuelle Kontrolle funktioniert vor dieser Zeit immer noch.",
           "start_entity": "Entität, die den Startzeitstatus darstellt und die oben festgelegte feste Startzeit überschreibt. Nützlich zur Automatisierung der Startzeit mit einer Entität (z. B. Sensor, der Aufwachzeit basierend auf Kalender oder Schlafverfolgung bereitstellt).",
           "end_time": "Beenden Sie die automatische Kontrolle nach dieser Zeit (24-Stunden-Format). Verwenden Sie dies, um Abendprivatsphäre zu behalten (auf 18:00 oder 19:00 setzen), zur Standardposition vor dem Schlafengehen zurückzukehren, oder leer lassen, um bis zum Sonnenuntergang zu fahren. Beispiel: ‚20:00' bedeutet, dass die automatische Kontrolle um 20:00 Uhr endet. Manuelle Kontrolle funktioniert nach dieser Zeit immer noch.",
-          "end_entity": "Entität, die den Endzeitstatus darstellt und die oben festgelegte feste Endzeit überschreibt. Nützlich zur Automatisierung der Endzeit mit einer Entität (z. B. Sensor, der Schlafenszeit basierend auf Kalender oder täglicher Routine bereitstellt).",
-          "return_sunset": "Wenn die betriebliche Endzeit erreicht ist, senden Sie Beschattungen in die aktuelle effektive Standardposition (die die Sonnenuntergangsposition ist, wenn der astronomische Sonnenuntergang bereits aufgetreten ist, ansonsten die normale Standardposition). Nützlich, wenn Ihre Endzeit vor Sonnenuntergang liegt und Sie die Beschattungen korrekt für den Abend positionieren möchten. Diese Bewegung tritt nur auf, wenn die Automatische Kontrolle AKTIVIERT ist – wenn die Automatische Kontrolle deaktiviert ist, bleibt die Beschattung dort, wo sie zur Endzeit ist."
+          "end_entity": "Entität, die den Endzeitstatus darstellt und die oben festgelegte feste Endzeit überschreibt. Nützlich zur Automatisierung der Endzeit mit einer Entität (z. B. Sensor, der Schlafenszeit basierend auf Kalender oder täglicher Routine bereitstellt)."
         }
       },
       "cover_entities": {
@@ -626,7 +624,8 @@
           "inverse_state": "Zustand umkehren (erforderlich für Beschattungen, die nicht HA-Richtlinien folgen)",
           "interp": "Positionskalibrierung aktivieren (benutzerdefinierte Öffnungs-/Schließungspositionszuordnung)",
           "sunrise_time_entity": "Sonnenaufgangs-Zeit-Entität",
-          "sunset_time_entity": "Sonnenuntergangs-Zeit-Entität"
+          "sunset_time_entity": "Sonnenuntergangs-Zeit-Entität",
+          "return_sunset": "Beschattungen zur aktuellen Standardposition verschieben, wenn die Endzeit erreicht wird"
         },
         "data_description": {
           "default_percentage": "Behangposition, wenn die Sonne nicht vor dem Fenster steht (0–100%). 0% = geschlossen (Jalousie heruntergelassen / Markise eingezogen), 50% = halb offen (ausgewogenes Licht und Datenschutz), 100% = offen (Jalousie hochgezogen / Markise ausgefahren). Dies ist die 'Ruheposition', die verwendet wird, wenn Sonnenverfolgung nicht aktiv ist (Sonne ist hinter dem Fenster, wird durch Hindernisse blockiert oder liegt außerhalb der Verfolgungszeiten).",
@@ -645,7 +644,8 @@
           "inverse_state": "Aktivieren Sie dies für Behänge, bei denen die Positionslogik umgekehrt ist. Standard: 0 = geschlossen/heruntergelassen, 100 = offen/hochgezogen. Invertiert: 0 = offen/hochgezogen, 100 = geschlossen/heruntergelassen. Markieren Sie dies NUR, wenn Ihr Behang entgegengesetztes Verhalten zeigt, 100% schließt statt öffnet, oder die Dokumentation sagt 'invertiert' oder 'umgekehrt'. Testen Sie Ihren Behang zunächst manuell, um sicherzustellen. Die meisten Behänge benötigen dies nicht.",
           "interp": "Aktivieren Sie benutzerdefinierte Positionszuordnung zur Kalibrierung von Behängen, die nicht linear auf 0–100 %-Befehle reagieren. Wenn aktiviert, wird ein Abschnitt 'Positionskalibrierung' im Optionsmenü angezeigt (unter Positionseinstellungen), wo Sie die Zuordnungswerte konfigurieren können. Anwendungsfälle: Behang bewegt sich nicht linear, bevorzugt bestimmte Bereiche (mehr geschlossen oder mehr offen), Kalibrierung für ungewöhnliches Behangverhalten. Deaktiviert lassen für normalen Betrieb.",
           "sunrise_time_entity": "Optionale Entität, deren Zustand eine Datum/Uhrzeit ist (z. B. Sun2 'Sonnenaufgang bei -4° Elevation'). Bei Einstellung ersetzt sie die durch astral berechnete Sonnenaufgangszeit als Grenze zum Schließen des Fensters morgens. Akzeptiert Sensor- oder input_datetime-Entitäten. Der Sonnenaufgang-Offset wird zusätzlich angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist.",
-          "sunset_time_entity": "Optionale Entität, deren Zustand eine Datum/Uhrzeit ist (z. B. Sun2 'Sonnenuntergang bei -4° Elevation'). Bei Einstellung ersetzt sie die durch astral berechnete Sonnenuntergangszeit als Fenstergrenze. Akzeptiert Sensor- oder input_datetime-Entitäten, die eine ISO-8601-Datum/Uhrzeit melden. Der Sonnenuntergang-Offset wird zusätzlich angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist."
+          "sunset_time_entity": "Optionale Entität, deren Zustand eine Datum/Uhrzeit ist (z. B. Sun2 'Sonnenuntergang bei -4° Elevation'). Bei Einstellung ersetzt sie die durch astral berechnete Sonnenuntergangszeit als Fenstergrenze. Akzeptiert Sensor- oder input_datetime-Entitäten, die eine ISO-8601-Datum/Uhrzeit melden. Der Sonnenuntergang-Offset wird zusätzlich angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist.",
+          "return_sunset": "Wenn die betriebliche Endzeit erreicht ist, senden Sie Beschattungen in die aktuelle effektive Standardposition (die die Sonnenuntergangsposition ist, wenn der astronomische Sonnenuntergang bereits aufgetreten ist, ansonsten die normale Standardposition). Nützlich, wenn Ihre Endzeit vor Sonnenuntergang liegt und Sie die Beschattungen korrekt für den Abend positionieren möchten. Diese Bewegung tritt nur auf, wenn die Automatische Kontrolle AKTIVIERT ist – wenn die Automatische Kontrolle deaktiviert ist, bleibt die Beschattung dort, wo sie zur Endzeit ist."
         }
       },
       "manual_override": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -109,6 +109,7 @@
           "sunset_use_my": "Use My at sunset",
           "sunset_offset": "Sunset Offset",
           "sunrise_offset": "Sunrise Offset",
+          "return_sunset": "Move covers to current default position when end time is reached",
           "sunset_time_entity": "Sunset Time Entity",
           "sunrise_time_entity": "Sunrise Time Entity",
           "open_close_threshold": "Open/Close threshold",
@@ -128,6 +129,7 @@
           "sunset_use_my": "When the sunset/end-time window activates, trigger the cover's My preset (via stop_cover) instead of the normal open/close fallback. Requires My position value to be set. Only affects non-position-capable covers (e.g. Somfy RTS).",
           "sunset_offset": "Minutes to shift sunset time (± adjustment). Positive value: Apply sunset position X minutes AFTER sunset. Negative value: Apply sunset position X minutes BEFORE sunset. Zero: Exactly at sunset. Use positive value (e.g., 30) if you want covers to stay open a bit past sunset. Use negative value (e.g., -30) to close early while sun is still low.",
           "sunrise_offset": "Minutes to shift sunrise time (± adjustment). Positive value: Start automatic control X minutes AFTER sunrise. Negative value: Start automatic control X minutes BEFORE sunrise. Zero: Exactly at sunrise. Use positive value (e.g., 60) if you want to sleep in past sunrise. Combines with Start Time setting (uses whichever is later).",
+          "return_sunset": "When the operational end time is reached, send covers to the current effective default position (which will be the sunset position if astronomical sunset has already occurred, otherwise the normal default). Useful when your end time is before sunset and you want covers positioned correctly for the evening. This movement only occurs when Automatic Control is ON — if Automatic Control is disabled, covers will stay where they are at end time.",
           "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). When set, replaces the astral-computed sunset time as the window boundary. Accepts sensor or input_datetime entities reporting an ISO-8601 datetime. Sunset Offset still applies on top. Falls back to astral if the entity is unavailable.",
           "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). When set, replaces the astral-computed sunrise time as the morning window-close boundary. Accepts sensor or input_datetime entities. Sunrise Offset still applies on top. Falls back to astral if the entity is unavailable.",
           "open_close_threshold": "Position threshold for covers that only support open/close commands (not position control). When the calculated position is greater than or equal to this threshold, the cover opens; when below, it closes. Default: 50% (opens at midpoint or above). Higher values (60-70%) keep cover closed more often, lower values (30-40%) open more often. Only affects covers without position support - covers with position control ignore this setting and use exact calculated positions.",
@@ -144,8 +146,7 @@
           "start_time": "Starting time",
           "start_entity": "Entity indicating starting time",
           "end_time": "End time",
-          "end_entity": "Entity indicating ending time",
-          "return_sunset": "Move covers to current default position when end time is reached"
+          "end_entity": "Entity indicating ending time"
         },
         "data_description": {
           "delta_position": "Minimum position change (%) required before adjusting the cover. Prevents tiny adjustments as sun moves slowly. Typical values: 1-2% (very responsive, may adjust frequently), 5% (balanced, recommended for most), 10% (less frequent, larger movements). Example: If cover is at 30% and sun moves slightly, only adjust if new position is 35% or more (with 5% threshold). Reduces motor wear and noise from constant tiny adjustments.",
@@ -153,8 +154,7 @@
           "start_time": "Don't start automatic control before this time (24-hour format). Use this to sleep in without morning blinds (set to 08:00 or later), match your routine (set to when you wake up), or leave blank to start at sunrise. Example: '07:30' means automatic control begins at 7:30 AM. Manual control still works before this time.",
           "start_entity": "Entity representing starting time state, overriding the fixed start time set above. Useful for automating the start time with an entity (e.g., sensor that provides wake-up time based on calendar or sleep tracking).",
           "end_time": "Stop automatic control after this time (24-hour format). Use this to keep evening privacy (set to 18:00 or 19:00), return to default before bed, or leave blank to continue until sunset. Example: '20:00' means automatic control stops at 8:00 PM. Manual control still works after this time.",
-          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine).",
-          "return_sunset": "When the operational end time is reached, send covers to the current effective default position (which will be the sunset position if astronomical sunset has already occurred, otherwise the normal default). Useful when your end time is before sunset and you want covers positioned correctly for the evening. This movement only occurs when Automatic Control is ON — if Automatic Control is disabled, covers will stay where they are at end time."
+          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine)."
         }
       },
       "manual_override": {
@@ -515,8 +515,7 @@
           "start_time": "Starting time",
           "start_entity": "Entity indicating starting time",
           "end_time": "End time",
-          "end_entity": "Entity indicating ending time",
-          "return_sunset": "Move covers to current default position when end time is reached"
+          "end_entity": "Entity indicating ending time"
         },
         "data_description": {
           "delta_position": "Minimum position change (%) required before adjusting the cover. Prevents tiny adjustments as sun moves slowly. Typical values: 1-2% (very responsive, may adjust frequently), 5% (balanced, recommended for most), 10% (less frequent, larger movements). Example: If cover is at 30% and sun moves slightly, only adjust if new position is 35% or more (with 5% threshold). Reduces motor wear and noise from constant tiny adjustments.",
@@ -524,8 +523,7 @@
           "start_time": "Don't start automatic control before this time (24-hour format). Use this to sleep in without morning blinds (set to 08:00 or later), match your routine (set to when you wake up), or leave blank to start at sunrise. Example: '07:30' means automatic control begins at 7:30 AM. Manual control still works before this time.",
           "start_entity": "Entity representing starting time state, overriding the fixed start time set above. Useful for automating the start time with an entity (e.g., sensor that provides wake-up time based on calendar or sleep tracking).",
           "end_time": "Stop automatic control after this time (24-hour format). Use this to keep evening privacy (set to 18:00 or 19:00), return to default before bed, or leave blank to continue until sunset. Example: '20:00' means automatic control stops at 8:00 PM. Manual control still works after this time.",
-          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine).",
-          "return_sunset": "When the operational end time is reached, send covers to the current effective default position (which will be the sunset position if astronomical sunset has already occurred, otherwise the normal default). Useful when your end time is before sunset and you want covers positioned correctly for the evening. This movement only occurs when Automatic Control is ON — if Automatic Control is disabled, covers will stay where they are at end time."
+          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine)."
         }
       },
       "cover_entities": {
@@ -622,6 +620,7 @@
           "sunset_use_my": "Use My at sunset",
           "sunset_offset": "Sunset Offset",
           "sunrise_offset": "Sunrise Offset",
+          "return_sunset": "Move covers to current default position when end time is reached",
           "sunset_time_entity": "Sunset Time Entity",
           "sunrise_time_entity": "Sunrise Time Entity",
           "open_close_threshold": "Open/Close threshold",
@@ -641,6 +640,7 @@
           "sunset_use_my": "When the sunset/end-time window activates, trigger the cover's My preset (via stop_cover) instead of the normal open/close fallback. Requires My position value to be set. Only affects non-position-capable covers (e.g. Somfy RTS).",
           "sunset_offset": "Minutes to shift sunset time (± adjustment). Positive value: Apply sunset position X minutes AFTER sunset. Negative value: Apply sunset position X minutes BEFORE sunset. Zero: Exactly at sunset. Use positive value (e.g., 30) if you want covers to stay open a bit past sunset. Use negative value (e.g., -30) to close early while sun is still low.",
           "sunrise_offset": "Minutes to shift sunrise time (± adjustment). Positive value: Start automatic control X minutes AFTER sunrise. Negative value: Start automatic control X minutes BEFORE sunrise. Zero: Exactly at sunrise. Use positive value (e.g., 60) if you want to sleep in past sunrise. Combines with Start Time setting (uses whichever is later).",
+          "return_sunset": "When the operational end time is reached, send covers to the current effective default position (which will be the sunset position if astronomical sunset has already occurred, otherwise the normal default). Useful when your end time is before sunset and you want covers positioned correctly for the evening. This movement only occurs when Automatic Control is ON — if Automatic Control is disabled, covers will stay where they are at end time.",
           "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). When set, replaces the astral-computed sunset time as the window boundary. Accepts sensor or input_datetime entities reporting an ISO-8601 datetime. Sunset Offset still applies on top. Falls back to astral if the entity is unavailable.",
           "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). When set, replaces the astral-computed sunrise time as the morning window-close boundary. Accepts sensor or input_datetime entities. Sunrise Offset still applies on top. Falls back to astral if the entity is unavailable.",
           "open_close_threshold": "Position threshold for covers that only support open/close commands (not position control). When the calculated position is greater than or equal to this threshold, the cover opens; when below, it closes. Default: 50% (opens at midpoint or above). Higher values (60-70%) keep cover closed more often, lower values (30-40%) open more often. Only affects covers without position support - covers with position control ignore this setting and use exact calculated positions.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -113,7 +113,8 @@
           "inverse_state": "Inverser l'état (nécessaire pour certains stores qui ne suivent pas les directives HA)",
           "interp": "Activer l'étalonnage de position (mappage custom position ouverture/fermeture)",
           "sunrise_time_entity": "Entité Heure de Lever du Soleil",
-          "sunset_time_entity": "Entité Heure de Coucher du Soleil"
+          "sunset_time_entity": "Entité Heure de Coucher du Soleil",
+          "return_sunset": "Déplacer les stores à la position par défaut actuelle quand l'heure de fin est atteinte"
         },
         "data_description": {
           "default_percentage": "Position du store quand le soleil n'est pas devant la fenêtre (0-100%). 0% = fermé (stores baissés / store banne rétracté), 50% = demi-ouvert (lumière et intimité équilibrées), 100% = ouvert (stores levés / store banne étendu). Ceci est la « position de repos » utilisée quand le suivi du soleil n'est pas actif (soleil derrière la fenêtre, bloqué par des obstacles, ou en dehors des heures de suivi).",
@@ -132,7 +133,8 @@
           "inverse_state": "Activez pour les stores où la logique de position est inversée. Standard : 0 = fermé/baissé, 100 = ouvert/levé. Inversé : 0 = ouvert/levé, 100 = fermé/baissé. Cochez ceci UNIQUEMENT si votre store montre un comportement opposé, 100% ferme au lieu d'ouvrir, ou la documentation dit « inversé » ou « inversé ». Testez votre store manuellement d'abord pour confirmer. La plupart des stores n'en ont pas besoin.",
           "interp": "Activez le mappage de position personnalisé pour étalonner les stores qui ne répondent pas linéairement aux commandes 0–100%. Quand activé, une section « Étalonnage de position » apparaîtra dans le menu des options (sous Paramètres de position) où vous pouvez configurer les valeurs de mappage. Cas d'utilisation : le store ne se déplace pas linéairement, préférez certaines plages (plus fermé ou plus ouvert), étalonner pour un comportement de store inhabituel. Laissez désactivé pour un fonctionnement normal.",
           "sunrise_time_entity": "Entité optionnelle dont l'état est une date/heure (ex. Sun2 « lever du soleil à -4° d'élévation »). Lorsqu'elle est définie, elle remplace l'heure de lever du soleil calculée par astral en tant que limite de fermeture de fenêtre le matin. Accepte les entités sensor ou input_datetime. Le Décalage Lever du Soleil s'applique toujours en plus. Bascule sur astral si l'entité n'est pas disponible.",
-          "sunset_time_entity": "Entité optionnelle dont l'état est une date/heure (ex. Sun2 « coucher du soleil à -4° d'élévation »). Lorsqu'elle est définie, elle remplace l'heure de coucher du soleil calculée par astral en tant que limite de fenêtre. Accepte les entités sensor ou input_datetime rapportant une date/heure ISO-8601. Le Décalage Coucher du Soleil s'applique toujours en plus. Bascule sur astral si l'entité n'est pas disponible."
+          "sunset_time_entity": "Entité optionnelle dont l'état est une date/heure (ex. Sun2 « coucher du soleil à -4° d'élévation »). Lorsqu'elle est définie, elle remplace l'heure de coucher du soleil calculée par astral en tant que limite de fenêtre. Accepte les entités sensor ou input_datetime rapportant une date/heure ISO-8601. Le Décalage Coucher du Soleil s'applique toujours en plus. Bascule sur astral si l'entité n'est pas disponible.",
+          "return_sunset": "Quand l'heure de fin opérationnelle est atteinte, envoyez les stores à la position par défaut actuelle effective (qui sera la position du coucher du soleil si le coucher du soleil astronomique s'est déjà produit, sinon la valeur par défaut normale). Utile quand votre heure de fin est avant le coucher du soleil et vous voulez que les stores soient positionnés correctement pour la soirée. Ce mouvement ne se produit que quand le contrôle automatique est ACTIVÉ — si le contrôle automatique est désactivé, les stores resteront où ils se trouvent à l'heure de fin."
         }
       },
       "automation": {
@@ -144,8 +146,7 @@
           "start_time": "Heure de début",
           "start_entity": "Entité indiquant l'heure de début",
           "end_time": "Heure de fin",
-          "end_entity": "Entité indiquant l'heure de fin",
-          "return_sunset": "Déplacer les stores à la position par défaut actuelle quand l'heure de fin est atteinte"
+          "end_entity": "Entité indiquant l'heure de fin"
         },
         "data_description": {
           "delta_position": "Changement de position minimum (%) requis avant d'ajuster le store. Empêche les minuscules ajustements tandis que le soleil se déplace lentement. Valeurs typiques : 1-2% (très réactif, peut ajuster fréquemment), 5% (équilibré, recommandé pour la plupart), 10% (moins fréquent, mouvements plus importants). Exemple : Si le store est à 30% et le soleil se déplace légèrement, n'ajustez que si la nouvelle position est 35% ou plus (avec un seuil de 5%). Réduit l'usure du moteur et le bruit des minuscules ajustements constants.",
@@ -153,8 +154,7 @@
           "start_time": "Ne commencez pas le contrôle automatique avant cette heure (format 24 heures). Utilisez ceci pour rester endormi sans stores du matin (réglez sur 08:00 ou plus tard), correspondez à votre routine (réglez sur l'heure du réveil), ou laissez vide pour commencer au lever du soleil. Exemple : '07:30' signifie que le contrôle automatique commence à 7:30 AM. Le contrôle manuel fonctionne toujours avant cette heure.",
           "start_entity": "Entité représentant l'état de l'heure de début, remplaçant l'heure de début fixe définie ci-dessus. Utile pour automatiser l'heure de début avec une entité (par ex., un capteur qui fournit l'heure du réveil en fonction du calendrier ou du suivi du sommeil).",
           "end_time": "Arrêtez le contrôle automatique après cette heure (format 24 heures). Utilisez ceci pour garder l'intimité du soir (réglez sur 18:00 ou 19:00), retournez à la valeur par défaut avant le coucher, ou laissez vide pour continuer jusqu'au coucher du soleil. Exemple : '20:00' signifie que le contrôle automatique s'arrête à 20:00. Le contrôle manuel fonctionne toujours après cette heure.",
-          "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité (par ex., un capteur qui fournit l'heure du coucher basée sur le calendrier ou la routine quotidienne).",
-          "return_sunset": "Quand l'heure de fin opérationnelle est atteinte, envoyez les stores à la position par défaut actuelle effective (qui sera la position du coucher du soleil si le coucher du soleil astronomique s'est déjà produit, sinon la valeur par défaut normale). Utile quand votre heure de fin est avant le coucher du soleil et vous voulez que les stores soient positionnés correctement pour la soirée. Ce mouvement ne se produit que quand le contrôle automatique est ACTIVÉ — si le contrôle automatique est désactivé, les stores resteront où ils se trouvent à l'heure de fin."
+          "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité (par ex., un capteur qui fournit l'heure du coucher basée sur le calendrier ou la routine quotidienne)."
         }
       },
       "manual_override": {
@@ -515,8 +515,7 @@
           "start_time": "Heure de début",
           "start_entity": "Entité indiquant l'heure de début",
           "end_time": "Heure de fin",
-          "end_entity": "Entité indiquant l'heure de fin",
-          "return_sunset": "Déplacer les stores à la position par défaut actuelle quand l'heure de fin est atteinte"
+          "end_entity": "Entité indiquant l'heure de fin"
         },
         "data_description": {
           "delta_position": "Changement de position minimum (%) requis avant d'ajuster le store. Empêche les minuscules ajustements tandis que le soleil se déplace lentement. Valeurs typiques : 1-2% (très réactif, peut ajuster fréquemment), 5% (équilibré, recommandé pour la plupart), 10% (moins fréquent, mouvements plus importants). Exemple : Si le store est à 30% et le soleil se déplace légèrement, n'ajustez que si la nouvelle position est 35% ou plus (avec un seuil de 5%). Réduit l'usure du moteur et le bruit des minuscules ajustements constants.",
@@ -524,8 +523,7 @@
           "start_time": "Ne commencez pas le contrôle automatique avant cette heure (format 24 heures). Utilisez ceci pour rester endormi sans stores du matin (réglez sur 08:00 ou plus tard), correspondez à votre routine (réglez sur l'heure du réveil), ou laissez vide pour commencer au lever du soleil. Exemple : '07:30' signifie que le contrôle automatique commence à 7:30 AM. Le contrôle manuel fonctionne toujours avant cette heure.",
           "start_entity": "Entité représentant l'état de l'heure de début, remplaçant l'heure de début fixe définie ci-dessus. Utile pour automatiser l'heure de début avec une entité (par ex., un capteur qui fournit l'heure du réveil en fonction du calendrier ou du suivi du sommeil).",
           "end_time": "Arrêtez le contrôle automatique après cette heure (format 24 heures). Utilisez ceci pour garder l'intimité du soir (réglez sur 18:00 ou 19:00), retournez à la valeur par défaut avant le coucher, ou laissez vide pour continuer jusqu'au coucher du soleil. Exemple : '20:00' signifie que le contrôle automatique s'arrête à 20:00. Le contrôle manuel fonctionne toujours après cette heure.",
-          "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité (par ex., un capteur qui fournit l'heure du coucher basée sur le calendrier ou la routine quotidienne).",
-          "return_sunset": "Quand l'heure de fin opérationnelle est atteinte, envoyez les stores à la position par défaut actuelle effective (qui sera la position du coucher du soleil si le coucher du soleil astronomique s'est déjà produit, sinon la valeur par défaut normale). Utile quand votre heure de fin est avant le coucher du soleil et vous voulez que les stores soient positionnés correctement pour la soirée. Ce mouvement ne se produit que quand le contrôle automatique est ACTIVÉ — si le contrôle automatique est désactivé, les stores resteront où ils se trouvent à l'heure de fin."
+          "end_entity": "Entité représentant l'état de l'heure de fin, remplaçant l'heure de fin fixe définie ci-dessus. Utile pour automatiser l'heure de fin avec une entité (par ex., un capteur qui fournit l'heure du coucher basée sur le calendrier ou la routine quotidienne)."
         }
       },
       "cover_entities": {
@@ -626,7 +624,8 @@
           "inverse_state": "Inverser l'état (nécessaire pour certains stores qui ne suivent pas les directives HA)",
           "interp": "Activer l'étalonnage de position (mappage custom position ouverture/fermeture)",
           "sunrise_time_entity": "Entité Heure de Lever du Soleil",
-          "sunset_time_entity": "Entité Heure de Coucher du Soleil"
+          "sunset_time_entity": "Entité Heure de Coucher du Soleil",
+          "return_sunset": "Déplacer les stores à la position par défaut actuelle quand l'heure de fin est atteinte"
         },
         "data_description": {
           "default_percentage": "Position du store quand le soleil n'est pas devant la fenêtre (0-100%). 0% = fermé (stores baissés / store banne rétracté), 50% = demi-ouvert (lumière et intimité équilibrées), 100% = ouvert (stores levés / store banne étendu). Ceci est la « position de repos » utilisée quand le suivi du soleil n'est pas actif (soleil derrière la fenêtre, bloqué par des obstacles, ou en dehors des heures de suivi).",
@@ -645,7 +644,8 @@
           "inverse_state": "Activez pour les stores où la logique de position est inversée. Standard : 0 = fermé/baissé, 100 = ouvert/levé. Inversé : 0 = ouvert/levé, 100 = fermé/baissé. Cochez ceci UNIQUEMENT si votre store montre un comportement opposé, 100% ferme au lieu d'ouvrir, ou la documentation dit « inversé » ou « inversé ». Testez votre store manuellement d'abord pour confirmer. La plupart des stores n'en ont pas besoin.",
           "interp": "Activez le mappage de position personnalisé pour étalonner les stores qui ne répondent pas linéairement aux commandes 0–100%. Quand activé, une section « Étalonnage de position » apparaîtra dans le menu des options (sous Paramètres de position) où vous pouvez configurer les valeurs de mappage. Cas d'utilisation : le store ne se déplace pas linéairement, préférez certaines plages (plus fermé ou plus ouvert), étalonner pour un comportement de store inhabituel. Laissez désactivé pour un fonctionnement normal.",
           "sunrise_time_entity": "Entité optionnelle dont l'état est une date/heure (ex. Sun2 « lever du soleil à -4° d'élévation »). Lorsqu'elle est définie, elle remplace l'heure de lever du soleil calculée par astral en tant que limite de fermeture de fenêtre le matin. Accepte les entités sensor ou input_datetime. Le Décalage Lever du Soleil s'applique toujours en plus. Bascule sur astral si l'entité n'est pas disponible.",
-          "sunset_time_entity": "Entité optionnelle dont l'état est une date/heure (ex. Sun2 « coucher du soleil à -4° d'élévation »). Lorsqu'elle est définie, elle remplace l'heure de coucher du soleil calculée par astral en tant que limite de fenêtre. Accepte les entités sensor ou input_datetime rapportant une date/heure ISO-8601. Le Décalage Coucher du Soleil s'applique toujours en plus. Bascule sur astral si l'entité n'est pas disponible."
+          "sunset_time_entity": "Entité optionnelle dont l'état est une date/heure (ex. Sun2 « coucher du soleil à -4° d'élévation »). Lorsqu'elle est définie, elle remplace l'heure de coucher du soleil calculée par astral en tant que limite de fenêtre. Accepte les entités sensor ou input_datetime rapportant une date/heure ISO-8601. Le Décalage Coucher du Soleil s'applique toujours en plus. Bascule sur astral si l'entité n'est pas disponible.",
+          "return_sunset": "Quand l'heure de fin opérationnelle est atteinte, envoyez les stores à la position par défaut actuelle effective (qui sera la position du coucher du soleil si le coucher du soleil astronomique s'est déjà produit, sinon la valeur par défaut normale). Utile quand votre heure de fin est avant le coucher du soleil et vous voulez que les stores soient positionnés correctement pour la soirée. Ce mouvement ne se produit que quand le contrôle automatique est ACTIVÉ — si le contrôle automatique est désactivé, les stores resteront où ils se trouvent à l'heure de fin."
         }
       },
       "manual_override": {

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -95,6 +95,7 @@ _POSITION = {
     # CONF_SUNSET_POS is Optional — omit to use default
     CONF_SUNSET_OFFSET: 0,
     CONF_SUNRISE_OFFSET: 0,
+    CONF_RETURN_SUNSET: False,
     CONF_INVERSE_STATE: False,
     "interp": False,
     "open_close_threshold": 50,
@@ -105,7 +106,6 @@ _AUTOMATION = {
     CONF_DELTA_TIME: 2,  # plain integer (minutes) per AUTOMATION_SCHEMA
     CONF_START_TIME: "08:00:00",
     CONF_END_TIME: "20:00:00",
-    CONF_RETURN_SUNSET: False,
     # start_entity / end_entity are Optional — omit
 }
 
@@ -738,6 +738,7 @@ def test_config_flow_does_not_import_async_get_translations() -> None:
                 CONF_ENABLE_MAX_POSITION: False,
                 CONF_SUNSET_OFFSET: 0,
                 CONF_SUNRISE_OFFSET: 0,
+                CONF_RETURN_SUNSET: False,
                 CONF_INVERSE_STATE: False,
                 "interp": False,
                 "open_close_threshold": 50,
@@ -750,7 +751,6 @@ def test_config_flow_does_not_import_async_get_translations() -> None:
                 CONF_DELTA_TIME: 2,
                 CONF_START_TIME: "08:00:00",
                 CONF_END_TIME: "20:00:00",
-                CONF_RETURN_SUNSET: False,
             },
         ),
         (


### PR DESCRIPTION
## Summary

Apply a consistent **master toggle → sensors → thresholds → actions** pattern across the options flow, and surface master toggles at the top of each step (addressing #364 user feedback — *"global toggles should be at the top"*).

- `POSITION_SCHEMA` — pair each `enable_*` toggle with its value; group sunset entity-sensors above sunset thresholds; relocate `return_sunset` in from `automation` (it's semantically a sunset action, not a timing-window concern).
- `AUTOMATION_SCHEMA` — entity sensors lifted above their plain-time counterparts; `return_sunset` removed.
- `weather_override_schema()` — all sensors grouped, then all thresholds, then action position/timeout. Was previously interleaved (`wind_sensor → wind_threshold → rain_sensor → rain_threshold …`).
- `light_cloud_schema()` — sensors grouped, then thresholds. Kept `cloudy_position` immediately below the master toggle to preserve the existing `test_light_cloud_master_toggle_is_first` regression guard.
- `temperature_climate_schema()` — sensors grouped above thresholds.

Cross-step move (`CONF_RETURN_SUNSET`):
- Schema declaration: `AUTOMATION_SCHEMA` → `POSITION_SCHEMA`
- `SYNC_CATEGORIES` membership: `"automation"` → `"position"`
- en.json / de.json / fr.json: JSON-tree entries moved from `step.automation` to `step.position` in both `config` and `options` flow blocks
- `tests/test_config_flow_integration.py` — `_AUTOMATION` and `_POSITION` test fixtures updated to reflect new schema placement

No option-key renames, no behavioral changes, no stored-config migrations.

The two formatting touch-ups in `config_types.py` and `diagnostics/builder.py` are ruff auto-fixes for over-length lines triggered when the auto-formatter ran during this branch's work.

## Testing
- ✅ 3699 tests passing
- ✅ Translation validator green; DE/FR sync at 1069/1069 keys
- Manual UI verification deferred — schemas and tests cover the structural change; UI render order in HA follows schema declaration order verbatim

## Related Issues
Refs #364