### PR TITLE
feat: let set-position covers reach true 0% in sun tracking

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1058,6 +1058,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             is_glare_zone_enabled=self._is_glare_zone_enabled,
             effective_default=effective_default,
             is_sunset_active=is_sunset_active,
+            cover_capabilities=getattr(
+                getattr(self, "_snapshot", None), "cover_capabilities", None
+            ),
         )
         self._pipeline_result = self._pipeline.evaluate(snapshot)
 
@@ -2031,6 +2034,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             in_time_window=self.check_adaptive_time,
             current_cover_position=self._compute_mean_cover_position(),
             is_glare_zone_enabled=self._is_glare_zone_enabled,
+            cover_capabilities=getattr(
+                getattr(self, "_snapshot", None), "cover_capabilities", None
+            ),
         )
         floors = gather_active_floors(snapshot)
         effective_floor_pos, _ = effective_floor(floors)

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -350,6 +350,22 @@ class CoverTypePolicy(ABC):
             return TILT_AXIS
         return primary
 
+    def position_axis_supported(self, caps: Any) -> bool:
+        """Whether *this entity* exposes the policy's primary (position) axis.
+
+        Reads the capability flag named by ``axes[0].capability_key`` so the
+        check stays behind the policy/axis abstraction — no hardcoded
+        capability-key literal at the call site. Used by the
+        solar floor gate (#569): a set-position-capable cover can be commanded
+        to a true 0 % during sun tracking, so the 1 % open/close-only floor
+        must not apply to it.
+
+        ``caps=None`` (entity not yet readable) defaults to ``True`` — the
+        instance-level rollup in the snapshot builder applies the conservative
+        mixed-instance rule on top of this.
+        """
+        return _caps_get(caps, self.axes[0].capability_key, default=True)
+
     def position_for_intent(self, *, sun_through: bool) -> int:
         """Map a semantic intent to the numeric value for the primary axis.
 

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -100,6 +100,7 @@ def build_forecast(
     step_minutes: int = FORECAST_STEP_MINUTES,
     minimize_movements: bool = False,
     max_coverage_steps: int = 1,
+    floor_active: bool = True,
 ) -> Forecast:
     """Compute the forecast for one cover.
 
@@ -133,6 +134,7 @@ def build_forecast(
         step_minutes=step_minutes,
         minimize_movements=minimize_movements,
         max_coverage_steps=max_coverage_steps,
+        floor_active=floor_active,
     )
     events = _build_events(
         sun_data=sun_data, cover_factory=cover_factory, samples=samples
@@ -149,6 +151,7 @@ def _build_samples(
     step_minutes: int,
     minimize_movements: bool = False,
     max_coverage_steps: int = 1,
+    floor_active: bool = True,
 ) -> list[ForecastSample]:
     """Walk the sun_data table at *step_minutes* cadence over the full calendar day.
 
@@ -201,6 +204,7 @@ def _build_samples(
                 minimize_movements=minimize_movements,
                 max_coverage_steps=max_coverage_steps,
                 policy=policy,
+                floor_active=floor_active,
             )
             samples.append(ForecastSample(t=t, position=pos, handler="solar"))
         else:
@@ -361,6 +365,15 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
             options=options,
         )
 
+    # Sun-tracking floor rollup (#569): mirror the live snapshot builder so the
+    # forecast strip matches what the cover is actually commanded to. The floor
+    # is off only when every bound entity supports the policy's position axis;
+    # missing caps (snapshot not built yet) default to floor active.
+    caps = getattr(coord._snapshot, "cover_capabilities", None) or {}  # noqa: SLF001
+    all_positionable = bool(caps) and all(
+        coord._policy.position_axis_supported(c) for c in caps.values()  # noqa: SLF001
+    )
+
     # The coverage direction the primitives need is read from the policy's
     # primary axis (single source of truth), so the shim passes the policy
     # straight through rather than precomputing full_coverage_at_zero.
@@ -376,4 +389,5 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
         max_coverage_steps=int(
             options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)
         ),
+        floor_active=not all_positionable,
     )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
@@ -17,7 +17,11 @@ from ...engine.covers.vertical import (
 )
 from ...const import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import apply_snapshot_limits, compute_raw_calculated_position
+from ..helpers import (
+    apply_snapshot_limits,
+    compute_raw_calculated_position,
+    solar_floor,
+)
 from ..types import PipelineResult, PipelineSnapshot
 
 _LOGGER = logging.getLogger(__name__)
@@ -105,7 +109,7 @@ class GlareZoneHandler(OverrideHandler):
         state = int(
             round(cover.calculate_percentage(effective_distance_override=min_distance))
         )
-        state = max(state, 1)
+        state = solar_floor(state, floor_active=snapshot.solar_floor_active)
         position = apply_snapshot_limits(snapshot, state, sun_valid=True)
 
         zone_names = ", ".join(contributing_zones)

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -25,6 +25,27 @@ if TYPE_CHECKING:
     from ..engine.covers.base import AdaptiveGeneralCover
 
 
+# The minimum sun-tracked position (%) for open/close-only covers. Keeping a
+# binary cover at >= 1 % stops it from fully retracting while the sun is still
+# in the field of view (a 0 % command means "open/retract" on a cover with no
+# set_position). Set-position-capable covers can reach a true 0 %, so the
+# floor is gated off for them at instance compute time (issue #569).
+SOLAR_TRACKING_FLOOR_PCT = 1
+
+
+def solar_floor(value: int, *, floor_active: bool) -> int:
+    """Apply the sun-tracking minimum-position floor when *floor_active*.
+
+    Single source of truth for the former ``max(state, 1)`` clamp that lived
+    in both :func:`solar_position_from_geometry` and the glare-zone handler.
+    When ``floor_active`` is False (every bound entity supports set_position),
+    the value passes through untouched so the cover can reach a true 0 %.
+    """
+    if floor_active:
+        return max(value, SOLAR_TRACKING_FLOOR_PCT)
+    return value
+
+
 def apply_config_limits(
     value: int,
     config: CoverConfig,
@@ -87,6 +108,7 @@ def solar_position_from_geometry(
     minimize_movements: bool,
     max_coverage_steps: int,
     policy: CoverTypePolicy | None,
+    floor_active: bool = True,
 ) -> int:
     """Sun-tracked position from raw geometry, with all standard transforms.
 
@@ -96,14 +118,16 @@ def solar_position_from_geometry(
     1. Calls ``cover.calculate_percentage()`` (pure geometry), rounded.
     2. Optionally quantizes into the configured number of discrete coverage
        levels (movement minimization — opt-in, rounds toward coverage).
-    3. Floors at 1 % so open/close-only covers never close while the sun is
-       still in the field of view.
+    3. Floors at ``SOLAR_TRACKING_FLOOR_PCT`` (1 %) so open/close-only covers
+       never close while the sun is still in the field of view — but only when
+       ``floor_active``. Set-position-capable instances pass ``floor_active``
+       False so the cover can reach a true 0 % (issue #569).
     4. Applies the configured min/max position limits (``sun_valid=True``).
 
     Should only be called when ``cover.direct_sun_valid`` is True.
 
     Returns:
-        Sun-tracked position (1–100 after floor, then limited).
+        Sun-tracked position (0–100; >= 1 only when ``floor_active``), limited.
 
     """
     state = int(round(cover.calculate_percentage()))
@@ -113,7 +137,7 @@ def solar_position_from_geometry(
             max_coverage_steps,
             full_coverage_at_zero=not policy.axes[0].open_blocks_sun,
         )
-    state = max(state, 1)
+    state = solar_floor(state, floor_active=floor_active)
     return apply_config_limits(state, config, sun_valid=True)
 
 
@@ -126,7 +150,8 @@ def compute_solar_position(snapshot: PipelineSnapshot) -> int:
         snapshot: Current pipeline snapshot.
 
     Returns:
-        Sun-tracked position (1–100 after floor, then limited).
+        Sun-tracked position (>= 1 only when ``snapshot.solar_floor_active``),
+        then limited.
 
     """
     return solar_position_from_geometry(
@@ -135,6 +160,7 @@ def compute_solar_position(snapshot: PipelineSnapshot) -> int:
         minimize_movements=getattr(snapshot, "minimize_movements", False),
         max_coverage_steps=getattr(snapshot, "max_coverage_steps", 1),
         policy=getattr(snapshot, "policy", None),
+        floor_active=getattr(snapshot, "solar_floor_active", True),
     )
 
 

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -261,6 +261,7 @@ class PipelineSnapshotBuilder:
         is_glare_zone_enabled: Callable[[int], bool],
         effective_default: int | None = None,
         is_sunset_active: bool | None = None,
+        cover_capabilities: dict | None = None,
     ) -> PipelineSnapshot:
         """Assemble the per-cycle :class:`PipelineSnapshot`.
 
@@ -276,6 +277,13 @@ class PipelineSnapshotBuilder:
         owns those switch attributes (``glare_zone_0``, ``glare_zone_1`` …);
         the builder reads them through this callable so it never reaches back
         into ``coordinator.self``.
+
+        ``cover_capabilities`` maps each bound entity_id to its
+        ``CoverCapabilities``.  It drives the sun-tracking floor rollup
+        (issue #569): the 1 % floor is switched off only when *every* bound
+        entity supports the policy's position axis (conservative
+        mixed-instance rule), so positionable covers reach a true 0 %.  ``None``
+        / empty leaves the floor active.
         """
         if effective_default is None or is_sunset_active is None:
             h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
@@ -298,6 +306,16 @@ class PipelineSnapshotBuilder:
             for idx, zone in enumerate(glare_zones_cfg.zones):
                 if is_glare_zone_enabled(idx):
                     active_zone_names.add(zone.name)
+
+        # Sun-tracking floor rollup (#569): switch the 1 % floor off only when
+        # every bound entity supports the policy's position axis. A mixed
+        # instance (any open/close-only entity) or unknown caps keeps the floor
+        # active, so a binary cover never fully retracts with sun in the FOV.
+        caps = cover_capabilities or {}
+        all_positionable = bool(caps) and all(
+            self._policy.position_axis_supported(c) for c in caps.values()
+        )
+        solar_floor_active = not all_positionable
 
         return PipelineSnapshot(
             cover=cover_data,
@@ -348,4 +366,5 @@ class PipelineSnapshotBuilder:
             ),
             default_tilt=options.get(CONF_DEFAULT_TILT),
             sunset_tilt=options.get(CONF_SUNSET_TILT),
+            solar_floor_active=solar_floor_active,
         )

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -201,6 +201,15 @@ class PipelineSnapshot:
     minimize_movements: bool = False
     max_coverage_steps: int = 1
 
+    # Whether the sun-tracking 1 % floor applies this cycle (issue #569). The
+    # solar branch and the glare-zone handler floor the geometric position at
+    # ``SOLAR_TRACKING_FLOOR_PCT`` so open/close-only covers never fully retract
+    # while the sun is in the FOV. The snapshot builder sets this False only
+    # when *every* bound entity supports set_position (conservative
+    # mixed-instance rollup) so positionable covers reach a true 0 %. Defaults
+    # to True so the floor stays in effect for snapshots that don't set it.
+    solar_floor_active: bool = True
+
 
 # ---------------------------------------------------------------------------
 # Output types

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -336,6 +336,78 @@ class TestReadAxisValue:
 
 
 # ---------------------------------------------------------------------------
+# position_axis_supported — does this entity expose the policy's primary axis?
+# ---------------------------------------------------------------------------
+
+
+class TestPositionAxisSupported:
+    """``position_axis_supported`` reads the primary axis capability per entity.
+
+    Used by the solar floor gate (#569): a set-position-capable cover can be
+    commanded to a true 0 % during sun tracking, so the 1 % floor must not
+    apply. The signal routes through the policy's ``axes[0].capability_key``
+    so no ``caps.get("has_set_position")`` literal leaks outside cover_types/.
+    """
+
+    @pytest.mark.unit
+    def test_blind_positionable_dict_true(self):
+        policy = get_policy("cover_blind")
+        assert policy.position_axis_supported({"has_set_position": True}) is True
+
+    @pytest.mark.unit
+    def test_blind_positionable_dict_false(self):
+        policy = get_policy("cover_blind")
+        assert policy.position_axis_supported({"has_set_position": False}) is False
+
+    @pytest.mark.unit
+    def test_blind_positionable_dataclass_true(self):
+        policy = get_policy("cover_blind")
+        caps = CoverCapabilities(
+            has_set_position=True,
+            has_set_tilt_position=False,
+            has_open=True,
+            has_close=True,
+        )
+        assert policy.position_axis_supported(caps) is True
+
+    @pytest.mark.unit
+    def test_blind_positionable_dataclass_false(self):
+        policy = get_policy("cover_blind")
+        caps = CoverCapabilities(
+            has_set_position=False,
+            has_set_tilt_position=False,
+            has_open=True,
+            has_close=True,
+        )
+        assert policy.position_axis_supported(caps) is False
+
+    @pytest.mark.unit
+    def test_none_caps_defaults_supported(self):
+        # caps unknown (entity not ready) → assume supported (default=True) so
+        # the floor is NOT spuriously applied. The instance-level rollup in the
+        # snapshot builder applies the conservative mixed-instance rule.
+        assert get_policy("cover_blind").position_axis_supported(None) is True
+
+    @pytest.mark.unit
+    def test_tilt_routes_to_tilt_capability(self):
+        # cover_tilt's primary axis is the tilt axis, so the "position axis"
+        # support check reads has_set_tilt_position, not has_set_position.
+        policy = get_policy("cover_tilt")
+        assert (
+            policy.position_axis_supported(
+                {"has_set_position": True, "has_set_tilt_position": False}
+            )
+            is False
+        )
+        assert (
+            policy.position_axis_supported(
+                {"has_set_position": False, "has_set_tilt_position": True}
+            )
+            is True
+        )
+
+
+# ---------------------------------------------------------------------------
 # Regression guard for CODING_GUIDELINES.md "no hardcoded capability strings"
 # ---------------------------------------------------------------------------
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -559,8 +559,21 @@ class TestForecastFloorAndRound:
             cover_factory=_solar_cover_factory(0),
             config=_make_config(),
             now=_NOW,
+            floor_active=True,
         )
         assert all(s.handler == "solar" and s.position == 1 for s in f.samples)
+
+    def test_positionable_solar_reaches_zero(self):
+        """A 0% geometry reaches a true 0% when the instance is positionable (#569)."""
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_solar_cover_factory(0),
+            config=_make_config(),
+            now=_NOW,
+            floor_active=False,
+        )
+        assert all(s.handler == "solar" and s.position == 0 for s in f.samples)
 
     def test_solar_percentage_is_rounded_not_truncated(self):
         """54.6% rounds to 55 (the live branch rounds; the old forecast truncated)."""

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -87,6 +87,7 @@ def make_snapshot(
     current_cover_position: int | None = None,
     default_tilt: int | None = None,
     sunset_tilt: int | None = None,
+    solar_floor_active: bool = True,
     # Convenience: configure mock cover
     direct_sun_valid: bool = False,
     calculate_percentage_return: float = 50.0,
@@ -135,4 +136,5 @@ def make_snapshot(
         current_cover_position=current_cover_position,
         default_tilt=default_tilt,
         sunset_tilt=sunset_tilt,
+        solar_floor_active=solar_floor_active,
     )

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -383,7 +383,7 @@ class TestGlareZoneBoundaryAtBaseDistance:
 
 
 class TestGlareZonePositionFloor:
-    """Verify the max(state, 1) clamp prevents position 0."""
+    """Verify the solar floor clamp prevents position 0 for open/close-only covers."""
 
     handler = GlareZoneHandler()
 
@@ -404,6 +404,7 @@ class TestGlareZonePositionFloor:
             cover_type="cover_blind",
             glare_zones=glare_cfg,
             active_zone_names={"desk"},
+            solar_floor_active=True,
         )
         result = self.handler.evaluate(snap)
         assert result is not None
@@ -426,10 +427,34 @@ class TestGlareZonePositionFloor:
             cover_type="cover_blind",
             glare_zones=glare_cfg,
             active_zone_names={"desk"},
+            solar_floor_active=True,
         )
         result = self.handler.evaluate(snap)
         assert result is not None
         assert result.position >= 1
+
+    def test_positionable_glare_zone_reaches_zero(self) -> None:
+        """Set-position-capable instance (floor off) reaches a true 0% (#569)."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=0.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=0.5, radius=0.0)],  # 0.5 m
+            window_width=2.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+            solar_floor_active=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.position == 0
 
 
 class TestGlareZonePositionLimits:

--- a/tests/test_pipeline/test_helpers.py
+++ b/tests/test_pipeline/test_helpers.py
@@ -10,10 +10,12 @@ from types import SimpleNamespace
 
 
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
+    SOLAR_TRACKING_FLOOR_PCT,
     apply_snapshot_limits,
     compute_default_position,
     compute_raw_calculated_position,
     compute_solar_position,
+    solar_floor,
 )
 
 # ---------------------------------------------------------------------------
@@ -58,6 +60,7 @@ def _make_snapshot(
     min_pos_sun_tracking=None,
     is_sunset_active=False,
     enable_sun_tracking=True,
+    solar_floor_active=True,
 ):
     return SimpleNamespace(
         cover=_make_cover(direct_sun_valid=direct_sun_valid, calc_pct=calc_pct),
@@ -71,6 +74,7 @@ def _make_snapshot(
         default_position=default_position,
         is_sunset_active=is_sunset_active,
         enable_sun_tracking=enable_sun_tracking,
+        solar_floor_active=solar_floor_active,
     )
 
 
@@ -126,6 +130,30 @@ class TestApplySnapshotLimits:
 
 
 # ---------------------------------------------------------------------------
+# solar_floor — the named, capability-gated floor primitive (#569)
+# ---------------------------------------------------------------------------
+
+
+class TestSolarFloor:
+    """The single source of truth for the solar-tracking 1 % floor."""
+
+    def test_constant_is_one(self):
+        assert SOLAR_TRACKING_FLOOR_PCT == 1
+
+    def test_floors_zero_when_active(self):
+        assert solar_floor(0, floor_active=True) == 1
+
+    def test_passes_through_above_floor_when_active(self):
+        assert solar_floor(40, floor_active=True) == 40
+
+    def test_reaches_zero_when_inactive(self):
+        assert solar_floor(0, floor_active=False) == 0
+
+    def test_passes_through_above_floor_when_inactive(self):
+        assert solar_floor(40, floor_active=False) == 40
+
+
+# ---------------------------------------------------------------------------
 # compute_solar_position
 # ---------------------------------------------------------------------------
 
@@ -140,7 +168,7 @@ class TestComputeSolarPosition:
 
     def test_floors_at_1(self):
         """Result is never 0 — floored to 1 to prevent open/close-only covers closing."""
-        snap = _make_snapshot(calc_pct=0.2)
+        snap = _make_snapshot(calc_pct=0.2, solar_floor_active=True)
         assert compute_solar_position(snap) == 1
 
     def test_applies_max_limit(self):
@@ -159,9 +187,19 @@ class TestComputeSolarPosition:
         assert compute_solar_position(snap) == 46
 
     def test_exactly_zero_floors_to_one(self):
-        """Exactly 0% from calculate_percentage becomes 1%."""
-        snap = _make_snapshot(calc_pct=0.0)
+        """Exactly 0% from calculate_percentage becomes 1% when the floor is active."""
+        snap = _make_snapshot(calc_pct=0.0, solar_floor_active=True)
         assert compute_solar_position(snap) == 1
+
+    def test_positionable_reaches_zero(self):
+        """Set-position-capable instance (floor off) reaches a true 0% (#569)."""
+        snap = _make_snapshot(calc_pct=0.0, solar_floor_active=False)
+        assert compute_solar_position(snap) == 0
+
+    def test_positionable_low_value_not_floored(self):
+        """A sub-1% geometry rounds to 0 and is NOT floored when positionable (#569)."""
+        snap = _make_snapshot(calc_pct=0.4, solar_floor_active=False)
+        assert compute_solar_position(snap) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -447,6 +447,93 @@ def test_build_consults_is_glare_zone_enabled_callable():
     assert snapshot.active_zone_names == frozenset({"zone_a"})
 
 
+# ---------------------------------------------------------------------------
+# solar_floor_active rollup (#569)
+# ---------------------------------------------------------------------------
+
+
+def _caps(*, has_set_position: bool):
+    from custom_components.adaptive_cover_pro.state.snapshot import CoverCapabilities
+
+    return CoverCapabilities(
+        has_set_position=has_set_position,
+        has_set_tilt_position=False,
+        has_open=True,
+        has_close=True,
+    )
+
+
+def _build_with_caps(builder, caps_map):
+    """Run ``builder.build`` with a given cover_capabilities map.
+
+    Wires ``policy.position_axis_supported`` to read ``has_set_position`` so
+    the rollup is exercised against realistic per-entity capability data.
+    """
+    builder._policy.position_axis_supported.side_effect = lambda c: c.has_set_position
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    return builder.build(
+        {},
+        cover_data=cover_data,
+        cover_type="cover_blind",
+        climate_readings=None,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda idx: False,
+        effective_default=0,
+        is_sunset_active=False,
+        cover_capabilities=caps_map,
+    )
+
+
+@pytest.mark.unit
+def test_solar_floor_inactive_when_all_entities_positionable():
+    """All bound entities support set_position → floor off (reaches 0%)."""
+    builder, _, _ = _make_builder()
+    snap = _build_with_caps(
+        builder,
+        {
+            "cover.a": _caps(has_set_position=True),
+            "cover.b": _caps(has_set_position=True),
+        },
+    )
+    assert snap.solar_floor_active is False
+
+
+@pytest.mark.unit
+def test_solar_floor_active_when_any_entity_open_close_only():
+    """A single open/close-only entity keeps the floor active (conservative)."""
+    builder, _, _ = _make_builder()
+    snap = _build_with_caps(
+        builder,
+        {
+            "cover.a": _caps(has_set_position=True),
+            "cover.b": _caps(has_set_position=False),
+        },
+    )
+    assert snap.solar_floor_active is True
+
+
+@pytest.mark.unit
+def test_solar_floor_active_when_caps_empty():
+    """Empty caps map → floor active (no positive evidence of positionability)."""
+    builder, _, _ = _make_builder()
+    snap = _build_with_caps(builder, {})
+    assert snap.solar_floor_active is True
+
+
+@pytest.mark.unit
+def test_solar_floor_active_when_caps_none():
+    """None caps (entities not readable) → floor active."""
+    builder, _, _ = _make_builder()
+    snap = _build_with_caps(builder, None)
+    assert snap.solar_floor_active is True
+
+
 @pytest.mark.unit
 def test_read_climate_use_lux_inferred_from_cloud_suppression():
     """Phase D preserves the Issue #268 cloud-suppression override."""


### PR DESCRIPTION
## Summary
Set-position-capable covers can now reach a true 0% during sun tracking. The hardcoded 1% floor in `solar_position_from_geometry` (and its duplicate in the glare-zone handler) is unified into a single capability-gated `solar_floor` helper. The floor still protects open/close-only covers, but switches off when every bound entity supports `set_position`. The forecast graph mirrors the live decision. No new config option - `min_position` continues to govern a deliberate hover.

## Testing
- ✅ 4276 tests passing (18 new)

## Related Issues
Refs #569