### PR TITLE
refactor: drop redundant/backwards vertical edge cases (#600)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -863,15 +863,10 @@ class ClimateInactiveReason:
 # and engine/sun_geometry.py. Tuning these affects how aggressively the
 # integration retreats from extreme sun geometries.
 
-# Edge-case thresholds for extreme sun positions.
-EDGE_CASE_LOW_ELEVATION = 2.0  # deg — below this, use low-elev path
-EDGE_CASE_HIGH_ELEVATION = 88.0  # deg — above this, use high-elev path
-EDGE_CASE_EXTREME_GAMMA = 85  # deg — max horizontal angle considered
-# Extreme gamma forces full closure ONLY when elevation is at/below this value
-# (issue #598). The "extreme gamma ⇒ full coverage" assumption holds only for a
-# grazing (low) sun; at higher elevation the ray descends steeply even at
-# extreme gamma, so the normal cos(gamma)-clamped projection is trusted instead.
-EDGE_CASE_EXTREME_GAMMA_ELEVATION = 45.0  # deg — above this, skip the full-close
+# Low-sun edge-case threshold. The former extreme-gamma (85°) and very-high-
+# elevation (88°) thresholds were removed in issue #600 once the projection
+# formula gained its own numerical guards; only the horizon-sun floor remains.
+EDGE_CASE_LOW_ELEVATION = 2.0  # deg — below this, force full coverage (closed)
 
 # Safety margin thresholds and multipliers.
 SAFETY_MARGIN_GAMMA_THRESHOLD = 45  # deg — angle where gamma margins start

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -7,9 +7,6 @@ from functools import lru_cache
 import numpy as np
 
 from .const import (
-    EDGE_CASE_EXTREME_GAMMA,
-    EDGE_CASE_EXTREME_GAMMA_ELEVATION,
-    EDGE_CASE_HIGH_ELEVATION,
     EDGE_CASE_LOW_ELEVATION,
     SAFETY_MARGIN_GAMMA_MAX,
     SAFETY_MARGIN_GAMMA_THRESHOLD,
@@ -62,31 +59,29 @@ def _safety_margin(gamma: float, sol_elev: float) -> float:
 def _edge_case(
     sol_elev: float, gamma: float, distance: float, h_win: float
 ) -> tuple[bool, float]:
-    """Compute the extreme-angle edge-case fallback — pure, memoised.
+    """Compute the low-sun edge-case fallback — pure, memoised.
 
     Companion to :func:`_safety_margin`; see it for the caching rationale.
+
+    Only the very-low-elevation guard remains (issue #600). The former
+    extreme-gamma and very-high-elevation branches were removed: the
+    projection in ``AdaptiveVerticalCover.calculate_position`` now carries its
+    own numerical guards — ``MIN_COS_GAMMA_CLAMP`` on the ``cos(gamma)``
+    divisor, ``MIN_TAN_ELEVATION_CLAMP`` on the sill division, and the
+    ``effective_distance < 0 → 0`` clamp (#358/#559) — so those two branches
+    either duplicated the normal path (very high elevation) or contradicted it
+    (extreme gamma forced fully-closed where the grazing geometry is open,
+    the root cause of #598). The low-elevation floor is retained as a
+    deliberate policy: a sun on the horizon should drive full coverage, and
+    the normal path does not enforce that for a zero-sill window.
+
+    ``gamma``, ``distance`` and ``h_win`` are unused now but kept on the
+    signature so the cached call site and ``EdgeCaseHandler.check_and_handle``
+    contract are unchanged.
     """
-    # Very low elevation: sun nearly horizontal, full coverage safest (position 0 = closed)
+    # Very low elevation: sun on the horizon — full coverage (position 0 = closed).
     if sol_elev < EDGE_CASE_LOW_ELEVATION:
         return (True, 0.0)
-
-    # Extreme gamma with a low sun: the ray grazes in nearly parallel to the
-    # facade and penetrates deeply, so full coverage is correct (position 0).
-    # At higher elevation (issue #598) the ray descends steeply even at extreme
-    # gamma — penetration is shallow — so forcing full closure produces a
-    # spurious fully-closed sample right at the FOV-entry edge. Above
-    # EDGE_CASE_EXTREME_GAMMA_ELEVATION we fall through to the normal projection,
-    # whose cos(gamma) divisor is already clamped (MIN_COS_GAMMA_CLAMP).
-    if (
-        abs(gamma) > EDGE_CASE_EXTREME_GAMMA
-        and sol_elev <= EDGE_CASE_EXTREME_GAMMA_ELEVATION
-    ):
-        return (True, 0.0)
-
-    # Very high elevation: sun nearly overhead, use simplified calculation
-    if sol_elev > EDGE_CASE_HIGH_ELEVATION:
-        simple_height = distance * np.tan(np.radians(sol_elev))
-        return (True, float(np.clip(simple_height, 0, h_win)))
 
     return (False, 0.0)
 

--- a/tests/test_geometric_accuracy.py
+++ b/tests/test_geometric_accuracy.py
@@ -198,65 +198,42 @@ class TestEdgeCases:
         is_edge_case, _ = cover._handle_edge_cases()
         assert is_edge_case is False
 
-    def test_edge_case_extreme_gamma(self, base_cover_params):
-        """Extreme gamma should fully cover (position 0 = closed)."""
-        cover = make_cover_with_angles(base_cover_params, gamma=86.0, sol_elev=45.0)
+    def test_extreme_gamma_no_longer_edge_case(self, base_cover_params):
+        """Issue #600: extreme gamma is handled by the normal clamped projection.
 
-        is_edge_case, position = cover._handle_edge_cases()
-
-        assert is_edge_case is True
-        assert position == 0.0
-
-    def test_edge_case_gamma_threshold(self, base_cover_params):
-        """Edge case should trigger above 85° gamma."""
-        # Well above threshold
-        cover = make_cover_with_angles(base_cover_params, gamma=87.0, sol_elev=45.0)
-        is_edge_case, _ = cover._handle_edge_cases()
-        assert is_edge_case is True
-
-        # Well below threshold
-        cover = make_cover_with_angles(base_cover_params, gamma=80.0, sol_elev=45.0)
-        is_edge_case, _ = cover._handle_edge_cases()
-        assert is_edge_case is False
-
-    def test_edge_case_negative_gamma(self, base_cover_params):
-        """Edge case should handle negative gamma correctly — position 0 = fully closed."""
-        cover = make_cover_with_angles(base_cover_params, gamma=-86.0, sol_elev=45.0)
-
-        is_edge_case, position = cover._handle_edge_cases()
-
-        assert is_edge_case is True
-        assert position == 0.0
+        The former |gamma|>85° full-close branch was removed; the projection's
+        cos(gamma) clamp keeps the result finite and bounded without it.
+        """
+        for gamma in (86.0, 89.0, -86.0, -89.0):
+            cover = make_cover_with_angles(
+                base_cover_params, gamma=gamma, sol_elev=45.0
+            )
+            is_edge_case, _ = cover._handle_edge_cases()
+            assert is_edge_case is False, f"gamma={gamma} should not be an edge case"
+            assert 0.0 <= cover.calculate_percentage() <= 100.0
 
     def test_extreme_gamma_high_elevation_not_full_close(self, base_cover_params):
-        """Issue #598: extreme gamma + high sun must NOT force fully-closed.
-
-        At high elevation the ray descends steeply even at extreme gamma, so the
-        normal projection applies instead of the grazing-sun full-close.
-        """
+        """Issue #598/#600: extreme gamma + high sun is open, not slammed closed."""
         cover = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=70.0)
         is_edge_case, _ = cover._handle_edge_cases()
         assert is_edge_case is False
+        assert cover.calculate_percentage() > 50
 
-    def test_extreme_gamma_low_elevation_still_full_closes(self, base_cover_params):
-        """Grazing low sun at extreme gamma still fully closes (position 0)."""
+    def test_extreme_gamma_low_elevation_not_edge_case(self, base_cover_params):
+        """Issue #600: grazing extreme gamma above the 2° floor uses the normal path.
+
+        Below the 2° floor the low-sun guard still closes — see
+        test_edge_case_very_low_elevation.
+        """
         cover = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=20.0)
-        is_edge_case, position = cover._handle_edge_cases()
-        assert is_edge_case is True
-        assert position == 0.0
-
-    def test_extreme_gamma_elevation_boundary(self, base_cover_params):
-        """Boundary at EDGE_CASE_EXTREME_GAMMA_ELEVATION (45°): ≤45 closes, >45 falls through."""
-        at = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=45.0)
-        assert at._handle_edge_cases()[0] is True
-        above = make_cover_with_angles(base_cover_params, gamma=88.0, sol_elev=45.5)
-        assert above._handle_edge_cases()[0] is False
+        is_edge_case, _ = cover._handle_edge_cases()
+        assert is_edge_case is False
 
     def test_fov_entry_no_spurious_close(self, base_cover_params):
         """Issue #598 regression: no 0→open jump across the 85° FOV edge at high sun.
 
-        Reproduces the side-yard-shade V-notch: a sample just inside the
-        extreme-gamma band (86°) at high elevation must stay open and match the
+        Reproduces the side-yard-shade V-notch: a sample just inside the former
+        extreme-gamma band (86°) at high elevation stays open and matches the
         sample just outside it (84°), rather than slamming to fully closed.
         """
         just_inside = make_cover_with_angles(
@@ -271,27 +248,37 @@ class TestEdgeCases:
         assert pct_inside > 50, f"FOV-entry sample slammed closed: {pct_inside}%"
         assert abs(pct_inside - pct_outside) <= 5
 
-    def test_edge_case_very_high_elevation(self, base_cover_params):
-        """Very high elevation should use simplified calculation."""
-        cover = make_cover_with_angles(base_cover_params, gamma=0.0, sol_elev=88.5)
+    def test_very_high_elevation_no_longer_edge_case(self, base_cover_params):
+        """Issue #600: near-overhead sun is handled by the normal projection.
 
-        is_edge_case, position = cover._handle_edge_cases()
+        The former >88° simplified branch was redundant — the normal path
+        saturates to h_win identically — and was removed.
+        """
+        for sol_elev in (88.5, 89.0, 89.9):
+            cover = make_cover_with_angles(
+                base_cover_params, gamma=0.0, sol_elev=sol_elev
+            )
+            is_edge_case, _ = cover._handle_edge_cases()
+            assert is_edge_case is False
+            assert 0.0 <= cover.calculate_percentage() <= 100.0
 
-        assert is_edge_case is True
-        # Should be clipped to h_win
-        assert 0 <= position <= cover.h_win
+    def test_pole_regions_finite_and_bounded(self, base_cover_params):
+        """Issue #600: the self-guarding projection never returns NaN/out-of-range.
 
-    def test_edge_case_high_elevation_threshold(self, base_cover_params):
-        """Edge case should trigger above 88° elevation."""
-        # Well above threshold
-        cover = make_cover_with_angles(base_cover_params, gamma=0.0, sol_elev=89.0)
-        is_edge_case, _ = cover._handle_edge_cases()
-        assert is_edge_case is True
-
-        # Well below threshold
-        cover = make_cover_with_angles(base_cover_params, gamma=0.0, sol_elev=85.0)
-        is_edge_case, _ = cover._handle_edge_cases()
-        assert is_edge_case is False
+        Sweeps the trig-pole regions the removed edge cases used to short-circuit
+        (elevation → 0/90, |gamma| → 90) and asserts every result is a finite
+        percentage in [0, 100]. The only forced full-close is the sub-2° floor.
+        """
+        for sol_elev in (0.1, 1.0, 2.0, 5.0, 45.0, 85.0, 88.0, 89.9):
+            for gamma in (0.0, 45.0, 80.0, 85.0, 89.0, 89.9, -89.0):
+                cover = make_cover_with_angles(
+                    base_cover_params, gamma=gamma, sol_elev=sol_elev
+                )
+                pct = cover.calculate_percentage()
+                assert np.isfinite(pct), f"non-finite at gamma={gamma}, elev={sol_elev}"
+                assert 0.0 <= pct <= 100.0
+                is_edge_case, _ = cover._handle_edge_cases()
+                assert is_edge_case is (sol_elev < 2.0)
 
     @pytest.mark.parametrize(
         "gamma,sol_elev",

--- a/tests/test_geometry_cache.py
+++ b/tests/test_geometry_cache.py
@@ -8,8 +8,6 @@ numeric results (caching must not change output) and confirm the cache is hit.
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from custom_components.adaptive_cover_pro.geometry import (
@@ -74,22 +72,15 @@ def test_edge_case_low_elevation():
 
 
 @pytest.mark.unit
-def test_edge_case_extreme_gamma():
-    assert EdgeCaseHandler.check_and_handle(45.0, 90.0, 2.0, 10.0) == (True, 0.0)
+def test_edge_case_extreme_gamma_not_handled():
+    # Issue #600: extreme gamma above the low-sun floor is no longer an edge case.
+    assert EdgeCaseHandler.check_and_handle(45.0, 90.0, 2.0, 10.0) == (False, 0.0)
 
 
 @pytest.mark.unit
-def test_edge_case_high_elevation():
-    is_edge, pos = EdgeCaseHandler.check_and_handle(89.0, 0.0, 0.05, 10.0)
-    assert is_edge is True
-    assert pos == pytest.approx(0.05 * math.tan(math.radians(89.0)))
-
-
-@pytest.mark.unit
-def test_edge_case_high_elevation_clipped_to_window():
-    is_edge, pos = EdgeCaseHandler.check_and_handle(89.0, 0.0, 5.0, 10.0)
-    assert is_edge is True
-    assert pos == 10.0  # clipped to h_win
+def test_edge_case_high_elevation_not_handled():
+    # Issue #600: the redundant >88° branch was removed; normal path handles it.
+    assert EdgeCaseHandler.check_and_handle(89.0, 0.0, 0.05, 10.0) == (False, 0.0)
 
 
 @pytest.mark.unit

--- a/tests/test_numpy_serialization.py
+++ b/tests/test_numpy_serialization.py
@@ -34,7 +34,7 @@ def _check_native_types(obj, path: str = "root") -> list[str]:
     elif isinstance(obj, dict):
         for k, v in obj.items():
             violations.extend(_check_native_types(v, f"{path}.{k}"))
-    elif isinstance(obj, (list, tuple)):
+    elif isinstance(obj, list | tuple):
         for i, v in enumerate(obj):
             violations.extend(_check_native_types(v, f"{path}[{i}]"))
     return violations
@@ -166,13 +166,13 @@ class TestEdgeCaseHandlerTypes:
         assert not isinstance(pos, np.floating)
 
     def test_high_elevation_returns_python_float(self) -> None:
-        """The high-elevation branch uses np.clip — must be wrapped in float()."""
+        """Issue #600: high elevation is no longer an edge case; types stay native."""
         from custom_components.adaptive_cover_pro.geometry import EdgeCaseHandler
 
         is_edge, pos = EdgeCaseHandler.check_and_handle(
             sol_elev=89.0, gamma=10.0, distance=3.0, h_win=2.5
         )
-        assert is_edge is True
+        assert is_edge is False
         assert isinstance(pos, float)
         assert not isinstance(pos, np.floating)
 
@@ -288,7 +288,7 @@ class TestInterpolatePositionTypes:
         )
 
         result = interpolate_position(50.0, 10.0, 90.0, None, None)
-        assert isinstance(result, (int, float)), f"Expected numeric, got {type(result)}"
+        assert isinstance(result, int | float), f"Expected numeric, got {type(result)}"
         assert not isinstance(result, np.floating), "Got numpy float"
 
     def test_returns_original_when_no_range(self) -> None:


### PR DESCRIPTION
## Summary

Simplifies `geometry.py::_edge_case()` down to the single guard that still earns its place. The handler was added (Feb 2026) as defensive fallbacks for three trig-pole regions, *before* the projection formula had any numerical guards of its own. It now does, so two of the three branches were either redundant or actively wrong.

Evidence: comparing `calculate_percentage()` with vs without the edge handler across the full `(gamma, elevation)` grid —

- **Elevation > 88° branch — removed.** Fully redundant: identical output to the normal path at every cell (the formula already saturates to `h_win`); in a rare non-saturating corner it was *less* correct (it dropped the `cos(gamma)` term).
- **\|gamma\| > 85° branch — removed.** Geometrically backwards: forced *closed* where the clamped projection says *open* (grazing sun ≈ parallel to glass → minimal entry). This was the root cause of #598; the elevation-gate added there was a band-aid and is now unnecessary.
- **Elevation < 2° branch — kept.** A deliberate low-sun policy floor: a sun on the horizon should drive full coverage, and the normal path doesn't enforce that for a zero-sill window. The one branch that isn't backwards.

The normal projection is self-guarding via `MIN_COS_GAMMA_CLAMP`, `MIN_TAN_ELEVATION_CLAMP`, and the `effective_distance < 0 → closed` clamp (#358/#559), plus the angle-dependent safety margin for conservatism at extreme angles.

## Changes
- `geometry.py` — `_edge_case()` reduced to the sub-2° floor; `gamma`/`distance`/`h_win` kept on the signature for the cached call-site contract.
- `const.py` — removed now-unused `EDGE_CASE_EXTREME_GAMMA`, `EDGE_CASE_EXTREME_GAMMA_ELEVATION` (from #598), and `EDGE_CASE_HIGH_ELEVATION`.
- Tests rewritten to the new contract, including a **pole-region sweep** (`test_pole_regions_finite_and_bounded`) asserting every result is finite and in [0, 100], with full-close only below 2°.
- Drive-by: fixed two latent `UP038` lint violations in `test_numpy_serialization.py` (surfaced because the file was touched).

## Testing
- ✅ 4496 tests passing
- ✅ ruff clean

## Related Issues
Closes #600. Supersedes the #598 elevation-gate band-aid (behavior preserved for that case — extreme gamma at high sun stays open).