### PR TITLE
fix: lift oscillating awning arm_length UI cap to 6m

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/oscillating_awning.py
+++ b/custom_components/adaptive_cover_pro/cover_types/oscillating_awning.py
@@ -33,6 +33,7 @@ from ..const import (
     DEFAULT_AWNING_MAX_ANGLE,
     DEFAULT_AWNING_MIN_ANGLE,
     DEFAULT_WINDOW_HEIGHT,
+    _RANGE_ARM_LENGTH,
 )
 from ..engine.covers import AdaptiveOscillatingCover
 from ..unit_system import length_default, length_selector
@@ -89,7 +90,12 @@ def geometry_oscillating_schema(hass: HomeAssistant | None = None) -> vol.Schema
             ): length_selector(hass, min_m=0.0, max_m=50, metric_step=0.01),
             vol.Required(
                 CONF_ARM_LENGTH, default=length_default(DEFAULT_ARM_LENGTH, hass)
-            ): length_selector(hass, min_m=0.1, max_m=3, metric_step=0.01),
+            ): length_selector(
+                hass,
+                min_m=_RANGE_ARM_LENGTH[0],
+                max_m=_RANGE_ARM_LENGTH[1],
+                metric_step=0.01,
+            ),
             vol.Required(
                 CONF_AWNING_MIN_ANGLE, default=DEFAULT_AWNING_MIN_ANGLE
             ): _sweep_angle_selector(),

--- a/tests/test_cover_types/test_oscillating_awning.py
+++ b/tests/test_cover_types/test_oscillating_awning.py
@@ -9,12 +9,16 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.config_types import OscillatingConfig
+import voluptuous as vol
+
 from custom_components.adaptive_cover_pro.const import (
     CONF_ARM_LENGTH,
     CONF_AWNING_ANGLE,
     CONF_AWNING_MAX_ANGLE,
     CONF_AWNING_MIN_ANGLE,
+    CONF_HEIGHT_WIN,
     CoverType,
+    _RANGE_ARM_LENGTH,
 )
 from custom_components.adaptive_cover_pro.cover_types import POLICY_REGISTRY, get_policy
 from custom_components.adaptive_cover_pro.engine.covers import AdaptiveOscillatingCover
@@ -266,3 +270,39 @@ def test_config_from_options_defaults():
     assert cfg.arm_length == 0.8
     assert cfg.min_angle == 0
     assert cfg.max_angle == 175
+
+
+def test_geometry_schema_accepts_arm_length_up_to_6m():
+    """Regression for #636: arm_length selector must accept values up to 6 m.
+
+    The config-flow geometry schema (the path the user hits at config-entry
+    creation) previously capped arm_length at 3 m, causing "Value 3.6 is too
+    large" when a user entered a physically-valid 3.6 m arm. The selector bound
+    must match _RANGE_ARM_LENGTH so the UI cap and the service-validator cap
+    share a single source of truth.
+    """
+    from custom_components.adaptive_cover_pro.cover_types.oscillating_awning import (
+        geometry_oscillating_schema,
+    )
+
+    schema = geometry_oscillating_schema()  # hass=None → metric (metres)
+
+    # Fill required geometry keys with valid in-range defaults; only arm_length
+    # is under test here.
+    base = {
+        CONF_HEIGHT_WIN: 1.5,
+        CONF_AWNING_MIN_ANGLE: 0,
+        CONF_AWNING_MAX_ANGLE: 175,
+    }
+
+    # 3.6 m was the reported value that was rejected.
+    result_36 = schema({**base, CONF_ARM_LENGTH: 3.6})
+    assert result_36[CONF_ARM_LENGTH] == pytest.approx(3.6)
+
+    # 6.0 m is the ceiling defined by _RANGE_ARM_LENGTH.
+    result_max = schema({**base, CONF_ARM_LENGTH: _RANGE_ARM_LENGTH[1]})
+    assert result_max[CONF_ARM_LENGTH] == pytest.approx(_RANGE_ARM_LENGTH[1])
+
+    # Values strictly above the ceiling must still be rejected.
+    with pytest.raises(vol.Invalid):
+        schema({**base, CONF_ARM_LENGTH: 6.1})


### PR DESCRIPTION
## Summary
The oscillating (drop-arm) awning's config-flow geometry selector hardcoded the Arm Length cap at `max_m=3`, a separate code path from the `_RANGE_ARM_LENGTH=(0.1, 6.0)` constant that #637 raised. #637 only lifted the service-call validator, so the UI still rejected values above 3 m at config-entry creation ("Value 3.6 is too large"). This points the selector's bounds at `_RANGE_ARM_LENGTH` (single source of truth), so the UI now accepts up to 6 m — matching the horizontal awning.

## Testing
- ✅ 769 tests passing
- Added regression test asserting the oscillating geometry schema accepts 3.6 m and 6.0 m and rejects 6.1 m

## Related Issues
Refs #636