### PR TITLE
fix: endpoint delta enforcement ignored when sunset/default equals 0 or 100 (#679)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -55,7 +55,10 @@ from ...const import (
     VENETIAN_TILT_VERIFY_POLL_SECONDS,
     VENETIAN_TILT_VERIFY_TOLERANCE,
 )
-from ...managers.cover_command.gates import check_position_delta
+from ...managers.cover_command.gates import (
+    check_position_delta,
+    filter_endpoint_specials,
+)
 from ...managers.cover_command.transit import is_state_in_transit
 from ...managers.manual_override import inverse_state
 
@@ -472,14 +475,14 @@ class DualAxisSequencer:
         if not force and self._get_min_change is not None:
             anchor, anchor_source = self._resolve_tilt_anchor(entity_id)
             # When endpoint-delta enforcement is enabled (issue #679), drop the
-            # 0/100 special bypass so the gate applies to the full endpoints too
-            # — mirrors the position axis in ``build_special_positions``.
-            tilt_specials = (
-                []
-                if self._get_enforce_delta_at_endpoints
+            # 0/100 special bypass so the gate applies to the full endpoints too.
+            # Delegates to filter_endpoint_specials (gates.py) — the same helper
+            # used by build_special_positions on the position axis.
+            enforced = bool(
+                self._get_enforce_delta_at_endpoints
                 and self._get_enforce_delta_at_endpoints()
-                else _TILT_SPECIAL_POSITIONS
             )
+            tilt_specials = filter_endpoint_specials(_TILT_SPECIAL_POSITIONS, enforced)
             if anchor is not None and not check_position_delta(
                 entity_id,
                 tilt_target,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/gates.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/gates.py
@@ -16,6 +16,26 @@ from __future__ import annotations
 
 import datetime as dt
 
+# Canonical endpoint values (mirrors POSITION_CLOSED / POSITION_OPEN from const.py;
+# kept as literals here so gates.py remains free of const imports).
+_ENDPOINT_VALUES: frozenset[int] = frozenset({0, 100})
+
+
+def filter_endpoint_specials(positions: list, enforced: bool) -> list:
+    """Remove 0/100 endpoint values from *positions* when *enforced* is True.
+
+    Single-point decision shared by :func:`build_special_positions` (routing.py)
+    and the venetian sequencer's tilt-specials computation (sequencer.py), so the
+    "drop endpoints when enforce_delta_at_endpoints is on" logic lives in exactly
+    one place (no-duplication guideline).
+
+    When *enforced* is False the list is returned unchanged — callers may pass the
+    same list they constructed; no copy is made in that branch.
+    """
+    if not enforced:
+        return positions
+    return [p for p in positions if p not in _ENDPOINT_VALUES]
+
 
 def check_position_delta(
     entity: str,

--- a/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
@@ -39,6 +39,7 @@ from ...cover_types.base import (
     CoverAxis,
     caps_get,
 )
+from .gates import filter_endpoint_specials
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -210,4 +211,4 @@ def build_special_positions(options: dict) -> list[int]:
         special_positions.append(sunset_pos)
     if my_position_value is not None:
         special_positions.append(my_position_value)
-    return special_positions
+    return filter_endpoint_specials(special_positions, enforce_endpoints)

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -831,6 +831,103 @@ def test_endpoints_bypass_delta_when_not_enforced(logger):
     )
 
 
+# --- enforce_delta_at_endpoints: endpoint re-injection via config values (#679 reopen) ---
+
+
+def test_enforce_endpoints_drops_endpoint_when_sunset_position_is_0(logger):
+    """enforce=True + sunset_position=0 must NOT re-inject 0 into specials (#679 reopen).
+
+    The original v2.30.0 fix dropped [0, 100] from the seed but still appended
+    sunset_position unconditionally. When sunset_position=0 (the reporter's exact
+    config) the endpoint 0 was re-added, and check_position_delta bypassed the gate
+    for target 0.  The fix must filter 0/100 AFTER appending config values.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENFORCE_DELTA_AT_ENDPOINTS,
+        CONF_SUNSET_POS,
+    )
+
+    options = {CONF_ENFORCE_DELTA_AT_ENDPOINTS: True, CONF_SUNSET_POS: 0}
+    positions = build_special_positions(options)
+    assert 0 not in positions
+    # 2 → 0, delta=2 < min_change=5; no longer bypassed — gate must return False.
+    assert (
+        check_position_delta("cover.x", 0, 5, positions, position=2, logger=logger)
+        is False
+    )
+
+
+def test_enforce_endpoints_drops_endpoint_when_default_percentage_is_100(logger):
+    """enforce=True + default_percentage=100 must NOT re-inject 100 into specials (#679 reopen).
+
+    When default_percentage=100 (the reporter's exact config) the endpoint 100 was
+    re-appended after the initial seed was dropped, letting 97→100 bypass the gate.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DEFAULT_HEIGHT,
+        CONF_ENFORCE_DELTA_AT_ENDPOINTS,
+    )
+
+    options = {CONF_ENFORCE_DELTA_AT_ENDPOINTS: True, CONF_DEFAULT_HEIGHT: 100}
+    positions = build_special_positions(options)
+    assert 100 not in positions
+    # 97 → 100, delta=3 < min_change=5; endpoint must now be gated — False.
+    assert (
+        check_position_delta("cover.x", 100, 5, positions, position=97, logger=logger)
+        is False
+    )
+
+
+def test_enforce_endpoints_off_keeps_0_and_100_via_config_values(logger):
+    """Regression lock: flag OFF → 0/100 from config values remain in specials (#629).
+
+    default_percentage=100 and sunset_position=0 must still bypass the gate when
+    enforce_delta_at_endpoints is False (the default).
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DEFAULT_HEIGHT,
+        CONF_ENFORCE_DELTA_AT_ENDPOINTS,
+        CONF_SUNSET_POS,
+    )
+
+    options = {
+        CONF_ENFORCE_DELTA_AT_ENDPOINTS: False,
+        CONF_DEFAULT_HEIGHT: 100,
+        CONF_SUNSET_POS: 0,
+    }
+    positions = build_special_positions(options)
+    assert 0 in positions
+    assert 100 in positions
+    # Both endpoints still bypass: gate returns True for near-endpoint moves.
+    assert (
+        check_position_delta("cover.x", 0, 5, positions, position=2, logger=logger)
+        is True
+    )
+    assert (
+        check_position_delta("cover.x", 100, 5, positions, position=97, logger=logger)
+        is True
+    )
+
+
+def test_enforce_endpoints_mid_range_sunset_still_bypasses(logger):
+    """enforce=True + sunset_position=40 → 40 remains special (only 0/100 are filtered)."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENFORCE_DELTA_AT_ENDPOINTS,
+        CONF_SUNSET_POS,
+    )
+
+    options = {CONF_ENFORCE_DELTA_AT_ENDPOINTS: True, CONF_SUNSET_POS: 40}
+    positions = build_special_positions(options)
+    assert 40 in positions
+    assert 0 not in positions
+    assert 100 not in positions
+    # 38 → 40, delta=2 < min_change=5 but target IS special (40) → bypassed (True).
+    assert (
+        check_position_delta("cover.x", 40, 5, positions, position=38, logger=logger)
+        is True
+    )
+
+
 # --- Tilt-only entity under cover_blind config (bug fix coverage) ---
 
 


### PR DESCRIPTION
## Summary
The `enforce_delta_at_endpoints` option (added in v2.30.0 for issue #679) was defeated for any config where `default_percentage` or `sunset_position` equals an endpoint. `build_special_positions()` dropped the literal `[0, 100]` seed when the option was on, then unconditionally re-appended `default_percentage` and `sunset_position` — so a coupled venetian with `default_percentage=100` / `sunset_position=0` got 0/100 back in the special list and kept bypassing the delta gate for target 0/100, chasing the impossible `0/100` state.

This adds a final-stage `filter_endpoint_specials` helper that drops 0 and 100 from the special list whenever the option is on, regardless of how they were added. The venetian tilt axis now shares the same helper.

## Testing
- ✅ 286 tests passing (4 new covering enforce=True with sunset_position=0 and default_percentage=100, plus flag-off and mid-range regression locks)

## Related Issues
Refs #679