### PR TITLE
feat: anticipate throttle window in solar target (#616)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -492,9 +492,18 @@ DEFAULT_WEATHER_TIMEOUT = 300  # seconds before resuming after clear
 # active time-of-day window.
 
 CONF_DELTA_POSITION = "delta_position"  # min % change to emit, range 1-90
-CONF_DELTA_TIME = "delta_time"  # min seconds between commands, range 2-60
+CONF_DELTA_TIME = "delta_time"  # min minutes between commands, range 2-60
 DEFAULT_DELTA_POSITION = 2  # minimum percentage change threshold
-DEFAULT_DELTA_TIME = 2  # minimum seconds between commands
+DEFAULT_DELTA_TIME = 2  # minimum minutes between commands
+
+# Anticipatory solar positioning (issue #616): when CONF_DELTA_TIME (the
+# minimum interval between position changes, in minutes) is the look-ahead
+# horizon, the solar handler samples this many future sun positions across
+# (now, now + delta_time] and commands the most-protective one so coverage is
+# guaranteed until the next allowed move. Bounded and small because the sun
+# moves slowly and covers step coarsely; the SunData table is only 5-min
+# resolution, so finer sampling buys nothing.
+SOLAR_ANTICIPATION_SAMPLES = 4
 # Allowed gap between commanded and reported position before the periodic
 # reconciliation pass treats the cover as "not arrived" and resends the
 # command. Distinct from CONF_DELTA_POSITION (movement hysteresis). Default
@@ -961,7 +970,7 @@ _RANGE_MAX_COVERAGE_STEPS = (1, 10)  # CONF_MAX_COVERAGE_STEPS, discrete levels
 
 # Automation timing.
 _RANGE_DELTA_POSITION = (1, 90)  # CONF_DELTA_POSITION, percent
-_RANGE_DELTA_TIME = (2, 60)  # CONF_DELTA_TIME, seconds
+_RANGE_DELTA_TIME = (2, 60)  # CONF_DELTA_TIME, minutes
 _RANGE_POSITION_TOLERANCE = (0, 20)  # CONF_POSITION_TOLERANCE, percent
 
 # Manual override.

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -437,6 +437,24 @@ class CoverTypePolicy(ABC):
             return POSITION_CLOSED if primary.open_blocks_sun else POSITION_OPEN
         return POSITION_OPEN if primary.open_blocks_sun else POSITION_CLOSED
 
+    def more_protective_position(self, a: int, b: int) -> int:
+        """Return whichever of two primary-axis positions blocks more sun.
+
+        Polymorphic over cover type via ``axes[0].open_blocks_sun``:
+
+          - ``open_blocks_sun=False`` (blind/tilt/venetian): lower % = more
+            coverage → ``min``
+          - ``open_blocks_sun=True`` (awning): higher % = more coverage → ``max``
+
+        The anticipation helper (issue #616) folds the live solar target plus
+        every valid future-window sample through this comparator so the
+        commanded position protects against the most-shaded moment in the
+        upcoming throttle interval.
+        """
+        if self.axes[0].open_blocks_sun:
+            return max(a, b)
+        return min(a, b)
+
     def read_axis_value(
         self,
         hass: HomeAssistant,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/solar.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/solar.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from ...const import ControlMethod
 from ..handler import OverrideHandler
-from ..helpers import compute_solar_position
+from ..helpers import anticipated_solar_position
 from ..types import PipelineResult, PipelineSnapshot
 
 
@@ -27,7 +27,7 @@ class SolarHandler(OverrideHandler):
         if not snapshot.cover.direct_sun_valid:
             return None
 
-        position = compute_solar_position(snapshot)
+        position = anticipated_solar_position(snapshot)
         reason = f"sun in FOV — position {position}%"
         if getattr(snapshot, "minimize_movements", False):
             steps = getattr(snapshot, "max_coverage_steps", 1)

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -14,8 +14,11 @@ registry — see issue #463.
 
 from __future__ import annotations
 
+import dataclasses
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
+from ..const import SOLAR_ANTICIPATION_SAMPLES
 from ..position_utils import PositionConverter
 from .types import PipelineSnapshot
 
@@ -164,15 +167,103 @@ def compute_solar_position(snapshot: PipelineSnapshot) -> int:
     )
 
 
-def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
-    """Return the raw geometric position for diagnostics.
+def anticipated_solar_position(snapshot: PipelineSnapshot) -> int:
+    """Most-protective sun-tracked position across the upcoming throttle window.
 
-    This is what the ``SolarHandler`` would compute when direct sun is valid,
-    or the effective default when the sun is outside the FOV.  Used by
-    overriding handlers (manual, motion, force, weather, climate) so that
-    the ``raw_calculated_position`` field on ``PipelineResult`` always reflects
-    the true sun-geometry result, independent of which handler claimed the
-    position.
+    The live solar target is computed from the *current* sun position, but the
+    "Minimum interval between position changes" (``CONF_DELTA_TIME``, minutes)
+    holds any queued move for that long. While it is held the sun keeps moving,
+    so a position that just covers "now" can drift out of coverage before the
+    next allowed move. This helper looks ahead across
+    ``(now, now + time_threshold_minutes]`` and returns the most-protective
+    sun-tracked position needed anywhere in that window, so coverage is
+    guaranteed until the cover is next allowed to move (issue #616).
+
+    The look-ahead reuses the forecast's sampling machinery: future sun angles
+    come from ``snapshot.cover.sun_data`` (the per-day 5-minute table) via
+    ``forecast._nearest_index``, each sample is a ``dataclasses.replace`` of the
+    live cover with the projected angles and ``eval_time`` (so the sunset gate
+    evaluates at the projected moment), and only samples where the sun is still
+    ``direct_sun_valid`` contribute. Each candidate is fully transformed by
+    :func:`solar_position_from_geometry` (quantize → floor → limits) before
+    comparison, then folded through the cover-type-polymorphic
+    :meth:`CoverTypePolicy.more_protective_position` comparator. The live
+    "now" target seeds the fold, so the result can only ever *increase*
+    protection relative to the current position.
+
+    When the horizon is ``<= 0`` (anticipation disabled / no throttle) this is
+    exactly :func:`compute_solar_position`.
+
+    Should only be called when ``snapshot.cover.direct_sun_valid`` is True.
+
+    Returns:
+        The most-protective sun-tracked position (limited) across the window.
+
+    """
+    live = compute_solar_position(snapshot)
+
+    horizon = getattr(snapshot, "time_threshold_minutes", 0)
+    policy: CoverTypePolicy | None = getattr(snapshot, "policy", None)
+    if horizon <= 0 or policy is None:
+        return live
+
+    # Lazy import: ``forecast`` imports from this module, so importing it at
+    # module scope would be circular.
+    from ..forecast import _nearest_index
+
+    cover = snapshot.cover
+    sun_data = cover.sun_data
+    times = list(sun_data.times)
+    if not times:
+        return live
+
+    azimuths = sun_data.solar_azimuth
+    elevations = sun_data.solar_elevation
+
+    now = getattr(cover, "eval_time", None) or datetime.now(UTC)
+
+    best = live
+    seen_indices: set[int] = set()
+    for n in range(1, SOLAR_ANTICIPATION_SAMPLES + 1):
+        fraction = n / SOLAR_ANTICIPATION_SAMPLES
+        sample_time = now + timedelta(minutes=horizon * fraction)
+        idx = _nearest_index(times, sample_time)
+        if idx is None or idx in seen_indices:
+            continue
+        seen_indices.add(idx)
+
+        future = dataclasses.replace(
+            cover,
+            sol_azi=float(azimuths[idx]),
+            sol_elev=float(elevations[idx]),
+        )
+        future.eval_time = times[idx]
+        if not future.direct_sun_valid:
+            continue
+
+        candidate = solar_position_from_geometry(
+            future,
+            snapshot.config,
+            minimize_movements=getattr(snapshot, "minimize_movements", False),
+            max_coverage_steps=getattr(snapshot, "max_coverage_steps", 1),
+            policy=policy,
+            floor_active=getattr(snapshot, "solar_floor_active", True),
+        )
+        best = policy.more_protective_position(best, candidate)
+
+    return best
+
+
+def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
+    """Return the commanded solar position for diagnostics.
+
+    This is what the ``SolarHandler`` would command when direct sun is valid —
+    the *anticipated* solar position (the most-protective value across the
+    upcoming throttle window, issue #616) — or the effective default when the
+    sun is outside the FOV.  Used by overriding handlers (manual, motion,
+    force, weather, climate) so that the ``raw_calculated_position`` field on
+    ``PipelineResult`` always reflects the commanded solar truth, independent
+    of which handler claimed the position.
 
     Args:
         snapshot: Current pipeline snapshot.
@@ -182,7 +273,7 @@ def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:
 
     """
     if snapshot.cover.direct_sun_valid and snapshot.enable_sun_tracking:
-        return compute_solar_position(snapshot)
+        return anticipated_solar_position(snapshot)
     if snapshot.is_sunset_active:
         return snapshot.default_position
     return apply_snapshot_limits(

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -34,6 +34,7 @@ from ..const import (
     CONF_CLOUDY_POSITION,
     CONF_DEFAULT_HEIGHT,
     CONF_DEFAULT_TILT,
+    CONF_DELTA_TIME,
     CONF_ENABLE_SUN_TRACKING,
     CONF_IRRADIANCE_ENTITY,
     CONF_IRRADIANCE_THRESHOLD,
@@ -384,4 +385,5 @@ class PipelineSnapshotBuilder:
             default_tilt=options.get(CONF_DEFAULT_TILT),
             sunset_tilt=options.get(CONF_SUNSET_TILT),
             solar_floor_active=solar_floor_active,
+            time_threshold_minutes=options.get(CONF_DELTA_TIME) or 0,
         )

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -215,6 +215,17 @@ class PipelineSnapshot:
     # to True so the floor stays in effect for snapshots that don't set it.
     solar_floor_active: bool = True
 
+    # Anticipatory-solar look-ahead horizon, in minutes (issue #616). Equals
+    # CONF_DELTA_TIME — the "Minimum interval between position changes" the
+    # send-gate throttles on. When > 0 the solar branch
+    # (:func:`pipeline.helpers.anticipated_solar_position`) samples future sun
+    # positions across ``(now, now + time_threshold_minutes]`` and commands the
+    # most-protective one, so coverage holds until the next allowed move. ``0``
+    # disables anticipation (identical-to-today live solar behaviour) and keeps
+    # the no-hass snapshot paths safe. Defaults to ``0`` so snapshots that don't
+    # set it behave exactly as before.
+    time_threshold_minutes: int = 0
+
 
 # ---------------------------------------------------------------------------
 # Output types

--- a/tests/test_cover_types/test_protective.py
+++ b/tests/test_cover_types/test_protective.py
@@ -1,0 +1,45 @@
+"""Tests for ``CoverTypePolicy.more_protective_position``.
+
+The polymorphic comparator the anticipation helper (issue #616) folds future
+sun-tracked samples through. "More protective" = "blocks more direct sun", which
+is cover-type dependent:
+
+  - blind / tilt / venetian (``open_blocks_sun=False``) → lower % = more coverage
+  - awning (``open_blocks_sun=True``)                    → higher % = more coverage
+
+The direction lives entirely on ``axes[0].open_blocks_sun`` so no cover-type
+string branch or hardcoded min/max leaks outside ``cover_types/``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+# Cover types whose primary axis closes (lower %) to block the sun.
+_LOWER_IS_PROTECTIVE = ["cover_blind", "cover_tilt", "cover_venetian"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("cover_type", _LOWER_IS_PROTECTIVE)
+def test_lower_percentage_is_more_protective(cover_type: str) -> None:
+    policy = get_policy(cover_type)
+    assert policy.more_protective_position(30, 70) == 30
+    # Argument order must not matter.
+    assert policy.more_protective_position(70, 30) == 30
+
+
+@pytest.mark.unit
+def test_higher_percentage_is_more_protective_for_awning() -> None:
+    policy = get_policy("cover_awning")
+    assert policy.more_protective_position(30, 70) == 70
+    assert policy.more_protective_position(70, 30) == 70
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "cover_type", ["cover_blind", "cover_awning", "cover_tilt", "cover_venetian"]
+)
+def test_equal_values_are_idempotent(cover_type: str) -> None:
+    assert get_policy(cover_type).more_protective_position(50, 50) == 50

--- a/tests/test_pipeline/test_solar_anticipation.py
+++ b/tests/test_pipeline/test_solar_anticipation.py
@@ -1,0 +1,348 @@
+"""Tests for anticipatory solar positioning across the throttle window (#616).
+
+When the solar handler wins and ``CONF_DELTA_TIME`` (minutes) > 0, the solar
+target is the most-protective position needed across ``[now, now + delta_time]``.
+The horizon is threaded onto the snapshot as ``time_threshold_minutes`` and the
+helper samples future sun positions, folding each valid sample through the
+policy's ``more_protective_position`` comparator.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DELTA_TIME,
+    SOLAR_ANTICIPATION_SAMPLES,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.pipeline.helpers import (
+    anticipated_solar_position,
+    compute_solar_position,
+)
+from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+    PipelineSnapshotBuilder,
+)
+from custom_components.adaptive_cover_pro.state.climate_provider import (
+    ClimateProvider,
+)
+from tests.cover_helpers import build_horizontal_cover, build_vertical_cover
+
+# A fixed reference day so all timestamps are deterministic.
+_DAY = datetime(2024, 6, 21, tzinfo=UTC)
+_STEP = timedelta(minutes=5)
+
+
+class _FakeSunData:
+    """Minimal SunData stand-in exposing the per-day 5-minute table.
+
+    The anticipation helper reads ``times`` / ``solar_azimuth`` /
+    ``solar_elevation`` and the geometry engine reads ``sunset()`` / ``sunrise()``
+    for the sunset gate. The table is centred on a noon reference so every
+    sampled ``eval_time`` falls in full daylight (sunset gate False).
+    """
+
+    def __init__(self, azimuths: list[float], elevations: list[float]):
+        start = _DAY.replace(hour=10)
+        self.times = [start + i * _STEP for i in range(len(azimuths))]
+        self.solar_azimuth = azimuths
+        self.solar_elevation = elevations
+
+    def sunset(self) -> datetime:
+        return _DAY.replace(hour=21)
+
+    def sunrise(self) -> datetime:
+        return _DAY.replace(hour=5)
+
+
+def _vertical_cover(sun_data: _FakeSunData, *, sol_azi: float, sol_elev: float):
+    cover = build_vertical_cover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sunset_pos=0,
+        sunset_off=0,
+        sunrise_off=0,
+        sun_data=sun_data,
+        fov_left=90,
+        fov_right=90,
+        win_azi=180,
+        h_def=50,
+        max_pos=100,
+        min_pos=0,
+        max_pos_bool=False,
+        min_pos_bool=False,
+        blind_spot_left=None,
+        blind_spot_right=None,
+        blind_spot_elevation=None,
+        blind_spot_on=False,
+        min_elevation=None,
+        max_elevation=None,
+        distance=0.5,
+        h_win=2.0,
+    )
+    cover.eval_time = sun_data.times[0]
+    return cover
+
+
+def _horizontal_cover(sun_data: _FakeSunData, *, sol_azi: float, sol_elev: float):
+    cover = build_horizontal_cover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sunset_pos=0,
+        sunset_off=0,
+        sunrise_off=0,
+        sun_data=sun_data,
+        fov_left=90,
+        fov_right=90,
+        win_azi=180,
+        h_def=100,
+        max_pos=100,
+        min_pos=0,
+        max_pos_bool=False,
+        min_pos_bool=False,
+        blind_spot_left=None,
+        blind_spot_right=None,
+        blind_spot_elevation=None,
+        blind_spot_on=False,
+        min_elevation=None,
+        max_elevation=None,
+        distance=0.5,
+        h_win=2.0,
+        awn_length=2.0,
+        awn_angle=0.0,
+    )
+    cover.eval_time = sun_data.times[0]
+    return cover
+
+
+def _snapshot(cover, *, cover_type: str, time_threshold_minutes: int):
+    return SimpleNamespace(
+        cover=cover,
+        config=cover.config,
+        cover_type=cover_type,
+        policy=get_policy(cover_type),
+        minimize_movements=False,
+        max_coverage_steps=1,
+        solar_floor_active=True,
+        time_threshold_minutes=time_threshold_minutes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — snapshot carries the horizon
+# ---------------------------------------------------------------------------
+
+
+def _make_builder() -> PipelineSnapshotBuilder:
+    hass = MagicMock()
+    hass.states.get.return_value = None
+    climate_provider = MagicMock(spec=ClimateProvider)
+    toggles = MagicMock()
+    toggles.lux_toggle = False
+    toggles.irradiance_toggle = False
+    toggles.temp_toggle = False
+    toggles.switch_mode = False
+    toggles.motion_control = False
+    policy = MagicMock()
+    policy.glare_zones_config.return_value = None
+    policy.position_axis_supported.return_value = True
+    return PipelineSnapshotBuilder(
+        hass=hass,
+        logger=MagicMock(),
+        climate_provider=climate_provider,
+        toggles=toggles,
+        policy=policy,
+        config_service=MagicMock(),
+    )
+
+
+def _build_snapshot_with_options(options: dict):
+    builder = _make_builder()
+    sun_data = _FakeSunData([180.0], [45.0])
+    cover = _vertical_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+    return builder.build(
+        options,
+        cover_data=cover,
+        cover_type="cover_blind",
+        climate_readings=None,
+        manual_override_active=False,
+        motion_timeout_active=False,
+        weather_override_active=False,
+        in_time_window=True,
+        current_cover_position=None,
+        is_glare_zone_enabled=lambda _idx: False,
+        effective_default=0,
+        is_sunset_active=False,
+    )
+
+
+@pytest.mark.unit
+def test_snapshot_carries_delta_time_as_horizon():
+    snap = _build_snapshot_with_options({CONF_DELTA_TIME: 15})
+    assert snap.time_threshold_minutes == 15
+
+
+@pytest.mark.unit
+def test_snapshot_horizon_defaults_to_zero_when_absent():
+    snap = _build_snapshot_with_options({})
+    assert snap.time_threshold_minutes == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — anticipation helper, geometry-driven
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_no_horizon_matches_live_solar_position():
+    # A flat table; horizon 0 → identical to the live solar position.
+    sun_data = _FakeSunData([180.0] * 6, [45.0] * 6)
+    cover = _vertical_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+    snap = _snapshot(cover, cover_type="cover_blind", time_threshold_minutes=0)
+    assert anticipated_solar_position(snap) == compute_solar_position(snap)
+
+
+@pytest.mark.unit
+def test_vertical_anticipates_more_protective_future_sample():
+    # Sun starts off-axis (gamma high → less coverage) and sweeps toward the
+    # window centre (gamma → 0 → deeper, more shade → lower %). Anticipation
+    # must pick the lower (more protective) future value.
+    azimuths = [220.0, 210.0, 200.0, 190.0, 180.0, 180.0]
+    elevations = [45.0] * 6
+    sun_data = _FakeSunData(azimuths, elevations)
+    cover = _vertical_cover(sun_data, sol_azi=220.0, sol_elev=45.0)
+    snap = _snapshot(cover, cover_type="cover_blind", time_threshold_minutes=25)
+
+    live = compute_solar_position(snap)
+    anticipated = anticipated_solar_position(snap)
+    assert anticipated < live
+    # It equals the most-protective sampled position — the centred-sun sample.
+    centred = _vertical_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+    centred_snap = _snapshot(
+        centred, cover_type="cover_blind", time_threshold_minutes=0
+    )
+    assert anticipated == compute_solar_position(centred_snap)
+
+
+@pytest.mark.unit
+def test_awning_anticipates_higher_future_sample():
+    # Awning: more protective = higher %. Sun sweeps into the window so the
+    # awning must extend further (higher %) ahead of time.
+    azimuths = [220.0, 210.0, 200.0, 190.0, 180.0, 180.0]
+    elevations = [45.0] * 6
+    sun_data = _FakeSunData(azimuths, elevations)
+    cover = _horizontal_cover(sun_data, sol_azi=220.0, sol_elev=45.0)
+    snap = _snapshot(cover, cover_type="cover_awning", time_threshold_minutes=25)
+
+    live = compute_solar_position(snap)
+    anticipated = anticipated_solar_position(snap)
+    assert anticipated > live
+
+
+@pytest.mark.unit
+def test_sun_leaving_fov_within_window_keeps_live_target():
+    # Sun starts centred (valid, deep coverage) and sweeps OUT of the FOV.
+    # Future samples become direct_sun_valid=False → skipped. Result equals
+    # the live target (no spurious change).
+    azimuths = [180.0, 250.0, 300.0, 330.0, 350.0, 5.0]
+    elevations = [45.0] * 6
+    sun_data = _FakeSunData(azimuths, elevations)
+    cover = _vertical_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+    snap = _snapshot(cover, cover_type="cover_blind", time_threshold_minutes=25)
+    assert anticipated_solar_position(snap) == compute_solar_position(snap)
+
+
+@pytest.mark.unit
+def test_empty_sun_data_table_falls_back_to_live():
+    # An empty table has no future angles to sample → live target unchanged.
+    sun_data = _FakeSunData([180.0], [45.0])
+    cover = _vertical_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+    # Replace the single-entry table with an empty one (the cover keeps its
+    # live angles, so compute_solar_position still works).
+    sun_data.times = []
+    sun_data.solar_azimuth = []
+    sun_data.solar_elevation = []
+    snap = _snapshot(cover, cover_type="cover_blind", time_threshold_minutes=25)
+    assert anticipated_solar_position(snap) == compute_solar_position(snap)
+
+
+@pytest.mark.unit
+def test_short_horizon_deduplicates_grid_indices():
+    # A horizon shorter than the 5-min grid makes every fractional sample snap
+    # to the same index, exercising the duplicate-index skip. The single deduped
+    # sample equals the live position, so the result is the live target.
+    sun_data = _FakeSunData([180.0] * 6, [45.0] * 6)
+    cover = _vertical_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+    snap = _snapshot(cover, cover_type="cover_blind", time_threshold_minutes=2)
+    assert anticipated_solar_position(snap) == compute_solar_position(snap)
+
+
+@pytest.mark.unit
+def test_sample_count_is_named_constant():
+    # Guard that the horizon sampler uses the named constant, not a literal.
+    assert isinstance(SOLAR_ANTICIPATION_SAMPLES, int)
+    assert SOLAR_ANTICIPATION_SAMPLES >= 1
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — solar handler routes through anticipation; raw position follows
+# ---------------------------------------------------------------------------
+
+
+def _full_snapshot(cover, *, cover_type: str, time_threshold_minutes: int):
+    """Build a snapshot with the extra fields the SolarHandler / raw path read."""
+    return SimpleNamespace(
+        cover=cover,
+        config=cover.config,
+        cover_type=cover_type,
+        policy=get_policy(cover_type),
+        minimize_movements=False,
+        max_coverage_steps=1,
+        solar_floor_active=True,
+        time_threshold_minutes=time_threshold_minutes,
+        in_time_window=True,
+        enable_sun_tracking=True,
+        is_sunset_active=False,
+        default_position=0,
+    )
+
+
+@pytest.mark.unit
+def test_solar_handler_returns_anticipated_position():
+    from custom_components.adaptive_cover_pro.pipeline.handlers.solar import (
+        SolarHandler,
+    )
+
+    azimuths = [220.0, 210.0, 200.0, 190.0, 180.0, 180.0]
+    sun_data = _FakeSunData(azimuths, [45.0] * 6)
+    cover = _vertical_cover(sun_data, sol_azi=220.0, sol_elev=45.0)
+    snap = _full_snapshot(cover, cover_type="cover_blind", time_threshold_minutes=25)
+
+    result = SolarHandler().evaluate(snap)
+    expected = anticipated_solar_position(snap)
+    assert result is not None
+    assert result.position == expected
+    assert result.raw_calculated_position == expected
+    # Anticipation must actually have moved the target below the live value.
+    assert expected < compute_solar_position(snap)
+
+
+@pytest.mark.unit
+def test_raw_calculated_position_routes_through_anticipation():
+    from custom_components.adaptive_cover_pro.pipeline.helpers import (
+        compute_raw_calculated_position,
+    )
+
+    azimuths = [220.0, 210.0, 200.0, 190.0, 180.0, 180.0]
+    sun_data = _FakeSunData(azimuths, [45.0] * 6)
+    cover = _vertical_cover(sun_data, sol_azi=220.0, sol_elev=45.0)
+    snap = _full_snapshot(cover, cover_type="cover_blind", time_threshold_minutes=25)
+
+    assert compute_raw_calculated_position(snap) == anticipated_solar_position(snap)
+    assert compute_raw_calculated_position(snap) < compute_solar_position(snap)


### PR DESCRIPTION
## Summary
The solar handler now computes the most-protective position needed across the upcoming "Minimum interval between position changes" (`delta_time`) throttle window, so a held position can't drift out of coverage before the next allowed move. Always-on (no toggle); the horizon reuses the configured interval, and behavior collapses to today's live-solar result when the interval is 0.

Reuses the engine end-to-end — future sun angles from the SunData table, `dataclasses.replace` per sample, the full `solar_position_from_geometry` transform/clamp, folded through a single cover-type-polymorphic comparator (`CoverTypePolicy.more_protective_position`). `raw_calculated_position` routes through the anticipated value so diagnostics/card show the commanded solar truth.

## Testing
- ✅ 4531 tests passing (19 new: comparator over all cover types + anticipation geometry/edge cases)

## Related Issues
Refs #616
Refs jrhubott/adaptive-cover-pro-card#163