### PR TITLE
fix: resolve climate thresholds on apply-user position path (#643)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -337,7 +337,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Renders templated threshold options to numbers once per cycle (#577).
         self._template_resolver = TemplateResolver(self.hass)
         # Current cycle's options after template resolution (for diagnostics).
-        self._resolved_options: dict = dict(self.config_entry.options)
+        # Resolved at construction so apply_user_position sees float thresholds
+        # even before the first _async_update_data cycle runs (#643).
+        self._resolved_options: dict = self._template_resolver.resolve(
+            self.config_entry.options
+        )
 
         # Sun data provider
         self._sun_provider = SunProvider(hass=self.hass)
@@ -2091,7 +2095,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         ``adaptive_cover_pro.set_position`` service when callers explicitly
         opt in.
         """
-        opts = options if options is not None else self.config_entry.options
+        opts = options if options is not None else self._resolved_options
         snapshot = self._snapshot_builder.build(
             opts,
             cover_data=self._cover_data,

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -360,6 +360,8 @@ async def _trigger_async_apply_user_position(coord):
     """
     coord.config_entry = MagicMock()
     coord.config_entry.options = {}
+    # After fix #643, async_apply_user_position falls back to _resolved_options.
+    coord._resolved_options = {}
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors = MagicMock(return_value=[])
     # Floor composition reads from a real PipelineSnapshot (#463).

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -13,7 +13,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
+from custom_components.adaptive_cover_pro.const import (
+    CONF_TEMP_HIGH,
+    CONF_TEMP_LOW,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+)
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
@@ -82,7 +86,13 @@ def _make_coord(
 
     coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
     coord.config_entry = MagicMock()
-    coord.config_entry.options = default_options if default_options is not None else {}
+    entry_opts = default_options if default_options is not None else {}
+    coord.config_entry.options = entry_opts
+    # After fix #643, async_apply_user_position falls back to
+    # _resolved_options (not config_entry.options).  Initialise it to the
+    # same dict so existing tests keep working; specific tests that want to
+    # exercise the resolved-vs-raw distinction set this attribute themselves.
+    coord._resolved_options = entry_opts
     # PipelineSnapshotBuilder mock — Phase D moved HA reads + snapshot
     # assembly onto this collaborator.  Both call-sites of
     # async_apply_user_position route through it.
@@ -504,3 +514,73 @@ async def test_custom_position_min_mode_preempts_when_request_below_floor_and_ha
     assert outcome == ("skipped", "preempted_by_custom_position_2")
     coord._cmd_svc.record_preempted_skip.assert_called_once()
     coord._cmd_svc.apply_position.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Issue #643: async_apply_user_position must use resolved options, not raw
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_user_position_renders_string_thresholds() -> None:
+    """apply_user_position must pass _resolved_options (floats) to build(), not
+    config_entry.options (raw strings).
+
+    Before the fix, line 2094 used ``self.config_entry.options`` as the
+    fallback, so a plain numeric string such as ``temp_low="21"`` flowed into
+    ClimateOptions.temp_low and then into ``is_winter``'s float < str
+    comparison → TypeError. After the fix, ``_resolved_options`` (already
+    float-normalized) is used instead.
+
+    This test confirms the contract: build() receives the float-resolved dict,
+    not the raw-string entry options, when options=None (the default path for
+    all user-action callers: set_position service, cover.py, button.py).
+    """
+    raw_entry_options = {CONF_TEMP_LOW: "21", CONF_TEMP_HIGH: "25"}
+    resolved_options = {CONF_TEMP_LOW: 21.0, CONF_TEMP_HIGH: 25.0}
+
+    coord, _ctx = _make_coord([], default_options=raw_entry_options)
+    # Simulate coordinator having already resolved options (normal update cycle).
+    coord._resolved_options = resolved_options
+
+    await coord.async_apply_user_position("cover.test", 50, trigger="set_position")
+
+    # build() must have been called with the float-resolved dict, NOT the raw entry opts.
+    coord._snapshot_builder.build.assert_called_once()
+    call_args, _call_kwargs = coord._snapshot_builder.build.call_args
+    opts_passed = call_args[0]
+    assert opts_passed is resolved_options, (
+        f"build() was called with {opts_passed!r} (raw config_entry.options) "
+        f"instead of the float-resolved _resolved_options {resolved_options!r}. "
+        "async_apply_user_position must fall back to self._resolved_options, not "
+        "self.config_entry.options."
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_user_position_explicit_options_not_overridden_by_resolved() -> (
+    None
+):
+    """When options is supplied explicitly, it takes priority over _resolved_options.
+
+    This is a regression guard: the fix to issue #643 must not accidentally
+    discard the ``options`` kwarg that callers supply. The existing contract
+    (explicit options win) must be preserved.
+    """
+    raw_entry_options = {CONF_TEMP_LOW: "21"}
+    resolved_options = {CONF_TEMP_LOW: 21.0}
+    explicit_options = {CONF_TEMP_LOW: 18.0, "from": "explicit"}
+
+    coord, _ctx = _make_coord([], default_options=raw_entry_options)
+    coord._resolved_options = resolved_options
+
+    await coord.async_apply_user_position(
+        "cover.test", 50, trigger="set_position", options=explicit_options
+    )
+
+    coord._snapshot_builder.build.assert_called_once()
+    call_args, _call_kwargs = coord._snapshot_builder.build.call_args
+    opts_passed = call_args[0]
+    assert (
+        opts_passed is explicit_options
+    ), "build() must use the explicitly supplied options when options != None."

--- a/tests/test_my_position_button.py
+++ b/tests/test_my_position_button.py
@@ -157,6 +157,8 @@ def _make_my_position_coord():
     coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
     coord.config_entry = MagicMock()
     coord.config_entry.options = {}
+    # After fix #643, async_apply_user_position falls back to _resolved_options.
+    coord._resolved_options = {}
     coord._snapshot_builder = MagicMock()
     coord._snapshot_builder.read_custom_position_sensors.return_value = []
     # Floor composition reads from a real PipelineSnapshot (#463).

--- a/tests/test_user_command_auto_control_off.py
+++ b/tests/test_user_command_auto_control_off.py
@@ -44,6 +44,8 @@ def _make_coord():
     coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
     coord.config_entry = MagicMock()
     coord.config_entry.options = {}
+    # After fix #643, async_apply_user_position falls back to _resolved_options.
+    coord._resolved_options = {}
 
     from tests.test_pipeline.conftest import make_snapshot  # noqa: PLC0415
 


### PR DESCRIPTION
## Summary
Fixes `TypeError: '<' not supported between instances of 'float' and 'str'` raised when controlling a climate-configured cover via the Lovelace card after upgrading to v2.28.0.

Since v2.28.0, the temp thresholds (`temp_low`/`temp_high`/`outside_threshold`) became templatable fields — their plain numeric-string values are only coerced to floats by the template resolver during the normal update cycle. The apply-user-position path (`set_position` service / card up-down controls) passed `options=None`, falling back to raw `config_entry.options`, so a string threshold reached the climate `is_winter` comparison and crashed.

The fix initializes `_resolved_options` via the template resolver at coordinator construction and has `async_apply_user_position` fall back to `self._resolved_options` instead of `self.config_entry.options`, so downstream always sees floats.

## Testing
- ✅ 4574 tests passing (full suite)

## Related Issues
Refs #643