### PR TITLE
fix: surface dry-run, housing offset, back-rotate lag in config summary

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1008,6 +1008,17 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
 
     lines: list[str] = []
 
+    # Dry-run banner — surfaced first because it overrides everything below: when
+    # on, the full decision chain is still computed and logged but no commands are
+    # sent, so covers never move. Without this the summary reads as if it drives
+    # covers regardless of the dry-run toggle on the Debug screen.
+    if config.get(CONF_DRY_RUN):
+        lines.append(
+            "⚠️ **Dry-run mode is ON** — positions are computed and logged, but "
+            "no commands are sent and covers will NOT move."
+        )
+        lines.append("")
+
     # =========================================================================
     # Section 1: Your Cover
     # =========================================================================
@@ -1464,6 +1475,9 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         limit_parts.append(f"Min change: {delta_pos}%")
     if delta_time is not None:
         limit_parts.append(f"Min interval: {delta_time} min")
+    pos_tol = config.get(CONF_POSITION_TOLERANCE)
+    if pos_tol is not None:
+        limit_parts.append(f"Position tolerance: {pos_tol}%")
     if config.get(CONF_INVERSE_STATE):
         limit_parts.append("Inverse state")
     oc_thresh = config.get(CONF_OPEN_CLOSE_THRESHOLD)
@@ -1553,7 +1567,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # =========================================================================
     # Section 4: Decision Priority (compact reference)
     # =========================================================================
-    def _ch(active: bool, short: str, pri: int) -> str:
+    def _ch(active: bool, short: str) -> str:
         mark = "✅" if active else "❌"
         return f"{mark}{short}"
 
@@ -1576,7 +1590,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         _chain_entries.append((_pri, f"Custom#{_slot}({_pri})", True))
     # Sort highest priority first
     _chain_entries.sort(key=lambda e: e[0], reverse=True)
-    chain = [_ch(active, short, pri) for pri, short, active in _chain_entries]
+    chain = [_ch(active, short) for _pri, short, active in _chain_entries]
 
     lines.append("")
     lines.append("**Decision Priority** (highest wins, ✅ active ❌ not configured)")

--- a/custom_components/adaptive_cover_pro/cover_types/oscillating_awning.py
+++ b/custom_components/adaptive_cover_pro/cover_types/oscillating_awning.py
@@ -166,6 +166,8 @@ class OscillatingAwningPolicy(CoverTypePolicy, register=True):
             parts.append(f"sweep {lo}°–{hi}°")
         if (v := config.get(CONF_HEIGHT_WIN)) is not None:
             parts.append(f"{v}m window height")
+        if (v := config.get(CONF_AWNING_HOUSING_OFFSET)) is not None:
+            parts.append(f"{v}m housing offset")
         return [", ".join(parts)] if parts else []
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -261,6 +261,11 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             CONF_VENETIAN_POST_SETTLE_HOLD, DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
         )
         post_settle_line = [f"post-settle hold {round(hold, 1)}s"]
+        lag = config.get(
+            CONF_VENETIAN_BACKROTATE_PUBLISH_LAG,
+            DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
+        )
+        backrotate_line = [f"back-rotate publish lag {round(lag, 1)}s"]
         return (
             window_dimensions_lines(config)
             + slat_line
@@ -270,6 +275,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             + min_tilt_line
             + max_tilt_line
             + post_settle_line
+            + backrotate_line
         )
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -211,6 +211,27 @@ def test_empty_config_returns_string():
     assert len(summary) > 0
 
 
+def test_dry_run_banner_shown_when_enabled():
+    """Dry-run banner is surfaced (and first) when dry_run is on."""
+    from custom_components.adaptive_cover_pro.const import CONF_DRY_RUN
+
+    summary = _build_config_summary({CONF_DRY_RUN: True}, CoverType.BLIND)
+    assert "Dry-run mode is ON" in summary
+    assert "covers will NOT move" in summary
+    # Must lead the summary, above the Your Cover section.
+    assert summary.index("Dry-run mode is ON") < summary.index("**Your Cover**")
+
+
+def test_dry_run_banner_absent_when_disabled():
+    """No dry-run banner when the flag is off or unset."""
+    from custom_components.adaptive_cover_pro.const import CONF_DRY_RUN
+
+    assert "Dry-run mode" not in _build_config_summary(
+        {CONF_DRY_RUN: False}, CoverType.BLIND
+    )
+    assert "Dry-run mode" not in _build_config_summary({}, CoverType.BLIND)
+
+
 def test_entity_included_in_your_cover():
     """Cover entity ID appears in the Your Cover line."""
     cfg = {CONF_ENTITIES: ["cover.living_room"]}
@@ -335,6 +356,38 @@ def test_geometry_venetian_shows_post_settle_hold_custom():
     cfg = {CONF_VENETIAN_POST_SETTLE_HOLD: 5.5}
     summary = _build_config_summary(cfg, CoverType.VENETIAN)
     assert "post-settle hold 5.5s" in summary
+
+
+def test_geometry_venetian_shows_backrotate_lag_default():
+    """Venetian summary includes back-rotate publish lag at the default (45.0 s)."""
+    summary = _build_config_summary({}, CoverType.VENETIAN)
+    assert "back-rotate publish lag 45.0s" in summary
+
+
+def test_geometry_venetian_shows_backrotate_lag_custom():
+    """Venetian summary reflects a custom back-rotate publish lag value."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_VENETIAN_BACKROTATE_PUBLISH_LAG,
+    )
+
+    cfg = {CONF_VENETIAN_BACKROTATE_PUBLISH_LAG: 60.0}
+    summary = _build_config_summary(cfg, CoverType.VENETIAN)
+    assert "back-rotate publish lag 60.0s" in summary
+
+
+def test_geometry_oscillating_awning_shows_housing_offset():
+    """Oscillating-awning summary renders the housing offset when configured."""
+    from custom_components.adaptive_cover_pro.const import CONF_AWNING_HOUSING_OFFSET
+
+    cfg = {CONF_AWNING_HOUSING_OFFSET: 0.25}
+    summary = _build_config_summary(cfg, CoverType.OSCILLATING_AWNING)
+    assert "0.25m housing offset" in summary
+
+
+def test_geometry_oscillating_awning_housing_offset_omitted_when_unset():
+    """Housing offset line is absent when the field is not configured."""
+    summary = _build_config_summary({}, CoverType.OSCILLATING_AWNING)
+    assert "housing offset" not in summary
 
 
 # ---------------------------------------------------------------------------
@@ -989,6 +1042,22 @@ def test_position_inverse_state_hidden_when_false():
     cfg = {CONF_INVERSE_STATE: False}
     summary = _build_config_summary(cfg, CoverType.BLIND)
     assert "Inverse state" not in summary
+
+
+def test_position_tolerance_shown_when_configured():
+    """Position tolerance appears in Position Limits when set."""
+    from custom_components.adaptive_cover_pro.const import CONF_POSITION_TOLERANCE
+
+    cfg = {CONF_DEFAULT_HEIGHT: 60, CONF_POSITION_TOLERANCE: 5}
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "Position tolerance: 5%" in summary
+
+
+def test_position_tolerance_hidden_when_unset():
+    """Position tolerance line is absent when the field is not configured."""
+    cfg = {CONF_DEFAULT_HEIGHT: 60}
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "Position tolerance" not in summary
 
 
 def test_position_interp_shown():

--- a/tests/test_cover_types/test_config_flow_dispatch.py
+++ b/tests/test_cover_types/test_config_flow_dispatch.py
@@ -119,6 +119,7 @@ class TestSummaryGeometryLines:
             "min tilt 0%",
             "max tilt 100%",
             "post-settle hold 3.0s",
+            "back-rotate publish lag 45.0s",
         ]
 
     def test_empty_config_renders_nothing(self):
@@ -133,6 +134,7 @@ class TestSummaryGeometryLines:
             "min tilt 0%",
             "max tilt 100%",
             "post-settle hold 3.0s",
+            "back-rotate publish lag 45.0s",
         ]
 
     def test_venetian_summary_shows_inverse_tilt_when_set(self):


### PR DESCRIPTION
## Summary
Audited the Configuration Summary screen (`_build_config_summary()`) against the live implementation. The decision chain, priorities, and units were all accurate, but I found one behavior mismatch and a few completeness gaps:

- **Dry-run never surfaced (HIGH):** the summary described the full decision chain as if it drives covers, but `dry_run` gates every command path (`cover_command/__init__.py:1050`, `:700`, `:1642`) — covers never move. Added a leading `⚠️ Dry-run mode is ON …` banner.
- **Oscillating-awning housing offset:** required geometry field, rendered by no line — added to `OscillatingAwningPolicy.summary_geometry_lines`.
- **Venetian back-rotate publish lag:** omitted while its sibling sequencing params were shown — added to `VenetianPolicy.summary_geometry_lines`.
- **Position tolerance:** added to the Position Limits one-liner.
- Removed an unused `pri` parameter in the `_ch()` priority-chain helper.

Diagnostics-only options (`debug_mode`, `debug_categories`, `manual_override_strategy`) are intentionally left out per the guidelines' exemption.

## Testing
- ✅ 3918 tests passing (full suite)
- ✅ ruff / black / prettier clean
- New tests in `test_config_flow_summary.py` (banner present/absent + ordering, housing offset, back-rotate lag, position tolerance); updated two exact-line venetian assertions in `test_config_flow_dispatch.py`.