### PR TITLE
fix: derive reveal FOV from arctan(width/depth), not half-width

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -16,11 +16,19 @@ from ..sun import SunData
 def fov_from_reveal(width_m: float, depth_m: float) -> int:
     """Symmetric FOV half-angle (degrees) from reveal width and depth.
 
-    Models the oblique-sun cutoff geometry of a cover mounted inside a reveal:
-    the recess depth ``depth_m`` in front of the cover blocks sun arriving at a
-    grazing azimuth, and the opening ``width_m`` sets how wide that gap is. The
-    half-angle is ``atan((width/2) / depth)`` — the angle at which the sun first
-    clears the reveal edge.
+    Models the full-exit cutoff geometry of a cover mounted inside a reveal
+    (top-down / plan view): as the sun swings to a grazing azimuth ``θ`` off the
+    window normal, the near reveal jamb casts a shadow that creeps across the
+    recessed cover. The cover is fully in shadow — no direct sun anywhere on it —
+    when the shadow reaches the **far** cover edge. The horizontal offset between
+    the near jamb and the far edge equals the full opening width ``w``; the recess
+    depth is ``d``. The sun fully exits when ``d·tan(θ) = w``, so::
+
+        θ_exit = arctan(w / d)
+
+    Using ``arctan((w/2)/d)`` (half-width) would give the angle at which the
+    shadow reaches only the center of the cover — an earlier, narrower cutoff that
+    under-reports the tracking FOV.
 
     A flush reveal (``depth_m <= 0``) or a degenerate opening (``width_m <= 0``)
     blocks nothing, so the FOV is the full hemisphere (the default half-angle).
@@ -29,7 +37,7 @@ def fov_from_reveal(width_m: float, depth_m: float) -> int:
     """
     if depth_m <= 0 or width_m <= 0:
         return DEFAULT_FOV_LEFT
-    deg = degrees(atan((width_m / 2) / depth_m))
+    deg = degrees(atan(width_m / depth_m))
     lo, hi = OPTION_RANGES[CONF_FOV_LEFT]
     return int(round(min(max(deg, lo), hi)))
 

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -2566,9 +2566,9 @@ def test_summary_shows_computed_fov_in_measurements_mode():
     cfg[CONF_WINDOW_WIDTH] = 1.2
     cfg[CONF_WINDOW_DEPTH] = 0.5
     summary = _build_config_summary(cfg, CoverType.BLIND)
-    # width 1.2 / depth 0.5 → atan(1.2) ≈ 50.19° → 50
+    # width 1.2 / depth 0.5 → atan(1.2/0.5) = atan(2.4) ≈ 67.38° → 67
     assert "Computed FOV" in summary
-    assert "50°/50°" in summary
+    assert "67°/67°" in summary
     assert "1.2 m width" in summary
     assert "0.5 m reveal depth" in summary
 

--- a/tests/test_engine/test_sun_geometry_fov.py
+++ b/tests/test_engine/test_sun_geometry_fov.py
@@ -16,14 +16,14 @@ from custom_components.adaptive_cover_pro.const import (
 from custom_components.adaptive_cover_pro.engine.sun_geometry import fov_from_reveal
 
 
-def test_width_2_depth_1_is_45_degrees():
-    # atan((2/2)/1) = atan(1) = 45°
-    assert fov_from_reveal(2.0, 1.0) == 45
+def test_width_2_depth_1_is_63_degrees():
+    # atan(2/1) = atan(2) ≈ 63.43° → rounds to 63
+    assert fov_from_reveal(2.0, 1.0) == 63
 
 
-def test_width_2_depth_half_is_63_degrees():
-    # atan((2/2)/0.5) = atan(2) ≈ 63.43° → rounds to 63
-    assert fov_from_reveal(2.0, 0.5) == 63
+def test_width_2_depth_half_is_76_degrees():
+    # atan(2/0.5) = atan(4) ≈ 75.96° → rounds to 76
+    assert fov_from_reveal(2.0, 0.5) == 76
 
 
 def test_zero_depth_is_full_hemisphere_default():
@@ -54,10 +54,20 @@ def test_returns_int():
 @pytest.mark.parametrize(
     ("width", "depth", "expected"),
     [
-        (1.0, 1.0, 27),  # atan(0.5) ≈ 26.57 → 27
-        (3.0, 1.0, 56),  # atan(1.5) ≈ 56.31 → 56
-        (1.2, 0.5, 50),  # atan(1.2) ≈ 50.19 → 50 (the summary example)
+        (1.0, 1.0, 45),  # atan(1.0) = 45.00° → 45
+        (3.0, 1.0, 72),  # atan(3.0) ≈ 71.57° → 72
+        (1.2, 0.5, 67),  # atan(2.4) ≈ 67.38° → 67 (the summary example)
     ],
 )
 def test_known_angles(width, depth, expected):
     assert fov_from_reveal(width, depth) == expected
+
+
+def test_real_world_reveal_0_84_x_0_25_is_73_degrees():
+    """Reporter's window: 0.84 m wide, 0.25 m deep reveal.
+
+    Ground truth: sun first reaches cover at ~228° for a 300° normal → 72° off-normal.
+    arctan(0.84 / 0.25) = arctan(3.36) ≈ 73.43° → rounds to 73.
+    Regression guard for issue #565 (buggy /2 formula returned 59).
+    """
+    assert fov_from_reveal(0.84, 0.25) == 73


### PR DESCRIPTION
## Summary
The "From measurements" FOV mode derived the horizontal field of view from window width and reveal depth as `arctan((width/2)/depth)`. The `/2` is geometrically wrong — it computes the azimuth at which the reveal shadow reaches the window center (half-shaded), not the far edge where direct sun fully exits. The correct half-FOV is `arctan(width/depth)`.

For the reporting window (0.84 m wide, 0.25 m reveal) the old math returned 59°; the fix returns 73°, matching the reporter's verified real-world value of 72° (window normal 300°, sun first reaching at 228°).

Single-line change in the `fov_from_reveal` helper plus a corrected docstring. Existing tests that encoded the buggy `(width/2)/depth` algebra were reconciled to the correct `arctan(width/depth)` model, and a regression test pins the reporter's window.

## Testing
- ✅ 214 passing (`test_sun_geometry_fov.py` + `test_config_flow_summary.py`); 67 passing (full engine suite)
- ✅ New regression test: `test_real_world_reveal_0_84_x_0_25_is_73_degrees`

## Related Issues
Refs #565