### PR TITLE
feat: refresh coordinator on diagnostics download when data is empty

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/__init__.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/__init__.py
@@ -53,22 +53,33 @@ async def async_get_config_entry_diagnostics(
             "status": "unavailable",
             "reason": "coordinator missing — the integration is not set up for this entry",
         }
-    elif coordinator.data is not None:
-        coordinator_diagnostics = _sanitize(coordinator.data.diagnostics)
     else:
-        # Data present-but-None: diagnostics requested before the first completed
-        # update cycle. Surface an explicit marker (not a bare None) and include
-        # the event buffer so there is still a timeline to triage from.
-        marker = {
-            "status": "unavailable",
-            "reason": "no completed update cycle yet — coordinator.data is None",
-        }
-        event_buffer = getattr(coordinator, "_event_buffer", None)
-        if event_buffer is not None:
-            timeline = _sanitize(event_buffer.snapshot())
-            marker["event_timeline"] = timeline
-            marker["data_window"] = DiagnosticsBuilder._compute_data_window(timeline)
-        coordinator_diagnostics = marker
+        if coordinator.data is None:
+            # Diagnostics requested before the first completed update cycle (e.g.
+            # right after a restart/reload). Trigger one refresh so the download
+            # captures a full snapshot instead of an empty marker. Scoped to the
+            # data-is-None case, so a normal download (data already present) never
+            # triggers an extra update cycle or cover commands.
+            await coordinator.async_refresh()
+
+        if coordinator.data is not None:
+            coordinator_diagnostics = _sanitize(coordinator.data.diagnostics)
+        else:
+            # The refresh did not yield data (first cycle still failing). Surface
+            # an explicit marker (not a bare None) and include the event buffer so
+            # there is still a timeline to triage from.
+            marker = {
+                "status": "unavailable",
+                "reason": "no completed update cycle yet — coordinator.data is None",
+            }
+            event_buffer = getattr(coordinator, "_event_buffer", None)
+            if event_buffer is not None:
+                timeline = _sanitize(event_buffer.snapshot())
+                marker["event_timeline"] = timeline
+                marker["data_window"] = DiagnosticsBuilder._compute_data_window(
+                    timeline
+                )
+            coordinator_diagnostics = marker
 
     return {
         "title": "Adaptive Cover Pro Configuration",

--- a/tests/test_diagnostics/test_export_unavailable.py
+++ b/tests/test_diagnostics/test_export_unavailable.py
@@ -8,7 +8,7 @@ bare ``None`` that gives no diagnostic clue about why the snapshot is empty.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntry
@@ -39,7 +39,7 @@ def _make_hass(coordinator, entry_id: str = "entry-1") -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_data_none_emits_marker_with_event_timeline():
-    """coordinator.data is None → status unavailable + sanitized event buffer."""
+    """coordinator.data is None and refresh yields nothing → marker + event buffer."""
     entry = _make_entry()
     events = [
         {"ts": "2026-06-22T20:00:00+00:00", "event": "manual_override_armed"},
@@ -47,6 +47,7 @@ async def test_data_none_emits_marker_with_event_timeline():
     ]
     coordinator = MagicMock()
     coordinator.data = None
+    coordinator.async_refresh = AsyncMock()  # refresh runs but leaves data None
     coordinator._event_buffer.snapshot.return_value = events
 
     hass = _make_hass(coordinator)
@@ -78,8 +79,9 @@ async def test_coordinator_missing_emits_marker_without_timeline():
 async def test_data_none_without_event_buffer_falls_back_to_reason_only():
     """A coordinator stub lacking _event_buffer → marker without timeline, no raise."""
     entry = _make_entry()
-    coordinator = MagicMock(spec=["data"])
+    coordinator = MagicMock(spec=["data", "async_refresh"])
     coordinator.data = None
+    coordinator.async_refresh = AsyncMock()
 
     hass = _make_hass(coordinator)
     result = await async_get_config_entry_diagnostics(hass, entry)
@@ -105,3 +107,62 @@ async def test_data_present_returns_sanitized_passthrough_not_marker():
     assert diag["control_status"] == "sun_tracking"
     assert diag["position"] == 42
     assert "status" not in diag or diag.get("status") != "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_data_none_triggers_refresh_then_returns_full_diagnostics():
+    """Data is None → one refresh runs; if it populates data, export the full snapshot."""
+    entry = _make_entry()
+    coordinator = MagicMock()
+    coordinator.data = None
+
+    async def _refresh():
+        # A completed update cycle populates coordinator.data.
+        populated = MagicMock()
+        populated.diagnostics = {"control_status": "sun_tracking", "position": 42}
+        coordinator.data = populated
+
+    coordinator.async_refresh = AsyncMock(side_effect=_refresh)
+
+    hass = _make_hass(coordinator)
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator.async_refresh.assert_awaited_once()
+    diag = result["diagnostics"]
+    assert diag["control_status"] == "sun_tracking"
+    assert diag["position"] == 42
+    assert diag.get("status") != "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_data_present_does_not_trigger_refresh():
+    """Data already present → no refresh (no extra update cycle / cover commands)."""
+    entry = _make_entry()
+    coordinator = MagicMock()
+    coordinator.data.diagnostics = {"control_status": "sun_tracking"}
+    coordinator.async_refresh = AsyncMock()
+
+    hass = _make_hass(coordinator)
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator.async_refresh.assert_not_awaited()
+    assert result["diagnostics"]["control_status"] == "sun_tracking"
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_falls_back_to_marker():
+    """Data is None and refresh leaves it None → refresh attempted once, marker returned."""
+    entry = _make_entry()
+    events = [{"ts": "2026-06-22T20:00:00+00:00", "event": "manual_override_armed"}]
+    coordinator = MagicMock()
+    coordinator.data = None
+    coordinator.async_refresh = AsyncMock()  # refresh runs but data stays None
+    coordinator._event_buffer.snapshot.return_value = events
+
+    hass = _make_hass(coordinator)
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator.async_refresh.assert_awaited_once()
+    diag = result["diagnostics"]
+    assert diag["status"] == "unavailable"
+    assert diag["event_timeline"] == events


### PR DESCRIPTION
## Summary
When config-entry diagnostics are downloaded before the first completed update cycle (e.g. right after a restart/reload), `coordinator.data` is None and the export returns only an "unavailable" marker (the #656 behavior). This triggers one `coordinator.async_refresh()` in that case so the download captures a full snapshot instead.

Scoped to the `data is None` branch only: a normal download (data already present) never triggers an extra update cycle. If the refresh still yields no data, the existing marker + event buffer remains the fallback.

**Behavioral note:** `async_refresh()` runs the full update cycle, which can send cover commands. Because this only fires when `data is None` (no cycle has run yet), it just pulls the integration's imminent first refresh slightly earlier — low marginal risk, and only in the post-restart window.

## Testing
- ✅ 4710 tests passing (+3 new: refresh-then-full-diagnostics, no-refresh-when-data-present, refresh-failure-falls-back-to-marker)

## Related Issues
Follow-up to #656 (diagnostics export hardening).