### PR TITLE
fix: correct translation keys for duplicate_configure step (#733)

### DIFF
--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -576,8 +576,8 @@
         "description": "Geben Sie die eindeutigen Einstellungen für die neue Beschattung ein. Alle anderen Einstellungen werden aus der Quelle kopiert.",
         "data": {
           "name": "Name",
-          "entities": "Beschattungsentitäten",
-          "azimuth": "Fenster-Azimut"
+          "group": "Beschattungsentitäten",
+          "set_azimuth": "Fenster-Azimut"
         }
       },
       "summary": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -606,8 +606,8 @@
         "description": "Enter the unique settings for the new cover. All other settings will be copied from the source.",
         "data": {
           "name": "Name",
-          "entities": "Cover entities",
-          "azimuth": "Window azimuth"
+          "group": "Cover Entities",
+          "set_azimuth": "Window Azimuth"
         }
       },
       "summary": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -576,8 +576,8 @@
         "description": "Entrez les paramètres uniques pour le nouveau store. Tous les autres paramètres seront copiés depuis la source.",
         "data": {
           "name": "Nom",
-          "entities": "Entités de store",
-          "azimuth": "Azimut de la fenêtre"
+          "group": "Entités de store",
+          "set_azimuth": "Azimut de la fenêtre"
         }
       },
       "summary": {

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -380,3 +380,30 @@ def test_geometry_description_no_field_enumeration() -> None:
         f"options.step.geometry.description still contains per-cover-type enumeration "
         f"(found {enumeration_marker!r}). Remove the second paragraph (issue #564)."
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #733 — duplicate_configure translation keys must match schema field names
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_configure_translation_keys_match_schema() -> None:
+    """duplicate_configure.data keys must match the actual schema field names.
+
+    CONF_ENTITIES = 'group', CONF_AZIMUTH = 'set_azimuth'. If these don't match,
+    HA renders the raw key as the label (regression guard for issue #733).
+    """
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    data = en["config"]["step"]["duplicate_configure"]["data"]
+    assert (
+        "group" in data
+    ), "duplicate_configure.data must have key 'group' (CONF_ENTITIES = 'group')"
+    assert (
+        "set_azimuth" in data
+    ), "duplicate_configure.data must have key 'set_azimuth' (CONF_AZIMUTH = 'set_azimuth')"
+    assert (
+        "entities" not in data
+    ), "Wrong key 'entities' in duplicate_configure.data — must be 'group' (CONF_ENTITIES)"
+    assert (
+        "azimuth" not in data
+    ), "Wrong key 'azimuth' in duplicate_configure.data — must be 'set_azimuth' (CONF_AZIMUTH)"


### PR DESCRIPTION
## Summary
The `duplicate_configure` config-flow step (Create new entry → Duplicate from…) rendered the `group` and `set_azimuth` fields as raw internal names. The en/de/fr translation files used keys `entities` and `azimuth`, but the schema declares those fields as `CONF_ENTITIES` (`group`) and `CONF_AZIMUTH` (`set_azimuth`). Home Assistant matches labels by exact field key, so the mismatched keys fell back to the raw names. Renamed the keys in all three translation files (preserving the translated label text) and added a regression test asserting the keys match the schema field names.

## Testing
- ✅ 29 tests passing (tests/test_translations.py, including new regression guard)

## Related Issues
Refs #733