### PR TITLE
refactor: pluggable subsystems + abstraction passes

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -488,6 +488,11 @@ CONF_MANUAL_IGNORE_INTERMEDIATE = "manual_ignore_intermediate"
 # If True, only commands routed through ACP (proxy entity or set_position
 # service) engage manual override; all other position changes are ignored.
 CONF_MANUAL_IGNORE_EXTERNAL = "manual_ignore_external"
+# Which manual-override detection strategy to use. Maps to a registered
+# OverrideDetector via managers.manual_override.get_detector. Changing this
+# selects a different detection pattern; takes effect on config-entry reload.
+CONF_MANUAL_OVERRIDE_STRATEGY = "manual_override_strategy"
+DEFAULT_MANUAL_OVERRIDE_STRATEGY = "position_delta"
 # Position threshold separating "open" vs "closed" classification, % (1-99).
 CONF_OPEN_CLOSE_THRESHOLD = "open_close_threshold"
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -54,7 +54,6 @@ from .const import (
     CONF_DEBUG_MODE,
     CONF_DEFAULT_HEIGHT,
     CONF_DRY_RUN,
-    CONF_ENABLE_SUN_TRACKING,
     CONF_ENTITIES,
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
@@ -80,8 +79,6 @@ from .const import (
     CONF_SUNSET_TIME_ENTITY,
     CONF_TRANSIT_TIMEOUT,
     CUSTOM_POSITION_SLOTS,
-    DEFAULT_CUSTOM_POSITION_ENABLED,
-    DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
     DEFAULT_MANUAL_OVERRIDE_STRATEGY,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
@@ -110,16 +107,8 @@ from .managers.time_window import TimeWindowManager
 from .managers.toggles import ToggleManager
 from .position_utils import interpolate_position
 from .pipeline.handlers import (
-    ClimateHandler,
-    CloudSuppressionHandler,
-    CustomPositionHandler,
-    DefaultHandler,
-    ForceOverrideHandler,
-    GlareZoneHandler,
     ManualOverrideHandler,
-    MotionTimeoutHandler,
-    SolarHandler,
-    WeatherOverrideHandler,
+    build_handlers,
 )
 from .pipeline.floors import effective_floor, gather_active_floors
 from .pipeline.registry import PipelineRegistry
@@ -1751,62 +1740,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.logger.debug("First refresh handled")
 
     def _build_pipeline(self) -> PipelineRegistry:
-        """Build the override pipeline, creating one CustomPositionHandler per slot.
+        """Build the override pipeline from the registry of handler factories.
 
         Called once at coordinator initialisation.  Because the integration
         reloads fully on every options change (see ``_async_update_listener``
-        in ``__init__.py``), this method always sees the current configuration
-        and there is no need to rebuild the pipeline at runtime.
-
-        Custom position slots are created only for entries that have both a
-        sensor and a position configured.  Each carries an independent priority
-        so the PipelineRegistry can sort them into the correct evaluation order
-        alongside all other handlers.
+        in ``__init__.py``), this always sees the current configuration and
+        there is no need to rebuild at runtime. Handler composition lives in
+        ``pipeline.handlers.build_handlers`` (registry-driven), so adding a
+        handler never touches the coordinator.
         """
-        options = self.config_entry.options
-        custom_handlers: list[CustomPositionHandler] = []
-        for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
-            sensor = options.get(slot_keys["sensor"])
-            position = options.get(slot_keys["position"])
-            enabled = bool(
-                options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED)
-            )
-            if sensor and position is not None and enabled:
-                priority = int(
-                    options.get(slot_keys["priority"])
-                    or DEFAULT_CUSTOM_POSITION_PRIORITY
-                )
-                raw_tilt = options.get(slot_keys["tilt"])
-                tilt = int(raw_tilt) if raw_tilt is not None else None
-                custom_handlers.append(
-                    CustomPositionHandler(
-                        slot=slot,
-                        entity_id=sensor,
-                        position=int(position),
-                        priority=priority,
-                        tilt=tilt,
-                    )
-                )
-
-        sun_tracking_enabled = options.get(CONF_ENABLE_SUN_TRACKING, True)
-        solar_handlers = [SolarHandler()] if sun_tracking_enabled else []
-        handlers = [
-            ForceOverrideHandler(),
-            WeatherOverrideHandler(),
-            ManualOverrideHandler(),
-            *custom_handlers,
-            MotionTimeoutHandler(),
-            CloudSuppressionHandler(),
-            ClimateHandler(),
-            GlareZoneHandler(),
-            *solar_handlers,
-            DefaultHandler(),
-        ]
+        handlers = build_handlers(self.config_entry.options)
         self.logger.debug(
-            "Pipeline built with %d custom position handler(s): %s; sun_tracking_enabled=%s",
-            len(custom_handlers),
-            [(h.name, h.priority) for h in custom_handlers],
-            sun_tracking_enabled,
+            "Pipeline built: %s",
+            [(h.name, h.priority) for h in handlers],
         )
         self._handler_by_name = {h.name: h for h in handlers}
         return PipelineRegistry(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -67,6 +67,8 @@ from .const import (
     CONF_MANUAL_IGNORE_INTERMEDIATE,
     CONF_MANUAL_OVERRIDE_DURATION,
     CONF_MANUAL_OVERRIDE_RESET,
+    CONF_MANUAL_OVERRIDE_STRATEGY,
+    CONF_MANUAL_THRESHOLD,
     CONF_MOTION_SENSORS,
     CONF_MY_POSITION_VALUE,
     CONF_OPEN_CLOSE_THRESHOLD,
@@ -81,6 +83,7 @@ from .const import (
     DEFAULT_CUSTOM_POSITION_ENABLED,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
+    DEFAULT_MANUAL_OVERRIDE_STRATEGY,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     DOMAIN,
     LOGGER,
@@ -95,7 +98,12 @@ from .managers.cover_command import (
     build_special_positions,
 )
 from .managers.grace_period import GracePeriodManager
-from .managers.manual_override import AdaptiveCoverManager, inverse_state
+from .managers.manual_override import (
+    AdaptiveCoverManager,
+    DetectorConfig,
+    get_detector,
+    inverse_state,
+)
 from .managers.motion import MotionManager
 from .managers.weather import WeatherManager
 from .managers.time_window import TimeWindowManager
@@ -265,6 +273,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.manual_duration,
             self.logger,
             event_buffer=self._event_buffer,
+            detector=get_detector(
+                self.config_entry.options.get(CONF_MANUAL_OVERRIDE_STRATEGY)
+                or DEFAULT_MANUAL_OVERRIDE_STRATEGY,
+                self._make_detector_config(self.config_entry.options),
+            ),
         )
         self.ignore_intermediate_states = self.config_entry.options.get(
             CONF_MANUAL_IGNORE_INTERMEDIATE, False
@@ -368,7 +381,18 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # coordinator's debug-categories gate (INFO when debug_mode +
             # category enabled, otherwise DEBUG).
             debug_log=self._debug_log,
+            # Clock the post-command window for time-based override detectors.
+            on_command_sent=self.manager.note_command_sent,
         )
+
+        # Wire the manual-override engine's edge + origin seams once. Any
+        # detection channel that flips a cover into manual override fires
+        # on_engaged → discard the latched command target (issue #215/#216);
+        # every current and future detector inherits this without coordinator
+        # changes. The ACP-origin predicate lets detectors distinguish
+        # ACP-issued context ids from genuine user actions.
+        self.manager.set_transition_callbacks(on_engaged=self._cmd_svc.discard_target)
+        self.manager.set_acp_context_predicate(self._cmd_svc.was_acp_position_context)
 
         # Late-bind cover-type policy dependencies (e.g. VenetianPolicy
         # constructs its DualAxisSequencer here once cmd_svc + grace_mgr are
@@ -424,6 +448,22 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # ``async_track_time_interval`` cancel handle.
         self._position_forecast: Forecast | None = None
         self._forecast_unsub: Callable[[], None] | None = None
+
+    def _make_detector_config(self, options) -> DetectorConfig:
+        """Build the manual-override DetectorConfig from raw options.
+
+        Single source of truth shared by manager construction and
+        ``update_config`` so the detector and the engine never drift.
+        """
+        return DetectorConfig(
+            manual_threshold=options.get(CONF_MANUAL_THRESHOLD),
+            command_window_seconds=float(
+                options.get(CONF_TRANSIT_TIMEOUT) or DEFAULT_TRANSIT_TIMEOUT_SECONDS
+            ),
+            reset=options.get(CONF_MANUAL_OVERRIDE_RESET, False),
+            duration=options.get(CONF_MANUAL_OVERRIDE_DURATION) or {"hours": 2},
+            ignore_external=options.get(CONF_MANUAL_IGNORE_EXTERNAL, False),
+        )
 
     # --- Property delegates for CoverCommandService state ---
 
@@ -717,17 +757,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return
 
         for entity_id in tracked:
-            was_manual = self.manager.is_cover_manual(entity_id)
+            # On the not-manual→manual edge the manager fires on_engaged →
+            # discard_target (issue #215/#216); see set_transition_callbacks.
             self.manager.handle_stop_service_call(
                 entity_id,
                 int(my_position_value),
                 self._cmd_svc.is_waiting_for_target,
             )
-            # When a cover transitions into manual override via stop_cover,
-            # discard any pre-existing safety-tagged target so reconciliation
-            # cannot resurrect it (issue #215/#216).
-            if not was_manual and self.manager.is_cover_manual(entity_id):
-                self._cmd_svc.discard_target(entity_id)
             # Update target so the next reconciliation compares against
             # My rather than the stale calculated state.
             self._cmd_svc.set_target(entity_id, int(my_position_value))
@@ -1610,7 +1646,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 and ctx.user_id is not None
                 and not self._cmd_svc.was_acp_position_context(ctx.id)
             ):
-                was_manual = self.manager.is_cover_manual(entity_id)
                 handled = self.manager.handle_user_initiated_state_change(
                     entity_id,
                     new_state_obj,
@@ -1619,8 +1654,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     context_id=ctx.id,
                 )
                 if handled:
-                    if not was_manual and self.manager.is_cover_manual(entity_id):
-                        self._cmd_svc.discard_target(entity_id)
+                    # On the not-manual→manual edge the manager fires
+                    # on_engaged → discard_target (issue #215/#216).
                     # Consume any pending target_just_reached flag so the
                     # numeric path doesn't fire later for the same entity.
                     self._target_just_reached.discard(entity_id)
@@ -1647,12 +1682,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             recorded_target = self._cmd_svc.get_target(entity_id)
             expected_position = state if recorded_target is None else recorded_target
 
-            was_manual = self.manager.is_cover_manual(entity_id)
             secondary_axis_check = (
                 self._policy.secondary_axis_check(self._pipeline_result, self._cmd_svc)
                 if self._pipeline_result is not None
                 else None
             )
+            # On the not-manual→manual edge the manager fires on_engaged →
+            # discard_target, so a freshly-detected override drops any
+            # pre-existing integration target (incl. safety-tagged end-time
+            # defaults) before reconciliation can resurrect it (issue #215/#216).
             self.manager.handle_state_change(
                 event_data,
                 expected_position,
@@ -1664,12 +1702,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 is_in_command_grace=self._grace_mgr.is_in_command_grace_period,
                 is_in_transit=self._cmd_svc._is_cover_in_transit,
             )
-            # When a cover transitions into manual override, discard any
-            # pre-existing integration target (including safety-tagged
-            # end-time defaults) so reconciliation cannot resurrect it
-            # later (issue #215/#216).
-            if not was_manual and self.manager.is_cover_manual(entity_id):
-                self._cmd_svc.discard_target(entity_id)
 
         self.cover_state_change = False
         self.logger.debug("Cover state change handled")
@@ -1801,6 +1833,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.manual_duration = rc.manual_override.duration
         self.manual_ignore_external = rc.manual_override.ignore_external
         self.manual_threshold = rc.tracking.manual_threshold
+        # Apply manual-override config to the engine + active detector at
+        # runtime (auto-reset duration, threshold, command window) so changes
+        # take effect without a reload. The detection *strategy* itself is
+        # selected at construction; switching it requires a config-entry reload.
+        self.manager.update_config(self._make_detector_config(options))
         self.start_value = rc.tracking.interp_start
         self.end_value = rc.tracking.interp_end
         self.normal_list = rc.tracking.interp_list
@@ -2533,5 +2570,5 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.logger.debug("Coordinator shutdown complete")
 
 
-# AdaptiveCoverManager and inverse_state have been moved to managers/manual_override.py
-# They are re-imported above to maintain backward compatibility.
+# AdaptiveCoverManager and inverse_state live in the managers/manual_override
+# package. They are re-imported above to maintain backward compatibility.

--- a/custom_components/adaptive_cover_pro/managers/common/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/common/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .event_recorder import EventRecorder
 from .timeout_controller import TimeoutController
 
-__all__ = ["TimeoutController"]
+__all__ = ["EventRecorder", "TimeoutController"]

--- a/custom_components/adaptive_cover_pro/managers/common/event_recorder.py
+++ b/custom_components/adaptive_cover_pro/managers/common/event_recorder.py
@@ -1,0 +1,43 @@
+"""Shared diagnostic-event recorder for managers.
+
+Centralises the ``{"ts": now, "event": name, **fields}`` shape every manager
+was hand-building before calling ``EventBuffer.record``. Composed, not
+inherited — managers hold an instance, the same philosophy as
+:class:`.timeout_controller.TimeoutController`.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ...diagnostics.event_buffer import EventBuffer
+
+
+class EventRecorder:
+    """Stamp and append a diagnostic event to an optional ring buffer.
+
+    No-ops when no buffer is attached, so callers never need their own
+    ``if buffer is not None`` guard. ``now_fn`` defaults to UTC-aware now and
+    can be injected for managers that own a mockable clock (e.g. MotionManager).
+    """
+
+    def __init__(
+        self,
+        event_buffer: EventBuffer | None,
+        *,
+        now_fn: Callable[[], dt.datetime] | None = None,
+    ) -> None:
+        """Bind to a buffer (or None) and an optional clock."""
+        self._event_buffer = event_buffer
+        self._now_fn = now_fn or (lambda: dt.datetime.now(dt.UTC))
+
+    def record(self, event: str, **fields: Any) -> None:
+        """Record ``event`` with ``fields``, stamping ``ts`` from the clock."""
+        if self._event_buffer is None:
+            return
+        self._event_buffer.record(
+            {"ts": self._now_fn().isoformat(), "event": event, **fields}
+        )

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -88,6 +88,7 @@ class CoverCommandService:
         *,
         event_buffer=None,
         debug_log=None,
+        on_command_sent=None,
     ) -> None:
         """Initialize the CoverCommandService.
 
@@ -113,6 +114,11 @@ class CoverCommandService:
                 by the manual-override classifier so its diagnostic lines respect
                 the coordinator's debug-categories gate.  Defaults to plain
                 ``logger.debug`` when omitted.
+            on_command_sent: Optional ``(entity_id) -> None`` callable invoked
+                whenever an outbound position command is dispatched (alongside
+                the command grace period start).  The coordinator wires this to
+                ``AdaptiveCoverManager.note_command_sent`` so time-based
+                manual-override detectors can clock the post-command window.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -139,6 +145,7 @@ class CoverCommandService:
         self._max_retries = max_retries
         self._wait_for_target_timeout_seconds = transit_timeout_seconds
         self._on_tick = on_tick
+        self._on_command_sent = on_command_sent
 
         # Per-entity positioning state — single source of truth.
         # All previously-parallel dicts/sets (target_call, _sent_at,
@@ -1612,6 +1619,8 @@ class CoverCommandService:
         # reconciliation knows whether to resend it when auto_control is off.
         s.is_safety = is_safety
         self._grace_mgr.start_command_grace_period(entity)
+        if self._on_command_sent is not None:
+            self._on_command_sent(entity)
 
         return plan.service, plan.service_data, plan.supports_position
 

--- a/custom_components/adaptive_cover_pro/managers/grace_period.py
+++ b/custom_components/adaptive_cover_pro/managers/grace_period.py
@@ -7,7 +7,7 @@ import datetime as dt
 from typing import TYPE_CHECKING
 
 from ..const import COMMAND_GRACE_PERIOD_SECONDS, STARTUP_GRACE_PERIOD_SECONDS
-from .common import TimeoutController
+from .common import EventRecorder, TimeoutController
 
 if TYPE_CHECKING:
     from ..diagnostics.event_buffer import EventBuffer
@@ -40,6 +40,7 @@ class GracePeriodManager:
         """
         self._logger = logger
         self._event_buffer = event_buffer
+        self._events = EventRecorder(event_buffer)
         self._command_grace_seconds = command_grace_seconds
         self._startup_grace_seconds = startup_grace_seconds
 
@@ -110,15 +111,11 @@ class GracePeriodManager:
         self._grace_period_tasks.pop(entity_id, None)
 
         self._logger.debug("Grace period expired for %s", entity_id)
-        if self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                    "event": "grace_period_expired",
-                    "entity_id": entity_id,
-                    "duration_seconds": self._command_grace_seconds,
-                }
-            )
+        self._events.record(
+            "grace_period_expired",
+            entity_id=entity_id,
+            duration_seconds=self._command_grace_seconds,
+        )
 
     def cancel_command_grace_period(self, entity_id: str) -> None:
         """Cancel grace period task for entity.
@@ -172,14 +169,10 @@ class GracePeriodManager:
         self._startup_timestamp = None
 
         self._logger.debug("Startup grace period expired")
-        if self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                    "event": "startup_grace_expired",
-                    "duration_seconds": self._startup_grace_seconds,
-                }
-            )
+        self._events.record(
+            "startup_grace_expired",
+            duration_seconds=self._startup_grace_seconds,
+        )
 
     # --- Cleanup ---
 

--- a/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
@@ -1,0 +1,49 @@
+"""Manual-override subsystem: the engine plus its pluggable detectors.
+
+Public surface is re-exported here so existing imports
+(``from ...managers.manual_override import AdaptiveCoverManager``) keep working
+unchanged, and so new detection patterns are reachable from one place.
+"""
+
+from __future__ import annotations
+
+from .detector import (
+    DetectionContext,
+    DetectorConfig,
+    OverrideDecision,
+    OverrideDetector,
+    StopToMy,
+    UserContextChange,
+    default_stop_to_my_decision,
+    default_user_context_decision,
+)
+from .manager import AdaptiveCoverManager, inverse_state
+from .position_delta import PositionDeltaDetector
+from .registry import DEFAULT_DETECTOR, DETECTOR_REGISTRY, get_detector
+from .secondary_axis import (
+    SecondaryAxisCheck,
+    SecondaryAxisResult,
+    effective_manual_threshold,
+)
+from .time_window import TimeWindowDetector
+
+__all__ = [
+    "DEFAULT_DETECTOR",
+    "DETECTOR_REGISTRY",
+    "AdaptiveCoverManager",
+    "DetectionContext",
+    "DetectorConfig",
+    "OverrideDecision",
+    "OverrideDetector",
+    "PositionDeltaDetector",
+    "SecondaryAxisCheck",
+    "SecondaryAxisResult",
+    "StopToMy",
+    "TimeWindowDetector",
+    "UserContextChange",
+    "default_stop_to_my_decision",
+    "default_user_context_decision",
+    "effective_manual_threshold",
+    "get_detector",
+    "inverse_state",
+]

--- a/custom_components/adaptive_cover_pro/managers/manual_override/detector.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/detector.py
@@ -1,0 +1,197 @@
+"""Pluggable manual-override detection strategy interface.
+
+A detector is a pure decision strategy — neither a manager (it holds no
+per-instance HA state) nor a ``CoverTypePolicy`` (it is not keyed by cover
+type). It inspects an immutable :class:`DetectionContext` and returns an
+:class:`OverrideDecision` describing what the engine should do. The engine
+(:class:`..manager.AdaptiveCoverManager`) owns all state and side effects;
+a detector never mutates the engine.
+
+``detect`` is the only abstract method. Every other hook has a
+behaviour-preserving default so a new detection pattern overrides only what
+it needs — and, because :class:`DetectionContext` already carries every
+signal, a new pattern is a drop-in (one new file + one registry line) with no
+coordinator changes.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+
+@dataclass(frozen=True, slots=True)
+class DetectionContext:
+    """Complete immutable snapshot of one cover state change.
+
+    Carries every signal a detector could need so a new detection pattern
+    never requires new wiring through the coordinator.
+    """
+
+    entity_id: str
+    our_state: int  # commanded/expected primary-axis position
+    new_state: Any  # HA State: .state / .attributes / .last_updated / .context
+    old_state: Any | None
+    new_position: int | None  # resolved via policy.read_axis_value
+    caps: Any  # CoverCapabilities
+    policy: Any  # CoverTypePolicy
+    manual_threshold: int | None
+    allow_reset: bool
+    is_acp_context: bool  # precomputed was_acp_position_context(ctx.id)
+    context_user_id: str | None
+    context_id: str | None
+    seconds_since_command: float | None  # engine-tracked since note_command_sent
+    secondary_axis_check: Any | None
+    is_waiting: Callable[[str], bool]
+    is_in_command_grace: Callable[[str], bool]
+    is_in_transit: Callable[[str], bool]
+    now: dt.datetime
+
+
+@dataclass(frozen=True, slots=True)
+class OverrideDecision:
+    """What the engine should do in response to a detector verdict.
+
+    The empty ``OverrideDecision()`` means "nothing happens" (no event, no
+    mark). ``record_primary_axis_suppression`` lets a detector ask the engine
+    to perform the Issue-#33 bookkeeping without touching that state itself.
+    ``allow_reset`` overrides the context's value when setting the timestamp.
+    """
+
+    mark_manual: bool = False
+    event_name: str | None = None
+    event_kwargs: dict[str, Any] | None = None
+    record_primary_axis_suppression: bool = False
+    suppression_delta: float | None = None
+    allow_reset: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UserContextChange:
+    """Input for the user-context channel (HA-context-confirmed user action)."""
+
+    entity_id: str
+    new_state: Any
+    allow_reset: bool
+    context_user_id: str | None
+    context_id: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class StopToMy:
+    """Input for the stop-service channel (user stop_cover to the 'My' preset)."""
+
+    entity_id: str
+    my_position_value: int
+    is_waiting: Callable[[str], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class DetectorConfig:
+    """Config bundle handed to a detector at construction and on option changes.
+
+    ``command_window_seconds`` comes from ``CONF_TRANSIT_TIMEOUT``. The
+    manual-override slice fields (``reset``/``duration``/``ignore_external``)
+    are engine-level but exposed so a detector MAY use them.
+    """
+
+    manual_threshold: int | None
+    command_window_seconds: float
+    reset: bool
+    duration: dict
+    ignore_external: bool
+
+
+def default_user_context_decision(change: UserContextChange) -> OverrideDecision:
+    """Today's behaviour: a confirmed user-context change marks manual override."""
+    return OverrideDecision(
+        mark_manual=True,
+        event_name="manual_override_set",
+        event_kwargs={
+            "our_state": None,
+            "new_position": None,
+            "reason": (
+                f"user-initiated state change "
+                f"(context user_id={change.context_user_id}, id={change.context_id})"
+            ),
+        },
+    )
+
+
+def default_stop_to_my_decision(stop: StopToMy) -> OverrideDecision | None:
+    """Today's behaviour: stop_cover to 'My' marks manual unless mid-command.
+
+    Returns ``None`` when the cover is still moving toward a commanded target
+    (the stop is the cover reaching that target, not a user touch).
+    """
+    if stop.is_waiting(stop.entity_id):
+        return None
+    return OverrideDecision(
+        mark_manual=True,
+        event_name="manual_override_set",
+        event_kwargs={
+            "our_state": stop.my_position_value,
+            "new_position": stop.my_position_value,
+            "reason": "user stop_cover to My position",
+        },
+    )
+
+
+class OverrideDetector(ABC):
+    """Pluggable manual-override detection strategy.
+
+    ``detect`` is the only abstract method; every other hook has a
+    behaviour-preserving default so a subclass overrides only what its pattern
+    needs. Detectors DECIDE; the engine owns state and side effects (a detector
+    never mutates the manager).
+    """
+
+    strategy_id: ClassVar[str]
+
+    @classmethod
+    def from_config(cls, config: DetectorConfig) -> OverrideDetector:  # noqa: ARG003
+        """Build a detector instance from config. Default ignores config."""
+        return cls()
+
+    # --- core decision (required) ---
+    @abstractmethod
+    def detect(self, context: DetectionContext) -> OverrideDecision:
+        """Decide whether a primary-axis state change is a manual override."""
+
+    # --- channel hooks (defaults reproduce today's behaviour) ---
+    def on_user_context_change(
+        self, change: UserContextChange
+    ) -> OverrideDecision | None:
+        """HA-context-confirmed user action. Default: mark manual."""
+        return default_user_context_decision(change)
+
+    def on_stop_to_my(self, stop: StopToMy) -> OverrideDecision | None:
+        """User stop_cover to the hardware 'My' preset. Default: mark unless waiting."""
+        return default_stop_to_my_decision(stop)
+
+    # --- lifecycle hooks (default no-op) ---
+    def note_command_sent(self, entity_id: str, now: dt.datetime) -> None:
+        """ACP just issued a command to ``entity_id`` (stateful detectors hook here)."""
+
+    def on_marked(self, entity_id: str) -> None:
+        """Handle a cover transitioning into manual override."""
+
+    def on_reset(self, entity_id: str) -> None:
+        """Handle a cover's manual override being cleared."""
+
+    def on_covers_added(self, entities) -> None:
+        """Covers were registered for tracking."""
+
+    # --- runtime config + persistence (defaults: no-op / stateless) ---
+    def update_config(self, config: DetectorConfig) -> None:
+        """Apply an options change without a reload."""
+
+    def serialize_state(self) -> dict:
+        """Return detector-specific state to persist across restart (default: none)."""
+        return {}
+
+    def restore_state(self, data: dict) -> None:
+        """Rehydrate detector-specific state from :meth:`serialize_state`."""

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -1,23 +1,40 @@
-"""Manual override management for Adaptive Cover Pro."""
+"""Manual-override engine for Adaptive Cover Pro.
+
+``AdaptiveCoverManager`` is the stateful host: it owns per-entity override
+state, the diagnostic ring buffer, the Issue-#33 suppression bookkeeping, and
+the command-timing clock. It delegates the *decision* — is this state change a
+manual override? — to a pluggable :class:`.detector.OverrideDetector` and
+applies the returned :class:`.detector.OverrideDecision`. Edge transitions
+(into/out of manual override) fire callbacks so command-side effects
+(``discard_target``) wire once and every current and future detector inherits
+them.
+"""
 
 from __future__ import annotations
 
 import collections
-import dataclasses
 import datetime as dt
 import logging
 from collections.abc import Callable
-from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from ..const import (
+from ...const import (
     CONF_VENETIAN_BACKROTATE_PUBLISH_LAG,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
-    POSITION_TOLERANCE_PERCENT,
 )
-from ..diagnostics.event_buffer import EventBuffer
-from ..helpers import check_cover_features
+from ...diagnostics.event_buffer import EventBuffer
+from ...helpers import check_cover_features
+from .detector import (
+    DetectionContext,
+    DetectorConfig,
+    OverrideDecision,
+    OverrideDetector,
+    StopToMy,
+    UserContextChange,
+)
+from .position_delta import PositionDeltaDetector
+from .secondary_axis import SecondaryAxisCheck
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,111 +47,9 @@ _PRIMARY_AXIS_SUPPRESSION_WINDOW = dt.timedelta(hours=24)
 _PRIMARY_AXIS_SUPPRESSION_WARN_THROTTLE = dt.timedelta(hours=1)
 
 
-def effective_manual_threshold(user_threshold: int | None) -> int:
-    """Resolve the effective manual-override threshold for a delta comparison.
-
-    Floored at ``POSITION_TOLERANCE_PERCENT`` so motor rounding and reporting
-    imprecision can't trip false positives even when the user configures
-    ``manual_threshold = 0`` or leaves it unset. Both the primary-axis check
-    in ``handle_state_change`` and the secondary-axis check in
-    ``SecondaryAxisCheck.evaluate`` delegate here; keeping the two in sync
-    via a single helper prevents the formula from drifting (e.g. the day
-    ``POSITION_TOLERANCE_PERCENT`` changes).
-    """
-    return max(
-        user_threshold if user_threshold is not None else 0, POSITION_TOLERANCE_PERCENT
-    )
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class SecondaryAxisResult:
-    """Outcome of evaluating a non-primary axis for manual-override drift.
-
-    ``consumed`` short-circuits the position-axis check (caller returns
-    immediately). ``is_manual`` triggers ``mark_manual_control`` +
-    ``set_last_updated``. ``event_name`` (with ``event_kwargs``) appends a
-    record to the diagnostics ring buffer.
-    """
-
-    consumed: bool = False
-    is_manual: bool = False
-    event_name: str | None = None
-    event_kwargs: dict[str, Any] | None = None
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class SecondaryAxisCheck:
-    """Per-cover-type plug for manual-override evaluation on a secondary axis.
-
-    Built once per cover-state-change cycle by ``CoverTypePolicy.secondary_axis_check``.
-    Encapsulates the expected value (e.g. tilt resolved by the engine), the
-    HA state attribute to read, an optional suppression callback (e.g.
-    venetian's motor back-rotate window), and a label that flavours the
-    diagnostic event names. ``handle_state_change`` calls ``evaluate`` once
-    and dispatches on the returned ``SecondaryAxisResult`` — the manager
-    itself stays ignorant of which axis is being checked.
-    """
-
-    expected: int
-    attribute: str  # e.g. "current_tilt_position"
-    label: str  # e.g. "tilt" — flavours the rejection-reason text
-    suppression: Callable[[str, float], bool] | None = None
-
-    def evaluate(
-        self,
-        entity_id: str,
-        new_state,
-        manual_threshold: int | None,
-    ) -> SecondaryAxisResult:
-        """Decide what (if anything) the secondary axis tells the manager to do."""
-        new_value = new_state.attributes.get(self.attribute)
-        if new_value is None:
-            return SecondaryAxisResult()
-
-        effective_threshold = effective_manual_threshold(manual_threshold)
-        delta = abs(self.expected - new_value)
-
-        # Check suppression BEFORE the on-target short-circuit. When the motor
-        # back-drives the position axis during tilt settling, tilt may arrive
-        # exactly on target while the position axis still shows back-drive drift.
-        # Returning consumed=False here would let the position-axis check run and
-        # falsely trip manual override on that drift.
-        if self.suppression is not None and self.suppression(entity_id, delta):
-            return SecondaryAxisResult(
-                consumed=True,
-                event_name="manual_override_rejected_tilt_suppression",
-                event_kwargs={
-                    "our_state": self.expected,
-                    "new_position": new_value,
-                    "effective_threshold": effective_threshold,
-                    "reason": (
-                        f"{self.label} delta {delta:.1f}% within venetian "
-                        "back-rotate window; suppressing both tilt and position checks"
-                    ),
-                },
-            )
-
-        if new_value == self.expected:
-            return SecondaryAxisResult()
-
-        if delta >= effective_threshold:
-            return SecondaryAxisResult(
-                consumed=True,
-                is_manual=True,
-                event_name="manual_override_set",
-                event_kwargs={
-                    "our_state": self.expected,
-                    "new_position": new_value,
-                    "effective_threshold": effective_threshold,
-                    "reason": (
-                        f"{self.label} delta {delta:.1f}% >= threshold {effective_threshold}%"
-                    ),
-                },
-            )
-
-        # Below threshold and not suppressed — preserve the legacy "silent
-        # fall-through" behavior so the position-axis check still runs.
-        return SecondaryAxisResult()
+def _never(_entity_id: str) -> bool:
+    """Default predicate: always False (gate disabled)."""
+    return False
 
 
 class AdaptiveCoverManager:
@@ -142,8 +57,10 @@ class AdaptiveCoverManager:
 
     Monitors cover position changes to detect user-initiated manual overrides.
     Maintains per-cover manual control state with configurable duration and
-    reset behavior. Provides methods to check, set, and reset manual override
-    status for individual covers or all tracked covers.
+    reset behavior. The detection decision is delegated to a pluggable
+    :class:`.detector.OverrideDetector` (default
+    :class:`.position_delta.PositionDeltaDetector`); this class owns all state
+    and side effects.
 
     """
 
@@ -154,6 +71,9 @@ class AdaptiveCoverManager:
         logger,
         *,
         event_buffer: EventBuffer | None = None,
+        detector: OverrideDetector | None = None,
+        on_engaged: Callable[[str], None] | None = None,
+        on_cleared: Callable[[list[str]], None] | None = None,
     ) -> None:
         """Initialize the AdaptiveCoverManager.
 
@@ -163,6 +83,12 @@ class AdaptiveCoverManager:
             logger: Logger instance for debug output
             event_buffer: Shared ring buffer owned by the coordinator. When None
                 a private buffer is created (useful for unit tests).
+            detector: Active detection strategy. Defaults to
+                ``PositionDeltaDetector`` (the historical behaviour).
+            on_engaged: Callback fired with the entity_id whenever a cover
+                transitions into manual override via a detection channel.
+            on_cleared: Callback fired with a list of entity_ids whenever
+                manual override is cleared (reset or auto-expiry).
 
         """
         self.hass = hass
@@ -187,6 +113,51 @@ class AdaptiveCoverManager:
             str, collections.deque[dt.datetime]
         ] = {}
         self._last_suppression_warn_at: dict[str, dt.datetime] = {}
+
+        self._detector: OverrideDetector = (
+            detector if detector is not None else PositionDeltaDetector()
+        )
+        self._on_engaged = on_engaged
+        self._on_cleared = on_cleared
+        # Last ACP command time per entity (float UTC timestamp), feeding the
+        # ``seconds_since_command`` context field for time-based detectors.
+        self._last_command_at: dict[str, float] = {}
+        # ACP-origin predicate over a context id; the coordinator wires the
+        # real one. Default treats nothing as ACP-originated.
+        self._is_acp_context_fn: Callable[[str | None], bool] = lambda _cid: False
+
+    # --- wiring -----------------------------------------------------------
+
+    def set_transition_callbacks(
+        self,
+        *,
+        on_engaged: Callable[[str], None] | None = None,
+        on_cleared: Callable[[list[str]], None] | None = None,
+    ) -> None:
+        """Register edge-transition callbacks after construction."""
+        self._on_engaged = on_engaged
+        self._on_cleared = on_cleared
+
+    def set_acp_context_predicate(self, fn: Callable[[str | None], bool]) -> None:
+        """Register the predicate that recognises ACP-originated context ids."""
+        self._is_acp_context_fn = fn
+
+    def update_config(self, config: DetectorConfig) -> None:
+        """Apply an options change at runtime (no reload).
+
+        Refreshes the auto-reset duration and forwards the config to the active
+        detector. This is what lets the manual-override duration take effect
+        without a config-entry reload.
+        """
+        self.reset_duration = dt.timedelta(**config.duration)
+        self._detector.update_config(config)
+
+    @property
+    def detector(self) -> OverrideDetector:
+        """Return the active detection strategy."""
+        return self._detector
+
+    # --- diagnostics bookkeeping -----------------------------------------
 
     def _record_primary_axis_suppression(self, entity_id: str, *, delta: float) -> None:
         """Log a primary-axis publish-lag suppression and throttle the WARN.
@@ -287,6 +258,56 @@ class AdaptiveCoverManager:
 
         """
         self.covers.update(entity)
+        self._detector.on_covers_added(entity)
+
+    # --- command-timing clock --------------------------------------------
+
+    def note_command_sent(self, entity_id: str) -> None:
+        """Record that ACP just issued a command to ``entity_id``.
+
+        Stamps the post-command settle clock (feeding ``seconds_since_command``
+        on the detection context) and notifies the active detector.
+        """
+        now = dt.datetime.now(dt.UTC)
+        self._last_command_at[entity_id] = now.timestamp()
+        self._detector.note_command_sent(entity_id, now)
+
+    def _seconds_since_command(self, entity_id: str, now: dt.datetime) -> float | None:
+        """Seconds since the last ACP command for ``entity_id`` (None if never)."""
+        ts = self._last_command_at.get(entity_id)
+        return (now.timestamp() - ts) if ts is not None else None
+
+    # --- decision application --------------------------------------------
+
+    def _apply_decision(
+        self,
+        entity_id: str,
+        decision: OverrideDecision,
+        *,
+        set_timestamp: Callable[[], None],
+    ) -> None:
+        """Apply a detector decision: record events, suppression, mark, fire edge.
+
+        ``set_timestamp`` is invoked (only when marking) to record the
+        per-channel ``manual_control_time``. The not-manual→manual edge fires
+        ``on_marked`` + the ``on_engaged`` callback.
+        """
+        if decision.event_name is not None:
+            self._record_event(
+                entity_id, decision.event_name, **(decision.event_kwargs or {})
+            )
+        if decision.record_primary_axis_suppression:
+            self._record_primary_axis_suppression(
+                entity_id, delta=decision.suppression_delta
+            )
+        if decision.mark_manual:
+            was_manual = self.is_cover_manual(entity_id)
+            self.mark_manual_control(entity_id)
+            set_timestamp()
+            if not was_manual:
+                self._detector.on_marked(entity_id)
+                if self._on_engaged is not None:
+                    self._on_engaged(entity_id)
 
     def handle_state_change(
         self,
@@ -303,10 +324,9 @@ class AdaptiveCoverManager:
     ):
         """Process state change for manual override.
 
-        Examines cover position changes to detect manual overrides by comparing
-        new position to expected position. Ignores changes during grace periods
-        (wait_for_target) and below threshold. Marks cover as manual and records
-        timestamp when manual change detected.
+        Runs the upstream gates (tracked / wait-for-target / command-grace /
+        secondary axis), resolves the primary-axis position, then delegates the
+        position decision to the active detector and applies its verdict.
 
         Args:
             states_data: StateChangedData with entity_id, old_state, new_state
@@ -319,22 +339,15 @@ class AdaptiveCoverManager:
                 is currently expected to be moving toward a commanded target.
             manual_threshold: Minimum position delta to trigger manual detection
             secondary_axis_check: Optional ``SecondaryAxisCheck`` supplied by
-                the cover-type policy (see ``CoverTypePolicy.secondary_axis_check``).
-                When provided, the secondary axis is evaluated up front and a
-                manual-override match short-circuits the position-axis check.
+                the cover-type policy. When provided, the secondary axis is
+                evaluated up front and a manual-override match short-circuits
+                the position-axis check.
             is_in_command_grace: Optional callable ``(entity_id) -> bool`` that
-                returns True while the integration's command-grace window is
-                active for this entity.  When True, all override detection is
-                suppressed — the position change is the cover responding to
-                the ACP command, not a user touch.  Supplied by the coordinator
-                via ``GracePeriodManager.is_in_command_grace_period``.
+                returns True while the command-grace window is active. When
+                True, override detection is suppressed.
             is_in_transit: Optional callable ``(entity_id) -> bool`` returning
-                True when HA reports the cover state as ``opening`` or
-                ``closing``.  When True, the position-axis check is skipped
-                because ``current_position`` lags the physical position during
-                travel (issue #271).  Supplied by the coordinator via
-                ``CoverCommandService._is_cover_in_transit`` so the predicate
-                lives in one place.
+                True when HA reports the cover state as ``opening``/``closing``;
+                passed through to the detector via the context (issue #271).
 
         """
         event = states_data
@@ -366,10 +379,6 @@ class AdaptiveCoverManager:
 
         if secondary_axis_check is not None:
             res = secondary_axis_check.evaluate(entity_id, new_state, manual_threshold)
-            if res.event_name is not None:
-                self._record_event(
-                    entity_id, res.event_name, **(res.event_kwargs or {})
-                )
             if res.is_manual:
                 self.logger.debug(
                     "Manual %s change for %s: ours=%s, new=%s",
@@ -378,8 +387,17 @@ class AdaptiveCoverManager:
                     secondary_axis_check.expected,
                     new_state.attributes.get(secondary_axis_check.attribute),
                 )
-                self.mark_manual_control(entity_id)
-                self.set_last_updated(entity_id, new_state, allow_reset)
+            self._apply_decision(
+                entity_id,
+                OverrideDecision(
+                    mark_manual=res.is_manual,
+                    event_name=res.event_name,
+                    event_kwargs=res.event_kwargs,
+                ),
+                set_timestamp=lambda: self.set_last_updated(
+                    entity_id, new_state, allow_reset
+                ),
+            )
             if res.consumed:
                 return
 
@@ -392,109 +410,41 @@ class AdaptiveCoverManager:
             self.hass, entity_id, caps, state_obj=new_state
         )
 
-        # Position still unavailable (entity in transient state like "opening")
-        # — nothing to compare against, skip override detection.
-        if new_position is None:
-            self.logger.debug(
-                "Position unavailable for %s (entity in transient state), skipping override check",
-                entity_id,
-            )
-            self._record_event(
-                entity_id,
-                "manual_override_rejected_position_unavailable",
-                our_state=our_state,
-                new_position=None,
-                reason="position unavailable (transient state)",
-            )
-            return
-
-        # Cover's own state attribute says it's still in transit. The
-        # current_position it just reported can lag the actual physical
-        # position — Zigbee covers that emit a single end-of-move report
-        # look like a stale-position event with state=closing/opening.
-        # Wait for the next event when the cover stops; that event runs
-        # the full position-math path.
-        if is_in_transit is not None and is_in_transit(entity_id):
-            new_state_str = getattr(new_state, "state", "unknown")
-            self._record_event(
-                entity_id,
-                "manual_override_rejected_in_transit",
-                our_state=our_state,
-                new_position=new_position,
-                reason=f"cover state '{new_state_str}' indicates in-transit",
-            )
-            return
-
-        # Issue #33 Phase 5: cross-axis publish-lag guard. Slow-bus
-        # actuators (Somfy IO via Tahoma, slow KNX, Fibaro/Shelly republish)
-        # publish a late ``current_position`` tens of seconds after the
-        # cover has physically stopped. Without this guard the threshold
-        # check below would treat the stale publish as a 100 % user touch.
-        # ``CoverTypePolicy.primary_axis_suppression`` defaults to False on
-        # non-venetian cover types — they don't share the back-rotate
-        # signature and so opt out automatically.
-        delta = abs(our_state - new_position)
-        if policy.primary_axis_suppression(entity_id, float(delta)):
-            self._record_event(
-                entity_id,
-                "manual_override_rejected_primary_axis_suppression",
-                our_state=our_state,
-                new_position=new_position,
-                effective_threshold=None,
-                reason=(
-                    f"primary-axis publish-lag suppression for {entity_id} "
-                    f"(delta {delta:.1f}%)"
-                ),
-            )
-            self._record_primary_axis_suppression(entity_id, delta=delta)
-            return
-
-        if new_position != our_state:
-            # Floor the threshold at POSITION_TOLERANCE_PERCENT so motor rounding
-            # / position-reporting imprecision can't trip false positives even
-            # when the user leaves manual_threshold unset. See
-            # ``effective_manual_threshold`` for the single-source-of-truth.
-            effective_threshold = effective_manual_threshold(manual_threshold)
-            if abs(our_state - new_position) <= effective_threshold:
-                self.logger.debug(
-                    "Position change %s%% is less than effective threshold %s%% for %s (user threshold=%s, tolerance floor=%s)",
-                    abs(our_state - new_position),
-                    effective_threshold,
-                    entity_id,
-                    manual_threshold,
-                    POSITION_TOLERANCE_PERCENT,
-                )
-                self._record_event(
-                    entity_id,
-                    "manual_override_rejected_within_threshold",
-                    our_state=our_state,
-                    new_position=new_position,
-                    effective_threshold=effective_threshold,
-                    reason=f"delta {abs(our_state - new_position):.1f}% < threshold {effective_threshold}%",
-                )
-                return
-            self.logger.debug(
-                "Manual change detected for %s. Our state: %s, new state: %s",
-                entity_id,
-                our_state,
-                new_position,
-            )
-            self.logger.debug(
-                "Set manual control for %s, for at least %s seconds, reset_allowed: %s",
-                entity_id,
-                self.reset_duration.total_seconds(),
-                allow_reset,
-            )
-            self._record_event(
-                entity_id,
-                "manual_override_set",
-                our_state=our_state,
-                new_position=new_position,
-                effective_threshold=effective_threshold,
-                reason=f"delta {abs(our_state - new_position):.1f}% >= threshold {effective_threshold}%",
-            )
-            self.mark_manual_control(entity_id)
-            self.set_last_updated(entity_id, new_state, allow_reset)
+        now = dt.datetime.now(dt.UTC)
+        ctx_obj = getattr(new_state, "context", None)
+        context_user_id = getattr(ctx_obj, "user_id", None) if ctx_obj else None
+        context_id = getattr(ctx_obj, "id", None) if ctx_obj else None
+        context = DetectionContext(
+            entity_id=entity_id,
+            our_state=our_state,
+            new_state=new_state,
+            old_state=getattr(event, "old_state", None),
+            new_position=new_position,
+            caps=caps,
+            policy=policy,
+            manual_threshold=manual_threshold,
+            allow_reset=allow_reset,
+            is_acp_context=self._is_acp_context_fn(context_id),
+            context_user_id=context_user_id,
+            context_id=context_id,
+            seconds_since_command=self._seconds_since_command(entity_id, now),
+            secondary_axis_check=secondary_axis_check,
+            is_waiting=is_waiting,
+            is_in_command_grace=is_in_command_grace or _never,
+            is_in_transit=is_in_transit or _never,
+            now=now,
+        )
+        decision = self._detector.detect(context)
+        resolved_allow_reset = (
+            decision.allow_reset if decision.allow_reset is not None else allow_reset
+        )
+        self._apply_decision(
+            entity_id,
+            decision,
+            set_timestamp=lambda: self.set_last_updated(
+                entity_id, new_state, resolved_allow_reset
+            ),
+        )
 
     def handle_user_initiated_state_change(
         self,
@@ -509,17 +459,26 @@ class AdaptiveCoverManager:
 
         Called from the coordinator when ``new_state.context`` carries a non-None
         ``user_id`` and ``context.id`` is **not** in the ACP position-context
-        tracker — i.e. a real user took action via the HA dashboard, voice
-        assistant, or another front-end. This path bypasses the position-math
-        comparison in :meth:`handle_state_change` because the math is unreliable
-        for assumed-state and OPEN/CLOSE-only covers (the live ``current_position``
-        either doesn't exist or has already been overwritten by ACP's
-        reconciliation by the time the queued event is drained).
+        tracker. Delegates to the active detector's ``on_user_context_change``
+        hook (default: mark manual). This path bypasses the position-math
+        comparison because the math is unreliable for assumed-state and
+        OPEN/CLOSE-only covers.
 
         Returns True when the override was set, False when the entity is not
-        tracked.
+        tracked (or the detector declined).
         """
         if entity_id not in self.covers:
+            return False
+        decision = self._detector.on_user_context_change(
+            UserContextChange(
+                entity_id=entity_id,
+                new_state=new_state,
+                allow_reset=allow_reset,
+                context_user_id=context_user_id,
+                context_id=context_id,
+            )
+        )
+        if decision is None:
             return False
         self.logger.debug(
             "Manual override via user-initiated state change for %s "
@@ -528,18 +487,16 @@ class AdaptiveCoverManager:
             context_user_id,
             context_id,
         )
-        self._record_event(
+        resolved_allow_reset = (
+            decision.allow_reset if decision.allow_reset is not None else allow_reset
+        )
+        self._apply_decision(
             entity_id,
-            "manual_override_set",
-            our_state=None,
-            new_position=None,
-            reason=(
-                f"user-initiated state change "
-                f"(context user_id={context_user_id}, id={context_id})"
+            decision,
+            set_timestamp=lambda: self.set_last_updated(
+                entity_id, new_state, resolved_allow_reset
             ),
         )
-        self.mark_manual_control(entity_id)
-        self.set_last_updated(entity_id, new_state, allow_reset)
         return True
 
     def handle_stop_service_call(
@@ -550,23 +507,28 @@ class AdaptiveCoverManager:
     ) -> None:
         """Mark manual override when a user-initiated cover.stop_cover is detected.
 
-        Called by the coordinator's EVENT_CALL_SERVICE handler after confirming
-        the stop was NOT originated by ACP (context-id check). This path covers
+        Delegates to the active detector's ``on_stop_to_my`` hook (default: mark
+        unless the cover is still moving toward a commanded target). Covers
         non-position-capable covers (e.g. Somfy RTS) where pressing STOP moves
-        the cover to the hardware "My" preset but never reports a new position,
-        so the normal state-change detection path is blind to it.
+        the cover to the hardware "My" preset but never reports a new position.
 
         Args:
             entity_id:        Cover entity_id that received stop_cover.
             my_position_value: The position (0–100) the My preset represents.
             is_waiting:       Callable(entity_id) -> bool from
-                              CoverCommandService; used as a belt-and-braces
-                              guard on top of the context-id filter.
+                              CoverCommandService.
 
         """
         if entity_id not in self.covers:
             return
-        if is_waiting(entity_id):
+        decision = self._detector.on_stop_to_my(
+            StopToMy(
+                entity_id=entity_id,
+                my_position_value=my_position_value,
+                is_waiting=is_waiting,
+            )
+        )
+        if decision is None:
             self.logger.debug(
                 "handle_stop_service_call: ignoring stop for %s — wait_for_target active",
                 entity_id,
@@ -577,15 +539,13 @@ class AdaptiveCoverManager:
             entity_id,
             my_position_value,
         )
-        self._record_event(
+        self._apply_decision(
             entity_id,
-            "manual_override_set",
-            our_state=my_position_value,
-            new_position=my_position_value,
-            reason="user stop_cover to My position",
+            decision,
+            set_timestamp=lambda: self.manual_control_time.setdefault(
+                entity_id, dt.datetime.now(dt.UTC)
+            ),
         )
-        self.mark_manual_control(entity_id)
-        self.manual_control_time.setdefault(entity_id, dt.datetime.now(dt.UTC))
 
     def set_last_updated(self, entity_id, new_state, allow_reset):
         """Set last updated time for manual control.
@@ -641,7 +601,10 @@ class AdaptiveCoverManager:
         Uses ``setdefault`` for ``manual_control_time`` so successive drags
         do not extend the override window (matches ``allow_reset=False``
         semantics).  Does not require the entity to be in ``self.covers`` —
-        the proxy may dispatch before ``add_covers`` runs.
+        the proxy may dispatch before ``add_covers`` runs. Does NOT fire the
+        ``on_engaged`` edge callback: these ACP-routed paths set a command
+        target immediately afterward, so the command-side discard would be
+        counter-productive.
 
         Args:
             entity_id: Cover entity ID to mark as manually overridden.
@@ -691,7 +654,8 @@ class AdaptiveCoverManager:
 
         Clears manual control flag and timestamp for cover. Called when duration
         expires, user presses reset button, or manual detection is disabled.
-        Re-enables automatic position commands.
+        Re-enables automatic position commands. Notifies the active detector and
+        fires the ``on_cleared`` edge callback.
 
         Args:
             entity_id: Cover entity ID to reset
@@ -707,6 +671,9 @@ class AdaptiveCoverManager:
             new_position=None,
             reason="manual override cleared",
         )
+        self._detector.on_reset(entity_id)
+        if self._on_cleared is not None:
+            self._on_cleared([entity_id])
 
     def is_cover_manual(self, entity_id):
         """Check if cover is manual.

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -25,6 +25,7 @@ from ...const import (
 )
 from ...diagnostics.event_buffer import EventBuffer
 from ...helpers import check_cover_features
+from ..common import EventRecorder
 from .detector import (
     DetectionContext,
     DetectorConfig,
@@ -103,6 +104,7 @@ class AdaptiveCoverManager:
             if event_buffer is not None
             else EventBuffer(maxlen=DEFAULT_DEBUG_EVENT_BUFFER_SIZE)
         )
+        self._events = EventRecorder(self._event_buffer)
         # Issue #33 Phase 5: rolling per-entity log of primary-axis publish-lag
         # suppressions and a per-entity WARN throttle. Both live on the
         # manager (per-instance state, side-effect bookkeeping); the
@@ -227,16 +229,13 @@ class AdaptiveCoverManager:
         reason: str = "",
     ) -> None:
         """Append a manual-override decision event to the shared ring buffer."""
-        self._event_buffer.record(
-            {
-                "ts": dt.datetime.now(dt.UTC).isoformat(),
-                "event": event_name,
-                "entity_id": entity_id,
-                "our_state": our_state,
-                "new_position": new_position,
-                "effective_threshold": effective_threshold,
-                "reason": reason,
-            }
+        self._events.record(
+            event_name,
+            entity_id=entity_id,
+            our_state=our_state,
+            new_position=new_position,
+            effective_threshold=effective_threshold,
+            reason=reason,
         )
 
     def get_event_buffer(self) -> list[dict]:

--- a/custom_components/adaptive_cover_pro/managers/manual_override/position_delta.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/position_delta.py
@@ -1,0 +1,118 @@
+"""Position-delta manual-override detector — the default strategy.
+
+Holds the original detection logic: a state change is a manual override when
+the cover's reported primary-axis position differs from the commanded position
+by more than the effective threshold, after guarding against transient states,
+in-transit reports, and slow-bus publish-lag (Issue #33). The engine handles
+the upstream gates (tracked / wait-for-target / command-grace / secondary
+axis) and resolves ``new_position`` before calling :meth:`detect`.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from .detector import DetectionContext, OverrideDecision, OverrideDetector
+from .secondary_axis import effective_manual_threshold
+
+
+class PositionDeltaDetector(OverrideDetector):
+    """Threshold-on-position-delta detection (the historical default)."""
+
+    strategy_id: ClassVar[str] = "position_delta"
+
+    def detect(self, context: DetectionContext) -> OverrideDecision:
+        """Decide manual override from the primary-axis position delta."""
+        entity_id = context.entity_id
+        our_state = context.our_state
+        new_position = context.new_position
+
+        # Position still unavailable (entity in transient state like "opening")
+        # — nothing to compare against, skip override detection.
+        if new_position is None:
+            return OverrideDecision(
+                event_name="manual_override_rejected_position_unavailable",
+                event_kwargs={
+                    "our_state": our_state,
+                    "new_position": None,
+                    "reason": "position unavailable (transient state)",
+                },
+            )
+
+        # Cover's own state attribute says it's still in transit. The
+        # current_position it just reported can lag the actual physical
+        # position — Zigbee covers that emit a single end-of-move report
+        # look like a stale-position event with state=closing/opening.
+        # Wait for the next event when the cover stops; that event runs
+        # the full position-math path.
+        if context.is_in_transit(entity_id):
+            new_state_str = getattr(context.new_state, "state", "unknown")
+            return OverrideDecision(
+                event_name="manual_override_rejected_in_transit",
+                event_kwargs={
+                    "our_state": our_state,
+                    "new_position": new_position,
+                    "reason": f"cover state '{new_state_str}' indicates in-transit",
+                },
+            )
+
+        # Issue #33 Phase 5: cross-axis publish-lag guard. Slow-bus
+        # actuators (Somfy IO via Tahoma, slow KNX, Fibaro/Shelly republish)
+        # publish a late ``current_position`` tens of seconds after the
+        # cover has physically stopped. Without this guard the threshold
+        # check below would treat the stale publish as a 100 % user touch.
+        # ``CoverTypePolicy.primary_axis_suppression`` defaults to False on
+        # non-venetian cover types — they don't share the back-rotate
+        # signature and so opt out automatically.
+        delta = abs(our_state - new_position)
+        if context.policy.primary_axis_suppression(entity_id, float(delta)):
+            return OverrideDecision(
+                event_name="manual_override_rejected_primary_axis_suppression",
+                event_kwargs={
+                    "our_state": our_state,
+                    "new_position": new_position,
+                    "effective_threshold": None,
+                    "reason": (
+                        f"primary-axis publish-lag suppression for {entity_id} "
+                        f"(delta {delta:.1f}%)"
+                    ),
+                },
+                record_primary_axis_suppression=True,
+                suppression_delta=float(delta),
+            )
+
+        if new_position == our_state:
+            return OverrideDecision()
+
+        # Floor the threshold at POSITION_TOLERANCE_PERCENT so motor rounding
+        # / position-reporting imprecision can't trip false positives even
+        # when the user leaves manual_threshold unset. See
+        # ``effective_manual_threshold`` for the single-source-of-truth.
+        effective_threshold = effective_manual_threshold(context.manual_threshold)
+        if abs(our_state - new_position) <= effective_threshold:
+            return OverrideDecision(
+                event_name="manual_override_rejected_within_threshold",
+                event_kwargs={
+                    "our_state": our_state,
+                    "new_position": new_position,
+                    "effective_threshold": effective_threshold,
+                    "reason": (
+                        f"delta {abs(our_state - new_position):.1f}% "
+                        f"< threshold {effective_threshold}%"
+                    ),
+                },
+            )
+
+        return OverrideDecision(
+            mark_manual=True,
+            event_name="manual_override_set",
+            event_kwargs={
+                "our_state": our_state,
+                "new_position": new_position,
+                "effective_threshold": effective_threshold,
+                "reason": (
+                    f"delta {abs(our_state - new_position):.1f}% "
+                    f">= threshold {effective_threshold}%"
+                ),
+            },
+        )

--- a/custom_components/adaptive_cover_pro/managers/manual_override/registry.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/registry.py
@@ -1,0 +1,30 @@
+"""Registry of manual-override detection strategies.
+
+Adding a new detection pattern is a drop-in: create one new detector module
+and add one line to ``DETECTOR_REGISTRY`` keyed by the detector's
+``strategy_id`` class attribute. Selection is data-driven (the engine reads
+``CONF_MANUAL_OVERRIDE_STRATEGY``), mirroring ``cover_types.get_policy``.
+"""
+
+from __future__ import annotations
+
+from .detector import DetectorConfig, OverrideDetector
+from .position_delta import PositionDeltaDetector
+from .time_window import TimeWindowDetector
+
+DETECTOR_REGISTRY: dict[str, type[OverrideDetector]] = {
+    PositionDeltaDetector.strategy_id: PositionDeltaDetector,
+    TimeWindowDetector.strategy_id: TimeWindowDetector,
+}
+
+DEFAULT_DETECTOR: type[OverrideDetector] = PositionDeltaDetector
+
+
+def get_detector(strategy_id: str | None, config: DetectorConfig) -> OverrideDetector:
+    """Return a detector instance for ``strategy_id`` built from ``config``.
+
+    Unknown or missing ids fall back to the default (position-delta) strategy,
+    preserving behaviour for entries configured before a strategy option exists.
+    """
+    cls = DETECTOR_REGISTRY.get(strategy_id) if strategy_id else None
+    return (cls or DEFAULT_DETECTOR).from_config(config)

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -1,0 +1,122 @@
+"""Secondary-axis manual-override check and the shared threshold formula.
+
+Co-located so the single-source-of-truth threshold helper sits next to both
+of its consumers — the position-delta detector
+(:mod:`.position_delta`) and the secondary-axis check below — without
+creating an import cycle through the manager.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Callable
+from typing import Any
+
+from ...const import POSITION_TOLERANCE_PERCENT
+
+
+def effective_manual_threshold(user_threshold: int | None) -> int:
+    """Resolve the effective manual-override threshold for a delta comparison.
+
+    Floored at ``POSITION_TOLERANCE_PERCENT`` so motor rounding and reporting
+    imprecision can't trip false positives even when the user configures
+    ``manual_threshold = 0`` or leaves it unset. Both the primary-axis check
+    in ``PositionDeltaDetector.detect`` and the secondary-axis check in
+    ``SecondaryAxisCheck.evaluate`` delegate here; keeping the two in sync
+    via a single helper prevents the formula from drifting (e.g. the day
+    ``POSITION_TOLERANCE_PERCENT`` changes).
+    """
+    return max(
+        user_threshold if user_threshold is not None else 0, POSITION_TOLERANCE_PERCENT
+    )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SecondaryAxisResult:
+    """Outcome of evaluating a non-primary axis for manual-override drift.
+
+    ``consumed`` short-circuits the position-axis check (caller returns
+    immediately). ``is_manual`` triggers ``mark_manual_control`` +
+    ``set_last_updated``. ``event_name`` (with ``event_kwargs``) appends a
+    record to the diagnostics ring buffer.
+    """
+
+    consumed: bool = False
+    is_manual: bool = False
+    event_name: str | None = None
+    event_kwargs: dict[str, Any] | None = None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class SecondaryAxisCheck:
+    """Per-cover-type plug for manual-override evaluation on a secondary axis.
+
+    Built once per cover-state-change cycle by ``CoverTypePolicy.secondary_axis_check``.
+    Encapsulates the expected value (e.g. tilt resolved by the engine), the
+    HA state attribute to read, an optional suppression callback (e.g.
+    venetian's motor back-rotate window), and a label that flavours the
+    diagnostic event names. The engine calls ``evaluate`` once and dispatches
+    on the returned ``SecondaryAxisResult`` — it stays ignorant of which axis
+    is being checked.
+    """
+
+    expected: int
+    attribute: str  # e.g. "current_tilt_position"
+    label: str  # e.g. "tilt" — flavours the rejection-reason text
+    suppression: Callable[[str, float], bool] | None = None
+
+    def evaluate(
+        self,
+        entity_id: str,
+        new_state,
+        manual_threshold: int | None,
+    ) -> SecondaryAxisResult:
+        """Decide what (if anything) the secondary axis tells the manager to do."""
+        new_value = new_state.attributes.get(self.attribute)
+        if new_value is None:
+            return SecondaryAxisResult()
+
+        effective_threshold = effective_manual_threshold(manual_threshold)
+        delta = abs(self.expected - new_value)
+
+        # Check suppression BEFORE the on-target short-circuit. When the motor
+        # back-drives the position axis during tilt settling, tilt may arrive
+        # exactly on target while the position axis still shows back-drive drift.
+        # Returning consumed=False here would let the position-axis check run and
+        # falsely trip manual override on that drift.
+        if self.suppression is not None and self.suppression(entity_id, delta):
+            return SecondaryAxisResult(
+                consumed=True,
+                event_name="manual_override_rejected_tilt_suppression",
+                event_kwargs={
+                    "our_state": self.expected,
+                    "new_position": new_value,
+                    "effective_threshold": effective_threshold,
+                    "reason": (
+                        f"{self.label} delta {delta:.1f}% within venetian "
+                        "back-rotate window; suppressing both tilt and position checks"
+                    ),
+                },
+            )
+
+        if new_value == self.expected:
+            return SecondaryAxisResult()
+
+        if delta >= effective_threshold:
+            return SecondaryAxisResult(
+                consumed=True,
+                is_manual=True,
+                event_name="manual_override_set",
+                event_kwargs={
+                    "our_state": self.expected,
+                    "new_position": new_value,
+                    "effective_threshold": effective_threshold,
+                    "reason": (
+                        f"{self.label} delta {delta:.1f}% >= threshold {effective_threshold}%"
+                    ),
+                },
+            )
+
+        # Below threshold and not suppressed — preserve the legacy "silent
+        # fall-through" behavior so the position-axis check still runs.
+        return SecondaryAxisResult()

--- a/custom_components/adaptive_cover_pro/managers/manual_override/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/time_window.py
@@ -1,0 +1,84 @@
+"""Time-window manual-override detector — a pure time-based alternative.
+
+During the window after an ACP command, every change is ignored. Once the
+window expires, the next position change away from the commanded state is a
+manual override. No delta threshold and no origin/context inspection — purely
+time-gated. Opt-in; ``PositionDeltaDetector`` remains the default.
+
+The window length reuses ``CONF_TRANSIT_TIMEOUT`` (default 45 s) — the option
+that already represents "how long after a command the cover may still be
+settling." The engine stamps the last-command time and supplies
+``seconds_since_command`` on the context.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ...const import DEFAULT_TRANSIT_TIMEOUT_SECONDS
+from .detector import (
+    DetectionContext,
+    DetectorConfig,
+    OverrideDecision,
+    OverrideDetector,
+)
+
+
+class TimeWindowDetector(OverrideDetector):
+    """Treat any movement outside the post-command window as a manual override."""
+
+    strategy_id: ClassVar[str] = "time_window"
+
+    def __init__(
+        self, window_seconds: float = float(DEFAULT_TRANSIT_TIMEOUT_SECONDS)
+    ) -> None:
+        """Initialise with the post-command settle window in seconds."""
+        self._window_seconds = window_seconds
+
+    @classmethod
+    def from_config(cls, config: DetectorConfig) -> TimeWindowDetector:
+        """Build from config, taking the window from ``command_window_seconds``."""
+        return cls(window_seconds=config.command_window_seconds)
+
+    def update_config(self, config: DetectorConfig) -> None:
+        """Apply a window change without a reload."""
+        self._window_seconds = config.command_window_seconds
+
+    def detect(self, context: DetectionContext) -> OverrideDecision:
+        """Decide manual override purely from time since the last ACP command."""
+        if context.new_position is None:
+            return OverrideDecision(
+                event_name="manual_override_rejected_position_unavailable",
+                event_kwargs={
+                    "our_state": context.our_state,
+                    "new_position": None,
+                    "reason": "position unavailable (transient state)",
+                },
+            )
+
+        elapsed = context.seconds_since_command
+        if elapsed is not None and elapsed < self._window_seconds:
+            return OverrideDecision(
+                event_name="manual_override_rejected_command_window",
+                event_kwargs={
+                    "our_state": context.our_state,
+                    "new_position": context.new_position,
+                    "reason": (
+                        f"within {self._window_seconds:.0f}s command window "
+                        f"({elapsed:.1f}s elapsed)"
+                    ),
+                },
+            )
+
+        if context.new_position == context.our_state:
+            return OverrideDecision()
+
+        return OverrideDecision(
+            mark_manual=True,
+            event_name="manual_override_set",
+            event_kwargs={
+                "our_state": context.our_state,
+                "new_position": context.new_position,
+                "reason": "movement after command window",
+            },
+        )

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from ..const import DEFAULT_MOTION_TIMEOUT
 from ..helpers import is_entity_active
-from .common import TimeoutController
+from .common import EventRecorder, TimeoutController
 
 
 class MotionManager:
@@ -40,6 +40,7 @@ class MotionManager:
         self._hass = hass
         self._logger = logger
         self._event_buffer = event_buffer
+        self._events = EventRecorder(event_buffer, now_fn=self._now)
 
         self._sensors: list[str] = []
         self._timeout_seconds: int = DEFAULT_MOTION_TIMEOUT
@@ -167,27 +168,15 @@ class MotionManager:
         """
         # Record the "cancelled" event before the controller swaps timers
         # so the diagnostic ring still shows the cancel-on-restart edge.
-        if self._timer.is_running and self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": self._now().isoformat(),
-                    "event": "motion_timeout_canceled",
-                }
-            )
+        if self._timer.is_running:
+            self._events.record("motion_timeout_canceled")
 
         timeout_seconds = self._timeout_seconds
         self._logger.info(
             "No motion detected - starting %s second timeout before using default position",
             timeout_seconds,
         )
-        if self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": self._now().isoformat(),
-                    "event": "motion_timeout_started",
-                    "timeout_seconds": timeout_seconds,
-                }
-            )
+        self._events.record("motion_timeout_started", timeout_seconds=timeout_seconds)
 
         async def _on_expire() -> None:
             await self._on_motion_timeout_expired(timeout_seconds, refresh_callback)
@@ -208,13 +197,7 @@ class MotionManager:
             self._logger.debug(
                 "Motion detected during timeout - canceling default position"
             )
-            if self._event_buffer is not None:
-                self._event_buffer.record(
-                    {
-                        "ts": self._now().isoformat(),
-                        "event": "motion_detected_during_timeout",
-                    }
-                )
+            self._events.record("motion_detected_during_timeout")
             return
 
         self._motion_timeout_active = True
@@ -222,24 +205,12 @@ class MotionManager:
             "Motion timeout expired (%s seconds) - using default position",
             timeout_seconds,
         )
-        if self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": self._now().isoformat(),
-                    "event": "motion_timeout_expired",
-                    "timeout_seconds": timeout_seconds,
-                }
-            )
+        self._events.record("motion_timeout_expired", timeout_seconds=timeout_seconds)
 
         await refresh_callback()
 
     def cancel_motion_timeout(self) -> None:
         """Cancel the running timeout task, if any."""
-        if self._timer.is_running and self._event_buffer is not None:
-            self._event_buffer.record(
-                {
-                    "ts": self._now().isoformat(),
-                    "event": "motion_timeout_canceled",
-                }
-            )
+        if self._timer.is_running:
+            self._events.record("motion_timeout_canceled")
         self._timer.cancel()

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 from ..const import BLANK_TIME
 from ..helpers import get_datetime_from_str, get_safe_state
+from .common import EventRecorder
 
 
 class TimeWindowManager:
@@ -35,6 +36,7 @@ class TimeWindowManager:
         self._hass = hass
         self.logger = logger
         self._event_buffer = event_buffer
+        self._events = EventRecorder(event_buffer)
         self._last_time_window_state: bool | None = None
 
         # Config values — set via update_config()
@@ -259,18 +261,12 @@ class TimeWindowManager:
                 "active" if self._last_time_window_state else "inactive",
                 "active" if current_state else "inactive",
             )
-            if self._event_buffer is not None:
-                import datetime as dt
-
-                self._event_buffer.record(
-                    {
-                        "ts": dt.datetime.now(dt.UTC).isoformat(),
-                        "event": "time_window_changed",
-                        "entity_id": "",
-                        "previous": self._last_time_window_state,
-                        "current": current_state,
-                    }
-                )
+            self._events.record(
+                "time_window_changed",
+                entity_id="",
+                previous=self._last_time_window_state,
+                current=current_state,
+            )
             self._last_time_window_state = current_state
 
             if current_state and on_window_open is not None:

--- a/custom_components/adaptive_cover_pro/managers/weather.py
+++ b/custom_components/adaptive_cover_pro/managers/weather.py
@@ -13,7 +13,7 @@ from ..const import (
     DEFAULT_WINDOW_AZIMUTH,
     DEGREES_IN_CIRCLE,
 )
-from .common import TimeoutController
+from .common import EventRecorder, TimeoutController
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -62,6 +62,7 @@ class WeatherManager:
         self._hass = hass
         self._logger = logger
         self._event_buffer = event_buffer
+        self._events = EventRecorder(event_buffer)
 
         # Config (updated via update_config)
         self._wind_speed_sensor: str | None = None
@@ -255,17 +256,12 @@ class WeatherManager:
         self.cancel_weather_timeout()
         previous = self._override_active
         self._override_active = True
-        if not previous and self._event_buffer is not None:
-            import datetime as dt
-
-            self._event_buffer.record(
-                {
-                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                    "event": "weather_override_changed",
-                    "entity_id": "",
-                    "previous": False,
-                    "current": True,
-                }
+        if not previous:
+            self._events.record(
+                "weather_override_changed",
+                entity_id="",
+                previous=False,
+                current=True,
             )
 
     def reconcile(self) -> str | None:
@@ -329,19 +325,13 @@ class WeatherManager:
             return
 
         self._override_active = False
-        if self._event_buffer is not None:
-            import datetime as dt
-
-            self._event_buffer.record(
-                {
-                    "ts": dt.datetime.now(dt.UTC).isoformat(),
-                    "event": "weather_override_changed",
-                    "entity_id": "",
-                    "previous": True,
-                    "current": False,
-                    "reason": f"clear-delay expired ({timeout_seconds}s)",
-                }
-            )
+        self._events.record(
+            "weather_override_changed",
+            entity_id="",
+            previous=True,
+            current=False,
+            reason=f"clear-delay expired ({timeout_seconds}s)",
+        )
         self._logger.info(
             "Weather clear-delay expired (%s seconds) — resuming normal control",
             timeout_seconds,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
@@ -1,5 +1,23 @@
-"""Built-in override handlers for the pipeline."""
+"""Built-in override handlers for the pipeline, plus the handler registry.
 
+Adding a handler is a one-place change: write the handler module, import it
+here, and add one entry to ``HANDLER_FACTORIES``. The coordinator builds the
+pipeline via :func:`build_handlers` and never needs editing — priority remains
+the handler's class attribute, so ``PipelineRegistry`` sorts the chain.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from ...const import (
+    CONF_ENABLE_SUN_TRACKING,
+    CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_ENABLED,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+)
+from ..handler import OverrideHandler
 from .climate import ClimateHandler
 from .cloud_suppression import CloudSuppressionHandler
 from .custom_position import CustomPositionHandler
@@ -11,15 +29,96 @@ from .motion_timeout import MotionTimeoutHandler
 from .solar import SolarHandler
 from .weather import WeatherOverrideHandler
 
+# A factory turns the live options into zero or more handler instances. Most
+# handlers are always-on singletons; a couple are config-driven (custom-position
+# slots, sun-tracking toggle).
+HandlerFactory = Callable[[Mapping[str, Any]], list[OverrideHandler]]
+
+
+def _single(cls: type[OverrideHandler]) -> HandlerFactory:
+    """Return a factory that always emits exactly one ``cls()``."""
+    return lambda _options: [cls()]
+
+
+def _custom_position_handlers(options: Mapping[str, Any]) -> list[OverrideHandler]:
+    """Build one ``CustomPositionHandler`` per configured + enabled slot.
+
+    A slot contributes a handler only when it has both a sensor and a position
+    and is enabled. Each carries an independent priority so the registry sorts
+    it into the correct evaluation order alongside the rest of the chain.
+    """
+    handlers: list[OverrideHandler] = []
+    for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
+        sensor = options.get(slot_keys["sensor"])
+        position = options.get(slot_keys["position"])
+        enabled = bool(
+            options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED)
+        )
+        if sensor and position is not None and enabled:
+            priority = int(
+                options.get(slot_keys["priority"]) or DEFAULT_CUSTOM_POSITION_PRIORITY
+            )
+            raw_tilt = options.get(slot_keys["tilt"])
+            tilt = int(raw_tilt) if raw_tilt is not None else None
+            handlers.append(
+                CustomPositionHandler(
+                    slot=slot,
+                    entity_id=sensor,
+                    position=int(position),
+                    priority=priority,
+                    tilt=tilt,
+                )
+            )
+    return handlers
+
+
+def _solar_handler(options: Mapping[str, Any]) -> list[OverrideHandler]:
+    """Emit the ``SolarHandler`` only when sun tracking is enabled."""
+    if options.get(CONF_ENABLE_SUN_TRACKING, True):
+        return [SolarHandler()]
+    return []
+
+
+# The registry. Order here is for readability only — PipelineRegistry sorts by
+# each handler's declared priority. Add a new handler with one entry.
+HANDLER_FACTORIES: tuple[HandlerFactory, ...] = (
+    _single(ForceOverrideHandler),
+    _single(WeatherOverrideHandler),
+    _single(ManualOverrideHandler),
+    _custom_position_handlers,
+    _single(MotionTimeoutHandler),
+    _single(CloudSuppressionHandler),
+    _single(ClimateHandler),
+    _single(GlareZoneHandler),
+    _solar_handler,
+    _single(DefaultHandler),
+)
+
+
+def build_handlers(options: Mapping[str, Any]) -> list[OverrideHandler]:
+    """Build every configured pipeline handler from ``options``.
+
+    Iterates the registry and flattens each factory's output. The result is
+    handed to ``PipelineRegistry``, which sorts by priority.
+    """
+    handlers: list[OverrideHandler] = []
+    for factory in HANDLER_FACTORIES:
+        handlers.extend(factory(options))
+    return handlers
+
+
 __all__ = [
+    "HANDLER_FACTORIES",
     "ClimateHandler",
     "CloudSuppressionHandler",
     "CustomPositionHandler",
     "DefaultHandler",
     "ForceOverrideHandler",
     "GlareZoneHandler",
+    "HandlerFactory",
     "ManualOverrideHandler",
     "MotionTimeoutHandler",
     "SolarHandler",
     "WeatherOverrideHandler",
+    "build_handlers",
 ]

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -12,12 +12,7 @@ from typing import Any, cast
 
 import numpy as np
 
-from ...const import (
-    CLIMATE_DEFAULT_TILT_ANGLE,
-    CLIMATE_SUMMER_TILT_ANGLE,
-    POSITION_CLOSED,
-)
-from ...cover_types import TiltPolicy, get_policy
+from ...cover_types import get_policy
 from ...cover_types.base import AXIS_NAME_TILT, CoverTypePolicy
 from ...engine.covers import AdaptiveTiltCover
 from ...const import ClimateStrategy, ControlMethod
@@ -28,6 +23,15 @@ from ..helpers import (
     compute_solar_position,
 )
 from ..types import PipelineResult, PipelineSnapshot
+from .climate_modes import (
+    NORMAL_WITH_PRESENCE,
+    NORMAL_WITHOUT_PRESENCE,
+    TILT_WITH_PRESENCE,
+    TILT_WITHOUT_PRESENCE,
+    ClimateContext,
+    ClimateRule,
+    evaluate_rules,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -162,142 +166,55 @@ class ClimateCoverState:
             return self.normal_with_presence()
         return self.normal_without_presence()
 
+    def _build_context(self, *, tilt: bool) -> ClimateContext:
+        """Bundle data + (for tilt covers) precomputed slat geometry for the rules.
+
+        ``gamma_deg``/``beta_deg`` are computed once here for tilt covers — the
+        same ``float(tilt_cover.gamma)`` / ``np.rad2deg(tilt_cover.beta)`` the
+        original routers used, evaluated regardless of validity to match the
+        prior behavior.
+        """
+        gamma_deg = 0.0
+        beta_deg = 0.0
+        if tilt:
+            tilt_cover = cast(AdaptiveTiltCover, self.cover)
+            # SunGeometry.gamma is already in degrees; pass it through unconverted.
+            gamma_deg = float(tilt_cover.gamma)
+            beta_deg = float(np.rad2deg(tilt_cover.beta))
+        return ClimateContext(
+            data=self.climate_data,
+            cover=self.cover,
+            default_position=self.default_position,
+            solar_position=self._solar_position,
+            gamma_deg=gamma_deg,
+            beta_deg=beta_deg,
+        )
+
+    def _run(self, rules: tuple[ClimateRule, ...], *, tilt: bool) -> int | None:
+        """Evaluate a rule table, record the chosen strategy, return its position."""
+        strategy, position = evaluate_rules(rules, self._build_context(tilt=tilt))
+        self.climate_strategy = strategy
+        return position
+
     def normal_with_presence(self) -> int | None:
         """Climate strategy for normal covers with occupants present.
 
         Returns None for the GLARE_CONTROL case — the pipeline falls through
         to GlareZoneHandler (priority 45) then SolarHandler (priority 40).
         """
-        is_summer = self.climate_data.is_summer
-        if self.climate_data.is_winter and self.cover.valid:
-            self.climate_strategy = ClimateStrategy.WINTER_HEATING
-            return self.climate_data.policy.position_for_intent(sun_through=True)
-        # Close for insulation when in winter and sun not hitting window.
-        if self.climate_data.is_winter and self.climate_data.winter_close_insulation:
-            self.climate_strategy = ClimateStrategy.WINTER_INSULATION
-            # 0 is correct for both blinds (lowered) and awnings (retracted).
-            return POSITION_CLOSED
-        # Low-light check applies in ALL seasons — if irradiance/lux indicates
-        # no real sun (even in summer), use default position rather than closing.
-        if (
-            self.climate_data.lux
-            or self.climate_data.irradiance
-            or not self.climate_data.is_sunny
-        ):
-            self.climate_strategy = ClimateStrategy.LOW_LIGHT
-            return self.default_position
-        if is_summer and self.climate_data.transparent_blind and self.cover.valid:
-            self.climate_strategy = ClimateStrategy.SUMMER_COOLING
-            return self.climate_data.policy.position_for_intent(sun_through=False)
-        self.climate_strategy = ClimateStrategy.GLARE_CONTROL
-        return None
+        return self._run(NORMAL_WITH_PRESENCE, tilt=False)
 
     def normal_without_presence(self) -> int:
         """Climate strategy for normal covers without occupants."""
-        if self.cover.valid:
-            # Low-light check overrides season logic — if irradiance/lux indicates
-            # no real sun (even in summer), use default position rather than closing.
-            if (
-                self.climate_data.lux
-                or self.climate_data.irradiance
-                or not self.climate_data.is_sunny
-            ):
-                self.climate_strategy = ClimateStrategy.LOW_LIGHT
-                return self.default_position
-            if self.climate_data.is_summer:
-                self.climate_strategy = ClimateStrategy.SUMMER_COOLING
-                return self.climate_data.policy.position_for_intent(sun_through=False)
-            if self.climate_data.is_winter:
-                self.climate_strategy = ClimateStrategy.WINTER_HEATING
-                return self.climate_data.policy.position_for_intent(sun_through=True)
-        # Close for insulation when in winter and sun not hitting window.
-        if self.climate_data.is_winter and self.climate_data.winter_close_insulation:
-            self.climate_strategy = ClimateStrategy.WINTER_INSULATION
-            # 0 is correct for both blinds (lowered) and awnings (retracted).
-            return POSITION_CLOSED
-        self.climate_strategy = ClimateStrategy.LOW_LIGHT
-        return self.default_position
+        return cast(int, self._run(NORMAL_WITHOUT_PRESENCE, tilt=False))
 
     def tilt_with_presence(self) -> int:
         """Climate strategy for tilt covers with occupants present."""
-        tilt_cover = cast(AdaptiveTiltCover, self.cover)
-        # SunGeometry.gamma is already in degrees; pass it through unconverted.
-        gamma_deg = float(tilt_cover.gamma)
-        if self.cover.valid:
-            if self.climate_data.is_summer and self.climate_data.is_winter:
-                # Conflicting season signals — fall through to glare control
-                pass
-            elif self.climate_data.is_winter:
-                self.climate_strategy = ClimateStrategy.WINTER_HEATING
-                return self._solar_position()
-            elif (
-                self.climate_data.lux
-                or self.climate_data.irradiance
-                or not self.climate_data.is_sunny
-            ):
-                # Low-light check applies in ALL seasons for tilt covers too
-                self.climate_strategy = ClimateStrategy.LOW_LIGHT
-                return self._solar_position()
-            elif self.climate_data.is_summer:
-                self.climate_strategy = ClimateStrategy.SUMMER_COOLING
-                return TiltPolicy.climate_tilt_percentage(
-                    angle_deg=CLIMATE_SUMMER_TILT_ANGLE,
-                    mode=tilt_cover.mode,
-                    gamma_deg=gamma_deg,
-                )
-        # Close for insulation when in winter and sun not hitting window.
-        if self.climate_data.is_winter and self.climate_data.winter_close_insulation:
-            self.climate_strategy = ClimateStrategy.WINTER_INSULATION
-            return POSITION_CLOSED
-        self.climate_strategy = ClimateStrategy.GLARE_CONTROL
-        return TiltPolicy.climate_tilt_percentage(
-            angle_deg=CLIMATE_DEFAULT_TILT_ANGLE,
-            mode=tilt_cover.mode,
-            gamma_deg=gamma_deg,
-        )
+        return cast(int, self._run(TILT_WITH_PRESENCE, tilt=True))
 
     def tilt_without_presence(self) -> int:
         """Climate strategy for tilt covers without occupants."""
-        tilt_cover = cast(AdaptiveTiltCover, self.cover)
-        # SunGeometry.gamma is already in degrees; pass it through unconverted.
-        gamma_deg = float(tilt_cover.gamma)
-        beta = float(np.rad2deg(tilt_cover.beta))
-        if tilt_cover.valid:
-            # Low-light check applies before summer cooling
-            if (
-                self.climate_data.lux
-                or self.climate_data.irradiance
-                or not self.climate_data.is_sunny
-            ):
-                self.climate_strategy = ClimateStrategy.LOW_LIGHT
-                return self._solar_position()
-            if self.climate_data.is_summer:
-                self.climate_strategy = ClimateStrategy.SUMMER_COOLING
-                return POSITION_CLOSED
-            if self.climate_data.is_winter and TiltPolicy.is_mode2(tilt_cover.mode):
-                self.climate_strategy = ClimateStrategy.WINTER_HEATING
-                # MODE2 winter heating opens the slat toward the sun.  Pre-fix
-                # this used a bespoke `(beta + 90) / 180 * 100` formula that
-                # ignored gamma; the helper preserves the positive-hemisphere
-                # answer (passing gamma_deg=0) and centralises the conversion.
-                return TiltPolicy.climate_tilt_percentage(
-                    angle_deg=beta,
-                    mode=tilt_cover.mode,
-                    gamma_deg=0.0,
-                    sun_through=True,
-                )
-            self.climate_strategy = ClimateStrategy.GLARE_CONTROL
-            return TiltPolicy.climate_tilt_percentage(
-                angle_deg=CLIMATE_DEFAULT_TILT_ANGLE,
-                mode=tilt_cover.mode,
-                gamma_deg=gamma_deg,
-            )
-        # Close for insulation when in winter and sun not hitting window.
-        if self.climate_data.is_winter and self.climate_data.winter_close_insulation:
-            self.climate_strategy = ClimateStrategy.WINTER_INSULATION
-            return POSITION_CLOSED
-        self.climate_strategy = ClimateStrategy.GLARE_CONTROL
-        return self._solar_position()
+        return cast(int, self._run(TILT_WITHOUT_PRESENCE, tilt=True))
 
     def tilt_state(self) -> int:
         """Route tilt cover based on presence.

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
@@ -1,0 +1,284 @@
+"""Declarative climate-mode rule tables.
+
+The four climate routers (normal/tilt × presence/no-presence) used to repeat the
+same season-condition expressions (low-light, winter-insulation, winter-heating,
+summer) in slightly different orders. This module factors the shared predicate
+vocabulary into one place (`ClimateContext` properties) and expresses each router
+as an ordered list of `ClimateRule`s evaluated first-match-wins. `ClimateCoverState`
+builds a context and delegates to `evaluate_rules`, preserving the exact branch
+order, `ClimateStrategy` labels, and position outputs of the original code.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from ...const import (
+    CLIMATE_DEFAULT_TILT_ANGLE,
+    CLIMATE_SUMMER_TILT_ANGLE,
+    POSITION_CLOSED,
+    ClimateStrategy,
+)
+from ...cover_types import TiltPolicy
+
+# ---------------------------------------------------------------------------
+# Context: shared predicate vocabulary + the data each position fn may need
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ClimateContext:
+    """Everything the climate rules read, with the season predicates centralised.
+
+    ``data`` is the ``ClimateCoverData``; ``cover`` the engine cover object;
+    ``solar_position`` is the bound ``ClimateCoverState._solar_position``.
+    ``gamma_deg``/``beta_deg`` are precomputed tilt geometry (0.0 for non-tilt
+    covers, which never consult the tilt position fns).
+    """
+
+    data: Any
+    cover: Any
+    default_position: int
+    solar_position: Callable[[], int]
+    gamma_deg: float = 0.0
+    beta_deg: float = 0.0
+
+    # --- shared season predicates (single source of truth) ---
+    @property
+    def cover_valid(self) -> bool:
+        """Whether the cover's geometry/sun calc is currently valid."""
+        return bool(self.cover.valid)
+
+    @property
+    def is_winter(self) -> bool:
+        """Whether the climate data reports a winter (heating) state."""
+        return bool(self.data.is_winter)
+
+    @property
+    def is_summer(self) -> bool:
+        """Whether the climate data reports a summer (cooling) state."""
+        return bool(self.data.is_summer)
+
+    @property
+    def is_low_light(self) -> bool:
+        """Whether lux/irradiance/no-sun indicates there's no real sun to manage."""
+        return bool(self.data.lux or self.data.irradiance or not self.data.is_sunny)
+
+    @property
+    def is_winter_insulation(self) -> bool:
+        """Whether it's winter and the user opted to close for heat retention."""
+        return bool(self.data.is_winter and self.data.winter_close_insulation)
+
+    @property
+    def is_tilt_mode2(self) -> bool:
+        """Whether the tilt cover runs in MODE2 (slat opens toward the sun)."""
+        return bool(TiltPolicy.is_mode2(self.cover.mode))
+
+
+# ---------------------------------------------------------------------------
+# Position functions (what each matched rule returns)
+# ---------------------------------------------------------------------------
+
+
+def _default(ctx: ClimateContext) -> int:
+    return ctx.default_position
+
+
+def _closed(ctx: ClimateContext) -> int:  # noqa: ARG001
+    # 0 is correct for both blinds (lowered) and awnings (retracted).
+    return POSITION_CLOSED
+
+
+def _solar(ctx: ClimateContext) -> int:
+    return ctx.solar_position()
+
+
+def _defer(ctx: ClimateContext) -> None:  # noqa: ARG001
+    # Normal GLARE_CONTROL: pipeline falls through to GlareZone/Solar.
+    return None
+
+
+def _intent_sun_through(ctx: ClimateContext) -> int:
+    return ctx.data.policy.position_for_intent(sun_through=True)
+
+
+def _intent_block_sun(ctx: ClimateContext) -> int:
+    return ctx.data.policy.position_for_intent(sun_through=False)
+
+
+def _tilt_summer(ctx: ClimateContext) -> int:
+    return TiltPolicy.climate_tilt_percentage(
+        angle_deg=CLIMATE_SUMMER_TILT_ANGLE,
+        mode=ctx.cover.mode,
+        gamma_deg=ctx.gamma_deg,
+    )
+
+
+def _tilt_default(ctx: ClimateContext) -> int:
+    return TiltPolicy.climate_tilt_percentage(
+        angle_deg=CLIMATE_DEFAULT_TILT_ANGLE,
+        mode=ctx.cover.mode,
+        gamma_deg=ctx.gamma_deg,
+    )
+
+
+def _tilt_winter_mode2(ctx: ClimateContext) -> int:
+    # MODE2 winter heating opens the slat toward the sun; passing gamma_deg=0.0
+    # preserves the historical positive-hemisphere answer.
+    return TiltPolicy.climate_tilt_percentage(
+        angle_deg=ctx.beta_deg,
+        mode=ctx.cover.mode,
+        gamma_deg=0.0,
+        sun_through=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule + evaluator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class ClimateRule:
+    """One climate branch: when ``predicate`` holds, claim ``strategy`` + ``position``."""
+
+    predicate: Callable[[ClimateContext], bool]
+    strategy: ClimateStrategy
+    position: Callable[[ClimateContext], int | None]
+
+
+def evaluate_rules(
+    rules: tuple[ClimateRule, ...], ctx: ClimateContext
+) -> tuple[ClimateStrategy, int | None]:
+    """Return (strategy, position) for the first matching rule.
+
+    Every table ends with an always-true catch-all, so a match is guaranteed.
+    """
+    for rule in rules:
+        if rule.predicate(ctx):
+            return rule.strategy, rule.position(ctx)
+    raise RuntimeError("climate rule table exhausted without a catch-all")
+
+
+_ALWAYS: Callable[[ClimateContext], bool] = lambda _ctx: True  # noqa: E731
+
+# ---------------------------------------------------------------------------
+# The four rule tables — branch order matches the original routers verbatim
+# ---------------------------------------------------------------------------
+
+# normal_with_presence: winter-heating → winter-insulation → low-light →
+# summer-cooling → glare(defer/None).
+NORMAL_WITH_PRESENCE: tuple[ClimateRule, ...] = (
+    ClimateRule(
+        lambda c: c.is_winter and c.cover_valid,
+        ClimateStrategy.WINTER_HEATING,
+        _intent_sun_through,
+    ),
+    ClimateRule(
+        lambda c: c.is_winter_insulation,
+        ClimateStrategy.WINTER_INSULATION,
+        _closed,
+    ),
+    ClimateRule(
+        lambda c: c.is_low_light,
+        ClimateStrategy.LOW_LIGHT,
+        _default,
+    ),
+    ClimateRule(
+        lambda c: c.is_summer and c.data.transparent_blind and c.cover_valid,
+        ClimateStrategy.SUMMER_COOLING,
+        _intent_block_sun,
+    ),
+    ClimateRule(_ALWAYS, ClimateStrategy.GLARE_CONTROL, _defer),
+)
+
+# normal_without_presence: inside cover.valid → low-light → summer → winter;
+# then winter-insulation; else low-light(default). Each valid-block rule carries
+# the cover_valid guard so the flat order matches the nested original.
+NORMAL_WITHOUT_PRESENCE: tuple[ClimateRule, ...] = (
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_low_light,
+        ClimateStrategy.LOW_LIGHT,
+        _default,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_summer,
+        ClimateStrategy.SUMMER_COOLING,
+        _intent_block_sun,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_winter,
+        ClimateStrategy.WINTER_HEATING,
+        _intent_sun_through,
+    ),
+    ClimateRule(
+        lambda c: c.is_winter_insulation,
+        ClimateStrategy.WINTER_INSULATION,
+        _closed,
+    ),
+    ClimateRule(_ALWAYS, ClimateStrategy.LOW_LIGHT, _default),
+)
+
+# tilt_with_presence: inside cover.valid (and only when NOT both-seasons, the
+# original's defensive `if is_summer and is_winter: pass`) → winter → low-light →
+# summer; then winter-insulation; else glare(tilt default). Seasons are mutually
+# exclusive in practice; the not-both guards preserve the misconfig fall-through.
+TILT_WITH_PRESENCE: tuple[ClimateRule, ...] = (
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_winter and not c.is_summer,
+        ClimateStrategy.WINTER_HEATING,
+        _solar,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid
+        and not (c.is_summer and c.is_winter)
+        and c.is_low_light,
+        ClimateStrategy.LOW_LIGHT,
+        _solar,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_summer and not c.is_winter,
+        ClimateStrategy.SUMMER_COOLING,
+        _tilt_summer,
+    ),
+    ClimateRule(
+        lambda c: c.is_winter_insulation,
+        ClimateStrategy.WINTER_INSULATION,
+        _closed,
+    ),
+    ClimateRule(_ALWAYS, ClimateStrategy.GLARE_CONTROL, _tilt_default),
+)
+
+# tilt_without_presence: inside cover.valid → low-light → summer(closed) →
+# winter+mode2 → glare(tilt default, the valid-block catch-all); then
+# winter-insulation; else glare(solar).
+TILT_WITHOUT_PRESENCE: tuple[ClimateRule, ...] = (
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_low_light,
+        ClimateStrategy.LOW_LIGHT,
+        _solar,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_summer,
+        ClimateStrategy.SUMMER_COOLING,
+        _closed,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid and c.is_winter and c.is_tilt_mode2,
+        ClimateStrategy.WINTER_HEATING,
+        _tilt_winter_mode2,
+    ),
+    ClimateRule(
+        lambda c: c.cover_valid,
+        ClimateStrategy.GLARE_CONTROL,
+        _tilt_default,
+    ),
+    ClimateRule(
+        lambda c: c.is_winter_insulation,
+        ClimateStrategy.WINTER_INSULATION,
+        _closed,
+    ),
+    ClimateRule(_ALWAYS, ClimateStrategy.GLARE_CONTROL, _solar),
+)

--- a/tests/test_climate_modes.py
+++ b/tests/test_climate_modes.py
@@ -1,0 +1,168 @@
+"""Unit tests for the climate-mode rule tables and shared predicates."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import ClimateStrategy
+from custom_components.adaptive_cover_pro.pipeline.handlers.climate_modes import (
+    NORMAL_WITH_PRESENCE,
+    NORMAL_WITHOUT_PRESENCE,
+    TILT_WITH_PRESENCE,
+    TILT_WITHOUT_PRESENCE,
+    ClimateContext,
+    ClimateRule,
+    evaluate_rules,
+)
+
+ALL_TABLES = [
+    NORMAL_WITH_PRESENCE,
+    NORMAL_WITHOUT_PRESENCE,
+    TILT_WITH_PRESENCE,
+    TILT_WITHOUT_PRESENCE,
+]
+
+
+def _ctx(
+    *,
+    valid=True,
+    is_winter=False,
+    is_summer=False,
+    lux=False,
+    irradiance=False,
+    is_sunny=True,
+    winter_close_insulation=False,
+    transparent_blind=False,
+    default_position=50,
+):
+    """Build a ClimateContext over a normal (non-tilt) cover with a mock policy."""
+    policy = MagicMock()
+    policy.position_for_intent.side_effect = lambda sun_through: (
+        "intent_open" if sun_through else "intent_block"
+    )
+    data = SimpleNamespace(
+        is_winter=is_winter,
+        is_summer=is_summer,
+        lux=lux,
+        irradiance=irradiance,
+        is_sunny=is_sunny,
+        winter_close_insulation=winter_close_insulation,
+        transparent_blind=transparent_blind,
+        policy=policy,
+    )
+    cover = SimpleNamespace(valid=valid, mode=None)
+    return ClimateContext(
+        data=data,
+        cover=cover,
+        default_position=default_position,
+        solar_position=lambda: "solar",
+    )
+
+
+# --- predicates ------------------------------------------------------------
+
+
+def test_is_low_light_any_signal():
+    assert _ctx(lux=True).is_low_light
+    assert _ctx(irradiance=True).is_low_light
+    assert _ctx(is_sunny=False).is_low_light
+    assert not _ctx().is_low_light
+
+
+def test_is_winter_insulation_requires_both():
+    assert _ctx(is_winter=True, winter_close_insulation=True).is_winter_insulation
+    assert not _ctx(is_winter=True, winter_close_insulation=False).is_winter_insulation
+    assert not _ctx(is_winter=False, winter_close_insulation=True).is_winter_insulation
+
+
+# --- evaluate_rules mechanics ---------------------------------------------
+
+
+def test_evaluate_rules_first_match_wins():
+    rules = (
+        ClimateRule(lambda c: False, ClimateStrategy.WINTER_HEATING, lambda c: 1),
+        ClimateRule(lambda c: True, ClimateStrategy.LOW_LIGHT, lambda c: 2),
+        ClimateRule(lambda c: True, ClimateStrategy.GLARE_CONTROL, lambda c: 3),
+    )
+    assert evaluate_rules(rules, _ctx()) == (ClimateStrategy.LOW_LIGHT, 2)
+
+
+def test_evaluate_rules_raises_without_catch_all():
+    rules = (ClimateRule(lambda c: False, ClimateStrategy.LOW_LIGHT, lambda c: 1),)
+    with pytest.raises(RuntimeError):
+        evaluate_rules(rules, _ctx())
+
+
+@pytest.mark.parametrize("table", ALL_TABLES)
+def test_every_table_ends_with_catch_all(table):
+    assert table[-1].predicate(_ctx()) is True
+
+
+# --- NORMAL_WITH_PRESENCE rows --------------------------------------------
+
+
+def test_nwp_winter_heating():
+    s, p = evaluate_rules(NORMAL_WITH_PRESENCE, _ctx(is_winter=True, valid=True))
+    assert s == ClimateStrategy.WINTER_HEATING
+    assert p == "intent_open"
+
+
+def test_nwp_winter_insulation_when_not_valid():
+    s, p = evaluate_rules(
+        NORMAL_WITH_PRESENCE,
+        _ctx(is_winter=True, valid=False, winter_close_insulation=True),
+    )
+    assert s == ClimateStrategy.WINTER_INSULATION
+    assert p == 0
+
+
+def test_nwp_low_light_returns_default():
+    s, p = evaluate_rules(NORMAL_WITH_PRESENCE, _ctx(lux=True, default_position=42))
+    assert s == ClimateStrategy.LOW_LIGHT
+    assert p == 42
+
+
+def test_nwp_summer_cooling_requires_transparent_and_valid():
+    s, p = evaluate_rules(
+        NORMAL_WITH_PRESENCE,
+        _ctx(is_summer=True, transparent_blind=True, valid=True),
+    )
+    assert s == ClimateStrategy.SUMMER_COOLING
+    assert p == "intent_block"
+
+
+def test_nwp_glare_defers_to_none():
+    # sunny, not winter/summer, valid → falls through to glare-control / defer
+    s, p = evaluate_rules(NORMAL_WITH_PRESENCE, _ctx())
+    assert s == ClimateStrategy.GLARE_CONTROL
+    assert p is None
+
+
+# --- NORMAL_WITHOUT_PRESENCE rows -----------------------------------------
+
+
+def test_nwop_low_light_first_inside_valid():
+    s, p = evaluate_rules(
+        NORMAL_WITHOUT_PRESENCE, _ctx(valid=True, lux=True, default_position=30)
+    )
+    assert s == ClimateStrategy.LOW_LIGHT
+    assert p == 30
+
+
+def test_nwop_summer_then_winter_order():
+    s, _ = evaluate_rules(NORMAL_WITHOUT_PRESENCE, _ctx(valid=True, is_summer=True))
+    assert s == ClimateStrategy.SUMMER_COOLING
+    s, _ = evaluate_rules(NORMAL_WITHOUT_PRESENCE, _ctx(valid=True, is_winter=True))
+    assert s == ClimateStrategy.WINTER_HEATING
+
+
+def test_nwop_fallthrough_low_light_default():
+    # not valid, not winter → final catch-all LOW_LIGHT/default
+    s, p = evaluate_rules(
+        NORMAL_WITHOUT_PRESENCE, _ctx(valid=False, default_position=55)
+    )
+    assert s == ClimateStrategy.LOW_LIGHT
+    assert p == 55

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -216,9 +216,9 @@ def test_build_pipeline_custom_position_priority_fallback():
     """_build_pipeline uses DEFAULT_CUSTOM_POSITION_PRIORITY when priority config is falsy."""
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
-        DEFAULT_CUSTOM_POSITION_PRIORITY,
     )
     from custom_components.adaptive_cover_pro.const import (
+        DEFAULT_CUSTOM_POSITION_PRIORITY,
         CONF_CUSTOM_POSITION_SENSOR_1,
         CONF_CUSTOM_POSITION_1,
         CONF_CUSTOM_POSITION_PRIORITY_1,
@@ -299,9 +299,9 @@ def test_read_custom_position_sensor_states_with_priority_fallback():
     """_read_custom_position_sensor_states uses default priority when config is falsy."""
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
-        DEFAULT_CUSTOM_POSITION_PRIORITY,
     )
     from custom_components.adaptive_cover_pro.const import (
+        DEFAULT_CUSTOM_POSITION_PRIORITY,
         CONF_CUSTOM_POSITION_SENSOR_1,
         CONF_CUSTOM_POSITION_1,
         CONF_CUSTOM_POSITION_PRIORITY_1,

--- a/tests/test_issue_293_force_true_auto_off.py
+++ b/tests/test_issue_293_force_true_auto_off.py
@@ -146,7 +146,12 @@ async def test_full_repro_user_recovery_observed():
 
     await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(coord, 50)
 
-    # Manual override must register, and discard_target must clear the latched
-    # target so reconciliation cannot resurrect it.
+    # Manual override observation must register even with auto_control=False.
+    # The latched-target discard now fires from the manager's on_engaged edge
+    # callback (wired to cmd_svc.discard_target) rather than this loop — see
+    # test_issue_293_state_change_observed_when_auto_off and the #215 test for
+    # the engine-level discard verification.
     coord.manager.handle_state_change.assert_called_once()
-    coord._cmd_svc.discard_target.assert_called_once_with("cover.awning")
+    assert (
+        coord.manager.handle_state_change.call_args.args[0].entity_id == "cover.awning"
+    )

--- a/tests/test_issue_293_state_change_observed_when_auto_off.py
+++ b/tests/test_issue_293_state_change_observed_when_auto_off.py
@@ -72,18 +72,48 @@ async def test_discard_target_called_when_observation_flips_to_manual():
     """When observation registers a manual override, latched target must be cleared.
 
     Without this, the unwanted force=True command's target_call would persist
-    and reconciliation could resurrect it.
+    and reconciliation could resurrect it. The discard now fires from the
+    manager's ``on_engaged`` edge callback (wired to ``cmd_svc.discard_target``),
+    so this drives a real engine and asserts the relocated seam.
     """
-    coord = _make_coord_auto_off()
-    coord.manager = MagicMock()
-    # is_cover_manual returns False (was_manual) before handle_state_change,
-    # then True (became manual) after — simulate via side_effect.
-    coord.manager.is_cover_manual.side_effect = [False, True]
-    coord._pending_cover_events = [_event("cover.a", 30)]
+    from custom_components.adaptive_cover_pro.managers.manual_override import (
+        AdaptiveCoverManager,
+    )
 
-    await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(coord, 50)
+    cmd_svc = MagicMock()
+    entity_id = "cover.a"
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration={"hours": 2},
+        logger=MagicMock(),
+        on_engaged=cmd_svc.discard_target,
+    )
+    manager.add_covers([entity_id])
 
-    coord._cmd_svc.discard_target.assert_called_once_with("cover.a")
+    # User moved the cover to 30 against the latched target of 100.
+    policy = MagicMock()
+    policy.read_axis_value.return_value = 30
+    policy.primary_axis_suppression.return_value = False
+
+    event = _event(entity_id, 30)
+    event.old_state = MagicMock()
+    event.new_state.state = "open"
+    event.new_state.context = None
+    event.new_state.last_updated = "2026-05-10T20:42:00+00:00"
+
+    manager.handle_state_change(
+        event,
+        100,  # latched target
+        policy,
+        False,  # allow_reset
+        lambda _e: False,  # is_waiting
+        5,  # manual_threshold
+        is_in_command_grace=lambda _e: False,
+        is_in_transit=lambda _e: False,
+    )
+
+    assert manager.is_cover_manual(entity_id)
+    cmd_svc.discard_target.assert_called_once_with(entity_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_managers/stub_detector.py
+++ b/tests/test_managers/stub_detector.py
@@ -1,0 +1,60 @@
+"""Minimal OverrideDetector stub for contract and engine-wiring tests.
+
+Mirrors the ``stub_policy`` pattern under ``tests/test_cover_types``: the
+smallest legal detector, used to prove the engine drives *any* detector the
+same way and that the registry/contract holds for future patterns.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from custom_components.adaptive_cover_pro.managers.manual_override import (
+    DetectionContext,
+    OverrideDecision,
+    OverrideDetector,
+)
+
+
+class StubDetector(OverrideDetector):
+    """A detector that optionally always marks, and records lifecycle calls."""
+
+    strategy_id: ClassVar[str] = "stub"
+
+    def __init__(self, *, force_mark: bool = False) -> None:
+        """Initialise; ``force_mark`` makes ``detect`` always mark manual."""
+        self._force_mark = force_mark
+        self.commands: list[str] = []
+        self.marked: list[str] = []
+        self.resets: list[str] = []
+        self.added: list = []
+
+    def detect(self, context: DetectionContext) -> OverrideDecision:
+        """Mark manual when configured to, otherwise no opinion."""
+        if self._force_mark:
+            return OverrideDecision(
+                mark_manual=True,
+                event_name="manual_override_set",
+                event_kwargs={
+                    "our_state": context.our_state,
+                    "new_position": context.new_position,
+                    "reason": "stub forced",
+                },
+            )
+        return OverrideDecision()
+
+    def note_command_sent(self, entity_id, now) -> None:  # noqa: ARG002
+        """Record that a command was noted."""
+        self.commands.append(entity_id)
+
+    def on_marked(self, entity_id) -> None:
+        """Record a mark transition."""
+        self.marked.append(entity_id)
+
+    def on_reset(self, entity_id) -> None:
+        """Record a reset."""
+        self.resets.append(entity_id)
+
+    def on_covers_added(self, entities) -> None:
+        """Record covers added."""
+        self.added.append(entities)

--- a/tests/test_managers/test_event_recorder.py
+++ b/tests/test_managers/test_event_recorder.py
@@ -1,0 +1,49 @@
+"""Tests for the shared EventRecorder helper."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from custom_components.adaptive_cover_pro.managers.common import EventRecorder
+
+
+class _FakeBuffer:
+    def __init__(self) -> None:
+        self.records: list[dict] = []
+
+    def record(self, event: dict) -> None:
+        self.records.append(event)
+
+
+def test_record_stamps_ts_and_event_and_fields():
+    buf = _FakeBuffer()
+    rec = EventRecorder(buf)
+    rec.record("something_happened", entity_id="cover.a", count=3)
+    assert len(buf.records) == 1
+    event = buf.records[0]
+    assert event["event"] == "something_happened"
+    assert event["entity_id"] == "cover.a"
+    assert event["count"] == 3
+    # ts is an ISO-8601 string parseable back to a datetime
+    assert isinstance(event["ts"], str)
+    dt.datetime.fromisoformat(event["ts"])
+
+
+def test_record_is_noop_without_buffer():
+    rec = EventRecorder(None)
+    # must not raise
+    rec.record("ignored", foo="bar")
+
+
+def test_custom_now_fn_drives_ts():
+    buf = _FakeBuffer()
+    fixed = dt.datetime(2026, 6, 4, 12, 0, 0, tzinfo=dt.UTC)
+    rec = EventRecorder(buf, now_fn=lambda: fixed)
+    rec.record("clocked")
+    assert buf.records[0]["ts"] == fixed.isoformat()
+
+
+def test_fields_only_no_extra_keys():
+    buf = _FakeBuffer()
+    EventRecorder(buf).record("bare")
+    assert set(buf.records[0]) == {"ts", "event"}

--- a/tests/test_managers/test_override_detector.py
+++ b/tests/test_managers/test_override_detector.py
@@ -1,0 +1,369 @@
+"""Tests for the pluggable manual-override detector subsystem.
+
+Covers the detector ABC contract + registry, the two shipped detectors as pure
+units, the default channel decisions, and the engine wiring (edge callbacks,
+command-timing clock, runtime config).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.manual_override import (
+    DETECTOR_REGISTRY,
+    AdaptiveCoverManager,
+    DetectionContext,
+    DetectorConfig,
+    OverrideDecision,
+    OverrideDetector,
+    PositionDeltaDetector,
+    StopToMy,
+    TimeWindowDetector,
+    UserContextChange,
+    default_stop_to_my_decision,
+    default_user_context_decision,
+    get_detector,
+)
+
+from .stub_detector import StubDetector
+
+
+def _ctx(
+    *,
+    our_state: int = 50,
+    new_position: int | None = 50,
+    manual_threshold: int | None = 5,
+    is_in_transit: bool = False,
+    primary_suppress: bool = False,
+    seconds_since_command: float | None = None,
+    new_state_str: str = "open",
+) -> DetectionContext:
+    """Build a DetectionContext for pure-unit detector tests."""
+    policy = MagicMock()
+    policy.primary_axis_suppression.return_value = primary_suppress
+    new_state = MagicMock()
+    new_state.state = new_state_str
+    return DetectionContext(
+        entity_id="cover.x",
+        our_state=our_state,
+        new_state=new_state,
+        old_state=None,
+        new_position=new_position,
+        caps=MagicMock(),
+        policy=policy,
+        manual_threshold=manual_threshold,
+        allow_reset=True,
+        is_acp_context=False,
+        context_user_id=None,
+        context_id=None,
+        seconds_since_command=seconds_since_command,
+        secondary_axis_check=None,
+        is_waiting=lambda _e: False,
+        is_in_command_grace=lambda _e: False,
+        is_in_transit=lambda _e: is_in_transit,
+        now=dt.datetime.now(dt.UTC),
+    )
+
+
+def _config(*, command_window_seconds: float = 45.0) -> DetectorConfig:
+    return DetectorConfig(
+        manual_threshold=5,
+        command_window_seconds=command_window_seconds,
+        reset=False,
+        duration={"hours": 2},
+        ignore_external=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry + ABC contract (parametrized over every registered detector + stub)
+# ---------------------------------------------------------------------------
+
+ALL_DETECTORS = [*DETECTOR_REGISTRY.values(), StubDetector]
+
+
+def test_registry_is_non_empty_and_well_formed():
+    assert DETECTOR_REGISTRY
+    for strategy_id, cls in DETECTOR_REGISTRY.items():
+        assert issubclass(cls, OverrideDetector)
+        assert cls.strategy_id == strategy_id
+        assert isinstance(strategy_id, str)
+
+
+@pytest.mark.parametrize("cls", ALL_DETECTORS, ids=lambda c: c.strategy_id)
+def test_detect_returns_decision_and_never_raises_on_none_position(cls):
+    detector = cls()
+    decision = detector.detect(_ctx(new_position=None))
+    assert isinstance(decision, OverrideDecision)
+
+
+def test_get_detector_selects_by_id():
+    cfg = _config()
+    assert isinstance(get_detector("position_delta", cfg), PositionDeltaDetector)
+    assert isinstance(get_detector("time_window", cfg), TimeWindowDetector)
+
+
+def test_get_detector_falls_back_to_default_for_missing_or_unknown():
+    cfg = _config()
+    assert isinstance(get_detector(None, cfg), PositionDeltaDetector)
+    assert isinstance(get_detector("does-not-exist", cfg), PositionDeltaDetector)
+
+
+def test_time_window_from_config_takes_window_from_command_window_seconds():
+    detector = get_detector("time_window", _config(command_window_seconds=90.0))
+    assert isinstance(detector, TimeWindowDetector)
+    # within a 90s window, a movement is rejected (not manual)
+    decision = detector.detect(
+        _ctx(our_state=100, new_position=0, seconds_since_command=30.0)
+    )
+    assert decision.mark_manual is False
+    assert decision.event_name == "manual_override_rejected_command_window"
+
+
+# ---------------------------------------------------------------------------
+# PositionDeltaDetector — pure unit per gate
+# ---------------------------------------------------------------------------
+
+
+def test_position_delta_unavailable():
+    d = PositionDeltaDetector().detect(_ctx(new_position=None))
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_position_unavailable"
+
+
+def test_position_delta_in_transit():
+    d = PositionDeltaDetector().detect(
+        _ctx(our_state=50, new_position=90, is_in_transit=True, new_state_str="opening")
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_in_transit"
+    assert "opening" in d.event_kwargs["reason"]
+
+
+def test_position_delta_primary_axis_suppression():
+    d = PositionDeltaDetector().detect(
+        _ctx(our_state=50, new_position=90, primary_suppress=True)
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_primary_axis_suppression"
+    assert d.record_primary_axis_suppression is True
+    assert d.suppression_delta == 40.0
+
+
+def test_position_delta_within_threshold():
+    d = PositionDeltaDetector().detect(
+        _ctx(our_state=50, new_position=52, manual_threshold=5)
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_within_threshold"
+
+
+def test_position_delta_over_threshold_marks():
+    d = PositionDeltaDetector().detect(
+        _ctx(our_state=50, new_position=80, manual_threshold=5)
+    )
+    assert d.mark_manual is True
+    assert d.event_name == "manual_override_set"
+
+
+def test_position_delta_equal_is_noop():
+    d = PositionDeltaDetector().detect(_ctx(our_state=50, new_position=50))
+    assert d == OverrideDecision()
+
+
+def test_position_delta_threshold_floored_at_tolerance():
+    # user threshold 0 → floored at POSITION_TOLERANCE_PERCENT (3); delta 3 within
+    d = PositionDeltaDetector().detect(
+        _ctx(our_state=37, new_position=34, manual_threshold=0)
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_within_threshold"
+
+
+# ---------------------------------------------------------------------------
+# TimeWindowDetector — pure unit
+# ---------------------------------------------------------------------------
+
+
+def test_time_window_within_window_rejects():
+    d = TimeWindowDetector(window_seconds=60).detect(
+        _ctx(our_state=100, new_position=0, seconds_since_command=10.0)
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_command_window"
+
+
+def test_time_window_after_window_marks_movement():
+    d = TimeWindowDetector(window_seconds=60).detect(
+        _ctx(our_state=100, new_position=0, seconds_since_command=120.0)
+    )
+    assert d.mark_manual is True
+    assert d.event_name == "manual_override_set"
+
+
+def test_time_window_no_command_recorded_marks_movement():
+    d = TimeWindowDetector(window_seconds=60).detect(
+        _ctx(our_state=100, new_position=0, seconds_since_command=None)
+    )
+    assert d.mark_manual is True
+
+
+def test_time_window_equal_position_is_noop():
+    d = TimeWindowDetector(window_seconds=60).detect(
+        _ctx(our_state=50, new_position=50, seconds_since_command=120.0)
+    )
+    assert d == OverrideDecision()
+
+
+def test_time_window_unavailable():
+    d = TimeWindowDetector(window_seconds=60).detect(_ctx(new_position=None))
+    assert d.event_name == "manual_override_rejected_position_unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Default channel decisions
+# ---------------------------------------------------------------------------
+
+
+def test_default_user_context_decision_marks():
+    d = default_user_context_decision(
+        UserContextChange(
+            entity_id="cover.x",
+            new_state=MagicMock(),
+            allow_reset=True,
+            context_user_id="holly",
+            context_id="ctx-1",
+        )
+    )
+    assert d.mark_manual is True
+    assert d.event_name == "manual_override_set"
+    assert "holly" in d.event_kwargs["reason"]
+
+
+def test_default_stop_to_my_decision_marks_when_not_waiting():
+    d = default_stop_to_my_decision(
+        StopToMy(entity_id="cover.x", my_position_value=40, is_waiting=lambda _e: False)
+    )
+    assert d is not None
+    assert d.mark_manual is True
+    assert d.event_kwargs["our_state"] == 40
+
+
+def test_default_stop_to_my_decision_declines_when_waiting():
+    d = default_stop_to_my_decision(
+        StopToMy(entity_id="cover.x", my_position_value=40, is_waiting=lambda _e: True)
+    )
+    assert d is None
+
+
+# ---------------------------------------------------------------------------
+# Engine wiring: edge callbacks, command clock, runtime config
+# ---------------------------------------------------------------------------
+
+
+def _engine(*, detector, on_engaged=None, on_cleared=None) -> AdaptiveCoverManager:
+    mgr = AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration={"hours": 2},
+        logger=MagicMock(),
+        detector=detector,
+        on_engaged=on_engaged,
+        on_cleared=on_cleared,
+    )
+    mgr.add_covers(["cover.a"])
+    return mgr
+
+
+def _drive(mgr, *, our_state=100, new_position=0):
+    policy = MagicMock()
+    policy.read_axis_value.return_value = new_position
+    policy.primary_axis_suppression.return_value = False
+    event = MagicMock()
+    event.entity_id = "cover.a"
+    event.old_state = MagicMock()
+    event.new_state = MagicMock()
+    event.new_state.state = "open"
+    event.new_state.attributes = {}
+    event.new_state.context = None
+    event.new_state.last_updated = dt.datetime.now(dt.UTC)
+    mgr.handle_state_change(
+        event,
+        our_state,
+        policy,
+        False,
+        lambda _e: False,
+        5,
+        is_in_command_grace=lambda _e: False,
+        is_in_transit=lambda _e: False,
+    )
+
+
+def test_on_engaged_fires_once_on_edge_only():
+    engaged: list[str] = []
+    mgr = _engine(detector=StubDetector(force_mark=True), on_engaged=engaged.append)
+    _drive(mgr)
+    assert mgr.is_cover_manual("cover.a")
+    assert engaged == ["cover.a"]
+    # second detection on an already-manual cover does not re-fire the edge
+    _drive(mgr)
+    assert engaged == ["cover.a"]
+
+
+def test_on_engaged_not_fired_by_mark_user_command():
+    engaged: list[str] = []
+    mgr = _engine(detector=StubDetector(), on_engaged=engaged.append)
+    mgr.mark_user_command("cover.a", reason="set_position")
+    assert mgr.is_cover_manual("cover.a")
+    assert engaged == []
+
+
+def test_on_cleared_fires_on_reset():
+    cleared: list[list[str]] = []
+    detector = StubDetector(force_mark=True)
+    mgr = _engine(detector=detector, on_cleared=cleared.append)
+    _drive(mgr)
+    mgr.reset("cover.a")
+    assert cleared == [["cover.a"]]
+    assert detector.resets == ["cover.a"]
+
+
+def test_note_command_sent_feeds_seconds_since_command():
+    # Without a recorded command, a movement is manual (no window).
+    mgr1 = _engine(detector=TimeWindowDetector(window_seconds=60))
+    _drive(mgr1)
+    assert mgr1.is_cover_manual("cover.a")
+
+    # After note_command_sent, the same movement is within the window → ignored.
+    mgr2 = _engine(detector=TimeWindowDetector(window_seconds=60))
+    mgr2.note_command_sent("cover.a")
+    _drive(mgr2)
+    assert not mgr2.is_cover_manual("cover.a")
+
+
+def test_update_config_reapplies_reset_duration():
+    mgr = _engine(detector=StubDetector())
+    assert mgr.reset_duration == dt.timedelta(hours=2)
+    mgr.update_config(
+        DetectorConfig(
+            manual_threshold=5,
+            command_window_seconds=45.0,
+            reset=False,
+            duration={"seconds": 1},
+            ignore_external=False,
+        )
+    )
+    assert mgr.reset_duration == dt.timedelta(seconds=1)
+
+
+def test_add_covers_notifies_detector():
+    detector = StubDetector()
+    AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration={"hours": 2},
+        logger=MagicMock(),
+        detector=detector,
+    ).add_covers(["cover.a", "cover.b"])
+    assert detector.added == [["cover.a", "cover.b"]]

--- a/tests/test_manual_override_user_context.py
+++ b/tests/test_manual_override_user_context.py
@@ -289,9 +289,6 @@ async def test_user_context_fast_path_marks_override_for_user_event():
 
     entity_id = "cover.patio_awning"
     coordinator = _make_coordinator(entity_id=entity_id, target=0)
-    # is_cover_manual: False before the fast-path, True after (simulating that
-    # handle_user_initiated_state_change marked the cover).
-    coordinator.manager.is_cover_manual = MagicMock(side_effect=[False, True])
     event_data = _make_state_change_data(
         entity_id,
         new_state_value="open",
@@ -310,8 +307,10 @@ async def test_user_context_fast_path_marks_override_for_user_event():
     assert call.kwargs["context_id"] == "ctx-holly-open-1"
     # Existing position-math path was NOT called
     coordinator.manager.handle_state_change.assert_not_called()
-    # And the latched target was discarded so reconciliation stops fighting
-    coordinator._cmd_svc.discard_target.assert_called_once_with(entity_id)
+    # The latched target is now discarded inside the manager's on_engaged edge
+    # callback (wired to _cmd_svc.discard_target), not by the coordinator, so it
+    # is no longer asserted at this seam — see test_override_detector for the
+    # engine-level edge behavior.
 
 
 @pytest.mark.asyncio

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -822,48 +822,57 @@ class TestIssue215StaleSafetyTarget:
         2. User manually closes at 20:42 (manual override starts)
         3. At step 2, discard_target() must clear the 100% safety target
         4. At 23:46 when override expires, nothing for reconcile to resend
+
+        The discard now lives in the manager's ``on_engaged`` edge callback
+        (wired by the coordinator to ``cmd_svc.discard_target``) rather than in
+        the coordinator's state-change loop, so this verifies the relocated
+        seam directly on a real engine.
         """
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            AdaptiveCoverManager,
         )
 
         cmd_svc = MagicMock()
         cmd_svc.discard_target = MagicMock()
 
-        coordinator = MagicMock()
-        coordinator.manual_toggle = True
-        coordinator.automatic_control = True
-        coordinator.manual_ignore_external = False
-        coordinator._is_in_startup_grace_period = MagicMock(return_value=False)
-        coordinator._target_just_reached = set()
-        coordinator._cmd_svc = cmd_svc
-        coordinator.logger = MagicMock()
-        coordinator._cover_type = "cover_blind"
-        coordinator.manual_reset = True
-        coordinator.manual_threshold = 5.0
-        coordinator._pending_cover_events = []
-        coordinator.cover_state_change = True
+        entity_id = "cover.smart_plug_in_unit"
+        manager = AdaptiveCoverManager(
+            hass=MagicMock(),
+            reset_duration={"hours": 2},
+            logger=MagicMock(),
+            on_engaged=cmd_svc.discard_target,
+        )
+        manager.add_covers([entity_id])
 
-        # Manager: entity is NOT yet in manual override, then IS after
-        manager = MagicMock()
-        manager.is_cover_manual.side_effect = [
-            False,  # was_manual check (before handle_state_change)
-            True,  # is_cover_manual check (after handle_state_change)
-        ]
-        manager.handle_state_change = MagicMock()
-        coordinator.manager = manager
+        # Policy reports the user-moved position (0) against the commanded
+        # safety target (100): a delta well past the threshold.
+        policy = MagicMock()
+        policy.read_axis_value.return_value = 0
+        policy.primary_axis_suppression.return_value = False
 
-        # Inject one fake state-change event representing user closing at 20:42
         event_data = MagicMock()
-        event_data.entity_id = "cover.smart_plug_in_unit"
-        coordinator._pending_cover_events = [event_data]
-        coordinator.cover_state_change = False  # method sets this flag
+        event_data.entity_id = entity_id
+        event_data.old_state = MagicMock()
+        new_state = MagicMock()
+        new_state.state = "open"
+        new_state.attributes = {}
+        new_state.context = None
+        new_state.last_updated = "2026-05-10T20:42:00+00:00"
+        event_data.new_state = new_state
 
-        await AdaptiveDataUpdateCoordinator.async_handle_cover_state_change(
-            coordinator, state=100
+        manager.handle_state_change(
+            event_data,
+            100,  # commanded safety target
+            policy,
+            True,  # allow_reset
+            lambda _e: False,  # is_waiting
+            5,  # manual_threshold
+            is_in_command_grace=lambda _e: False,
+            is_in_transit=lambda _e: False,
         )
 
-        cmd_svc.discard_target.assert_called_once_with("cover.smart_plug_in_unit")
+        assert manager.is_cover_manual(entity_id)
+        cmd_svc.discard_target.assert_called_once_with(entity_id)
 
     def test_reconcile_skips_after_manual_override_discards_target(self):
         """After discard_target() the entity has no target_call entry, so


### PR DESCRIPTION
## Summary

Four self-contained abstraction refactors, each behaviour-identical and independently committed.

**1. Pluggable manual-override detection engine** (`e09ec65`)
Extracts detection behind an `OverrideDetector` ABC so a new detection pattern is a drop-in (one file + one registry line) with no coordinator edits. `managers/manual_override.py` becomes a package: detector ABC + `DetectionContext`/`OverrideDecision`, `PositionDeltaDetector` (default, today's exact logic), `TimeWindowDetector` (pure time-based, window from `transit_timeout`), and a registry mirroring `get_policy()`. The engine owns state and routes all channels through the active detector, firing `on_engaged`/`on_cleared` edge callbacks so `discard_target` wires once — removing three hand-rolled coordinator sites. Adds `note_command_sent` clocking and runtime `update_config` (fixes the frozen-`reset_duration` reload limitation). Selection via `CONF_MANUAL_OVERRIDE_STRATEGY`, default `position_delta`.

**2. Shared `EventRecorder`** (`d0a08f1`)
Extracts the repeated `{"ts", "event", ...}` dict + `buffer.record` into `managers/common/EventRecorder`. Motion / weather / grace-period / time-window and the manual-override engine delegate to it, dropping ~10 duplicated sites and the per-site `None`-buffer guards. MotionManager injects its mockable clock via `now_fn` so timestamps are unchanged.

**3. Climate-mode strategy via rule tables** (`a56dedd`)
Replaces the four parallel `ClimateCoverState` routers — which repeated the same season-condition expressions in different orders — with declarative `ClimateRule` tables sharing one predicate vocabulary (`ClimateContext`), evaluated first-match-wins. Router methods become thin delegators, so existing climate unit tests pass unedited. Branch order, `ClimateStrategy` labels, and tilt geometry formulas (incl. the defensive both-seasons fall-through) preserved verbatim.

**4. Registry-driven pipeline handler composition** (`1561205`)
Moves handler-list construction out of `coordinator._build_pipeline()` into a `HANDLER_FACTORIES` registry + `build_handlers()` in `pipeline.handlers`. Adding a handler is now one registry entry with no coordinator edit. `_build_pipeline()` stays as a thin delegator; priority remains the handler class attribute.

## Testing
- ✅ 3840 tests passing (`pytest tests/ -n auto`)
- ✅ `ruff` + `black` clean
- New focused suites: `test_override_detector`, `test_event_recorder`, `test_climate_modes`
- Existing suites are the parity net — behaviour-identical refactors; a few tests asserting relocated internals were updated to the new seams

## Related Issues
None — internal refactors / abstraction passes.
