### PR TITLE
fix: migrate legacy custom-position sensor key to list on upgrade (#563)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -44,7 +44,11 @@ from .const import (
     _LOGGER,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
-from .helpers import custom_position_slot_sensors, motion_entities
+from .helpers import (
+    copy_legacy_slot_sensors_to_list,
+    custom_position_slot_sensors,
+    motion_entities,
+)
 from .templates import is_template_string
 from .migrations import (
     async_prune_legacy_entities,
@@ -384,6 +388,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry.data.get("name", entry.entry_id),
             )
         new_minor = 2
+
+    # v3.2 → v3.3: copy each legacy custom_position_sensor_N single-sensor key
+    # into the new custom_position_sensors_N list key so pre-multi-sensor entries
+    # prefill the options-flow multi-select correctly (issue #563 trailing defect).
+    # Additive + rollback-safe: legacy keys are left intact.
+    if new_version == 3 and new_minor < 3:
+        if copy_legacy_slot_sensors_to_list(new_options):
+            _LOGGER.info(
+                "Migrated legacy single-sensor keys of %s into list keys",
+                entry.data.get("name", entry.entry_id),
+            )
+        new_minor = 3
 
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -61,6 +61,28 @@ def custom_position_slot_sensors(
     return [legacy] if legacy else []
 
 
+def copy_legacy_slot_sensors_to_list(options: dict) -> bool:
+    """Promote each slot's legacy single-sensor key into the new list key.
+
+    Called by the v3.2 → v3.3 migration (issue #563). For every custom-position
+    slot where the new ``sensors`` list key is absent AND the legacy ``sensor``
+    key holds a non-empty value, the legacy value is wrapped in a one-element
+    list and written under the ``sensors`` key. The legacy key is left intact
+    (additive / rollback-safe: same invariant as the v3.2 migration). Slots
+    whose list key already exists, or that have no legacy sensor configured,
+    are skipped. Returns ``True`` when at least one slot was updated.
+    """
+    changed = False
+    for slot_keys in CUSTOM_POSITION_SLOTS.values():
+        if slot_keys["sensors"] in options:
+            continue
+        legacy = options.get(slot_keys["sensor"])
+        if legacy:
+            options[slot_keys["sensors"]] = [legacy]
+            changed = True
+    return changed
+
+
 def mirror_legacy_slot_sensor_keys(options: dict) -> None:
     """Mirror each slot's first sensor into the legacy single-sensor key.
 

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -246,7 +246,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -256,7 +256,9 @@ async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
 
     Rollback contract: an older release must find its config exactly as it
     left it — the old ForceOverrideHandler reads the legacy keys and ignores
-    the slot-5 keys (it only iterates slots 1–4).
+    the slot-5 keys (it only iterates slots 1–4). The v3.3 migration promotes
+    the slot-1 legacy key into the list key so the multi-select prefills;
+    the legacy key itself is left intact.
     """
     options = {
         **_FORCE_OPTIONS,
@@ -267,20 +269,20 @@ async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
     await async_migrate_entry(hass, entry)
     for key, value in options.items():
         assert entry.options[key] == value, f"legacy key {key} changed"
-    # No new-format list keys are written for slots 1-4 — the read fallback
-    # covers them, and skipping the wrap avoids stale copies after rollback
-    # edits to the legacy keys.
-    for slot_n in (1, 2, 3, 4):
+    # v3.3 migration promotes the legacy sensor key into the list key for slot 1.
+    assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
+    # Slots 2–4 had no legacy sensor configured — no list key is created.
+    for slot_n in (2, 3, 4):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
 
 async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> None:
-    """Absent force override config → minor bump only, slot 5 stays free."""
+    """Absent force override config → minor bumps to 3 (through v3.3), slot 5 stays free."""
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=1)
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -293,7 +295,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -312,7 +314,7 @@ async def test_migrate_v3_2_missing_position_defaults_to_zero(
 
 
 async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
-    """A v1 entry with force override config ends at 3.2 with slot 5 populated."""
+    """A v1 entry with force override config ends at 3.3 with slot 5 populated."""
     entry = _make_entry(
         hass,
         {CONF_WINDOW_WIDTH: 200, **_FORCE_OPTIONS},
@@ -320,7 +322,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 2
+    assert entry.minor_version == 3
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -337,3 +339,68 @@ async def test_migrate_v3_2_is_idempotent(hass: HomeAssistant) -> None:
     # …a second migration run must not clobber it.
     await async_migrate_entry(hass, entry)
     assert entry.options == snapshot
+
+
+# ---------------------------------------------------------------------------
+# Migration: v3.2 → v3.3 — copy legacy custom_position_sensor_N into list key
+# (issue #563 trailing defect). Additive + rollback-safe.
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
+    hass: HomeAssistant,
+) -> None:
+    """Legacy single-sensor key is promoted into the new list key on migration."""
+    entry = _make_entry(
+        hass,
+        {"custom_position_sensor_1": "binary_sensor.table", "custom_position_1": 10},
+        version=3,
+        minor_version=2,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
+    assert entry.minor_version == 3
+
+
+async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
+    """Migration is additive: the legacy sensor key is NOT removed."""
+    entry = _make_entry(
+        hass,
+        {"custom_position_sensor_1": "binary_sensor.table", "custom_position_1": 10},
+        version=3,
+        minor_version=2,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensor"]] == "binary_sensor.table"
+
+
+async def test_migrate_v3_3_does_not_overwrite_existing_list(
+    hass: HomeAssistant,
+) -> None:
+    """If sensors list already exists it is left unchanged."""
+    entry = _make_entry(
+        hass,
+        {
+            "custom_position_sensor_1": "binary_sensor.a",
+            "custom_position_sensors_1": ["binary_sensor.b"],
+            "custom_position_1": 10,
+        },
+        version=3,
+        minor_version=2,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.options["custom_position_sensors_1"] == ["binary_sensor.b"]
+
+
+async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
+    """No legacy sensor keys → minor bumps to 3, no sensors_N list created."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=2,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.minor_version == 3
+    for slot_n in (1, 2, 3, 4, 5):
+        assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options


### PR DESCRIPTION
## Summary
After the Forced Override → Custom Positions merge, a pre-multi-sensor config entry kept its trigger under the legacy single key `custom_position_sensor_N`. The options-flow multi-select binds to the new list key `custom_position_sensors_N`, which migration never populated — so the "Sensors N" field opened empty, and saving the page wiped the binding. This adds a v3.2→v3.3 minor migration that copies any non-empty legacy single-sensor value into the new list key when the list key is absent, leaving the legacy key intact (additive, rollback-safe — same invariant as the v3.2 force-override migration).

## Testing
- ✅ 22 tests passing in test_config_entry_migration.py (4 new + 5 updated); 90 passing across migration + config-flow files

## Related Issues
Refs #563