### PR TITLE
fix: apply position tolerance to same-position command gate (#507)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -940,16 +940,23 @@ class CoverCommandService:
                 current_position=_current,
             )
 
-        # Same-position short-circuit — applies to ALL callers, including force=True.
-        # Issuing set_cover_position with the current position is always a no-op
-        # physically but causes audible relay clicks on many motors (issue #290).
+        # Same-position band — applies to ALL callers, including force=True and
+        # is_safety=True.  Issuing set_cover_position when the cover is already
+        # at (or within user-configured tolerance of) the target is a physical
+        # no-op that causes audible relay clicks on many motors (issue #290).
+        # The band is governed by _position_tolerance (CONF_POSITION_TOLERANCE,
+        # default POSITION_TOLERANCE_PERCENT = 3) so the user controls the
+        # dead-band width; raising it suppresses repeated commands when a motor
+        # physically cannot reach the commanded special-position target (issue
+        # #507).  At the default of 3 this also gives the main command gate the
+        # same tolerance the reconciliation path already used.
         # sun_just_appeared is the one exception: the sun transitioning in/out of
         # validity is a sentinel that we must re-confirm the cover position even
         # if it hasn't changed numerically.
         if (
             not context.sun_just_appeared
             and _current is not None
-            and _current == position
+            and abs(_current - position) <= self._position_tolerance
         ):
             if context.policy is not None and context.tilt is not None:
                 await context.policy.maybe_update_tilt_only(

--- a/tests/test_coordinator_logging.py
+++ b/tests/test_coordinator_logging.py
@@ -63,14 +63,18 @@ class TestApplyPositionGateLogging:
 
     @pytest.mark.asyncio
     async def test_skips_position_delta_too_small(self):
-        """Returns skip when position delta is below min_change."""
+        """Returns skip when position delta is below min_change.
+
+        Uses delta=4 (50→54) which is outside the default tolerance band
+        (POSITION_TOLERANCE_PERCENT=3, |50-54|=4 > 3) but below min_change=5.
+        """
         svc = _make_cmd_svc()
-        # Current position = 50, target = 51, min_change = 5 → delta too small
+        # Current position = 50, target = 54, min_change = 5 → delta too small
         svc._get_current_position = MagicMock(return_value=50)
         ctx = _make_context(min_change=5)
 
         outcome, reason = await svc.apply_position(
-            "cover.test", 51, "solar", context=ctx
+            "cover.test", 54, "solar", context=ctx
         )
 
         assert outcome == "skipped"
@@ -143,8 +147,13 @@ class TestApplyPositionGateLogging:
 
     @pytest.mark.asyncio
     async def test_force_bypasses_delta_and_manual_override_gates(self):
-        """force=True bypasses delta/time/manual_override but NOT auto_control (issue #293)."""
+        """force=True bypasses delta/time/manual_override but NOT auto_control (issue #293).
+
+        Uses current=50 so the cover is far from target=0 (|50-0|=50 > tolerance=3),
+        confirming that force bypasses delta/manual_override, not the same-position band.
+        """
         svc = _make_cmd_svc()
+        svc._get_current_position = MagicMock(return_value=50)
 
         with patch(
             "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",

--- a/tests/test_cover_command_force_gate.py
+++ b/tests/test_cover_command_force_gate.py
@@ -104,7 +104,10 @@ class TestSafetyBypassStillWorks:
 
     @pytest.mark.asyncio
     async def test_is_safety_proceeds_when_auto_control_off(self, svc, hass):
-        with _patch_caps():
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=50),
+        ):
             outcome, _detail = await svc.apply_position(
                 "cover.test",
                 0,
@@ -123,7 +126,10 @@ class TestSafetyBypassStillWorks:
         ["force_override", "weather", "synthetic_safety"],
     )
     async def test_safety_callers_bypass_gate(self, svc, hass, trigger):
-        with _patch_caps():
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=60),
+        ):
             outcome, _ = await svc.apply_position(
                 f"cover.{trigger}",
                 25,

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -368,8 +368,10 @@ async def test_tilt_on_target_plus_position_back_drive_does_not_trip_manual_over
     )
 
     entity_id = "cover.venetian_morning"
-    # Motor back-drove to 37% after the tilt command.
-    hass.states.get.return_value = _state_with_position(37)
+    # Motor back-drove to 38% after the tilt command (drift=4 > default tolerance=3).
+    # Using 38 rather than 37 ensures the cover is outside the same-position band
+    # so apply_position fires the position command and stamps the suppression window.
+    hass.states.get.return_value = _state_with_position(38)
 
     with _patch_caps_dual_axis():
         await svc.apply_position(
@@ -390,7 +392,7 @@ async def test_tilt_on_target_plus_position_back_drive_does_not_trip_manual_over
     event.entity_id = entity_id
     event.new_state = MagicMock()
     event.new_state.state = "stopped"
-    event.new_state.attributes = {"current_position": 37, "current_tilt_position": 70}
+    event.new_state.attributes = {"current_position": 38, "current_tilt_position": 70}
     event.new_state.last_updated = dt.datetime.now(dt.UTC)
 
     mgr.handle_state_change(

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -669,3 +669,172 @@ async def test_apply_position_proceeds_when_state_loaded_with_unknown_position(
         outcome, reason = await cmd_svc.apply_position("cover.zw", 50, "solar", _ctx())
 
     assert reason != "cover_unavailable"
+
+
+# --- position_tolerance same-position band (issue #507) ---
+
+
+def _ctx_with_special() -> PositionContext:
+    """PositionContext that passes every gate except same-position."""
+    return PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=10,
+        time_threshold=0,
+        special_positions=[0, 100],
+    )
+
+
+def _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance: int):
+    """CoverCommandService with a specific position_tolerance."""
+    svc = CoverCommandService(
+        hass=mock_hass,
+        logger=logger,
+        cover_type="cover_blind",
+        grace_mgr=grace_mgr,
+        position_tolerance=tolerance,
+    )
+    return svc
+
+
+def _stub_state(mock_hass, current_position: int) -> None:
+    """Wire mock_hass so apply_position sees an available cover at *current_position*."""
+    state_obj = MagicMock()
+    state_obj.state = "open"
+    state_obj.attributes = {
+        "current_position": current_position,
+        "supported_features": 15,
+    }
+    mock_hass.states.get.return_value = state_obj
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+
+
+@pytest.mark.asyncio
+async def test_apply_position_within_tolerance_skips_normal_path(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #507 — cover at 98, target 100, tolerance=8: storm-repro, normal path.
+
+    With |98-100|=2 <= tolerance=8 the same-position band must suppress the
+    command.  No set_cover_position service call is made and last_skipped_action
+    records the skip.  This is the exact scenario from the diagnostics report.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
+    _stub_state(mock_hass, current_position=98)
+
+    with patch.object(svc, "_get_current_position", return_value=98):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "default", _ctx_with_special()
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+    assert svc.last_skipped_action["entity_id"] == "cover.test"
+    assert svc.last_skipped_action["reason"] == "same_position"
+
+
+@pytest.mark.asyncio
+async def test_apply_position_within_tolerance_skips_force_path(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #507 — force=True within tolerance is ALSO suppressed (user decision).
+
+    The user owns position_tolerance, so if the cover is already within tolerance
+    of the target no command should be sent regardless of force/safety.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
+    _stub_state(mock_hass, current_position=98)
+
+    ctx = _ctx_with_special()
+    ctx = PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=10,
+        time_threshold=0,
+        special_positions=[0, 100],
+        force=True,
+        is_safety=True,
+    )
+
+    with patch.object(svc, "_get_current_position", return_value=98):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "force_override", ctx
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_exact_equality_still_skips(mock_hass, logger, grace_mgr):
+    """Exact-equality case still skips with default tolerance=0."""
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=0)
+    _stub_state(mock_hass, current_position=100)
+
+    with patch.object(svc, "_get_current_position", return_value=100):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "default", _ctx_with_special()
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_out_of_band_sends_command(mock_hass, logger, grace_mgr):
+    """Issue #507 — cover at 90, target 100, tolerance=8: |90-100|=10 > 8, genuine move.
+
+    A cover genuinely far from the target must still be commanded (#127 preserved).
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
+    _stub_state(mock_hass, current_position=90)
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=90),
+        patch.object(svc, "_check_position_delta", return_value=True),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("set_cover_position", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "default", _ctx_with_special()
+        )
+
+    assert outcome == "sent"
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_zero_tolerance_sends_command(mock_hass, logger, grace_mgr):
+    """Issue #507 — position_tolerance=0 (default): backward-compat, genuine moves proceed.
+
+    Covers at 98 targeting 100 with default tolerance=0 must still be commanded,
+    so that existing behaviour is unchanged when the option is not configured.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=0)
+    _stub_state(mock_hass, current_position=98)
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=98),
+        patch.object(svc, "_check_position_delta", return_value=True),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("set_cover_position", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "default", _ctx_with_special()
+        )
+
+    assert outcome == "sent"
+    mock_hass.services.async_call.assert_called_once()

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -102,9 +102,11 @@ async def test_apply_skips_auto_control_off(svc):
 
 @pytest.mark.asyncio
 async def test_apply_skips_delta_too_small(svc):
+    # delta=4 (50→54) is outside the tolerance band (svc has position_tolerance=3,
+    # so |50-54|=4 > 3) but still below min_change=5 → delta_too_small gate fires.
     _patch_position(svc, 50)
     outcome, reason = await svc.apply_position(
-        "cover.test", 51, "solar", context=_ctx(min_change=5)
+        "cover.test", 54, "solar", context=_ctx(min_change=5)
     )
     assert outcome == "skipped"
     assert reason == "delta_too_small"
@@ -199,6 +201,9 @@ async def test_apply_sends_when_all_gates_pass(svc, mock_hass):
 @pytest.mark.asyncio
 async def test_apply_force_bypasses_delta_and_manual_override_gates(svc, mock_hass):
     """force=True bypasses delta/time/manual_override but NOT auto_control (issue #293)."""
+    # Use current=50 so the cover is genuinely far from target=0 (|50-0|=50 > tolerance=3)
+    # confirming force bypasses delta/manual_override, not the same-position band.
+    _patch_position(svc, 50)
     with _patch_caps():
         outcome, _ = await svc.apply_position(
             "cover.test",
@@ -1066,6 +1071,9 @@ async def test_force_apply_bypasses_time_delta_gate(svc, mock_hass):
     """
     import datetime as _dt
 
+    # Use current=50 so cover is far from target=0 (|50-0|=50 > tolerance=3)
+    # ensuring the same-position band doesn't interfere.
+    _patch_position(svc, 50)
     recent = _dt.datetime.now(_dt.UTC) - _dt.timedelta(seconds=30)  # 0.5 min ago
     with (
         _patch_caps(),
@@ -1087,8 +1095,12 @@ async def test_force_apply_bypasses_time_delta_gate(svc, mock_hass):
 
 @pytest.mark.asyncio
 async def test_force_apply_bypasses_position_delta_gate(svc, mock_hass):
-    """force=True must bypass delta_too_small so safety commands always get sent."""
-    _patch_position(svc, 61)  # Would be delta=1 which is < min_change=5
+    """force=True must bypass delta_too_small so safety commands always get sent.
+
+    Uses current=64, target=60 (delta=4): outside tolerance=3 but below
+    min_change=5, confirming force bypasses the delta gate (not the band).
+    """
+    _patch_position(svc, 64)  # delta=4 to target=60 → outside tolerance=3, below min_change=5
     with _patch_caps():
         outcome, detail = await svc.apply_position(
             "cover.test",
@@ -1166,12 +1178,11 @@ async def test_safety_target_set_on_open_close_force(svc, mock_hass):
 async def test_special_position_target_bypasses_delta(svc, mock_hass):
     """Moving TO a special position (0, 100, default, sunset) bypasses delta check.
 
-    Scenario: cover is at 55%, min_change=10, target is 0% (special).
-    Normally delta=55 >= 10 would pass, but even if delta were small,
-    special positions bypass it.  This test uses a scenario where delta
-    would be blocked if not for the special bypass: cover at 99%, target=100%.
+    Scenario: cover at 96%, target=100% (special).  delta=4 is outside the
+    tolerance band (svc has position_tolerance=3, |96-100|=4 > 3) but below
+    min_change=5; the special-position bypass lets the command through.
     """
-    _patch_position(svc, 99)  # delta=1, below min_change=5
+    _patch_position(svc, 96)  # delta=4 → outside tolerance=3, below min_change=5
     with (
         _patch_caps(),
         patch(
@@ -1193,8 +1204,9 @@ async def test_special_position_target_bypasses_delta(svc, mock_hass):
 async def test_special_position_current_bypasses_delta(svc, mock_hass):
     """Moving FROM a special position also bypasses the delta check.
 
-    Cover is at 0% (special), target is 2% — delta=2 < min_change=5.
-    Because current position (0%) is special, the check is bypassed.
+    Cover is at 0% (special), target is 4% — delta=4 is outside tolerance=3
+    (svc has position_tolerance=3) but below min_change=5.  Because current
+    position (0%) is special, the check is bypassed.
     """
     _patch_position(svc, 0)  # current is special
     with (
@@ -1206,7 +1218,7 @@ async def test_special_position_current_bypasses_delta(svc, mock_hass):
     ):
         outcome, _ = await svc.apply_position(
             "cover.test",
-            2,  # small delta=2, but moving FROM special position
+            4,  # delta=4 outside tolerance=3, below min_change=5, FROM special
             "solar",
             context=_ctx(min_change=5, special_positions=[0, 100, 50]),
         )
@@ -1218,11 +1230,13 @@ async def test_non_special_small_delta_is_blocked(svc, mock_hass):
     """Without a special position, a small delta IS blocked by min_change.
 
     Control: verify that without the special bypass, a small delta fails.
+    Uses delta=4 (55→59) which is outside tolerance=3 (svc has position_tolerance=3)
+    but below min_change=5, so the delta gate fires.
     """
-    _patch_position(svc, 55)  # delta=2 < min_change=5, no special positions
+    _patch_position(svc, 55)  # delta=4 to 59 → outside tolerance=3, below min_change=5
     outcome, reason = await svc.apply_position(
         "cover.test",
-        57,  # delta=2 < min_change=5
+        59,  # delta=4 < min_change=5, |55-59|=4 > tolerance=3
         "solar",
         context=_ctx(min_change=5, special_positions=[]),  # no specials
     )
@@ -1330,11 +1344,15 @@ async def test_sun_just_appeared_bypasses_delta(svc, mock_hass):
 
 @pytest.mark.asyncio
 async def test_sun_just_appeared_false_enforces_delta(svc, mock_hass):
-    """With sun_just_appeared=False, small delta is still blocked."""
-    _patch_position(svc, 50)  # delta=1 < min_change=5
+    """With sun_just_appeared=False, small delta is still blocked.
+
+    Uses delta=4 (50→54) which is outside tolerance=3 (svc has position_tolerance=3)
+    but below min_change=5, confirming the delta gate enforces the threshold.
+    """
+    _patch_position(svc, 50)  # delta=4 to 54 → outside tolerance=3, below min_change=5
     outcome, reason = await svc.apply_position(
         "cover.test",
-        51,
+        54,
         "solar",
         context=_ctx(
             min_change=5,
@@ -1434,8 +1452,12 @@ async def test_force_true_bypasses_time_delta_and_position_delta(svc, mock_hass)
     Verifies that no single gate can block a force=True command, which is
     required for force override release, manual override expiry, and safety
     handlers to work reliably.
+
+    Uses current=56, target=60 (delta=4): outside tolerance=3 (svc has
+    position_tolerance=3) but below min_change=5, so both time and position
+    delta gates would block without force=True.
     """
-    _patch_position(svc, 59)  # delta=1, below min_change=5
+    _patch_position(svc, 56)  # delta=4 to target=60 → outside tolerance=3, below min_change=5
     recent = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=30)
     with (
         _patch_caps(),
@@ -1514,11 +1536,16 @@ async def test_apply_dry_run_skips_service_call(svc, mock_hass):
 
 @pytest.mark.asyncio
 async def test_dry_run_still_honors_earlier_gates(svc, mock_hass):
-    """When delta is too small AND dry-run is on, delta gate fires before dry-run."""
+    """When delta is too small AND dry-run is on, delta gate fires before dry-run.
+
+    Uses delta=4 (50→54) which is outside tolerance=3 (svc has position_tolerance=3)
+    but below min_change=5, confirming the delta gate still fires before the dry-run
+    skip when the position change is genuinely below the threshold.
+    """
     svc.dry_run = True
     _patch_position(svc, 50)
     outcome, reason = await svc.apply_position(
-        "cover.test", 51, "solar", context=_ctx(min_change=5)
+        "cover.test", 54, "solar", context=_ctx(min_change=5)
     )
     assert outcome == "skipped"
     assert reason == "delta_too_small"

--- a/tests/test_switch_auto_control_off_return.py
+++ b/tests/test_switch_auto_control_off_return.py
@@ -54,6 +54,9 @@ def _make_coord_with_real_cmd_svc(hass):
         open_close_threshold=50,
     )
     cmd_svc._enabled = True
+    # Stub current position so abs(current - 60) is computable and outside
+    # the tolerance band (cover is at 0, target will be 60 — far apart).
+    cmd_svc._get_current_position = MagicMock(return_value=0)
     coord._cmd_svc = cmd_svc
 
     def _build_ctx(


### PR DESCRIPTION
## Summary
The "Position match tolerance" option (`position_tolerance`) shipped in v2.25.0 only governed the reconciliation loop, not the main update-cycle command gate. A cover that settles a few percent short of a commanded special position (e.g. reports 98% when commanded to 100%) kept being re-commanded every cycle because the same-position short-circuit used exact equality — producing repeated commands and audible relay clicks. Raising the tolerance had no effect on this path.

This widens the same-position short-circuit from exact equality to a tolerance band (`abs(current - target) <= position_tolerance`), so a cover already within the configured tolerance of the target is treated as arrived and not re-commanded. The band runs before the special-position bypass and the delta/time gates and applies to all command paths, including force and weather-safety overrides — if the cover is within tolerance of the target, no command fires. Default tolerance is 3%, giving the command gate the same tolerance the reconciliation path already used.

## Testing
- ✅ 3783 tests passing (5 new #507 regression tests; existing tests updated for the deliberate behavior change)

## Related Issues
Refs #507