### PR TITLE
fix: honor custom position on tilt-only venetian (#499)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -29,6 +29,7 @@ from ...const import (
     CONF_VENETIAN_MODE,
     CONF_VENETIAN_POST_SETTLE_HOLD,
     CONF_VENETIAN_TILT_SKIP_ABOVE,
+    ControlMethod,
     DEFAULT_MAX_TILT,
     DEFAULT_MIN_TILT,
     DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
@@ -79,6 +80,19 @@ _VENETIAN_EXTRA_KEYS = (
     CONF_INVERSE_TILT,
     CONF_MAX_TILT,
     CONF_MIN_TILT,
+)
+
+# Control methods that carry an explicit, user-specified position.
+# The tilt-only carriage-close rewrite does not apply to these — the
+# user's position wins over "close carriage, let tilt filter".
+_EXPLICIT_USER_POSITION_METHODS = frozenset(
+    {
+        ControlMethod.CUSTOM_POSITION,
+        ControlMethod.FORCE,
+        ControlMethod.WEATHER,
+        ControlMethod.MANUAL,
+        ControlMethod.MOTION,
+    }
 )
 
 
@@ -320,8 +334,6 @@ class VenetianPolicy(CoverTypePolicy):
         branch even when the sun is below the horizon (issue #33), so
         direct_sun_valid is the authoritative signal.
         """
-        from ...const import ControlMethod
-
         if result.control_method != ControlMethod.SOLAR:
             return True
         return cover is None or not cover.direct_sun_valid
@@ -355,7 +367,10 @@ class VenetianPolicy(CoverTypePolicy):
             handler_tilt = result.tilt
             position = result.position
             trace = list(result.decision_trace)
-            if self._venetian_mode == VENETIAN_MODE_TILT_ONLY:
+            if (
+                self._venetian_mode == VENETIAN_MODE_TILT_ONLY
+                and result.control_method not in _EXPLICIT_USER_POSITION_METHODS
+            ):
                 trace.append(
                     DecisionStep(
                         handler="venetian_mode",

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -160,6 +160,26 @@ class TestPostPipelineResolveTiltOnlyMode:
         )
         assert out.position == 50
 
+    def test_tilt_only_honors_explicit_custom_position(self):
+        """tilt_only must not rewrite position when a custom-position handler supplied it.
+
+        Regression for issue #499: CUSTOM_POSITION + tilt_only silently dropped
+        the user-configured position by collapsing it to POSITION_CLOSED.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        result = PipelineResult(
+            position=100,
+            control_method=ControlMethod.CUSTOM_POSITION,
+            tilt=100,
+            reason="test",
+        )
+        out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+        assert out.position == 100
+        assert out.tilt == 100
+
 
 class TestPostPipelineResolveNoSunStrip:
     """Tilt must be stripped when SOLAR is emitted but direct sun is not hitting the window.
@@ -317,6 +337,7 @@ class TestPostPipelineResolveHandlerTilt:
             )
             out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
             assert out.tilt == handler_tilt
+            assert out.position == 50
 
     def test_handler_tilt_honored_for_default_path(self):
         """Handler-supplied tilt on DEFAULT (default_tilt / sunset_tilt) must survive."""


### PR DESCRIPTION
## Summary
On a venetian cover with `venetian_mode = tilt_only`, the post-pipeline policy was rewriting `position` to 0 whenever a handler supplied a tilt, even when the position came from an explicit user override (custom position, force-override, weather, manual, motion). The user's configured "open + tilt" custom position collapsed to "closed + tilt".

I narrowed the tilt-only carriage-close rewrite to control methods that do NOT carry explicit user-supplied position. SOLAR and DEFAULT keep the existing behavior (close carriage, let tilt filter). CUSTOM_POSITION, FORCE, WEATHER, MANUAL, MOTION now preserve their position.

## Testing
- ✅ 803 tests passing (802 prior + 1 new regression test in `test_venetian_post_pipeline.py`)

## Related Issues
Refs #499