### PR TITLE
fix: resolve ACP-owned non-cover entity service targets (#665)

### DIFF
--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import ServiceCall, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -89,6 +90,9 @@ def _resolve_targets(
                         coord = all_coordinators[entry_id]
                         result.setdefault(coord, None)
 
+    # Fetch entity registry once for the ACP-owned non-cover entity fallback
+    ent_reg = er.async_get(hass)
+
     # Resolve entity_ids → coordinator + per-entity filter
     for eid in entity_ids:
         owned = False
@@ -106,6 +110,14 @@ def _resolve_targets(
                     elif existing is not None:
                         existing.add(eid)
                     # If existing is None (whole-coordinator), keep it
+        if not owned:
+            # Fallback: look up the entity registry to find any ACP-owned entity
+            # (e.g. diagnostic sensor, switch, button) by its config_entry_id.
+            reg_entry = ent_reg.async_get(eid)
+            if reg_entry and reg_entry.config_entry_id in all_coordinators:
+                coord = all_coordinators[reg_entry.config_entry_id]
+                result.setdefault(coord, None)
+                owned = True
         if not owned:
             _LOGGER.debug(
                 "integration_service: entity %s is not managed by any ACP instance — skipping",

--- a/tests/test_global_services.py
+++ b/tests/test_global_services.py
@@ -479,6 +479,80 @@ async def test_emergency_stop_no_target_hits_all_instances():
 
 
 # ---------------------------------------------------------------------------
+# _resolve_targets — ACP-owned non-cover entity (issue #665)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_diagnostic_sensor_maps_to_owning_coordinator():
+    """ACP-owned non-cover entity (e.g. decision_trace sensor) resolves to its coordinator.
+
+    The sensor is not in coord.entities (which only holds cover entity_ids), so the
+    primary loop can't find it.  The entity-registry fallback must map it via
+    config_entry_id → coordinator.
+    """
+    coord = _make_coordinator(["cover.kuche"])
+    hass = _make_hass({"entry_abc": coord})
+    call = _make_call(entity_id="sensor.ac_kuche_ost_decision_trace")
+
+    fake_entry = MagicMock()
+    fake_entry.config_entry_id = "entry_abc"
+
+    ent_reg_mock = MagicMock()
+    ent_reg_mock.async_get = MagicMock(return_value=fake_entry)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.er.async_get",
+        return_value=ent_reg_mock,
+    ):
+        result = _resolve_targets(hass, call)
+
+    assert coord in result, "owning coordinator not found via registry fallback"
+    assert result[coord] is None
+
+
+def test_resolve_truly_foreign_entity_still_skipped():
+    """A genuinely foreign entity (unknown config_entry_id) must still resolve to {}.
+
+    The registry fallback must not over-match: if the entity's config_entry_id
+    is not in all_coordinators (or the entity isn't in the registry at all),
+    the result must be empty.
+    """
+    coord = _make_coordinator(["cover.kuche"])
+    hass = _make_hass({"entry_abc": coord})
+    call = _make_call(entity_id="sensor.some_foreign_sensor")
+
+    # Case 1: registry returns None for this entity
+    ent_reg_mock = MagicMock()
+    ent_reg_mock.async_get = MagicMock(return_value=None)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.er.async_get",
+        return_value=ent_reg_mock,
+    ):
+        result = _resolve_targets(hass, call)
+
+    assert (
+        result == {}
+    ), "foreign entity (registry miss) must not resolve to any coordinator"
+
+    # Case 2: registry returns an entry but with a config_entry_id we don't own
+    fake_entry = MagicMock()
+    fake_entry.config_entry_id = "some_other_entry_id"
+    ent_reg_mock2 = MagicMock()
+    ent_reg_mock2.async_get = MagicMock(return_value=fake_entry)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.er.async_get",
+        return_value=ent_reg_mock2,
+    ):
+        result2 = _resolve_targets(hass, call)
+
+    assert (
+        result2 == {}
+    ), "entity with foreign config_entry_id must not resolve to any coordinator"
+
+
+# ---------------------------------------------------------------------------
 # async_unload_services
 # ---------------------------------------------------------------------------
 

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -1643,3 +1643,63 @@ class TestSunsetSunriseTimeEntity:
         mock_update.assert_called_once()
         new_opts = mock_update.call_args[1]["options"]
         assert new_opts.get("sunrise_time_entity") == "sensor.custom_sunrise"
+
+
+# ---------------------------------------------------------------------------
+# Issue #665 — diagnostic sensor target resolution (e2e)
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticSensorTargetResolution:
+    """E2E: service call targeted at the decision-trace sensor must persist options.
+
+    Before the fix, targeting sensor.*_decision_trace silently no-ops because
+    the entity is not in coord.entities (which holds only cover entity_ids).
+    After the fix, _resolve_targets falls back to the entity registry and maps
+    the sensor's config_entry_id → coordinator so the options are written.
+    """
+
+    async def test_set_sunset_sunrise_via_diagnostic_sensor_target(
+        self, hass: HomeAssistant
+    ):
+        """set_sunset_sunrise targeted at the decision-trace sensor writes options."""
+        entry = await _setup(hass, entry_id="diag_ss_01")
+
+        # The decision-trace sensor entity_id for this integration instance.
+        diag_sensor = "sensor.options_cover_decision_trace"
+
+        # Simulate the entity registry knowing this sensor belongs to our entry.
+        fake_reg_entry = MagicMock()
+        fake_reg_entry.config_entry_id = entry.entry_id
+
+        ent_reg_mock = MagicMock()
+        ent_reg_mock.async_get = MagicMock(return_value=fake_reg_entry)
+
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+            patch(
+                "custom_components.adaptive_cover_pro.services.er.async_get",
+                return_value=ent_reg_mock,
+            ),
+        ):
+            hass.states.async_set(diag_sensor, "on", {})
+            await hass.services.async_call(
+                DOMAIN,
+                "set_sunset_sunrise",
+                {CONF_SUNSET_POS: 0, CONF_SUNSET_OFFSET: 120},
+                blocking=True,
+                target={"entity_id": [diag_sensor]},
+            )
+            await hass.async_block_till_done()
+
+        mock_update.assert_called_once(), (
+            "async_update_entry must be called — service must not silently no-op"
+        )
+        new_opts = mock_update.call_args[1]["options"]
+        assert (
+            new_opts[CONF_SUNSET_POS] == 0
+        ), f"sunset_position must be 0, got {new_opts.get(CONF_SUNSET_POS)!r}"
+        assert (
+            new_opts[CONF_SUNSET_OFFSET] == 120
+        ), f"sunset_offset must be 120, got {new_opts.get(CONF_SUNSET_OFFSET)!r}"


### PR DESCRIPTION
## Summary
`set_position_limits` and `set_sunset_sunrise` silently no-opped (returned success but persisted nothing) when targeted at an ACP-owned non-cover entity such as the `sensor.*_decision_trace` diagnostic sensor. `_resolve_targets` only matched `entity_id` targets against each coordinator's cover-entity list, so the diagnostic sensor resolved to zero targets and the section handler looped over nothing.

This adds an entity-registry fallback: when an `entity_id` target isn't a known cover, look it up in the entity registry and map its `config_entry_id` to the owning coordinator (whole-coordinator, mirroring the `device_id` path). Genuinely foreign entities still resolve to nothing and log the existing skip warning.

## Testing
- ✅ 152 tests passing (149 baseline + 3 new)

## Related Issues
Refs #665

https://claude.ai/code/session_01Q9FJKJ7rgpB7tkWFxzq9NA