### PR TITLE
fix: re-assert venetian tilt after a close that back-rotates the slats

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -317,6 +317,23 @@ class DualAxisSequencer:
         # leak from a prior cycle. ``stamp_position_command`` pops; this
         # write puts the fresh settle stamp back.
         self._stamp_settled(entity_id)
+        # A position move can mechanically back-rotate the slats on real
+        # motors (Somfy IO via Tahoma, KNX): the carriage bottoming out at /
+        # near POSITION_CLOSED drags the tilt shut regardless of the angle we
+        # last commanded. Any prior verification of the stored tilt target is
+        # therefore stale the moment the carriage has travelled. Drop the
+        # verified flag so the post-settle send below re-reads the actuator
+        # and re-asserts tilt on drift, instead of short-circuiting on the
+        # target-unchanged + already-verified dedup in ``_send_tilt_command``
+        # and leaving the slats wherever the motor parked them.
+        #
+        # Opening transitions already force tilt through
+        # ``before_position_command`` (and that force-send discards the flag);
+        # closing transitions had no equivalent, so a close to 0 left the
+        # slats shut until some later open happened to clear the flag — an
+        # intermittent, state-dependent blackout. This closes that gap on the
+        # closing path.
+        self._tilt_targets_verified.discard(entity_id)
         await self._send_tilt_command(
             entity_id,
             tilt_target=tilt_target,

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -2224,3 +2224,66 @@ class TestClearTiltTargets:
         seq.clear_tilt_targets()
 
         assert seq._suppression_at == before
+
+
+@pytest.mark.asyncio
+class TestRunSequenceReverifiesTiltAfterPositionMove:
+    """``run_sequence`` must re-assert tilt after a close that back-rotates slats.
+
+    Real motors (Somfy IO via Tahoma, KNX) drag the slats shut when the
+    carriage bottoms out at POSITION_CLOSED. If a prior cycle marked the
+    stored tilt target ``verified``, the target-unchanged dedup in
+    ``_send_tilt_command`` would short-circuit AND skip the verify, leaving
+    the slats wherever the motor parked them — an intermittent blackout that
+    only self-corrected when a later open happened to clear the verified flag.
+
+    ``run_sequence`` therefore discards the verified flag before the
+    post-settle send so the actuator is always re-read after the carriage has
+    moved.
+    """
+
+    async def test_reasserts_tilt_when_motor_backrotated_slats_on_close(self):
+        """Verified target 100, but the close left actual tilt at 1 → must re-send.
+
+        Without the fix the dedup short-circuits on (target unchanged + already
+        verified) and emits zero service calls, so the slats stay shut.
+        """
+        # Actuator reads back 1 (slats dragged shut by the close to 0).
+        hass, seq = _build_sequencer(get_current_tilt_position=lambda _eid: 1)
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 0))
+        # Prior cycle left a verified tilt target of 100 (slats open).
+        seq._tilt_targets["cover.x"] = 100
+        seq._tilt_targets_verified.add("cover.x")
+
+        await seq.run_sequence(
+            "cover.x", position_target=0, tilt_target=100, reason="solar"
+        )
+
+        # The post-settle verify sees actual=1 vs target=100, detects drift,
+        # and the bounded drift-retry force-resends the tilt command.
+        assert hass.services.async_call.call_count >= 1
+        last_call = hass.services.async_call.call_args.args
+        assert last_call[1] == "set_cover_tilt_position"
+        assert last_call[2]["tilt_position"] == 100
+        # Drift never clears on this still-shut mock, so the stale target is gone.
+        assert seq.last_tilt_target("cover.x") is None
+
+    async def test_no_redundant_command_when_slats_already_correct(self):
+        """Verified target 100 and actual already 100 → no spurious relay click.
+
+        Discarding the verified flag must not turn every close into an extra
+        service call: when the actuator confirms the tilt already landed, the
+        re-verify passes and re-marks the target verified without re-sending.
+        """
+        hass, seq = _build_sequencer(get_current_tilt_position=lambda _eid: 100)
+        seq._wait_for_position_settle = AsyncMock(return_value=(True, 0))
+        seq._tilt_targets["cover.x"] = 100
+        seq._tilt_targets_verified.add("cover.x")
+
+        await seq.run_sequence(
+            "cover.x", position_target=0, tilt_target=100, reason="solar"
+        )
+
+        assert hass.services.async_call.call_count == 0
+        assert seq.last_tilt_target("cover.x") == 100
+        assert "cover.x" in seq._tilt_targets_verified

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -33,13 +33,13 @@ from custom_components.adaptive_cover_pro.cover_types.venetian.sequencer import 
 def _zero_post_tilt_delay(monkeypatch):
     """Skip real-motor delays in unit tests.
 
-    Zeroes the post-tilt rebase delay (1.5 s) and the verify-retry poll
-    interval (1.0 s) so the test suite doesn't spend real time waiting on
-    asyncio.sleep. The post-settle hold is a per-instance parameter
-    (``post_settle_hold_seconds``) defaulting to 0 in ``_build_sequencer``
-    — no monkeypatching needed for that delay. The retry sample COUNT
-    (``VENETIAN_TILT_VERIFY_MAX_SAMPLES``) is left at its production value
-    because it is the behaviour under test.
+    Zeroes the post-tilt rebase delay (1.5 s), the verify-retry poll
+    interval (1.0 s), and the drift-retry delay (2.0 s) so the test suite
+    doesn't spend real time waiting on asyncio.sleep. The post-settle hold
+    is a per-instance parameter (``post_settle_hold_seconds``) defaulting to
+    0 in ``_build_sequencer`` — no monkeypatching needed for that delay. The
+    retry sample COUNT (``VENETIAN_TILT_VERIFY_MAX_SAMPLES``) is left at its
+    production value because it is the behaviour under test.
     """
     monkeypatch.setattr(
         "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
@@ -49,6 +49,11 @@ def _zero_post_tilt_delay(monkeypatch):
     monkeypatch.setattr(
         "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
         "VENETIAN_TILT_VERIFY_POLL_SECONDS",
+        0,
+    )
+    monkeypatch.setattr(
+        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
+        "VENETIAN_DRIFT_RETRY_DELAY_SECONDS",
         0,
     )
 


### PR DESCRIPTION
## Description

On venetian covers, a position command that drives the carriage to (or near) `POSITION_CLOSED` mechanically **back-rotates the slats shut** on real motors (Somfy IO via Tahoma, KNX). The dual-axis sequencer is meant to re-assert the intended tilt after the carriage settles, but it can silently skip that re-assert:

In `DualAxisSequencer.run_sequence` → `_send_tilt_command`, the **target-unchanged dedup** short-circuits when the stored tilt target already equals the new target, and it only runs the post-settle verify when the entity is **not** in `_tilt_targets_verified`:

```python
if not force and tilt_target == self._tilt_targets.get(entity_id):
    ...
    if verify and entity_id not in self._tilt_targets_verified:   # skipped when already verified
        await self._verify_and_record_tilt(...)
    return
```

So when a prior cycle had verified the target (e.g. tilt `100` while the blind was raised), a later **close to `0`** hits the dedup, finds the entity already verified, **skips the verify**, and returns without re-reading the actuator — leaving the slats wherever the motor parked them (fully shut).

The bug is **intermittent and state-dependent**: opening transitions force tilt through `before_position_command` (which discards the verified flag), so a close that happens to follow an open self-corrects, while a close *without* a preceding open stays shut. In the field this showed up as an exterior venetian blind dropping to a full blackout at the descending edge of its solar-tracking window on some days but not others.

### Fix

`run_sequence` now discards the entity from `_tilt_targets_verified` **before** the post-settle send. Any verification of the stored tilt is stale the moment the carriage has travelled, so the post-settle `_send_tilt_command` re-reads the actuator and re-asserts tilt on drift via the existing verify → drift-retry path. Opening transitions already force tilt; this closes the symmetric gap on the **closing** path.

This is the lighter of two options — it only re-sends when the verify actually detects drift, rather than unconditionally `force=True`-ing every close (which would add redundant relay clicks when the slats are already correct).

## Motivation and Context

- fixes: venetian slats left fully closed after a position move to `0` when the stored tilt target was already marked verified (no re-assert on the closing path).

## How has this been tested?

New `TestRunSequenceReverifiesTiltAfterPositionMove` in `tests/test_cover_types/test_venetian_sequencer.py`:

- `test_reasserts_tilt_when_motor_backrotated_slats_on_close` — verified target `100`, actuator reads back `1` after the close → a `set_cover_tilt_position` command is now emitted (pre-fix: **0** service calls).
- `test_no_redundant_command_when_slats_already_correct` — verified target `100`, actuator already at `100` → re-verify passes, **no** redundant service call, target stays verified (guards against turning every close into an extra relay click).

```
tests/test_cover_types/test_venetian_sequencer.py  108 passed
tests/test_cover_command_venetian.py + test_manual_override_venetian.py + tests/test_cover_types/  499 passed
black --check  clean   |   ruff check  clean
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.