### PR TITLE
fix: track daytime-gate sources for immediate reposition (#632)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_CALL_SERVICE, Platform
 from homeassistant.core import HomeAssistant
@@ -16,6 +18,8 @@ from homeassistant.helpers.template import Template
 
 from .const import (
     CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_DAYTIME_GATE_SENSORS,
+    CONF_DAYTIME_GATE_TEMPLATE,
     CONF_DEVICE_ID,
     CONF_ENABLE_MY_POSITION_ENTITIES,
     CONF_ENABLE_POSITION_MATCHING,
@@ -80,6 +84,37 @@ async def async_initialize_integration(
     return True
 
 
+def _register_template_tracker(
+    hass: HomeAssistant,
+    entry: AdaptiveConfigEntry,
+    template_str: str | None,
+    action: Callable,
+    description: str,
+) -> None:
+    """Track one rendered template result, wiring teardown to the entry.
+
+    Shared by the occupancy, custom-position, weather, and daytime-gate
+    templates (issues #577/#563/#639/#632): tracking the rendered result gives
+    a template-only override sensor-grade immediacy — the cover reacts the
+    instant the template flips, with no companion binary sensor and no polling.
+    Non-templates are skipped; render/parse failures are logged and skipped.
+    """
+    if not is_template_string(template_str):
+        return
+    try:
+        _track_info = async_track_template_result(
+            hass,
+            [TrackTemplate(Template(template_str, hass), None)],
+            action,
+        )
+    except (TemplateError, ValueError) as err:
+        _LOGGER.warning(
+            "%s failed to register (%r): %s", description, template_str, err
+        )
+    else:
+        entry.async_on_unload(_track_info.async_remove)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> bool:
     """Set up Adaptive Cover Pro from a config entry."""
 
@@ -120,6 +155,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     # than waiting for the next periodic refresh or another entity change.
     for _slot_keys in CUSTOM_POSITION_SLOTS.values():
         _entities.extend(custom_position_slot_sensors(entry.options, _slot_keys))
+
+    # Add daytime gate sensors (issue #632) so flipping the gate OFF (dark)
+    # triggers an immediate positioning cycle — same immediacy as lux/irradiance.
+    _entities.extend(entry.options.get(CONF_DAYTIME_GATE_SENSORS, []))
 
     _LOGGER.debug("Setting up entry %s", entry.data.get("name"))
 
@@ -163,44 +202,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     # the rendered result means the cover reacts the instant the template flips
     # truthy — same immediacy as a motion sensor, no polling. Re-registered on
     # every reload (options changes trigger a full reload).
-    _motion_template = entry.options.get(CONF_MOTION_TEMPLATE)
-    if is_template_string(_motion_template):
-        try:
-            _track_info = async_track_template_result(
-                hass,
-                [TrackTemplate(Template(_motion_template, hass), None)],
-                coordinator.async_check_motion_template_change,
-            )
-        except (TemplateError, ValueError) as err:
-            _LOGGER.warning(
-                "Motion occupancy template failed to register (%r): %s",
-                _motion_template,
-                err,
-            )
-        else:
-            entry.async_on_unload(_track_info.async_remove)
+    _register_template_tracker(
+        hass,
+        entry,
+        entry.options.get(CONF_MOTION_TEMPLATE),
+        coordinator.async_check_motion_template_change,
+        "Motion occupancy template",
+    )
 
     # Register each custom-position slot's optional condition template (issue
     # #563). Same pattern as the occupancy template above: tracking the
     # rendered result gives sensor-grade immediacy when a template flips.
     for _slot_keys in CUSTOM_POSITION_SLOTS.values():
-        _slot_template = entry.options.get(_slot_keys["template"])
-        if not is_template_string(_slot_template):
-            continue
-        try:
-            _track_info = async_track_template_result(
-                hass,
-                [TrackTemplate(Template(_slot_template, hass), None)],
-                coordinator.async_check_custom_position_template_change,
-            )
-        except (TemplateError, ValueError) as err:
-            _LOGGER.warning(
-                "Custom position template failed to register (%r): %s",
-                _slot_template,
-                err,
-            )
-        else:
-            entry.async_on_unload(_track_info.async_remove)
+        _register_template_tracker(
+            hass,
+            entry,
+            entry.options.get(_slot_keys["template"]),
+            coordinator.async_check_custom_position_template_change,
+            "Custom position template",
+        )
 
     # Register weather sensor listeners separately (need custom handler for clear-delay)
     _weather_sensor_ids: list[str] = []
@@ -233,22 +253,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
         entry.options.get(CONF_WEATHER_IS_RAINING_TEMPLATE),
         entry.options.get(CONF_WEATHER_IS_WINDY_TEMPLATE),
     ]:
-        if not is_template_string(_weather_template):
-            continue
-        try:
-            _track_info = async_track_template_result(
-                hass,
-                [TrackTemplate(Template(_weather_template, hass), None)],
-                coordinator.async_check_weather_template_change,
-            )
-        except (TemplateError, ValueError) as err:
-            _LOGGER.warning(
-                "Weather condition template failed to register (%r): %s",
-                _weather_template,
-                err,
-            )
-        else:
-            entry.async_on_unload(_track_info.async_remove)
+        _register_template_tracker(
+            hass,
+            entry,
+            _weather_template,
+            coordinator.async_check_weather_template_change,
+            "Weather condition template",
+        )
+
+    # Register the optional daytime-gate template (issue #632). Tracking the
+    # rendered result gives the gate the same sensor-grade immediacy as the
+    # occupancy and weather templates — the cover repositions the instant the
+    # template flips dark, with no polling.
+    _register_template_tracker(
+        hass,
+        entry,
+        entry.options.get(CONF_DAYTIME_GATE_TEMPLATE),
+        coordinator.async_check_daytime_gate_template_change,
+        "Daytime gate template",
+    )
 
     # Register cleanup for cover command service reconciliation timer
     entry.async_on_unload(coordinator._cmd_svc.stop)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -908,6 +908,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._custom_position_template_trigger = True
         await self.async_refresh()
 
+    async def async_check_daytime_gate_template_change(
+        self, event: Event | None, updates: list
+    ) -> None:
+        """Handle the daytime-gate template's rendered result changing (#632).
+
+        Routed from ``async_track_template_result`` so the cover repositions the
+        instant the gate template flips dark — the same immediacy as a gate binary
+        sensor or weather template, with no polling. The tracked result only
+        signals *that* the template changed; ``TimeWindowManager.gate_is_daytime``
+        re-reads live sensor/template state during the subsequent refresh so the
+        OR/AND combine mode is honoured.
+        """
+        self.state_change = True
+        await self.async_refresh()
+
     async def _handle_occupancy_change(self, *, source: str) -> None:
         """Apply an occupancy-source transition shared by sensors and the template.
 

--- a/tests/test_init_entity_tracking.py
+++ b/tests/test_init_entity_tracking.py
@@ -13,6 +13,8 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_DAYTIME_GATE_SENSORS,
+    CONF_DAYTIME_GATE_TEMPLATE,
     CONF_END_ENTITY,
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
@@ -178,4 +180,76 @@ async def test_end_entity_tracked(hass) -> None:
     assert "sensor.sun_next_setting" in all_tracked, (
         "CONF_END_ENTITY must be registered for state-change tracking so the "
         "coordinator refreshes immediately when sensor.sun_next_setting rolls over."
+    )
+
+
+async def test_daytime_gate_sensor_tracked(hass) -> None:
+    """Daytime gate sensor triggers immediate reposition when the gate flips dark (issue #632).
+
+    The gate short-circuits the astral sunset/sunrise boundary; when it flips OFF
+    (dark) the cover must move to sunset_position immediately rather than waiting
+    for the next sun.sun update (~1-2 min). Registering the sensor in the tracked
+    entity list gives it the same response time as lux, irradiance, and other
+    immediate-reaction sensors.
+    """
+    _, calls = await _setup_entry_capture_tracked(
+        hass,
+        extra_options={CONF_DAYTIME_GATE_SENSORS: ["binary_sensor.daytime_gate"]},
+        entry_id="track_gate_01",
+    )
+    all_tracked = [e for call in calls for e in call]
+    assert "binary_sensor.daytime_gate" in all_tracked, (
+        "CONF_DAYTIME_GATE_SENSORS must be registered for state-change tracking "
+        "so the cover reacts the instant the gate flips dark (issue #632)."
+    )
+
+
+async def test_unset_daytime_gate_not_tracked(hass) -> None:
+    """When no gate sensors are configured, no gate entity leaks into the tracked list."""
+    _, calls = await _setup_entry_capture_tracked(hass, entry_id="track_gate_none_01")
+    all_tracked = [e for call in calls for e in call]
+    assert (
+        "binary_sensor.daytime_gate" not in all_tracked
+    ), "Unconfigured gate sensors must not appear in the tracked entity list."
+
+
+async def test_daytime_gate_template_registered(hass) -> None:
+    """Daytime gate template is registered via async_track_template_result (issue #632).
+
+    When the gate is expressed as a Jinja template instead of (or in addition to)
+    a binary sensor, it must be tracked so the cover reacts the instant the
+    template changes — same immediacy as the occupancy and weather templates.
+    """
+    from unittest.mock import patch as mock_patch
+
+    gate_template = "{{ states('sensor.lux') | int > 100 }}"
+    opts = {**{}, CONF_DAYTIME_GATE_TEMPLATE: gate_template}
+
+    template_registered_calls: list[str] = []
+
+    from homeassistant.helpers import event as ha_event
+
+    original_template = ha_event.async_track_template_result
+
+    def _capture_template(hass_, track_templates, callback):
+        for tt in track_templates:
+            template_registered_calls.append(tt.template.template)
+        return original_template(hass_, track_templates, callback)
+
+    with (
+        mock_patch(
+            "custom_components.adaptive_cover_pro.async_track_template_result",
+            side_effect=_capture_template,
+        ),
+        _patch_coordinator_refresh(),
+    ):
+        _, _ = await _setup_entry_capture_tracked(
+            hass,
+            extra_options=opts,
+            entry_id="track_gate_tmpl_01",
+        )
+
+    assert gate_template in template_registered_calls, (
+        "CONF_DAYTIME_GATE_TEMPLATE must be registered via async_track_template_result "
+        "so the cover reacts the instant the template flips (issue #632)."
     )


### PR DESCRIPTION
## Summary
The daytime-gate feature (issue #632) computed the correct sunset position but never registered its gate sensors or template as state-change listeners, so a gate flip didn't trigger an immediate positioning cycle — the cover only repositioned on the next `sun.sun` update (up to ~2 min late). This tracks `CONF_DAYTIME_GATE_SENSORS` via the `_entities` list and registers `CONF_DAYTIME_GATE_TEMPLATE` for template tracking, giving the gate the same immediacy as lux/irradiance and the occupancy/weather templates. The four duplicated template-registration blocks (motion / custom-position / weather / gate) are unified into one `_register_template_tracker` helper.

This complements #658, which fixed the underlying suppression bug that kept the cover from closing at all when the gate read dark.

## Testing
- ✅ 4707 tests passing (+ new gate-tracking tests in `test_init_entity_tracking.py`)

## Related Issues
Refs #632

https://claude.ai/code/session_01BQaB28wmuvmmuAdGbCJP6G