### PR TITLE
fix: scope same-position tolerance to endpoints 0/100 (#507)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -689,9 +689,11 @@ SOLAR_ANTICIPATION_SAMPLES = 4
 # reconciliation pass treats the cover as "not arrived" and resends the
 # command. Distinct from CONF_DELTA_POSITION (movement hysteresis). Default
 # is POSITION_TOLERANCE_PERCENT (see section 20). Range 0-20. Issue #507.
-# NOTE: this is a reconciliation-only tolerance. The command-emission
-# same-position gate must NOT use it — it keys off exact equality, and
-# movement hysteresis is owned by CONF_DELTA_POSITION (issue #567).
+# NOTE: the command-emission same-position gate uses this tolerance ONLY
+# for the hard endpoints (target 0 or 100) where the delta gate is bypassed
+# (issue #507/#629); for all other targets it keys off exact equality so
+# mid-range tracking moves are unaffected (issue #567).  Movement hysteresis
+# for non-endpoint targets is owned by CONF_DELTA_POSITION.
 CONF_POSITION_TOLERANCE = "position_tolerance"
 # When True, the periodic reconciliation pass actively resends a command on a
 # position mismatch until the cover reaches the target. When False (the

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -988,18 +988,25 @@ class CoverCommandService:
 
         # Same-position band — applies to ALL callers, including force=True and
         # is_safety=True.  Issuing set_cover_position when the cover is already
-        # EXACTLY at the target is a true no-op that causes audible relay clicks
-        # on many motors (issue #290), so we suppress it here.
+        # at the target is a true no-op that causes audible relay clicks on many
+        # motors (issue #290), so we suppress it here.
         #
-        # This gate keys off EXACT equality only — it is NOT a hysteresis band.
-        # Movement hysteresis (how big a move must be before we re-command) is
-        # owned solely by _check_position_delta below, governed by the user's
-        # CONF_DELTA_POSITION.  Using the reconciliation tolerance here conflated
-        # the two concepts and suppressed legitimate small tracking moves (issue
-        # #567).  The relay-click / unreachable-target suppression that motivated
-        # the old tolerance band (issue #507) lives in the reconciliation path
-        # (run_reconciliation_pass: tolerance match + max_retries give-up), where
-        # _position_tolerance correctly belongs — not here.
+        # For non-endpoint targets (normal solar tracking moves) this gate uses
+        # EXACT equality only — it is NOT a hysteresis band.  Movement hysteresis
+        # (how big a move must be before we re-command) is owned solely by
+        # _check_position_delta below, governed by the user's CONF_DELTA_POSITION.
+        # Using the reconciliation tolerance for all targets conflated the two
+        # concepts and suppressed legitimate small tracking moves (issue #567).
+        #
+        # For the two hard mechanical endpoints (0 and 100) the delta gate is
+        # bypassed entirely (special-target bypass, issue #629/#127), so there is
+        # no hysteresis fallback.  A motor that physically settles a few percent
+        # short of a full-open/full-close endpoint would therefore be re-commanded
+        # every update cycle, causing audible relay clicks (issue #507).  To
+        # prevent this we apply _position_tolerance here, but ONLY when the target
+        # is 0 or 100 — the literal mechanical stops, not mid-range setpoints.
+        # Mid-range specials (default_height, sunset_pos, my_position) keep exact
+        # equality so a within-tolerance drift from those still triggers a move.
         #
         # sun_just_appeared is the one exception: the sun transitioning in/out of
         # validity is a sentinel that we must re-confirm the cover position even
@@ -1007,7 +1014,10 @@ class CoverCommandService:
         if (
             not context.sun_just_appeared
             and _current is not None
-            and _current == position
+            and (
+                _current == position
+                or (position in (0, 100) and self._at_target(_current, position))
+            )
         ):
             if context.policy is not None and context.tilt is not None:
                 await context.policy.maybe_update_tilt_only(
@@ -1176,6 +1186,19 @@ class CoverCommandService:
         return "sent", service
 
     # ------------------------------------------------------------------ #
+    # Position-tolerance helpers
+    # ------------------------------------------------------------------ #
+
+    def _at_target(self, actual: int, target: int) -> bool:
+        """Return True if *actual* is within ``_position_tolerance`` of *target*.
+
+        Single source of truth for the "close enough" predicate used by
+        check_target_reached, run_reconciliation_pass, get_diagnostics, and
+        the same-position gate in apply_position (endpoint-only tolerance).
+        """
+        return abs(actual - target) <= self._position_tolerance
+
+    # ------------------------------------------------------------------ #
     # Target-reached notification (called by coordinator state-change handler)
     # ------------------------------------------------------------------ #
 
@@ -1205,7 +1228,7 @@ class CoverCommandService:
             return False
 
         target = s.target
-        if abs(reported_position - target) <= self._position_tolerance:
+        if self._at_target(reported_position, target):
             s.waiting = False
             s.retry_count = 0
             self._logger.debug(
@@ -1348,7 +1371,7 @@ class CoverCommandService:
                 continue
 
             # 7. Check match
-            if abs(actual - target) <= self._position_tolerance:
+            if self._at_target(actual, target):
                 s.retry_count = 0
                 self._logger.debug(
                     "Reconcile: %s at target (actual=%s target=%s)",
@@ -1439,7 +1462,7 @@ class CoverCommandService:
         at_target = (
             target is not None
             and actual is not None
-            and abs(actual - target) <= self._position_tolerance
+            and self._at_target(actual, target)
         )
         return {
             "target": target,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
@@ -185,9 +185,10 @@ def build_special_positions(options: dict) -> list[int]:
     Special positions (0, 100, default_height, sunset_pos) bypass the
     *delta-threshold* check so covers are always allowed to transition
     TO or FROM these key values even when the position change is smaller
-    than ``min_change``.  They do NOT bypass the same-position short-circuit
-    added in ``_check_position_delta`` — if the cover is already at the
-    target, no command is sent regardless of whether the target is special.
+    than ``min_change``.  They do NOT bypass the same-position short-circuit in
+    ``apply_position`` — if the cover is already at or within
+    endpoint-tolerance of the target,
+    no command is sent regardless of whether the target is special.
 
     When ``CONF_ENFORCE_DELTA_AT_ENDPOINTS`` is enabled (issue #679), the 0
     and 100 endpoints are omitted so the normal delta gate runs for those

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -878,9 +878,17 @@ async def test_coupled_cover_parks_at_reachable_position_with_option_on(svc, has
 
 
 @pytest.mark.asyncio
-async def test_coupled_cover_with_option_off_recovers_via_actual_aware_dedup(svc, hass):
-    """Flag OFF: 0 still bypasses delta (issue #629), but the actual-aware tilt
-    dedup recovers the slats — the cover never sticks permanently at 0/0.
+async def test_coupled_cover_with_option_off_stable_at_reachable_endpoint(svc, hass):
+    """Flag OFF: cover at reachable position 3 (within tolerance of endpoint 0) stays.
+
+    Issue #507 regression lock: when the cover's reachable resting position (3)
+    is within _position_tolerance of the hard endpoint (0), the same-position
+    gate treats the cover as "at the endpoint" and suppresses the command.  This
+    prevents the relay-click storm that repeated set_cover_position commands (every
+    solar cycle) would cause for a motor whose mechanical limit is 3% short of 0.
+
+    The cover and tilt are BOTH already at their desired state (3/100 is the
+    stable resting position; tilt=100 is correct), so no commands are needed.
     """
     from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
         EventBuffer,
@@ -894,28 +902,11 @@ async def test_coupled_cover_with_option_off_recovers_via_actual_aware_dedup(svc
     cover = _CoupledCover(position=3, tilt=100)
     policy = _attach_coupled_policy(svc, hass, cover, buf)
 
-    def _service_side_effect(domain, service, data, **_):
-        if service == "set_cover_position":
-            cover.position = data["position"]
-            cover.tilt = 0  # coupled: position command back-drives the slats
-            policy._sequencer._wait_for_position_settle = AsyncMock(
-                return_value=(True, cover.position)
-            )
-        elif service == "set_cover_tilt_position":
-            cover.tilt = data["tilt_position"]
-            if cover.position == 0 and cover.tilt >= 100:
-                cover.position = 3
-                policy._sequencer._wait_for_position_settle = AsyncMock(
-                    return_value=(True, cover.position)
-                )
-        return None
+    hass.services.async_call.side_effect = lambda *a, **kw: None
 
-    hass.services.async_call.side_effect = _service_side_effect
-
-    # Cycle: solar wants 0/100. 0 IS special (flag off) → position command fires
-    # → cover drives to 0/0 (tilt back-driven). after_position_command →
-    # run_sequence sends tilt 100 → coupled rise → settles at 3/100. The
-    # actual-aware dedup re-sends tilt because the live actuator drifted to 0.
+    # Solar wants 0/100. Cover is at 3/100 — within endpoint tolerance (default 3%)
+    # of position=0.  The same-position gate fires: abs(3-0)=3 <= 3 → skip.
+    # No position command is sent; no tilt command is needed (tilt already 100).
     hass.states.get.return_value = cover.state()
     with _patch_caps_dual_axis():
         outcome, _ = await svc.apply_position(
@@ -925,14 +916,10 @@ async def test_coupled_cover_with_option_off_recovers_via_actual_aware_dedup(svc
             _coupled_ctx(policy, tilt=100, special_positions=specials),
         )
 
-    assert outcome == "sent"
-    # The position command fired (0 is special) and a tilt command recovered
-    # the slats — the cover is NOT stuck at 0/0.
-    tilt_calls = [
-        c
-        for c in hass.services.async_call.call_args_list
-        if c.args[1] == "set_cover_tilt_position" and c.args[2]["tilt_position"] == 100
-    ]
-    assert tilt_calls, "tilt must be re-driven to 100 — no permanent 0/0 (issue #679)"
-    assert cover.tilt == 100
+    assert outcome == "skipped"
+    # No position command fired — the motor is already at its mechanical stop,
+    # within endpoint tolerance of 0.  No tilt command either (tilt already 100).
+    hass.services.async_call.assert_not_called()
+    # Cover rests stably at the reachable endpoint position, tilt correct.
     assert cover.position == 3
+    assert cover.tilt == 100

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1005,18 +1005,85 @@ def _stub_state(mock_hass, current_position: int) -> None:
     mock_hass.services.async_call = AsyncMock(return_value=None)
 
 
+# --- endpoint-only tolerance (issue #507 regression fix) ---
+
+
 @pytest.mark.asyncio
-async def test_apply_position_within_tolerance_band_now_sends(
+async def test_endpoint_target_within_tolerance_skips_on_main_path(
     mock_hass, logger, grace_mgr
 ):
-    """Issue #567 (was #507) — cover at 98, target 100, tolerance=8: now SENT.
+    """Issue #507 regression — cover at 98, target 100, tolerance=8: SKIPPED.
 
-    The same-position SEND gate uses exact equality, not the reconciliation
-    tolerance.  98 != 100, so with the special target bypassing the movement
-    delta gate (#127) the command is sent.  Under the old #507 tolerance band
-    (|98-100|=2 <= 8) this was wrongly suppressed as same_position; the
-    relay-click / unreachable-target suppression now lives in the
-    reconciliation path, not in this command-emission gate.
+    A motor that physically settles 2% short of the open endpoint (100) must
+    not be re-commanded every solar update cycle.  The same-position gate
+    applies a tolerance band when the target is a hard endpoint (0 or 100),
+    so abs(98-100)=2 <= 8 is treated as same_position and the command is not
+    sent.  The band is limited to endpoints so that mid-range tracking moves
+    (issue #567) keep using exact equality.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
+    _stub_state(mock_hass, current_position=98)
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=98),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("set_cover_position", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 100, "solar", _ctx_with_special()
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_zero_within_tolerance_skips_on_main_path(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #507 regression — cover at 2, target 0, tolerance=8: SKIPPED.
+
+    Symmetric case for the closed endpoint: a motor pinned 2% above fully
+    closed must not be re-commanded every cycle.  The endpoint tolerance band
+    applies to target=0 just as it does to target=100.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
+    _stub_state(mock_hass, current_position=2)
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=2),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("set_cover_position", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test", 0, "solar", _ctx_with_special()
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_within_tolerance_band_skips_endpoint(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #507 regression lock — cover at 98, target 100, tolerance=8: SKIPPED.
+
+    The same-position gate applies _position_tolerance when the target is a
+    hard endpoint (0 or 100).  abs(98-100)=2 <= 8, so the cover is treated as
+    at the target and the command is suppressed, preventing relay clicks when a
+    motor physically settles a few percent short of its mechanical stop.
+    Mid-range targets keep exact-equality semantics (issue #567 preserved).
     """
     svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
     _stub_state(mock_hass, current_position=98)
@@ -1034,23 +1101,23 @@ async def test_apply_position_within_tolerance_band_now_sends(
             "cover.test", 100, "default", _ctx_with_special()
         )
 
-    assert outcome == "sent"
-    mock_hass.services.async_call.assert_called_once()
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_unreachable_target_suppressed_by_reconcile_not_command_gate(
+async def test_force_endpoint_within_tolerance_skips_command_gate(
     mock_hass, logger, grace_mgr
 ):
-    """Issue #567 (was #507) — #507's relay-click suppression lives in reconcile.
+    """Issue #507 regression lock — force/safety endpoint within tolerance: SKIPPED.
 
-    A force/safety target within the reconciliation tolerance but not exactly at
-    the cover's rest position is SENT through the command gate (exact-equality
-    gate doesn't suppress it).  The repeated re-commanding of an unreachable
-    target is what #507 was really about, and that is suppressed by the
-    reconciliation give-up path (max_retries) — not by the command-emission
-    gate.  Here we assert the command gate sends; the give-up behavior is
-    covered by ``test_reconcile_gives_up_on_unreachable_target``.
+    The same-position gate applies endpoint-tolerance BEFORE the force/safety
+    bypass path.  Cover at 98, target 100, tolerance=8: abs(98-100)=2 <= 8 so
+    the gate fires and no command is sent, even with force=True / is_safety=True.
+    This prevents the relay-click storm that triggered issue #507.
+    The reconciliation give-up path (test_reconcile_gives_up_on_unreachable_target)
+    handles targets that are genuinely out of tolerance.
     """
     svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
     _stub_state(mock_hass, current_position=98)
@@ -1079,8 +1146,9 @@ async def test_unreachable_target_suppressed_by_reconcile_not_command_gate(
             "cover.test", 100, "force_override", ctx
         )
 
-    assert outcome == "sent"
-    mock_hass.services.async_call.assert_called_once()
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1243,21 +1311,22 @@ async def test_apply_position_one_percent_tracking_move_is_sent(
 
 
 @pytest.mark.asyncio
-async def test_same_position_band_uses_exact_equality_not_tolerance(
+async def test_endpoint_within_tolerance_skips_in_tracking_context(
     mock_hass, logger, grace_mgr
 ):
-    """Issue #567 — the same-position band keys off exact equality, not tolerance.
+    """Issue #507/#567 combined — endpoint tolerance skips; mid-range stays exact.
 
-    Cover at 98 commanded to 100 (a special position) with tolerance=8 and
-    min_change=10.  98 != 100 so the same-position band does NOT fire; the
-    special target bypasses the movement-delta gate (#127), so the command is
-    sent.  Before the fix the tolerance band (|98-100|=2 <= 8) suppressed it.
+    Cover at 98 commanded to 100 (endpoint) with tolerance=8 and min_change=10.
+    The same-position gate uses _position_tolerance for endpoints (0/100):
+    abs(98-100)=2 <= 8 fires and the command is skipped.
+    In a tracking context a mid-range target (not 0 or 100) keeps exact equality
+    so issue #567 (small tracking moves suppressed) stays fixed.
     """
     svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
     _stub_state(mock_hass, current_position=98)
 
-    # _check_position_delta is NOT patched — the special target (100) bypasses
-    # the delta gate via special_positions, so the real gate is exercised.
+    # _check_position_delta is NOT patched — the same-position gate fires first
+    # so the delta gate is never reached.
     with (
         patch.object(svc, "_get_current_position", return_value=98),
         patch.object(svc, "_check_time_delta", return_value=True),
@@ -1270,6 +1339,47 @@ async def test_same_position_band_uses_exact_equality_not_tolerance(
         outcome, reason = await svc.apply_position(
             "cover.test", 100, "solar", _ctx_tracking(min_change=10)
         )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_midrange_special_position_within_tolerance_sends(
+    mock_hass, logger, grace_mgr
+):
+    """Endpoint tolerance does NOT widen to mid-range special positions (#567 guard).
+
+    Cover at 47 commanded to default_height=50 (a mid-range special position)
+    with tolerance=8 and min_change=10.  The endpoint tolerance band applies
+    only to targets 0 and 100; for all other targets the gate uses exact
+    equality.  47 != 50, so the gate does not fire and the command is sent.
+    This confirms the fix did not accidentally widen the band to all specials.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=8)
+    _stub_state(mock_hass, current_position=47)
+
+    ctx = PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=10,
+        time_threshold=0,
+        # 50 is a mid-range special (default_height); 0 and 100 also present
+        special_positions=[0, 50, 100],
+    )
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=47),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("set_cover_position", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position("cover.test", 50, "default", ctx)
 
     assert outcome == "sent"
     mock_hass.services.async_call.assert_called_once()


### PR DESCRIPTION
## Summary
The same-position command gate used exact equality, so a cover settling a few percent short of a hard endpoint (e.g. reporting 98 when commanded to 100) was re-commanded every update cycle, causing audible relay clicking. The v2.25.2 tolerance band that fixed this was reverted in #574 to fix #567 (where the band wrongly suppressed legitimate small tracking moves).

This scopes the tolerance band to the hard endpoints (0 and 100) only, keeping exact equality for normal tracking moves and mid-range special positions. That reconciles #507 and #567: endpoints accept a motor settling within the configured Position match tolerance, while fine-grained tracking is unaffected.

Adds a `_at_target` helper to unify the tolerance predicate (was duplicated in three places).

## Testing
- ✅ 5321 tests passing (full suite)

## Related Issues
Refs #507