### PR TITLE
feat: FOV-mode selector — derive FOV from reveal depth (#565)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -77,6 +77,7 @@ from .const import (
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_FOV_LEFT,
+    CONF_FOV_MODE,
     CONF_FOV_RIGHT,
     CONF_HEIGHT_WIN,
     CONF_INTERP,
@@ -436,6 +437,20 @@ _SUN_TRACKING_SPECS = _spec(
         default=DEFAULT_WINDOW_AZIMUTH,
         required=True,
         make_selector=_number(minimum=0, maximum=359, unit="°"),
+    ),
+    # FOV-mode selector (#565). Vertical-blind only — BlindPolicy advertises it
+    # as a sun-tracking extra; awning/tilt never render it. Declared here so it
+    # carries SELECT validation metadata and a single-sourced default.
+    FieldSpec(
+        CONF_FOV_MODE,
+        SECTION_SUN_TRACKING,
+        ValidatorKind.SELECT,
+        default=const.FovMode.ANGLES.value,
+        select_options=tuple(m.value for m in const.FovMode),
+        make_selector=_select(
+            *[m.value for m in const.FovMode],
+            translation_key="fov_mode",
+        ),
     ),
     FieldSpec(
         CONF_FOV_LEFT,

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -53,6 +53,7 @@ from .const import (
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_FOV_LEFT,
+    CONF_FOV_MODE,
     CONF_FOV_RIGHT,
     CONF_HEIGHT_WIN,
     CONF_INTERP,
@@ -145,7 +146,9 @@ from .const import (
     MODE2_OPEN_HORIZONTAL_PERCENT,
     DOMAIN,
     CoverType,
+    FovMode,
 )
+from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2064,19 +2067,98 @@ def _geometry_unit_keys(
     return (policy.geometry_length_keys(), policy.geometry_slat_keys())
 
 
-def _get_sun_tracking_schema(
-    sensor_type: str | None, hass: HomeAssistant | None = None
-) -> vol.Schema:
-    """Return sun tracking schema, adding glare-zones toggle for cover types that support it."""
-    base = sun_tracking_schema(hass) if hass is not None else SUN_TRACKING_SCHEMA
-    if sensor_type in POLICY_REGISTRY and get_policy(sensor_type).supports_glare_zones:
-        return base.extend(
-            {
-                vol.Optional(
-                    CONF_ENABLE_GLARE_ZONES, default=False
-                ): selector.BooleanSelector(),
-            }
+def _fov_mode_supported(sensor_type: str | None) -> bool:
+    """Whether *sensor_type*'s policy exposes the two-mode FOV selector (#565)."""
+    return sensor_type in POLICY_REGISTRY and get_policy(sensor_type).supports_fov_mode
+
+
+_SUN_TRACKING_WIKI = (
+    "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Sun-Tracking"
+)
+
+
+def _sun_tracking_placeholders(
+    sensor_type: str | None,
+    mode: str | None,
+    source_config: dict[str, Any],
+) -> dict[str, str]:
+    """Build description placeholders for the sun-tracking form.
+
+    Always includes ``learn_more``; in Measurements mode (#565) it adds a
+    read-only ``computed_fov`` line so the user sees the derived FOV.
+    """
+    # ``computed_fov`` is referenced unconditionally in the step description
+    # template, so it must always be present — empty string outside Measurements
+    # mode (HA raises if a referenced placeholder is missing).
+    computed = ""
+    if _fov_mode_supported(sensor_type) and str(mode) == FovMode.MEASUREMENTS:
+        computed = computed_fov_line(
+            source_config.get(CONF_WINDOW_WIDTH),
+            source_config.get(CONF_WINDOW_DEPTH),
         )
+    return {"learn_more": _SUN_TRACKING_WIKI, "computed_fov": computed}
+
+
+def _resolve_fov_mode_submit(
+    sensor_type: str | None,
+    prior_mode: str | None,
+    user_input: dict[str, Any],
+    source_config: dict[str, Any],
+) -> str | None:
+    """Process a sun-tracking submit for the FOV-mode selector (#565).
+
+    Single home for the FOV-mode save logic shared by the create-flow and
+    options-flow ``async_step_sun_tracking`` handlers (no-duplication
+    guideline). Returns the mode to **re-render** the form in (when the user
+    switched modes — HA can't hide fields mid-render), or ``None`` to proceed.
+
+    When proceeding in ``MEASUREMENTS`` mode the derived
+    ``fov_left``/``fov_right`` are written into *user_input* from the entry's
+    current window width + reveal depth, so the engine (which reads the stored
+    fov values unchanged) gets the computed angles. ``window_depth`` is left
+    untouched. In ``ANGLES`` mode the user's typed fov values pass through.
+    """
+    if not _fov_mode_supported(sensor_type) or CONF_FOV_MODE not in user_input:
+        return None
+
+    submitted = str(user_input[CONF_FOV_MODE])
+    resolved_prior = str(prior_mode) if prior_mode is not None else FovMode.ANGLES
+    if submitted != resolved_prior:
+        # Mode changed → re-render so the right fields show/hide.
+        return submitted
+
+    if submitted == FovMode.MEASUREMENTS:
+        width = float(source_config.get(CONF_WINDOW_WIDTH) or 0.0)
+        depth = float(source_config.get(CONF_WINDOW_DEPTH) or 0.0)
+        derived = fov_from_reveal(width, depth)
+        user_input[CONF_FOV_LEFT] = derived
+        user_input[CONF_FOV_RIGHT] = derived
+    return None
+
+
+def _get_sun_tracking_schema(
+    sensor_type: str | None,
+    hass: HomeAssistant | None = None,
+    mode: str | None = None,
+) -> vol.Schema:
+    """Return sun tracking schema for *sensor_type* in the given FOV *mode*.
+
+    Adds the glare-zones toggle for cover types that support it, and routes the
+    FOV-field shaping (mode selector + per-mode slider visibility, #565) through
+    the cover-type policy so no cover-type string branching leaks out here.
+    """
+    base = sun_tracking_schema(hass) if hass is not None else SUN_TRACKING_SCHEMA
+    if sensor_type in POLICY_REGISTRY:
+        policy = get_policy(sensor_type)
+        base = policy.fov_mode_schema(base, mode)
+        if policy.supports_glare_zones:
+            base = base.extend(
+                {
+                    vol.Optional(
+                        CONF_ENABLE_GLARE_ZONES, default=False
+                    ): selector.BooleanSelector(),
+                }
+            )
     return base
 
 
@@ -2269,21 +2351,23 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_sun_tracking(self, user_input: dict[str, Any] | None = None):
         """Configure sun tracking parameters."""
+        prior_mode = self.config.get(CONF_FOV_MODE)
         if user_input is not None:
             self.optional_entities([CONF_MIN_ELEVATION, CONF_MAX_ELEVATION], user_input)
+            rerender = _resolve_fov_mode_submit(
+                self.type_blind, prior_mode, user_input, self.config
+            )
+            if rerender is not None:
+                return self._show_sun_tracking_form(mode=rerender)
             if (
                 user_input.get(CONF_MAX_ELEVATION) is not None
                 and user_input.get(CONF_MIN_ELEVATION) is not None
                 and user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]
             ):
-                return self.async_show_form(
-                    step_id="sun_tracking",
-                    data_schema=_get_sun_tracking_schema(self.type_blind, self.hass),
+                return self._show_sun_tracking_form(
+                    mode=user_input.get(CONF_FOV_MODE, prior_mode),
                     errors={
                         CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                    },
-                    description_placeholders={
-                        "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Sun-Tracking"
                     },
                 )
             canonical = user_input_to_canonical(
@@ -2291,12 +2375,22 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             )
             self.config.update(canonical)
             return await self.async_step_position()
+        return self._show_sun_tracking_form(mode=prior_mode)
+
+    def _show_sun_tracking_form(
+        self,
+        *,
+        mode: str | None = None,
+        errors: dict | None = None,
+    ):
+        """Render the create-flow sun-tracking form for the given FOV *mode*."""
         return self.async_show_form(
             step_id="sun_tracking",
-            data_schema=_get_sun_tracking_schema(self.type_blind, self.hass),
-            description_placeholders={
-                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Sun-Tracking"
-            },
+            data_schema=_get_sun_tracking_schema(self.type_blind, self.hass, mode),
+            errors=errors,
+            description_placeholders=_sun_tracking_placeholders(
+                self.type_blind, mode, self.config
+            ),
         )
 
     async def async_step_position(self, user_input: dict[str, Any] | None = None):
@@ -2920,27 +3014,24 @@ class OptionsFlowHandler(OptionsFlow):
 
     async def async_step_sun_tracking(self, user_input: dict[str, Any] | None = None):
         """Adjust sun tracking parameters."""
+        prior_mode = self.options.get(CONF_FOV_MODE)
         if user_input is not None:
             self.optional_entities([CONF_MIN_ELEVATION, CONF_MAX_ELEVATION], user_input)
+            rerender = _resolve_fov_mode_submit(
+                self.sensor_type, prior_mode, user_input, self.options
+            )
+            if rerender is not None:
+                return self._show_sun_tracking_form(user_input, mode=rerender)
             if (
                 user_input.get(CONF_MAX_ELEVATION) is not None
                 and user_input.get(CONF_MIN_ELEVATION) is not None
                 and user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]
             ):
-                schema = _get_sun_tracking_schema(self.sensor_type, self.hass)
-                suggested = options_to_display(
-                    self.hass,
-                    user_input or self.options,
-                    length_keys=_SUN_TRACKING_LENGTH_KEYS,
-                )
-                return self.async_show_form(
-                    step_id="sun_tracking",
-                    data_schema=self.add_suggested_values_to_schema(schema, suggested),
+                return self._show_sun_tracking_form(
+                    user_input,
+                    mode=user_input.get(CONF_FOV_MODE, prior_mode),
                     errors={
                         CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                    },
-                    description_placeholders={
-                        "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Sun-Tracking"
                     },
                 )
             canonical = user_input_to_canonical(
@@ -2948,18 +3039,27 @@ class OptionsFlowHandler(OptionsFlow):
             )
             self.options.update(canonical)
             return await self.async_step_init()
-        schema = _get_sun_tracking_schema(self.sensor_type, self.hass)
+        return self._show_sun_tracking_form(self.options, mode=prior_mode)
+
+    def _show_sun_tracking_form(
+        self,
+        values: dict[str, Any],
+        *,
+        mode: str | None = None,
+        errors: dict | None = None,
+    ):
+        """Render the sun-tracking form for the given FOV *mode* (#565)."""
+        schema = _get_sun_tracking_schema(self.sensor_type, self.hass, mode)
         suggested = options_to_display(
-            self.hass,
-            user_input or self.options,
-            length_keys=_SUN_TRACKING_LENGTH_KEYS,
+            self.hass, values, length_keys=_SUN_TRACKING_LENGTH_KEYS
         )
         return self.async_show_form(
             step_id="sun_tracking",
             data_schema=self.add_suggested_values_to_schema(schema, suggested),
-            description_placeholders={
-                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Sun-Tracking"
-            },
+            errors=errors,
+            description_placeholders=_sun_tracking_placeholders(
+                self.sensor_type, mode, self.options
+            ),
         )
 
     async def async_step_position(self, user_input: dict[str, Any] | None = None):

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2358,6 +2358,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 self.type_blind, prior_mode, user_input, self.config
             )
             if rerender is not None:
+                self.config[CONF_FOV_MODE] = rerender
                 return self._show_sun_tracking_form(mode=rerender)
             if (
                 user_input.get(CONF_MAX_ELEVATION) is not None
@@ -3029,6 +3030,7 @@ class OptionsFlowHandler(OptionsFlow):
                 self.hass, user_input, length_keys=_SUN_TRACKING_LENGTH_KEYS
             )
             if rerender is not None:
+                self.options[CONF_FOV_MODE] = rerender
                 return self._show_sun_tracking_form(canonical, mode=rerender)
             if (
                 user_input.get(CONF_MAX_ELEVATION) is not None

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3020,23 +3020,28 @@ class OptionsFlowHandler(OptionsFlow):
             rerender = _resolve_fov_mode_submit(
                 self.sensor_type, prior_mode, user_input, self.options
             )
+            # Canonicalize once: ``_show_sun_tracking_form`` re-displays via
+            # ``options_to_display``, so feeding it raw (already display-unit)
+            # input would convert metres->inches a second time and the value
+            # would compound on every rerender (#565). Canonical here keeps the
+            # rerender re-feed symmetric with the initial render and save path.
+            canonical = user_input_to_canonical(
+                self.hass, user_input, length_keys=_SUN_TRACKING_LENGTH_KEYS
+            )
             if rerender is not None:
-                return self._show_sun_tracking_form(user_input, mode=rerender)
+                return self._show_sun_tracking_form(canonical, mode=rerender)
             if (
                 user_input.get(CONF_MAX_ELEVATION) is not None
                 and user_input.get(CONF_MIN_ELEVATION) is not None
                 and user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]
             ):
                 return self._show_sun_tracking_form(
-                    user_input,
+                    canonical,
                     mode=user_input.get(CONF_FOV_MODE, prior_mode),
                     errors={
                         CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
                     },
                 )
-            canonical = user_input_to_canonical(
-                self.hass, user_input, length_keys=_SUN_TRACKING_LENGTH_KEYS
-            )
             self.options.update(canonical)
             return await self.async_step_init()
         return self._show_sun_tracking_form(self.options, mode=prior_mode)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -96,6 +96,7 @@ CONF_FOV_LEFT = "fov_left"  # left half-FOV from azimuth, degrees 0-180
 CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
 DEFAULT_FOV_LEFT = 90  # degrees; matches config flow default
 DEFAULT_FOV_RIGHT = 90  # degrees; matches config flow default
+CONF_FOV_MODE = "fov_mode"  # how horizontal tracking is defined; see FovMode
 CONF_ENTITIES = "group"  # list of HA cover entity_ids controlled
 CONF_ENABLE_PROXY_COVER = "enable_proxy_cover"  # opt-in proxy cover platform
 DEFAULT_ENABLE_PROXY_COVER = False
@@ -924,6 +925,26 @@ _RANGE_VENETIAN_BACKROTATE_PUBLISH_LAG = (
     MIN_VENETIAN_BACKROTATE_PUBLISH_LAG,
     MAX_VENETIAN_BACKROTATE_PUBLISH_LAG,
 )  # CONF_VENETIAN_BACKROTATE_PUBLISH_LAG, seconds
+
+
+# Defined here (above the ``config_fields`` import) because ``config_fields``
+# reads ``FovMode`` at module-import time to build the FOV-mode FieldSpec. Same
+# import-ordering rule as ``VENETIAN_MODES`` above — names config_fields needs
+# must exist before the ``from .config_fields import OPTION_RANGES`` line.
+class FovMode(StrEnum):
+    """How the horizontal field-of-view is defined for a vertical blind (#565).
+
+    ``ANGLES`` (default) shows the manual ``fov_left``/``fov_right`` sliders —
+    identical to historical behaviour. ``MEASUREMENTS`` hides those sliders and
+    derives a symmetric FOV from the window width + reveal depth via
+    :func:`engine.sun_geometry.fov_from_reveal`; the derived value is stored
+    into ``fov_left``/``fov_right`` at save time so the engine is unchanged.
+
+    Absent from a config entry → treated as ``ANGLES`` (back-compat).
+    """
+
+    ANGLES = "angles"
+    MEASUREMENTS = "measurements"
 
 
 # ``OPTION_RANGES`` is now assembled from the single field registry in

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -185,6 +185,28 @@ class CoverTypePolicy(ABC):
     # in ``config_flow._build_custom_position_schema_dict``.
     custom_position_includes_tilt: ClassVar[bool] = False
 
+    # Whether the sun-tracking step exposes the two-mode FOV selector (#565):
+    # "Angles" (manual fov_left/right sliders) vs "Measurements" (FOV derived
+    # from window width + reveal depth). Only meaningful for vertical blinds —
+    # awnings/tilt always use the plain fov sliders. BlindPolicy flips this on
+    # and overrides ``fov_mode_schema`` to do the per-mode field shaping.
+    supports_fov_mode: ClassVar[bool] = False
+
+    def fov_mode_schema(
+        self,
+        base: vol.Schema,
+        mode: str | None = None,  # noqa: ARG002
+    ) -> vol.Schema:
+        """Shape the sun-tracking schema's FOV fields for the given mode.
+
+        The default (every cover type except vertical blinds) returns *base*
+        unchanged — no mode selector, plain fov_left/right sliders. BlindPolicy
+        overrides this to insert the mode selector and hide the fov sliders in
+        Measurements mode. Keeping the logic on the policy keeps cover-type
+        branching inside ``cover_types/`` (cover-type-abstraction guideline).
+        """
+        return base
+
     @abstractmethod
     def build_calc_engine(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/blind.py
+++ b/custom_components/adaptive_cover_pro/cover_types/blind.py
@@ -84,6 +84,43 @@ class BlindPolicy(CoverTypePolicy, register=True):
     axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
     supports_glare_zones = True
     supports_return_to_default_switch = True
+    supports_fov_mode = True
+
+    def fov_mode_schema(
+        self,
+        base: vol.Schema,
+        mode: str | None = None,
+    ) -> vol.Schema:
+        """Insert the FOV-mode selector; hide the fov sliders in Measurements.
+
+        The mode selector is placed immediately before the fov sliders. In
+        ``MEASUREMENTS`` mode the ``fov_left``/``fov_right`` sliders are dropped
+        (the FOV is derived from window width + reveal depth at save time); in
+        ``ANGLES`` mode they stay exactly as today.
+        """
+        from .. import config_fields as cf
+        from ..const import CONF_FOV_LEFT, CONF_FOV_MODE, CONF_FOV_RIGHT, FovMode
+
+        resolved = mode if mode is not None else FovMode.ANGLES
+        hide_sliders = str(resolved) == FovMode.MEASUREMENTS
+
+        spec = cf.FIELD_SPECS[CONF_FOV_MODE]
+        mode_marker, mode_selector = spec.to_marker(None, None)
+
+        rebuilt: dict = {}
+        inserted = False
+        for marker, sel in base.schema.items():
+            key = str(marker)
+            if key in (CONF_FOV_LEFT, CONF_FOV_RIGHT):
+                if not inserted:
+                    rebuilt[mode_marker] = mode_selector
+                    inserted = True
+                if hide_sliders:
+                    continue
+            rebuilt[marker] = sel
+        if not inserted:
+            rebuilt[mode_marker] = mode_selector
+        return vol.Schema(rebuilt)
 
     def section_order(self, options: dict | None = None) -> tuple[str, ...]:
         """Vertical blinds add the glare-zones section after the blind spot."""
@@ -94,12 +131,12 @@ class BlindPolicy(CoverTypePolicy, register=True):
         return tuple(order)
 
     def extra_field_keys(self, section: str) -> tuple[str, ...]:
-        """Add the glare-zones enable toggle to the sun-tracking section."""
+        """Add the FOV-mode selector + glare-zones toggle to sun tracking."""
         from .. import config_fields as cf
-        from ..const import CONF_ENABLE_GLARE_ZONES
+        from ..const import CONF_ENABLE_GLARE_ZONES, CONF_FOV_MODE
 
         if section == cf.SECTION_SUN_TRACKING:
-            return (CONF_ENABLE_GLARE_ZONES,)
+            return (CONF_FOV_MODE, CONF_ENABLE_GLARE_ZONES)
         return ()
 
     def wiki_anchor(self) -> str:
@@ -155,8 +192,25 @@ class BlindPolicy(CoverTypePolicy, register=True):
         return selector.EntityFilterSelectorConfig(domain="cover")
 
     def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
-        """Render the window-dimensions block."""
-        return window_dimensions_lines(config)
+        """Render the window-dimensions block, plus the computed FOV (#565).
+
+        In Measurements FOV mode the FOV is derived from the window width +
+        reveal depth, so the summary appends a read-only "Computed FOV ≈ …"
+        line via the shared ``computed_fov_line`` helper (same formula as the
+        save path — no second arctan).
+        """
+        from ..const import CONF_FOV_MODE, FovMode
+        from ..engine.sun_geometry import computed_fov_line
+
+        lines = window_dimensions_lines(config)
+        if str(config.get(CONF_FOV_MODE)) == FovMode.MEASUREMENTS:
+            lines.append(
+                computed_fov_line(
+                    config.get(CONF_WINDOW_WIDTH),
+                    config.get(CONF_WINDOW_DEPTH),
+                )
+            )
+        return lines
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:
         """Warn when no bound entity advertises ``set_position``."""

--- a/custom_components/adaptive_cover_pro/cover_types/blind.py
+++ b/custom_components/adaptive_cover_pro/cover_types/blind.py
@@ -77,6 +77,20 @@ def geometry_vertical_schema(hass: HomeAssistant | None = None) -> vol.Schema:
 GEOMETRY_VERTICAL_SCHEMA = geometry_vertical_schema()
 
 
+def _as_optional(marker: vol.Marker) -> vol.Optional:
+    """Re-emit *marker* as ``vol.Optional``, preserving its default if any.
+
+    Used so the fov sliders are not ``vol.Required`` (#565): a Required field
+    triggers HA's frontend client-side "all required fields filled" check,
+    which blocks switching to Measurements mode before the backend can
+    re-render with the sliders hidden. The existing ``default`` callable is
+    reused so no ``90`` literal is duplicated here.
+    """
+    if marker.default is vol.UNDEFINED:
+        return vol.Optional(str(marker))
+    return vol.Optional(str(marker), default=marker.default)
+
+
 class BlindPolicy(CoverTypePolicy, register=True):
     """Cover that moves vertically (raise/lower)."""
 
@@ -117,6 +131,10 @@ class BlindPolicy(CoverTypePolicy, register=True):
                     inserted = True
                 if hide_sliders:
                     continue
+                # Optional so the frontend Required check never blocks a mode
+                # switch (#565); default preserved, so ANGLES is unchanged.
+                rebuilt[_as_optional(marker)] = sel
+                continue
             rebuilt[marker] = sel
         if not inserted:
             rebuilt[mode_marker] = mode_selector

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -4,12 +4,47 @@ Extracted from AdaptiveGeneralCover to enable standalone testing and reuse.
 """
 
 from datetime import UTC, datetime, timedelta
+from math import atan, degrees
 
 import pandas as pd
 
 from ..config_types import CoverConfig
-from ..const import DEGREES_IN_CIRCLE
+from ..const import CONF_FOV_LEFT, DEFAULT_FOV_LEFT, DEGREES_IN_CIRCLE, OPTION_RANGES
 from ..sun import SunData
+
+
+def fov_from_reveal(width_m: float, depth_m: float) -> int:
+    """Symmetric FOV half-angle (degrees) from reveal width and depth.
+
+    Models the oblique-sun cutoff geometry of a cover mounted inside a reveal:
+    the recess depth ``depth_m`` in front of the cover blocks sun arriving at a
+    grazing azimuth, and the opening ``width_m`` sets how wide that gap is. The
+    half-angle is ``atan((width/2) / depth)`` — the angle at which the sun first
+    clears the reveal edge.
+
+    A flush reveal (``depth_m <= 0``) or a degenerate opening (``width_m <= 0``)
+    blocks nothing, so the FOV is the full hemisphere (the default half-angle).
+    The result is clamped to the configured FOV range and rounded to an integer
+    because ``fov_left``/``fov_right`` are stored as integer degrees.
+    """
+    if depth_m <= 0 or width_m <= 0:
+        return DEFAULT_FOV_LEFT
+    deg = degrees(atan((width_m / 2) / depth_m))
+    lo, hi = OPTION_RANGES[CONF_FOV_LEFT]
+    return int(round(min(max(deg, lo), hi)))
+
+
+def computed_fov_line(width_m: float | None, depth_m: float | None) -> str:
+    """Read-only "Computed FOV ≈ 50°/50° (…)" line for Measurements mode (#565).
+
+    The single formatter shared by the sun-tracking page placeholder and the
+    config-flow summary. Delegates the angle to :func:`fov_from_reveal` so the
+    arctan lives in exactly one place.
+    """
+    w = float(width_m or 0.0)
+    d = float(depth_m or 0.0)
+    deg = fov_from_reveal(w, d)
+    return f"Computed FOV ≈ {deg}°/{deg}° ({w:g} m width, {d:g} m reveal depth)"
 
 
 class SunGeometry:

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.28.0-beta.2"
+  "version": "2.28.0-beta.3"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.27.0"
+  "version": "2.28.0-beta.1"
 }

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2.28.0-beta.1"
+  "version": "2.28.0-beta.2"
 }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -91,7 +91,8 @@
           "enable_glare_zones": "Blendungszonen aktivieren",
           "distance_shaded_area": "Beschatteter Bereich",
           "minimize_movements": "Bewegungen minimieren",
-          "max_coverage_steps": "Maximale Abdeckungsschritte"
+          "max_coverage_steps": "Maximale Abdeckungsschritte",
+          "fov_mode": "Sichtfeld definieren nach"
         },
         "data_description": {
           "enable_sun_tracking": "Wenn aktiviert, verfolgen Beschattungen die Sonne innerhalb der konfigurierten Sichtfeld- und Höhengrenzen (Solarpositionierung). Deaktivieren Sie, um die distanzbasierte Solarpositionierung zu überspringen und dabei Blendungszonen (durch ihren eigenen Schalter gesteuert), Klima-, Bewegungs-, manuelle Übersteuerung, benutzerdefinierte Positionen und andere Übersteuerungen zu behalten. Standard: aktiviert.",
@@ -104,7 +105,8 @@
           "enable_glare_zones": "Schützen Sie bestimmte Bodenbereiche vor direkter Sonnenblendung (nur vertikale Beschattungen)",
           "distance_shaded_area": "Wie weit Sie ZULASSEN möchten, dass direktes Sonnenlicht in den Raum eindringt. Wird in der Einheit angezeigt, auf die Home Assistant konfiguriert ist. Dies definiert Ihre akzeptable 'Blendungszone' — der Bereich, in dem Sonnenlicht den Boden erreichen kann. Die Beschattungsposition passt sich an, um diese Grenze zu wahren, während sich die Sonne über den Himmel bewegt. Häufige Konfigurationen: Null (0 m / 0 in) hält direktes Sonnenlicht daran ab, die Glasebene zu passieren (vollständiger Verschluss an heißen Tagen); Kleine Blendungszone (0,3–0,5 m / 12–20 in) hält Sonnenlicht sehr nah am Fenster; Mittlere Blendungszone (0,5–1,0 m / 20–40 in) ermöglicht Sonnenlicht auf Schreibtisch oder Sitzbereich; Große Blendungszone (2,0–3,0 m / 79–118 in) ermöglicht Sonnenlicht tief in den Raum. WICHTIG: GRÖSSERER Wert = MEHR Sonnenlicht zulassen weiter in den Raum = Beschattung bleibt HÖHER/MEHR GEÖFFNET; KLEINERER Wert = WENIGER Sonnenlicht in Raum = Beschattung fällt TIEFER/MEHR GESCHLOSSEN. Messen Sie von der Innenseite Ihres Fensters zu dem Punkt, an dem die Sonnengrenze sein soll.",
           "minimize_movements": "Reduzieren Sie, wie oft sich die Beschattung während der Sonnenverfolgung repositioniert, indem Sie auf wenige feste Abdeckungsstufen einrasten, anstatt der Sonne kontinuierlich zu folgen. Rundet zu MEHR Abdeckung, damit direkte Sonneneinstrahlung durch die Rundung nicht durchkommt. Tauscht etwas Tageslicht gegen weitaus weniger Motorbewegungen. Standard: deaktiviert.",
-          "max_coverage_steps": "Wie viele unterschiedliche Positionen die Beschattung auf dem Weg zur vollständigen Abdeckung nutzen darf, wenn ‚Bewegungen minimieren' aktiviert ist (1–10). 1 = sofort zur vollständigen Abdeckung springen, wenn die Sonne in das Sichtfeld eintritt, und dort bleiben, bis sie es verlässt (die wenigsten Bewegungen). Höhere Werte verfolgen die Sonne schrittweise in dieser Anzahl von Schritten. Standard: 1."
+          "max_coverage_steps": "Wie viele unterschiedliche Positionen die Beschattung auf dem Weg zur vollständigen Abdeckung nutzen darf, wenn ‚Bewegungen minimieren' aktiviert ist (1–10). 1 = sofort zur vollständigen Abdeckung springen, wenn die Sonne in das Sichtfeld eintritt, und dort bleiben, bis sie es verlässt (die wenigsten Bewegungen). Höhere Werte verfolgen die Sonne schrittweise in dieser Anzahl von Schritten. Standard: 1.",
+          "fov_mode": "Wie das linke/rechte Sichtfeld eingestellt wird. **Nach Winkeln** (Standard) behält die manuellen Schieberegler unten bei. **Aus Messungen** blendet die Schieberegler aus und leitet ein symmetrisches Sichtfeld aus der Fensterbreite und der Laibungstiefe ab — die Laibungstiefe wird von der äußeren Wandfläche gemessen, wo die Beschattung angebracht ist. Fensterbreite und Laibungstiefe auf der Seite „Beschattungsgeometrie\" einstellen; das berechnete Sichtfeld wird oben angezeigt."
         }
       },
       "position": {
@@ -630,7 +632,8 @@
           "enable_glare_zones": "Blendungszonen aktivieren",
           "distance_shaded_area": "Beschatteter Bereich",
           "minimize_movements": "Bewegungen minimieren",
-          "max_coverage_steps": "Maximale Abdeckungsschritte"
+          "max_coverage_steps": "Maximale Abdeckungsschritte",
+          "fov_mode": "Sichtfeld definieren nach"
         },
         "data_description": {
           "enable_sun_tracking": "Wenn aktiviert, verfolgen Behänge die Sonne innerhalb der konfigurierten Sichtweite und Höhenlimits (Solarpositionierung). Deaktivieren Sie, um distanzbasierte Solarpositionierung zu überspringen, während Blendungszonen beibehalten werden (kontrolliert durch ihren eigenen Schalter), Klimamodi, Bewegung, manuelle Übersteuerung, benutzerdefinierte Positionen und andere Übersteuerungen aktiv bleiben. Standard: aktiviert.",
@@ -643,7 +646,8 @@
           "enable_glare_zones": "Schützen Sie bestimmte Bodenbereiche vor direkter Sonnenblendung (nur vertikale Behänge)",
           "distance_shaded_area": "Wie weit Sie ZULASSEN möchten, dass direktes Sonnenlicht in den Raum eindringt. Wird in der Einheit angezeigt, auf die Home Assistant konfiguriert ist. Dies definiert Ihre akzeptable 'Blendungszone' — der Bereich, in dem Sonnenlicht den Boden erreichen kann. Die Beschattungsposition passt sich an, um diese Grenze zu wahren, während sich die Sonne über den Himmel bewegt. Häufige Konfigurationen: Null (0 m / 0 in) hält direktes Sonnenlicht daran ab, die Glasebene zu passieren (vollständiger Verschluss an heißen Tagen); Kleine Blendungszone (0,3–0,5 m / 12–20 in) hält Sonnenlicht sehr nah am Fenster; Mittlere Blendungszone (0,5–1,0 m / 20–40 in) ermöglicht Sonnenlicht auf Schreibtisch oder Sitzbereich; Große Blendungszone (2,0–3,0 m / 79–118 in) ermöglicht Sonnenlicht tief in den Raum. WICHTIG: GRÖSSERER Wert = MEHR Sonnenlicht zulassen weiter in den Raum = Beschattung bleibt HÖHER/MEHR GEÖFFNET; KLEINERER Wert = WENIGER Sonnenlicht in Raum = Beschattung fällt TIEFER/MEHR GESCHLOSSEN. Messen Sie von der Innenseite Ihres Fensters zu dem Punkt, an dem die Sonnengrenze sein soll.",
           "minimize_movements": "Reduzieren Sie, wie oft sich die Beschattung während der Sonnenverfolgung repositioniert, indem Sie auf wenige feste Abdeckungsstufen einrasten, anstatt der Sonne kontinuierlich zu folgen. Rundet zu MEHR Abdeckung, damit direkte Sonneneinstrahlung durch die Rundung nicht durchkommt. Tauscht etwas Tageslicht gegen weitaus weniger Motorbewegungen. Standard: deaktiviert.",
-          "max_coverage_steps": "Wie viele unterschiedliche Positionen die Beschattung auf dem Weg zur vollständigen Abdeckung nutzen darf, wenn ‚Bewegungen minimieren' aktiviert ist (1–10). 1 = sofort zur vollständigen Abdeckung springen, wenn die Sonne in das Sichtfeld eintritt, und dort bleiben, bis sie es verlässt (die wenigsten Bewegungen). Höhere Werte verfolgen die Sonne schrittweise in dieser Anzahl von Schritten. Standard: 1."
+          "max_coverage_steps": "Wie viele unterschiedliche Positionen die Beschattung auf dem Weg zur vollständigen Abdeckung nutzen darf, wenn ‚Bewegungen minimieren' aktiviert ist (1–10). 1 = sofort zur vollständigen Abdeckung springen, wenn die Sonne in das Sichtfeld eintritt, und dort bleiben, bis sie es verlässt (die wenigsten Bewegungen). Höhere Werte verfolgen die Sonne schrittweise in dieser Anzahl von Schritten. Standard: 1.",
+          "fov_mode": "Wie das linke/rechte Sichtfeld eingestellt wird. **Nach Winkeln** (Standard) behält die manuellen Schieberegler unten bei. **Aus Messungen** blendet die Schieberegler aus und leitet ein symmetrisches Sichtfeld aus der Fensterbreite und der Laibungstiefe ab — die Laibungstiefe wird von der äußeren Wandfläche gemessen, wo die Beschattung angebracht ist. Fensterbreite und Laibungstiefe auf der Seite „Beschattungsgeometrie\" einstellen; das berechnete Sichtfeld wird oben angezeigt."
         }
       },
       "position": {
@@ -1190,6 +1194,12 @@
       "options": {
         "return_to_default": "Standardposition zurückkehren",
         "hold_position": "Aktuelle Position halten"
+      }
+    },
+    "fov_mode": {
+      "options": {
+        "angles": "Nach Winkeln (Sichtfeld von links/rechts direkt einstellen)",
+        "measurements": "Aus Messungen (Sichtfeld aus Fensterbreite und Laibungstiefe ableiten)"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -79,12 +79,13 @@
       },
       "sun_tracking": {
         "title": "Sun Tracking",
-        "description": "Set your window's compass direction and the angular range where the sun is visible. The integration tracks the sun within this field of view and holds the cover at its default position when the sun is outside it.\n\n**Azimuth** is the compass bearing your window faces (0° = North, 90° = East, 180° = South, 270° = West). **FOV** defines how far left and right from centre the sun is tracked. **Elevation limits** filter out very low angles (sunrise glare) or very high angles (zenith) where blocking may not be needed.\n\n[Learn more]({learn_more})",
+        "description": "Set your window's compass direction and the angular range where the sun is visible. The integration tracks the sun within this field of view and holds the cover at its default position when the sun is outside it.\n\n**Azimuth** is the compass bearing your window faces (0° = North, 90° = East, 180° = South, 270° = West). **FOV** defines how far left and right from centre the sun is tracked. Choose **By angles** to set the field of view directly, or **From measurements** to derive it from the window width and reveal depth. **Elevation limits** filter out very low angles (sunrise glare) or very high angles (zenith) where blocking may not be needed.\n\n{computed_fov}\n\n[Learn more]({learn_more})",
         "data": {
           "enable_sun_tracking": "Enable sun tracking",
           "minimize_movements": "Minimize movements",
           "max_coverage_steps": "Maximum coverage steps",
           "set_azimuth": "Window Azimuth",
+          "fov_mode": "Define field of view by",
           "fov_left": "Field of view left",
           "fov_right": "Field of view right",
           "min_elevation": "Minimum Elevation of the sun",
@@ -95,6 +96,7 @@
         },
         "data_description": {
           "enable_sun_tracking": "When enabled, covers track the sun within the configured FOV and elevation limits (solar positioning). Disable to skip distance-based solar positioning while keeping glare zones (controlled by their own switch), climate, motion, manual override, custom positions, and other overrides active. Default: enabled.",
+          "fov_mode": "How the left/right field of view is set. **By angles** (default) keeps the manual sliders below. **From measurements** hides the sliders and derives a symmetric field of view from the window width and the reveal depth — the reveal depth is measured from the outer wall face, where the actual cover is located. Set the window width and reveal depth on the Cover Geometry page; the computed field of view is shown above.",
           "minimize_movements": "Reduce how often the cover repositions while tracking the sun by snapping to a few fixed coverage levels instead of following the sun continuously. Rounds toward MORE coverage, so direct sun is never let in by the rounding. Trades some natural light for far fewer motor movements. Default: off.",
           "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the field of view and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1.",
           "set_azimuth": "Direction your window faces (0-359°). North=0°, East=90°, South=180°, West=270°. Example: A south-facing window = 180°. Use a compass app or check sun at noon to determine. This tells the integration where your window points so it can calculate sun angles accurately.",
@@ -618,12 +620,13 @@
       },
       "sun_tracking": {
         "title": "Sun Tracking",
-        "description": "Set your window's compass direction and the angular range where the sun is visible. The integration tracks the sun within this field of view and holds the cover at its default position when the sun is outside it.\n\n**Azimuth** is the compass bearing your window faces (0° = North, 90° = East, 180° = South, 270° = West). **FOV** defines how far left and right from centre the sun is tracked. **Elevation limits** filter out very low angles (sunrise glare) or very high angles (zenith) where blocking may not be needed.\n\n[Learn more]({learn_more})",
+        "description": "Set your window's compass direction and the angular range where the sun is visible. The integration tracks the sun within this field of view and holds the cover at its default position when the sun is outside it.\n\n**Azimuth** is the compass bearing your window faces (0° = North, 90° = East, 180° = South, 270° = West). **FOV** defines how far left and right from centre the sun is tracked. Choose **By angles** to set the field of view directly, or **From measurements** to derive it from the window width and reveal depth. **Elevation limits** filter out very low angles (sunrise glare) or very high angles (zenith) where blocking may not be needed.\n\n{computed_fov}\n\n[Learn more]({learn_more})",
         "data": {
           "enable_sun_tracking": "Enable sun tracking",
           "minimize_movements": "Minimize movements",
           "max_coverage_steps": "Maximum coverage steps",
           "set_azimuth": "Window Azimuth",
+          "fov_mode": "Define field of view by",
           "fov_left": "Field of view left",
           "fov_right": "Field of view right",
           "min_elevation": "Minimum Elevation of the sun",
@@ -634,6 +637,7 @@
         },
         "data_description": {
           "enable_sun_tracking": "When enabled, covers track the sun within the configured FOV and elevation limits (solar positioning). Disable to skip distance-based solar positioning while keeping glare zones (controlled by their own switch), climate, motion, manual override, custom positions, and other overrides active. Default: enabled.",
+          "fov_mode": "How the left/right field of view is set. **By angles** (default) keeps the manual sliders below. **From measurements** hides the sliders and derives a symmetric field of view from the window width and the reveal depth — the reveal depth is measured from the outer wall face, where the actual cover is located. Set the window width and reveal depth on the Cover Geometry page; the computed field of view is shown above.",
           "minimize_movements": "Reduce how often the cover repositions while tracking the sun by snapping to a few fixed coverage levels instead of following the sun continuously. Rounds toward MORE coverage, so direct sun is never let in by the rounding. Trades some natural light for far fewer motor movements. Default: off.",
           "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the field of view and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1.",
           "set_azimuth": "Direction your window faces (0-359°). North=0°, East=90°, South=180°, West=270°. Example: A south-facing window = 180°. Use a compass app or check sun at noon to determine. This tells the integration where your window points so it can calculate sun angles accurately.",
@@ -1144,6 +1148,12 @@
       "options": {
         "mode1": "single direction (0% = closed / 100% = open)",
         "mode2": "bi-directional (0% = closed / 50% = open / 100% = closed)"
+      }
+    },
+    "fov_mode": {
+      "options": {
+        "angles": "By angles (set left/right field of view directly)",
+        "measurements": "From measurements (derive field of view from window width and reveal depth)"
       }
     },
     "debug_categories": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -91,7 +91,8 @@
           "enable_glare_zones": "Activer les zones d'éblouissement",
           "distance_shaded_area": "Zone ombragée",
           "minimize_movements": "Minimiser les mouvements",
-          "max_coverage_steps": "Étapes de couverture maximale"
+          "max_coverage_steps": "Étapes de couverture maximale",
+          "fov_mode": "Définir le champ de vision par"
         },
         "data_description": {
           "enable_sun_tracking": "Lorsqu'il est activé, les stores suivent le soleil dans les limites de FOV et d'élévation configurées (positionnement solaire). Désactivez pour ignorer le positionnement solaire basé sur la distance tout en gardant les zones d'éblouissement (contrôlées par leur propre commutateur), le climat, le mouvement, la dérogation manuelle, les positions personnalisées et autres dérogations actifs. Par défaut : activé.",
@@ -104,7 +105,8 @@
           "enable_glare_zones": "Protégez les zones de sol spécifiques de l'éblouissement direct du soleil (stores verticaux uniquement)",
           "distance_shaded_area": "Jusqu'où vous souhaitez AUTORISER la lumière directe du soleil à pénétrer dans la pièce. Affichée dans l'unité configurée pour Home Assistant. Cela définit votre « zone d'éblouissement » acceptable — la zone où la lumière du soleil peut atteindre le sol. La position de la store s'ajuste pour maintenir cette limite alors que le soleil se déplace dans le ciel. Configurations courantes : Zéro (0 m / 0 in) empêche la lumière directe du soleil de dépasser le plan de vitre (fermeture complète les jours chauds) ; Petite zone d'éblouissement (0,3–0,5 m / 12–20 in) garde le soleil très près de la fenêtre ; Zone d'éblouissement moyenne (0,5–1,0 m / 20–40 in) permet au soleil d'atteindre le bureau ou la zone de repos ; Grande zone d'éblouissement (2,0–3,0 m / 79–118 in) permet à la lumière du soleil de pénétrer profondément dans la pièce. CONCEPT CLÉ : PLUS GRANDE valeur = PLUS de lumière du soleil autorisée plus profondément dans la pièce = la store reste PLUS HAUTE/PLUS OUVERTE ; PLUS PETITE valeur = MOINS de lumière du soleil dans la pièce = la store descend PLUS BAS/PLUS FERMÉE. Mesurez de l'intérieur de votre fenêtre jusqu'au point où vous souhaitez que la limite solaire se situe.",
           "minimize_movements": "Réduire la fréquence de repositionnement de la protection lors du suivi du soleil en s'accrochant à quelques niveaux de couverture fixes au lieu de suivre le soleil en continu. Arrondit vers PLUS de couverture, donc le soleil direct ne s'échappe jamais de l'arrondi. Échange un peu de lumière naturelle contre beaucoup moins de mouvements moteurs. Par défaut : désactivé.",
-          "max_coverage_steps": "Nombre de positions distinctes que la protection peut utiliser pour atteindre la couverture complète lorsque « Minimiser les mouvements » est activé (1-10). 1 = sauter directement à la couverture complète dès que le soleil entre dans le champ de vision et rester là jusqu'à ce qu'il quitte (mouvements les moins nombreux). Les valeurs plus élevées suivent le soleil plus graduellement en ce nombre d'étapes. Par défaut : 1."
+          "max_coverage_steps": "Nombre de positions distinctes que la protection peut utiliser pour atteindre la couverture complète lorsque « Minimiser les mouvements » est activé (1-10). 1 = sauter directement à la couverture complète dès que le soleil entre dans le champ de vision et rester là jusqu'à ce qu'il quitte (mouvements les moins nombreux). Les valeurs plus élevées suivent le soleil plus graduellement en ce nombre d'étapes. Par défaut : 1.",
+          "fov_mode": "Comment le champ de vision gauche/droite est défini. **Par angles** (par défaut) conserve les curseurs manuels ci-dessous. **À partir de mesures** masque les curseurs et dérive un champ de vision symétrique à partir de la largeur de la fenêtre et de la profondeur de tableau — la profondeur de tableau est mesurée à partir de la face extérieure du mur, où la store est réellement situé. Définissez la largeur de la fenêtre et la profondeur de tableau sur la page Géométrie de la couverture ; le champ de vision calculé s'affiche ci-dessus."
         }
       },
       "position": {
@@ -630,7 +632,8 @@
           "enable_glare_zones": "Activer les zones d'éblouissement",
           "distance_shaded_area": "Zone ombragée",
           "minimize_movements": "Minimiser les mouvements",
-          "max_coverage_steps": "Étapes de couverture maximale"
+          "max_coverage_steps": "Étapes de couverture maximale",
+          "fov_mode": "Définir le champ de vision par"
         },
         "data_description": {
           "enable_sun_tracking": "Lorsqu'il est activé, les stores suivent le soleil dans les limites de FOV et d'élévation configurées (positionnement solaire). Désactivez pour ignorer le positionnement solaire basé sur la distance tout en gardant les zones d'éblouissement (contrôlées par leur propre commutateur), le climat, le mouvement, la dérogation manuelle, les positions personnalisées et autres dérogations actifs. Par défaut : activé.",
@@ -643,7 +646,8 @@
           "enable_glare_zones": "Protégez les zones de sol spécifiques de l'éblouissement direct du soleil (stores verticaux uniquement)",
           "distance_shaded_area": "Jusqu'où vous souhaitez AUTORISER la lumière directe du soleil à pénétrer dans la pièce. Affichée dans l'unité configurée pour Home Assistant. Cela définit votre « zone d'éblouissement » acceptable — la zone où la lumière du soleil peut atteindre le sol. La position de la store s'ajuste pour maintenir cette limite alors que le soleil se déplace dans le ciel. Configurations courantes : Zéro (0 m / 0 in) empêche la lumière directe du soleil de dépasser le plan de vitre (fermeture complète les jours chauds) ; Petite zone d'éblouissement (0,3–0,5 m / 12–20 in) garde le soleil très près de la fenêtre ; Zone d'éblouissement moyenne (0,5–1,0 m / 20–40 in) permet au soleil d'atteindre le bureau ou la zone de repos ; Grande zone d'éblouissement (2,0–3,0 m / 79–118 in) permet à la lumière du soleil de pénétrer profondément dans la pièce. CONCEPT CLÉ : PLUS GRANDE valeur = PLUS de lumière du soleil autorisée plus profondément dans la pièce = la store reste PLUS HAUTE/PLUS OUVERTE ; PLUS PETITE valeur = MOINS de lumière du soleil dans la pièce = la store descend PLUS BAS/PLUS FERMÉE. Mesurez de l'intérieur de votre fenêtre jusqu'au point où vous souhaitez que la limite solaire se situe.",
           "minimize_movements": "Réduire la fréquence de repositionnement de la protection lors du suivi du soleil en s'accrochant à quelques niveaux de couverture fixes au lieu de suivre le soleil en continu. Arrondit vers PLUS de couverture, donc le soleil direct ne s'échappe jamais de l'arrondi. Échange un peu de lumière naturelle contre beaucoup moins de mouvements moteurs. Par défaut : désactivé.",
-          "max_coverage_steps": "Nombre de positions distinctes que la protection peut utiliser pour atteindre la couverture complète lorsque « Minimiser les mouvements » est activé (1-10). 1 = sauter directement à la couverture complète dès que le soleil entre dans le champ de vision et rester là jusqu'à ce qu'il quitte (mouvements les moins nombreux). Les valeurs plus élevées suivent le soleil plus graduellement en ce nombre d'étapes. Par défaut : 1."
+          "max_coverage_steps": "Nombre de positions distinctes que la protection peut utiliser pour atteindre la couverture complète lorsque « Minimiser les mouvements » est activé (1-10). 1 = sauter directement à la couverture complète dès que le soleil entre dans le champ de vision et rester là jusqu'à ce qu'il quitte (mouvements les moins nombreux). Les valeurs plus élevées suivent le soleil plus graduellement en ce nombre d'étapes. Par défaut : 1.",
+          "fov_mode": "Comment le champ de vision gauche/droite est défini. **Par angles** (par défaut) conserve les curseurs manuels ci-dessous. **À partir de mesures** masque les curseurs et dérive un champ de vision symétrique à partir de la largeur de la fenêtre et de la profondeur de tableau — la profondeur de tableau est mesurée à partir de la face extérieure du mur, où la store est réellement situé. Définissez la largeur de la fenêtre et la profondeur de tableau sur la page Géométrie de la couverture ; le champ de vision calculé s'affiche ci-dessus."
         }
       },
       "position": {
@@ -1190,6 +1194,12 @@
       "options": {
         "return_to_default": "Retourner à la position par défaut",
         "hold_position": "Maintenir la position actuelle"
+      }
+    },
+    "fov_mode": {
+      "options": {
+        "angles": "Par angles (définir directement le champ de vision gauche/droite)",
+        "measurements": "À partir de mesures (dériver le champ de vision à partir de la largeur de la fenêtre et de la profondeur de tableau)"
       }
     }
   },

--- a/release_notes/v2.28.0-beta.1.md
+++ b/release_notes/v2.28.0-beta.1.md
@@ -1,0 +1,51 @@
+This beta introduces a FOV-mode selector that lets you derive field-of-view from physical reveal measurements instead of manually entering angles, patches a low-sun edge-case that incorrectly left covers open at near-zero elevations, and ships several performance and robustness improvements under the hood.
+
+## 🎯 Highlights
+
+**Beta — please test and report back.**
+
+- Try the new FOV-mode selector: configure a window using `MEASUREMENTS` mode (reveal depth → `fov_from_reveal()`) and confirm the computed angles match your physical window.
+- Verify the low-sun behavior change: at very low sun elevations the cover now returns 0 (fully closed) rather than the previous h_win value (fully open). Confirm this is correct for your installation.
+- Geometry caching and write-gating are internal changes — normal operation should be unchanged. Flag any unexpected behavior.
+
+## ✨ Features
+
+### FOV-mode selector (#565)
+
+Adds a `FovMode` enum (`ANGLES | MEASUREMENTS`) and a new `CONF_FOV_MODE` option to the config flow. When `MEASUREMENTS` mode is selected, the integration derives the field of view from physical reveal depth via `fov_from_reveal()` rather than requiring manual angle entry. The `fov_mode_schema()` helper builds the relevant config-flow step, and `supports_fov_mode` on the cover-type policy gates the option to cover types where it applies. Translations updated for English, German, and French.
+
+## 🐛 Bug Fixes
+
+### Low-sun edge case returns closed position (#559, #562)
+
+At very low sun elevations a geometry edge case caused the cover calculation to return h_win (fully open) instead of 0 (fully closed). The fix corrects the return value so the cover closes rather than opens when the sun is near the horizon. Verified by `test_low_elevation_calc_percentage_is_fully_closed`.
+
+## 🔧 Internal
+
+### Write-gating, geometry caching, and sun availability guard (#543)
+
+Three robustness and performance improvements shipped together:
+
+- **Write-gating:** `_acp_render_signature()` detects when a calculated position is identical to the last written value and skips the HA state write, reducing redundant entity updates.
+- **Geometry cache:** Pure geometry helpers are decorated with `@lru_cache(maxsize=512)`, eliminating repeated identical calculations across update cycles.
+- **Sun availability guard:** A guard on `sun.sun` suppresses solar tracking when the sun entity is unavailable, preventing stale or error-state data from driving cover commands.
+
+## 🧪 Testing
+
+Test suite grows from 4,214 to 4,271 (+57 net new tests). New modules:
+
+- `test_config_flow_fov_mode.py` / `test_fov_mode.py` — FOV-mode selector and `fov_from_reveal()` calculation
+- `test_entity_write_gating.py` — write-gating behavior
+- `test_geometry_cache.py` — cache correctness and hit behavior
+- `test_sun_unavailable_guard.py` — solar tracking suppression when sun entity unavailable
+
+## Compatibility
+
+Requires Home Assistant 2026.3.0+. No new coupled-component requirements.
+
+## References
+
+[#543]: https://github.com/jrhubott/adaptive-cover-pro/issues/543
+[#559]: https://github.com/jrhubott/adaptive-cover-pro/issues/559
+[#562]: https://github.com/jrhubott/adaptive-cover-pro/issues/562
+[#565]: https://github.com/jrhubott/adaptive-cover-pro/issues/565

--- a/release_notes/v2.28.0-beta.2.md
+++ b/release_notes/v2.28.0-beta.2.md
@@ -1,0 +1,62 @@
+This beta builds on beta.1 (FOV-mode selector, low-sun edge-case fix, write-gating and geometry caching) by adding two config-flow bug fixes that unblock Measurements mode in practice: the mode switch can now be saved without the frontend blocking it, and imperial shaded-area values no longer compound on each form rerender.
+
+## 🎯 Highlights
+
+**Beta — please test and report back.**
+
+- Try the new FOV-mode selector: configure a window using `MEASUREMENTS` mode (reveal depth → `fov_from_reveal()`) and confirm the computed angles match your physical window.
+- Verify you can now switch to and save Measurements mode without the frontend blocking the save — this was broken in beta.1 and is fixed in beta.2.
+- If your installation uses imperial units, toggle FOV mode and confirm the shaded-area depth value stays stable (does not compound) across rerenders.
+- Verify the low-sun behavior change: at very low sun elevations the cover now returns 0 (fully closed) rather than the previous h_win value (fully open). Confirm this is correct for your installation.
+- Geometry caching and write-gating are internal changes — normal operation should be unchanged. Flag any unexpected behavior.
+
+## ✨ Features
+
+### FOV-mode selector (#565)
+
+Adds a `FovMode` enum (`ANGLES | MEASUREMENTS`) and a new `CONF_FOV_MODE` option to the config flow. When `MEASUREMENTS` mode is selected, the integration derives the field of view from physical reveal depth via `fov_from_reveal()` rather than requiring manual angle entry. The `fov_mode_schema()` helper builds the relevant config-flow step, and `supports_fov_mode` on the cover-type policy gates the option to cover types where it applies. Translations updated for English, German, and French.
+
+## 🐛 Bug Fixes
+
+### Measurements mode config-flow save blocked and imperial values compounding (#565)
+
+Two bugs found during testing of the beta.1 FOV-mode selector, both in the config flow:
+
+**Measurements mode could not be saved.** The FOV sliders (`CONF_MAX_ELEVATION`, `CONF_MIN_ELEVATION`) were emitted as `vol.Required` voluptuous markers. A `vol.Required` field triggers Home Assistant's frontend "all required fields filled" check, which blocked switching to Measurements mode before the backend could re-render the form with the sliders hidden. A new helper `_as_optional()` in `cover_types/blind.py` re-emits each affected marker as `vol.Optional`, preserving its existing default so the ANGLES default of 90 is unchanged and not duplicated. With the sliders `vol.Optional`, the frontend check no longer blocks the mode switch. Awnings are unaffected — their FOV fields stay `vol.Required`.
+
+**Imperial shaded-area value compounded on every form rerender.** `_show_sun_tracking_form` in `config_flow.py` runs `options_to_display` (converting canonical metres to display inches). When a mode switch triggered a rerender, the raw already-display-unit `user_input` was fed back in and converted metres→inches a second time, so the value compounded on each rerender. The fix calls `user_input_to_canonical(...)` once up front (using `_SUN_TRACKING_LENGTH_KEYS`) and feeds that canonical value into every `_show_sun_tracking_form` re-display path, keeping the rerender re-feed symmetric with the initial render and the save path.
+
+### Low-sun edge case returns closed position (#559, #562)
+
+At very low sun elevations a geometry edge case caused the cover calculation to return h_win (fully open) instead of 0 (fully closed). The fix corrects the return value so the cover closes rather than opens when the sun is near the horizon. Verified by `test_low_elevation_calc_percentage_is_fully_closed`.
+
+## 🔧 Internal
+
+### Write-gating, geometry caching, and sun availability guard (#543)
+
+Three robustness and performance improvements shipped together:
+
+- **Write-gating:** `_acp_render_signature()` detects when a calculated position is identical to the last written value and skips the HA state write, reducing redundant entity updates.
+- **Geometry cache:** Pure geometry helpers are decorated with `@lru_cache(maxsize=512)`, eliminating repeated identical calculations across update cycles.
+- **Sun availability guard:** A guard on `sun.sun` suppresses solar tracking when the sun entity is unavailable, preventing stale or error-state data from driving cover commands.
+
+## 🧪 Testing
+
+Test suite grows from 4,214 to 4,276 (+62 net new tests across both betas). New modules:
+
+- `test_config_flow_fov_mode.py` / `test_fov_mode.py` — FOV-mode selector and `fov_from_reveal()` calculation
+- `test_entity_write_gating.py` — write-gating behavior
+- `test_geometry_cache.py` — cache correctness and hit behavior
+- `test_sun_unavailable_guard.py` — solar tracking suppression when sun entity unavailable
+- `test_blind_fov_fields_are_optional`, `test_awning_fov_fields_stay_required`, `test_measurements_mode_submittable_without_fov`, `test_imperial_shaded_area_stable_across_mode_switch_rerender` — config-flow correctness for the beta.2 fixes
+
+## Compatibility
+
+Requires Home Assistant 2026.3.0+. No new coupled-component requirements.
+
+## References
+
+[#543]: https://github.com/jrhubott/adaptive-cover-pro/issues/543
+[#559]: https://github.com/jrhubott/adaptive-cover-pro/issues/559
+[#562]: https://github.com/jrhubott/adaptive-cover-pro/issues/562
+[#565]: https://github.com/jrhubott/adaptive-cover-pro/issues/565

--- a/release_notes/v2.28.0-beta.3.md
+++ b/release_notes/v2.28.0-beta.3.md
@@ -1,0 +1,68 @@
+This beta builds on beta.2 (FOV-mode selector, Measurements-mode config-flow save, imperial shaded-area compounding fix) by landing four targeted fixes: the FOV-mode selection now persists correctly on re-render so the save loop is gone, small 1–3% solar tracking moves are no longer swallowed by the same-position gate, set-position covers can reach true 0% during solar tracking, and string entity_id targets in services resolve correctly regardless of case or spacing.
+
+## 🎯 Highlights
+
+**Beta — please test and report back.**
+
+- Configure a window using `MEASUREMENTS` mode and confirm the mode sticks — previous betas had a save loop where the mode selection didn't persist on re-render. This is now fixed.
+- Verify small solar tracking adjustments (1–3%) are sent to the cover. beta.2 silently swallowed these moves; they should now go through.
+- If you have a set-position cover with a geometry path that previously stopped short of fully closed, confirm it reaches 0% during solar tracking.
+- Try the FOV-mode selector end-to-end: switch between `ANGLES` and `MEASUREMENTS` mode, save, reload, and confirm the saved mode is the one that loads.
+- Verify service calls that pass a string `entity_id` target resolve correctly, especially for sunset/sunrise time entity services.
+
+## ✨ Features
+
+### Set-position covers can reach true 0% in solar tracking (#569, #572)
+
+Adds a `solar_floor()` helper and a `position_axis_supported()` method on `CoverTypePolicy` to distinguish covers with the SET_POSITION capability from those limited to open/close/stop/tilt. Covers that support arbitrary position commands can now close fully (true 0%) during solar tracking. Previously, a geometry oversight in some paths prevented these covers from reaching 0%, leaving them stopped short of fully closed.
+
+## 🐛 Bug Fixes
+
+### FOV mode not persisted on re-render causes save loop (#565)
+
+When a FOV-mode switch triggered a re-render in `ConfigFlowHandler` or `OptionsFlowHandler`, the selected mode was passed to `_show_sun_tracking_form` but not written back into `self.config` or `self.options`. The form re-rendered with the old stored mode, which differed from the displayed mode, causing an infinite re-render cycle. The fix writes `CONF_FOV_MODE` into the config/options dict before calling `_show_sun_tracking_form`, so the persisted value and the displayed value stay in sync. Covered by `test_create_flow_switch_to_measurements_then_save`, `test_imperial_switch_to_measurements_then_save`, and `test_switching_to_measurements_then_submitting_saves`.
+
+### Same-position gate used tolerance band, swallowing 1–3% tracking moves (#567, #574)
+
+A position tolerance band introduced in #567 widened the same-position gate so that positions within the tolerance range were treated as identical and not sent. This silently dropped small solar tracking adjustments. The fix reverts the same-position gate to exact equality; movement hysteresis is preserved in the reconcile path, which is the right place for it. Covered by `test_apply_position_one_percent_tracking_move_is_sent`, `test_same_position_band_uses_exact_equality_not_tolerance`, `test_unreachable_target_suppressed_by_reconcile_not_command_gate`, and `test_reconcile_gives_up_on_unreachable_target`.
+
+### String entity_id in service targets not normalizing correctly (#570, #571)
+
+Services that accept a string `entity_id` target now normalize the value before resolution, so case or spacing variations no longer cause silent failures. Adds regression test coverage via `TestStringEntityIdRegression`, and adds coverage for the sunset/sunrise time entity service paths via `TestSunsetSunriseTimeEntity`, including `test_set_option_sunset_time_entity_accepted` and `test_set_option_sunrise_time_entity_accepted`.
+
+### Previously in this beta line
+
+**Measurements mode config-flow save and imperial shaded-area compounding (beta.2, #565):** The FOV sliders were emitted as `vol.Required` markers, blocking the frontend from switching to Measurements mode. A `_as_optional()` helper re-emits them as `vol.Optional` to unblock the mode switch. Imperial shaded-area values also compounded on each re-render because `user_input` was fed back into `_show_sun_tracking_form` without first converting it back to canonical metres; the fix calls `user_input_to_canonical()` once up front.
+
+**Low-sun edge case returns closed position (beta.1, #559, #562):** At very low sun elevations, a geometry edge case returned h_win (fully open) instead of 0 (fully closed). The cover now closes when the sun is near the horizon.
+
+## 🔧 Internal
+
+### Write-gating, geometry caching, and sun availability guard (#543)
+
+Shipped in beta.1, carried here for completeness:
+
+- **Write-gating:** `_acp_render_signature()` detects when a calculated position matches the last written value and skips the HA state write, reducing redundant entity updates.
+- **Geometry cache:** Pure geometry helpers decorated with `@lru_cache(maxsize=512)` eliminate repeated identical calculations across update cycles.
+- **Sun availability guard:** A guard on `sun.sun` suppresses solar tracking when the sun entity is unavailable, preventing stale or error-state data from driving cover commands.
+
+## 🧪 Testing
+
+4,316 tests passing (up from ~4,276 at beta.2).
+
+## Compatibility
+
+Requires Home Assistant 2026.3.0+. No new coupled-component requirements.
+
+## References
+
+[#543]: https://github.com/jrhubott/adaptive-cover-pro/issues/543
+[#559]: https://github.com/jrhubott/adaptive-cover-pro/issues/559
+[#562]: https://github.com/jrhubott/adaptive-cover-pro/issues/562
+[#565]: https://github.com/jrhubott/adaptive-cover-pro/issues/565
+[#567]: https://github.com/jrhubott/adaptive-cover-pro/issues/567
+[#569]: https://github.com/jrhubott/adaptive-cover-pro/issues/569
+[#570]: https://github.com/jrhubott/adaptive-cover-pro/issues/570
+[#571]: https://github.com/jrhubott/adaptive-cover-pro/issues/571
+[#572]: https://github.com/jrhubott/adaptive-cover-pro/issues/572
+[#574]: https://github.com/jrhubott/adaptive-cover-pro/issues/574

--- a/tests/test_config_flow_fov_mode.py
+++ b/tests/test_config_flow_fov_mode.py
@@ -1,0 +1,188 @@
+"""Config-flow behaviour for the two-mode FOV selector (#565).
+
+Covers per-mode schema rendering, the re-render-on-mode-change pattern, the
+save path that derives fov_left/right in MEASUREMENTS mode, and backward
+compatibility when ``fov_mode`` is absent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.config_flow import (
+    OptionsFlowHandler,
+    _get_sun_tracking_schema,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_FOV_LEFT,
+    CONF_FOV_MODE,
+    CONF_FOV_RIGHT,
+    CONF_WINDOW_DEPTH,
+    CONF_WINDOW_WIDTH,
+    FovMode,
+)
+from custom_components.adaptive_cover_pro.const import CoverType
+
+
+def _keys(schema) -> set[str]:
+    return {str(m) for m in schema.schema}
+
+
+# ----------------------------------------------------------------------------
+# Per-mode schema rendering
+# ----------------------------------------------------------------------------
+
+
+def test_blind_angles_mode_shows_fov_sliders():
+    schema = _get_sun_tracking_schema(CoverType.BLIND, mode=FovMode.ANGLES)
+    keys = _keys(schema)
+    assert CONF_FOV_LEFT in keys
+    assert CONF_FOV_RIGHT in keys
+    assert CONF_FOV_MODE in keys
+
+
+def test_blind_measurements_mode_hides_fov_sliders():
+    schema = _get_sun_tracking_schema(CoverType.BLIND, mode=FovMode.MEASUREMENTS)
+    keys = _keys(schema)
+    assert CONF_FOV_LEFT not in keys
+    assert CONF_FOV_RIGHT not in keys
+    # The mode selector itself stays so the user can switch back.
+    assert CONF_FOV_MODE in keys
+
+
+def test_blind_default_mode_is_angles():
+    # No mode passed → behaves as ANGLES (sliders shown).
+    schema = _get_sun_tracking_schema(CoverType.BLIND)
+    keys = _keys(schema)
+    assert CONF_FOV_LEFT in keys
+    assert CONF_FOV_RIGHT in keys
+
+
+def test_awning_never_gets_mode_selector():
+    schema = _get_sun_tracking_schema(CoverType.AWNING, mode=FovMode.MEASUREMENTS)
+    keys = _keys(schema)
+    assert CONF_FOV_MODE not in keys
+    # Awnings keep their fov sliders regardless of mode argument.
+    assert CONF_FOV_LEFT in keys
+    assert CONF_FOV_RIGHT in keys
+
+
+# ----------------------------------------------------------------------------
+# Save-path derivation (options flow)
+# ----------------------------------------------------------------------------
+
+
+def _options_flow(options: dict) -> OptionsFlowHandler:
+    entry = MagicMock()
+    entry.options = dict(options)
+    entry.data = {"sensor_type": CoverType.BLIND}
+    flow = OptionsFlowHandler(entry)
+    flow.hass = MagicMock()
+    flow.sensor_type = CoverType.BLIND
+    flow.options = dict(options)
+    flow.async_step_init = AsyncMock(return_value={"type": "menu"})
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_measurements_mode_stores_derived_fov():
+    # width 2.0 / depth 0.5 → atan(2) ≈ 63°. The form was already in
+    # Measurements mode (stored mode == MEASUREMENTS), so submitting it derives
+    # and saves rather than re-rendering.
+    flow = _options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_FOV_LEFT: 90,
+            CONF_FOV_RIGHT: 90,
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+        }
+    )
+    await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert flow.options[CONF_FOV_LEFT] == 63
+    assert flow.options[CONF_FOV_RIGHT] == 63
+    # window_depth itself is untouched.
+    assert flow.options[CONF_WINDOW_DEPTH] == 0.5
+    assert flow.options[CONF_FOV_MODE] == FovMode.MEASUREMENTS
+
+
+@pytest.mark.asyncio
+async def test_angles_mode_keeps_typed_fov():
+    flow = _options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+        }
+    )
+    await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.ANGLES,
+            CONF_FOV_LEFT: 30,
+            CONF_FOV_RIGHT: 40,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert flow.options[CONF_FOV_LEFT] == 30
+    assert flow.options[CONF_FOV_RIGHT] == 40
+
+
+@pytest.mark.asyncio
+async def test_absent_fov_mode_behaves_as_angles():
+    # Backward compat: no CONF_FOV_MODE in submission → typed fov untouched,
+    # no derivation runs.
+    flow = _options_flow({CONF_WINDOW_WIDTH: 2.0, CONF_WINDOW_DEPTH: 0.5})
+    await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_LEFT: 55,
+            CONF_FOV_RIGHT: 65,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert flow.options[CONF_FOV_LEFT] == 55
+    assert flow.options[CONF_FOV_RIGHT] == 65
+
+
+# ----------------------------------------------------------------------------
+# Re-render on mode change
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_switching_to_measurements_rerenders_form_not_next_step():
+    # Form was built in ANGLES (the stored/default mode); submitting a different
+    # mode must re-show the sun_tracking form, not advance to the next step.
+    flow = _options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_FOV_MODE: FovMode.ANGLES,
+        }
+    )
+    advanced = False
+
+    async def _next():
+        nonlocal advanced
+        advanced = True
+        return {"type": "menu"}
+
+    flow.async_step_init = _next
+    result = await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            CONF_FOV_LEFT: 90,
+            CONF_FOV_RIGHT: 90,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert advanced is False
+    assert result["type"] == "form"
+    assert result["step_id"] == "sun_tracking"
+    # The re-rendered form is in MEASUREMENTS mode (sliders hidden).
+    assert CONF_FOV_LEFT not in _keys(result["data_schema"])

--- a/tests/test_config_flow_fov_mode.py
+++ b/tests/test_config_flow_fov_mode.py
@@ -14,6 +14,7 @@ import voluptuous as vol
 from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from custom_components.adaptive_cover_pro.config_flow import (
+    ConfigFlowHandler,
     OptionsFlowHandler,
     _get_sun_tracking_schema,
 )
@@ -287,10 +288,149 @@ async def test_imperial_shaded_area_stable_across_mode_switch_rerender():
     s1 = _suggested(result1, CONF_DISTANCE)
     assert s1 == pytest.approx(expected_in, abs=0.1)
 
-    # Feed the re-rendered value back through another rerender — it must stay
-    # put, not compound.
+    # The re-rendered suggested value must not have compounded (metres->inches
+    # applied twice). After the fix the second submit saves rather than
+    # looping, so we only verify value-stability on the first re-render, then
+    # assert that saving terminates correctly.
+    assert s1 == pytest.approx(expected_in, abs=0.1)
+
+    # Second submit with the (un-compounded) inch value: must save, not loop.
     result2 = await flow.async_step_sun_tracking(
         {CONF_FOV_MODE: FovMode.MEASUREMENTS, CONF_DISTANCE: s1}
     )
-    assert result2["step_id"] == "sun_tracking"
-    assert _suggested(result2, CONF_DISTANCE) == pytest.approx(expected_in, abs=0.1)
+    assert (
+        result2["type"] == "menu"
+    ), f"second imperial submit must save, not loop; got {result2['type']}"
+
+
+# ----------------------------------------------------------------------------
+# Switch-then-save regression tests (#565) — the perpetual re-render loop
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_switching_to_measurements_then_submitting_saves():
+    # #565: seed flow in ANGLES; submit MEASUREMENTS once (expect re-render);
+    # submit MEASUREMENTS a SECOND time and assert it advances out of
+    # sun_tracking and persists the derived fov values.
+    # width 2.0 / depth 0.5 → atan(2) ≈ 63°.
+    flow = _options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_FOV_LEFT: 90,
+            CONF_FOV_RIGHT: 90,
+            CONF_FOV_MODE: FovMode.ANGLES,
+        }
+    )
+
+    # First submit: mode change (ANGLES → MEASUREMENTS) → must re-render.
+    result1 = await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert result1["type"] == "form"
+    assert result1["step_id"] == "sun_tracking"
+
+    # Second submit: mode is now MEASUREMENTS (no change) → must save.
+    result2 = await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert (
+        result2["type"] == "menu"
+    ), f"expected save (menu) on second submit, got {result2!r}"
+    assert flow.options[CONF_FOV_MODE] == FovMode.MEASUREMENTS
+    assert flow.options[CONF_FOV_LEFT] == 63
+
+
+@pytest.mark.asyncio
+async def test_imperial_switch_to_measurements_then_save():
+    # #565 imperial variant: same two-submit sequence; the second submit must
+    # save and the stored CONF_DISTANCE round-trips to canonical ~0.5 m.
+    flow = _imperial_options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_DISTANCE: 0.5,  # canonical metres
+            CONF_FOV_MODE: FovMode.ANGLES,
+        }
+    )
+    # The display value the form shows for stored 0.5 m (≈19.7 in).
+    expected_in = options_to_display(
+        flow.hass, {CONF_DISTANCE: 0.5}, length_keys=(CONF_DISTANCE,)
+    )[CONF_DISTANCE]
+
+    # First submit: mode switch → re-render.
+    result1 = await flow.async_step_sun_tracking(
+        {CONF_FOV_MODE: FovMode.MEASUREMENTS, CONF_DISTANCE: expected_in}
+    )
+    assert result1["type"] == "form"
+    assert result1["step_id"] == "sun_tracking"
+
+    # Second submit: same mode → must save (advance past sun_tracking).
+    result2 = await flow.async_step_sun_tracking(
+        {CONF_FOV_MODE: FovMode.MEASUREMENTS, CONF_DISTANCE: expected_in}
+    )
+    assert (
+        result2["type"] == "menu"
+    ), f"expected save (menu) on second submit, got {result2!r}"
+    # The stored distance is in canonical metres; round-trip must be ~0.5 m.
+    import math
+
+    stored_m = flow.options.get(CONF_DISTANCE)
+    assert stored_m is not None
+    assert math.isclose(
+        stored_m, 0.5, abs_tol=0.05
+    ), f"stored CONF_DISTANCE {stored_m!r} is not ~0.5 m"
+
+
+def _create_flow(sensor_type: str = CoverType.BLIND) -> ConfigFlowHandler:
+    """Build a minimal ConfigFlowHandler suitable for unit tests."""
+    flow = ConfigFlowHandler.__new__(ConfigFlowHandler)
+    flow.hass = MagicMock()
+    flow.hass.config.units = MagicMock()
+    flow.hass.config.units.is_metric = True
+    flow.hass.states.get.return_value = None
+    flow.type_blind = sensor_type
+    flow.config = {}
+    flow.async_step_position = AsyncMock(
+        return_value={"type": "form", "step_id": "position"}
+    )
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_create_flow_switch_to_measurements_then_save():
+    # #565 create-flow: seed flow with no fov_mode (defaults ANGLES); submit
+    # MEASUREMENTS once (expect re-render); submit MEASUREMENTS a SECOND time
+    # and assert it calls async_step_position (advances) and persists the mode.
+    flow = _create_flow()
+    flow.config[CONF_WINDOW_WIDTH] = 2.0
+    flow.config[CONF_WINDOW_DEPTH] = 0.5
+
+    # First submit: mode switch (absent/ANGLES → MEASUREMENTS) → re-render.
+    result1 = await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert result1["type"] == "form"
+    assert result1["step_id"] == "sun_tracking"
+
+    # Second submit: still MEASUREMENTS → must advance to position step.
+    result2 = await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert (
+        result2["step_id"] == "position"
+    ), f"expected advance to position on second submit, got {result2!r}"
+    assert flow.config[CONF_FOV_MODE] == FovMode.MEASUREMENTS

--- a/tests/test_config_flow_fov_mode.py
+++ b/tests/test_config_flow_fov_mode.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import voluptuous as vol
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from custom_components.adaptive_cover_pro.config_flow import (
     OptionsFlowHandler,
     _get_sun_tracking_schema,
 )
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DISTANCE,
     CONF_FOV_LEFT,
     CONF_FOV_MODE,
     CONF_FOV_RIGHT,
@@ -24,10 +27,25 @@ from custom_components.adaptive_cover_pro.const import (
     FovMode,
 )
 from custom_components.adaptive_cover_pro.const import CoverType
+from custom_components.adaptive_cover_pro.unit_system import options_to_display
 
 
 def _keys(schema) -> set[str]:
     return {str(m) for m in schema.schema}
+
+
+def _marker_for(schema, key) -> vol.Marker:
+    for m in schema.schema:
+        if str(m) == key:
+            return m
+    raise AssertionError(f"{key!r} not in schema")
+
+
+def _suggested(result, key):
+    for m in result["data_schema"].schema:
+        if str(m) == key and m.description:
+            return m.description.get("suggested_value")
+    raise AssertionError(f"no suggested_value for {key!r}")
 
 
 # ----------------------------------------------------------------------------
@@ -67,6 +85,26 @@ def test_awning_never_gets_mode_selector():
     # Awnings keep their fov sliders regardless of mode argument.
     assert CONF_FOV_LEFT in keys
     assert CONF_FOV_RIGHT in keys
+
+
+@pytest.mark.parametrize("mode", [FovMode.ANGLES, None])
+def test_blind_fov_fields_are_optional(mode):
+    # #565: the fov sliders must be vol.Optional so HA's frontend client-side
+    # "required field" check never blocks switching to Measurements mode before
+    # the backend can re-render with them hidden. The default is preserved.
+    schema = _get_sun_tracking_schema(CoverType.BLIND, mode=mode)
+    assert isinstance(_marker_for(schema, CONF_FOV_LEFT), vol.Optional)
+    assert isinstance(_marker_for(schema, CONF_FOV_RIGHT), vol.Optional)
+    assert _marker_for(schema, CONF_FOV_LEFT).default() == 90
+    assert _marker_for(schema, CONF_FOV_RIGHT).default() == 90
+
+
+def test_awning_fov_fields_stay_required():
+    # Only blinds relax requiredness (they own the FOV-mode feature). Awnings
+    # have no mode selector, so their fov sliders stay vol.Required.
+    schema = _get_sun_tracking_schema(CoverType.AWNING, mode=None)
+    assert isinstance(_marker_for(schema, CONF_FOV_LEFT), vol.Required)
+    assert isinstance(_marker_for(schema, CONF_FOV_RIGHT), vol.Required)
 
 
 # ----------------------------------------------------------------------------
@@ -186,3 +224,73 @@ async def test_switching_to_measurements_rerenders_form_not_next_step():
     assert result["step_id"] == "sun_tracking"
     # The re-rendered form is in MEASUREMENTS mode (sliders hidden).
     assert CONF_FOV_LEFT not in _keys(result["data_schema"])
+
+
+@pytest.mark.asyncio
+async def test_measurements_mode_submittable_without_fov():
+    # #565: a user in Measurements mode submits the form without any fov
+    # values (the sliders are hidden). The save must succeed and backfill the
+    # derived angles from width/depth — it must not block on "required fov".
+    flow = _options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+        }
+    )
+    result = await flow.async_step_sun_tracking(
+        {CONF_FOV_MODE: FovMode.MEASUREMENTS, "distance_shaded_area": 0.5}
+    )
+    assert result["type"] == "menu"  # advanced (saved), not re-rendered
+    assert flow.options[CONF_FOV_LEFT] == 63
+    assert flow.options[CONF_FOV_RIGHT] == 63
+
+
+# ----------------------------------------------------------------------------
+# Imperial round-trip stability across rerenders (#565)
+# ----------------------------------------------------------------------------
+
+
+def _imperial_options_flow(options: dict) -> OptionsFlowHandler:
+    flow = _options_flow(options)
+    flow.hass.config.units = US_CUSTOMARY_SYSTEM
+    flow.hass.states.get.return_value = None
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_imperial_shaded_area_stable_across_mode_switch_rerender():
+    # #565: switching FOV mode re-renders the form. On an imperial hass the
+    # "shaded area" (distance) value must NOT be re-converted metres->inches a
+    # second time — otherwise it compounds (~x39 per rerender) until it
+    # overruns the slider/OPTION_RANGES max and the form becomes unsaveable.
+    flow = _imperial_options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_DISTANCE: 0.5,  # canonical metres
+            CONF_FOV_MODE: FovMode.ANGLES,
+        }
+    )
+    # The value the form displays for a stored 0.5 m (≈19.7 in).
+    expected_in = options_to_display(
+        flow.hass, {CONF_DISTANCE: 0.5}, length_keys=(CONF_DISTANCE,)
+    )[CONF_DISTANCE]
+
+    # First mode switch (ANGLES -> MEASUREMENTS) re-renders the form. The user
+    # submits the inch value the form currently shows.
+    result1 = await flow.async_step_sun_tracking(
+        {CONF_FOV_MODE: FovMode.MEASUREMENTS, CONF_DISTANCE: expected_in}
+    )
+    assert result1["type"] == "form"
+    assert result1["step_id"] == "sun_tracking"
+    s1 = _suggested(result1, CONF_DISTANCE)
+    assert s1 == pytest.approx(expected_in, abs=0.1)
+
+    # Feed the re-rendered value back through another rerender — it must stay
+    # put, not compound.
+    result2 = await flow.async_step_sun_tracking(
+        {CONF_FOV_MODE: FovMode.MEASUREMENTS, CONF_DISTANCE: s1}
+    )
+    assert result2["step_id"] == "sun_tracking"
+    assert _suggested(result2, CONF_DISTANCE) == pytest.approx(expected_in, abs=0.1)

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -86,10 +86,12 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_WIND_SPEED_SENSOR,
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
     CONF_TRANSIT_TIMEOUT,
+    CONF_FOV_MODE,
     CONF_WINDOW_DEPTH,
     CONF_WINDOW_WIDTH,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     CoverType,
+    FovMode,
 )
 
 # ---------------------------------------------------------------------------
@@ -2523,3 +2525,41 @@ def test_summary_without_entities_uses_offset_annotation():
     assert "+30" in summary or "30 min" in summary
     # The entity IDs should NOT appear
     assert "sun2" not in summary
+
+
+# ---------------------------------------------------------------------------
+# FOV-mode computed-FOV summary line (#565)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_shows_computed_fov_in_measurements_mode():
+    """Measurements mode appends a read-only 'Computed FOV ≈ ...' summary line."""
+    cfg = _minimal_vertical()
+    cfg[CONF_FOV_MODE] = FovMode.MEASUREMENTS
+    cfg[CONF_WINDOW_WIDTH] = 1.2
+    cfg[CONF_WINDOW_DEPTH] = 0.5
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    # width 1.2 / depth 0.5 → atan(1.2) ≈ 50.19° → 50
+    assert "Computed FOV" in summary
+    assert "50°/50°" in summary
+    assert "1.2 m width" in summary
+    assert "0.5 m reveal depth" in summary
+
+
+def test_summary_omits_computed_fov_in_angles_mode():
+    """Angles mode (the default) never shows the computed-FOV line."""
+    cfg = _minimal_vertical()
+    cfg[CONF_FOV_MODE] = FovMode.ANGLES
+    cfg[CONF_WINDOW_WIDTH] = 1.2
+    cfg[CONF_WINDOW_DEPTH] = 0.5
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "Computed FOV" not in summary
+
+
+def test_summary_omits_computed_fov_when_mode_absent():
+    """Absent fov_mode (back-compat) behaves as angles — no computed line."""
+    cfg = _minimal_vertical()
+    cfg[CONF_WINDOW_WIDTH] = 1.2
+    cfg[CONF_WINDOW_DEPTH] = 0.5
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "Computed FOV" not in summary

--- a/tests/test_engine/test_sun_geometry_fov.py
+++ b/tests/test_engine/test_sun_geometry_fov.py
@@ -1,0 +1,63 @@
+"""Tests for the ``fov_from_reveal`` derivation helper (issue #565).
+
+The Measurements FOV mode derives a symmetric half-angle from the window
+opening width and the reveal (recess) depth in front of the cover. The helper
+is the single source of that arctan — both the config-flow save path and the
+summary display call it.
+"""
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_FOV_LEFT,
+    DEFAULT_FOV_LEFT,
+    OPTION_RANGES,
+)
+from custom_components.adaptive_cover_pro.engine.sun_geometry import fov_from_reveal
+
+
+def test_width_2_depth_1_is_45_degrees():
+    # atan((2/2)/1) = atan(1) = 45°
+    assert fov_from_reveal(2.0, 1.0) == 45
+
+
+def test_width_2_depth_half_is_63_degrees():
+    # atan((2/2)/0.5) = atan(2) ≈ 63.43° → rounds to 63
+    assert fov_from_reveal(2.0, 0.5) == 63
+
+
+def test_zero_depth_is_full_hemisphere_default():
+    assert fov_from_reveal(2.0, 0.0) == DEFAULT_FOV_LEFT
+    assert fov_from_reveal(2.0, 0.0) == 90
+
+
+def test_zero_width_is_full_hemisphere_default():
+    assert fov_from_reveal(0.0, 1.0) == DEFAULT_FOV_LEFT
+
+
+def test_negative_inputs_fall_back_to_default():
+    assert fov_from_reveal(-1.0, 1.0) == DEFAULT_FOV_LEFT
+    assert fov_from_reveal(2.0, -1.0) == DEFAULT_FOV_LEFT
+
+
+def test_result_clamped_to_fov_range():
+    lo, hi = OPTION_RANGES[CONF_FOV_LEFT]
+    # Very wide, very shallow → angle approaches 90, never exceeds the range.
+    assert fov_from_reveal(50.0, 0.01) <= hi
+    assert fov_from_reveal(50.0, 0.01) >= lo
+
+
+def test_returns_int():
+    assert isinstance(fov_from_reveal(1.2, 0.5), int)
+
+
+@pytest.mark.parametrize(
+    ("width", "depth", "expected"),
+    [
+        (1.0, 1.0, 27),  # atan(0.5) ≈ 26.57 → 27
+        (3.0, 1.0, 56),  # atan(1.5) ≈ 56.31 → 56
+        (1.2, 0.5, 50),  # atan(1.2) ≈ 50.19 → 50 (the summary example)
+    ],
+)
+def test_known_angles(width, depth, expected):
+    assert fov_from_reveal(width, depth) == expected

--- a/tests/test_fov_mode.py
+++ b/tests/test_fov_mode.py
@@ -1,0 +1,51 @@
+"""Tests for the FOV-mode selector vocabulary and field registration (#565).
+
+The two-mode FOV selector adds a ``CONF_FOV_MODE`` option and a ``FovMode``
+StrEnum. ANGLES is the default (today's fov_left/right sliders); MEASUREMENTS
+derives the FOV from the window width + reveal depth. No new measurement fields.
+"""
+
+from __future__ import annotations
+
+from custom_components.adaptive_cover_pro import config_fields as cf
+from custom_components.adaptive_cover_pro.const import CONF_FOV_MODE, FovMode
+
+
+def test_fov_mode_enum_values():
+    assert FovMode.ANGLES == "angles"
+    assert FovMode.MEASUREMENTS == "measurements"
+
+
+def test_conf_fov_mode_key():
+    assert CONF_FOV_MODE == "fov_mode"
+
+
+def test_fov_mode_default_is_angles():
+    assert FovMode.ANGLES.value == cf.option_default(CONF_FOV_MODE)
+
+
+def test_fov_mode_field_spec_registered_as_select():
+    spec = cf.FIELD_SPECS[CONF_FOV_MODE]
+    assert spec.validator is cf.ValidatorKind.SELECT
+    assert spec.select_options == tuple(m.value for m in FovMode)
+
+
+def test_fov_mode_in_sun_tracking_section():
+    spec = cf.FIELD_SPECS[CONF_FOV_MODE]
+    assert spec.section == cf.SECTION_SUN_TRACKING
+
+
+def test_fov_mode_is_a_valid_blind_option_key():
+    # The options-service rejects keys not in live_option_keys, so the blind
+    # policy must advertise CONF_FOV_MODE for saves to be accepted.
+    from custom_components.adaptive_cover_pro.const import CoverType
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    assert CONF_FOV_MODE in get_policy(CoverType.BLIND).live_option_keys()
+
+
+def test_fov_mode_not_a_valid_awning_option_key():
+    from custom_components.adaptive_cover_pro.const import CoverType
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    assert CONF_FOV_MODE not in get_policy(CoverType.AWNING).live_option_keys()


### PR DESCRIPTION
## Summary
Adds a "Define field of view by" mode selector to the Sun-tracking options page, addressing the #565 confusion between Window depth (Geometry) and FOV left/right (Sun tracking).

- **By angles** (default) — unchanged: the manual `fov_left`/`fov_right` sliders. Existing installs stay here, so no behavior change and no config-entry migration.
- **From measurements** — hides the FOV sliders and derives a symmetric FOV from the existing `window_width` + `window_depth` (reveal depth) via `arctan((width/2)/depth)`. Zero new measurement fields.

The computed FOV is shown read-only on the Sun-tracking page and in the config-flow summary. The reveal-depth help text clarifies it is measured from the outer wall face, where the actual cover is located.

Key correction from the issue discussion: `window_depth` and FOV are orthogonal in code (depth feeds the drop calc; FOV is an azimuth gate), so there is no depth→FOV inversion — the derived FOV is computed from reveal width + depth, which for a reveal-mounted blind is the cover's recess. The single `fov_from_reveal` helper feeds both the save path and the summary display (no duplicated arctan).

Subsumes the derivation idea from #550 as the "From measurements" mode.

## Testing
- ✅ 471 config-flow / engine / summary / translations tests passing (full suite 4269 passing)
- New: test_sun_geometry_fov.py, test_fov_mode.py, test_config_flow_fov_mode.py, plus summary tests

## Related Issues
Refs #565
Refs #550