### PR TITLE
fix: custom-position floor trace mislabels gapped slots (#496)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -345,6 +345,17 @@ CUSTOM_POSITION_SLOTS: dict[int, dict[str, str]] = {
     n: _custom_position_slot_keys(n) for n in CUSTOM_POSITION_SLOT_NUMBERS
 }
 
+
+def custom_position_handler_name(slot: int) -> str:
+    """Return the canonical decision-trace handler name for a custom slot.
+
+    Single source of truth for the ``custom_position_N`` name (issue #496).
+    Both ``CustomPositionHandler.name`` and the floor-composition trace source
+    delegate here so the two can never drift to different numbering schemes.
+    """
+    return f"custom_position_{slot}"
+
+
 # Slot 1 — named aliases for each of the five sub-keys.
 CONF_CUSTOM_POSITION_SENSOR_1 = CUSTOM_POSITION_SLOTS[1]["sensor"]  # trigger
 CONF_CUSTOM_POSITION_1 = CUSTOM_POSITION_SLOTS[1]["position"]  # 0-100

--- a/custom_components/adaptive_cover_pro/pipeline/floors.py
+++ b/custom_components/adaptive_cover_pro/pipeline/floors.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 
+from ..const import custom_position_handler_name
 from .types import PipelineSnapshot
 
 
@@ -55,12 +56,12 @@ def gather_active_floors(snapshot: PipelineSnapshot) -> list[FloorClampInfo]:
     path is hardware-pinned and never participates in floor semantics.
     """
     floors: list[FloorClampInfo] = []
-    for index, state in enumerate(snapshot.custom_position_sensors, start=1):
+    for state in snapshot.custom_position_sensors:
         if state.is_on and state.min_mode and not state.use_my:
             label = state.sensor_name or state.entity_id
             floors.append(
                 FloorClampInfo(
-                    source=f"custom_position_{index}",
+                    source=custom_position_handler_name(state.slot),
                     label=label,
                     position=state.position,
                 )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, custom_position_handler_name
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -57,7 +57,7 @@ class CustomPositionHandler(OverrideHandler):
     @property
     def name(self) -> str:  # type: ignore[override]
         """Handler name includes the slot number for clear decision-trace output."""
-        return f"custom_position_{self._slot}"
+        return custom_position_handler_name(self._slot)
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
         """Return the configured position when this slot's sensor is active.

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -174,7 +174,7 @@ class PipelineSnapshotBuilder:
         position).
         """
         result: list[CustomPositionSensorState] = []
-        for slot_keys in CUSTOM_POSITION_SLOTS.values():
+        for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
             sensor = options.get(slot_keys["sensor"])
             position = options.get(slot_keys["position"])
             enabled = bool(
@@ -204,6 +204,7 @@ class PipelineSnapshotBuilder:
                         use_my=use_my,
                         tilt=tilt,
                         sensor_name=sensor_name,
+                        slot=slot,
                     )
                 )
         return result

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -53,6 +53,11 @@ class CustomPositionSensorState:
     # downstream diagnostics can show e.g. "Custom · Table extension" instead of
     # just "Custom #1". None when the sensor isn't loaded or has no friendly_name.
     sensor_name: str | None = None
+    # Real 1-4 slot number this state was built from. The snapshot's sensor list
+    # is compacted (gaps skipped), so the list index does NOT recover the slot;
+    # carry it explicitly so the floor trace can label the correct
+    # custom_position_N handler (issue #496). 0 = unset.
+    slot: int = 0
 
 
 @dataclass(frozen=True)

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -93,6 +93,7 @@ def _cp_state(
     sensor_name: str | None = None,
     use_my: bool = False,
     priority: int = DEFAULT_CUSTOM_POSITION_PRIORITY,
+    slot: int = 0,
 ) -> CustomPositionSensorState:
     return CustomPositionSensorState(
         entity_id=entity_id,
@@ -102,6 +103,7 @@ def _cp_state(
         min_mode=min_mode,
         use_my=use_my,
         sensor_name=sensor_name,
+        slot=slot,
     )
 
 
@@ -250,6 +252,92 @@ def test_two_custom_floors_pick_highest() -> None:
     ]
     assert len(clamp_steps) == 1
     assert "Floor60" in clamp_steps[0].reason
+
+
+def test_gapped_custom_floor_slots_label_real_slot() -> None:
+    """Gapped slots (#3/#4 active, #1/#2 empty) label the real slot, not list index.
+
+    Mirrors the issue #496 reporter's config: only custom-position slots 3 and 4
+    are configured. The compacted ``custom_position_sensors`` list has two
+    entries, so an ``enumerate(start=1)`` index would mislabel them as
+    ``custom_position_1`` / ``custom_position_2``. The trace must instead carry
+    the real slot names and the registry dedup must remove the deferred handlers'
+    "sensor not active" skip steps for both active slots.
+    """
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        default_position=90,
+        direct_sun_valid=False,
+        # Compacted list in CUSTOM_POSITION_SLOTS order: slot 3 then slot 4.
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp3",
+                is_on=True,
+                position=100,
+                min_mode=True,
+                sensor_name="Mode aeration",
+                slot=3,
+            ),
+            _cp_state(
+                "binary_sensor.cp4",
+                is_on=True,
+                position=80,
+                min_mode=True,
+                sensor_name="Mode shade",
+                slot=4,
+            ),
+        ],
+    )
+    handlers = [
+        _cp_handler(4, "binary_sensor.cp4", 80),
+        _cp_handler(3, "binary_sensor.cp3", 100),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+
+    # (a) winner clamped to the highest floor (max(80, 100) = 100).
+    assert result.position == 100
+
+    # (b) the inactive 80% floor step is labelled custom_position_4 (never 1/2),
+    #     and the matched floor_clamp references the slot-3 active source.
+    inactive_floor_steps = [
+        s
+        for s in result.decision_trace
+        if s.handler.startswith("custom_position_")
+        and not s.matched
+        and s.position == 80
+    ]
+    assert len(inactive_floor_steps) == 1
+    assert inactive_floor_steps[0].handler == "custom_position_4"
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+    assert "Mode aeration" in clamp_steps[0].reason
+
+    # (c) no "sensor not active" reason survives for an active slot.
+    for s in result.decision_trace:
+        if s.handler in ("custom_position_3", "custom_position_4"):
+            assert "sensor not active" not in s.reason
+
+    # (d) each real slot is represented exactly once and there are zero phantom
+    #     slots 1/2. Slot 3 is the winning floor, so it surfaces only as the
+    #     floor_clamp step (no redundant custom_position_3 entry — the registry
+    #     dedup deliberately omits the winner's inactive step). Slot 4 is the
+    #     non-winning floor, surfacing as exactly one custom_position_4 step.
+    cp3_steps = [s for s in result.decision_trace if s.handler == "custom_position_3"]
+    cp4_steps = [s for s in result.decision_trace if s.handler == "custom_position_4"]
+    assert len(cp3_steps) == 0  # represented by floor_clamp instead
+    assert len(cp4_steps) == 1
+    assert "Mode aeration" in clamp_steps[0].reason  # slot 3 == the floor_clamp
+    assert not any(
+        s.handler in ("custom_position_1", "custom_position_2")
+        for s in result.decision_trace
+    )
 
 
 def test_real_position_custom_slot_clamped_by_floor_slot() -> None:


### PR DESCRIPTION
## Summary
Fixes the floor decision-trace labeling for non-contiguous custom-position slots. `gather_active_floors()` built the `custom_position_N` source name from a compacted-list index instead of the real slot, so with gapped slots (e.g. #3/#4 configured, #1/#2 empty) floors were mislabeled and stale "sensor not active" steps survived for active slots. Now the real slot is carried on the sensor state and the `custom_position_{n}` name is single-sourced so the handler name and floor source can't drift. The max-of-floors behavior was already correct and is unchanged.

## Testing
- ✅ 3727 tests passing

## Related Issues
Refs #496