### PR TITLE
feat: vertical-drop shade model for oscillating awning (#586)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -132,6 +132,21 @@ DEFAULT_AWNING_MIN_ANGLE = 0  # degrees — arm vertical / fully retracted
 DEFAULT_AWNING_MAX_ANGLE = 175  # degrees — reporter's full sweep (#412)
 DEFAULT_AWNING_HOUSING_OFFSET = 0.0  # metres
 
+# Vertical-drop (lip-height) shade model for the oscillating awning (#586).
+# The drop-arm's fabric lip descends as the arm sweeps past horizontal, shading
+# the window face down to a protected boundary. The solver scans the arm-sweep
+# arc and selects the smallest angle whose lip shadow reaches the boundary.
+#
+# Default/fallback protected boundary on the window face (window-bottom datum,
+# metres). The LIVE boundary is derived from the inherited vertical sill/depth/
+# distance solve (the exposed-glass height); this constant is only the fallback
+# when that solve leaves the whole face exposed.
+OSCILLATING_PROTECTED_BOUNDARY_DEFAULT = 0.0  # metres (window bottom)
+# Arc-scan resolution: number of arm-angle samples across the [min, max] sweep.
+# 0.1° steps over a 180° sweep — fine enough that the pinned positions are
+# stable to <0.1%.
+OSCILLATING_ARC_SCAN_SAMPLES = 1801
+
 
 # =============================================================================
 # 5. Tilt / Venetian Slat Geometry

--- a/custom_components/adaptive_cover_pro/engine/covers/oscillating.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/oscillating.py
@@ -1,19 +1,30 @@
-"""Oscillating (drop-arm / pivoting) awning cover calculation (#412).
+"""Oscillating (drop-arm / pivoting) awning cover calculation (#412, #586).
 
-Unlike a fixed-angle awning, an oscillating awning's arm sweeps through an arc
-as it opens, so the fabric's horizontal reach is a function of the open
-percentage rather than a configured constant. This engine:
+A drop-arm awning pivots above the window top; as the arm sweeps from folded-up
+(θ=min_angle) through horizontal (θ≈90°) to straight-down (θ=max_angle) the
+fabric *lip* descends down the window face. The shading-relevant quantity at low
+sun is how far that lip drops, not merely how far it reaches horizontally.
 
-1. Computes the horizontal reach (metres) needed to shade the window at the
-   configured shaded distance — reusing the horizontal-awning projection math
-   with a flat fabric (the needed *reach*, independent of the arm sweep).
-2. Inverts the arm-sweep arc to find the open percentage whose fabric tip
-   reaches that far: ``reach(p) = arm_length · sin(theta(p))`` where
-   ``theta(p) = min_angle + (max_angle − min_angle)·p/100``.
+The earlier model (#412) credited only the horizontal reach
+(``reach = arm·sin θ``), which peaks at θ=90° = exactly 50% of a 0–180° sweep,
+so the awning never commanded more than 50% no matter how low the sun got — the
+lip's vertical drop past horizontal was ignored. Issue #586 replaces that with a
+**vertical-drop (lip-height) shade model**:
 
-This is a first-order geometric model (linear arm sweep, arc projection). It
-matches the reporter's description in #412 (arm length + total sweep angle) and
-can be refined with measured angle-vs-extension data later.
+1. Pivot sits at ``pivot_y = h_win + housing_offset`` above the window bottom.
+2. At arm angle θ the lip tip is at horizontal reach ``R(θ) = arm·sin θ`` and
+   height ``lip_y(θ) = pivot_y + arm·cos θ`` (θ=0 → lip up the wall, θ=90° →
+   lip at the pivot, θ=180° → lip a full arm below the pivot).
+3. A sun ray grazing the lip drops back toward the wall at the same
+   foreshortened slope the vertical engine uses (``tan(elev)/cos(gamma)``), so
+   the lip's shadow top on the window face is
+   ``shadow_top(θ) = lip_y(θ) − R(θ)·tan(elev)/cos(gamma)``.
+4. The solver scans the sweep and returns the smallest θ whose shadow_top
+   reaches the **protected boundary** — the exposed-glass height the inherited
+   vertical sill/depth/distance solve leaves uncovered (so window_depth,
+   sill_height and distance still influence the result). If no angle reaches the
+   boundary it fails open (max coverage), driving position → 100% at very low
+   sun. θ>90° (pos>50%) is now reachable by construction.
 """
 
 from __future__ import annotations
@@ -21,14 +32,56 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
+from numpy import cos, sin, tan
+from numpy import radians as rad
 
 from ...config_types import OscillatingConfig
+from ...const import (
+    OSCILLATING_ARC_SCAN_SAMPLES,
+    OSCILLATING_PROTECTED_BOUNDARY_DEFAULT,
+)
 from .horizontal import AdaptiveHorizontalCover
+from .vertical import MIN_COS_GAMMA_CLAMP, AdaptiveVerticalCover
+
+
+def _foreshortened_drop_per_reach(sol_elev: float, gamma: float) -> float:
+    """Vertical drop of a sun ray per metre of horizontal lip reach.
+
+    A ray grazing the lip descends toward the wall at ``tan(elev)`` per metre of
+    in-room depth; the surface-azimuth foreshortening divides by ``cos(gamma)``.
+    Shares the ``MIN_COS_GAMMA_CLAMP`` guard with the vertical engine so a
+    near-90° gamma cannot divide by zero (single source of truth for the
+    foreshortening factor used on the window face).
+    """
+    cos_gamma = float(cos(rad(gamma)))
+    cos_gamma_clamped = max(abs(cos_gamma), MIN_COS_GAMMA_CLAMP) * (
+        1 if cos_gamma >= 0 else -1
+    )
+    return float(tan(rad(sol_elev))) / cos_gamma_clamped
+
+
+def _lip_shadow_top(
+    theta_deg: float,
+    *,
+    arm_length: float,
+    pivot_y: float,
+    sol_elev: float,
+    gamma: float,
+) -> float:
+    """Window-face height of the lip's shadow top at arm angle ``theta_deg``.
+
+    ``pivot_y`` is measured in the window-bottom=0 datum. Lower return values
+    mean the lip shades further down the face (more coverage).
+    """
+    theta = rad(theta_deg)
+    reach = arm_length * float(sin(theta))
+    lip_y = pivot_y + arm_length * float(cos(theta))
+    return lip_y - reach * _foreshortened_drop_per_reach(sol_elev, gamma)
 
 
 @dataclass
 class AdaptiveOscillatingCover(AdaptiveHorizontalCover):
-    """Calculate state for oscillating (drop-arm) awnings."""
+    """Calculate state for oscillating (drop-arm) awnings via the lip-drop model."""
 
     osc_config: OscillatingConfig = None  # type: ignore[assignment]
 
@@ -39,21 +92,30 @@ class AdaptiveOscillatingCover(AdaptiveHorizontalCover):
 
     @property
     def awn_angle(self) -> float:
-        """Use a flat fabric for the *needed-reach* projection.
-
-        The arm sweep is applied in ``calculate_percentage`` via the arc
-        inverse, so the reach computation itself treats the fabric as
-        horizontal (angle 0).
-        """
+        """Flat fabric for any inherited reach projection (unused by the solver)."""
         return 0.0
 
-    def calculate_percentage(self) -> float:
-        """Map the needed horizontal reach to an open percentage via the arc.
+    def _protected_boundary(self) -> float:
+        """Window-face height the lip must shade down to (window-bottom datum).
 
-        ``calculate_position`` (inherited) returns the horizontal reach in
-        metres needed to block the sun, clamped to ``arm_length``. The open
-        percentage is the point on the linear arm sweep whose fabric tip
-        projects that far.
+        Derived from the inherited vertical sill/depth/distance solve so that
+        window_depth, sill_height and distance stay load-bearing: the vertical
+        engine returns the blind height (from the bottom) that must be covered
+        to stop sun reaching the protected zone — i.e. the awning lip only needs
+        to shade the face DOWN TO that height, not necessarily the window
+        bottom. When the vertical solve leaves the whole face exposed it returns
+        0.0, which equals OSCILLATING_PROTECTED_BOUNDARY_DEFAULT (the fallback).
+        """
+        boundary = AdaptiveVerticalCover.calculate_position(self)
+        # The vertical solve already clamps to [0, h_win]; default is the floor.
+        return max(boundary, OSCILLATING_PROTECTED_BOUNDARY_DEFAULT)
+
+    def calculate_percentage(self) -> float:
+        """Solve the arm-sweep arc for the lip-drop shade objective (#586).
+
+        Scans θ ∈ [min_angle, max_angle] and returns the smallest angle whose
+        lip shadow reaches the protected boundary, mapped to an open percentage.
+        Fails open (max coverage) when the boundary is unreachable.
         """
         arm = self.osc_config.arm_length
         lo = float(self.osc_config.min_angle)
@@ -61,10 +123,39 @@ class AdaptiveOscillatingCover(AdaptiveHorizontalCover):
         if arm <= 0 or hi <= lo:
             return 0.0
 
-        needed = self.calculate_position()
-        frac = float(np.clip(needed / arm, 0.0, 1.0))
-        # Arm angle (from the closed position) whose horizontal projection
-        # equals the needed reach: reach = arm · sin(theta).
-        theta = float(np.degrees(np.arcsin(frac)))
+        pivot_y = self.h_win + self.osc_config.housing_offset
+        boundary = self._protected_boundary()
+
+        thetas = np.linspace(lo, hi, OSCILLATING_ARC_SCAN_SAMPLES)
+        shadow_tops = np.array(
+            [
+                _lip_shadow_top(
+                    t,
+                    arm_length=arm,
+                    pivot_y=pivot_y,
+                    sol_elev=self.sol_elev,
+                    gamma=self.gamma,
+                )
+                for t in thetas
+            ]
+        )
+
+        reaches = np.flatnonzero(shadow_tops <= boundary)
+        if reaches.size:
+            # Smallest angle that shades down to the boundary (full shade).
+            theta = float(thetas[reaches[0]])
+        else:
+            # Unreachable → maximise coverage (fail open toward pos→100%).
+            theta = float(thetas[int(np.argmin(shadow_tops))])
+
+        self.logger.debug(
+            "Oscillating calc: elev=%.1f°, gamma=%.1f°, pivot_y=%.3f, "
+            "boundary=%.3f, theta=%.2f°",
+            self.sol_elev,
+            self.gamma,
+            pivot_y,
+            boundary,
+            theta,
+        )
         pos = (theta - lo) / (hi - lo) * 100.0
         return float(np.clip(pos, 0, 100))

--- a/tests/test_cover_types/test_oscillating_awning.py
+++ b/tests/test_cover_types/test_oscillating_awning.py
@@ -4,7 +4,7 @@ abstraction capabilities it exercises (#412).
 
 from __future__ import annotations
 
-import math
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,6 +18,11 @@ from custom_components.adaptive_cover_pro.const import (
 )
 from custom_components.adaptive_cover_pro.cover_types import POLICY_REGISTRY, get_policy
 from custom_components.adaptive_cover_pro.engine.covers import AdaptiveOscillatingCover
+from tests.cover_helpers import (
+    make_cover_config,
+    make_horizontal_config,
+    make_vertical_config,
+)
 
 
 def test_registered_and_in_picker():
@@ -58,28 +63,195 @@ def test_validation_rejects_angle_accepts_arm_length():
         )
 
 
-def _osc_engine(arm: float, lo: float, hi: float) -> AdaptiveOscillatingCover:
-    """Build an engine instance without the heavy sun/config plumbing."""
-    eng = object.__new__(AdaptiveOscillatingCover)
-    eng.osc_config = OscillatingConfig(
-        arm_length=arm, min_angle=lo, max_angle=hi, housing_offset=0.0
+# gamma = (win_azi − sol_azi + 180) % 360 − 180.  With win_azi=180 a sol_azi of
+# (180 − gamma) produces exactly the requested surface-solar azimuth, so these
+# tests can drive a real engine (sill/depth/distance wired through the inherited
+# vertical solve) while pinning gamma precisely.
+_WIN_AZI = 180.0
+
+
+def _osc_full(
+    *,
+    arm: float = 0.85,
+    housing: float = 0.15,
+    h_win: float = 1.5,
+    sol_elev: float,
+    gamma: float,
+    distance: float = 0.01,
+    window_depth: float = 0.15,
+    sill_height: float = 0.73,
+    lo: float = 0.0,
+    hi: float = 180.0,
+) -> AdaptiveOscillatingCover:
+    """Build a fully-plumbed oscillating engine driving the real geometry.
+
+    ``gamma`` is realised by offsetting ``sol_azi`` from the window azimuth.
+    """
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+    return AdaptiveOscillatingCover(
+        logger=MagicMock(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=sol_elev,
+        sun_data=sun_data,
+        config=make_cover_config(win_azi=_WIN_AZI, fov_left=90, fov_right=103),
+        vert_config=make_vertical_config(
+            distance=distance,
+            h_win=h_win,
+            window_depth=window_depth,
+            sill_height=sill_height,
+        ),
+        horiz_config=make_horizontal_config(),
+        osc_config=OscillatingConfig(
+            arm_length=arm, min_angle=lo, max_angle=hi, housing_offset=housing
+        ),
     )
-    return eng
 
 
-@pytest.mark.parametrize(
-    ("reach", "expected_pos"),
-    [
-        (0.0, 0.0),  # no reach needed → closed
-        (0.8, 50.0),  # full arm reach → 90° → halfway through a 0-180 sweep
-        (0.8 * math.sin(math.radians(45)), 25.0),  # 45° → quarter sweep
-        (5.0, 50.0),  # over-reach clamps to full arm (90°)
-    ],
-)
-def test_engine_reach_to_percentage_arc(reach, expected_pos):
-    eng = _osc_engine(arm=0.8, lo=0.0, hi=180.0)
-    eng.calculate_position = lambda: reach  # shadow the inherited reach calc
-    assert eng.calculate_percentage() == pytest.approx(expected_pos, abs=0.5)
+def test_low_elevation_extends_past_fifty_percent():
+    """#586: drop-arm lip must descend past horizontal at low sun.
+
+    Reporter config (arm 0.85 m, housing 0.15 m, window 1.5 m). At the reported
+    sun (elev 29.9°, gamma 57.6°) the old horizontal-reach model capped the
+    position at exactly 50%; the vertical-drop model must drive the arm past
+    horizontal (θ > 90° → pos > 50%). Lowering the sun further drops the lip
+    even more (monotonic in coverage).
+    """
+    mid = _osc_full(sol_elev=29.9, gamma=57.6).calculate_percentage()
+    low = _osc_full(sol_elev=8.0, gamma=57.6).calculate_percentage()
+    assert mid > 50.0
+    assert low > mid
+    assert low <= 100.0
+
+
+def test_reporter_case_pinned_position():
+    """#586 reporter geometry pins to the wired vertical-drop solution.
+
+    With the reporter's sill (0.73 m) the inherited vertical solve clamps the
+    protected boundary to the window bottom (0.0), so the lip must shade the
+    full face. The solved arm angle is ≈133° → ≈73.9%.
+    """
+    pos = _osc_full(sol_elev=29.9, gamma=57.6).calculate_percentage()
+    assert pos == pytest.approx(73.9, abs=1.0)
+
+
+def test_position_non_increasing_as_elevation_rises():
+    """Higher sun → less coverage needed → position non-increasing (fixed gamma)."""
+    positions = [
+        _osc_full(sol_elev=elev, gamma=57.6).calculate_percentage()
+        for elev in (5.0, 15.0, 30.0, 45.0, 60.0, 75.0)
+    ]
+    for higher, lower in zip(positions, positions[1:], strict=False):
+        assert lower <= higher + 1e-6
+
+
+def test_housing_offset_affects_position():
+    """housing_offset (pivot height above window top) is now load-bearing.
+
+    With exposed glass above the protected boundary (sill 0 so the vertical
+    solve leaves a real boundary > 0), a higher pivot lets the lip start higher
+    and reach the boundary at a larger arm angle → higher position.
+    """
+    common = {"sol_elev": 29.9, "gamma": 57.6, "sill_height": 0.0, "distance": 0.8}
+    low = _osc_full(housing=0.0, **common).calculate_percentage()
+    high = _osc_full(housing=0.5, **common).calculate_percentage()
+    assert high != low
+    assert high > low
+
+
+def test_sill_or_depth_affects_position():
+    """Changing sill_height / window_depth changes the protected boundary.
+
+    Proves the boundary stays wired to the inherited sill/depth/distance solve
+    rather than being pinned at the window bottom.
+    """
+    # A small sill brings the protected boundary into the window interior so the
+    # window_depth contribution (which raises the boundary) is observable rather
+    # than clamped at the window top.
+    base = {"sol_elev": 35.0, "gamma": 57.6, "sill_height": 0.4, "distance": 0.6}
+    baseline = _osc_full(window_depth=0.0, **base).calculate_percentage()
+    deeper = _osc_full(window_depth=0.4, **base).calculate_percentage()
+    assert deeper != baseline
+
+    sill_base = {"sol_elev": 35.0, "gamma": 57.6, "window_depth": 0.0, "distance": 1.2}
+    sill_low = _osc_full(sill_height=0.0, **sill_base).calculate_percentage()
+    sill_high = _osc_full(sill_height=0.5, **sill_base).calculate_percentage()
+    assert sill_high != sill_low
+
+
+def test_awn_properties_track_arm():
+    """The horizontal-parent reach properties stay wired for substitutability.
+
+    ``awn_length`` reflects the arm length and ``awn_angle`` is flat (0) so the
+    inherited ``AdaptiveHorizontalCover`` paths remain Liskov-substitutable.
+    """
+    eng = _osc_full(arm=0.85, sol_elev=29.9, gamma=57.6)
+    assert eng.awn_length == pytest.approx(0.85)
+    assert eng.awn_angle == 0.0
+
+
+def test_degenerate_guards():
+    """Degenerate geometry stays bounded and never raises."""
+    # arm = 0 → no reach → fully closed.
+    zero_arm = _osc_full(arm=0.0, sol_elev=29.9, gamma=57.6).calculate_percentage()
+    assert zero_arm == 0.0
+    # hi <= lo → degenerate sweep → 0.0.
+    flat = _osc_full(sol_elev=29.9, gamma=57.6, lo=90.0, hi=90.0).calculate_percentage()
+    assert flat == 0.0
+    # gamma ≈ 90° must use the cos-gamma clamp (no ZeroDivision).
+    grazing = _osc_full(sol_elev=29.9, gamma=89.9).calculate_percentage()
+    assert 0.0 <= grazing <= 100.0
+    # Very high sun → little coverage needed but never negative.
+    high_sun = _osc_full(sol_elev=85.0, gamma=10.0).calculate_percentage()
+    assert high_sun >= 0.0
+
+
+def test_lip_shadow_top_helper_geometry():
+    """#586: lip-shadow helper geometry.
+
+    At the sweep endpoints the reach is zero, so the shadow top sits exactly at
+    the lip: a full arm above the pivot at θ=0, a full arm below it at θ=180°.
+    Between them the shadow descends to a mid-sweep minimum (max coverage) — the
+    lip's reach (hence foreshortened drop) peaks near θ=90° while it keeps
+    falling, so coverage is deepest past horizontal, not at θ=180°. This is the
+    physics the solver's fail-open branch relies on (argmin lands mid-sweep).
+    """
+    from custom_components.adaptive_cover_pro.engine.covers.oscillating import (
+        _lip_shadow_top,
+    )
+
+    kw = {"arm_length": 0.85, "pivot_y": 1.65, "sol_elev": 29.9, "gamma": 57.6}
+    # Endpoints: no reach → shadow top is the bare lip height.
+    assert _lip_shadow_top(0.0, **kw) == pytest.approx(1.65 + 0.85)
+    assert _lip_shadow_top(180.0, **kw) == pytest.approx(1.65 - 0.85)
+    # Descends monotonically from θ=0 up to a mid-sweep minimum…
+    rising = [_lip_shadow_top(t, **kw) for t in (0.0, 30.0, 60.0, 90.0, 120.0)]
+    for higher, lower in zip(rising, rising[1:], strict=False):
+        assert lower < higher
+    # …and the deepest coverage is past horizontal (θ > 90°), below both ends.
+    deepest = min(_lip_shadow_top(t, **kw) for t in range(0, 181))
+    assert deepest < _lip_shadow_top(0.0, **kw)
+    assert deepest < _lip_shadow_top(180.0, **kw)
+
+
+def test_solver_drives_position_to_reach_boundary():
+    """#586: the solver picks a larger arm angle for a lower boundary.
+
+    Lower protected boundaries demand the lip drop further (larger θ). A high
+    boundary (at the lip's starting height) needs almost no sweep; the full-face
+    case (boundary=0) must drive the arm strictly past horizontal (>50%), which
+    the old reach-capped model could never do.
+    """
+    high = _osc_full(sol_elev=29.9, gamma=57.6)
+    high._protected_boundary = lambda: 2.3  # type: ignore[method-assign]
+    low = _osc_full(sol_elev=29.9, gamma=57.6)
+    low._protected_boundary = lambda: 0.0  # type: ignore[method-assign]
+
+    high_pos = high.calculate_percentage()
+    low_pos = low.calculate_percentage()
+    assert high_pos < 50.0  # lip barely needs to move
+    assert low_pos > 50.0  # must sweep past horizontal — impossible pre-#586
+    assert low_pos > high_pos
 
 
 def test_reporter_sweep_is_linear_175_over_100():


### PR DESCRIPTION
## Summary
The oscillating-awning position calc previously credited only the drop-arm's horizontal reach (`reach = arm·sin θ`), which peaks at θ=90° = 50% of the 0–180° sweep — so the awning could never exceed 50% regardless of config. This replaces that with a vertical-drop (lip-height) shade model: as the arm swings past horizontal the fabric lip descends, and the engine solves for the minimum extension whose lip shadows the window down to the exposed-glass boundary. Positions can now exceed 50% at low sun elevation, tracking the sun the way a drop-arm awning physically shades. The previously-unused `housing_offset` config is now load-bearing (sets the pivot height), and `window_depth`/`sill_height`/`distance` still influence the result via the inherited exposed-glass boundary. This is the only behavior for the (beta) oscillating-awning cover type — no toggle.

## Testing
- ✅ 26 tests passing (scoped: oscillating-awning + horizontal-awning suites)
- ✅ 502 tests passing across the affected engine/cover suites (vertical, horizontal, calculation, geometry, cover_types)
- ✅ Fixed-angle horizontal awning + vertical sill/depth math unchanged (bit-identical)

## Related Issues
Refs #586