### PR TITLE
fix: guard async_unload_entry for non-cover building profiles (#712)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -369,9 +369,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
 
 async def async_unload_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> bool:
     """Unload a config entry."""
+    # Virtual entry types (Building Profile, controls_cover == False) forwarded
+    # no platforms in async_setup_entry, so unloading platforms would raise
+    # "Config entry was never loaded!". Mirror the setup short-circuit.
+    if not get_policy(entry.data[CONF_SENSOR_TYPE]).controls_cover:
+        await async_unload_services(hass)
+        return True
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         await async_unload_services(hass)
-
     return unload_ok
 
 

--- a/tests/test_init_building_profile.py
+++ b/tests/test_init_building_profile.py
@@ -1,10 +1,11 @@
-"""Setup-path behaviour for the virtual Building Profile entry type.
+"""Setup-path and unload-path behaviour for the virtual Building Profile entry type.
 
 A ``cover_building_profile`` config entry holds shared building-level sensor
 IDs and registers no platforms. ``async_setup_entry`` must short-circuit
 before constructing the coordinator or forwarding any platform, while still
 registering an update listener so future commits can propagate profile
-changes to linked covers.
+changes to linked covers. ``async_unload_entry`` must symmetrically skip
+``async_unload_platforms`` for the same virtual entry types.
 """
 
 from __future__ import annotations
@@ -14,7 +15,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.adaptive_cover_pro import async_setup_entry
+from custom_components.adaptive_cover_pro import (
+    PLATFORMS,
+    async_setup_entry,
+    async_unload_entry,
+)
 from custom_components.adaptive_cover_pro.const import (
     CONF_SENSOR_TYPE,
     DOMAIN,
@@ -50,3 +55,49 @@ async def test_building_profile_entry_skips_coordinator(hass) -> None:
     mock_coord.assert_not_called()
     mock_forward.assert_not_called()
     add_listener.assert_called_once()
+
+
+async def test_building_profile_entry_unloads_without_platforms(hass) -> None:
+    """Profile unload must NOT call async_unload_platforms (entry loaded no platforms)."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Building", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={},
+        entry_id="profile_02",
+        title="Building",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            hass.config_entries, "async_unload_platforms", return_value=True
+        ) as mock_unload_platforms,
+        patch("custom_components.adaptive_cover_pro.async_unload_services"),
+    ):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    mock_unload_platforms.assert_not_called()
+
+
+async def test_real_cover_entry_unloads_platforms(hass) -> None:
+    """Cover entries (controls_cover=True) must call async_unload_platforms with PLATFORMS."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "My Blind", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={},
+        entry_id="cover_01",
+        title="My Blind",
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            hass.config_entries, "async_unload_platforms", return_value=True
+        ) as mock_unload_platforms,
+        patch("custom_components.adaptive_cover_pro.async_unload_services"),
+    ):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    mock_unload_platforms.assert_called_once_with(entry, PLATFORMS)


### PR DESCRIPTION
## Summary
A virtual "Building Profile" config entry forwards zero platforms in `async_setup_entry` (it short-circuits when its policy does not control a cover), but `async_unload_entry` unconditionally called `async_unload_platforms(entry, PLATFORMS)` for every entry. On reload/unload of a Building Profile entry, HA raised `ValueError: Config entry was never loaded!` for all 6 platforms, which surfaced as "unloading failed" and left entities unavailable. This adds the symmetric `controls_cover` guard to `async_unload_entry`, matching `async_setup_entry` and `async_remove_entry`.

## Testing
- ✅ 5116 tests passing (includes two new unload tests for building-profile and real-cover entries)

## Related Issues
Refs #712