### PR TITLE
fix: venetian full endpoint 0/0 and 100/100 use close/open (#755)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -564,10 +564,23 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         return replace(result, position=position, tilt=tilt, decision_trace=trace)
 
     def position_context_overrides(self, result: PipelineResult) -> dict[str, Any]:
-        """Thread the resolved tilt into ``PositionContext.tilt``."""
+        """Thread the resolved tilt into ``PositionContext.tilt``.
+
+        When BOTH axes target the same full mechanical endpoint (0/0 or
+        100/100) also set the cover-type-agnostic ``full_endpoint_target`` flag
+        so the command manager forces close_cover/open_cover instead of dropping
+        the move as same_position (issue #755). Only the venetian policy knows
+        the paired tilt, so this decision lives here.
+        """
         if result is None or result.tilt is None:
             return {}
-        return {"tilt": result.tilt}
+        overrides: dict[str, Any] = {"tilt": result.tilt}
+        if result.position == result.tilt and result.position in (
+            POSITION_CLOSED,
+            POSITION_OPEN,
+        ):
+            overrides["full_endpoint_target"] = True
+        return overrides
 
     def attach(self, **kwargs: Any) -> None:  # noqa: D401
         """Construct the dual-axis sequencer once cmd_svc is available."""

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from typing import Any
 
 from homeassistant.components.cover.const import DOMAIN as COVER_DOMAIN
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
@@ -17,6 +17,8 @@ from ...const import (
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     MAX_POSITION_RETRIES,
     POSITION_CHECK_INTERVAL_MINUTES,
+    POSITION_CLOSED,
+    POSITION_OPEN,
     POSITION_TOLERANCE_PERCENT,
 )
 from ...cover_types.base import (
@@ -958,6 +960,20 @@ class CoverCommandService:
 
         _current = self._get_current_position(entity_id)
 
+        # Full mechanical endpoint forcing (issue #755). When the owning
+        # cover-type policy (venetian) flagged this update as a paired full
+        # endpoint (0/0 or 100/100), the endpoint_use_open_close feature is on,
+        # and the cover is not actually parked at the mechanical stop (HA state
+        # not closed/open — NOT a position tolerance), bypass the same-position
+        # band and the delta/time gates so route_service_call can emit
+        # close_cover/open_cover (#697). This is cover-type-agnostic: the flag
+        # carries the decision, the manager never inspects cover type.
+        force_endpoint = (
+            context.full_endpoint_target
+            and self._endpoint_use_open_close
+            and not self._is_at_mechanical_stop(state_obj, position)
+        )
+
         # Hard kill switch — blocks ALL commands, including safety overrides and
         # force=True calls.  Must be checked before any bypass branch.
         if not self._enabled:
@@ -1011,8 +1027,16 @@ class CoverCommandService:
         # sun_just_appeared is the one exception: the sun transitioning in/out of
         # validity is a sentinel that we must re-confirm the cover position even
         # if it hasn't changed numerically.
+        #
+        # force_endpoint is the other exception (issue #755): a venetian whose
+        # desired final state is a full mechanical endpoint (0/0 or 100/100) must
+        # NOT be swallowed by this _position_tolerance carve-out — it falls
+        # through to routing so close_cover/open_cover fires. Idempotency for
+        # that case is owned by the HA-state mechanical-stop check above, not by
+        # tolerance, so the gap can't be reintroduced here.
         if (
             not context.sun_just_appeared
+            and not force_endpoint
             and _current is not None
             and (
                 _current == position
@@ -1035,7 +1059,7 @@ class CoverCommandService:
                 current_position=_current,
             )
 
-        if not context.force:
+        if not context.force and not force_endpoint:
             if not self._check_position_delta(
                 entity_id,
                 position,
@@ -1197,6 +1221,20 @@ class CoverCommandService:
         the same-position gate in apply_position (endpoint-only tolerance).
         """
         return abs(actual - target) <= self._position_tolerance
+
+    def _is_at_mechanical_stop(self, state_obj, position: int) -> bool:
+        """Return True if the cover is parked at the full mechanical stop.
+
+        Idempotency check for the issue #755 endpoint forcing: uses the HA
+        entity *state* (``closed`` for 0, ``open`` for 100) rather than position
+        tolerance, matching hardware that reports closed/open only at the exact
+        endpoint. Returns False for any non-endpoint target.
+        """
+        if position == POSITION_CLOSED:
+            return state_obj is not None and state_obj.state == STATE_CLOSED
+        if position == POSITION_OPEN:
+            return state_obj is not None and state_obj.state == STATE_OPEN
+        return False
 
     # ------------------------------------------------------------------ #
     # Target-reached notification (called by coordinator state-change handler)

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -84,3 +84,7 @@ class PositionContext:
     # dual-axis covers can run their settle+tilt sequence without leaking the
     # logic into this shared service.
     policy: Any = None
+    # Set by the owning cover-type policy (venetian) when BOTH axes target the
+    # same full mechanical endpoint (0/0 or 100/100). Cover-type-agnostic: the
+    # manager only honors the bool, never inspects cover type. Issue #755.
+    full_endpoint_target: bool = False

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -539,6 +539,38 @@ def test_position_context_overrides_returns_empty_when_no_tilt() -> None:
     assert policy.position_context_overrides(None) == {}
 
 
+@pytest.mark.parametrize(
+    ("position", "tilt", "expect_flag"),
+    [
+        (0, 0, True),  # full closed endpoint
+        (100, 100, True),  # full open endpoint
+        (0, 100, False),  # solar 0/100 — legitimate non-endpoint
+        (100, 0, False),  # carriage open, slats closed — not a full endpoint
+        (0, 50, False),  # mismatched axes
+        (40, 40, False),  # equal but mid-range, not a mechanical stop
+    ],
+)
+def test_position_context_overrides_sets_full_endpoint_flag(
+    position: int, tilt: int, expect_flag: bool
+) -> None:
+    """A paired full mechanical endpoint (0/0 or 100/100) sets the bypass flag.
+
+    Issue #755 — the venetian policy is the only place that knows both axes,
+    so it owns the "is this a full endpoint" decision and exposes it via a
+    cover-type-agnostic PositionContext flag. Tilt must still be threaded in
+    every case.
+    """
+    policy = VenetianPolicy()
+    result = MagicMock()
+    result.position = position
+    result.tilt = tilt
+
+    overrides = policy.position_context_overrides(result)
+
+    assert overrides["tilt"] == tilt  # tilt always threaded
+    assert overrides.get("full_endpoint_target", False) is expect_flag
+
+
 def test_sequencer_property_exposes_attached_sequencer() -> None:
     """The ``sequencer`` property returns whatever attach() wired in."""
     policy = VenetianPolicy()

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1090,10 +1090,14 @@ def _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance: int):
     return svc
 
 
-def _stub_state(mock_hass, current_position: int) -> None:
-    """Wire mock_hass so apply_position sees an available cover at *current_position*."""
+def _stub_state(mock_hass, current_position: int, state: str = "open") -> None:
+    """Wire mock_hass so apply_position sees an available cover at *current_position*.
+
+    ``state`` is the HA entity state string (e.g. "open", "closed") used by the
+    mechanical-stop check (issue #755).
+    """
     state_obj = MagicMock()
-    state_obj.state = "open"
+    state_obj.state = state
     state_obj.attributes = {
         "current_position": current_position,
         "supported_features": 15,
@@ -1168,6 +1172,221 @@ async def test_endpoint_zero_within_tolerance_skips_on_main_path(
     assert outcome == "skipped"
     assert reason == "same_position"
     mock_hass.services.async_call.assert_not_called()
+
+
+# --- full mechanical endpoint forcing (issue #755) ---
+
+
+def _ctx_full_endpoint(
+    *, full_endpoint_target: bool, tilt: int | None
+) -> PositionContext:
+    """PositionContext for a venetian whose desired final state is a full endpoint."""
+    return PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=10,
+        time_threshold=0,
+        special_positions=[0, 100],
+        tilt=tilt,
+        full_endpoint_target=full_endpoint_target,
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_endpoint_zero_forces_close_cover_when_not_closed(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #755 — venetian 0/0 within tolerance but not mechanically closed: SENT.
+
+    Cover reports current_position=3 and HA state "open". The full-endpoint
+    flag is set (0/0), endpoint_use_open_close is on, so the same-position band
+    must be bypassed and close_cover issued.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=3, state="open")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=3),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("close_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=0),
+        )
+
+    assert outcome == "sent"
+    assert reason == "close_cover"
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_full_endpoint_hundred_forces_open_cover_when_not_open(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #755 — venetian 100/100 within tolerance but not mechanically open: SENT."""
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=97, state="closed")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=97),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("open_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            100,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=100),
+        )
+
+    assert outcome == "sent"
+    assert reason == "open_cover"
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_solar_zero_tilt_open_does_not_force(mock_hass, logger, grace_mgr):
+    """Issue #679 regression guard — solar 0/100 is NOT a full endpoint: SKIPPED.
+
+    Position 0 with tilt 100 is a legitimate non-endpoint state. With the
+    full-endpoint flag absent, the existing same-position band still suppresses
+    the no-op move at current_position=3.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=3, state="open")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=3),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("close_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "solar",
+            _ctx_full_endpoint(full_endpoint_target=False, tilt=100),
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_endpoint_zero_already_closed_skips(mock_hass, logger, grace_mgr):
+    """Issue #755 idempotency — already mechanically closed (state closed): SKIPPED."""
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=0, state="closed")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=0),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("close_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=0),
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_endpoint_no_force_when_open_close_disabled(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #755 scoping (#507 guard) — endpoint_use_open_close off: SKIPPED.
+
+    The forcing is scoped to the endpoint_use_open_close feature. With it
+    disabled the same-position band behaves exactly as before #755.
+    """
+    svc = CoverCommandService(
+        hass=mock_hass,
+        logger=logger,
+        cover_type="cover_blind",
+        grace_mgr=grace_mgr,
+        position_tolerance=3,
+        endpoint_use_open_close=False,
+    )
+    _stub_state(mock_hass, current_position=3, state="open")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=3),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("close_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=0),
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_full_endpoint_inverted_zero_forces_open_cover(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #755 inversion lock — post-inverse 0/0 intent arrives as 100: SENT.
+
+    Inversion happens upstream of apply_position. ACP's 0/0 intent under
+    inverse_state becomes position 100; the manager adds no inversion logic and
+    simply forces open_cover because the cover is not mechanically open.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=97, state="closed")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=97),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(
+            svc,
+            "_prepare_service_call",
+            return_value=("open_cover", {"entity_id": "cover.test"}, True),
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            100,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=100),
+        )
+
+    assert outcome == "sent"
+    assert reason == "open_cover"
+    mock_hass.services.async_call.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The same-position tolerance band in apply_position was dropping the position command for full venetian endpoints (0/0 or 100/100), bypassing the configured close_cover/open_cover command. VenetianPolicy now flags full-endpoint targets via a cover-type-agnostic PositionContext flag, and apply_position honors it to force the endpoint command (scoped to endpoint_use_open_close and idempotent on HA state). Preserves existing #679 (0/100 solar tracking) and #507 (same-position tolerance) behavior.

## Testing
- ✅ 835 tests passing (tests/test_managers/test_cover_command.py + tests/test_cover_types/), including existing #507 regression tests unchanged

## Related Issues
Refs #755