### PR TITLE
fix: enable position matching for upgraded covers (#591, #606)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_CLOUD_COVERAGE_ENTITY,
     CONF_DEVICE_ID,
     CONF_ENABLE_MY_POSITION_ENTITIES,
+    CONF_ENABLE_POSITION_MATCHING,
     CONF_END_ENTITY,
     CONF_ENTITIES,
     CONF_START_ENTITY,
@@ -400,6 +401,15 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 entry.data.get("name", entry.entry_id),
             )
         new_minor = 3
+
+    # v3.3 → v3.4: enable position matching by default for every pre-existing
+    # entry so upgrading covers keep the old reconcile/chase behavior instead of
+    # silently flipping to the new command-once default (issue #591, #606). New
+    # installs created on v3.4 onwards default to False via the config-flow
+    # schema. Additive + rollback-safe: the key is only filled when absent.
+    if new_version == 3 and new_minor < 4:
+        new_options.setdefault(CONF_ENABLE_POSITION_MATCHING, True)
+        new_minor = 4
 
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2656,12 +2656,14 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle ConfigFlow."""
 
     VERSION = 3
-    # 3.3 (issue #563 trailing defect): MINOR_VERSION raised so HA triggers
-    # async_migrate_entry for entries sitting at 3.2.  The v3.2→v3.3 block
-    # (copy legacy custom_position_sensor_N into the new list key) was already
-    # in __init__.py but was unreachable because the gate version was too low.
-    # Rollback-safe: migration is additive (legacy keys retained).
-    MINOR_VERSION = 3
+    # 3.4 (issue #591/#606): MINOR_VERSION raised so HA triggers
+    # async_migrate_entry for entries below 3.4.  The v3.3→v3.4 block enables
+    # position matching for every pre-existing entry so upgrades keep the old
+    # reconcile/chase behavior; new installs default to off via the schema.
+    # 3.3 (issue #563 trailing defect): copy legacy custom_position_sensor_N
+    # into the new list key.
+    # Rollback-safe: every migration block is additive (existing keys retained).
+    MINOR_VERSION = 4
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()
@@ -3155,6 +3157,9 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         )
         options.setdefault(CONF_MOTION_SENSORS, [])
         options.setdefault(CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT)
+        options.setdefault(
+            CONF_ENABLE_POSITION_MATCHING, DEFAULT_ENABLE_POSITION_MATCHING
+        )
 
         return self.async_create_entry(
             title=title,

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -246,7 +246,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -277,12 +277,12 @@ async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
 
 
 async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> None:
-    """Absent force override config → minor bumps to 3 (through v3.3), slot 5 stays free."""
+    """Absent force override config → minor bumps to 4 (through v3.4), slot 5 stays free."""
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=1)
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -295,7 +295,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -314,7 +314,7 @@ async def test_migrate_v3_2_missing_position_defaults_to_zero(
 
 
 async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
-    """A v1 entry with force override config ends at 3.3 with slot 5 populated."""
+    """A v1 entry with force override config ends at 3.4 with slot 5 populated."""
     entry = _make_entry(
         hass,
         {CONF_WINDOW_WIDTH: 200, **_FORCE_OPTIONS},
@@ -322,7 +322,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -359,7 +359,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -393,7 +393,7 @@ async def test_migrate_v3_3_does_not_overwrite_existing_list(
 
 
 async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
-    """No legacy sensor keys → minor bumps to 3, no sensors_N list created."""
+    """No legacy sensor keys → minor bumps to 4, no sensors_N list created."""
     entry = _make_entry(
         hass,
         {"azimuth": 180},
@@ -401,9 +401,65 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 3
+    assert entry.minor_version == 4
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
+
+
+# ---------------------------------------------------------------------------
+# Migration: v3.3 → v3.4 — enable position matching by default for existing
+# entries so upgrades keep the old reconcile/chase behavior (issue #591, #606).
+# Additive: the key is only filled when absent.
+# ---------------------------------------------------------------------------
+
+from custom_components.adaptive_cover_pro.const import (  # noqa: E402
+    CONF_ENABLE_POSITION_MATCHING,
+)
+
+
+async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
+    hass: HomeAssistant,
+) -> None:
+    """A pre-existing entry without the key gets position matching enabled."""
+    entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
+    assert entry.minor_version == 4
+
+
+async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
+    """An explicit True is left untouched."""
+    entry = _make_entry(
+        hass,
+        {CONF_ENABLE_POSITION_MATCHING: True},
+        version=3,
+        minor_version=3,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
+    assert entry.minor_version == 4
+
+
+async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
+    """A user/new-install opt-out (False) is respected, not clobbered to True."""
+    entry = _make_entry(
+        hass,
+        {CONF_ENABLE_POSITION_MATCHING: False},
+        version=3,
+        minor_version=3,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
+    assert entry.minor_version == 4
+
+
+async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
+    """A genuine v1 entry ends at 3.4 with position matching enabled."""
+    entry = _make_entry(hass, {CONF_WINDOW_WIDTH: 200}, version=1)
+    await async_migrate_entry(hass, entry)
+    assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
+    assert entry.version == 3
+    assert entry.minor_version == 4
 
 
 # ---------------------------------------------------------------------------
@@ -422,10 +478,10 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 3 (the v3.2 → v3.3 copy of
-    custom_position_sensor_N into the list key, per issue #563).  Raise this
-    assertion whenever a new minor migration block is added.
+    Currently the highest target is 4 (the v3.3 → v3.4 enable-position-matching
+    setdefault, per issue #591/#606).  Raise this assertion whenever a new minor
+    migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 3
+    assert ConfigFlowHandler.MINOR_VERSION == 4


### PR DESCRIPTION
## Summary
Position matching was made opt-in and defaulted to **off** in #591, but there was no config-entry migration. Every existing install that upgrades silently went from "always reconcile" to command-once, which surfaced as #606 ("Position Match Tolerance is not respected" after upgrade).

This adds a `v3.3 → v3.4` minor migration that `setdefault`s `enable_position_matching` to `True` for any pre-existing entry, so upgrading covers keep the old reconcile/chase behavior. New installs are unaffected — the config-flow schema already writes `False`, and the migration only runs on entries below the current version. Mirrors the existing `v2 → v3` `enable_my_position_entities` migration (additive + rollback-safe; the key is only filled when absent, so an explicit `True`/`False` is respected).

Also bumps `MINOR_VERSION` 3 → 4 (so HA triggers the migration on entries at 3.3) and adds a defensive `setdefault` in `async_step_update` for quick-setup new installs.

Caveat for the beta cohort: anyone on beta.9/beta.10 who never toggled the option has the key absent and will be flipped to on — the intended "restore old behavior" outcome; the toggle stays user-adjustable.

## Testing
- ✅ 27/27 config-entry migration tests pass (4 new for the v3.4 block; reachability-lock and cascade asserts updated to minor 4)
- ✅ 4512 tests passing (full suite)
- ✅ ruff + black clean

## Related Issues
Refs #591, #606
