### PR TITLE
feat: surface held position in manual override decision trace

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -536,6 +536,11 @@ class DiagnosticsBuilder:
                     "matched": step.matched,
                     "reason": step.reason,
                     "position": step.position,
+                    **(
+                        {"held_position": step.held_position}
+                        if step.held_position is not None
+                        else {}
+                    ),
                 }
                 for step in result.decision_trace
             ]

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
@@ -37,13 +37,25 @@ class ManualOverrideHandler(OverrideHandler):
 
         if snapshot.cover.direct_sun_valid:
             position = compute_solar_position(snapshot)
-            reason = f"manual override active — holding solar position {position}%"
+            if held_position is not None:
+                reason = (
+                    f"manual override active — holding {held_position}%"
+                    f" (solar would-be {position}%)"
+                )
+            else:
+                reason = f"manual override active — solar would-be {position}%"
         else:
             position = compute_default_position(snapshot)
             pos_label = (
                 "sunset position" if snapshot.is_sunset_active else "default position"
             )
-            reason = f"manual override active — holding {pos_label} {position}%"
+            if held_position is not None:
+                reason = (
+                    f"manual override active — holding {held_position}%"
+                    f" ({pos_label} would be {position}%)"
+                )
+            else:
+                reason = f"manual override active — {pos_label} {position}%"
 
         return PipelineResult(
             position=position,

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -83,6 +83,7 @@ class PipelineRegistry:
                             matched=True,
                             reason=result.reason,
                             position=result.position,
+                            held_position=result.held_position,
                         )
                     )
                 else:

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -230,6 +230,12 @@ class DecisionStep:
     reason: str
     position: int | None
     tilt: int | None = None
+    # Physical position the cover is held at during a manual override step.
+    # Set by PipelineRegistry only for the manual_override winning step
+    # (propagated from PipelineResult.held_position). None for all other
+    # handlers and all other steps. Consumers must use explicit is-not-None
+    # checks because 0% (fully closed) is a valid held position.
+    held_position: int | None = None
 
 
 @dataclass(frozen=True)

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -914,6 +914,11 @@ def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
                 "reason": step.reason,
                 "position": step.position,
                 **({"tilt": step.tilt} if step.tilt is not None else {}),
+                **(
+                    {"held_position": step.held_position}
+                    if step.held_position is not None
+                    else {}
+                ),
             }
             for step in result.decision_trace
         ]

--- a/tests/test_debug_diagnostics.py
+++ b/tests/test_debug_diagnostics.py
@@ -827,3 +827,48 @@ class TestMotionHoldDiagnostics:
         trace = result["decision_trace"]
         motion_step = next(s for s in trace if s["handler"] == "motion_timeout")
         assert "holding" in motion_step["reason"].lower()
+
+    def test_decision_trace_manual_override_step_includes_held_position(self):
+        """When manual override is active, the serialized step includes held_position."""
+        pr = PipelineResult(
+            position=60,
+            control_method=ControlMethod.MANUAL,
+            reason="manual override active — holding 44% (solar would-be 60%)",
+            held_position=44,
+            decision_trace=[
+                DecisionStep(
+                    handler="manual_override",
+                    matched=True,
+                    reason="manual override active — holding 44% (solar would-be 60%)",
+                    position=60,
+                    held_position=44,
+                )
+            ],
+        )
+        ctx = _base_ctx(pipeline_result=pr)
+        result, _ = DiagnosticsBuilder().build(ctx)
+        trace = result["decision_trace"]
+        mo_step = next(s for s in trace if s["handler"] == "manual_override")
+        assert mo_step["position"] == 60
+        assert mo_step["held_position"] == 44
+
+    def test_decision_trace_non_override_steps_omit_held_position(self):
+        """Steps without held_position do not include the key in serialized output."""
+        pr = PipelineResult(
+            position=50,
+            control_method=ControlMethod.SOLAR,
+            reason="sun in FOV",
+            decision_trace=[
+                DecisionStep(
+                    handler="solar",
+                    matched=True,
+                    reason="sun in FOV",
+                    position=50,
+                )
+            ],
+        )
+        ctx = _base_ctx(pipeline_result=pr)
+        result, _ = DiagnosticsBuilder().build(ctx)
+        trace = result["decision_trace"]
+        solar_step = next(s for s in trace if s["handler"] == "solar")
+        assert "held_position" not in solar_step

--- a/tests/test_pipeline/test_manual_override_held_position.py
+++ b/tests/test_pipeline/test_manual_override_held_position.py
@@ -17,7 +17,10 @@ from custom_components.adaptive_cover_pro.diagnostics.builder import (
 )
 from custom_components.adaptive_cover_pro.const import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import ManualOverrideHandler
-from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    DecisionStep,
+    PipelineResult,
+)
 from custom_components.adaptive_cover_pro.sensor import _cover_position_value
 
 from tests.test_pipeline.conftest import make_snapshot
@@ -224,3 +227,190 @@ def test_diagnostics_explanation_shows_held_vs_solar_divergence() -> None:
     assert "100" in explanation
     assert "20" in explanation
     assert "manual override" in explanation.lower()
+
+
+# ---------------------------------------------------------------------------
+# 11. DecisionStep accepts held_position field (issue #608)
+# ---------------------------------------------------------------------------
+
+
+def test_decision_step_accepts_held_position() -> None:
+    """DecisionStep with held_position carries the value distinctly from position."""
+    step = DecisionStep(
+        handler="manual_override",
+        matched=True,
+        reason="manual override active — holding 44% (solar would-be 60%)",
+        position=60,
+        held_position=44,
+    )
+    assert step.position == 60
+    assert step.held_position == 44
+
+
+def test_decision_step_held_position_defaults_to_none() -> None:
+    """DecisionStep without held_position has held_position=None by default."""
+    step = DecisionStep(
+        handler="solar",
+        matched=True,
+        reason="sun in FOV",
+        position=60,
+    )
+    assert step.held_position is None
+
+
+# ---------------------------------------------------------------------------
+# 12. Registry passes held_position to the winning DecisionStep (issue #608)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_manual_override_step_carries_held_position() -> None:
+    """When ManualOverrideHandler wins, its DecisionStep.held_position == physical position."""
+    from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+    from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
+        DefaultHandler,
+    )
+
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=True,
+        calculate_percentage_return=60.0,
+        current_cover_position=44,
+    )
+    registry = PipelineRegistry([ManualOverrideHandler(), DefaultHandler()])
+    result = registry.evaluate(snap)
+    mo_step = next(s for s in result.decision_trace if s.handler == "manual_override")
+    assert mo_step.matched is True
+    assert mo_step.position == 60  # solar would-be
+    assert mo_step.held_position == 44  # physical held position
+
+
+def test_registry_non_winning_steps_have_none_held_position() -> None:
+    """Non-winning DecisionStep entries have held_position=None."""
+    from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+    from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
+        DefaultHandler,
+    )
+
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=True,
+        calculate_percentage_return=60.0,
+        current_cover_position=44,
+    )
+    registry = PipelineRegistry([ManualOverrideHandler(), DefaultHandler()])
+    result = registry.evaluate(snap)
+    # DefaultHandler is not the winner; its step should have held_position=None
+    default_step = next(
+        (s for s in result.decision_trace if s.handler == "default"), None
+    )
+    assert default_step is not None
+    assert default_step.held_position is None
+
+
+# ---------------------------------------------------------------------------
+# 13. Reason strings name both held and solar values (issue #608)
+# ---------------------------------------------------------------------------
+
+
+def test_handler_reason_string_names_held_and_solar_when_both_known() -> None:
+    """When sun is in FOV and held_position is known, reason cites both values."""
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=True,
+        calculate_percentage_return=60.0,
+        current_cover_position=44,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    # Reason must name the physical held position
+    assert "44" in result.reason
+    # Reason must name the solar would-be
+    assert "60" in result.reason
+    assert "manual override" in result.reason.lower()
+
+
+def test_handler_reason_string_when_held_position_unknown_in_fov() -> None:
+    """When current_cover_position is None, reason omits held_position (FOV branch)."""
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=True,
+        calculate_percentage_return=60.0,
+        current_cover_position=None,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    assert "60" in result.reason
+    assert "None" not in result.reason
+
+
+def test_handler_reason_string_outside_fov_held_known() -> None:
+    """When sun is outside FOV and held_position is known, reason cites both."""
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=False,
+        current_cover_position=30,
+        default_position=0,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    assert "30" in result.reason
+    assert "None" not in result.reason
+    assert "manual override" in result.reason.lower()
+
+
+def test_handler_reason_string_outside_fov_held_none() -> None:
+    """When sun is outside FOV and held_position is None, reason omits held_position."""
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=False,
+        current_cover_position=None,
+        default_position=0,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    assert "None" not in result.reason
+    assert "manual override" in result.reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# 14. Sensor trace attrs include held_position for manual_override step (issue #608)
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_trace_attrs_include_held_position_for_manual_override() -> None:
+    """The decision_trace sensor attribute trace includes held_position for manual_override."""
+    step_with_held = DecisionStep(
+        handler="manual_override",
+        matched=True,
+        reason="holding 44% (solar would-be 60%)",
+        position=60,
+        held_position=44,
+    )
+    step_without_held = DecisionStep(
+        handler="solar",
+        matched=False,
+        reason="outprioritized by manual_override",
+        position=60,
+    )
+    # Build trace items using the same conditional-include idiom as sensor.py
+    trace_items = []
+    for step in [step_with_held, step_without_held]:
+        item = {
+            "handler": step.handler,
+            "matched": step.matched,
+            "reason": step.reason,
+            "position": step.position,
+            **({"tilt": step.tilt} if step.tilt is not None else {}),
+            **(
+                {"held_position": step.held_position}
+                if step.held_position is not None
+                else {}
+            ),
+        }
+        trace_items.append(item)
+    assert trace_items[0]["held_position"] == 44
+    assert "held_position" not in trace_items[1]


### PR DESCRIPTION
## Summary
The `manual_override` decision-trace step reported the solar would-be position (e.g. 60%) while the cover is actually held at a divergent position (e.g. 44%), reading as if the override targets the solar value. This adds a non-breaking `held_position` field to `DecisionStep`, forwards the existing `PipelineResult.held_position` onto the winning step in the registry, revises the handler's reason strings to distinguish held vs. would-be, and surfaces the field through diagnostics and the decision_trace sensor attribute (same conditional-include idiom as `tilt`). The card consumes it via jrhubott/adaptive-cover-pro-card#161.

## Testing
- ✅ 4508 tests passing

## Related Issues
Refs #608