### PR TITLE
fix: show Building Profile step in cover create flow (#693)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -286,6 +286,7 @@ from .profile_link import (  # noqa: E402
     _covers_linked_to,
     clear_cover_override,
     compute_override_keys,
+    merge_profile_into_config,
     profile_for_cover,
 )
 
@@ -3333,11 +3334,19 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                     },
                 )
             self.config.update(canonical)
+            # In full setup, offer to link this cover to a Building Profile when
+            # any profiles exist. Check profiles first so the guard short-circuits
+            # safely in unit tests that build a bare ConfigFlowHandler without
+            # initialising setup_mode (profiles are [] with a MagicMock hass).
+            if (
+                _building_profile_entries(self.hass)
+                and self.setup_mode != "quick"
+                and get_policy(self.type_blind).controls_cover
+            ):
+                return await self.async_step_building_profile()
             # L1 physical setup: the blind-spot sub-step (when enabled) attaches
             # to the window here, before L2 positions. Quick setup skips it.
-            if self.config.get(CONF_ENABLE_BLIND_SPOT) and self.setup_mode != "quick":
-                return await self.async_step_blind_spot()
-            return await self.async_step_position()
+            return await self._route_after_window_config()
         return self._show_sun_tracking_form(self.config)
 
     def _show_sun_tracking_form(
@@ -3358,6 +3367,67 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             description_placeholders=_sun_tracking_placeholders(
                 self.type_blind, self.config
             ),
+        )
+
+    async def _route_after_window_config(self) -> FlowResult:
+        """Route to blind_spot or position after all window-config steps complete.
+
+        Called from ``async_step_sun_tracking`` (no profiles path) and from
+        ``async_step_building_profile`` (after profile selection), so the routing
+        logic lives in one place instead of being mirrored in both callers.
+        """
+        if self.config.get(CONF_ENABLE_BLIND_SPOT) and self.setup_mode != "quick":
+            return await self.async_step_blind_spot()
+        return await self.async_step_position()
+
+    async def async_step_building_profile(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Link this new cover to a Building Profile during creation.
+
+        Merges the profile's non-empty shared-sensor keys directly into
+        ``self.config`` (there is no existing entry yet) and stores
+        ``CONF_BUILDING_PROFILE_ID``. Selecting the none/skip choice leaves
+        the cover unlinked. On submit, routes to the same blind_spot/position
+        step that ``async_step_sun_tracking`` would have used, via the shared
+        ``_route_after_window_config`` helper.
+        """
+        if user_input is not None:
+            chosen = user_input.get(CONF_BUILDING_PROFILE_ID) or _PROFILE_NONE_SENTINEL
+            if chosen != _PROFILE_NONE_SENTINEL:
+                profile = self.hass.config_entries.async_get_entry(chosen)
+                if profile is not None:
+                    # Store only the link ID here. The sensor-value merge is
+                    # applied at entry-creation time (async_step_update) so that
+                    # profile values survive subsequent form steps that call
+                    # optional_entities() and overwrite absent keys with None.
+                    self.config[CONF_BUILDING_PROFILE_ID] = profile.entry_id
+            return await self._route_after_window_config()
+
+        profiles = _building_profile_entries(self.hass)
+        options = [
+            {"value": _PROFILE_NONE_SENTINEL, "label": "None (unlinked)"},
+            *({"value": e.entry_id, "label": e.title} for e in profiles),
+        ]
+        current = self.config.get(CONF_BUILDING_PROFILE_ID) or _PROFILE_NONE_SENTINEL
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_BUILDING_PROFILE_ID, default=current
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
+            }
+        )
+        return self.async_show_form(
+            step_id="building_profile",
+            data_schema=schema,
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
+            },
         )
 
     async def async_step_position(self, user_input: dict[str, Any] | None = None):
@@ -3653,6 +3723,16 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             options.setdefault(
                 CONF_ENABLE_POSITION_MATCHING, DEFAULT_ENABLE_POSITION_MATCHING
             )
+
+        # If the user linked a Building Profile during creation, merge its
+        # non-empty shared-sensor keys into options now — after all form steps
+        # have run. This ensures profile values survive optional_entities() calls
+        # in later steps that would otherwise overwrite absent keys with None.
+        profile_id = options.get(CONF_BUILDING_PROFILE_ID)
+        if profile_id:
+            _profile_entry = self.hass.config_entries.async_get_entry(profile_id)
+            if _profile_entry is not None:
+                merge_profile_into_config(_profile_entry, options)
 
         return self.async_create_entry(
             title=title,

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -108,6 +108,28 @@ def profile_for_cover(
     return hass.config_entries.async_get_entry(profile_id)
 
 
+def merge_profile_into_config(
+    profile_entry: ConfigEntry,
+    config_dict: dict,
+    *,
+    overridden: frozenset[str] = frozenset(),
+) -> None:
+    """Merge a profile's non-empty shared-sensor keys into a plain dict.
+
+    Skips keys the cover has locally overridden. Safe to call from both the
+    create flow (no existing entry, no overrides) and ``_copy_profile_to_cover``
+    (existing entry, may have overrides). Does NOT stamp
+    ``CONF_BUILDING_PROFILE_ID`` — callers handle that so each context can
+    write it in the right place.
+    """
+    subset = {
+        k: v
+        for k, v in profile_entry.options.items()
+        if k in BUILDING_PROFILE_SENSOR_KEYS and _is_set(v) and k not in overridden
+    }
+    config_dict.update(subset)
+
+
 def _copy_profile_to_cover(
     hass: HomeAssistant, profile_entry: ConfigEntry, cover_entry: ConfigEntry
 ) -> None:
@@ -120,21 +142,18 @@ def _copy_profile_to_cover(
     the ``async_update_entry`` merge — the update fires the cover's self-reload
     listener. The single shared copier; both linking and the profile-change
     propagation listener reuse it.
+
+    Delegates the key-subset logic to ``merge_profile_into_config`` so there is
+    a single source of truth for which keys are copied and how overrides are
+    respected.
     """
     overridden = effective_profile_overrides(cover_entry.options)
-    subset = {
-        k: v
-        for k, v in profile_entry.options.items()
-        if k in BUILDING_PROFILE_SENSOR_KEYS and _is_set(v) and k not in overridden
+    new_options: dict = {
+        **cover_entry.options,
+        CONF_BUILDING_PROFILE_ID: profile_entry.entry_id,
     }
-    hass.config_entries.async_update_entry(
-        cover_entry,
-        options={
-            **cover_entry.options,
-            **subset,
-            CONF_BUILDING_PROFILE_ID: profile_entry.entry_id,
-        },
-    )
+    merge_profile_into_config(profile_entry, new_options, overridden=overridden)
+    hass.config_entries.async_update_entry(cover_entry, options=new_options)
 
 
 def clear_cover_override(

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -735,6 +735,16 @@
           "weather_wind_direction_sensor": "Optional: Trigger Wind-Übersteuerung nur, wenn Wind gegen das Azimut dieses Fensters weht (innerhalb der Richtungstoleranz). Leer lassen, um Übersteuerung allein auf Windgeschwindigkeit zu triggern, unabhängig von der Richtung.",
           "weather_wind_speed_sensor": "Numerischer Sensor, der Windgeschwindigkeit meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren."
         }
+      },
+      "building_profile": {
+        "title": "Gebäudeprofil",
+        "description": "Verknüpfe diese Abdeckung mit einem Gebäudeprofil, um gebäudeweite Sensoren über mehrere Abdeckungen zu teilen. Durch die Verknüpfung werden die Sensoren des Profils in diese Abdeckung kopiert; leere Profilfelder behalten die eigenen Werte dieser Abdeckung.\n\n[Mehr erfahren]({learn_more})",
+        "data": {
+          "building_profile_id": "Gebäudeprofil"
+        },
+        "data_description": {
+          "building_profile_id": "Verknüpfe diese Abdeckung mit einem Gebäudeprofil, um seine gemeinsamen gebäudeweiten Sensoren zu erben. Wähle „Keine (nicht verknüpft)\" aus, um die Profilverknüpfung zu überspringen und die Sensoren dieser Abdeckung lokal zu verwalten."
+        }
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -735,6 +735,16 @@
           "weather_wind_direction_sensor": "Optional: only trigger wind override when wind blows toward this window's azimuth (within the direction tolerance). Leave empty to trigger on wind speed alone regardless of direction.",
           "weather_wind_speed_sensor": "Numeric sensor reporting wind speed. Override activates when the value meets or exceeds the threshold. Leave empty to ignore wind speed."
         }
+      },
+      "building_profile": {
+        "title": "Building Profile",
+        "description": "Link this cover to a Building Profile to share building-level sensors across covers. Linking copies the profile's sensors into this cover; blank profile fields keep this cover's own values.\n\n[Learn more]({learn_more})",
+        "data": {
+          "building_profile_id": "Building Profile"
+        },
+        "data_description": {
+          "building_profile_id": "Link this cover to a Building Profile to inherit its shared building-level sensors. Select 'None (unlinked)' to skip profile linking and manage this cover's sensors locally."
+        }
       }
     },
     "abort": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -735,6 +735,16 @@
           "weather_wind_direction_sensor": "Optionnel : ne déclenchez la dérogation vent que quand le vent souffle vers l'azimut de cette fenêtre (dans la tolérance de direction). Laissez vide pour déclencher uniquement sur la vitesse du vent indépendamment de la direction.",
           "weather_wind_speed_sensor": "Capteur numérique signalant la vitesse du vent. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer la vitesse du vent."
         }
+      },
+      "building_profile": {
+        "title": "Profil de bâtiment",
+        "description": "Associez ce volet à un Profil de bâtiment pour partager les capteurs à l'échelle du bâtiment entre les volets. L'association copie les capteurs du profil dans ce volet ; les champs de profil vides conservent les valeurs propres de ce volet.\n\n[En savoir plus]({learn_more})",
+        "data": {
+          "building_profile_id": "Profil de bâtiment"
+        },
+        "data_description": {
+          "building_profile_id": "Associez ce volet à un Profil de bâtiment pour hériter de ses capteurs partagés à l'échelle du bâtiment. Sélectionnez « Aucun (non lié) » pour ignorer l'association de profil et gérer les capteurs de ce volet localement."
+        }
       }
     },
     "abort": {

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -24,6 +24,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_AWNING_MAX_ANGLE,
     CONF_AWNING_MIN_ANGLE,
     CONF_AZIMUTH,
+    CONF_BUILDING_PROFILE_ID,
     CONF_CLIMATE_MODE,
     CONF_DEFAULT_HEIGHT,
     CONF_DELTA_POSITION,
@@ -42,6 +43,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MAX_ELEVATION,
     CONF_MAX_POSITION,
+    CONF_OUTSIDETEMP_ENTITY,
     CONF_VENETIAN_MODE,
     CONF_ENABLE_MAX_POSITION,
     CONF_MIN_ELEVATION,
@@ -507,6 +509,179 @@ async def test_full_setup_vertical_creates_entry(hass: HomeAssistant) -> None:
     assert CONF_DELTA_POSITION in opts
     assert opts[CONF_DELTA_TIME] is not None
     assert opts[CONF_MANUAL_OVERRIDE_DURATION] is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase 2b: Full-setup — building profile integration (issue #693)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_full_setup_includes_building_profile_step_when_profile_exists(
+    hass: HomeAssistant,
+) -> None:
+    """Full-setup create flow surfaces building_profile step when profiles exist.
+
+    Regression test for issue #693: the step was absent from ConfigFlow and
+    only existed in OptionsFlowHandler.
+    """
+    # Register a building profile so _building_profile_entries(hass) is non-empty.
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "My Building", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={CONF_OUTSIDETEMP_ENTITY: "sensor.outside_temp"},
+        entry_id="test_profile_693",
+        title="My Building",
+    )
+    profile.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Profile Blind", CONF_MODE: CoverType.BLIND},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "full_setup"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _VERTICAL_GEOMETRY
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _SUN_TRACKING
+    )
+    # The building_profile step must appear when profiles exist.
+    assert result["step_id"] == "building_profile"
+
+    # Submit with a profile chosen.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_BUILDING_PROFILE_ID: "test_profile_693"}
+    )
+    # blind_spot is False in _SUN_TRACKING → position is next.
+    assert result["step_id"] == "position"
+
+    # Walk through the remaining steps to create the entry.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _POSITION
+    )
+    assert result["step_id"] == "behavior"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _BEHAVIOR
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _WEATHER_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _MANUAL_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _CUSTOM_POSITION
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _MOTION_OVERRIDE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _LIGHT_CLOUD
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _TEMPERATURE_CLIMATE
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _AUTOMATION
+    )
+    assert result["step_id"] == "summary"
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == "create_entry"
+
+    opts = result["result"].options
+    assert opts.get(CONF_BUILDING_PROFILE_ID) == "test_profile_693"
+    assert opts.get(CONF_OUTSIDETEMP_ENTITY) == "sensor.outside_temp"
+
+
+@pytest.mark.integration
+async def test_full_setup_skips_building_profile_step_when_no_profiles(
+    hass: HomeAssistant,
+) -> None:
+    """Full-setup create flow skips building_profile step when no profiles exist.
+
+    When _building_profile_entries(hass) is empty the flow jumps directly to
+    position (or blind_spot), preserving the pre-#693 path.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "No Profile Blind", CONF_MODE: CoverType.BLIND},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "full_setup"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _VERTICAL_GEOMETRY
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _SUN_TRACKING
+    )
+    # No profiles registered → skip directly to position.
+    assert result["step_id"] == "position"
+
+
+@pytest.mark.integration
+async def test_quick_setup_skips_building_profile_step_even_when_profiles_exist(
+    hass: HomeAssistant,
+) -> None:
+    """Quick-setup path bypasses the building_profile step even when profiles exist."""
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={},
+        entry_id="test_profile_quick",
+        title="Bldg",
+    )
+    profile.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Quick Blind", CONF_MODE: CoverType.BLIND},
+    )
+    # Quick setup
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "quick_setup"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _VERTICAL_GEOMETRY
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _SUN_TRACKING
+    )
+    # Quick setup never shows the building_profile step.
+    assert result["step_id"] == "position"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The Building Profile link step appeared only in the options (edit) flow, never in the cover-creation wizard, so creating a new cover with full details skipped profile linking entirely (reported by @FredM67). This adds `async_step_building_profile` to the create flow, shown between sun-tracking and position/blind-spot steps when building profiles exist and setup isn't "quick". A shared `merge_profile_into_config` helper folds the profile's sensors into the new cover's config, reusing the existing copy logic with no duplication. DE/FR translations added.

## Testing
- ✅ 68 config-flow + building-profile-link tests passing
- ✅ Translation parity validator + 43 translation tests passing (DE/FR complete)

## Related Issues
Refs #693