### PR TITLE
test: cut suite runtime 5x by neutralizing venetian sleeps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,14 +13,16 @@ python_files = "test_*.py"
 python_classes = "Test*"
 python_functions = "test_*"
 asyncio_mode = "auto"
+# Coverage is NOT enabled here: it would run on every bare `pytest tests/test_x.py`
+# (whole-package measurement + a stray coverage.xml) with no benefit to the
+# inner dev loop. CI (.github/workflows/tests.yml) and `scripts/test coverage`
+# pass --cov explicitly where it's actually wanted.
 addopts = [
     "--strict-markers",
     "--strict-config",
-    "--cov=custom_components/adaptive_cover_pro",
-    "--cov-report=term-missing",
-    "--cov-report=xml",
 ]
 markers = [
     "unit: Unit tests (fast, no I/O)",
     "integration: Integration tests (slower, may require Home Assistant)",
+    "perf: Wall-clock performance-budget tests (flaky on loaded hosts; skip with -m 'not perf')",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,6 @@ nbconvert>=7.17.1  # For executing notebooks in CI
 pytest>=9.0.3  # pinned by pytest-homeassistant-custom-component to ==9.0.3
 pytest-asyncio>=1.3.0  # pinned by pytest-homeassistant-custom-component to ==1.3.0
 pytest-cov>=7.1.0
+pytest-xdist>=3.8.0  # parallel test execution — the documented `pytest -n auto` runner
 pytest-homeassistant-custom-component==0.13.340
 hypothesis>=6.155.7

--- a/scripts/test
+++ b/scripts/test
@@ -4,6 +4,7 @@
 #
 # Usage:
 #   ./scripts/test              # Run all tests
+#   ./scripts/test fast         # Parallel, skip wall-clock perf-budget tests (inner loop)
 #   ./scripts/test unit         # Run only unit tests
 #   ./scripts/test coverage     # Run with detailed coverage
 
@@ -18,6 +19,10 @@ echo -e "${GREEN}Adaptive Cover Pro Test Runner${RESET}"
 echo ""
 
 case "${1:-all}" in
+  fast)
+    echo "Running fast inner loop (parallel, no perf budgets)..."
+    pytest -n auto -m "not perf" -q
+    ;;
   unit)
     echo "Running unit tests only..."
     pytest -m unit -v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,40 @@ def expected_lingering_timers(request) -> bool:
     return False
 
 
+@pytest.fixture
+def neutralize_venetian_delays(monkeypatch):
+    """Zero the venetian sequencer's real-motor sleep delays for unit tests.
+
+    The dual-axis sequencer waits on several real ``asyncio.sleep`` timers
+    that model physical actuator lag (post-settle hold, post-tilt rebase,
+    drift-retry, tilt-verify poll). In production these are seconds; in tests
+    they add up to ~50 s of pure idle-waiting across the venetian suites.
+
+    Single source of truth for that neutralization — venetian behavioral test
+    files opt in with
+    ``pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")``
+    instead of each re-declaring its own delay-zeroing fixture.
+
+    Only the *pure-delay* constants are touched. The settle-loop constants
+    (``..._POLL_SECONDS`` / ``..._STARTUP_GRACE_SECONDS`` / ``..._TIMEOUT_SECONDS``)
+    drive branch logic and are asserted on by some tests, so they are left at
+    production values; the few settle-loop tests patch them locally.
+    """
+    seq = "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
+    monkeypatch.setattr(seq + "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS", 0)
+    monkeypatch.setattr(seq + "VENETIAN_TILT_VERIFY_POLL_SECONDS", 0)
+    monkeypatch.setattr(seq + "VENETIAN_DRIFT_RETRY_DELAY_SECONDS", 0)
+    # The 3.0 s post-settle hold is an ``attach()`` default, not a sleep-site
+    # constant; zero the default so policies built without an explicit value
+    # don't pay it. Patched in the policy namespace only — the config-summary
+    # path reads the const namespace, so summary tests keep the 3.0 s default.
+    monkeypatch.setattr(
+        "custom_components.adaptive_cover_pro.cover_types.venetian.policy."
+        "DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS",
+        0,
+    )
+
+
 @pytest.fixture(autouse=True)
 def _auto_enable_custom_integrations(request):
     """Auto-enable custom integration discovery for real HA integration tests.

--- a/tests/cover/test_proxy_cover_commands.py
+++ b/tests/cover/test_proxy_cover_commands.py
@@ -19,7 +19,12 @@ from tests.ha_helpers import (
     _patch_coordinator_refresh,
 )
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    # The venetian proxy tests drive the real dual-axis sequencer end-to-end;
+    # zero its motor-lag sleeps so they don't wait on real asyncio timers.
+    pytest.mark.usefixtures("neutralize_venetian_delays"),
+]
 
 
 async def _setup_proxy(

--- a/tests/test_cover_command_venetian.py
+++ b/tests/test_cover_command_venetian.py
@@ -29,15 +29,7 @@ from custom_components.adaptive_cover_pro.managers.cover_command import (
     build_special_positions,
 )
 
-
-@pytest.fixture(autouse=True)
-def _zero_post_tilt_delay(monkeypatch):
-    """Skip the 1.5s real-motor settle delay in unit tests."""
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
-        "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
-        0,
-    )
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
 
 
 @pytest.fixture

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -21,6 +21,10 @@ from custom_components.adaptive_cover_pro.const import (
 from custom_components.adaptive_cover_pro.cover_types.venetian import VenetianPolicy
 from custom_components.adaptive_cover_pro.managers.cover_command import PositionContext
 
+# Zero the real-motor sleep delays — the apply-user-tilt tests route through the
+# sequencer's post-tilt rebase delay otherwise.
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
+
 
 def test_retract_threshold_constants_exist() -> None:
     """CONF and DEFAULT constants for the retract threshold must be exported."""

--- a/tests/test_cover_types/test_venetian_drift_reset.py
+++ b/tests/test_cover_types/test_venetian_drift_reset.py
@@ -34,20 +34,7 @@ from custom_components.adaptive_cover_pro.cover_types.venetian.sequencer import 
 )
 from custom_components.adaptive_cover_pro.diagnostics.event_buffer import EventBuffer
 
-
-@pytest.fixture(autouse=True)
-def _zero_post_tilt_delay(monkeypatch):
-    """Skip real-motor delays so the suite doesn't sleep on asyncio waits."""
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
-        "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
-        0,
-    )
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
-        "VENETIAN_TILT_VERIFY_POLL_SECONDS",
-        0,
-    )
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
 
 
 def _build_sequencer(

--- a/tests/test_cover_types/test_venetian_sequencer.py
+++ b/tests/test_cover_types/test_venetian_sequencer.py
@@ -28,34 +28,13 @@ from custom_components.adaptive_cover_pro.cover_types.venetian.sequencer import 
     DualAxisSequencer,
 )
 
-
-@pytest.fixture(autouse=True)
-def _zero_post_tilt_delay(monkeypatch):
-    """Skip real-motor delays in unit tests.
-
-    Zeroes the post-tilt rebase delay (1.5 s), the verify-retry poll
-    interval (1.0 s), and the drift-retry delay (2.0 s) so the test suite
-    doesn't spend real time waiting on asyncio.sleep. The post-settle hold
-    is a per-instance parameter (``post_settle_hold_seconds``) defaulting to
-    0 in ``_build_sequencer`` — no monkeypatching needed for that delay. The
-    retry sample COUNT (``VENETIAN_TILT_VERIFY_MAX_SAMPLES``) is left at its
-    production value because it is the behaviour under test.
-    """
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
-        "VENETIAN_POST_TILT_REBASE_DELAY_SECONDS",
-        0,
-    )
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
-        "VENETIAN_TILT_VERIFY_POLL_SECONDS",
-        0,
-    )
-    monkeypatch.setattr(
-        "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
-        "VENETIAN_DRIFT_RETRY_DELAY_SECONDS",
-        0,
-    )
+# Zero the real-motor delays (post-tilt rebase, verify poll, drift retry, and
+# the post-settle-hold default) for every test in this module. The settle-loop
+# constants (poll/grace/timeout) are NOT zeroed here — they drive branch logic
+# and are asserted on / patched locally by the settle tests below. The retry
+# sample COUNT (``VENETIAN_TILT_VERIFY_MAX_SAMPLES``) is left at its production
+# value because it is the behaviour under test.
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
 
 
 def _build_sequencer(
@@ -616,6 +595,14 @@ class TestPostTiltRebase:
             "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
             "VENETIAN_POSITION_SETTLE_POLL_SECONDS",
             0,
+        )
+        # No motion is ever observed, so stall declaration waits out the real
+        # startup grace (6 s). Shrink it — the test asserts the stall outcome,
+        # not the wall-clock duration.
+        monkeypatch.setattr(
+            "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer."
+            "VENETIAN_POSITION_SETTLE_STARTUP_GRACE_SECONDS",
+            0.01,
         )
 
         set_cmd_pos = MagicMock()

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -16,6 +16,8 @@ import datetime as dt
 from collections.abc import Callable
 from unittest.mock import MagicMock
 
+import pytest
+
 from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.cover_types.venetian import (
     DualAxisSequencer,
@@ -32,6 +34,10 @@ from custom_components.adaptive_cover_pro.managers.manual_override import (
     SecondaryAxisCheck,
 )
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+# Zero the real-motor sleep delays — these tests drive run_sequence/attach()
+# against the real sequencer, which otherwise waits on the post-tilt rebase delay.
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
 
 
 def _make_event(entity_id: str, *, position: int | None, tilt: int | None):

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -23,7 +23,10 @@ from tests.cover_helpers import (
     build_vertical_cover,
 )
 
-pytestmark = pytest.mark.unit
+# Every test here asserts a wall-clock budget (`elapsed_ms < N`), which is
+# flaky on loaded hosts. Tag `perf` so the fast inner loop can skip them with
+# `-m "not perf"`; CI still runs them.
+pytestmark = [pytest.mark.unit, pytest.mark.perf]
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
## Summary

The test suite was gated by ~20 venetian sequencer tests running **real `asyncio.sleep`** timers — one 11s, one 6s, ~13 at 3.0s, three at 1.5s. The existing per-file fixtures zeroed the post-tilt rebase delay but not the **3.0s post-settle-hold** (an `attach()` default) nor the **6.0s settle startup-grace**, so those ran full-length. Coverage (in default `addopts`) was a red herring — only ~4% overhead under `-n auto`.

Changes:
- **Add one shared `neutralize_venetian_delays` fixture** in `tests/conftest.py`; opt the venetian behavioral files into it via `pytestmark` and **delete the three duplicated `_zero_post_tilt_delay` fixtures**. The hold default is patched in the *policy* namespace only, so config-summary tests keep the production 3.0s; the single real-settle-loop test shrinks the startup-grace locally.
- **Pin `pytest-xdist`** in `requirements-dev.txt` so the documented `pytest -n auto` works on a fresh `./scripts/setup`.
- **Drop `--cov` from default `addopts`** — CI and `scripts/test coverage` pass it explicitly, so bare/single-file runs no longer measure coverage or write a stray `coverage.xml`.
- **Add a `perf` marker** on the wall-clock-budget tests in `test_performance.py` and a `./scripts/test fast` mode (`-n auto -m "not perf"`) for the inner loop.

No production code changed — `custom_components/**` is untouched; production timing is unchanged.

## Testing
- ✅ 5321 tests passing
- Venetian files: **58s → 2s** serial
- Full suite `-n auto`: **~38s → ~7s** (5× faster); no venetian test in the slowest-15 except the deliberate 0.5s hold-assertion test
- `-m perf` selects exactly 6 tests; `-m "not perf"` deselects them
- Ruff + black clean; bare runs no longer emit `coverage.xml`; CI coverage path unchanged

## Related Issues
None

https://claude.ai/code/session_01U6jZvw4qT2ZPk1o3tXAu2n