### PR TITLE
fix: hold night position when schedule start time is blank (#492)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
 
 from .const import (
+    BLANK_TIME,
     CONF_AWNING_ANGLE,
     CONF_AZIMUTH,
     CONF_BLIND_SPOT_ELEVATION,
@@ -434,11 +435,14 @@ AUTOMATION_SCHEMA = vol.Schema(
         vol.Optional(CONF_START_ENTITY): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
         ),
-        vol.Optional(CONF_START_TIME, default="00:00:00"): selector.TimeSelector(),
+        # No default: a cleared TimeSelector must leave the key absent so it can
+        # be stripped (issue #492). Blank stripping is enforced in
+        # async_step_automation since the suggested-values path can re-add it.
+        vol.Optional(CONF_START_TIME): selector.TimeSelector(),
         vol.Optional(CONF_END_ENTITY): selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
         ),
-        vol.Optional(CONF_END_TIME, default="00:00:00"): selector.TimeSelector(),
+        vol.Optional(CONF_END_TIME): selector.TimeSelector(),
     }
 )
 
@@ -1693,13 +1697,21 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     timing_parts = []
     if start_entity:
         timing_parts.append(f"from {start_entity}")
-    elif start_time:
+    elif start_time and start_time != BLANK_TIME:
         timing_parts.append(f"from {start_time}")
     if end_entity:
         timing_parts.append(f"until {end_entity}")
-    elif end_time:
+    elif end_time and end_time != BLANK_TIME:
         timing_parts.append(f"until {end_time}")
-    if timing_parts or sunset_pos is not None:
+    # A schedule key present but blank (cleared TimeSelector → "00:00:00") still
+    # means the user configured the automation window — show "Active during
+    # daylight" rather than nothing, so the summary reflects the real behavior
+    # (issue #492). CONF_*_TIME default to BLANK_TIME, so test membership too.
+    schedule_configured = any(
+        config.get(key) not in (None, BLANK_TIME)
+        for key in (CONF_START_ENTITY, CONF_END_ENTITY)
+    ) or any(key in config for key in (CONF_START_TIME, CONF_END_TIME))
+    if timing_parts or sunset_pos is not None or schedule_configured:
         timing_str = (
             " ".join(timing_parts) if timing_parts else "Active during daylight"
         )
@@ -3387,6 +3399,14 @@ class OptionsFlowHandler(OptionsFlow):
         """Manage automation options."""
         if user_input is not None:
             self.optional_entities([CONF_START_ENTITY, CONF_END_ENTITY], user_input)
+            # A cleared TimeSelector either omits the key or coerces to the blank
+            # sentinel "00:00:00". Treat both as "unset": drop the key from the
+            # submission and from any previously-stored option so it never
+            # persists as a literal midnight window (issue #492).
+            for time_key in (CONF_START_TIME, CONF_END_TIME):
+                if user_input.get(time_key) in (None, BLANK_TIME):
+                    user_input.pop(time_key, None)
+                    self.options.pop(time_key, None)
             self.options.update(user_input)
             return await self.async_step_init()
         return self.async_show_form(

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -431,6 +431,10 @@ CONF_START_TIME = "start_time"  # active-window start "HH:MM:SS"
 CONF_START_ENTITY = "start_entity"  # input_datetime overriding start_time
 CONF_END_TIME = "end_time"  # active-window end "HH:MM:SS"
 CONF_END_ENTITY = "end_entity"  # input_datetime overriding end_time
+# Blank/unset sentinel for start/end times: HA's TimeSelector cannot emit a
+# true None, so a cleared field coerces to midnight. Treated as "no time set"
+# everywhere (see issue #492).
+BLANK_TIME = "00:00:00"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -967,23 +967,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # (astronomical_sunrise + sunrise_offset).
         h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
         sunset_pos_cfg = options.get(CONF_SUNSET_POS)  # None when not configured
-        sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
-        sunrise_off = int(
-            options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
-        )
-        sunset_time = _read_time_entity(self.hass, options.get(CONF_SUNSET_TIME_ENTITY))
-        sunrise_time = _read_time_entity(
-            self.hass, options.get(CONF_SUNRISE_TIME_ENTITY)
-        )
-        effective_default, is_sunset_active = compute_effective_default(
-            h_def=h_def,
-            sunset_pos=sunset_pos_cfg,
-            sun_data=cover_data.sun_data,
-            sunset_off=sunset_off,
-            sunrise_off=sunrise_off,
-            sunset_time=sunset_time,
-            sunrise_time=sunrise_time,
-            after_start_time=self.after_start_time,
+        effective_default, is_sunset_active = self._compute_current_effective_default(
+            options, cover_data=cover_data
         )
         self.logger.debug(
             "Effective default: %s (sunset_active=%s, h_def=%s, sunset_pos=%s)",
@@ -1887,6 +1872,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         return self._time_mgr.after_start_time
 
     @property
+    def window_explicitly_started(self):
+        """Whether a real (non-blank) start time is configured and has passed.
+
+        Delegates to TimeWindowManager. Distinct from ``after_start_time``
+        (issue #492): feeds ``compute_effective_default`` so a blank start time
+        does not suppress the overnight position after midnight.
+        """
+        return self._time_mgr.window_explicitly_started
+
+    @property
     def _end_time(self) -> dt.datetime | None:
         """Get end time — delegates to TimeWindowManager."""
         return self._time_mgr.end_time
@@ -2437,11 +2432,24 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         await self._check_sunset_window_transition()
 
-    def _compute_current_effective_default(self, options: dict) -> tuple[int, bool]:
+    def _compute_current_effective_default(
+        self, options: dict, cover_data=None
+    ) -> tuple[int, bool]:
         """Return (effective_pos, is_sunset_active) for the current moment.
 
-        Shared by _on_window_closed and _check_sunset_window_transition so the
-        same options-reading and compute_effective_default call is not duplicated.
+        Single source of truth for reading the sunset/sunrise options and
+        calling ``compute_effective_default``. Shared by the main update cycle
+        (``_calculate_cover_state``), ``_on_window_closed`` and
+        ``_check_sunset_window_transition`` so the options-reading and the
+        ``window_explicitly_started`` signal are not duplicated.
+
+        Args:
+            options: The config-entry options dict.
+            cover_data: An already-computed cover-data object whose ``sun_data``
+                is reused. When ``None`` the cover data is computed fresh via
+                ``get_blind_data`` (the transition call sites have no cover_data
+                in hand).
+
         """
         h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
         sunset_pos_cfg = options.get(CONF_SUNSET_POS)
@@ -2453,7 +2461,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         sunrise_time = _read_time_entity(
             self.hass, options.get(CONF_SUNRISE_TIME_ENTITY)
         )
-        cover_data = self.get_blind_data(options=options)
+        if cover_data is None:
+            cover_data = self.get_blind_data(options=options)
         return compute_effective_default(
             h_def=h_def,
             sunset_pos=sunset_pos_cfg,
@@ -2462,7 +2471,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             sunrise_off=sunrise_off,
             sunset_time=sunset_time,
             sunrise_time=sunrise_time,
-            after_start_time=self.after_start_time,
+            window_explicitly_started=self.window_explicitly_started,
         )
 
     async def _check_sunset_window_transition(self) -> None:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -202,7 +202,7 @@ def compute_effective_default(
     *,
     sunset_time: dt.datetime | None = None,
     sunrise_time: dt.datetime | None = None,
-    after_start_time: bool = False,
+    window_explicitly_started: bool = False,
 ) -> tuple[int, bool]:
     """Return the effective default cover position based on astronomical sunset/sunrise.
 
@@ -228,12 +228,17 @@ def compute_effective_default(
         sunrise_time: Optional override for the sunrise boundary (naive-local datetime).
             When provided, replaces the astral-computed sunrise. ``sunrise_off`` still
             applies on top. Falls back to astral when ``None``.
-        after_start_time: When ``True``, the user's operational window has already
-            started. In that case the ``before_sunrise`` branch is suppressed so that
-            a start_time earlier than astronomical sunrise (a valid config on short
-            winter days) does not incorrectly apply the sunset/night position.
-            Defaults to ``False`` for backward-compatibility with call sites that do
-            not have start_time context.
+        window_explicitly_started: When ``True``, a *real* (non-blank) start_time
+            or start entity is configured and has already passed. In that case the
+            ``before_sunrise`` branch is suppressed so that a start_time earlier than
+            astronomical sunrise (a valid config on short winter days, issue #438)
+            does not incorrectly apply the sunset/night position once the user's
+            window opens. This is distinct from a window that is merely "open"
+            because no start time is set: the blank sentinel ``BLANK_TIME``
+            ("00:00:00") must NOT suppress the night position (issue #492), so it
+            maps to ``False`` here even though the active-window check treats blank
+            as "no start restriction". Defaults to ``False`` for call sites without
+            start_time context.
 
     Returns:
         A ``(effective_default, is_sunset_active)`` tuple where
@@ -257,10 +262,14 @@ def compute_effective_default(
 
     after_sunset = now_naive > (sunset + timedelta(minutes=sunset_off))
     before_sunrise = now_naive < (sunrise + timedelta(minutes=sunrise_off))
-    # Suppress before_sunrise when the operational window has already started:
-    # start_time < astronomical_sunrise is a valid user config (e.g. start at 08:00,
-    # sunrise at 08:15 in winter). Once the user's window opens, nighttime rules end.
-    is_sunset_active = after_sunset or (before_sunrise and not after_start_time)
+    # Suppress before_sunrise only when the operational window has *explicitly*
+    # started: a real start_time < astronomical_sunrise is a valid user config
+    # (e.g. start at 08:00, sunrise at 08:15 in winter, issue #438) and once that
+    # window opens nighttime rules end. A blank start_time (issue #492) does NOT
+    # count as explicitly started, so the night position holds after midnight.
+    is_sunset_active = after_sunset or (
+        before_sunrise and not window_explicitly_started
+    )
 
     effective = int(sunset_pos) if is_sunset_active else int(h_def)
     return effective, is_sunset_active

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
 
     from ..config_context_adapter import ConfigContextAdapter
 
+from ..const import BLANK_TIME
 from ..helpers import get_datetime_from_str, get_safe_state
 
 
@@ -104,14 +105,16 @@ class TimeWindowManager:
             return time.replace(year=today.year, month=today.month, day=today.day)
         return time
 
-    @property
-    def after_start_time(self) -> bool:
-        """Check if current time is after start time.
+    def _start_has_passed(self) -> bool | None:
+        """Evaluate the configured start time against now.
 
         Returns:
-            True if current time is after configured start time (from entity
-            or static config), False otherwise. Returns True if no start time
-            configured.
+            ``True``/``False`` when a *real* start time (entity or non-blank
+            static config) is configured — whether ``now`` is at/after it.
+            ``None`` when there is no real start time: no entity and the static
+            value is either unset or the blank sentinel ``BLANK_TIME``, or the
+            entity/config value could not be parsed. ``None`` means "no explicit
+            operational-window start" — distinct from an explicit 00:00 start.
 
         """
         now = dt.datetime.now()
@@ -121,29 +124,57 @@ class TimeWindowManager:
             )
             if time is None:
                 self.logger.debug(
-                    "Start time entity %s returned None, treating as start passed",
+                    "Start time entity %s returned None, treating as no start set",
                     self._start_time_entity,
                 )
-                return True
+                return None
             time = self._normalize_to_today(time)
             self.logger.debug(
                 "Start time: %s, now: %s, now >= time: %s ", time, now, now >= time
             )
             self._cached_start_time = time
             return now >= time
-        if self._start_time is not None:
+        if self._start_time is not None and self._start_time != BLANK_TIME:
             time = get_datetime_from_str(self._start_time)
             if time is None:
                 self.logger.debug(
-                    "Start time config value could not be parsed, treating as start passed"
+                    "Start time config value could not be parsed, treating as no start set"
                 )
-                return True
+                return None
             self.logger.debug(
                 "Start time: %s, now: %s, now >= time: %s", time, now, now >= time
             )
             self._cached_start_time = time
             return now >= time
-        return True
+        return None
+
+    @property
+    def after_start_time(self) -> bool:
+        """Check if current time is after start time.
+
+        Returns:
+            True if current time is after configured start time (from entity
+            or static config), False otherwise. Returns True if no start time
+            configured (including the blank sentinel) — the active-window logic
+            keys on this meaning "no start restriction".
+
+        """
+        passed = self._start_has_passed()
+        return True if passed is None else passed
+
+    @property
+    def window_explicitly_started(self) -> bool:
+        """Whether a real (non-blank) start time is configured AND has passed.
+
+        Distinct from :pyattr:`after_start_time`, which returns True for the
+        no-start / blank-sentinel case. Used by ``compute_effective_default`` to
+        suppress the overnight position only when the user's operational window
+        has genuinely opened — not when the start time is merely blank
+        (issue #492). Returns False when no real start is configured.
+
+        """
+        passed = self._start_has_passed()
+        return False if passed is None else passed
 
     @property
     def end_time(self) -> dt.datetime | None:

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from ..const import (
+    BLANK_TIME,
     CONF_AWNING_ANGLE,
     CONF_AZIMUTH,
     CONF_BLIND_SPOT_ELEVATION,
@@ -599,7 +600,7 @@ def _cross_field_validate(patch: dict, current: dict) -> None:
     if CONF_START_TIME in patch or CONF_START_ENTITY in patch:
         st = merged_active.get(CONF_START_TIME)
         se = merged_active.get(CONF_START_ENTITY)
-        if st and st != "00:00:00" and se:
+        if st and st != BLANK_TIME and se:
             raise ServiceValidationError(
                 f"start_time ('{st}') and start_entity ('{se}') are mutually exclusive. "
                 "Set one or the other, not both."
@@ -608,7 +609,7 @@ def _cross_field_validate(patch: dict, current: dict) -> None:
     if CONF_END_TIME in patch or CONF_END_ENTITY in patch:
         et = merged_active.get(CONF_END_TIME)
         ee = merged_active.get(CONF_END_ENTITY)
-        if et and et != "00:00:00" and ee:
+        if et and et != BLANK_TIME and ee:
             raise ServiceValidationError(
                 f"end_time ('{et}') and end_entity ('{ee}') are mutually exclusive. "
                 "Set one or the other, not both."

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -1289,6 +1289,62 @@ async def test_options_flow_custom_position_clears_sensor_position_and_priority(
         ), f"{slot['priority']} should be None after clearing"
 
 
+@pytest.mark.integration
+async def test_cleared_start_time_persists_blank(hass: HomeAssistant) -> None:
+    """Clearing the start time in the automation step must not persist '00:00:00'.
+
+    Regression for issue #492: a previously-saved start_time of '08:00:00' that
+    the user clears (the form omits the key) must end up absent/None in stored
+    options, never the blank sentinel '00:00:00' — otherwise the night position
+    is suppressed every night after midnight.
+    """
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    pre_options = dict(VERTICAL_OPTIONS)  # start_time = "08:00:00"
+    pre_options[CONF_START_TIME] = "08:00:00"
+    pre_options[CONF_END_TIME] = "20:00:00"
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Clear Time", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=pre_options,
+        entry_id="clear_start_time_01",
+        title="Clear Time",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == "menu"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "automation"}
+    )
+    assert result["step_id"] == "automation"
+
+    # Submit the automation step omitting the time keys (cleared TimeSelectors).
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_DELTA_POSITION: 5, CONF_DELTA_TIME: 2},
+    )
+    assert result["type"] in ("form", "menu")
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "done"}
+    )
+    assert result["type"] == "create_entry"
+
+    saved = result["data"]
+    assert (
+        saved.get(CONF_START_TIME) is None
+    ), f"start_time should be absent/None, got {saved.get(CONF_START_TIME)!r}"
+    assert (
+        saved.get(CONF_END_TIME) is None
+    ), f"end_time should be absent/None, got {saved.get(CONF_END_TIME)!r}"
+
+
 # ---------------------------------------------------------------------------
 # Regression: clearing Is Sunny sensor in light_cloud step (issue #377)
 # ---------------------------------------------------------------------------

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -401,6 +401,22 @@ def test_start_entity_preferred_over_default_start_time():
     assert "until 00:00:00" not in summary
 
 
+def test_blank_start_end_time_not_shown_as_literal():
+    """Blank-sentinel start/end times must not render as 'from 00:00:00'.
+
+    Regression for issue #492: a cleared TimeSelector coerces to the blank
+    sentinel '00:00:00'. The summary must treat it as unset (sunrise/sunset)
+    rather than printing a literal midnight window.
+    """
+    from custom_components.adaptive_cover_pro.const import BLANK_TIME
+
+    cfg = {CONF_START_TIME: BLANK_TIME, CONF_END_TIME: BLANK_TIME}
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "from 00:00:00" not in summary
+    assert "until 00:00:00" not in summary
+    assert "Active during daylight" in summary
+
+
 def test_explicit_start_time_used_when_no_entity():
     """Static time is used when no entity is configured."""
     cfg = {CONF_START_TIME: "07:00", CONF_END_TIME: "21:00"}

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -515,7 +515,7 @@ class TestEntityOverride:
 
 
 class TestStartTimeSuppressesBeforeSunrise:
-    """When after_start_time=True the before-sunrise branch must not activate sunset_pos.
+    """When window_explicitly_started=True the before-sunrise branch must not activate sunset_pos.
 
     Regression for issue #438: start_time < astronomical_sunrise caused
     sunset_pos (0%) to be used instead of default_pos (100%) in the morning.
@@ -533,14 +533,14 @@ class TestStartTimeSuppressesBeforeSunrise:
                 sun_data=sun,
                 sunset_off=0,
                 sunrise_off=0,
-                after_start_time=True,
+                window_explicitly_started=True,
             )
         # Operational window is open → sunset_pos must NOT apply
         assert result == 100
         assert active is False
 
     def test_before_sunrise_without_start_time_still_returns_sunset_pos(self):
-        """Existing behaviour preserved when after_start_time=False (default)."""
+        """Existing behaviour preserved when window_explicitly_started=False (default)."""
         sun = _make_sun_data(sunrise_hour=8, sunrise_minute=10, sunset_hour=18)
         today = dt.date.today()
         now = dt.datetime(today.year, today.month, today.day, 8, 5, 0)
@@ -551,14 +551,14 @@ class TestStartTimeSuppressesBeforeSunrise:
                 sun_data=sun,
                 sunset_off=0,
                 sunrise_off=0,
-                after_start_time=False,
+                window_explicitly_started=False,
             )
         # No start_time context → classic before-sunrise behaviour
         assert result == 0
         assert active is True
 
     def test_before_sunrise_after_start_time_with_positive_sunrise_offset(self):
-        """after_start_time=True also suppresses when sunrise_off extends the window."""
+        """window_explicitly_started=True also suppresses when sunrise_off extends the window."""
         sun = _make_sun_data(sunrise_hour=6, sunset_hour=18)
         today = dt.date.today()
         # sunrise=06:00, offset=120 → window would close at 08:00 without start_time fix
@@ -570,13 +570,13 @@ class TestStartTimeSuppressesBeforeSunrise:
                 sun_data=sun,
                 sunset_off=0,
                 sunrise_off=120,
-                after_start_time=True,
+                window_explicitly_started=True,
             )
         assert result == 100
         assert active is False
 
     def test_after_sunset_not_affected_by_after_start_time(self):
-        """after_start_time=True must NOT suppress the after-sunset branch."""
+        """window_explicitly_started=True must NOT suppress the after-sunset branch."""
         sun = _make_sun_data(sunrise_hour=6, sunset_hour=18)
         today = dt.date.today()
         now = dt.datetime(today.year, today.month, today.day, 19, 0, 0)  # after sunset
@@ -587,8 +587,46 @@ class TestStartTimeSuppressesBeforeSunrise:
                 sun_data=sun,
                 sunset_off=0,
                 sunrise_off=0,
-                after_start_time=True,
+                window_explicitly_started=True,
             )
         # after sunset → sunset_pos still applies regardless of start_time
+        assert result == 0
+        assert active is True
+
+
+# ---------------------------------------------------------------------------
+# Blank start_time must NOT suppress the night position (issue #492)
+# ---------------------------------------------------------------------------
+
+
+class TestBlankStartTimeNightAfterMidnight:
+    """Blank-sentinel start_time must not suppress the overnight position.
+
+    Regression for issue #492: with a blank/unset start_time the
+    ``after_start_time`` signal is always True, but that must NOT cancel the
+    before-sunrise night branch. The distinct ``window_explicitly_started``
+    signal is False for a blank start_time, so the night position holds.
+    """
+
+    def test_blank_start_time_at_one_minute_past_midnight_holds_sunset_pos(self):
+        # #492 reproducer: sunrise 04:19, sunset 21:31, now 00:01.
+        sun = _make_sun_data(
+            sunrise_hour=4,
+            sunrise_minute=19,
+            sunset_hour=21,
+            sunset_minute=31,
+        )
+        today = dt.date.today()
+        now = dt.datetime(today.year, today.month, today.day, 0, 1, 0)
+        with _freeze_now(now):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                window_explicitly_started=False,
+            )
+        # Blank start_time → window not explicitly started → night position holds
         assert result == 0
         assert active is True

--- a/tests/test_effective_default_integration.py
+++ b/tests/test_effective_default_integration.py
@@ -418,11 +418,12 @@ class TestStartTimeSuppressesSunsetDuringOperationalWindow:
         the operational window is open even if before astronomical sunrise.
 
         Scenario: sunrise=08:00, sunrise_off=10 → window closes at 08:10.
-        now=08:05 → before_sunrise normally True, but after_start_time suppresses it.
+        now=08:05 → before_sunrise normally True, but window_explicitly_started
+        suppresses it.
         """
         sun_data = _make_sun_data(sunset_hour=18, sunrise_hour=8)
         # sunrise=08:00, offset=10 → boundary at 08:10; now=08:05 → before_sunrise
-        # without fix; suppressed with after_start_time=True.
+        # without fix; suppressed with window_explicitly_started=True.
         with _freeze_now(_today(8, 5)):
             effective, is_sunset_active = compute_effective_default(
                 h_def=100,
@@ -430,7 +431,7 @@ class TestStartTimeSuppressesSunsetDuringOperationalWindow:
                 sun_data=sun_data,
                 sunset_off=0,
                 sunrise_off=10,
-                after_start_time=True,
+                window_explicitly_started=True,
             )
 
         assert is_sunset_active is False


### PR DESCRIPTION
## Summary
At 00:01 a vertical blind opened to the daytime default instead of holding the sunset/night position until sunrise. The night-hold branch in `compute_effective_default` was suppressed whenever `after_start_time` was true, and the blank-sentinel start time `00:00:00` made that always true. This introduces a distinct `window_explicitly_started` signal (true only when a real, non-blank start time is configured and has passed) and suppresses the night branch on that instead, preserving the genuine #438 winter behavior. Clearing the start/end time in config flow now persists as blank rather than resetting to `00:00:00`, and the config summary no longer renders a literal `00:00:00` for blank times.

## Testing
- ✅ 3723 tests passing

## Related Issues
Refs #492