### PR TITLE
fix: scope building profile template fields, surface in UI (#720)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_dynamic.py
+++ b/custom_components/adaptive_cover_pro/config_dynamic.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_CLOUDY_POSITION,
     CONF_DAYTIME_GATE_SENSORS,
     CONF_DAYTIME_GATE_TEMPLATE,
+    CONF_DAYTIME_GATE_TEMPLATE_MODE,
     CONF_DISTANCE,
     CONF_ENABLE_BLIND_SPOT,
     CONF_ENABLE_SUN_TRACKING,
@@ -57,8 +58,14 @@ from .const import (
     CONF_PRESENCE_ENTITY,
     CONF_PRESENCE_TEMPLATE,
     CONF_PRESENCE_TEMPLATE_MODE,
+    CONF_ENABLE_POSITION_MATCHING,
+    CONF_INVERSE_STATE,
+    CONF_POSITION_TOLERANCE,
+    CONF_RETURN_SUNSET,
     CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR,
+    CONF_SUNRISE_OFFSET,
     CONF_SUNRISE_TIME_ENTITY,
+    CONF_SUNSET_OFFSET,
     CONF_SUNSET_TIME_ENTITY,
     CONF_TEMP_ENTITY,
     CONF_TEMP_HIGH,
@@ -86,6 +93,7 @@ from .const import (
     CONF_WINTER_CLOSE_INSULATION,
     DEFAULT_BLIND_SPOT_ELEVATION_MODE,
     DEFAULT_CLOUD_COVERAGE_THRESHOLD,
+    DEFAULT_ENABLE_POSITION_MATCHING,
     DEFAULT_GLARE_ZONE_Z,
     DEFAULT_WEATHER_RAIN_THRESHOLD,
     DEFAULT_WEATHER_TIMEOUT,
@@ -158,6 +166,21 @@ def _drop_hidden(schema_dict: dict, hidden: frozenset[str]) -> dict:
     }
 
 
+def _template_combine_mode_selector() -> selector.SelectSelector:
+    """Return the shared OR/AND combine-mode selector (template condition fields).
+
+    Single source of truth for the ``template_combine_mode`` SelectSelector
+    used by ``_condition_template_schema`` and ``building_profile_sensors_schema``.
+    """
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=[m.value for m in TemplateCombineMode],
+            mode=selector.SelectSelectorMode.LIST,
+            translation_key="template_combine_mode",
+        )
+    )
+
+
 def _condition_template_schema(template_key: str, mode_key: str) -> dict:
     """Build a schema fragment for a condition template + combine mode (#639).
 
@@ -170,13 +193,7 @@ def _condition_template_schema(template_key: str, mode_key: str) -> dict:
         vol.Optional(template_key): selector.TemplateSelector(),
         vol.Optional(
             mode_key, default=DEFAULT_TEMPLATE_COMBINE_MODE
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=[m.value for m in TemplateCombineMode],
-                mode=selector.SelectSelectorMode.LIST,
-                translation_key="template_combine_mode",
-            )
-        ),
+        ): _template_combine_mode_selector(),
     }
 
 
@@ -460,6 +477,7 @@ def building_profile_sensors_schema() -> vol.Schema:
         ),
         CONF_IS_SUNNY_SENSOR: binary_on_selector(),
         CONF_IS_SUNNY_TEMPLATE: selector.TemplateSelector(),
+        CONF_IS_SUNNY_TEMPLATE_MODE: _template_combine_mode_selector(),
         CONF_LUX_ENTITY: numeric_selector(device_class="illuminance"),
         CONF_IRRADIANCE_ENTITY: numeric_selector(device_class="irradiance"),
         CONF_CLOUD_COVERAGE_ENTITY: numeric_selector(),
@@ -469,14 +487,17 @@ def building_profile_sensors_schema() -> vol.Schema:
         CONF_WEATHER_RAIN_SENSOR: numeric_selector(),
         CONF_WEATHER_IS_RAINING_SENSOR: binary_on_selector(),
         CONF_WEATHER_IS_RAINING_TEMPLATE: selector.TemplateSelector(),
+        CONF_WEATHER_IS_RAINING_TEMPLATE_MODE: _template_combine_mode_selector(),
         CONF_WEATHER_IS_WINDY_SENSOR: binary_on_selector(),
         CONF_WEATHER_IS_WINDY_TEMPLATE: selector.TemplateSelector(),
+        CONF_WEATHER_IS_WINDY_TEMPLATE_MODE: _template_combine_mode_selector(),
         CONF_WEATHER_SEVERE_SENSORS: binary_on_selector(multiple=True),
         # Outside temperature
         CONF_OUTSIDETEMP_ENTITY: numeric_selector(),
         # Daytime gate
         CONF_DAYTIME_GATE_SENSORS: binary_on_selector(multiple=True),
         CONF_DAYTIME_GATE_TEMPLATE: selector.TemplateSelector(),
+        CONF_DAYTIME_GATE_TEMPLATE_MODE: _template_combine_mode_selector(),
         # Sunrise / sunset time entities (offsets stay per-cover)
         CONF_SUNSET_TIME_ENTITY: selector.EntitySelector(
             selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
@@ -498,35 +519,93 @@ def temperature_climate_schema(
     hass: HomeAssistant | None = None, options: dict | None = None
 ) -> vol.Schema:
     """Climate-temperature schema. Temp thresholds accept number or template."""
-    return vol.Schema(
-        {
-            vol.Optional(CONF_CLIMATE_MODE, default=False): selector.BooleanSelector(),
-            vol.Optional(CONF_TEMP_ENTITY): selector.EntitySelector(
-                selector.EntityFilterSelectorConfig(domain=["climate", "sensor"])
-            ),
-            vol.Optional(
-                CONF_OUTSIDETEMP_ENTITY, default=vol.UNDEFINED
-            ): numeric_selector(),
-            vol.Optional(
-                CONF_PRESENCE_ENTITY, default=vol.UNDEFINED
-            ): presence_like_selector(),
-            **_condition_template_schema(
-                CONF_PRESENCE_TEMPLATE, CONF_PRESENCE_TEMPLATE_MODE
-            ),
-            vol.Optional(CONF_TEMP_LOW, default="21"): _threshold_selector(),
-            vol.Optional(CONF_TEMP_HIGH, default="25"): _threshold_selector(),
-            vol.Optional(CONF_OUTSIDE_THRESHOLD, default="25"): _threshold_selector(),
-            vol.Optional(
-                CONF_TRANSPARENT_BLIND, default=False
-            ): selector.BooleanSelector(),
-            vol.Optional(
-                CONF_WINTER_CLOSE_INSULATION, default=False
-            ): selector.BooleanSelector(),
-            vol.Optional(
-                CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR, default=False
-            ): selector.BooleanSelector(),
-        }
-    )
+    schema: dict = {
+        vol.Optional(CONF_CLIMATE_MODE, default=False): selector.BooleanSelector(),
+        vol.Optional(CONF_TEMP_ENTITY): selector.EntitySelector(
+            selector.EntityFilterSelectorConfig(domain=["climate", "sensor"])
+        ),
+        vol.Optional(
+            CONF_OUTSIDETEMP_ENTITY, default=vol.UNDEFINED
+        ): numeric_selector(),
+        vol.Optional(
+            CONF_PRESENCE_ENTITY, default=vol.UNDEFINED
+        ): presence_like_selector(),
+        **_condition_template_schema(
+            CONF_PRESENCE_TEMPLATE, CONF_PRESENCE_TEMPLATE_MODE
+        ),
+        vol.Optional(CONF_TEMP_LOW, default="21"): _threshold_selector(),
+        vol.Optional(CONF_TEMP_HIGH, default="25"): _threshold_selector(),
+        vol.Optional(CONF_OUTSIDE_THRESHOLD, default="25"): _threshold_selector(),
+        vol.Optional(CONF_TRANSPARENT_BLIND, default=False): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_WINTER_CLOSE_INSULATION, default=False
+        ): selector.BooleanSelector(),
+        vol.Optional(
+            CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR, default=False
+        ): selector.BooleanSelector(),
+    }
+    return vol.Schema(_drop_hidden(schema, _hidden_profile_keys(options)))
+
+
+def behavior_schema(options: dict | None = None) -> vol.Schema:
+    """Behavior schema (L2b: timing & thresholds), with profile-owned keys hidden.
+
+    Converts the formerly static ``BEHAVIOR_SCHEMA`` in ``config_flow`` into a
+    per-call builder so linked covers don't show fields the Building Profile owns:
+    ``CONF_SUNSET_TIME_ENTITY``, ``CONF_SUNRISE_TIME_ENTITY``,
+    ``CONF_DAYTIME_GATE_SENSORS``, ``CONF_DAYTIME_GATE_TEMPLATE``, and
+    ``CONF_DAYTIME_GATE_TEMPLATE_MODE`` (issue #720). Per-cover fields
+    (``CONF_SUNSET_OFFSET``, ``CONF_SUNRISE_OFFSET``, ``CONF_INVERSE_STATE``,
+    ``CONF_POSITION_TOLERANCE``, ``CONF_ENABLE_POSITION_MATCHING``) are always
+    rendered.
+    """
+    schema: dict = {
+        vol.Optional(CONF_SUNSET_TIME_ENTITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
+        ),
+        vol.Optional(CONF_SUNRISE_TIME_ENTITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=["sensor", "input_datetime"])
+        ),
+        vol.Optional(CONF_SUNSET_OFFSET, default=0): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=-120,
+                max=120,
+                mode=selector.NumberSelectorMode.BOX,
+                unit_of_measurement="minutes",
+            )
+        ),
+        vol.Optional(CONF_SUNRISE_OFFSET, default=0): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=-120,
+                max=120,
+                mode=selector.NumberSelectorMode.BOX,
+                unit_of_measurement="minutes",
+            )
+        ),
+        vol.Optional(CONF_RETURN_SUNSET, default=False): selector.BooleanSelector(),
+        vol.Optional(CONF_DAYTIME_GATE_SENSORS, default=[]): binary_on_selector(
+            multiple=True
+        ),
+        vol.Optional(CONF_DAYTIME_GATE_TEMPLATE): selector.TemplateSelector(),
+        vol.Optional(
+            CONF_DAYTIME_GATE_TEMPLATE_MODE, default=DEFAULT_TEMPLATE_COMBINE_MODE
+        ): _template_combine_mode_selector(),
+        vol.Optional(CONF_POSITION_TOLERANCE, default=3): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0,
+                max=20,
+                step=1,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="%",
+            )
+        ),
+        vol.Optional(
+            CONF_ENABLE_POSITION_MATCHING,
+            default=DEFAULT_ENABLE_POSITION_MATCHING,
+        ): selector.BooleanSelector(),
+        vol.Optional(CONF_INVERSE_STATE, default=False): selector.BooleanSelector(),
+    }
+    return vol.Schema(_drop_hidden(schema, _hidden_profile_keys(options)))
 
 
 def glare_zones_schema(

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -265,6 +265,7 @@ from .unit_system import (  # noqa: E402
 # call sites. config_flow is a consumer of these — not their owner.
 from . import config_fields  # noqa: E402
 from .config_dynamic import (  # noqa: E402
+    behavior_schema as _behavior_schema,
     blind_spot_schema,
     building_profile_sensors_schema,
     glare_zones_schema as _glare_zones_schema,
@@ -1191,6 +1192,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     ),
     "headers.your_cover": "**Your Cover**",
     "cover.type_with_entities": "{type_label} controlling {entity_str}",
+    "cover.building_profile": "🏢 Linked to building profile: {name}",
     "headers.cover_warnings": "**Cover Warnings**",
     "headers.how_it_decides": "**How It Decides** (first matching rule wins)",
     # --- singular/plural words ---
@@ -1694,6 +1696,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # the translated ``geometry.*`` bundle (or the policy-key-less EN default,
     # which still renders English over the policy's own base layer).
     lines.extend(summary_policy.summary_geometry_lines(config, L))
+
+    # Building profile link — show the profile name when this is a linked cover.
+    _profile_id = config.get(CONF_BUILDING_PROFILE_ID)
+    if _profile_id and hass is not None:
+        _profile_entry = hass.config_entries.async_get_entry(_profile_id)
+        if _profile_entry is not None:
+            lines.append(L["cover.building_profile"].format(name=_profile_entry.title))
 
     # =========================================================================
     # Section 1c: Cover Capability Warnings
@@ -3342,7 +3351,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_weather_override()
         return self.async_show_form(
             step_id="behavior",
-            data_schema=BEHAVIOR_SCHEMA,
+            data_schema=_behavior_schema(self.config),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Position",
                 "position_matching_wiki": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Position-Matching",
@@ -3808,12 +3817,24 @@ class OptionsFlowHandler(OptionsFlow):
         # Icons are embedded directly in each translation string (e.g. "🪟 Covers & Device").
         menu_options: list[str] = keys
 
+        # Build the profile_line placeholder: shows the linked profile's title
+        # when this cover is linked, or collapses to "" when unlinked.
+        _linked_profile_id = self.options.get(CONF_BUILDING_PROFILE_ID)
+        _profile_line = ""
+        if _linked_profile_id:
+            _profile_entry = self.hass.config_entries.async_get_entry(
+                _linked_profile_id
+            )
+            if _profile_entry is not None:
+                _profile_line = f"\n🏢 Building Profile: **{_profile_entry.title}**"
+
         return self.async_show_menu(  # type: ignore[return-value]
             step_id="init",
             menu_options=menu_options,
             description_placeholders={
                 "instance_name": self.config_entry.title,
                 "coffee_url": "https://www.buymeacoffee.com/jrhubott",
+                "profile_line": _profile_line,
             },
         )
 
@@ -3972,7 +3993,7 @@ class OptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="behavior",
             data_schema=self.add_suggested_values_to_schema(
-                BEHAVIOR_SCHEMA, user_input or self.options
+                _behavior_schema(self.options), user_input or self.options
             ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Position",

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1328,8 +1328,10 @@ class CoverType(StrEnum):
 # so they live here — ``const`` cannot import from ``config_flow`` (circular).
 # ``BUILDING_PROFILE_SENSOR_KEYS`` is the set of option keys a Building Profile
 # owns and copies into each linked cover. Threshold/reaction keys, presence,
-# the sunrise/sunset OFFSETS, and all ``*_template_mode`` keys are deliberately
-# excluded — they stay per-cover.
+# and the sunrise/sunset OFFSETS are deliberately excluded — they stay per-cover.
+# The four ``*_template_mode`` keys are profile-owned (moved from per-cover in
+# issue #720): they render in the profile screen, are copied to linked covers,
+# and are hidden on the per-cover weather/light/behavior forms.
 
 LIGHT_CLOUD_SENSOR_KEYS = frozenset(
     {
@@ -1339,6 +1341,7 @@ LIGHT_CLOUD_SENSOR_KEYS = frozenset(
         CONF_CLOUD_COVERAGE_ENTITY,
         CONF_IS_SUNNY_SENSOR,
         CONF_IS_SUNNY_TEMPLATE,
+        CONF_IS_SUNNY_TEMPLATE_MODE,
     }
 )
 
@@ -1349,8 +1352,10 @@ WEATHER_OVERRIDE_SENSOR_KEYS = frozenset(
         CONF_WEATHER_RAIN_SENSOR,
         CONF_WEATHER_IS_RAINING_SENSOR,
         CONF_WEATHER_IS_RAINING_TEMPLATE,
+        CONF_WEATHER_IS_RAINING_TEMPLATE_MODE,
         CONF_WEATHER_IS_WINDY_SENSOR,
         CONF_WEATHER_IS_WINDY_TEMPLATE,
+        CONF_WEATHER_IS_WINDY_TEMPLATE_MODE,
         CONF_WEATHER_SEVERE_SENSORS,
     }
 )
@@ -1363,6 +1368,7 @@ BUILDING_PROFILE_SENSOR_KEYS = (
             CONF_OUTSIDETEMP_ENTITY,
             CONF_DAYTIME_GATE_SENSORS,
             CONF_DAYTIME_GATE_TEMPLATE,
+            CONF_DAYTIME_GATE_TEMPLATE_MODE,
             CONF_SUNSET_TIME_ENTITY,
             CONF_SUNRISE_TIME_ENTITY,
         }

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -12,7 +12,8 @@
     "decision_priority": "**Entscheidungspriorität** (höchste gewinnt, ✅ aktiv ❌ nicht konfiguriert)"
   },
   "cover": {
-    "type_with_entities": "{type_label} steuert {entity_str}"
+    "type_with_entities": "{type_label} steuert {entity_str}",
+    "building_profile": "🏢 Verknüpft mit Gebäudeprofil: {name}"
   },
   "words": {
     "sensor_singular": "Sensor",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -12,7 +12,8 @@
     "decision_priority": "**Decision Priority** (highest wins, ✅ active ❌ not configured)"
   },
   "cover": {
-    "type_with_entities": "{type_label} controlling {entity_str}"
+    "type_with_entities": "{type_label} controlling {entity_str}",
+    "building_profile": "🏢 Linked to building profile: {name}"
   },
   "words": {
     "sensor_singular": "sensor",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -12,7 +12,8 @@
     "decision_priority": "**Priorité de décision** (la plus élevée gagne, ✅ actif ❌ non configuré)"
   },
   "cover": {
-    "type_with_entities": "{type_label} contrôlant {entity_str}"
+    "type_with_entities": "{type_label} contrôlant {entity_str}",
+    "building_profile": "🏢 Lié au profil de bâtiment : {name}"
   },
   "words": {
     "sensor_singular": "détecteur",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -767,7 +767,7 @@
           "pipeline_priorities": "🔀 Handler-Prioritäten",
           "building_profile": "🏢 Gebäudeprofil"
         },
-        "description": "Konfiguration: **{instance_name}**\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
+        "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
       "automation": {
         "title": "Bewegung & Zeitplan",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -743,7 +743,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "Configuring: **{instance_name}**\n\nIf Adaptive Cover Pro has been useful, you can [☕ Buy Me a Coffee]({coffee_url}).",
+        "description": "Configuring: **{instance_name}**{profile_line}\n\nIf Adaptive Cover Pro has been useful, you can [☕ Buy Me a Coffee]({coffee_url}).",
         "menu_options": {
           "cover_entities": "🪟 Covers & Device",
           "geometry": "📐 Cover Geometry",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -767,7 +767,7 @@
           "pipeline_priorities": "🔀 Priorités des gestionnaires",
           "building_profile": "🏢 Profil de bâtiment"
         },
-        "description": "Configuration : **{instance_name}**\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
+        "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
       "automation": {
         "title": "Mouvement & Programme",

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -171,3 +171,74 @@ async def test_building_profile_options_flow_saves_sensors(
     result = await flow.async_step_profile_sensors({CONF_LUX_ENTITY: "sensor.new_lux"})
     assert result["type"] == "create_entry"
     assert result["data"][CONF_LUX_ENTITY] == "sensor.new_lux"
+
+
+# ---------------------------------------------------------------------------
+# profile_line placeholder in options init step (issue #720 Part 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_init_step_profile_line_populated_for_linked_cover(
+    hass: HomeAssistant,
+) -> None:
+    """async_step_init must populate profile_line with the profile title."""
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={},
+        entry_id="profile_1",
+        title="Main House",
+    )
+    profile.add_to_hass(hass)
+    cover = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "C1", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_BUILDING_PROFILE_ID: "profile_1"},
+        entry_id="cover_1",
+        title="Cover One",
+    )
+    cover.add_to_hass(hass)
+
+    flow = OptionsFlowHandler(cover)
+    flow.hass = hass
+    # HA's OptionsFlow.config_entry resolves via self.handler (the entry_id).
+    flow.handler = cover.entry_id
+
+    result = await flow.async_step_init()
+
+    placeholders = result.get("description_placeholders", {})
+    assert (
+        "profile_line" in placeholders
+    ), "description_placeholders must include 'profile_line'"
+    assert (
+        "Main House" in placeholders["profile_line"]
+    ), "profile_line must contain the linked profile's title"
+
+
+@pytest.mark.integration
+async def test_init_step_profile_line_empty_for_unlinked_cover(
+    hass: HomeAssistant,
+) -> None:
+    """async_step_init must have an empty profile_line when cover is not linked."""
+    cover = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "C1", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={},
+        entry_id="cover_1",
+        title="Cover One",
+    )
+    cover.add_to_hass(hass)
+
+    flow = OptionsFlowHandler(cover)
+    flow.hass = hass
+    # HA's OptionsFlow.config_entry resolves via self.handler (the entry_id).
+    flow.handler = cover.entry_id
+
+    result = await flow.async_step_init()
+
+    placeholders = result.get("description_placeholders", {})
+    profile_line = placeholders.get("profile_line", "MISSING")
+    assert (
+        profile_line == ""
+    ), f"profile_line must be empty for unlinked cover, got: {profile_line!r}"

--- a/tests/test_building_profile_link.py
+++ b/tests/test_building_profile_link.py
@@ -17,16 +17,33 @@ import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.config_dynamic import (
+    behavior_schema,
+    building_profile_sensors_schema,
     light_cloud_schema,
+    temperature_climate_schema,
     weather_override_schema,
 )
 from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
 from custom_components.adaptive_cover_pro.const import (
     CONF_BUILDING_PROFILE_ID,
+    CONF_CLIMATE_MODE,
     CONF_CLOUDY_POSITION,
+    CONF_DAYTIME_GATE_SENSORS,
+    CONF_DAYTIME_GATE_TEMPLATE,
+    CONF_DAYTIME_GATE_TEMPLATE_MODE,
+    CONF_INVERSE_STATE,
     CONF_IRRADIANCE_ENTITY,
+    CONF_IS_SUNNY_TEMPLATE_MODE,
     CONF_LUX_ENTITY,
+    CONF_OUTSIDETEMP_ENTITY,
+    CONF_PRESENCE_TEMPLATE_MODE,
     CONF_SENSOR_TYPE,
+    CONF_SUNRISE_OFFSET,
+    CONF_SUNRISE_TIME_ENTITY,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_TIME_ENTITY,
+    CONF_WEATHER_IS_RAINING_TEMPLATE_MODE,
+    CONF_WEATHER_IS_WINDY_TEMPLATE_MODE,
     CONF_WEATHER_RAIN_SENSOR,
     CONF_WEATHER_RAIN_THRESHOLD,
     DOMAIN,
@@ -103,3 +120,88 @@ def test_linked_cover_hides_profile_pickers() -> None:
     assert CONF_LUX_ENTITY not in lc_linked
     # Non-profile field remains.
     assert CONF_CLOUDY_POSITION in lc_linked
+
+
+# ---------------------------------------------------------------------------
+# New tests for issue #720: template-mode keys become fully profile-owned
+# ---------------------------------------------------------------------------
+
+
+def test_template_modes_in_building_profile_sensors_schema() -> None:
+    """All four *_template_mode keys must appear in building_profile_sensors_schema."""
+    keys = _schema_keys(building_profile_sensors_schema())
+    assert (
+        CONF_WEATHER_IS_RAINING_TEMPLATE_MODE in keys
+    ), "weather_is_raining_template_mode must render in profile screen"
+    assert (
+        CONF_WEATHER_IS_WINDY_TEMPLATE_MODE in keys
+    ), "weather_is_windy_template_mode must render in profile screen"
+    assert (
+        CONF_IS_SUNNY_TEMPLATE_MODE in keys
+    ), "is_sunny_template_mode must render in profile screen"
+    assert (
+        CONF_DAYTIME_GATE_TEMPLATE_MODE in keys
+    ), "daytime_gate_template_mode must render in profile screen"
+
+
+def test_template_modes_hidden_on_linked_weather_and_light_schemas() -> None:
+    """Template-mode keys are hidden on per-cover weather/light screens when linked."""
+    linked = {CONF_BUILDING_PROFILE_ID: "profile_1"}
+    unlinked: dict = {}
+
+    wo_linked = _schema_keys(weather_override_schema(None, linked))
+    wo_unlinked = _schema_keys(weather_override_schema(None, unlinked))
+    # Present when unlinked, absent when linked.
+    assert CONF_WEATHER_IS_RAINING_TEMPLATE_MODE in wo_unlinked
+    assert CONF_WEATHER_IS_RAINING_TEMPLATE_MODE not in wo_linked
+    assert CONF_WEATHER_IS_WINDY_TEMPLATE_MODE in wo_unlinked
+    assert CONF_WEATHER_IS_WINDY_TEMPLATE_MODE not in wo_linked
+
+    lc_linked = _schema_keys(light_cloud_schema(None, linked))
+    lc_unlinked = _schema_keys(light_cloud_schema(None, unlinked))
+    assert CONF_IS_SUNNY_TEMPLATE_MODE in lc_unlinked
+    assert CONF_IS_SUNNY_TEMPLATE_MODE not in lc_linked
+
+
+def test_outsidetemp_hidden_on_linked_climate_schema() -> None:
+    """CONF_OUTSIDETEMP_ENTITY must be absent from temperature_climate_schema when linked."""
+    linked = {CONF_BUILDING_PROFILE_ID: "profile_1"}
+    unlinked: dict = {}
+
+    climate_linked = _schema_keys(temperature_climate_schema(None, linked))
+    climate_unlinked = _schema_keys(temperature_climate_schema(None, unlinked))
+
+    assert (
+        CONF_OUTSIDETEMP_ENTITY in climate_unlinked
+    ), "outsidetemp_entity must appear when unlinked"
+    assert (
+        CONF_OUTSIDETEMP_ENTITY not in climate_linked
+    ), "outsidetemp_entity must be hidden when linked"
+    # Per-cover climate fields must remain on linked covers.
+    assert CONF_CLIMATE_MODE in climate_linked
+    assert CONF_PRESENCE_TEMPLATE_MODE in climate_linked
+
+
+def test_behavior_schema_hides_profile_keys_on_linked_cover() -> None:
+    """behavior_schema() hides profile-owned behavior keys when cover is linked."""
+    linked = {CONF_BUILDING_PROFILE_ID: "profile_1"}
+    unlinked: dict = {}
+
+    bh_linked = _schema_keys(behavior_schema(linked))
+    bh_unlinked = _schema_keys(behavior_schema(unlinked))
+
+    # All five profile-owned behavior keys hidden when linked.
+    for key in (
+        CONF_SUNSET_TIME_ENTITY,
+        CONF_SUNRISE_TIME_ENTITY,
+        CONF_DAYTIME_GATE_SENSORS,
+        CONF_DAYTIME_GATE_TEMPLATE,
+        CONF_DAYTIME_GATE_TEMPLATE_MODE,
+    ):
+        assert key in bh_unlinked, f"{key} should be present when unlinked"
+        assert key not in bh_linked, f"{key} should be hidden when linked"
+
+    # Per-cover behavior fields must remain on linked covers.
+    assert CONF_INVERSE_STATE in bh_linked
+    assert CONF_SUNSET_OFFSET in bh_linked
+    assert CONF_SUNRISE_OFFSET in bh_linked

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -11,6 +11,7 @@ from custom_components.adaptive_cover_pro.config_flow import (
 from custom_components.adaptive_cover_pro.const import (
     CONF_AWNING_ANGLE,
     CONF_AZIMUTH,
+    CONF_BUILDING_PROFILE_ID,
     CONF_DAYTIME_GATE_SENSORS,
     CONF_DAYTIME_GATE_TEMPLATE,
     CONF_DAYTIME_GATE_TEMPLATE_MODE,
@@ -3063,3 +3064,53 @@ def test_summary_gate_template_mode_and():
     cfg[CONF_DAYTIME_GATE_TEMPLATE_MODE] = "and"
     summary = _build_config_summary(cfg, CoverType.BLIND)
     assert "daytime gate" in summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Section: Building Profile link in summary (issue #720)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_building_profile_line_when_linked() -> None:
+    """_build_config_summary shows the linked profile title when linked."""
+
+    class _FakeEntry:
+        def __init__(self, title: str) -> None:
+            self.title = title
+
+    class _FakeStates:
+        """Minimal hass.states stub so _check_cover_capabilities doesn't crash."""
+
+        def get(self, entity_id: str):  # noqa: D102
+            return None
+
+    class _FakeConfigEntries:
+        def __init__(self, entries: dict) -> None:
+            self._entries = entries
+
+        def async_get_entry(self, entry_id: str):  # noqa: D102
+            return self._entries.get(entry_id)
+
+    class _FakeHass:
+        def __init__(self, entries: dict) -> None:
+            self.config_entries = _FakeConfigEntries(entries)
+            self.states = _FakeStates()
+
+    hass = _FakeHass({"profile_1": _FakeEntry("Main House")})
+    cfg = _minimal_vertical()
+    cfg[CONF_BUILDING_PROFILE_ID] = "profile_1"
+    summary = _build_config_summary(cfg, CoverType.BLIND, hass=hass)
+
+    assert (
+        "building profile" in summary.lower()
+    ), "Summary must mention 'building profile' for a linked cover"
+    assert "Main House" in summary, "Summary must include the linked profile's title"
+
+
+def test_summary_building_profile_line_absent_when_unlinked() -> None:
+    """_build_config_summary has no profile line when CONF_BUILDING_PROFILE_ID is absent."""
+    cfg = _minimal_vertical()
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert (
+        "building profile" not in summary.lower()
+    ), "Summary must not mention 'building profile' for an unlinked cover"


### PR DESCRIPTION
## Summary
When a Building Profile is assigned, the four `*_template_mode` selectors (Is Raining/Windy template logic, sunny, daytime-gate) are now fully profile-owned: they appear in the Building Profile configuration screen, are copied to linked covers, and are hidden on the per-cover screen. I also wired `_drop_hidden` into the climate and behavior schemas so the remaining profile-owned fields (outside-temp entity, sunset/sunrise time entities, daytime-gate sensors/template) are hidden on linked covers. The assigned profile now also shows in the Configuration Summary and on the options menu under the "Configuring:" line.

Root cause: the four `*_template_mode` keys were excluded from `BUILDING_PROFILE_SENSOR_KEYS`, the single set that drives copy + per-cover hiding + profile-screen rendering — so the modes were missing from the profile screen yet left orphaned on the per-cover screen.

## Testing
- ✅ 5141 tests passing (full suite); 8 new tests added
- ✅ Translation parity validator green (DE/FR)

## Related Issues
Refs #720