### PR TITLE
feat: allow glare without sun tracking

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -466,6 +466,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+# Option keys that a live coordinator can apply without a full reload, mapped
+# to the coordinator coroutine that applies them. When *every* changed option
+# key is in this map the listener applies them in place (rebuilds the pipeline,
+# no reload); any other changed key forces a full reload so all listeners and
+# pipeline handlers pick up the new values. This is the single rebuild path —
+# the option-backed switches only persist the value and rely on the listener.
+_RUNTIME_APPLICABLE_OPTIONS: dict[str, str] = {
+    CONF_ENABLE_SUN_TRACKING: "async_apply_sun_tracking_update",
+}
+
+
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     coordinator = entry.runtime_data
@@ -481,8 +492,11 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
         if not changed_keys:
             return
-        if changed_keys == {CONF_ENABLE_SUN_TRACKING}:
-            await coordinator.async_apply_sun_tracking_update()
+        if changed_keys.issubset(_RUNTIME_APPLICABLE_OPTIONS):
+            for apply_name in {
+                _RUNTIME_APPLICABLE_OPTIONS[key] for key in changed_keys
+            }:
+                await getattr(coordinator, apply_name)()
             return
 
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_ENABLE_MY_POSITION_ENTITIES,
     CONF_ENABLE_POSITION_MATCHING,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_END_ENTITY,
     CONF_ENTITIES,
     CONF_START_ENTITY,
@@ -467,4 +468,21 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
+    coordinator = entry.runtime_data
+    previous_options = coordinator._cached_options
+    if previous_options is not None:
+        current_options = dict(entry.options)
+        previous_options = dict(previous_options)
+        changed_keys = {
+            key
+            for key in current_options.keys() | previous_options.keys()
+            if current_options.get(key) != previous_options.get(key)
+        }
+
+        if not changed_keys:
+            return
+        if changed_keys == {CONF_ENABLE_SUN_TRACKING}:
+            await coordinator.async_apply_sun_tracking_update()
+            return
+
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -319,7 +319,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._pipeline = self._build_pipeline()
         self._pipeline_result = None
 
-        self._cached_options = None
+        # Snapshot of the last raw config-entry options. The update listener
+        # uses it to distinguish Sun Tracking-only changes from options that
+        # still require a full reload.
+        self._cached_options = dict(self.config_entry.options)
 
         # Initialize configuration service
         self._config_service = ConfigurationService(
@@ -1235,7 +1238,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Run the main coordinator update cycle: calculate position, send commands, build diagnostics."""
         self.logger.debug("Updating data")
         if self.first_refresh:
-            self._cached_options = self.config_entry.options
+            self._cached_options = dict(self.config_entry.options)
 
         # Render any templated threshold options to numbers for this cycle, so
         # every downstream consumer (RuntimeConfig, climate reads) sees a number,
@@ -1915,15 +1918,28 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._is_reload = False
         self.logger.debug("First refresh handled")
 
+    async def async_apply_sun_tracking_update(self) -> None:
+        """Rebuild the pipeline after Sun Tracking changes without a reload.
+
+        ``enable_sun_tracking`` changes only pipeline composition; they do not
+        alter entity listeners or cover geometry. The refresh evaluates the new
+        winner immediately while the command path keeps its normal gates.
+        """
+        self._pipeline = self._build_pipeline()
+        self._cached_options = dict(self.config_entry.options)
+        # The Sun Tracking switch renders from config_entry.options; notify
+        # listeners so service/options-flow changes redraw the entity too.
+        self.async_update_listeners()
+        self.state_change = True
+        await self.async_refresh()
+
     def _build_pipeline(self) -> PipelineRegistry:
         """Build the override pipeline from the registry of handler factories.
 
-        Called once at coordinator initialisation.  Because the integration
-        reloads fully on every options change (see ``_async_update_listener``
-        in ``__init__.py``), this always sees the current configuration and
-        there is no need to rebuild at runtime. Handler composition lives in
-        ``pipeline.handlers.build_handlers`` (registry-driven), so adding a
-        handler never touches the coordinator.
+        Called at coordinator initialisation and when Sun Tracking is toggled at
+        runtime. Other options changes still reload the integration.
+        Handler composition lives in ``pipeline.handlers.build_handlers``
+        (registry-driven), so adding a handler never touches the coordinator.
         """
         handlers = build_handlers(self.config_entry.options)
         self.logger.debug(

--- a/custom_components/adaptive_cover_pro/icons.json
+++ b/custom_components/adaptive_cover_pro/icons.json
@@ -53,6 +53,12 @@
           "off": "mdi:window-shutter"
         }
       },
+      "sun_tracking": {
+        "default": "mdi:weather-sunny",
+        "state": {
+          "off": "mdi:weather-sunny-off"
+        }
+      },
       "manual_toggle": {
         "default": "mdi:hand-back-left",
         "state": {

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
@@ -113,7 +113,14 @@ class GlareZoneHandler(OverrideHandler):
             round(cover.calculate_percentage(effective_distance_override=min_distance))
         )
         state = solar_floor(state, floor_active=snapshot.solar_floor_active)
-        position = apply_snapshot_limits(snapshot, state, sun_valid=True)
+        # ``sun_valid`` follows the live tracking state: the sun-only limits
+        # (``*_sun_only`` and ``min_pos_sun_tracking``) apply only while Sun
+        # Tracking is enabled — matching ``compute_default_position`` /
+        # ``compute_raw_calculated_position``. With tracking off, the glare
+        # position and the Default it is weighed against share the same regime.
+        position = apply_snapshot_limits(
+            snapshot, state, sun_valid=snapshot.enable_sun_tracking
+        )
         if not snapshot.enable_sun_tracking:
             default_position = compute_default_position(snapshot)
             if (

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
@@ -19,6 +19,7 @@ from ...const import ControlMethod
 from ..handler import OverrideHandler
 from ..helpers import (
     apply_snapshot_limits,
+    compute_default_position,
     compute_raw_calculated_position,
     solar_floor,
 )
@@ -28,13 +29,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class GlareZoneHandler(OverrideHandler):
-    """Lower the blind further when active glare zones need more protection than SolarHandler.
+    """Lower the blind when active glare zones need more protection.
 
     Priority 45 — below ClimateHandler (50), above SolarHandler (40).
     Only applies to vertical covers (cover_blind). Computes effective distances
     for all active glare zones using pure geometry, then returns a position
-    based on the minimum (closest) zone distance when it is less than the
-    cover's base distance.
+    based on the minimum (closest) zone distance when it is more protective
+    than the lower-priority fallback.
 
     ClimateHandler defers its GLARE_CONTROL case (returns None), so this
     handler fires naturally when climate mode is on and the sun is tracking.
@@ -42,11 +43,13 @@ class GlareZoneHandler(OverrideHandler):
     and cover-type gates.
 
     Geometry: smaller effective distance → lower position% → more blind deployed.
-    A zone closer to the window than the base distance is in the illuminated area
-    and needs the blind lowered further than SolarHandler would compute.
+    With Sun Tracking enabled, a zone closer to the window than the base distance
+    needs the blind lowered further than SolarHandler would compute. With Sun
+    Tracking disabled, the computed glare-zone position is compared to Default.
 
     Falls through to SolarHandler (returns None) when all zones are at or beyond
-    the base distance (already in shadow from normal solar tracking).
+    the base distance. Falls through to Default when Sun Tracking is disabled
+    and the glare-zone position would not be more protective.
     """
 
     name = "glare_zone"
@@ -101,7 +104,7 @@ class GlareZoneHandler(OverrideHandler):
         min_distance = min(d for _, d in zone_results)
         contributing_zones = [name for name, d in zone_results if d == min_distance]
 
-        if min_distance >= base_distance:
+        if snapshot.enable_sun_tracking and min_distance >= base_distance:
             # All zones are at or beyond the base distance — they're already in
             # shadow from SolarHandler's normal calculation. No override needed.
             return None
@@ -111,6 +114,13 @@ class GlareZoneHandler(OverrideHandler):
         )
         state = solar_floor(state, floor_active=snapshot.solar_floor_active)
         position = apply_snapshot_limits(snapshot, state, sun_valid=True)
+        if not snapshot.enable_sun_tracking:
+            default_position = compute_default_position(snapshot)
+            if (
+                policy.more_protective_position(position, default_position)
+                == default_position
+            ):
+                return None
 
         zone_names = ", ".join(contributing_zones)
         z_adjusted = any(zones_by_name[name].z > 0 for name in contributing_zones)

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -18,6 +18,7 @@ from .const import (
     CONF_CLOUD_SUPPRESSION,
     CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_GLARE_ZONES,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
     CONF_OUTSIDETEMP_ENTITY,
@@ -28,6 +29,24 @@ from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
 from .entity_base import AdaptiveCoverBaseEntity
 from .helpers import motion_entities
+from .services.options_service import apply_options_patch, validate_options_patch
+
+
+type _OptionApplyCallback = Callable[[AdaptiveDataUpdateCoordinator], Awaitable[None]]
+
+
+@dataclass(frozen=True, slots=True)
+class _SwitchOption:
+    """Pair option storage with the live coordinator apply hook."""
+
+    option_key: str
+    apply: _OptionApplyCallback
+
+
+async def _apply_sun_tracking_option(
+    coordinator: AdaptiveDataUpdateCoordinator,
+) -> None:
+    await coordinator.async_apply_sun_tracking_update()
 
 
 @dataclass(frozen=True, slots=True)
@@ -40,14 +59,19 @@ class _SwitchSpec:
     `key`. The two are intentionally different (e.g. `Manual Override` vs
     `manual_toggle`) and the test in
     `tests/test_switch_actions.py:204` pins this asymmetry.
+
+    ``option`` marks a switch backed by config_entry.options. Bundling the
+    option key with the apply hook prevents a spec from persisting a value
+    without also defining how the live coordinator observes it.
     """
 
     switch_name: str  # → unique_id suffix; LOCKED
-    key: str  # translation_key + coordinator attribute name
+    key: str  # translation_key; also coordinator attribute name for runtime switches
     initial_state: bool
     enabled_default: bool = True
     display_name: str | None = None
     enabled_when: Callable[[ConfigEntry], bool] = field(default=lambda _: True)
+    option: _SwitchOption | None = None
 
 
 def _has_climate_mode(entry: ConfigEntry) -> bool:
@@ -104,6 +128,15 @@ _SWITCH_SPECS: tuple[_SwitchSpec, ...] = (
         switch_name="Automatic Control",
         key="automatic_control",
         initial_state=True,
+    ),
+    _SwitchSpec(
+        switch_name="Sun Tracking",
+        key="sun_tracking",
+        initial_state=True,
+        option=_SwitchOption(
+            option_key=CONF_ENABLE_SUN_TRACKING,
+            apply=_apply_sun_tracking_option,
+        ),
     ),
     _SwitchSpec(
         switch_name="Manual Override",
@@ -209,10 +242,13 @@ async def async_setup_entry(
             config_entry,
             coordinator,
             spec.switch_name,
-            spec.initial_state,
+            bool(config_entry.options.get(spec.option.option_key, spec.initial_state))
+            if spec.option
+            else spec.initial_state,
             spec.key,
             enabled_default=spec.enabled_default,
             display_name=spec.display_name,
+            option=spec.option,
         )
         for spec in specs
     )
@@ -220,6 +256,8 @@ async def async_setup_entry(
 
 class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
     """Representation of a adaptive cover switch."""
+
+    _option: _SwitchOption | None = None
 
     def __init__(
         self,
@@ -234,6 +272,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         *,
         enabled_default: bool = True,
         display_name: str | None = None,
+        option: _SwitchOption | None = None,
     ) -> None:
         """Initialize the switch."""
         super().__init__(entry_id, hass, config_entry, coordinator)
@@ -243,8 +282,11 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         self._switch_name = display_name or switch_name
         self._attr_device_class = device_class
         self._initial_state = initial_state
+        self._option = option
         self._attr_unique_id = f"{entry_id}_{switch_name}"
         self._attr_entity_registry_enabled_default = enabled_default
+        if option is not None:
+            self._attr_is_on = initial_state
 
         self.coordinator.logger.debug("Setup switch")
 
@@ -253,10 +295,29 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         """Name of the entity."""
         return self._switch_name
 
+    @property
+    def is_on(self) -> bool | None:
+        """Return the switch state.
+
+        Option-backed switches read config_entry.options so service/options-flow
+        changes are reflected without RestoreEntity state drift.
+        """
+        if self._option is not None:
+            return bool(
+                self.config_entry.options.get(
+                    self._option.option_key,
+                    self._initial_state,
+                )
+            )
+        return self._attr_is_on
+
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.coordinator.logger.debug("Turning on")
         self._attr_is_on = True
+        if self._option is not None:
+            await self._async_set_option(True)
+            return
         setattr(self.coordinator, self._key, True)
         if self._key == "automatic_control" and kwargs.get("added") is not True:
             # Issue #33 defense-in-depth: invalidate the venetian sequencer's
@@ -284,6 +345,9 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         """Turn the device off."""
         self.coordinator.logger.debug("Turning off")
         self._attr_is_on = False
+        if self._option is not None:
+            await self._async_set_option(False)
+            return
         setattr(self.coordinator, self._key, False)
         if self._key == "enabled_toggle" and kwargs.get("added") is not True:
             # Stop any ACP-in-flight cover moves FIRST (before the gate closes),
@@ -329,6 +393,14 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
+
+        if self._option is not None:
+            # A restored state could conflict with a value changed through the
+            # service/options flow; persisted options remain authoritative.
+            self._attr_is_on = self._initial_state
+            return
+
         last_state = await self.async_get_last_state()
         self.coordinator.logger.debug("%s: last state is %s", self._name, last_state)
         if (last_state is None and self._initial_state) or (
@@ -337,3 +409,13 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
             await self.async_turn_on(added=True)
         else:
             await self.async_turn_off(added=True)
+
+    async def _async_set_option(self, value: bool) -> None:
+        """Use the shared options path so validation and services stay aligned."""
+        assert self._option is not None
+        patch = {self._option.option_key: value}
+        sensor_type = self.config_entry.data.get(CONF_SENSOR_TYPE)
+        validate_options_patch(patch, dict(self.config_entry.options), sensor_type)
+        await apply_options_patch(self.hass, self.coordinator, patch)
+        await self._option.apply(self.coordinator)
+        self.schedule_update_ha_state()

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -32,23 +32,6 @@ from .helpers import motion_entities
 from .services.options_service import apply_options_patch, validate_options_patch
 
 
-type _OptionApplyCallback = Callable[[AdaptiveDataUpdateCoordinator], Awaitable[None]]
-
-
-@dataclass(frozen=True, slots=True)
-class _SwitchOption:
-    """Pair option storage with the live coordinator apply hook."""
-
-    option_key: str
-    apply: _OptionApplyCallback
-
-
-async def _apply_sun_tracking_option(
-    coordinator: AdaptiveDataUpdateCoordinator,
-) -> None:
-    await coordinator.async_apply_sun_tracking_update()
-
-
 @dataclass(frozen=True, slots=True)
 class _SwitchSpec:
     """Spec for a single AdaptiveCoverSwitch instance.
@@ -60,18 +43,19 @@ class _SwitchSpec:
     `manual_toggle`) and the test in
     `tests/test_switch_actions.py:204` pins this asymmetry.
 
-    ``option`` marks a switch backed by config_entry.options. Bundling the
-    option key with the apply hook prevents a spec from persisting a value
-    without also defining how the live coordinator observes it.
+    ``option_key`` marks a switch backed by ``config_entry.options`` instead of
+    a coordinator attribute. The coordinator's update listener maps the
+    persisted change to its runtime action (see ``_RUNTIME_APPLICABLE_OPTIONS``
+    in ``__init__``), so the switch only persists — it never rebuilds directly.
     """
 
     switch_name: str  # → unique_id suffix; LOCKED
-    key: str  # translation_key; also coordinator attribute name for runtime switches
+    key: str  # translation_key; legacy switches also reuse it as the coordinator attr
     initial_state: bool
     enabled_default: bool = True
     display_name: str | None = None
     enabled_when: Callable[[ConfigEntry], bool] = field(default=lambda _: True)
-    option: _SwitchOption | None = None
+    option_key: str | None = None
 
 
 def _has_climate_mode(entry: ConfigEntry) -> bool:
@@ -133,10 +117,7 @@ _SWITCH_SPECS: tuple[_SwitchSpec, ...] = (
         switch_name="Sun Tracking",
         key="sun_tracking",
         initial_state=True,
-        option=_SwitchOption(
-            option_key=CONF_ENABLE_SUN_TRACKING,
-            apply=_apply_sun_tracking_option,
-        ),
+        option_key=CONF_ENABLE_SUN_TRACKING,
     ),
     _SwitchSpec(
         switch_name="Manual Override",
@@ -242,13 +223,15 @@ async def async_setup_entry(
             config_entry,
             coordinator,
             spec.switch_name,
-            bool(config_entry.options.get(spec.option.option_key, spec.initial_state))
-            if spec.option
-            else spec.initial_state,
+            (
+                bool(config_entry.options.get(spec.option_key, spec.initial_state))
+                if spec.option_key
+                else spec.initial_state
+            ),
             spec.key,
             enabled_default=spec.enabled_default,
             display_name=spec.display_name,
-            option=spec.option,
+            option_key=spec.option_key,
         )
         for spec in specs
     )
@@ -257,7 +240,7 @@ async def async_setup_entry(
 class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
     """Representation of a adaptive cover switch."""
 
-    _option: _SwitchOption | None = None
+    _option_key: str | None = None
 
     def __init__(
         self,
@@ -272,7 +255,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         *,
         enabled_default: bool = True,
         display_name: str | None = None,
-        option: _SwitchOption | None = None,
+        option_key: str | None = None,
     ) -> None:
         """Initialize the switch."""
         super().__init__(entry_id, hass, config_entry, coordinator)
@@ -282,11 +265,9 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         self._switch_name = display_name or switch_name
         self._attr_device_class = device_class
         self._initial_state = initial_state
-        self._option = option
+        self._option_key = option_key
         self._attr_unique_id = f"{entry_id}_{switch_name}"
         self._attr_entity_registry_enabled_default = enabled_default
-        if option is not None:
-            self._attr_is_on = initial_state
 
         self.coordinator.logger.debug("Setup switch")
 
@@ -302,10 +283,10 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         Option-backed switches read config_entry.options so service/options-flow
         changes are reflected without RestoreEntity state drift.
         """
-        if self._option is not None:
+        if self._option_key is not None:
             return bool(
                 self.config_entry.options.get(
-                    self._option.option_key,
+                    self._option_key,
                     self._initial_state,
                 )
             )
@@ -314,10 +295,10 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.coordinator.logger.debug("Turning on")
-        self._attr_is_on = True
-        if self._option is not None:
+        if self._option_key is not None:
             await self._async_set_option(True)
             return
+        self._attr_is_on = True
         setattr(self.coordinator, self._key, True)
         if self._key == "automatic_control" and kwargs.get("added") is not True:
             # Issue #33 defense-in-depth: invalidate the venetian sequencer's
@@ -344,10 +325,10 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         self.coordinator.logger.debug("Turning off")
-        self._attr_is_on = False
-        if self._option is not None:
+        if self._option_key is not None:
             await self._async_set_option(False)
             return
+        self._attr_is_on = False
         setattr(self.coordinator, self._key, False)
         if self._key == "enabled_toggle" and kwargs.get("added") is not True:
             # Stop any ACP-in-flight cover moves FIRST (before the gate closes),
@@ -395,10 +376,11 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         """Call when entity about to be added to hass."""
         await super().async_added_to_hass()
 
-        if self._option is not None:
-            # A restored state could conflict with a value changed through the
-            # service/options flow; persisted options remain authoritative.
-            self._attr_is_on = self._initial_state
+        if self._option_key is not None:
+            # Option-backed switches derive is_on from config_entry.options, so
+            # there is no RestoreEntity state to reconcile — persisted options
+            # win. The coordinator listener (registered via super) applies any
+            # runtime change.
             return
 
         last_state = await self.async_get_last_state()
@@ -411,11 +393,18 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
             await self.async_turn_off(added=True)
 
     async def _async_set_option(self, value: bool) -> None:
-        """Use the shared options path so validation and services stay aligned."""
-        assert self._option is not None
-        patch = {self._option.option_key: value}
+        """Persist the option through the shared services path.
+
+        The coordinator's update listener (``_async_update_listener``) maps the
+        persisted change to its runtime action, so there is a single rebuild
+        path whether the option is changed here, by a service, or in the
+        options flow. The immediate ``schedule_update_ha_state`` redraws this
+        switch from the freshly-persisted option without waiting for the
+        listener-driven refresh.
+        """
+        assert self._option_key is not None
+        patch = {self._option_key: value}
         sensor_type = self.config_entry.data.get(CONF_SENSOR_TYPE)
         validate_options_patch(patch, dict(self.config_entry.options), sensor_type)
         await apply_options_patch(self.hass, self.coordinator, patch)
-        await self._option.apply(self.coordinator)
         self.schedule_update_ha_state()

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1251,6 +1251,13 @@
           "off": "Off"
         }
       },
+      "sun_tracking": {
+        "name": "Sonnenverfolgung",
+        "state": {
+          "on": "An",
+          "off": "Aus"
+        }
+      },
       "motion_control": {
         "name": "Bewegungssteuerung",
         "state": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1251,6 +1251,13 @@
           "off": "Off"
         }
       },
+      "sun_tracking": {
+        "name": "Sun Tracking",
+        "state": {
+          "on": "On",
+          "off": "Off"
+        }
+      },
       "motion_control": {
         "name": "Motion Control",
         "state": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1251,6 +1251,13 @@
           "off": "Off"
         }
       },
+      "sun_tracking": {
+        "name": "Suivi du soleil",
+        "state": {
+          "on": "Activé",
+          "off": "Désactivé"
+        }
+      },
       "motion_control": {
         "name": "Contrôle du mouvement",
         "state": {

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -6,12 +6,15 @@ options-change-triggered reload, and multi-entry independence.
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENTITIES,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_MOTION_SENSORS,
     CONF_MOTION_TEMPLATE,
@@ -161,6 +164,34 @@ async def test_options_update_triggers_reload(hass: HomeAssistant) -> None:
     assert coord_before is not coord_after
 
 
+@pytest.mark.integration
+async def test_sun_tracking_only_update_refreshes_without_reload(
+    hass: HomeAssistant,
+) -> None:
+    """Sun Tracking toggle rebuilds the pipeline on the existing coordinator."""
+    entry = await _setup(hass, entry_id="sun_tracking_runtime_01")
+    coordinator = entry.runtime_data
+    coordinator._cached_options = dict(entry.options)
+    new_pipeline = MagicMock()
+    coordinator._build_pipeline = MagicMock(return_value=new_pipeline)
+    coordinator.async_update_listeners = MagicMock()
+    coordinator.async_refresh = AsyncMock()
+
+    new_options = dict(entry.options)
+    new_options[CONF_ENABLE_SUN_TRACKING] = not entry.options.get(
+        CONF_ENABLE_SUN_TRACKING, True
+    )
+    hass.config_entries.async_update_entry(entry, options=new_options)
+    await hass.async_block_till_done()
+
+    assert entry.runtime_data is coordinator
+    assert coordinator._pipeline is new_pipeline
+    assert coordinator.state_change is True
+    coordinator.async_update_listeners.assert_called_once()
+    coordinator.async_refresh.assert_awaited_once()
+    assert coordinator._cached_options == new_options
+
+
 # ---------------------------------------------------------------------------
 # 4b: Entity change wiring (verify listeners are registered)
 # ---------------------------------------------------------------------------
@@ -264,9 +295,9 @@ async def test_last_update_success_time_attribute_exists(hass: HomeAssistant) ->
     import datetime as _dt
 
     val = coordinator._last_update_success_time
-    assert val is None or isinstance(
-        val, _dt.datetime
-    ), f"_last_update_success_time must be None or datetime, got {type(val)}"
+    assert val is None or isinstance(val, _dt.datetime), (
+        f"_last_update_success_time must be None or datetime, got {type(val)}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -382,6 +382,64 @@ class TestGlareZoneBoundaryAtBaseDistance:
         assert self.handler.evaluate(snap) is None
 
 
+class TestGlareZoneWithoutSunTracking:
+    """Glare-only mode compares active zones against Default, not base Solar."""
+
+    handler = GlareZoneHandler()
+
+    def test_sun_tracking_disabled_zone_can_win_with_zero_base_distance(self) -> None:
+        """A disabled SolarHandler must not make distance_shaded_area=0 suppress glare."""
+        cover = _make_vertical_cover(
+            distance=0.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=25.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=1.0, radius=0.0)],
+            window_width=2.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            default_position=100,
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+            enable_sun_tracking=False,
+        )
+
+        result = self.handler.evaluate(snap)
+
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+        assert result.position == 25
+
+    def test_sun_tracking_disabled_falls_through_when_default_more_protective(
+        self,
+    ) -> None:
+        """If Default is already as protective as glare, leave Default in control."""
+        cover = _make_vertical_cover(
+            distance=0.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=50.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=1.0, radius=0.0)],
+            window_width=2.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            default_position=20,
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+            enable_sun_tracking=False,
+        )
+
+        assert self.handler.evaluate(snap) is None
+
+
 class TestGlareZonePositionFloor:
     """Verify the solar floor clamp prevents position 0 for open/close-only covers."""
 

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -439,6 +439,40 @@ class TestGlareZoneWithoutSunTracking:
 
         assert self.handler.evaluate(snap) is None
 
+    def test_sun_tracking_disabled_does_not_apply_sun_tracking_floor(self) -> None:
+        """Sun-tracking-only limits must not clamp the glare position when off.
+
+        ``sun_valid`` follows ``enable_sun_tracking``: with tracking disabled the
+        ``min_pos_sun_tracking`` floor stays inert, so the computed glare
+        position survives instead of being lifted to the sun-tracking minimum.
+        """
+        cover = _make_vertical_cover(
+            distance=0.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=25.0,
+        )
+        # A sun-tracking-only floor that would clamp 25 -> 50 if (wrongly) applied.
+        cover.config.min_pos_sun_tracking = 50
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=1.0, radius=0.0)],
+            window_width=2.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            default_position=100,
+            glare_zones=glare_cfg,
+            active_zone_names={"desk"},
+            enable_sun_tracking=False,
+        )
+
+        result = self.handler.evaluate(snap)
+
+        assert result is not None
+        assert result.control_method == ControlMethod.GLARE_ZONE
+        assert result.position == 25
+
 
 class TestGlareZonePositionFloor:
     """Verify the solar floor clamp prevents position 0 for open/close-only covers."""

--- a/tests/test_pipeline/test_sun_tracking_toggle.py
+++ b/tests/test_pipeline/test_sun_tracking_toggle.py
@@ -127,6 +127,53 @@ def test_sun_tracking_disabled_pipeline_falls_through_to_default():
 
 
 @pytest.mark.unit
+def test_sun_tracking_disabled_pipeline_allows_glare_zone_to_win():
+    """With Solar removed, active glare zones compare against Default."""
+    from custom_components.adaptive_cover_pro.config_types import (
+        GlareZone,
+        GlareZonesConfig,
+    )
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.engine.covers.vertical import (
+        AdaptiveVerticalCover,
+    )
+    from tests.test_pipeline.conftest import make_snapshot
+
+    coord = _make_coordinator({CONF_ENABLE_SUN_TRACKING: False})
+    registry = coord._build_pipeline()
+
+    cover = MagicMock(spec=AdaptiveVerticalCover)
+    cover.direct_sun_valid = True
+    cover.distance = 0.0
+    cover.gamma = 0.0
+    cover.sol_elev = 45.0
+    cover.calculate_percentage = MagicMock(return_value=25.0)
+    cover.config = MagicMock()
+    cover.config.min_pos = None
+    cover.config.max_pos = None
+    cover.config.min_pos_sun_only = False
+    cover.config.max_pos_sun_only = False
+    cover.config.min_pos_sun_tracking = None
+
+    snap = make_snapshot(
+        cover=cover,
+        direct_sun_valid=True,
+        default_position=100,
+        glare_zones=GlareZonesConfig(
+            zones=[GlareZone(name="desk", x=0.0, y=1.0, radius=0.0)],
+            window_width=2.0,
+        ),
+        active_zone_names={"desk"},
+        enable_sun_tracking=False,
+    )
+    result = registry.evaluate(snap)
+
+    assert result is not None
+    assert result.control_method == ControlMethod.GLARE_ZONE
+    assert result.position == 25
+
+
+@pytest.mark.unit
 def test_safety_slot_min_mode_with_sun_tracking_off_uses_default():
     """A priority-100 safety slot (migrated force override, #563) defers in
     min_mode; with sun tracking off, the winner is DefaultHandler

--- a/tests/test_switch_actions.py
+++ b/tests/test_switch_actions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -12,6 +12,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_CLOUD_SUPPRESSION,
     CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_GLARE_ZONES,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
     CONF_SENSOR_TYPE,
@@ -22,6 +23,7 @@ from custom_components.adaptive_cover_pro.switch import (
     AdaptiveCoverSwitch,
     _has_irradiance_feature,
     _has_lux_feature,
+    _SwitchOption,
 )
 
 
@@ -37,6 +39,7 @@ def _make_coordinator(mock_hass=None):
     coord = MagicMock()
     coord.hass = mock_hass or MagicMock()
     coord.logger = MagicMock()
+    coord.async_add_listener = MagicMock(return_value=lambda: None)
     coord.entities = []
     coord._cmd_svc = MagicMock()
     coord._cmd_svc.apply_position = AsyncMock()
@@ -46,6 +49,7 @@ def _make_coordinator(mock_hass=None):
     coord.check_adaptive_time = True
     coord._build_position_context = MagicMock(return_value=MagicMock())
     coord.async_refresh = AsyncMock()
+    coord.async_apply_sun_tracking_update = AsyncMock()
     coord.state = 50
     return coord
 
@@ -269,6 +273,103 @@ async def test_turn_off_non_automatic_control_key_no_special_logic():
     coord.manager.reset.assert_not_called()
     coord._cmd_svc.apply_position.assert_not_called()
     coord.async_refresh.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Option-backed Sun Tracking switch
+# ---------------------------------------------------------------------------
+
+
+def _make_sun_tracking_switch(
+    *,
+    enabled: bool,
+    option_apply=None,
+) -> AdaptiveCoverSwitch:
+    """Create a Sun Tracking switch wired to mocked options persistence."""
+    coord = _make_coordinator()
+    entry = _make_config_entry(options={CONF_ENABLE_SUN_TRACKING: enabled})
+    coord.config_entry = entry
+    option_apply = option_apply or AsyncMock()
+    return AdaptiveCoverSwitch(
+        entry_id="test_entry",
+        hass=coord.hass,
+        config_entry=entry,
+        coordinator=coord,
+        switch_name="Sun Tracking",
+        initial_state=enabled,
+        key="sun_tracking",
+        option=_SwitchOption(
+            option_key=CONF_ENABLE_SUN_TRACKING,
+            apply=option_apply,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("enabled", [True, False])
+async def test_sun_tracking_uses_config_option_as_source_of_truth(enabled):
+    """The switch initializes from options instead of stale restored state."""
+    switch = _make_sun_tracking_switch(enabled=enabled)
+    switch.async_get_last_state = AsyncMock()
+
+    await switch.async_added_to_hass()
+
+    assert switch.is_on is enabled
+    switch.async_get_last_state.assert_not_awaited()
+    switch.coordinator.async_add_listener.assert_called_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("method", "enabled"), [("async_turn_on", True), ("async_turn_off", False)]
+)
+async def test_sun_tracking_persists_option(method, enabled):
+    """Runtime changes persist through the in-place options update path."""
+    option_apply = AsyncMock()
+    switch = _make_sun_tracking_switch(
+        enabled=not enabled,
+        option_apply=option_apply,
+    )
+    original_options = dict(switch.config_entry.options)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.switch.validate_options_patch"
+        ) as mock_validate,
+        patch(
+            "custom_components.adaptive_cover_pro.switch.apply_options_patch",
+            new_callable=AsyncMock,
+        ) as mock_apply,
+    ):
+        mock_apply.side_effect = lambda _hass, _coordinator, option_patch: setattr(
+            switch.config_entry,
+            "options",
+            {**switch.config_entry.options, **option_patch},
+        )
+        await getattr(switch, method)()
+
+    expected_patch = {CONF_ENABLE_SUN_TRACKING: enabled}
+    mock_validate.assert_called_once_with(
+        expected_patch,
+        original_options,
+        CoverType.BLIND,
+    )
+    mock_apply.assert_awaited_once_with(switch.hass, switch.coordinator, expected_patch)
+    assert switch.is_on is enabled
+    option_apply.assert_awaited_once_with(switch.coordinator)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("enabled", [True, False])
+def test_sun_tracking_reflects_external_option_updates(enabled):
+    """Service and options-flow changes are visible without entity reload."""
+    switch = _make_sun_tracking_switch(enabled=not enabled)
+
+    switch.config_entry.options = {CONF_ENABLE_SUN_TRACKING: enabled}
+
+    assert switch.is_on is enabled
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_switch_actions.py
+++ b/tests/test_switch_actions.py
@@ -23,7 +23,6 @@ from custom_components.adaptive_cover_pro.switch import (
     AdaptiveCoverSwitch,
     _has_irradiance_feature,
     _has_lux_feature,
-    _SwitchOption,
 )
 
 
@@ -280,16 +279,11 @@ async def test_turn_off_non_automatic_control_key_no_special_logic():
 # ---------------------------------------------------------------------------
 
 
-def _make_sun_tracking_switch(
-    *,
-    enabled: bool,
-    option_apply=None,
-) -> AdaptiveCoverSwitch:
+def _make_sun_tracking_switch(*, enabled: bool) -> AdaptiveCoverSwitch:
     """Create a Sun Tracking switch wired to mocked options persistence."""
     coord = _make_coordinator()
     entry = _make_config_entry(options={CONF_ENABLE_SUN_TRACKING: enabled})
     coord.config_entry = entry
-    option_apply = option_apply or AsyncMock()
     return AdaptiveCoverSwitch(
         entry_id="test_entry",
         hass=coord.hass,
@@ -298,10 +292,7 @@ def _make_sun_tracking_switch(
         switch_name="Sun Tracking",
         initial_state=enabled,
         key="sun_tracking",
-        option=_SwitchOption(
-            option_key=CONF_ENABLE_SUN_TRACKING,
-            apply=option_apply,
-        ),
+        option_key=CONF_ENABLE_SUN_TRACKING,
     )
 
 
@@ -327,11 +318,7 @@ async def test_sun_tracking_uses_config_option_as_source_of_truth(enabled):
 )
 async def test_sun_tracking_persists_option(method, enabled):
     """Runtime changes persist through the in-place options update path."""
-    option_apply = AsyncMock()
-    switch = _make_sun_tracking_switch(
-        enabled=not enabled,
-        option_apply=option_apply,
-    )
+    switch = _make_sun_tracking_switch(enabled=not enabled)
     original_options = dict(switch.config_entry.options)
 
     with (
@@ -358,7 +345,6 @@ async def test_sun_tracking_persists_option(method, enabled):
     )
     mock_apply.assert_awaited_once_with(switch.hass, switch.coordinator, expected_patch)
     assert switch.is_on is enabled
-    option_apply.assert_awaited_once_with(switch.coordinator)
 
 
 @pytest.mark.unit

--- a/tests/test_unique_id_snapshot.py
+++ b/tests/test_unique_id_snapshot.py
@@ -96,6 +96,7 @@ EXPECTED_UNIQUE_ID_SUFFIXES = sorted(
         # --- switch platform (uses display switch_name, not translation key) ---
         "Integration Enabled",
         "Automatic Control",
+        "Sun Tracking",
         "Manual Override",  # translation key is "manual_toggle"; unique_id keeps display name
         "Climate Mode",
         "Outside Temperature",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Following https://github.com/jrhubott/adaptive-cover-pro/issues/498, I added the sun tracking switch entity.

After some testing, even when Sun Tracking was disabled, Glare Zones were still compared against the base solar shaded distance. With distance_shaded_area set to 0 for example, this meant glare zones could never win, even though the solar handler was disabled. I fixed it by keeping the old comparison when Sun Tracking is enabled but comparing Glare Zones against the default position when Sun Tracking is disabled.

Not sure if this can be considered as a fix in the "Types of changes" section?

## Motivation and Context

- fixes: https://github.com/jrhubott/adaptive-cover-pro/issues/498

## How has this been tested?

Tested on my own HA instance on vertical covers with a glare zone and sun tracking enabled/disabled:
- the sun tracking switch is correctly synchronized with the existing `enable_sun_tracking` service and the config option
- sun tracking still works when enabled
- sun tracking disabled with glare zone works as intended (with the fix detailed above)

## Screenshots (if appropriate):

<img width="1844" height="919" alt="2026-06-25_15h17_32" src="https://github.com/user-attachments/assets/1b36f896-79c9-4877-bf66-3b2437fc855e" />
<img width="503" height="858" alt="2026-06-25_15h17_13" src="https://github.com/user-attachments/assets/0bb9e2ba-c201-4c63-a2cc-e0f442c8bd5b" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (non-breaking which updates existing code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
