### PR TITLE
fix: set_* services silently no-op on string entity_id (#570)

### DIFF
--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from homeassistant.core import ServiceCall, SupportsResponse
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 
 if TYPE_CHECKING:
@@ -41,9 +42,9 @@ def _resolve_targets(
     """
     all_coordinators: dict = hass.data.get(DOMAIN, {})
 
-    entity_ids: list[str] = list(call.data.get("entity_id", []))
-    device_ids: list[str] = list(call.data.get("device_id", []))
-    area_ids: list[str] = list(call.data.get("area_id", []))
+    entity_ids: list[str] = cv.ensure_list(call.data.get("entity_id"))
+    device_ids: list[str] = cv.ensure_list(call.data.get("device_id"))
+    area_ids: list[str] = cv.ensure_list(call.data.get("area_id"))
 
     # Expand area_ids → device_ids
     if area_ids:
@@ -92,6 +93,14 @@ def _resolve_targets(
                 "integration_service: entity %s is not managed by any ACP instance — skipping",
                 eid,
             )
+
+    if (entity_ids or device_ids or area_ids) and not result:
+        _LOGGER.warning(
+            "integration_service: target %s/%s/%s resolved to no ACP instances — nothing updated",
+            entity_ids,
+            device_ids,
+            area_ids,
+        )
 
     return result
 

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -90,8 +90,10 @@ from ..const import (
     CONF_START_ENTITY,
     CONF_START_TIME,
     CONF_SUNRISE_OFFSET,
+    CONF_SUNRISE_TIME_ENTITY,
     CONF_SUNSET_OFFSET,
     CONF_SUNSET_POS,
+    CONF_SUNSET_TIME_ENTITY,
     CONF_SUNSET_TILT,
     CONF_SUNSET_USE_MY,
     CONF_TEMP_ENTITY,
@@ -249,6 +251,8 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_SUNSET_USE_MY: _bool_v(),
     CONF_SUNSET_OFFSET: _range(CONF_SUNSET_OFFSET),
     CONF_SUNRISE_OFFSET: _range(CONF_SUNRISE_OFFSET),
+    CONF_SUNSET_TIME_ENTITY: _entity_v(),
+    CONF_SUNRISE_TIME_ENTITY: _entity_v(),
     CONF_OPEN_CLOSE_THRESHOLD: _range(CONF_OPEN_CLOSE_THRESHOLD),
     CONF_INVERSE_STATE: _bool_v(),
     # Explicit tilt (venetian only) — None means use solar-computed tilt.
@@ -379,6 +383,8 @@ _SECTION_SUNSET_SUNRISE = frozenset(
         CONF_SUNRISE_OFFSET,
         CONF_SUNSET_USE_MY,
         CONF_MY_POSITION_VALUE,
+        CONF_SUNSET_TIME_ENTITY,
+        CONF_SUNRISE_TIME_ENTITY,
     }
 )
 

--- a/tests/test_global_services.py
+++ b/tests/test_global_services.py
@@ -61,19 +61,34 @@ def _get_handler(hass: MagicMock, service_name: str):
     raise ValueError(f"Service {service_name!r} was never registered")
 
 
-def _make_call(entity_id=None, device_id=None, area_id=None) -> MagicMock:
+def _make_call(entity_id=None, device_id=None, area_id=None, raw=False) -> MagicMock:
+    """Build a mock ServiceCall.
+
+    When ``raw=True`` the caller controls the exact type of entity_id/device_id/area_id
+    (string or list) — no isinstance-wrapping is applied.  This is needed to exercise
+    the string-input code path that is the subject of issue #570.
+    """
     call = MagicMock()
     call.data = {}
-    if entity_id:
-        call.data["entity_id"] = (
-            entity_id if isinstance(entity_id, list) else [entity_id]
-        )
-    if device_id:
-        call.data["device_id"] = (
-            device_id if isinstance(device_id, list) else [device_id]
-        )
-    if area_id:
-        call.data["area_id"] = area_id if isinstance(area_id, list) else [area_id]
+    if entity_id is not None:
+        if raw:
+            call.data["entity_id"] = entity_id
+        else:
+            call.data["entity_id"] = (
+                entity_id if isinstance(entity_id, list) else [entity_id]
+            )
+    if device_id is not None:
+        if raw:
+            call.data["device_id"] = device_id
+        else:
+            call.data["device_id"] = (
+                device_id if isinstance(device_id, list) else [device_id]
+            )
+    if area_id is not None:
+        if raw:
+            call.data["area_id"] = area_id
+        else:
+            call.data["area_id"] = area_id if isinstance(area_id, list) else [area_id]
     return call
 
 
@@ -172,6 +187,121 @@ def test_resolve_entity_id_within_device_coordinator_not_narrowed():
 
     # device_id set None (all covers) — entity_id should not narrow it
     assert result[coord_a] is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_targets — string input (issue #570 regression tests)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_string_entity_id_normalized():
+    """RAW string entity_id (not list-wrapped) must resolve to the owning coordinator.
+
+    Before the fix, list("cover.living") char-splits and resolves to {}.
+    """
+    coord_a = _make_coordinator(["cover.living"])
+    coord_b = _make_coordinator(["cover.bedroom"])
+    hass = _make_hass({"entry_a": coord_a, "entry_b": coord_b})
+    # raw=True passes the string directly — no isinstance wrapping
+    call = _make_call(entity_id="cover.living", raw=True)
+
+    result = _resolve_targets(hass, call)
+
+    assert (
+        coord_a in result
+    ), "owning coordinator not found when entity_id is a raw string"
+    assert coord_b not in result
+    assert result[coord_a] == {"cover.living"}
+
+
+def test_resolve_string_device_id_normalized():
+    """RAW string device_id (not list-wrapped) must resolve to the owning coordinator.
+
+    The discriminating mock only returns the real device for the FULL id string
+    "device_xyz"; single-character lookups return None (as a real registry would).
+    This ensures the fix is what makes it pass — not a permissive MagicMock.
+    """
+    coord_a = _make_coordinator(["cover.a"])
+    hass = _make_hass({"entry_abc": coord_a})
+
+    full_device_id = "device_xyz"
+
+    fake_device = MagicMock()
+    fake_device.config_entries = ["entry_abc"]
+    fake_device.area_id = None
+
+    def _discriminating_get(device_id):
+        return fake_device if device_id == full_device_id else None
+
+    dev_reg_mock = MagicMock()
+    dev_reg_mock.async_get = MagicMock(side_effect=_discriminating_get)
+
+    call = _make_call(device_id=full_device_id, raw=True)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.dr.async_get",
+        return_value=dev_reg_mock,
+    ):
+        result = _resolve_targets(hass, call)
+
+    assert coord_a in result, "coordinator not found when device_id is a raw string"
+    assert result[coord_a] is None
+
+
+def test_resolve_string_area_id_normalized():
+    """RAW string area_id (not list-wrapped) must expand and resolve correctly."""
+    coord_a = _make_coordinator(["cover.a"])
+    hass = _make_hass({"entry_abc": coord_a})
+
+    # The area device
+    area_device = MagicMock()
+    area_device.area_id = "area_living"
+    area_device.id = "device_xyz"
+
+    # Config entry device
+    config_device = MagicMock()
+    config_device.config_entries = ["entry_abc"]
+    config_device.area_id = None
+
+    dev_reg_mock = MagicMock()
+    # devices.values() used for area expansion
+    dev_reg_mock.devices = MagicMock()
+    dev_reg_mock.devices.values = MagicMock(return_value=[area_device])
+    # async_get called for device_id resolution
+    dev_reg_mock.async_get = MagicMock(return_value=config_device)
+    config_device.config_entries = ["entry_abc"]
+
+    call = _make_call(area_id="area_living", raw=True)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.dr.async_get",
+        return_value=dev_reg_mock,
+    ):
+        result = _resolve_targets(hass, call)
+
+    assert coord_a in result, "coordinator not found when area_id is a raw string"
+
+
+def test_resolve_explicit_target_no_match_logs_warning(caplog):
+    """When an explicit entity_id target resolves to no coordinators, a WARNING is logged."""
+    import logging
+
+    coord_a = _make_coordinator(["cover.living"])
+    hass = _make_hass({"entry_a": coord_a})
+    # raw=True: pass as a list still (explicit target, just no match)
+    call = _make_call(entity_id="cover.unmanaged_and_explicit")
+
+    with caplog.at_level(
+        logging.WARNING, logger="custom_components.adaptive_cover_pro.services"
+    ):
+        result = _resolve_targets(hass, call)
+
+    assert result == {}
+    assert any(
+        "resolved to no ACP" in r.message for r in caplog.records
+    ), "Expected a WARNING about unresolved targets, got: " + str(
+        [r.message for r in caplog.records]
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -1426,3 +1426,172 @@ class TestSetVenetian:
         assert CONF_VENETIAN_BACKROTATE_PUBLISH_LAG in _SECTION_VENETIAN
         # Skip CONF_VENETIAN_TILT_SKIP_ABOVE import — use length check
         assert len(_SECTION_VENETIAN) == 4
+
+
+# ---------------------------------------------------------------------------
+# Issue #570 — string entity_id regression tests (end-to-end service path)
+# ---------------------------------------------------------------------------
+
+
+class TestStringEntityIdRegression:
+    """Regression tests for issue #570: bare-string entity_id must work.
+
+    Before the fix, list("cover.test_blind") char-splits, matches no coordinator,
+    and the service returns success having changed nothing (silent no-op).
+    """
+
+    async def test_set_automation_timing_string_entity_id(self, hass: HomeAssistant):
+        """set_automation_timing with a STRING entity_id (not list) must apply the patch."""
+        await _setup(hass, entry_id="str_eid_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            # Pass entity_id as a bare string (not a list) — mirrors what HA
+            # services called from YAML/templates can deliver.
+            await hass.services.async_call(
+                DOMAIN,
+                "set_automation_timing",
+                {CONF_DELTA_POSITION: 7},
+                blocking=True,
+                target={"entity_id": "cover.test_blind"},  # <-- string, not list
+            )
+            await hass.async_block_till_done()
+
+        mock_update.assert_called_once(), "async_update_entry must be called once"
+        new_opts = mock_update.call_args[1]["options"]
+        assert (
+            new_opts[CONF_DELTA_POSITION] == 7
+        ), f"Expected delta_position=7 in options, got: {new_opts.get(CONF_DELTA_POSITION)}"
+
+    async def test_set_automation_timing_list_entity_id_still_works(
+        self, hass: HomeAssistant
+    ):
+        """Existing list entity_id path must remain green after the fix."""
+        await _setup(hass, entry_id="str_eid_list_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_automation_timing", {CONF_DELTA_POSITION: 5})
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_DELTA_POSITION] == 5
+
+
+# ---------------------------------------------------------------------------
+# Issue #570 secondary gap — sunset_time_entity / sunrise_time_entity
+# ---------------------------------------------------------------------------
+
+
+class TestSunsetSunriseTimeEntity:
+    """Tests for set_option and set_sunset_sunrise with *_time_entity keys.
+
+    These are valid config-flow options (CONF_SUNSET_TIME_ENTITY,
+    CONF_SUNRISE_TIME_ENTITY) that were missing from FIELD_VALIDATORS and
+    _SECTION_SUNSET_SUNRISE, causing set_option to reject them as "Unknown
+    option" and set_sunset_sunrise to silently drop them.
+    """
+
+    def test_sunset_time_entity_in_field_validators(self):
+        """CONF_SUNSET_TIME_ENTITY must be in FIELD_VALIDATORS."""
+        from custom_components.adaptive_cover_pro.const import CONF_SUNSET_TIME_ENTITY
+
+        assert (
+            CONF_SUNSET_TIME_ENTITY in FIELD_VALIDATORS
+        ), "sunset_time_entity missing from FIELD_VALIDATORS"
+
+    def test_sunrise_time_entity_in_field_validators(self):
+        """CONF_SUNRISE_TIME_ENTITY must be in FIELD_VALIDATORS."""
+        from custom_components.adaptive_cover_pro.const import CONF_SUNRISE_TIME_ENTITY
+
+        assert (
+            CONF_SUNRISE_TIME_ENTITY in FIELD_VALIDATORS
+        ), "sunrise_time_entity missing from FIELD_VALIDATORS"
+
+    def test_sunset_time_entity_in_all_settable_keys(self):
+        """CONF_SUNSET_TIME_ENTITY must be in ALL_SETTABLE_KEYS (via _SECTION_SUNSET_SUNRISE)."""
+        from custom_components.adaptive_cover_pro.const import CONF_SUNSET_TIME_ENTITY
+
+        assert (
+            CONF_SUNSET_TIME_ENTITY in ALL_SETTABLE_KEYS
+        ), "sunset_time_entity missing from ALL_SETTABLE_KEYS"
+
+    def test_sunrise_time_entity_in_all_settable_keys(self):
+        """CONF_SUNRISE_TIME_ENTITY must be in ALL_SETTABLE_KEYS (via _SECTION_SUNSET_SUNRISE)."""
+        from custom_components.adaptive_cover_pro.const import CONF_SUNRISE_TIME_ENTITY
+
+        assert (
+            CONF_SUNRISE_TIME_ENTITY in ALL_SETTABLE_KEYS
+        ), "sunrise_time_entity missing from ALL_SETTABLE_KEYS"
+
+    async def test_set_option_sunset_time_entity_accepted(self, hass: HomeAssistant):
+        """set_option must accept sunset_time_entity without 'Unknown option' error."""
+        await _setup(hass, entry_id="ste_opt_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_option",
+                {"option": "sunset_time_entity", "value": "sensor.my_sunset"},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts.get("sunset_time_entity") == "sensor.my_sunset"
+
+    async def test_set_option_sunrise_time_entity_accepted(self, hass: HomeAssistant):
+        """set_option must accept sunrise_time_entity without 'Unknown option' error."""
+        await _setup(hass, entry_id="ste_opt_02")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_option",
+                {"option": "sunrise_time_entity", "value": "sensor.my_sunrise"},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts.get("sunrise_time_entity") == "sensor.my_sunrise"
+
+    async def test_set_sunset_sunrise_carries_time_entity(self, hass: HomeAssistant):
+        """set_sunset_sunrise must persist sunset_time_entity into options."""
+        await _setup(hass, entry_id="ste_ss_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_sunset_sunrise",
+                {"sunset_time_entity": "sensor.custom_sunset"},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts.get("sunset_time_entity") == "sensor.custom_sunset"
+
+    async def test_set_sunset_sunrise_carries_sunrise_time_entity(
+        self, hass: HomeAssistant
+    ):
+        """set_sunset_sunrise must persist sunrise_time_entity into options."""
+        await _setup(hass, entry_id="ste_ss_02")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_sunset_sunrise",
+                {"sunrise_time_entity": "sensor.custom_sunrise"},
+            )
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts.get("sunrise_time_entity") == "sensor.custom_sunrise"


### PR DESCRIPTION
## Summary
The schema-less `set_*` options services silently no-op'd (while reporting success) when `entity_id` was passed as a bare string. `_resolve_targets()` did `list(call.data.get("entity_id", []))`, which character-splits a string into single chars that match no coordinator, so the handler looped zero times and nothing was written. Same bug affected `device_id`/`area_id`.

Fix: normalize all three target keys with `cv.ensure_list` — one change covers all 16 `set_*` services (including `set_custom_position`). Added a warning log when an explicit target resolves to zero ACP instances (both reporters asked for this), and string-`entity_id` regression tests at the unit and end-to-end level so it can't regress. Also folded in a secondary gap: `sunset_time_entity`/`sunrise_time_entity` were missing from `FIELD_VALIDATORS`/`_SECTION_SUNSET_SUNRISE`, so `set_option` rejected them — now accepted.

## Testing
- ✅ 151 tests passing (up from 137; 14 new regression tests)
- ✅ ruff + black clean

## Related Issues
Refs #570