### PR TITLE
fix: persist all create-flow fields on new cover save (#565)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -137,6 +137,9 @@ from .const import (
     CONF_WEATHER_BYPASS_AUTO_CONTROL,
     CONF_WINDOW_DEPTH,
     CONF_WINDOW_WIDTH,
+    DEFAULT_DELTA_POSITION,
+    DEFAULT_DELTA_TIME,
+    DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MOTION_TIMEOUT,
     CONF_DEBUG_CATEGORIES,
     CONF_DEBUG_EVENT_BUFFER_SIZE,
@@ -2779,37 +2782,48 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             rerender = _resolve_fov_mode_submit(
                 self.type_blind, prior_mode, user_input, self.config
             )
+            # Canonicalize once: ``_show_sun_tracking_form`` re-displays via
+            # ``options_to_display``, so feeding it raw (already display-unit)
+            # input would convert metres->inches a second time and the value
+            # would compound on every rerender (#565). Canonical here keeps the
+            # rerender re-feed symmetric with the initial render and save path.
+            canonical = user_input_to_canonical(
+                self.hass, user_input, length_keys=_SUN_TRACKING_LENGTH_KEYS
+            )
             if rerender is not None:
                 self.config[CONF_FOV_MODE] = rerender
-                return self._show_sun_tracking_form(mode=rerender)
+                return self._show_sun_tracking_form(canonical, mode=rerender)
             if (
                 user_input.get(CONF_MAX_ELEVATION) is not None
                 and user_input.get(CONF_MIN_ELEVATION) is not None
                 and user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]
             ):
                 return self._show_sun_tracking_form(
+                    canonical,
                     mode=user_input.get(CONF_FOV_MODE, prior_mode),
                     errors={
                         CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
                     },
                 )
-            canonical = user_input_to_canonical(
-                self.hass, user_input, length_keys=_SUN_TRACKING_LENGTH_KEYS
-            )
             self.config.update(canonical)
             return await self.async_step_position()
-        return self._show_sun_tracking_form(mode=prior_mode)
+        return self._show_sun_tracking_form(self.config, mode=prior_mode)
 
     def _show_sun_tracking_form(
         self,
+        values: dict[str, Any] | None = None,
         *,
         mode: str | None = None,
         errors: dict | None = None,
     ):
         """Render the create-flow sun-tracking form for the given FOV *mode*."""
+        schema = _get_sun_tracking_schema(self.type_blind, self.hass, mode)
+        suggested = options_to_display(
+            self.hass, values or self.config, length_keys=_SUN_TRACKING_LENGTH_KEYS
+        )
         return self.async_show_form(
             step_id="sun_tracking",
-            data_schema=_get_sun_tracking_schema(self.type_blind, self.hass, mode),
+            data_schema=self.add_suggested_values_to_schema(schema, suggested),
             errors=errors,
             description_placeholders=_sun_tracking_placeholders(
                 self.type_blind, mode, self.config
@@ -3073,110 +3087,37 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             title = self.config["name"]
         else:
             title = f"{_cover_type_label(self.type_blind)} {self.config['name']}"
+
+        # Build options from the full accumulated config dict, mirroring the
+        # options-flow contract (data=self.options).  Strip only the data-level
+        # keys that belong in entry.data rather than entry.options; override
+        # CONF_MODE (which holds the cover-type string in self.config) with the
+        # strategy-mode value stored on self.mode.
+        _DATA_KEYS = {"name", CONF_SENSOR_TYPE}
+        options = {k: v for k, v in self.config.items() if k not in _DATA_KEYS}
+        # CONF_MODE in self.config is the cover-type selector value (CoverType.*).
+        # entry.options["mode"] must carry the strategy mode ("basic" / "advanced").
+        options[CONF_MODE] = self.mode
+
+        # Quick setup skips some steps (e.g. automation) leaving critical keys
+        # absent from self.config.  Apply constant-backed defaults so the
+        # coordinator never receives None for gating values (issue #133).
+        options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
+        options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
+        options.setdefault(
+            CONF_MANUAL_OVERRIDE_DURATION, DEFAULT_MANUAL_OVERRIDE_DURATION
+        )
+        options.setdefault(CONF_MOTION_SENSORS, [])
+        options.setdefault(CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT)
+        options.setdefault(CONF_FORCE_OVERRIDE_SENSORS, [])
+
         return self.async_create_entry(
             title=title,
             data={
                 "name": self.config["name"],
                 CONF_SENSOR_TYPE: self.type_blind,
             },
-            options={
-                CONF_MODE: self.mode,
-                CONF_AZIMUTH: self.config.get(CONF_AZIMUTH),
-                CONF_HEIGHT_WIN: self.config.get(CONF_HEIGHT_WIN),
-                CONF_DISTANCE: self.config.get(CONF_DISTANCE),
-                CONF_WINDOW_DEPTH: self.config.get(CONF_WINDOW_DEPTH),
-                CONF_SILL_HEIGHT: self.config.get(CONF_SILL_HEIGHT),
-                CONF_DEFAULT_HEIGHT: self.config.get(CONF_DEFAULT_HEIGHT),
-                CONF_MAX_POSITION: self.config.get(CONF_MAX_POSITION),
-                CONF_ENABLE_MAX_POSITION: self.config.get(CONF_ENABLE_MAX_POSITION),
-                CONF_MIN_POSITION: self.config.get(CONF_MIN_POSITION),
-                CONF_ENABLE_MIN_POSITION: self.config.get(CONF_ENABLE_MIN_POSITION),
-                CONF_FOV_LEFT: self.config.get(CONF_FOV_LEFT),
-                CONF_FOV_RIGHT: self.config.get(CONF_FOV_RIGHT),
-                CONF_ENTITIES: self.config.get(CONF_ENTITIES),
-                CONF_INVERSE_STATE: self.config.get(CONF_INVERSE_STATE),
-                CONF_SUNSET_POS: self.config.get(CONF_SUNSET_POS),
-                CONF_SUNSET_OFFSET: self.config.get(CONF_SUNSET_OFFSET),
-                CONF_SUNRISE_OFFSET: self.config.get(CONF_SUNRISE_OFFSET),
-                CONF_SUNSET_TIME_ENTITY: self.config.get(CONF_SUNSET_TIME_ENTITY),
-                CONF_SUNRISE_TIME_ENTITY: self.config.get(CONF_SUNRISE_TIME_ENTITY),
-                CONF_LENGTH_AWNING: self.config.get(CONF_LENGTH_AWNING),
-                CONF_AWNING_ANGLE: self.config.get(CONF_AWNING_ANGLE),
-                CONF_TILT_DISTANCE: self.config.get(CONF_TILT_DISTANCE),
-                CONF_TILT_DEPTH: self.config.get(CONF_TILT_DEPTH),
-                CONF_TILT_MODE: self.config.get(CONF_TILT_MODE),
-                CONF_TEMP_ENTITY: self.config.get(CONF_TEMP_ENTITY),
-                CONF_PRESENCE_ENTITY: self.config.get(CONF_PRESENCE_ENTITY),
-                CONF_WEATHER_ENTITY: self.config.get(CONF_WEATHER_ENTITY),
-                CONF_TEMP_LOW: self.config.get(CONF_TEMP_LOW),
-                CONF_TEMP_HIGH: self.config.get(CONF_TEMP_HIGH),
-                CONF_OUTSIDETEMP_ENTITY: self.config.get(CONF_OUTSIDETEMP_ENTITY),
-                CONF_CLIMATE_MODE: self.config.get(CONF_CLIMATE_MODE),
-                CONF_WEATHER_STATE: self.config.get(CONF_WEATHER_STATE),
-                CONF_DELTA_POSITION: self.config.get(CONF_DELTA_POSITION) or 2,
-                CONF_DELTA_TIME: self.config.get(CONF_DELTA_TIME) or 2,
-                CONF_START_TIME: self.config.get(CONF_START_TIME),
-                CONF_START_ENTITY: self.config.get(CONF_START_ENTITY),
-                CONF_END_TIME: self.config.get(CONF_END_TIME),
-                CONF_END_ENTITY: self.config.get(CONF_END_ENTITY),
-                CONF_FORCE_OVERRIDE_SENSORS: self.config.get(
-                    CONF_FORCE_OVERRIDE_SENSORS, []
-                ),
-                CONF_FORCE_OVERRIDE_POSITION: self.config.get(
-                    CONF_FORCE_OVERRIDE_POSITION, 0
-                ),
-                CONF_MOTION_SENSORS: self.config.get(CONF_MOTION_SENSORS, []),
-                CONF_MOTION_TIMEOUT: self.config.get(
-                    CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT
-                ),
-                CONF_MANUAL_OVERRIDE_DURATION: self.config.get(
-                    CONF_MANUAL_OVERRIDE_DURATION
-                )
-                or {"hours": 2},
-                CONF_MANUAL_OVERRIDE_RESET: self.config.get(CONF_MANUAL_OVERRIDE_RESET),
-                CONF_MANUAL_THRESHOLD: self.config.get(CONF_MANUAL_THRESHOLD),
-                CONF_MANUAL_IGNORE_INTERMEDIATE: self.config.get(
-                    CONF_MANUAL_IGNORE_INTERMEDIATE
-                ),
-                CONF_MANUAL_IGNORE_EXTERNAL: self.config.get(
-                    CONF_MANUAL_IGNORE_EXTERNAL
-                ),
-                CONF_OPEN_CLOSE_THRESHOLD: self.config.get(
-                    CONF_OPEN_CLOSE_THRESHOLD, 50
-                ),
-                CONF_BLIND_SPOT_RIGHT: self.config.get(CONF_BLIND_SPOT_RIGHT, None),
-                CONF_BLIND_SPOT_LEFT: self.config.get(CONF_BLIND_SPOT_LEFT, None),
-                CONF_BLIND_SPOT_ELEVATION: self.config.get(
-                    CONF_BLIND_SPOT_ELEVATION, None
-                ),
-                CONF_ENABLE_BLIND_SPOT: self.config.get(CONF_ENABLE_BLIND_SPOT),
-                CONF_ENABLE_SUN_TRACKING: self.config.get(
-                    CONF_ENABLE_SUN_TRACKING, True
-                ),
-                CONF_MIN_ELEVATION: self.config.get(CONF_MIN_ELEVATION, None),
-                CONF_MAX_ELEVATION: self.config.get(CONF_MAX_ELEVATION, None),
-                CONF_TRANSPARENT_BLIND: self.config.get(CONF_TRANSPARENT_BLIND, False),
-                CONF_WINTER_CLOSE_INSULATION: self.config.get(
-                    CONF_WINTER_CLOSE_INSULATION, False
-                ),
-                CONF_INTERP: self.config.get(CONF_INTERP),
-                CONF_INTERP_START: self.config.get(CONF_INTERP_START, None),
-                CONF_INTERP_END: self.config.get(CONF_INTERP_END, None),
-                CONF_INTERP_LIST: self.config.get(CONF_INTERP_LIST, []),
-                CONF_INTERP_LIST_NEW: self.config.get(CONF_INTERP_LIST_NEW, []),
-                CONF_LUX_ENTITY: self.config.get(CONF_LUX_ENTITY),
-                CONF_LUX_THRESHOLD: self.config.get(CONF_LUX_THRESHOLD),
-                CONF_IRRADIANCE_ENTITY: self.config.get(CONF_IRRADIANCE_ENTITY),
-                CONF_IRRADIANCE_THRESHOLD: self.config.get(CONF_IRRADIANCE_THRESHOLD),
-                CONF_CLOUD_COVERAGE_ENTITY: self.config.get(CONF_CLOUD_COVERAGE_ENTITY),
-                CONF_CLOUD_COVERAGE_THRESHOLD: self.config.get(
-                    CONF_CLOUD_COVERAGE_THRESHOLD
-                ),
-                CONF_OUTSIDE_THRESHOLD: self.config.get(CONF_OUTSIDE_THRESHOLD),
-                CONF_DEVICE_ID: self.config.get(CONF_DEVICE_ID),
-                CONF_RETURN_SUNSET: self.config.get(CONF_RETURN_SUNSET, False),
-                CONF_CLOUD_SUPPRESSION: self.config.get(CONF_CLOUD_SUPPRESSION, False),
-            },
+            options=options,
         )
 
     async def async_step_duplicate_existing(

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -465,6 +465,8 @@ DEFAULT_WEATHER_TIMEOUT = 300  # seconds before resuming after clear
 
 CONF_DELTA_POSITION = "delta_position"  # min % change to emit, range 1-90
 CONF_DELTA_TIME = "delta_time"  # min seconds between commands, range 2-60
+DEFAULT_DELTA_POSITION = 2  # minimum percentage change threshold
+DEFAULT_DELTA_TIME = 2  # minimum seconds between commands
 # Allowed gap between commanded and reported position before the periodic
 # reconciliation pass treats the cover as "not arrived" and resends the
 # command. Distinct from CONF_DELTA_POSITION (movement hysteresis). Default
@@ -505,6 +507,7 @@ CONF_INTERP_LIST_NEW = "interp_list_new"  # new-format control points
 
 # How long a manual override stays active before automation resumes.
 CONF_MANUAL_OVERRIDE_DURATION = "manual_override_duration"
+DEFAULT_MANUAL_OVERRIDE_DURATION: dict = {"hours": 2}  # default hold duration
 # If True, the manual override is reset when end_time is reached.
 CONF_MANUAL_OVERRIDE_RESET = "manual_override_reset"
 CONF_MANUAL_THRESHOLD = "manual_threshold"  # % delta = manual touch, 0-99

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -34,6 +34,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_ENABLE_GLARE_ZONES,
     CONF_ENTITIES,
     CONF_FOV_LEFT,
+    CONF_FOV_MODE,
     CONF_FOV_RIGHT,
     CONF_HEIGHT_WIN,
     CONF_MANUAL_IGNORE_INTERMEDIATE,
@@ -57,9 +58,11 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_INVERSE_STATE,
     CONF_IS_SUNNY_SENSOR,
     CONF_WINDOW_DEPTH,
+    CONF_WINDOW_WIDTH,
     CUSTOM_POSITION_SLOTS,
     DOMAIN,
     CoverType,
+    FovMode,
 )
 
 pytestmark = pytest.mark.integration
@@ -1982,3 +1985,172 @@ async def test_options_flow_position_step_clears_sunset_pos_when_omitted(
     assert (
         saved.get(CONF_SUNSET_POS) is None
     ), "sunset_position must be None after clearing, not retain previous value 0"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for issue #565 — create-flow persistence drop (Defect A & B)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_full_setup_persists_fov_mode_and_window_width(
+    hass: HomeAssistant,
+) -> None:
+    """Create flow must persist CONF_FOV_MODE and CONF_WINDOW_WIDTH to entry.options.
+
+    Regression guard for issue #565 Defect A: the hardcoded 73-key allowlist in
+    async_step_update silently dropped keys not in the list, including fov_mode
+    and window_width. Feeding them in the multi-step flow and asserting they land
+    in entry.options catches any re-introduction of the allowlist pattern.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Persist Test Blind", CONF_MODE: CoverType.BLIND},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "full_setup"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    # Feed CONF_WINDOW_WIDTH in the geometry step
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**_VERTICAL_GEOMETRY, CONF_WINDOW_WIDTH: 1.6},
+    )
+    # First sun_tracking submit: switch mode from default (ANGLES) to MEASUREMENTS.
+    # This triggers a re-render — the MEASUREMENTS schema hides fov_left/fov_right.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_AZIMUTH: 180,
+            CONF_FOV_LEFT: 45,
+            CONF_FOV_RIGHT: 45,
+            CONF_DISTANCE: 0.5,
+            "blind_spot": False,
+            "enable_glare_zones": False,
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+        },
+    )
+    # Re-render is expected on mode switch; second submit in MEASUREMENTS mode
+    # must not include fov_left/fov_right (hidden by MEASUREMENTS schema).
+    assert (
+        result.get("step_id") == "sun_tracking"
+    ), f"expected re-render on mode switch, got {result!r}"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_AZIMUTH: 180,
+            CONF_DISTANCE: 0.5,
+            "blind_spot": False,
+            "enable_glare_zones": False,
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+        },
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _POSITION
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _AUTOMATION
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _MANUAL_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _FORCE_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _CUSTOM_POSITION
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _MOTION_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _WEATHER_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _LIGHT_CLOUD
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _TEMPERATURE_CLIMATE
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "summary"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == "create_entry"
+
+    opts = result["result"].options
+    assert opts.get(CONF_FOV_MODE) == FovMode.MEASUREMENTS, (
+        f"CONF_FOV_MODE was dropped by async_step_update allowlist; "
+        f"got {opts.get(CONF_FOV_MODE)!r}"
+    )
+    assert opts.get(CONF_WINDOW_WIDTH) == 1.6, (
+        f"CONF_WINDOW_WIDTH was dropped by async_step_update allowlist; "
+        f"got {opts.get(CONF_WINDOW_WIDTH)!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_flow_sun_tracking_rerender_keeps_typed_azimuth() -> None:
+    """Create-flow FOV-mode re-render must not discard the azimuth the user typed.
+
+    Regression guard for issue #565 Defect B: the create-flow _show_sun_tracking_form
+    took no ``values`` argument and never called add_suggested_values_to_schema, so
+    after a mode-switch re-render the form redrew with the bare schema defaults
+    (DEFAULT_WINDOW_AZIMUTH) instead of the user's just-typed value.
+
+    After the fix, the re-rendered form carries the typed azimuth as a suggested value
+    and self.config[CONF_AZIMUTH] is preserved on the subsequent same-mode submit.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
+
+    flow = ConfigFlowHandler.__new__(ConfigFlowHandler)
+    flow.hass = MagicMock()
+    flow.hass.config.units = MagicMock()
+    flow.hass.config.units.is_metric = True
+    flow.hass.states.get.return_value = None
+    flow.type_blind = CoverType.BLIND
+    flow.config = {CONF_WINDOW_WIDTH: 2.0, CONF_WINDOW_DEPTH: 0.5}
+    flow.async_step_position = AsyncMock(
+        return_value={"type": "form", "step_id": "position"}
+    )
+
+    # First submit: no stored fov_mode (None → ANGLES default), user switches to
+    # MEASUREMENTS and types azimuth 137.  _resolve_fov_mode_submit detects a mode
+    # change → re-render path.
+    result = await flow.async_step_sun_tracking(
+        {
+            CONF_AZIMUTH: 137,
+            CONF_FOV_LEFT: 30,
+            CONF_FOV_RIGHT: 30,
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            CONF_DISTANCE: 0.5,
+        }
+    )
+    assert result["type"] == "form", "expected re-render on mode switch"
+    assert result["step_id"] == "sun_tracking"
+
+    # After the fix: the re-rendered form must carry 137 as suggested_value for
+    # CONF_AZIMUTH — the user's just-typed input must not be discarded.
+    schema = result.get("data_schema")
+    assert schema is not None, "re-render must return a data_schema"
+    suggested_azimuth = None
+    for marker in schema.schema:
+        if str(marker) == CONF_AZIMUTH and marker.description:
+            suggested_azimuth = marker.description.get("suggested_value")
+            break
+    assert suggested_azimuth == 137, (
+        f"Re-rendered form must carry typed azimuth 137 as suggested_value, "
+        f"got {suggested_azimuth!r}. "
+        "Defect B: create-flow _show_sun_tracking_form discards typed input."
+    )


### PR DESCRIPTION
## Summary
The config create flow assembled the new entry's `options` from a hardcoded allowlist in `async_step_update`, silently dropping any collected field not on the list (fov_mode, window width, and others). It now persists the full accumulated config dict, matching the options flow. Separately, switching FOV mode on the create flow re-rendered the sun-tracking form without re-feeding typed values, so a just-entered azimuth reverted to the default; the form now re-feeds values via add_suggested_values_to_schema. Editing an existing cover was unaffected and is unchanged.

## Testing
- ✅ 4420 tests passing (2 new regression tests: full create round-trip persists fov_mode + window width; sun-tracking re-render keeps typed azimuth)

## Related Issues
Refs #565