### PR TITLE
perf+fix: gate redundant writes, cache geometry, sun.sun guard

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1885,8 +1885,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         sun_data = self._sun_provider.create_sun_data(self.hass.config.time_zone)
         config = self._config_service.get_common_data(options)
         _raw_azi, _raw_elev = self.pos_sun
+        # When sun.sun is unavailable both attributes read as None. Falling back
+        # to 0.0/0.0 is dangerous: azimuth=0, elevation=0 is a valid-looking sun
+        # position (on the horizon, due north) that can land inside a window's FOV
+        # and trigger spurious cover commands off a phantom sun. When the entity
+        # is truly unavailable, drop elevation below the horizon (-1.0) so
+        # valid_elevation is False (for the default and min-configured cases) and
+        # no solar positioning runs until sun.sun recovers.
+        _sun_unavailable = _raw_azi is None and _raw_elev is None
+        if _sun_unavailable:
+            self.logger.warning(
+                "sun.sun attributes unavailable — solar tracking disabled until "
+                "the sun entity reports valid azimuth/elevation"
+            )
         sol_azi = _raw_azi if _raw_azi is not None else 0.0
-        sol_elev = _raw_elev if _raw_elev is not None else 0.0
+        sol_elev = (
+            _raw_elev if _raw_elev is not None else (-1.0 if _sun_unavailable else 0.0)
+        )
         return self._policy.build_calc_engine(
             logger=self.logger,
             sol_azi=sol_azi,

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -39,7 +39,7 @@ from .cover_types.base import (
     STATE_ATTR_TILT_POSITION,
     caps_get,
 )
-from .entity_base import AdaptiveCoverBaseEntity
+from .entity_base import _SENTINEL, AdaptiveCoverBaseEntity
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -122,6 +122,11 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
             self._attr_name = f"{title} Managed ({label})"
         else:
             self._attr_name = f"{title} Managed"
+        # Render signature of the last source-mirror write. Kept separate from
+        # the base-class coordinator-update gate because the proxy renders from
+        # source state, not coordinator.data — the two write paths must not
+        # share one cache field.
+        self._proxy_source_sig: object = _SENTINEL
 
     # ---- availability + mirroring -------------------------------------- #
 
@@ -196,6 +201,29 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
 
     @callback
     def _handle_source_event(self, event: Event) -> None:
+        """Mirror the source cover, skipping writes that carry no new state.
+
+        Rapid OPENING/CLOSING intermediate events often repeat the same
+        observable state; writing each one floods HA with no-op updates. Gate on
+        the rendered surface (state flags, position, tilt, supported features).
+        Fails open so a comparison error can never stall the mirror.
+        """
+        try:
+            sig = (
+                self.available,
+                self.is_opening,
+                self.is_closing,
+                self.current_cover_position,
+                self.current_cover_tilt_position,
+                int(self.supported_features),
+            )
+        except Exception:  # noqa: BLE001 - never let a signature error suppress a write
+            self._proxy_source_sig = _SENTINEL
+            self.async_write_ha_state()
+            return
+        if sig == self._proxy_source_sig:
+            return
+        self._proxy_source_sig = sig
         self.async_write_ha_state()
 
     # ---- command routing ---------------------------------------------- #

--- a/custom_components/adaptive_cover_pro/entity_base.py
+++ b/custom_components/adaptive_cover_pro/entity_base.py
@@ -20,6 +20,12 @@ if TYPE_CHECKING:
     from .coordinator import AdaptiveDataUpdateCoordinator
 
 
+# Unique marker for "no state has been written yet". A fresh object() never
+# compares equal to any render signature, so the first coordinator update
+# always writes.
+_SENTINEL = object()
+
+
 class AdaptiveCoverBaseEntity(CoordinatorEntity["AdaptiveDataUpdateCoordinator"]):
     """Base class for all Adaptive Cover Pro entities."""
 
@@ -42,6 +48,8 @@ class AdaptiveCoverBaseEntity(CoordinatorEntity["AdaptiveDataUpdateCoordinator"]
         self._name = config_entry.data["name"]
         self._cover_type = config_entry.data[CONF_SENSOR_TYPE]
         self._device_id = entry_id
+        # Render signature of the last write; gates redundant async_write_ha_state.
+        self._acp_last_write_sig: object = _SENTINEL
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -99,8 +107,45 @@ class AdaptiveCoverBaseEntity(CoordinatorEntity["AdaptiveDataUpdateCoordinator"]
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        """Handle updated data from coordinator."""
+        """Write HA state only when this entity's render output changed.
+
+        The coordinator notifies every listener on each update cycle, but most
+        cycles leave an individual entity's rendered value unchanged (e.g. a sun
+        micro-move or a chatty temperature sensor that doesn't shift the computed
+        position). Skipping the write in that case avoids a state-machine update,
+        a bus event, and a recorder row per entity per cycle.
+
+        Fails open: any error building the signature resets the cache and writes,
+        so a comparison bug can never suppress a legitimate state update.
+        """
+        try:
+            sig = self._acp_render_signature()
+        except Exception:  # noqa: BLE001 - never let a signature error suppress a write
+            self._acp_last_write_sig = _SENTINEL
+            self.async_write_ha_state()
+            return
+        if sig == self._acp_last_write_sig:
+            return
+        self._acp_last_write_sig = sig
         self.async_write_ha_state()
+
+    def _acp_render_signature(self) -> object:
+        """Return a cheap, comparable snapshot of everything HA renders.
+
+        ``self.state`` is resolved by HA's base ``Entity`` subclass for each
+        platform (sensor native_value, binary_sensor/switch is_on, cover
+        position), so a single signature works uniformly. ``extra_state_attributes``
+        is snapshotted via ``repr`` to give a stable token even if a subclass
+        reuses a mutable mapping across cycles; the attribute values here are
+        plain dicts/lists/scalars/datetimes, so the repr is deterministic and far
+        cheaper than a full state write. ``available`` is included so the
+        coordinator-data availability flip (see :meth:`available`) forces a write.
+        """
+        return (
+            self.available,
+            self.state,
+            repr(self.extra_state_attributes),
+        )
 
 
 class AdaptiveCoverSensorBase(AdaptiveCoverBaseEntity):

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 import numpy as np
 
 from .const import (
@@ -17,6 +19,68 @@ from .const import (
 )
 
 
+@lru_cache(maxsize=512)
+def _safety_margin(gamma: float, sol_elev: float) -> float:
+    """Compute the safety-margin multiplier — pure, process-wide memoised.
+
+    Pulled out of ``SafetyMarginCalculator.calculate`` so the result is shared
+    across every cover (and every config entry) at the same sun angles within a
+    cycle. Pure ``float -> float``, no rounding (rounding would change numeric
+    output); ``maxsize`` bounds memory. Assumes finite inputs (elevation 0-90,
+    gamma -180..180) — NaN would defeat caching but never reaches here.
+    """
+    margin = 1.0
+
+    # Gamma margin: increases at extreme horizontal angles
+    gamma_abs = abs(gamma)
+    if gamma_abs > SAFETY_MARGIN_GAMMA_THRESHOLD:
+        # Normalized transition: 0 at threshold, 1 at 90°
+        t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
+            90 - SAFETY_MARGIN_GAMMA_THRESHOLD
+        )
+        t = float(np.clip(t, 0, 1))
+        smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
+        margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
+
+    # Elevation margin: increases at very low/high angles
+    if sol_elev < SAFETY_MARGIN_LOW_ELEV_THRESHOLD:
+        t = (
+            SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
+        ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
+        margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
+    elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
+        t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
+            90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
+        )
+        margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
+
+    return float(margin)
+
+
+@lru_cache(maxsize=512)
+def _edge_case(
+    sol_elev: float, gamma: float, distance: float, h_win: float
+) -> tuple[bool, float]:
+    """Compute the extreme-angle edge-case fallback — pure, memoised.
+
+    Companion to :func:`_safety_margin`; see it for the caching rationale.
+    """
+    # Very low elevation: sun nearly horizontal, full coverage safest
+    if sol_elev < EDGE_CASE_LOW_ELEVATION:
+        return (True, h_win)
+
+    # Extreme gamma: sun perpendicular to window, full coverage
+    if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
+        return (True, h_win)
+
+    # Very high elevation: sun nearly overhead, use simplified calculation
+    if sol_elev > EDGE_CASE_HIGH_ELEVATION:
+        simple_height = distance * np.tan(np.radians(sol_elev))
+        return (True, float(np.clip(simple_height, 0, h_win)))
+
+    return (False, 0.0)
+
+
 class SafetyMarginCalculator:
     """Calculates angle-dependent safety margins for sun blocking accuracy."""
 
@@ -28,6 +92,9 @@ class SafetyMarginCalculator:
         - Gamma margin: increases at extreme horizontal angles
         - Elevation margin: increases at very low or high angles
 
+        Delegates to the module-level cached :func:`_safety_margin` so the result
+        is shared across all instances at the same sun angles.
+
         Args:
             gamma: Surface solar azimuth in degrees (-180 to 180)
             sol_elev: Sun elevation angle in degrees (0-90)
@@ -36,32 +103,7 @@ class SafetyMarginCalculator:
             Safety margin multiplier (1.0 to 1.45)
 
         """
-        margin = 1.0
-
-        # Gamma margin: increases at extreme horizontal angles
-        gamma_abs = abs(gamma)
-        if gamma_abs > SAFETY_MARGIN_GAMMA_THRESHOLD:
-            # Normalized transition: 0 at threshold, 1 at 90°
-            t = (gamma_abs - SAFETY_MARGIN_GAMMA_THRESHOLD) / (
-                90 - SAFETY_MARGIN_GAMMA_THRESHOLD
-            )
-            t = float(np.clip(t, 0, 1))
-            smooth_t = t * t * (3 - 2 * t)  # Smoothstep interpolation
-            margin += SAFETY_MARGIN_GAMMA_MAX * smooth_t
-
-        # Elevation margin: increases at very low/high angles
-        if sol_elev < SAFETY_MARGIN_LOW_ELEV_THRESHOLD:
-            t = (
-                SAFETY_MARGIN_LOW_ELEV_THRESHOLD - sol_elev
-            ) / SAFETY_MARGIN_LOW_ELEV_THRESHOLD
-            margin += SAFETY_MARGIN_LOW_ELEV_MAX * float(np.clip(t, 0, 1))
-        elif sol_elev > SAFETY_MARGIN_HIGH_ELEV_THRESHOLD:
-            t = (sol_elev - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD) / (
-                90 - SAFETY_MARGIN_HIGH_ELEV_THRESHOLD
-            )
-            margin += SAFETY_MARGIN_HIGH_ELEV_MAX * float(np.clip(t, 0, 1))
-
-        return float(margin)
+        return _safety_margin(gamma, sol_elev)
 
 
 class EdgeCaseHandler:
@@ -74,7 +116,8 @@ class EdgeCaseHandler:
         """Check for edge cases and return fallback position if needed.
 
         Provides robust behavior at edge cases where standard geometric
-        calculations become unstable or inaccurate.
+        calculations become unstable or inaccurate. Delegates to the
+        module-level cached :func:`_edge_case`.
 
         Args:
             sol_elev: Sun elevation angle in degrees (0-90)
@@ -88,17 +131,4 @@ class EdgeCaseHandler:
             - position: Safe fallback position (only valid if is_edge_case=True)
 
         """
-        # Very low elevation: sun nearly horizontal, full coverage safest
-        if sol_elev < EDGE_CASE_LOW_ELEVATION:
-            return (True, h_win)
-
-        # Extreme gamma: sun perpendicular to window, full coverage
-        if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
-            return (True, h_win)
-
-        # Very high elevation: sun nearly overhead, use simplified calculation
-        if sol_elev > EDGE_CASE_HIGH_ELEVATION:
-            simple_height = distance * np.tan(np.radians(sol_elev))
-            return (True, float(np.clip(simple_height, 0, h_win)))
-
-        return (False, 0.0)
+        return _edge_case(sol_elev, gamma, distance, h_win)

--- a/custom_components/adaptive_cover_pro/sun.py
+++ b/custom_components/adaptive_cover_pro/sun.py
@@ -133,21 +133,33 @@ class SunData:
     def times(self) -> pd.DatetimeIndex:
         """Today's 5-minute timeline (cached per day)."""
         self._ensure_today()
-        assert self._cache_times is not None  # for type narrowing
+        # Explicit RuntimeError instead of assert: assert is stripped under
+        # optimized builds (python -O), which would turn a failed cache fill into
+        # a silent None dereference instead of a clear error.
+        if self._cache_times is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_times is None after _ensure_today()"
+            )
         return self._cache_times
 
     @property
     def solar_azimuth(self) -> list[float]:
         """Solar azimuth at each entry in :attr:`times` (cached per day)."""
         self._ensure_today()
-        assert self._cache_azi is not None
+        if self._cache_azi is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_azi is None after _ensure_today()"
+            )
         return self._cache_azi
 
     @property
     def solar_elevation(self) -> list[float]:
         """Solar elevation at each entry in :attr:`times` (cached per day)."""
         self._ensure_today()
-        assert self._cache_ele is not None
+        if self._cache_ele is None:
+            raise RuntimeError(  # pragma: no cover
+                "SunData cache fill failed: _cache_ele is None after _ensure_today()"
+            )
         return self._cache_ele
 
     def sunset(self) -> datetime:

--- a/tests/test_entity_write_gating.py
+++ b/tests/test_entity_write_gating.py
@@ -1,0 +1,228 @@
+"""Tests for per-entity write gating in AdaptiveCoverBaseEntity.
+
+The coordinator notifies every listener on each update cycle. Most cycles leave
+an individual entity's rendered output unchanged (sun micro-move, chatty temp
+sensor), so writing every entity every cycle floods HA's state machine, event
+bus, and recorder with no-op updates.
+
+``AdaptiveCoverBaseEntity._handle_coordinator_update`` now gates the write on a
+render signature ``(available, state, repr(extra_state_attributes))`` and only
+calls ``async_write_ha_state()`` when that signature changes. The proxy cover's
+independent source-mirror path (``_handle_source_event``) has its own parallel
+gate. These tests pin both behaviours, including the fail-open contract.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import CONF_SENSOR_TYPE, CoverType
+from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
+from custom_components.adaptive_cover_pro.entity_base import (
+    _SENTINEL,
+    AdaptiveCoverBaseEntity,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config.units.temperature_unit = "°C"
+    return hass
+
+
+def _make_config_entry():
+    entry = MagicMock()
+    entry.entry_id = "test_gate_entry"
+    entry.title = "Test"
+    entry.data = {"name": "Test", CONF_SENSOR_TYPE: CoverType.BLIND}
+    entry.options = {}
+    return entry
+
+
+def _make_coordinator(*, data=None):
+    coord = MagicMock()
+    coord.data = data
+    coord.last_update_success = True
+    coord.logger = MagicMock()
+    coord.hass = _make_hass()
+    return coord
+
+
+class _GateEntity(AdaptiveCoverBaseEntity):
+    """Minimal concrete entity with controllable render surface.
+
+    ``state`` and ``extra_state_attributes`` read from plain attributes so each
+    test can drive the render signature directly. ``available`` is inherited
+    from the base class (False while ``coordinator.data`` is None).
+    """
+
+    def __init__(self, coord, *, state="idle", attrs=None) -> None:
+        super().__init__("test_gate_entry", _make_hass(), _make_config_entry(), coord)
+        self._test_state = state
+        self._test_attrs = attrs
+
+    @property
+    def state(self):
+        return self._test_state
+
+    @property
+    def extra_state_attributes(self):
+        return self._test_attrs
+
+
+def _build(coord=None, **kwargs) -> _GateEntity:
+    entity = _GateEntity(coord or _make_coordinator(data={"ready": True}), **kwargs)
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+# ---------------------------------------------------------------------------
+# Base-class coordinator-update gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_first_update_always_writes():
+    entity = _build()
+    entity._handle_coordinator_update()
+    entity.async_write_ha_state.assert_called_once()
+    assert entity._acp_last_write_sig is not _SENTINEL
+
+
+@pytest.mark.unit
+def test_unchanged_update_suppressed():
+    entity = _build()
+    entity._handle_coordinator_update()
+    entity._handle_coordinator_update()
+    entity._handle_coordinator_update()
+    entity.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.unit
+def test_changed_state_writes():
+    entity = _build(state="idle")
+    entity._handle_coordinator_update()
+    entity._test_state = "active"
+    entity._handle_coordinator_update()
+    assert entity.async_write_ha_state.call_count == 2
+
+
+@pytest.mark.unit
+def test_changed_attributes_writes():
+    entity = _build(attrs={"trace": [1, 2]})
+    entity._handle_coordinator_update()
+    entity._test_attrs = {"trace": [1, 2, 3]}
+    entity._handle_coordinator_update()
+    assert entity.async_write_ha_state.call_count == 2
+
+
+@pytest.mark.unit
+def test_availability_flip_writes():
+    coord = _make_coordinator(data=None)  # available -> False
+    entity = _build(coord)
+    entity._handle_coordinator_update()  # first write (unavailable)
+    assert entity.async_write_ha_state.call_count == 1
+    coord.data = {"ready": True}  # available -> True
+    entity._handle_coordinator_update()
+    assert entity.async_write_ha_state.call_count == 2
+
+
+@pytest.mark.unit
+def test_signature_exception_fails_open():
+    entity = _build()
+    entity._handle_coordinator_update()
+    entity.async_write_ha_state.reset_mock()
+
+    # Force the signature build to raise on the next update.
+    boom = property(lambda self: (_ for _ in ()).throw(RuntimeError("boom")))
+    type(entity).extra_state_attributes = boom
+    try:
+        entity._handle_coordinator_update()
+    finally:
+        # Restore so the class isn't left poisoned for other tests.
+        type(entity).extra_state_attributes = _GateEntity.extra_state_attributes
+
+    entity.async_write_ha_state.assert_called_once()
+    assert entity._acp_last_write_sig is _SENTINEL
+
+
+@pytest.mark.unit
+def test_attribute_mutation_in_place_detected():
+    """A subclass that mutates a reused dict must still trigger a write.
+
+    repr-snapshotting the attributes (rather than holding the live mapping)
+    guards against the alias trap where ``prev is current`` would compare equal.
+    """
+    shared = {"count": 1}
+    entity = _build(attrs=shared)
+    entity._handle_coordinator_update()
+    shared["count"] = 2  # same object, mutated in place
+    entity._handle_coordinator_update()
+    assert entity.async_write_ha_state.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Proxy cover source-event gating
+# ---------------------------------------------------------------------------
+
+
+class _FakeState:
+    def __init__(self, state: str, attributes: dict) -> None:
+        self.state = state
+        self.attributes = attributes
+
+
+def _make_proxy():
+    hass = _make_hass()
+    holder = {"state": None}
+    hass.states.get = MagicMock(side_effect=lambda _eid: holder["state"])
+    proxy = AdaptiveProxyCover(
+        entry_id="test_gate_entry",
+        hass=hass,
+        config_entry=_make_config_entry(),
+        coordinator=_make_coordinator(data={"ready": True}),
+        source_entity_id="cover.test_source",
+        multi=False,
+    )
+    proxy.async_write_ha_state = MagicMock()
+    return proxy, holder
+
+
+@pytest.mark.unit
+def test_proxy_unchanged_source_event_suppressed():
+    proxy, holder = _make_proxy()
+    holder["state"] = _FakeState(
+        "open", {"current_position": 50, "supported_features": 15}
+    )
+    event = MagicMock()
+    proxy._handle_source_event(event)
+    proxy._handle_source_event(event)  # identical observable state
+    proxy.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.unit
+def test_proxy_changed_position_writes():
+    proxy, holder = _make_proxy()
+    holder["state"] = _FakeState(
+        "open", {"current_position": 50, "supported_features": 15}
+    )
+    event = MagicMock()
+    proxy._handle_source_event(event)
+    holder["state"] = _FakeState(
+        "open", {"current_position": 70, "supported_features": 15}
+    )
+    proxy._handle_source_event(event)
+    assert proxy.async_write_ha_state.call_count == 2
+
+
+@pytest.mark.unit
+def test_proxy_source_gate_is_separate_from_base_gate():
+    proxy, _holder = _make_proxy()
+    assert proxy._proxy_source_sig is _SENTINEL
+    assert proxy._acp_last_write_sig is _SENTINEL

--- a/tests/test_geometry_cache.py
+++ b/tests/test_geometry_cache.py
@@ -1,0 +1,105 @@
+"""Tests for the lru_cache memoisation of the pure geometry functions.
+
+``SafetyMarginCalculator.calculate`` and ``EdgeCaseHandler.check_and_handle``
+delegate to module-level ``@lru_cache`` functions so identical sun angles are
+computed once and shared across every cover/config entry. These tests pin the
+numeric results (caching must not change output) and confirm the cache is hit.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from custom_components.adaptive_cover_pro.geometry import (
+    EdgeCaseHandler,
+    SafetyMarginCalculator,
+    _edge_case,
+    _safety_margin,
+)
+
+# ---------------------------------------------------------------------------
+# Safety margin — pinned values (caching must not alter these)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("gamma", "sol_elev", "expected"),
+    [
+        (0.0, 45.0, 1.0),  # normal angles -> baseline
+        (45.0, 45.0, 1.0),  # gamma at threshold (not >) -> baseline
+        (90.0, 45.0, 1.2),  # extreme gamma -> +0.20 (smoothstep = 1 at 90°)
+        (0.0, 0.0, 1.15),  # low elevation -> +0.15
+        (0.0, 90.0, 1.10),  # high elevation -> +0.10
+    ],
+)
+def test_safety_margin_values(gamma, sol_elev, expected):
+    assert SafetyMarginCalculator.calculate(gamma, sol_elev) == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_safety_margin_delegates_to_cached_function():
+    assert SafetyMarginCalculator.calculate(12.3, 33.0) == _safety_margin(12.3, 33.0)
+
+
+@pytest.mark.unit
+def test_safety_margin_is_cached():
+    _safety_margin.cache_clear()
+    SafetyMarginCalculator.calculate(60.0, 20.0)
+    SafetyMarginCalculator.calculate(60.0, 20.0)  # same args -> cache hit
+    assert _safety_margin.cache_info().hits >= 1
+
+
+@pytest.mark.unit
+def test_safety_margin_distinct_keys_distinct_results():
+    _safety_margin.cache_clear()
+    a = SafetyMarginCalculator.calculate(90.0, 45.0)
+    b = SafetyMarginCalculator.calculate(0.0, 0.0)
+    assert a != b
+    # Two distinct keys cached, no cross-contamination.
+    assert SafetyMarginCalculator.calculate(90.0, 45.0) == a
+    assert SafetyMarginCalculator.calculate(0.0, 0.0) == b
+
+
+# ---------------------------------------------------------------------------
+# Edge case handler — all four branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_edge_case_low_elevation():
+    assert EdgeCaseHandler.check_and_handle(1.0, 0.0, 2.0, 10.0) == (True, 10.0)
+
+
+@pytest.mark.unit
+def test_edge_case_extreme_gamma():
+    assert EdgeCaseHandler.check_and_handle(45.0, 90.0, 2.0, 10.0) == (True, 10.0)
+
+
+@pytest.mark.unit
+def test_edge_case_high_elevation():
+    is_edge, pos = EdgeCaseHandler.check_and_handle(89.0, 0.0, 0.05, 10.0)
+    assert is_edge is True
+    assert pos == pytest.approx(0.05 * math.tan(math.radians(89.0)))
+
+
+@pytest.mark.unit
+def test_edge_case_high_elevation_clipped_to_window():
+    is_edge, pos = EdgeCaseHandler.check_and_handle(89.0, 0.0, 5.0, 10.0)
+    assert is_edge is True
+    assert pos == 10.0  # clipped to h_win
+
+
+@pytest.mark.unit
+def test_edge_case_normal_returns_false():
+    assert EdgeCaseHandler.check_and_handle(45.0, 0.0, 2.0, 10.0) == (False, 0.0)
+
+
+@pytest.mark.unit
+def test_edge_case_is_cached():
+    _edge_case.cache_clear()
+    EdgeCaseHandler.check_and_handle(45.0, 0.0, 2.0, 10.0)
+    EdgeCaseHandler.check_and_handle(45.0, 0.0, 2.0, 10.0)
+    assert _edge_case.cache_info().hits >= 1

--- a/tests/test_sun_unavailable_guard.py
+++ b/tests/test_sun_unavailable_guard.py
@@ -1,0 +1,79 @@
+"""Tests for the sun.sun unavailability guard in coordinator.get_blind_data.
+
+When sun.sun drops out, both azimuth and elevation read as None. Falling back to
+0.0/0.0 is a valid-looking on-the-horizon sun that can trigger spurious cover
+commands. The guard instead drops elevation to -1.0 (below the horizon) so
+valid_elevation is False and solar tracking is suppressed until the entity
+recovers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+
+
+class _FakeState:
+    def __init__(self, attributes: dict) -> None:
+        self.attributes = attributes
+
+
+def _make_coordinator(sun_state) -> AdaptiveDataUpdateCoordinator:
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    hass = MagicMock()
+    hass.config.time_zone = "UTC"
+    hass.states.get = MagicMock(
+        side_effect=lambda eid: sun_state if eid == "sun.sun" else None
+    )
+    coord.hass = hass
+    coord._sun_provider = MagicMock()
+    coord._config_service = MagicMock()
+    coord._policy = MagicMock()
+    return coord
+
+
+def _captured_elev_azi(coord) -> tuple[float, float]:
+    coord.get_blind_data(options={})
+    _, kwargs = coord._policy.build_calc_engine.call_args
+    return kwargs["sol_elev"], kwargs["sol_azi"]
+
+
+@pytest.mark.unit
+def test_unavailable_sun_drops_elevation_below_horizon():
+    coord = _make_coordinator(sun_state=None)  # states.get -> None: attrs are None
+    sol_elev, sol_azi = _captured_elev_azi(coord)
+    assert sol_elev == -1.0
+    assert sol_azi == 0.0
+
+
+@pytest.mark.unit
+def test_unavailable_sun_logs_warning():
+    coord = _make_coordinator(sun_state=None)
+    coord.get_blind_data(options={})
+    assert coord.logger.warning.called
+
+
+@pytest.mark.unit
+def test_available_sun_uses_reported_values():
+    coord = _make_coordinator(
+        sun_state=_FakeState({"azimuth": 180.0, "elevation": 45.0})
+    )
+    sol_elev, sol_azi = _captured_elev_azi(coord)
+    assert sol_elev == 45.0
+    assert sol_azi == 180.0
+    coord.logger.warning.assert_not_called()
+
+
+@pytest.mark.unit
+def test_zero_elevation_at_horizon_not_treated_as_unavailable():
+    """A real elevation of 0.0 must pass through, not be coerced to -1.0."""
+    coord = _make_coordinator(sun_state=_FakeState({"azimuth": 90.0, "elevation": 0.0}))
+    sol_elev, _ = _captured_elev_azi(coord)
+    assert sol_elev == 0.0
+    coord.logger.warning.assert_not_called()


### PR DESCRIPTION
## Summary

Reduces redundant `async_write_ha_state` calls and repeated geometry math, plus two robustness fixes, inspired by #540 (which was incomplete). The higher-risk pipeline short-circuit is split into #542 for a measured follow-up.

**Layer 1 — per-entity write gating.** #540 only change-gated the proxy cover and CPU; it never touched the ~30 sensor/switch/binary_sensor entities that write on every coordinator cycle. Each inherits `AdaptiveCoverBaseEntity._handle_coordinator_update`, which called `async_write_ha_state()` unconditionally, and the `DataUpdateCoordinator` notifies every listener each cycle. I added one gate at that base-class chokepoint: it compares a render signature `(available, state, repr(extra_state_attributes))` and writes only when it changes. Fails open on any error so a comparison bug can never suppress a real update. The proxy cover's independent source-mirror path (`_handle_source_event`) got its own parallel gate.

**Layer 2 — geometry `lru_cache`.** `SafetyMarginCalculator.calculate` and `EdgeCaseHandler.check_and_handle` now delegate to module-level `@lru_cache` functions, shared process-wide across covers and config entries. This replaces #540's never-wired `SunGeometryCache` (dead code).

**Robustness fixes (salvaged from #540).**
- `sun.sun` unavailability guard: when the entity drops out, drop elevation to -1.0 so `valid_elevation` is False and solar tracking is suppressed, instead of falling back to a valid-looking 0/0 sun that can trigger spurious cover commands.
- `sun.py` cache guards: replace three `assert` statements with explicit `RuntimeError`, since `assert` is stripped under `python -O`.

## Testing

- ✅ New tests: `tests/test_entity_write_gating.py`, `tests/test_geometry_cache.py`, `tests/test_sun_unavailable_guard.py`
- ✅ 3966 passing, full suite
- ✅ Ruff + black clean

## Related Issues

Inspired by #540. Pipeline recompute short-circuit tracked in #542; HACS `zip_release` investigation in #544.
