### PR TITLE
fix: exclude building profiles from duplicate-from list (#732)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -283,6 +283,7 @@ from .priority_chain import build_priority_chain  # noqa: E402
 from .profile_link import (  # noqa: E402
     _building_profile_entries,
     _copy_profile_to_cover,
+    _cover_entries,
     _covers_linked_to,
     clear_cover_override,
     compute_override_keys,
@@ -3141,7 +3142,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         Creating a cover and creating a building profile are distinct top-level
         choices. The duplicate option only appears when prior entries exist.
         """
-        acp_entries = self.hass.config_entries.async_entries(DOMAIN)
+        acp_entries = _cover_entries(self.hass)
         menu_options = ["create_new", "create_building_profile"] + (
             ["duplicate_existing"] if acp_entries else []
         )
@@ -3753,7 +3754,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Select the source cover to duplicate from."""
-        acp_entries = self.hass.config_entries.async_entries(DOMAIN)
+        acp_entries = _cover_entries(self.hass)
 
         if not acp_entries:
             return self.async_abort(reason="source_not_found")  # type: ignore[return-value]

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -83,6 +83,15 @@ def _building_profile_entries(hass: HomeAssistant) -> list[ConfigEntry]:
     ]
 
 
+def _cover_entries(hass: HomeAssistant) -> list[ConfigEntry]:
+    """Return all physical cover config entries (controls_cover == True)."""
+    return [
+        e
+        for e in hass.config_entries.async_entries(DOMAIN)
+        if get_policy(e.data.get(CONF_SENSOR_TYPE)).controls_cover
+    ]
+
+
 def _covers_linked_to(
     hass: HomeAssistant, profile_entry: ConfigEntry
 ) -> list[ConfigEntry]:

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -14,7 +14,10 @@ import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+from custom_components.adaptive_cover_pro.config_flow import (
+    ConfigFlowHandler,
+    OptionsFlowHandler,
+)
 from custom_components.adaptive_cover_pro.const import (
     BUILDING_PROFILE_SENSOR_KEYS,
     CONF_BUILDING_PROFILE_ID,
@@ -420,3 +423,35 @@ async def test_init_step_profile_line_empty_for_unlinked_cover(
     assert (
         profile_line == ""
     ), f"profile_line must be empty for unlinked cover, got: {profile_line!r}"
+
+
+# ---------------------------------------------------------------------------
+# Duplicate menu visibility — issue #732
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_user_menu_hides_duplicate_when_only_building_profile(
+    hass: HomeAssistant,
+) -> None:
+    """'duplicate_existing' must not appear when only Building Profile entries exist.
+
+    Building Profile entries (controls_cover=False) are not valid duplicate sources,
+    so the option must be hidden rather than leading to source_not_found.
+    """
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "My Smart Home", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={},
+        entry_id="profile_1",
+        title="Building Profile My Smart Home",
+    )
+    profile.add_to_hass(hass)
+
+    handler = ConfigFlowHandler()
+    handler.hass = hass
+
+    result = await handler.async_step_user()
+
+    assert result["type"] == "menu"
+    assert "duplicate_existing" not in result["menu_options"]

--- a/tests/test_duplicate_sync.py
+++ b/tests/test_duplicate_sync.py
@@ -38,6 +38,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
+    CONF_SENSOR_TYPE,
     CONF_TEMP_ENTITY,
     CONF_TEMP_HIGH,
     CONF_TEMP_LOW,
@@ -48,6 +49,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_STATE,
     CONF_WEATHER_WIND_SPEED_SENSOR,
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
+    CoverType,
 )
 
 
@@ -477,3 +479,54 @@ class TestEnsureUniqueName:
         )
         result = await handler._ensure_unique_name("Living Room", suffix="Copy")
         assert result == "Living Room (Copy 3)"
+
+
+class TestDuplicateSelectFilter:
+    """async_step_duplicate_select must exclude Building Profile entries (issue #732)."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_select_excludes_building_profiles(self):
+        """Building Profile entries must not appear as duplicate sources."""
+        bp_entry = MagicMock()
+        bp_entry.entry_id = "profile_1"
+        bp_entry.title = "Building Profile My Smart Home"
+        bp_entry.data = {CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE}
+
+        cover_entry = MagicMock()
+        cover_entry.entry_id = "cover_1"
+        cover_entry.title = "Vertical Blind"
+        cover_entry.data = {CONF_SENSOR_TYPE: CoverType.BLIND}
+
+        handler = ConfigFlowHandler()
+        handler.hass = MagicMock()
+        handler.hass.config_entries.async_entries.return_value = [bp_entry, cover_entry]
+
+        result = await handler.async_step_duplicate_select()
+
+        assert result["type"] == "form"
+        schema = result["data_schema"]
+        option_values = None
+        for marker, sel in schema.schema.items():
+            if str(marker.schema) == "source_entry":
+                option_values = [o["value"] for o in sel.config["options"]]
+                break
+        assert option_values is not None, "source_entry selector not found in schema"
+        assert "cover_1" in option_values
+        assert "profile_1" not in option_values
+
+    @pytest.mark.asyncio
+    async def test_duplicate_select_aborts_when_only_building_profiles(self):
+        """async_step_duplicate_select must abort when no cover entries remain after filtering."""
+        bp_entry = MagicMock()
+        bp_entry.entry_id = "profile_1"
+        bp_entry.title = "Building Profile My Smart Home"
+        bp_entry.data = {CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE}
+
+        handler = ConfigFlowHandler()
+        handler.hass = MagicMock()
+        handler.hass.config_entries.async_entries.return_value = [bp_entry]
+
+        result = await handler.async_step_duplicate_select()
+
+        assert result["type"] == "abort"
+        assert result["reason"] == "source_not_found"


### PR DESCRIPTION
## Summary
When adding a new cover instance and choosing "duplicate from..." an existing instance, virtual Building Profile entries (which don't control a cover) wrongly appeared in the list of instances you could duplicate from. I added a `_cover_entries()` helper (the inverse of the existing `_building_profile_entries()`) and use it in both `async_step_user` and `async_step_duplicate_select` so only real cover instances are offered.

## Testing
- ✅ 49 tests passing in the two affected test files (3 new regression tests)
- ✅ 485 tests passing across the broader config-flow area

## Related Issues
Refs #732