### PR TITLE
fix: floor ignored under manual override (#534)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1508,9 +1508,18 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # gate would otherwise drop the return-to-calculated command.  Short-
         # circuit when the set is empty so callers that bypass __init__ (e.g.
         # gate-matrix fixtures) don't need to wire _last_state_change_entity.
+        # When the manual-override hold is the winner, a floor sensor releasing
+        # must NOT take the release force-path — otherwise the override's
+        # theoretical default (e.g. 90%) would be force-driven onto the cover.
+        # The cover stays where the floor left it; the override keeps holding
+        # the (now recomputed) physical position (#534).
+        override_holding = (
+            self._pipeline_result is not None
+            and self._pipeline_result.control_method is ControlMethod.MANUAL
+        )
         trigger_entity: str | None = None
         custom_position_released = False
-        if custom_position_released_entities:
+        if custom_position_released_entities and not override_holding:
             trigger_entity = self._last_state_change_entity
             custom_position_released = (
                 trigger_entity is not None
@@ -1534,11 +1543,20 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.logger.debug("Outside time window — skipping position update")
             return
 
+        # A floor-clamp raised the winner this cycle (#534).  When manual
+        # override holds the cover below an active floor, the clamped value is
+        # already in cover-position space and must bypass the time/position
+        # delta gates so the raise reaches the cover.
+        floor_clamp = bool(
+            self._pipeline_result is not None
+            and self._pipeline_result.floor_clamp_applied
+        )
         use_force = (
             is_safety
             or force_override_released
             or custom_position_sensor_triggered
             or custom_position_released
+            or floor_clamp
         )
         if force_override_released:
             reason = "force_override_cleared"
@@ -1553,6 +1571,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 "Custom-position sensor %s released — bypassing time/position "
                 "delta gates to return to calculated position %s",
                 trigger_entity,
+                state,
+            )
+        elif floor_clamp:
+            reason = "floor_clamp"
+            self.logger.debug(
+                "Floor clamp active — bypassing time/position delta gates to "
+                "raise cover to floor position %s",
                 state,
             )
         else:

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -138,15 +138,26 @@ class PipelineRegistry:
         # arithmetic lives in exactly one place (pipeline/floors.py).
         active_floors = gather_active_floors(snapshot)
         floor_pos, floor_info = effective_floor(active_floors)
+        # The position the floor must raise: where the cover will actually end
+        # up.  manual_override holds the cover at held_position (its physical
+        # position), not winner.position (the theoretical default it shadows),
+        # so the floor must clamp against held_position when present (#534).
+        # Every other handler leaves held_position=None, so this preserves the
+        # existing behaviour exactly.
+        effective_winner_pos = (
+            winner.held_position
+            if winner.held_position is not None
+            else winner.position
+        )
         clamped_position = winner.position
-        if floor_info is not None and floor_pos > winner.position:
+        if floor_info is not None and floor_pos > effective_winner_pos:
             clamped_position = floor_pos
             trace.append(
                 DecisionStep(
                     handler="floor_clamp",
                     matched=True,
                     reason=(
-                        f"floor raised winner from {winner.position}% to "
+                        f"floor raised winner from {effective_winner_pos}% to "
                         f"{floor_pos}% by {floor_info.label}"
                     ),
                     position=floor_pos,
@@ -162,7 +173,7 @@ class PipelineRegistry:
             if (
                 floor_info is not None
                 and info is floor_info
-                and floor_pos > winner.position
+                and floor_pos > effective_winner_pos
             ):
                 continue  # this floor *did* win — already emitted as floor_clamp
             trace.append(
@@ -171,7 +182,7 @@ class PipelineRegistry:
                     matched=False,
                     reason=(
                         f"floor {info.position}% inactive "
-                        f"(winner {winner.position}% above floor)"
+                        f"(winner {effective_winner_pos}% above floor)"
                     ),
                     position=info.position,
                 )

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -30,12 +30,14 @@ def _make_pipeline_result(
     position: int = 50,
     control_method: ControlMethod = ControlMethod.SOLAR,
     bypass_auto_control: bool = False,
+    floor_clamp_applied: bool = False,
 ) -> PipelineResult:
     return PipelineResult(
         position=position,
         control_method=control_method,
         reason="test",
         bypass_auto_control=bypass_auto_control,
+        floor_clamp_applied=floor_clamp_applied,
     )
 
 
@@ -394,6 +396,80 @@ class TestCustomPositionSensorEdgeTriggerBypassesGate:
         )
 
         coordinator._cmd_svc.apply_position.assert_not_called()
+
+
+class TestFloorClampUnderManualOverride:
+    """A floor-clamp under an armed manual override must dispatch and not snap to default (#534)."""
+
+    @pytest.mark.asyncio
+    async def test_floor_clamp_forces_dispatch_under_manual_override(self):
+        """A floor-clamped position under manual override calls context with force=True."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=80,
+            control_method=ControlMethod.MANUAL,
+            floor_clamp_applied=True,
+        )
+        coordinator = _make_coordinator(
+            entities=["cover.blind"],
+            pipeline_result=result,
+        )
+        coordinator.manager.is_cover_manual.return_value = True
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator, state=80, options={}
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.blind",
+            {},
+            force=True,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_floor_release_under_armed_override_does_not_force_to_default(self):
+        """Floor sensor off while override armed: stay at floor, no force to default (#534).
+
+        When the floor sensor releases and manual override is still the winner,
+        the manual-hold winner re-emits its theoretical default (90).  The
+        coordinator must NOT take the custom_position_released force path —
+        otherwise it would drive the cover to that default.  force stays False.
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=90,
+            control_method=ControlMethod.MANUAL,
+            floor_clamp_applied=False,
+        )
+        coordinator = _make_coordinator(
+            entities=["cover.blind"],
+            pipeline_result=result,
+        )
+        coordinator.manager.is_cover_manual.return_value = True
+        coordinator._last_state_change_entity = "binary_sensor.cp1"
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator,
+            state=90,
+            options={},
+            custom_position_released_entities={"binary_sensor.cp1"},
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.blind",
+            {},
+            force=False,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
 
 
 class TestCustomPositionSensorReleaseEdgeBypassesGate:

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -22,6 +22,9 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import (
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
+from custom_components.adaptive_cover_pro.pipeline.handlers.manual_override import (
+    ManualOverrideHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.weather import (
     WeatherOverrideHandler,
 )
@@ -584,6 +587,89 @@ def test_inactive_floor_below_winner_keeps_flag_false() -> None:
     result = registry.evaluate(snap)
     assert result.position == 80
     assert result.floor_clamp_applied is False
+
+
+def test_floor_raises_manual_override_held_below_floor() -> None:
+    """A floor raises the cover when manual override holds it below the floor (#534).
+
+    Manual override wins with ``position`` = theoretical default (90) but
+    ``held_position`` = the cover's actual physical position (50).  A min-mode
+    floor at 80% must be measured against the *physical* 50%, not the
+    theoretical 90% — so the floor fires and raises the cover to 80%.
+    """
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        manual_override_active=True,
+        current_cover_position=50,
+        default_position=90,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=80,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [
+        _cp_handler(1, "binary_sensor.cp1", 80),
+        ManualOverrideHandler(),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "manual_override"
+    assert result.position == 80
+    assert result.floor_clamp_applied is True
+    clamp_steps = [
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    ]
+    assert len(clamp_steps) == 1
+
+
+def test_floor_above_held_position_is_inert_under_manual_override() -> None:
+    """Floor below the cover's physical position does NOT clamp (#534 inert branch).
+
+    Manual override holds the cover at 85% (physical), floor is 80% — the cover
+    already sits above the floor, so no clamp is applied.
+    """
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        manual_override_active=True,
+        current_cover_position=85,
+        default_position=90,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=80,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [
+        _cp_handler(1, "binary_sensor.cp1", 80),
+        ManualOverrideHandler(),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "manual_override"
+    # No clamp: the held physical position (85) is already above the floor (80).
+    assert result.floor_clamp_applied is False
+    assert not any(
+        s.handler == "floor_clamp" and s.matched for s in result.decision_trace
+    )
 
 
 def test_decision_trace_does_not_mislabel_winner() -> None:


### PR DESCRIPTION
## Summary
The pipeline's floor-clamp pass compared the floor threshold against the manual override's theoretical hold position (90% default) instead of the cover's actual physical position (50% in the reporter's case). This meant a min-mode floor never engaged while a manual override was armed. I've fixed this by comparing against the cover's actual held position, so a floor now raises the cover whenever it physically sits below the floor, even under manual override. The dispatch path now force-applies a floor-clamped position past the override gate, and when the floor sensor later clears with the override still armed, the cover stays at the floor rather than snapping to the override default.

Note: the reporter's priority-82 expectation is a separate matter. Min-mode floors deliberately bypass the priority chain (issue #463), so priority has no effect in floor mode. Only exact-mode custom positions use priority.

## Testing
- ✅ 3927 tests passing (4 new regression tests)

## Related Issues
Refs #534