### PR TITLE
fix: resolve diagnostics coordinator from runtime_data (#753)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_WINDOW_WIDTH,
     CUSTOM_POSITION_SAFETY_PRIORITY,
     CUSTOM_POSITION_SLOTS,
+    DIAG_CACHE_KEY,
     DOMAIN,
     _LOGGER,
 )
@@ -389,7 +390,11 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     from every cover still linked to it so their profile pickers re-expose on the
     next options view. The last-copied sensor IDs are deliberately left in place
     so the covers keep functioning. Removing a real cover does nothing here.
+
+    Also drops the entry's last-good diagnostics snapshot from the hass.data cache
+    (written each update cycle, kept across reloads) so it does not leak.
     """
+    hass.data.get(DIAG_CACHE_KEY, {}).pop(entry.entry_id, None)
     if get_policy(entry.data.get(CONF_SENSOR_TYPE)).controls_cover:
         return
     for cover in _covers_linked_to(hass, entry):

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -60,6 +60,10 @@ from enum import Enum, StrEnum
 # Domain string, package-level loggers, and HA service-call attribute keys.
 
 DOMAIN = "adaptive_cover_pro"  # HA integration domain; must match manifest.json
+# hass.data slot holding the last-good diagnostics snapshot per entry_id. Lives
+# outside the coordinator so it survives a reload (when entry.runtime_data is
+# briefly unset) and can be served by the diagnostics download as a stale fallback.
+DIAG_CACHE_KEY = f"{DOMAIN}_last_diagnostics"
 LOGGER = logging.getLogger(__package__)  # package-scoped logger
 _LOGGER = logging.getLogger(__name__)  # module-scoped; also imported by button.py
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -85,6 +85,7 @@ from .const import (
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
     DEFAULT_MANUAL_OVERRIDE_STRATEGY,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
+    DIAG_CACHE_KEY,
     DOMAIN,
     LOGGER,
     POSITION_TOLERANCE_PERCENT,
@@ -1418,6 +1419,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Build diagnostic data (always enabled)
         diagnostics = self.build_diagnostic_data()
 
+        # Cache this snapshot outside the coordinator so a diagnostics download
+        # during a reload window (when entry.runtime_data is briefly unset) can
+        # still serve the last-good data instead of an empty marker.
+        self._cache_last_good_diagnostics(diagnostics)
+
         # Record successful update time (after build_diagnostic_data so the
         # diagnostic for this cycle reports the *previous* completed success).
         self._last_update_success_time = dt.datetime.now(dt.UTC)
@@ -2506,6 +2512,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self._last_position_explanation = explanation
 
         return diagnostics
+
+    def _cache_last_good_diagnostics(self, diagnostics: dict) -> None:
+        """Store the latest diagnostics snapshot in hass.data, keyed by entry_id.
+
+        Survives a coordinator teardown (unlike the in-memory event buffer), so the
+        diagnostics download can fall back to it when ``entry.runtime_data`` is
+        briefly unset during a reload. Pruned in ``async_remove_entry``.
+        """
+        cache = self.hass.data.setdefault(DIAG_CACHE_KEY, {})
+        cache[self.config_entry.entry_id] = {
+            "diagnostics": diagnostics,
+            "ts": dt.datetime.now(dt.UTC),
+        }
 
     @property
     def state(self) -> int:

--- a/custom_components/adaptive_cover_pro/diagnostics/__init__.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/__init__.py
@@ -44,16 +44,14 @@ async def async_get_config_entry_diagnostics(
 ):
     """Return config entry diagnostics."""
     from custom_components.adaptive_cover_pro.const import (
-        DOMAIN as _DOMAIN,
+        DIAG_CACHE_KEY,
     )  # noqa: PLC0415
 
-    coordinator = hass.data.get(_DOMAIN, {}).get(config_entry.entry_id)
-    if coordinator is None:
-        coordinator_diagnostics = {
-            "status": "unavailable",
-            "reason": "coordinator missing — the integration is not set up for this entry",
-        }
-    else:
+    # The coordinator lives on entry.runtime_data (the registry every platform
+    # reads). Virtual Building-Profile entries have no coordinator, so this is
+    # legitimately None for them.
+    coordinator = getattr(config_entry, "runtime_data", None)
+    if coordinator is not None:
         if coordinator.data is None:
             # Diagnostics requested before the first completed update cycle (e.g.
             # right after a restart/reload). Trigger one refresh so the download
@@ -80,11 +78,42 @@ async def async_get_config_entry_diagnostics(
                     timeline
                 )
             coordinator_diagnostics = marker
+    else:
+        # No live coordinator — typically a reload window (entry.runtime_data is
+        # briefly unset) or a not-yet-loaded entry. Fall back to the last-good
+        # snapshot cached in hass.data so the download is still useful, annotated
+        # as stale so the reader knows it is not live.
+        cached = hass.data.get(DIAG_CACHE_KEY, {}).get(config_entry.entry_id)
+        if cached is not None:
+            snapshot = _sanitize(cached["diagnostics"])
+            age_seconds = (dt.datetime.now(dt.UTC) - cached["ts"]).total_seconds()
+            cache_status = {
+                "stale": True,
+                "captured_at": cached["ts"].isoformat(),
+                "age_seconds": round(age_seconds, 1),
+            }
+            coordinator_diagnostics = (
+                {**snapshot, "cache_status": cache_status}
+                if isinstance(snapshot, dict)
+                else {"cache_status": cache_status, "snapshot": snapshot}
+            )
+        else:
+            coordinator_diagnostics = {
+                "status": "unavailable",
+                "reason": "coordinator missing — the integration is not set up for this entry",
+            }
 
     return {
         "title": "Adaptive Cover Pro Configuration",
         "type": "config_entry",
         "identifier": config_entry.entry_id,
+        # Envelope triage fields HA core's diagnostics wrapper does not provide.
+        # Always present, so even a marker-only download states whether the entry
+        # is set up and which migration schema it is on.
+        "config_entry_state": config_entry.state.value,
+        "config_entry_version": config_entry.version,
+        "config_entry_minor_version": config_entry.minor_version,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
         "config_data": dict(config_entry.data),
         "config_options": dict(config_entry.options),
         "diagnostics": coordinator_diagnostics,

--- a/tests/test_diagnostics/test_export_unavailable.py
+++ b/tests/test_diagnostics/test_export_unavailable.py
@@ -11,29 +11,31 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
-from custom_components.adaptive_cover_pro.const import DOMAIN
 from custom_components.adaptive_cover_pro.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 
 
-def _make_entry(entry_id: str = "entry-1") -> MagicMock:
+def _make_entry(coordinator=None, entry_id: str = "entry-1") -> MagicMock:
+    """Build a config-entry mock; the coordinator lives on runtime_data."""
     entry = MagicMock(spec=ConfigEntry)
     entry.entry_id = entry_id
     entry.data = {"name": "Test"}
     entry.options = {"opt": 1}
+    entry.runtime_data = coordinator
+    # Envelope triage fields read straight off the entry.
+    entry.state = ConfigEntryState.LOADED
+    entry.version = 1
+    entry.minor_version = 1
     return entry
 
 
-def _make_hass(coordinator, entry_id: str = "entry-1") -> MagicMock:
+def _make_hass() -> MagicMock:
     hass = MagicMock(spec=HomeAssistant)
-    data = (
-        {DOMAIN: {entry_id: coordinator}} if coordinator is not None else {DOMAIN: {}}
-    )
-    hass.data = data
+    hass.data = {}
     return hass
 
 
@@ -50,7 +52,8 @@ async def test_data_none_emits_marker_with_event_timeline():
     coordinator.async_refresh = AsyncMock()  # refresh runs but leaves data None
     coordinator._event_buffer.snapshot.return_value = events
 
-    hass = _make_hass(coordinator)
+    entry.runtime_data = coordinator
+    hass = _make_hass()
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     diag = result["diagnostics"]
@@ -64,7 +67,7 @@ async def test_data_none_emits_marker_with_event_timeline():
 async def test_coordinator_missing_emits_marker_without_timeline():
     """No coordinator at all → status unavailable, reason mentions missing, no timeline."""
     entry = _make_entry()
-    hass = _make_hass(None)
+    hass = _make_hass()
 
     result = await async_get_config_entry_diagnostics(hass, entry)
 
@@ -83,7 +86,8 @@ async def test_data_none_without_event_buffer_falls_back_to_reason_only():
     coordinator.data = None
     coordinator.async_refresh = AsyncMock()
 
-    hass = _make_hass(coordinator)
+    entry.runtime_data = coordinator
+    hass = _make_hass()
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     diag = result["diagnostics"]
@@ -100,7 +104,8 @@ async def test_data_present_returns_sanitized_passthrough_not_marker():
     coordinator = MagicMock()
     coordinator.data.diagnostics = {"control_status": "sun_tracking", "position": 42}
 
-    hass = _make_hass(coordinator)
+    entry.runtime_data = coordinator
+    hass = _make_hass()
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     diag = result["diagnostics"]
@@ -124,7 +129,8 @@ async def test_data_none_triggers_refresh_then_returns_full_diagnostics():
 
     coordinator.async_refresh = AsyncMock(side_effect=_refresh)
 
-    hass = _make_hass(coordinator)
+    entry.runtime_data = coordinator
+    hass = _make_hass()
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     coordinator.async_refresh.assert_awaited_once()
@@ -142,7 +148,8 @@ async def test_data_present_does_not_trigger_refresh():
     coordinator.data.diagnostics = {"control_status": "sun_tracking"}
     coordinator.async_refresh = AsyncMock()
 
-    hass = _make_hass(coordinator)
+    entry.runtime_data = coordinator
+    hass = _make_hass()
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     coordinator.async_refresh.assert_not_awaited()
@@ -159,7 +166,8 @@ async def test_refresh_failure_falls_back_to_marker():
     coordinator.async_refresh = AsyncMock()  # refresh runs but data stays None
     coordinator._event_buffer.snapshot.return_value = events
 
-    hass = _make_hass(coordinator)
+    entry.runtime_data = coordinator
+    hass = _make_hass()
     result = await async_get_config_entry_diagnostics(hass, entry)
 
     coordinator.async_refresh.assert_awaited_once()

--- a/tests/test_diagnostics_integration.py
+++ b/tests/test_diagnostics_integration.py
@@ -7,6 +7,7 @@ data and that numpy float64 values do not cause JSON serialization errors
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 
 import numpy as np
@@ -16,6 +17,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_SENSOR_TYPE,
+    DIAG_CACHE_KEY,
     DOMAIN,
     CoverType,
 )
@@ -93,6 +95,75 @@ async def test_diagnostics_contains_entry_id(hass: HomeAssistant) -> None:
     result = await async_get_config_entry_diagnostics(hass, entry)
     assert "identifier" in result
     assert result["identifier"] == entry.entry_id
+
+
+@pytest.mark.integration
+async def test_diagnostics_contains_real_builder_output(hass: HomeAssistant) -> None:
+    """The diagnostics sub-key must carry real builder output, not the marker.
+
+    Regression guard for the lookup bug: the download handler read the legacy
+    ``hass.data[DOMAIN]`` registry after the coordinator moved to
+    ``entry.runtime_data``, so every download returned the "coordinator missing"
+    marker. Asserting the ``meta`` block (with the integration version) is present
+    fails on the buggy lookup and passes once it resolves runtime_data.
+    """
+    entry = await _setup(hass, entry_id="diag_real_01")
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    diag = result["diagnostics"]
+    assert diag.get("status") != "unavailable", f"Got unavailable marker: {diag}"
+    assert "meta" in diag, f"Expected real builder output, got: {diag}"
+    assert diag["meta"].get("integration_version"), "meta.integration_version missing"
+
+
+@pytest.mark.integration
+async def test_diagnostics_envelope_triage_fields(hass: HomeAssistant) -> None:
+    """Envelope carries triage fields HA core's wrapper does not provide."""
+    entry = await _setup(hass, entry_id="diag_envelope_01")
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    assert "config_entry_state" in result
+    assert "generated_at" in result
+    assert "config_entry_version" in result
+    assert "config_entry_minor_version" in result
+    # generated_at must be a parseable ISO timestamp.
+    dt.datetime.fromisoformat(result["generated_at"])
+
+
+@pytest.mark.integration
+async def test_diagnostics_reload_window_serves_cached_snapshot(
+    hass: HomeAssistant,
+) -> None:
+    """With no live coordinator but a cached snapshot, serve it marked stale."""
+    entry = await _setup(hass, entry_id="diag_cache_01")
+    # Simulate the reload window: runtime_data briefly unset, cache populated.
+    entry.runtime_data = None
+    captured = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=42)
+    hass.data.setdefault(DIAG_CACHE_KEY, {})[entry.entry_id] = {
+        "diagnostics": {"meta": {"integration_version": "9.9.9"}},
+        "ts": captured,
+    }
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    diag = result["diagnostics"]
+    assert diag["meta"]["integration_version"] == "9.9.9"
+    assert diag["cache_status"]["stale"] is True
+    assert diag["cache_status"]["age_seconds"] >= 42
+
+
+@pytest.mark.integration
+async def test_diagnostics_no_coordinator_no_cache_marker(
+    hass: HomeAssistant,
+) -> None:
+    """With neither coordinator nor cache, return the marker plus entry state."""
+    entry = await _setup(hass, entry_id="diag_marker_01")
+    entry.runtime_data = None
+    hass.data.get(DIAG_CACHE_KEY, {}).pop(entry.entry_id, None)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    diag = result["diagnostics"]
+    assert diag["status"] == "unavailable"
+    assert "coordinator missing" in diag["reason"]
+    # The envelope still states whether the entry is set up.
+    assert "config_entry_state" in result
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary

The diagnostics download (`async_get_config_entry_diagnostics`) resolved the coordinator from the legacy `hass.data[DOMAIN][entry_id]` registry, but commit 8f9eb8d2 moved coordinator storage to `entry.runtime_data` and stopped writing `hass.data[DOMAIN]`. The lookup therefore returned `None` on **every** download since v2.30.x, always emitting the "coordinator missing" marker — so downloaded diagnostics were empty of decision data (only the config envelope survived). This blocked real triage in #726.

Changes:
- Resolve the coordinator from `entry.runtime_data` (the registry every platform reads).
- Cache the last-good diagnostics snapshot in `hass.data` (survives a reload) and serve it, marked stale, when `runtime_data` is briefly unset during a reload window.
- Add envelope triage fields HA core's wrapper doesn't supply: `config_entry_state`, `generated_at`, `config_entry_version`/`minor_version`.
- Regression test asserting the `diagnostics` sub-key carries real builder output (`meta.integration_version`) — the gap that let this ship — plus stale-cache fallback and marker tests.

## Testing
- ✅ Full suite: 5329 passed (ruff + black clean)

## Related Issues
Refs #753
Refs #726