### PR TITLE
feat: live solar_calculation diagnostic sensor for all cover types

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -973,6 +973,25 @@ WINDOW_DEPTH_GAMMA_THRESHOLD = 10  # deg — min gamma for depth contribution
 
 
 # =============================================================================
+# Solar-calculation trace keys (issue #682)
+# =============================================================================
+# Stable key names for the per-cycle raw geometric solar-position trace that
+# each calc engine records in ``_last_calc_details``. The new
+# ``solar_calculation`` diagnostic sensor and the diagnostics download both read
+# this single dict. Suffix convention: ``_deg`` = degrees, ``_m`` = metres,
+# ``_pct`` = percent (0-100), raw ratios carry no suffix.
+#
+# Common to every cover type (stamped by the engine; ``cover_type`` stamped by
+# the builder from config — engines never branch on their own type string).
+TRACE_KEY_COVER_TYPE = "cover_type"
+TRACE_KEY_SOL_ELEV_DEG = "sol_elev_deg"
+TRACE_KEY_GAMMA_DEG = "gamma_deg"
+TRACE_KEY_POSITION_PCT = "position_pct"
+# Venetian dual-axis: the tilt sub-trace nests under this key.
+TRACE_KEY_TILT = "tilt"
+
+
+# =============================================================================
 # 25. UI Defaults & Validation Caps
 # =============================================================================
 # Default values shown in the config-flow UI and hard caps not derived from

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -50,6 +50,7 @@ from ...const import (
     MIN_VENETIAN_TILT_SKIP_ABOVE,
     POSITION_CLOSED,
     POSITION_OPEN,
+    TRACE_KEY_TILT,
     VENETIAN_MODE_POSITION_AND_TILT,
     VENETIAN_MODE_TILT_ONLY,
     VENETIAN_MODES,
@@ -479,6 +480,17 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             logger=logger,
         )
         tilt = venetian_calc.tilt_for_position(result.position)
+        # Issue #682: merge the (otherwise transient) tilt engine's raw trace into
+        # the position engine's _last_calc_details under a `tilt` sub-key so the
+        # live solar_calculation sensor and the diagnostics download surface BOTH
+        # axes. Guarded: only when the position engine recorded a dict trace and
+        # the tilt engine produced one (this branch is the non-suppressed path).
+        tilt_trace = getattr(
+            venetian_calc._tilt, "_last_calc_details", None
+        )  # noqa: SLF001
+        cover_trace = getattr(cover, "_last_calc_details", None)
+        if isinstance(cover_trace, dict) and tilt_trace is not None:
+            cover_trace[TRACE_KEY_TILT] = tilt_trace
         # Movement minimization: quantize the slat tilt into the same number of
         # discrete coverage levels as the carriage position (which the solar
         # branch already quantized). The tilt axis closes at 0%, so full coverage

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -366,14 +366,57 @@ class DiagnosticsBuilder:
         return diagnostics
 
     @staticmethod
-    def _build_position_calc_details(ctx: DiagnosticContext) -> dict:
-        """Surface the cover's per-cycle calc trace when one was recorded."""
+    def _round_trace_value(key: str, value: Any) -> Any:
+        """Round one raw trace leaf at the presentation boundary (issue #682).
+
+        Convention (issue #140 §Display Rounding): degrees/ratios that aren't
+        positions → 1 decimal for angles, ~3 decimals for unit-less ratios;
+        distances (``_m``) → 3 decimals; positions/percent → integer; everything
+        else (bools, strings, lists, None) passes through untouched. Rounding
+        happens here — never inside the calc engines.
+        """
+        if not isinstance(value, int | float) or isinstance(value, bool):
+            return value
+        if key.endswith("_pct") or key.endswith("_position") or key == "max_degrees":
+            return int(round(value))
+        if key.endswith("_deg"):
+            return round(value, 1)
+        if key.endswith("_m"):
+            return round(value, 3)
+        # Unit-less ratios (cos_gamma, safety_margin, discriminant, beta_rad, …).
+        return round(value, 3)
+
+    @classmethod
+    def _round_trace(cls, trace: dict) -> dict:
+        """Return a rounded copy of a trace dict, recursing into nested sub-traces.
+
+        Copies rather than mutating so the engine's ``_last_calc_details`` keeps
+        full precision for any other reader.
+        """
+        rounded: dict = {}
+        for key, value in trace.items():
+            if isinstance(value, dict):
+                rounded[key] = cls._round_trace(value)
+            else:
+                rounded[key] = cls._round_trace_value(key, value)
+        return rounded
+
+    @classmethod
+    def _build_position_calc_details(cls, ctx: DiagnosticContext) -> dict:
+        """Surface the cover's per-cycle calc trace when one was recorded.
+
+        Stamps the ``cover_type`` discriminator from ``ctx.cover_type`` (config
+        data — engines never branch on their own type string) and rounds every
+        numeric leaf at this presentation boundary.
+        """
         if not ctx.cover:
             return {}
         calc_details = getattr(ctx.cover, "_last_calc_details", None)
         if calc_details is None:
             return {}
-        return {"calculation_details": calc_details}
+        details = cls._round_trace(calc_details)
+        details["cover_type"] = ctx.cover_type
+        return {"calculation_details": details}
 
     @staticmethod
     def _build_time_window(ctx: DiagnosticContext) -> dict:

--- a/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
@@ -9,6 +9,11 @@ from numpy import sin
 from numpy import radians as rad
 
 from ...config_types import HorizontalConfig
+from ...const import (
+    TRACE_KEY_GAMMA_DEG,
+    TRACE_KEY_POSITION_PCT,
+    TRACE_KEY_SOL_ELEV_DEG,
+)
 from ...position_utils import PositionConverter
 from .vertical import AdaptiveVerticalCover
 
@@ -33,6 +38,43 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
     def awn_angle(self) -> float:
         """Get awning angle from horiz_config."""
         return self.horiz_config.awn_angle
+
+    def _build_horizontal_trace(
+        self,
+        *,
+        awn_angle: float,
+        a_angle: float,
+        c_angle: float,
+        vertical_position: float,
+        sin_c: float,
+        sin_c_near_zero: bool,
+        length: float,
+        result: float,
+        clamped_to_awn_length: bool,
+    ) -> dict:
+        """Assemble the raw horizontal solar-calculation trace (issue #682).
+
+        Set AFTER the ``super().calculate_position()`` call so the awning trace
+        overwrites the vertical trace that the super sets on ``_last_calc_details``
+        (the latent overwrite bug noted in issue #682). Single source for both the
+        sin_c guard return and the normal/clip return. Raw native floats — rounding
+        happens at the ``DiagnosticsBuilder`` presentation boundary.
+        """
+        return {
+            TRACE_KEY_SOL_ELEV_DEG: float(self.sol_elev),
+            TRACE_KEY_GAMMA_DEG: float(self.gamma),
+            TRACE_KEY_POSITION_PCT: PositionConverter.to_percentage(
+                result, self.awn_length
+            ),
+            "awn_angle_deg": float(awn_angle),
+            "a_angle_deg": float(a_angle),
+            "c_angle_deg": float(c_angle),
+            "vertical_position_m": float(vertical_position),
+            "sin_c": float(sin_c),
+            "sin_c_near_zero": bool(sin_c_near_zero),
+            "length_m": float(length),
+            "clamped_to_awn_length": bool(clamped_to_awn_length),
+        }
 
     def calculate_position(self) -> float:
         """Calculate awning extension length using trigonometric projection.
@@ -66,9 +108,20 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
                 "Horizontal calc: c_angle=%.2f° near zero — returning full extension",
                 c_angle,
             )
+            self._last_calc_details = self._build_horizontal_trace(
+                awn_angle=awn_angle,
+                a_angle=a_angle,
+                c_angle=c_angle,
+                vertical_position=vertical_position,
+                sin_c=sin_c,
+                sin_c_near_zero=True,
+                length=self.awn_length,
+                result=self.awn_length,
+                clamped_to_awn_length=False,
+            )
             return self.awn_length
 
-        length = ((self.h_win - vertical_position) * sin(rad(a_angle))) / sin_c
+        length = float(((self.h_win - vertical_position) * sin(rad(a_angle))) / sin_c)
         self.logger.debug(
             "Horizontal calc: elev=%.1f°, gamma=%.1f°, awn_angle=%s°, "
             "vertical_pos=%.3f, length=%.3f",
@@ -78,7 +131,19 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
             vertical_position,
             length,
         )
-        return float(np.clip(length, 0, self.awn_length))
+        result = float(np.clip(length, 0, self.awn_length))
+        self._last_calc_details = self._build_horizontal_trace(
+            awn_angle=awn_angle,
+            a_angle=a_angle,
+            c_angle=c_angle,
+            vertical_position=vertical_position,
+            sin_c=sin_c,
+            sin_c_near_zero=False,
+            length=length,
+            result=result,
+            clamped_to_awn_length=bool(length > self.awn_length),
+        )
+        return result
 
     def calculate_percentage(self) -> float:
         """Convert awning extension to percentage for Home Assistant.

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -9,7 +9,12 @@ from numpy import cos, tan
 from numpy import radians as rad
 
 from ...config_types import TiltConfig
-from ...const import TiltMode
+from ...const import (
+    TRACE_KEY_GAMMA_DEG,
+    TRACE_KEY_POSITION_PCT,
+    TRACE_KEY_SOL_ELEV_DEG,
+    TiltMode,
+)
 from ...position_utils import PositionConverter
 from .base import AdaptiveGeneralCover
 
@@ -50,6 +55,47 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         beta = np.arctan(tan(rad(self.sol_elev)) / cos(rad(self.gamma)))
         return beta
 
+    def _max_degrees(self) -> int:
+        """Resolve max slat degrees for the configured mode (string or enum)."""
+        if isinstance(self.mode, TiltMode):
+            return self.mode.max_degrees
+        return TiltMode(self.mode).max_degrees
+
+    def _build_trace(
+        self,
+        *,
+        beta: float,
+        discriminant: float,
+        negative_discriminant: bool,
+        slat_angle_raw_deg: float | None,
+        nan_result: bool,
+        max_degrees: int,
+        result: float,
+    ) -> dict:
+        """Assemble the raw tilt solar-calculation trace (issue #682).
+
+        Single source for the negative-discriminant guard, the NaN guard, and the
+        normal return path so the key set never drifts. Raw native floats — the
+        ``DiagnosticsBuilder`` rounds at the presentation boundary.
+        """
+        mode_value = self.mode.value if isinstance(self.mode, TiltMode) else self.mode
+        return {
+            TRACE_KEY_SOL_ELEV_DEG: float(self.sol_elev),
+            TRACE_KEY_GAMMA_DEG: float(self.gamma),
+            TRACE_KEY_POSITION_PCT: PositionConverter.to_percentage(
+                result, max_degrees
+            ),
+            "beta_rad": float(beta),
+            "discriminant": float(discriminant),
+            "negative_discriminant": bool(negative_discriminant),
+            "slat_angle_raw_deg": (
+                None if slat_angle_raw_deg is None else float(slat_angle_raw_deg)
+            ),
+            "nan_result": bool(nan_result),
+            "max_degrees": int(max_degrees),
+            "tilt_mode": str(mode_value),
+        }
+
     def calculate_position(self) -> float:
         """Calculate optimal slat tilt angle to block direct sun.
 
@@ -69,6 +115,7 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
 
         """
         beta = self.beta
+        max_degrees = self._max_degrees()
 
         # Guard: discriminant can be negative when slat_distance/depth ratio is
         # large relative to tan(beta), making sqrt of a negative.  NumPy returns
@@ -78,6 +125,15 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
             self.logger.debug(
                 "Tilt calc: negative discriminant (%.4f) — returning 0° (closed)",
                 float(discriminant),
+            )
+            self._last_calc_details = self._build_trace(
+                beta=beta,
+                discriminant=discriminant,
+                negative_discriminant=True,
+                slat_angle_raw_deg=None,
+                nan_result=False,
+                max_degrees=max_degrees,
+                result=0.0,
             )
             return 0.0
 
@@ -94,14 +150,19 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
                 self.gamma,
                 float(beta),
             )
+            self._last_calc_details = self._build_trace(
+                beta=beta,
+                discriminant=discriminant,
+                negative_discriminant=False,
+                slat_angle_raw_deg=None,
+                nan_result=True,
+                max_degrees=max_degrees,
+                result=0.0,
+            )
             return 0.0
 
-        if isinstance(self.mode, TiltMode):
-            max_degrees = self.mode.max_degrees
-        else:
-            max_degrees = TiltMode(self.mode).max_degrees
-
-        result = max(0.0, min(float(max_degrees), result))
+        slat_angle_raw_deg = float(result)
+        result = max(0.0, min(float(max_degrees), float(result)))
 
         self.logger.debug(
             "Tilt calc: elev=%.1f°, gamma=%.1f°, beta=%.4f rad, slat_angle=%.1f°",
@@ -109,6 +170,15 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
             self.gamma,
             beta,
             result,
+        )
+        self._last_calc_details = self._build_trace(
+            beta=beta,
+            discriminant=discriminant,
+            negative_discriminant=False,
+            slat_angle_raw_deg=slat_angle_raw_deg,
+            nan_result=False,
+            max_degrees=max_degrees,
+            result=result,
         )
         return result
 

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -9,7 +9,12 @@ from numpy import cos, sin, tan
 from numpy import radians as rad
 
 from ...config_types import GlareZone, GlareZonesConfig, VerticalConfig
-from ...const import WINDOW_DEPTH_GAMMA_THRESHOLD
+from ...const import (
+    TRACE_KEY_GAMMA_DEG,
+    TRACE_KEY_POSITION_PCT,
+    TRACE_KEY_SOL_ELEV_DEG,
+    WINDOW_DEPTH_GAMMA_THRESHOLD,
+)
 from ...geometry import EdgeCaseHandler, SafetyMarginCalculator
 from ...position_utils import PositionConverter
 from .base import AdaptiveGeneralCover
@@ -152,6 +157,50 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
             self.sol_elev, self.gamma, self.distance, self.h_win
         )
 
+    def _build_vertical_trace(
+        self,
+        *,
+        edge_case_detected: bool,
+        safety_margin: float,
+        effective_distance: float,
+        effective_distance_source: str,
+        window_depth_contribution: float,
+        sill_height_offset: float,
+        cos_gamma: float,
+        cos_gamma_clamped: float,
+        path_length: float,
+        base_height: float,
+        adjusted_height: float,
+        result: float,
+        clamped_to_window: bool,
+    ) -> dict:
+        """Assemble the raw vertical solar-calculation trace (issue #682).
+
+        Single source for both the edge-case and normal return paths so the key
+        set never drifts between them. Values are raw native floats — rounding
+        happens at the presentation boundary (``DiagnosticsBuilder``), never here.
+        ``glare_zones_active`` is left empty; the GlareZoneHandler populates it
+        downstream via diagnostics.
+        """
+        return {
+            TRACE_KEY_SOL_ELEV_DEG: float(self.sol_elev),
+            TRACE_KEY_GAMMA_DEG: float(self.gamma),
+            TRACE_KEY_POSITION_PCT: PositionConverter.to_percentage(result, self.h_win),
+            "edge_case_detected": bool(edge_case_detected),
+            "effective_distance_m": effective_distance,
+            "effective_distance_source": effective_distance_source,
+            "window_depth_contribution_m": window_depth_contribution,
+            "sill_height_offset_m": sill_height_offset,
+            "safety_margin": safety_margin,
+            "glare_zones_active": [],
+            "cos_gamma": cos_gamma,
+            "cos_gamma_clamped": cos_gamma_clamped,
+            "path_length_m": path_length,
+            "base_height_m": base_height,
+            "adjusted_height_m": adjusted_height,
+            "clamped_to_window": bool(clamped_to_window),
+        }
+
     def calculate_position(
         self, effective_distance_override: float | None = None
     ) -> float:
@@ -183,15 +232,21 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
                 self.gamma,
                 edge_position,
             )
-            self._last_calc_details = {
-                "edge_case_detected": True,
-                "safety_margin": 1.0,
-                "effective_distance": self.distance,
-                "window_depth_contribution": 0.0,
-                "sill_height_offset": 0.0,
-                "glare_zones_active": [],
-                "effective_distance_source": "edge_case",
-            }
+            self._last_calc_details = self._build_vertical_trace(
+                edge_case_detected=True,
+                safety_margin=1.0,
+                effective_distance=float(self.distance),
+                effective_distance_source="edge_case",
+                window_depth_contribution=0.0,
+                sill_height_offset=0.0,
+                cos_gamma=float(cos(rad(self.gamma))),
+                cos_gamma_clamped=float(cos(rad(self.gamma))),
+                path_length=0.0,
+                base_height=0.0,
+                adjusted_height=0.0,
+                result=edge_position,
+                clamped_to_window=False,
+            )
             return edge_position
 
         # Use override from handler (e.g. GlareZoneHandler) or base distance
@@ -256,6 +311,7 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         safety_margin = self._calculate_safety_margin(self.gamma, self.sol_elev)
         adjusted_height = base_height * safety_margin
         result = float(np.clip(adjusted_height, 0, self.h_win))
+        clamped_to_window = bool(adjusted_height > self.h_win)
 
         self.logger.debug(
             "Vertical calc: elev=%.1f°, gamma=%.1f°, dist=%.3f→%.3f "
@@ -273,15 +329,21 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
             result,
             effective_distance_source,
         )
-        self._last_calc_details = {
-            "edge_case_detected": False,
-            "safety_margin": round(safety_margin, 4),
-            "effective_distance": round(effective_distance, 4),
-            "window_depth_contribution": round(depth_contribution, 4),
-            "sill_height_offset": round(sill_offset, 4),
-            "glare_zones_active": [],  # populated by GlareZoneHandler via diagnostics
-            "effective_distance_source": effective_distance_source,
-        }
+        self._last_calc_details = self._build_vertical_trace(
+            edge_case_detected=False,
+            safety_margin=float(safety_margin),
+            effective_distance=float(effective_distance),
+            effective_distance_source=effective_distance_source,
+            window_depth_contribution=float(depth_contribution),
+            sill_height_offset=float(sill_offset),
+            cos_gamma=float(cos_gamma),
+            cos_gamma_clamped=float(cos_gamma_clamped),
+            path_length=float(path_length),
+            base_height=float(base_height),
+            adjusted_height=float(adjusted_height),
+            result=result,
+            clamped_to_window=clamped_to_window,
+        )
         return result
 
     def calculate_percentage(

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_FRIENDLY_NAME, PERCENTAGE
+from homeassistant.const import ATTR_FRIENDLY_NAME, MATCH_ALL, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -332,7 +332,10 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         if calc_details:
             attrs["edge_case_detected"] = calc_details.get("edge_case_detected")
             attrs["safety_margin"] = calc_details.get("safety_margin")
-            attrs["effective_distance"] = calc_details.get("effective_distance")
+            # The trace key is suffixed (effective_distance_m), but the companion
+            # card depends on the legacy `effective_distance` attribute name on the
+            # cover_position sensor — map it back so the card stays byte-identical.
+            attrs["effective_distance"] = calc_details.get("effective_distance_m")
 
     snapshot = s.coordinator._snapshot  # noqa: SLF001
     if snapshot and snapshot.cover_positions:
@@ -771,6 +774,35 @@ def _climate_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any]:
     return attrs
 
 
+def _solar_calculation_details(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
+    """Read the raw solar-calculation trace from diagnostics (single source).
+
+    The trace is the same ``calculation_details`` dict that the diagnostics
+    download surfaces — the sensor and the download therefore read one source.
+    """
+    diagnostics = s.data.diagnostics if s.data else None
+    if not diagnostics:
+        return None
+    return diagnostics.get("calculation_details") or None
+
+
+def _solar_calculation_value(s: _ACPDiagnosticSensor) -> int | None:
+    """State = raw geometric position percentage (pre-interpolation, pre-inverse).
+
+    For venetian this is the lift/position axis (top-level ``position_pct``); the
+    tilt axis rides in the attributes under the nested ``tilt`` sub-key.
+    """
+    details = _solar_calculation_details(s)
+    if details is None:
+        return None
+    return details.get("position_pct")
+
+
+def _solar_calculation_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
+    """Attributes = the full raw calculation_details trace dict."""
+    return _solar_calculation_details(s)
+
+
 def _decision_trace_value(s: _ACPDiagnosticSensor) -> str:
     result = s.coordinator._pipeline_result  # noqa: SLF001
     if result is None:
@@ -1085,6 +1117,20 @@ _DIAGNOSTIC_SPECS: tuple[_SensorSpec, ...] = (
         suggested_display_precision=1,
         value_fn=_sun_position_value,
         attrs_fn=_sun_position_attrs,
+    ),
+    _SensorSpec(
+        suffix="solar_calculation",
+        display_name="Solar Calculation",
+        icon="mdi:sun-angle-outline",
+        translation_key="solar_calculation",
+        state_class=SensorStateClass.MEASUREMENT,
+        unit=PERCENTAGE,
+        suggested_display_precision=0,
+        value_fn=_solar_calculation_value,
+        attrs_fn=_solar_calculation_attrs,
+        # The raw trace can be large and changes every cycle — keep all attributes
+        # out of the recorder DB while the small numeric state still records.
+        unrecorded_attributes=frozenset({MATCH_ALL}),
     ),
     _SensorSpec(
         suffix="control_status",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1230,6 +1230,9 @@
           "winter_mode": "Wintermodus",
           "intermediate": "Übergang"
         }
+      },
+      "solar_calculation": {
+        "name": "Solarberechnung"
       }
     },
     "switch": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1189,6 +1189,9 @@
   },
   "entity": {
     "sensor": {
+      "solar_calculation": {
+        "name": "Solar Calculation"
+      },
       "control_status": {
         "state": {
           "force_override_active": "Force override active",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1230,6 +1230,9 @@
           "winter_mode": "Mode hiver",
           "intermediate": "Intermédiaire"
         }
+      },
+      "solar_calculation": {
+        "name": "Calcul solaire"
       }
     },
     "switch": {

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -522,3 +522,56 @@ class TestPostPipelineResolveHandlerTilt:
         handler_names = [s.handler for s in out.decision_trace]
         assert "venetian_engine" in handler_names
         assert "venetian_handler_tilt" not in handler_names
+
+
+class TestPostPipelineResolveTiltSubTrace:
+    """The venetian tilt sub-trace is merged into the position engine's trace.
+
+    Issue #682: the tilt engine inside ``post_pipeline_resolve`` is transient and
+    its ``_last_calc_details`` was discarded. The merge writes it under a ``tilt``
+    sub-key on the position engine's (``cover``) ``_last_calc_details`` so the
+    live ``solar_calculation`` sensor and the diagnostics download both surface
+    both axes.
+    """
+
+    @staticmethod
+    def _cover_with_trace(*, direct_sun_valid: bool = True):
+        """Build a cover stub with a real-dict _last_calc_details (position trace)."""
+        cover = MagicMock()
+        cover.direct_sun_valid = direct_sun_valid
+        # Real dict, as the vertical engine would have set during the pipeline.
+        cover._last_calc_details = {
+            "sol_elev_deg": 45.0,
+            "gamma_deg": 0.0,
+            "position_pct": 25,
+            "effective_distance_m": 0.5,
+        }
+        return cover
+
+    def test_tilt_subtrace_present_after_solar_resolve(self):
+        policy = _make_policy()
+        kwargs = dict(_solar_kwargs())
+        cover = self._cover_with_trace()
+        kwargs["cover"] = cover
+        policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SOLAR, position=50), **kwargs
+        )
+        details = cover._last_calc_details
+        assert "tilt" in details
+        # The tilt sub-trace carries the tilt-engine keys.
+        assert "beta_rad" in details["tilt"]
+        assert "tilt_mode" in details["tilt"]
+        # The position (vertical) keys remain at the top level.
+        assert "effective_distance_m" in details
+
+    def test_no_tilt_subtrace_when_tilt_suppressed(self):
+        """Suppressed-tilt branch must NOT merge a tilt sub-trace."""
+        policy = _make_policy()
+        cover = self._cover_with_trace(direct_sun_valid=False)
+        kwargs = dict(_solar_kwargs())
+        kwargs["cover"] = cover
+        # direct_sun_valid False → tilt suppressed; the merge must be guarded.
+        policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SOLAR, position=80), **kwargs
+        )
+        assert "tilt" not in cover._last_calc_details

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -445,11 +445,15 @@ class TestPositionDiagnostics:
         assert "last_updated" in diag
 
     def test_calculation_details_included(self, builder: DiagnosticsBuilder):
-        """Calculation details from cover are included."""
+        """Calculation details from cover are surfaced, with cover_type stamped."""
         details = {"edge_case": True, "safety_margin": 1.1}
         cover = _make_cover(calc_details=details)
-        diag, _ = builder.build(_base_ctx(cover=cover))
-        assert diag["calculation_details"] == details
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        out = diag["calculation_details"]
+        # Original keys are preserved; the builder stamps the cover_type discriminator.
+        assert out["edge_case"] is True
+        assert out["safety_margin"] == pytest.approx(1.1)
+        assert out["cover_type"] == "cover_blind"
 
 
 # ---------------------------------------------------------------------------
@@ -1426,3 +1430,220 @@ class TestTiltOnlyCustomSlotSurfacing:
         assert "tilt fixed" not in explanation
         assert "tilt fixed" not in diag["control_state_reason"]
         assert diag["control_state_reason"] == "Sun in FOV"
+
+
+# ---------------------------------------------------------------------------
+# Solar-calculation trace (issue #682) — cover_type stamp + boundary rounding
+# ---------------------------------------------------------------------------
+
+
+class TestCalculationDetailsTrace:
+    """`_build_position_calc_details` stamps cover_type and rounds at the boundary."""
+
+    def _raw_vertical_trace(self) -> dict:
+        """Return a raw, deliberately un-rounded vertical trace as an engine emits."""
+        return {
+            "sol_elev_deg": 45.123456,
+            "gamma_deg": -12.98765,
+            "position_pct": 25,
+            "edge_case_detected": False,
+            "effective_distance_m": 0.512345,
+            "effective_distance_source": "base",
+            "window_depth_contribution_m": 0.0,
+            "sill_height_offset_m": 0.0,
+            "safety_margin": 1.234567,
+            "glare_zones_active": [],
+            "cos_gamma": 0.974370,
+            "cos_gamma_clamped": 0.974370,
+            "path_length_m": 0.525678,
+            "base_height_m": 0.525678,
+            "adjusted_height_m": 0.648911,
+            "clamped_to_window": False,
+        }
+
+    def test_cover_type_stamped_from_ctx(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        details = diag["calculation_details"]
+        assert details["cover_type"] == "cover_blind"
+
+    def test_cover_type_matches_ctx_cover_type(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        ctx = _base_ctx(cover=cover, cover_type="cover_venetian")
+        diag, _ = builder.build(ctx)
+        assert diag["calculation_details"]["cover_type"] == ctx.cover_type
+
+    def test_angles_rounded_one_decimal(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        details = diag["calculation_details"]
+        assert details["sol_elev_deg"] == 45.1
+        assert details["gamma_deg"] == -13.0
+
+    def test_distances_rounded_three_decimals(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        details = diag["calculation_details"]
+        assert details["effective_distance_m"] == 0.512
+        assert details["path_length_m"] == 0.526
+
+    def test_position_pct_is_integer(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        details_pct = diag["calculation_details"]["position_pct"]
+        assert isinstance(details_pct, int)
+        assert details_pct == 25
+
+    def test_ratios_rounded(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        details = diag["calculation_details"]
+        # safety_margin / cos_gamma are unit-less ratios → kept at a few decimals.
+        assert details["safety_margin"] == pytest.approx(1.235, abs=1e-3)
+
+    def test_booleans_and_strings_passthrough(self, builder: DiagnosticsBuilder):
+        cover = _make_cover(calc_details=self._raw_vertical_trace())
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        details = diag["calculation_details"]
+        assert details["edge_case_detected"] is False
+        assert details["effective_distance_source"] == "base"
+        assert details["glare_zones_active"] == []
+
+    def test_does_not_mutate_engine_trace(self, builder: DiagnosticsBuilder):
+        """The builder must round into a copy, not mutate the engine's dict."""
+        raw = self._raw_vertical_trace()
+        cover = _make_cover(calc_details=raw)
+        builder.build(_base_ctx(cover=cover, cover_type="cover_blind"))
+        # Engine's dict keeps full precision.
+        assert raw["sol_elev_deg"] == 45.123456
+
+    def test_nested_tilt_subtrace_rounded(self, builder: DiagnosticsBuilder):
+        """Venetian nested tilt sub-trace is rounded the same way."""
+        trace = self._raw_vertical_trace()
+        trace["tilt"] = {
+            "sol_elev_deg": 45.987654,
+            "gamma_deg": 5.55555,
+            "position_pct": 60,
+            "beta_rad": 0.7853981,
+            "discriminant": 1.234567,
+            "negative_discriminant": False,
+            "slat_angle_raw_deg": 88.7654,
+            "nan_result": False,
+            "max_degrees": 90,
+            "tilt_mode": "mode1",
+        }
+        cover = _make_cover(calc_details=trace)
+        diag, _ = builder.build(_base_ctx(cover=cover, cover_type="cover_venetian"))
+        tilt = diag["calculation_details"]["tilt"]
+        assert tilt["sol_elev_deg"] == 46.0
+        assert tilt["slat_angle_raw_deg"] == 88.8
+        assert tilt["position_pct"] == 60
+
+
+class TestCalculationDetailsAllCoverTypes:
+    """Single-source proof (issue #682): the same calculation_details rail that
+    feeds the live solar_calculation sensor carries enriched, type-correct traces
+    for every cover type in the diagnostics build — no extra download plumbing.
+    """
+
+    def _build_for(self, cover, cover_type: str) -> dict:
+        # Exercise the exact rail (_build_position_calc_details) that both the
+        # live sensor and the diagnostics download read — no full build() needed.
+        out = DiagnosticsBuilder._build_position_calc_details(
+            _base_ctx(cover=cover, cover_type=cover_type)
+        )
+        return out["calculation_details"]
+
+    def test_vertical_trace_in_diagnostics(self):
+        from tests.cover_helpers import build_vertical_cover
+
+        cover = build_vertical_cover(
+            logger=SimpleNamespace(debug=lambda *a, **k: None),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sun_data=SimpleNamespace(),
+            win_azi=180,
+            distance=0.5,
+            h_win=2.0,
+        )
+        cover.calculate_position()
+        details = self._build_for(cover, "cover_blind")
+        assert details["cover_type"] == "cover_blind"
+        assert "effective_distance_m" in details
+        assert "position_pct" in details
+
+    def test_horizontal_trace_in_diagnostics(self):
+        from tests.cover_helpers import build_horizontal_cover
+
+        cover = build_horizontal_cover(
+            logger=SimpleNamespace(debug=lambda *a, **k: None),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sun_data=SimpleNamespace(),
+            win_azi=180,
+            distance=0.5,
+            h_win=2.0,
+            awn_length=2.0,
+            awn_angle=0,
+        )
+        cover.calculate_position()
+        details = self._build_for(cover, "cover_awning")
+        assert details["cover_type"] == "cover_awning"
+        # Horizontal-shaped, not vertical (latent-overwrite regression).
+        assert "awn_angle_deg" in details
+        assert "effective_distance_m" not in details
+
+    def test_tilt_trace_in_diagnostics(self):
+        from tests.cover_helpers import build_tilt_cover
+
+        cover = build_tilt_cover(
+            logger=SimpleNamespace(debug=lambda *a, **k: None),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sun_data=SimpleNamespace(),
+            win_azi=180,
+            slat_distance=0.03,
+            depth=0.05,
+            mode="mode1",
+        )
+        cover.calculate_position()
+        details = self._build_for(cover, "cover_tilt")
+        assert details["cover_type"] == "cover_tilt"
+        assert "beta_rad" in details
+        assert "tilt_mode" in details
+
+    def test_venetian_nested_tilt_in_diagnostics(self):
+        """Venetian: position keys at top level + nested tilt sub-key, both rounded."""
+        from tests.cover_helpers import build_vertical_cover
+
+        cover = build_vertical_cover(
+            logger=SimpleNamespace(debug=lambda *a, **k: None),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sun_data=SimpleNamespace(),
+            win_azi=180,
+            distance=0.5,
+            h_win=2.0,
+        )
+        cover.calculate_position()
+        # Simulate the venetian policy merge: tilt engine trace under `tilt`.
+        from tests.cover_helpers import build_tilt_cover
+
+        tilt = build_tilt_cover(
+            logger=SimpleNamespace(debug=lambda *a, **k: None),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            sun_data=SimpleNamespace(),
+            win_azi=180,
+            slat_distance=0.03,
+            depth=0.05,
+            mode="mode1",
+        )
+        tilt.calculate_position()
+        cover._last_calc_details["tilt"] = tilt._last_calc_details
+        details = self._build_for(cover, "cover_venetian")
+        assert details["cover_type"] == "cover_venetian"
+        assert "tilt" in details
+        assert "beta_rad" in details["tilt"]
+        # Top-level position axis present.
+        assert "position_pct" in details

--- a/tests/test_solar_calc_trace.py
+++ b/tests/test_solar_calc_trace.py
@@ -1,0 +1,344 @@
+"""Tests for the raw solar-calculation trace (`_last_calc_details`) — issue #682.
+
+Each calc engine records a per-cycle raw geometric trace consumed by the new
+`solar_calculation` diagnostic sensor and the diagnostics download. These tests
+assert the stable key set per cover type, the guard-branch flags, and that the
+trace is engine-shaped (not borrowed from a super call).
+"""
+
+import numpy as np
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    TRACE_KEY_GAMMA_DEG,
+    TRACE_KEY_POSITION_PCT,
+    TRACE_KEY_SOL_ELEV_DEG,
+)
+
+
+def _check_native_types(obj, path: str = "root") -> list[str]:
+    """Return paths whose leaves are numpy scalar types (must be empty)."""
+    violations: list[str] = []
+    if isinstance(obj, np.generic):
+        violations.append(f"{path}: {type(obj).__module__}.{type(obj).__name__}")
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            violations.extend(_check_native_types(v, f"{path}.{k}"))
+    elif isinstance(obj, list | tuple):
+        for i, v in enumerate(obj):
+            violations.extend(_check_native_types(v, f"{path}[{i}]"))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Vertical (cover_blind)
+# ---------------------------------------------------------------------------
+
+
+class TestVerticalTrace:
+    """AdaptiveVerticalCover raw trace."""
+
+    _NORMAL_KEYS = {
+        TRACE_KEY_SOL_ELEV_DEG,
+        TRACE_KEY_GAMMA_DEG,
+        TRACE_KEY_POSITION_PCT,
+        "edge_case_detected",
+        "effective_distance_m",
+        "effective_distance_source",
+        "window_depth_contribution_m",
+        "sill_height_offset_m",
+        "safety_margin",
+        "glare_zones_active",
+        "cos_gamma",
+        "cos_gamma_clamped",
+        "path_length_m",
+        "base_height_m",
+        "adjusted_height_m",
+        "clamped_to_window",
+    }
+
+    def test_normal_branch_keys(self, vertical_cover_instance):
+        vertical_cover_instance.calculate_position()
+        details = vertical_cover_instance._last_calc_details
+        assert set(details) == self._NORMAL_KEYS
+        assert details["edge_case_detected"] is False
+        assert details["effective_distance_source"] == "base"
+        assert details[TRACE_KEY_SOL_ELEV_DEG] == pytest.approx(45.0)
+        assert details[TRACE_KEY_GAMMA_DEG] == pytest.approx(0.0)
+        # position_pct is the raw vertical percentage (height / h_win * 100).
+        assert details[TRACE_KEY_POSITION_PCT] == 25  # 0.5m / 2.0m
+
+    def test_normal_branch_native_types(self, vertical_cover_instance):
+        vertical_cover_instance.calculate_position()
+        violations = _check_native_types(vertical_cover_instance._last_calc_details)
+        assert not violations, violations
+
+    def test_clamped_to_window_flag(self, vertical_cover_instance):
+        """High sun clips height to h_win → clamped_to_window True."""
+        vertical_cover_instance.sol_elev = 80.0
+        vertical_cover_instance.calculate_position()
+        details = vertical_cover_instance._last_calc_details
+        assert details["clamped_to_window"] is True
+        assert details[TRACE_KEY_POSITION_PCT] == 100
+
+    def test_not_clamped_flag(self, vertical_cover_instance):
+        vertical_cover_instance.calculate_position()
+        assert vertical_cover_instance._last_calc_details["clamped_to_window"] is False
+
+    def test_edge_case_branch(self, vertical_cover_instance):
+        """Very-low-elevation edge case → edge_case_detected True + native types."""
+        vertical_cover_instance.sol_elev = 1.0  # below EDGE_CASE_LOW_ELEVATION (2.0)
+        vertical_cover_instance.calculate_position()
+        details = vertical_cover_instance._last_calc_details
+        assert details["edge_case_detected"] is True
+        assert details["effective_distance_source"] == "edge_case"
+        assert details["safety_margin"] == 1.0
+        assert TRACE_KEY_SOL_ELEV_DEG in details
+        assert TRACE_KEY_GAMMA_DEG in details
+        assert TRACE_KEY_POSITION_PCT in details
+        assert not _check_native_types(details)
+
+    def test_glare_zone_source(self, vertical_cover_instance):
+        vertical_cover_instance.calculate_position(effective_distance_override=1.0)
+        details = vertical_cover_instance._last_calc_details
+        assert details["effective_distance_source"] == "glare_zone"
+        assert details["effective_distance_m"] == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Tilt (cover_tilt)
+# ---------------------------------------------------------------------------
+
+
+class TestTiltTrace:
+    """AdaptiveTiltCover raw trace."""
+
+    _KEYS = {
+        TRACE_KEY_SOL_ELEV_DEG,
+        TRACE_KEY_GAMMA_DEG,
+        TRACE_KEY_POSITION_PCT,
+        "beta_rad",
+        "discriminant",
+        "negative_discriminant",
+        "slat_angle_raw_deg",
+        "nan_result",
+        "max_degrees",
+        "tilt_mode",
+    }
+
+    def test_normal_branch_keys(self, tilt_cover_instance):
+        # depth > slat_distance keeps the discriminant positive (normal path).
+        tilt_cover_instance.depth = 0.05
+        tilt_cover_instance.calculate_position()
+        details = tilt_cover_instance._last_calc_details
+        assert set(details) == self._KEYS
+        assert details["negative_discriminant"] is False
+        assert details["nan_result"] is False
+        assert details["slat_angle_raw_deg"] is not None
+        assert details["max_degrees"] == 90  # mode1
+        assert details["tilt_mode"] == "mode1"
+        assert details[TRACE_KEY_SOL_ELEV_DEG] == pytest.approx(45.0)
+
+    def test_normal_branch_native_types(self, tilt_cover_instance):
+        tilt_cover_instance.depth = 0.05
+        tilt_cover_instance.calculate_position()
+        assert not _check_native_types(tilt_cover_instance._last_calc_details)
+
+    def test_negative_discriminant_branch(self, tilt_cover_instance):
+        """slat_distance >> depth makes discriminant negative → guard returns 0°."""
+        tilt_cover_instance.slat_distance = 1.0
+        tilt_cover_instance.depth = 0.01
+        result = tilt_cover_instance.calculate_position()
+        details = tilt_cover_instance._last_calc_details
+        assert result == 0.0
+        assert details["negative_discriminant"] is True
+        assert details["discriminant"] < 0
+        assert details["slat_angle_raw_deg"] is None
+        assert details[TRACE_KEY_POSITION_PCT] == 0
+        assert not _check_native_types(details)
+
+    def test_nan_result_branch(self, tilt_cover_instance, monkeypatch):
+        """A NaN slat result trips the nan guard → nan_result True, returns 0°."""
+        import custom_components.adaptive_cover_pro.engine.covers.tilt as tilt_mod
+
+        # Positive-discriminant geometry so we reach the rad2deg/NaN guard.
+        tilt_cover_instance.depth = 0.05
+        monkeypatch.setattr(tilt_mod.np, "rad2deg", lambda _x: np.float64("nan"))
+        result = tilt_cover_instance.calculate_position()
+        details = tilt_cover_instance._last_calc_details
+        assert result == 0.0
+        assert details["nan_result"] is True
+        assert details["negative_discriminant"] is False
+        assert not _check_native_types(details)
+
+    def test_mode2_max_degrees(self, tilt_cover_instance):
+        tilt_cover_instance.tilt_config.mode = "mode2"
+        tilt_cover_instance.calculate_position()
+        details = tilt_cover_instance._last_calc_details
+        assert details["max_degrees"] == 180
+        assert details["tilt_mode"] == "mode2"
+
+
+# ---------------------------------------------------------------------------
+# Horizontal (cover_awning) — incl. latent-overwrite regression
+# ---------------------------------------------------------------------------
+
+
+class TestHorizontalTrace:
+    """AdaptiveHorizontalCover raw trace and the super-call overwrite regression."""
+
+    _KEYS = {
+        TRACE_KEY_SOL_ELEV_DEG,
+        TRACE_KEY_GAMMA_DEG,
+        TRACE_KEY_POSITION_PCT,
+        "awn_angle_deg",
+        "a_angle_deg",
+        "c_angle_deg",
+        "vertical_position_m",
+        "sin_c",
+        "sin_c_near_zero",
+        "length_m",
+        "clamped_to_awn_length",
+    }
+
+    def test_trace_is_horizontal_not_vertical(self, horizontal_cover_instance):
+        """Regression: the super().calculate_position() call sets the vertical
+        trace, but the horizontal trace must win — proving horizontal keys, NOT
+        vertical ones like effective_distance_m.
+        """
+        horizontal_cover_instance.calculate_position()
+        details = horizontal_cover_instance._last_calc_details
+        assert set(details) == self._KEYS
+        # The vertical shape must not leak through.
+        assert "effective_distance_m" not in details
+        assert "awn_angle_deg" in details
+
+    def test_normal_branch_values(self, horizontal_cover_instance):
+        horizontal_cover_instance.calculate_position()
+        details = horizontal_cover_instance._last_calc_details
+        assert details["sin_c_near_zero"] is False
+        assert details[TRACE_KEY_SOL_ELEV_DEG] == pytest.approx(45.0)
+        assert details["a_angle_deg"] == pytest.approx(45.0)  # 90 - sol_elev
+
+    def test_native_types(self, horizontal_cover_instance):
+        horizontal_cover_instance.calculate_position()
+        assert not _check_native_types(horizontal_cover_instance._last_calc_details)
+
+    def test_sin_c_near_zero_guard(self, horizontal_cover_instance):
+        """c_angle = awn_angle + sol_elev; both ≈ 0 → sin(c_angle) ≈ 0 → guard fires."""
+        # awn_angle_calc = 90 - awn_angle, a_angle = 90 - sol_elev,
+        # c_angle = 180 - awn_angle_calc - a_angle = awn_angle + sol_elev.
+        horizontal_cover_instance.sol_elev = 0.0
+        horizontal_cover_instance.horiz_config.awn_angle = 0.0
+        result = horizontal_cover_instance.calculate_position()
+        details = horizontal_cover_instance._last_calc_details
+        assert details["sin_c_near_zero"] is True
+        assert result == horizontal_cover_instance.awn_length
+        assert details["length_m"] == pytest.approx(
+            horizontal_cover_instance.awn_length
+        )
+        assert not _check_native_types(details)
+
+    def test_clamped_to_awn_length_flag(self, horizontal_cover_instance):
+        """A short awning forces the geometric length over the limit → clamp flag."""
+        horizontal_cover_instance.horiz_config.awn_length = 0.01
+        horizontal_cover_instance.sol_elev = 20.0
+        horizontal_cover_instance.calculate_position()
+        details = horizontal_cover_instance._last_calc_details
+        assert details["clamped_to_awn_length"] is True
+
+
+# ---------------------------------------------------------------------------
+# solar_calculation diagnostic sensor (issue #682)
+# ---------------------------------------------------------------------------
+
+
+class TestSolarCalculationSensorSpec:
+    """The new solar_calculation diagnostic sensor spec wiring."""
+
+    def _spec(self):
+        from custom_components.adaptive_cover_pro.sensor import _DIAGNOSTIC_SPECS
+
+        for spec in _DIAGNOSTIC_SPECS:
+            if spec.suffix == "solar_calculation":
+                return spec
+        raise AssertionError("solar_calculation spec not registered")
+
+    def _stub_sensor(self, calc_details):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            data=SimpleNamespace(
+                diagnostics=(
+                    {"calculation_details": calc_details}
+                    if calc_details is not None
+                    else {}
+                )
+            )
+        )
+
+    def test_spec_registered(self):
+        spec = self._spec()
+        assert spec.translation_key == "solar_calculation"
+        assert spec.unit == "%"
+        assert spec.suggested_display_precision == 0
+
+    def test_state_class_measurement(self):
+        from homeassistant.components.sensor import SensorStateClass
+
+        assert self._spec().state_class == SensorStateClass.MEASUREMENT
+
+    def test_value_is_raw_position_pct(self):
+        spec = self._spec()
+        s = self._stub_sensor({"cover_type": "cover_blind", "position_pct": 42})
+        assert spec.value_fn(s) == 42
+
+    def test_value_none_when_no_calc_details(self):
+        spec = self._spec()
+        s = self._stub_sensor(None)
+        assert spec.value_fn(s) is None
+
+    def test_value_for_venetian_uses_top_level_position(self):
+        """Venetian: state is the lift/position axis (top-level position_pct)."""
+        spec = self._spec()
+        s = self._stub_sensor(
+            {
+                "cover_type": "cover_venetian",
+                "position_pct": 30,
+                "tilt": {"position_pct": 70},
+            }
+        )
+        assert spec.value_fn(s) == 30
+
+    def test_attrs_are_full_trace(self):
+        spec = self._spec()
+        trace = {"cover_type": "cover_blind", "position_pct": 42, "gamma_deg": 5.0}
+        s = self._stub_sensor(trace)
+        assert spec.attrs_fn(s) == trace
+
+    def test_attrs_none_when_no_calc_details(self):
+        spec = self._spec()
+        s = self._stub_sensor(None)
+        assert spec.attrs_fn(s) is None
+
+    def test_unrecorded_attributes_match_all(self):
+        from homeassistant.const import MATCH_ALL
+
+        assert MATCH_ALL in self._spec().unrecorded_attributes
+
+    def test_resolved_class_has_match_all(self):
+        from homeassistant.const import MATCH_ALL
+
+        from custom_components.adaptive_cover_pro.sensor import _DIAGNOSTIC_CLASSES
+
+        cls = _DIAGNOSTIC_CLASSES["solar_calculation"]
+        assert MATCH_ALL in cls._unrecorded_attributes
+
+    def test_is_diagnostic_and_enabled_by_default(self):
+        from types import SimpleNamespace
+
+        spec = self._spec()
+        assert spec.diagnostic is True
+        # enabled_when defaults to always-True (no per-type gating).
+        entry = SimpleNamespace(options={}, data={})
+        assert spec.enabled_when(entry) is True

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -46,6 +46,7 @@ _EXPECTED_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
         "decision_trace",
         "motion_status",
         "position_forecast",
+        "solar_calculation",
     }
 )
 

--- a/tests/test_unique_id_snapshot.py
+++ b/tests/test_unique_id_snapshot.py
@@ -84,6 +84,7 @@ EXPECTED_UNIQUE_ID_SUFFIXES = sorted(
         "Start Sun",
         "End Sun",
         "sun_position",
+        "solar_calculation",
         "control_status",
         "decision_trace",
         "last_skipped_action",


### PR DESCRIPTION
## Summary
Adds a live `solar_calculation` diagnostic sensor that exposes the full raw geometric solar-position calculation trace (inputs → intermediates → output) for all four cover types — vertical, horizontal, tilt, and venetian — so users can see *how* the Solar handler arrived at its position, not just that it won.

- Reuses the existing `_last_calc_details` → `data.diagnostics["calculation_details"]` rail, so the live sensor and the downloadable diagnostics JSON read one source.
- Clean suffixed v1 schema with a `cover_type` discriminator and unit-suffixed keys (`_deg`, `_m`); numeric rounding applied at the builder boundary.
- Sensor sets `_unrecorded_attributes = frozenset({MATCH_ALL})` — the bulky geometry attributes never hit the recorder DB; only the raw position % state records.
- Fixes a latent bug: the horizontal engine inherited the vertical trace via `super()`; it now writes its own trace after the super call.
- Closes the venetian dual-axis gap: the tilt sub-trace is merged under a `tilt` sub-key (previously discarded).
- Reports raw solar geometry only — the sensor's `position_pct` is the engine's pre-interpolation, pre-inverse output and may legitimately differ from the commanded position.
- DE/FR translations synced.

## Testing
- ✅ 4831 tests passing (full suite)

## Follow-ups (not in this PR)
- Wiki page documenting the per-cover-type attribute schema.
- Companion card rendering of the breakdown.

## Related Issues
Refs #682