### PR TITLE
fix: engage override on context-less remote move with no command target (#654)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/manual_override/detector.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/detector.py
@@ -36,6 +36,7 @@ class DetectionContext:
     new_state: Any  # HA State: .state / .attributes / .last_updated / .context
     old_state: Any | None
     new_position: int | None  # resolved via policy.read_axis_value
+    old_position: int | None  # prior primary-axis value (resolved from old_state)
     caps: Any  # CoverCapabilities
     policy: Any  # CoverTypePolicy
     manual_threshold: int | None

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -415,6 +415,12 @@ class AdaptiveCoverManager:
         new_position = policy.read_axis_value(
             self.hass, entity_id, caps, state_obj=new_state
         )
+        old_state_obj = getattr(event, "old_state", None)
+        old_position = (
+            policy.read_axis_value(self.hass, entity_id, caps, state_obj=old_state_obj)
+            if old_state_obj is not None
+            else None
+        )
 
         now = dt.datetime.now(dt.UTC)
         ctx_obj = getattr(new_state, "context", None)
@@ -424,8 +430,9 @@ class AdaptiveCoverManager:
             entity_id=entity_id,
             our_state=our_state,
             new_state=new_state,
-            old_state=getattr(event, "old_state", None),
+            old_state=old_state_obj,
             new_position=new_position,
+            old_position=old_position,
             caps=caps,
             policy=policy,
             manual_threshold=manual_threshold,

--- a/custom_components/adaptive_cover_pro/managers/manual_override/position_delta.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/position_delta.py
@@ -28,20 +28,56 @@ class PositionDeltaDetector(OverrideDetector):
         our_state = context.our_state
         new_position = context.new_position
 
+        # Floor the threshold at POSITION_TOLERANCE_PERCENT so motor rounding /
+        # position-reporting imprecision can't trip false positives even when
+        # the user leaves manual_threshold unset. Computed once and reused by
+        # both the no-target move check (#654) and the recorded-target delta
+        # comparison below. See ``effective_manual_threshold`` for the
+        # single-source-of-truth.
+        effective_threshold = effective_manual_threshold(context.manual_threshold)
+
         # Issue #546: no command was ever sent for this entity, so ``our_state``
         # is the pipeline's theoretical default rather than a commanded
         # position. Comparing the cover's real resting position against it is
         # meaningless and produced a false override when the cover sat at its
-        # sunset position while the pipeline default diverged. The legitimate
-        # user-move signals (HA-context fast-path, stop-to-My) never route
-        # through ``detect``, so suppressing here cannot mask a real user touch.
+        # sunset position while the pipeline default diverged.
+        #
+        # Issue #654: a context-less physical-remote move (no HA user_id) does
+        # route through ``detect``, so a blanket suppression here masks it. Tell
+        # the two apart by the prior position: a real move shows the position
+        # changing between old_state and new_state by more than the threshold;
+        # a resting-position republish (or unknown old position) shows no move.
+        # Only the latter is the meaningless default-vs-resting divergence.
         if not context.has_recorded_target:
+            old_position = context.old_position
+            is_real_move = (
+                old_position is not None
+                and new_position is not None
+                and abs(old_position - new_position) > effective_threshold
+            )
+            if not is_real_move:
+                return OverrideDecision(
+                    event_name="manual_override_rejected_no_command_target",
+                    event_kwargs={
+                        "our_state": our_state,
+                        "new_position": new_position,
+                        "reason": "no recorded command target (our_state is pipeline default)",
+                    },
+                )
+            # The move itself is the user touch. ``our_state`` is meaningless
+            # here, so record ``new_position`` (where the user left the cover)
+            # as the manual position.
             return OverrideDecision(
-                event_name="manual_override_rejected_no_command_target",
+                mark_manual=True,
+                event_name="manual_override_set",
                 event_kwargs={
-                    "our_state": our_state,
+                    "our_state": new_position,
                     "new_position": new_position,
-                    "reason": "no recorded command target (our_state is pipeline default)",
+                    "effective_threshold": effective_threshold,
+                    "reason": (
+                        f"context-less move {old_position}% -> {new_position}% "
+                        f">= threshold {effective_threshold}% (no recorded target)"
+                    ),
                 },
             )
 
@@ -102,11 +138,6 @@ class PositionDeltaDetector(OverrideDetector):
         if new_position == our_state:
             return OverrideDecision()
 
-        # Floor the threshold at POSITION_TOLERANCE_PERCENT so motor rounding
-        # / position-reporting imprecision can't trip false positives even
-        # when the user leaves manual_threshold unset. See
-        # ``effective_manual_threshold`` for the single-source-of-truth.
-        effective_threshold = effective_manual_threshold(context.manual_threshold)
         if abs(our_state - new_position) <= effective_threshold:
             return OverrideDecision(
                 event_name="manual_override_rejected_within_threshold",

--- a/tests/test_false_manual_override_on_automation.py
+++ b/tests/test_false_manual_override_on_automation.py
@@ -760,3 +760,67 @@ async def test_user_context_change_marks_override_even_without_recorded_target()
 
     coordinator.manager.handle_user_initiated_state_change.assert_called_once()
     coordinator.manager.handle_state_change.assert_not_called()
+
+
+# ===========================================================================
+# Issue #654: context-less remote move with no recorded target must engage
+# ===========================================================================
+
+
+def test_no_recorded_target_real_move_engages_override_end_to_end():
+    """No recorded target + a real position move → manual override engages (#654).
+
+    A physical-remote move arrives with no HA user_id (numeric path) and ACP has
+    never commanded the cover (target=None → has_recorded_target=False). The move
+    is real because the position changed from old_state (25%) to new_state (80%),
+    so the override must engage despite the missing command target.
+    """
+    manager = _make_manager()
+    entity_id = "cover.test"
+
+    state_data = _make_state_change_data(entity_id, position=80)
+    state_data.old_state.attributes = {"current_position": 25}
+
+    manager.handle_state_change(
+        state_data,
+        our_state=100,  # meaningless pipeline default (never commanded)
+        policy=get_policy("cover_blind"),
+        allow_reset=False,
+        is_waiting=lambda _eid: False,
+        manual_threshold=3,
+        has_recorded_target=False,
+    )
+
+    assert manager.is_cover_manual(entity_id), (
+        "A real context-less move (25% → 80%) with no recorded target must "
+        "engage manual override"
+    )
+
+
+def test_no_recorded_target_resting_republish_no_override_end_to_end():
+    """No recorded target + resting-position republish → no override (#546).
+
+    Same numeric path, but the cover republishes its resting position (old == new
+    == 25%). There is no move, only pipeline-default divergence, so the override
+    must stay suppressed.
+    """
+    manager = _make_manager()
+    entity_id = "cover.test"
+
+    state_data = _make_state_change_data(entity_id, position=25)
+    state_data.old_state.attributes = {"current_position": 25}
+
+    manager.handle_state_change(
+        state_data,
+        our_state=100,  # meaningless pipeline default (never commanded)
+        policy=get_policy("cover_blind"),
+        allow_reset=False,
+        is_waiting=lambda _eid: False,
+        manual_threshold=3,
+        has_recorded_target=False,
+    )
+
+    assert not manager.is_cover_manual(entity_id), (
+        "A resting-position republish (25% → 25%) with no recorded target must "
+        "NOT engage manual override"
+    )

--- a/tests/test_managers/test_override_detector.py
+++ b/tests/test_managers/test_override_detector.py
@@ -35,6 +35,7 @@ def _ctx(
     *,
     our_state: int = 50,
     new_position: int | None = 50,
+    old_position: int | None = None,
     manual_threshold: int | None = 5,
     is_in_transit: bool = False,
     primary_suppress: bool = False,
@@ -53,6 +54,7 @@ def _ctx(
         new_state=new_state,
         old_state=None,
         new_position=new_position,
+        old_position=old_position,
         caps=MagicMock(),
         policy=policy,
         manual_threshold=manual_threshold,
@@ -185,18 +187,76 @@ def test_position_delta_threshold_floored_at_tolerance():
     assert d.event_name == "manual_override_rejected_within_threshold"
 
 
-def test_position_delta_no_recorded_target_suppresses_override():
-    """No recorded command target → numeric delta is meaningless, no override.
+def test_position_delta_no_recorded_target_resting_position_still_suppressed():
+    """No recorded target + cover resting (old≈new) → still suppressed (#546).
 
     Issue #546: when ACP never sent a command, ``our_state`` is the pipeline's
-    theoretical default, not a commanded position. Comparing a real cover
-    position against it is meaningless and must NOT mark manual override.
+    theoretical default, not a commanded position. A cover simply republishing
+    its resting position (old == new) must NOT mark manual override, even though
+    that position differs wildly from the meaningless default.
     """
     d = PositionDeltaDetector().detect(
         _ctx(
             our_state=100,
+            old_position=25,
             new_position=25,
             manual_threshold=3,
+            has_recorded_target=False,
+        )
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_no_command_target"
+
+
+def test_position_delta_no_recorded_target_real_move_marks_override():
+    """No recorded target + a real move (old≠new) → marks override (#654).
+
+    A context-less physical-remote move shows the position changing between
+    old_state and new_state. Even without a recorded command target, that
+    change itself is the user touch and must engage the override, recording
+    new_position (where the user left it) as the manual position.
+    """
+    d = PositionDeltaDetector().detect(
+        _ctx(
+            our_state=100,
+            old_position=25,
+            new_position=80,
+            manual_threshold=3,
+            has_recorded_target=False,
+        )
+    )
+    assert d.mark_manual is True
+    assert d.event_name == "manual_override_set"
+    assert d.event_kwargs["new_position"] == 80
+
+
+def test_position_delta_no_recorded_target_old_position_none_suppressed():
+    """No recorded target + unknown old position → cannot prove a move, suppress."""
+    d = PositionDeltaDetector().detect(
+        _ctx(
+            our_state=100,
+            old_position=None,
+            new_position=80,
+            manual_threshold=3,
+            has_recorded_target=False,
+        )
+    )
+    assert d.mark_manual is False
+    assert d.event_name == "manual_override_rejected_no_command_target"
+
+
+def test_position_delta_no_recorded_target_subthreshold_move_suppressed():
+    """No recorded target + tiny move (2% < tolerance floor 3%) → suppressed.
+
+    A sub-tolerance drift between old and new is motor imprecision, not a user
+    touch, so it stays suppressed even with no recorded command target.
+    """
+    d = PositionDeltaDetector().detect(
+        _ctx(
+            our_state=100,
+            old_position=25,
+            new_position=27,
+            manual_threshold=0,
             has_recorded_target=False,
         )
     )


### PR DESCRIPTION
## Summary
A context-less physical-remote move on a cover ACP has never commanded was dropped without engaging manual override. The HA-context fast-path is skipped when `user_id` is None (a physical remote carries none), so the event reached the numeric detector — where the Issue #546 guard suppressed it because no command target was recorded. ACP would then reposition the cover on the next cycle.

This refines the #546 guard in `position_delta.detect()` so it suppresses only pipeline-default divergence (cover resting where it is; `our_state` is a never-commanded default), not a genuine move. It distinguishes the two via the now-carried `DetectionContext.old_position`: a real move shows `abs(old - new) > effective_threshold` and engages (recording `new_position`); a resting-position republish (old≈new, or prior position unknown) stays suppressed — so #546 does not regress.

## Testing
- ✅ 4722 tests passing (manual-override area: 590, baseline 585 + 5 new regression tests covering the real-move, resting-republish, unknown-prior-position, and sub-threshold cases at both detector and end-to-end levels)

## Related Issues
Refs #654