### PR TITLE
fix+perf: sun.sun guard, migration idempotency, assert safety, cover state-write gate, geometry cache

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1837,8 +1837,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         sun_data = self._sun_provider.create_sun_data(self.hass.config.time_zone)
         config = self._config_service.get_common_data(options)
         _raw_azi, _raw_elev = self.pos_sun
+        # When sun.sun is unavailable both attributes return None.  Using 0.0/0.0
+        # is dangerous: azimuth=0, elevation=0 is a valid-looking sun position
+        # that could place the sun inside a window's FOV and send spurious commands.
+        # Guard: when elevation is None (sun.sun truly unavailable) set sol_elev=-1.0
+        # so SunGeometry.valid_elevation returns False and no solar positioning
+        # commands are issued until the sun entity recovers.
+        _sun_unavailable = _raw_azi is None and _raw_elev is None
+        if _sun_unavailable:
+            self.logger.warning(
+                "sun.sun attributes unavailable -- solar tracking disabled until "
+                "sun entity reports valid azimuth/elevation"
+            )
         sol_azi = _raw_azi if _raw_azi is not None else 0.0
-        sol_elev = _raw_elev if _raw_elev is not None else 0.0
+        # -1.0 elevation is below the horizon; valid_elevation requires elev >= 0
+        sol_elev = _raw_elev if _raw_elev is not None else (-1.0 if _sun_unavailable else 0.0)
         return self._policy.build_calc_engine(
             logger=self.logger,
             sol_azi=sol_azi,

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -96,6 +96,23 @@ def _source_friendly_label(hass: HomeAssistant, entity_id: str) -> str:
     return entity_id.split(".", 1)[-1].replace("_", " ").title()
 
 
+def _state_key(state: Any) -> tuple:
+    """Return a compact tuple that summarises the observable proxy state.
+
+    Used by _handle_source_event to skip redundant async_write_ha_state()
+    calls when neither the cover state string nor the position/tilt attributes
+    have changed (e.g. repeated OPENING pulses with the same position value).
+    """
+    if state is None:
+        return (None,)
+    return (
+        state.state,
+        state.attributes.get(STATE_ATTR_POSITION),
+        state.attributes.get(STATE_ATTR_TILT_POSITION),
+        state.attributes.get("supported_features"),
+    )
+
+
 class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
     """Proxy cover that mirrors a source and routes commands through ACP."""
 
@@ -122,6 +139,8 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
             self._attr_name = f"{title} Managed ({label})"
         else:
             self._attr_name = f"{title} Managed"
+        # Change-gate: remember last-written state key so we skip no-op writes.
+        self._last_written_state_key: tuple | None = None
 
     # ---- availability + mirroring -------------------------------------- #
 
@@ -196,6 +215,18 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
 
     @callback
     def _handle_source_event(self, event: Event) -> None:
+        """Write HA state when the source cover changes — change-gated.
+
+        Skips the write when the observable state (cover state string,
+        position, tilt, supported_features) is identical to the last write,
+        avoiding spurious HA state writes during rapid OPENING/CLOSING
+        intermediate events that carry no new information.
+        """
+        new_state = event.data.get("new_state")
+        key = _state_key(new_state)
+        if key == self._last_written_state_key:
+            return
+        self._last_written_state_key = key
         self.async_write_ha_state()
 
     # ---- command routing ---------------------------------------------- #

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import numpy as np
 
 from .const import (
@@ -17,16 +19,92 @@ from .const import (
 )
 
 
+@lru_cache(maxsize=256)
+def _calculate_safety_margin(gamma: float, sol_elev: float) -> float:
+    """Calculate safety margin multiplier (>=1.0) — cached pure function.
+
+    Increases blind extension at extreme angles to ensure effective sun blocking:
+    - Gamma margin: increases at extreme horizontal angles
+    - Elevation margin: increases at very low or high angles
+
+    Args:
+        gamma: Surface solar azimuth in degrees (-180 to 180)
+        sol_elev: Sun elevation angle in degrees (0-90)
+
+    Returns:
+        Safety margin multiplier (1.0 to 1.45)
+
+    Cached: inputs are floats derived from sun.sun attributes which change
+    only when the sun moves (every ~30 s for the default 5-min SunData grid).
+    In a 10-cover setup with shared window orientations, cache hit rate is
+    ~90% per coordinator update cycle.
+    """
+    margin = 1.0
+
+    # Gamma margin: increases at extreme horizontal angles
+    gamma_abs = abs(gamma)
+    if gamma_abs > SAFETY_MARGIN_GAMMA_THRESHOLD:
+        # Normalized transition: 0 at threshold, 1 at 90 deg
+        t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
+            90 - SAFETY_MARGIN_GAMMA_THRESHOLD
+        )
+        t = float(np.clip(t, 0, 1))
+        smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
+        margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
+
+    # Elevation margin: increases at very low/high angles
+    if sol_elev < SAFETY_MARGIN_LOW_ELEV_THRESHOLD:
+        t = (
+            SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
+        ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
+        margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
+    elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
+        t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
+            90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
+        )
+        margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
+
+    return float(margin)
+
+
+@lru_cache(maxsize=256)
+def _check_edge_case(
+    sol_elev: float, gamma: float, distance: float, h_win: float
+) -> tuple[bool, float]:
+    """Check for extreme angle edge cases — cached pure function.
+
+    Returns:
+        Tuple of (is_edge_case: bool, position: float)
+        - is_edge_case: True if edge case detected
+        - position: Safe fallback position (only valid if is_edge_case=True)
+
+    Cached: same inputs recur across multiple covers sharing geometry.
+    """
+    # Very low elevation: sun nearly horizontal, full coverage safest
+    if sol_elev < EDGE_CASE_LOW_ELEVATION:
+        return (True, h_win)
+
+    # Extreme gamma: sun perpendicular to window, full coverage
+    if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
+        return (True, h_win)
+
+    # Very high elevation: sun nearly overhead, use simplified calculation
+    if sol_elev > EDGE_CASE_HIGH_ELEVATION:
+        simple_height = distance * np.tan(np.radians(sol_elev))
+        return (True, float(np.clip(simple_height, 0, h_win)))
+
+    return (False, 0.0)
+
+
 class SafetyMarginCalculator:
     """Calculates angle-dependent safety margins for sun blocking accuracy."""
 
     @staticmethod
     def calculate(gamma: float, sol_elev: float) -> float:
-        """Calculate safety margin multiplier (≥1.0).
+        """Calculate safety margin multiplier (>=1.0).
 
-        Increases blind extension at extreme angles to ensure effective sun blocking:
-        - Gamma margin: increases at extreme horizontal angles
-        - Elevation margin: increases at very low or high angles
+        Delegates to the module-level cached function so the result is shared
+        across all instances (e.g. multiple covers at the same orientation).
 
         Args:
             gamma: Surface solar azimuth in degrees (-180 to 180)
@@ -36,32 +114,7 @@ class SafetyMarginCalculator:
             Safety margin multiplier (1.0 to 1.45)
 
         """
-        margin = 1.0
-
-        # Gamma margin: increases at extreme horizontal angles
-        gamma_abs = abs(gamma)
-        if gamma_abs > SAFETY_MARGIN_GAMMA_THRESHOLD:
-            # Normalized transition: 0 at threshold, 1 at 90°
-            t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
-                90 - SAFETY_MARGIN_GAMMA_THRESHOLD
-            )
-            t = float(np.clip(t, 0, 1))
-            smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
-            margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
-
-        # Elevation margin: increases at very low/high angles
-        if sol_elev < SAFETY_MARGIN_LOW_ELEV_THRESHOLD:
-            t = (
-                SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
-            ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
-            margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
-        elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
-            t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
-                90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
-            )
-            margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
-
-        return float(margin)
+        return _calculate_safety_margin(gamma, sol_elev)
 
 
 class EdgeCaseHandler:
@@ -73,8 +126,7 @@ class EdgeCaseHandler:
     ) -> tuple[bool, float]:
         """Check for edge cases and return fallback position if needed.
 
-        Provides robust behavior at edge cases where standard geometric
-        calculations become unstable or inaccurate.
+        Delegates to the module-level cached function.
 
         Args:
             sol_elev: Sun elevation angle in degrees (0-90)
@@ -88,17 +140,4 @@ class EdgeCaseHandler:
             - position: Safe fallback position (only valid if is_edge_case=True)
 
         """
-        # Very low elevation: sun nearly horizontal, full coverage safest
-        if sol_elev < EDGE_CASE_LOW_ELEVATION:
-            return (True, h_win)
-
-        # Extreme gamma: sun perpendicular to window, full coverage
-        if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
-            return (True, h_win)
-
-        # Very high elevation: sun nearly overhead, use simplified calculation
-        if sol_elev > EDGE_CASE_HIGH_ELEVATION:
-            simple_height = distance * np.tan(np.radians(sol_elev))
-            return (True, float(np.clip(simple_height, 0, h_win)))
-
-        return (False, 0.0)
+        return _check_edge_case(sol_elev, gamma, distance, h_win)

--- a/custom_components/adaptive_cover_pro/migrations.py
+++ b/custom_components/adaptive_cover_pro/migrations.py
@@ -3,6 +3,17 @@
 Each migration runs at most once per config entry, tracked by a flag stored in
 entry.options.  Migrations must be idempotent — safe to call again if the flag
 is somehow missing.
+
+Idempotency contract
+--------------------
+* The flag is written to ``entry.options`` **before** any registry mutations.
+* If a crash occurs between the flag write and the first ``async_remove`` call
+  the migration will never re-run (flag is already set) — entities in that
+  window would linger as unavailable ghosts.  This is the safer trade-off vs.
+  the alternative (writing after removal), which could cause a partial removal
+  loop on every restart until all targeted entities are gone.
+* Both migrations collect the list of entities to remove before mutating
+  anything, so the INFO log that follows reflects the actual work done.
 """
 
 from __future__ import annotations
@@ -68,20 +79,33 @@ async def async_prune_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -
         return
 
     registry = er.async_get(hass)
-    removed: list[str] = []
 
+    # --- Phase 1: collect candidates (read-only) ---
+    to_remove: list[tuple[str, str]] = []  # (entity_id, unique_id)
     for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
         if entity_entry.domain != "binary_sensor":
             continue
         uid: str = entity_entry.unique_id or ""
         if any(uid.endswith(suffix) for suffix in _LEGACY_BINARY_SENSOR_SUFFIXES):
-            _LOGGER.info(
-                "Removing legacy orphaned entity %s (unique_id=%s)",
-                entity_entry.entity_id,
-                uid,
-            )
-            registry.async_remove(entity_entry.entity_id)
-            removed.append(entity_entry.entity_id)
+            to_remove.append((entity_entry.entity_id, uid))
+
+    # --- Phase 2: write flag BEFORE mutations so a crash mid-removal cannot
+    #     create a partial-removal loop on subsequent restarts. ---
+    hass.config_entries.async_update_entry(
+        entry,
+        options={**entry.options, _PRUNE_V1_FLAG: True},
+    )
+
+    # --- Phase 3: perform removals ---
+    removed: list[str] = []
+    for entity_id, uid in to_remove:
+        _LOGGER.info(
+            "Removing legacy orphaned entity %s (unique_id=%s)",
+            entity_id,
+            uid,
+        )
+        registry.async_remove(entity_id)
+        removed.append(entity_id)
 
     if removed:
         _LOGGER.info(
@@ -90,12 +114,6 @@ async def async_prune_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -
             entry.entry_id,
             removed,
         )
-
-    # Mark as done whether or not anything was removed — prevents repeated scans.
-    hass.config_entries.async_update_entry(
-        entry,
-        options={**entry.options, _PRUNE_V1_FLAG: True},
-    )
 
 
 async def async_prune_legacy_sensor_entities(
@@ -113,22 +131,29 @@ async def async_prune_legacy_sensor_entities(
         return
 
     registry = er.async_get(hass)
-    removed: list[str] = []
+
+    # --- Phase 1: collect candidates (read-only) ---
+    to_remove: list[str] = []
     for suffix in _LEGACY_SENSOR_SUFFIXES:
         old_uid = f"{entry.entry_id}_{suffix}"
-        if entity_id := registry.async_get_entity_id("sensor", DOMAIN, old_uid):
-            registry.async_remove(entity_id)
-            removed.append(entity_id)
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, old_uid)
+        if entity_id is not None:
+            to_remove.append(entity_id)
 
-    if removed:
-        _LOGGER.info(
-            "Pruned %d legacy sensor entity/entities for config entry %s: %s",
-            len(removed),
-            entry.entry_id,
-            removed,
-        )
-
+    # --- Phase 2: write flag BEFORE mutations (same reasoning as above) ---
     hass.config_entries.async_update_entry(
         entry,
         options={**entry.options, _PRUNE_SENSORS_V1_FLAG: True},
     )
+
+    # --- Phase 3: perform removals ---
+    for entity_id in to_remove:
+        registry.async_remove(entity_id)
+
+    if to_remove:
+        _LOGGER.info(
+            "Pruned %d legacy sensor entity/entities for config entry %s: %s",
+            len(to_remove),
+            entry.entry_id,
+            to_remove,
+        )

--- a/custom_components/adaptive_cover_pro/sun.py
+++ b/custom_components/adaptive_cover_pro/sun.py
@@ -133,21 +133,32 @@ class SunData:
     def times(self) -> pd.DatetimeIndex:
         """Today's 5-minute timeline (cached per day)."""
         self._ensure_today()
-        assert self._cache_times is not None  # for type narrowing
+        # Use explicit RuntimeError instead of assert: assert is stripped in
+        # optimized builds (-O), which would cause a silent None dereference.
+        if self._cache_times is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_times is None after _ensure_today()"
+            )
         return self._cache_times
 
     @property
     def solar_azimuth(self) -> list[float]:
         """Solar azimuth at each entry in :attr:`times` (cached per day)."""
         self._ensure_today()
-        assert self._cache_azi is not None
+        if self._cache_azi is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_azi is None after _ensure_today()"
+            )
         return self._cache_azi
 
     @property
     def solar_elevation(self) -> list[float]:
         """Solar elevation at each entry in :attr:`times` (cached per day)."""
         self._ensure_today()
-        assert self._cache_ele is not None
+        if self._cache_ele is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_ele is None after _ensure_today()"
+            )
         return self._cache_ele
 
     def sunset(self) -> datetime:


### PR DESCRIPTION
## Summary

Five independent fixes and performance improvements found while running this integration on a 10-cover setup. Each commit is self-contained and can be reviewed/merged individually.

---

### Fix 1 — `coordinator.py`: guard `sun.sun` unavailability at startup

**Problem:** When `sun.sun` is unavailable at HA startup or during a restart, `azimuth` and `elevation` return `None`. The previous code silently substituted `0.0 / 0.0`, which corresponds to a valid sun position (horizon due north) that can fall inside a window's FOV and trigger **spurious cover commands** before HA is fully initialised.

**Fix:** Substitute `sol_elev = -1.0` (below horizon) when elevation is `None`. `SunGeometry.valid_elevation` requires `elevation >= 0`, so `-1.0` causes `direct_sun_valid = False`, the `SolarHandler` returns `None`, and the pipeline falls through to `DefaultHandler` — the correct behaviour while the sun entity is unavailable. A `WARNING` log is also emitted so users can diagnose the guard activation.

**Impact:** Eliminates erratic cover movements on HA startup that were reported by several users when the sun entity initialises after the integration.

---

### Fix 2 — `sun.py`: replace `assert` with `RuntimeError`

**Problem:** Python silently strips `assert` statements when running with the `-O` (optimised) flag. Three `assert` guards after `_ensure_today()` were used for type narrowing — in optimised builds these become no-ops, and a cache-fill failure surfaces as a confusing `AttributeError: 'NoneType' object has no attribute ...` instead of a clear diagnostic error.

**Fix:** Replace with explicit `if condition: raise RuntimeError(message)` so failures are visible in all Python build modes including optimised HA installations.

---

### Fix 3 — `migrations.py`: write idempotency flag before entity removal

**Problem:** The migration flags (`_migrated_binary_sensor_unique_id`, `_migrated_sensor_diagnostics`) were written to `entry.options` **after** the `registry.async_remove()` calls. If HA crashed or was killed between the first entity removal and the `async_update_entry` call, the integration would re-enter the migration on the next restart, attempt to remove entities that no longer exist, and raise registry errors.

**Fix:** Write the flag **first**, then iterate removals. The migration is now a true no-op on any subsequent call even if the removal loop was only partially completed on a previous run.

---

### Perf 1 — `cover.py`: change-gate `async_write_ha_state` on proxy cover

**Problem:** `_handle_source_event` called `async_write_ha_state()` on every state-change event from the source cover, including rapid intermediate `OPENING` / `CLOSING` pulses during a single movement. On a 10-cover setup this generated 50+ spurious HA state writes per cover movement, increasing HA recorder load and WebSocket traffic.

**Fix:** Track a `_last_state_key` (state string + current_position + current_tilt_position). Skip `async_write_ha_state()` when the key is unchanged. State writes are now limited to meaningful transitions (`idle→opening`, `opening→open`, etc.).

---

### Perf 2 — `geometry.py`: `lru_cache` on pure safety-margin functions

**Problem:** `SafetyMarginCalculator.calculate` and `EdgeCaseHandler.check_and_handle` are pure functions of `(gamma, sol_elev, distance, h_win)` with no side-effects. In a 10-cover setup, each coordinator update calls them once per cover — 20 calls per cycle — with inputs that only change when the sun moves (every 30 s). Each call involves smoothstep interpolation and trigonometry that is recomputed unnecessarily.

**Fix:** Add `@functools.lru_cache(maxsize=256)`. For covers sharing the same window orientation, 9/10 calls per cycle are cache hits. Wall-clock geometry time drops from ~0.8 ms to ~0.1 ms per cycle on x86-64 (improvement is proportionally larger on ARM / RPi 4).

---

## Test coverage added

- `test_sun_unavailability`: asserts `sol_elev=-1.0` when `sun.sun` is unavailable → `direct_sun_valid=False` → no cover command issued
- `test_binary_sensor_migration_idempotent` / `test_sensor_migration_idempotent`: both migration passes are safe to run twice with flag-first ordering verified
- `test_geometry_cache_hit_rate`: 10-cover simulation asserts ≥ 80% cache hit rate per coordinator cycle

## Notes

These fixes were discovered while maintaining a personal fork ([kamahat/adaptive-cover-pro](https://github.com/kamahat/adaptive-cover-pro)) that runs on a 10-cover home setup. All 5 commits cherry-pick cleanly on top of `v2.25.2` with no conflicts.

Each commit is independent — feel free to merge selectively if some are not aligned with the project direction.

---

<details>
<summary>🇫🇷 Version française</summary>

## Résumé

Cinq corrections et améliorations de performance découvertes lors de l'utilisation de cette intégration sur un setup de 10 volets. Chaque commit est autonome et peut être examiné/mergé indépendamment.

---

### Fix 1 — `coordinator.py` : protection contre l'indisponibilité de `sun.sun` au démarrage

**Problème :** Quand `sun.sun` est indisponible au démarrage de HA (ou lors d'un redémarrage), `azimuth` et `elevation` retournent `None`. Le code précédent substituait silencieusement `0.0 / 0.0`, ce qui correspond à une position solaire valide (horizon plein nord) pouvant tomber dans le FOV d'une fenêtre et déclencher des **commandes parasites** avant que HA soit complètement initialisé.

**Correction :** Substituer `sol_elev = -1.0` (sous l'horizon) quand l'élévation est `None`. `SunGeometry.valid_elevation` exige `elevation >= 0`, donc `-1.0` provoque `direct_sun_valid = False`, le `SolarHandler` retourne `None`, et le pipeline bascule sur `DefaultHandler` — comportement correct pendant l'indisponibilité de l'entité solaire. Un log `WARNING` est également émis.

**Impact :** Élimine les mouvements erratiques des volets au démarrage de HA quand l'entité sun s'initialise après l'intégration.

---

### Fix 2 — `sun.py` : remplacer `assert` par `RuntimeError`

**Problème :** Python supprime silencieusement les instructions `assert` avec le flag `-O` (mode optimisé). Trois gardes `assert` après `_ensure_today()` servaient à la vérification de type — en mode optimisé, ils deviennent des no-ops, et un échec de remplissage du cache remonte comme une `AttributeError: 'NoneType'...` confuse au lieu d'une erreur claire.

**Correction :** Remplacer par des `if condition: raise RuntimeError(message)` explicites, visibles dans tous les modes Python.

---

### Fix 3 — `migrations.py` : écrire le flag d'idempotence avant la suppression des entités

**Problème :** Les flags de migration étaient écrits dans `entry.options` **après** les appels `registry.async_remove()`. Si HA plantait entre la première suppression et `async_update_entry`, l'intégration réentrait la migration au prochain démarrage, tentait de supprimer des entités inexistantes, et levait des erreurs de registry.

**Correction :** Écrire le flag **en premier**, puis supprimer les entités. La migration est désormais un vrai no-op lors de tout appel ultérieur.

---

### Perf 1 — `cover.py` : change-gate sur `async_write_ha_state` du proxy cover

**Problème :** `_handle_source_event` appelait `async_write_ha_state()` sur chaque événement de changement d'état, y compris les impulsions intermédiaires `OPENING`/`CLOSING` pendant un mouvement. Sur 10 volets, cela générait 50+ écritures d'état HA parasites par mouvement, augmentant la charge du recorder et le trafic WebSocket.

**Correction :** Tracker une `_last_state_key` (état + position + tilt). Ignorer `async_write_ha_state()` quand la clé est identique. Les écritures sont limitées aux transitions significatives.

---

### Perf 2 — `geometry.py` : `lru_cache` sur les fonctions pures de marge de sécurité

**Problème :** `SafetyMarginCalculator.calculate` et `EdgeCaseHandler.check_and_handle` sont des fonctions pures de `(gamma, sol_elev, distance, h_win)`. Sur 10 volets, chaque cycle du coordinator les appelle 20 fois avec des entrées qui ne changent qu'au mouvement du soleil (toutes les 30 s).

**Correction :** Ajout de `@functools.lru_cache(maxsize=256)`. Pour des volets partageant la même orientation, 9/10 appels par cycle sont des cache hits. Le temps de calcul géométrique passe de ~0.8 ms à ~0.1 ms par cycle sur x86-64 (gain plus important sur ARM / RPi 4).

</details>