### PR TITLE
fix: next-event sunset boundary never activates night position (#531)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -31,6 +31,7 @@ except ImportError:
     # Fallback for older Home Assistant versions
     EventStateChangedData = dict  # type: ignore[misc,assignment]
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import dt as dt_util
 
 from .config_types import RuntimeConfig
 from .helpers import (
@@ -131,6 +132,14 @@ def _read_time_entity(hass: HomeAssistant, entity_id: str | None) -> dt.datetime
 
     Returns naive-local datetime on success; None if entity_id is None,
     the entity is unavailable, or the state cannot be parsed.
+
+    The entity's *time-of-day* is re-anchored onto today's local date and the
+    original date component is discarded. This makes a "next-event" sensor
+    (e.g. ``sensor.sun_next_setting``, which rolls over to *tomorrow's*
+    setting the instant today's sun sets) behave like a fixed daily wall-clock
+    time. ``compute_effective_default`` already compares the boundary against
+    *today's* clock, so a future-dated boundary would otherwise make the
+    ``after_sunset`` comparison structurally unreachable (issue #531 follow-up).
     """
     if entity_id is None:
         return None
@@ -138,7 +147,13 @@ def _read_time_entity(hass: HomeAssistant, entity_id: str | None) -> dt.datetime
     if raw is None:
         return None
     try:
-        return get_datetime_from_str(raw)
+        parsed = get_datetime_from_str(raw)
+        today_local = dt_util.now().date()
+        return parsed.replace(
+            year=today_local.year,
+            month=today_local.month,
+            day=today_local.day,
+        )
     except Exception:  # noqa: BLE001
         _LOGGER.debug(
             "Could not parse time entity %s state %r as datetime",

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -735,7 +735,12 @@ def test_read_time_entity_returns_none_for_unavailable():
 
 @pytest.mark.unit
 def test_read_time_entity_parses_iso_datetime():
-    """_read_time_entity returns a naive-local datetime for a valid ISO-8601 string."""
+    """_read_time_entity re-anchors a parsed datetime onto today's local date.
+
+    The entity's time-of-day is preserved; its date is replaced with today's
+    local date so "next-event" sensors behave like a fixed daily wall-clock
+    time (issue #531 follow-up).
+    """
     import datetime as dt
 
     from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
@@ -745,13 +750,190 @@ def test_read_time_entity_parses_iso_datetime():
     mock_state.state = "2026-05-22T21:00:00"
     mock_hass = MagicMock()
     mock_hass.states.get.return_value = mock_state
-    result = _read_time_entity(mock_hass, "sensor.sunset_entity")
+
+    today_local = dt.datetime(2026, 6, 7, 12, 0, 0)
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+        return_value=today_local,
+    ):
+        result = _read_time_entity(mock_hass, "sensor.sunset_entity")
     assert result is not None
     assert isinstance(result, dt.datetime)
     assert result.year == 2026
-    assert result.month == 5
-    assert result.day == 22
+    assert result.month == 6
+    assert result.day == 7
     assert result.hour == 21
+    assert result.tzinfo is None
+
+
+@pytest.mark.unit
+def test_read_time_entity_reanchors_future_next_setting_to_today():
+    """A future-dated ``sensor.sun_next_setting`` re-anchors to today's date.
+
+    Regression for issue #531 follow-up: a "next setting" sensor rolls over to
+    *tomorrow* once today's sun has set. The boundary must keep the entity's
+    time-of-day but be projected onto today's local date so the
+    ``after_sunset`` comparison stays reachable.
+    """
+    import datetime as dt
+    from zoneinfo import ZoneInfo
+
+    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+
+    paris = ZoneInfo("Europe/Paris")
+    mock_state = MagicMock()
+    mock_state.state = "2026-06-08T19:01:00+00:00"  # tomorrow UTC = 21:01 Paris
+    mock_hass = MagicMock()
+    mock_hass.states.get.return_value = mock_state
+
+    now_local = dt.datetime(2026, 6, 7, 21, 30, 0, tzinfo=paris)
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+        patch(
+            "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+            return_value=now_local,
+        ),
+    ):
+        result = _read_time_entity(mock_hass, "sensor.sun_next_setting")
+
+    assert result is not None
+    assert result.date() == dt.date(2026, 6, 7)
+    assert result.hour == 21
+    assert result.minute == 1
+    assert result.tzinfo is None
+
+
+@pytest.mark.unit
+def test_read_time_entity_reanchors_future_next_rising_to_today():
+    """A future-dated ``sensor.sun_next_rising`` re-anchors to today's date."""
+    import datetime as dt
+    from zoneinfo import ZoneInfo
+
+    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+
+    paris = ZoneInfo("Europe/Paris")
+    mock_state = MagicMock()
+    mock_state.state = "2026-06-08T04:46:00+00:00"  # tomorrow UTC = 06:46 Paris
+    mock_hass = MagicMock()
+    mock_hass.states.get.return_value = mock_state
+
+    now_local = dt.datetime(2026, 6, 7, 21, 30, 0, tzinfo=paris)
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+        patch(
+            "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+            return_value=now_local,
+        ),
+    ):
+        result = _read_time_entity(mock_hass, "sensor.sun_next_rising")
+
+    assert result is not None
+    assert result.date() == dt.date(2026, 6, 7)
+    assert result.hour == 6
+    assert result.minute == 46
+    assert result.tzinfo is None
+
+
+@pytest.mark.unit
+def test_read_time_entity_today_dated_entity_unchanged_time_of_day():
+    """A today-dated entity keeps its time-of-day after re-anchoring."""
+    import datetime as dt
+    from zoneinfo import ZoneInfo
+
+    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+
+    paris = ZoneInfo("Europe/Paris")
+    mock_state = MagicMock()
+    mock_state.state = "2026-06-07T21:00:00+02:00"  # today 21:00 Paris
+    mock_hass = MagicMock()
+    mock_hass.states.get.return_value = mock_state
+
+    now_local = dt.datetime(2026, 6, 7, 21, 30, 0, tzinfo=paris)
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+        patch(
+            "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+            return_value=now_local,
+        ),
+    ):
+        result = _read_time_entity(mock_hass, "sensor.sunset_entity")
+
+    assert result is not None
+    assert result.date() == dt.date(2026, 6, 7)
+    assert result.hour == 21
+
+
+@pytest.mark.unit
+def test_read_time_entity_dst_spring_forward_boundary():
+    """Re-anchoring onto a spring-forward day yields a valid post-transition instant.
+
+    On 2026-03-29 Paris springs forward (02:00 CET → 03:00 CEST). A boundary
+    time-of-day of 03:30 is valid post-transition (CEST, +02:00). Re-anchoring
+    must not raise, and ``_local_naive_to_utc_naive`` on the result must yield
+    01:30 UTC.
+    """
+    import datetime as dt
+    from zoneinfo import ZoneInfo
+
+    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _local_naive_to_utc_naive
+
+    paris = ZoneInfo("Europe/Paris")
+    # Future-dated entity whose local time-of-day is 03:30 Paris (CEST +02:00).
+    mock_state = MagicMock()
+    mock_state.state = "2026-04-05T01:30:00+00:00"  # = 03:30 Paris CEST, future date
+    mock_hass = MagicMock()
+    mock_hass.states.get.return_value = mock_state
+
+    now_local = dt.datetime(2026, 3, 29, 12, 0, 0, tzinfo=paris)
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+        patch(
+            "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+            return_value=now_local,
+        ),
+    ):
+        result = _read_time_entity(mock_hass, "sensor.sun_next_setting")
+
+        assert result is not None
+        assert result.date() == dt.date(2026, 3, 29)
+        assert result.hour == 3
+        assert result.minute == 30
+        utc_naive = _local_naive_to_utc_naive(result)
+
+    assert utc_naive == dt.datetime(2026, 3, 29, 1, 30, 0)
+
+
+@pytest.mark.unit
+def test_read_time_entity_near_midnight_sunset_projects_to_today():
+    """A near-midnight time-of-day (00:15) projects onto today's date."""
+    import datetime as dt
+    from zoneinfo import ZoneInfo
+
+    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+
+    paris = ZoneInfo("Europe/Paris")
+    mock_state = MagicMock()
+    mock_state.state = (
+        "2026-06-08T22:15:00+00:00"  # tomorrow UTC = 00:15 Paris (+1 day)
+    )
+    mock_hass = MagicMock()
+    mock_hass.states.get.return_value = mock_state
+
+    now_local = dt.datetime(2026, 6, 7, 21, 30, 0, tzinfo=paris)
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+        patch(
+            "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+            return_value=now_local,
+        ),
+    ):
+        result = _read_time_entity(mock_hass, "sensor.sun_next_setting")
+
+    assert result is not None
+    assert result.date() == dt.date(2026, 6, 7)
+    assert result.hour == 0
+    assert result.minute == 15
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -35,9 +35,16 @@ def _make_sun_data(
     sunset_minute: int = 0,
     sunrise_hour: int = 6,
     sunrise_minute: int = 0,
+    day: dt.date | None = None,
 ) -> MagicMock:
-    """Return a mock SunData with controllable sunset/sunrise times (naive UTC)."""
-    today = dt.date.today()
+    """Return a mock SunData with controllable sunset/sunrise times (naive UTC).
+
+    ``day`` pins the astral fallback date; defaults to ``dt.date.today()``.
+    Tests that freeze ``now`` to an explicit calendar date must pass the same
+    ``day`` so the astral sunrise/sunset fallback stays on that date (otherwise
+    the comparison drifts when the real wall-clock date rolls over).
+    """
+    today = day or dt.date.today()
     sunset_dt = dt.datetime(
         today.year, today.month, today.day, sunset_hour, sunset_minute, 0
     )
@@ -671,7 +678,7 @@ class TestEntityOverrideTimezone:
         converted to naive-UTC 09:00, so 09:38 > 09:00 → active (correct).
         """
         paris = self._paris_tz()
-        sun = _make_sun_data(sunset_hour=20, sunrise_hour=4)
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=4, day=dt.date(2026, 6, 6))
 
         # Produce the boundary the same way the real coordinator does:
         # get_datetime_from_str on a tz-aware entity string.
@@ -722,7 +729,7 @@ class TestEntityOverrideTimezone:
         regression check; here we verify the positive-UTC-offset case is also correct.
         """
         paris = self._paris_tz()
-        sun = _make_sun_data(sunset_hour=21, sunrise_hour=5)
+        sun = _make_sun_data(sunset_hour=21, sunrise_hour=5, day=dt.date(2026, 6, 6))
 
         entity_state = "2026-06-06T07:00:00+02:00"
         with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris):
@@ -763,7 +770,7 @@ class TestEntityOverrideTimezone:
           - Expected: is_sunset_active=False
         """
         paris = self._paris_tz()
-        sun = _make_sun_data(sunset_hour=20, sunrise_hour=4)
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=4, day=dt.date(2026, 6, 6))
 
         entity_state = "2026-06-06T11:00:00+02:00"
         with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris):
@@ -790,3 +797,104 @@ class TestEntityOverrideTimezone:
             f"got active={active}"
         )
         assert result == 100
+
+    def test_future_next_setting_entity_activates_night_position(self):
+        """A future-dated ``sensor.sun_next_setting`` still activates the night position.
+
+        Issue #531 follow-up: once today's sun has set, a "next setting" sensor
+        reports *tomorrow's* setting. The coordinator re-anchors that onto
+        today's date, so after dusk the after-sunset branch fires correctly.
+        """
+        from unittest.mock import MagicMock as _MagicMock
+
+        from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+
+        paris = self._paris_tz()
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=4, day=dt.date(2026, 6, 7))
+
+        mock_state = _MagicMock()
+        mock_state.state = "2026-06-08T19:01:00+00:00"  # tomorrow UTC = 21:01 Paris
+        mock_hass = _MagicMock()
+        mock_hass.states.get.return_value = mock_state
+
+        now_local = dt.datetime(2026, 6, 7, 21, 30, 0, tzinfo=paris)
+        with (
+            patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+            patch(
+                "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+                return_value=now_local,
+            ),
+        ):
+            sunset_boundary = _read_time_entity(mock_hass, "sensor.sun_next_setting")
+
+        # 19:30 UTC = 21:30 Paris → after the 21:01 Paris (= 19:01 UTC) boundary
+        frozen_utc = dt.datetime(2026, 6, 7, 19, 30, 0)
+        with (
+            patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+            _freeze_now(frozen_utc),
+        ):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                sunset_time=sunset_boundary,
+                sunrise_time=None,
+            )
+
+        assert active is True, (
+            f"Expected is_sunset_active=True after dusk with a future next_setting "
+            f"boundary, got active={active}"
+        )
+        assert result == 0
+
+    def test_future_next_rising_entity_holds_then_releases(self):
+        """A future-dated ``sensor.sun_next_rising`` holds the night position pre-dawn.
+
+        Before the re-anchored sunrise the overnight window must remain active.
+        """
+        from unittest.mock import MagicMock as _MagicMock
+
+        from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+
+        paris = self._paris_tz()
+        sun = _make_sun_data(sunset_hour=21, sunrise_hour=5, day=dt.date(2026, 6, 7))
+
+        mock_state = _MagicMock()
+        mock_state.state = "2026-06-08T04:46:00+00:00"  # tomorrow UTC = 06:46 Paris
+        mock_hass = _MagicMock()
+        mock_hass.states.get.return_value = mock_state
+
+        now_local = dt.datetime(2026, 6, 7, 3, 0, 0, tzinfo=paris)
+        with (
+            patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+            patch(
+                "custom_components.adaptive_cover_pro.coordinator.dt_util.now",
+                return_value=now_local,
+            ),
+        ):
+            sunrise_boundary = _read_time_entity(mock_hass, "sensor.sun_next_rising")
+
+        # 01:00 UTC = 03:00 Paris → before the 06:46 Paris (= 04:46 UTC) boundary
+        frozen_utc = dt.datetime(2026, 6, 7, 1, 0, 0)
+        with (
+            patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", paris),
+            _freeze_now(frozen_utc),
+        ):
+            result, active = compute_effective_default(
+                h_def=100,
+                sunset_pos=0,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                sunset_time=None,
+                sunrise_time=sunrise_boundary,
+                window_explicitly_started=False,
+            )
+
+        assert active is True, (
+            f"Expected is_sunset_active=True before a future next_rising boundary, "
+            f"got active={active}"
+        )
+        assert result == 0


### PR DESCRIPTION
## Summary
A "next-event" sensor (e.g. `sensor.sun_next_setting`) used as the sunset/sunrise boundary reports tomorrow's setting once today's sun has set. `compute_effective_default` compares the boundary against today's clock, so the future-dated boundary made the after-sunset branch unreachable and the cover held its default position all night. `_read_time_entity` now re-anchors the entity's time-of-day onto today's local date at the single boundary-read path, so a "next setting" sensor behaves like a fixed daily wall-clock time. The shipped timezone-frame conversion is untouched.

This is a follow-up to the #531 frame fix that shipped in v2.25.3 (fixed-time helpers and the blank/astral default already worked; only next-event sun entities failed).

## Testing
- ✅ 3938 tests passing (7 new: 5 re-anchor unit tests incl. DST + near-midnight, 2 e2e night-activation tests)
- ✅ 100% patch coverage, lint clean

## Related Issues
Refs #531