### PR TITLE
fix: make per-day predicted sun window tilt-aware for roof windows (#729)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
@@ -34,7 +34,10 @@ Pitch convention (``roof_pitch`` β, FROM HORIZONTAL):
 from __future__ import annotations
 
 from dataclasses import dataclass
-from math import atan, atan2, cos, degrees, radians, sin, tan
+from datetime import datetime
+from math import atan, cos, degrees, radians, sin, tan
+
+import numpy as np
 
 from ...config_types import RoofWindowConfig
 from .vertical import AdaptiveVerticalCover
@@ -55,6 +58,39 @@ TRACE_KEY_COS_AOI = "cos_aoi"
 TRACE_KEY_SLOPE_RATIO = "slope_ratio"
 TRACE_KEY_RIDGE_GATE_ENABLED = "ridge_gate_enabled"
 TRACE_KEY_RIDGE_GATE_OCCLUDED = "ridge_gate_occluded"
+
+
+# ---------------------------------------------------------------------------
+# Pure tilted-plane geometry (single source of truth for scalar + vector paths)
+# ---------------------------------------------------------------------------
+# These accept floats OR pandas/numpy arrays (numpy ufuncs broadcast either),
+# so the scalar gate methods and the vectorized per-day predicted window (#729)
+# share ONE copy of the cos(AOI) / effective-gamma trig.
+
+
+def roof_cos_aoi(gamma, elev, pitch):
+    """Cosine of the angle of incidence on the tilted glass (``s·n``).
+
+    ``cos(AOI) = sinβ·cos(elev)·cos(gamma) + cosβ·sin(elev)``. Positive → the
+    sun strikes the outer face. Scalar or array inputs.
+    """
+    beta = np.radians(pitch)
+    e = np.radians(elev)
+    g = np.radians(gamma)
+    return np.sin(beta) * np.cos(e) * np.cos(g) + np.cos(beta) * np.sin(e)
+
+
+def roof_effective_gamma(gamma, elev, pitch):
+    """In-plane (tilted-glass) FOV azimuth ``atan2(cos(elev)·sin(gamma), cos(AOI))``.
+
+    Reduces to the horizontal gamma at β=90° and widens with decreasing pitch.
+    Scalar or array inputs (the vectorized form feeds the predicted-window gate).
+    """
+    e = np.radians(elev)
+    g = np.radians(gamma)
+    return np.degrees(
+        np.arctan2(np.cos(e) * np.sin(g), roof_cos_aoi(gamma, elev, pitch))
+    )
 
 
 @dataclass
@@ -85,24 +121,20 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
         At β=90° this is ``cos(elev)·cos(gamma)`` (the vertical case); at β=0°
         it is ``sin(elev)`` (a flat skylight, azimuth-independent).
         """
-        beta = radians(self.roof_pitch)
-        elev = radians(self.sol_elev)
-        cos_dazi = cos(radians(self.gamma))
-        return sin(beta) * cos(elev) * cos_dazi + cos(beta) * sin(elev)
+        return float(roof_cos_aoi(self.gamma, self.sol_elev, self.roof_pitch))
 
     def _effective_gamma(self) -> float:
         """FOV azimuth measured in the tilted glass plane (#212).
 
-        atan2(s.x_hat, s.n) = atan2(cos(elev)*sin(gamma), cos(AOI)). Reduces to the
-        horizontal gamma at beta=90 and widens with decreasing pitch, so the user
-        FOV bounds the in-plane sideways angle, not the raw horizontal azimuth.
-        The position projection still uses the real gamma; only acceptance moves to
-        the tilted plane. effective_gamma is elevation-dependent (the FOV breathes
-        with sun height), which is correct for a tilted plane.
+        Scalar wrapper over the shared :func:`roof_effective_gamma` helper:
+        atan2(cos(elev)*sin(gamma), cos(AOI)). Reduces to the horizontal gamma at
+        beta=90 and widens with decreasing pitch, so the user FOV bounds the
+        in-plane sideways angle, not the raw horizontal azimuth. The position
+        projection still uses the real gamma; only acceptance moves to the tilted
+        plane. effective_gamma is elevation-dependent (the FOV breathes with sun
+        height), which is correct for a tilted plane.
         """
-        elev = radians(self.sol_elev)
-        s_dot_x = cos(elev) * sin(radians(self.gamma))
-        return degrees(atan2(s_dot_x, self._cos_aoi()))
+        return float(roof_effective_gamma(self.gamma, self.sol_elev, self.roof_pitch))
 
     @property
     def fov_angle(self) -> float:
@@ -115,6 +147,30 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
         if self.roof_pitch == VERTICAL_GLASS_PITCH_DEG:
             return super().fov_angle  # bit-for-bit vertical anchor
         return self._effective_gamma()
+
+    def solar_times_with_position(
+        self,
+    ) -> tuple[
+        tuple[datetime, float, float] | None,
+        tuple[datetime, float, float] | None,
+    ]:
+        """Per-day predicted sun window with the tilted-plane FOV gate (#729).
+
+        The base delegates to ``SunGeometry`` with the raw-azimuth vertical gate.
+        A pitched roof "sees" a wider azimuth swath, so the predicted window must
+        use the same in-plane effective gamma the live ``fov_angle`` gate uses —
+        otherwise the predicted sun-leave time lags the live ``direct_sun_valid``
+        by 1–2 h. At vertical glass (β=90°) there is no widening, so delegate with
+        the ``None`` (vertical) gate to preserve the bit-for-bit anchor.
+        """
+        pitch = self.roof_pitch
+        if pitch == VERTICAL_GLASS_PITCH_DEG:
+            return self.solar.solar_times_with_position()
+        return self.solar.solar_times_with_position(
+            fov_angle_series=lambda gamma, elev: roof_effective_gamma(
+                gamma, elev, pitch
+            )
+        )
 
     def _is_sun_behind_ridge(self) -> bool:
         """Whether the roof above the window occludes the sun (ridge gate, #212).

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -3,6 +3,7 @@
 Extracted from AdaptiveGeneralCover to enable standalone testing and reuse.
 """
 
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from math import atan, degrees
 
@@ -20,9 +21,21 @@ from ..const import (
 from ..sun import SunData
 
 
+def _in_fov_cone(angle, fov_left, fov_right):
+    """Whether *angle* is inside the asymmetric FOV cone (scalar or Series).
+
+    The ONE FOV-containment predicate: ``-fov_right < angle < fov_left``. Shared
+    by the scalar :func:`azimuth_within_fov` and the vectorized injected-transform
+    path in :meth:`SunGeometry.solar_times_with_position`, so the live gate and the
+    per-day predicted window apply identical boundary semantics (strict ``<``/``>``).
+    Works for scalar floats and pandas Series alike (bitwise ``&``).
+    """
+    return (angle < fov_left) & (angle > -fov_right)
+
+
 def azimuth_within_fov(angle: float, fov_left: float, fov_right: float) -> bool:
     """Sun azimuth (deg, relative to window normal) inside the FOV cone."""
-    return bool((angle < fov_left) & (angle > -fov_right))
+    return bool(_in_fov_cone(angle, fov_left, fov_right))
 
 
 def fov_from_reveal(width_m: float, depth_m: float) -> int:
@@ -365,11 +378,21 @@ class SunGeometry:
 
     def solar_times_with_position(
         self,
+        fov_angle_series: Callable[[pd.Series, pd.Series], pd.Series] | None = None,
     ) -> tuple[
         tuple[datetime, float, float] | None,
         tuple[datetime, float, float] | None,
     ]:
         """Like solar_times() but also returns sun azimuth/elevation at entry/exit.
+
+        ``fov_angle_series`` is the polymorphic FOV hook for cover types whose
+        acceptance cone is not the raw horizontal azimuth (e.g. a pitched roof
+        window, where the gate is measured in the tilted glass plane — #729). It
+        takes ``(gamma_series, elevation_series)`` and returns the effective-gamma
+        series that is then tested against the FOV with the SAME predicate as the
+        live scalar gate. ``None`` (the default) keeps the exact inline raw-azimuth
+        vertical gate, so the vertical / non-roof window output is unchanged
+        bit-for-bit.
 
         Returns:
             Tuple (start, end). Each element is either None (sun never enters FOV
@@ -388,9 +411,19 @@ class SunGeometry:
         elev = solpos["elevation"]
 
         # Azimuth in FOV
-        in_fov = (alpha - self.azi_min_abs) % DEGREES_IN_CIRCLE <= (
-            self.azi_max_abs - self.azi_min_abs
-        ) % DEGREES_IN_CIRCLE
+        if fov_angle_series is None:
+            # Vertical gate (bit-for-bit): raw azimuth vs the absolute FOV edges.
+            in_fov = (alpha - self.azi_min_abs) % DEGREES_IN_CIRCLE <= (
+                self.azi_max_abs - self.azi_min_abs
+            ) % DEGREES_IN_CIRCLE
+        else:
+            # Tilt-aware gate: route the in-plane effective gamma through the same
+            # FOV-cone predicate the live scalar gate uses (#729).
+            gamma_series = (self.config.win_azi - alpha + 180) % DEGREES_IN_CIRCLE - 180
+            eff_gamma = fov_angle_series(gamma_series, elev)
+            in_fov = _in_fov_cone(
+                eff_gamma, self.config.fov_left, self.config.fov_right
+            )
 
         # Elevation check — matches valid_elevation property logic, except the
         # "no bounds set" default here is `elev > 0` (strictly above horizon)

--- a/tests/test_cover_types/test_roof_window.py
+++ b/tests/test_cover_types/test_roof_window.py
@@ -15,10 +15,11 @@ azimuth, so each case can drive a real engine while pinning gamma precisely.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from math import atan, atan2, cos, degrees, radians, sin, tan
 from unittest.mock import MagicMock
 
+import pandas as pd
 import pytest
 
 from custom_components.adaptive_cover_pro.config_types import RoofWindowConfig
@@ -108,6 +109,40 @@ def _vertical(
             sill_height=sill_height,
         ),
     )
+
+
+def _make_sweep_sun_data(*, gammas, elev, win_azi=_WIN_AZI):
+    """Full-day sun grid: solar_azimuth = win_azi - gamma per sample, constant elev.
+
+    Sunrise/sunset pinned to the grid edges so in_sun_window covers the whole day.
+    """
+    today = date.today()
+    times = pd.date_range(
+        start=pd.Timestamp(today), periods=len(gammas), freq="5min", tz="UTC"
+    )
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+    sun_data.times = times
+    sun_data.solar_azimuth = [win_azi - g for g in gammas]
+    sun_data.solar_elevation = [elev] * len(gammas)
+    sun_data.sunrise.return_value = times[0].replace(tzinfo=None)
+    sun_data.sunset.return_value = times[-1].replace(tzinfo=None)
+    return sun_data
+
+
+def _live_window_oracle(*, roof_pitch, elev, gammas, fov, sun_data):
+    """First/last (time, azi, elev) where the LIVE scalar direct_sun_valid is True."""
+    hits = []
+    for i, g in enumerate(gammas):
+        ts = sun_data.times[i]
+        cover = _roof(
+            roof_pitch=roof_pitch, sol_elev=elev, gamma=g, fov_left=fov, fov_right=fov
+        )
+        cover.sun_data = sun_data
+        cover.eval_time = ts.to_pydatetime()
+        if cover.direct_sun_valid:
+            hits.append((ts.to_pydatetime(), _WIN_AZI - g, elev))
+    return (hits[0], hits[-1]) if hits else (None, None)
 
 
 # ---------------------------------------------------------------------------
@@ -627,3 +662,62 @@ def test_wide_gamma_does_not_force_full_coverage():
     # forced-closed 0.0 the inherited edge case used to return.
     assert 0.0 < pos <= 2.0
     assert roof._last_calc_details["edge_case_detected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — per-day predicted sun window is tilt-aware (#729)
+#
+# The live scalar direct_sun_valid became tilt-aware in #728, but the per-day
+# predicted window (solar_times_with_position) still used the inline raw-azimuth
+# vertical gate. These tests pin the predicted window to the live transitions.
+# ---------------------------------------------------------------------------
+
+_SWEEP_GAMMAS = [130 - 5 * i for i in range(53)]  # +130 .. -130
+
+
+def test_roof_predicted_window_matches_live_direct_sun_valid_pitch45():
+    sun_data = _make_sweep_sun_data(gammas=_SWEEP_GAMMAS, elev=60.0)
+    roof = _roof(roof_pitch=45, sol_elev=60.0, gamma=0.0, fov_left=85, fov_right=85)
+    roof.sun_data = sun_data
+    start, end = roof.solar_times_with_position()
+    exp_start, exp_end = _live_window_oracle(
+        roof_pitch=45, elev=60.0, gammas=_SWEEP_GAMMAS, fov=85, sun_data=sun_data
+    )
+    assert start is not None and end is not None
+    assert start[0] == exp_start[0] and end[0] == exp_end[0]
+    assert start[1] == pytest.approx(exp_start[1]) and start[2] == pytest.approx(
+        exp_start[2]
+    )
+    assert end[1] == pytest.approx(exp_end[1]) and end[2] == pytest.approx(exp_end[2])
+
+
+def test_roof_predicted_window_wider_than_vertical_gate_pitch45():
+    sun_data = _make_sweep_sun_data(gammas=_SWEEP_GAMMAS, elev=60.0)
+    roof = _roof(roof_pitch=45, sol_elev=60.0, gamma=0.0, fov_left=85, fov_right=85)
+    roof.sun_data = sun_data
+    vert = _vertical(sol_elev=60.0, gamma=0.0, fov_left=85, fov_right=85)
+    vert.sun_data = sun_data
+    r_start, r_end = roof.solar_times_with_position()
+    v_start, v_end = vert.solar_times_with_position()
+    assert r_start[0] < v_start[0]
+    assert r_end[0] > v_end[0]
+
+
+def test_roof_predicted_window_matches_live_direct_sun_valid_pitch30():
+    sun_data = _make_sweep_sun_data(gammas=_SWEEP_GAMMAS, elev=45.0)
+    roof = _roof(roof_pitch=30, sol_elev=45.0, gamma=0.0, fov_left=85, fov_right=85)
+    roof.sun_data = sun_data
+    start, end = roof.solar_times_with_position()
+    exp_start, exp_end = _live_window_oracle(
+        roof_pitch=30, elev=45.0, gammas=_SWEEP_GAMMAS, fov=85, sun_data=sun_data
+    )
+    assert start[0] == exp_start[0] and end[0] == exp_end[0]
+
+
+def test_roof_pitch90_predicted_window_bitforbit_vertical():
+    sun_data = _make_sweep_sun_data(gammas=_SWEEP_GAMMAS, elev=60.0)
+    roof = _roof(roof_pitch=90, sol_elev=60.0, gamma=0.0, fov_left=45, fov_right=45)
+    roof.sun_data = sun_data
+    vert = _vertical(sol_elev=60.0, gamma=0.0, fov_left=45, fov_right=45)
+    vert.sun_data = sun_data
+    assert roof.solar_times_with_position() == vert.solar_times_with_position()

--- a/tests/test_solar_math_review.py
+++ b/tests/test_solar_math_review.py
@@ -866,3 +866,19 @@ class TestSolarTimes:
         start, end = sg.solar_times_with_position()
         assert start is None
         assert end is None
+
+    def test_solar_times_with_position_default_equals_no_arg(self):
+        """fov_angle_series=None must reproduce the no-arg vertical gate exactly."""
+        sun_data = _make_full_day_sun_data(azimuth=180.0, elevation=30.0)
+        config = make_cover_config(win_azi=180, fov_left=45, fov_right=45)
+        sg = SunGeometry(
+            sol_azi=180.0,
+            sol_elev=30.0,
+            sun_data=sun_data,
+            config=config,
+            logger=MagicMock(),
+        )
+        assert (
+            sg.solar_times_with_position(fov_angle_series=None)
+            == sg.solar_times_with_position()
+        )


### PR DESCRIPTION
## Summary
PR #728 made the live, per-cycle FOV gate tilt-aware for roof windows, but the per-day predicted sun window (`SunGeometry.solar_times_with_position()`) still used the raw-azimuth vertical gate and the roof cover didn't override it. So a roof-window user's predicted sun-leave time (sensors + companion card) lagged 1-2h behind when the cover actually stopped tracking.

This routes the predicted window's azimuth test through the tilted-plane effective-gamma transform via an injected `fov_angle_series` callable on `solar_times_with_position` (default `None` keeps the vertical path bit-for-bit; `roof_pitch == 90` passes `None` to preserve the anchor). The scalar and vectorized paths now share one `roof_effective_gamma`/`roof_cos_aoi` helper, so they can't drift.

## Testing
- 5288 tests passing
- 5 new regression tests: predicted window matches live `direct_sun_valid` at pitch 45 degrees and 30 degrees, roof window wider than the vertical gate, and `beta=90` predicted window bit-for-bit unchanged.

## Related Issues
Refs #729