### PR TITLE
feat: daytime gate graceful fallback when gate sensor unavailable

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -276,6 +276,12 @@ CONF_SUNRISE_TIME_ENTITY = "sunrise_time_entity"
 CONF_DAYTIME_GATE_SENSORS = "daytime_gate_sensors"  # on/active = daytime/track
 CONF_DAYTIME_GATE_TEMPLATE = "daytime_gate_template"  # truthy = daytime/track
 CONF_DAYTIME_GATE_TEMPLATE_MODE = "daytime_gate_template_mode"  # TemplateCombineMode
+# Grace window (seconds) for which the gate holds its last-known daytime/dark
+# verdict when every gate source goes indeterminate (sensors unavailable/unknown/
+# missing, template unrenderable) — issue #742. After this elapses with no usable
+# source the gate falls back to the astronomical sunset/sunrise window (resolves to
+# ``daytime_gate=None``). Fixed, not user-configurable.
+DEFAULT_DAYTIME_GATE_GRACE_SECONDS = 120.0
 # Explicit tilt for venetian covers (0-100). None = use solar-computed tilt.
 CONF_DEFAULT_TILT = "default_tilt"  # tilt when no handler fires
 CONF_SUNSET_TILT = (

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     # Fallback for older Home Assistant versions
     EventStateChangedData = dict  # type: ignore[misc,assignment]
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
@@ -498,6 +499,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # ``async_track_time_interval`` cancel handle.
         self._position_forecast: Forecast | None = None
         self._forecast_unsub: Callable[[], None] | None = None
+
+        # Issue #742: cancel handle for the single ``async_call_later`` wake that
+        # flips the daytime gate from HOLDING its last-known verdict to the
+        # astronomical fallback the moment the grace window expires (otherwise the
+        # fallback would wait for the next state-change/periodic refresh).
+        self._gate_fallback_unsub: Callable[[], None] | None = None
 
     def _make_detector_config(self, options) -> DetectorConfig:
         """Build the manual-override DetectorConfig from raw options.
@@ -1420,6 +1427,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if hasattr(self._cover_data, "_last_calc_details"):
             details = self._cover_data._last_calc_details  # noqa: SLF001
             glare_active = len(details.get("glare_zones_active", [])) > 0
+
+        # Issue #742: now that the gate verdict is resolved for this cycle, arm a
+        # single wake at grace expiry if the gate is HOLDING its last-known value.
+        self._schedule_gate_fallback_wake()
 
         return AdaptiveCoverData(
             climate_mode_toggle=self.switch_mode,
@@ -2798,14 +2809,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if cover_data is None:
             cover_data = self.get_blind_data(options=options)
         # A configured daytime gate (issue #632) OWNS the day/night boundary:
-        # pass its daytime/dark verdict (True=daytime→no sunset, False=dark→apply
-        # sunset position) only when configured, else None so
-        # compute_effective_default keeps the astronomical decision.
-        daytime_gate = (
-            self._time_mgr.gate_is_daytime
-            if self._time_mgr.gate_is_configured
-            else None
-        )
+        # ``effective_daytime_gate`` is the single tri-state verdict to forward —
+        # True=daytime→no sunset, False=dark→apply sunset position, None=defer to
+        # the astronomical decision. None covers both an unconfigured gate and the
+        # graceful fallback after every gate source has been indeterminate past the
+        # grace window (issue #742).
+        daytime_gate = self._time_mgr.effective_daytime_gate
         # End-of-window position (issue #625): an optional, clearable position
         # applied once the operating window is clock-closed. ``before_end_time``
         # is True all morning (end is later today), so the override only fires in
@@ -2826,6 +2835,32 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             end_of_window_pos=eow_pos,
             end_of_window_active=window_is_closed,
         )
+
+    @callback
+    def _schedule_gate_fallback_wake(self) -> None:
+        """Schedule one refresh at daytime-gate grace expiry (issue #742).
+
+        While the gate is HOLDING its last-known verdict, nothing else would
+        trigger the fall-back to the astronomical window until the next
+        state-change or periodic refresh. Schedule a single ``async_call_later``
+        wake at the remaining grace so the fallback engages promptly. Any
+        in-flight wake is cancelled first so there is never more than one; a
+        determinate (or already-fallen-back) gate schedules none.
+        """
+        if self._gate_fallback_unsub is not None:
+            self._gate_fallback_unsub()
+            self._gate_fallback_unsub = None
+        secs = self._time_mgr.seconds_until_gate_fallback()
+        if secs is None:
+            return
+        self._gate_fallback_unsub = async_call_later(
+            self.hass, secs, self._on_gate_fallback_due
+        )
+
+    async def _on_gate_fallback_due(self, _now: dt.datetime) -> None:
+        """Fire when the daytime-gate grace window expires: request a refresh."""
+        self._gate_fallback_unsub = None
+        await self.async_request_refresh()
 
     async def _check_sunset_window_transition(self) -> None:
         """Delegate astronomical-sunset-window transition handling to the tracker.
@@ -2877,6 +2912,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._forecast_unsub is not None:
             self._forecast_unsub()
             self._forecast_unsub = None
+
+        # Cancel the daytime-gate fallback wake (issue #742).
+        if self._gate_fallback_unsub is not None:
+            self._gate_fallback_unsub()
+            self._gate_fallback_unsub = None
 
         self.logger.debug("Coordinator shutdown complete")
 

--- a/custom_components/adaptive_cover_pro/managers/common/graceful_source.py
+++ b/custom_components/adaptive_cover_pro/managers/common/graceful_source.py
@@ -1,0 +1,137 @@
+"""Grace-period state machine for an intermittently indeterminate source.
+
+A small, reusable kernel for the pattern "a source usually has a verdict, but
+sometimes goes indeterminate (sensor unavailable, template unrenderable); don't
+react to a transient blip — hold the last-known verdict for a grace window, and
+only after the window expires fall back to whatever the caller decides".
+
+The kernel owns ONLY the state machine. It is deliberately HA-free and
+asyncio-free: no ``hass``, no entities, no tasks, no knowledge of what
+"fall back" means (astronomical sunset, a safe position, "assume present", …).
+The caller feeds it a tri-state verdict each cycle and maps the returned
+:class:`SourceResolution` onto its own policy. This is what lets opposite-
+direction consumers (fail-open gate vs. fail-closed safety) reuse it later.
+
+Time is injected as a ``clock`` callable (defaults to :func:`time.monotonic`) so
+tests drive the grace window deterministically. Evaluation is stateless re-eval:
+:meth:`observe` is idempotent within a cycle — the grace anchor is fixed at the
+first indeterminate sighting and never advanced by repeat calls at the same
+clock value. Managers compose this; they do not inherit from it.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum, auto
+
+
+class SourceResolution(Enum):
+    """How a source's current verdict should be applied this cycle."""
+
+    DETERMINATE = auto()  # source produced a real verdict this cycle
+    HOLDING = auto()  # indeterminate, within grace → use last_known
+    FELL_BACK = auto()  # indeterminate past grace (or never seen) → caller's fallback
+
+
+@dataclass(frozen=True, slots=True)
+class Resolution:
+    """The outcome of one :meth:`GracefulSource.observe` call.
+
+    ``value`` carries the verdict to use: the live verdict for DETERMINATE, the
+    held last-known verdict for HOLDING, and ``None`` for FELL_BACK (or a source
+    that has never produced a verdict).
+    """
+
+    state: SourceResolution
+    value: bool | None
+
+
+class GracefulSource:
+    """Track a tri-state verdict source through a grace window.
+
+    Feed :meth:`observe` the source's verdict each cycle (``True``/``False`` for
+    a real verdict, ``None`` when the source is indeterminate). The returned
+    :class:`Resolution` tells the caller whether to use the live verdict, hold
+    the last-known one, or apply its own fallback.
+    """
+
+    def __init__(
+        self,
+        grace_seconds: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Initialize with the grace window length and an injectable clock.
+
+        Args:
+            grace_seconds: How long to hold the last-known verdict after the
+                source first goes indeterminate, before reporting FELL_BACK.
+            clock: Monotonic time source returning seconds. Injected so tests
+                can advance time deterministically.
+
+        """
+        self._grace_seconds = grace_seconds
+        self._clock = clock
+        self._last_known: bool | None = None
+        self._indeterminate_since: float | None = None
+
+    def observe(self, verdict: bool | None, *, now: float | None = None) -> Resolution:
+        """Record this cycle's verdict and resolve how it should be applied.
+
+        Args:
+            verdict: ``True``/``False`` for a real verdict; ``None`` when the
+                source is indeterminate this cycle.
+            now: Optional clock override (seconds). Defaults to the injected
+                clock — supplied mainly for callers that already sampled time.
+
+        Returns:
+            A :class:`Resolution`. A real verdict records last-known, clears the
+            grace anchor, and returns DETERMINATE. ``None`` with no last-known
+            ever returns FELL_BACK without arming the timer. ``None`` with a
+            last-known fixes the grace anchor on first sight and returns HOLDING
+            until ``grace_seconds`` elapse, then FELL_BACK.
+
+        """
+        if verdict is not None:
+            self._last_known = verdict
+            self._indeterminate_since = None
+            return Resolution(SourceResolution.DETERMINATE, verdict)
+
+        # Indeterminate this cycle.
+        if self._last_known is None:
+            # Never observed a real verdict → nothing to hold. Never arm the
+            # timer; the caller falls back immediately.
+            return Resolution(SourceResolution.FELL_BACK, None)
+
+        current = self._clock() if now is None else now
+        if self._indeterminate_since is None:
+            # Fix the anchor on first sight; idempotent for repeats this cycle.
+            self._indeterminate_since = current
+        if current - self._indeterminate_since >= self._grace_seconds:
+            return Resolution(SourceResolution.FELL_BACK, None)
+        return Resolution(SourceResolution.HOLDING, self._last_known)
+
+    def remaining(self, *, now: float | None = None) -> float | None:
+        """Return seconds until a HOLDING source flips to FELL_BACK.
+
+        Returns ``None`` when there is no pending flip: the source is
+        determinate, has never produced a verdict, or has already fallen back.
+        Used by the caller to schedule a single prompt wake-up at expiry.
+        """
+        if self._indeterminate_since is None or self._last_known is None:
+            return None
+        current = self._clock() if now is None else now
+        remaining = self._grace_seconds - (current - self._indeterminate_since)
+        return remaining if remaining > 0 else None
+
+    @property
+    def last_known(self) -> bool | None:
+        """The most recent real verdict observed, or ``None`` if never seen."""
+        return self._last_known
+
+    def reset(self) -> None:
+        """Forget the last-known verdict and any in-flight grace window."""
+        self._last_known = None
+        self._indeterminate_since = None

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import datetime as dt
+import time
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -10,10 +12,19 @@ if TYPE_CHECKING:
 
     from ..config_context_adapter import ConfigContextAdapter
 
-from ..const import BLANK_TIME, DEFAULT_TEMPLATE_COMBINE_MODE
-from ..helpers import get_datetime_from_str, get_safe_state, is_entity_active
-from ..templates import combine_with_mode, is_template_string, render_condition
+from ..const import (
+    BLANK_TIME,
+    DEFAULT_DAYTIME_GATE_GRACE_SECONDS,
+    DEFAULT_TEMPLATE_COMBINE_MODE,
+)
+from ..helpers import get_datetime_from_str, get_safe_state
+from ..templates import (
+    combine_with_mode,
+    is_template_string,
+    render_condition_or_none,
+)
 from .common import EventRecorder
+from .common.graceful_source import GracefulSource, Resolution, SourceResolution
 
 
 class TimeWindowManager:
@@ -24,7 +35,12 @@ class TimeWindowManager:
     """
 
     def __init__(
-        self, hass: HomeAssistant, logger: ConfigContextAdapter, *, event_buffer=None
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        *,
+        event_buffer=None,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         """Initialize time window manager.
 
@@ -32,6 +48,8 @@ class TimeWindowManager:
             hass: Home Assistant instance
             logger: Context-aware logger
             event_buffer: Shared diagnostic ring buffer (optional).
+            clock: Monotonic time source (seconds) for the daytime-gate grace
+                window. Injected so tests drive the grace timer deterministically.
 
         """
         self._hass = hass
@@ -50,6 +68,11 @@ class TimeWindowManager:
         self._gate_sensors: list[str] = []
         self._gate_template: str | None = None
         self._gate_template_mode: str = DEFAULT_TEMPLATE_COMBINE_MODE
+
+        # Daytime-gate graceful-fallback state machine (issue #742): holds the
+        # last-known daytime/dark verdict for a grace window when every gate
+        # source goes indeterminate, then falls back to the astronomical window.
+        self._graceful = GracefulSource(DEFAULT_DAYTIME_GATE_GRACE_SECONDS, clock=clock)
 
         # Cached start time from last evaluation (for diagnostics)
         self._cached_start_time: dt.datetime | None = None
@@ -81,7 +104,17 @@ class TimeWindowManager:
         self._start_time_entity = start_time_entity
         self._end_time_config = end_time
         self._end_time_entity = end_time_entity
-        self._gate_sensors = list(gate_sensors)
+        # update_config runs every cycle, so only forget the held verdict when the
+        # gate config actually changed (issue #742) — otherwise a steady config
+        # would reset the grace machine each cycle and never hold anything.
+        new_sensors = list(gate_sensors)
+        if (
+            new_sensors != self._gate_sensors
+            or gate_template != self._gate_template
+            or gate_template_mode != self._gate_template_mode
+        ):
+            self._graceful.reset()
+        self._gate_sensors = new_sensors
         self._gate_template = gate_template
         self._gate_template_mode = gate_template_mode
 
@@ -129,52 +162,97 @@ class TimeWindowManager:
         """
         return bool(self._gate_sensors) or is_template_string(self._gate_template)
 
+    def _gate_verdict(self) -> bool | None:
+        """Read the gate's *live* daytime verdict, or ``None`` when indeterminate.
+
+        Tri-state — isolates the "is the gate indeterminate?" rule so the global
+        fail-open contract of :func:`is_entity_active` (other features depend on
+        it) stays untouched (issue #742):
+
+        * **sensor opinion** — ``None`` when there are no sensors or every
+          configured sensor reads invalid (``get_safe_state`` is ``None`` —
+          unavailable/unknown/missing); otherwise ``any`` valid sensor is ``"on"``.
+        * **template opinion** — :func:`render_condition_or_none` gives ``None``
+          when the template is absent or unrenderable, else its boolean.
+        * **combine** — both ``None`` → ``None`` (fully indeterminate); exactly
+          one ``None`` → the other; both present → folded via the configured
+          OR/AND mode (matching the pre-#742 gate evaluation).
+        """
+        sensor_states = [get_safe_state(self._hass, sid) for sid in self._gate_sensors]
+        valid_states = [s for s in sensor_states if s is not None]
+        sensor_opinion: bool | None = (
+            None if not valid_states else any(s == "on" for s in valid_states)
+        )
+        template_opinion = render_condition_or_none(self._hass, self._gate_template)
+
+        if sensor_opinion is None and template_opinion is None:
+            return None
+        if sensor_opinion is None:
+            return template_opinion
+        if template_opinion is None:
+            return sensor_opinion
+        return combine_with_mode(
+            template_opinion,
+            sensor_opinion,
+            self._gate_template_mode,
+            has_template=True,
+            has_others=True,
+        )
+
+    def _resolve(self) -> Resolution:
+        """Feed this cycle's gate verdict to the grace machine (idempotent)."""
+        return self._graceful.observe(self._gate_verdict())
+
+    @property
+    def effective_daytime_gate(self) -> bool | None:
+        """Tri-state gate verdict the coordinator forwards to the astral engine.
+
+        ``None`` means "no gate opinion → use the astronomical sunset/sunrise
+        window" — the single value passed as ``daytime_gate`` to
+        ``compute_effective_default`` (issue #632/#742). It is ``None`` when the
+        gate is unconfigured, and also when every gate source has been
+        indeterminate past the grace window (FELL_BACK). While a source is
+        determinate it is the live verdict; within the grace window it is the
+        held last-known verdict (HOLDING).
+        """
+        if not self.gate_is_configured:
+            return None
+        resolution = self._resolve()
+        if resolution.state is SourceResolution.FELL_BACK:
+            return None
+        return resolution.value
+
     @property
     def gate_is_daytime(self) -> bool:
         """Whether the daytime gate reports "daytime" (ACP should sun-track).
 
-        Mirrors :pyattr:`MotionManager.is_motion_detected`: the gate template and
-        the gate sensors are combined per the configured mode. Returns True when
-        the gate is unconfigured (feature disabled → astronomical fallback). The
-        template renders fail-open to *daytime* (``default=True``) — unlike motion's
-        ``default=False`` — so a broken template never forces a premature sunset.
+        Derived from :pyattr:`effective_daytime_gate`: ``None`` (unconfigured or
+        grace-expired fallback) reads as daytime so the clock factor of
+        :pyattr:`is_active` collapses to the pre-gate astronomical behaviour.
         """
-        if not self.gate_is_configured:
-            return True  # Unconfigured → daytime → astronomical fallback
-
-        has_template = is_template_string(self._gate_template)
-        # default=True ONLY when a template is actually set: fail-open to daytime so
-        # a broken template never slams the cover to the sunset position (motion's
-        # gate fails closed; this one must not, because "dark" here ends sun
-        # tracking). With no template the source must be neutral for the combine
-        # (False), or OR would read daytime even when a sensor says dark.
-        template_truthy = (
-            render_condition(self._hass, self._gate_template, default=True)
-            if has_template
-            else False
-        )
-        sensors_active = any(
-            is_entity_active(self._hass, sid) for sid in self._gate_sensors
-        )
-        return combine_with_mode(
-            template_truthy,
-            sensors_active,
-            self._gate_template_mode,
-            has_template=has_template,
-            has_others=bool(self._gate_sensors),
-        )
+        eff = self.effective_daytime_gate
+        return True if eff is None else eff
 
     @property
     def gate_is_dark(self) -> bool:
-        """Whether a *configured* gate reports "dark" (apply the sunset position).
+        """Whether a *configured* gate currently reports "dark".
 
-        ``None``-safe inverse of :pyattr:`gate_is_daytime` that stays False when the
-        gate is unconfigured, so the coordinator can pass it straight through as the
-        ``daytime_gate`` override to ``compute_effective_default`` (issue #632):
-        ``True`` forces the sunset position, ``False`` (here, unconfigured) leaves
-        the astronomical decision untouched.
+        False when the gate is unconfigured or has fallen back to astronomical
+        (``effective_daytime_gate`` is ``None``), so the gate-dark night position
+        only fires on a genuine dark verdict (live or held).
         """
         return self.gate_is_configured and not self.gate_is_daytime
+
+    def seconds_until_gate_fallback(self) -> float | None:
+        """Seconds until a HELD gate verdict expires to the astronomical fallback.
+
+        ``None`` when no prompt wake is needed (gate determinate, never observed,
+        already fell back, or unconfigured). The coordinator uses this to schedule
+        a single ``async_call_later`` refresh so the fallback engages promptly at
+        grace expiry instead of waiting for the next state-change/periodic cycle.
+        """
+        self._resolve()
+        return self._graceful.remaining()
 
     def _normalize_to_today(self, time: dt.datetime) -> dt.datetime:
         """Normalize a future-dated entity time to today's date.

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -1082,6 +1082,36 @@ class TestDaytimeGateOverride:
         assert active is False
         assert result == 80
 
+    def test_gate_none_is_the_fell_back_astral_target(self):
+        """Issue #742: the graceful-fallback target (daytime_gate=None) is astral.
+
+        When the gate has been indeterminate past its grace window the manager
+        resolves ``effective_daytime_gate`` to ``None``; this confirms that value
+        re-enters the astronomical sunset/sunrise branch (no new astral code) —
+        same outcome as an unconfigured gate at the same instant.
+        """
+        sun = _make_sun_data(sunrise_hour=6, sunset_hour=20)
+        today = dt.date.today()
+        # Past astral sunset → astral branch must activate the sunset position.
+        evening = dt.datetime(today.year, today.month, today.day, 21, 0, 0)
+        with _freeze_now(evening):
+            fell_back = compute_effective_default(
+                h_def=80,
+                sunset_pos=20,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+                daytime_gate=None,
+            )
+            no_gate = compute_effective_default(
+                h_def=80,
+                sunset_pos=20,
+                sun_data=sun,
+                sunset_off=0,
+                sunrise_off=0,
+            )
+        assert fell_back == no_gate == (20, True)
+
     def test_gate_false_ignores_window_explicitly_started(self):
         # The gate short-circuits before the window_explicitly_started branch.
         sun = _make_sun_data(sunrise_hour=6, sunset_hour=20)

--- a/tests/test_end_of_window_position.py
+++ b/tests/test_end_of_window_position.py
@@ -49,6 +49,7 @@ def _coord_with_window(
     time_mgr.gate_is_daytime = True
     time_mgr.gate_is_dark = False
     time_mgr.gate_is_configured = False  # astral path, no gate
+    time_mgr.effective_daytime_gate = None  # no gate → astral (issue #742)
     time_mgr.window_explicitly_started = False
     coord._time_mgr = time_mgr
 

--- a/tests/test_graceful_source.py
+++ b/tests/test_graceful_source.py
@@ -1,0 +1,114 @@
+"""Unit tests for the GracefulSource grace-period state machine (issue #742).
+
+GracefulSource is a pure, HA-free, asyncio-free kernel: it tracks a tri-state
+"verdict" source (bool / bool / None=indeterminate) and decides, on each
+``observe``, whether the caller should use the live verdict (DETERMINATE), the
+last-known verdict during a grace window (HOLDING), or apply its own fallback
+(FELL_BACK). A fake monotonic clock drives time so the grace window is exact.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.common.graceful_source import (
+    GracefulSource,
+    Resolution,
+    SourceResolution,
+)
+
+
+@pytest.fixture
+def clock():
+    """Return a mutable fake clock: ``t[0]`` is "now", read via the callable."""
+    t = [0.0]
+    return t
+
+
+def _src(clock, grace: float = 120.0) -> GracefulSource:
+    return GracefulSource(grace, clock=lambda: clock[0])
+
+
+def test_determinate_records_last_known(clock):
+    src = _src(clock)
+    assert src.observe(True) == Resolution(SourceResolution.DETERMINATE, True)
+    assert src.last_known is True
+    assert src.observe(False) == Resolution(SourceResolution.DETERMINATE, False)
+    assert src.last_known is False
+
+
+def test_holding_returns_last_known_within_grace(clock):
+    src = _src(clock)
+    src.observe(True)
+    clock[0] = 60.0
+    assert src.observe(None) == Resolution(SourceResolution.HOLDING, True)
+    clock[0] = 119.0
+    assert src.observe(None) == Resolution(SourceResolution.HOLDING, True)
+
+
+def test_fell_back_after_grace(clock):
+    src = _src(clock)
+    src.observe(True)
+    # Indeterminacy begins now: the first observe(None) starts the grace window.
+    assert src.observe(None) == Resolution(SourceResolution.HOLDING, True)
+    clock[0] = 121.0
+    # Still indeterminate past the grace window → fall back.
+    assert src.observe(None) == Resolution(SourceResolution.FELL_BACK, None)
+
+
+def test_no_last_known_falls_back_immediately(clock):
+    src = _src(clock)
+    assert src.observe(None) == Resolution(SourceResolution.FELL_BACK, None)
+    # Never armed the timer → remaining stays None.
+    assert src.remaining() is None
+
+
+def test_recovery_cancels_grace_and_rearms(clock):
+    src = _src(clock)
+    src.observe(True)
+    clock[0] = 60.0
+    assert src.observe(None).state is SourceResolution.HOLDING
+    # A real verdict clears the grace window.
+    assert src.observe(True) == Resolution(SourceResolution.DETERMINATE, True)
+    assert src.remaining() is None
+    # The machine is re-armed: a later indeterminacy starts a fresh window.
+    clock[0] = 200.0
+    assert src.observe(None) == Resolution(SourceResolution.HOLDING, True)
+
+
+def test_idempotent_observe_does_not_advance(clock):
+    src = _src(clock)
+    src.observe(True)
+    clock[0] = 50.0
+    assert src.observe(None) == Resolution(SourceResolution.HOLDING, True)
+    # Repeated observe(None) at the SAME clock value must not move the anchor.
+    assert src.observe(None) == Resolution(SourceResolution.HOLDING, True)
+    # The anchor is fixed at first sight (t=50), so at t=170 (120 later) it flips.
+    clock[0] = 171.0
+    assert src.observe(None) == Resolution(SourceResolution.FELL_BACK, None)
+
+
+def test_remaining_drives_wake(clock):
+    src = _src(clock)
+    src.observe(True)
+    # Indeterminate at t=0 → full grace remaining.
+    assert src.observe(None).state is SourceResolution.HOLDING
+    assert src.remaining() == pytest.approx(120.0)
+    clock[0] = 119.0
+    assert src.remaining() == pytest.approx(1.0)
+    clock[0] = 121.0
+    assert src.remaining() is None
+    # Determinate again → no wake needed.
+    src.observe(True)
+    assert src.remaining() is None
+
+
+def test_reset_forgets_state(clock):
+    src = _src(clock)
+    src.observe(True)
+    clock[0] = 30.0
+    assert src.observe(None).state is SourceResolution.HOLDING
+    src.reset()
+    assert src.last_known is None
+    # With no last-known, the next indeterminacy falls back immediately.
+    assert src.observe(None) == Resolution(SourceResolution.FELL_BACK, None)

--- a/tests/test_issue_632_daytime_gate.py
+++ b/tests/test_issue_632_daytime_gate.py
@@ -10,7 +10,7 @@ back to the astronomical sunset/sunrise calc — zero regression.
 from __future__ import annotations
 
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -102,11 +102,53 @@ def test_gate_sensor_on_keeps_window_open(mgr):
     assert mgr.is_active is True
 
 
-def test_gate_sensor_unknown_fails_open_to_daytime(mgr):
-    # Sensor never reported (no state) → is_entity_active fail-open → daytime.
+def _clock_mgr():
+    """Build a gate manager with an injectable fake clock (issue #742).
+
+    Returns ``(mgr, clock)`` where ``clock`` is a one-element list whose value is
+    "now" in seconds — mutate ``clock[0]`` to advance the grace window.
+    """
+    hass = _FakeHass()
+    clock = [0.0]
+    mgr = TimeWindowManager(
+        hass, logging.getLogger("test_issue_632_clock"), clock=lambda: clock[0]
+    )
+    return mgr, clock
+
+
+def test_gate_sensor_indeterminate_since_startup_falls_back_to_astral():
+    # Issue #742 (a): a gate source that has NEVER reported a verdict cannot be
+    # held — there is no last-known value — so the gate falls back to the
+    # astronomical window immediately (effective_daytime_gate is None → clock-open).
+    mgr, _clock = _clock_mgr()
     _configure_gate(mgr, sensors=["binary_sensor.never_reported"])
+    assert mgr.effective_daytime_gate is None
     assert mgr.gate_is_daytime is True
+    assert mgr.gate_is_dark is False
     assert mgr.is_active is True
+
+
+def test_gate_sensor_reported_then_gone_holds_then_falls_back():
+    # Issue #742 (b): a sensor that reported a verdict and then went unavailable is
+    # held for the grace window, then falls back to astronomical once it expires.
+    mgr, clock = _clock_mgr()
+    _configure_gate(mgr, sensors=["binary_sensor.gate"])
+
+    # Real verdict observed → recorded as last-known.
+    mgr._hass.states.set("binary_sensor.gate", "on")
+    clock[0] = 0.0
+    assert mgr.effective_daytime_gate is True
+
+    # Source goes unavailable inside the grace window → hold last-known daytime.
+    mgr._hass.states.set("binary_sensor.gate", "unavailable")
+    clock[0] = 60.0
+    assert mgr.effective_daytime_gate is True  # HOLDING
+
+    # Still unavailable past the grace window → fall back to astronomical.
+    clock[0] = 60.0 + 121.0
+    assert mgr.effective_daytime_gate is None  # FELL_BACK
+    assert mgr.gate_is_daytime is True
+    assert mgr.gate_is_dark is False
 
 
 def test_gate_multiple_sensors_any_on_is_daytime(mgr):
@@ -189,8 +231,9 @@ def _coord_with_gate(*, gate_is_dark: bool, gate_is_configured: bool):
     coord.hass.states.get.return_value = None  # no sunset/sunrise time entities
 
     time_mgr = MagicMock()
-    # gate_is_daytime is the verdict the coordinator forwards as ``daytime_gate``;
-    # keep gate_is_dark consistent as its inverse when configured.
+    # effective_daytime_gate is the verdict the coordinator forwards as
+    # ``daytime_gate`` (issue #742); keep gate_is_daytime/gate_is_dark consistent.
+    time_mgr.effective_daytime_gate = (not gate_is_dark) if gate_is_configured else None
     time_mgr.gate_is_daytime = (not gate_is_dark) if gate_is_configured else True
     time_mgr.gate_is_dark = gate_is_dark if gate_is_configured else False
     time_mgr.gate_is_configured = gate_is_configured
@@ -240,3 +283,100 @@ def test_coordinator_unconfigured_gate_uses_astronomical():
     eff, is_sunset_active = coord._compute_current_effective_default(options)
     assert isinstance(is_sunset_active, bool)
     assert eff in (20, 80)
+
+
+# ---------------------------------------------------------------------------
+# Coordinator wiring — graceful gate fallback (issue #742)
+# ---------------------------------------------------------------------------
+
+
+def test_coordinator_forwards_effective_daytime_gate_when_fell_back():
+    """A configured-but-fell-back gate forwards daytime_gate=None (astral)."""
+    coord = _coord_with_gate(gate_is_dark=True, gate_is_configured=True)
+    # Gate is configured and would read dark, BUT has fallen back to astronomical:
+    # the coordinator must forward the *effective* value (None), not gate_is_daytime.
+    coord._time_mgr.effective_daytime_gate = None
+    options = {CONF_SUNSET_POS: 20, "default_percentage": 80}
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+        return_value=(80, False),
+    ) as m:
+        coord._compute_current_effective_default(options)
+    assert m.call_args.kwargs["daytime_gate"] is None
+
+
+def _coord_for_wake(secs):
+    """Minimal coordinator stub for the gate-fallback wake scheduler."""
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord.hass = MagicMock()
+    coord._gate_fallback_unsub = None
+    time_mgr = MagicMock()
+    time_mgr.seconds_until_gate_fallback.return_value = secs
+    coord._time_mgr = time_mgr
+    return coord
+
+
+def test_schedule_gate_fallback_wake_when_holding():
+    """A HOLDING gate (remaining seconds) schedules exactly one async_call_later wake."""
+    coord = _coord_for_wake(secs=42.0)
+    cancel = MagicMock()
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.async_call_later",
+        return_value=cancel,
+    ) as m:
+        coord._schedule_gate_fallback_wake()
+    m.assert_called_once()
+    assert m.call_args.args[0] is coord.hass
+    assert m.call_args.args[1] == 42.0
+    assert coord._gate_fallback_unsub is cancel
+
+
+def test_schedule_gate_fallback_wake_no_wake_when_determinate():
+    """A determinate gate (None remaining) schedules no wake."""
+    coord = _coord_for_wake(secs=None)
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.async_call_later"
+    ) as m:
+        coord._schedule_gate_fallback_wake()
+    m.assert_not_called()
+    assert coord._gate_fallback_unsub is None
+
+
+def test_schedule_gate_fallback_wake_cancels_previous():
+    """A new wake cancels the previous in-flight handle first."""
+    coord = _coord_for_wake(secs=10.0)
+    previous = MagicMock()
+    coord._gate_fallback_unsub = previous
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.async_call_later",
+        return_value=MagicMock(),
+    ):
+        coord._schedule_gate_fallback_wake()
+    previous.assert_called_once()
+
+
+async def test_gate_fallback_due_callback_requests_refresh():
+    """The scheduled callback clears the handle and requests a refresh."""
+    coord = _coord_for_wake(secs=None)
+    coord._gate_fallback_unsub = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+    await coord._on_gate_fallback_due(None)
+    assert coord._gate_fallback_unsub is None
+    coord.async_request_refresh.assert_awaited_once()
+
+
+async def test_async_shutdown_cancels_gate_fallback_handle():
+    """async_shutdown cancels and clears the gate-fallback wake handle."""
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._grace_mgr = MagicMock()
+    coord._cancel_motion_timeout = MagicMock()
+    coord._cancel_weather_timeout = MagicMock()
+    coord._cmd_svc = MagicMock()
+    coord._forecast_unsub = None
+    cancel = MagicMock()
+    coord._gate_fallback_unsub = cancel
+    await coord.async_shutdown()
+    cancel.assert_called_once()
+    assert coord._gate_fallback_unsub is None

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -722,6 +722,199 @@ async def test_check_transition_no_on_window_open_no_error():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Daytime-gate graceful fallback (issue #742)
+# ---------------------------------------------------------------------------
+
+
+class _FakeState:
+    def __init__(self, state: str) -> None:
+        self.state = state
+        self.attributes: dict = {}
+
+
+class _FakeStates:
+    def __init__(self) -> None:
+        self._d: dict[str, _FakeState] = {}
+
+    def set(self, entity_id: str, state: str) -> None:
+        self._d[entity_id] = _FakeState(state)
+
+    def get(self, entity_id: str):
+        return self._d.get(entity_id)
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.states = _FakeStates()
+
+
+def _clock_manager():
+    """TimeWindowManager with a fake hass + injectable fake clock (seconds)."""
+    hass = _FakeHass()
+    clock = [0.0]
+    logger = MagicMock()
+    mgr = TimeWindowManager(hass=hass, logger=logger, clock=lambda: clock[0])
+    return mgr, clock
+
+
+def _gate(mgr, *, sensors=(), template=None, mode="or"):
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity=None,
+        gate_sensors=list(sensors),
+        gate_template=template,
+        gate_template_mode=mode,
+    )
+
+
+@pytest.mark.unit
+def test_gate_determinate_records_and_tracks():
+    """A live verdict is tracked directly and recorded for later holding."""
+    mgr, _clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    mgr._hass.states.set("binary_sensor.gate", "on")
+    assert mgr.effective_daytime_gate is True
+    assert mgr.is_active is True
+    mgr._hass.states.set("binary_sensor.gate", "off")
+    assert mgr.effective_daytime_gate is False
+    assert mgr.gate_is_dark is True
+    assert mgr.is_active is False
+
+
+@pytest.mark.unit
+def test_gate_within_grace_holds_last_known_dark():
+    """A dark verdict that goes indeterminate is held dark within the grace window."""
+    mgr, clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    mgr._hass.states.set("binary_sensor.gate", "off")
+    clock[0] = 0.0
+    assert mgr.effective_daytime_gate is False  # records dark
+    mgr._hass.states.set("binary_sensor.gate", "unknown")
+    clock[0] = 30.0
+    assert mgr.effective_daytime_gate is False  # HOLDING dark
+    assert mgr.gate_is_dark is True
+    assert mgr.is_active is False
+
+
+@pytest.mark.unit
+def test_gate_within_grace_no_last_known_falls_to_astral():
+    """No verdict ever observed → cannot hold → astral fallback (clock-open)."""
+    mgr, _clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])  # never reported
+    assert mgr.effective_daytime_gate is None
+    assert mgr.gate_is_daytime is True
+    assert mgr.is_active is True
+
+
+@pytest.mark.unit
+def test_gate_grace_expired_effective_none_and_clock_open():
+    """Past the grace window the gate falls back: effective None, is_active clock-open."""
+    mgr, clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    mgr._hass.states.set("binary_sensor.gate", "off")
+    clock[0] = 0.0
+    assert mgr.effective_daytime_gate is False
+    mgr._hass.states.set("binary_sensor.gate", "unavailable")
+    clock[0] = 1.0
+    assert mgr.effective_daytime_gate is False  # HOLDING (anchor=1.0)
+    clock[0] = 1.0 + 121.0
+    assert mgr.effective_daytime_gate is None  # FELL_BACK
+    assert mgr.is_active is True  # clock-open astral fallback
+
+
+@pytest.mark.unit
+def test_gate_one_valid_one_invalid_sensor_is_not_indeterminate():
+    """One valid sensor + one dead sensor is a real verdict, not indeterminate."""
+    mgr, _clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.a", "binary_sensor.b"])
+    mgr._hass.states.set("binary_sensor.a", "on")
+    mgr._hass.states.set("binary_sensor.b", "unavailable")
+    # b is ignored (invalid); a says on → daytime, determinately.
+    assert mgr.effective_daytime_gate is True
+    assert mgr.seconds_until_gate_fallback() is None
+
+
+@pytest.mark.unit
+def test_gate_valid_template_with_dead_sensor_is_not_indeterminate():
+    """A valid template opinion stands even when the only sensor is dead."""
+    mgr, _clock = _clock_manager()
+
+    # Render a fixed template result via the module-level render helper.
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.time_window."
+        "render_condition_or_none",
+        return_value=False,
+    ):
+        _gate(
+            mgr,
+            sensors=["binary_sensor.dead"],
+            template="{{ false }}",
+        )
+        mgr._hass.states.set("binary_sensor.dead", "unavailable")
+        # sensor opinion None, template opinion False → dark, determinately.
+        assert mgr.effective_daytime_gate is False
+        assert mgr.seconds_until_gate_fallback() is None
+
+
+@pytest.mark.unit
+def test_seconds_until_gate_fallback_phases():
+    """seconds_until_gate_fallback: None determinate / ~remaining holding / None expired."""
+    mgr, clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    mgr._hass.states.set("binary_sensor.gate", "on")
+    clock[0] = 0.0
+    assert mgr.effective_daytime_gate is True
+    assert mgr.seconds_until_gate_fallback() is None  # determinate → no wake
+
+    mgr._hass.states.set("binary_sensor.gate", "unavailable")
+    clock[0] = 20.0
+    # First indeterminate observation anchors the window at t=20 → full grace left.
+    assert mgr.effective_daytime_gate is True  # HOLDING
+    assert mgr.seconds_until_gate_fallback() == pytest.approx(120.0)
+    # 20s into the window → ~100s remain.
+    clock[0] = 40.0
+    assert mgr.seconds_until_gate_fallback() == pytest.approx(100.0)
+
+    clock[0] = 20.0 + 121.0
+    assert mgr.effective_daytime_gate is None  # FELL_BACK
+    assert mgr.seconds_until_gate_fallback() is None
+
+
+@pytest.mark.unit
+def test_update_config_no_reset_when_gate_unchanged_preserves_hold():
+    """An identical update_config call must NOT forget the held verdict."""
+    mgr, clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    mgr._hass.states.set("binary_sensor.gate", "on")
+    clock[0] = 0.0
+    assert mgr.effective_daytime_gate is True  # record last-known
+    mgr._hass.states.set("binary_sensor.gate", "unavailable")
+    clock[0] = 10.0
+    assert mgr.effective_daytime_gate is True  # HOLDING
+
+    # Re-apply the SAME gate config (as the coordinator does every cycle).
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    clock[0] = 20.0
+    assert mgr.effective_daytime_gate is True  # still HOLDING — not reset
+
+
+@pytest.mark.unit
+def test_update_config_resets_when_gate_changed_forgets_last_known():
+    """Changing the sensor list forgets the held verdict (fresh grace machine)."""
+    mgr, clock = _clock_manager()
+    _gate(mgr, sensors=["binary_sensor.gate"])
+    mgr._hass.states.set("binary_sensor.gate", "on")
+    clock[0] = 0.0
+    assert mgr.effective_daytime_gate is True  # record last-known on the old sensor
+
+    # Switch to a different (never-reported) sensor → reset → no last-known.
+    _gate(mgr, sensors=["binary_sensor.other"])
+    assert mgr.effective_daytime_gate is None  # FELL_BACK (nothing to hold)
+
+
 @pytest.mark.unit
 def test_after_start_time_with_utc_iso_sun_sensor_string():
     """Entity state is a real UTC ISO string — is converted through to local wall-clock.


### PR DESCRIPTION
## Summary
When the Daytime Gate's sources (binary sensors and/or template) all go unavailable/unknown, the cover previously repositioned immediately on the wrong verdict (binary sensors fail open to "daytime"). This adds a grace window: the gate holds its last-known verdict for 120s, then — if still indeterminate or never observed — falls back to ACP's astronomical sunset/sunrise window (the existing `daytime_gate=None` path). Implemented via a new reusable `GracefulSource` state-machine kernel in `managers/common/`, with the daytime gate as its first adopter.

## Testing
- ✅ 5318 tests passing (full suite)
- New `GracefulSource` kernel unit tests; updated daytime-gate behavior tests; new TimeWindowManager phase tests; coordinator wake-scheduling tests.

## Related Issues
Refs #742