### PR TITLE
chore: guard HACS zip install path in release tooling

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -849,6 +849,36 @@ verify_zip_asset() {
             fi
         fi
 
+        # Verify internal ZIP structure: manifest.json must be at archive root,
+        # no folder-prefixed entries (guards against the double-nesting footgun — see #544).
+        local tmp_dir
+        tmp_dir=$(mktemp -d)
+
+        if gh release download "$tag" -p "$asset_name" -D "$tmp_dir" 2>/dev/null; then
+            local zip_listing
+            zip_listing=$(unzip -Z1 "$tmp_dir/$asset_name" 2>/dev/null)
+
+            if ! echo "$zip_listing" | grep -qx "manifest.json"; then
+                log_error "ZIP structure invalid: manifest.json not found at archive root"
+                log_error "This would cause a double-nested HACS install path (see issue #544)"
+                rm -rf "$tmp_dir"
+                exit 1
+            fi
+
+            if echo "$zip_listing" | grep -qE "^(custom_components|adaptive_cover_pro)/"; then
+                log_error "ZIP structure invalid: entries are wrapped in a folder prefix"
+                log_error "This would cause a double-nested HACS install path (see issue #544)"
+                rm -rf "$tmp_dir"
+                exit 1
+            fi
+
+            log_success "ZIP structure verified: manifest.json at archive root, no folder nesting"
+        else
+            log_warning "ZIP structure could not be verified (download failed); asset existence already confirmed"
+        fi
+
+        rm -rf "$tmp_dir"
+
         return 0
     else
         log_error "ZIP asset not found: $asset_name"


### PR DESCRIPTION
## Summary
Issue #544 asked me to verify whether `hacs.json`'s `zip_release: true` + `filename: adaptive_cover_pro.zip` produces a double-nested HACS install path (as reported in #540). I downloaded the actual published v2.26.0 release zip and confirmed it does **not**: `manifest.json` and `__init__.py` are at the archive root, exactly what HACS expects. The current config is correct and #540's removal of those keys should not be cherry-picked.

This PR does not change `hacs.json`. Instead it hardens `verify_zip_asset()` in `scripts/release` to assert the published zip's internal structure at release time — `manifest.json` at the archive root and no `custom_components/`- or `adaptive_cover_pro/`-prefixed entries — turning the latent footgun into a release-time guard. Existing existence/size checks are unchanged; a download failure during verification warns rather than aborting the release.

## Testing
- ✅ Verified the new structure assertion passes on a correctly-structured zip and fails on a folder-wrapped zip (behavioral check against synthetic zips)
- ✅ `bash -n scripts/release` clean

## Related Issues
Refs #544