### PR TITLE
fix: evaluate forecast sunset gate at sample time, not wall-clock (#516)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -55,13 +55,22 @@ class AdaptiveGeneralCover(ABC):
 
     @property
     def solar(self) -> SunGeometry:
-        """Build a SunGeometry from current field values (always fresh)."""
+        """Build a SunGeometry from current field values (always fresh).
+
+        ``eval_time`` is read via ``getattr`` rather than being a dataclass
+        field: the base carries no default field of its own (subclasses add
+        non-default config fields after it, which would break dataclass field
+        ordering). The forecast sets ``cover.eval_time`` dynamically per sample
+        so its time-dependent gates are evaluated at the projected time; the
+        live path never sets it, so it stays ``None`` → wall-clock now.
+        """
         return SunGeometry(
             self.sol_azi,
             self.sol_elev,
             self.sun_data,
             self.config,
             self.logger,
+            eval_time=getattr(self, "eval_time", None),
         )
 
     def __getattr__(self, name: str) -> object:
@@ -152,7 +161,7 @@ class AdaptiveGeneralCover(ABC):
         return self.solar.is_sun_in_blind_spot
 
     def solar_times(self) -> tuple[datetime | None, datetime | None]:
-        """Delegate to SunGeometry.solar_times()."""
+        """Delegate to the SunGeometry solar_times helper."""
         return self.solar.solar_times()
 
     def solar_times_with_position(
@@ -161,7 +170,7 @@ class AdaptiveGeneralCover(ABC):
         tuple[datetime, float, float] | None,
         tuple[datetime, float, float] | None,
     ]:
-        """Delegate to SunGeometry.solar_times_with_position()."""
+        """Delegate to the SunGeometry solar_times_with_position helper."""
         return self.solar.solar_times_with_position()
 
     # ------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -26,13 +26,23 @@ class SunGeometry:
         sun_data: SunData,
         config: CoverConfig,
         logger: object,
+        eval_time: datetime | None = None,
     ) -> None:
-        """Initialise with sun position, solar data, cover config, and logger."""
+        """Initialise with sun position, solar data, cover config, and logger.
+
+        ``eval_time`` is the moment the time-dependent gates (sunset/sunrise
+        offset) should be evaluated against. The live pipeline leaves it
+        ``None`` so those gates use wall-clock now. The forecast passes the
+        timestamp of the sample it is projecting so each point on the
+        full-day strip is evaluated at *its own* time rather than the moment
+        the forecast happens to be recomputed (issue #516).
+        """
         self.sol_azi = sol_azi
         self.sol_elev = sol_elev
         self.sun_data = sun_data
         self.config = config
         self.logger = logger
+        self.eval_time = eval_time
 
     # ------------------------------------------------------------------
     # Azimuth helpers
@@ -141,7 +151,8 @@ class SunGeometry:
         """
         sunset = self.sun_data.sunset().replace(tzinfo=None)
         sunrise = self.sun_data.sunrise().replace(tzinfo=None)
-        now_naive = datetime.now(UTC).replace(tzinfo=None)
+        ref = self.eval_time.astimezone(UTC) if self.eval_time else datetime.now(UTC)
+        now_naive = ref.replace(tzinfo=None)
         after_sunset = now_naive > (sunset + timedelta(minutes=self.config.sunset_off))
         before_sunrise = now_naive < (
             sunrise + timedelta(minutes=self.config.sunrise_off)

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -150,6 +150,11 @@ def _build_samples(
         azi = float(azis[idx])
         ele = float(eles[idx])
         cover = cover_factory(azi, ele)
+        # Evaluate the cover's time-dependent gates (sunset/sunrise offset) at
+        # *this sample's* time, not wall-clock now — otherwise a forecast
+        # recomputed after sunset marks the whole projected day as suppressed
+        # and every sample collapses to the default position (issue #516).
+        cover.eval_time = t
         if cover.direct_sun_valid:
             samples.append(
                 ForecastSample(
@@ -185,6 +190,14 @@ def _build_events(
         events.append(ForecastEvent(t=sunrise, kind=EVENT_SUNRISE, label="Sunrise"))
     if sunset is not None:
         events.append(ForecastEvent(t=sunset, kind=EVENT_SUNSET, label="Sunset"))
+    # Forward-looking event so the sensor's "next event" state stays a real
+    # timestamp late in the evening once today's events are all in the past,
+    # instead of resolving to None / Unknown (issue #516).
+    next_sunrise = sun_data.next_sunrise()
+    if next_sunrise is not None:
+        events.append(
+            ForecastEvent(t=next_sunrise, kind=EVENT_SUNRISE, label="Sunrise")
+        )
 
     prev_sample: ForecastSample | None = None
     for sample in samples:
@@ -241,6 +254,7 @@ def _refine_fov_crossing(
         return None
     for i in range(start_idx, min(end_idx, len(times) - 1) + 1):
         cover = cover_factory(float(azis[i]), float(eles[i]))
+        cover.eval_time = times[i]
         if bool(cover.direct_sun_valid) == target_valid:
             return times[i]
     return None

--- a/custom_components/adaptive_cover_pro/sun.py
+++ b/custom_components/adaptive_cover_pro/sun.py
@@ -177,3 +177,23 @@ class SunData:
             # Polar night: sun never rises — treat as very early morning
             today = date.today()
             return datetime(today.year, today.month, today.day, 0, 1, 0)  # noqa: DTZ001
+
+    def next_sunrise(self) -> datetime:
+        """Fetch tomorrow's sunrise time.
+
+        Lets the forecast expose a still-upcoming event late in the evening,
+        after today's sunrise/sunset/FOV events have all passed, so the
+        ``position_forecast`` sensor keeps a real timestamp instead of going
+        ``Unknown`` (issue #516).
+
+        Returns an early-morning sentinel (00:01 tomorrow) at polar latitudes
+        during polar night when astral raises ValueError.
+        """
+        tomorrow = date.today() + timedelta(days=1)
+        try:
+            return self.location.sunrise(tomorrow, local=False)
+        except (ValueError, AttributeError):
+            # Polar night: sun never rises — treat as very early morning
+            return datetime(
+                tomorrow.year, tomorrow.month, tomorrow.day, 0, 1, 0
+            )  # noqa: DTZ001

--- a/tests/test_engine/test_sun_geometry.py
+++ b/tests/test_engine/test_sun_geometry.py
@@ -182,6 +182,43 @@ class TestSunsetValid:
         sg = SunGeometry(180.0, 45.0, sun_data, _make_config(), _make_logger())
         assert sg.sunset_valid is True
 
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_eval_time_overrides_wall_clock(self, mock_dt):
+        """eval_time at noon → not sunset, even when the wall clock is evening.
+
+        Regression for issue #516: the forecast walks the day and must evaluate
+        each sample's sunset/sunrise gate at *its own* time, not at the moment
+        the forecast happens to be recomputed.
+        """
+        from datetime import UTC as _UTC
+
+        mock_dt.now.return_value = datetime(2024, 1, 1, 22, 0, 0)  # evening
+        mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        sun_data = _make_sun_data()
+        sun_data.sunset.return_value = datetime(2024, 1, 1, 18, 0, 0)
+        sun_data.sunrise.return_value = datetime(2024, 1, 1, 6, 0, 0)
+        noon = datetime(2024, 1, 1, 12, 0, 0, tzinfo=_UTC)
+        sg = SunGeometry(
+            180.0, 45.0, sun_data, _make_config(), _make_logger(), eval_time=noon
+        )
+        assert sg.sunset_valid is False
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_eval_time_evening_is_sunset(self, mock_dt):
+        """eval_time after sunset → sunset gate active, regardless of wall clock."""
+        from datetime import UTC as _UTC
+
+        mock_dt.now.return_value = datetime(2024, 1, 1, 12, 0, 0)  # midday clock
+        mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+        sun_data = _make_sun_data()
+        sun_data.sunset.return_value = datetime(2024, 1, 1, 18, 0, 0)
+        sun_data.sunrise.return_value = datetime(2024, 1, 1, 6, 0, 0)
+        evening = datetime(2024, 1, 1, 19, 0, 0, tzinfo=_UTC)
+        sg = SunGeometry(
+            180.0, 45.0, sun_data, _make_config(), _make_logger(), eval_time=evening
+        )
+        assert sg.sunset_valid is True
+
 
 # ------------------------------------------------------------------
 # direct_sun_valid

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -39,6 +39,7 @@ def _make_sun_data(
     ele_at: float = 30.0,
     sunrise: datetime | None = None,
     sunset: datetime | None = None,
+    next_sunrise: datetime | None = None,
 ):
     """Build a minimal SunData stand-in for forecast tests.
 
@@ -46,6 +47,10 @@ def _make_sun_data(
     starting at _DAY_START (local midnight), matching real SunData semantics
     (00:00 → 24:00 inclusive at 5-min cadence = 289 points).  Tests that need
     a varying sun pattern can patch the azimuth/elevation lists after construction.
+
+    ``next_sunrise`` defaults to None so the forward-looking forecast event
+    (issue #516) is omitted unless a test opts in — keeps event-count
+    assertions on the today-only events stable.
     """
     times = [_DAY_START + timedelta(minutes=i * step_minutes) for i in range(n_samples)]
     sd = MagicMock()
@@ -54,6 +59,7 @@ def _make_sun_data(
     sd.solar_elevation = [ele_at] * n_samples
     sd.sunrise = MagicMock(return_value=sunrise)
     sd.sunset = MagicMock(return_value=sunset)
+    sd.next_sunrise = MagicMock(return_value=next_sunrise)
     return sd
 
 
@@ -151,6 +157,67 @@ class TestBuildForecastSamples:
         )
         assert f.samples == ()
         assert f.events == ()
+
+
+class _EvalTimeCover:
+    """Fake cover whose direct_sun_valid depends on the per-sample eval_time.
+
+    Mirrors the real engine's time-dependent sunset gate (issue #516): solar
+    is only valid between 10:00 and 16:00 of the *sample's own* timestamp. If
+    the forecast failed to set ``eval_time`` per sample (the bug), reading
+    ``direct_sun_valid`` would raise on ``None.hour`` — so this also guards
+    against a regression to wall-clock evaluation.
+    """
+
+    def __init__(self) -> None:
+        self.eval_time = None
+
+    @property
+    def direct_sun_valid(self) -> bool:
+        return 10 <= self.eval_time.hour < 16
+
+    def calculate_percentage(self) -> int:
+        return 40
+
+
+class TestForecastEvaluatesPerSampleTime:
+    """Regression for #516: per-sample sunset gate, not wall-clock now."""
+
+    def test_midday_samples_track_even_when_built_in_the_evening(self):
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=lambda _azi, _ele: _EvalTimeCover(),
+            default_position=100,
+            now=datetime(2026, 6, 1, 23, 0, tzinfo=UTC),  # built late in the day
+        )
+        # The curve is NOT flat: midday samples track the sun...
+        solar = [s for s in f.samples if s.handler == "solar"]
+        assert (
+            solar
+        ), "no solar samples — forecast collapsed to all-default (the #516 bug)"
+        assert all(10 <= s.t.hour < 16 for s in solar)
+        assert all(s.position == 40 for s in solar)
+        # ...while off-hours sit at the default.
+        assert any(s.handler == "default" and s.position == 100 for s in f.samples)
+
+    def test_forward_sunrise_event_is_appended(self):
+        next_rise = _DAY_START + timedelta(days=1, hours=5, minutes=40)
+        sd = _make_sun_data(
+            sunrise=_DAY_START + timedelta(hours=5),
+            sunset=_DAY_START + timedelta(hours=20),
+            next_sunrise=next_rise,
+        )
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            default_position=0,
+            now=_NOW,
+        )
+        sunrise_events = [e for e in f.events if e.kind == EVENT_SUNRISE]
+        # Today's sunrise plus tomorrow's forward-looking one.
+        assert len(sunrise_events) == 2
+        assert sunrise_events[-1].t == next_rise
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor_position_forecast.py
+++ b/tests/test_sensor_position_forecast.py
@@ -127,6 +127,35 @@ def test_value_returns_none_when_no_upcoming_events(monkeypatch):
 
 
 @pytest.mark.unit
+def test_value_resolves_to_forward_sunrise_late_in_day(monkeypatch):
+    """Issue #516: with today's events past, the state points at tomorrow's sunrise.
+
+    `build_forecast` now appends a forward-looking next-sunrise event so the
+    sensor stays a real timestamp late in the evening instead of going Unknown.
+    """
+    from custom_components.adaptive_cover_pro.forecast import (
+        Forecast,
+        ForecastEvent,
+    )
+    from custom_components.adaptive_cover_pro import sensor as sensor_mod
+    from custom_components.adaptive_cover_pro.sensor import _position_forecast_value
+
+    past_sunset = _NOW - timedelta(hours=3)
+    next_sunrise = _NOW + timedelta(hours=8)
+    forecast = Forecast(
+        samples=(),
+        events=(
+            ForecastEvent(t=past_sunset, kind="sunset", label="Sunset"),
+            ForecastEvent(t=next_sunrise, kind="sunrise", label="Sunrise"),
+        ),
+    )
+    sensor = _make_sensor_with_coord(forecast)
+    monkeypatch.setattr(sensor_mod.dt_util, "now", lambda: _NOW)
+
+    assert _position_forecast_value(sensor) == next_sunrise
+
+
+@pytest.mark.unit
 def test_no_recompute_across_n_state_writes(monkeypatch):
     """Driving N back-to-back reads through both callables triggers zero recomputes.
 


### PR DESCRIPTION
## Summary
Late in the day the `position_forecast` sensor went `Unknown` with an all-100 forecast attribute (flat 100% strip on the companion card, reported as card #122).

Root cause: `SunGeometry.sunset_valid` evaluated the sunset/sunrise offset gate against wall-clock `datetime.now()` instead of the timestamp each forecast sample projects. The forecast holds window geometry fixed and walks the sun across the day, but every sample asked "is it *currently* past sunset?" rather than "is *this sample's time* past sunset?" Once the real clock passed today's sunset, the gate closed for the whole projected day — every sample collapsed to the default position, the FOV events vanished, and with today's events all past the sensor had no upcoming event to report.

This is not a regression of the #510/#511 full-day work — that shipped fine; the samples were all computed, they all defaulted.

## Changes
- Thread an optional `eval_time` into `SunGeometry`; the forecast sets `cover.eval_time` per sample so each point is gated at its own time. The live pipeline leaves it `None` and keeps using wall-clock now — behaviour unchanged.
- Read `eval_time` via `getattr` on the cover (not a dataclass field) to avoid breaking subclass field ordering.
- Add `SunData.next_sunrise()` and append a forward next-sunrise event so the sensor state stays a real timestamp late in the evening instead of `Unknown`.

## Testing
- ✅ 3778 tests passing (full suite)
- New: per-sample tracking when the forecast is built at 23:00, forward-event append, `eval_time` override in `sun_geometry`, late-evening sensor-state resolution
- Lint + all pre-commit hooks green

## Related Issues
Refs #516
