### PR TITLE
fix: proxy tilt drives the slat axis, not the carriage (#684)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2263,6 +2263,34 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         return await self._cmd_svc.apply_position(entity_id, clamped, trigger, ctx)
 
+    async def async_apply_user_tilt(
+        self,
+        entity_id: str,
+        tilt: int,
+        *,
+        trigger: str,
+    ) -> tuple[str, str]:
+        """Apply a user-initiated tilt to a single cover (issue #684).
+
+        Dedicated tilt-axis entry point for the opt-in proxy cover (and any
+        future user-facing tilt command). Engages manual override, then
+        delegates to the cover-type policy's ``apply_user_tilt`` hook. Cover
+        types with an independent tilt axis (venetian) drive ONLY the tilt
+        slats — the carriage is left untouched. Cover types whose primary axis
+        already IS the tilt (``cover_tilt``) return not-handled from the base
+        hook, so we fall back to ``async_apply_user_position`` (a tilt there is
+        a position move).
+        """
+        self.manager.mark_user_command(entity_id, reason=trigger)
+        handled = await self._policy.apply_user_tilt(
+            entity_id, tilt=int(tilt), reason=trigger
+        )
+        if handled:
+            return "sent", ""
+        return await self.async_apply_user_position(
+            entity_id, int(tilt), trigger=trigger
+        )
+
     async def async_apply_user_stop(
         self,
         entity_id: str,

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2269,26 +2269,37 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         tilt: int,
         *,
         trigger: str,
+        force: bool = False,
     ) -> tuple[str, str]:
         """Apply a user-initiated tilt to a single cover (issue #684).
 
-        Dedicated tilt-axis entry point for the opt-in proxy cover (and any
-        future user-facing tilt command). Engages manual override, then
-        delegates to the cover-type policy's ``apply_user_tilt`` hook. Cover
-        types with an independent tilt axis (venetian) drive ONLY the tilt
-        slats — the carriage is left untouched. Cover types whose primary axis
-        already IS the tilt (``cover_tilt``) return not-handled from the base
-        hook, so we fall back to ``async_apply_user_position`` (a tilt there is
-        a position move).
+        Dedicated tilt-axis entry point for the opt-in proxy cover, the
+        ``adaptive_cover_pro.set_tilt`` service, and any future user-facing
+        tilt command. Delegates to the cover-type policy's ``apply_user_tilt``
+        hook. Cover types with an independent tilt axis (venetian) drive ONLY
+        the tilt slats — the carriage is left untouched. Cover types whose
+        primary axis already IS the tilt (``cover_tilt``) return not-handled
+        from the base hook, so we fall back to ``async_apply_user_position``
+        (a tilt there is a position move).
+
+        ``force`` (default ``False``) governs manual-override engagement only:
+        when ``False`` (the proxy slider / default service call) manual override
+        is engaged like a dashboard control; when ``True`` engagement is
+        skipped, matching ``set_position``'s force semantics. There is no
+        pipeline-preemption check on the tilt path (by design); ``force`` is
+        threaded through to the ``async_apply_user_position`` fallback so the
+        ``cover_tilt`` case stays consistent. The venetian sequencer's internal
+        force-resend for an explicit command is independent and stays always-on.
         """
-        self.manager.mark_user_command(entity_id, reason=trigger)
+        if not force:
+            self.manager.mark_user_command(entity_id, reason=trigger)
         handled = await self._policy.apply_user_tilt(
             entity_id, tilt=int(tilt), reason=trigger
         )
         if handled:
             return "sent", ""
         return await self.async_apply_user_position(
-            entity_id, int(tilt), trigger=trigger
+            entity_id, int(tilt), trigger=trigger, force=force
         )
 
     async def async_apply_user_stop(

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -274,14 +274,20 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         )
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
-        """Route tilt position via the helper when the source supports tilt."""
+        """Route the requested tilt onto the dedicated tilt axis (issue #684).
+
+        Dual-axis covers (venetian) must move only the slats — routing a tilt
+        through ``async_apply_user_position`` previously drove the carriage to
+        the requested value and left the slats untouched. ``async_apply_user_tilt``
+        dispatches through the cover-type policy so the carriage stays put.
+        """
         if not self._source_available():
             return
         if not caps_get(self._source_caps(), CAP_HAS_SET_TILT_POSITION):
             return
-        position = int(kwargs["tilt_position"])
-        await self.coordinator.async_apply_user_position(
-            self._source_entity_id, position, trigger=TRIGGER_PROXY_TILT
+        tilt = int(kwargs["tilt_position"])
+        await self.coordinator.async_apply_user_tilt(
+            self._source_entity_id, tilt, trigger=TRIGGER_PROXY_TILT
         )
 
     async def async_stop_cover(self, **kwargs: Any) -> None:

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -350,6 +350,27 @@ class CoverTypePolicy(ABC):
         """
         return
 
+    async def apply_user_tilt(
+        self,
+        entity_id: str,  # noqa: ARG002
+        *,
+        tilt: int,  # noqa: ARG002
+        reason: str,  # noqa: ARG002
+    ) -> bool:
+        """Apply a user-requested tilt on the dedicated tilt axis.
+
+        Returns ``True`` when the request was handled on a real tilt axis;
+        ``False`` (the default) when the cover type has no independent tilt
+        axis, so the coordinator falls back to its position path.
+
+        This is correct for ``cover_tilt``, whose *primary* axis already IS
+        the tilt slats — a user tilt request there is just a position move and
+        belongs in ``async_apply_user_position``. Only dual-axis covers
+        (venetian) override this to drive tilt without touching the carriage
+        (issue #684).
+        """
+        return False
+
     async def before_position_command(
         self,
         cmd_svc,  # noqa: ARG002

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -663,6 +663,35 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             reason=reason,
         )
 
+    async def apply_user_tilt(
+        self,
+        entity_id: str,
+        *,
+        tilt: int,
+        reason: str,
+    ) -> bool:
+        """Drive a user-requested tilt on the tilt axis ONLY (issue #684).
+
+        A venetian is dual-axis: the proxy/user must be able to set slat tilt
+        without moving the carriage. We read the *current* carriage position
+        purely as a reference for the sequencer's pairing/rebase logic — it is
+        never commanded — and force the tilt send so a user re-requesting the
+        current angle still fires. ``update_tilt_only`` →
+        ``_send_tilt_command`` applies ``_to_wire`` internally, so inverse-tilt
+        is handled for free.
+        """
+        if self._sequencer is None:
+            return False
+        current_position = self._sequencer._get_current_position(entity_id)
+        await self._sequencer.update_tilt_only(
+            entity_id,
+            tilt_target=tilt,
+            current_position=current_position,
+            reason=reason,
+            force=True,
+        )
+        return True
+
     def _is_in_tilt_command_grace(self, entity_id: str, delta: float = 0.0) -> bool:
         """Return True when the entity is inside the command-grace window.
 

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -693,14 +693,20 @@ class DualAxisSequencer:
         tilt_target: int,
         current_position: int | None,
         reason: str,
+        force: bool = False,
     ) -> None:
         """Emit a tilt command without a position settle wait or suppression stamp.
 
         Used by VenetianPolicy when the position axis won't fire this cycle
         (cover is already at the commanded position) so tilt can still track
         the sun continuously.
+
+        ``force=True`` bypasses the target-unchanged dedup here AND threads the
+        same flag into ``_send_tilt_command`` so it skips the dedup/min-delta
+        gates. Used by the user-tilt path (issue #684): a user explicitly
+        re-requesting the current tilt is not a no-op.
         """
-        if self._target_already_satisfied(entity_id, tilt_target):
+        if not force and self._target_already_satisfied(entity_id, tilt_target):
             self._record_event(
                 "tilt_command_skipped",
                 reason=_TILT_SKIP_TARGET_UNCHANGED,
@@ -715,6 +721,7 @@ class DualAxisSequencer:
             tilt_target=tilt_target,
             position_target=current_position if current_position is not None else 0,
             reason=reason,
+            force=force,
         )
 
     def _rebase_commanded_position(self, entity_id: str, position_target: int) -> None:

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -89,6 +89,39 @@ set_position:
       selector:
         boolean:
 
+set_tilt:
+  name: Set tilt
+  description: >-
+    Set the slat/tilt axis of the targeted covers. On venetian (dual-axis)
+    covers this drives ONLY the tilt slats and leaves the carriage untouched;
+    on cover types whose primary axis already is the tilt it behaves like a
+    tilt move. By default the call engages manual override; set force=true to
+    skip manual-override engagement (matching set_position's force semantics).
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    tilt:
+      name: Tilt
+      description: "Target tilt (0–100%)."
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    force:
+      name: Force
+      description: >-
+        When true, skip manual-override engagement. Default false — service
+        calls engage manual override like a dashboard slider.
+      required: false
+      default: false
+      selector:
+        boolean:
+
 set_position_limits:
   name: Set position limits
   description: >-

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -21,6 +21,7 @@ from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagno
 from .export_service import EXPORT_CONFIG_SCHEMA, async_handle_export
 from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
+from .set_tilt_service import SET_TILT_SCHEMA, async_handle_set_tilt
 from .stop_service import async_handle_stop
 
 _LOGGER = logging.getLogger(__name__)
@@ -199,6 +200,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, "set_position", async_handle_set_position, schema=SET_POSITION_SCHEMA
     )
+    hass.services.async_register(
+        DOMAIN, "set_tilt", async_handle_set_tilt, schema=SET_TILT_SCHEMA
+    )
     hass.services.async_register(DOMAIN, "stop", async_handle_stop)
 
     register_options_services(hass)
@@ -218,6 +222,7 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "integration_disable")
     hass.services.async_remove(DOMAIN, "emergency_stop")
     hass.services.async_remove(DOMAIN, "set_position")
+    hass.services.async_remove(DOMAIN, "set_tilt")
     hass.services.async_remove(DOMAIN, "stop")
     for name in OPTIONS_SERVICE_NAMES:
         hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/set_tilt_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_tilt_service.py
@@ -1,0 +1,62 @@
+"""set_tilt service — drives the slat/tilt axis on dual-axis covers (issue #684).
+
+Thin target-resolution layer over ``Coordinator.async_apply_user_tilt``, which
+owns the policy-hook dispatch (venetian slats untouched carriage) and the
+``cover_tilt`` position fall-back. Mirrors ``set_position_service`` exactly,
+delegating to the dedicated tilt entry point instead of the position one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+from voluptuous.validators import Coerce, Range
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+_LOGGER = logging.getLogger(__name__)
+
+SET_TILT_SCHEMA = cv.make_entity_service_schema(
+    {
+        vol.Required("tilt"): vol.All(Coerce(int), Range(min=0, max=100)),
+        vol.Optional("force", default=False): bool,
+    }
+)
+
+
+def _resolve_targets(hass, call):
+    """Thin re-export so tests can patch the local name."""
+    from . import _resolve_targets as _rt  # noqa: PLC0415
+
+    return _rt(hass, call)
+
+
+async def async_handle_set_tilt(call: ServiceCall) -> None:
+    """Handle the set_tilt service call.
+
+    Resolves the target block to one or more coordinators (each with an
+    optional entity filter), then delegates each command to
+    ``coord.async_apply_user_tilt`` — the single source of truth for tilt-axis
+    dispatch (venetian slats, ``cover_tilt`` position fall-back).
+
+    ``force`` (default ``False``) propagates through: when ``False`` the service
+    engages manual override like a dashboard slider; when ``True`` it skips
+    manual-override engagement, matching ``set_position``'s semantics.
+    """
+    hass = call.hass
+    requested: int = call.data["tilt"]
+    force: bool = call.data.get("force", False)
+    targets = _resolve_targets(hass, call)
+
+    for coord, entity_filter in targets.items():
+        entity_ids: list[str] = (
+            list(entity_filter) if entity_filter is not None else list(coord.entities)
+        )
+        for entity_id in entity_ids:
+            await coord.async_apply_user_tilt(
+                entity_id, requested, trigger="set_tilt", force=force
+            )

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1928,6 +1928,20 @@
     "stop": {
       "name": "Beschattung stoppen",
       "description": "Sendet stop_cover an die gewählten Beschattungen über den ACP-Proxy. Aktiviert Manuelle Übersteuerung, sodass der nächste automatische Zyklus die Beschattung nicht gegen die Bedienung aussteuert. Verwenden Sie dies statt cover.stop_cover, wenn manual_ignore_external aktiviert ist."
+    },
+    "set_tilt": {
+      "name": "Neigung setzen",
+      "description": "Stellt die Lamellen-/Neigungsachse der Beschattung ein. Bei Jalousien (dual-axis Beschattungen) treibt dies nur die Neigungs-Lamellen an und lässt den Schlitten unverändert; bei Beschattungstypen, deren primäre Achse bereits die Neigung ist, verhält sich dies wie eine Neigungs-Bewegung. Standardmäßig aktiviert der Aufruf die Manuelle Übersteuerung; setzen Sie force=true, um die Aktivierung der Manuellen Übersteuerung zu überspringen (entspricht der force-Semantik von set_position).",
+      "fields": {
+        "tilt": {
+          "name": "Neigung",
+          "description": "Ziel-Neigung (0–100%)."
+        },
+        "force": {
+          "name": "Erzwingen",
+          "description": "Wenn aktiviert, die Aktivierung der Manuellen Übersteuerung überspringen. Standard: deaktiviert — Dienstaufrufe aktivieren die Manuelle Übersteuerung wie ein Dashboard-Schieberegler."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1928,6 +1928,20 @@
           "description": "When true, bypass the priority pipeline check and skip manual-override engagement. Default false — service calls respect force_override / weather and engage manual override like a dashboard slider."
         }
       }
+    },
+    "set_tilt": {
+      "name": "Set tilt",
+      "description": "Sets the slat/tilt axis of the cover. On venetian (dual-axis) covers this drives only the tilt slats and leaves the carriage untouched; on cover types whose primary axis already is the tilt it behaves like a tilt move. By default the call engages manual override; set force=true to skip manual-override engagement (matching set_position's force semantics).",
+      "fields": {
+        "tilt": {
+          "name": "Tilt",
+          "description": "Target tilt (0–100%)."
+        },
+        "force": {
+          "name": "Force",
+          "description": "When true, skip manual-override engagement. Default false — service calls engage manual override like a dashboard slider."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1928,6 +1928,20 @@
     "stop": {
       "name": "Arrêter la protection",
       "description": "Envoie stop_cover aux protections ciblées via le proxy ACP. Active la dérogation manuelle afin que le prochain cycle automatique ne contre-commande pas la protection. Utilisez ce service à la place de cover.stop_cover quand manual_ignore_external est activé."
+    },
+    "set_tilt": {
+      "name": "Définir l'inclinaison",
+      "description": "Définit l'axe inclinaison/lamelle de la protection. Sur les stores vénitiens (à double axe), cela entraîne uniquement les lamelles d'inclinaison et laisse le chariot inchangé ; sur les types de protection dont l'axe principal est déjà l'inclinaison, cela se comporte comme un mouvement d'inclinaison. Par défaut, l'appel engage la dérogation manuelle ; mettez force=true pour ignorer l'engagement de dérogation manuelle (correspondant à la sémantique de force de set_position).",
+      "fields": {
+        "tilt": {
+          "name": "Inclinaison",
+          "description": "Inclinaison cible (0–100%)."
+        },
+        "force": {
+          "name": "Forcer",
+          "description": "Lorsque cette option est activée, ignore l'engagement de dérogation manuelle. Par défaut false — les appels de service engagent la dérogation manuelle comme un curseur du tableau de bord."
+        }
+      }
     }
   }
 }

--- a/tests/cover/test_proxy_cover_commands.py
+++ b/tests/cover/test_proxy_cover_commands.py
@@ -13,7 +13,11 @@ from custom_components.adaptive_cover_pro.const import (
     DOMAIN,
     CoverType,
 )
-from tests.ha_helpers import VERTICAL_OPTIONS, TILT_OPTIONS, _patch_coordinator_refresh
+from tests.ha_helpers import (
+    VERTICAL_OPTIONS,
+    TILT_OPTIONS,
+    _patch_coordinator_refresh,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -133,30 +137,98 @@ async def test_close_cover_calls_apply_user_position_with_0(hass) -> None:
     )
 
 
-async def test_set_cover_tilt_position_routes_through_apply_user_position(hass) -> None:
-    """Tilt-capable cover: ``cover.set_cover_tilt_position`` routes through the helper."""
+async def test_proxy_tilt_routes_to_apply_user_tilt(hass) -> None:
+    """Venetian proxy: ``set_cover_tilt_position`` delegates to ``async_apply_user_tilt``.
+
+    Issue #684: the proxy tilt setter must drive the *tilt* axis, not the
+    position parameter of ``async_apply_user_position``. The requested tilt
+    flows into the dedicated tilt entry point with the ``proxy_tilt`` trigger,
+    and the position helper is left untouched.
+    """
     entry, coord, proxy_eid = await _setup_proxy(
         hass,
-        cover_type=CoverType.TILT,
+        cover_type=CoverType.VENETIAN,
         source="cover.venetian",
         entry_id="proxy_cmd_tilt",
+        options=dict(VERTICAL_OPTIONS),
         attrs={
             "current_position": 50,
-            "current_tilt_position": 50,
+            "current_tilt_position": 80,
             "supported_features": 143 | 128,
         },
     )
+    coord.async_apply_user_tilt = AsyncMock(return_value=("sent", ""))
     coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
 
     await hass.services.async_call(
         "cover",
         "set_cover_tilt_position",
-        {"entity_id": proxy_eid, "tilt_position": 75},
+        {"entity_id": proxy_eid, "tilt_position": 10},
         blocking=True,
     )
-    coord.async_apply_user_position.assert_awaited_once_with(
-        "cover.venetian", 75, trigger="proxy_tilt"
+    coord.async_apply_user_tilt.assert_awaited_once_with(
+        "cover.venetian", 10, trigger="proxy_tilt"
     )
+    coord.async_apply_user_position.assert_not_awaited()
+
+
+async def test_proxy_tilt_sends_real_tilt_service_leaves_carriage_unchanged(
+    hass,
+) -> None:
+    """End-to-end: a proxy tilt request lands ``set_cover_tilt_position`` on the source.
+
+    Core of issue #684 — the entry point is NOT mocked. A venetian dual-axis
+    source at position 50 / tilt 80 receiving a tilt request of 10 must emit
+    exactly one ``cover.set_cover_tilt_position`` (tilt_position == 10) on the
+    source and ZERO ``cover.set_cover_position`` calls (carriage unchanged).
+    """
+    from homeassistant.const import EVENT_CALL_SERVICE
+
+    entry, coord, proxy_eid = await _setup_proxy(
+        hass,
+        cover_type=CoverType.VENETIAN,
+        source="cover.venetian",
+        entry_id="proxy_cmd_tilt_real",
+        options=dict(VERTICAL_OPTIONS),
+        attrs={
+            "current_position": 50,
+            "current_tilt_position": 80,
+            "supported_features": 143 | 128,
+        },
+    )
+
+    tilt_calls: list[dict] = []
+    position_calls: list[dict] = []
+
+    def _on_event(event):
+        if event.data.get("domain") != "cover":
+            return
+        data = dict(event.data.get("service_data") or {})
+        if data.get("entity_id") != "cover.venetian":
+            return
+        if event.data.get("service") == "set_cover_tilt_position":
+            tilt_calls.append(data)
+        elif event.data.get("service") == "set_cover_position":
+            position_calls.append(data)
+
+    hass.bus.async_listen(EVENT_CALL_SERVICE, _on_event)
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_tilt_position",
+        {"entity_id": proxy_eid, "tilt_position": 10},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    # At least one real tilt service call lands on the source, and every tilt
+    # call requests the user value (10) — a static mock source never publishes
+    # the new tilt, so the verify path may fire a bounded drift retry of the
+    # SAME value (issue #500), which is correct production behavior.
+    assert tilt_calls, f"no tilt service call reached the source: {tilt_calls}"
+    assert all(c.get("tilt_position") == 10 for c in tilt_calls), tilt_calls
+    # Core of #684: the carriage must NOT be commanded.
+    assert position_calls == [], f"carriage moved unexpectedly: {position_calls}"
 
 
 async def test_stop_cover_forwards_directly_no_clamp(hass) -> None:

--- a/tests/services/test_set_tilt_service.py
+++ b/tests/services/test_set_tilt_service.py
@@ -1,0 +1,233 @@
+"""Tests for the set_tilt service handler (issue #684 follow-up).
+
+Mirrors ``tests/services/test_set_position_service.py``: the handler resolves
+targets via the shared ``_resolve_targets`` shim and delegates each command to
+``Coordinator.async_apply_user_tilt`` with the tilt value, ``trigger="set_tilt"``,
+and ``force`` propagation. The coordinator method is mocked here.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+
+def _make_coord(*, entities: list[str] | None = None):
+    coord = MagicMock()
+    coord.entities = entities or ["cover.venetian"]
+    coord.async_apply_user_tilt = AsyncMock(return_value=("sent", ""))
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_rejects_missing_tilt() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_TILT_SCHEMA({})
+
+
+def test_schema_rejects_tilt_out_of_range() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_TILT_SCHEMA({"tilt": 150})
+
+
+def test_schema_rejects_negative_tilt() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_TILT_SCHEMA({"tilt": -1})
+
+
+def test_schema_accepts_boundary_values() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    assert SET_TILT_SCHEMA({"tilt": 0, "entity_id": ["cover.t"]})["tilt"] == 0
+    assert SET_TILT_SCHEMA({"tilt": 100, "entity_id": ["cover.t"]})["tilt"] == 100
+
+
+def test_schema_coerces_string_to_int() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    result = SET_TILT_SCHEMA({"tilt": "40", "entity_id": ["cover.t"]})
+    assert result["tilt"] == 40
+    assert isinstance(result["tilt"], int)
+
+
+def test_schema_accepts_force_parameter() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    result = SET_TILT_SCHEMA({"tilt": 50, "force": True, "entity_id": ["cover.t"]})
+    assert result["tilt"] == 50
+    assert result["force"] is True
+
+
+def test_schema_defaults_force_to_false() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    result = SET_TILT_SCHEMA({"tilt": 50, "entity_id": ["cover.t"]})
+    assert result.get("force") is False
+
+
+def test_schema_accepts_ha_injected_target_keys() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        SET_TILT_SCHEMA,
+    )
+
+    assert SET_TILT_SCHEMA({"tilt": 50, "entity_id": ["cover.t"]})["tilt"] == 50
+    assert SET_TILT_SCHEMA({"tilt": 30, "device_id": ["abc"]})["tilt"] == 30
+    assert SET_TILT_SCHEMA({"tilt": 75, "area_id": ["lr"]})["tilt"] == 75
+
+
+# ---------------------------------------------------------------------------
+# Wrapper coverage: thin _resolve_targets re-export
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_targets_wrapper_delegates_to_services_module() -> None:
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        _resolve_targets as wrapper,
+    )
+
+    sentinel_hass = MagicMock(name="hass")
+    sentinel_call = MagicMock(name="call")
+    expected = {"coord_x": None}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services._resolve_targets",
+        return_value=expected,
+    ) as real:
+        result = wrapper(sentinel_hass, sentinel_call)
+
+    real.assert_called_once_with(sentinel_hass, sentinel_call)
+    assert result is expected
+
+
+# ---------------------------------------------------------------------------
+# Handler delegation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_delegates_to_apply_user_tilt_default_force_false() -> None:
+    """Without ``force``, the handler delegates with force=False."""
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        async_handle_set_tilt,
+    )
+
+    coord = _make_coord()
+    call = MagicMock()
+    call.data = {"tilt": 40}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_tilt_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_tilt(call)
+
+    coord.async_apply_user_tilt.assert_awaited_once_with(
+        "cover.venetian", 40, trigger="set_tilt", force=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_force_true_propagates() -> None:
+    """force=True propagates through to async_apply_user_tilt."""
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        async_handle_set_tilt,
+    )
+
+    coord = _make_coord()
+    call = MagicMock()
+    call.data = {"tilt": 70, "force": True}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_tilt_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_tilt(call)
+
+    coord.async_apply_user_tilt.assert_awaited_once_with(
+        "cover.venetian", 70, trigger="set_tilt", force=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_entity_filter_limits_commands() -> None:
+    """When entity_filter is a set, only those entities get commanded."""
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        async_handle_set_tilt,
+    )
+
+    coord = _make_coord(entities=["cover.a", "cover.b"])
+    call = MagicMock()
+    call.data = {"tilt": 60}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_tilt_service._resolve_targets",
+        return_value={coord: {"cover.a"}},
+    ):
+        await async_handle_set_tilt(call)
+
+    commanded = [c.args[0] for c in coord.async_apply_user_tilt.await_args_list]
+    assert commanded == ["cover.a"]
+
+
+@pytest.mark.asyncio
+async def test_no_filter_commands_all_entities() -> None:
+    """When entity_filter is None, all coordinator entities are commanded."""
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        async_handle_set_tilt,
+    )
+
+    coord = _make_coord(entities=["cover.a", "cover.b"])
+    call = MagicMock()
+    call.data = {"tilt": 60}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_tilt_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_tilt(call)
+
+    commanded = sorted(c.args[0] for c in coord.async_apply_user_tilt.await_args_list)
+    assert commanded == ["cover.a", "cover.b"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_entity_id_silently_skipped() -> None:
+    """No resolved coordinators → nothing commanded, no exception."""
+    from custom_components.adaptive_cover_pro.services.set_tilt_service import (
+        async_handle_set_tilt,
+    )
+
+    call = MagicMock()
+    call.data = {"entity_id": ["cover.unknown"], "tilt": 40}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_tilt_service._resolve_targets",
+        return_value={},
+    ):
+        await async_handle_set_tilt(call)

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -644,6 +644,39 @@ async def test_async_apply_user_tilt_falls_back_to_position_for_non_venetian() -
     outcome = await coord.async_apply_user_tilt("cover.blind", 33, trigger="proxy_tilt")
 
     coord.async_apply_user_position.assert_awaited_once_with(
-        "cover.blind", 33, trigger="proxy_tilt"
+        "cover.blind", 33, trigger="proxy_tilt", force=False
     )
     assert outcome == ("sent", "fallback")
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_tilt_force_false_engages_manual_override() -> None:
+    """force=False (default) engages manual override before delegating."""
+    from custom_components.adaptive_cover_pro.cover_types import BlindPolicy
+
+    coord = _make_tilt_coord(policy=BlindPolicy())
+
+    await coord.async_apply_user_tilt("cover.blind", 33, trigger="set_tilt")
+
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.blind", reason="set_tilt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_tilt_force_true_skips_override_and_threads_force() -> (
+    None
+):
+    """force=True does NOT engage manual override and threads force into the
+    non-venetian position fallback.
+    """
+    from custom_components.adaptive_cover_pro.cover_types import BlindPolicy
+
+    coord = _make_tilt_coord(policy=BlindPolicy())
+
+    await coord.async_apply_user_tilt("cover.blind", 33, trigger="set_tilt", force=True)
+
+    coord.manager.mark_user_command.assert_not_called()
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.blind", 33, trigger="set_tilt", force=True
+    )

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -584,3 +584,66 @@ async def test_apply_user_position_explicit_options_not_overridden_by_resolved()
     assert (
         opts_passed is explicit_options
     ), "build() must use the explicitly supplied options when options != None."
+
+
+# ---------------------------------------------------------------------------
+# async_apply_user_tilt — issue #684 dedicated tilt-axis entry point
+# ---------------------------------------------------------------------------
+
+
+def _make_tilt_coord(*, policy):
+    """Build a coordinator-shaped mock that exposes the real ``async_apply_user_tilt``.
+
+    Binds the real method off the class so the manual-override engagement and
+    the policy-hook dispatch / position fall-back can be exercised against
+    mocked collaborators.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+    coord._policy = policy
+    coord.manager = MagicMock()
+    coord.manager.mark_user_command = MagicMock()
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", "fallback"))
+    coord.async_apply_user_tilt = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_tilt.__get__(coord)
+    )
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_tilt_engages_override_and_delegates_to_policy() -> None:
+    """Venetian: the tilt entry point engages manual override and delegates to the policy."""
+    policy = MagicMock()
+    policy.apply_user_tilt = AsyncMock(return_value=True)
+    coord = _make_tilt_coord(policy=policy)
+
+    outcome = await coord.async_apply_user_tilt(
+        "cover.venetian", 10, trigger="proxy_tilt"
+    )
+
+    coord.manager.mark_user_command.assert_called_once_with(
+        "cover.venetian", reason="proxy_tilt"
+    )
+    policy.apply_user_tilt.assert_awaited_once_with(
+        "cover.venetian", tilt=10, reason="proxy_tilt"
+    )
+    coord.async_apply_user_position.assert_not_awaited()
+    assert outcome == ("sent", "")
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_tilt_falls_back_to_position_for_non_venetian() -> None:
+    """Non-venetian: the base hook returns False → fall back to async_apply_user_position."""
+    from custom_components.adaptive_cover_pro.cover_types import BlindPolicy
+
+    coord = _make_tilt_coord(policy=BlindPolicy())
+
+    outcome = await coord.async_apply_user_tilt("cover.blind", 33, trigger="proxy_tilt")
+
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.blind", 33, trigger="proxy_tilt"
+    )
+    assert outcome == ("sent", "fallback")

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -786,3 +786,87 @@ class TestBeforePositionCommandTiltFirstOnOpen:
             context=_ctx(policy, tilt=POSITION_OPEN),
             reason="solar",
         )
+
+
+@pytest.mark.asyncio
+class TestVenetianApplyUserTilt:
+    """Issue #684: a user tilt request drives ONLY the tilt axis.
+
+    ``apply_user_tilt`` routes the requested tilt through the sequencer's
+    tilt-only path with the *current* carriage position as a reference — the
+    carriage must never be commanded. ``force=True`` bypasses the
+    target-unchanged dedup so a tilt equal to the last-sent value still fires
+    (a user explicitly re-requesting it is not a no-op).
+    """
+
+    def _policy_with_real_sequencer(self, *, current_position: int, invert_tilt=None):
+        from tests.test_cover_types.test_venetian_sequencer import _build_sequencer
+
+        policy = VenetianPolicy()
+        hass, seq = _build_sequencer(
+            current_positions=[current_position, current_position, current_position],
+            invert_tilt=invert_tilt,
+        )
+        policy._sequencer = seq
+        policy._tilt_skip_above = 95
+        return hass, policy
+
+    async def test_apply_user_tilt_drives_sequencer_with_current_position(self) -> None:
+        hass, policy = self._policy_with_real_sequencer(current_position=50)
+
+        handled = await policy.apply_user_tilt(
+            "cover.venetian_x", tilt=10, reason="proxy_tilt"
+        )
+
+        assert handled is True
+        # Exactly one tilt service call, paired with the current carriage
+        # position as reference — and NO set_cover_position.
+        calls = hass.services.async_call.await_args_list
+        tilt_calls = [c for c in calls if c.args[1] == "set_cover_tilt_position"]
+        position_calls = [c for c in calls if c.args[1] == "set_cover_position"]
+        assert len(tilt_calls) == 1, f"expected one tilt call, got {calls}"
+        assert tilt_calls[0].args[2]["tilt_position"] == 10
+        assert position_calls == [], f"carriage commanded: {position_calls}"
+
+    async def test_force_path_resends_unchanged_tilt(self) -> None:
+        """A tilt equal to the last-sent target still fires (force bypasses dedup)."""
+        hass, policy = self._policy_with_real_sequencer(current_position=50)
+        # Seed the stored target so the dedup would otherwise short-circuit.
+        policy._sequencer._tilt_targets["cover.venetian_x"] = 10
+
+        handled = await policy.apply_user_tilt(
+            "cover.venetian_x", tilt=10, reason="proxy_tilt"
+        )
+
+        assert handled is True
+        tilt_calls = [
+            c
+            for c in hass.services.async_call.await_args_list
+            if c.args[1] == "set_cover_tilt_position"
+        ]
+        assert len(tilt_calls) == 1, "force must bypass the target-unchanged dedup"
+        assert tilt_calls[0].args[2]["tilt_position"] == 10
+
+    async def test_inverse_tilt_lands_wire_value_on_source(self) -> None:
+        """invert_tilt ON: a request of 10 lands the inverted wire value (90).
+
+        The sequencer's ``_send_tilt_command`` applies ``_to_wire`` internally,
+        so routing the user tilt through ``update_tilt_only`` gets inverse
+        handling for free (no parallel transform in the proxy/coordinator).
+        """
+        hass, policy = self._policy_with_real_sequencer(
+            current_position=50, invert_tilt=lambda: True
+        )
+
+        handled = await policy.apply_user_tilt(
+            "cover.venetian_x", tilt=10, reason="proxy_tilt"
+        )
+
+        assert handled is True
+        tilt_calls = [
+            c
+            for c in hass.services.async_call.await_args_list
+            if c.args[1] == "set_cover_tilt_position"
+        ]
+        assert len(tilt_calls) == 1, f"expected one tilt call, got {tilt_calls}"
+        assert tilt_calls[0].args[2]["tilt_position"] == 90

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -134,6 +134,29 @@ async def test_set_position_service_removed_after_all_entries_unloaded(hass) -> 
     ), "set_position service should be removed when last entry is unloaded"
 
 
+@pytest.mark.integration
+async def test_set_tilt_service_registered_after_setup(hass) -> None:
+    """set_tilt service is registered after async_setup_services."""
+    await _setup(hass, entry_id="st_reg_01")
+    assert hass.services.has_service(
+        DOMAIN, "set_tilt"
+    ), "set_tilt service should be registered after setup"
+
+
+@pytest.mark.integration
+async def test_set_tilt_service_removed_after_all_entries_unloaded(hass) -> None:
+    """set_tilt service is removed when the last entry is unloaded."""
+    entry = await _setup(hass, entry_id="st_unload_01")
+    assert hass.services.has_service(DOMAIN, "set_tilt")
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not hass.services.has_service(
+        DOMAIN, "set_tilt"
+    ), "set_tilt service should be removed when last entry is unloaded"
+
+
 # ---------------------------------------------------------------------------
 # Wrapper coverage: thin _resolve_targets re-export
 # ---------------------------------------------------------------------------

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -76,6 +76,7 @@ REGISTERED_SERVICES = {
     "integration_disable",
     "emergency_stop",
     "set_position",
+    "set_tilt",
     # Options services (registered via register_options_services / OPTIONS_SERVICE_NAMES)
     "set_position_limits",
     "set_sunset_sunrise",


### PR DESCRIPTION
## Summary
The venetian proxy entity's tilt control fed the requested tilt into the carriage-position path (`async_apply_user_position`), so setting tilt to 10% moved the cover to 10% **height** while the slats stayed put (the stale paired tilt of 100% in the logs). This adds a policy-driven `async_apply_user_tilt` entry point: `VenetianPolicy` drives only the slats through the sequencer (force-resend, inverse-tilt applied), while cover types whose primary axis is already tilt fall back to the position path.

Also adds a user-facing `adaptive_cover_pro.set_tilt` service mirroring `set_position`, so automations can command the slat axis directly. DE/FR translations synced.

## Testing
- ✅ 4860 tests passing

## Related Issues
Refs #684
Reported in discussion #675.