### PR TITLE
fix: point awaiting-release comment at nightly dev build

### DIFF
--- a/.github/workflows/mark-awaiting-release.yml
+++ b/.github/workflows/mark-awaiting-release.yml
@@ -109,7 +109,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: num,
-                  body: `A fix for this issue has been merged and will ship in the next stable release.`,
+                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\nIt is also included in the next [nightly dev build](https://github.com/${context.repo.owner}/${context.repo.repo}/releases) (a \`.dev\` pre-release built from \`develop\` each night) if you'd like to test it early.`,
                 });
                 console.log(`Labeled issue #${num} as awaiting-release.`);
               } else if (item.state_reason === 'completed') {
@@ -132,7 +132,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: num,
-                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\n_(This issue was briefly auto-closed by a commit keyword and has been reopened to follow the normal release lifecycle.)_`,
+                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\nIt is also included in the next [nightly dev build](https://github.com/${context.repo.owner}/${context.repo.repo}/releases) (a \`.dev\` pre-release built from \`develop\` each night) if you'd like to test it early.\n\n_(This issue was briefly auto-closed by a commit keyword and has been reopened to follow the normal release lifecycle.)_`,
                 });
                 console.log(`Reopened and labeled issue #${num} as awaiting-release.`);
               } else {


### PR DESCRIPTION
## Summary
When `mark-awaiting-release.yml` comments on a fixed issue, it now also tells the reporter the fix is in the next **nightly dev build** — a `.dev<date>` pre-release built from `develop` each night and published as an installable GitHub pre-release — so they can test it before the stable release.

Updated both comment paths (open-issue and reopened-auto-closed) with a link to the Releases page.

## Testing
- ✅ YAML validated by pre-commit (check yaml, prettier)
- Behavior is GitHub-Actions-only; no unit tests apply.

## Related Issues
None — follow-up to #761.

https://claude.ai/code/session_01AtppBRQyMpfzvdnx6jshS5