### PR TITLE
fix: bump MINOR_VERSION so custom-position sensor migration runs (#563)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2656,10 +2656,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle ConfigFlow."""
 
     VERSION = 3
-    # 3.2 (issue #563): force override merged into custom-position slot 5.
-    # Minor bump on purpose — older releases can still load 3.2 entries, so
-    # users can roll back; the migration is additive (legacy keys retained).
-    MINOR_VERSION = 2
+    # 3.3 (issue #563 trailing defect): MINOR_VERSION raised so HA triggers
+    # async_migrate_entry for entries sitting at 3.2.  The v3.2→v3.3 block
+    # (copy legacy custom_position_sensor_N into the new list key) was already
+    # in __init__.py but was unreachable because the gate version was too low.
+    # Rollback-safe: migration is additive (legacy keys retained).
+    MINOR_VERSION = 3
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -404,3 +404,28 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
     assert entry.minor_version == 3
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
+
+
+# ---------------------------------------------------------------------------
+# Reachability lock: config-flow handler version constants must cover every
+# migration block that exists in __init__.py.
+# ---------------------------------------------------------------------------
+
+
+def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
+    """ConfigFlowHandler.MINOR_VERSION must equal the highest minor version any
+    migration block in async_migrate_entry targets.
+
+    HA only invokes async_migrate_entry when an entry's stored
+    (version, minor_version) is strictly less than the handler's class
+    (VERSION, MINOR_VERSION).  If MINOR_VERSION is too low, entries sitting at
+    that minor are never seen as stale and the migration is dead code in
+    production.
+
+    Currently the highest target is 3 (the v3.2 → v3.3 copy of
+    custom_position_sensor_N into the list key, per issue #563).  Raise this
+    assertion whenever a new minor migration block is added.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
+
+    assert ConfigFlowHandler.MINOR_VERSION == 3


### PR DESCRIPTION
## Summary
The v3.2→v3.3 migration that copies a slot's legacy `custom_position_sensor_N` into the new `custom_position_sensors_N` list key was unreachable: `config_flow.py` still declared `MINOR_VERSION = 2`, so Home Assistant never saw existing minor-2 entries as stale and never invoked `async_migrate_entry`. The Custom Positions "Sensors N" multi-select therefore stayed empty after beta.10. This bumps `MINOR_VERSION` to 3 so the existing, additive, rollback-safe migration actually runs.

## Testing
- ✅ 74 tests passing (migration + config-flow integration suites)
- Added a regression test asserting MINOR_VERSION reaches the highest migration target.

## Related Issues
Refs #563