### PR TITLE
feat: show active tilt-only custom slot in Control Status string

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -211,15 +211,21 @@ class DiagnosticsBuilder:
     @staticmethod
     def _get_control_state_reason(ctx: DiagnosticContext) -> str:
         """Get the current control state reason from pipeline result or cover geometry."""
-        if ctx.pipeline_result is not None:
-            method = ctx.pipeline_result.control_method
-            if method == ControlMethod.MOTION:
-                return "Motion Timeout"
-            if method == ControlMethod.MANUAL:
-                return "Manual Override"
-        if ctx.cover:
-            return ctx.cover.control_state_reason
-        return "Unknown"
+        result = ctx.pipeline_result
+        if result is not None and result.control_method == ControlMethod.MOTION:
+            reason = "Motion Timeout"
+        elif result is not None and result.control_method == ControlMethod.MANUAL:
+            reason = "Manual Override"
+        elif ctx.cover:
+            reason = ctx.cover.control_state_reason
+        else:
+            reason = "Unknown"
+
+        # An applied tilt-only custom slot is otherwise invisible on the tracker
+        # entity because the position winner owns the status (#667).
+        if result is not None and result.tilt_only_slot is not None:
+            reason = f"{reason} — tilt fixed by Custom #{result.tilt_only_slot}"
+        return reason
 
     @staticmethod
     def _build_position_explanation(ctx: DiagnosticContext) -> str:
@@ -257,6 +263,13 @@ class DiagnosticsBuilder:
             parts.append(
                 f"manual override active — holding cover at {result.held_position}%"
                 f" (solar would be {result.raw_calculated_position}%)"
+            )
+
+        # Surface an applied tilt-only custom slot alongside the position winner
+        # so it is visible in the Control Status string (#667).
+        if result.tilt_only_slot is not None:
+            parts.append(
+                f"tilt fixed at {result.tilt}% by Custom #{result.tilt_only_slot}"
             )
 
         # Append post-processing transforms if they changed the value

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -202,6 +202,10 @@ class PipelineRegistry:
         tilt_contribution = resolve_tilt_axis(snapshot)
         tilt_overlay: int | None = None
         tilt_only_active = False
+        # Slot number of the tilt-only contribution that was actually applied —
+        # surfaced in the Control Status string (#667). Stays None when the
+        # contribution is deferred (winner already set tilt).
+        tilt_only_slot_applied: int | None = None
         if tilt_contribution is not None:
             tilt_only_active = True
             # Replace any trace step for the contributing slot — it came from the
@@ -210,6 +214,7 @@ class PipelineRegistry:
             trace = _drop_trace_steps(trace, {tilt_contribution.source})
             if winner.tilt is None:
                 tilt_overlay = tilt_contribution.tilt
+                tilt_only_slot_applied = tilt_contribution.slot
                 trace.append(
                     DecisionStep(
                         handler=tilt_contribution.source,
@@ -261,6 +266,7 @@ class PipelineRegistry:
             default_position=snapshot.default_position,
             is_sunset_active=snapshot.is_sunset_active,
             tilt_only_contribution_active=tilt_only_active,
+            tilt_only_slot=tilt_only_slot_applied,
             **merged,
         )
         if self._event_buffer is not None:

--- a/custom_components/adaptive_cover_pro/pipeline/tilt_axis.py
+++ b/custom_components/adaptive_cover_pro/pipeline/tilt_axis.py
@@ -35,12 +35,15 @@ class TiltAxisContribution:
         label:  Human-readable name used in the trace reason — the bound
                 sensor's friendly name, or its entity_id when unnamed.
         tilt:   The slat angle (0–100) to overlay onto the position winner.
+        slot:   1-based slot number of the contributing custom-position slot,
+                surfaced in the Control Status string when applied (#667).
 
     """
 
     source: str
     label: str
     tilt: int
+    slot: int
 
 
 def gather_tilt_only_contributions(
@@ -64,6 +67,7 @@ def gather_tilt_only_contributions(
                     source=custom_position_handler_name(state.slot),
                     label=label,
                     tilt=state.tilt,
+                    slot=state.slot,
                 )
             )
     return contributions
@@ -92,4 +96,5 @@ def resolve_tilt_axis(snapshot: PipelineSnapshot) -> TiltAxisContribution | None
         source=custom_position_handler_name(winner_state.slot),
         label=label,
         tilt=winner_state.tilt,
+        slot=winner_state.slot,
     )

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -313,6 +313,13 @@ class PipelineResult:
     # inside cover_types/.
     tilt_only_contribution_active: bool = False
 
+    # 1-based slot number of the tilt-only contribution that was *applied*
+    # (overlaid its slat angle onto the position winner). Set by the registry
+    # only when the overlay actually took effect (winner's own tilt was None);
+    # None when no tilt-only slot fired or when it was deferred because the
+    # winner already set tilt. Surfaced in the Control Status string (#667).
+    tilt_only_slot: int | None = None
+
     # When True, the coordinator should route this command through
     # CoverCommandService.send_my_position() on non-position-capable covers
     # (cover.stop_cover while stationary → triggers the Somfy "My" hardware preset).

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -74,6 +74,8 @@ def _make_pr(
     configured_cloudy_pos: int | None = None,
     bypass_auto_control: bool = False,
     is_safety: bool = False,
+    tilt: int | None = None,
+    tilt_only_slot: int | None = None,
 ) -> PipelineResult:
     """Build a PipelineResult with sensible defaults."""
     return PipelineResult(
@@ -91,6 +93,8 @@ def _make_pr(
         configured_cloudy_pos=configured_cloudy_pos,
         bypass_auto_control=bypass_auto_control,
         is_safety=is_safety,
+        tilt=tilt,
+        tilt_only_slot=tilt_only_slot,
     )
 
 
@@ -1380,3 +1384,45 @@ class TestForecast:
         assert "solar-tracking-only" in description
         assert "does not model" in description
         assert "decision_trace" in description
+
+
+# ---------------------------------------------------------------------------
+# Issue #667: surface an active tilt-only custom slot in the Control Status
+# tracker entity (position_explanation + control_state_reason).
+# ---------------------------------------------------------------------------
+
+
+class TestTiltOnlyCustomSlotSurfacing:
+    """An applied tilt-only custom slot is visible on the Control Status tracker."""
+
+    def test_position_explanation_appends_tilt_only_slot(
+        self, builder: DiagnosticsBuilder
+    ):
+        """position_explanation mentions the tilt-only slot alongside the winner."""
+        pr = _make_pr(
+            reason="solar position 45%",
+            tilt=30,
+            tilt_only_slot=1,
+        )
+        diag, explanation = builder.build(_base_ctx(pipeline_result=pr))
+        assert "solar position 45%" in explanation
+        assert "tilt fixed at 30% by Custom #1" in explanation
+        assert explanation == diag["position_explanation"]
+
+    def test_control_state_reason_appends_tilt_only_slot(
+        self, builder: DiagnosticsBuilder
+    ):
+        """control_state_reason gains a tilt-only suffix for the tracker entity."""
+        pr = _make_pr(reason="solar position 45%", tilt=30, tilt_only_slot=2)
+        diag, _ = builder.build(_base_ctx(pipeline_result=pr))
+        assert diag["control_state_reason"] == "Sun in FOV — tilt fixed by Custom #2"
+
+    def test_no_tilt_only_slot_leaves_strings_unchanged(
+        self, builder: DiagnosticsBuilder
+    ):
+        """With no applied tilt-only slot, neither string mentions a tilt fix."""
+        pr = _make_pr(reason="solar position 45%", tilt=None, tilt_only_slot=None)
+        diag, explanation = builder.build(_base_ctx(pipeline_result=pr))
+        assert "tilt fixed" not in explanation
+        assert "tilt fixed" not in diag["control_state_reason"]
+        assert diag["control_state_reason"] == "Sun in FOV"

--- a/tests/test_pipeline/test_tilt_only_contribution.py
+++ b/tests/test_pipeline/test_tilt_only_contribution.py
@@ -229,6 +229,7 @@ class TestResolveTiltAxis:
         assert info.tilt == 42
         assert info.source == "custom_position_2"
         assert info.label == "Glare slot"
+        assert info.slot == 2
 
     def test_highest_priority_wins(self) -> None:
         from custom_components.adaptive_cover_pro.pipeline.tilt_axis import (
@@ -326,6 +327,8 @@ class TestRegistryOverlaysTilt:
         assert result.position == 60
         assert result.tilt == 25
         assert result.tilt_only_contribution_active is True
+        # The applied tilt-only slot identity is recorded for diagnostics (#667).
+        assert result.tilt_only_slot == 1
 
     def test_trace_has_matched_tilt_step_no_stale_skip(self) -> None:
         cover = _solar_cover(calculate_percentage_return=60.0)
@@ -417,6 +420,8 @@ class TestFillWhenUnset:
         ]
         assert len(deferred) == 1
         assert deferred[0].matched is False
+        # Deferred (not applied) → no slot recorded for the Control Status surface (#667).
+        assert result.tilt_only_slot is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A *tilt-only* custom-position slot fixes the slat angle but defers the position axis, so the position winner (e.g. solar) owned the Control Status display and the active tilt slot was invisible — users assumed it wasn't firing. This carries the applied tilt-only slot's identity through the registry tilt-axis overlay onto `PipelineResult.tilt_only_slot`, then surfaces it in the position explanation and the Control Status sensor's `reason` attribute as "— tilt fixed by Custom #N", alongside the position winner. Recorded only when the overlay actually applied (winner tilt was None), not when deferred.

## Testing
- ✅ 4728 tests passing

## Related Issues
Refs #667