### PR TITLE
feat: expose sun-state classification in diagnostics (#552)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1048,3 +1048,20 @@ class ControlMethod(StrEnum):
 
     GLARE_ZONE = "glare_zone"
     """Glare zone protection active; cover extends to shield a floor zone."""
+
+
+class SunState(StrEnum):
+    """Authoritative sun classification for the companion Lovelace card.
+
+    Matches the card's three legend states (polar-chart dot colour).
+    Values are part of the diagnostics wire format — must stay byte-stable.
+    """
+
+    OUTSIDE_FOV = "outside_fov"
+    """Sun azimuth is outside the window's field of view."""
+
+    IN_FOV_NOT_VALID = "in_fov_not_valid"
+    """Sun azimuth is inside FOV but direct-sun is blocked (elevation, sunset offset, or blind spot)."""
+
+    HITTING = "hitting"
+    """Sun is directly hitting the window (direct_sun_valid is True)."""

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from ..const import ControlStatus
-from ..const import ClimateStrategy, ControlMethod
+from ..const import ClimateStrategy, ControlMethod, SunState
 
 # ---------------------------------------------------------------------------
 # Context dataclass – the coordinator populates this before calling build()
@@ -384,19 +384,33 @@ class DiagnosticsBuilder:
     @staticmethod
     def _build_sun_validity(ctx: DiagnosticContext) -> dict:
         """Build sun validity diagnostics."""
-        diagnostics: dict = {}
-        if ctx.cover:
-            diagnostics["sun_validity"] = {
-                "valid": ctx.cover.valid,
-                "valid_elevation": ctx.cover.valid_elevation,
-                "in_blind_spot": getattr(ctx.cover, "is_sun_in_blind_spot", None),
+        if not ctx.cover:
+            return {}
+        cover = ctx.cover
+        in_fov = getattr(cover, "in_fov", None)
+        direct_sv = getattr(cover, "direct_sun_valid", None)
+        # Derive sun_state from primitives (not from control_state_reason string)
+        if direct_sv:
+            sun_state = SunState.HITTING
+        elif in_fov:
+            sun_state = SunState.IN_FOV_NOT_VALID
+        else:
+            sun_state = SunState.OUTSIDE_FOV
+        return {
+            "sun_validity": {
+                "valid": cover.valid,
+                "valid_elevation": cover.valid_elevation,
+                "in_blind_spot": getattr(cover, "is_sun_in_blind_spot", None),
                 # True when current time is within the astronomical sunset window
                 # (after sunset+offset or before sunrise+offset). When True, the
                 # solar handler is suppressed (direct_sun_valid is False) even if
                 # the sun is geometrically in front of the window.
-                "sunset_window_active": getattr(ctx.cover, "sunset_valid", None),
+                "sunset_window_active": getattr(cover, "sunset_valid", None),
+                "in_fov": in_fov,
+                "direct_sun_valid": direct_sv,
+                "sun_state": sun_state.value,
             }
-        return diagnostics
+        }
 
     @staticmethod
     def _build_climate(ctx: DiagnosticContext) -> dict:

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -160,6 +160,11 @@ class AdaptiveGeneralCover(ABC):
         """Delegate to SunGeometry.is_sun_in_blind_spot."""
         return self.solar.is_sun_in_blind_spot
 
+    @property
+    def in_fov(self) -> bool:
+        """Delegate to SunGeometry.in_fov."""
+        return self.solar.in_fov
+
     def solar_times(self) -> tuple[datetime | None, datetime | None]:
         """Delegate to the SunGeometry solar_times helper."""
         return self.solar.solar_times()

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -141,6 +141,18 @@ class SunGeometry:
         return valid
 
     @property
+    def in_fov(self) -> bool:
+        """Check if sun azimuth is within the window's field of view (elevation ignored).
+
+        Returns True when the sun's azimuth projects into the FOV regardless of
+        whether the elevation is valid. Used by the companion card to distinguish
+        "outside FOV" from "in FOV but blocked by elevation/sunset/blind-spot".
+        """
+        azi_min = self.config.fov_left
+        azi_max = self.config.fov_right
+        return bool((self.gamma < azi_min) & (self.gamma > -azi_max))
+
+    @property
     def sunset_valid(self) -> bool:
         """Check if current time is within sunset/sunrise offset period.
 

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -39,6 +39,7 @@ def _make_cover(
     direct_sun_valid: bool = True,
     sunset_valid: bool = False,
     control_state_reason: str = "Sun in FOV",
+    in_fov: bool = True,
     calc_details: dict | None = None,
 ) -> SimpleNamespace:
     """Create a minimal cover mock."""
@@ -50,6 +51,7 @@ def _make_cover(
         direct_sun_valid=direct_sun_valid,
         sunset_valid=sunset_valid,
         control_state_reason=control_state_reason,
+        in_fov=in_fov,
     )
     if calc_details is not None:
         cover._last_calc_details = calc_details
@@ -490,6 +492,46 @@ class TestSunValidityDiagnostics:
         """Sun validity absent when no cover."""
         diag, _ = builder.build(_base_ctx(cover=None))
         assert "sun_validity" not in diag
+
+    def test_sun_validity_includes_in_fov(self, builder: DiagnosticsBuilder):
+        """sun_validity includes in_fov field."""
+        diag, _ = builder.build(_base_ctx())
+        sv = diag["sun_validity"]
+        assert sv["in_fov"] is True
+
+    def test_sun_validity_includes_direct_sun_valid(self, builder: DiagnosticsBuilder):
+        """sun_validity includes direct_sun_valid field."""
+        diag, _ = builder.build(_base_ctx())
+        sv = diag["sun_validity"]
+        assert sv["direct_sun_valid"] is True
+
+    def test_sun_state_hitting_when_direct_sun_valid(self, builder: DiagnosticsBuilder):
+        """sun_state is 'hitting' when direct_sun_valid=True."""
+        cover = _make_cover(direct_sun_valid=True, in_fov=True)
+        diag, _ = builder.build(_base_ctx(cover=cover))
+        assert diag["sun_validity"]["sun_state"] == "hitting"
+
+    def test_sun_state_in_fov_not_valid_when_in_fov_but_not_direct(
+        self, builder: DiagnosticsBuilder
+    ):
+        """sun_state is 'in_fov_not_valid' when in_fov=True but direct_sun_valid=False."""
+        cover = _make_cover(direct_sun_valid=False, in_fov=True, valid=True)
+        diag, _ = builder.build(_base_ctx(cover=cover))
+        assert diag["sun_validity"]["sun_state"] == "in_fov_not_valid"
+
+    def test_sun_state_outside_fov_when_not_in_fov(self, builder: DiagnosticsBuilder):
+        """sun_state is 'outside_fov' when in_fov=False."""
+        cover = _make_cover(direct_sun_valid=False, in_fov=False, valid=False)
+        diag, _ = builder.build(_base_ctx(cover=cover))
+        assert diag["sun_validity"]["sun_state"] == "outside_fov"
+
+    def test_sun_state_hitting_takes_priority_over_in_fov(
+        self, builder: DiagnosticsBuilder
+    ):
+        """sun_state is 'hitting' (not 'in_fov_not_valid') when direct_sun_valid=True."""
+        cover = _make_cover(direct_sun_valid=True, in_fov=True)
+        diag, _ = builder.build(_base_ctx(cover=cover))
+        assert diag["sun_validity"]["sun_state"] == "hitting"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engine/test_sun_geometry.py
+++ b/tests/test_engine/test_sun_geometry.py
@@ -375,3 +375,33 @@ class TestBlindSpot:
         )
         sg = SunGeometry(160.0, 45.0, _make_sun_data(), config, _make_logger())
         assert sg.is_sun_in_blind_spot is False
+
+
+# ------------------------------------------------------------------
+# in_fov
+# ------------------------------------------------------------------
+
+
+class TestInFov:
+    """Tests for in_fov azimuth-only FOV membership."""
+
+    def test_in_fov_true_when_azimuth_in_fov_regardless_of_elevation(self):
+        """in_fov is True even when elevation is below horizon (valid_elevation=False)."""
+        # sol_elev=-5 means below horizon → valid_elevation=False, valid=False
+        # But azimuth is directly ahead (180) which is within the FOV
+        sg = SunGeometry(180.0, -5.0, _make_sun_data(), _make_config(), _make_logger())
+        assert sg.valid_elevation is False
+        assert sg.valid is False
+        assert sg.in_fov is True
+
+    def test_in_fov_false_when_azimuth_outside_fov(self):
+        """in_fov is False when azimuth is clearly outside the window FOV."""
+        # Window at 180, FOV ±45. Sun at azimuth 10 → gamma ≈ 170 → outside FOV
+        sg = SunGeometry(10.0, 45.0, _make_sun_data(), _make_config(), _make_logger())
+        assert sg.in_fov is False
+
+    def test_in_fov_true_when_valid_is_true(self):
+        """When valid=True (both azimuth and elevation pass), in_fov must also be True."""
+        sg = SunGeometry(180.0, 45.0, _make_sun_data(), _make_config(), _make_logger())
+        assert sg.valid is True
+        assert sg.in_fov is True


### PR DESCRIPTION
## Summary
The `sun_validity` diagnostics block now exposes the engine's authoritative sun classification so the companion card can stop re-deriving it client-side. Adds three fields: `in_fov` (azimuth-only FOV membership), `direct_sun_valid` (the boolean the solar handler gates on), and `sun_state` (`outside_fov` / `in_fov_not_valid` / `hitting`).

New: `SunState` StrEnum in `const.py`; an azimuth-only `in_fov` property on `SunGeometry` with a delegate on the cover base. `sun_state` is derived from the two primitives, not from `control_state_reason` (no duplication of the gate cascade).

## Testing
- ✅ 3955 tests passing (+9 new: 3 for `in_fov` geometry, 6 for the new diagnostics fields)

## Related Issues
Refs #552