### PR TITLE
fix: dispatch override on resolved-target change, not lost state edge (#756)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -322,6 +322,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._pipeline = self._build_pipeline()
         self._pipeline_result = None
 
+        # Resolved-target signature last handed to the dispatch path (issue
+        # #756). The dispatch decision compares the current cycle's resolved
+        # target against this so an override that wins the pipeline is sent even
+        # when the transient ``state_change`` edge was lost (clobbered by a long
+        # in-flight venetian settle/tilt sequence holding the update cycle).
+        self._last_dispatched_target_sig: tuple | None = None
+
         # Snapshot of the last raw config-entry options. The update listener
         # uses it to distinguish Sun Tracking-only changes from options that
         # still require a full reload.
@@ -470,6 +477,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             get_enforce_delta_at_endpoints=lambda: self._enforce_delta_at_endpoints,
             get_tilt_reset_threshold=lambda: self._venetian_tilt_reset_threshold,
             get_tilt_reset_direction=lambda: self._venetian_tilt_reset_direction,
+            # Wake the update cycle at suppression expiry so a deferred
+            # tilt-only update fires promptly (issue #756). No-op for
+            # single-axis policies (base attach ignores it).
+            schedule_refresh_after=self._schedule_refresh_after,
         )
 
         # Time window manager (start/end time checks)
@@ -506,6 +517,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # astronomical fallback the moment the grace window expires (otherwise the
         # fallback would wait for the next state-change/periodic refresh).
         self._gate_fallback_unsub: Callable[[], None] | None = None
+
+        # Issue #756: cancel handle for the single ``async_call_later`` wake that
+        # re-runs the update cycle at venetian back-rotate suppression expiry, so
+        # a tilt-only update deferred while the window was open fires promptly.
+        self._refresh_after_unsub: Callable[[], None] | None = None
 
     def _make_detector_config(self, options) -> DetectorConfig:
         """Build the manual-override DetectorConfig from raw options.
@@ -1383,20 +1399,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             released_slots
         )
 
-        # Handle types of changes
-        if self.state_change:
-            await self.async_handle_state_change(
-                state,
-                options,
-                custom_position_released_entities,
-                safety_release=safety_release,
-                template_release=template_release,
-            )
-        elif auto_expired:
-            # One or more manual overrides just timed out.  Proactively send
-            # the fresh pipeline position so covers don't linger at the
-            # user-moved position until the next solar/entity-state event.
-            await self._async_send_after_override_clear(state, options)
+        # Handle types of changes — single dispatch authority (issue #756).
+        await self._dispatch_for_cycle(
+            state,
+            options,
+            auto_expired=auto_expired,
+            custom_position_released_entities=custom_position_released_entities,
+            safety_release=safety_release,
+            template_release=template_release,
+        )
         if self.cover_state_change:
             await self.async_handle_cover_state_change(state)
         if self.first_refresh:
@@ -1665,6 +1676,88 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 sent.add(cover)
         return sent
 
+    def _resolved_target_signature(self) -> tuple | None:
+        """Signature of this cycle's resolved cover target (issue #756).
+
+        Captures everything that decides what command would be sent —
+        winning handler, final position (post interpolation / inverse-state),
+        tilt, and the safety / bypass / skip / floor-clamp flags. Comparing it
+        against ``_last_dispatched_target_sig`` lets the dispatch path fire when
+        the resolved target changes between cycles even if the transient
+        ``state_change`` edge was lost. ``None`` when no pipeline result exists.
+        """
+        result = self._pipeline_result
+        if result is None:
+            return None
+        return (
+            result.control_method.value,
+            self.state,
+            result.tilt,
+            result.is_safety,
+            result.bypass_auto_control,
+            result.skip_command,
+            result.floor_clamp_applied,
+        )
+
+    async def _dispatch_for_cycle(
+        self,
+        state: int,
+        options,
+        *,
+        auto_expired: bool,
+        custom_position_released_entities: set[str],
+        safety_release: bool,
+        template_release: bool,
+    ) -> None:
+        """Decide and run command dispatch for this update cycle (issue #756).
+
+        The single dispatch authority. Dispatch fires when either:
+          * a tracked-entity ``state_change`` edge arrived this cycle, OR
+          * the resolved cover target changed versus the last-dispatched one
+            (``target_changed``) — even with no ``state_change`` edge. This is
+            the #756 fix: a long-blocking venetian settle/tilt sequence holding
+            the update cycle could clobber the ``state_change`` flag, stranding
+            an override that had already won the pipeline. Comparing resolved
+            targets recovers the lost dispatch on the very next cycle.
+
+        The last-dispatched signature is recorded only when no cover still has a
+        pending secondary-axis (venetian tilt) command, so a deferred tilt keeps
+        being re-attempted until it actually sends.
+        """
+        current_sig = self._resolved_target_signature()
+        target_changed = (
+            self._last_dispatched_target_sig is not None
+            and current_sig is not None
+            and current_sig != self._last_dispatched_target_sig
+        )
+        if self.state_change:
+            await self.async_handle_state_change(
+                state,
+                options,
+                custom_position_released_entities,
+                safety_release=safety_release,
+                template_release=template_release,
+                target_changed=target_changed,
+            )
+        elif auto_expired:
+            # One or more manual overrides just timed out.  Proactively send
+            # the fresh pipeline position so covers don't linger at the
+            # user-moved position until the next solar/entity-state event.
+            await self._async_send_after_override_clear(state, options)
+        elif target_changed:
+            # No state_change edge this cycle, but the resolved target moved
+            # since the last dispatch — send it through the same path.
+            await self.async_handle_state_change(
+                state,
+                options,
+                custom_position_released_entities,
+                safety_release=safety_release,
+                template_release=template_release,
+                target_changed=True,
+            )
+        if not any(self._policy.has_pending_secondary_axis(e) for e in self.entities):
+            self._last_dispatched_target_sig = current_sig
+
     async def async_handle_state_change(
         self,
         state: int,
@@ -1673,6 +1766,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         *,
         safety_release: bool = False,
         template_release: bool = False,
+        target_changed: bool = False,
     ):
         """Send position commands to all covers when a tracked entity changes.
 
@@ -1754,6 +1848,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             or custom_position_sensor_triggered
             or custom_position_released
             or floor_clamp
+            or target_changed
         )
         if custom_position_released or safety_release:
             reason = "custom_position_released"
@@ -1768,6 +1863,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.logger.debug(
                 "Floor clamp active — bypassing time/position delta gates to "
                 "raise cover to floor position %s",
+                state,
+            )
+        elif target_changed and not self.state_change:
+            # Issue #756: dispatch driven purely by a resolved-target change
+            # (the lost-state-change-edge recovery), with no other force driver.
+            reason = "target_changed"
+            self.logger.debug(
+                "Resolved target changed without a state-change edge — "
+                "bypassing time/position delta gates to send position %s",
                 state,
             )
         else:
@@ -2881,6 +2985,29 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._gate_fallback_unsub = None
         await self.async_request_refresh()
 
+    @callback
+    def _schedule_refresh_after(self, secs: float) -> None:
+        """Schedule one refresh ``secs`` from now (issue #756).
+
+        Injected into the cover-type policy so a venetian tilt-only update that
+        was deferred while the back-rotate suppression window was open gets a
+        prompt wake at window expiry — instead of waiting for the next
+        unrelated tracked-entity change. Any in-flight wake is cancelled first
+        so there is never more than one outstanding.
+        """
+        if self._refresh_after_unsub is not None:
+            self._refresh_after_unsub()
+            self._refresh_after_unsub = None
+        delay = secs if secs and secs > 0 else 0
+        self._refresh_after_unsub = async_call_later(
+            self.hass, delay, self._on_refresh_after_due
+        )
+
+    async def _on_refresh_after_due(self, _now: dt.datetime) -> None:
+        """Fire when a scheduled deferred-tilt wake is due: request a refresh."""
+        self._refresh_after_unsub = None
+        await self.async_request_refresh()
+
     async def _check_sunset_window_transition(self) -> None:
         """Delegate astronomical-sunset-window transition handling to the tracker.
 
@@ -2936,6 +3063,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._gate_fallback_unsub is not None:
             self._gate_fallback_unsub()
             self._gate_fallback_unsub = None
+
+        # Cancel the deferred-tilt refresh wake (issue #756).
+        if self._refresh_after_unsub is not None:
+            self._refresh_after_unsub()
+            self._refresh_after_unsub = None
 
         self.logger.debug("Coordinator shutdown complete")
 

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -297,6 +297,21 @@ class CoverTypePolicy(ABC):
         """
         return
 
+    def has_pending_secondary_axis(
+        self,
+        entity_id: str,  # noqa: ARG002
+    ) -> bool:
+        """Return whether a secondary-axis command is deferred for this entity.
+
+        Issue #756: dual-axis covers (venetian) can defer a tilt-only update
+        when the back-rotate suppression window from the prior position
+        sequence is still open. While such a tilt is pending the coordinator
+        must not record the resolved-target signature as dispatched — otherwise
+        the deferred tilt would never be re-attempted. Single-axis cover types
+        have no second axis to defer, so the safe Liskov default is ``False``.
+        """
+        return False
+
     def is_in_tilt_suppression(
         self,
         entity_id: str,  # noqa: ARG002

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -232,6 +232,10 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         self._tilt_skip_above: int = DEFAULT_VENETIAN_TILT_SKIP_ABOVE
         self._venetian_mode: str = DEFAULT_VENETIAN_MODE
         self._last_tilt: int | None = None
+        # Coordinator callback to schedule a single refresh after N seconds,
+        # wired in attach(). Used to wake the update cycle at suppression expiry
+        # so a deferred tilt-only update fires promptly (issue #756).
+        self._schedule_refresh_after: Any | None = None
 
     def disallowed_geometry_fields(
         self,
@@ -613,6 +617,8 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             self._tilt_skip_above = int(kwargs["tilt_skip_above"])
         if "venetian_mode" in kwargs:
             self._venetian_mode = str(kwargs["venetian_mode"])
+        # Coordinator wake callback for deferred-tilt flushing (issue #756).
+        self._schedule_refresh_after = kwargs.get("schedule_refresh_after")
 
     @property
     def sequencer(self) -> DualAxisSequencer | None:
@@ -696,15 +702,37 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             return
         if self._last_tilt is None:
             return
-        if self._sequencer.is_in_suppression(entity_id):
-            return
         tilt_target = self._resolve_skip_above_tilt(current_position, self._last_tilt)
+        if self._sequencer.is_in_suppression(entity_id):
+            # Issue #756: a tilt-only update that lands inside the prior
+            # sequence's back-rotate suppression window cannot send yet. Record
+            # the deferred tilt and schedule a single wake at suppression expiry
+            # so it fires promptly — instead of being dropped until the next
+            # unrelated tracked-entity change. has_pending_secondary_axis keeps
+            # the coordinator re-attempting dispatch in the meantime.
+            self._sequencer.record_pending_tilt(
+                entity_id,
+                tilt_target=tilt_target,
+                current_position=current_position,
+                reason=reason,
+            )
+            if self._schedule_refresh_after is not None:
+                remaining = self._sequencer.suppression_remaining_seconds(entity_id)
+                if remaining is not None:
+                    self._schedule_refresh_after(remaining)
+            return
         await self._sequencer.update_tilt_only(
             entity_id,
             tilt_target=tilt_target,
             current_position=current_position,
             reason=reason,
         )
+
+    def has_pending_secondary_axis(self, entity_id: str) -> bool:
+        """Return True while a deferred tilt-only update is queued (issue #756)."""
+        if self._sequencer is None:
+            return False
+        return self._sequencer.has_pending_tilt(entity_id)
 
     async def apply_user_tilt(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -178,6 +178,11 @@ class DualAxisSequencer:
         # guard (not reason-string sniffing): the reset's own open + return
         # sends must neither re-accumulate nor re-trigger another reset.
         self._reset_in_progress: set[str] = set()
+        # Tilt-only updates deferred because the back-rotate suppression window
+        # was still open (issue #756). Keyed by entity_id; cleared the moment a
+        # tilt actually sends via ``update_tilt_only``. Drives
+        # ``has_pending_tilt`` so the coordinator keeps re-attempting dispatch.
+        self._pending_tilt: dict[str, dict] = {}
 
     # -- tilt inversion ---------------------------------------------------- #
 
@@ -277,6 +282,47 @@ class DualAxisSequencer:
         if ts is None:
             return False
         return self._seconds_since(ts) < VENETIAN_TILT_SUPPRESSION_SECONDS
+
+    def suppression_remaining_seconds(self, entity_id: str) -> float | None:
+        """Seconds until the back-rotate suppression window closes (issue #756).
+
+        Returns ``None`` when no position command has been stamped for this
+        entity (no window open), otherwise the remaining seconds clamped to
+        ``>= 0`` so a just-expired window schedules an immediate wake.
+        """
+        ts = self._suppression_at.get(entity_id)
+        if ts is None:
+            return None
+        remaining = VENETIAN_TILT_SUPPRESSION_SECONDS - self._seconds_since(ts)
+        return remaining if remaining > 0 else 0.0
+
+    # -- deferred tilt (issue #756) --------------------------------------- #
+
+    def record_pending_tilt(
+        self,
+        entity_id: str,
+        *,
+        tilt_target: int | None,
+        current_position: int | None,
+        reason: str,
+    ) -> None:
+        """Queue a tilt-only update that was deferred by the suppression window.
+
+        Issue #756: when the override resolves with the carriage already at
+        target but the slat tilt differs, ``maybe_update_tilt_only`` cannot
+        send while the prior sequence's back-rotate window is open. Recording
+        the intent lets ``has_pending_tilt`` keep the coordinator re-attempting
+        dispatch until the window closes.
+        """
+        self._pending_tilt[entity_id] = {
+            "tilt_target": tilt_target,
+            "current_position": current_position,
+            "reason": reason,
+        }
+
+    def has_pending_tilt(self, entity_id: str) -> bool:
+        """Return whether a deferred tilt-only update is queued (issue #756)."""
+        return entity_id in self._pending_tilt
 
     def is_in_suppression_with_cap(self, entity_id: str, delta: float) -> bool:
         """Suppress back-rotate drift only when the delta is plausibly motor drift.
@@ -746,6 +792,9 @@ class DualAxisSequencer:
         gates. Used by the user-tilt path (issue #684): a user explicitly
         re-requesting the current tilt is not a no-op.
         """
+        # Any tilt-only send for this entity satisfies (or supersedes) a
+        # previously deferred tilt, so clear the pending marker (issue #756).
+        self._pending_tilt.pop(entity_id, None)
         if not force and self._target_already_satisfied(entity_id, tilt_target):
             self._record_event(
                 "tilt_command_skipped",

--- a/tests/test_issue_632_daytime_gate.py
+++ b/tests/test_issue_632_daytime_gate.py
@@ -375,6 +375,7 @@ async def test_async_shutdown_cancels_gate_fallback_handle():
     coord._cancel_weather_timeout = MagicMock()
     coord._cmd_svc = MagicMock()
     coord._forecast_unsub = None
+    coord._refresh_after_unsub = None
     cancel = MagicMock()
     coord._gate_fallback_unsub = cancel
     await coord.async_shutdown()

--- a/tests/test_issue_756_override_dispatch_during_sequence.py
+++ b/tests/test_issue_756_override_dispatch_during_sequence.py
@@ -1,0 +1,341 @@
+"""Issue #756 — override dispatch during a long in-flight venetian sequence.
+
+A higher-priority ``custom_position`` override wins the pipeline immediately,
+but its command was never dispatched at the moment it won because dispatch was
+keyed on the transient ``state_change`` edge. A long-blocking venetian
+settle/tilt sequence holding the coordinator's single in-flight update cycle
+clobbered that edge, stranding the override for ~3 min until an unrelated
+tracked-entity change re-triggered the dispatch path.
+
+The fix makes dispatch robust to a lost ``state_change`` edge by dispatching on
+a *resolved-target change* between cycles: the coordinator compares the resolved
+``(control_method, state, tilt, is_safety, bypass, skip, floor_clamp)``
+signature against the last-dispatched one and routes through the existing
+``async_handle_state_change`` path when it differs — even when ``state_change``
+is False.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+# ---------------------------------------------------------------------------
+# _dispatch_for_cycle — the single dispatch authority
+# ---------------------------------------------------------------------------
+
+
+def _make_dispatch_coordinator(
+    *,
+    state_change: bool,
+    last_sig: tuple | None,
+    current_sig: tuple | None,
+    auto_expired: bool = False,
+    has_pending: bool = False,
+    entities: list[str] | None = None,
+):
+    """Build a minimal mock coordinator for _dispatch_for_cycle tests."""
+    coordinator = MagicMock()
+    coordinator.entities = entities if entities is not None else ["cover.bedroom"]
+    coordinator.state_change = state_change
+    coordinator._last_dispatched_target_sig = last_sig
+    coordinator._resolved_target_signature = MagicMock(return_value=current_sig)
+    coordinator.async_handle_state_change = AsyncMock()
+    coordinator._async_send_after_override_clear = AsyncMock()
+    coordinator._policy = MagicMock()
+    coordinator._policy.has_pending_secondary_axis = MagicMock(return_value=has_pending)
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_override_dispatches_when_target_changed_despite_lost_state_change_edge():
+    """The headline #756 race: state_change edge lost, but the resolved target
+    changed since the last dispatch, so the override must still be sent.
+    """
+    prior_sig = ("solar", 50, None, False, False, False, False)
+    winner_sig = ("custom_position", 0, 0, False, True, False, False)
+    coordinator = _make_dispatch_coordinator(
+        state_change=False,
+        last_sig=prior_sig,
+        current_sig=winner_sig,
+    )
+
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coordinator,
+        0,
+        {},
+        auto_expired=False,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+
+    coordinator.async_handle_state_change.assert_awaited_once()
+    _, kwargs = coordinator.async_handle_state_change.call_args
+    assert kwargs.get("target_changed") is True
+    coordinator._async_send_after_override_clear.assert_not_awaited()
+    # Nothing pending → the new target signature is recorded as last-dispatched.
+    assert coordinator._last_dispatched_target_sig == winner_sig
+
+
+@pytest.mark.asyncio
+async def test_no_dispatch_when_target_unchanged_and_no_state_change():
+    """Steady state: same resolved target, no state_change → no dispatch."""
+    sig = ("custom_position", 0, 0, False, True, False, False)
+    coordinator = _make_dispatch_coordinator(
+        state_change=False,
+        last_sig=sig,
+        current_sig=sig,
+    )
+
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coordinator,
+        0,
+        {},
+        auto_expired=False,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+
+    coordinator.async_handle_state_change.assert_not_awaited()
+    coordinator._async_send_after_override_clear.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_state_change_branch_still_dispatches_and_records_sig():
+    """A normal tracked-entity change routes through the state_change branch and
+    records the resolved target as last-dispatched.
+    """
+    sig = ("solar", 50, None, False, False, False, False)
+    coordinator = _make_dispatch_coordinator(
+        state_change=True,
+        last_sig=None,
+        current_sig=sig,
+    )
+
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coordinator,
+        50,
+        {},
+        auto_expired=False,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+
+    coordinator.async_handle_state_change.assert_awaited_once()
+    # target_changed is False here (no prior sig to compare against).
+    _, kwargs = coordinator.async_handle_state_change.call_args
+    assert kwargs.get("target_changed") is False
+    assert coordinator._last_dispatched_target_sig == sig
+
+
+@pytest.mark.asyncio
+async def test_auto_expired_branch_unchanged():
+    """When a manual override just expired (and no state_change), the existing
+    after-override-clear path runs — not async_handle_state_change.
+    """
+    sig = ("solar", 50, None, False, False, False, False)
+    coordinator = _make_dispatch_coordinator(
+        state_change=False,
+        last_sig=sig,
+        current_sig=sig,  # unchanged → target_changed False
+        auto_expired=True,
+    )
+
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coordinator,
+        50,
+        {},
+        auto_expired=True,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+
+    coordinator._async_send_after_override_clear.assert_awaited_once()
+    coordinator.async_handle_state_change.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pending_secondary_axis_defers_signature_recording():
+    """While a venetian tilt is still pending, the last-dispatched signature is
+    NOT recorded, so the next cycle re-evaluates target_changed and gets another
+    chance to flush the deferred tilt.
+    """
+    prior_sig = ("solar", 50, None, False, False, False, False)
+    winner_sig = ("custom_position", 0, 0, False, True, False, False)
+    coordinator = _make_dispatch_coordinator(
+        state_change=False,
+        last_sig=prior_sig,
+        current_sig=winner_sig,
+        has_pending=True,
+    )
+
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coordinator,
+        0,
+        {},
+        auto_expired=False,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+
+    coordinator.async_handle_state_change.assert_awaited_once()
+    # Pending tilt → signature stays at the prior value so target_changed fires
+    # again next cycle.
+    assert coordinator._last_dispatched_target_sig == prior_sig
+
+
+# ---------------------------------------------------------------------------
+# _resolved_target_signature
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_target_signature_none_without_pipeline_result():
+    coordinator = MagicMock()
+    coordinator._pipeline_result = None
+    assert AdaptiveDataUpdateCoordinator._resolved_target_signature(coordinator) is None
+
+
+def test_resolved_target_signature_tuple_content():
+    coordinator = MagicMock()
+    coordinator.state = 0
+    coordinator._pipeline_result = PipelineResult(
+        position=0,
+        control_method=ControlMethod.CUSTOM_POSITION,
+        reason="custom",
+        tilt=0,
+        is_safety=False,
+        bypass_auto_control=True,
+        skip_command=False,
+        floor_clamp_applied=False,
+    )
+
+    sig = AdaptiveDataUpdateCoordinator._resolved_target_signature(coordinator)
+
+    assert sig == (
+        ControlMethod.CUSTOM_POSITION.value,
+        0,  # self.state
+        0,  # tilt
+        False,  # is_safety
+        True,  # bypass_auto_control
+        False,  # skip_command
+        False,  # floor_clamp_applied
+    )
+
+
+# ---------------------------------------------------------------------------
+# async_handle_state_change — target_changed force + reason
+# ---------------------------------------------------------------------------
+
+
+def _make_state_change_coordinator(*, pipeline_result: PipelineResult):
+    coordinator = MagicMock()
+    coordinator.entities = ["cover.bedroom"]
+    coordinator.logger = MagicMock()
+    coordinator.state_change = False
+    coordinator._pipeline_result = pipeline_result
+    coordinator._pipeline_bypasses_auto_control = pipeline_result.bypass_auto_control
+    coordinator._pipeline_is_safety_handler = pipeline_result.is_safety
+    coordinator.clock_window_open = True
+    coordinator._last_state_change_entity = None
+    coordinator._custom_position_template_trigger = False
+    coordinator._check_sun_validity_transition = MagicMock(return_value=False)
+    coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
+    coordinator._build_position_context = MagicMock(return_value=MagicMock())
+    coordinator._dispatch_to_cover = AsyncMock()
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_target_changed_forces_dispatch_and_sets_reason():
+    """target_changed=True (with no other force driver) must bypass the
+    delta/time gates (force=True) and label the trace 'target_changed'.
+    """
+    result = PipelineResult(
+        position=0,
+        control_method=ControlMethod.CUSTOM_POSITION,
+        reason="custom",
+        tilt=0,
+        bypass_auto_control=True,
+    )
+    coordinator = _make_state_change_coordinator(pipeline_result=result)
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, 0, {}, target_changed=True
+    )
+
+    coordinator._build_position_context.assert_called_once()
+    _, kwargs = coordinator._build_position_context.call_args
+    assert kwargs["force"] is True
+    coordinator._dispatch_to_cover.assert_awaited_once()
+    dispatch_args = coordinator._dispatch_to_cover.call_args.args
+    assert dispatch_args[2] == "target_changed"
+
+
+# ---------------------------------------------------------------------------
+# _schedule_refresh_after — deferred-tilt wake (issue #756)
+# ---------------------------------------------------------------------------
+
+
+def _coord_for_wake():
+    coord = MagicMock()
+    coord.hass = MagicMock()
+    coord._refresh_after_unsub = None
+    return coord
+
+
+def test_schedule_refresh_after_schedules_single_wake():
+    coord = _coord_for_wake()
+    cancel = MagicMock()
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.async_call_later",
+        return_value=cancel,
+    ) as m:
+        AdaptiveDataUpdateCoordinator._schedule_refresh_after(coord, 42.0)
+    m.assert_called_once()
+    assert m.call_args.args[0] is coord.hass
+    assert m.call_args.args[1] == 42.0
+    assert coord._refresh_after_unsub is cancel
+
+
+def test_schedule_refresh_after_clamps_nonpositive_to_zero():
+    coord = _coord_for_wake()
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.async_call_later",
+        return_value=MagicMock(),
+    ) as m:
+        AdaptiveDataUpdateCoordinator._schedule_refresh_after(coord, 0)
+    assert m.call_args.args[1] == 0
+
+
+def test_schedule_refresh_after_cancels_previous():
+    coord = _coord_for_wake()
+    previous = MagicMock()
+    coord._refresh_after_unsub = previous
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.async_call_later",
+        return_value=MagicMock(),
+    ):
+        AdaptiveDataUpdateCoordinator._schedule_refresh_after(coord, 10.0)
+    previous.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_due_callback_requests_refresh():
+    coord = _coord_for_wake()
+    coord._refresh_after_unsub = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+    await AdaptiveDataUpdateCoordinator._on_refresh_after_due(coord, None)
+    assert coord._refresh_after_unsub is None
+    coord.async_request_refresh.assert_awaited_once()

--- a/tests/test_issue_756_venetian_tilt_tail.py
+++ b/tests/test_issue_756_venetian_tilt_tail.py
@@ -1,0 +1,135 @@
+"""Issue #756 — venetian deferred-tilt tail.
+
+When the override resolves with the carriage already at target (same_position)
+but the slat tilt differs, ``maybe_update_tilt_only`` early-returns while the
+back-rotate suppression window from the prior solar sequence is still open.
+Previously the tilt was simply dropped until the next unrelated state change.
+
+The fix RECORDS the deferred tilt and schedules a single refresh at suppression
+expiry so the tilt fires promptly. ``has_pending_secondary_axis`` reports True
+while the tilt is pending; the pending state clears once the tilt actually
+sends.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    VENETIAN_TILT_SUPPRESSION_SECONDS,
+)
+from custom_components.adaptive_cover_pro.cover_types import (
+    BlindPolicy,
+    VenetianPolicy,
+)
+
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
+
+_ENTITY = "cover.bedroom"
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return h
+
+
+@pytest.fixture
+def schedule_refresh_after():
+    return MagicMock()
+
+
+@pytest.fixture
+def policy(hass, schedule_refresh_after):
+    p = VenetianPolicy()
+    p.attach(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=lambda eid: 0,
+        set_commanded_position=MagicMock(),
+        position_tolerance=5,
+        is_dry_run=lambda: True,
+        schedule_refresh_after=schedule_refresh_after,
+    )
+    return p
+
+
+def test_base_policy_has_no_pending_secondary_axis():
+    """Single-axis covers never carry a deferred secondary axis (Liskov default)."""
+    assert BlindPolicy().has_pending_secondary_axis(_ENTITY) is False
+
+
+def test_unattached_venetian_has_no_pending_secondary_axis():
+    """Before attach() wires a sequencer, the venetian reports no pending axis."""
+    assert VenetianPolicy().has_pending_secondary_axis(_ENTITY) is False
+
+
+@pytest.mark.asyncio
+async def test_tilt_deferred_and_refresh_scheduled_during_suppression(
+    policy, schedule_refresh_after
+):
+    """A tilt-only update that lands inside the suppression window is recorded as
+    pending and a refresh is scheduled at suppression expiry.
+    """
+    policy._last_tilt = 0
+    # Open the back-rotate suppression window (fresh position command stamp).
+    policy._sequencer.stamp_position_command(_ENTITY)
+    assert policy._sequencer.is_in_suppression(_ENTITY)
+
+    await policy.maybe_update_tilt_only(
+        _ENTITY,
+        current_position=0,
+        context=MagicMock(),
+        reason="custom_position",
+    )
+
+    # The tilt is queued, not sent.
+    assert policy.has_pending_secondary_axis(_ENTITY) is True
+    schedule_refresh_after.assert_called_once()
+    secs = schedule_refresh_after.call_args.args[0]
+    assert 0 < secs <= VENETIAN_TILT_SUPPRESSION_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_pending_tilt_fires_and_clears_after_suppression_expires(
+    policy, schedule_refresh_after
+):
+    """Once the suppression window has elapsed, the next tilt-only attempt sends
+    the tilt and clears the pending state.
+    """
+    policy._last_tilt = 0
+    policy._sequencer.stamp_position_command(_ENTITY)
+
+    # First attempt defers (still suppressed).
+    await policy.maybe_update_tilt_only(
+        _ENTITY,
+        current_position=0,
+        context=MagicMock(),
+        reason="custom_position",
+    )
+    assert policy.has_pending_secondary_axis(_ENTITY) is True
+
+    # Backdate the suppression stamp so the window has closed.
+    policy._sequencer._suppression_at[_ENTITY] = dt.datetime.now(dt.UTC) - dt.timedelta(
+        seconds=VENETIAN_TILT_SUPPRESSION_SECONDS + 5
+    )
+    assert not policy._sequencer.is_in_suppression(_ENTITY)
+
+    await policy.maybe_update_tilt_only(
+        _ENTITY,
+        current_position=0,
+        context=MagicMock(),
+        reason="custom_position",
+    )
+
+    # Tilt sent → pending cleared.
+    assert policy.has_pending_secondary_axis(_ENTITY) is False
+
+
+def test_suppression_remaining_seconds_none_without_stamp(policy):
+    assert policy._sequencer.suppression_remaining_seconds(_ENTITY) is None

--- a/tests/test_weather_override.py
+++ b/tests/test_weather_override.py
@@ -415,6 +415,9 @@ async def test_recover_on_restart_called_before_calculate_on_first_refresh():
     coordinator.async_handle_first_refresh = AsyncMock()
     coordinator._update_solar_times_if_needed = AsyncMock(return_value=(None, None))
     coordinator._pipeline_result = MagicMock()
+    # Dispatch is exercised by its own tests; stub the extracted step so the
+    # update cycle stays awaitable here (issue #756 method extraction).
+    coordinator._dispatch_for_cycle = AsyncMock()
     hass.async_add_executor_job = (
         AsyncMock()
     )  # issue #655: prime_cache offloaded to executor
@@ -465,6 +468,9 @@ async def test_recover_on_restart_not_called_on_subsequent_refresh():
     coordinator.manager.reset_if_needed = AsyncMock(return_value=False)
     coordinator._update_solar_times_if_needed = AsyncMock(return_value=(None, None))
     coordinator._pipeline_result = MagicMock()
+    # Dispatch is exercised by its own tests; stub the extracted step so the
+    # update cycle stays awaitable here (issue #756 method extraction).
+    coordinator._dispatch_for_cycle = AsyncMock()
     hass.async_add_executor_job = (
         AsyncMock()
     )  # issue #655: prime_cache offloaded to executor


### PR DESCRIPTION
## Summary
A higher-priority `custom_position` override won the pipeline immediately but its command was never dispatched — dispatch was keyed on the transient `state_change` edge, which a long-blocking venetian settle/tilt sequence clobbered while holding the in-flight update cycle. The override (notably tilt → 0) was stranded ~3 min until an unrelated entity change re-set the edge.

**Part A** — the coordinator now dispatches on a resolved-target signature change between cycles, independent of the lost edge, routed through the existing `async_handle_state_change` gate path (no duplicated gate logic).

**Part B** — the venetian deferred-tilt tail records the pending tilt when suppression blocks it and schedules a single suppression-expiry wake, so the slats close promptly instead of on the next cadence tick.

Confirmed against the reporter's 2.30.2 diagnostics.

## Testing
- ✅ Full suite 5358 passing
- ✅ 17 new regression tests (headline lost-edge race + venetian tilt-tail)
- ✅ ruff + black clean

## Related Issues
Refs #756

https://claude.ai/code/session_019MmpegnLiPHULRxajiQJi4