### PR TITLE
fix: make vertical extreme-gamma edge case elevation-aware (#598)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -867,6 +867,11 @@ class ClimateInactiveReason:
 EDGE_CASE_LOW_ELEVATION = 2.0  # deg — below this, use low-elev path
 EDGE_CASE_HIGH_ELEVATION = 88.0  # deg — above this, use high-elev path
 EDGE_CASE_EXTREME_GAMMA = 85  # deg — max horizontal angle considered
+# Extreme gamma forces full closure ONLY when elevation is at/below this value
+# (issue #598). The "extreme gamma ⇒ full coverage" assumption holds only for a
+# grazing (low) sun; at higher elevation the ray descends steeply even at
+# extreme gamma, so the normal cos(gamma)-clamped projection is trusted instead.
+EDGE_CASE_EXTREME_GAMMA_ELEVATION = 45.0  # deg — above this, skip the full-close
 
 # Safety margin thresholds and multipliers.
 SAFETY_MARGIN_GAMMA_THRESHOLD = 45  # deg — angle where gamma margins start

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from .const import (
     EDGE_CASE_EXTREME_GAMMA,
+    EDGE_CASE_EXTREME_GAMMA_ELEVATION,
     EDGE_CASE_HIGH_ELEVATION,
     EDGE_CASE_LOW_ELEVATION,
     SAFETY_MARGIN_GAMMA_MAX,
@@ -69,8 +70,17 @@ def _edge_case(
     if sol_elev < EDGE_CASE_LOW_ELEVATION:
         return (True, 0.0)
 
-    # Extreme gamma: sun perpendicular to window, full coverage (position 0 = closed)
-    if abs(gamma) > EDGE_CASE_EXTREME_GAMMA:
+    # Extreme gamma with a low sun: the ray grazes in nearly parallel to the
+    # facade and penetrates deeply, so full coverage is correct (position 0).
+    # At higher elevation (issue #598) the ray descends steeply even at extreme
+    # gamma — penetration is shallow — so forcing full closure produces a
+    # spurious fully-closed sample right at the FOV-entry edge. Above
+    # EDGE_CASE_EXTREME_GAMMA_ELEVATION we fall through to the normal projection,
+    # whose cos(gamma) divisor is already clamped (MIN_COS_GAMMA_CLAMP).
+    if (
+        abs(gamma) > EDGE_CASE_EXTREME_GAMMA
+        and sol_elev <= EDGE_CASE_EXTREME_GAMMA_ELEVATION
+    ):
         return (True, 0.0)
 
     # Very high elevation: sun nearly overhead, use simplified calculation

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -228,6 +228,49 @@ class TestEdgeCases:
         assert is_edge_case is True
         assert position == 0.0
 
+    def test_extreme_gamma_high_elevation_not_full_close(self, base_cover_params):
+        """Issue #598: extreme gamma + high sun must NOT force fully-closed.
+
+        At high elevation the ray descends steeply even at extreme gamma, so the
+        normal projection applies instead of the grazing-sun full-close.
+        """
+        cover = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=70.0)
+        is_edge_case, _ = cover._handle_edge_cases()
+        assert is_edge_case is False
+
+    def test_extreme_gamma_low_elevation_still_full_closes(self, base_cover_params):
+        """Grazing low sun at extreme gamma still fully closes (position 0)."""
+        cover = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=20.0)
+        is_edge_case, position = cover._handle_edge_cases()
+        assert is_edge_case is True
+        assert position == 0.0
+
+    def test_extreme_gamma_elevation_boundary(self, base_cover_params):
+        """Boundary at EDGE_CASE_EXTREME_GAMMA_ELEVATION (45°): ≤45 closes, >45 falls through."""
+        at = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=45.0)
+        assert at._handle_edge_cases()[0] is True
+        above = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=45.5)
+        assert above._handle_edge_cases()[0] is False
+
+    def test_fov_entry_no_spurious_close(self, base_cover_params):
+        """Issue #598 regression: no 0→open jump across the 85° FOV edge at high sun.
+
+        Reproduces the side-yard-shade V-notch: a sample just inside the
+        extreme-gamma band (86°) at high elevation must stay open and match the
+        sample just outside it (84°), rather than slamming to fully closed.
+        """
+        just_inside = make_cover_with_angles(
+            base_cover_params, gamma=86.0, sol_elev=70.0
+        )
+        just_outside = make_cover_with_angles(
+            base_cover_params, gamma=84.0, sol_elev=70.0
+        )
+        pct_inside = just_inside.calculate_percentage()
+        pct_outside = just_outside.calculate_percentage()
+        # Pre-fix the inside sample returned 0 (spurious full-close).
+        assert pct_inside > 50, f"FOV-entry sample slammed closed: {pct_inside}%"
+        assert abs(pct_inside - pct_outside) <= 5
+
     def test_edge_case_very_high_elevation(self, base_cover_params):
         """Very high elevation should use simplified calculation."""
         cover = make_cover_with_angles(base_cover_params, gamma=0.0, sol_elev=88.5)

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -806,6 +806,7 @@ class TestPositionExplanationChangeDetection:
         # Minimal stubs for DiagnosticContext construction
         coord.pos_sun = [180.0, 45.0]
         coord._cover_data = _make_cover()
+        coord._position_forecast = None
         coord._climate_mode = False
         coord._pipeline_result = _make_pr()
         type(coord).check_adaptive_time = PropertyMock(return_value=True)


### PR DESCRIPTION
## Summary

Fixes the spurious **fully-closed sample at the FOV-entry edge** of a vertical blind whose field of view reaches the geometric limit (`fov_left: 90`). The forecast (and the live cover) showed a one-sample 0→100 flap right as the sun entered the tracking window — a "V notch."

Root cause: `geometry.py::_edge_case()` forced fully-closed whenever `|gamma| > 85°`, **regardless of elevation**. The FOV gate admits the sun while `0 < gamma < 90`, so the 85–90° band at the entry edge had the solar handler active but the edge handler overriding to closed. The next sample (gamma < 85°) ran the normal projection and — at high midday elevation — correctly returned open, producing the discontinuity.

The "extreme gamma ⇒ full coverage" assumption only holds for a **grazing (low) sun**. At high elevation the ray descends steeply even at extreme gamma (shallow penetration), so the normal projection (whose `cos(gamma)` divisor is already clamped via `MIN_COS_GAMMA_CLAMP`) is the right answer.

## Change
- New constant `EDGE_CASE_EXTREME_GAMMA_ELEVATION = 45.0°`.
- The extreme-gamma full-close now fires only when `sol_elev <= 45°`; above that it falls through to the normal projection. Existing extreme-gamma tests (all at `elev ≤ 45`) keep their current behavior.

## Testing
- ✅ 4500 tests passing
- New regression tests in `test_geometric_accuracy.py`: extreme gamma at high elevation is not an edge case; low-elevation grazing still full-closes; the 45° boundary; and a FOV-entry continuity check (gamma 86° vs 84° at high sun stay open and within 5%).

## Also included
- Repairs a test-mock regression on `develop` from the earlier diagnostics-forecast change (a4d721d): `test_position_explanation.py`'s spec'd mock coordinator was missing the new `_position_forecast` attribute. One-line stub added.

## Related Issues
Refs #598