### PR TITLE
fix: cover returns to night/custom position after override reset when gate-dark (#656)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1538,9 +1538,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """
         target_covers = entities if entities is not None else list(self.entities)
 
-        if not self.check_adaptive_time:
+        if not self.clock_window_open:
             self.logger.debug(
-                "Manual override cleared for %s but outside active-hours window — "
+                "Manual override cleared for %s but outside the clock window — "
                 "skipping reposition (pipeline position was %s; will apply when "
                 "window opens)",
                 target_covers,
@@ -1643,11 +1643,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # pipeline still evaluates so diagnostics/sensor state remain correct.
         custom_position_sensor_triggered = self._is_custom_position_sensor_trigger()
 
-        if not self.check_adaptive_time and not is_safety and not safety_release:
+        if not self.clock_window_open and not is_safety and not safety_release:
             self.state_change = False
             self._last_state_change_entity = None
             self._custom_position_template_trigger = False
-            self.logger.debug("Outside time window — skipping position update")
+            self.logger.debug("Outside the clock window — skipping position update")
             return
 
         # A floor-clamp raised the winner this cycle (#534).  When manual
@@ -2035,6 +2035,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     def check_adaptive_time(self):
         """Check if current time is within operational window — delegates to TimeWindowManager."""
         return self._time_mgr.is_active
+
+    @property
+    def clock_window_open(self):
+        """Whether the user's start/end clock window is open — delegates to TimeWindowManager."""
+        return self._time_mgr.clock_window_open
 
     @property
     def after_start_time(self):

--- a/custom_components/adaptive_cover_pro/diagnostics/__init__.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/__init__.py
@@ -23,11 +23,11 @@ def _sanitize(obj):
 
     if isinstance(obj, dict):
         return {k: _sanitize(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple)):
+    if isinstance(obj, list | tuple):
         return [_sanitize(v) for v in obj]
-    if isinstance(obj, (set, frozenset)):
+    if isinstance(obj, set | frozenset):
         return sorted(_sanitize(v) for v in obj)
-    if isinstance(obj, (dt.datetime, dt.date, dt.time)):
+    if isinstance(obj, dt.datetime | dt.date | dt.time):
         return obj.isoformat()
     if isinstance(obj, enum.Enum):
         return obj.value
@@ -48,9 +48,27 @@ async def async_get_config_entry_diagnostics(
     )  # noqa: PLC0415
 
     coordinator = hass.data.get(_DOMAIN, {}).get(config_entry.entry_id)
-    coordinator_diagnostics = None
-    if coordinator is not None and coordinator.data is not None:
+    if coordinator is None:
+        coordinator_diagnostics = {
+            "status": "unavailable",
+            "reason": "coordinator missing — the integration is not set up for this entry",
+        }
+    elif coordinator.data is not None:
         coordinator_diagnostics = _sanitize(coordinator.data.diagnostics)
+    else:
+        # Data present-but-None: diagnostics requested before the first completed
+        # update cycle. Surface an explicit marker (not a bare None) and include
+        # the event buffer so there is still a timeline to triage from.
+        marker = {
+            "status": "unavailable",
+            "reason": "no completed update cycle yet — coordinator.data is None",
+        }
+        event_buffer = getattr(coordinator, "_event_buffer", None)
+        if event_buffer is not None:
+            timeline = _sanitize(event_buffer.snapshot())
+            marker["event_timeline"] = timeline
+            marker["data_window"] = DiagnosticsBuilder._compute_data_window(timeline)
+        coordinator_diagnostics = marker
 
     return {
         "title": "Adaptive Cover Pro Configuration",

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -490,6 +490,22 @@ class DiagnosticsBuilder:
         return diagnostics
 
     @staticmethod
+    def _compute_data_window(timeline) -> dict:
+        """Summarize the time span and capture moment of an event timeline.
+
+        ``start``/``end`` are the earliest/latest ``ts`` in the timeline (None
+        when empty); ``captured_at`` is the UTC ISO timestamp the snapshot was
+        taken. Shared by ``_build_debug_info`` and the diagnostics export
+        null-case marker so both describe their window identically (#656).
+        """
+        stamps = [e["ts"] for e in (timeline or []) if e.get("ts")]
+        return {
+            "start": min(stamps) if stamps else None,
+            "end": max(stamps) if stamps else None,
+            "captured_at": dt.datetime.now(dt.UTC).isoformat(),
+        }
+
+    @staticmethod
     def _build_debug_info(ctx: DiagnosticContext) -> dict:
         """Build debug & diagnostics section."""
         diagnostics: dict = {}
@@ -499,6 +515,9 @@ class DiagnosticsBuilder:
 
         # Unified event timeline from the shared ring buffer
         timeline = ctx.event_timeline or ctx.manual_override_events
+        # Always record the data window so a downloaded snapshot is
+        # self-describing — even when the timeline is empty (#656).
+        diagnostics["data_window"] = DiagnosticsBuilder._compute_data_window(timeline)
         if timeline:
             diagnostics["event_timeline"] = timeline
             # Backward-compat filtered alias for consumers that read manual_override_history

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -108,6 +108,19 @@ class TimeWindowManager:
         return self.before_end_time and self.after_start_time and self.gate_is_daytime
 
     @property
+    def clock_window_open(self) -> bool:
+        """Whether the user's start/end CLOCK window is open, ignoring the daytime gate.
+
+        This is :pyattr:`is_active` without the ``gate_is_daytime`` factor.
+        ``is_active`` conflates "outside the user's start/end clock" (ACP must stay
+        hands-off — #215/#216) with "the daytime gate reads dark" (ACP has a
+        well-defined night/default position it should still send — #656).
+        Suppression sites that only care about the clock consult THIS; the
+        gate-dark case is exposed separately via :pyattr:`gate_is_dark`.
+        """
+        return self.before_end_time and self.after_start_time
+
+    @property
     def gate_is_configured(self) -> bool:
         """Return True when a daytime gate source — sensor or template — is set.
 

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -388,6 +388,7 @@ class TestCustomPositionSensorEdgeTriggerBypassesGate:
         coordinator.check_adaptive_time = (
             False  # outside time window — before start_time
         )
+        coordinator.clock_window_open = False  # clock genuinely closed (pre-start)
         coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=True)
 
         await AdaptiveDataUpdateCoordinator.async_handle_state_change(
@@ -616,6 +617,7 @@ class TestCustomPositionSensorReleaseEdgeBypassesGate:
 
         coordinator = self._make_release_coordinator()
         coordinator.check_adaptive_time = False  # outside time window — after end_time
+        coordinator.clock_window_open = False  # clock genuinely closed (after end_time)
 
         await AdaptiveDataUpdateCoordinator.async_handle_state_change(
             coordinator,
@@ -642,6 +644,7 @@ class TestCustomPositionSensorReleaseEdgeBypassesGate:
         coordinator.check_adaptive_time = (
             False  # outside time window — before start_time
         )
+        coordinator.clock_window_open = False  # clock genuinely closed (pre-start)
         coordinator._last_state_change_entity = "binary_sensor.movie_time"
 
         await AdaptiveDataUpdateCoordinator.async_handle_state_change(
@@ -668,6 +671,7 @@ class TestCustomPositionSensorReleaseEdgeBypassesGate:
 
         coordinator = self._make_release_coordinator()
         coordinator.check_adaptive_time = False  # outside time window — sunset active
+        coordinator.clock_window_open = False  # clock genuinely closed (outside window)
         coordinator._last_state_change_entity = "binary_sensor.movie_time"
 
         await AdaptiveDataUpdateCoordinator.async_handle_state_change(

--- a/tests/test_diagnostics/test_data_window.py
+++ b/tests/test_diagnostics/test_data_window.py
@@ -1,0 +1,82 @@
+"""Tests for the diagnostics data_window metadata (issue #656).
+
+``data_window`` records the time span covered by the event timeline plus the
+moment the snapshot was captured, so a downloaded diagnostics file is
+self-describing: a triager can tell at a glance how recent and how wide the
+captured window is.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from custom_components.adaptive_cover_pro.diagnostics.builder import (
+    DiagnosticsBuilder,
+)
+from tests.test_diagnostics.test_builder import _base_ctx
+
+# ---------------------------------------------------------------------------
+# _compute_data_window — staticmethod unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_data_window_spans_earliest_to_latest():
+    """Start == earliest ts, end == latest ts across the timeline."""
+    timeline = [
+        {"ts": "2026-06-22T20:05:00+00:00", "event": "b"},
+        {"ts": "2026-06-22T20:00:00+00:00", "event": "a"},
+        {"ts": "2026-06-22T20:10:00+00:00", "event": "c"},
+    ]
+    window = DiagnosticsBuilder._compute_data_window(timeline)
+
+    assert window["start"] == "2026-06-22T20:00:00+00:00"
+    assert window["end"] == "2026-06-22T20:10:00+00:00"
+    captured = dt.datetime.fromisoformat(window["captured_at"])
+    assert captured.tzinfo == dt.UTC
+
+
+def test_compute_data_window_empty_timeline_has_none_bounds():
+    """Empty (or None) timeline → start None, end None, captured_at still valid."""
+    for timeline in ([], None):
+        window = DiagnosticsBuilder._compute_data_window(timeline)
+        assert window["start"] is None
+        assert window["end"] is None
+        captured = dt.datetime.fromisoformat(window["captured_at"])
+        assert captured.tzinfo == dt.UTC
+
+
+def test_compute_data_window_captured_at_parses_as_utc():
+    """captured_at parses with fromisoformat and carries UTC tzinfo."""
+    window = DiagnosticsBuilder._compute_data_window(
+        [{"ts": "2026-06-22T20:00:00+00:00"}]
+    )
+    captured = dt.datetime.fromisoformat(window["captured_at"])
+    assert captured.tzinfo == dt.UTC
+
+
+# ---------------------------------------------------------------------------
+# data_window emitted alongside event_timeline in debug info
+# ---------------------------------------------------------------------------
+
+
+def test_data_window_sits_alongside_event_timeline():
+    """_build_debug_info emits data_window matching the timeline bounds."""
+    timeline = [
+        {"ts": "2026-06-22T20:00:00+00:00", "event": "manual_override_armed"},
+        {"ts": "2026-06-22T20:08:00+00:00", "event": "manual_override_cleared"},
+    ]
+    diag = DiagnosticsBuilder._build_debug_info(_base_ctx(event_timeline=timeline))
+
+    assert diag["event_timeline"] == timeline
+    assert diag["data_window"]["start"] == "2026-06-22T20:00:00+00:00"
+    assert diag["data_window"]["end"] == "2026-06-22T20:08:00+00:00"
+
+
+def test_data_window_emitted_even_when_timeline_empty():
+    """data_window is emitted unconditionally, with None bounds when no events."""
+    diag = DiagnosticsBuilder._build_debug_info(_base_ctx(event_timeline=None))
+
+    assert diag["data_window"]["start"] is None
+    assert diag["data_window"]["end"] is None
+    captured = dt.datetime.fromisoformat(diag["data_window"]["captured_at"])
+    assert captured.tzinfo == dt.UTC

--- a/tests/test_diagnostics/test_export_unavailable.py
+++ b/tests/test_diagnostics/test_export_unavailable.py
@@ -1,0 +1,107 @@
+"""Tests for the diagnostics export null-case marker (issue #656).
+
+When a user downloads diagnostics before the coordinator has completed an
+update cycle, ``coordinator.data`` is None. The export must surface an explicit
+"unavailable" marker (with the sanitized event buffer when present) instead of a
+bare ``None`` that gives no diagnostic clue about why the snapshot is empty.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from custom_components.adaptive_cover_pro.const import DOMAIN
+from custom_components.adaptive_cover_pro.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+
+def _make_entry(entry_id: str = "entry-1") -> MagicMock:
+    entry = MagicMock(spec=ConfigEntry)
+    entry.entry_id = entry_id
+    entry.data = {"name": "Test"}
+    entry.options = {"opt": 1}
+    return entry
+
+
+def _make_hass(coordinator, entry_id: str = "entry-1") -> MagicMock:
+    hass = MagicMock(spec=HomeAssistant)
+    data = (
+        {DOMAIN: {entry_id: coordinator}} if coordinator is not None else {DOMAIN: {}}
+    )
+    hass.data = data
+    return hass
+
+
+@pytest.mark.asyncio
+async def test_data_none_emits_marker_with_event_timeline():
+    """coordinator.data is None → status unavailable + sanitized event buffer."""
+    entry = _make_entry()
+    events = [
+        {"ts": "2026-06-22T20:00:00+00:00", "event": "manual_override_armed"},
+        {"ts": "2026-06-22T20:05:00+00:00", "event": "manual_override_cleared"},
+    ]
+    coordinator = MagicMock()
+    coordinator.data = None
+    coordinator._event_buffer.snapshot.return_value = events
+
+    hass = _make_hass(coordinator)
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    diag = result["diagnostics"]
+    assert diag is not None, "marker must not be a bare None"
+    assert diag["status"] == "unavailable"
+    assert "no completed update cycle" in diag["reason"]
+    assert diag["event_timeline"] == events
+
+
+@pytest.mark.asyncio
+async def test_coordinator_missing_emits_marker_without_timeline():
+    """No coordinator at all → status unavailable, reason mentions missing, no timeline."""
+    entry = _make_entry()
+    hass = _make_hass(None)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    diag = result["diagnostics"]
+    assert diag is not None
+    assert diag["status"] == "unavailable"
+    assert "coordinator missing" in diag["reason"]
+    assert "event_timeline" not in diag
+
+
+@pytest.mark.asyncio
+async def test_data_none_without_event_buffer_falls_back_to_reason_only():
+    """A coordinator stub lacking _event_buffer → marker without timeline, no raise."""
+    entry = _make_entry()
+    coordinator = MagicMock(spec=["data"])
+    coordinator.data = None
+
+    hass = _make_hass(coordinator)
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    diag = result["diagnostics"]
+    assert diag is not None
+    assert diag["status"] == "unavailable"
+    assert "no completed update cycle" in diag["reason"]
+    assert "event_timeline" not in diag
+
+
+@pytest.mark.asyncio
+async def test_data_present_returns_sanitized_passthrough_not_marker():
+    """coordinator.data.diagnostics present → sanitized pass-through, NOT the marker."""
+    entry = _make_entry()
+    coordinator = MagicMock()
+    coordinator.data.diagnostics = {"control_status": "sun_tracking", "position": 42}
+
+    hass = _make_hass(coordinator)
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    diag = result["diagnostics"]
+    assert diag["control_status"] == "sun_tracking"
+    assert diag["position"] == 42
+    assert "status" not in diag or diag.get("status") != "unavailable"

--- a/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
+++ b/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
@@ -73,6 +73,7 @@ def _make_coord_with_stale_default():
     coord.manager = manager
     coord._time_mgr = MagicMock()
     coord._time_mgr.is_active = True  # check_adaptive_time delegates here
+    coord._time_mgr.clock_window_open = True  # clock_window_open delegates here (#656)
     coord._check_sun_validity_transition = MagicMock(return_value=False)
     coord._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coord._last_state_change_entity = None
@@ -241,6 +242,7 @@ async def test_auto_control_on_outside_time_window_does_not_dispatch():
     """
     coord = _make_coord_with_stale_default()
     coord._time_mgr.is_active = False  # outside time window
+    coord._time_mgr.clock_window_open = False  # clock genuinely closed (#656)
     _wire_solar_refresh(coord)
 
     switch = _make_switch(coord)

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -29,10 +29,24 @@ UTC = dt.UTC
 # ---------------------------------------------------------------------------
 
 
-def _make_coordinator(*, check_adaptive_time: bool, automatic_control: bool = True):
-    """Build a minimal mock coordinator for testing _async_send_after_override_clear."""
+def _make_coordinator(
+    *,
+    check_adaptive_time: bool,
+    automatic_control: bool = True,
+    clock_window_open: bool | None = None,
+):
+    """Build a minimal mock coordinator for testing _async_send_after_override_clear.
+
+    ``clock_window_open`` defaults to mirror ``check_adaptive_time`` because every
+    scenario in this file models "outside the window" as a genuinely closed clock
+    (after end_time / before start_time). The gate-dark case (clock open, gate
+    dark) is exercised explicitly by passing ``clock_window_open=True`` (#656).
+    """
     coordinator = MagicMock()
     coordinator.check_adaptive_time = check_adaptive_time
+    coordinator.clock_window_open = (
+        check_adaptive_time if clock_window_open is None else clock_window_open
+    )
     coordinator.automatic_control = automatic_control
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
@@ -98,6 +112,39 @@ async def test_override_clear_sends_position_inside_time_window():
         "manual_override_cleared",
         context=coordinator._build_position_context.return_value,
     )
+
+
+@pytest.mark.asyncio
+async def test_override_clear_sends_when_gate_dark_but_clock_open():
+    """Override clear at night (gate dark, clock still open) must dispatch the night position.
+
+    Issue #656: with a degenerate clock (start/end = 00:00) the user's clock
+    window stays open all night; is_active is False purely because the daytime
+    gate reads dark. The pipeline computes the correct night/default position
+    (here 0), and clearing the override must send it — not leave the cover where
+    the user last parked it.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(
+        check_adaptive_time=False,  # gate dark → is_active False
+        clock_window_open=True,  # but the clock is still open
+        automatic_control=True,
+    )
+
+    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, state=0, options={}
+    )
+
+    coordinator._cmd_svc.apply_position.assert_called_once_with(
+        "cover.test_blind",
+        0,
+        "manual_override_cleared",
+        context=coordinator._build_position_context.return_value,
+    )
+    assert result == {"cover.test_blind"}
 
 
 @pytest.mark.asyncio
@@ -326,11 +373,22 @@ async def test_override_clear_outside_window_takes_precedence_over_auto_control(
 
 
 def _make_state_change_coordinator(
-    *, check_adaptive_time: bool, bypass_auto_control: bool = False
+    *,
+    check_adaptive_time: bool,
+    bypass_auto_control: bool = False,
+    clock_window_open: bool | None = None,
 ):
-    """Build a minimal mock coordinator for testing async_handle_state_change."""
+    """Build a minimal mock coordinator for testing async_handle_state_change.
+
+    ``clock_window_open`` defaults to mirror ``check_adaptive_time`` (genuinely
+    closed clock). Pass ``clock_window_open=True`` to model the gate-dark case
+    where the clock is open but the daytime gate reads dark (#656).
+    """
     coordinator = MagicMock()
     coordinator.check_adaptive_time = check_adaptive_time
+    coordinator.clock_window_open = (
+        check_adaptive_time if clock_window_open is None else clock_window_open
+    )
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
@@ -391,6 +449,31 @@ async def test_state_change_sends_inside_time_window():
         coordinator, state=50, options={}
     )
 
+    coordinator._cmd_svc.apply_position.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_state_change_dispatches_when_gate_dark_but_clock_open():
+    """A normal-update state change at night (gate dark, clock open) must dispatch.
+
+    Issue #656: the reporter's custom-position handler wins the pipeline but the
+    L1646 guard suppressed dispatch because is_active was False (gate dark). With
+    the clock window still open, the computed night/custom position must be sent.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_state_change_coordinator(
+        check_adaptive_time=False,  # gate dark → is_active False
+        clock_window_open=True,  # but the clock is still open
+    )
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=50, options={}
+    )
+
+    # The L1646 early-return must NOT be taken: a command is dispatched.
     coordinator._cmd_svc.apply_position.assert_called_once()
 
 

--- a/tests/test_reset_button_time_window.py
+++ b/tests/test_reset_button_time_window.py
@@ -16,14 +16,24 @@ from unittest.mock import AsyncMock, MagicMock
 # ---------------------------------------------------------------------------
 
 
-def _make_coordinator(*, check_adaptive_time=True, automatic_control=True):
-    """Minimal coordinator mock for testing _async_send_after_override_clear."""
+def _make_coordinator(
+    *, check_adaptive_time=True, automatic_control=True, clock_window_open=None
+):
+    """Minimal coordinator mock for testing _async_send_after_override_clear.
+
+    ``clock_window_open`` defaults to mirror ``check_adaptive_time`` (closed clock
+    when outside the window). Pass ``clock_window_open=True`` to model the
+    gate-dark case: clock still open, daytime gate reads dark (#656).
+    """
     from custom_components.adaptive_cover_pro.managers.cover_command import (
         PositionContext,
     )
 
     coordinator = MagicMock()
     coordinator.check_adaptive_time = check_adaptive_time
+    coordinator.clock_window_open = (
+        check_adaptive_time if clock_window_open is None else clock_window_open
+    )
     coordinator.automatic_control = automatic_control
     coordinator.entities = ["cover.test"]
     coordinator.logger = MagicMock()
@@ -60,13 +70,18 @@ def _make_button(coordinator, entities):
 
 
 @pytest.mark.asyncio
-async def test_send_after_override_clear_skips_when_outside_time_window():
-    """apply_position must not be called when check_adaptive_time is False."""
+async def test_send_after_override_clear_skips_when_clock_window_closed():
+    """apply_position must not be called when the user's start/end clock is closed.
+
+    Re-scoped from the old "outside time window" test (issue #656): the guard now
+    suppresses only when the *clock* window is genuinely closed — not merely when
+    the daytime gate reads dark. Model the closed-clock case explicitly.
+    """
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
 
-    coordinator = _make_coordinator(check_adaptive_time=False)
+    coordinator = _make_coordinator(check_adaptive_time=False, clock_window_open=False)
 
     result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
         coordinator, 75, {}
@@ -74,6 +89,35 @@ async def test_send_after_override_clear_skips_when_outside_time_window():
 
     coordinator._cmd_svc.apply_position.assert_not_called()
     assert result == set()
+
+
+@pytest.mark.asyncio
+async def test_send_after_override_clear_sends_when_gate_dark_but_clock_open():
+    """apply_position MUST be called with the night position when gate dark but clock open.
+
+    Issue #656 core fix: clearing a manual override at night (degenerate clock so
+    the clock window stays open; daytime gate reads dark so is_active is False)
+    must dispatch the pipeline's night position (0), returning the cover to its
+    computed default instead of leaving it where the user parked it.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coordinator = _make_coordinator(
+        check_adaptive_time=False,  # gate dark → is_active False
+        clock_window_open=True,  # clock still open
+        automatic_control=True,
+    )
+
+    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        coordinator, 0, {}
+    )
+
+    coordinator._cmd_svc.apply_position.assert_called_once()
+    sent_position = coordinator._cmd_svc.apply_position.call_args[0][1]
+    assert sent_position == 0
+    assert result == {"cover.test"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -244,6 +244,119 @@ def test_is_active_logs_error_when_start_after_end():
 
 
 # ---------------------------------------------------------------------------
+# clock_window_open: the gate-free clock predicate (issue #656)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_clock_window_open_true_when_gate_dark_but_clock_open():
+    """clock_window_open is True when the clock is open even if the gate reads dark.
+
+    Issue #656: is_active folds the daytime gate into the clock window, so a
+    gate-dark night reads is_active=False even when the user's start/end clock
+    is still open. clock_window_open must stay True in that case so suppression
+    sites that only care about the clock still dispatch the night position.
+    """
+    from unittest.mock import PropertyMock
+    from custom_components.adaptive_cover_pro.managers.time_window import (
+        TimeWindowManager,
+    )
+
+    mgr = _make_manager()
+
+    with (
+        patch.object(
+            TimeWindowManager,
+            "before_end_time",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch.object(
+            TimeWindowManager,
+            "after_start_time",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+        patch.object(
+            TimeWindowManager,
+            "gate_is_daytime",
+            new_callable=PropertyMock,
+            return_value=False,  # gate reads dark
+        ),
+    ):
+        assert mgr.clock_window_open is True
+        # is_active simultaneously False because the gate is dark
+        assert mgr.is_active is False
+
+
+@pytest.mark.unit
+def test_clock_window_open_false_when_clock_closed():
+    """clock_window_open is False when the user's start/end clock is genuinely closed."""
+    from unittest.mock import PropertyMock
+    from custom_components.adaptive_cover_pro.managers.time_window import (
+        TimeWindowManager,
+    )
+
+    mgr = _make_manager()
+
+    with (
+        patch.object(
+            TimeWindowManager,
+            "before_end_time",
+            new_callable=PropertyMock,
+            return_value=False,  # clock closed (after end time)
+        ),
+        patch.object(
+            TimeWindowManager,
+            "after_start_time",
+            new_callable=PropertyMock,
+            return_value=True,
+        ),
+    ):
+        assert mgr.clock_window_open is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("before_end", [True, False])
+@pytest.mark.parametrize("after_start", [True, False])
+@pytest.mark.parametrize("gate_daytime", [True, False])
+def test_is_active_is_clock_window_open_and_gate(before_end, after_start, gate_daytime):
+    """Lock the slice: is_active == (clock_window_open and gate_is_daytime).
+
+    is_active must remain exactly the clock predicate ANDed with the daytime
+    gate — clock_window_open is is_active with the gate factor removed.
+    """
+    from unittest.mock import PropertyMock
+    from custom_components.adaptive_cover_pro.managers.time_window import (
+        TimeWindowManager,
+    )
+
+    mgr = _make_manager()
+
+    with (
+        patch.object(
+            TimeWindowManager,
+            "before_end_time",
+            new_callable=PropertyMock,
+            return_value=before_end,
+        ),
+        patch.object(
+            TimeWindowManager,
+            "after_start_time",
+            new_callable=PropertyMock,
+            return_value=after_start,
+        ),
+        patch.object(
+            TimeWindowManager,
+            "gate_is_daytime",
+            new_callable=PropertyMock,
+            return_value=gate_daytime,
+        ),
+    ):
+        assert mgr.is_active == (mgr.clock_window_open and gate_daytime)
+
+
+# ---------------------------------------------------------------------------
 # check_transition
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
After a manual-override reset (or any non-safety handler win) while the daytime gate reads dark, the cover stayed put even though the pipeline picked the correct winner. Root cause: `check_adaptive_time` conflated "outside the user's start/end clock" with "the daytime gate reads dark". Added a `clock_window_open` predicate (is_active minus the gate factor) and switched both suppression sites to it, so suppression only fires when the clock window is genuinely closed; gate-dark now dispatches the computed night/default/custom position. The reporter's follow-up (custom position also not moving) is the same root cause and is fixed by the same change.

Also hardens config-entry diagnostics: emits an informative "unavailable" marker (with any buffered events) instead of a bare null when no completed update cycle has run, plus a `data_window` (start/end/captured_at) block so diagnostics can be correlated against the HA log.

## Testing
- ✅ 4702 tests passing (+22 new)

## Related Issues
Refs #656