### PR TITLE
feat: emit full-day position forecast aligned to 00:00-24:00

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -198,12 +198,11 @@ CONF_SUNSET_TILT = (
 # 8a. Forecast Timeline
 # =============================================================================
 # Sampling cadence and boundary-event vocabulary for the dashboard forecast
-# strip built by ``forecast.build_forecast``. 15-minute steps over a 12-hour
-# window are dense enough to read smoothly and cheap enough to compute in well
-# under a second on a Pi 4.
+# strip built by ``forecast.build_forecast``. 15-minute steps over the full
+# local calendar day (00:00 → 24:00) are dense enough to read smoothly and
+# cheap enough to compute in well under a second on a Pi 4.
 
 FORECAST_STEP_MINUTES = 15  # cadence between forecast samples, minutes
-FORECAST_WINDOW_HOURS = 12  # forecast lookahead, hours
 
 EVENT_SUNRISE = "sunrise"  # boundary event: sun rises above horizon
 EVENT_SUNSET = "sunset"  # boundary event: sun sets below horizon

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -29,7 +29,6 @@ from .const import (
     EVENT_SUNRISE,
     EVENT_SUNSET,
     FORECAST_STEP_MINUTES,
-    FORECAST_WINDOW_HOURS,
     SUN_DATA_STEP_SECONDS,
 )
 
@@ -89,23 +88,28 @@ def build_forecast(
     default_position: int,
     now: datetime,
     step_minutes: int = FORECAST_STEP_MINUTES,
-    window_hours: int = FORECAST_WINDOW_HOURS,
 ) -> Forecast:
     """Compute the forecast for one cover.
+
+    Walks the full local calendar day (00:00 → 24:00) using the solar position
+    table already stored in *sun_data*, so the companion card's elevation chart
+    and sample strip share the same time axis.
 
     ``cover_factory`` is a closure that builds a cover engine for an
     arbitrary (sol_azi, sol_elev) pair; the caller is responsible for
     passing the same configuration / sun_data the live cover uses.
     Decoupling the factory from this helper keeps the function pure and
     trivially testable with a stub cover.
+
+    ``now`` is retained on the signature for caller context (e.g. tests
+    anchoring time, scripts passing wall-clock time) and for future
+    use — the samples deliberately cover the full day regardless of ``now``.
     """
     samples = _build_samples(
         sun_data=sun_data,
         cover_factory=cover_factory,
         default_position=default_position,
-        now=now,
         step_minutes=step_minutes,
-        window_hours=window_hours,
     )
     events = _build_events(
         sun_data=sun_data, cover_factory=cover_factory, samples=samples
@@ -118,21 +122,26 @@ def _build_samples(
     sun_data: SunData,
     cover_factory: Callable[[float, float], AdaptiveGeneralCover],
     default_position: int,
-    now: datetime,
     step_minutes: int,
-    window_hours: int,
 ) -> list[ForecastSample]:
-    """Walk the sun_data table at *step_minutes* cadence for *window_hours*."""
+    """Walk the sun_data table at *step_minutes* cadence over the full calendar day.
+
+    Uses ``times[0]`` (local midnight 00:00) as the loop start and
+    ``times[-1]`` (next midnight 24:00) as the loop end, so the sample
+    strip always covers the same 24-hour window as the companion card's
+    elevation chart regardless of what time ``build_forecast`` is called.
+    """
     times = list(sun_data.times)
     azis = list(sun_data.solar_azimuth)
     eles = list(sun_data.solar_elevation)
     if not times:
         return []
-    horizon = now + timedelta(hours=window_hours)
+    day_start = times[0]
+    horizon = times[-1]
     step = timedelta(minutes=step_minutes)
 
     samples: list[ForecastSample] = []
-    t = now
+    t = day_start
     while t <= horizon:
         idx = _nearest_index(times, t)
         if idx is None:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -16,7 +16,6 @@ from custom_components.adaptive_cover_pro.forecast import (
     EVENT_SUNRISE,
     EVENT_SUNSET,
     FORECAST_STEP_MINUTES,
-    FORECAST_WINDOW_HOURS,
     Forecast,
     ForecastEvent,
     ForecastSample,
@@ -28,11 +27,13 @@ from custom_components.adaptive_cover_pro.forecast import (
 # ---------------------------------------------------------------------------
 
 _NOW = datetime(2026, 6, 1, 6, 0, tzinfo=UTC)
+# Midnight anchor: real SunData.times start at local 00:00 on the current day.
+_DAY_START = datetime(2026, 6, 1, 0, 0, tzinfo=UTC)
 
 
 def _make_sun_data(
     *,
-    n_samples: int = 96,
+    n_samples: int = 289,
     step_minutes: int = 5,
     azi_at: float = 180.0,
     ele_at: float = 30.0,
@@ -42,10 +43,11 @@ def _make_sun_data(
     """Build a minimal SunData stand-in for forecast tests.
 
     Produces a constant-sun timeline for *n_samples* steps of *step_minutes*
-    starting at _NOW.  Tests that need a varying sun pattern can patch the
-    azimuth/elevation lists after construction.
+    starting at _DAY_START (local midnight), matching real SunData semantics
+    (00:00 → 24:00 inclusive at 5-min cadence = 289 points).  Tests that need
+    a varying sun pattern can patch the azimuth/elevation lists after construction.
     """
-    times = [_NOW + timedelta(minutes=i * step_minutes) for i in range(n_samples)]
+    times = [_DAY_START + timedelta(minutes=i * step_minutes) for i in range(n_samples)]
     sd = MagicMock()
     sd.times = times
     sd.solar_azimuth = [azi_at] * n_samples
@@ -80,7 +82,7 @@ def _make_cover_factory(*, solar_valid: bool, percentage: int = 40):
 class TestBuildForecastSamples:
     """build_forecast emits one sample per tick over the configured window."""
 
-    def test_default_cadence_emits_step_per_15_minutes_for_12_hours(self):
+    def test_default_cadence_emits_samples_for_full_calendar_day(self):
         sd = _make_sun_data()
         f = build_forecast(
             sun_data=sd,
@@ -88,8 +90,8 @@ class TestBuildForecastSamples:
             default_position=10,
             now=_NOW,
         )
-        # 12 hours of 15-minute steps inclusive at both ends = 12 * 60 / 15 + 1.
-        expected = (FORECAST_WINDOW_HOURS * 60 // FORECAST_STEP_MINUTES) + 1
+        # Full calendar day (00:00 → 24:00) at 15-minute steps inclusive = 24 * 60 / 15 + 1 = 97.
+        expected = (24 * 60 // FORECAST_STEP_MINUTES) + 1
         assert len(f.samples) == expected
         # All samples carry the configured default since solar isn't valid.
         assert all(s.position == 10 and s.handler == "default" for s in f.samples)
@@ -104,17 +106,37 @@ class TestBuildForecastSamples:
         )
         assert all(s.position == 55 and s.handler == "solar" for s in f.samples)
 
-    def test_custom_step_and_window_produce_proportional_sample_count(self):
-        sd = _make_sun_data(n_samples=200, step_minutes=5)
+    def test_custom_step_covers_full_day_proportionally(self):
+        sd = _make_sun_data(n_samples=289, step_minutes=5)
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
             default_position=0,
             now=_NOW,
             step_minutes=30,
-            window_hours=4,
         )
-        assert len(f.samples) == (4 * 60 // 30) + 1
+        # Full calendar day (00:00 → 24:00) at 30-minute steps = 24 * 60 / 30 + 1 = 49.
+        assert len(f.samples) == (24 * 60 // 30) + 1
+
+    def test_full_day_forecast_starts_at_midnight_ends_at_midnight(self):
+        """First sample is at local midnight, last sample is at the next midnight."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+        )
+        assert len(f.samples) > 0, "forecast produced no samples"
+        # First sample matches the first time in sun_data (midnight).
+        assert f.samples[0].t == _DAY_START, (
+            f"first sample at {f.samples[0].t}, expected {_DAY_START}"
+        )
+        # Last sample is at next midnight: _DAY_START + 24 h.
+        expected_last = _DAY_START + timedelta(hours=24)
+        assert f.samples[-1].t == expected_last, (
+            f"last sample at {f.samples[-1].t}, expected {expected_last}"
+        )
 
     def test_empty_sun_data_returns_empty_samples_and_events(self):
         sd = _make_sun_data(n_samples=0)
@@ -215,17 +237,17 @@ class TestBuildForecastEvents:
         Post-fix the event time is the SunData grid point where
         ``direct_sun_valid`` actually flips True — accurate to the 5-min grid.
         """
-        # 12 hours at 5-min step covers the full forecast window exactly.
-        n_samples = 12 * 60 // 5 + 1
+        # Full calendar day at 5-min step = 289 samples (00:00 → 24:00).
+        n_samples = 24 * 60 // 5 + 1
         sd = _make_sun_data(n_samples=n_samples, step_minutes=5)
         # Encode "time" into azimuth so a factory ignoring ele can decide by azi.
         sd.solar_azimuth = [float(i) for i in range(n_samples)]
 
-        # Crossing index 20 = 100 min from _NOW; 15-min samples bracket it
-        # at 90 min (azi 18) and 105 min (azi 21) — so a naive enter event
+        # Crossing index 20 = 100 min from _DAY_START (00:00); 15-min samples bracket
+        # it at 90 min (azi 18) and 105 min (azi 21) — so a naive enter event
         # would land at 105 min, but the true crossing is at 100 min.
         crossing_idx = 20
-        crossing_time = _NOW + timedelta(minutes=crossing_idx * 5)
+        crossing_time = _DAY_START + timedelta(minutes=crossing_idx * 5)
 
         def factory(azi, _ele):
             cover = MagicMock()


### PR DESCRIPTION
## Summary
`_build_samples` walked from `now → now + FORECAST_WINDOW_HOURS` (12h), so the companion card's position-forecast strip started at the current hour and misaligned with the elevation chart's fixed 00:00→24:00 x-axis. Changed the loop bounds to span the full local calendar day (`times[0]`→`times[-1]`, local midnight→next midnight). `SunData.times` already spans the full day at 5-min cadence, so no extra astral work was needed. Removed the now-unused `window_hours` parameter and the `FORECAST_WINDOW_HOURS` constant (no remaining consumers). The forecast sensor now emits 97 samples covering the full day.

## Testing
- ✅ 3729 tests passing (42 in test_forecast.py)

## Related Issues
Refs #510