### PR TITLE
feat: simplify Cover Geometry step description (#564)

### DIFF
--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -31,7 +31,7 @@
       },
       "geometry": {
         "title": "Beschattungsgeometrie",
-        "description": "Geben Sie Ihre Maße für Beschattungselemente und Fenster ein. Die Integration berechnet damit genau, wie weit das Beschattungselement herunterfahren oder ausfahren muss, um direkte Sonneneinstrahlung zu blockieren und gleichzeitig natürliches Licht zu maximieren.\n\n**Fensterhöhe** und **schattierter Bereich** sind erforderlich für Jalousien und Markisen. **Fenstertiefe** und **Fenstersillhöhe** verbessern die geometrische Genauigkeit für tiefer liegende Fenster. **Markisenspanne** und **Winkel** gelten für horizontale Markisen. **Lamellendicke** und **Lamellenschranke** sind erforderlich für Neigungs-/Venetian-Beschattungselemente.\n\n{geometry_wiki_link}",
+        "description": "Geben Sie Ihre Maße für Beschattungselemente und Fenster ein. Die Integration berechnet damit genau, wie weit das Beschattungselement herunterfahren oder ausfahren muss, um direkte Sonneneinstrahlung zu blockieren und gleichzeitig natürliches Licht zu maximieren.\n\n{geometry_wiki_link}",
         "data": {
           "window_height": "Fensterhöhe",
           "distance_shaded_area": "Beschatteter Bereich",
@@ -576,7 +576,7 @@
       },
       "geometry": {
         "title": "Beschattungsgeometrie",
-        "description": "Geben Sie Ihre Maße für Beschattungselemente und Fenster ein. Die Integration berechnet damit genau, wie weit das Beschattungselement herunterfahren oder ausfahren muss, um direkte Sonneneinstrahlung zu blockieren und gleichzeitig natürliches Licht zu maximieren.\n\n**Fensterhöhe** und **schattierter Bereich** sind erforderlich für Jalousien und Markisen. **Fenstertiefe** und **Fenstersillhöhe** verbessern die geometrische Genauigkeit für tiefer liegende Fenster. **Markisenspanne** und **Winkel** gelten für horizontale Markisen. **Lamellendicke** und **Lamellenschranke** sind erforderlich für Neigungs-/Venetian-Beschattungselemente.\n\n{geometry_wiki_link}",
+        "description": "Geben Sie Ihre Maße für Beschattungselemente und Fenster ein. Die Integration berechnet damit genau, wie weit das Beschattungselement herunterfahren oder ausfahren muss, um direkte Sonneneinstrahlung zu blockieren und gleichzeitig natürliches Licht zu maximieren.\n\n{geometry_wiki_link}",
         "data": {
           "window_height": "Fensterhöhe",
           "distance_shaded_area": "Beschatteter Bereich",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -31,7 +31,7 @@
       },
       "geometry": {
         "title": "Cover Geometry",
-        "description": "Enter your cover and window measurements. The integration uses these to calculate exactly how far to lower or extend the cover to block direct sunlight while maximising natural light.\n\n**Window height** and **shaded area** are required for vertical blinds and awnings. **Reveal depth** and **sill height** improve geometric accuracy for windows set back into the wall. **Awning span** and **angle** apply to horizontal awnings. **Slat depth** and **spacing** are required for tilt/venetian covers.\n\n{geometry_wiki_link}",
+        "description": "Enter your cover and window measurements. The integration uses these to calculate exactly how far to lower or extend the cover to block direct sunlight while maximising natural light.\n\n{geometry_wiki_link}",
         "data": {
           "window_height": "Window Height",
           "distance_shaded_area": "Shaded area",
@@ -576,7 +576,7 @@
       },
       "geometry": {
         "title": "Cover Geometry",
-        "description": "Enter your cover and window measurements. The integration uses these to calculate exactly how far to lower or extend the cover to block direct sunlight while maximising natural light.\n\n**Window height** and **shaded area** are required for vertical blinds and awnings. **Reveal depth** and **sill height** improve geometric accuracy for windows set back into the wall. **Awning span** and **angle** apply to horizontal awnings. **Slat depth** and **spacing** are required for tilt/venetian covers.\n\n{geometry_wiki_link}",
+        "description": "Enter your cover and window measurements. The integration uses these to calculate exactly how far to lower or extend the cover to block direct sunlight while maximising natural light.\n\n{geometry_wiki_link}",
         "data": {
           "window_height": "Window Height",
           "distance_shaded_area": "Shaded area",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -31,7 +31,7 @@
       },
       "geometry": {
         "title": "Géométrie du store",
-        "description": "Saisissez vos mesures de protection et de fenêtre. L'intégration les utilise pour calculer exactement la distance à laquelle abaisser ou dérouler la protection afin de bloquer la lumière directe du soleil tout en maximisant la lumière naturelle.\n\n**Hauteur de fenêtre** et **zone ombrée** sont obligatoires pour les stores verticaux et les stores bannes. **Profondeur de révélation** et **hauteur d'appui** améliorent la précision géométrique pour les fenêtres encastrées dans le mur. **Largeur et angle de store banne** s'appliquent aux stores bannes horizontaux. **Profondeur et espacement des lamelles** sont obligatoires pour les stores inclinables/vénitiens.\n\n{geometry_wiki_link}",
+        "description": "Saisissez vos mesures de protection et de fenêtre. L'intégration les utilise pour calculer exactement la distance à laquelle abaisser ou dérouler la protection afin de bloquer la lumière directe du soleil tout en maximisant la lumière naturelle.\n\n{geometry_wiki_link}",
         "data": {
           "window_height": "Hauteur de la fenêtre",
           "distance_shaded_area": "Zone ombragée",
@@ -576,7 +576,7 @@
       },
       "geometry": {
         "title": "Géométrie du store",
-        "description": "Saisissez vos mesures de protection et de fenêtre. L'intégration les utilise pour calculer exactement la distance à laquelle abaisser ou dérouler la protection afin de bloquer la lumière directe du soleil tout en maximisant la lumière naturelle.\n\n**Hauteur de fenêtre** et **zone ombrée** sont obligatoires pour les stores verticaux et les stores bannes. **Profondeur de révélation** et **hauteur d'appui** améliorent la précision géométrique pour les fenêtres encastrées dans le mur. **Largeur et angle de store banne** s'appliquent aux stores bannes horizontaux. **Profondeur et espacement des lamelles** sont obligatoires pour les stores inclinables/vénitiens.\n\n{geometry_wiki_link}",
+        "description": "Saisissez vos mesures de protection et de fenêtre. L'intégration les utilise pour calculer exactement la distance à laquelle abaisser ou dérouler la protection afin de bloquer la lumière directe du soleil tout en maximisant la lumière naturelle.\n\n{geometry_wiki_link}",
         "data": {
           "window_height": "Hauteur de la fenêtre",
           "distance_shaded_area": "Zone ombragée",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -315,3 +315,33 @@ def test_fr_cloud_suppression_decision_trace_state() -> None:
     assert (
         "nuageux" in value.lower()
     ), f"FR cloud_suppression state label should reference cloudy weather; got: {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #564 — geometry description must not contain per-cover-type field enumeration
+# ---------------------------------------------------------------------------
+
+
+def test_geometry_description_no_field_enumeration() -> None:
+    """The geometry step description must NOT contain the per-cover-type field enumeration.
+
+    The second paragraph ("**Window height** and **shaded area** are required for vertical
+    blinds and awnings...") is redundant because the form already hides irrelevant fields.
+    It must be absent from both config.step.geometry.description and
+    options.step.geometry.description in en.json (issue #564).
+    """
+    en = _load(TRANSLATIONS_DIR / "en.json")
+
+    cfg_desc = en["config"]["step"]["geometry"]["description"]
+    opt_desc = en["options"]["step"]["geometry"]["description"]
+
+    enumeration_marker = "required for vertical"
+
+    assert enumeration_marker not in cfg_desc, (
+        f"config.step.geometry.description still contains per-cover-type enumeration "
+        f"(found {enumeration_marker!r}). Remove the second paragraph (issue #564)."
+    )
+    assert enumeration_marker not in opt_desc, (
+        f"options.step.geometry.description still contains per-cover-type enumeration "
+        f"(found {enumeration_marker!r}). Remove the second paragraph (issue #564)."
+    )


### PR DESCRIPTION
## Summary
Removes the redundant second paragraph from the "Cover Geometry" config-flow step description. It enumerated which fields apply to which cover type, but the form already only shows the fields relevant to the selected cover type, so the list added reading load without value. The first sentence (why measurements matter) and the wiki link are kept. Applied to both the create and options flows across en/de/fr.

## Testing
- ✅ Translation suite: 26 passing (added a regression guard)
- ✅ Full suite: 4421 passing, 0 failing

## Related Issues
Refs #564