### PR TITLE
fix: bypass tilt min-delta gate for special tilt positions (#629)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -37,6 +37,8 @@ from ...const import (
     ATTR_TILT_POSITION,
     DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
     DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
+    POSITION_CLOSED,
+    POSITION_OPEN,
     VENETIAN_BACKROTATE_MAX_DELTA_PERCENT,
     VENETIAN_DRIFT_RETRY_DELAY_SECONDS,
     VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES,
@@ -74,6 +76,12 @@ _REBASE_SKIP_SETTLE_FAILED = "settle_failed"
 # previously-stored target (fallback when the actuator can't be read).
 _ANCHOR_SOURCE_ACTUAL = "actual"
 _ANCHOR_SOURCE_TARGET_FALLBACK = "target_fallback"
+
+# Special tilt positions that always bypass the min-delta gate (issue #629).
+# A tilt command to fully-open (100) or fully-closed (0) is explicit user
+# intent and must never be silently swallowed by drift suppression. This
+# mirrors the position-axis behaviour in ``managers/cover_command/routing.py``.
+_TILT_SPECIAL_POSITIONS: list[int] = [POSITION_CLOSED, POSITION_OPEN]
 
 
 class DualAxisSequencer:
@@ -390,7 +398,7 @@ class DualAxisSequencer:
                 entity_id,
                 tilt_target,
                 self._get_min_change(),
-                None,
+                _TILT_SPECIAL_POSITIONS,
                 position=anchor,
                 logger=self._logger,
                 axis_label="tilt",

--- a/custom_components/adaptive_cover_pro/managers/cover_command/gates.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/gates.py
@@ -38,8 +38,9 @@ def check_position_delta(
     Same-position short-circuit is handled upstream in apply_position and
     applies to all callers including force=True (issue #290).
 
-    ``special_positions`` may be ``None`` (treated as empty — no bypass for
-    special values). Used by the tilt axis, which has no special positions.
+    ``special_positions`` may be ``None`` (treated as empty, so no bypass for
+    special values). Both the position axis and the tilt axis pass the special
+    set [0, 100] so fully-open/closed targets are never gated (issue #629).
     ``axis_label`` appears in debug log lines for readability.
     """
     _special = special_positions or []

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -1883,6 +1883,122 @@ class TestTiltDeltaGate:
         assert hass.services.async_call.call_count == 1
 
 
+@pytest.mark.asyncio
+class TestTiltSpecialPositionBypass:
+    """Tilt commands to 0 or 100 must bypass the min-delta gate (issue #629).
+
+    The position axis already bypasses the delta gate for special positions
+    (0, 100) via ``routing.build_special_positions``. The tilt axis must do the
+    same — a custom-position tilt-only command to 100 (slats fully open) or 0
+    (slats fully closed) is explicit user intent and must never be silently
+    swallowed by the min-delta drift-suppression gate.
+    """
+
+    async def test_tilt_to_100_bypasses_delta_gate_when_near_100(self):
+        """Tilt→100 fires even when the actuator is within min_change of 100.
+
+        Scenario from issue #629: venetian_mode=tilt_only, slot 1 tilt=100,
+        delta_position=12. Actuator at 95 (delta 5 < 12). Without the
+        special-position bypass the gate suppresses the command; with it the
+        service call must fire.
+
+        The actuator reads 95 for the verify step too, so verify sees drift
+        (|95-100|=5 > VENETIAN_TILT_VERIFY_TOLERANCE=5? actually 5 == 5 so
+        within tolerance → target kept). We use tilt_position=97 as the
+        actuator reading to ensure verify sees 3 delta (in-tolerance at 5).
+        """
+        buf = EventBuffer(maxlen=20)
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 12,
+            get_current_tilt_position=lambda _eid: 97,  # delta=3 from 100, in-tolerance
+            event_buffer=buf,
+        )
+        # Prior target ≠ 100 so the dedup short-circuit does not fire.
+        seq._tilt_targets["cover.x"] = 80
+
+        await seq.update_tilt_only(
+            "cover.x", tilt_target=100, current_position=0, reason="custom_position_1"
+        )
+
+        assert hass.services.async_call.call_count == 1, (
+            "set_cover_tilt_position was not called — tilt→100 was suppressed by "
+            "the min-delta gate instead of bypassing it as a special position"
+        )
+        call_args = hass.services.async_call.call_args.args
+        assert call_args[1] == "set_cover_tilt_position"
+        assert call_args[2]["tilt_position"] == 100
+        # No delta_too_small skip event must have been recorded.
+        skipped_delta = [
+            e
+            for e in buf.snapshot()
+            if e["event"] == "tilt_command_skipped"
+            and e.get("reason") == "delta_too_small"
+        ]
+        assert skipped_delta == [], f"Unexpected delta_too_small skip: {skipped_delta}"
+
+    async def test_tilt_to_0_bypasses_delta_gate_when_near_0(self):
+        """Tilt→0 (slats fully closed) fires even when actuator is within min_change of 0.
+
+        Actuator at 5 (delta 5 < 12). The gate must bypass for the special
+        position 0 the same way it does for 100.
+        """
+        buf = EventBuffer(maxlen=20)
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 12,
+            get_current_tilt_position=lambda _eid: 3,  # delta=3 from 0, in-tolerance
+            event_buffer=buf,
+        )
+        seq._tilt_targets["cover.x"] = 50
+
+        await seq.update_tilt_only(
+            "cover.x", tilt_target=0, current_position=0, reason="custom_position_1"
+        )
+
+        assert hass.services.async_call.call_count == 1, (
+            "set_cover_tilt_position was not called — tilt→0 was suppressed by "
+            "the min-delta gate instead of bypassing it as a special position"
+        )
+        skipped_delta = [
+            e
+            for e in buf.snapshot()
+            if e["event"] == "tilt_command_skipped"
+            and e.get("reason") == "delta_too_small"
+        ]
+        assert (
+            skipped_delta == []
+        ), f"Unexpected delta_too_small skip for tilt→0: {skipped_delta}"
+
+    async def test_non_special_small_tilt_move_still_gated(self):
+        """A small move to a non-special tilt value (55→60) is still suppressed.
+
+        This regression guard preserves the drift-suppression behavior the gate
+        was built for: sun-tracking micro-moves that don't cross a special value
+        must not bypass the gate.
+        """
+        buf = EventBuffer(maxlen=20)
+        hass, seq = _build_sequencer(
+            get_min_change=lambda: 12,
+            get_current_tilt_position=lambda _eid: 55,
+            event_buffer=buf,
+        )
+        seq._tilt_targets["cover.x"] = 50
+
+        await seq._send_tilt_command(
+            "cover.x", tilt_target=60, position_target=40, reason="solar"
+        )
+
+        assert (
+            hass.services.async_call.call_count == 0
+        ), "Non-special tilt move (55→60, delta=5 < min_change=12) must remain gated"
+        skipped_delta = [
+            e
+            for e in buf.snapshot()
+            if e["event"] == "tilt_command_skipped"
+            and e.get("reason") == "delta_too_small"
+        ]
+        assert len(skipped_delta) == 1
+
+
 class TestResolveTiltAnchor:
     """``_resolve_tilt_anchor`` returns the right (value, source) for each branch.
 


### PR DESCRIPTION
## Summary
On dual-axis venetian blinds, a custom-position tilt-only command to a special tilt value (fully-open 100 or fully-closed 0) could be silently dropped. The tilt axis ran the same min-delta gate as the position axis but never passed the special-position bypass, so a tilt to 100 within `delta_position` of the current slat angle was swallowed as `delta_too_small` and no service call fired (issue #629, "nothing visual happens").

The fix makes the tilt axis pass the special set `[0, 100]` (named constant `_TILT_SPECIAL_POSITIONS`) to the shared `check_position_delta`, so tilt moves to fully-open/closed bypass the delta gate the same way position moves already do. No new option, no behaviour change for non-special tilt targets (small sun-tracking moves stay gated).

## Testing
- ✅ 650 tests passing in the venetian/tilt/sequencer/cover_command/post_pipeline slice, including 3 new regression tests (tilt→100 and tilt→0 bypass; non-special small move still gated)

## Related Issues
Refs #629