### PR TITLE
fix: avoid tzdata blocking call at startup (#655)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1253,6 +1253,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         # Get data for the blind and update manager
         cover_data = self.get_blind_data(options=options)
+
+        # Pre-warm the SunData cache off the event loop. On HAOS (no OS tz data),
+        # pd.date_range(tz=<named-tz>) in _ensure_today() blocks the loop by
+        # importing tzdata. One executor call per first-of-day cycle fills the
+        # module-level _DAY_CACHE; subsequent accesses in this cycle are Tier 1 hits.
+        # Calling unconditionally is safe — prime_cache() is a no-op when warm.
+        # Issue #655.
+        await self.hass.async_add_executor_job(cover_data.sun_data.prime_cache)
+
         self._update_manager_and_covers()
 
         # Reset expired manual overrides BEFORE running the pipeline so the

--- a/custom_components/adaptive_cover_pro/sun.py
+++ b/custom_components/adaptive_cover_pro/sun.py
@@ -161,6 +161,21 @@ class SunData:
             )
         return self._cache_ele
 
+    def prime_cache(self) -> None:
+        """Pre-warm the day cache — call from an executor, never inline on the event loop.
+
+        Accessing ``pd.date_range(tz=<named-tz>)`` on a system without OS-level
+        IANA tz data (e.g. HAOS on Raspberry Pi) triggers
+        ``importlib.import_module('tzdata')`` which HA's loop watchdog flags as
+        a blocking call. This method exists so the cache fill runs in a thread
+        pool worker via ``hass.async_add_executor_job(sun_data.prime_cache)``.
+
+        If the cache is already warm for today, accessing ``self.times`` is a
+        Tier 1 fast-path hit (no lock, no I/O) — so calling this unconditionally
+        is safe and cheap. Issue #655.
+        """
+        _ = self.times  # Forces Tier 3 fill if cache is cold; no-op if warm.
+
     def sunset(self) -> datetime:
         """Fetch sunset time.
 

--- a/tests/test_boot_perf.py
+++ b/tests/test_boot_perf.py
@@ -162,3 +162,47 @@ async def test_forecast_recompute_routes_through_executor(hass: HomeAssistant) -
 
     # The initial forecast recompute went through the executor.
     assert "build_forecast_for_coord" in executor_calls
+
+
+@pytest.mark.integration
+async def test_sun_data_cache_primed_via_executor(hass: HomeAssistant) -> None:
+    """SunData._ensure_today() must NOT run synchronously on the event loop.
+
+    On HAOS (no OS tz data), pd.date_range(tz=<named-tz>) triggers
+    importlib.import_module('tzdata') which HA's loop watchdog flags as a
+    blocking call. The fix: prime the SunData cache via an executor job
+    during _async_update_data, before any pipeline handler accesses
+    sun_data.times.
+
+    This test spies on async_add_executor_job and asserts that prime_cache
+    was dispatched through it during entry setup. Issue #655.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "TzdataTest", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="tzdata_test_01",
+        title="TzdataTest",
+    )
+    entry.add_to_hass(hass)
+
+    executor_calls: list[str] = []
+    orig = hass.async_add_executor_job
+
+    def _spy(target, *args):
+        name = getattr(target, "__name__", str(target))
+        executor_calls.append(name)
+        return orig(target, *args)
+
+    hass.async_add_executor_job = _spy
+    try:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    finally:
+        hass.async_add_executor_job = orig
+
+    # After the fix, SunData cache priming MUST go through the executor.
+    # "prime_cache" must appear in the recorded executor calls. Issue #655.
+    assert (
+        "prime_cache" in executor_calls
+    ), f"SunData.prime_cache not found in executor calls: {executor_calls}"

--- a/tests/test_sun.py
+++ b/tests/test_sun.py
@@ -155,3 +155,18 @@ def test_timeline_spans_one_day_at_5min_freq():
     assert len(times) == 289
     span = times[-1] - times[0]
     assert span == timedelta(days=1)
+
+
+@pytest.mark.unit
+def test_prime_cache_warms_ensure_today():
+    """SunData.prime_cache() populates the day cache so subsequent accesses are Tier 1 hits.
+
+    Regression guard for issue #655: prime_cache() is the method called via
+    hass.async_add_executor_job to pre-warm _ensure_today() off the event loop.
+    Verifies the cache is cold before the call and warm afterwards.
+    """
+    sd = _make_sun_data()
+    assert sd._cache_day is None  # cold before call
+    sd.prime_cache()
+    assert sd._cache_day is not None  # warm after call
+    assert sd._cache_times is not None

--- a/tests/test_weather_override.py
+++ b/tests/test_weather_override.py
@@ -415,6 +415,9 @@ async def test_recover_on_restart_called_before_calculate_on_first_refresh():
     coordinator.async_handle_first_refresh = AsyncMock()
     coordinator._update_solar_times_if_needed = AsyncMock(return_value=(None, None))
     coordinator._pipeline_result = MagicMock()
+    hass.async_add_executor_job = (
+        AsyncMock()
+    )  # issue #655: prime_cache offloaded to executor
 
     call_order: list[str] = []
     original_recover = (
@@ -462,6 +465,9 @@ async def test_recover_on_restart_not_called_on_subsequent_refresh():
     coordinator.manager.reset_if_needed = AsyncMock(return_value=False)
     coordinator._update_solar_times_if_needed = AsyncMock(return_value=(None, None))
     coordinator._pipeline_result = MagicMock()
+    hass.async_add_executor_job = (
+        AsyncMock()
+    )  # issue #655: prime_cache offloaded to executor
 
     call_order: list[str] = []
 


### PR DESCRIPTION
## Summary
On HAOS without OS-level IANA tz data, `SunData._ensure_today()` ran `pd.date_range(tz=<named-tz>)` synchronously on the event loop during the coordinator's first update at startup. That makes pandas fall back to importing `tzdata`, which blocks the loop and HA's watchdog flags it.

The cache fill now runs in an executor: a new `SunData.prime_cache()` is invoked via `await self.hass.async_add_executor_job(...)` from `_async_update_data()`, moving the one-time `tzdata` import off the event loop. `prime_cache()` is a no-op when the cache is already warm, so it's safe to call unconditionally each cycle.

## Testing
- ✅ 4682 tests passing — added a unit test for `prime_cache()` and a boot-perf regression guard asserting the cache is primed via the executor

## Related Issues
Refs #655

https://claude.ai/code/session_01RemXCqoS3ArLWp5PucqcQ5