### PR TITLE
fix: low-sun edge case returns 0 (closed) not h_win (open) (#559)

### DIFF
--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -65,13 +65,13 @@ def _edge_case(
 
     Companion to :func:`_safety_margin`; see it for the caching rationale.
     """
-    # Very low elevation: sun nearly horizontal, full coverage safest
+    # Very low elevation: sun nearly horizontal, full coverage safest (position 0 = closed)
     if sol_elev < EDGE_CASE_LOW_ELEVATION:
-        return (True, h_win)
+        return (True, 0.0)
 
-    # Extreme gamma: sun perpendicular to window, full coverage
+    # Extreme gamma: sun perpendicular to window, full coverage (position 0 = closed)
     if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
-        return (True, h_win)
+        return (True, 0.0)
 
     # Very high elevation: sun nearly overhead, use simplified calculation
     if sol_elev > EDGE_CASE_HIGH_ELEVATION:

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -178,13 +178,13 @@ class TestEdgeCases:
     """Test edge case handling for extreme angles."""
 
     def test_edge_case_very_low_elevation(self, base_cover_params):
-        """Very low elevation should return full window coverage."""
+        """Very low elevation should fully cover (position 0 = closed)."""
         cover = make_cover_with_angles(base_cover_params, gamma=0.0, sol_elev=1.0)
 
         is_edge_case, position = cover._handle_edge_cases()
 
         assert is_edge_case is True
-        assert position == cover.h_win
+        assert position == 0.0
 
     def test_edge_case_elevation_threshold(self, base_cover_params):
         """Edge case should trigger below 2° elevation."""
@@ -199,13 +199,13 @@ class TestEdgeCases:
         assert is_edge_case is False
 
     def test_edge_case_extreme_gamma(self, base_cover_params):
-        """Extreme gamma should return full window coverage."""
+        """Extreme gamma should fully cover (position 0 = closed)."""
         cover = make_cover_with_angles(base_cover_params, gamma=86.0, sol_elev=45.0)
 
         is_edge_case, position = cover._handle_edge_cases()
 
         assert is_edge_case is True
-        assert position == cover.h_win
+        assert position == 0.0
 
     def test_edge_case_gamma_threshold(self, base_cover_params):
         """Edge case should trigger above 85° gamma."""
@@ -220,13 +220,13 @@ class TestEdgeCases:
         assert is_edge_case is False
 
     def test_edge_case_negative_gamma(self, base_cover_params):
-        """Edge case should handle negative gamma correctly."""
+        """Edge case should handle negative gamma correctly — position 0 = fully closed."""
         cover = make_cover_with_angles(base_cover_params, gamma=-86.0, sol_elev=45.0)
 
         is_edge_case, position = cover._handle_edge_cases()
 
         assert is_edge_case is True
-        assert position == cover.h_win
+        assert position == 0.0
 
     def test_edge_case_very_high_elevation(self, base_cover_params):
         """Very high elevation should use simplified calculation."""
@@ -272,20 +272,26 @@ class TestEdgeCases:
             is_edge_case is False
         ), f"False edge case at gamma={gamma}, elev={sol_elev}"
 
+    def test_low_elevation_calc_percentage_is_fully_closed(self, base_cover_params):
+        """Sub-2° sun must drive the blind CLOSED (≈0%), not open (100%) — issue #559."""
+        cover = make_cover_with_angles(base_cover_params, gamma=24.6, sol_elev=0.6)
+        pct = cover.calculate_percentage()
+        assert pct <= 1, f"low-sun edge case should be ≈0% (closed), got {pct}%"
+
 
 class TestEnhancedCalculatePosition:
     """Test the enhanced calculate_position method."""
 
     def test_calculate_position_uses_edge_case_handling(self, base_cover_params):
-        """calculate_position should use edge case handling."""
+        """calculate_position should use edge case handling — position 0 = fully closed."""
         cover = make_cover_with_angles(
             base_cover_params, gamma=0.0, sol_elev=1.5
         )  # Triggers edge case
 
         position = cover.calculate_position()
 
-        # Should return full coverage
-        assert position == cover.h_win
+        # Should return full coverage (position 0 = closed)
+        assert position == 0.0
 
     def test_calculate_position_applies_safety_margin(self, base_cover_params):
         """calculate_position should apply safety margins at extreme angles."""

--- a/tests/test_geometry_cache.py
+++ b/tests/test_geometry_cache.py
@@ -70,12 +70,12 @@ def test_safety_margin_distinct_keys_distinct_results():
 
 @pytest.mark.unit
 def test_edge_case_low_elevation():
-    assert EdgeCaseHandler.check_and_handle(1.0, 0.0, 2.0, 10.0) == (True, 10.0)
+    assert EdgeCaseHandler.check_and_handle(1.0, 0.0, 2.0, 10.0) == (True, 0.0)
 
 
 @pytest.mark.unit
 def test_edge_case_extreme_gamma():
-    assert EdgeCaseHandler.check_and_handle(45.0, 90.0, 2.0, 10.0) == (True, 10.0)
+    assert EdgeCaseHandler.check_and_handle(45.0, 90.0, 2.0, 10.0) == (True, 0.0)
 
 
 @pytest.mark.unit

--- a/tests/test_sill_height.py
+++ b/tests/test_sill_height.py
@@ -385,7 +385,7 @@ class TestEdgeCasesAtThreshold:
     def test_elevation_below_threshold_edge_case_overrides_sill(
         self, base_cover_params
     ):
-        """At sol_elev < 2° (edge case), result is h_win regardless of sill_height."""
+        """At sol_elev < 2° (edge case), result is 0.0 (closed) regardless of sill_height."""
         # Edge case handler runs BEFORE sill_height calculation, so sill_height is irrelevant
         cover_no_sill = make_vertical_cover(base_cover_params, gamma=0.0, sol_elev=1.0)
         cover_with_sill = make_vertical_cover(
@@ -395,9 +395,9 @@ class TestEdgeCasesAtThreshold:
         pos_no_sill = cover_no_sill.calculate_position()
         pos_with_sill = cover_with_sill.calculate_position()
 
-        # Both should return h_win (edge case handler fires first)
-        assert pos_no_sill == cover_no_sill.h_win
-        assert pos_with_sill == cover_with_sill.h_win
+        # Both should return 0.0 (fully closed — edge case handler fires first, position 0 = closed)
+        assert pos_no_sill == 0.0
+        assert pos_with_sill == 0.0
 
     def test_elevation_below_threshold_different_sill_heights_same_result(
         self, base_cover_params


### PR DESCRIPTION
## Summary
The vertical-blind low-sun edge case in `geometry.py` `_edge_case()` returned `h_win` (full window height), which the height→percentage conversion maps to 100% = fully OPEN — the geometric inverse of the documented "full coverage" intent. Below 2° elevation (or |gamma| > 85°) the blind flew fully open instead of closing to block the low sun. Fixed both low-sun branches to return `0.0` (0% = fully closed/covered); the high-elevation branch is unchanged. Same inversion class as #304/#358 on the sibling sill path.

## Testing
- ✅ 4243 tests passing
- Added a percentage-level regression pinning sub-2° sun → ≈0% (closed) at the reporter's exact angles, plus flipped the stale bug-encoding assertions across the geometry test suite.

## Related Issues
Refs #559