### PR TITLE
feat: forecast matches runtime position calculations

### DIFF
--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -22,10 +22,8 @@ from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 from .const import (
-    CONF_DEFAULT_HEIGHT,
     CONF_MAX_COVERAGE_STEPS,
     CONF_MINIMIZE_MOVEMENTS,
-    DEFAULT_DEFAULT_HEIGHT,
     DEFAULT_MAX_COVERAGE_STEPS,
     DEFAULT_MINIMIZE_MOVEMENTS,
     EVENT_FOV_ENTER,
@@ -35,10 +33,16 @@ from .const import (
     FORECAST_STEP_MINUTES,
     SUN_DATA_STEP_SECONDS,
 )
-from .position_utils import PositionConverter
+from .helpers import compute_effective_default
+from .pipeline.helpers import (
+    default_position_with_limits,
+    solar_position_from_geometry,
+)
 
 if TYPE_CHECKING:
+    from .config_types import CoverConfig
     from .coordinator import AdaptiveDataUpdateCoordinator
+    from .cover_types.base import CoverTypePolicy
     from .engine.covers.base import AdaptiveGeneralCover
     from .sun import SunData
 
@@ -90,18 +94,26 @@ def build_forecast(
     *,
     sun_data: SunData,
     cover_factory: Callable[[float, float], AdaptiveGeneralCover],
-    default_position: int,
+    config: CoverConfig,
+    policy: CoverTypePolicy | None = None,
     now: datetime,
     step_minutes: int = FORECAST_STEP_MINUTES,
     minimize_movements: bool = False,
     max_coverage_steps: int = 1,
-    full_coverage_at_zero: bool = True,
 ) -> Forecast:
     """Compute the forecast for one cover.
 
     Walks the full local calendar day (00:00 → 24:00) using the solar position
     table already stored in *sun_data*, so the companion card's elevation chart
     and sample strip share the same time axis.
+
+    Each sample's position is computed through the **same** shared primitives
+    the live pipeline uses (``solar_position_from_geometry`` /
+    ``default_position_with_limits`` in :mod:`pipeline.helpers`), so the
+    forecast strip matches what the cover is actually commanded to — including
+    min/max position limits, the 1 % floor, movement minimization, and the
+    sunset-aware effective default. *config* and *policy* supply everything
+    those primitives need.
 
     ``cover_factory`` is a closure that builds a cover engine for an
     arbitrary (sol_azi, sol_elev) pair; the caller is responsible for
@@ -116,11 +128,11 @@ def build_forecast(
     samples = _build_samples(
         sun_data=sun_data,
         cover_factory=cover_factory,
-        default_position=default_position,
+        config=config,
+        policy=policy,
         step_minutes=step_minutes,
         minimize_movements=minimize_movements,
         max_coverage_steps=max_coverage_steps,
-        full_coverage_at_zero=full_coverage_at_zero,
     )
     events = _build_events(
         sun_data=sun_data, cover_factory=cover_factory, samples=samples
@@ -132,11 +144,11 @@ def _build_samples(
     *,
     sun_data: SunData,
     cover_factory: Callable[[float, float], AdaptiveGeneralCover],
-    default_position: int,
+    config: CoverConfig,
+    policy: CoverTypePolicy | None = None,
     step_minutes: int,
     minimize_movements: bool = False,
     max_coverage_steps: int = 1,
-    full_coverage_at_zero: bool = True,
 ) -> list[ForecastSample]:
     """Walk the sun_data table at *step_minutes* cadence over the full calendar day.
 
@@ -144,6 +156,19 @@ def _build_samples(
     ``times[-1]`` (next midnight 24:00) as the loop end, so the sample
     strip always covers the same 24-hour window as the companion card's
     elevation chart regardless of what time ``build_forecast`` is called.
+
+    Each sample routes through the same ``pipeline.helpers`` primitives the live
+    pipeline uses, so positions are identical to runtime. The effective default
+    (and whether the sunset position is active) is recomputed at *each sample's*
+    time via :func:`compute_effective_default`, mirroring the live snapshot
+    builder rather than holding a static default. Note: the forecast projects
+    solar tracking whenever the sun is in the FOV regardless of the
+    ``enable_sun_tracking`` toggle — the card's purpose is to show where the
+    cover *would* sit, so that mode gate is deliberately not applied here.
+    For the same reason the operational start/end-time window is not modeled,
+    so ``compute_effective_default`` is called without ``window_explicitly_started``
+    (defaults False) — the night position is governed purely by the
+    astronomical sunset/sunrise window at each sample time.
     """
     times = list(sun_data.times)
     azis = list(sun_data.solar_azimuth)
@@ -170,18 +195,29 @@ def _build_samples(
         # and every sample collapses to the default position (issue #516).
         cover.eval_time = t
         if cover.direct_sun_valid:
-            pos = int(cover.calculate_percentage())
-            if minimize_movements:
-                # Mirror the live solar branch so the forecast strip matches the
-                # quantized positions the cover will actually be commanded to.
-                pos = PositionConverter.quantize_to_coverage_steps(
-                    pos, max_coverage_steps, full_coverage_at_zero
-                )
+            pos = solar_position_from_geometry(
+                cover,
+                config,
+                minimize_movements=minimize_movements,
+                max_coverage_steps=max_coverage_steps,
+                policy=policy,
+            )
             samples.append(ForecastSample(t=t, position=pos, handler="solar"))
         else:
-            samples.append(
-                ForecastSample(t=t, position=int(default_position), handler="default")
+            # Sunset-aware effective default at this sample's projected time,
+            # then the same limit treatment the live default branch applies.
+            eff_default, is_sunset = compute_effective_default(
+                config.h_def,
+                config.sunset_pos,
+                sun_data,
+                config.sunset_off,
+                config.sunrise_off,
+                eval_time=t,
             )
+            pos = default_position_with_limits(
+                eff_default, config, is_sunset_active=is_sunset
+            )
+            samples.append(ForecastSample(t=t, position=pos, handler="default"))
         t += step
     return samples
 
@@ -325,15 +361,14 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
             options=options,
         )
 
-    # Coverage direction comes from the policy's primary axis (single source of
-    # truth): awning blocks the sun when open (full coverage at 100%), every
-    # other cover type at 0%.
-    full_coverage_at_zero = not coord._policy.axes[0].open_blocks_sun  # noqa: SLF001
-
+    # The coverage direction the primitives need is read from the policy's
+    # primary axis (single source of truth), so the shim passes the policy
+    # straight through rather than precomputing full_coverage_at_zero.
     return build_forecast(
         sun_data=sun_data,
         cover_factory=make_cover,
-        default_position=int(options.get(CONF_DEFAULT_HEIGHT, DEFAULT_DEFAULT_HEIGHT)),
+        config=config,
+        policy=coord._policy,  # noqa: SLF001
         now=dt_util.now(),
         minimize_movements=bool(
             options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS)
@@ -341,5 +376,4 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
         max_coverage_steps=int(
             options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)
         ),
-        full_coverage_at_zero=full_coverage_at_zero,
     )

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -218,6 +218,19 @@ def check_cover_features(hass: HomeAssistant, entity_id: str) -> dict[str, bool]
     }
 
 
+def _eval_time_to_utc_naive(eval_time: dt.datetime) -> dt.datetime:
+    """Normalize an evaluation time to naive-UTC for sunset/sunrise comparison.
+
+    Accepts either a tz-aware datetime (e.g. a sample time from
+    ``SunData.times``, which is tz-aware local) — converted to UTC — or a
+    naive-local wall-clock value, interpreted via :func:`_local_naive_to_utc_naive`.
+    Mirrors how ``compute_effective_default`` normalizes its ``now`` reference.
+    """
+    if eval_time.tzinfo is not None:
+        return dt_util.as_utc(eval_time).replace(tzinfo=None)
+    return _local_naive_to_utc_naive(eval_time)
+
+
 def _local_naive_to_utc_naive(local_naive: dt.datetime) -> dt.datetime:
     """Convert a naive-local wall-clock datetime to a naive-UTC datetime.
 
@@ -244,6 +257,7 @@ def compute_effective_default(
     sunset_time: dt.datetime | None = None,
     sunrise_time: dt.datetime | None = None,
     window_explicitly_started: bool = False,
+    eval_time: dt.datetime | None = None,
 ) -> tuple[int, bool]:
     """Return the effective default cover position based on astronomical sunset/sunrise.
 
@@ -280,6 +294,11 @@ def compute_effective_default(
             maps to ``False`` here even though the active-window check treats blank
             as "no start restriction". Defaults to ``False`` for call sites without
             start_time context.
+        eval_time: Optional time at which to evaluate the sunset/sunrise window.
+            When provided (tz-aware or naive-local), it replaces wall-clock now —
+            this lets the forecast project the effective default at each future
+            sample time instead of "now". ``None`` (default) preserves the live
+            behavior of evaluating against the current moment.
 
     Returns:
         A ``(effective_default, is_sunset_active)`` tuple where
@@ -299,7 +318,11 @@ def compute_effective_default(
         if sunrise_time is not None
         else sun_data.sunrise().replace(tzinfo=None)
     )
-    now_naive = dt.datetime.now(UTC).replace(tzinfo=None)
+    now_naive = (
+        _eval_time_to_utc_naive(eval_time)
+        if eval_time is not None
+        else dt.datetime.now(UTC).replace(tzinfo=None)
+    )
 
     after_sunset = now_naive > (sunset + timedelta(minutes=sunset_off))
     before_sunrise = now_naive < (sunrise + timedelta(minutes=sunrise_off))

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -14,8 +14,48 @@ registry — see issue #463.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ..position_utils import PositionConverter
 from .types import PipelineSnapshot
+
+if TYPE_CHECKING:
+    from ..config_types import CoverConfig
+    from ..cover_types.base import CoverTypePolicy
+    from ..engine.covers.base import AdaptiveGeneralCover
+
+
+def apply_config_limits(
+    value: int,
+    config: CoverConfig,
+    *,
+    sun_valid: bool,
+) -> int:
+    """Apply the configured min/max position limits from a bare ``CoverConfig``.
+
+    The single point where the five limit fields are unpacked into
+    ``PositionConverter.apply_limits()``. Snapshot-free so both the live
+    pipeline (via :func:`apply_snapshot_limits`) and the forecast (which has no
+    snapshot) share the exact same clamping.
+
+    Args:
+        value:     Raw position (0–100) to constrain.
+        config:    Cover configuration providing the limit fields.
+        sun_valid: Whether the sun is currently in the valid tracking zone.
+
+    Returns:
+        Constrained position value (0–100).
+
+    """
+    return PositionConverter.apply_limits(
+        value,
+        config.min_pos,
+        config.max_pos,
+        config.min_pos_sun_only,
+        config.max_pos_sun_only,
+        sun_valid,
+        sun_tracking_min_pos=config.min_pos_sun_tracking,
+    )
 
 
 def apply_snapshot_limits(
@@ -26,8 +66,7 @@ def apply_snapshot_limits(
 ) -> int:
     """Apply the configured min/max position limits from *snapshot*.
 
-    Replaces the 6-argument ``PositionConverter.apply_limits()`` call that was
-    copy-pasted into every handler.
+    Thin adapter over :func:`apply_config_limits` using the snapshot's config.
 
     Args:
         snapshot: Current pipeline snapshot (provides config limits).
@@ -38,26 +77,48 @@ def apply_snapshot_limits(
         Constrained position value (0–100).
 
     """
-    return PositionConverter.apply_limits(
-        value,
-        snapshot.config.min_pos,
-        snapshot.config.max_pos,
-        snapshot.config.min_pos_sun_only,
-        snapshot.config.max_pos_sun_only,
-        sun_valid,
-        sun_tracking_min_pos=snapshot.config.min_pos_sun_tracking,
-    )
+    return apply_config_limits(value, snapshot.config, sun_valid=sun_valid)
+
+
+def solar_position_from_geometry(
+    cover: AdaptiveGeneralCover,
+    config: CoverConfig,
+    *,
+    minimize_movements: bool,
+    max_coverage_steps: int,
+    policy: CoverTypePolicy | None,
+) -> int:
+    """Sun-tracked position from raw geometry, with all standard transforms.
+
+    Snapshot-free single source of truth for the solar branch, shared by the
+    live pipeline (:func:`compute_solar_position`) and the forecast:
+
+    1. Calls ``cover.calculate_percentage()`` (pure geometry), rounded.
+    2. Optionally quantizes into the configured number of discrete coverage
+       levels (movement minimization — opt-in, rounds toward coverage).
+    3. Floors at 1 % so open/close-only covers never close while the sun is
+       still in the field of view.
+    4. Applies the configured min/max position limits (``sun_valid=True``).
+
+    Should only be called when ``cover.direct_sun_valid`` is True.
+
+    Returns:
+        Sun-tracked position (1–100 after floor, then limited).
+
+    """
+    state = int(round(cover.calculate_percentage()))
+    if minimize_movements and policy is not None:
+        state = PositionConverter.quantize_to_coverage_steps(
+            state,
+            max_coverage_steps,
+            full_coverage_at_zero=not policy.axes[0].open_blocks_sun,
+        )
+    state = max(state, 1)
+    return apply_config_limits(state, config, sun_valid=True)
 
 
 def compute_solar_position(snapshot: PipelineSnapshot) -> int:
-    """Return the sun-tracked position with all standard transforms applied.
-
-    1. Calls ``cover.calculate_percentage()`` (pure geometry).
-    2. Optionally quantizes the result into the configured number of discrete
-       coverage levels (movement minimization — opt-in, rounds toward coverage).
-    3. Floors the result at 1 % so open/close-only covers never close while
-       the sun is still in the field of view.
-    4. Applies the configured min/max position limits.
+    """Sun-tracked position for the live pipeline — adapter over the primitive.
 
     Should only be called when ``snapshot.cover.direct_sun_valid`` is True.
 
@@ -68,16 +129,13 @@ def compute_solar_position(snapshot: PipelineSnapshot) -> int:
         Sun-tracked position (1–100 after floor, then limited).
 
     """
-    state = int(round(snapshot.cover.calculate_percentage()))
-    policy = getattr(snapshot, "policy", None)
-    if getattr(snapshot, "minimize_movements", False) and policy is not None:
-        state = PositionConverter.quantize_to_coverage_steps(
-            state,
-            getattr(snapshot, "max_coverage_steps", 1),
-            full_coverage_at_zero=not policy.axes[0].open_blocks_sun,
-        )
-    state = max(state, 1)
-    return apply_snapshot_limits(snapshot, state, sun_valid=True)
+    return solar_position_from_geometry(
+        snapshot.cover,
+        snapshot.config,
+        minimize_movements=getattr(snapshot, "minimize_movements", False),
+        max_coverage_steps=getattr(snapshot, "max_coverage_steps", 1),
+        policy=getattr(snapshot, "policy", None),
+    )
 
 
 def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
@@ -108,16 +166,36 @@ def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
     )
 
 
+def default_position_with_limits(
+    default_pos: int,
+    config: CoverConfig,
+    *,
+    is_sunset_active: bool,
+) -> int:
+    """Effective default position with limits applied — snapshot-free primitive.
+
+    Applies the configured min/max limits with ``sun_valid=False`` so sun-only
+    limits are not enforced when the sun is outside the FOV. When
+    *is_sunset_active* is True the limits are bypassed entirely — the sunset
+    position is an explicit user configuration for nighttime and should not be
+    clamped by min/max safety limits (#128).
+
+    Shared by the live pipeline (:func:`compute_default_position`) and the
+    forecast.
+
+    Returns:
+        Effective default position (0–100, limited).
+
+    """
+    if is_sunset_active:
+        return default_pos
+    return apply_config_limits(default_pos, config, sun_valid=False)
+
+
 def compute_default_position(snapshot: PipelineSnapshot) -> int:
-    """Return the effective default position with limits applied.
+    """Effective default position for the live pipeline — adapter over primitive.
 
-    Uses ``snapshot.default_position`` (the sunset-aware single source of truth)
-    and applies configured min/max position limits with ``sun_valid=False`` so
-    sun-only limits are not enforced when the sun is outside the FOV.
-
-    When ``snapshot.is_sunset_active`` is True, limits are bypassed entirely —
-    the sunset position is an explicit user configuration for nighttime and
-    should not be clamped by min/max safety limits (#128).
+    Uses ``snapshot.default_position`` (the sunset-aware single source of truth).
 
     Args:
         snapshot: Current pipeline snapshot.
@@ -126,10 +204,8 @@ def compute_default_position(snapshot: PipelineSnapshot) -> int:
         Effective default position (0–100, limited).
 
     """
-    if snapshot.is_sunset_active:
-        return snapshot.default_position
-    return apply_snapshot_limits(
-        snapshot,
+    return default_position_with_limits(
         snapshot.default_position,
-        sun_valid=False,
+        snapshot.config,
+        is_sunset_active=snapshot.is_sunset_active,
     )

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -898,3 +898,87 @@ class TestEntityOverrideTimezone:
             f"got active={active}"
         )
         assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# eval_time override (forecast parity)
+#
+# The forecast projects the effective default at each future sample time by
+# passing eval_time, instead of evaluating against wall-clock now.
+# ---------------------------------------------------------------------------
+
+
+class TestEvalTime:
+    """eval_time replaces wall-clock now when provided; None preserves it."""
+
+    def test_aware_eval_time_in_sunset_window_activates(self):
+        """A tz-aware eval_time past sunset → sunset position active."""
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=6)
+        today = dt.date.today()
+        # Build eval_t BEFORE _freeze_now: that patcher replaces the global
+        # datetime class, so constructing a datetime inside the block yields a
+        # MagicMock. Wall-clock now is frozen to midday to prove eval_time wins.
+        eval_t = dt.datetime(today.year, today.month, today.day, 22, 0, 0, tzinfo=UTC)
+        with _freeze_now(dt.datetime(today.year, today.month, today.day, 12, 0, 0)):
+            result, active = compute_effective_default(
+                h_def=80,
+                sunset_pos=20,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                eval_time=eval_t,
+            )
+        assert active is True
+        assert result == 20
+
+    def test_aware_eval_time_at_midday_is_daytime_even_when_now_is_night(self):
+        """eval_time overrides a post-sunset wall clock → daytime h_def."""
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=6)
+        today = dt.date.today()
+        # eval_t built before the patcher (see note above); now is frozen to
+        # deep night, which would otherwise be sunset-active.
+        eval_t = dt.datetime(today.year, today.month, today.day, 12, 0, 0, tzinfo=UTC)
+        with _freeze_now(dt.datetime(today.year, today.month, today.day, 23, 0, 0)):
+            result, active = compute_effective_default(
+                h_def=80,
+                sunset_pos=20,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                eval_time=eval_t,
+            )
+        assert active is False
+        assert result == 80
+
+    def test_naive_eval_time_interpreted_as_local(self):
+        """A naive eval_time is read as local wall-clock (UTC zone here)."""
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=6)
+        today = dt.date.today()
+        naive_night = dt.datetime(today.year, today.month, today.day, 22, 0, 0)
+        with patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", UTC):
+            result, active = compute_effective_default(
+                h_def=80,
+                sunset_pos=20,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                eval_time=naive_night,
+            )
+        assert active is True
+        assert result == 20
+
+    def test_eval_time_none_falls_back_to_now(self):
+        """eval_time=None preserves the wall-clock behaviour (no regression)."""
+        sun = _make_sun_data(sunset_hour=20, sunrise_hour=6)
+        today = dt.date.today()
+        with _freeze_now(dt.datetime(today.year, today.month, today.day, 22, 0, 0)):
+            result, active = compute_effective_default(
+                h_def=80,
+                sunset_pos=20,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                eval_time=None,
+            )
+        assert active is True
+        assert result == 20

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -80,6 +80,32 @@ def _make_cover_factory(*, solar_valid: bool, percentage: int = 40):
     return factory
 
 
+def _make_config(**overrides):
+    """Build a minimal CoverConfig, overriding individual fields by name.
+
+    Starts from ``CoverConfig.from_options({})`` (all sane defaults:
+    ``min_pos=0``, ``max_pos=100``, ``sunset_pos=None``, etc.) so tests only
+    name the fields they care about — e.g. ``_make_config(h_def=10)`` or
+    ``_make_config(min_pos=30, min_pos_sun_tracking=40)``.
+    """
+    import dataclasses
+
+    from custom_components.adaptive_cover_pro.config_types import CoverConfig
+
+    return dataclasses.replace(CoverConfig.from_options({}), **overrides)
+
+
+def _make_policy(*, open_blocks_sun: bool = False):
+    """Stub CoverTypePolicy exposing the single axis attribute the solar
+    primitive reads for coverage direction (``full_coverage_at_zero``).
+    """
+    policy = MagicMock()
+    axis = MagicMock()
+    axis.open_blocks_sun = open_blocks_sun
+    policy.axes = [axis]
+    return policy
+
+
 # ---------------------------------------------------------------------------
 # Sample series shape
 # ---------------------------------------------------------------------------
@@ -93,7 +119,7 @@ class TestBuildForecastSamples:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=10,
+            config=_make_config(h_def=10),
             now=_NOW,
         )
         # Full calendar day (00:00 → 24:00) at 15-minute steps inclusive = 24 * 60 / 15 + 1 = 97.
@@ -107,24 +133,41 @@ class TestBuildForecastSamples:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=True, percentage=55),
-            default_position=10,
+            config=_make_config(h_def=10),
             now=_NOW,
         )
         assert all(s.position == 55 and s.handler == "solar" for s in f.samples)
 
     def test_minimize_movements_quantizes_solar_samples(self):
-        """N=1 blind snaps every in-FOV solar sample to full coverage (0%)."""
+        """N=2 steps snap a 55% solar sample to the 50% coverage level.
+
+        Matches the live solar branch exactly (quantize → floor-at-1 → limits),
+        with coverage direction taken from the policy's primary axis.
+        """
         sd = _make_sun_data()
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=True, percentage=55),
-            default_position=10,
+            config=_make_config(h_def=10),
+            policy=_make_policy(open_blocks_sun=False),  # full_coverage_at_zero
+            now=_NOW,
+            minimize_movements=True,
+            max_coverage_steps=2,
+        )
+        assert all(s.position == 50 and s.handler == "solar" for s in f.samples)
+
+    def test_minimize_movements_without_policy_is_noop(self):
+        """No policy → no quantization (matches the live `policy is None` guard)."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=True, percentage=55),
+            config=_make_config(h_def=10),
             now=_NOW,
             minimize_movements=True,
             max_coverage_steps=1,
-            full_coverage_at_zero=True,
         )
-        assert all(s.position == 0 and s.handler == "solar" for s in f.samples)
+        assert all(s.position == 55 and s.handler == "solar" for s in f.samples)
 
     def test_minimize_movements_does_not_touch_default_samples(self):
         """Default (non-solar) samples are never quantized."""
@@ -132,7 +175,8 @@ class TestBuildForecastSamples:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=10,
+            config=_make_config(h_def=10),
+            policy=_make_policy(open_blocks_sun=False),
             now=_NOW,
             minimize_movements=True,
             max_coverage_steps=1,
@@ -144,7 +188,7 @@ class TestBuildForecastSamples:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
             step_minutes=30,
         )
@@ -157,7 +201,7 @@ class TestBuildForecastSamples:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         assert len(f.samples) > 0, "forecast produced no samples"
@@ -179,7 +223,7 @@ class TestBuildForecastSamples:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         assert f.samples == ()
@@ -215,7 +259,7 @@ class TestForecastEvaluatesPerSampleTime:
         f = build_forecast(
             sun_data=sd,
             cover_factory=lambda _azi, _ele: _EvalTimeCover(),
-            default_position=100,
+            config=_make_config(h_def=100),
             now=datetime(2026, 6, 1, 23, 0, tzinfo=UTC),  # built late in the day
         )
         # The curve is NOT flat: midday samples track the sun...
@@ -238,7 +282,7 @@ class TestForecastEvaluatesPerSampleTime:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         sunrise_events = [e for e in f.events if e.kind == EVENT_SUNRISE]
@@ -262,7 +306,7 @@ class TestBuildForecastEvents:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         kinds = [e.kind for e in f.events]
@@ -274,7 +318,7 @@ class TestBuildForecastEvents:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         assert EVENT_SUNRISE not in [e.kind for e in f.events]
@@ -316,7 +360,7 @@ class TestBuildForecastEvents:
         f = build_forecast(
             sun_data=sd,
             cover_factory=toggling_factory,
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         kinds = [e.kind for e in f.events]
@@ -350,7 +394,7 @@ class TestBuildForecastEvents:
             return cover
 
         f = build_forecast(
-            sun_data=sd, cover_factory=factory, default_position=0, now=_NOW
+            sun_data=sd, cover_factory=factory, config=_make_config(), now=_NOW
         )
 
         enter_events = [e for e in f.events if e.kind == EVENT_FOV_ENTER]
@@ -367,7 +411,7 @@ class TestBuildForecastEvents:
         f = build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=0,
+            config=_make_config(),
             now=_NOW,
         )
         times = [e.t for e in f.events]
@@ -410,15 +454,200 @@ class TestForecastToAttrs:
 
 @pytest.mark.parametrize("default", [0, 50, 100])
 def test_default_position_round_trips_through_samples(default: int):
-    """Whatever default_position we pass appears verbatim in non-solar samples."""
+    """The configured default height appears verbatim in non-solar samples.
+
+    With no min/max limits configured and no sunset position, the default
+    branch passes the effective default through unchanged.
+    """
     sd = _make_sun_data()
     f = build_forecast(
         sun_data=sd,
         cover_factory=_make_cover_factory(solar_valid=False),
-        default_position=default,
+        config=_make_config(h_def=default),
         now=_NOW,
     )
     assert {s.position for s in f.samples} == {default}
+
+
+# ---------------------------------------------------------------------------
+# Runtime parity: limits, floor-at-1, rounding, sunset — the forecast must
+# match what the live pipeline commands, because it routes every sample
+# through the same pipeline.helpers primitives.
+# ---------------------------------------------------------------------------
+
+
+def _solar_cover_factory(percentage):
+    """Cover factory: direct sun valid, calculate_percentage() → *percentage*."""
+
+    def factory(_azi, _ele):
+        cover = MagicMock()
+        cover.direct_sun_valid = True
+        cover.calculate_percentage = MagicMock(return_value=percentage)
+        return cover
+
+    return factory
+
+
+class TestForecastLimits:
+    """min/max position settings flow into the forecast (the reported gap)."""
+
+    def test_min_position_floors_solar_samples(self):
+        """min_position=30 with a 10% geometry → solar samples floored to 30."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(10),
+            config=_make_config(min_pos=30),
+            now=_NOW,
+        )
+        assert all(s.handler == "solar" and s.position == 30 for s in f.samples)
+
+    def test_max_position_caps_solar_samples(self):
+        """max_position=70 with a 90% geometry → solar samples capped at 70."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(90),
+            config=_make_config(max_pos=70),
+            now=_NOW,
+        )
+        assert all(s.handler == "solar" and s.position == 70 for s in f.samples)
+
+    def test_sun_only_min_not_applied_to_default_samples(self):
+        """enable_min_position (sun-only) → floor skipped when sun is out of FOV."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            config=_make_config(h_def=5, min_pos=30, min_pos_sun_only=True),
+            now=_NOW,
+        )
+        # Sun-only floor must NOT raise the default to 30 — it stays 5.
+        assert all(s.handler == "default" and s.position == 5 for s in f.samples)
+
+    def test_always_enforced_min_applied_to_default_samples(self):
+        """Always-enforce min (sun_only=False) raises default samples to the floor."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            config=_make_config(h_def=5, min_pos=30, min_pos_sun_only=False),
+            now=_NOW,
+        )
+        assert all(s.position == 30 for s in f.samples)
+
+    def test_sun_tracking_floor_overrides_min_on_solar_samples(self):
+        """min_position_sun_tracking overrides min_position while sun-tracking."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(10),
+            config=_make_config(min_pos=20, min_pos_sun_tracking=40),
+            now=_NOW,
+        )
+        assert all(s.position == 40 for s in f.samples)
+
+
+class TestForecastFloorAndRound:
+    """Solar samples are floored at 1% and rounded, matching the live branch."""
+
+    def test_solar_floored_at_one_percent(self):
+        """A 0% geometry never closes an open/close blind — floors to 1."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(0),
+            config=_make_config(),
+            now=_NOW,
+        )
+        assert all(s.handler == "solar" and s.position == 1 for s in f.samples)
+
+    def test_solar_percentage_is_rounded_not_truncated(self):
+        """54.6% rounds to 55 (the live branch rounds; the old forecast truncated)."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(54.6),
+            config=_make_config(),
+            now=_NOW,
+        )
+        assert all(s.position == 55 for s in f.samples)
+
+
+class TestForecastSunsetParity:
+    """Default samples use the sunset position inside the sunset window."""
+
+    def test_sunset_position_used_and_not_clamped_in_window(self):
+        sunrise = _DAY_START + timedelta(hours=6)
+        sunset = _DAY_START + timedelta(hours=20)
+        sd = _make_sun_data(sunrise=sunrise, sunset=sunset)
+        # sunset_pos=20 sits BELOW an always-enforced min_pos=30: the sunset
+        # window must bypass the clamp (#128), while daytime defaults still clamp.
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            config=_make_config(
+                h_def=80, sunset_pos=20, min_pos=30, min_pos_sun_only=False
+            ),
+            now=_NOW,
+        )
+        pos_at = {s.t: s.position for s in f.samples}
+        # Deep night (before sunrise / after sunset): sunset position, unclamped.
+        assert pos_at[_DAY_START + timedelta(hours=2)] == 20
+        assert pos_at[_DAY_START + timedelta(hours=22)] == 20
+        # Midday (outside the sunset window): daytime default, clamped to min.
+        assert pos_at[_DAY_START + timedelta(hours=12)] == 80
+        assert {s.position for s in f.samples} == {20, 80}
+
+
+class TestForecastMatchesLivePipeline:
+    """Anti-drift lock: forecast samples == the live snapshot-based helpers."""
+
+    def test_solar_sample_equals_compute_solar_position(self):
+        from custom_components.adaptive_cover_pro.pipeline.helpers import (
+            compute_solar_position,
+        )
+
+        from tests.conftest import make_snapshot_for_cover
+
+        config = _make_config(min_pos=30, max_pos=90)
+        # Live snapshot over an equivalent cover at the same geometry/config.
+        live_cover = MagicMock()
+        live_cover.config = config
+        live_cover.calculate_percentage = MagicMock(return_value=10)
+        snapshot = make_snapshot_for_cover(live_cover)
+        live = compute_solar_position(snapshot)
+
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(10),
+            config=config,
+            now=_NOW,
+        )
+        assert all(s.position == live for s in f.samples)
+
+    def test_default_sample_equals_compute_default_position(self):
+        from custom_components.adaptive_cover_pro.pipeline.helpers import (
+            compute_default_position,
+        )
+
+        from tests.conftest import make_snapshot_for_cover
+
+        config = _make_config(h_def=5, min_pos=30, min_pos_sun_only=False)
+        live_cover = MagicMock()
+        live_cover.config = config
+        snapshot = make_snapshot_for_cover(live_cover, default_position=5)
+        live = compute_default_position(snapshot)
+
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            config=config,
+            now=_NOW,
+        )
+        assert all(s.position == live for s in f.samples)
 
 
 # ---------------------------------------------------------------------------
@@ -783,7 +1012,7 @@ def test_build_forecast_with_real_sun_data_caches_timeline():
         build_forecast(
             sun_data=sd,
             cover_factory=_make_cover_factory(solar_valid=False),
-            default_position=10,
+            config=_make_config(h_def=10),
             now=_NOW,
         )
     assert (


### PR DESCRIPTION
## Summary
The **Position Forecast** sensor re-implemented a subset of the live position math, so it silently diverged from what the cover is actually commanded to. Reported symptom: the forecast ignored the **Min Position** settings. Root cause was broader — three divergences:

1. **Min/max limits** never applied (the reported bug) — dropped Min Position, *Apply min only during sun tracking* (`enable_min_position`), *Min Position During Sun Tracking* (`min_position_sun_tracking`), and both max-position settings.
2. **Floor-at-1 / rounding** — runtime floors solar at 1% and rounds; the forecast truncated and never floored.
3. **Sunset / effective-default** — runtime swaps in `sunset_position` during the sunset window; the forecast used the raw default height.

Fixed by making the forecast call the **same code** as the live pipeline rather than re-implementing it:

- Extracted the position math from the snapshot-coupled `pipeline/helpers.py` into snapshot-free primitives: `solar_position_from_geometry`, `default_position_with_limits`, `apply_config_limits`. The live helpers (`compute_solar_position` / `compute_default_position` / `apply_snapshot_limits`) are now thin adapters over them — behavior-preserving.
- `forecast.py` `_build_samples` calls those primitives and recomputes the sunset-aware effective default at each sample's projected time.
- `compute_effective_default` gained an `eval_time` kwarg (default `None` = wall-clock now, so the live snapshot builder is untouched).

Two boundaries kept by design (documented in `_build_samples`): the forecast still projects solar tracking regardless of `enable_sun_tracking`, and ignores the operational start/end-time window — both are "where would the cover sit" product intent, not calc mismatches.

## Testing
- ✅ 4214 tests passing (full suite), lint clean
- New: `TestForecastLimits`, `TestForecastFloorAndRound`, `TestForecastSunsetParity`, `TestEvalTime`
- New anti-drift lock: `TestForecastMatchesLivePipeline` asserts forecast samples equal `compute_solar_position` / `compute_default_position` for the same geometry/config — fails loudly if the two paths ever diverge again

## Related Issues
Surfaces all min-position settings (and max/floor/sunset) in the forecast strip.