### PR TITLE
fix: make roof-window FOV gate tilt-aware (#212)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from ...config_context_adapter import ConfigContextAdapter
 from ...config_types import CoverConfig
 from ...sun import SunData
-from ..sun_geometry import SunGeometry
+from ..sun_geometry import SunGeometry, azimuth_within_fov
 
 _COVER_CONFIG_FIELDS = frozenset(
     {
@@ -161,9 +161,22 @@ class AdaptiveGeneralCover(ABC):
         return self.solar.is_sun_in_blind_spot
 
     @property
+    def fov_angle(self) -> float:
+        """Azimuth angle compared against the FOV (vertical = horizontal gamma).
+
+        Polymorphic hook: cover types whose acceptance cone is not the raw
+        horizontal azimuth (e.g. a pitched roof window, where the gate must be
+        measured in the tilted glass plane — #212) override this. The position
+        projection still uses the raw ``gamma``; only the FOV gate reads here.
+        """
+        return self.gamma
+
+    @property
     def in_fov(self) -> bool:
-        """Delegate to SunGeometry.in_fov."""
-        return self.solar.in_fov
+        """Whether the sun azimuth is within the FOV (elevation ignored)."""
+        return azimuth_within_fov(
+            self.fov_angle, self.config.fov_left, self.config.fov_right
+        )
 
     def solar_times(self) -> tuple[datetime | None, datetime | None]:
         """Delegate to the SunGeometry solar_times helper."""
@@ -190,10 +203,11 @@ class AdaptiveGeneralCover(ABC):
     @property
     def valid(self) -> bool:
         """Check if sun is in front of window within field of view."""
-        azi_min = self.config.fov_left
-        azi_max = self.config.fov_right
         valid = bool(
-            (self.gamma < azi_min) & (self.gamma > -azi_max) & (self.valid_elevation)
+            azimuth_within_fov(
+                self.fov_angle, self.config.fov_left, self.config.fov_right
+            )
+            and self.valid_elevation
         )
         self.logger.debug("Sun in front of window (ignoring blindspot)? %s", valid)
         return valid

--- a/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
@@ -34,7 +34,7 @@ Pitch convention (``roof_pitch`` β, FROM HORIZONTAL):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import atan, cos, degrees, radians, sin, tan
+from math import atan, atan2, cos, degrees, radians, sin, tan
 
 from ...config_types import RoofWindowConfig
 from .vertical import AdaptiveVerticalCover
@@ -89,6 +89,32 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
         elev = radians(self.sol_elev)
         cos_dazi = cos(radians(self.gamma))
         return sin(beta) * cos(elev) * cos_dazi + cos(beta) * sin(elev)
+
+    def _effective_gamma(self) -> float:
+        """FOV azimuth measured in the tilted glass plane (#212).
+
+        atan2(s.x_hat, s.n) = atan2(cos(elev)*sin(gamma), cos(AOI)). Reduces to the
+        horizontal gamma at beta=90 and widens with decreasing pitch, so the user
+        FOV bounds the in-plane sideways angle, not the raw horizontal azimuth.
+        The position projection still uses the real gamma; only acceptance moves to
+        the tilted plane. effective_gamma is elevation-dependent (the FOV breathes
+        with sun height), which is correct for a tilted plane.
+        """
+        elev = radians(self.sol_elev)
+        s_dot_x = cos(elev) * sin(radians(self.gamma))
+        return degrees(atan2(s_dot_x, self._cos_aoi()))
+
+    @property
+    def fov_angle(self) -> float:
+        """Roof-window FOV gate angle: the tilted-plane azimuth (#212).
+
+        At vertical glass this is bit-for-bit the horizontal gamma (the
+        regression anchor); below vertical it is the elevation-dependent
+        in-plane azimuth, so the FOV "breathes" with sun height.
+        """
+        if self.roof_pitch == VERTICAL_GLASS_PITCH_DEG:
+            return super().fov_angle  # bit-for-bit vertical anchor
+        return self._effective_gamma()
 
     def _is_sun_behind_ridge(self) -> bool:
         """Whether the roof above the window occludes the sun (ridge gate, #212).

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -20,6 +20,11 @@ from ..const import (
 from ..sun import SunData
 
 
+def azimuth_within_fov(angle: float, fov_left: float, fov_right: float) -> bool:
+    """Sun azimuth (deg, relative to window normal) inside the FOV cone."""
+    return bool((angle < fov_left) & (angle > -fov_right))
+
+
 def fov_from_reveal(width_m: float, depth_m: float) -> int:
     """Symmetric FOV half-angle (degrees) from reveal width and depth.
 
@@ -196,10 +201,9 @@ class SunGeometry:
             False if sun behind window, outside FOV, or elevation invalid.
 
         """
-        azi_min = self.config.fov_left
-        azi_max = self.config.fov_right
         valid = bool(
-            (self.gamma < azi_min) & (self.gamma > -azi_max) & (self.valid_elevation)
+            azimuth_within_fov(self.gamma, self.config.fov_left, self.config.fov_right)
+            and self.valid_elevation
         )
         self.logger.debug("Sun in front of window (ignoring blindspot)? %s", valid)
         return valid
@@ -212,9 +216,9 @@ class SunGeometry:
         whether the elevation is valid. Used by the companion card to distinguish
         "outside FOV" from "in FOV but blocked by elevation/sunset/blind-spot".
         """
-        azi_min = self.config.fov_left
-        azi_max = self.config.fov_right
-        return bool((self.gamma < azi_min) & (self.gamma > -azi_max))
+        return azimuth_within_fov(
+            self.gamma, self.config.fov_left, self.config.fov_right
+        )
 
     @property
     def sunset_valid(self) -> bool:

--- a/tests/test_cover_types/test_roof_window.py
+++ b/tests/test_cover_types/test_roof_window.py
@@ -16,7 +16,7 @@ azimuth, so each case can drive a real engine while pinning gamma precisely.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from math import atan, cos, degrees, radians, sin, tan
+from math import atan, atan2, cos, degrees, radians, sin, tan
 from unittest.mock import MagicMock
 
 import pytest
@@ -522,3 +522,108 @@ def test_summary_omits_ridge_height_when_zero():
     joined = " ".join(lines)
     assert "roof pitch 35°" in joined
     assert "roof above window" not in joined
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — tilt-aware azimuth FOV gate (#212)
+#
+# On a pitched roof window the glass "sees" a far wider azimuth swath than a
+# vertical wall, so the bare ``|gamma| < fov`` gate dropped the sun while the
+# glass was still fully lit. The acceptance gate now compares the in-plane
+# (tilted-glass) azimuth — ``fov_angle`` = effective gamma — against the FOV,
+# while the position projection keeps the raw horizontal gamma.
+# ---------------------------------------------------------------------------
+
+
+def _effective_gamma(pitch: float, elev: float, gamma: float) -> float:
+    """FOV azimuth in the tilted glass plane — the expectation Option B derives.
+
+    ``atan2(cos(elev)·sin(gamma), cos(AOI))`` with
+    ``cos(AOI) = sinβ·cos(elev)·cos(gamma) + cosβ·sin(elev)``.
+    """
+    beta = radians(pitch)
+    e = radians(elev)
+    cos_aoi = sin(beta) * cos(e) * cos(radians(gamma)) + cos(beta) * sin(e)
+    return degrees(atan2(cos(e) * sin(radians(gamma)), cos_aoi))
+
+
+@pytest.mark.parametrize("gamma", [-85.0, -105.0, -125.0, -165.0])
+def test_reporter_geometry_stays_valid_beyond_fov(gamma):
+    """β=45°, FOV 85°, elev 60°: lit glass stays valid even past raw |gamma|=fov."""
+    roof = _roof(roof_pitch=45, sol_elev=60.0, gamma=gamma, fov_left=85, fov_right=85)
+    assert roof._cos_aoi() > 0
+    assert roof.valid is True
+    assert roof.direct_sun_valid is True
+    assert roof.control_state_reason == "Direct Sun"
+
+
+@pytest.mark.parametrize("gamma", [-105.0, -125.0, -165.0])
+def test_in_fov_tracks_illumination_for_tilted_pitch(gamma):
+    """in_fov follows the tilted-plane gate, not the raw horizontal azimuth."""
+    roof = _roof(roof_pitch=45, sol_elev=60.0, gamma=gamma, fov_left=85, fov_right=85)
+    assert roof.in_fov is True
+
+
+@pytest.mark.parametrize("gamma", [-85.0, -110.0, -140.0])
+def test_pitch_30_stays_valid_beyond_fov(gamma):
+    """A shallower pitch (β=30°) widens acceptance even further."""
+    roof = _roof(roof_pitch=30, sol_elev=45.0, gamma=gamma, fov_left=85, fov_right=85)
+    assert roof._cos_aoi() > 0
+    assert roof.valid is True
+
+
+def test_effective_gamma_within_fov_when_lit():
+    """fov_angle is the in-plane azimuth — inside FOV and distinct from raw gamma."""
+    for gamma in (-85.0, -105.0, -125.0, -165.0):
+        roof = _roof(
+            roof_pitch=45, sol_elev=60.0, gamma=gamma, fov_left=85, fov_right=85
+        )
+        assert abs(roof.fov_angle) < 85
+        assert roof.fov_angle != pytest.approx(roof.gamma)
+    # gamma=-125 projects to ≈ -45° in the β=45/elev=60 tilted plane.
+    roof = _roof(roof_pitch=45, sol_elev=60.0, gamma=-125.0, fov_left=85, fov_right=85)
+    assert roof.fov_angle == pytest.approx(-45.0, abs=0.5)
+
+
+def test_narrow_fov_still_rejects_far_sideways_sun():
+    """A user-narrowed FOV still cuts a sun whose in-plane azimuth exceeds it."""
+    pitch, elev, gamma, fov = 45.0, 20.0, -60.0, 20
+    # Intent: the in-plane azimuth exceeds the narrow FOV while the glass is lit.
+    assert abs(_effective_gamma(pitch, elev, gamma)) > fov
+    roof = _roof(
+        roof_pitch=pitch, sol_elev=elev, gamma=gamma, fov_left=fov, fov_right=fov
+    )
+    assert roof._cos_aoi() > 0
+    assert roof.valid is False
+
+
+@pytest.mark.parametrize("fov", [70, 85, 90])
+@pytest.mark.parametrize("elev", [-5.0, 0.0, 30.0, 70.0])
+@pytest.mark.parametrize("gamma", [-89.0, -80.0, -10.0, 0.0, 10.0, 80.0, 89.0])
+def test_pitch_90_validity_unchanged_with_narrow_fov(fov, elev, gamma):
+    """β=90° vertical anchor: every gate matches the vertical engine bit-for-bit."""
+    roof = _roof(roof_pitch=90, sol_elev=elev, gamma=gamma, fov_left=fov, fov_right=fov)
+    vert = _vertical(sol_elev=elev, gamma=gamma, fov_left=fov, fov_right=fov)
+    assert roof.valid == vert.valid
+    assert roof.in_fov == vert.in_fov
+    assert roof.direct_sun_valid == vert.direct_sun_valid
+    assert roof.fov_angle == vert.gamma
+
+
+def test_wide_gamma_does_not_force_full_coverage():
+    """The removed |gamma|>85 → full-coverage edge case stays gone for roof (#212)."""
+    roof = _roof(
+        roof_pitch=45,
+        sol_elev=60.0,
+        gamma=-125.0,
+        distance=1.0,
+        h_win=2.0,
+        fov_left=85,
+        fov_right=85,
+    )
+    assert roof.valid is True
+    pos = roof.calculate_position()
+    # A real geometric projection (here it saturates at h_win), NOT the old
+    # forced-closed 0.0 the inherited edge case used to return.
+    assert 0.0 < pos <= 2.0
+    assert roof._last_calc_details["edge_case_detected"] is False


### PR DESCRIPTION
## Summary
The roof-window cover type (shipped v2.30.0-beta.3) returned to default about 1 to 2 hours too early because its azimuth field-of-view gate reused the vertical-window check. The illumination test was tilt-aware, but the FOV gate compared the raw horizontal azimuth difference against the FOV, so the sun was dropped at `|gamma| > fov` even while the tilted glass was still lit.

The FOV gate now computes an effective in-plane azimuth (gamma transformed into the tilted glass plane via an atan2 of the cross-slope and out-of-plane components), exposed through a new polymorphic `fov_angle` hook. Roof windows widen acceptance correctly with pitch; vertical windows (pitch 90) reduce to the original gamma bit-for-bit. The duplicated FOV comparison is unified behind a single `azimuth_within_fov` predicate.

## Testing
- ✅ 5280 tests passing (full suite)
- ✅ 213 roof-window tests (was 141), including new beta=45/30 regression tests asserting validity holds beyond the raw-gamma FOV while the glass is lit, and a pinned beta=90 vertical-equivalence anchor at non-default FOV

## Related Issues
Refs #212