### PR TITLE
perf/fix: pipeline short-circuit, sun geometry cache, robustness fixes

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1,5 +1,3 @@
-"""The Coordinator for Adaptive Cover Pro."""
-
 from __future__ import annotations
 
 import asyncio
@@ -121,6 +119,7 @@ from .state.cover_provider import CoverProvider
 from .state.snapshot import CoverStateSnapshot, SunSnapshot
 from .state.sun_provider import SunProvider
 from .state.window_transition_tracker import WindowTransitionTracker
+from .state.update_fingerprint import UpdateFingerprint
 
 _MANIFEST_VERSION: str = json.loads(
     (pathlib.Path(__file__).parent / "manifest.json").read_text()
@@ -450,9 +449,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # HA's DataUpdateCoordinator only exposes last_update_success (bool);
         # we track the timestamp ourselves so diagnostics can report it.
         self._last_update_success_time: dt.datetime | None = None
+        # Fingerprint of last update cycle; short-circuits _calculate_cover_state (3.4).
+        self._last_fingerprint: UpdateFingerprint | None = None
 
         # Issue #437: forecast cache + scheduling.  The forecast is heavy
-        # (~289-call astral walk × 49-sample window) and must NOT run inline
+        # (~289-call astral walk x 49-sample window) and must NOT run inline
         # on the event loop every state-write.  ``_position_forecast`` is
         # the live cache that ``_async_update_data`` promotes into
         # ``AdaptiveCoverData.position_forecast`` each cycle; the sensor
@@ -587,7 +588,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # task helper (not hass.async_create_background_task): it ties the
         # task to the entry, which keeps a hard reference until the
         # coroutine completes.  hass.async_create_background_task can race
-        # with the GC when called from a sync timer callback — tasks were
+        # with the GC when called from a sync timer callback -- tasks were
         # being destroyed before reaching their first await, surfacing as
         # "Task was destroyed but it is pending!" in the HA log.
         self.config_entry.async_create_background_task(
@@ -597,8 +598,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
 
         # Periodic recompute aligned to wall-clock 5-minute boundaries
-        # (:00, :05, :10, …) so every entry's forecast attribute updates
-        # in lockstep — the dashboard sees one synchronised refresh
+        # (:00, :05, :10, ...) so every entry's forecast attribute updates
+        # in lockstep -- the dashboard sees one synchronised refresh
         # instead of staggered per-entry ticks.  The forecast is a
         # 12-hour outlook, so refreshing more often than every few
         # minutes adds no information.  The timer fires a background
@@ -629,7 +630,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         Issue #437: the underlying :func:`build_forecast_for_coord` walks
         289 solar samples and constructs a fresh ``AdaptiveGeneralCover``
-        per tick — running this on the event loop blocks for hundreds of
+        per tick -- running this on the event loop blocks for hundreds of
         milliseconds on ARM hosts and trips HA's bootstrap-stage-2
         timeout. Offloading to the executor keeps the loop responsive.
 
@@ -643,7 +644,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             forecast = await self.hass.async_add_executor_job(
                 build_forecast_for_coord, self
             )
-        except Exception:  # noqa: BLE001 — defensive degradation
+        except Exception:  # noqa: BLE001 -- defensive degradation
             forecast = None
         self._position_forecast = forecast
         if self.data is not None:
@@ -660,7 +661,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         old_val = old_state.state if old_state else "None"
         new_val = new_state.state if new_state else "None"
         self.logger.debug(
-            "Entity state change: %s (%s → %s)", entity_id, old_val, new_val
+            "Entity state change: %s (%s -> %s)", entity_id, old_val, new_val
         )
         self._last_state_change_entity = entity_id
         self.state_change = True
@@ -721,7 +722,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         This path covers non-position-capable covers (e.g. Somfy RTS) where
         pressing STOP moves to the hardware "My" preset without ever reporting
-        a new position — the normal state-change detection is blind to it.
+        a new position -- the normal state-change detection is blind to it.
         """
         data = event.data
         if data.get("domain") != "cover" or data.get("service") != "stop_cover":
@@ -755,7 +756,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return
 
         # When manual_ignore_external is on, treat external stop_cover calls
-        # the same as external set_cover_position — only ACP-routed commands
+        # the same as external set_cover_position -- only ACP-routed commands
         # engage manual override.
         if self.manual_ignore_external:
             self.logger.debug(
@@ -769,7 +770,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if my_position_value is None:
             self.logger.debug(
                 "async_check_cover_service_call: user stop_cover on %s but "
-                "my_position_value not configured — skipping manual override",
+                "my_position_value not configured -- skipping manual override",
                 tracked,
             )
             return
@@ -813,7 +814,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if is_now_active:
             if not self._weather_mgr.is_weather_override_active:
                 self.logger.info(
-                    "Weather conditions active (%s) — retracting covers", entity_id
+                    "Weather conditions active (%s) -- retracting covers", entity_id
                 )
                 self._weather_mgr.record_conditions_active()
                 self.state_change = True
@@ -872,7 +873,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     def process_entity_state_change(self):
         """Check if cover position change was user-initiated (manual override detection).
 
-        Thin shim over :meth:`CoverCommandService.classify_state_change` —
+        Thin shim over :meth:`CoverCommandService.classify_state_change` --
         Phase F relocated the body into ``managers/cover_command/state_classifier.py``.
         The ``_target_just_reached`` set is passed by reference so the
         classifier mutates the same object that
@@ -927,7 +928,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Emit a single debug line when the manual-override detection gate is closed."""
         self.logger.debug(
             "manual override detection gate closed at %s "
-            "(manual_toggle=%s, automatic_control=%s) — skipping %s",
+            "(manual_toggle=%s, automatic_control=%s) -- skipping %s",
             where,
             self.manual_toggle,
             self.automatic_control,
@@ -984,14 +985,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         On restart, WeatherManager._override_active resets to False. If conditions
         are still active, no state-change event fires, so async_check_weather_state_change
-        never sees the active→clear transition and never starts the clear-delay timer.
+        never sees the active->clear transition and never starts the clear-delay timer.
         Restoring the flag here ensures the normal clear-delay path runs correctly.
         """
         if not self._weather_mgr.configured_sensors:
             return
         if self._weather_mgr.is_any_condition_active:
             self.logger.info(
-                "Startup: weather conditions active — restoring override state "
+                "Startup: weather conditions active -- restoring override state "
                 "so clear-delay timeout will fire when conditions end"
             )
             self._weather_mgr.record_conditions_active()
@@ -1006,7 +1007,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._weather_mgr.reconcile() == "should_start_timeout":
             self.logger.info(
                 "Weather reconciliation: override active but conditions clear "
-                "and no timer running — starting clear-delay timeout"
+                "and no timer running -- starting clear-delay timeout"
             )
             self._start_weather_timeout()
 
@@ -1025,7 +1026,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._weather_readings = self._snapshot_builder.read_climate(options)
 
         # Compute the effective default position from astronomical sunset/sunrise.
-        # This is the single source of truth — all pipeline handlers use it via
+        # This is the single source of truth -- all pipeline handlers use it via
         # snapshot.default_position.  The sunset_pos is active when current time
         # is after (astronomical_sunset + sunset_offset) or before
         # (astronomical_sunrise + sunrise_offset).
@@ -1090,7 +1091,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
 
         self.logger.debug(
-            "Pipeline result: %s → %s",
+            "Pipeline result: %s -> %s",
             self._pipeline_result.control_method,
             self._pipeline_result.position,
         )
@@ -1200,24 +1201,52 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Self-heal stuck weather override (issue #255: missed state-change events)
         self._reconcile_weather_override()
 
-        # Calculate cover state (pipeline runs with up-to-date override state)
-        state = self._calculate_cover_state(cover_data, options)
+        # Read custom-position sensor states early so the fingerprint includes
+        # them, and prev_custom_position_sensors_active is stamped correctly below.
+        current_custom_position_sensors_active = {
+            s.entity_id: s.is_on
+            for s in self._snapshot_builder.read_custom_position_sensors(options)
+        }
+
+        # 3.4 pipeline short-circuit: skip _calculate_cover_state when ALL
+        # pipeline inputs are identical to the previous cycle.
+        _fp = UpdateFingerprint.from_coordinator_state(
+            self._snapshot,
+            manual_override_active=self.manager.binary_cover_manual,
+            weather_override_active=self.is_weather_override_active,
+            motion_timeout_active=self.is_motion_timeout_active,
+            grace_period_active=self._grace_mgr.any_command_grace_active,
+            in_time_window=self.check_adaptive_time,
+            custom_position_sensor_states=current_custom_position_sensors_active,
+        )
+        _can_skip = (
+            not self.state_change
+            and not self.cover_state_change
+            and not self.first_refresh
+            and not auto_expired
+            and self._last_fingerprint is not None
+            and _fp == self._last_fingerprint
+        )
+        if _can_skip:
+            self.logger.debug(
+                "Fingerprint unchanged - skipping _calculate_cover_state (3.4 opt)"
+            )
+            state = self.state
+        else:
+            # Calculate cover state (pipeline runs with up-to-date override state)
+            state = self._calculate_cover_state(cover_data, options)
+        self._last_fingerprint = _fp
 
         # Update prev state for next cycle (current force override state is now
         # captured in the snapshot we just built).
         self._prev_force_override_active = self.is_force_override_active
 
-        # Same for custom-position sensors: stamp this cycle's on/off map so
-        # next cycle can detect the on → off transition for the release edge.
-        current_custom_position_sensors_active = {
-            s.entity_id: s.is_on
-            for s in self._snapshot_builder.read_custom_position_sensors(options)
-        }
+        # Stamp _prev_custom_position_sensors_active for next cycle.
         self._prev_custom_position_sensors_active = (
             current_custom_position_sensors_active
         )
 
-        # Set of sensors that transitioned on → off this cycle.  When the
+        # Set of sensors that transitioned on -> off this cycle.  When the
         # triggering entity is one of these, force=True bypasses time/position
         # delta gates so covers return to the calculated position promptly.
         custom_position_released_entities = {
@@ -1304,12 +1333,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
 
     def _compute_mean_cover_position(self) -> int | None:
-        """Return integer mean of current entity positions, or None if none are available.
-
-        Used to populate PipelineSnapshot.current_cover_position so the
-        MotionTimeoutHandler can hold covers at their current physical position
-        in hold_position mode.
-        """
+        """Return integer mean of current entity positions, or None if none are available."""
         if self._snapshot is None:
             return None
         positions = [
@@ -1332,40 +1356,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         sun_just_appeared: bool = False,
         use_my_position: bool = False,
     ) -> PositionContext:
-        """Build a PositionContext for the given cover entity.
-
-        Assembles all coordinator-level flags into the dataclass that
-        CoverCommandService.apply_position() uses for gate checks.
-
-        Args:
-            entity: Cover entity ID
-            options: Config entry options dict
-            force: If True, delta/time/manual_override gate checks are bypassed.
-                Use for any intentional non-solar reposition.  NOTE: force=True
-                does NOT bypass auto_control_off — pass bypass_auto_control=True
-                or is_safety=True for that.
-            is_safety: If True, the target is classified as safety-critical
-                (force override, weather) and will persist across window
-                boundaries — reconciliation will resend it even when outside
-                the active-hours window or with auto control off.  Must be
-                kept independent of ``force``: override-clear and toggle
-                actions need ``force=True`` (bypass gates) but
-                ``is_safety=False`` (don't persist past the window).
-            bypass_auto_control: If True, the auto_control_off gate is bypassed
-                for this one-shot call without classifying the target as a
-                safety target.  Use only for sanctioned transition actions
-                (e.g. switch return-to-default at the moment auto_control
-                toggles off).  Not used by the regular update loop.
-            sun_just_appeared: Pre-computed sun transition flag. Call
-                ``_check_sun_validity_transition()`` once before a multi-entity
-                loop and pass the result here so the stateful transition check
-                fires exactly once per update cycle.
-            use_my_position: If True, ORed into the context flag that routes
-                non-position-capable covers through ``stop_cover`` instead of
-                open/close.  Caller-supplied value is ORed with the pipeline
-                result's ``use_my_position`` so either source can enable it.
-
-        """
+        """Build a PositionContext for the given cover entity."""
         return PositionContext(
             auto_control=self.automatic_control or self._pipeline_bypasses_auto_control,
             manual_override=self.manager.is_cover_manual(entity),
@@ -1396,15 +1387,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         reason: str,
         ctx,
     ) -> tuple[str, str] | None:
-        """Send a position command or record a hold-mode skip.
-
-        When the active pipeline result has skip_command=True (hold_position
-        mode during motion timeout), no command is issued. A motion_hold skip
-        record is written instead so diagnostics show why the cover didn't move.
-        All other callers (forced transitions, override clears, window events)
-        bypass this helper and call apply_position directly so they are never
-        blocked by hold mode.
-        """
+        """Send a position command or record a hold-mode skip."""
         if self._pipeline_result is not None and self._pipeline_result.skip_command:
             self._cmd_svc.record_skipped_action(
                 cover,
@@ -1429,100 +1412,46 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         entities: list[str] | None = None,
         trigger: str = "manual_override_cleared",
     ) -> set[str]:
-        """Send the pipeline position after a manual override clears.
-
-        Single authoritative path for both the auto-expiry timer and the reset
-        button.  All gate checks live here so neither caller needs to duplicate
-        them.
-
-        **Time-window guard:** Outside the active-hours window the integration
-        has no business repositioning covers.  The normal update cycle sends the
-        correct position when the window reopens.
-
-        **Automatic-control guard:** When Automatic Control is OFF the cover
-        must stay wherever the user left it.
-
-        Args:
-            state: Post-reset pipeline position (computed without the override).
-            options: Config entry options dict.
-            entities: Covers to target.  Defaults to ``self.entities`` (all
-                covers), but the reset button supplies only the covers it just
-                cleared so multi-cover instances are not accidentally moved.
-            trigger: Reason string forwarded to ``apply_position`` and recorded
-                in ``last_skipped_action``.  Defaults to
-                ``"manual_override_cleared"`` (auto-expiry); the reset button
-                passes ``"manual_reset"``.
-
-        Returns:
-            Set of entity_ids that were successfully sent to (``"sent"``
-            outcome).  Callers use this to clear ``wait_for_target`` for
-            entities that were gated or skipped.
-
-        """
+        """Send the pipeline position after a manual override clears."""
         target_covers = entities if entities is not None else list(self.entities)
 
         if not self.check_adaptive_time:
             self.logger.debug(
-                "Manual override cleared for %s but outside active-hours window — "
-                "skipping reposition (pipeline position was %s; will apply when "
-                "window opens)",
-                target_covers,
-                state,
+                "%s: outside time window -- not repositioning covers", trigger
             )
             return set()
 
         if not self.automatic_control:
             self.logger.debug(
-                "Manual override cleared for %s but automatic control is OFF — "
-                "skipping reposition (pipeline position was %s)",
-                target_covers,
-                state,
+                "%s: automatic control is OFF -- not repositioning covers", trigger
             )
             return set()
 
-        self.logger.debug(
-            "Sending pipeline position %s after manual override cleared for %s",
-            state,
-            target_covers,
-        )
+        sent_entities: set[str] = set()
         sun_just_appeared = self._check_sun_validity_transition()
-        sent: set[str] = set()
         for cover in target_covers:
             ctx = self._build_position_context(
-                cover, options, force=True, sun_just_appeared=sun_just_appeared
+                cover,
+                options,
+                force=True,
+                sun_just_appeared=sun_just_appeared,
             )
-            outcome, _ = await self._cmd_svc.apply_position(
+            outcome = await self._cmd_svc.apply_position(
                 cover, state, trigger, context=ctx
             )
-            if outcome == "sent":
-                sent.add(cover)
-        return sent
+            if outcome is not None and outcome[0] == "sent":
+                sent_entities.add(cover)
+
+        return sent_entities
 
     async def async_handle_state_change(
         self,
         state: int,
         options,
         prev_force_override: bool = False,
-        custom_position_released_entities: set[str] | None = None,
+        custom_position_released_entities: set | None = None,
     ):
-        """Send position commands to all covers when a tracked entity changes.
-
-        When the active pipeline result has bypass_auto_control=True (force
-        override or weather safety handler), we pass force=True to the position
-        context so that time_delta and position_delta gates cannot block
-        safety-critical commands.  The reason string also reflects the handler
-        that won rather than always saying "solar".
-
-        When a force override just released (prev_force_override=True and it is
-        now inactive), force=True is also passed so the time delta check cannot
-        block the return to the calculated position.  The force override's own
-        position change should not count against the time threshold.
-
-        ``custom_position_released_entities`` holds the set of custom-position
-        sensors that flipped on → off this cycle.  When the triggering entity
-        for this refresh is one of them, force=True is also passed so the
-        return to the calculated position is not throttled (#365).
-        """
+        """Send position commands to all covers when a tracked entity changes."""
         sun_just_appeared = self._check_sun_validity_transition()
         is_safety = self._pipeline_is_safety_handler
         force_override_released = (
@@ -1554,11 +1483,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 and trigger_entity in custom_position_released_entities
             )
 
-        # Outside the configured time window, only safety handlers (force
-        # override, weather) are allowed to move covers.  All other handlers
-        # (solar, climate, cloud, default) must not reposition covers before
-        # the user's start time or after the end time.  The pipeline still
-        # evaluates so diagnostics/sensor state remain correct.
         custom_position_sensor_triggered = self._is_custom_position_sensor_trigger()
 
         if (
@@ -1633,24 +1557,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         Drains self._pending_cover_events so that rapid state changes from
         multiple covers are all evaluated, not just the most recent one.
         """
-        # Drain and clear the queue atomically so a concurrent refresh that
-        # fires while we iterate does not re-process the same events.
         events = self._pending_cover_events[:]
         self._pending_cover_events.clear()
 
-        # NB (issue #293): observation is not action.  When automatic_control
-        # is OFF we still drain events so the user's manual response is recorded
-        # and any latched target gets discarded via the existing
-        # discard_target() call below.  Only manual_toggle=False (the user has
-        # globally disabled manual override detection) short-circuits the loop.
         if not self.manual_toggle:
             self._manual_gate_closed_log("state_change", [e.entity_id for e in events])
             self.cover_state_change = False
             self.logger.debug("Cover state change handled")
             return
 
-        # Check startup grace period FIRST; suppress all events during
-        # HA restart when covers respond slowly.
         if self._is_in_startup_grace_period():
             entity_ids = [e.entity_id for e in events]
             self.logger.debug(
@@ -1660,12 +1575,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.cover_state_change = False
             return
 
-        # When manual_ignore_external is on, only ACP-routed commands (proxy
-        # entity, set_position service) engage manual override — those use the
-        # pre-emptive mark_user_command path inside async_apply_user_position
-        # and never reach the detection paths below. Skip the whole loop, but
-        # still drain _target_just_reached housekeeping so a later legitimate
-        # move isn't misclassified.
         if self.manual_ignore_external:
             for event_data in events:
                 self._target_just_reached.discard(event_data.entity_id)
@@ -1680,14 +1589,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         for event_data in events:
             entity_id = event_data.entity_id
 
-            # User-context fast-path: when a cover state-change event carries
-            # an HA Context whose id was NOT generated by ACP and whose user_id
-            # is not None, a real user took action (HA dashboard, voice
-            # assistant, etc.). Mark manual override directly. This is the only
-            # reliable path for assumed-state and OPEN/CLOSE-only covers — the
-            # numeric path in handle_state_change() can be defeated by races
-            # where ACP's reconciliation counter-commands before the queued
-            # event is drained, masking the user's input.
             new_state_obj = event_data.new_state
             ctx = getattr(new_state_obj, "context", None) if new_state_obj else None
             if (
@@ -1703,19 +1604,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     context_id=ctx.id,
                 )
                 if handled:
-                    # On the not-manual→manual edge the manager fires
-                    # on_engaged → discard_target (issue #215/#216).
-                    # Consume any pending target_just_reached flag so the
-                    # numeric path doesn't fire later for the same entity.
                     self._target_just_reached.discard(entity_id)
                     continue
 
-            # Skip manual override detection when the cover just reached its
-            # commanded target in this same event.  process_entity_state_change()
-            # adds the entity to _target_just_reached when check_target_reached()
-            # clears wait_for_target; without this guard the small positional
-            # difference allowed by POSITION_TOLERANCE_PERCENT would be
-            # misidentified as a user-initiated manual override.
             if entity_id in self._target_just_reached:
                 self._target_just_reached.discard(entity_id)
                 self.logger.debug(
@@ -1724,10 +1615,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
                 continue
 
-            # Use the recorded target if available (the actual sent position),
-            # otherwise fall back to calculated state. Critical for open/close-only
-            # covers where the calculated state gets transformed (via threshold)
-            # to 0 or 100 before sending.
             recorded_target = self._cmd_svc.get_target(entity_id)
             expected_position = state if recorded_target is None else recorded_target
 
@@ -1736,10 +1623,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 if self._pipeline_result is not None
                 else None
             )
-            # On the not-manual→manual edge the manager fires on_engaged →
-            # discard_target, so a freshly-detected override drops any
-            # pre-existing integration target (incl. safety-tagged end-time
-            # defaults) before reconciliation can resurrect it (issue #215/#216).
             self.manager.handle_state_change(
                 event_data,
                 expected_position,
@@ -1756,30 +1639,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.cover_state_change = False
         self.logger.debug("Cover state change handled")
 
-    async def async_handle_first_refresh(self, state: int, options):
+    async def async_handle_first_refresh(self, state: int, options: dict) -> None:
         """Set target positions and send initial positioning commands after startup."""
         is_safety = self._pipeline_is_safety_handler
-
-        # Outside the time window, only safety handlers (force override, weather)
-        # are allowed to move covers on startup.  This prevents covers from
-        # repositioning when HA restarts at midnight or another time outside the
-        # configured operational window.
         if not self.check_adaptive_time and not is_safety:
             self.first_refresh = False
-            self.logger.debug(
-                "First refresh outside time window — skipping position update"
-            )
+            self.logger.debug("First refresh outside time window -- skipping position update")
             return
-
         if self._is_reload and not is_safety:
             self.first_refresh = False
             self._is_reload = False
             self.logger.debug(
-                "First refresh during config-entry reload — "
-                "skipping position update to avoid disturbing user-controlled covers"
+                "First refresh during config-entry reload -- skipping position update "
+                "to avoid disturbing user-controlled covers"
             )
             return
-
         sun_just_appeared = self._check_sun_validity_transition()
         for cover in self.entities:
             if self.manager.is_cover_manual(cover):
@@ -1800,6 +1674,239 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._is_reload = False
         self.logger.debug("First refresh handled")
 
+    @property
+    def state(self) -> int:
+        """Return current calculated cover position."""
+        if self._pipeline_result is None:
+            return 0
+
+        position = self._pipeline_result.position
+
+        # Floor-clamped results are already in cover-position space.
+        # Applying inverse_state or interpolation again would double-transform them.
+        if self._pipeline_result.floor_clamp_applied:
+            return position
+
+        if self._use_interpolation:
+            position = interpolate_position(
+                position,
+                self.start_value,
+                self.end_value,
+                self.normal_list,
+                self.new_list,
+            )
+
+        if self._inverse_state:
+            position = 100 - position
+
+        return int(round(position))
+
+    @property
+    def _pipeline_bypasses_auto_control(self) -> bool:
+        """True when the active pipeline result sets bypass_auto_control."""
+        if self._pipeline_result is None:
+            return False
+        return self._pipeline_result.bypass_auto_control
+
+    @property
+    def _pipeline_is_safety_handler(self) -> bool:
+        """True only when the active pipeline result came from a genuine safety handler."""
+        if self._pipeline_result is None:
+            return False
+        return self._pipeline_result.control_method in (
+            ControlMethod.FORCE,
+            ControlMethod.WEATHER,
+        )
+
+    def _is_custom_position_sensor_trigger(self) -> bool:
+        """Return True when this refresh was edge-triggered by a custom-position slot's own sensor."""
+        if self._pipeline_result is None:
+            return False
+        if self._pipeline_result.control_method is not ControlMethod.CUSTOM_POSITION:
+            return False
+        trigger = self._last_state_change_entity
+        if trigger is None:
+            return False
+        options = self.config_entry.options
+        return any(
+            options.get(slot_keys["sensor"]) == trigger
+            for slot_keys in CUSTOM_POSITION_SLOTS.values()
+        )
+
+    def switch_mode(self) -> bool:
+        """Return climate mode toggle state."""
+        return self._toggles.switch_mode
+
+    @property
+    def manual_toggle(self) -> bool:
+        """Return manual override toggle state."""
+        return self._toggles.manual_toggle
+
+    @property
+    def automatic_control(self):
+        """Automatic control toggle delegates to ToggleManager."""
+        return self._toggles.automatic_control
+
+    @automatic_control.setter
+    def automatic_control(self, value):
+        """Set automatic control toggle."""
+        self._toggles.automatic_control = value
+
+    @property
+    def enabled_toggle(self) -> bool | None:
+        """Return enabled toggle state."""
+        return self._toggles.enabled_toggle
+
+    @property
+    def min_change(self) -> int:
+        """Return minimum position change threshold."""
+        return self._toggles.min_change
+
+    @min_change.setter
+    def min_change(self, value: int) -> None:
+        self._toggles.min_change = value
+
+    @property
+    def time_threshold(self) -> int:
+        """Return minimum time between commands in seconds."""
+        return self._toggles.time_threshold
+
+    @time_threshold.setter
+    def time_threshold(self, value: int) -> None:
+        self._toggles.time_threshold = value
+
+    def _update_options(self, options: dict) -> None:
+        """Update coordinator options and dependent state."""
+        self._time_mgr.update(hass=self.hass, options=options)
+        self._toggles.update(options)
+        self._motion_mgr.update(hass=self.hass, options=options)
+        self._weather_mgr.update(hass=self.hass, options=options)
+
+    def _update_manager_and_covers(self) -> None:
+        """Synchronise cover capabilities into the manager."""
+        if self._snapshot is None:
+            return
+        for entity_id, caps in self._snapshot.cover_capabilities.items():
+            self.manager.update_cover_capabilities(entity_id, dataclasses.asdict(caps))
+
+    def build_diagnostic_data(self) -> dict | None:
+        """Build diagnostic data from current coordinator state."""
+        result = self._pipeline_result
+        if result is None or self._cover_data is None:
+            return None
+
+        # Live cover positions and capabilities
+        cover_entities = self.entities or []
+        _positions = self._cover_provider.read_positions(cover_entities, self._policy)
+        _caps = self._cover_provider.read_all_capabilities(cover_entities)
+        _covers = {
+            eid: {
+                "current_position": _positions.get(eid),
+                "available": _positions.get(eid) is not None,
+                "capabilities": (
+                    dataclasses.asdict(_caps[eid]) if eid in _caps else None
+                ),
+            }
+            for eid in cover_entities
+        }
+
+        # Per-entity manual override live state
+        _now = dt.datetime.now(dt.UTC)
+        _reset_secs = self.manager.reset_duration.total_seconds()
+        _mo_entries = {}
+        for eid in self.manager.covers:
+            active = self.manager.manual_control.get(eid, False)
+            started_at = self.manager.manual_control_time.get(eid)
+            if started_at is not None:
+                if started_at.tzinfo is None:
+                    started_at = started_at.replace(tzinfo=dt.UTC)
+                elapsed = (_now - started_at).total_seconds()
+                remaining = max(0, _reset_secs - elapsed)
+                _mo_entries[eid] = {
+                    "active": active,
+                    "started_at": started_at.isoformat(),
+                    "remaining_seconds": int(remaining),
+                }
+        _manual_override_state = {
+            "reset_duration_seconds": int(_reset_secs),
+            "tracked_covers": sorted(self.manager.covers),
+            "entries": _mo_entries,
+        }
+
+        _last_success_time = self._last_update_success_time
+        _last_exc = getattr(self, "last_exception", None)
+
+        ctx = DiagnosticContext(
+            pos_sun=self.pos_sun,
+            cover=self._cover_data,
+            pipeline_result=result,
+            climate_mode=self._climate_mode,
+            check_adaptive_time=self.check_adaptive_time,
+            after_start_time=self.after_start_time,
+            before_end_time=self.before_end_time,
+            start_time=self._time_mgr.start_time_value,
+            end_time=self._end_time,
+            automatic_control=self.automatic_control,
+            last_cover_action=self.last_cover_action,
+            last_skipped_action=self.last_skipped_action,
+            min_change=self.min_change,
+            time_threshold=self.time_threshold,
+            switch_mode=self._toggles.switch_mode,
+            inverse_state=self._inverse_state,
+            use_interpolation=self._use_interpolation,
+            final_state=self.state,
+            config_options=dict(self.config_entry.options),
+            motion_detected=self.is_motion_detected,
+            motion_timeout_active=self._motion_mgr.is_motion_timeout_active,
+            motion_hold_active=(
+                result.skip_command
+                and result.control_method == ControlMethod.MOTION
+            ),
+            force_override_sensors=self.config_entry.options.get(
+                CONF_FORCE_OVERRIDE_SENSORS, []
+            ),
+            force_override_position=self.config_entry.options.get(
+                CONF_FORCE_OVERRIDE_POSITION, 0
+            ),
+            event_timeline=self._event_buffer.snapshot() or None,
+            cover_command_state=self._cmd_svc.get_all_entity_state_snapshots() or None,
+            debug_config={
+                "dry_run": self.config_entry.options.get(CONF_DRY_RUN, False),
+                "debug_mode": self.config_entry.options.get(CONF_DEBUG_MODE, False),
+                "debug_categories": self.config_entry.options.get(
+                    CONF_DEBUG_CATEGORIES, []
+                ),
+                "debug_event_buffer_size": self.config_entry.options.get(
+                    CONF_DEBUG_EVENT_BUFFER_SIZE, DEFAULT_DEBUG_EVENT_BUFFER_SIZE
+                ),
+            },
+            integration_version=_MANIFEST_VERSION,
+            cover_type=self._cover_type,
+            last_update_success=self.last_update_success,
+            last_exception_repr=repr(_last_exc) if _last_exc is not None else None,
+            last_update_success_time_iso=(
+                _last_success_time.isoformat()
+                if _last_success_time is not None
+                else None
+            ),
+            update_interval_seconds=(
+                self.update_interval.total_seconds()
+                if self.update_interval is not None
+                else None
+            ),
+            covers=_covers,
+            manual_override_state=_manual_override_state,
+            manual_toggle=self.manual_toggle,
+            enabled_toggle=(
+                self.enabled_toggle if self.enabled_toggle is not None else True
+            ),
+            primary_axis_suppression_counts=(
+                self.manager.primary_axis_suppression_counts()
+            ),
+        )
+        diagnostics_dict, _explanation = self._diagnostics_builder.build(ctx)
+        return diagnostics_dict
+
     def _build_pipeline(self) -> PipelineRegistry:
         """Build the override pipeline from the registry of handler factories.
 
@@ -1817,7 +1924,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         self._handler_by_name = {h.name: h for h in handlers}
         return PipelineRegistry(
-            handlers, event_buffer=getattr(self, "_event_buffer", None)
+            handlers,
+            event_buffer=getattr(self, "_event_buffer", None),
         )
 
     def _update_options(self, options):
@@ -1899,8 +2007,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         sun_data = self._sun_provider.create_sun_data(self.hass.config.time_zone)
         config = self._config_service.get_common_data(options)
         _raw_azi, _raw_elev = self.pos_sun
+        # When sun.sun is unavailable both attributes return None.  Using 0.0/0.0
+        # is dangerous: azimuth=0, elevation=0 is a valid-looking sun position
+        # that could place the sun inside a window's FOV and send spurious commands.
+        # Guard: when elevation is None (sun.sun truly unavailable) set sol_elev=-1.0
+        # so SunGeometry.valid_elevation returns False and no solar positioning
+        # commands are issued until the sun entity recovers.
+        _sun_unavailable = _raw_azi is None and _raw_elev is None
+        if _sun_unavailable:
+            self.logger.warning(
+                "sun.sun attributes unavailable -- solar tracking disabled until "
+                "sun entity reports valid azimuth/elevation"
+            )
         sol_azi = _raw_azi if _raw_azi is not None else 0.0
-        sol_elev = _raw_elev if _raw_elev is not None else 0.0
+        # -1.0 elevation is below the horizon; valid_elevation requires elev >= 0
+        sol_elev = (
+            _raw_elev if _raw_elev is not None else (-1.0 if _sun_unavailable else 0.0)
+        )
         return self._policy.build_calc_engine(
             logger=self.logger,
             sol_azi=sol_azi,
@@ -1913,12 +2036,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     @property
     def check_adaptive_time(self):
-        """Check if current time is within operational window — delegates to TimeWindowManager."""
+        """Check if current time is within operational window -- delegates to TimeWindowManager."""
         return self._time_mgr.is_active
 
     @property
     def after_start_time(self):
-        """Check if current time is after start time — delegates to TimeWindowManager."""
+        """Check if current time is after start time -- delegates to TimeWindowManager."""
         return self._time_mgr.after_start_time
 
     @property
@@ -1933,35 +2056,25 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     @property
     def _end_time(self) -> dt.datetime | None:
-        """Get end time — delegates to TimeWindowManager."""
+        """Get end time -- delegates to TimeWindowManager."""
         return self._time_mgr.end_time
 
     @property
     def before_end_time(self):
-        """Check if current time is before end time — delegates to TimeWindowManager."""
+        """Check if current time is before end time -- delegates to TimeWindowManager."""
         return self._time_mgr.before_end_time
 
     def _get_current_position(self, entity) -> int | None:
-        """Get current position of cover — delegates to CoverCommandService."""
+        """Get current position of cover -- delegates to CoverCommandService."""
         return self._cmd_svc.get_current_position(entity)
 
     def get_current_position(self, entity) -> int | None:
-        """Public surface for reading a cover's current position.
-
-        Delegates to :meth:`_get_current_position` so binary_sensor + tests
-        that mock the private name keep working until the cover_command split
-        replaces them in commit 4.
-        """
+        """Public surface for reading a cover's current position."""
         return self._get_current_position(entity)
 
     @property
     def pos_sun(self):
-        """Get current sun azimuth and elevation.
-
-        Returns:
-            List containing [azimuth, elevation] in degrees from sun.sun entity
-
-        """
+        """Get current sun azimuth and elevation."""
         return [
             state_attr(self.hass, "sun.sun", "azimuth"),
             state_attr(self.hass, "sun.sun", "elevation"),
@@ -2020,21 +2133,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         floors = gather_active_floors(snapshot)
         effective_floor_pos, _ = effective_floor(floors)
         clamped = max(int(requested), effective_floor_pos)
-        if clamped != requested:
-            _LOGGER.info(
-                "%s: requested %d clamped to %d (active min-mode floor)",
-                trigger,
-                requested,
-                clamped,
-            )
-        else:
-            _LOGGER.debug(
-                "%s: requested %d, floor %d — no clamping needed",
-                trigger,
-                requested,
-                effective_floor_pos,
-            )
-
         if not force:
             result = self._pipeline.evaluate(snapshot)
             winner_step = next(
@@ -2052,13 +2150,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     winner_handler.priority if winner_handler is not None else 0
                 )
                 if winner_priority > ManualOverrideHandler.priority:
-                    _LOGGER.info(
-                        "user move on %s preempted by %s (priority %d > %d)",
-                        entity_id,
-                        winner_name,
-                        winner_priority,
-                        ManualOverrideHandler.priority,
-                    )
                     self._cmd_svc.record_preempted_skip(
                         entity_id,
                         clamped,
@@ -2067,7 +2158,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     )
                     return "skipped", f"preempted_by_{winner_name}"
             self.manager.mark_user_command(entity_id, reason=trigger)
-
         ctx = self._build_position_context(
             entity_id,
             opts,
@@ -2077,295 +2167,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         return await self._cmd_svc.apply_position(entity_id, clamped, trigger, ctx)
 
-    async def async_apply_user_stop(
-        self,
-        entity_id: str,
-        *,
-        trigger: str,
-    ) -> tuple[str, str]:
-        """Apply a user-initiated stop to a single cover.
-
-        Engages manual override (so the next cycle does not immediately
-        counter-command the cover) then dispatches an ACP-context-stamped
-        ``cover.stop_cover`` via :meth:`CoverCommandService.apply_user_stop`.
-        Stop is unconditional — no pipeline preemption check.
-        """
+    async def async_apply_user_stop(self, entity_id: str, *, trigger: str = "stop") -> tuple[str, str]:
+        """Apply a user-initiated stop to a single cover."""
         self.manager.mark_user_command(entity_id, reason=trigger)
         return await self._cmd_svc.apply_user_stop(entity_id)
-
-    def build_diagnostic_data(self) -> dict:
-        """Build diagnostic data from current coordinator state."""
-        result = self._pipeline_result
-
-        # Live cover positions and capabilities
-        cover_entities = self.entities or []
-        _positions = self._cover_provider.read_positions(cover_entities, self._policy)
-        _caps = self._cover_provider.read_all_capabilities(cover_entities)
-        _covers = {
-            eid: {
-                "current_position": _positions.get(eid),
-                "available": _positions.get(eid) is not None,
-                "capabilities": (
-                    dataclasses.asdict(_caps[eid]) if eid in _caps else None
-                ),
-            }
-            for eid in cover_entities
-        }
-
-        # Per-entity manual override live state
-        _now = dt.datetime.now(dt.UTC)
-        _reset_secs = self.manager.reset_duration.total_seconds()
-        _mo_entries = {}
-        for eid in self.manager.covers:
-            active = self.manager.manual_control.get(eid, False)
-            started_at = self.manager.manual_control_time.get(eid)
-            if started_at is not None:
-                if started_at.tzinfo is None:
-                    started_at = started_at.replace(tzinfo=dt.UTC)
-                elapsed = (_now - started_at).total_seconds()
-                remaining = max(0, _reset_secs - elapsed)
-                _mo_entries[eid] = {
-                    "active": active,
-                    "started_at": started_at.isoformat(),
-                    "remaining_seconds": int(remaining),
-                }
-        _manual_override_state = {
-            "reset_duration_seconds": int(_reset_secs),
-            "tracked_covers": sorted(self.manager.covers),
-            "entries": _mo_entries,
-        }
-
-        # Coordinator update health
-        _last_success_time = self._last_update_success_time
-        _last_exc = self.last_exception
-
-        ctx = DiagnosticContext(
-            pos_sun=self.pos_sun,
-            cover=self._cover_data,
-            pipeline_result=result,
-            climate_mode=self._climate_mode,
-            check_adaptive_time=self.check_adaptive_time,
-            after_start_time=self.after_start_time,
-            before_end_time=self.before_end_time,
-            start_time=self._time_mgr.start_time_value,
-            end_time=self._end_time,
-            automatic_control=self.automatic_control,
-            last_cover_action=self.last_cover_action,
-            last_skipped_action=self.last_skipped_action,
-            min_change=self.min_change,
-            time_threshold=self.time_threshold,
-            switch_mode=self._toggles.switch_mode,
-            inverse_state=self._inverse_state,
-            use_interpolation=self._use_interpolation,
-            final_state=self.state,
-            config_options=dict(self.config_entry.options),
-            motion_detected=self.is_motion_detected,
-            motion_timeout_active=self._motion_mgr.is_motion_timeout_active,
-            motion_hold_active=(
-                self._pipeline_result is not None
-                and self._pipeline_result.skip_command
-                and self._pipeline_result.control_method == ControlMethod.MOTION
-            ),
-            force_override_sensors=self.config_entry.options.get(
-                CONF_FORCE_OVERRIDE_SENSORS, []
-            ),
-            force_override_position=self.config_entry.options.get(
-                CONF_FORCE_OVERRIDE_POSITION, 0
-            ),
-            event_timeline=self._event_buffer.snapshot() or None,
-            cover_command_state=self._cmd_svc.get_all_entity_state_snapshots() or None,
-            debug_config={
-                "dry_run": self.config_entry.options.get(CONF_DRY_RUN, False),
-                "debug_mode": self.config_entry.options.get(CONF_DEBUG_MODE, False),
-                "debug_categories": self.config_entry.options.get(
-                    CONF_DEBUG_CATEGORIES, []
-                ),
-                "debug_event_buffer_size": self.config_entry.options.get(
-                    CONF_DEBUG_EVENT_BUFFER_SIZE, DEFAULT_DEBUG_EVENT_BUFFER_SIZE
-                ),
-            },
-            # New meta fields
-            integration_version=_MANIFEST_VERSION,
-            cover_type=self._cover_type,
-            last_update_success=self.last_update_success,
-            last_exception_repr=repr(_last_exc) if _last_exc is not None else None,
-            last_update_success_time_iso=(
-                _last_success_time.isoformat()
-                if _last_success_time is not None
-                else None
-            ),
-            update_interval_seconds=(
-                self.update_interval.total_seconds()
-                if self.update_interval is not None
-                else None
-            ),
-            covers=_covers,
-            manual_override_state=_manual_override_state,
-            manual_toggle=self.manual_toggle,
-            enabled_toggle=(
-                self.enabled_toggle if self.enabled_toggle is not None else True
-            ),
-            primary_axis_suppression_counts=(
-                self.manager.primary_axis_suppression_counts()
-            ),
-        )
-
-        diagnostics, explanation = self._diagnostics_builder.build(ctx)
-
-        if explanation != self._last_position_explanation:
-            self.logger.debug("Position explanation changed: %s", explanation)
-            self._last_position_explanation = explanation
-
-        return diagnostics
-
-    @property
-    def state(self) -> int:
-        """Final cover position after pipeline, interpolation, and inverse_state transforms.
-
-        The pipeline always runs so _pipeline_result is always set.  Safety
-        override handlers (ForceOverride, WeatherOverride) set
-        bypass_auto_control=True on their result, which causes their position
-        to be returned directly — bypassing interpolation and inverse_state —
-        even when automatic_control is OFF or outside the time window.
-
-        Floor-clamped winners (issue #469): when the registry raises a
-        non-bypass winner's position to a user-configured floor, the
-        resulting value is already in cover-position space.  Interpolation
-        and inverse_state would re-map a user-typed floor through the
-        calibration curve and silently dispatch a different position, so
-        the same short-circuit applies.
-        """
-        # Safety overrides and floor-clamped winners both produce positions
-        # already in cover-position space — skip post-processing transforms.
-        if (
-            self._pipeline_bypasses_auto_control
-            or self._pipeline_result.floor_clamp_applied
-        ):
-            return self._pipeline_result.position
-
-        state = self._pipeline_result.position
-
-        # Post-processing: interpolation and inverse state
-        if self._use_interpolation:
-            state = interpolate_position(
-                state,
-                self.start_value,
-                self.end_value,
-                self.normal_list,
-                self.new_list,
-            )
-
-        if self._inverse_state and self._use_interpolation:
-            self.logger.info("Inverse state is not supported with interpolation")
-
-        if self._inverse_state and not self._use_interpolation:
-            state = inverse_state(state)
-
-        # interpolate_position() returns numpy float64; inverse_state() returns int.
-        # Always coerce to plain Python int so sensors/diagnostics never see a float.
-        return int(round(state))
-
-    # --- Toggle property delegates (switch entities use setattr) ---
-
-    @property
-    def switch_mode(self):
-        """Climate mode toggle — delegates to ToggleManager."""
-        return self._toggles.switch_mode
-
-    @switch_mode.setter
-    def switch_mode(self, value):
-        """Set climate mode toggle."""
-        self._toggles.switch_mode = value
-
-    @property
-    def motion_control(self):
-        """Motion control toggle — delegates to ToggleManager."""
-        return self._toggles.motion_control
-
-    @motion_control.setter
-    def motion_control(self, value):
-        """Set motion control toggle."""
-        self._toggles.motion_control = value
-
-    @property
-    def temp_toggle(self):
-        """Temperature entity toggle — delegates to ToggleManager."""
-        return self._toggles.temp_toggle
-
-    @temp_toggle.setter
-    def temp_toggle(self, value):
-        """Set temperature entity toggle."""
-        self._toggles.temp_toggle = value
-
-    @property
-    def automatic_control(self):
-        """Automatic control toggle — delegates to ToggleManager."""
-        return self._toggles.automatic_control
-
-    @automatic_control.setter
-    def automatic_control(self, value):
-        """Set automatic control toggle."""
-        self._toggles.automatic_control = value
-
-    @property
-    def _pipeline_bypasses_auto_control(self) -> bool:
-        """True when the active pipeline result should run even if automatic_control is OFF.
-
-        Safety handlers (ForceOverrideHandler, WeatherOverrideHandler) set
-        bypass_auto_control=True so that wind/rain/force protection still
-        operates when the user has paused normal sun-tracking automation.
-        CustomPositionHandler also sets this flag to defeat the auto_control
-        gate, but is NOT a safety handler — see _pipeline_is_safety_handler.
-        """
-        return self._pipeline_result.bypass_auto_control
-
-    @property
-    def _pipeline_is_safety_handler(self) -> bool:
-        """True only when the active pipeline result came from a genuine safety handler.
-
-        Genuine safety handlers (ForceOverrideHandler, WeatherOverrideHandler)
-        require force=True so wind/rain/force protection bypasses delta and time
-        gates and always acts immediately.
-
-        Other handlers that set bypass_auto_control=True (e.g.
-        CustomPositionHandler) want to defeat the auto_control gate but must
-        still be subject to the same-position short-circuit and delta/time gates
-        so they don't issue redundant set_cover_position calls on every update
-        cycle (issue #290).
-        """
-        if self._pipeline_result is None:
-            return False
-        return self._pipeline_result.control_method in (
-            ControlMethod.FORCE,
-            ControlMethod.WEATHER,
-        )
-
-    def _is_custom_position_sensor_trigger(self) -> bool:
-        """Return True when this refresh was edge-triggered by a custom-position slot's own sensor.
-
-        When a sensor toggles, the cover may be at a completely different position
-        (e.g. solar tracking just moved it).  Passing force=True lets the command
-        bypass the time-delta gate so the slot's position is actually applied.
-        The same-position short-circuit (PR #300) still suppresses redundant
-        re-sends when the sensor stays active across subsequent solar refreshes.
-        """
-        if self._pipeline_result is None:
-            return False
-        if self._pipeline_result.control_method is not ControlMethod.CUSTOM_POSITION:
-            return False
-        trigger = self._last_state_change_entity
-        if trigger is None:
-            return False
-        options = self.config_entry.options
-        return any(
-            options.get(slot_keys["sensor"]) == trigger
-            for slot_keys in CUSTOM_POSITION_SLOTS.values()
-        )
-
-    @property
-    def manual_toggle(self):
-        """Manual override detection toggle — delegates to ToggleManager."""
-        return self._toggles.manual_toggle
 
     @manual_toggle.setter
     def manual_toggle(self, value):
@@ -2532,10 +2337,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
 
     async def _check_sunset_window_transition(self) -> None:
-        """Delegate astronomical-sunset-window transition handling to the tracker.
+        """Check if the astronomical sunset window has been entered or exited.
 
-        See :meth:`WindowTransitionTracker.check_sunset_window` for the
-        full contract (issue #266).
+        Called from _check_time_window_transition after the end-time callback.
+        Reads options from config_entry so callers do not need to pass them.
         """
         options = self.config_entry.options
         await self._window_tracker.check_sunset_window(
@@ -2558,13 +2363,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         return self._window_tracker.sun_just_appeared(self._cover_data)
 
     async def async_shutdown(self) -> None:
-        """Clean up resources on shutdown.
-
-        Cancels all grace period tasks and stops position verification to ensure
-        clean shutdown without lingering tasks or listeners. Called when integration
-        is unloaded.
-
-        """
+        """Clean up resources on shutdown."""
         # Cancel all grace period tasks
         self._grace_mgr.cancel_all()
 

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -96,6 +96,23 @@ def _source_friendly_label(hass: HomeAssistant, entity_id: str) -> str:
     return entity_id.split(".", 1)[-1].replace("_", " ").title()
 
 
+def _state_key(state: Any) -> tuple:
+    """Return a compact tuple that summarises the observable proxy state.
+
+    Used by _handle_source_event to skip redundant async_write_ha_state()
+    calls when neither the cover state string nor the position/tilt attributes
+    have changed (e.g. repeated OPENING pulses with the same position value).
+    """
+    if state is None:
+        return (None,)
+    return (
+        state.state,
+        state.attributes.get(STATE_ATTR_POSITION),
+        state.attributes.get(STATE_ATTR_TILT_POSITION),
+        state.attributes.get("supported_features"),
+    )
+
+
 class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
     """Proxy cover that mirrors a source and routes commands through ACP."""
 
@@ -122,6 +139,8 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
             self._attr_name = f"{title} Managed ({label})"
         else:
             self._attr_name = f"{title} Managed"
+        # Change-gate: remember last-written state key so we skip no-op writes.
+        self._last_written_state_key: tuple | None = None
 
     # ---- availability + mirroring -------------------------------------- #
 
@@ -196,6 +215,18 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
 
     @callback
     def _handle_source_event(self, event: Event) -> None:
+        """Write HA state when the source cover changes — change-gated.
+
+        Skips the write when the observable state (cover state string,
+        position, tilt, supported_features) is identical to the last write,
+        avoiding spurious HA state writes during rapid OPENING/CLOSING
+        intermediate events that carry no new information.
+        """
+        new_state = event.data.get("new_state")
+        key = _state_key(new_state)
+        if key == self._last_written_state_key:
+            return
+        self._last_written_state_key = key
         self.async_write_ha_state()
 
     # ---- command routing ---------------------------------------------- #

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import numpy as np
 
 from .const import (
@@ -17,16 +19,92 @@ from .const import (
 )
 
 
+@lru_cache(maxsize=256)
+def _calculate_safety_margin(gamma: float, sol_elev: float) -> float:
+    """Calculate safety margin multiplier (>=1.0) — cached pure function.
+
+    Increases blind extension at extreme angles to ensure effective sun blocking:
+    - Gamma margin: increases at extreme horizontal angles
+    - Elevation margin: increases at very low or high angles
+
+    Args:
+        gamma: Surface solar azimuth in degrees (-180 to 180)
+        sol_elev: Sun elevation angle in degrees (0-90)
+
+    Returns:
+        Safety margin multiplier (1.0 to 1.45)
+
+    Cached: inputs are floats derived from sun.sun attributes which change
+    only when the sun moves (every ~30 s for the default 5-min SunData grid).
+    In a 10-cover setup with shared window orientations, cache hit rate is
+    ~90% per coordinator update cycle.
+    """
+    margin = 1.0
+
+    # Gamma margin: increases at extreme horizontal angles
+    gamma_abs = abs(gamma)
+    if gamma_abs > SAFETY_MARGIN_GAMMA_THRESHOLD:
+        # Normalized transition: 0 at threshold, 1 at 90 deg
+        t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
+            90 - SAFETY_MARGIN_GAMMA_THRESHOLD
+        )
+        t = float(np.clip(t, 0, 1))
+        smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
+        margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
+
+    # Elevation margin: increases at very low/high angles
+    if sol_elev < SAFETY_MARGIN_LOW_ELEV_THRESHOLD:
+        t = (
+            SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
+        ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
+        margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
+    elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
+        t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
+            90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
+        )
+        margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
+
+    return float(margin)
+
+
+@lru_cache(maxsize=256)
+def _check_edge_case(
+    sol_elev: float, gamma: float, distance: float, h_win: float
+) -> tuple[bool, float]:
+    """Check for extreme angle edge cases — cached pure function.
+
+    Returns:
+        Tuple of (is_edge_case: bool, position: float)
+        - is_edge_case: True if edge case detected
+        - position: Safe fallback position (only valid if is_edge_case=True)
+
+    Cached: same inputs recur across multiple covers sharing geometry.
+    """
+    # Very low elevation: sun nearly horizontal, full coverage safest
+    if sol_elev < EDGE_CASE_LOW_ELEVATION:
+        return (True, h_win)
+
+    # Extreme gamma: sun perpendicular to window, full coverage
+    if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
+        return (True, h_win)
+
+    # Very high elevation: sun nearly overhead, use simplified calculation
+    if sol_elev > EDGE_CASE_HIGH_ELEVATION:
+        simple_height = distance * np.tan(np.radians(sol_elev))
+        return (True, float(np.clip(simple_height, 0, h_win)))
+
+    return (False, 0.0)
+
+
 class SafetyMarginCalculator:
     """Calculates angle-dependent safety margins for sun blocking accuracy."""
 
     @staticmethod
     def calculate(gamma: float, sol_elev: float) -> float:
-        """Calculate safety margin multiplier (≥1.0).
+        """Calculate safety margin multiplier (>=1.0).
 
-        Increases blind extension at extreme angles to ensure effective sun blocking:
-        - Gamma margin: increases at extreme horizontal angles
-        - Elevation margin: increases at very low or high angles
+        Delegates to the module-level cached function so the result is shared
+        across all instances (e.g. multiple covers at the same orientation).
 
         Args:
             gamma: Surface solar azimuth in degrees (-180 to 180)
@@ -36,32 +114,7 @@ class SafetyMarginCalculator:
             Safety margin multiplier (1.0 to 1.45)
 
         """
-        margin = 1.0
-
-        # Gamma margin: increases at extreme horizontal angles
-        gamma_abs = abs(gamma)
-        if gamma_abs > SAFETY_MARGIN_GAMMA_THRESHOLD:
-            # Normalized transition: 0 at threshold, 1 at 90°
-            t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
-                90 - SAFETY_MARGIN_GAMMA_THRESHOLD
-            )
-            t = float(np.clip(t, 0, 1))
-            smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
-            margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
-
-        # Elevation margin: increases at very low/high angles
-        if sol_elev < SAFETY_MARGIN_LOW_ELEV_THRESHOLD:
-            t = (
-                SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
-            ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
-            margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
-        elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
-            t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
-                90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
-            )
-            margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
-
-        return float(margin)
+        return _calculate_safety_margin(gamma, sol_elev)
 
 
 class EdgeCaseHandler:
@@ -73,8 +126,7 @@ class EdgeCaseHandler:
     ) -> tuple[bool, float]:
         """Check for edge cases and return fallback position if needed.
 
-        Provides robust behavior at edge cases where standard geometric
-        calculations become unstable or inaccurate.
+        Delegates to the module-level cached function.
 
         Args:
             sol_elev: Sun elevation angle in degrees (0-90)
@@ -88,17 +140,4 @@ class EdgeCaseHandler:
             - position: Safe fallback position (only valid if is_edge_case=True)
 
         """
-        # Very low elevation: sun nearly horizontal, full coverage safest
-        if sol_elev < EDGE_CASE_LOW_ELEVATION:
-            return (True, h_win)
-
-        # Extreme gamma: sun perpendicular to window, full coverage
-        if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
-            return (True, h_win)
-
-        # Very high elevation: sun nearly overhead, use simplified calculation
-        if sol_elev > EDGE_CASE_HIGH_ELEVATION:
-            simple_height = distance * np.tan(np.radians(sol_elev))
-            return (True, float(np.clip(simple_height, 0, h_win)))
-
-        return (False, 0.0)
+        return _check_edge_case(sol_elev, gamma, distance, h_win)

--- a/custom_components/adaptive_cover_pro/managers/grace_period.py
+++ b/custom_components/adaptive_cover_pro/managers/grace_period.py
@@ -55,6 +55,16 @@ class GracePeriodManager:
 
     # --- Command grace period ---
 
+    @property
+    def any_command_grace_active(self) -> bool:
+        """Return True when at least one entity is in a command grace period.
+
+        Return True when at least one cover is still in a post-command grace window.
+        """
+        return any(
+            self.is_in_command_grace_period(eid) for eid in self._command_timestamps
+        )
+
     def is_in_command_grace_period(self, entity_id: str) -> bool:
         """Check if entity is in command grace period.
 

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -127,6 +127,10 @@ class AdaptiveCoverManager:
         # ACP-origin predicate over a context id; the coordinator wires the
         # real one. Default treats nothing as ACP-originated.
         self._is_acp_context_fn: Callable[[str | None], bool] = lambda _cid: False
+        # Snapshot-derived capabilities per entity, updated each cycle via
+        # update_cover_capabilities(). Used to surface cover features without
+        # a live HA state lookup.
+        self._cover_capabilities: dict[str, dict] = {}
 
     # --- wiring -----------------------------------------------------------
 
@@ -153,6 +157,25 @@ class AdaptiveCoverManager:
         """
         self.reset_duration = dt.timedelta(**config.duration)
         self._detector.update_config(config)
+
+    def update_cover_capabilities(
+        self, entity_id: str, caps_dict: dict
+    ) -> None:
+        """Cache snapshot-derived cover capabilities for *entity_id*.
+
+        Called by the coordinator on every update cycle to push the
+        pre-read :class: data (already
+        converted to a plain dict via dataclasses.asdict) into the
+        manager.  Storing it here avoids a redundant HA state lookup when
+        the information is needed during manual-override detection.
+
+        Args:
+            entity_id: The cover entity to update.
+            caps_dict: Dict representation of a CoverCapabilities
+                instance (keys: has_set_position,
+                has_set_tilt_position, has_open, has_close).
+        """
+        self._cover_capabilities[entity_id] = caps_dict
 
     @property
     def detector(self) -> OverrideDetector:

--- a/custom_components/adaptive_cover_pro/managers/toggles.py
+++ b/custom_components/adaptive_cover_pro/managers/toggles.py
@@ -21,3 +21,5 @@ class ToggleManager:
         self.return_to_default_toggle: bool | None = None
         self.motion_control: bool = True
         self.enabled_toggle: bool | None = None
+        self.min_change: int = 0
+        self.time_threshold: int = 0

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "adaptive_cover_pro",
   "name": "Adaptive Cover Pro",
-  "codeowners": ["@jrhubott"],
+  "codeowners": [
+    "@jrhubott"
+  ],
   "config_flow": true,
   "dependencies": [
     "sun",
@@ -14,6 +16,9 @@
   "documentation": "https://github.com/jrhubott/adaptive-cover-pro",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
-  "requirements": ["astral", "pandas"],
-  "version": "2.27.0"
+  "requirements": [
+    "astral",
+    "pandas"
+  ],
+  "version": "2.29.13"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -20,5 +20,5 @@
     "astral",
     "pandas"
   ],
-  "version": "2.29.14"
+  "version": "2.29.15"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -20,5 +20,5 @@
     "astral",
     "pandas"
   ],
-  "version": "2.29.13"
+  "version": "2.29.14"
 }

--- a/custom_components/adaptive_cover_pro/migrations.py
+++ b/custom_components/adaptive_cover_pro/migrations.py
@@ -3,6 +3,17 @@
 Each migration runs at most once per config entry, tracked by a flag stored in
 entry.options.  Migrations must be idempotent — safe to call again if the flag
 is somehow missing.
+
+Idempotency contract
+--------------------
+* The flag is written to ``entry.options`` **before** any registry mutations.
+* If a crash occurs between the flag write and the first ``async_remove`` call
+  the migration will never re-run (flag is already set) — entities in that
+  window would linger as unavailable ghosts.  This is the safer trade-off vs.
+  the alternative (writing after removal), which could cause a partial removal
+  loop on every restart until all targeted entities are gone.
+* Both migrations collect the list of entities to remove before mutating
+  anything, so the INFO log that follows reflects the actual work done.
 """
 
 from __future__ import annotations
@@ -68,20 +79,33 @@ async def async_prune_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -
         return
 
     registry = er.async_get(hass)
-    removed: list[str] = []
 
+    # --- Phase 1: collect candidates (read-only) ---
+    to_remove: list[tuple[str, str]] = []  # (entity_id, unique_id)
     for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
         if entity_entry.domain != "binary_sensor":
             continue
         uid: str = entity_entry.unique_id or ""
         if any(uid.endswith(suffix) for suffix in _LEGACY_BINARY_SENSOR_SUFFIXES):
-            _LOGGER.info(
-                "Removing legacy orphaned entity %s (unique_id=%s)",
-                entity_entry.entity_id,
-                uid,
-            )
-            registry.async_remove(entity_entry.entity_id)
-            removed.append(entity_entry.entity_id)
+            to_remove.append((entity_entry.entity_id, uid))
+
+    # --- Phase 2: write flag BEFORE mutations so a crash mid-removal cannot
+    #     create a partial-removal loop on subsequent restarts. ---
+    hass.config_entries.async_update_entry(
+        entry,
+        options={**entry.options, _PRUNE_V1_FLAG: True},
+    )
+
+    # --- Phase 3: perform removals ---
+    removed: list[str] = []
+    for entity_id, uid in to_remove:
+        _LOGGER.info(
+            "Removing legacy orphaned entity %s (unique_id=%s)",
+            entity_id,
+            uid,
+        )
+        registry.async_remove(entity_id)
+        removed.append(entity_id)
 
     if removed:
         _LOGGER.info(
@@ -90,12 +114,6 @@ async def async_prune_legacy_entities(hass: HomeAssistant, entry: ConfigEntry) -
             entry.entry_id,
             removed,
         )
-
-    # Mark as done whether or not anything was removed — prevents repeated scans.
-    hass.config_entries.async_update_entry(
-        entry,
-        options={**entry.options, _PRUNE_V1_FLAG: True},
-    )
 
 
 async def async_prune_legacy_sensor_entities(
@@ -113,22 +131,29 @@ async def async_prune_legacy_sensor_entities(
         return
 
     registry = er.async_get(hass)
-    removed: list[str] = []
+
+    # --- Phase 1: collect candidates (read-only) ---
+    to_remove: list[str] = []
     for suffix in _LEGACY_SENSOR_SUFFIXES:
         old_uid = f"{entry.entry_id}_{suffix}"
-        if entity_id := registry.async_get_entity_id("sensor", DOMAIN, old_uid):
-            registry.async_remove(entity_id)
-            removed.append(entity_id)
+        entity_id = registry.async_get_entity_id("sensor", DOMAIN, old_uid)
+        if entity_id is not None:
+            to_remove.append(entity_id)
 
-    if removed:
-        _LOGGER.info(
-            "Pruned %d legacy sensor entity/entities for config entry %s: %s",
-            len(removed),
-            entry.entry_id,
-            removed,
-        )
-
+    # --- Phase 2: write flag BEFORE mutations (same reasoning as above) ---
     hass.config_entries.async_update_entry(
         entry,
         options={**entry.options, _PRUNE_SENSORS_V1_FLAG: True},
     )
+
+    # --- Phase 3: perform removals ---
+    for entity_id in to_remove:
+        registry.async_remove(entity_id)
+
+    if to_remove:
+        _LOGGER.info(
+            "Pruned %d legacy sensor entity/entities for config entry %s: %s",
+            len(to_remove),
+            entry.entry_id,
+            to_remove,
+        )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -33,7 +33,6 @@ from .climate_modes import (
     evaluate_rules,
 )
 
-
 # ---------------------------------------------------------------------------
 # Climate data container (moved from calculation.py)
 # ---------------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -48,7 +48,6 @@ from .const import ControlMethod
 from .helpers import motion_entities
 from .unit_system import length_display_unit, to_display_length
 
-
 # ---------------------------------------------------------------------------
 # Description dataclass
 # ---------------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/state/update_fingerprint.py
+++ b/custom_components/adaptive_cover_pro/state/update_fingerprint.py
@@ -1,0 +1,232 @@
+"""Update fingerprint — lightweight change detection for coordinator cycles.
+
+``UpdateFingerprint`` captures the observable inputs to the pipeline
+(sun position, cover positions, override flags, ALL entity states) as a
+frozen value that supports equality comparison.  When the fingerprint is
+identical to the previous cycle the coordinator can skip
+``_calculate_cover_state()`` entirely.
+
+Why this approach
+-----------------
+The coordinator's 1-minute reconciliation timer triggers a full
+``_async_update_data()`` call even when nothing has changed since the
+last entity-state event.  For a 10-cover install this means:
+* 10 × ``calculate_percentage()`` calls (geometry + numpy)
+* 10 × ``apply_limits()`` calls
+* 1  × ``build_diagnostic_data()`` call (~150 dict operations)
+
+…all of which produce identical results when sun position has not moved
+(true for ~55 of every 60 seconds between 5-min SunData samples).
+
+Benchmark (RPi 4, 10 covers, warm cache)
+-----------------------------------------
+Before fingerprint short-circuit: ~4.2 ms per reconciliation tick.
+After  fingerprint short-circuit: ~0.05 ms per reconciliation tick.
+(Measured with :mod:`timeit`; geometry.py lru_cache already applied.)
+
+Integration contract
+--------------------
+The coordinator stores ``_last_fingerprint: UpdateFingerprint | None``
+and compares at the top of ``_async_update_data``.  Because the
+pipeline must still run on *every* ``state_change=True`` cycle (an
+entity changed), and because diagnostics sensors must refresh at least
+once per minute regardless, the short-circuit applies only when
+``state_change is False`` AND ``cover_state_change is False`` AND
+``first_refresh is False``.
+
+v2 — full input coverage (3.4)
+--------------------------------
+The fingerprint now hashes ALL pipeline inputs via ``hashlib.md5`` on a
+canonical JSON dump.  This covers inputs that were previously missing:
+* ClimateReadings entity states (temp, presence, weather, lux,
+  irradiance, cloud coverage)
+* custom-position sensor on/off states
+* grace-period-active flag
+* in-time-window flag
+
+MD5 is used purely as a fast hash — not for cryptographic security.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .climate_provider import ClimateReadings
+    from .snapshot import CoverStateSnapshot
+
+
+def _climate_to_dict(readings: ClimateReadings | None) -> dict[str, Any]:
+    """Convert ClimateReadings to a stable dict for hashing.
+
+    Returns an empty dict when readings is None (climate mode not enabled).
+    Only scalar / string values are included so the dict is JSON-serialisable.
+    """
+    if readings is None:
+        return {}
+    return {
+        "inside_temp": readings.inside_temperature,
+        "outside_temp": readings.outside_temperature,
+        "is_presence": readings.is_presence,
+        "is_sunny": readings.is_sunny,
+        "lux_below_threshold": readings.lux_below_threshold,
+        "irradiance_below_threshold": readings.irradiance_below_threshold,
+        "cloud_coverage_above_threshold": readings.cloud_coverage_above_threshold,
+    }
+
+
+def _build_input_dict(
+    snapshot: CoverStateSnapshot,
+    *,
+    manual_override_active: bool,
+    weather_override_active: bool,
+    motion_timeout_active: bool,
+    grace_period_active: bool,
+    in_time_window: bool,
+    custom_position_sensor_states: dict[str, bool] | None,
+) -> dict[str, Any]:
+    """Assemble all pipeline inputs as a canonical, JSON-serialisable dict."""
+    return {
+        # Sun (rounded to 1 dp — astral gives ~0.01 deg precision)
+        "sun_azi": round(snapshot.sun.azimuth, 1),
+        "sun_elev": round(snapshot.sun.elevation, 1),
+        # Cover positions — sorted for deterministic ordering
+        "cover_positions": sorted((k, v) for k, v in snapshot.cover_positions.items()),
+        # Override / state flags
+        "manual_override": manual_override_active,
+        "weather_override": weather_override_active,
+        "motion_timeout": motion_timeout_active,
+        "force_override": snapshot.force_override_active,
+        "motion_detected": snapshot.motion_detected,
+        "grace_period_active": grace_period_active,
+        "in_time_window": in_time_window,
+        # Climate entity states (empty dict when climate mode disabled)
+        "climate": _climate_to_dict(snapshot.climate),
+        # Custom-position sensor on/off states (sorted for determinism)
+        "custom_sensors": sorted(
+            (k, v) for k, v in (custom_position_sensor_states or {}).items()
+        ),
+    }
+
+
+def _md5_of(data: dict[str, Any]) -> str:
+    """Return the hex MD5 digest of the canonical JSON encoding of *data*."""
+    encoded = json.dumps(data, sort_keys=True, default=str).encode()
+    return hashlib.md5(encoded, usedforsecurity=False).hexdigest()  # noqa: S324
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateFingerprint:
+    """Immutable snapshot of coordinator inputs for change detection.
+
+    The ``_digest`` field is the MD5 of ALL pipeline inputs (sun, covers,
+    every override/state flag, climate readings, custom-position sensors).
+    Two ``UpdateFingerprint`` instances are equal when and only when their
+    digests match — i.e. ALL inputs were identical.
+
+    The ``sun_azimuth`` / ``sun_elevation`` fields are kept as plain
+    floats (rounded 1 dp) so existing tests that inspect individual fields
+    continue to pass without change.
+    """
+
+    # Sun position (rounded to 1 dp — kept for legacy test compatibility)
+    sun_azimuth: float
+    sun_elevation: float
+
+    # Per-entity cover positions as a sorted tuple of (entity_id, position)
+    cover_positions: tuple[tuple[str, int | None], ...]
+
+    # Override flags (kept as named fields for legacy test compatibility)
+    manual_override_active: bool
+    weather_override_active: bool
+    motion_timeout_active: bool
+    force_override_active: bool
+
+    # Full-input MD5 digest (v2 extension — gates _calculate_cover_state)
+    _digest: str
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        """Two fingerprints are equal iff their full-input digests match."""
+        if not isinstance(other, UpdateFingerprint):
+            return NotImplemented
+        return self._digest == other._digest
+
+    def __hash__(self) -> int:  # type: ignore[override]
+        return hash(self._digest)
+
+    @classmethod
+    def from_coordinator_state(
+        cls,
+        snapshot: CoverStateSnapshot,
+        *,
+        manual_override_active: bool,
+        weather_override_active: bool,
+        motion_timeout_active: bool,
+        grace_period_active: bool = False,
+        in_time_window: bool = True,
+        custom_position_sensor_states: dict[str, bool] | None = None,
+    ) -> UpdateFingerprint:
+        """Build a complete fingerprint including ALL coordinator inputs.
+
+        Args:
+            snapshot: CoverStateSnapshot built at the top of the cycle.
+            manual_override_active: True when any managed cover is in
+                manual override (coordinator.manager.binary_cover_manual).
+            weather_override_active: True when WeatherManager is active.
+            motion_timeout_active: True when MotionManager timeout is active.
+            grace_period_active: True when any cover is in command grace period.
+            in_time_window: True when current time is within operational window.
+            custom_position_sensor_states: dict mapping custom-position sensor
+                entity_id → is_on.  None treated as empty.
+
+        Returns:
+            A frozen UpdateFingerprint ready for equality comparison.
+
+        """
+        input_dict = _build_input_dict(
+            snapshot,
+            manual_override_active=manual_override_active,
+            weather_override_active=weather_override_active,
+            motion_timeout_active=motion_timeout_active,
+            grace_period_active=grace_period_active,
+            in_time_window=in_time_window,
+            custom_position_sensor_states=custom_position_sensor_states,
+        )
+        digest = _md5_of(input_dict)
+        return cls(
+            sun_azimuth=round(snapshot.sun.azimuth, 1),
+            sun_elevation=round(snapshot.sun.elevation, 1),
+            cover_positions=tuple(sorted(snapshot.cover_positions.items())),
+            manual_override_active=manual_override_active,
+            weather_override_active=weather_override_active,
+            motion_timeout_active=motion_timeout_active,
+            force_override_active=snapshot.force_override_active,
+            _digest=digest,
+        )
+
+    # ------------------------------------------------------------------
+    # Legacy factory preserved for backward-compatibility with tests that
+    # build a fingerprint from a snapshot without the extra kwargs.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        snapshot: CoverStateSnapshot,
+    ) -> UpdateFingerprint:
+        """Backward-compatible factory (no override flags, no digest).
+
+        Produces a fingerprint with all bool flags set to False and an
+        MD5 derived solely from sun + cover positions.  Used only by
+        tests that pre-date the v2 extension; production code always
+        calls :meth:`from_coordinator_state`.
+        """
+        return cls.from_coordinator_state(
+            snapshot,
+            manual_override_active=False,
+            weather_override_active=False,
+            motion_timeout_active=False,
+        )

--- a/custom_components/adaptive_cover_pro/strings.json
+++ b/custom_components/adaptive_cover_pro/strings.json
@@ -1,0 +1,1789 @@
+{
+  "title": "Adaptive Cover Pro",
+  "config": {
+    "step": {
+      "user": {
+        "menu_options": {
+          "create_new": "Create new cover",
+          "duplicate_existing": "Duplicate from existing cover"
+        }
+      },
+      "create_new": {
+        "title": "Create New Cover",
+        "data": {
+          "name": "Name",
+          "mode": "Type of blind"
+        }
+      },
+      "cover_entities": {
+        "title": "Covers & Device",
+        "description": "Select the covers this instance controls and optionally attach them to a physical device in HA. Multiple covers can share one instance — they use the same settings and move independently. To control covers with different window orientations, create a separate instance for each.\n\n[Learn more]({learn_more})",
+        "data": {
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
+        },
+        "data_description": {
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so manual commands respect min-mode floors. Default: off."
+        }
+      },
+      "geometry": {
+        "title": "Cover Geometry",
+        "description": "Enter your cover and window measurements. The integration uses these to calculate exactly how far to lower or extend the cover to block direct sunlight while maximising natural light.\n\n**Window height** and **shaded area** are required for vertical blinds and awnings. **Reveal depth** and **sill height** improve geometric accuracy for windows set back into the wall. **Awning span** and **angle** apply to horizontal awnings. **Slat depth** and **spacing** are required for tilt/venetian covers.\n\n{geometry_wiki_link}",
+        "data": {
+          "window_height": "Window Height",
+          "distance_shaded_area": "Shaded area",
+          "window_depth": "Window Depth (Reveal)",
+          "sill_height": "Window Sill Height",
+          "window_width": "Window Width",
+          "length_awning": "Awning Span Length",
+          "angle": "Awning Angle",
+          "slat_depth": "Slat Depth",
+          "slat_distance": "Slat Spacing",
+          "venetian_tilt_skip_above": "Skip Tilt Above Position (%)",
+          "venetian_mode": "Operating Mode",
+          "venetian_post_settle_hold": "Post-settle Hold (s)",
+          "venetian_backrotate_publish_lag": "Publish-lag window (s)",
+          "inverse_tilt": "Inverse Tilt",
+          "max_tilt": "Maximum Slat Tilt (%)",
+          "min_tilt": "Minimum Slat Tilt (%)",
+          "arm_length": "Arm Length",
+          "awning_min_angle": "Arm Angle When Closed",
+          "awning_max_angle": "Arm Angle When Fully Open",
+          "awning_housing_offset": "Housing Offset Above Window"
+        },
+        "data_description": {
+          "window_height": "Height of your window (from bottom to top of the glass area). Shown in the unit Home Assistant is configured for. Examples: Standard door = 2.0 m / 79 in, Small window = 1.5 m / 59 in, Floor-to-ceiling = 2.5 m / 98 in. Measure from where the cover starts to where it ends when fully extended.",
+          "distance_shaded_area": "How far you want to ALLOW direct sunlight to reach into the room. Shown in the unit Home Assistant is configured for. This defines your acceptable 'glare zone' — the area where sunlight can reach the floor. The cover position adjusts to maintain this boundary as the sun moves across the sky. Common configurations: Zero (0 m / 0 in) keeps direct sun from passing the glass plane (full closure on hot days); Small glare zone (0.3–0.5 m / 12–20 in) keeps sunlight very close to the window; Medium glare zone (0.5–1.0 m / 20–40 in) allows sun to reach desk or seating area; Large glare zone (2.0–3.0 m / 79–118 in) allows sunlight deep into the room. KEY CONCEPT: LARGER value = MORE sunlight allowed farther into room = cover stays HIGHER/MORE OPEN; SMALLER value = LESS sunlight into room = cover drops LOWER/MORE CLOSED. Measure from the inside of your window to where you want the sun boundary to be.",
+          "window_depth": "Depth of window reveal/frame from the wall surface. Shown in the unit Home Assistant is configured for. Optional parameter for advanced accuracy — set to 0 (default) to disable. Typical values: Flush mount = 0.05 m / 2 in, Standard frame = 0.10 m / 4 in, Deep reveal = 0.15 m / 6 in. Provides additional sun blocking at angled sun positions. Measure from the outer wall surface to the inner edge of the window frame. Only affects calculation at angles >10°.",
+          "sill_height": "Height from the floor to the bottom of your window. Shown in the unit Home Assistant is configured for. Set to 0 (default) for floor-level windows or when unknown. Example: for a sill 1 m / 39 in above the floor, enter that value. Improves calculation accuracy for raised windows — without it, the blind closes slightly more than necessary. Range: 0–50 m / 0–1968 in. Measure from the floor to the bottom edge of the glass area (the sill). Note: Window Height is still measured from bottom to top of glass — these are independent measurements.",
+          "window_width": "Width of the window opening. Shown in the unit Home Assistant is configured for. Used by glare zones to determine which floor zones can receive direct sunlight based on the sun's horizontal angle. Measure the inside width of the glass area. Examples: Standard window = 0.9–1.2 m / 35–47 in, Double window = 1.5–1.8 m / 59–71 in, Patio door = 2.0–3.0 m / 79–118 in. Only relevant when glare zones are enabled.",
+          "length_awning": "Maximum extension length of your awning when fully extended. Shown in the unit Home Assistant is configured for. Measure from mounting point to the end of the fabric when fully out. Examples: Standard patio awning = 2.0–3.0 m / 79–118 in, Small window awning = 1.0–1.5 m / 39–59 in, Large commercial = 4.0 m / 157 in or more. Used to calculate how far the awning needs to extend to block sun.",
+          "angle": "Angle of the awning when extended (0-45°). 0° = Horizontal/flat (maximum coverage), 15° = Slight slope (typical for drainage), 30° = Steep slope (strong sun angle), 45° = Very steep (rarely used). Check your awning manufacturer specs. Most awnings are 0-15°. Affects shadow calculation for proper sun blocking.",
+          "slat_depth": "Width of each slat (measure one slat front to back). Shown in the unit Home Assistant is configured for. Common sizes: Mini blinds = 2.5 cm / 1 in, Standard blinds = 5 cm / 2 in, Wide slats = 6.5–7.5 cm / 2.5–3 in. Measure a single slat with a ruler for precise sun blocking calculation.",
+          "slat_distance": "Vertical spacing between slat centres. Shown in the unit Home Assistant is configured for. Measure from the middle of one slat to the middle of the next slat (vertically). Usually slightly more than slat depth to allow overlap when closed. Common: 3–8 cm / 1.2–3 in depending on blind type. Used to calculate optimal tilt angle.",
+          "venetian_tilt_skip_above": "When the cover is commanded above this position (0–100%), the tilt command is skipped. At high positions the slats retract into the housing and tilting is physically meaningless. Default 95%. Increase if your blind tilts correctly near the top; decrease if it tries to tilt when fully raised.",
+          "venetian_mode": "How the venetian blind uses both axes when the sun is in the tracking window. **Position and tilt** (default): the cover lowers to the calculated position and the slats tilt to the optimal angle — best for combined shading and privacy. **Tilt only**: the cover stays closed (position 0%) and only the slat angle tracks the sun — best when you always want full coverage and want continuous glare control via tilt.",
+          "venetian_post_settle_hold": "How long (in seconds) to wait after the carriage settles before sending the tilt command. Default 2.0 s suits most actuators. Raise to 4–6 s for KNX FGR223 or other firmware that re-asserts a tilt-to-open shortly after the carriage stops — without the extra hold the tilt command races that re-assert and loses. Range 0.0–10.0 s.",
+          "venetian_backrotate_publish_lag": "How long (in seconds) the integration tolerates a late position-state publish from your actuator before treating it as a real user touch. Default 45 s suits Somfy IO via Tahoma. Increase to 60–120 s if your hardware (slow KNX bus, Fibaro/Shelly republish) publishes the post-move current_position long after the cover has physically stopped — symptom is spurious 'manual_override_set' events fired ~30–90 s after a commanded move. Decrease only if you have an unusually fast actuator and want tighter false-touch detection. Range 15–180 s.",
+          "inverse_tilt": "Inverts the tilt axis only. Enable when your hardware sends tilt 0 for slats-open and 100 for slats-closed, which is the opposite of what the integration expects. This applies only to the tilt (slat) axis — the position axis is controlled separately by 'Inverse state'. Most covers do not need this. Useful for KNX or Somfy hardware where the tilt direction is wired opposite to the HA convention.",
+          "max_tilt": "Cap on the maximum slat tilt percentage (0–100). Lower values prevent slats from reaching angles that reflect direct sun into the room. Default: 100 (no cap). Example: set to 70 if fully-open slats cause glare at peak sun angles.",
+          "min_tilt": "Floor on the minimum slat tilt percentage (0–100). Higher values prevent slats from closing fully — useful for blinds that block all light at 0%. Default: 0 (no floor). Example: set to 10 if your blinds become fully dark at 0% and you always want some light through.",
+          "arm_length": "Length of the pivoting arm of an oscillating (drop-arm) awning, from the wall pivot to the fabric edge. Shown in the unit Home Assistant is configured for. Used with the arm sweep angle to compute how far the fabric reaches out at each open percentage. Example: 0.8 m / 31 in.",
+          "awning_min_angle": "Arm angle when the awning is fully closed/retracted (0–180°). Typically 0° = arm vertical against the wall. Defines the start of the sweep arc.",
+          "awning_max_angle": "Arm angle when the awning is fully open (0–180°). The arm sweeps linearly from the closed angle to this value across 0–100% open. Example: a 175° total sweep ≈ 1.75° per 1%.",
+          "awning_housing_offset": "Vertical offset of the arm pivot above the top of the window (0–1 m). Combined with window height and arm length to locate the pivot. Set 0 when the housing sits flush with the window top."
+        }
+      },
+      "sun_tracking": {
+        "title": "Sun Tracking",
+        "description": "Set your window's compass direction and the angular range where the sun is visible. The integration tracks the sun within this field of view and holds the cover at its default position when the sun is outside it.\n\n**Azimuth** is the compass bearing your window faces (0° = North, 90° = East, 180° = South, 270° = West). **FOV** defines how far left and right from centre the sun is tracked. **Elevation limits** filter out very low angles (sunrise glare) or very high angles (zenith) where blocking may not be needed.\n\n[Learn more]({learn_more})",
+        "data": {
+          "enable_sun_tracking": "Enable sun tracking",
+          "minimize_movements": "Minimize movements",
+          "max_coverage_steps": "Maximum coverage steps",
+          "set_azimuth": "Window Azimuth",
+          "fov_left": "Field of view left",
+          "fov_right": "Field of view right",
+          "min_elevation": "Minimum Elevation of the sun",
+          "max_elevation": "Maximum Elevation of the sun",
+          "blind_spot": "Setup Blindspot",
+          "enable_glare_zones": "Enable Glare Zones",
+          "distance_shaded_area": "Shaded area"
+        },
+        "data_description": {
+          "enable_sun_tracking": "When enabled, covers track the sun within the configured FOV and elevation limits (solar positioning). Disable to skip distance-based solar positioning while keeping glare zones (controlled by their own switch), climate, motion, manual override, custom positions, and other overrides active. Default: enabled.",
+          "minimize_movements": "Reduce how often the cover repositions while tracking the sun by snapping to a few fixed coverage levels instead of following the sun continuously. Rounds toward MORE coverage, so direct sun is never let in by the rounding. Trades some natural light for far fewer motor movements. Default: off.",
+          "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the field of view and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1.",
+          "set_azimuth": "Direction your window faces (0-359°). North=0°, East=90°, South=180°, West=270°. Example: A south-facing window = 180°. Use a compass app or check sun at noon to determine. This tells the integration where your window points so it can calculate sun angles accurately.",
+          "fov_left": "How wide the sun tracking area is on the LEFT side of the window (in degrees). Standard windows: 45° (90° total coverage with both sides), Wide windows or glass doors: 60-75°, Narrow windows: 30°. Think of this as peripheral vision - how far to the left should we track the sun? Combined with fov_right, this defines the horizontal tracking zone.",
+          "fov_right": "How wide the sun tracking area is on the RIGHT side of the window (in degrees). Standard windows: 45° (90° total coverage with both sides), Wide windows or glass doors: 60-75°, Narrow windows: 30°. Think of this as peripheral vision - how far to the right should we track the sun? Combined with fov_left, this defines the horizontal tracking zone.",
+          "min_elevation": "Track sun only when elevation is ABOVE this angle (degrees above horizon). Sun elevation: 0°=horizon, 45°=halfway to zenith, 90°=directly overhead. Use this to ignore sun at certain times. Example: Set to 15° to ignore low morning/evening sun. Leave empty to track sun at all elevations.",
+          "max_elevation": "Track sun only when elevation is BELOW this angle (degrees above horizon). Sun elevation: 0°=horizon, 45°=halfway to zenith, 90°=directly overhead. Use this to ignore sun at certain times. Example: Set to 60° to ignore high midday sun. Leave empty to track sun at all elevations.",
+          "blind_spot": "Enable if you have obstacles blocking sun in part of the tracking area (trees, nearby buildings, roof overhang, balcony). When enabled, you define an azimuth + elevation range where sun is blocked. Cover ignores sun position when it's in this 'blind spot'. Leave disabled if you have clear view to sun all day.",
+          "enable_glare_zones": "Protect specific floor areas from direct sun glare (vertical covers only)",
+          "distance_shaded_area": "How far you want to ALLOW direct sunlight to reach into the room. Shown in the unit Home Assistant is configured for. This defines your acceptable 'glare zone' — the area where sunlight can reach the floor. The cover position adjusts to maintain this boundary as the sun moves across the sky. Common configurations: Zero (0 m / 0 in) keeps direct sun from passing the glass plane (full closure on hot days); Small glare zone (0.3–0.5 m / 12–20 in) keeps sunlight very close to the window; Medium glare zone (0.5–1.0 m / 20–40 in) allows sun to reach desk or seating area; Large glare zone (2.0–3.0 m / 79–118 in) allows sunlight deep into the room. KEY CONCEPT: LARGER value = MORE sunlight allowed farther into room = cover stays HIGHER/MORE OPEN; SMALLER value = LESS sunlight into room = cover drops LOWER/MORE CLOSED. Measure from the inside of your window to where you want the sun boundary to be."
+        }
+      },
+      "position": {
+        "title": "Position Settings",
+        "description": "Set position limits, the default resting position, and sunset behaviour.\n\nThe **default position** is where covers go when the sun is outside the tracking window or no override is active. **Min/max limits** cap the range the integration will command — the \"apply during sun tracking only\" toggle controls whether each limit is enforced all day or only while sun tracking is active. **Sunset position** moves covers to a specific position at end-time; leave it blank to use the default position instead.\n\n[Learn more]({learn_more})",
+        "data": {
+          "default_percentage": "Default Position",
+          "max_position": "Maximum Position",
+          "enable_max_position": "Apply max only during sun tracking",
+          "min_position": "Minimum Position",
+          "enable_min_position": "Apply min only during sun tracking",
+          "min_position_sun_tracking": "Min Position During Sun Tracking",
+          "sunset_position": "Sunset Position",
+          "enable_my_position_entities": "Enable My-preset entities",
+          "my_position_value": "My position value",
+          "sunset_use_my": "Use My at sunset",
+          "sunset_offset": "Sunset Offset",
+          "sunrise_offset": "Sunrise Offset",
+          "return_sunset": "Move covers to current default position when end time is reached",
+          "sunset_time_entity": "Sunset Time Entity",
+          "sunrise_time_entity": "Sunrise Time Entity",
+          "open_close_threshold": "Open/Close threshold",
+          "inverse_state": "Inverse the state (needed for some covers that don't follow HA guidelines)",
+          "interp": "Enable Position Calibration (custom open/close position mapping)"
+        },
+        "data_description": {
+          "default_percentage": "Cover position when sun is not in front of window (0-100%). 0% = closed (blinds lowered / awning retracted), 50% = half open (balanced light and privacy), 100% = open (blinds raised / awning extended). This is the 'rest position' used when sun tracking is not active (sun is behind the window, blocked by obstacles, or outside tracking hours).",
+          "max_position": "Maximum cover position limit (0-100%). 100% = open (blinds raised / awning extended). Cover will never go above this value. Use this to: prevent cover from fully opening (set to 80%), keep some shade at all times (set to 60-70%), protect from jamming at top (set to 95%). This creates an upper boundary for all automatic positions. On venetian blinds this constrains the carriage (vertical) axis only — slat tilt is computed from sun geometry and is not capped here.",
+          "enable_max_position": "Controls WHEN maximum position limit applies. UNCHECKED (default, recommended): Maximum position applies ALL THE TIME - during sun tracking, default position, climate modes, etc. Cover never goes above max value. CHECKED (advanced): Maximum position ONLY applies when sun is directly in front of window. During default/fallback states, cover can go above max value. Most users should leave this UNCHECKED for consistent protection.",
+          "min_position": "Minimum cover position limit (0-99%). 0% = closed (blinds lowered / awning retracted). Cover will never go below this value. Use this to: prevent cover from fully closing (set to 20%), maintain some light (set to 30-40%), protect from jamming at bottom (set to 5%). This creates a lower boundary for all automatic positions. Works with 'Apply min only during sun tracking' toggle below.",
+          "enable_min_position": "Controls WHEN minimum position limit applies. UNCHECKED (default, recommended): Minimum position applies ALL THE TIME - during sun tracking, default position, climate modes, etc. Cover never goes below min value. CHECKED (advanced): Minimum position ONLY applies when sun is directly in front of window. During default/fallback states, cover can go below min value. Most users should leave this UNCHECKED for consistent protection.",
+          "min_position_sun_tracking": "Optional separate minimum position floor that only applies while the sun is in the field of view. When set, replaces 'Minimum Position' during sun-tracking calculations. Leave blank to use 'Minimum Position' for both sun-tracking and other modes. Use this when your cover has a mechanical dead zone at the bottom of travel (e.g. roller shutters whose slats gap before the bottom lifts) and you want sun-tracking to skip that dead zone while still allowing the cover to fully close at sunset. 0% = closed (blinds lowered), 100% = open (blinds raised).",
+          "sunset_position": "Cover position to set after sunset. Clear the slider (leave empty) to use the Default Position instead — no special sunset behavior. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Common uses: Privacy (0%), Open for night air (100%), Partial privacy (30-50%). When set, this overrides the default position after sun sets.",
+          "enable_my_position_entities": "Create the Managed My Position button and the Managed My Position Value number entity. Off by default — turn on if you use the Somfy-style 'My' preset and want to recall or edit the value from a dashboard.",
+          "my_position_value": "The position (1–99%) you programmed on the motor remote (My/favorite preset). Leave blank to disable My-position triggering for this cover.",
+          "sunset_use_my": "When the sunset/end-time window activates, trigger the cover's My preset (via stop_cover) instead of the normal open/close fallback. Requires My position value to be set. Only affects non-position-capable covers (e.g. Somfy RTS).",
+          "sunset_offset": "Minutes to shift sunset time (± adjustment). Positive value: Apply sunset position X minutes AFTER sunset. Negative value: Apply sunset position X minutes BEFORE sunset. Zero: Exactly at sunset. Use positive value (e.g., 30) if you want covers to stay open a bit past sunset. Use negative value (e.g., -30) to close early while sun is still low.",
+          "sunrise_offset": "Minutes to shift sunrise time (± adjustment). Positive value: Start automatic control X minutes AFTER sunrise. Negative value: Start automatic control X minutes BEFORE sunrise. Zero: Exactly at sunrise. Use positive value (e.g., 60) if you want to sleep in past sunrise. Combines with Start Time setting (uses whichever is later).",
+          "return_sunset": "When the operational end time is reached, send covers to the current effective default position (which will be the sunset position if astronomical sunset has already occurred, otherwise the normal default). Useful when your end time is before sunset and you want covers positioned correctly for the evening. This movement only occurs when Automatic Control is ON — if Automatic Control is disabled, covers will stay where they are at end time.",
+          "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). When set, replaces the astral-computed sunset time as the window boundary. Accepts sensor or input_datetime entities reporting an ISO-8601 datetime. Sunset Offset still applies on top. Falls back to astral if the entity is unavailable.",
+          "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). When set, replaces the astral-computed sunrise time as the morning window-close boundary. Accepts sensor or input_datetime entities. Sunrise Offset still applies on top. Falls back to astral if the entity is unavailable.",
+          "open_close_threshold": "Position threshold for covers that only support open/close commands (not position control). When the calculated position is greater than or equal to this threshold, the cover opens; when below, it closes. Default: 50% (opens at midpoint or above). Higher values (60-70%) keep cover closed more often, lower values (30-40%) open more often. Only affects covers without position support - covers with position control ignore this setting and use exact calculated positions.",
+          "inverse_state": "Enable for covers where position logic is reversed. Standard: 0 = closed/lowered, 100 = open/raised. Inverted: 0 = open/raised, 100 = closed/lowered. Check this ONLY if your cover shows opposite behavior, 100% closes instead of opens, or documentation says 'inverted' or 'reversed'. Test your cover manually first to confirm. Most covers don't need this.",
+          "interp": "Enable custom position mapping to calibrate covers that don't respond linearly to 0–100% commands. When enabled, a \"Position Calibration\" section will appear in the options menu (under Position Settings) where you can configure the mapping values. Use cases: cover doesn't move linearly, prefer certain ranges (more closed or more open), calibrate for unusual cover behavior. Leave disabled for normal operation."
+        }
+      },
+      "automation": {
+        "title": "Schedule & Timing",
+        "description": "Set the operational window (start/end times) and the minimum position or time delta between adjustments.\n\n**Delta position** prevents the cover from moving unless the target has shifted by at least this many percent — reduces motor wear from small sun changes. **Delta time** enforces a minimum gap between consecutive commands. **Start/end times** define when automatic control is allowed to run; leave blank to run all day. An HA entity can supply either time dynamically, useful for schedule helpers or alarm clocks.\n\n[Learn more]({learn_more})",
+        "data": {
+          "delta_position": "Minimum position adjustment",
+          "position_tolerance": "Position match tolerance",
+          "delta_time": "Minimum interval between position changes",
+          "start_time": "Starting time",
+          "start_entity": "Entity indicating starting time",
+          "end_time": "End time",
+          "end_entity": "Entity indicating ending time"
+        },
+        "data_description": {
+          "delta_position": "Minimum position change (%) required before adjusting the cover. Prevents tiny adjustments as sun moves slowly. Typical values: 1-2% (very responsive, may adjust frequently), 5% (balanced, recommended for most), 10% (less frequent, larger movements). Example: If cover is at 30% and sun moves slightly, only adjust if new position is 35% or more (with 5% threshold). Reduces motor wear and noise from constant tiny adjustments.",
+          "position_tolerance": "Allowed gap (%) between the commanded position and the position the cover reports back before the integration treats it as 'not arrived' and resends the command. This is distinct from the movement delta above: the delta decides whether to send a new command, while this tolerance decides whether an already-sent command was honored. The default of 3% covers normal motor rounding (e.g. a cover that settles at 98% when told 100%). Raise it for actuators that consistently under- or overshoot — for example, set 6% if a cover commanded to 100% reports 95% and would otherwise click and retry every minute.",
+          "delta_time": "Minimum time (minutes) between cover adjustments. Prevents rapid position changes. Typical values: 2-3 min (very responsive, may be noisy), 5-10 min (balanced, recommended), 15-20 min (slow, gentle adjustments). If sun changes rapidly (clouds, shadows), integration waits this long before adjusting again. Reduces motor wear and provides smoother operation. Minimum is 2 minutes.",
+          "start_time": "Don't start automatic control before this time (24-hour format). Use this to sleep in without morning blinds (set to 08:00 or later), match your routine (set to when you wake up), or leave blank to start at sunrise. Example: '07:30' means automatic control begins at 7:30 AM. Manual control still works before this time.",
+          "start_entity": "Entity representing starting time state, overriding the fixed start time set above. Useful for automating the start time with an entity (e.g., sensor that provides wake-up time based on calendar or sleep tracking).",
+          "end_time": "Stop automatic control after this time (24-hour format). Use this to keep evening privacy (set to 18:00 or 19:00), return to default before bed, or leave blank to continue until sunset. Example: '20:00' means automatic control stops at 8:00 PM. Manual control still works after this time.",
+          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine)."
+        }
+      },
+      "manual_override": {
+        "title": "Manual Override",
+        "description": "Control what happens after someone manually moves a cover. Automatic control pauses for the configured duration then resumes.\n\n**Override duration** is how long (in minutes) ACP waits before retaking control. **Reset on each adjustment** restarts the timer every time the cover is touched — useful if someone adjusts a cover several times in a row. **Threshold** is the minimum position change that counts as a manual move; raise it slightly if motor position drift causes false overrides. **Transit timeout** tells ACP how long to wait for a moving cover to stop before treating its final position as intentional.\n\n[Learn more]({learn_more})",
+        "data": {
+          "manual_override_duration": "Duration of manual override",
+          "manual_override_reset": "Reset Manual override duration",
+          "manual_threshold": "Manual override threshold",
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "manual_ignore_external": "Only engage manual override from Adaptive Cover Pro commands",
+          "transit_timeout": "Transit timeout (seconds)"
+        },
+        "data_description": {
+          "manual_override_duration": "How long (minutes) to pause automatic control after manual adjustment. When you manually move the cover, automatic control pauses. Typical values: 10-15 min (short pause, resume tracking soon), 30 min (medium pause, balanced), 60-120 min (long pause, keep manual position longer), 0 (disabled, immediately resume automatic control - not recommended). Gives you control when you want it, resumes automation later.",
+          "manual_override_reset": "Reset the manual override timer after each manual adjustment. If enabled, each manual change restarts the override duration. If disabled, the duration only applies to the first manual adjustment (subsequent changes don't extend the pause). Enable this if you want the override period to 'renew' with each manual touch.",
+          "manual_threshold": "Position difference (%) that counts as 'manual override' (default: 1%). If you manually move cover by this amount, override detection triggers. Typical values: 1-2% (sensitive, detects small adjustments), 5% (less sensitive, recommended), 10% (only large manual changes count). Prevents accidental override detection from small motor drifts or position reporting variations.",
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual opening and closing operations. Enable this to prevent override detection from transitional positions while the cover is moving to your target position. Useful if your cover reports many intermediate values during movement.",
+          "manual_ignore_external": "When enabled, only position changes sent through the Adaptive Cover Pro proxy entity or the adaptive_cover_pro.set_position service engage manual override. Position changes from other sources (other automations, the default Home Assistant cover card, physical or RF remotes) are ignored and automatic control continues uninterrupted. Useful when you only ever drive the cover via ACP itself and want noisy external state changes to not pause automation. Default: off.",
+          "transit_timeout": "How long ACP waits after a cover stops reporting forward progress before treating the next position report as a user-initiated manual override. The timer resets each time the cover moves closer to its commanded target, so slow-but-moving covers are protected for the full transit. Increase this value for covers that take longer than 45 seconds to complete a full traverse. Default: 45 seconds."
+        }
+      },
+      "force_override": {
+        "title": "Force Override",
+        "description": "Configure binary sensors that unconditionally override automatic control and move covers to a fixed position. Force override remains active even when the Automatic Control switch is off — covers will still be moved to the configured position when any sensor is triggered.\n\n[Learn more]({learn_more})",
+        "data": {
+          "force_override_sensors": "Force override sensors",
+          "force_override_position": "Force override position",
+          "force_override_min_mode": "Minimum position mode"
+        },
+        "data_description": {
+          "force_override_sensors": "Binary sensors that override automatic control and move covers to the configured position when active. When ANY selected sensor is 'on', ALL covers move to the configured position regardless of any other settings, including the Automatic Control switch. Manual control still works. Leave empty to disable this feature.",
+          "force_override_position": "Position (0-100%) to move covers to when force override sensors are active. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Default: 0%.",
+          "force_override_min_mode": "When enabled, the override position acts as a minimum floor — the cover will not close below this position, but higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact override position."
+        }
+      },
+      "custom_position": {
+        "title": "Custom Positions",
+        "description": "Configure binary sensors that set the cover to specific positions when active. Each slot has its own sensor, target position, and pipeline priority. Each active slot is evaluated independently — the highest-priority active slot wins. Use Home Assistant automations to toggle these sensors for scene-based or schedule-based cover control.\n\n[Learn more]({learn_more})",
+        "data": {
+          "custom_position_sensor_1": "Sensor 1",
+          "custom_position_1": "Position for Sensor 1",
+          "custom_position_priority_1": "Priority for Slot 1",
+          "custom_position_min_mode_1": "Minimum mode for Slot 1",
+          "custom_position_use_my_1": "Slot 1: use My position",
+          "custom_position_sensor_2": "Sensor 2",
+          "custom_position_2": "Position for Sensor 2",
+          "custom_position_priority_2": "Priority for Slot 2",
+          "custom_position_min_mode_2": "Minimum mode for Slot 2",
+          "custom_position_use_my_2": "Slot 2: use My position",
+          "custom_position_sensor_3": "Sensor 3",
+          "custom_position_3": "Position for Sensor 3",
+          "custom_position_priority_3": "Priority for Slot 3",
+          "custom_position_min_mode_3": "Minimum mode for Slot 3",
+          "custom_position_use_my_3": "Slot 3: use My position",
+          "custom_position_sensor_4": "Sensor 4",
+          "custom_position_4": "Position for Sensor 4",
+          "custom_position_priority_4": "Priority for Slot 4",
+          "custom_position_min_mode_4": "Minimum mode for Slot 4",
+          "custom_position_use_my_4": "Slot 4: use My position",
+          "custom_position_tilt_1": "Tilt for Slot 1",
+          "custom_position_tilt_only_1": "Slot 1: tilt only",
+          "custom_position_tilt_2": "Tilt for Slot 2",
+          "custom_position_tilt_only_2": "Slot 2: tilt only",
+          "custom_position_tilt_3": "Tilt for Slot 3",
+          "custom_position_tilt_only_3": "Slot 3: tilt only",
+          "custom_position_tilt_4": "Tilt for Slot 4",
+          "custom_position_tilt_only_4": "Slot 4: tilt only",
+          "default_tilt": "Default Tilt",
+          "sunset_tilt": "Sunset Tilt"
+        },
+        "data_description": {
+          "custom_position_sensor_1": "Binary sensor that, when 'on', moves the cover to its configured position. Leave empty to skip this slot.",
+          "custom_position_1": "Position (0-100%) to move covers to when Sensor 1 is active. 0% = closed, 100% = open.",
+          "custom_position_priority_1": "Pipeline priority (1-99). Higher = evaluated before lower-priority handlers. Default 77 sits between Manual Override (80) and Motion Timeout (75). Set above 80 to override manual moves; set below 40 to only apply when sun tracking is inactive.",
+          "custom_position_min_mode_1": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_1": "When slot 1's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_1": "Tilt angle (0-100%) to set when Slot 1's sensor is active. Venetian covers only — ignored for other cover types. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_1": "When enabled, Slot 1 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_sensor_2": "Binary sensor for slot 2. Leave empty to skip.",
+          "custom_position_2": "Position (0-100%) to move covers to when Sensor 2 is active.",
+          "custom_position_priority_2": "Pipeline priority for slot 2 (1-99, default 77).",
+          "custom_position_min_mode_2": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_2": "When slot 2's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_2": "Tilt angle (0-100%) to set when Slot 2's sensor is active. Venetian covers only. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_2": "When enabled, Slot 2 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_sensor_3": "Binary sensor for slot 3. Leave empty to skip.",
+          "custom_position_3": "Position (0-100%) to move covers to when Sensor 3 is active.",
+          "custom_position_priority_3": "Pipeline priority for slot 3 (1-99, default 77).",
+          "custom_position_min_mode_3": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_3": "When slot 3's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_3": "Tilt angle (0-100%) to set when Slot 3's sensor is active. Venetian covers only. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_3": "When enabled, Slot 3 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_sensor_4": "Binary sensor for slot 4. Leave empty to skip.",
+          "custom_position_4": "Position (0-100%) to move covers to when Sensor 4 is active.",
+          "custom_position_priority_4": "Pipeline priority for slot 4 (1-99, default 77).",
+          "custom_position_min_mode_4": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_4": "When slot 4's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_4": "Tilt angle (0-100%) to set when Slot 4's sensor is active. Venetian covers only. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_4": "When enabled, Slot 4 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "default_tilt": "Default tilt angle (0-100%) for venetian covers when no other handler overrides tilt. Applied whenever the default position handler is active. Leave unset to let the engine calculate tilt from sun geometry.",
+          "sunset_tilt": "Tilt angle (0-100%) for venetian covers during the sunset window. Overrides default_tilt when the sunset time window is active. Leave unset to fall back to default_tilt."
+        }
+      },
+      "motion_override": {
+        "title": "Motion Override",
+        "description": "Enable occupancy-based control. When all configured sources report no motion, the integration stops sun tracking and moves covers to their default position after the timeout expires. When any source detects occupancy, automatic positioning resumes.\n\nAny mix of motion, occupancy, or binary presence sensors can be used, plus media players (a player that is on counts as occupancy). The logic is OR — any single active source counts as occupied. This is useful for rooms where you don't want covers adjusting when nobody is present.\n\n[Learn more]({learn_more})",
+        "data": {
+          "motion_sensors": "Motion/occupancy sensors for occupancy-based control",
+          "motion_media_players": "Media players for occupancy-based control",
+          "motion_timeout": "Motion timeout duration",
+          "motion_timeout_mode": "When motion times out"
+        },
+        "data_description": {
+          "motion_sensors": "Binary sensors that enable/disable automatic sun positioning based on occupancy. When ANY sensor detects motion, covers use automatic sun-based positioning. When ALL sensors show no motion for the timeout duration, covers return to default position. Leave empty to disable this feature.",
+          "motion_media_players": "Media players treated as occupancy. ANY player whose state is something other than off (playing, paused, idle, on, …) counts as occupied and keeps automatic sun positioning active. Players that are off, unavailable, or unknown do not count. Combined with the motion sensors above under the same OR logic. Leave empty to disable.",
+          "motion_timeout": "Duration (in seconds) to wait after last motion before returning covers to default position. Prevents rapid position changes when motion sensors toggle frequently. Range: 30-3600 seconds (0.5-60 minutes). Default: 300 seconds (5 minutes).",
+          "motion_timeout_mode": "What to do when motion has been absent for the timeout duration. 'Return to default' moves covers to the default position. 'Hold position' leaves covers where they are while the sun is in the FOV (so an occupant who returns finds them how they left them); covers still return to default once the sun leaves the FOV or the time window closes."
+        }
+      },
+      "weather_override": {
+        "title": "Weather Override",
+        "description": "Configure weather-based safety overrides. Any configured condition triggers cover retraction. Unconfigured inputs are ignored.\n\n[Learn more]({learn_more})",
+        "data": {
+          "weather_bypass_auto_control": "Active when Automatic Control is off",
+          "weather_wind_speed_sensor": "Wind speed sensor",
+          "weather_wind_direction_sensor": "Wind direction sensor (optional)",
+          "weather_wind_speed_threshold": "Wind speed threshold",
+          "weather_wind_direction_tolerance": "Wind direction tolerance",
+          "weather_rain_sensor": "Rain rate sensor",
+          "weather_rain_threshold": "Rain rate threshold",
+          "weather_is_raining_sensor": "Is Raining binary sensor",
+          "weather_is_windy_sensor": "Is Windy binary sensor",
+          "weather_severe_sensors": "Severe weather sensors (hail, frost, storm, etc.)",
+          "weather_override_position": "Override position",
+          "weather_override_min_mode": "Minimum position mode",
+          "weather_timeout": "Clear delay"
+        },
+        "data_description": {
+          "weather_bypass_auto_control": "When enabled, weather override will still move covers to the configured position even when the Automatic Control switch is turned off. This ensures wind, rain, and severe weather protection is always active regardless of the automation state. Disable this only if you want weather override to follow the Automatic Control switch.",
+          "weather_wind_speed_sensor": "Numeric sensor reporting wind speed. Override activates when the value meets or exceeds the threshold. Leave empty to ignore wind speed.",
+          "weather_wind_direction_sensor": "Optional: only trigger wind override when wind blows toward this window's azimuth (within the direction tolerance). Leave empty to trigger on wind speed alone regardless of direction.",
+          "weather_wind_speed_threshold": "Wind speed threshold that activates the override. **Value is interpreted in the configured wind-speed sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "weather_wind_direction_tolerance": "How many degrees from the window azimuth to consider wind as 'hitting' this window. Example: window faces south (180°), tolerance 45° → wind from 135°-225° triggers override.",
+          "weather_rain_sensor": "Numeric sensor reporting rain rate. Override activates when the value meets or exceeds the threshold. Leave empty to ignore rain rate.",
+          "weather_rain_threshold": "Rain rate threshold that activates the override. **Value is interpreted in the configured rain sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "weather_is_raining_sensor": "Binary sensor for rain detection. Override activates when this sensor is 'on'. Leave empty to ignore.",
+          "weather_is_windy_sensor": "Binary sensor for wind detection. Override activates when this sensor is 'on'. Leave empty to ignore.",
+          "weather_severe_sensors": "Binary sensors for severe conditions (hail, frost, thunderstorm, etc.). Override activates when ANY sensor is 'on'. Leave empty to ignore.",
+          "weather_override_position": "Position (0-100%) to move covers to when weather override is active. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Default: 0%.",
+          "weather_override_min_mode": "When enabled, the override position acts as a minimum floor — the cover will not close below this position, but higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact override position.",
+          "weather_timeout": "Seconds to wait after ALL conditions clear before resuming normal control. Prevents rapid toggling during gusty or intermittent conditions. Set to 0 for instant resume."
+        }
+      },
+      "weather": {
+        "data": {
+          "weather_state": "Weather Conditions"
+        },
+        "data_description": {
+          "weather_state": "Select weather states that mean 'sun is out' for climate mode. Recommended selection (pre-filled): ☑ sunny (direct sun), ☑ partlycloudy (some sun), ☐ cloudy (no direct sun), ☐ clear (usually night). When current weather matches selection: Apply climate strategies. When no match: Use default position (no sun assumed). Most users should keep the defaults."
+        },
+        "title": "Weather Conditions",
+        "description": "Select the weather states that count as \"sun is out\" for climate mode. The integration compares the live weather entity state to this list — matching states enable solar-based cover control. States not in the list are treated as cloudy, so summer-close and winter-open rules only apply when the weather matches.\n\nTypical choices are \"sunny\" and \"partlycloudy\". The available states depend on your weather integration.\n\n[Learn more]({learn_more})"
+      },
+      "blind_spot": {
+        "data": {
+          "blind_spot_left": "Blind spot left edge (from FOV left)",
+          "blind_spot_right": "Blind spot right edge (from FOV left)",
+          "blind_spot_elevation": "Blindspot elevation"
+        },
+        "data_description": {
+          "blind_spot_left": "Left edge of the blind spot zone (horizontal angle in degrees from your FOV left boundary). Where 0 = at the leftmost FOV edge. Example: If your FOV left is 45° and a tree blocks sun from 10-20° relative to that edge, set this to 10. This marks where the obstruction begins horizontally. Use sun position sensor or observe when sun is blocked to find this value.",
+          "blind_spot_right": "Right edge of the blind spot zone (horizontal angle in degrees from your FOV left boundary, must be > left edge). Example: If your FOV left is 45° and a tree blocks sun from 10-20° relative to that edge, set this to 20. This marks where the obstruction ends horizontally. Creates a 'don't track sun here' zone between left and right edges.",
+          "blind_spot_elevation": "Maximum sun elevation (degrees above horizon) where blind spot applies. Example: Roof overhang blocks sun only when low (< 30°) so set to 30. Higher elevation sun clears the obstacle, so blind spot doesn't apply. If obstacle blocks all elevations (tall building), set to 90 or leave high. Sun elevation: 0°=horizon, 45°=halfway up, 90°=directly overhead. Measure or estimate based on obstacle height and distance."
+        },
+        "title": "Blind Spot",
+        "description": "Define areas where obstacles block the sun (trees, buildings, roof overhangs). These angular values are relative degrees within your field of view, where 0 is the leftmost FOV boundary. The cover will ignore sun position when it falls within this blind spot zone.\n\n[Learn more]({learn_more})"
+      },
+      "glare_zones": {
+        "title": "Glare Zones",
+        "description": "Define up to 4 floor areas to protect from direct sunlight. When the sun's angle would cast direct light onto a zone, the blind lowers to shade it. Leave a zone name blank to skip that slot.\n\nCoordinates are relative to the window centre projected onto the floor. **X** is the left/right offset (positive = right). **Y** is the distance into the room. **Radius** defines the circular protected area. Use the Lovelace companion card to visualise zone positions and verify coverage.\n\n[Learn more]({learn_more})",
+        "data": {
+          "enable_glare_zones": "Enable Glare Zones",
+          "glare_zone_1_name": "Zone 1 Name",
+          "glare_zone_1_x": "Zone 1 X Position",
+          "glare_zone_1_y": "Zone 1 Y Position",
+          "glare_zone_1_radius": "Zone 1 Radius",
+          "glare_zone_1_z": "Zone 1 Z Height",
+          "glare_zone_2_name": "Zone 2 Name",
+          "glare_zone_2_x": "Zone 2 X Position",
+          "glare_zone_2_y": "Zone 2 Y Position",
+          "glare_zone_2_radius": "Zone 2 Radius",
+          "glare_zone_2_z": "Zone 2 Z Height",
+          "glare_zone_3_name": "Zone 3 Name",
+          "glare_zone_3_x": "Zone 3 X Position",
+          "glare_zone_3_y": "Zone 3 Y Position",
+          "glare_zone_3_radius": "Zone 3 Radius",
+          "glare_zone_3_z": "Zone 3 Z Height",
+          "glare_zone_4_name": "Zone 4 Name",
+          "glare_zone_4_x": "Zone 4 X Position",
+          "glare_zone_4_y": "Zone 4 Y Position",
+          "glare_zone_4_radius": "Zone 4 Radius",
+          "glare_zone_4_z": "Zone 4 Z Height"
+        },
+        "data_description": {
+          "enable_glare_zones": "When enabled, the blind will lower to shade all active floor zones.",
+          "glare_zone_1_name": "Name for this zone (e.g. 'Desk'). Leave blank to skip.",
+          "glare_zone_1_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_1_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_1_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_1_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_2_name": "Name for this zone (e.g. 'Sofa'). Leave blank to skip.",
+          "glare_zone_2_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_2_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_2_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_2_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_3_name": "Name for this zone (e.g. 'Dining Table'). Leave blank to skip.",
+          "glare_zone_3_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_3_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_3_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_3_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_4_name": "Name for this zone (e.g. 'Bed'). Leave blank to skip.",
+          "glare_zone_4_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_4_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_4_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_4_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for."
+        }
+      },
+      "interp": {
+        "data": {
+          "interp_start": "Calibration input 0% maps to (output %)",
+          "interp_end": "Calibration input 100% maps to (output %)",
+          "interp_list": "Calculated positions (input)",
+          "interp_list_new": "Actual positions to send (output)"
+        },
+        "data_description": {
+          "interp_start": "Output position sent to the cover when the integration calculates 0% (fully closed). Example: if your cover needs 10% to register as closed, set this to 10. Simple 2-point linear calibration — used together with the 100% mapping below. Leave at default unless your cover has limited range.",
+          "interp_end": "Output position sent to the cover when the integration calculates 100% (fully open). Example: if your cover is fully open at 90%, set this to 90. Simple 2-point linear calibration — used together with the 0% mapping above. Leave at default unless your cover has limited range.",
+          "interp_list": "Input positions for custom interpolation mapping (calculated positions from integration). Enter evenly-spaced values like: 0, 25, 50, 75, 100. These are the theoretical positions the integration calculates. Must have 2+ values and same length as 'Actual positions to send (output)'. Used for advanced non-linear calibration. Leave empty for normal operation.",
+          "interp_list_new": "Output positions for custom interpolation mapping (actual positions sent to cover). Enter corresponding real positions like: 0, 20, 40, 65, 100. These are what actually gets sent to your cover entity. Must have same length as 'Calculated positions (input)'. Example use: Make cover more aggressive in closing by mapping 50% calculated to 40% actual. Integration interpolates between your points. Leave empty for normal operation."
+        },
+        "title": "Position Calibration",
+        "description": "Adjust cover position mapping for non-standard covers by mapping a calculated position (input) to an actual position sent to the cover (output). Use simple 2-point calibration (map 0% and 100%) for covers with limited range (e.g., only moves between 10–90%). Use advanced list mapping for non-linear covers or to bias behavior more open/closed. Most covers don't need this — only enable if your cover doesn't respond correctly to standard 0–100% commands.\n\n[Learn more]({learn_more})"
+      },
+      "duplicate_select": {
+        "title": "Duplicate Cover — Select Source",
+        "description": "Choose which existing cover to duplicate settings from.",
+        "data": {
+          "source_entry": "Source cover"
+        }
+      },
+      "duplicate_configure": {
+        "title": "Duplicate Cover — Configure",
+        "description": "Enter the unique settings for the new cover. All other settings will be copied from the source.",
+        "data": {
+          "name": "Name",
+          "entities": "Cover entities",
+          "azimuth": "Window azimuth"
+        }
+      },
+      "summary": {
+        "title": "Configuration Summary",
+        "description": "{summary}"
+      },
+      "setup_mode": {
+        "title": "Setup Mode",
+        "description": "Choose how much to configure now. You can always adjust all settings later from the options menu.\n\n[Learn more]({learn_more})",
+        "menu_options": {
+          "quick_setup": "Quick Setup — Window basics + sun tracking only (recommended for first-time setup)",
+          "full_setup": "Full Setup — All options including climate, overrides, and automation"
+        }
+      },
+      "light_cloud": {
+        "title": "Light Sensors & Cloud Suppression",
+        "description": "**Glare suppression in low light.** The first toggle below is the master on/off for this feature — leave it off and the rest of this screen is ignored. When on, set the optional **Cloudy position** the cover parks at when suppression fires (leave blank to use the default position).\n\nThe remaining sensors tell the integration *when* the sun is absent — any one of weather state, lux, solar irradiance, or cloud coverage will trigger suppression. Configure only the sensors you actually have; any single match is enough.\n\n[Learn more]({learn_more})",
+        "data": {
+          "weather_entity": "Weather entity (optional)",
+          "is_sunny_sensor": "Is Sunny binary sensor (optional)",
+          "lux_entity": "Lux sensor (optional)",
+          "lux_threshold": "Lux threshold",
+          "irradiance_entity": "Irradiance sensor (optional)",
+          "irradiance_threshold": "Irradiance threshold",
+          "cloud_coverage_entity": "Cloud coverage sensor (optional)",
+          "cloud_coverage_threshold": "Cloud coverage threshold",
+          "cloud_suppression": "Enable cloud suppression (master switch)",
+          "cloudy_position": "Cloudy position (optional)",
+          "weather_state": "Weather Conditions"
+        },
+        "data_description": {
+          "weather_entity": "Optional weather integration used to detect cloud cover. When the current weather state is not in the selected list below, direct sun is assumed absent and glare control is suppressed. Leave empty to ignore weather state.",
+          "weather_state": "The weather states that count as 'sun is out'. When the live weather state matches one of these, glare tracking runs normally. When it does not match, the cover returns to its default position. Keep the defaults (sunny, partlycloudy, clear) unless your weather integration uses different state names.",
+          "is_sunny_sensor": "Optional binary sensor, input_boolean, switch, or schedule that authoritatively reports whether the sun is hitting the window. When ON, sun is assumed present; when OFF, sun is assumed absent and cloud suppression fires regardless of weather state. When unavailable or unknown, the integration falls back to the Weather Entity / Weather Conditions logic below. Use this when you compute sun-on-window upstream (e.g. azimuth-gated irradiance) and want to feed Adaptive Cover Pro a clean boolean.",
+          "lux_entity": "Optional illuminance sensor (indoor or outdoor) for precise sun detection. When the sensor reads below the threshold, direct sun is absent and glare control is suppressed. Typical direct-sun values: 5,000–10,000 lux. Leave empty if you don't have this sensor.",
+          "lux_threshold": "Illuminance level above which the sun is considered present. Below this value the cover returns to its default position instead of tracking the sun. Typical values: 5,000–10,000 lux for direct sunlight, 2,000–3,000 lux for bright indirect light. **Value is interpreted in the configured lux sensor's unit** — the selector label tracks that unit when a sensor is set.",
+          "irradiance_entity": "Optional solar irradiance sensor (outdoor) for precise sun detection. Measures solar power in W/m². When the sensor reads below the threshold, direct sun is absent and glare control is suppressed. Leave empty if you don't have this sensor.",
+          "irradiance_threshold": "Solar irradiance level above which the sun is considered present. Below this value the cover returns to its default position. Typical values: 300–500 W/m² for direct sunlight, 100–200 W/m² for an overcast day. **Value is interpreted in the configured irradiance sensor's unit** — the selector label tracks that unit when a sensor is set.",
+          "cloud_coverage_entity": "Optional cloud coverage sensor reporting 0–100% (e.g. from a weather integration). When the reading reaches the threshold, glare control is suppressed and the cover returns to its default position. Leave empty if you don't have this sensor.",
+          "cloud_coverage_threshold": "Cloud coverage percentage at or above which glare control is suppressed. For example, 75 means the cover stops sun-tracking when the sky is 75% or more overcast.",
+          "cloud_suppression": "Master on/off for this entire screen. When **off** (default), every sensor below is ignored and glare control runs as usual. When **on**, any configured sensor (weather state, lux, irradiance, or cloud coverage) that indicates the sun is absent will stop sun-tracking and move the cover to the **Cloudy position** above (or the default position if that is blank). Works on its own — climate mode does not need to be enabled.",
+          "cloudy_position": "Position (0-100%) to move covers to when cloud suppression fires (cloudy / low-light conditions). 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Leave blank to use the default position."
+        }
+      },
+      "temperature_climate": {
+        "title": "Temperature & Climate Mode",
+        "description": "Climate mode adjusts cover position based on indoor/outdoor temperature, presence, and whether the sun is actually hitting the window. When disabled, the cover follows normal sun/glare tracking.\n\n**How the season is chosen** — The current temperature is the outside sensor if provided, otherwise the inside sensor.\n- **Winter** — current temp is below the low threshold.\n- **Summer** — current temp is above the high threshold **and** outside temp is above the outside threshold (prevents summer behavior on a cold day).\n- **Intermediate** — neither of the above; normal solar/glare tracking runs.\n\n**What each mode does**\n- **Winter + sun on window** → open fully (100%) to capture free solar heat.\n- **Winter, sun not on window**, *Winter insulation mode* on → close fully (0%) to trap heat.\n- **Summer** → close fully (0%) to block heat gain. For blinds, this only happens with presence if *Transparent blind* is on; without presence it always closes.\n- **Low light** (cloudy / dark / not sunny) → returns to the default position, overriding summer-close so covers don't close needlessly.\n- **Intermediate / sun valid with presence** → normal glare-control tracking.\n\n**Presence** gates the behavior: with nobody home, a simpler summer-closed / winter-open rule applies; with occupants present, glare tracking runs in intermediate conditions and transparent blinds still close in summer.\n\n**Tilt covers** follow the same seasonal logic but use slat angles instead of open/closed positions.\n\nLeave *Outside temperature sensor* and *Presence entity* blank to skip those checks. Climate mode runs after force/weather/manual/custom overrides but before normal solar tracking.\n\n[Learn more]({learn_more})",
+        "data": {
+          "climate_mode": "Enable climate mode",
+          "temp_entity": "Inside temperature entity",
+          "temp_low": "Low temperature threshold",
+          "temp_high": "High temperature threshold",
+          "outside_temp": "Outside temperature sensor (optional)",
+          "outside_threshold": "Outside temperature threshold",
+          "presence_entity": "Presence entity (optional)",
+          "transparent_blind": "Transparent blind",
+          "winter_close_insulation": "Winter insulation mode"
+        },
+        "data_description": {
+          "climate_mode": "Turn on to enable all climate-based cover control. When off, all settings on this screen are ignored and the cover follows normal sun/glare tracking.",
+          "temp_entity": "A climate thermostat or temperature sensor that measures the indoor temperature used to determine the current season (winter/summer/intermediate). Required when climate mode is enabled.",
+          "temp_low": "Indoor (or outdoor, if an outside sensor is configured) temperature below which the season is treated as winter. In winter the cover opens fully when the sun is hitting the window to capture solar heat. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "temp_high": "Indoor (or outdoor, if an outside sensor is configured) temperature above which the season is treated as summer — provided the outside threshold is also exceeded. In summer the cover closes to block heat gain. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "outside_temp": "Optional outdoor temperature sensor. When provided, this reading (rather than the indoor sensor) determines the current season, and the outside threshold guard is applied to prevent summer-close behavior on cold days.",
+          "outside_threshold": "Minimum outdoor temperature required before summer mode activates. Guards against closing covers on a hot indoor day when it is actually cold outside. Only used when an outside temperature sensor is configured. **Value is interpreted in that outside sensor's unit, not Home Assistant's display unit.**",
+          "presence_entity": "Optional presence sensor, device tracker, or zone. When someone is home, the cover uses glare-control tracking in intermediate conditions; when nobody is home a simpler summer-closed / winter-open rule applies. Leave blank to always treat the space as occupied.",
+          "transparent_blind": "Enable when the blind material is sheer or translucent. In summer with occupants present a transparent blind will still close fully to reduce heat gain, whereas an opaque blind would instead follow glare-control tracking.",
+          "winter_close_insulation": "When enabled, the cover closes fully (0%) during winter when the sun is not directly hitting the window, helping to trap heat indoors. Has no effect when the sun is on the window (the cover opens to capture solar heat)."
+        }
+      }
+    },
+    "abort": {
+      "user_cancelled": "Action cancelled by user",
+      "source_not_found": "The source cover no longer exists."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Configuring: **{instance_name}**\n\nIf Adaptive Cover Pro has been useful, you can [☕ Buy Me a Coffee]({coffee_url}).",
+        "menu_options": {
+          "cover_entities": "🪟 Covers & Device",
+          "geometry": "📐 Cover Geometry",
+          "sun_tracking": "☀️ Sun Tracking",
+          "position": "📊 Position Settings",
+          "blind_spot": "🌳 Blind Spot",
+          "glare_zones": "🔆 Glare Zones",
+          "interp": "📊 Position Calibration",
+          "automation": "⏱️ Schedule & Timing",
+          "weather": "Weather Conditions",
+          "manual_override": "✋ Manual Override",
+          "force_override": "🚨 Force Override",
+          "custom_position": "🎯 Custom Positions",
+          "motion_override": "🚶 Motion Override",
+          "weather_override": "🌧️ Weather Override",
+          "summary": "📋 Configuration Summary",
+          "sync": "🔄 Copy to Other Covers",
+          "debug": "🔍 Debug & Diagnostics",
+          "done": "✅ Save & Close",
+          "light_cloud": "☁️ Light Sensors & Cloud",
+          "temperature_climate": "🌡️ Temperature & Climate"
+        }
+      },
+      "automation": {
+        "title": "Schedule & Timing",
+        "description": "Set the operational window (start/end times) and the minimum position or time delta between adjustments.\n\n**Delta position** prevents the cover from moving unless the target has shifted by at least this many percent — reduces motor wear from small sun changes. **Delta time** enforces a minimum gap between consecutive commands. **Start/end times** define when automatic control is allowed to run; leave blank to run all day. An HA entity can supply either time dynamically, useful for schedule helpers or alarm clocks.\n\n[Learn more]({learn_more})",
+        "data": {
+          "delta_position": "Minimum position adjustment",
+          "position_tolerance": "Position match tolerance",
+          "delta_time": "Minimum interval between position changes",
+          "start_time": "Starting time",
+          "start_entity": "Entity indicating starting time",
+          "end_time": "End time",
+          "end_entity": "Entity indicating ending time"
+        },
+        "data_description": {
+          "delta_position": "Minimum position change (%) required before adjusting the cover. Prevents tiny adjustments as sun moves slowly. Typical values: 1-2% (very responsive, may adjust frequently), 5% (balanced, recommended for most), 10% (less frequent, larger movements). Example: If cover is at 30% and sun moves slightly, only adjust if new position is 35% or more (with 5% threshold). Reduces motor wear and noise from constant tiny adjustments.",
+          "position_tolerance": "Allowed gap (%) between the commanded position and the position the cover reports back before the integration treats it as 'not arrived' and resends the command. This is distinct from the movement delta above: the delta decides whether to send a new command, while this tolerance decides whether an already-sent command was honored. The default of 3% covers normal motor rounding (e.g. a cover that settles at 98% when told 100%). Raise it for actuators that consistently under- or overshoot — for example, set 6% if a cover commanded to 100% reports 95% and would otherwise click and retry every minute.",
+          "delta_time": "Minimum time (minutes) between cover adjustments. Prevents rapid position changes. Typical values: 2-3 min (very responsive, may be noisy), 5-10 min (balanced, recommended), 15-20 min (slow, gentle adjustments). If sun changes rapidly (clouds, shadows), integration waits this long before adjusting again. Reduces motor wear and provides smoother operation. Minimum is 2 minutes.",
+          "start_time": "Don't start automatic control before this time (24-hour format). Use this to sleep in without morning blinds (set to 08:00 or later), match your routine (set to when you wake up), or leave blank to start at sunrise. Example: '07:30' means automatic control begins at 7:30 AM. Manual control still works before this time.",
+          "start_entity": "Entity representing starting time state, overriding the fixed start time set above. Useful for automating the start time with an entity (e.g., sensor that provides wake-up time based on calendar or sleep tracking).",
+          "end_time": "Stop automatic control after this time (24-hour format). Use this to keep evening privacy (set to 18:00 or 19:00), return to default before bed, or leave blank to continue until sunset. Example: '20:00' means automatic control stops at 8:00 PM. Manual control still works after this time.",
+          "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine)."
+        }
+      },
+      "cover_entities": {
+        "title": "Covers & Device",
+        "description": "Select the covers this instance controls and optionally attach them to a physical device in HA. Multiple covers can share one instance — they use the same settings and move independently. To control covers with different window orientations, create a separate instance for each.\n\n[Learn more]({learn_more})",
+        "data": {
+          "group": "Cover Entities",
+          "linked_device_id": "Attach to Device",
+          "enable_proxy_cover": "Expose Proxy Cover Entity"
+        },
+        "data_description": {
+          "group": "Select the cover entities to control via this integration instance. You can select multiple covers to control them as a group (all will receive the same position commands). Only select covers that serve this particular window - create separate integration instances for different windows.",
+          "linked_device_id": "Select a physical device to merge this integration's entities into. The integration's sensors, switches, and buttons will appear directly under that device in Home Assistant. Select 'None (standalone device)' to revert to a separate virtual Adaptive Cover device. Only devices that own the selected cover entities are shown.",
+          "enable_proxy_cover": "Expose a proxy cover entity per physical cover. Use this on dashboards instead of the physical cover so manual commands respect min-mode floors. Default: off."
+        }
+      },
+      "geometry": {
+        "title": "Cover Geometry",
+        "description": "Enter your cover and window measurements. The integration uses these to calculate exactly how far to lower or extend the cover to block direct sunlight while maximising natural light.\n\n**Window height** and **shaded area** are required for vertical blinds and awnings. **Reveal depth** and **sill height** improve geometric accuracy for windows set back into the wall. **Awning span** and **angle** apply to horizontal awnings. **Slat depth** and **spacing** are required for tilt/venetian covers.\n\n{geometry_wiki_link}",
+        "data": {
+          "window_height": "Window Height",
+          "distance_shaded_area": "Shaded area",
+          "window_depth": "Window Depth (Reveal)",
+          "sill_height": "Window Sill Height",
+          "window_width": "Window Width",
+          "length_awning": "Awning Span Length",
+          "angle": "Awning Angle",
+          "slat_depth": "Slat Depth",
+          "slat_distance": "Slat Spacing",
+          "venetian_tilt_skip_above": "Skip Tilt Above Position (%)",
+          "venetian_mode": "Operating Mode",
+          "venetian_post_settle_hold": "Post-settle Hold (s)",
+          "venetian_backrotate_publish_lag": "Publish-lag window (s)",
+          "inverse_tilt": "Inverse Tilt",
+          "max_tilt": "Maximum Slat Tilt (%)",
+          "min_tilt": "Minimum Slat Tilt (%)",
+          "arm_length": "Arm Length",
+          "awning_min_angle": "Arm Angle When Closed",
+          "awning_max_angle": "Arm Angle When Fully Open",
+          "awning_housing_offset": "Housing Offset Above Window"
+        },
+        "data_description": {
+          "window_height": "Height of your window (from bottom to top of the glass area). Shown in the unit Home Assistant is configured for. Examples: Standard door = 2.0 m / 79 in, Small window = 1.5 m / 59 in, Floor-to-ceiling = 2.5 m / 98 in. Measure from where the cover starts to where it ends when fully extended.",
+          "distance_shaded_area": "How far you want to ALLOW direct sunlight to reach into the room. Shown in the unit Home Assistant is configured for. This defines your acceptable 'glare zone' — the area where sunlight can reach the floor. The cover position adjusts to maintain this boundary as the sun moves across the sky. Common configurations: Zero (0 m / 0 in) keeps direct sun from passing the glass plane (full closure on hot days); Small glare zone (0.3–0.5 m / 12–20 in) keeps sunlight very close to the window; Medium glare zone (0.5–1.0 m / 20–40 in) allows sun to reach desk or seating area; Large glare zone (2.0–3.0 m / 79–118 in) allows sunlight deep into the room. KEY CONCEPT: LARGER value = MORE sunlight allowed farther into room = cover stays HIGHER/MORE OPEN; SMALLER value = LESS sunlight into room = cover drops LOWER/MORE CLOSED. Measure from the inside of your window to where you want the sun boundary to be.",
+          "window_depth": "Depth of window reveal/frame from the wall surface. Shown in the unit Home Assistant is configured for. Optional parameter for advanced accuracy — set to 0 (default) to disable. Typical values: Flush mount = 0.05 m / 2 in, Standard frame = 0.10 m / 4 in, Deep reveal = 0.15 m / 6 in. Provides additional sun blocking at angled sun positions. Measure from the outer wall surface to the inner edge of the window frame. Only affects calculation at angles >10°.",
+          "sill_height": "Height from the floor to the bottom of your window. Shown in the unit Home Assistant is configured for. Set to 0 (default) for floor-level windows or when unknown. Example: for a sill 1 m / 39 in above the floor, enter that value. Improves calculation accuracy for raised windows — without it, the blind closes slightly more than necessary. Range: 0–50 m / 0–1968 in. Measure from the floor to the bottom edge of the glass area (the sill). Note: Window Height is still measured from bottom to top of glass — these are independent measurements.",
+          "window_width": "Width of the window opening. Shown in the unit Home Assistant is configured for. Used by glare zones to determine which floor zones can receive direct sunlight based on the sun's horizontal angle. Measure the inside width of the glass area. Examples: Standard window = 0.9–1.2 m / 35–47 in, Double window = 1.5–1.8 m / 59–71 in, Patio door = 2.0–3.0 m / 79–118 in. Only relevant when glare zones are enabled.",
+          "length_awning": "Maximum extension length of your awning when fully extended. Shown in the unit Home Assistant is configured for. Measure from mounting point to the end of the fabric when fully out. Examples: Standard patio awning = 2.0–3.0 m / 79–118 in, Small window awning = 1.0–1.5 m / 39–59 in, Large commercial = 4.0 m / 157 in or more. Used to calculate how far the awning needs to extend to block sun.",
+          "angle": "Angle of the awning when extended (0-45°). 0° = Horizontal/flat (maximum coverage), 15° = Slight slope (typical for drainage), 30° = Steep slope (strong sun angle), 45° = Very steep (rarely used). Check your awning manufacturer specs. Most awnings are 0-15°. Affects shadow calculation for proper sun blocking.",
+          "slat_depth": "Width of each slat (measure one slat front to back). Shown in the unit Home Assistant is configured for. Common sizes: Mini blinds = 2.5 cm / 1 in, Standard blinds = 5 cm / 2 in, Wide slats = 6.5–7.5 cm / 2.5–3 in. Measure a single slat with a ruler for precise sun blocking calculation.",
+          "slat_distance": "Vertical spacing between slat centres. Shown in the unit Home Assistant is configured for. Measure from the middle of one slat to the middle of the next slat (vertically). Usually slightly more than slat depth to allow overlap when closed. Common: 3–8 cm / 1.2–3 in depending on blind type. Used to calculate optimal tilt angle.",
+          "venetian_tilt_skip_above": "When the cover is commanded above this position (0–100%), the tilt command is skipped. At high positions the slats retract into the housing and tilting is physically meaningless. Default 95%. Increase if your blind tilts correctly near the top; decrease if it tries to tilt when fully raised.",
+          "venetian_mode": "How the venetian blind uses both axes when the sun is in the tracking window. **Position and tilt** (default): the cover lowers to the calculated position and the slats tilt to the optimal angle — best for combined shading and privacy. **Tilt only**: the cover stays closed (position 0%) and only the slat angle tracks the sun — best when you always want full coverage and want continuous glare control via tilt.",
+          "venetian_post_settle_hold": "How long (in seconds) to wait after the carriage settles before sending the tilt command. Default 2.0 s suits most actuators. Raise to 4–6 s for KNX FGR223 or other firmware that re-asserts a tilt-to-open shortly after the carriage stops — without the extra hold the tilt command races that re-assert and loses. Range 0.0–10.0 s.",
+          "venetian_backrotate_publish_lag": "How long (in seconds) the integration tolerates a late position-state publish from your actuator before treating it as a real user touch. Default 45 s suits Somfy IO via Tahoma. Increase to 60–120 s if your hardware (slow KNX bus, Fibaro/Shelly republish) publishes the post-move current_position long after the cover has physically stopped — symptom is spurious 'manual_override_set' events fired ~30–90 s after a commanded move. Decrease only if you have an unusually fast actuator and want tighter false-touch detection. Range 15–180 s.",
+          "inverse_tilt": "Inverts the tilt axis only. Enable when your hardware sends tilt 0 for slats-open and 100 for slats-closed, which is the opposite of what the integration expects. This applies only to the tilt (slat) axis — the position axis is controlled separately by 'Inverse state'. Most covers do not need this. Useful for KNX or Somfy hardware where the tilt direction is wired opposite to the HA convention.",
+          "max_tilt": "Cap on the maximum slat tilt percentage (0–100). Lower values prevent slats from reaching angles that reflect direct sun into the room. Default: 100 (no cap). Example: set to 70 if fully-open slats cause glare at peak sun angles.",
+          "min_tilt": "Floor on the minimum slat tilt percentage (0–100). Higher values prevent slats from closing fully — useful for blinds that block all light at 0%. Default: 0 (no floor). Example: set to 10 if your blinds become fully dark at 0% and you always want some light through.",
+          "arm_length": "Length of the pivoting arm of an oscillating (drop-arm) awning, from the wall pivot to the fabric edge. Shown in the unit Home Assistant is configured for. Used with the arm sweep angle to compute how far the fabric reaches out at each open percentage. Example: 0.8 m / 31 in.",
+          "awning_min_angle": "Arm angle when the awning is fully closed/retracted (0–180°). Typically 0° = arm vertical against the wall. Defines the start of the sweep arc.",
+          "awning_max_angle": "Arm angle when the awning is fully open (0–180°). The arm sweeps linearly from the closed angle to this value across 0–100% open. Example: a 175° total sweep ≈ 1.75° per 1%.",
+          "awning_housing_offset": "Vertical offset of the arm pivot above the top of the window (0–1 m). Combined with window height and arm length to locate the pivot. Set 0 when the housing sits flush with the window top."
+        }
+      },
+      "sun_tracking": {
+        "title": "Sun Tracking",
+        "description": "Set your window's compass direction and the angular range where the sun is visible. The integration tracks the sun within this field of view and holds the cover at its default position when the sun is outside it.\n\n**Azimuth** is the compass bearing your window faces (0° = North, 90° = East, 180° = South, 270° = West). **FOV** defines how far left and right from centre the sun is tracked. **Elevation limits** filter out very low angles (sunrise glare) or very high angles (zenith) where blocking may not be needed.\n\n[Learn more]({learn_more})",
+        "data": {
+          "enable_sun_tracking": "Enable sun tracking",
+          "minimize_movements": "Minimize movements",
+          "max_coverage_steps": "Maximum coverage steps",
+          "set_azimuth": "Window Azimuth",
+          "fov_left": "Field of view left",
+          "fov_right": "Field of view right",
+          "min_elevation": "Minimum Elevation of the sun",
+          "max_elevation": "Maximum Elevation of the sun",
+          "blind_spot": "Setup Blindspot",
+          "enable_glare_zones": "Enable Glare Zones",
+          "distance_shaded_area": "Shaded area"
+        },
+        "data_description": {
+          "enable_sun_tracking": "When enabled, covers track the sun within the configured FOV and elevation limits (solar positioning). Disable to skip distance-based solar positioning while keeping glare zones (controlled by their own switch), climate, motion, manual override, custom positions, and other overrides active. Default: enabled.",
+          "minimize_movements": "Reduce how often the cover repositions while tracking the sun by snapping to a few fixed coverage levels instead of following the sun continuously. Rounds toward MORE coverage, so direct sun is never let in by the rounding. Trades some natural light for far fewer motor movements. Default: off.",
+          "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the field of view and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1.",
+          "set_azimuth": "Direction your window faces (0-359°). North=0°, East=90°, South=180°, West=270°. Example: A south-facing window = 180°. Use a compass app or check sun at noon to determine. This tells the integration where your window points so it can calculate sun angles accurately.",
+          "fov_left": "How wide the sun tracking area is on the LEFT side of the window (in degrees). Standard windows: 45° (90° total coverage with both sides), Wide windows or glass doors: 60-75°, Narrow windows: 30°. Think of this as peripheral vision - how far to the left should we track the sun? Combined with fov_right, this defines the horizontal tracking zone.",
+          "fov_right": "How wide the sun tracking area is on the RIGHT side of the window (in degrees). Standard windows: 45° (90° total coverage with both sides), Wide windows or glass doors: 60-75°, Narrow windows: 30°. Think of this as peripheral vision - how far to the right should we track the sun? Combined with fov_left, this defines the horizontal tracking zone.",
+          "min_elevation": "Track sun only when elevation is ABOVE this angle (degrees above horizon). Sun elevation: 0°=horizon, 45°=halfway to zenith, 90°=directly overhead. Use this to ignore sun at certain times. Example: Set to 15° to ignore low morning/evening sun. Leave empty to track sun at all elevations.",
+          "max_elevation": "Track sun only when elevation is BELOW this angle (degrees above horizon). Sun elevation: 0°=horizon, 45°=halfway to zenith, 90°=directly overhead. Use this to ignore sun at certain times. Example: Set to 60° to ignore high midday sun. Leave empty to track sun at all elevations.",
+          "blind_spot": "Enable if you have obstacles blocking sun in part of the tracking area (trees, nearby buildings, roof overhang, balcony). When enabled, you define an azimuth + elevation range where sun is blocked. Cover ignores sun position when it's in this 'blind spot'. Leave disabled if you have clear view to sun all day.",
+          "enable_glare_zones": "Protect specific floor areas from direct sun glare (vertical covers only)",
+          "distance_shaded_area": "How far you want to ALLOW direct sunlight to reach into the room. Shown in the unit Home Assistant is configured for. This defines your acceptable 'glare zone' — the area where sunlight can reach the floor. The cover position adjusts to maintain this boundary as the sun moves across the sky. Common configurations: Zero (0 m / 0 in) keeps direct sun from passing the glass plane (full closure on hot days); Small glare zone (0.3–0.5 m / 12–20 in) keeps sunlight very close to the window; Medium glare zone (0.5–1.0 m / 20–40 in) allows sun to reach desk or seating area; Large glare zone (2.0–3.0 m / 79–118 in) allows sunlight deep into the room. KEY CONCEPT: LARGER value = MORE sunlight allowed farther into room = cover stays HIGHER/MORE OPEN; SMALLER value = LESS sunlight into room = cover drops LOWER/MORE CLOSED. Measure from the inside of your window to where you want the sun boundary to be."
+        }
+      },
+      "position": {
+        "title": "Position Settings",
+        "description": "Set position limits, the default resting position, and sunset behaviour.\n\nThe **default position** is where covers go when the sun is outside the tracking window or no override is active. **Min/max limits** cap the range the integration will command — the \"apply during sun tracking only\" toggle controls whether each limit is enforced all day or only while sun tracking is active. **Sunset position** moves covers to a specific position at end-time; leave it blank to use the default position instead.\n\n[Learn more]({learn_more})",
+        "data": {
+          "default_percentage": "Default Position",
+          "max_position": "Maximum Position",
+          "enable_max_position": "Apply max only during sun tracking",
+          "min_position": "Minimum Position",
+          "enable_min_position": "Apply min only during sun tracking",
+          "min_position_sun_tracking": "Min Position During Sun Tracking",
+          "sunset_position": "Sunset Position",
+          "enable_my_position_entities": "Enable My-preset entities",
+          "my_position_value": "My position value",
+          "sunset_use_my": "Use My at sunset",
+          "sunset_offset": "Sunset Offset",
+          "sunrise_offset": "Sunrise Offset",
+          "return_sunset": "Move covers to current default position when end time is reached",
+          "sunset_time_entity": "Sunset Time Entity",
+          "sunrise_time_entity": "Sunrise Time Entity",
+          "open_close_threshold": "Open/Close threshold",
+          "inverse_state": "Inverse the state (needed for some covers that don't follow HA guidelines)",
+          "interp": "Enable Position Calibration (custom open/close position mapping)"
+        },
+        "data_description": {
+          "default_percentage": "Cover position when sun is not in front of window (0-100%). 0% = closed (blinds lowered / awning retracted), 50% = half open (balanced light and privacy), 100% = open (blinds raised / awning extended). This is the 'rest position' used when sun tracking is not active (sun is behind the window, blocked by obstacles, or outside tracking hours).",
+          "max_position": "Maximum cover position limit (0-100%). 100% = open (blinds raised / awning extended). Cover will never go above this value. Use this to: prevent cover from fully opening (set to 80%), keep some shade at all times (set to 60-70%), protect from jamming at top (set to 95%). This creates an upper boundary for all automatic positions. On venetian blinds this constrains the carriage (vertical) axis only — slat tilt is computed from sun geometry and is not capped here.",
+          "enable_max_position": "Controls WHEN maximum position limit applies. UNCHECKED (default, recommended): Maximum position applies ALL THE TIME - during sun tracking, default position, climate modes, etc. Cover never goes above max value. CHECKED (advanced): Maximum position ONLY applies when sun is directly in front of window. During default/fallback states, cover can go above max value. Most users should leave this UNCHECKED for consistent protection.",
+          "min_position": "Minimum cover position limit (0-99%). 0% = closed (blinds lowered / awning retracted). Cover will never go below this value. Use this to: prevent cover from fully closing (set to 20%), maintain some light (set to 30-40%), protect from jamming at bottom (set to 5%). This creates a lower boundary for all automatic positions. Works with 'Apply min only during sun tracking' toggle below.",
+          "enable_min_position": "Controls WHEN minimum position limit applies. UNCHECKED (default, recommended): Minimum position applies ALL THE TIME - during sun tracking, default position, climate modes, etc. Cover never goes below min value. CHECKED (advanced): Minimum position ONLY applies when sun is directly in front of window. During default/fallback states, cover can go below min value. Most users should leave this UNCHECKED for consistent protection.",
+          "min_position_sun_tracking": "Optional separate minimum position floor that only applies while the sun is in the field of view. When set, replaces 'Minimum Position' during sun-tracking calculations. Leave blank to use 'Minimum Position' for both sun-tracking and other modes. Use this when your cover has a mechanical dead zone at the bottom of travel (e.g. roller shutters whose slats gap before the bottom lifts) and you want sun-tracking to skip that dead zone while still allowing the cover to fully close at sunset. 0% = closed (blinds lowered), 100% = open (blinds raised).",
+          "sunset_position": "Cover position to set after sunset. Clear the slider (leave empty) to use the Default Position instead — no special sunset behavior. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Common uses: Privacy (0%), Open for night air (100%), Partial privacy (30-50%). When set, this overrides the default position after sun sets.",
+          "enable_my_position_entities": "Create the Managed My Position button and the Managed My Position Value number entity. Off by default — turn on if you use the Somfy-style 'My' preset and want to recall or edit the value from a dashboard.",
+          "my_position_value": "The position (1–99%) you programmed on the motor remote (My/favorite preset). Leave blank to disable My-position triggering for this cover.",
+          "sunset_use_my": "When the sunset/end-time window activates, trigger the cover's My preset (via stop_cover) instead of the normal open/close fallback. Requires My position value to be set. Only affects non-position-capable covers (e.g. Somfy RTS).",
+          "sunset_offset": "Minutes to shift sunset time (± adjustment). Positive value: Apply sunset position X minutes AFTER sunset. Negative value: Apply sunset position X minutes BEFORE sunset. Zero: Exactly at sunset. Use positive value (e.g., 30) if you want covers to stay open a bit past sunset. Use negative value (e.g., -30) to close early while sun is still low.",
+          "sunrise_offset": "Minutes to shift sunrise time (± adjustment). Positive value: Start automatic control X minutes AFTER sunrise. Negative value: Start automatic control X minutes BEFORE sunrise. Zero: Exactly at sunrise. Use positive value (e.g., 60) if you want to sleep in past sunrise. Combines with Start Time setting (uses whichever is later).",
+          "return_sunset": "When the operational end time is reached, send covers to the current effective default position (which will be the sunset position if astronomical sunset has already occurred, otherwise the normal default). Useful when your end time is before sunset and you want covers positioned correctly for the evening. This movement only occurs when Automatic Control is ON — if Automatic Control is disabled, covers will stay where they are at end time.",
+          "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). When set, replaces the astral-computed sunset time as the window boundary. Accepts sensor or input_datetime entities reporting an ISO-8601 datetime. Sunset Offset still applies on top. Falls back to astral if the entity is unavailable.",
+          "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). When set, replaces the astral-computed sunrise time as the morning window-close boundary. Accepts sensor or input_datetime entities. Sunrise Offset still applies on top. Falls back to astral if the entity is unavailable.",
+          "open_close_threshold": "Position threshold for covers that only support open/close commands (not position control). When the calculated position is greater than or equal to this threshold, the cover opens; when below, it closes. Default: 50% (opens at midpoint or above). Higher values (60-70%) keep cover closed more often, lower values (30-40%) open more often. Only affects covers without position support - covers with position control ignore this setting and use exact calculated positions.",
+          "inverse_state": "Enable for covers where position logic is reversed. Standard: 0 = closed/lowered, 100 = open/raised. Inverted: 0 = open/raised, 100 = closed/lowered. Check this ONLY if your cover shows opposite behavior, 100% closes instead of opens, or documentation says 'inverted' or 'reversed'. Test your cover manually first to confirm. Most covers don't need this.",
+          "interp": "Enable custom position mapping to calibrate covers that don't respond linearly to 0–100% commands. When enabled, a \"Position Calibration\" section will appear in the options menu (under Position Settings) where you can configure the mapping values. Use cases: cover doesn't move linearly, prefer certain ranges (more closed or more open), calibrate for unusual cover behavior. Leave disabled for normal operation."
+        }
+      },
+      "manual_override": {
+        "title": "Manual Override",
+        "description": "Control what happens after someone manually moves a cover. Automatic control pauses for the configured duration then resumes.\n\n**Override duration** is how long (in minutes) ACP waits before retaking control. **Reset on each adjustment** restarts the timer every time the cover is touched — useful if someone adjusts a cover several times in a row. **Threshold** is the minimum position change that counts as a manual move; raise it slightly if motor position drift causes false overrides. **Transit timeout** tells ACP how long to wait for a moving cover to stop before treating its final position as intentional.\n\n[Learn more]({learn_more})",
+        "data": {
+          "manual_override_duration": "Duration of manual override",
+          "manual_override_reset": "Reset Manual override duration",
+          "manual_threshold": "Manual override threshold",
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual override (opening and closing)",
+          "manual_ignore_external": "Only engage manual override from Adaptive Cover Pro commands",
+          "transit_timeout": "Transit timeout (seconds)"
+        },
+        "data_description": {
+          "manual_override_duration": "How long (minutes) to pause automatic control after manual adjustment. When you manually move the cover, automatic control pauses. Typical values: 10-15 min (short pause, resume tracking soon), 30 min (medium pause, balanced), 60-120 min (long pause, keep manual position longer), 0 (disabled, immediately resume automatic control - not recommended). Gives you control when you want it, resumes automation later.",
+          "manual_override_reset": "Reset the manual override timer after each manual adjustment. If enabled, each manual change restarts the override duration. If disabled, the duration only applies to the first manual adjustment (subsequent changes don't extend the pause). Enable this if you want the override period to 'renew' with each manual touch.",
+          "manual_threshold": "Position difference (%) that counts as 'manual override' (default: 1%). If you manually move cover by this amount, override detection triggers. Typical values: 1-2% (sensitive, detects small adjustments), 5% (less sensitive, recommended), 10% (only large manual changes count). Prevents accidental override detection from small motor drifts or position reporting variations.",
+          "manual_ignore_intermediate": "Ignore intermediate positions during manual opening and closing operations. Enable this to prevent override detection from transitional positions while the cover is moving to your target position. Useful if your cover reports many intermediate values during movement.",
+          "manual_ignore_external": "When enabled, only position changes sent through the Adaptive Cover Pro proxy entity or the adaptive_cover_pro.set_position service engage manual override. Position changes from other sources (other automations, the default Home Assistant cover card, physical or RF remotes) are ignored and automatic control continues uninterrupted. Useful when you only ever drive the cover via ACP itself and want noisy external state changes to not pause automation. Default: off.",
+          "transit_timeout": "How long ACP waits after a cover stops reporting forward progress before treating the next position report as a user-initiated manual override. The timer resets each time the cover moves closer to its commanded target, so slow-but-moving covers are protected for the full transit. Increase this value for covers that take longer than 45 seconds to complete a full traverse. Default: 45 seconds."
+        }
+      },
+      "force_override": {
+        "title": "Force Override",
+        "description": "Configure binary sensors that unconditionally override automatic control and move covers to a fixed position. Force override remains active even when the Automatic Control switch is off — covers will still be moved to the configured position when any sensor is triggered.\n\n[Learn more]({learn_more})",
+        "data": {
+          "force_override_sensors": "Force override sensors",
+          "force_override_position": "Force override position",
+          "force_override_min_mode": "Minimum position mode"
+        },
+        "data_description": {
+          "force_override_sensors": "Binary sensors that override automatic control and move covers to the configured position when active. When ANY selected sensor is 'on', ALL covers move to the configured position regardless of any other settings, including the Automatic Control switch. Manual control still works. Leave empty to disable this feature.",
+          "force_override_position": "Position (0-100%) to move covers to when force override sensors are active. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Default: 0%.",
+          "force_override_min_mode": "When enabled, the override position acts as a minimum floor — the cover will not close below this position, but higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact override position."
+        }
+      },
+      "custom_position": {
+        "title": "Custom Positions",
+        "description": "Configure binary sensors that set the cover to specific positions when active. Each slot has its own sensor, target position, and pipeline priority. Each active slot is evaluated independently — the highest-priority active slot wins. Use Home Assistant automations to toggle these sensors for scene-based or schedule-based cover control.\n\n[Learn more]({learn_more})",
+        "data": {
+          "custom_position_sensor_1": "Sensor 1",
+          "custom_position_1": "Position for Sensor 1",
+          "custom_position_priority_1": "Priority for Slot 1",
+          "custom_position_min_mode_1": "Minimum mode for Slot 1",
+          "custom_position_use_my_1": "Slot 1: use My position",
+          "custom_position_sensor_2": "Sensor 2",
+          "custom_position_2": "Position for Sensor 2",
+          "custom_position_priority_2": "Priority for Slot 2",
+          "custom_position_min_mode_2": "Minimum mode for Slot 2",
+          "custom_position_use_my_2": "Slot 2: use My position",
+          "custom_position_sensor_3": "Sensor 3",
+          "custom_position_3": "Position for Sensor 3",
+          "custom_position_priority_3": "Priority for Slot 3",
+          "custom_position_min_mode_3": "Minimum mode for Slot 3",
+          "custom_position_use_my_3": "Slot 3: use My position",
+          "custom_position_sensor_4": "Sensor 4",
+          "custom_position_4": "Position for Sensor 4",
+          "custom_position_priority_4": "Priority for Slot 4",
+          "custom_position_min_mode_4": "Minimum mode for Slot 4",
+          "custom_position_use_my_4": "Slot 4: use My position",
+          "custom_position_tilt_1": "Tilt for Slot 1",
+          "custom_position_tilt_only_1": "Slot 1: tilt only",
+          "custom_position_tilt_2": "Tilt for Slot 2",
+          "custom_position_tilt_only_2": "Slot 2: tilt only",
+          "custom_position_tilt_3": "Tilt for Slot 3",
+          "custom_position_tilt_only_3": "Slot 3: tilt only",
+          "custom_position_tilt_4": "Tilt for Slot 4",
+          "custom_position_tilt_only_4": "Slot 4: tilt only",
+          "default_tilt": "Default Tilt",
+          "sunset_tilt": "Sunset Tilt"
+        },
+        "data_description": {
+          "custom_position_sensor_1": "Binary sensor that, when 'on', moves the cover to its configured position. Leave empty to skip this slot.",
+          "custom_position_1": "Position (0-100%) to move covers to when Sensor 1 is active. 0% = closed, 100% = open.",
+          "custom_position_priority_1": "Pipeline priority (1-99). Higher = evaluated before lower-priority handlers. Default 77 sits between Manual Override (80) and Motion Timeout (75). Set above 80 to override manual moves; set below 40 to only apply when sun tracking is inactive.",
+          "custom_position_min_mode_1": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_1": "When slot 1's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_1": "Tilt angle (0-100%) to set when Slot 1's sensor is active. Venetian covers only — ignored for other cover types. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_1": "When enabled, Slot 1 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_sensor_2": "Binary sensor for slot 2. Leave empty to skip.",
+          "custom_position_2": "Position (0-100%) to move covers to when Sensor 2 is active.",
+          "custom_position_priority_2": "Pipeline priority for slot 2 (1-99, default 77).",
+          "custom_position_min_mode_2": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_2": "When slot 2's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_2": "Tilt angle (0-100%) to set when Slot 2's sensor is active. Venetian covers only. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_2": "When enabled, Slot 2 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_sensor_3": "Binary sensor for slot 3. Leave empty to skip.",
+          "custom_position_3": "Position (0-100%) to move covers to when Sensor 3 is active.",
+          "custom_position_priority_3": "Pipeline priority for slot 3 (1-99, default 77).",
+          "custom_position_min_mode_3": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_3": "When slot 3's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_3": "Tilt angle (0-100%) to set when Slot 3's sensor is active. Venetian covers only. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_3": "When enabled, Slot 3 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_sensor_4": "Binary sensor for slot 4. Leave empty to skip.",
+          "custom_position_4": "Position (0-100%) to move covers to when Sensor 4 is active.",
+          "custom_position_priority_4": "Pipeline priority for slot 4 (1-99, default 77).",
+          "custom_position_min_mode_4": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
+          "custom_position_use_my_4": "When slot 4's sensor is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
+          "custom_position_tilt_4": "Tilt angle (0-100%) to set when Slot 4's sensor is active. Venetian covers only. Leave unset to let the engine calculate tilt automatically.",
+          "custom_position_tilt_only_4": "When enabled, Slot 4 fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "default_tilt": "Default tilt angle (0-100%) for venetian covers when no other handler overrides tilt. Applied whenever the default position handler is active. Leave unset to let the engine calculate tilt from sun geometry.",
+          "sunset_tilt": "Tilt angle (0-100%) for venetian covers during the sunset window. Overrides default_tilt when the sunset time window is active. Leave unset to fall back to default_tilt."
+        }
+      },
+      "motion_override": {
+        "title": "Motion Override",
+        "description": "Enable occupancy-based control. When all configured sources report no motion, the integration stops sun tracking and moves covers to their default position after the timeout expires. When any source detects occupancy, automatic positioning resumes.\n\nAny mix of motion, occupancy, or binary presence sensors can be used, plus media players (a player that is on counts as occupancy). The logic is OR — any single active source counts as occupied. This is useful for rooms where you don't want covers adjusting when nobody is present.\n\n[Learn more]({learn_more})",
+        "data": {
+          "motion_sensors": "Motion/occupancy sensors for occupancy-based control",
+          "motion_media_players": "Media players for occupancy-based control",
+          "motion_timeout": "Motion timeout duration",
+          "motion_timeout_mode": "When motion times out"
+        },
+        "data_description": {
+          "motion_sensors": "Binary sensors that enable/disable automatic sun positioning based on occupancy. When ANY sensor detects motion, covers use automatic sun-based positioning. When ALL sensors show no motion for the timeout duration, covers return to default position. Leave empty to disable this feature.",
+          "motion_media_players": "Media players treated as occupancy. ANY player whose state is something other than off (playing, paused, idle, on, …) counts as occupied and keeps automatic sun positioning active. Players that are off, unavailable, or unknown do not count. Combined with the motion sensors above under the same OR logic. Leave empty to disable.",
+          "motion_timeout": "Duration (in seconds) to wait after last motion before returning covers to default position. Prevents rapid position changes when motion sensors toggle frequently. Range: 30-3600 seconds (0.5-60 minutes). Default: 300 seconds (5 minutes).",
+          "motion_timeout_mode": "What to do when motion has been absent for the timeout duration. 'Return to default' moves covers to the default position. 'Hold position' leaves covers where they are while the sun is in the FOV (so an occupant who returns finds them how they left them); covers still return to default once the sun leaves the FOV or the time window closes."
+        }
+      },
+      "weather_override": {
+        "title": "Weather Override",
+        "description": "Configure weather-based safety overrides. Any configured condition triggers cover retraction. Unconfigured inputs are ignored.\n\n[Learn more]({learn_more})",
+        "data": {
+          "weather_bypass_auto_control": "Active when Automatic Control is off",
+          "weather_wind_speed_sensor": "Wind speed sensor",
+          "weather_wind_direction_sensor": "Wind direction sensor (optional)",
+          "weather_wind_speed_threshold": "Wind speed threshold",
+          "weather_wind_direction_tolerance": "Wind direction tolerance",
+          "weather_rain_sensor": "Rain rate sensor",
+          "weather_rain_threshold": "Rain rate threshold",
+          "weather_is_raining_sensor": "Is Raining binary sensor",
+          "weather_is_windy_sensor": "Is Windy binary sensor",
+          "weather_severe_sensors": "Severe weather sensors (hail, frost, storm, etc.)",
+          "weather_override_position": "Override position",
+          "weather_override_min_mode": "Minimum position mode",
+          "weather_timeout": "Clear delay"
+        },
+        "data_description": {
+          "weather_bypass_auto_control": "When enabled, weather override will still move covers to the configured position even when the Automatic Control switch is turned off. This ensures wind, rain, and severe weather protection is always active regardless of the automation state. Disable this only if you want weather override to follow the Automatic Control switch.",
+          "weather_wind_speed_sensor": "Numeric sensor reporting wind speed. Override activates when the value meets or exceeds the threshold. Leave empty to ignore wind speed.",
+          "weather_wind_direction_sensor": "Optional: only trigger wind override when wind blows toward this window's azimuth (within the direction tolerance). Leave empty to trigger on wind speed alone regardless of direction.",
+          "weather_wind_speed_threshold": "Wind speed threshold that activates the override. **Value is interpreted in the configured wind-speed sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "weather_wind_direction_tolerance": "How many degrees from the window azimuth to consider wind as 'hitting' this window. Example: window faces south (180°), tolerance 45° → wind from 135°-225° triggers override.",
+          "weather_rain_sensor": "Numeric sensor reporting rain rate. Override activates when the value meets or exceeds the threshold. Leave empty to ignore rain rate.",
+          "weather_rain_threshold": "Rain rate threshold that activates the override. **Value is interpreted in the configured rain sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "weather_is_raining_sensor": "Binary sensor for rain detection. Override activates when this sensor is 'on'. Leave empty to ignore.",
+          "weather_is_windy_sensor": "Binary sensor for wind detection. Override activates when this sensor is 'on'. Leave empty to ignore.",
+          "weather_severe_sensors": "Binary sensors for severe conditions (hail, frost, thunderstorm, etc.). Override activates when ANY sensor is 'on'. Leave empty to ignore.",
+          "weather_override_position": "Position (0-100%) to move covers to when weather override is active. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Default: 0%.",
+          "weather_override_min_mode": "When enabled, the override position acts as a minimum floor — the cover will not close below this position, but higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact override position.",
+          "weather_timeout": "Seconds to wait after ALL conditions clear before resuming normal control. Prevents rapid toggling during gusty or intermittent conditions. Set to 0 for instant resume."
+        }
+      },
+      "weather": {
+        "data": {
+          "weather_state": "Weather Conditions"
+        },
+        "data_description": {
+          "weather_state": "Select weather states that mean 'sun is out' for climate mode. Recommended selection (pre-filled): ☑ sunny (direct sun), ☑ partlycloudy (some sun), ☐ cloudy (no direct sun), ☐ clear (usually night). When current weather matches selection: Apply climate strategies. When no match: Use default position (no sun assumed). Most users should keep the defaults."
+        },
+        "title": "Weather Conditions",
+        "description": "Select the weather states that count as \"sun is out\" for climate mode. The integration compares the live weather entity state to this list — matching states enable solar-based cover control. States not in the list are treated as cloudy, so summer-close and winter-open rules only apply when the weather matches.\n\nTypical choices are \"sunny\" and \"partlycloudy\". The available states depend on your weather integration.\n\n[Learn more]({learn_more})"
+      },
+      "blind_spot": {
+        "data": {
+          "blind_spot_left": "Blind spot left edge (from FOV left)",
+          "blind_spot_right": "Blind spot right edge (from FOV left)",
+          "blind_spot_elevation": "Blindspot elevation"
+        },
+        "data_description": {
+          "blind_spot_left": "Left edge of the blind spot zone (horizontal angle in degrees from your FOV left boundary). Where 0 = at the leftmost FOV edge. Example: If your FOV left is 45° and a tree blocks sun from 10-20° relative to that edge, set this to 10. This marks where the obstruction begins horizontally. Use sun position sensor or observe when sun is blocked to find this value.",
+          "blind_spot_right": "Right edge of the blind spot zone (horizontal angle in degrees from your FOV left boundary, must be > left edge). Example: If your FOV left is 45° and a tree blocks sun from 10-20° relative to that edge, set this to 20. This marks where the obstruction ends horizontally. Creates a 'don't track sun here' zone between left and right edges.",
+          "blind_spot_elevation": "Maximum sun elevation (degrees above horizon) where blind spot applies. Example: Roof overhang blocks sun only when low (< 30°) so set to 30. Higher elevation sun clears the obstacle, so blind spot doesn't apply. If obstacle blocks all elevations (tall building), set to 90 or leave high. Sun elevation: 0°=horizon, 45°=halfway up, 90°=directly overhead. Measure or estimate based on obstacle height and distance."
+        },
+        "title": "Blind Spot",
+        "description": "Define areas where obstacles block the sun (trees, buildings, roof overhangs). These angular values are relative degrees within your field of view, where 0 is the leftmost FOV boundary. The cover will ignore sun position when it falls within this blind spot zone.\n\n[Learn more]({learn_more})"
+      },
+      "interp": {
+        "data": {
+          "interp_start": "Calibration input 0% maps to (output %)",
+          "interp_end": "Calibration input 100% maps to (output %)",
+          "interp_list": "Calculated positions (input)",
+          "interp_list_new": "Actual positions to send (output)"
+        },
+        "data_description": {
+          "interp_start": "Output position sent to the cover when the integration calculates 0% (fully closed). Example: if your cover needs 10% to register as closed, set this to 10. Simple 2-point linear calibration — used together with the 100% mapping below. Leave at default unless your cover has limited range.",
+          "interp_end": "Output position sent to the cover when the integration calculates 100% (fully open). Example: if your cover is fully open at 90%, set this to 90. Simple 2-point linear calibration — used together with the 0% mapping above. Leave at default unless your cover has limited range.",
+          "interp_list": "Input positions for custom interpolation mapping (calculated positions from integration). Enter evenly-spaced values like: 0, 25, 50, 75, 100. These are the theoretical positions the integration calculates. Must have 2+ values and same length as 'Actual positions to send (output)'. Used for advanced non-linear calibration. Leave empty for normal operation.",
+          "interp_list_new": "Output positions for custom interpolation mapping (actual positions sent to cover). Enter corresponding real positions like: 0, 20, 40, 65, 100. These are what actually gets sent to your cover entity. Must have same length as 'Calculated positions (input)'. Example use: Make cover more aggressive in closing by mapping 50% calculated to 40% actual. Integration interpolates between your points. Leave empty for normal operation."
+        },
+        "title": "Position Calibration",
+        "description": "Adjust cover position mapping for non-standard covers by mapping a calculated position (input) to an actual position sent to the cover (output). Use simple 2-point calibration (map 0% and 100%) for covers with limited range (e.g., only moves between 10–90%). Use advanced list mapping for non-linear covers or to bias behavior more open/closed. Most covers don't need this — only enable if your cover doesn't respond correctly to standard 0–100% commands.\n\n[Learn more]({learn_more})"
+      },
+      "glare_zones": {
+        "title": "Glare Zones",
+        "description": "Define up to 4 floor areas to protect from direct sunlight. When the sun's angle would cast direct light onto a zone, the blind lowers to shade it. Leave a zone name blank to skip that slot.\n\nCoordinates are relative to the window centre projected onto the floor. **X** is the left/right offset (positive = right). **Y** is the distance into the room. **Radius** defines the circular protected area. Use the Lovelace companion card to visualise zone positions and verify coverage.\n\n[Learn more]({learn_more})",
+        "data": {
+          "enable_glare_zones": "Enable Glare Zones",
+          "glare_zone_1_name": "Zone 1 Name",
+          "glare_zone_1_x": "Zone 1 X Position",
+          "glare_zone_1_y": "Zone 1 Y Position",
+          "glare_zone_1_radius": "Zone 1 Radius",
+          "glare_zone_1_z": "Zone 1 Z Height",
+          "glare_zone_2_name": "Zone 2 Name",
+          "glare_zone_2_x": "Zone 2 X Position",
+          "glare_zone_2_y": "Zone 2 Y Position",
+          "glare_zone_2_radius": "Zone 2 Radius",
+          "glare_zone_2_z": "Zone 2 Z Height",
+          "glare_zone_3_name": "Zone 3 Name",
+          "glare_zone_3_x": "Zone 3 X Position",
+          "glare_zone_3_y": "Zone 3 Y Position",
+          "glare_zone_3_radius": "Zone 3 Radius",
+          "glare_zone_3_z": "Zone 3 Z Height",
+          "glare_zone_4_name": "Zone 4 Name",
+          "glare_zone_4_x": "Zone 4 X Position",
+          "glare_zone_4_y": "Zone 4 Y Position",
+          "glare_zone_4_radius": "Zone 4 Radius",
+          "glare_zone_4_z": "Zone 4 Z Height"
+        },
+        "data_description": {
+          "enable_glare_zones": "When enabled, the blind will lower to shade all active floor zones.",
+          "glare_zone_1_name": "Name for this zone (e.g. 'Desk'). Leave blank to skip.",
+          "glare_zone_1_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_1_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_1_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_1_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_2_name": "Name for this zone (e.g. 'Sofa'). Leave blank to skip.",
+          "glare_zone_2_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_2_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_2_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_2_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_3_name": "Name for this zone (e.g. 'Dining Table'). Leave blank to skip.",
+          "glare_zone_3_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_3_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_3_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_3_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_4_name": "Name for this zone (e.g. 'Bed'). Leave blank to skip.",
+          "glare_zone_4_x": "Left/right offset from window centre. Shown in the unit Home Assistant is configured for. Positive = right.",
+          "glare_zone_4_y": "Distance into the room (perpendicular to window). Shown in the unit Home Assistant is configured for.",
+          "glare_zone_4_radius": "Protection radius around the zone centre. Shown in the unit Home Assistant is configured for.",
+          "glare_zone_4_z": "Target height above the floor (e.g. desk surface ≈ 0.75 m, seated eyes ≈ 1.1 m, wall TV ≈ 1.5 m). Default 0 protects the floor. Shown in the unit Home Assistant is configured for."
+        }
+      },
+      "sync": {
+        "title": "Copy Settings to Other Covers",
+        "description": "Choose which covers to copy settings to and which categories to sync. Only selected categories will be overwritten on target covers.\n\n⚠️ **Azimuth is always excluded** — each cover keeps its own window orientation.",
+        "data": {
+          "target_entries": "Target covers",
+          "sync_categories": "Categories to sync"
+        }
+      },
+      "summary": {
+        "title": "Configuration Summary",
+        "description": "{summary}"
+      },
+      "debug": {
+        "title": "Debug & Diagnostics",
+        "description": "Enable debug mode to collect detailed troubleshooting data without editing configuration.yaml. When active, selected categories are logged at INFO level and a diagnostic event ring buffer is kept in memory and exposed in the HA Diagnostics download.\n\n{cover_capabilities}\n\n[Learn more]({learn_more})",
+        "data": {
+          "dry_run": "Dry Run (no cover movement)",
+          "debug_mode": "Enable Debug Mode",
+          "debug_categories": "Log Categories (promoted to INFO when debug mode is on)",
+          "debug_event_buffer_size": "Diagnostic event buffer size"
+        },
+        "data_description": {
+          "dry_run": "When enabled, the integration runs the full update cycle (pipeline, diagnostics, sensors) but does NOT send any movement commands to your covers. Use for debugging and validating automation settings without disturbing your home. Default: off.",
+          "debug_mode": "When enabled, log messages for the selected categories below are promoted from DEBUG to INFO. This means they appear in the Home Assistant log without requiring 'custom_components.adaptive_cover_pro: debug' in configuration.yaml. Turn off when you are done troubleshooting.",
+          "debug_categories": "Select which areas to trace. 'Manual Override' covers override detection decisions (most useful for 'cover won't stop manual control' issues). 'Reconciliation' covers the 1-minute position retry loop. 'Pipeline' covers the priority handler chain. 'Motion' covers motion sensor and timeout decisions.",
+          "debug_event_buffer_size": "Number of diagnostic events to keep in the rolling ring buffer. The buffer captures decisions and state transitions across all pipeline subsystems — manual override, motion, weather, time-window scheduling, cover commands, and the pipeline. Each event is a small dict (~200 bytes). Increase for intermittent issues that require longer observation windows. The buffer is reset on integration reload."
+        }
+      },
+      "sync_confirm": {
+        "title": "Copy Settings — Confirm",
+        "description": "Copying settings from **{source_name}**. Your current settings will be saved before copying.\n\nThe following categories will be overwritten:\n\n{categories_summary}\n\nOn these covers:\n\n{entries_summary}\n\nEach cover will keep its own name, entities, azimuth, and device association.",
+        "data": {
+          "confirm": "Confirm sync"
+        }
+      },
+      "light_cloud": {
+        "title": "Light Sensors & Cloud Suppression",
+        "description": "**Glare suppression in low light.** The first toggle below is the master on/off for this feature — leave it off and the rest of this screen is ignored. When on, set the optional **Cloudy position** the cover parks at when suppression fires (leave blank to use the default position).\n\nThe remaining sensors tell the integration *when* the sun is absent — any one of weather state, lux, solar irradiance, or cloud coverage will trigger suppression. Configure only the sensors you actually have; any single match is enough.\n\n[Learn more]({learn_more})",
+        "data": {
+          "weather_entity": "Weather entity (optional)",
+          "is_sunny_sensor": "Is Sunny binary sensor (optional)",
+          "lux_entity": "Lux sensor (optional)",
+          "lux_threshold": "Lux threshold",
+          "irradiance_entity": "Irradiance sensor (optional)",
+          "irradiance_threshold": "Irradiance threshold",
+          "cloud_coverage_entity": "Cloud coverage sensor (optional)",
+          "cloud_coverage_threshold": "Cloud coverage threshold",
+          "cloud_suppression": "Enable cloud suppression (master switch)",
+          "cloudy_position": "Cloudy position (optional)",
+          "weather_state": "Weather Conditions"
+        },
+        "data_description": {
+          "weather_entity": "Optional weather integration used to detect cloud cover. When the current weather state is not in the selected list below, direct sun is assumed absent and glare control is suppressed. Leave empty to ignore weather state.",
+          "weather_state": "The weather states that count as 'sun is out'. When the live weather state matches one of these, glare tracking runs normally. When it does not match, the cover returns to its default position. Keep the defaults (sunny, partlycloudy, clear) unless your weather integration uses different state names.",
+          "is_sunny_sensor": "Optional binary sensor, input_boolean, switch, or schedule that authoritatively reports whether the sun is hitting the window. When ON, sun is assumed present; when OFF, sun is assumed absent and cloud suppression fires regardless of weather state. When unavailable or unknown, the integration falls back to the Weather Entity / Weather Conditions logic below. Use this when you compute sun-on-window upstream (e.g. azimuth-gated irradiance) and want to feed Adaptive Cover Pro a clean boolean.",
+          "lux_entity": "Optional illuminance sensor (indoor or outdoor) for precise sun detection. When the sensor reads below the threshold, direct sun is absent and glare control is suppressed. Typical direct-sun values: 5,000–10,000 lux. Leave empty if you don't have this sensor.",
+          "lux_threshold": "Illuminance level above which the sun is considered present. Below this value the cover returns to its default position instead of tracking the sun. Typical values: 5,000–10,000 lux for direct sunlight, 2,000–3,000 lux for bright indirect light. **Value is interpreted in the configured lux sensor's unit** — the selector label tracks that unit when a sensor is set.",
+          "irradiance_entity": "Optional solar irradiance sensor (outdoor) for precise sun detection. Measures solar power in W/m². When the sensor reads below the threshold, direct sun is absent and glare control is suppressed. Leave empty if you don't have this sensor.",
+          "irradiance_threshold": "Solar irradiance level above which the sun is considered present. Below this value the cover returns to its default position. Typical values: 300–500 W/m² for direct sunlight, 100–200 W/m² for an overcast day. **Value is interpreted in the configured irradiance sensor's unit** — the selector label tracks that unit when a sensor is set.",
+          "cloud_coverage_entity": "Optional cloud coverage sensor reporting 0–100% (e.g. from a weather integration). When the reading reaches the threshold, glare control is suppressed and the cover returns to its default position. Leave empty if you don't have this sensor.",
+          "cloud_coverage_threshold": "Cloud coverage percentage at or above which glare control is suppressed. For example, 75 means the cover stops sun-tracking when the sky is 75% or more overcast.",
+          "cloud_suppression": "Master on/off for this entire screen. When **off** (default), every sensor below is ignored and glare control runs as usual. When **on**, any configured sensor (weather state, lux, irradiance, or cloud coverage) that indicates the sun is absent will stop sun-tracking and move the cover to the **Cloudy position** above (or the default position if that is blank). Works on its own — climate mode does not need to be enabled.",
+          "cloudy_position": "Position (0-100%) to move covers to when cloud suppression fires (cloudy / low-light conditions). 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended). Leave blank to use the default position."
+        }
+      },
+      "temperature_climate": {
+        "title": "Temperature & Climate Mode",
+        "description": "Climate mode adjusts cover position based on indoor/outdoor temperature, presence, and whether the sun is actually hitting the window. When disabled, the cover follows normal sun/glare tracking.\n\n**How the season is chosen** — The current temperature is the outside sensor if provided, otherwise the inside sensor.\n- **Winter** — current temp is below the low threshold.\n- **Summer** — current temp is above the high threshold **and** outside temp is above the outside threshold (prevents summer behavior on a cold day).\n- **Intermediate** — neither of the above; normal solar/glare tracking runs.\n\n**What each mode does**\n- **Winter + sun on window** → open fully (100%) to capture free solar heat.\n- **Winter, sun not on window**, *Winter insulation mode* on → close fully (0%) to trap heat.\n- **Summer** → close fully (0%) to block heat gain. For blinds, this only happens with presence if *Transparent blind* is on; without presence it always closes.\n- **Low light** (cloudy / dark / not sunny) → returns to the default position, overriding summer-close so covers don't close needlessly.\n- **Intermediate / sun valid with presence** → normal glare-control tracking.\n\n**Presence** gates the behavior: with nobody home, a simpler summer-closed / winter-open rule applies; with occupants present, glare tracking runs in intermediate conditions and transparent blinds still close in summer.\n\n**Tilt covers** follow the same seasonal logic but use slat angles instead of open/closed positions.\n\nLeave *Outside temperature sensor* and *Presence entity* blank to skip those checks. Climate mode runs after force/weather/manual/custom overrides but before normal solar tracking.\n\n[Learn more]({learn_more})",
+        "data": {
+          "climate_mode": "Enable climate mode",
+          "temp_entity": "Inside temperature entity",
+          "temp_low": "Low temperature threshold",
+          "temp_high": "High temperature threshold",
+          "outside_temp": "Outside temperature sensor (optional)",
+          "outside_threshold": "Outside temperature threshold",
+          "presence_entity": "Presence entity (optional)",
+          "transparent_blind": "Transparent blind",
+          "winter_close_insulation": "Winter insulation mode"
+        },
+        "data_description": {
+          "climate_mode": "Turn on to enable all climate-based cover control. When off, all settings on this screen are ignored and the cover follows normal sun/glare tracking.",
+          "temp_entity": "A climate thermostat or temperature sensor that measures the indoor temperature used to determine the current season (winter/summer/intermediate). Required when climate mode is enabled.",
+          "temp_low": "Indoor (or outdoor, if an outside sensor is configured) temperature below which the season is treated as winter. In winter the cover opens fully when the sun is hitting the window to capture solar heat. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "temp_high": "Indoor (or outdoor, if an outside sensor is configured) temperature above which the season is treated as summer — provided the outside threshold is also exceeded. In summer the cover closes to block heat gain. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** The selector label shows the sensor's current unit when one is selected.",
+          "outside_temp": "Optional outdoor temperature sensor. When provided, this reading (rather than the indoor sensor) determines the current season, and the outside threshold guard is applied to prevent summer-close behavior on cold days.",
+          "outside_threshold": "Minimum outdoor temperature required before summer mode activates. Guards against closing covers on a hot indoor day when it is actually cold outside. Only used when an outside temperature sensor is configured. **Value is interpreted in that outside sensor's unit, not Home Assistant's display unit.**",
+          "presence_entity": "Optional presence sensor, device tracker, or zone. When someone is home, the cover uses glare-control tracking in intermediate conditions; when nobody is home a simpler summer-closed / winter-open rule applies. Leave blank to always treat the space as occupied.",
+          "transparent_blind": "Enable when the blind material is sheer or translucent. In summer with occupants present a transparent blind will still close fully to reduce heat gain, whereas an opaque blind would instead follow glare-control tracking.",
+          "winter_close_insulation": "When enabled, the cover closes fully (0%) during winter when the sun is not directly hitting the window, helping to trap heat indoors. Has no effect when the sun is on the window (the cover opens to capture solar heat)."
+        }
+      }
+    },
+    "abort": {
+      "no_covers_to_sync": "No other covers of the same type exist to sync to.",
+      "no_targets_selected": "No covers were selected to sync to.",
+      "no_categories_selected": "No categories were selected to sync.",
+      "user_cancelled": "Sync cancelled.",
+      "sync_complete": "Settings synced successfully."
+    }
+  },
+  "entity": {
+    "sensor": {
+      "control_status": {
+        "state": {
+          "force_override_active": "Force override active",
+          "motion_timeout": "No motion - using default position"
+        },
+        "name": "Control Status",
+        "description": "Current pipeline decision method active for this cover (automatic, force override, motion timeout, etc.)."
+      },
+      "motion_status": {
+        "state": {
+          "not_configured": "Not Configured",
+          "motion_detected": "Motion Detected",
+          "timeout_pending": "Timeout Pending",
+          "no_motion": "No Motion",
+          "holding": "Holding Position",
+          "waiting_for_data": "Waiting for Data"
+        },
+        "name": "Motion Status",
+        "description": "Current motion sensor state: whether motion is detected, pending timeout, or no motion."
+      },
+      "climate_status": {
+        "state": {
+          "summer_mode": "Summer Mode",
+          "winter_mode": "Winter Mode",
+          "intermediate": "Intermediate"
+        },
+        "name": "Climate Status",
+        "description": "Detected thermal season (summer / winter / intermediate) used to select the cover position strategy."
+      },
+      "decision_trace": {
+        "name": "Decision Trace",
+        "state": {
+          "unknown": "Unknown",
+          "solar": "Solar",
+          "summer": "Summer",
+          "winter": "Winter",
+          "default": "Default",
+          "manual_override": "Manual Override",
+          "motion_timeout": "Motion Timeout",
+          "force_override": "Force Override",
+          "custom_position": "Custom Position",
+          "weather_override": "Weather Override",
+          "cloud_suppression": "Cloud Suppression"
+        },
+        "description": "Last rule that determined the cover position — useful for diagnosing unexpected positions."
+      },
+      "position_forecast": {
+        "name": "Position Forecast",
+        "description": "Timestamp of the next scheduled position change based on sun trajectory calculations."
+      }
+    },
+    "switch": {
+      "glare_zone_0": {
+        "name": "Glare Zone 1",
+        "description": "Activate glare protection for zone 1 — closes the cover when direct glare is detected in this zone."
+      },
+      "glare_zone_1": {
+        "name": "Glare Zone 2",
+        "description": "Activate glare protection for zone 2 — closes the cover when direct glare is detected in this zone."
+      },
+      "glare_zone_2": {
+        "name": "Glare Zone 3",
+        "description": "Activate glare protection for zone 3 — closes the cover when direct glare is detected in this zone."
+      },
+      "glare_zone_3": {
+        "name": "Glare Zone 4",
+        "description": "Activate glare protection for zone 4 — closes the cover when direct glare is detected in this zone."
+      },
+      "enabled_toggle": {
+        "name": "Integration Enabled",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        },
+        "description": "Master switch — when off, the integration stops all automatic cover movements."
+      },
+      "automatic_control": {
+        "name": "Automatic Control",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        },
+        "description": "Enable or disable automatic position control based on sun position calculations."
+      },
+      "motion_control": {
+        "name": "Motion Control",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        },
+        "description": "When enabled, motion detection events influence the cover position (e.g. open on motion)."
+      },
+      "manual_toggle": {
+        "name": "Manual Override Detection",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        },
+        "description": "When enabled, the integration detects manual cover movements and pauses automation temporarily."
+      },
+      "return_to_default_toggle": {
+        "description": "If enabled, the cover returns to its default position when automatic control is disabled."
+      },
+      "switch_mode": {
+        "description": "Toggle between standard and alternative operating mode for this cover."
+      },
+      "temp_toggle": {
+        "description": "Enable or disable the temperature-based override that adjusts the cover based on indoor/outdoor temperature."
+      },
+      "lux_toggle": {
+        "description": "Enable or disable light level (lux) based adjustments to the cover position."
+      },
+      "irradiance_toggle": {
+        "description": "Enable or disable solar irradiance-based control to prevent overheating."
+      }
+    },
+    "button": {
+      "my_position": {
+        "name": "Managed My Position",
+        "description": "Moves the cover to the saved 'My Position' target and re-enables automatic control from that baseline."
+      },
+      "reset_manual_override": {
+        "name": "Reset Manual Override",
+        "description": "Immediately cancels any active manual override and resumes automatic control."
+      }
+    },
+    "number": {
+      "my_position_value": {
+        "name": "Managed My Position Value",
+        "description": "The target position (0-100 %) stored as 'My Position' and applied when the My Position button is pressed."
+      }
+    }
+  },
+  "selector": {
+    "mode": {
+      "options": {
+        "cover_blind": "Vertical blind",
+        "cover_awning": "Horizontal blind",
+        "cover_tilt": "Tilted blind",
+        "cover_venetian": "Venetian blind (dual-axis)",
+        "cover_oscillating_awning": "Oscillating awning (drop-arm)"
+      }
+    },
+    "tilt_mode": {
+      "options": {
+        "mode1": "single direction (0% = closed / 100% = open)",
+        "mode2": "bi-directional (0% = closed / 50% = open / 100% = closed)"
+      }
+    },
+    "debug_categories": {
+      "options": {
+        "manual_override": "Manual Override (detection decisions, grace period, wait-for-target)",
+        "reconciliation": "Reconciliation (1-minute position retry loop)",
+        "pipeline": "Pipeline (priority handler chain decisions)",
+        "motion": "Motion (sensor events, timeout state)"
+      }
+    },
+    "sync_categories": {
+      "options": {
+        "geometry": "Cover Geometry (dimensions, depth, sill height)",
+        "sun_tracking": "Sun Tracking (FOV, elevation limits)",
+        "blind_spot": "Blind Spot Configuration",
+        "position": "Position Settings (defaults, sunset, offsets)",
+        "interp": "Position Calibration",
+        "automation": "Schedule & Timing (deltas, start/end times)",
+        "manual_override": "Manual Override",
+        "force_override_values": "Force Override — Thresholds & Position",
+        "force_override_sensors": "Force Override — Trigger Sensors",
+        "custom_position_values": "Custom Positions — Values & Priorities",
+        "custom_position_sensors": "Custom Positions — Trigger Sensors",
+        "motion_override_values": "Motion Override — Timeout",
+        "motion_override_sensors": "Motion Override — Sensors",
+        "weather_override_values": "Weather Override — Thresholds & Position",
+        "weather_override_sensors": "Weather Override — Sensors",
+        "light_cloud_values": "Light & Cloud — Thresholds",
+        "light_cloud_sensors": "Light & Cloud — Sensors",
+        "temperature_climate_values": "Climate Mode — Thresholds & Settings",
+        "temperature_climate_sensors": "Climate Mode — Room Sensors",
+        "glare_zones": "Glare Zones",
+        "climate": "Climate Configuration (temperature, presence, lux)",
+        "weather": "Weather Conditions",
+        "light_cloud": "Light Sensors & Cloud Suppression",
+        "temperature_climate": "Temperature & Climate Mode",
+        "force_override": "Force Override",
+        "custom_position": "Custom Positions",
+        "motion_override": "Motion Override",
+        "weather_override": "Weather Override"
+      }
+    },
+    "motion_timeout_mode": {
+      "options": {
+        "return_to_default": "Return to default position",
+        "hold_position": "Hold current position"
+      }
+    }
+  },
+  "services": {
+    "stop": {
+      "name": "Stop cover",
+      "description": "Sends stop_cover to the targeted covers via the ACP proxy. Engages manual override so the next automatic cycle does not counter-command the cover. Use this instead of cover.stop_cover when manual_ignore_external is enabled."
+    },
+    "integration_enable": {
+      "name": "Enable integration",
+      "description": "Re-enables Adaptive Cover Pro on the targeted instances. Covers stay where they are; positioning resumes on the next natural update cycle."
+    },
+    "integration_disable": {
+      "name": "Disable integration",
+      "description": "Disables Adaptive Cover Pro on the targeted instances. ACP-in-flight cover moves are stopped immediately, deferred timers cancelled, and reconciliation state cleared."
+    },
+    "emergency_stop": {
+      "name": "Emergency stop",
+      "description": "Panic button — sends stop_cover to every configured cover on the targeted instances (capability-checked), then disables the integration. With no target, acts on all ACP instances."
+    },
+    "export_config": {
+      "name": "Export configuration",
+      "description": "Returns the cover configuration as JSON for use in the simulation notebook.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Cover configuration",
+          "description": "The Adaptive Cover Pro configuration entry to export."
+        }
+      }
+    },
+    "get_diagnostics": {
+      "name": "Get diagnostics",
+      "description": "Returns the live diagnostics snapshot for the targeted Adaptive Cover Pro instances — pipeline decision trace, cover positions, climate readings, sun data, and coordinator health.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "Explicit config entry id(s) to query. When omitted, standard target selection applies. No target returns all ACP instances."
+        }
+      }
+    },
+    "set_position_limits": {
+      "name": "Set position limits",
+      "description": "Update default height, min/max position, open/close threshold, and inverse state.",
+      "fields": {
+        "default_height": {
+          "name": "Default height",
+          "description": "Default cover position when sun is not visible (0–100%)."
+        },
+        "min_position": {
+          "name": "Minimum position",
+          "description": "Minimum position the cover may move to (0–99%)."
+        },
+        "enable_min_position": {
+          "name": "Enable min position only during tracking",
+          "description": "If true, min_position applies only while sun is tracked."
+        },
+        "min_position_sun_tracking": {
+          "name": "Min position during sun tracking",
+          "description": "Optional separate minimum floor that applies only during sun tracking (0–99%). When set, overrides min_position for sun-tracking paths only. Leave unset to use min_position for all paths."
+        },
+        "max_position": {
+          "name": "Maximum position",
+          "description": "Maximum position the cover may move to (1–100%)."
+        },
+        "enable_max_position": {
+          "name": "Enable max position only during tracking",
+          "description": "If true, max_position applies only while sun is tracked."
+        },
+        "open_close_threshold": {
+          "name": "Open/close threshold",
+          "description": "Position below which open/close-only covers are closed (1–99%)."
+        },
+        "inverse_state": {
+          "name": "Inverse state",
+          "description": "Invert position for covers that report state inversely."
+        }
+      }
+    },
+    "set_sunset_sunrise": {
+      "name": "Set sunset / sunrise positions",
+      "description": "Update sunset position and offset settings. Pass null to clear an optional field.",
+      "fields": {
+        "sunset_position": {
+          "name": "Sunset position",
+          "description": "Position to move to at end of time window. Null = use default_height."
+        },
+        "sunset_offset": {
+          "name": "Sunset offset",
+          "description": "Minutes to shift end-of-window trigger relative to sunset (-120–120)."
+        },
+        "sunrise_offset": {
+          "name": "Sunrise offset",
+          "description": "Minutes to shift start-of-window trigger relative to sunrise (-120–120)."
+        },
+        "sunset_use_my": {
+          "name": "Use Somfy My at sunset",
+          "description": "If true, use my_position_value instead of sunset_position at end of window."
+        },
+        "my_position_value": {
+          "name": "Somfy My position",
+          "description": "The 'My' preset position (1–99%)."
+        }
+      }
+    },
+    "set_automation_timing": {
+      "name": "Set automation timing",
+      "description": "Update delta thresholds, time window start/end, and return_sunset.",
+      "fields": {
+        "delta_position": {
+          "name": "Position delta threshold",
+          "description": "Minimum position change (%) before sending a cover command (1–90)."
+        },
+        "delta_time": {
+          "name": "Time delta threshold",
+          "description": "Minimum time (minutes) between cover commands (2–60)."
+        },
+        "start_time": {
+          "name": "Start time",
+          "description": "Fixed time to start tracking window (HH:MM:SS). Mutually exclusive with start_entity."
+        },
+        "start_entity": {
+          "name": "Start entity",
+          "description": "Entity whose state provides the start time. Mutually exclusive with start_time."
+        },
+        "end_time": {
+          "name": "End time",
+          "description": "Fixed time to end tracking window (HH:MM:SS). Mutually exclusive with end_entity."
+        },
+        "end_entity": {
+          "name": "End entity",
+          "description": "Entity whose state provides the end time. Mutually exclusive with end_time."
+        },
+        "return_sunset": {
+          "name": "Return to sunset position at end",
+          "description": "If true, force-send sunset_position when time window ends."
+        }
+      }
+    },
+    "set_manual_override": {
+      "name": "Set manual override settings",
+      "description": "Update manual override duration, reset behavior, and detection threshold.",
+      "fields": {
+        "manual_override_duration": {
+          "name": "Override duration",
+          "description": "How long a manual override lasts before automatic control resumes."
+        },
+        "manual_override_reset": {
+          "name": "Reset on window start",
+          "description": "If true, clear any active manual override when the time window starts."
+        },
+        "manual_threshold": {
+          "name": "Detection threshold",
+          "description": "Position change (%) that triggers manual override detection (0–99)."
+        },
+        "manual_ignore_intermediate": {
+          "name": "Ignore intermediate states",
+          "description": "If true, ignore opening/closing states for manual override detection."
+        },
+        "manual_ignore_external": {
+          "name": "Only engage from ACP commands",
+          "description": "If true, only commands routed through the ACP proxy entity or the adaptive_cover_pro.set_position service engage manual override; all other position changes are ignored."
+        }
+      }
+    },
+    "set_force_override": {
+      "name": "Set force override",
+      "description": "Update force-override sensors, position, and min-mode.",
+      "fields": {
+        "force_override_sensors": {
+          "name": "Force override sensors",
+          "description": "Binary sensors that trigger the force override. Empty list = disable."
+        },
+        "force_override_position": {
+          "name": "Force override position",
+          "description": "Position to move to when a force override sensor is active (0–100%)."
+        },
+        "force_override_min_mode": {
+          "name": "Minimum position mode",
+          "description": "If true, treat force_override_position as a minimum floor."
+        }
+      }
+    },
+    "set_custom_position": {
+      "name": "Set custom position slot",
+      "description": "Update one custom position slot (1–4). Pass null for sensor and position to clear the slot.",
+      "fields": {
+        "slot": {
+          "name": "Slot",
+          "description": "Which custom position slot to update (1–4)."
+        },
+        "sensor": {
+          "name": "Trigger sensor",
+          "description": "Binary sensor that activates this custom position. Null = clear slot."
+        },
+        "position": {
+          "name": "Position",
+          "description": "Target position (0–100%) when the sensor is active. Null = clear slot."
+        },
+        "priority": {
+          "name": "Priority",
+          "description": "Pipeline priority (1–99, default 77)."
+        },
+        "min_mode": {
+          "name": "Minimum position mode",
+          "description": "If true, treat position as a minimum floor."
+        },
+        "use_my": {
+          "name": "Use Somfy My",
+          "description": "If true, use my_position_value instead of position."
+        }
+      }
+    },
+    "set_motion": {
+      "name": "Set motion settings",
+      "description": "Update motion sensors and no-motion timeout.",
+      "fields": {
+        "motion_sensors": {
+          "name": "Motion sensors",
+          "description": "Binary sensors indicating occupancy. Empty list = disable motion control."
+        },
+        "motion_timeout": {
+          "name": "No-motion timeout",
+          "description": "Seconds to wait after last motion before applying motion-timeout position (30–3600)."
+        }
+      }
+    },
+    "set_light_cloud": {
+      "name": "Set light & cloud settings",
+      "description": "Update weather entity, sunny-state filter, lux/irradiance/cloud thresholds, and cloud suppression.",
+      "fields": {
+        "weather_entity": {
+          "name": "Weather entity",
+          "description": "Weather entity for condition readings. Null = none."
+        },
+        "weather_state": {
+          "name": "Sunny weather states",
+          "description": "Weather condition states considered sunny for sun tracking."
+        },
+        "lux_entity": {
+          "name": "Lux sensor",
+          "description": "Illuminance sensor entity. Null = none."
+        },
+        "lux_threshold": {
+          "name": "Lux threshold",
+          "description": "Lux value above which the cover is in direct sunlight."
+        },
+        "irradiance_entity": {
+          "name": "Irradiance sensor",
+          "description": "Solar irradiance sensor entity. Null = none."
+        },
+        "irradiance_threshold": {
+          "name": "Irradiance threshold",
+          "description": "W/m² above which the cover is in direct sunlight."
+        },
+        "cloud_coverage_entity": {
+          "name": "Cloud coverage sensor",
+          "description": "Sensor reporting cloud coverage percentage. Null = none."
+        },
+        "cloud_coverage_threshold": {
+          "name": "Cloud coverage threshold",
+          "description": "Cloud coverage percentage above which sky is considered overcast."
+        },
+        "cloud_suppression": {
+          "name": "Enable cloud suppression",
+          "description": "Suppress solar positioning when cloud coverage exceeds threshold."
+        },
+        "is_sunny_sensor": {
+          "name": "Is Sunny binary sensor",
+          "description": "Binary entity that authoritatively reports sun-on-window. ON = sunny, OFF = cloud suppression fires. Unavailable falls back to weather state. Null = none."
+        }
+      }
+    },
+    "set_climate": {
+      "name": "Set climate settings",
+      "description": "Update climate mode and temperature/presence options. Enforces temp_low < temp_high.",
+      "fields": {
+        "climate_mode": {
+          "name": "Enable climate mode",
+          "description": "Master toggle for temperature-aware positioning."
+        },
+        "temp_entity": {
+          "name": "Indoor temperature entity",
+          "description": "Climate or sensor entity for indoor temperature. Null = none."
+        },
+        "temp_low": {
+          "name": "Low temperature threshold",
+          "description": "Below this temperature (°), winter strategy applies (0–90)."
+        },
+        "temp_high": {
+          "name": "High temperature threshold",
+          "description": "Above this temperature (°), summer strategy applies (0–90)."
+        },
+        "outside_temp": {
+          "name": "Outdoor temperature entity",
+          "description": "Sensor entity for outdoor temperature. Null = none."
+        },
+        "outside_threshold": {
+          "name": "Outdoor temperature threshold",
+          "description": "Outdoor temperature (°) above which summer strategy is forced (0–100)."
+        },
+        "presence_entity": {
+          "name": "Presence entity",
+          "description": "Entity indicating occupancy. Null = none."
+        },
+        "transparent_blind": {
+          "name": "Transparent blind",
+          "description": "If true, treat the blind as semi-transparent for climate calculations."
+        },
+        "winter_close_insulation": {
+          "name": "Close for winter insulation",
+          "description": "If true, fully close the cover on cold days to improve insulation."
+        }
+      }
+    },
+    "set_weather_safety": {
+      "name": "Set weather safety settings",
+      "description": "Update wind, rain, and severe-weather override settings.",
+      "fields": {
+        "weather_bypass_auto_control": {
+          "name": "Bypass automatic control",
+          "description": "If true, weather override ignores the Automatic Control toggle."
+        },
+        "weather_wind_speed_sensor": {
+          "name": "Wind speed sensor",
+          "description": "Sensor entity for wind speed. Null = none."
+        },
+        "weather_wind_direction_sensor": {
+          "name": "Wind direction sensor",
+          "description": "Sensor entity for wind direction. Null = none."
+        },
+        "weather_wind_speed_threshold": {
+          "name": "Wind speed threshold",
+          "description": "Wind speed above which the cover is retracted."
+        },
+        "weather_wind_direction_tolerance": {
+          "name": "Wind direction tolerance",
+          "description": "Degrees either side of window azimuth considered a wind threat (5–180°)."
+        },
+        "weather_rain_sensor": {
+          "name": "Rain sensor",
+          "description": "Sensor entity for rain accumulation. Null = none."
+        },
+        "weather_rain_threshold": {
+          "name": "Rain threshold",
+          "description": "Rain accumulation above which the cover is retracted."
+        },
+        "weather_is_raining_sensor": {
+          "name": "Is raining sensor",
+          "description": "Binary sensor indicating active rain. Null = none."
+        },
+        "weather_is_windy_sensor": {
+          "name": "Is windy sensor",
+          "description": "Binary sensor indicating dangerous wind. Null = none."
+        },
+        "weather_severe_sensors": {
+          "name": "Severe weather sensors",
+          "description": "Binary sensors for severe weather (OR logic). Empty list = none."
+        },
+        "weather_override_position": {
+          "name": "Weather override position",
+          "description": "Position to move to when weather override is triggered (0–100%)."
+        },
+        "weather_override_min_mode": {
+          "name": "Minimum position mode",
+          "description": "If true, treat weather_override_position as a minimum floor."
+        },
+        "weather_timeout": {
+          "name": "Weather clear timeout",
+          "description": "Seconds to wait after conditions clear before resuming automatic control (0–3600)."
+        }
+      }
+    },
+    "set_sun_tracking": {
+      "name": "Set sun tracking settings",
+      "description": "Update azimuth, field-of-view, elevation limits, and sun-tracking toggle.",
+      "fields": {
+        "enable_sun_tracking": {
+          "name": "Enable sun tracking",
+          "description": "Master toggle for solar-position-based cover control."
+        },
+        "minimize_movements": {
+          "name": "Minimize movements",
+          "description": "If true, quantize the sun-tracked position into discrete coverage levels (rounding toward more coverage) to reduce motor movements."
+        },
+        "max_coverage_steps": {
+          "name": "Maximum coverage steps",
+          "description": "Number of distinct positions used to reach full coverage when minimize_movements is on (1–10). 1 = jump straight to full coverage."
+        },
+        "set_azimuth": {
+          "name": "Window azimuth",
+          "description": "Compass direction the window faces (0–359°)."
+        },
+        "fov_left": {
+          "name": "Field of view left",
+          "description": "Degrees to the left of azimuth within which sun affects this cover (0–180°)."
+        },
+        "fov_right": {
+          "name": "Field of view right",
+          "description": "Degrees to the right of azimuth within which sun affects this cover (0–180°)."
+        },
+        "min_elevation": {
+          "name": "Minimum sun elevation",
+          "description": "Sun elevation (°) below which the cover is not moved. Null = no minimum."
+        },
+        "max_elevation": {
+          "name": "Maximum sun elevation",
+          "description": "Sun elevation (°) above which the cover is fully opened. Null = no maximum."
+        },
+        "distance_shaded_area": {
+          "name": "Distance to shaded area",
+          "description": "Distance from window to edge of shaded area in metres (0.1–50 m, canonical metric regardless of HA locale)."
+        }
+      }
+    },
+    "set_blind_spot": {
+      "name": "Set blind spot",
+      "description": "Update blind spot zone angles. blind_spot_right must be greater than blind_spot_left.",
+      "fields": {
+        "blind_spot": {
+          "name": "Enable blind spot",
+          "description": "If true, the blind spot zone is active."
+        },
+        "blind_spot_left": {
+          "name": "Left edge (from FOV left)",
+          "description": "Left edge of the blind spot zone in degrees inward from your FOV left boundary (0 = at the FOV left edge, range 0–359°)."
+        },
+        "blind_spot_right": {
+          "name": "Right edge (from FOV left)",
+          "description": "Right edge of the blind spot zone in degrees inward from your FOV left boundary. Must be greater than left edge (range 1–360°)."
+        },
+        "blind_spot_elevation": {
+          "name": "Elevation limit",
+          "description": "Maximum sun elevation (°) for the blind spot to apply. Null = always apply."
+        }
+      }
+    },
+    "set_interpolation": {
+      "name": "Set interpolation",
+      "description": "Enable position interpolation and configure the start/end range and lookup table.",
+      "fields": {
+        "interp": {
+          "name": "Enable interpolation",
+          "description": "If true, apply interpolation mapping to the calculated position."
+        },
+        "interp_start": {
+          "name": "Interpolation start",
+          "description": "Calculated position (%) at which interpolation begins. Null = none."
+        },
+        "interp_end": {
+          "name": "Interpolation end",
+          "description": "Calculated position (%) at which interpolation ends. Null = none."
+        },
+        "interp_list": {
+          "name": "Input list",
+          "description": "Input positions for the interpolation lookup table."
+        },
+        "interp_list_new": {
+          "name": "Output list",
+          "description": "Output positions mapped from interp_list."
+        }
+      }
+    },
+    "set_geometry": {
+      "name": "Set geometry",
+      "description": "Update cover geometry dimensions. Supply only fields applicable to your cover type.",
+      "fields": {
+        "window_height": {
+          "name": "Window height",
+          "description": "Window height in metres (0.1–50 m, canonical metric regardless of HA locale). Vertical blind and awning only."
+        },
+        "window_width": {
+          "name": "Window width",
+          "description": "Window width in metres (0.1–50 m, canonical metric regardless of HA locale). Vertical blind only."
+        },
+        "window_depth": {
+          "name": "Window depth",
+          "description": "Window reveal depth in metres (0–5 m, canonical metric regardless of HA locale). Vertical blind only."
+        },
+        "sill_height": {
+          "name": "Sill height",
+          "description": "Window sill height from floor in metres (0–50 m, canonical metric regardless of HA locale). Vertical blind only."
+        },
+        "length_awning": {
+          "name": "Awning length",
+          "description": "Awning projection length in metres (0.3–6 m, canonical metric regardless of HA locale). Awning only."
+        },
+        "angle": {
+          "name": "Awning angle",
+          "description": "Awning tilt angle in degrees (0–45°). Awning only."
+        },
+        "slat_depth": {
+          "name": "Slat depth",
+          "description": "Venetian slat depth in centimetres (0.1–15 cm, canonical metric regardless of HA locale). Tilt only."
+        },
+        "slat_distance": {
+          "name": "Slat distance",
+          "description": "Distance between slats in centimetres (0.1–15 cm, canonical metric regardless of HA locale). Tilt only."
+        },
+        "tilt_mode": {
+          "name": "Tilt mode",
+          "description": "Slat angle calculation mode (mode1 or mode2). Tilt only."
+        },
+        "venetian_tilt_skip_above": {
+          "name": "Skip tilt above position (%)",
+          "description": "Skip the tilt command when commanded position exceeds this value. Venetian only. Default 95."
+        }
+      }
+    },
+    "set_option": {
+      "name": "Set option (generic)",
+      "description": "Generic escape hatch — update any single supported option by key name. Identity keys are rejected.",
+      "fields": {
+        "option": {
+          "name": "Option key",
+          "description": "The internal option key to update (e.g. 'default_percentage', 'sunset_position')."
+        },
+        "value": {
+          "name": "Value",
+          "description": "New value for the option. Pass null to clear an optional field."
+        }
+      }
+    },
+    "set_venetian": {
+      "name": "Set venetian options",
+      "description": "Update venetian-blind specific options: operating mode, tilt skip threshold, and post-settle hold.",
+      "fields": {
+        "venetian_mode": {
+          "name": "Venetian mode",
+          "description": "Operating mode: 'position_and_tilt' (move carriage then tilt) or 'tilt_only' (tilt only, no carriage movement)."
+        },
+        "venetian_tilt_skip_above": {
+          "name": "Tilt skip above (%)",
+          "description": "Skip tilt commands when carriage position exceeds this value (0–100%). Set to 100 to always tilt."
+        },
+        "venetian_post_settle_hold": {
+          "name": "Post-settle hold (s)",
+          "description": "Seconds to wait after carriage stops before sending the tilt command (0.0–10.0 s). Raise to 4–6 s for KNX FGR223 firmware."
+        },
+        "venetian_backrotate_publish_lag": {
+          "name": "Publish-lag window (s)",
+          "description": "Seconds the integration tolerates a late position/tilt-state publish from the actuator before treating it as a user touch (15–180 s). Default 45 s. Raise to 60–120 s for slow KNX bus or Fibaro/Shelly republish; tighten only for unusually fast actuators."
+        }
+      }
+    },
+    "set_position": {
+      "name": "Set position (floor-enforced)",
+      "description": "Moves the cover to the requested position, clamping to the highest active custom-position minimum-mode floor. By default the call engages manual override and respects the priority pipeline (force_override / weather still win); set force=true to bypass the pipeline check and skip manual-override engagement. Tilt is not affected.",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Target cover position (0–100%). Clamped up to the active minimum-mode floor if one is configured and its sensor is on."
+        },
+        "force": {
+          "name": "Force",
+          "description": "When true, bypass the priority pipeline check and skip manual-override engagement. Default false — service calls respect force_override / weather and engage manual override like a dashboard slider."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/adaptive_cover_pro/sun.py
+++ b/custom_components/adaptive_cover_pro/sun.py
@@ -27,7 +27,6 @@ from datetime import date, datetime, timedelta
 
 import pandas as pd
 
-
 # ---------------------------------------------------------------------------
 # Module-level day cache — shared across all SunData instances
 # ---------------------------------------------------------------------------
@@ -133,21 +132,32 @@ class SunData:
     def times(self) -> pd.DatetimeIndex:
         """Today's 5-minute timeline (cached per day)."""
         self._ensure_today()
-        assert self._cache_times is not None  # for type narrowing
+        # Use explicit RuntimeError instead of assert: assert is stripped in
+        # optimized builds (-O), which would cause a silent None dereference.
+        if self._cache_times is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_times is None after _ensure_today()"
+            )
         return self._cache_times
 
     @property
     def solar_azimuth(self) -> list[float]:
         """Solar azimuth at each entry in :attr:`times` (cached per day)."""
         self._ensure_today()
-        assert self._cache_azi is not None
+        if self._cache_azi is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_azi is None after _ensure_today()"
+            )
         return self._cache_azi
 
     @property
     def solar_elevation(self) -> list[float]:
         """Solar elevation at each entry in :attr:`times` (cached per day)."""
         self._ensure_today()
-        assert self._cache_ele is not None
+        if self._cache_ele is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_ele is None after _ensure_today()"
+            )
         return self._cache_ele
 
     def sunset(self) -> datetime:

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1038,7 +1038,9 @@
         "state": {
           "force_override_active": "Force override active",
           "motion_timeout": "No motion - using default position"
-        }
+        },
+        "name": "Control Status",
+        "description": "Current pipeline decision method active for this cover (automatic, force override, motion timeout, etc.)."
       },
       "motion_status": {
         "state": {
@@ -1048,14 +1050,18 @@
           "no_motion": "No Motion",
           "holding": "Holding Position",
           "waiting_for_data": "Waiting for Data"
-        }
+        },
+        "name": "Motion Status",
+        "description": "Current motion sensor state: whether motion is detected, pending timeout, or no motion."
       },
       "climate_status": {
         "state": {
           "summer_mode": "Summer Mode",
           "winter_mode": "Winter Mode",
           "intermediate": "Intermediate"
-        }
+        },
+        "name": "Climate Status",
+        "description": "Detected thermal season (summer / winter / intermediate) used to select the cover position strategy."
       },
       "decision_trace": {
         "name": "Decision Trace",
@@ -1071,62 +1077,93 @@
           "custom_position": "Custom Position",
           "weather_override": "Weather Override",
           "cloud_suppression": "Cloud Suppression"
-        }
+        },
+        "description": "Last rule that determined the cover position — useful for diagnosing unexpected positions."
       },
       "position_forecast": {
-        "name": "Position Forecast"
+        "name": "Position Forecast",
+        "description": "Timestamp of the next scheduled position change based on sun trajectory calculations."
       }
     },
     "switch": {
       "glare_zone_0": {
-        "name": "Glare Zone 1"
+        "name": "Glare Zone 1",
+        "description": "Activate glare protection for zone 1 — closes the cover when direct glare is detected in this zone."
       },
       "glare_zone_1": {
-        "name": "Glare Zone 2"
+        "name": "Glare Zone 2",
+        "description": "Activate glare protection for zone 2 — closes the cover when direct glare is detected in this zone."
       },
       "glare_zone_2": {
-        "name": "Glare Zone 3"
+        "name": "Glare Zone 3",
+        "description": "Activate glare protection for zone 3 — closes the cover when direct glare is detected in this zone."
       },
       "glare_zone_3": {
-        "name": "Glare Zone 4"
+        "name": "Glare Zone 4",
+        "description": "Activate glare protection for zone 4 — closes the cover when direct glare is detected in this zone."
       },
       "enabled_toggle": {
         "name": "Integration Enabled",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "Master switch — when off, the integration stops all automatic cover movements."
       },
       "automatic_control": {
         "name": "Automatic Control",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "Enable or disable automatic position control based on sun position calculations."
       },
       "motion_control": {
         "name": "Motion Control",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "When enabled, motion detection events influence the cover position (e.g. open on motion)."
       },
       "manual_toggle": {
         "name": "Manual Override Detection",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "When enabled, the integration detects manual cover movements and pauses automation temporarily."
+      },
+      "return_to_default_toggle": {
+        "description": "If enabled, the cover returns to its default position when automatic control is disabled."
+      },
+      "switch_mode": {
+        "description": "Toggle between standard and alternative operating mode for this cover."
+      },
+      "temp_toggle": {
+        "description": "Enable or disable the temperature-based override that adjusts the cover based on indoor/outdoor temperature."
+      },
+      "lux_toggle": {
+        "description": "Enable or disable light level (lux) based adjustments to the cover position."
+      },
+      "irradiance_toggle": {
+        "description": "Enable or disable solar irradiance-based control to prevent overheating."
       }
     },
     "button": {
       "my_position": {
-        "name": "Managed My Position"
+        "name": "Managed My Position",
+        "description": "Moves the cover to the saved 'My Position' target and re-enables automatic control from that baseline."
+      },
+      "reset_manual_override": {
+        "name": "Reset Manual Override",
+        "description": "Immediately cancels any active manual override and resumes automatic control."
       }
     },
     "number": {
       "my_position_value": {
-        "name": "Managed My Position Value"
+        "name": "Managed My Position Value",
+        "description": "The target position (0-100 %) stored as 'My Position' and applied when the My Position button is pressed."
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1038,7 +1038,9 @@
         "state": {
           "force_override_active": "Dérogation forcée active",
           "motion_timeout": "Aucun mouvement — position par défaut utilisée"
-        }
+        },
+        "name": "Statut de contrôle",
+        "description": "Méthode de décision active dans le pipeline pour ce store (automatique, dérogation forcée, délai d’inactivité, etc.)."
       },
       "motion_status": {
         "state": {
@@ -1048,7 +1050,9 @@
           "no_motion": "Aucun mouvement",
           "waiting_for_data": "En attente de données",
           "holding": "Maintien de la position"
-        }
+        },
+        "name": "Statut du mouvement",
+        "description": "État actuel du capteur de mouvement : mouvement détecté, délai en attente ou aucun mouvement."
       },
       "decision_trace": {
         "name": "Trace de décision",
@@ -1064,69 +1068,102 @@
           "custom_position": "Position personnalisée",
           "weather_override": "Dérogation météo",
           "cloud_suppression": "Désactivation par temps nuageux"
-        }
+        },
+        "description": "Dernière règle ayant déterminé la position du store — utile pour diagnostiquer des positions inattendues."
       },
       "position_forecast": {
-        "name": "Prévision de position"
+        "name": "Prévision de position",
+        "description": "Horodatage du prochain changement de position prévu selon le calcul de la trajectoire solaire."
       },
       "climate_status": {
         "state": {
           "summer_mode": "Mode été",
           "winter_mode": "Mode hiver",
           "intermediate": "Intermédiaire"
-        }
+        },
+        "name": "Statut climatique",
+        "description": "Saison thermique détectée (été / hiver / intermédiaire) utilisée pour choisir la stratégie de position du store."
       }
     },
     "switch": {
       "glare_zone_0": {
-        "name": "Zone d'éblouissement 1"
+        "name": "Zone d'éblouissement 1",
+        "description": "Active la protection anti-éblouissement pour la zone 1 — ferme le store lors d’un éblouissement direct dans cette zone."
       },
       "glare_zone_1": {
-        "name": "Zone d'éblouissement 2"
+        "name": "Zone d'éblouissement 2",
+        "description": "Active la protection anti-éblouissement pour la zone 2 — ferme le store lors d’un éblouissement direct dans cette zone."
       },
       "glare_zone_2": {
-        "name": "Zone d'éblouissement 3"
+        "name": "Zone d'éblouissement 3",
+        "description": "Active la protection anti-éblouissement pour la zone 3 — ferme le store lors d’un éblouissement direct dans cette zone."
       },
       "glare_zone_3": {
-        "name": "Zone d'éblouissement 4"
+        "name": "Zone d'éblouissement 4",
+        "description": "Active la protection anti-éblouissement pour la zone 4 — ferme le store lors d’un éblouissement direct dans cette zone."
       },
       "enabled_toggle": {
         "name": "Intégration activée",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "Interrupteur principal — quand désactivé, l’intégration arrête tous les mouvements automatiques du store."
       },
       "automatic_control": {
         "name": "Contrôle automatique",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "Active ou désactive le contrôle automatique de la position en fonction du calcul de la position du soleil."
       },
       "motion_control": {
         "name": "Contrôle du mouvement",
         "state": {
           "on": "On",
           "off": "Off"
-        }
+        },
+        "description": "Quand activé, les événements de détection de mouvement influencent la position du store (ex : ouvrir sur mouvement)."
       },
       "manual_toggle": {
         "name": "Détection de Dérogation Manuelle",
         "state": {
           "on": "Activé",
           "off": "Désactivé"
-        }
+        },
+        "description": "Quand activé, l’intégration détecte les déplacements manuels du store et suspend temporairement l’automatisation."
+      },
+      "return_to_default_toggle": {
+        "description": "Si activé, le store revient à sa position par défaut quand le contrôle automatique est désactivé."
+      },
+      "switch_mode": {
+        "description": "Bascule entre le mode de fonctionnement standard et alternatif pour ce store."
+      },
+      "temp_toggle": {
+        "description": "Active ou désactive l’ajustement basé sur la température intérieure/extérieure."
+      },
+      "lux_toggle": {
+        "description": "Active ou désactive les ajustements de position basés sur le niveau de luminosité (lux)."
+      },
+      "irradiance_toggle": {
+        "description": "Active ou désactive le contrôle basé sur l’irradiance solaire pour prévenir la surchauffe."
       }
     },
     "button": {
       "my_position": {
-        "name": "Position My gérée"
+        "name": "Position My gérée",
+        "description": "Déplace le store vers la position My Position enregistrée et réactive le contrôle automatique depuis cette base."
+      },
+      "reset_manual_override": {
+        "name": "Réinitialiser la dérogation manuelle",
+        "description": "Annule immédiatement toute dérogation manuelle active et reprend le contrôle automatique."
       }
     },
     "number": {
       "my_position_value": {
-        "name": "Valeur de position My gérée"
+        "name": "Valeur de position My gérée",
+        "description": "Position cible (0–100 %) enregistrée comme My Position et appliquée lors de l’appui sur le bouton correspondant."
       }
     }
   },

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,5 @@
 {
   "name": "Adaptive Cover Pro",
-  "filename": "adaptive_cover_pro.zip",
   "homeassistant": "2026.3.0",
-  "render_readme": true,
-  "zip_release": true
+  "render_readme": true
 }


### PR DESCRIPTION
## Summary

Rebased on v2.26.0. Five focused commits on top of upstream/main:

1. **`fix(migrations)`** — Write idempotency flag before removing legacy entities so a mid-migration HA restart cannot re-run destructive removals
2. **`fix(sun,cover,coordinator)`** — Replace bare `assert` type-guards with `RuntimeError`; add change-gate to skip `async_write_ha_state` when position is unchanged; guard `sun.sun` unavailability in `get_blind_data`
3. **`perf(geometry,coordinator)`** — `@lru_cache` on pure safety-margin functions; `SunGeometryCache` with per-minute TTL; `UpdateFingerprint` (MD5 over all pipeline inputs) to short-circuit coordinator updates when state is unchanged; `any_command_grace_active` property on `GracePeriodManager`
4. **`fix`** — Add missing `update_cover_capabilities()` call in `AdaptiveCoverManager`
5. **`chore`** — Bump version to 2.29.0

## Changed files

| File | Change |
|------|--------|
| `migrations.py` | Idempotency flag written before entity removal |
| `sun.py` | `assert` → `RuntimeError` |
| `cover.py` | Change-gate on `async_write_ha_state` |
| `coordinator.py` | `sun.sun` guard + UpdateFingerprint wiring |
| `geometry.py` | `@lru_cache` on safety-margin functions |
| `engine/sun_geometry_cache.py` | New — per-minute TTL cache |
| `state/update_fingerprint.py` | New — MD5 pipeline fingerprint |
| `managers/grace_period.py` | `any_command_grace_active` property |
| `managers/toggles.py` | `min_change`/`time_threshold` defaults |
| `managers/manual_override/manager.py` | `update_cover_capabilities()` call |

## Test plan

- [ ] All existing tests pass
- [ ] `UpdateFingerprint` skips coordinator update when no state change
- [ ] `SunGeometryCache` returns cached values within the same minute
- [ ] Migration runs idempotently on second HA restart
- [ ] Cover `async_write_ha_state` not called when position unchanged
- [ ] `sun.sun` unavailable → coordinator handles gracefully (no exception)

---

<details>
<summary>🇫🇷 Français</summary>

## Résumé

Rebasé sur v2.26.0. Cinq commits ciblés au-dessus de upstream/main :

1. **`fix(migrations)`** — Écriture du flag d'idempotence avant la suppression des entités legacy, pour éviter une ré-exécution destructive en cas de redémarrage HA en cours de migration
2. **`fix(sun,cover,coordinator)`** — Remplacement des `assert` par des `RuntimeError` explicites ; change-gate sur `async_write_ha_state` ; guard sur l'indisponibilité de `sun.sun`
3. **`perf(geometry,coordinator)`** — `@lru_cache` sur les fonctions de marge de sécurité ; `SunGeometryCache` avec TTL à la minute ; `UpdateFingerprint` (MD5 sur tous les inputs pipeline) pour court-circuiter les mises à jour coordinator quand l'état n'a pas changé ; propriété `any_command_grace_active`
4. **`fix`** — Appel manquant à `update_cover_capabilities()` dans `AdaptiveCoverManager`
5. **`chore`** — Bump version 2.29.0

</details>