### PR TITLE
ci: auto-retarget PRs from main to develop

### DIFF
--- a/.github/workflows/retarget-pr-to-develop.yml
+++ b/.github/workflows/retarget-pr-to-develop.yml
@@ -1,0 +1,62 @@
+name: "Retarget PRs to develop"
+
+# PRs default to the repo's default branch (main), but daily work — features
+# and fixes — must land on develop. main only moves at stable-release time
+# (develop → main forward-merge) or via an intentional hotfix. This workflow
+# auto-retargets any PR opened against main to develop, with one exception:
+# PRs authored by the maintainer (jrhubott) are assumed intentional (hotfix or
+# forward-merge) and left alone.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retarget:
+    name: "Move base from main to develop"
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v9
+        with:
+          script: |
+            const MAINTAINER = "jrhubott";
+            const pr = context.payload.pull_request;
+
+            if (pr.base.ref !== "main") {
+              console.log(`Base is ${pr.base.ref}, not main — nothing to do.`);
+              return;
+            }
+
+            // Maintainer-authored PRs against main are intentional (hotfix,
+            // forward-merge). Leave them alone.
+            if (pr.user.login === MAINTAINER) {
+              console.log(`PR #${pr.number} authored by ${MAINTAINER} — leaving base as main.`);
+              return;
+            }
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              base: "develop",
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                "I've retargeted this PR from `main` to `develop`.",
+                "",
+                "In this repo, features and fixes land on `develop`; `main` only moves at",
+                "stable-release time. Your change is unaffected — this just points it at the",
+                "right integration branch. Thanks for contributing! 🙏",
+              ].join("\n"),
+            });
+
+            console.log(`PR #${pr.number} retargeted to develop.`);


### PR DESCRIPTION
## Summary
Adds `.github/workflows/retarget-pr-to-develop.yml` — a workflow that auto-retargets PRs opened against `main` over to `develop`, with an explanatory comment.

Daily work (features, fixes) belongs on `develop`; `main` only moves at stable-release time. Contributors naturally open PRs against `main` (the default branch), so this corrects the base automatically instead of by hand.

**Behavior:**
- Triggers on `pull_request_target` (opened/reopened) targeting `main`
- Skips PRs authored by `jrhubott` — maintainer hotfixes and forward-merges legitimately target `main`
- For everyone else: flips base `main` → `develop` via the API + posts a comment

**Why it must live on `main`:** `pull_request_target` runs the workflow definition from the PR's *base* branch, so it only takes effect once merged to `main`. Hence this hotfix-style PR rather than landing on `develop`.

**Safety:** uses `pull_request_target` (needed for write access on fork PRs) but never checks out PR code and runs no untrusted scripts — avoiding the usual `pull_request_target` footgun. Uses the default `GITHUB_TOKEN` with `pull-requests: write`.

## Testing
- ✅ YAML validated locally
- ✅ Pre-commit (yaml check, prettier) passed
- Logic mirrors the manual retarget done on #694

https://claude.ai/code/session_015n5NPJgjtXaJhZHokSmTuu