### PR TITLE
fix: include cloud in enabled_handlers for all sensor sources

### DIFF
--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -26,6 +26,9 @@ from .const import (
     CONF_ENABLE_GLARE_ZONES,
     CONF_ENABLE_SUN_TRACKING,
     CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_IRRADIANCE_ENTITY,
+    CONF_IS_SUNNY_SENSOR,
+    CONF_LUX_ENTITY,
     CONF_MOTION_SENSORS,
     CONF_SENSOR_TYPE,
     CONF_WEATHER_ENTITY,
@@ -759,7 +762,15 @@ def _configured_handlers(opts: Mapping[str, Any]) -> list[str]:
         enabled.append("custom_position")
     if opts.get(CONF_MOTION_SENSORS):
         enabled.append("motion")
-    if opts.get(CONF_CLOUD_SUPPRESSION) and opts.get(CONF_CLOUD_COVERAGE_ENTITY):
+    if opts.get(CONF_CLOUD_SUPPRESSION) and any(
+        opts.get(k)
+        for k in (
+            CONF_IS_SUNNY_SENSOR,
+            CONF_LUX_ENTITY,
+            CONF_IRRADIANCE_ENTITY,
+            CONF_CLOUD_COVERAGE_ENTITY,
+        )
+    ):
         enabled.append("cloud")
     if opts.get(CONF_CLIMATE_MODE):
         enabled.append("climate")

--- a/tests/test_decision_trace_enabled_handlers.py
+++ b/tests/test_decision_trace_enabled_handlers.py
@@ -20,6 +20,9 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_ENABLE_GLARE_ZONES,
     CONF_ENABLE_SUN_TRACKING,
     CONF_FORCE_OVERRIDE_SENSORS,
+    CONF_IRRADIANCE_ENTITY,
+    CONF_IS_SUNNY_SENSOR,
+    CONF_LUX_ENTITY,
     CONF_MOTION_SENSORS,
     CONF_SENSOR_TYPE,
     CONF_WEATHER_ENTITY,
@@ -174,6 +177,25 @@ def test_cloud_disabled_when_only_entity_set():
 def test_cloud_enabled_when_both_set():
     enabled = _enabled(
         {CONF_CLOUD_SUPPRESSION: True, CONF_CLOUD_COVERAGE_ENTITY: "sensor.cloud"}
+    )
+    assert "cloud" in enabled
+
+
+def test_cloud_enabled_when_is_sunny_sensor_configured():
+    enabled = _enabled(
+        {CONF_CLOUD_SUPPRESSION: True, CONF_IS_SUNNY_SENSOR: "binary_sensor.ensoleille"}
+    )
+    assert "cloud" in enabled
+
+
+def test_cloud_enabled_when_lux_entity_configured():
+    enabled = _enabled({CONF_CLOUD_SUPPRESSION: True, CONF_LUX_ENTITY: "sensor.lux"})
+    assert "cloud" in enabled
+
+
+def test_cloud_enabled_when_irradiance_entity_configured():
+    enabled = _enabled(
+        {CONF_CLOUD_SUPPRESSION: True, CONF_IRRADIANCE_ENTITY: "sensor.irradiance"}
     )
     assert "cloud" in enabled
 


### PR DESCRIPTION
## Summary
`_configured_handlers()` only added `cloud` to `enabled_handlers` when a cloud-coverage % entity was configured, but the cloud suppression handler also fires on `is_sunny_sensor`, `lux_entity`, or `irradiance_entity`. Covers a config using any of those four sources now correctly advertise `cloud` in `enabled_handlers`, fixing the Lovelace card's cloud-badge/decision-strip gating.

## Testing
- ✅ 3726 tests passing (3 new regression tests for is_sunny_sensor / lux_entity / irradiance_entity)

## Related Issues
Refs #494