### PR TITLE
feat: show FOV sliders in Measurements mode with derived default (#565)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2593,9 +2593,11 @@ def _resolve_fov_mode_submit(
     if submitted == FovMode.MEASUREMENTS:
         width = float(source_config.get(CONF_WINDOW_WIDTH) or 0.0)
         depth = float(source_config.get(CONF_WINDOW_DEPTH) or 0.0)
-        derived = fov_from_reveal(width, depth)
-        user_input[CONF_FOV_LEFT] = derived
-        user_input[CONF_FOV_RIGHT] = derived
+        derived = round(fov_from_reveal(width, depth))
+        if CONF_FOV_LEFT not in user_input:
+            user_input[CONF_FOV_LEFT] = derived
+        if CONF_FOV_RIGHT not in user_input:
+            user_input[CONF_FOV_RIGHT] = derived
     return None
 
 
@@ -2603,17 +2605,22 @@ def _get_sun_tracking_schema(
     sensor_type: str | None,
     hass: HomeAssistant | None = None,
     mode: str | None = None,
+    source_config: dict | None = None,
 ) -> vol.Schema:
     """Return sun tracking schema for *sensor_type* in the given FOV *mode*.
 
     Adds the glare-zones toggle for cover types that support it, and routes the
     FOV-field shaping (mode selector + per-mode slider visibility, #565) through
     the cover-type policy so no cover-type string branching leaks out here.
+
+    *source_config* is forwarded to the policy so that, in Measurements mode,
+    the fov sliders can be pre-populated with the geometric suggested_value
+    derived from the stored window width + reveal depth.
     """
     base = sun_tracking_schema(hass) if hass is not None else SUN_TRACKING_SCHEMA
     if sensor_type in POLICY_REGISTRY:
         policy = get_policy(sensor_type)
-        base = policy.fov_mode_schema(base, mode)
+        base = policy.fov_mode_schema(base, mode, source_config=source_config)
         if policy.supports_glare_zones:
             base = base.extend(
                 {
@@ -2859,7 +2866,9 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict | None = None,
     ):
         """Render the create-flow sun-tracking form for the given FOV *mode*."""
-        schema = _get_sun_tracking_schema(self.type_blind, self.hass, mode)
+        schema = _get_sun_tracking_schema(
+            self.type_blind, self.hass, mode, source_config=self.config
+        )
         suggested = options_to_display(
             self.hass, values or self.config, length_keys=_SUN_TRACKING_LENGTH_KEYS
         )
@@ -3452,7 +3461,9 @@ class OptionsFlowHandler(OptionsFlow):
         errors: dict | None = None,
     ):
         """Render the sun-tracking form for the given FOV *mode* (#565)."""
-        schema = _get_sun_tracking_schema(self.sensor_type, self.hass, mode)
+        schema = _get_sun_tracking_schema(
+            self.sensor_type, self.hass, mode, source_config=self.options
+        )
         suggested = options_to_display(
             self.hass, values, length_keys=_SUN_TRACKING_LENGTH_KEYS
         )

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -196,14 +196,18 @@ class CoverTypePolicy(ABC):
         self,
         base: vol.Schema,
         mode: str | None = None,  # noqa: ARG002
+        *,
+        source_config: dict | None = None,  # noqa: ARG002
     ) -> vol.Schema:
         """Shape the sun-tracking schema's FOV fields for the given mode.
 
         The default (every cover type except vertical blinds) returns *base*
         unchanged — no mode selector, plain fov_left/right sliders. BlindPolicy
-        overrides this to insert the mode selector and hide the fov sliders in
-        Measurements mode. Keeping the logic on the policy keeps cover-type
-        branching inside ``cover_types/`` (cover-type-abstraction guideline).
+        overrides this to insert the mode selector and, in Measurements mode,
+        show the fov sliders pre-populated with the derived angle as a
+        suggested_value so the user can override either angle independently.
+        Keeping the logic on the policy keeps cover-type branching inside
+        ``cover_types/`` (cover-type-abstraction guideline).
         """
         return base
 

--- a/custom_components/adaptive_cover_pro/cover_types/blind.py
+++ b/custom_components/adaptive_cover_pro/cover_types/blind.py
@@ -105,19 +105,31 @@ class BlindPolicy(CoverTypePolicy, register=True):
         self,
         base: vol.Schema,
         mode: str | None = None,
+        *,
+        source_config: dict | None = None,
     ) -> vol.Schema:
-        """Insert the FOV-mode selector; hide the fov sliders in Measurements.
+        """Insert the FOV-mode selector; show fov sliders with suggested_value.
 
-        The mode selector is placed immediately before the fov sliders. In
-        ``MEASUREMENTS`` mode the ``fov_left``/``fov_right`` sliders are dropped
-        (the FOV is derived from window width + reveal depth at save time); in
-        ``ANGLES`` mode they stay exactly as today.
+        The mode selector is placed immediately before the fov sliders. In both
+        ``ANGLES`` and ``MEASUREMENTS`` modes the sliders are shown. In
+        ``MEASUREMENTS`` mode they carry a ``suggested_value`` derived from the
+        window width + reveal depth so the user sees the geometric starting point
+        and can override either angle independently (#565). On save the user's
+        typed values are used when present; the derived value is the fallback.
         """
         from .. import config_fields as cf
         from ..const import CONF_FOV_LEFT, CONF_FOV_MODE, CONF_FOV_RIGHT, FovMode
+        from ..engine.sun_geometry import fov_from_reveal
 
         resolved = mode if mode is not None else FovMode.ANGLES
-        hide_sliders = str(resolved) == FovMode.MEASUREMENTS
+        in_measurements_mode = str(resolved) == FovMode.MEASUREMENTS
+
+        # Derive the suggested FOV once from width/depth when in Measurements.
+        derived: int | None = None
+        if in_measurements_mode:
+            width = float((source_config or {}).get(CONF_WINDOW_WIDTH) or 0.0)
+            depth = float((source_config or {}).get(CONF_WINDOW_DEPTH) or 0.0)
+            derived = round(fov_from_reveal(width, depth)) if depth > 0 else None
 
         spec = cf.FIELD_SPECS[CONF_FOV_MODE]
         mode_marker, mode_selector = spec.to_marker(None, None)
@@ -130,11 +142,16 @@ class BlindPolicy(CoverTypePolicy, register=True):
                 if not inserted:
                     rebuilt[mode_marker] = mode_selector
                     inserted = True
-                if hide_sliders:
-                    continue
-                # Optional so the frontend Required check never blocks a mode
-                # switch (#565); default preserved, so ANGLES is unchanged.
-                rebuilt[_as_optional(marker)] = sel
+                if in_measurements_mode and derived is not None:
+                    # Show slider pre-populated with derived angle as an editable
+                    # starting point; user can override either angle independently.
+                    rebuilt[
+                        vol.Optional(key, description={"suggested_value": derived})
+                    ] = sel
+                else:
+                    # Optional so the frontend Required check never blocks a mode
+                    # switch (#565); default preserved, so ANGLES is unchanged.
+                    rebuilt[_as_optional(marker)] = sel
                 continue
             rebuilt[marker] = sel
         if not inserted:

--- a/tests/test_config_flow_fov_mode.py
+++ b/tests/test_config_flow_fov_mode.py
@@ -62,13 +62,33 @@ def test_blind_angles_mode_shows_fov_sliders():
     assert CONF_FOV_MODE in keys
 
 
-def test_blind_measurements_mode_hides_fov_sliders():
+def test_blind_measurements_mode_shows_fov_sliders():
     schema = _get_sun_tracking_schema(CoverType.BLIND, mode=FovMode.MEASUREMENTS)
     keys = _keys(schema)
-    assert CONF_FOV_LEFT not in keys
-    assert CONF_FOV_RIGHT not in keys
+    assert CONF_FOV_LEFT in keys
+    assert CONF_FOV_RIGHT in keys
     # The mode selector itself stays so the user can switch back.
     assert CONF_FOV_MODE in keys
+
+
+def test_blind_measurements_mode_sliders_have_suggested_value():
+    import math
+
+    schema = _get_sun_tracking_schema(
+        CoverType.BLIND,
+        mode=FovMode.MEASUREMENTS,
+        source_config={CONF_WINDOW_WIDTH: 2.0, CONF_WINDOW_DEPTH: 0.5},
+    )
+    expected = round(math.degrees(math.atan(2.0 / 0.5)))  # ≈ 76
+
+    def _get_suggested(schema, key):
+        for m in schema.schema:
+            if str(m) == key and m.description:
+                return m.description.get("suggested_value")
+        raise AssertionError(f"no suggested_value for {key!r}")
+
+    assert _get_suggested(schema, CONF_FOV_LEFT) == expected
+    assert _get_suggested(schema, CONF_FOV_RIGHT) == expected
 
 
 def test_blind_default_mode_is_angles():
@@ -153,6 +173,32 @@ async def test_measurements_mode_stores_derived_fov():
 
 
 @pytest.mark.asyncio
+async def test_measurements_mode_stores_user_override_fov():
+    # When sliders are shown in MEASUREMENTS mode and the user types explicit
+    # values, those values must be stored — NOT overwritten by the derived angle.
+    flow = _options_flow(
+        {
+            CONF_WINDOW_WIDTH: 2.0,
+            CONF_WINDOW_DEPTH: 0.5,
+            CONF_FOV_LEFT: 90,
+            CONF_FOV_RIGHT: 90,
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+        }
+    )
+    await flow.async_step_sun_tracking(
+        {
+            CONF_FOV_MODE: FovMode.MEASUREMENTS,
+            CONF_FOV_LEFT: 90,
+            CONF_FOV_RIGHT: 60,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    # User typed 90 and 60 — derived would be 76. Must keep user values.
+    assert flow.options[CONF_FOV_LEFT] == 90
+    assert flow.options[CONF_FOV_RIGHT] == 60
+
+
+@pytest.mark.asyncio
 async def test_angles_mode_keeps_typed_fov():
     flow = _options_flow(
         {
@@ -223,8 +269,10 @@ async def test_switching_to_measurements_rerenders_form_not_next_step():
     assert advanced is False
     assert result["type"] == "form"
     assert result["step_id"] == "sun_tracking"
-    # The re-rendered form is in MEASUREMENTS mode (sliders hidden).
-    assert CONF_FOV_LEFT not in _keys(result["data_schema"])
+    # The re-rendered form is in MEASUREMENTS mode (sliders shown with
+    # suggested_value derived from window width + reveal depth).
+    assert CONF_FOV_LEFT in _keys(result["data_schema"])
+    assert CONF_FOV_RIGHT in _keys(result["data_schema"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
In `FovMode.MEASUREMENTS` mode, the FOV left/right sliders were hidden entirely. This change shows them with the derived angle pre-filled as a suggested value (editable), so users with non-standard window constructions can override one or both halves while still benefiting from the geometric starting point.

On save, user-typed values are used when present; the derived value is backfilled only when the sliders were absent.

## Testing
- ✅ 4454 tests passing
- New: `test_blind_measurements_mode_shows_fov_sliders`, `test_blind_measurements_mode_sliders_have_suggested_value`, `test_measurements_mode_stores_user_override_fov`

## Related Issues
Refs #565