### PR TITLE
feat: translate cover-type label and dimension block (#258)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -909,10 +909,17 @@ async def _compute_todays_sun_times(hass: HomeAssistant, config: dict) -> dict |
     return await hass.async_add_executor_job(_compute)
 
 
-def _cover_type_label(sensor_type: str | None) -> str:
-    """Return the human-readable label for a cover type, falling back to 'Cover'."""
+def _cover_type_label(
+    sensor_type: str | None, labels: dict[str, str] | None = None
+) -> str:
+    """Return the human-readable label for a cover type, falling back to 'Cover'.
+
+    ``labels`` is the translated ``cover_types.*`` bundle threaded from
+    ``_build_config_summary``; ``None`` (entry titles, no flow context) keeps
+    the policy's English default.
+    """
     if sensor_type is not None and sensor_type in POLICY_REGISTRY:
-        return get_policy(sensor_type).display_label()
+        return get_policy(sensor_type).display_label(labels)
     return "Cover"
 
 
@@ -1214,7 +1221,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     """
     L = labels or _SUMMARY_LABELS_EN
     # ---- Gather all values up front ----------------------------------------
-    type_label = _cover_type_label(sensor_type)
+    # ``L`` here is the FULL flow bundle (``_SUMMARY_LABELS_EN`` keys + the
+    # policy-owned ``cover_types.*`` / ``geometry.*`` keys when a translated
+    # bundle is loaded). The policies layer it over their own English base
+    # (``COVER_TYPE_LABELS_EN`` / ``GEOMETRY_LABELS_EN``), so passing ``L`` —
+    # even the policy-key-less ``_SUMMARY_LABELS_EN`` default — still yields
+    # English for the policy lines while translating everything present.
+    type_label = _cover_type_label(sensor_type, L)
 
     entities: list[str] = config.get(CONF_ENTITIES) or []
     default_pos = config.get(CONF_DEFAULT_HEIGHT, 0)
@@ -1326,8 +1339,10 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # Physical dimensions in plain English. The render mode is per-cover-type;
     # each ``CoverTypePolicy.summary_geometry_lines`` owns its block. Legacy
     # configs without ``sensor_type`` fall back to the vertical-blind layout
-    # via ``summary_policy`` chosen at the top of this function.
-    lines.extend(summary_policy.summary_geometry_lines(config))
+    # via ``summary_policy`` chosen at the top of this function. ``L`` threads
+    # the translated ``geometry.*`` bundle (or the policy-key-less EN default,
+    # which still renders English over the policy's own base layer).
+    lines.extend(summary_policy.summary_geometry_lines(config, L))
 
     # =========================================================================
     # Section 1c: Cover Capability Warnings

--- a/custom_components/adaptive_cover_pro/cover_types/_helpers.py
+++ b/custom_components/adaptive_cover_pro/cover_types/_helpers.py
@@ -5,28 +5,34 @@ from __future__ import annotations
 from typing import Any
 
 from ..const import CONF_DISTANCE, CONF_HEIGHT_WIN, CONF_SILL_HEIGHT, CONF_WINDOW_DEPTH
+from ._summary_labels import GEOMETRY_LABELS_EN
 
 
-def window_dimensions_lines(config: dict[str, Any]) -> list[str]:
+def window_dimensions_lines(
+    config: dict[str, Any], labels: dict[str, str] | None = None
+) -> list[str]:
     """Render the "<H>m tall window, blocking sun <D>m..." block.
 
     Used by both ``BlindPolicy`` and ``VenetianPolicy`` since their geometry
-    summary leads with the same window-dimensions sentence.
+    summary leads with the same window-dimensions sentence. ``labels`` overlays
+    translated templates on the English base (``GEOMETRY_LABELS_EN``); ``None``
+    or a missing key falls back to English.
     """
+    L = {**GEOMETRY_LABELS_EN, **(labels or {})}
     h = config.get(CONF_HEIGHT_WIN)
     d = config.get(CONF_DISTANCE)
     depth = config.get(CONF_WINDOW_DEPTH) or 0
     sill = config.get(CONF_SILL_HEIGHT) or 0
     dim_parts: list[str] = []
     if h is not None:
-        dim_parts.append(f"{h}m tall window")
+        dim_parts.append(L["geometry.window.tall"].format(h=h))
     if d is not None:
-        dim_parts.append(f"blocking sun {d}m from the glass")
+        dim_parts.append(L["geometry.window.blocking_glass"].format(d=d))
     extras: list[str] = []
     if depth > 0:
-        extras.append(f"reveal {depth}m")
+        extras.append(L["geometry.window.reveal"].format(depth=depth))
     if sill > 0:
-        extras.append(f"sill {sill}m")
+        extras.append(L["geometry.window.sill"].format(sill=sill))
     dim_str = ", ".join(dim_parts)
     if extras:
         dim_str += f" ({', '.join(extras)})"

--- a/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
+++ b/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
@@ -1,0 +1,81 @@
+"""Code-owned English source for the policy summary i18n (follow-up to #258).
+
+The cover-type label and the physical-dimension / geometry block of the config
+summary are policy-owned (per ``CODING_GUIDELINES.md`` — per-type labels and
+geometry rendering live on the policy, never branched on cover-type strings
+outside ``cover_types/``). So their English source lives here, NOT in
+``config_flow._SUMMARY_LABELS_EN``.
+
+Two dicts:
+
+* ``COVER_TYPE_LABELS_EN`` — the 5 ``cover_types.*`` keys → English label.
+* ``GEOMETRY_LABELS_EN`` — the deduplicated ``geometry.*`` keys → English
+  ``str.format`` template.
+
+Each policy method (``display_label`` / ``summary_geometry_lines`` / the shared
+``window_dimensions_lines`` helper / ``computed_fov_line``) resolves with the
+matching dict as its base layer, overlaid by whatever translated ``labels`` dict
+it receives:
+
+    L = {**GEOMETRY_LABELS_EN, **(labels or {})}
+    L["geometry.slat.depth"].format(v=...)
+
+so English is used when ``labels`` is ``None`` (e.g. sensor names with no flow
+context) or when a key is untranslated — fully backward-compatible.
+
+``en.json["config_summary"]["cover_types"]`` and ``...["geometry"]`` mirror
+these exact keys/values (prefix-stripped). A drift test in
+``tests/test_policy_summary_i18n.py`` keeps the two in lockstep, exactly like
+#258's ``_SUMMARY_LABELS_EN`` ↔ en.json byte-identity guard.
+"""
+
+from __future__ import annotations
+
+# --- Cover-type labels (namespace config_summary.cover_types.*) -------------
+COVER_TYPE_LABELS_EN: dict[str, str] = {
+    "cover_types.blind": "Vertical Blind",
+    "cover_types.awning": "Horizontal Awning",
+    "cover_types.tilt": "Venetian / Tilt Blind",
+    "cover_types.oscillating_awning": "Oscillating Awning",
+    "cover_types.venetian": "Venetian Blind (Dual-Axis)",
+}
+
+# --- Geometry / physical-dimension templates (namespace config_summary.geometry.*)
+#
+# Deduplicated: keys whose English text is byte-identical across cover types are
+# shared (slat depth/spacing/mode → tilt + venetian; window height → awning +
+# oscillating; window dims → blind + venetian via the shared helper).
+GEOMETRY_LABELS_EN: dict[str, str] = {
+    # Window-dimensions block (blind + venetian, via window_dimensions_lines).
+    "geometry.window.tall": "{h}m tall window",
+    "geometry.window.blocking_glass": "blocking sun {d}m from the glass",
+    "geometry.window.reveal": "reveal {depth}m",
+    "geometry.window.sill": "sill {sill}m",
+    # Shared window-height line (awning + oscillating awning).
+    "geometry.window.height": "{v}m window height",
+    # Awning.
+    "geometry.awning.length": "{v}m awning",
+    "geometry.awning.angle": "angled at {v}°",
+    "geometry.awning.blocking_wall": "blocking sun {v}m from wall",
+    # Slat block (tilt + venetian).
+    "geometry.slat.depth": "slat depth {v}cm",
+    "geometry.slat.spacing": "spacing {v}cm",
+    "geometry.slat.mode": "mode: {v}",
+    # Oscillating awning.
+    "geometry.oscillating.arm": "{v}m arm",
+    "geometry.oscillating.sweep": "sweep {lo}°–{hi}°",
+    "geometry.oscillating.housing_offset": "{v}m housing offset",
+    # Venetian-only extras.
+    "geometry.venetian.skip_tilt": "skip tilt when position > {skip_above}%",
+    "geometry.venetian.mode_position_and_tilt": "position and tilt",
+    "geometry.venetian.mode_tilt_only": "tilt only",
+    "geometry.venetian.inverse_tilt": "Inverse tilt",
+    "geometry.venetian.max_tilt": "max tilt {max_tilt}%",
+    "geometry.venetian.min_tilt": "min tilt {min_tilt}%",
+    "geometry.venetian.post_settle_hold": "post-settle hold {hold}s",
+    "geometry.venetian.backrotate_lag": "back-rotate publish lag {lag}s",
+    # Computed-FOV read-only line (blind + venetian Measurements mode, #565).
+    "geometry.fov.computed": (
+        "Computed FOV ≈ {deg}°/{deg}° " "({w} m width, {d} m reveal depth)"
+    ),
+}

--- a/custom_components/adaptive_cover_pro/cover_types/awning.py
+++ b/custom_components/adaptive_cover_pro/cover_types/awning.py
@@ -18,6 +18,7 @@ from ..const import (
 )
 from ..engine.covers import AdaptiveHorizontalCover
 from ..unit_system import length_default, length_selector
+from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from .base import (
     CAP_HAS_SET_POSITION,
     POSITION_AXIS_OPEN_BLOCKS_SUN,
@@ -84,9 +85,10 @@ class AwningPolicy(CoverTypePolicy, register=True):
         """Horizontal-awning geometry page."""
         return "Configuration-Horizontal"
 
-    def display_label(self) -> str:
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
         """User-facing label for horizontal awnings."""
-        return "Horizontal Awning"
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.awning"]
 
     def disallowed_geometry_fields(
         self,
@@ -120,17 +122,20 @@ class AwningPolicy(CoverTypePolicy, register=True):
         """Plain ``cover`` domain — no extra capability requirement."""
         return selector.EntityFilterSelectorConfig(domain="cover")
 
-    def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
         """Render the awning-length / angle / window block."""
+        L = {**GEOMETRY_LABELS_EN, **(labels or {})}
         parts: list[str] = []
         if (v := config.get(CONF_LENGTH_AWNING)) is not None:
-            parts.append(f"{v}m awning")
+            parts.append(L["geometry.awning.length"].format(v=v))
         if (v := config.get(CONF_AWNING_ANGLE)) is not None:
-            parts.append(f"angled at {v}°")
+            parts.append(L["geometry.awning.angle"].format(v=v))
         if (v := config.get(CONF_HEIGHT_WIN)) is not None:
-            parts.append(f"{v}m window height")
+            parts.append(L["geometry.window.height"].format(v=v))
         if (v := config.get(CONF_DISTANCE)) is not None:
-            parts.append(f"blocking sun {v}m from wall")
+            parts.append(L["geometry.awning.blocking_wall"].format(v=v))
         return [", ".join(parts)] if parts else []
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -626,12 +626,16 @@ class CoverTypePolicy(ABC):
         return ()
 
     def summary_geometry_lines(
-        self, config: dict[str, Any]
-    ) -> list[str]:  # noqa: ARG002
+        self,
+        config: dict[str, Any],  # noqa: ARG002
+        labels: dict[str, str] | None = None,  # noqa: ARG002
+    ) -> list[str]:
         """Return the user-facing geometry summary lines for the config flow.
 
         Default: no geometry summary. Override to render the
         cover-type-specific geometry block in ``_build_config_summary``.
+        ``labels`` overlays translated ``geometry.*`` templates on the English
+        base; ``None`` keeps English (back-compat).
         """
         return []
 
@@ -646,7 +650,9 @@ class CoverTypePolicy(ABC):
         """
         return "Cover-Types"
 
-    def display_label(self) -> str:
+    def display_label(
+        self, labels: dict[str, str] | None = None
+    ) -> str:  # noqa: ARG002
         """Return the human-readable label for this cover type.
 
         Used by ``config_flow._build_config_summary`` and any other UI
@@ -654,5 +660,9 @@ class CoverTypePolicy(ABC):
         ``cover_type`` slug for stub policies; every concrete policy
         overrides to its user-facing name. Replaces the legacy
         ``type_labels`` dict in ``config_flow.py``.
+
+        ``labels`` is the translated ``cover_types.*`` bundle; the base
+        default is only reached for unknown/stub types and has no key, so it
+        ignores ``labels`` and returns the titlecased slug.
         """
         return self.cover_type.removeprefix("cover_").replace("_", " ").title()

--- a/custom_components/adaptive_cover_pro/cover_types/blind.py
+++ b/custom_components/adaptive_cover_pro/cover_types/blind.py
@@ -19,6 +19,7 @@ from ..const import (
 from ..engine.covers import AdaptiveVerticalCover
 from ..unit_system import length_default, length_selector
 from ._helpers import window_dimensions_lines
+from ._summary_labels import COVER_TYPE_LABELS_EN
 from .base import (
     CAP_HAS_SET_POSITION,
     POSITION_AXIS,
@@ -161,9 +162,10 @@ class BlindPolicy(CoverTypePolicy, register=True):
         """Vertical-blind geometry page."""
         return "Configuration-Vertical"
 
-    def display_label(self) -> str:
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
         """User-facing label for vertical blinds."""
-        return "Vertical Blind"
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.blind"]
 
     def disallowed_geometry_fields(
         self,
@@ -209,7 +211,9 @@ class BlindPolicy(CoverTypePolicy, register=True):
         """Plain ``cover`` domain — no extra capability requirement."""
         return selector.EntityFilterSelectorConfig(domain="cover")
 
-    def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
         """Render the window-dimensions block, plus the computed FOV (#565).
 
         In Measurements FOV mode the FOV is derived from the window width +
@@ -220,12 +224,13 @@ class BlindPolicy(CoverTypePolicy, register=True):
         from ..const import CONF_FOV_MODE, FovMode
         from ..engine.sun_geometry import computed_fov_line
 
-        lines = window_dimensions_lines(config)
+        lines = window_dimensions_lines(config, labels)
         if str(config.get(CONF_FOV_MODE)) == FovMode.MEASUREMENTS:
             lines.append(
                 computed_fov_line(
                     config.get(CONF_WINDOW_WIDTH),
                     config.get(CONF_WINDOW_DEPTH),
+                    labels,
                 )
             )
         return lines

--- a/custom_components/adaptive_cover_pro/cover_types/oscillating_awning.py
+++ b/custom_components/adaptive_cover_pro/cover_types/oscillating_awning.py
@@ -36,6 +36,7 @@ from ..const import (
 )
 from ..engine.covers import AdaptiveOscillatingCover
 from ..unit_system import length_default, length_selector
+from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from .base import (
     CAP_HAS_SET_POSITION,
     POSITION_AXIS_OPEN_BLOCKS_SUN,
@@ -123,9 +124,10 @@ class OscillatingAwningPolicy(CoverTypePolicy, register=True):
         """Oscillating-awning geometry page."""
         return "Configuration-Oscillating-Awning"
 
-    def display_label(self) -> str:
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
         """User-facing label for oscillating awnings."""
-        return "Oscillating Awning"
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.oscillating_awning"]
 
     def disallowed_geometry_fields(
         self,
@@ -155,19 +157,22 @@ class OscillatingAwningPolicy(CoverTypePolicy, register=True):
         """Plain ``cover`` domain — no extra capability requirement."""
         return selector.EntityFilterSelectorConfig(domain="cover")
 
-    def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
         """Render the arm-length / sweep / window block."""
+        L = {**GEOMETRY_LABELS_EN, **(labels or {})}
         parts: list[str] = []
         if (v := config.get(CONF_ARM_LENGTH)) is not None:
-            parts.append(f"{v}m arm")
+            parts.append(L["geometry.oscillating.arm"].format(v=v))
         lo = config.get(CONF_AWNING_MIN_ANGLE)
         hi = config.get(CONF_AWNING_MAX_ANGLE)
         if lo is not None and hi is not None:
-            parts.append(f"sweep {lo}°–{hi}°")
+            parts.append(L["geometry.oscillating.sweep"].format(lo=lo, hi=hi))
         if (v := config.get(CONF_HEIGHT_WIN)) is not None:
-            parts.append(f"{v}m window height")
+            parts.append(L["geometry.window.height"].format(v=v))
         if (v := config.get(CONF_AWNING_HOUSING_OFFSET)) is not None:
-            parts.append(f"{v}m housing offset")
+            parts.append(L["geometry.oscillating.housing_offset"].format(v=v))
         return [", ".join(parts)] if parts else []
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -16,6 +16,7 @@ from ..const import (
 from ..engine.covers import AdaptiveTiltCover
 from ..const import TiltMode
 from ..unit_system import slat_default, slat_selector
+from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from .base import (
     CAP_HAS_SET_TILT_POSITION,
     TILT_AXIS,
@@ -86,9 +87,10 @@ class TiltPolicy(CoverTypePolicy, register=True):
         """Slat-tilt geometry page."""
         return "Configuration-Tilt"
 
-    def display_label(self) -> str:
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
         """User-facing label for tilt-only covers."""
-        return "Venetian / Tilt Blind"
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.tilt"]
 
     def disallowed_geometry_fields(
         self,
@@ -122,15 +124,18 @@ class TiltPolicy(CoverTypePolicy, register=True):
         """Require entities that advertise ``set_tilt_position``."""
         return TILT_CAPABLE_ENTITY_FILTER
 
-    def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
         """Render the slat-depth / spacing / mode block."""
+        L = {**GEOMETRY_LABELS_EN, **(labels or {})}
         parts: list[str] = []
         if (v := config.get(CONF_TILT_DEPTH)) is not None:
-            parts.append(f"slat depth {v}cm")
+            parts.append(L["geometry.slat.depth"].format(v=v))
         if (v := config.get(CONF_TILT_DISTANCE)) is not None:
-            parts.append(f"spacing {v}cm")
+            parts.append(L["geometry.slat.spacing"].format(v=v))
         if (v := config.get(CONF_TILT_MODE)) is not None:
-            parts.append(f"mode: {v}")
+            parts.append(L["geometry.slat.mode"].format(v=v))
         return [", ".join(parts)] if parts else []
 
     def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -55,6 +55,7 @@ from ...managers.manual_override import SecondaryAxisCheck
 from ...pipeline.types import DecisionStep
 from ...position_utils import PositionConverter
 from .._helpers import window_dimensions_lines
+from .._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from ..base import (
     CAP_HAS_SET_POSITION,
     CAP_HAS_SET_TILT_POSITION,
@@ -178,9 +179,10 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         """Dual-axis venetian wiki page."""
         return "Venetian-Blinds"
 
-    def display_label(self) -> str:
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
         """User-facing label for dual-axis venetians."""
-        return "Venetian Blind (Dual-Axis)"
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.venetian"]
 
     def __init__(self) -> None:
         """Initialise without a sequencer; ``attach()`` wires one up later."""
@@ -235,44 +237,57 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         """
         return TILT_CAPABLE_ENTITY_FILTER
 
-    def summary_geometry_lines(self, config: dict[str, Any]) -> list[str]:
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
         """Render window dimensions plus the slat-config block."""
         from ...const import CONF_TILT_DEPTH, CONF_TILT_DISTANCE, CONF_TILT_MODE
 
+        L = {**GEOMETRY_LABELS_EN, **(labels or {})}
         tilt_parts: list[str] = []
         if (v := config.get(CONF_TILT_DEPTH)) is not None:
-            tilt_parts.append(f"slat depth {v}cm")
+            tilt_parts.append(L["geometry.slat.depth"].format(v=v))
         if (v := config.get(CONF_TILT_DISTANCE)) is not None:
-            tilt_parts.append(f"spacing {v}cm")
+            tilt_parts.append(L["geometry.slat.spacing"].format(v=v))
         if (v := config.get(CONF_TILT_MODE)) is not None:
-            tilt_parts.append(f"mode: {v}")
+            tilt_parts.append(L["geometry.slat.mode"].format(v=v))
         slat_line = [", ".join(tilt_parts)] if tilt_parts else []
         skip_above = config.get(
             CONF_VENETIAN_TILT_SKIP_ABOVE, DEFAULT_VENETIAN_TILT_SKIP_ABOVE
         )
-        retract_line = [f"skip tilt when position > {skip_above}%"]
+        retract_line = [L["geometry.venetian.skip_tilt"].format(skip_above=skip_above)]
         venetian_mode = config.get(CONF_VENETIAN_MODE, DEFAULT_VENETIAN_MODE)
         _mode_label = {
-            VENETIAN_MODE_POSITION_AND_TILT: "position and tilt",
-            VENETIAN_MODE_TILT_ONLY: "tilt only",
+            VENETIAN_MODE_POSITION_AND_TILT: L[
+                "geometry.venetian.mode_position_and_tilt"
+            ],
+            VENETIAN_MODE_TILT_ONLY: L["geometry.venetian.mode_tilt_only"],
         }.get(venetian_mode, venetian_mode)
-        mode_line = [f"mode: {_mode_label}"]
-        inverse_tilt_line = ["Inverse tilt"] if config.get(CONF_INVERSE_TILT) else []
+        mode_line = [L["geometry.slat.mode"].format(v=_mode_label)]
+        inverse_tilt_line = (
+            [L["geometry.venetian.inverse_tilt"]]
+            if config.get(CONF_INVERSE_TILT)
+            else []
+        )
         max_tilt = config.get(CONF_MAX_TILT, DEFAULT_MAX_TILT)
-        max_tilt_line = [f"max tilt {max_tilt}%"]
+        max_tilt_line = [L["geometry.venetian.max_tilt"].format(max_tilt=max_tilt)]
         min_tilt = config.get(CONF_MIN_TILT, DEFAULT_MIN_TILT)
-        min_tilt_line = [f"min tilt {min_tilt}%"]
+        min_tilt_line = [L["geometry.venetian.min_tilt"].format(min_tilt=min_tilt)]
         hold = config.get(
             CONF_VENETIAN_POST_SETTLE_HOLD, DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS
         )
-        post_settle_line = [f"post-settle hold {round(hold, 1)}s"]
+        post_settle_line = [
+            L["geometry.venetian.post_settle_hold"].format(hold=round(hold, 1))
+        ]
         lag = config.get(
             CONF_VENETIAN_BACKROTATE_PUBLISH_LAG,
             DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
         )
-        backrotate_line = [f"back-rotate publish lag {round(lag, 1)}s"]
+        backrotate_line = [
+            L["geometry.venetian.backrotate_lag"].format(lag=round(lag, 1))
+        ]
         return (
-            window_dimensions_lines(config)
+            window_dimensions_lines(config, labels)
             + slat_line
             + retract_line
             + mode_line

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -34,17 +34,31 @@ def fov_from_reveal(width_m: float, depth_m: float) -> int:
     return int(round(min(max(deg, lo), hi)))
 
 
-def computed_fov_line(width_m: float | None, depth_m: float | None) -> str:
+def computed_fov_line(
+    width_m: float | None,
+    depth_m: float | None,
+    labels: dict[str, str] | None = None,
+) -> str:
     """Read-only "Computed FOV ≈ 50°/50° (…)" line for Measurements mode (#565).
 
     The single formatter shared by the sun-tracking page placeholder and the
     config-flow summary. Delegates the angle to :func:`fov_from_reveal` so the
     arctan lives in exactly one place.
+
+    ``labels`` overlays a translated ``geometry.fov.computed`` template on the
+    English base (``GEOMETRY_LABELS_EN``); ``None`` or a missing key keeps
+    English. The engine has 0 HA imports — ``labels`` is a plain dict, so this
+    stays decoupled from ``config_flow``/``hass``.
     """
+    # Local import keeps the cover_types → engine dependency one-directional at
+    # module load (engine is imported by cover_types, not the reverse).
+    from ..cover_types._summary_labels import GEOMETRY_LABELS_EN
+
     w = float(width_m or 0.0)
     d = float(depth_m or 0.0)
     deg = fov_from_reveal(w, d)
-    return f"Computed FOV ≈ {deg}°/{deg}° ({w:g} m width, {d:g} m reveal depth)"
+    L = {**GEOMETRY_LABELS_EN, **(labels or {})}
+    return L["geometry.fov.computed"].format(deg=deg, w=f"{w:g}", d=f"{d:g}")
 
 
 class SunGeometry:

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1933,6 +1933,50 @@
       "label_my_set": "My ({pos}%)",
       "label_my_unset": "My (nicht gesetzt → {pct}%)",
       "label_plain": "{pct}%"
+    },
+    "cover_types": {
+      "blind": "Vertikale Jalousie",
+      "awning": "Horizontale Markise",
+      "tilt": "Jalousie / Neigung",
+      "oscillating_awning": "Schwenkmarkise",
+      "venetian": "Jalousie (Zwei-Achsen)"
+    },
+    "geometry": {
+      "window": {
+        "tall": "{h}m hohes Fenster",
+        "blocking_glass": "Sonne {d}m vor dem Glas blockiert",
+        "reveal": "Laibung {depth}m",
+        "sill": "Fensterbank {sill}m",
+        "height": "{v}m Fensterhöhe"
+      },
+      "awning": {
+        "length": "{v}m Markise",
+        "angle": "Winkel {v}°",
+        "blocking_wall": "Sonne {v}m vor der Wand blockiert"
+      },
+      "slat": {
+        "depth": "Lamellentiefe {v}cm",
+        "spacing": "Abstand {v}cm",
+        "mode": "Modus: {v}"
+      },
+      "oscillating": {
+        "arm": "{v}m Arm",
+        "sweep": "Schwenkbereich {lo}°–{hi}°",
+        "housing_offset": "{v}m Gehäuseversatz"
+      },
+      "venetian": {
+        "skip_tilt": "Neigung überspringen wenn Position > {skip_above}%",
+        "mode_position_and_tilt": "Position und Neigung",
+        "mode_tilt_only": "Nur Neigung",
+        "inverse_tilt": "Inverse Neigung",
+        "max_tilt": "max. Neigung {max_tilt}%",
+        "min_tilt": "min. Neigung {min_tilt}%",
+        "post_settle_hold": "Nach-Stabilisierungshalte {hold}s",
+        "backrotate_lag": "Rück-Rotationsverzögerung {lag}s"
+      },
+      "fov": {
+        "computed": "Berechnetes Sichtfeld ≈ {deg}°/{deg}° ({w}m Breite, {d}m Laibungstiefe)"
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1933,6 +1933,50 @@
       "label_my_set": "My ({pos}%)",
       "label_my_unset": "My (not set → {pct}%)",
       "label_plain": "{pct}%"
+    },
+    "cover_types": {
+      "blind": "Vertical Blind",
+      "awning": "Horizontal Awning",
+      "tilt": "Venetian / Tilt Blind",
+      "oscillating_awning": "Oscillating Awning",
+      "venetian": "Venetian Blind (Dual-Axis)"
+    },
+    "geometry": {
+      "window": {
+        "tall": "{h}m tall window",
+        "blocking_glass": "blocking sun {d}m from the glass",
+        "reveal": "reveal {depth}m",
+        "sill": "sill {sill}m",
+        "height": "{v}m window height"
+      },
+      "awning": {
+        "length": "{v}m awning",
+        "angle": "angled at {v}°",
+        "blocking_wall": "blocking sun {v}m from wall"
+      },
+      "slat": {
+        "depth": "slat depth {v}cm",
+        "spacing": "spacing {v}cm",
+        "mode": "mode: {v}"
+      },
+      "oscillating": {
+        "arm": "{v}m arm",
+        "sweep": "sweep {lo}°–{hi}°",
+        "housing_offset": "{v}m housing offset"
+      },
+      "venetian": {
+        "skip_tilt": "skip tilt when position > {skip_above}%",
+        "mode_position_and_tilt": "position and tilt",
+        "mode_tilt_only": "tilt only",
+        "inverse_tilt": "Inverse tilt",
+        "max_tilt": "max tilt {max_tilt}%",
+        "min_tilt": "min tilt {min_tilt}%",
+        "post_settle_hold": "post-settle hold {hold}s",
+        "backrotate_lag": "back-rotate publish lag {lag}s"
+      },
+      "fov": {
+        "computed": "Computed FOV ≈ {deg}°/{deg}° ({w} m width, {d} m reveal depth)"
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1933,6 +1933,50 @@
       "label_my_set": "My ({pos}%)",
       "label_my_unset": "My (non défini → {pct}%)",
       "label_plain": "{pct}%"
+    },
+    "cover_types": {
+      "blind": "Store vertical",
+      "awning": "Store banne horizontal",
+      "tilt": "Store vénitien / inclinaison",
+      "oscillating_awning": "Store oscillant",
+      "venetian": "Store vénitien (deux axes)"
+    },
+    "geometry": {
+      "window": {
+        "tall": "fenêtre de {h}m de haut",
+        "blocking_glass": "bloque le soleil {d}m de la vitre",
+        "reveal": "tableau {depth}m",
+        "sill": "appui {sill}m",
+        "height": "hauteur de fenêtre {v}m"
+      },
+      "awning": {
+        "length": "store banne de {v}m",
+        "angle": "incliné à {v}°",
+        "blocking_wall": "bloque le soleil {v}m du mur"
+      },
+      "slat": {
+        "depth": "profondeur de lamelle {v}cm",
+        "spacing": "espacement {v}cm",
+        "mode": "mode : {v}"
+      },
+      "oscillating": {
+        "arm": "bras {v}m",
+        "sweep": "amplitude {lo}°–{hi}°",
+        "housing_offset": "décalage du boîtier {v}m"
+      },
+      "venetian": {
+        "skip_tilt": "sauter l'inclinaison quand position > {skip_above}%",
+        "mode_position_and_tilt": "position et inclinaison",
+        "mode_tilt_only": "inclinaison seule",
+        "inverse_tilt": "Inclinaison inversée",
+        "max_tilt": "inclinaison max {max_tilt}%",
+        "min_tilt": "inclinaison min {min_tilt}%",
+        "post_settle_hold": "maintien post-stabilisation {hold}s",
+        "backrotate_lag": "délai de publication back-rotate {lag}s"
+      },
+      "fov": {
+        "computed": "FOV calculé ≈ {deg}°/{deg}° (largeur {w}m, profondeur tableau {d}m)"
+      }
     }
   }
 }

--- a/tests/test_policy_summary_i18n.py
+++ b/tests/test_policy_summary_i18n.py
@@ -1,0 +1,142 @@
+"""Tests for policy-owned i18n of the config summary (follow-up to #258).
+
+The cover-type label (``display_label``) and the physical-dimension /
+geometry block (``summary_geometry_lines`` + the shared helper) were deferred
+from #258 as policy-owned. This file covers the new machinery:
+
+* the ``labels`` override param on ``display_label`` and
+  ``summary_geometry_lines`` (and the shared ``window_dimensions_lines``),
+* English back-compat when ``labels`` is ``None`` or a key is untranslated,
+* a drift guard that ``en.json``'s ``config_summary.cover_types`` /
+  ``config_summary.geometry`` subtrees are byte-identical to the code-owned
+  ``COVER_TYPE_LABELS_EN`` / ``GEOMETRY_LABELS_EN`` dicts.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DISTANCE,
+    CONF_HEIGHT_WIN,
+    CONF_TILT_DEPTH,
+    CONF_TILT_DISTANCE,
+    CONF_TILT_MODE,
+)
+from custom_components.adaptive_cover_pro.cover_types._summary_labels import (
+    COVER_TYPE_LABELS_EN,
+    GEOMETRY_LABELS_EN,
+)
+from custom_components.adaptive_cover_pro.cover_types.awning import AwningPolicy
+from custom_components.adaptive_cover_pro.cover_types.blind import BlindPolicy
+from custom_components.adaptive_cover_pro.cover_types.oscillating_awning import (
+    OscillatingAwningPolicy,
+)
+from custom_components.adaptive_cover_pro.cover_types.tilt import TiltPolicy
+from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
+    VenetianPolicy,
+)
+
+pytestmark = pytest.mark.unit
+
+TRANSLATIONS_DIR = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "translations"
+)
+
+
+# ---------------------------------------------------------------------------
+# (a) display_label override + English back-compat
+# ---------------------------------------------------------------------------
+
+
+def test_display_label_override_and_default() -> None:
+    """A labels override wins; ``labels=None`` keeps the English default."""
+    assert BlindPolicy().display_label(labels={"cover_types.blind": "FOO"}) == "FOO"
+    assert BlindPolicy().display_label() == "Vertical Blind"
+    # Each concrete policy's English default stays exactly what #258 shipped.
+    assert AwningPolicy().display_label() == "Horizontal Awning"
+    assert TiltPolicy().display_label() == "Venetian / Tilt Blind"
+    assert OscillatingAwningPolicy().display_label() == "Oscillating Awning"
+    assert VenetianPolicy().display_label() == "Venetian Blind (Dual-Axis)"
+
+
+def test_display_label_untranslated_key_falls_back_to_english() -> None:
+    """An override dict missing the policy's key still yields English."""
+    assert AwningPolicy().display_label(labels={"cover_types.blind": "X"}) == (
+        "Horizontal Awning"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) summary_geometry_lines override leaves non-overridden lines English
+# ---------------------------------------------------------------------------
+
+
+def test_tilt_geometry_override_one_line_other_stays_english() -> None:
+    """Overriding one geometry template translates only that line."""
+    config = {CONF_TILT_DEPTH: 3.0, CONF_TILT_DISTANCE: 2.0, CONF_TILT_MODE: "mode2"}
+    labels = {"geometry.slat.depth": "Lamellentiefe {v}cm"}
+    out = TiltPolicy().summary_geometry_lines(config, labels=labels)
+    joined = ", ".join(out)
+    assert "Lamellentiefe 3.0cm" in joined  # overridden
+    assert "spacing 2.0cm" in joined  # non-overridden → English
+    assert "mode: mode2" in joined  # non-overridden → English
+
+
+def test_tilt_geometry_default_is_english() -> None:
+    """``labels=None`` yields byte-identical English (back-compat)."""
+    config = {CONF_TILT_DEPTH: 3.0, CONF_TILT_DISTANCE: 2.0, CONF_TILT_MODE: "mode2"}
+    out = TiltPolicy().summary_geometry_lines(config)
+    assert out == ["slat depth 3.0cm, spacing 2.0cm, mode: mode2"]
+
+
+def test_blind_window_dims_override() -> None:
+    """The shared window-dimensions helper honors a labels override."""
+    config = {CONF_HEIGHT_WIN: 2.1, CONF_DISTANCE: 0.5}
+    labels = {"geometry.window.tall": "{h}m hohes Fenster"}
+    out = BlindPolicy().summary_geometry_lines(config, labels=labels)
+    joined = ", ".join(out)
+    assert "2.1m hohes Fenster" in joined  # overridden
+    assert "blocking sun 0.5m from the glass" in joined  # English
+
+
+# ---------------------------------------------------------------------------
+# (c) drift guard — en.json subtrees byte-identical to the code dicts
+# ---------------------------------------------------------------------------
+
+
+def _flatten(node: object, prefix: str = "") -> dict[str, str]:
+    out: dict[str, str] = {}
+    if isinstance(node, dict):
+        for k, v in node.items():
+            out.update(_flatten(v, f"{prefix}.{k}" if prefix else k))
+    elif isinstance(node, str):
+        out[prefix] = node
+    return out
+
+
+def _en_config_summary() -> dict:
+    with (TRANSLATIONS_DIR / "en.json").open(encoding="utf-8") as fh:
+        return json.load(fh)["config_summary"]
+
+
+def test_cover_type_labels_match_en_json() -> None:
+    """``en.json['config_summary']['cover_types']`` == ``COVER_TYPE_LABELS_EN``."""
+    en = _flatten(_en_config_summary().get("cover_types", {}))
+    expected = {
+        k.removeprefix("cover_types."): v for k, v in COVER_TYPE_LABELS_EN.items()
+    }
+    assert en == expected
+
+
+def test_geometry_labels_match_en_json() -> None:
+    """``en.json['config_summary']['geometry']`` == ``GEOMETRY_LABELS_EN``."""
+    en = _flatten(_en_config_summary().get("geometry", {}))
+    expected = {k.removeprefix("geometry."): v for k, v in GEOMETRY_LABELS_EN.items()}
+    assert en == expected


### PR DESCRIPTION
## Summary
Follow-up to #258 (PR #575). Makes the two policy-owned pieces of the Configuration Summary translatable — the **cover-type label** (`display_label()`) and the **physical-dimension / geometry block** (`summary_geometry_lines()` + the shared `window_dimensions_lines()` helper and `computed_fov_line()`).

Architecture keeps the cover-type abstraction intact: English lives in a new single source `cover_types/_summary_labels.py` (`COVER_TYPE_LABELS_EN` + `GEOMETRY_LABELS_EN`); each policy method gains an optional `labels` param and resolves `{**…_EN, **(labels or {})}`, so `display_label()` called with no flow context (sensor names) stays English and backward-compatible. `_build_config_summary` threads the per-user-language `labels` dict down to the policies. No `sensor_type` branching escapes `cover_types/`; the engine's `computed_fov_line` takes a plain `labels` dict and adds no HA import.

New keys: `config_summary.cover_types.*` (5) + `config_summary.geometry.*` (23), authored in `en.json` and propagated to DE/FR. A drift-guard test asserts the en.json values stay byte-identical to the code-owned English dicts.

## Testing
- ✅ 4327 tests passing (full suite), 96% coverage. The ~30 existing byte-identical English summary/geometry assertions pass unchanged.

## Related Issues
Refs #258