### PR TITLE
fix: route Building Profile options flow to sensor-only step (#715)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3741,6 +3741,12 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Manage the options."""
+        # Building Profile entries have no cover, geometry, or handlers to
+        # configure — route straight to the sensor-only step (mirrors the
+        # create flow's async_step_create_building_profile).
+        if not get_policy(self.sensor_type).controls_cover:
+            return await self.async_step_profile_sensors()
+
         # Ordered by the 4-layer pipeline model (#613): physical setup →
         # positions → handlers in priority order → global motion constraints.
 
@@ -4130,6 +4136,28 @@ class OptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="building_profile",
             data_schema=schema,
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
+            },
+        )
+
+    async def async_step_profile_sensors(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the shared building-level sensor IDs on a Building Profile entry.
+
+        This is the only options step for a profile: it exposes exactly the
+        ``BUILDING_PROFILE_SENSOR_KEYS`` pickers and saves on submit.  Mirrors
+        the create-flow's ``async_step_create_building_profile`` sensor section.
+        """
+        if user_input is not None:
+            self.options.update(user_input)
+            return self.async_create_entry(title="", data=self.options)
+
+        schema = building_profile_sensors_schema()
+        return self.async_show_form(
+            step_id="profile_sensors",
+            data_schema=self.add_suggested_values_to_schema(schema, self.options),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
             },

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1473,6 +1473,52 @@
         "data_description": {
           "building_profile_id": "Verknüpfe diese Abdeckung mit einem Gebäudeprofil, um dessen gemeinsame gebäudeweite Sensoren zu übernehmen. Wähle 'Keines (nicht verknüpft)', um die Sensoren dieser Abdeckung lokal zu verwalten."
         }
+      },
+      "profile_sensors": {
+        "title": "Gebäudeprofil — Gemeinsame Sensoren",
+        "description": "Bearbeite die gemeinsamen gebäudeweiten Sensor-Entitäten. Verknüpfte Abdeckungen übernehmen diese Sensoren; lasse ein Feld leer, damit jede Abdeckung ihren eigenen lokalen Wert behält.\n\n[Mehr erfahren]({learn_more})",
+        "data": {
+          "cloud_coverage_entity": "Wolkendecken-Sensor (optional)",
+          "daytime_gate_sensors": "Tageslicht-Gate-Sensoren",
+          "daytime_gate_template": "Tageslicht-Gate-Vorlage (optional)",
+          "irradiance_entity": "Strahlungssensor (optional)",
+          "is_sunny_sensor": "Binärsensor \"Sonne scheint\" (optional)",
+          "is_sunny_template": "Vorlage \"Is Sunny\" (optional)",
+          "lux_entity": "Luxsensor (optional)",
+          "outside_temp": "Außentemperatursensor (optional)",
+          "sunrise_time_entity": "Sonnenaufgangs-Zeit-Entität",
+          "sunset_time_entity": "Sonnenuntergangs-Zeit-Entität",
+          "weather_entity": "Wetter-Entität (optional)",
+          "weather_is_raining_sensor": "Regnet Binärsensor",
+          "weather_is_raining_template": "Vorlage \"Is Raining\" (optional)",
+          "weather_is_windy_sensor": "Ist windig Binärsensor",
+          "weather_is_windy_template": "Vorlage \"Is Windy\" (optional)",
+          "weather_rain_sensor": "Regenrate-Sensor",
+          "weather_severe_sensors": "Schwerwetter-Sensoren (Hagel, Frost, Sturm, usw.)",
+          "weather_wind_direction_sensor": "Windrichtungssensor (optional)",
+          "weather_wind_speed_sensor": "Windgeschwindigkeitssensor"
+        },
+        "data_description": {
+          "cloud_coverage_entity": "Optionaler Wolkenbedeckungssensor, der 0–100 % meldet (z. B. von einer Wetterintegrationen). Wenn der Wert den Schwellwert erreicht, wird die Blendungskontrolle unterdrückt und die Beschattung kehrt zu ihrer Standardposition zurück. Leer lassen, wenn Sie diesen Sensor nicht haben.",
+          "daytime_gate_sensors": "Optionale Binärsensoren (oder input_boolean / switch / schedule), die entscheiden, wann es für die Sonnennachführung 'Tag' ist. Bei AN lädt die Integration die Sonnennachführung; bei AUS wird die Sonnenuntergangsposition angewendet. Verwenden Sie einen 'Hell genug'-Binärsensor basierend auf Helligkeit, damit echtes Licht – nicht die Uhr – das Tracking-Fenster öffnet und schließt: Beschattungen folgen weiterhin der Sonne an hellen Abenden nach astronomischem Sonnenuntergang und bleiben an dunklen, bewölkten Morgen in der Sonnenuntergangsposition. Wenn gesetzt, ERSETZT dies die astronomische Sonnenuntergangs-/Sonnenaufgangsgrenze (Sonnenuntergangs-/Sonnenaufgangsversatz werden ignoriert). Ein nicht verfügbarer oder unbekannter Sensor wird als Tag behandelt, sodass die Nachführung nicht nur stoppt, weil ein Sensor noch nicht gemeldet hat. Lassen Sie leer, um die astronomische Sonnenuntergangs-/Sonnenaufgangsberechnung zu verwenden.",
+          "daytime_gate_template": "Optionale Home Assistant Jinja2-Vorlage, die 'Tag' für die Sonnennachführung entscheidet. Wenn sie wahr wird (on/true/1), lädt die Integration die Sonnennachführung; wenn falsch, wird die Sonnenuntergangsposition angewendet. Wie es mit den Gate-Sensoren oben kombiniert wird (ODER oder UND), wird durch 'Tageslicht-Gate-Logik' unten gesetzt. Es kann allein ohne Sensoren stehen. Beispiel: eine Sun2-Höhenvorlage oder ein Helligkeitsvergleich. Eine Vorlage, die nicht gerendert werden kann, wird als Tag behandelt, sodass eine fehlerhafte Vorlage niemals einen vorzeitigen Sonnenuntergang erzwingt. Wenn gesetzt (allein oder mit Sensoren), ERSETZT dies die astronomische Sonnenuntergangs-/Sonnenaufgangsgrenze. Lassen Sie leer, um zu deaktivieren.",
+          "irradiance_entity": "Optionaler Solarbestrahlungssensor (außen) zur genauen Sonnenerkennung. Misst Sonnenenergie in W/m². Wenn der Sensor unter dem Schwellwert liegt, ist kein direktes Sonnenlicht vorhanden und die Blendungskontrolle wird unterdrückt. Leer lassen, wenn Sie diesen Sensor nicht haben.",
+          "is_sunny_sensor": "Optionaler Binärsensor, input_boolean, Schalter oder Zeitplan, der angibt, ob die Sonne auf das Fenster scheint. Bei EIN wird Sonneneinstrahlung angenommen; bei AUS wird Wolkenunterdrückung unabhängig vom Wetterzustand aktiviert. Bei Nicht verfügbar oder Unbekannt fällt die Integration auf die nachstehende Wetter-Entität/Wetterbedingungen-Logik zurück. Verwenden Sie diese Option, wenn Sie die Sonneneinstrahlung auf das Fenster upstream berechnen (z. B. Azimut-geregelte Bestrahlung) und Adaptive Cover Pro ein eindeutiges Boolesches Signal geben möchten.",
+          "is_sunny_template": "Optionale Home-Assistant-Jinja2-Vorlage, die entscheidet, ob die Sonne auf das Fenster fällt. Wenn sie als wahr (on/true/1) ausgewertet wird, wird angenommen, dass die Sonne vorhanden ist; wenn sie als falsch ausgewertet wird, wird angenommen, dass sie abwesend ist und die Wolkenunterdrückung wird ausgelöst. Wie sie sich mit dem Binärsensor \"Is Sunny\" oben kombiniert (OR oder AND), wird durch die Einstellung \"Logik der Vorlage 'Is Sunny'\" unten definiert; sie kann auch ohne Sensor allein verwendet werden. Beispiel: ein Azimut-/Höhenvergleich oder ein Lux-Schwellenwert. Eine Vorlage, die leer ist oder nicht gerendert werden kann, äußert sich nicht, sodass die Integration auf den Sensor und dann auf die Wetterentität/Wetterbedingungen zurückgreift. Lassen Sie leer, um zu deaktivieren.",
+          "lux_entity": "Optionaler Lichtsensor (innen oder außen) zur genauen Sonnenerkennung. Wenn der Sensor unter dem Schwellwert liegt, ist kein direktes Sonnenlicht vorhanden und die Blendungskontrolle wird unterdrückt. Typische Direktsonnenwerte: 5.000–10.000 Lux. Leer lassen, wenn Sie diesen Sensor nicht haben.",
+          "outside_temp": "Optionaler Außentemperatursensor. Wenn bereitgestellt, bestimmt dieser Wert (anstelle des Innensensors) die aktuelle Jahreszeit, und die Außenschwelle-Schutzmaßnahme wird angewendet, um Sommerverhalten bei kalten Außentagen zu verhindern.",
+          "sunrise_time_entity": "Optionale Entität, deren Status ein Datum/Zeit ist (z.B. Sun2 „Sonnenaufgang bei -4° Höhe\"). Falls gesetzt, ersetzt es die astral-berechnete Sonnenaufgangszeit als Morgen-Fenster-Schließgrenze. Akzeptiert sensor oder input_datetime Entitäten. Sonnenaufgang-Versatz wird immer noch oben angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist.",
+          "sunset_time_entity": "Optionale Entität, deren Status ein Datum/Zeit ist (z.B. Sun2 „Sonnenuntergang bei -4° Höhe\"). Falls gesetzt, ersetzt es die astral-berechnete Sonnenuntergangszeit als Fenster-Grenze. Akzeptiert sensor oder input_datetime Entitäten, die ISO-8601 Datum/Zeit melden. Sonnenuntergang-Versatz wird immer noch oben angewendet. Fällt auf astral zurück, wenn die Entität nicht verfügbar ist.",
+          "weather_entity": "Optionale Wetterintegrationen zur Erkennung von Wolkenbedeckung. Wenn der aktuelle Wetterzustand nicht in der unten ausgewählten Liste enthalten ist, wird angenommen, dass direktes Sonnenlicht nicht vorhanden ist, und die Blendungskontrolle wird unterdrückt. Leer lassen, um den Wetterzustand zu ignorieren.",
+          "weather_is_raining_sensor": "Binärsensor zur Regenerkennung. Übersteuerung aktiviert sich, wenn dieser Sensor ‚an' ist. Leer lassen zum Ignorieren.",
+          "weather_is_raining_template": "Optionale Home-Assistant-Jinja2-Vorlage, die entscheidet, ob es regnet. Wenn sie als wahr (on/true/1) ausgewertet wird, wird die Übersteuerung aktiviert. Wie sie sich mit dem Binärsensor \"Is Raining\" oben kombiniert (OR oder AND), wird durch die Einstellung \"Logik der Vorlage 'Is Raining'\" unten definiert; sie kann auch ohne Sensor allein verwendet werden und reagiert sofort auf den Wechsel der Vorlage. Beispiel: Leiten Sie \"regnet\" aus einem numerischen Regenrate-Schwellenwert ab. Eine Vorlage, die leer ist oder nicht gerendert werden kann, äußert sich nicht (kein Widerrufen). Lassen Sie leer, um zu deaktivieren.",
+          "weather_is_windy_sensor": "Binärsensor zur Windelkennung. Übersteuerung aktiviert sich, wenn dieser Sensor ‚an' ist. Leer lassen zum Ignorieren.",
+          "weather_is_windy_template": "Optionale Home-Assistant-Jinja2-Vorlage, die entscheidet, ob es windig ist. Wenn sie als wahr (on/true/1) ausgewertet wird, wird die Übersteuerung aktiviert. Wie sie sich mit dem Binärsensor \"Is Windy\" oben kombiniert (OR oder AND), wird durch die Einstellung \"Logik der Vorlage 'Is Windy'\" unten definiert; sie kann auch ohne Sensor allein verwendet werden und reagiert sofort auf den Wechsel der Vorlage. Beispiel: Leiten Sie \"windig\" aus einem numerischen Windgeschwindigkeit-Schwellenwert ab. Eine Vorlage, die leer ist oder nicht gerendert werden kann, äußert sich nicht (kein Widerrufen). Lassen Sie leer, um zu deaktivieren.",
+          "weather_rain_sensor": "Numerischer Sensor, der Niederschlagsrate meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren.",
+          "weather_severe_sensors": "Binärsensoren für schwere Bedingungen (Hagel, Frost, Gewitter usw.). Übersteuerung aktiviert sich, wenn EIN Sensor ‚an' ist. Leer lassen zum Ignorieren.",
+          "weather_wind_direction_sensor": "Optional: Trigger Wind-Übersteuerung nur, wenn Wind gegen das Azimut dieses Fensters weht (innerhalb der Richtungstoleranz). Leer lassen, um Übersteuerung allein auf Windgeschwindigkeit zu triggern, unabhängig von der Richtung.",
+          "weather_wind_speed_sensor": "Numerischer Sensor, der Windgeschwindigkeit meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren."
+        }
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1473,6 +1473,52 @@
         "data_description": {
           "building_profile_id": "Link this cover to a Building Profile to inherit its shared building-level sensors. Select 'None (unlinked)' to manage this cover's sensors locally."
         }
+      },
+      "profile_sensors": {
+        "title": "Building Profile — Shared Sensors",
+        "description": "Edit the building-level sensor entity IDs shared across linked covers. Linked covers inherit these sensors; leave a field blank to let each cover keep its own local value.\n\n[Learn more]({learn_more})",
+        "data": {
+          "cloud_coverage_entity": "Cloud coverage sensor (optional)",
+          "daytime_gate_sensors": "Daytime gate sensors",
+          "daytime_gate_template": "Daytime gate template (optional)",
+          "irradiance_entity": "Irradiance sensor (optional)",
+          "is_sunny_sensor": "Is Sunny binary sensor (optional)",
+          "is_sunny_template": "Is Sunny template (optional)",
+          "lux_entity": "Lux sensor (optional)",
+          "outside_temp": "Outside temperature sensor (optional)",
+          "sunrise_time_entity": "Sunrise Time Entity",
+          "sunset_time_entity": "Sunset Time Entity",
+          "weather_entity": "Weather entity (optional)",
+          "weather_is_raining_sensor": "Is Raining binary sensor",
+          "weather_is_raining_template": "Is Raining template (optional)",
+          "weather_is_windy_sensor": "Is Windy binary sensor",
+          "weather_is_windy_template": "Is Windy template (optional)",
+          "weather_rain_sensor": "Rain rate sensor",
+          "weather_severe_sensors": "Severe weather sensors (hail, frost, storm, etc.)",
+          "weather_wind_direction_sensor": "Wind direction sensor (optional)",
+          "weather_wind_speed_sensor": "Wind speed sensor"
+        },
+        "data_description": {
+          "cloud_coverage_entity": "Optional cloud coverage sensor reporting 0–100% (e.g. from a weather integration). When the reading reaches the threshold, glare control is suppressed and the cover returns to its default position. Leave empty if you don't have this sensor.",
+          "daytime_gate_sensors": "Optional binary sensors (or input_boolean / switch / schedule) that decide when it is 'daytime' for sun tracking. When ON the integration sun-tracks; when OFF it applies the Sunset Position. Leave empty to use the astronomical sunset/sunrise calculation.",
+          "daytime_gate_template": "Optional Home Assistant Jinja2 template that decides 'daytime' for sun tracking. Leave empty to disable.",
+          "irradiance_entity": "Optional solar irradiance sensor (outdoor) for precise sun detection. Measures solar power in W/m². Leave empty if you don't have this sensor.",
+          "is_sunny_sensor": "Optional binary sensor, input_boolean, switch, or schedule that authoritatively reports whether the sun is hitting the window. Leave empty to use weather/lux logic.",
+          "is_sunny_template": "Optional Home Assistant Jinja2 template that decides whether the sun is on the window. Leave empty to disable.",
+          "lux_entity": "Optional illuminance sensor (indoor or outdoor) for precise sun detection. Leave empty if you don't have this sensor.",
+          "outside_temp": "Optional outdoor temperature sensor. When provided, this reading determines the current season for all linked covers.",
+          "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). Falls back to astral if unavailable.",
+          "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). Falls back to astral if unavailable.",
+          "weather_entity": "Optional weather integration used to detect cloud cover. Leave empty to ignore weather state.",
+          "weather_is_raining_sensor": "Binary sensor for rain detection. Override activates when this sensor is 'on'. Leave empty to ignore.",
+          "weather_is_raining_template": "Optional Home Assistant Jinja2 template that decides whether it is raining. Leave empty to disable.",
+          "weather_is_windy_sensor": "Binary sensor for wind detection. Override activates when this sensor is 'on'. Leave empty to ignore.",
+          "weather_is_windy_template": "Optional Home Assistant Jinja2 template that decides whether it is windy. Leave empty to disable.",
+          "weather_rain_sensor": "Numeric sensor reporting rain rate. Override activates when the value meets or exceeds the threshold. Leave empty to ignore rain rate.",
+          "weather_severe_sensors": "Binary sensors for severe conditions (hail, frost, thunderstorm, etc.). Override activates when ANY sensor is 'on'. Leave empty to ignore.",
+          "weather_wind_direction_sensor": "Optional: only trigger wind override when wind blows toward this window's azimuth. Leave empty to trigger on wind speed alone.",
+          "weather_wind_speed_sensor": "Numeric sensor reporting wind speed. Override activates when the value meets or exceeds the threshold. Leave empty to ignore wind speed."
+        }
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1473,6 +1473,52 @@
         "data_description": {
           "building_profile_id": "Liez ce volet à un profil de bâtiment pour hériter de ses capteurs partagés à l'échelle du bâtiment. Sélectionnez « Aucun (non lié) » pour gérer les capteurs de ce volet localement."
         }
+      },
+      "profile_sensors": {
+        "title": "Profil de bâtiment — Capteurs Partagés",
+        "description": "Modifiez les ID d'entités de capteurs au niveau du bâtiment partagés entre les volets liés. Les volets liés héritent de ces capteurs ; laissez un champ vide pour que chaque volet conserve sa propre valeur locale.\n\n[En savoir plus]({learn_more})",
+        "data": {
+          "cloud_coverage_entity": "Capteur de couverture nuageuse (optionnel)",
+          "daytime_gate_sensors": "Capteurs du filtre de jour",
+          "daytime_gate_template": "Modèle du filtre de jour (optionnel)",
+          "irradiance_entity": "Capteur d'irradiance (optionnel)",
+          "is_sunny_sensor": "Capteur binaire « Ensoleillé » (optionnel)",
+          "is_sunny_template": "Modèle Is Sunny (optionnel)",
+          "lux_entity": "Capteur de lux (optionnel)",
+          "outside_temp": "Capteur de température extérieure (optionnel)",
+          "sunrise_time_entity": "Entité Heure de Lever du Soleil",
+          "sunset_time_entity": "Entité Heure de Coucher du Soleil",
+          "weather_entity": "Entité météo (optionnelle)",
+          "weather_is_raining_sensor": "Capteur binaire En train de pleuvoir",
+          "weather_is_raining_template": "Modèle Is Raining (optionnel)",
+          "weather_is_windy_sensor": "Capteur binaire Venteux",
+          "weather_is_windy_template": "Modèle Is Windy (optionnel)",
+          "weather_rain_sensor": "Capteur de taux de pluie",
+          "weather_severe_sensors": "Capteurs de conditions météorologiques graves (grêle, gel, tempête, etc.)",
+          "weather_wind_direction_sensor": "Capteur de direction du vent (optionnel)",
+          "weather_wind_speed_sensor": "Capteur de vitesse du vent"
+        },
+        "data_description": {
+          "cloud_coverage_entity": "Capteur de couverture nuageuse optionnel indiquant une valeur de 0 à 100 % (par ex. d'une intégration météo). Quand la valeur atteint le seuil, le contrôle de l'éblouissement est supprimé et le store revient à sa position par défaut. Laissez vide si vous ne disposez pas de ce capteur.",
+          "daytime_gate_sensors": "Capteurs binaires optionnels (ou input_boolean / switch / schedule) qui décident si c'est « jour » pour le suivi du soleil. Lorsqu'ils sont activés, l'intégration assure le suivi du soleil ; lorsqu'ils sont désactivés, elle applique la Position de coucher de soleil. Utilisez un capteur binaire « assez lumineux » basé sur le lux pour que la lumière réelle — et non l'horloge — ouvre et ferme la fenêtre de suivi : les protections continuent le suivi lors de soirées lumineuses après le coucher du soleil astronomique, et restent à la position de coucher de soleil lors des matins sombres et nuageux. Lorsqu'ils sont définis, ils REMPLACENT la limite de coucher/lever astronomique du soleil (les décalages de coucher/lever de soleil sont ignorés). Un capteur indisponible ou inconnu est traité comme jour, de sorte que le suivi ne s'arrête jamais simplement parce qu'un capteur n'a pas signalé. Laissez vide pour utiliser le calcul de coucher/lever de soleil astronomique.",
+          "daytime_gate_template": "Modèle Jinja2 Home Assistant optionnel qui décide si c'est « jour » pour le suivi du soleil. Lorsqu'il s'évalue comme vrai (on/true/1), l'intégration assure le suivi du soleil ; lorsqu'il s'évalue comme faux, elle applique la Position de coucher de soleil. La manière dont il se combine avec les capteurs du filtre ci-dessus (OR ou AND) est définie par « Logique du filtre de jour » ci-dessous. Il peut fonctionner seul sans capteurs. Exemple : un modèle d'élévation Sun2, ou une comparaison lux. Un modèle qui ne peut pas être évalué est traité comme jour, de sorte qu'un modèle cassé ne force jamais un coucher de soleil prématuré. Lorsqu'il est défini (seul ou avec des capteurs), il REMPLACE la limite de coucher/lever astronomique du soleil. Laissez vide pour désactiver.",
+          "irradiance_entity": "Capteur d'irradiance solaire optionnel (extérieur) pour une détection précise du soleil. Mesure la puissance solaire en W/m². Quand le capteur lit une valeur inférieure au seuil, le soleil direct est absent et le contrôle de l'éblouissement est supprimé. Laissez vide si vous ne disposez pas de ce capteur.",
+          "is_sunny_sensor": "Capteur binaire, input_boolean, interrupteur ou planning optionnel qui rapporte de manière fiable si le soleil frappe la fenêtre. Lorsque ACTIVÉ, le soleil est supposé présent ; lorsque DÉSACTIVÉ, le soleil est supposé absent et la suppression des nuages se déclenche indépendamment de l'état météorologique. En cas d'indisponibilité ou d'état inconnu, l'intégration revient à la logique de l'entité météo / conditions météorologiques ci-dessous. Utilisez ceci si vous calculez le soleil-sur-fenêtre en amont (par exemple, irradiance filtrée par azimut) et que vous souhaitez fournir à Adaptive Cover Pro un booléen épuré.",
+          "is_sunny_template": "Modèle Jinja2 Home Assistant optionnel qui détermine si le soleil brille sur la fenêtre. Lorsqu'il s'évalue à vrai (on/true/1), le soleil est supposé présent ; lorsqu'il est faux, il est supposé absent et la suppression nuageuse s'active. La façon dont il se combine avec le capteur binaire Is Sunny ci-dessus (OU ou ET) est définie par la « logique du modèle Is Sunny » ci-dessous ; il peut fonctionner seul sans capteur. Exemple : une comparaison azimut/élévation ou un seuil de lux. Un modèle vide ou qui ne s'évalue pas n'exprime aucune opinion, l'intégration revient donc au capteur, puis à la logique de l'entité météo / conditions météo. Laissez vide pour désactiver.",
+          "lux_entity": "Capteur d'éclairement optionnel (intérieur ou extérieur) pour une détection précise du soleil. Quand le capteur lit une valeur inférieure au seuil, le soleil direct est absent et le contrôle de l'éblouissement est supprimé. Valeurs typiques en plein soleil : 5 000-10 000 lux. Laissez vide si vous ne disposez pas de ce capteur.",
+          "outside_temp": "Capteur de température extérieure optionnel. Quand configuré, cette valeur (plutôt que le capteur intérieur) détermine la saison actuelle, et le seuil extérieur est appliqué pour éviter que le store se ferme comme en été lors d'une journée intérieure chaude mais extérieure froide.",
+          "sunrise_time_entity": "Entité optionnelle dont l'état est un datetime (par exemple Sun2 « lever du soleil à -4° d'élévation »). Quand défini, remplace l'heure de lever du soleil calculée par astral comme limite de fermeture de la fenêtre du matin. Accepte les entités sensor ou input_datetime. Le Décalage du lever du soleil s'applique toujours en plus. Revient à astral si l'entité n'est pas disponible.",
+          "sunset_time_entity": "Entité optionnelle dont l'état est un datetime (par exemple Sun2 « coucher du soleil à -4° d'élévation »). Quand défini, remplace l'heure de coucher du soleil calculée par astral comme limite de la fenêtre. Accepte les entités sensor ou input_datetime rapportant un datetime ISO-8601. Le Décalage du coucher du soleil s'applique toujours en plus. Revient à astral si l'entité n'est pas disponible.",
+          "weather_entity": "Intégration météo optionnelle utilisée pour détecter la couverture nuageuse. Quand l'état météo actuel ne figure pas dans la liste sélectionnée ci-dessous, le soleil direct est supposé absent et le contrôle de l'éblouissement est supprimé. Laissez vide pour ignorer l'état météo.",
+          "weather_is_raining_sensor": "Capteur binaire pour la détection de pluie. La dérogation s'active quand ce capteur est « activé ». Laissez vide pour ignorer.",
+          "weather_is_raining_template": "Modèle Jinja2 Home Assistant optionnel qui détermine s'il pleut. Lorsqu'il s'évalue à vrai (on/true/1), la dérogation s'active. La façon dont il se combine avec le capteur binaire Is Raining ci-dessus (OU ou ET) est définie par la « logique du modèle Is Raining » ci-dessous ; il peut fonctionner seul sans capteur et réagit instantanément quand le modèle bascule. Exemple : dériver « pluie » d'un seuil de taux de pluie numérique. Un modèle vide ou qui ne s'évalue pas n'exprime aucune opinion (pas de rétractation). Laissez vide pour désactiver.",
+          "weather_is_windy_sensor": "Capteur binaire pour la détection du vent. La dérogation s'active quand ce capteur est « activé ». Laissez vide pour ignorer.",
+          "weather_is_windy_template": "Modèle Jinja2 Home Assistant optionnel qui détermine s'il fait du vent. Lorsqu'il s'évalue à vrai (on/true/1), la dérogation s'active. La façon dont il se combine avec le capteur binaire Is Windy ci-dessus (OU ou ET) est définie par la « logique du modèle Is Windy » ci-dessous ; il peut fonctionner seul sans capteur et réagit instantanément quand le modèle bascule. Exemple : dériver « venteux » d'un seuil de vitesse du vent numérique. Un modèle vide ou qui ne s'évalue pas n'exprime aucune opinion (pas de rétractation). Laissez vide pour désactiver.",
+          "weather_rain_sensor": "Capteur numérique signalant le taux de pluie. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer le taux de pluie.",
+          "weather_severe_sensors": "Capteurs binaires pour les conditions graves (grêle, gel, tempête, etc.). La dérogation s'active quand N'IMPORTE QUEL capteur est « activé ». Laissez vide pour ignorer.",
+          "weather_wind_direction_sensor": "Optionnel : ne déclenchez la dérogation vent que quand le vent souffle vers l'azimut de cette fenêtre (dans la tolérance de direction). Laissez vide pour déclencher uniquement sur la vitesse du vent indépendamment de la direction.",
+          "weather_wind_speed_sensor": "Capteur numérique signalant la vitesse du vent. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer la vitesse du vent."
+        }
       }
     },
     "abort": {

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -111,3 +111,63 @@ async def test_building_profile_link_selector_lists_profiles(
     assert "cover_2" not in values
     # A none/unlink choice is offered.
     assert "" in values or "__none__" in values
+
+
+@pytest.mark.integration
+async def test_building_profile_options_flow_shows_sensor_only_step(
+    hass: HomeAssistant,
+) -> None:
+    """Clicking Configure on a Building Profile entry shows sensor pickers only,
+    not the full cover-options menu.
+    """
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={CONF_LUX_ENTITY: "sensor.existing_lux"},
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+
+    flow = OptionsFlowHandler(profile)
+    flow.hass = hass
+
+    # async_step_init must NOT return a 14-item cover menu — it must route to
+    # the sensor-only step.
+    result = await flow.async_step_init()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "profile_sensors"
+    schema_keys = _schema_keys(result["data_schema"])
+    # Only sensor picker keys — no cover/geometry/handler keys.
+    assert schema_keys <= BUILDING_PROFILE_SENSOR_KEYS
+    # Existing sensor value is pre-filled via add_suggested_values_to_schema.
+    suggested = {
+        str(m.schema): m.description.get("suggested_value")
+        for m in result["data_schema"].schema
+        if hasattr(m, "description") and isinstance(m.description, dict)
+    }
+    assert suggested.get(CONF_LUX_ENTITY) == "sensor.existing_lux"
+
+
+@pytest.mark.integration
+async def test_building_profile_options_flow_saves_sensors(
+    hass: HomeAssistant,
+) -> None:
+    """Submitting the profile_sensors step saves options and closes the flow."""
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={},
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+
+    flow = OptionsFlowHandler(profile)
+    flow.hass = hass
+
+    # Submitting sensor data must produce create_entry (save).
+    result = await flow.async_step_profile_sensors({CONF_LUX_ENTITY: "sensor.new_lux"})
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_LUX_ENTITY] == "sensor.new_lux"


### PR DESCRIPTION
## Summary
Clicking **Configure** on a Building Profile entry opened the full cover-options dialog (geometry, thresholds, handlers) instead of the intended sensor-picker-only screen. A Building Profile controls no cover and has no geometry or handlers, so those fields are meaningless for it.

Root cause: `OptionsFlowHandler.async_step_init()` built the full cover-options menu for every entry type, with no guard for entries whose policy has `controls_cover=False`. This adds an early-return guard that routes such entries to a new sensor-only `async_step_profile_sensors` step, reusing the existing `building_profile_sensors_schema()` (no duplication) and gating on the `controls_cover` policy flag rather than a cover-type string branch. Symmetric with the profile create flow. Added the `profile_sensors` translation step (en + de + fr).

## Testing
- ✅ 65 tests passing (2 new regression tests for the profile options flow: sensor-only step shown + sensors saved)
- ✅ Translation validator green (de/fr synced, 1622/1622)

## Related Issues
Refs #715