### PR TITLE
feat: snap to active min/max floor past delta gate (#474)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
@@ -23,7 +23,11 @@ from homeassistant.const import ATTR_ENTITY_ID
 
 from ...const import (
     CONF_DEFAULT_HEIGHT,
+    CONF_ENABLE_MAX_POSITION,
+    CONF_ENABLE_MIN_POSITION,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
+    CONF_MAX_POSITION,
+    CONF_MIN_POSITION,
     CONF_MY_POSITION_VALUE,
     CONF_SUNSET_POS,
     DEFAULT_ENDPOINT_USE_OPEN_CLOSE,
@@ -197,6 +201,17 @@ def build_special_positions(options: dict) -> list[int]:
     guarantee byte-for-byte. Useful on mechanically coupled covers where
     commanding a full endpoint disturbs the tilt axis.
 
+    Active position limits (issue #474): when ``CONF_MIN_POSITION`` /
+    ``CONF_MAX_POSITION`` is set AND the corresponding enable flag is
+    ``False`` (always-enforced, not sun-tracking-only), the limit value is
+    added to the special set.  This lets a target pinned to the configured
+    floor or ceiling bypass the delta gate and snap to the limit — the same
+    guarantee that endpoints (0/100) and default_height already have.
+    Conservative v1 restricts the bypass to always-enforced limits because
+    ``build_special_positions`` does not receive sun_valid context; the
+    sun-tracking-only case (enable flag = True) is handled by the ordinary
+    delta comparison once the limit is actually active.
+
     """
     enforce_endpoints = options.get(
         CONF_ENFORCE_DELTA_AT_ENDPOINTS, DEFAULT_ENFORCE_DELTA_AT_ENDPOINTS
@@ -211,4 +226,14 @@ def build_special_positions(options: dict) -> list[int]:
         special_positions.append(sunset_pos)
     if my_position_value is not None:
         special_positions.append(my_position_value)
+
+    # Issue #474: always-enforced position limits bypass the delta gate.
+    min_position = options.get(CONF_MIN_POSITION)
+    if min_position is not None and options.get(CONF_ENABLE_MIN_POSITION) is False:
+        special_positions.append(min_position)
+
+    max_position = options.get(CONF_MAX_POSITION)
+    if max_position is not None and options.get(CONF_ENABLE_MAX_POSITION) is False:
+        special_positions.append(max_position)
+
     return filter_endpoint_specials(special_positions, enforce_endpoints)

--- a/tests/test_delta_position.py
+++ b/tests/test_delta_position.py
@@ -201,3 +201,79 @@ def test_button_reset_respects_delta():
 
     # This test documents the fix for Issue #10
     pass
+
+
+# ---------------------------------------------------------------------------
+# Issue #474 — snap-to-floor: active position limits bypass the delta gate
+# ---------------------------------------------------------------------------
+
+
+def test_build_special_positions_includes_active_min_floor():
+    """Active floor (always-enforced) is included in special positions (issue #474).
+
+    When enable_min_position is False the floor is always enforced regardless of
+    sun-tracking state.  A target pinned to 25 must bypass the delta gate so the
+    cover can reach its configured floor even when the delta is below min_change.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENABLE_MIN_POSITION,
+        CONF_MIN_POSITION,
+    )
+
+    options = {CONF_MIN_POSITION: 25, CONF_ENABLE_MIN_POSITION: False}
+    special = build_special_positions(options)
+    assert 25 in special
+
+
+def test_delta_bypassed_when_target_is_active_min_floor():
+    """Cover at 29%, target 25% (active floor), delta_position=5 → command sent (issue #474).
+
+    Exact symptom from the issue: the 4-point delta (29→25) is below the 5% threshold
+    so the gate suppresses it — unless the floor (25) is in the special-positions set.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENABLE_MIN_POSITION,
+        CONF_MIN_POSITION,
+    )
+
+    svc = _make_cmd_svc(current_position=29)
+    options = {CONF_MIN_POSITION: 25, CONF_ENABLE_MIN_POSITION: False}
+    special = build_special_positions(options)
+    result = svc._check_position_delta(
+        "cover.test", 25, min_change=5, special_positions=special
+    )
+    assert result is True  # floor bypass — command must reach the configured floor
+
+
+def test_build_special_positions_includes_active_max_ceiling():
+    """Active ceiling (always-enforced) is included in special positions (issue #474).
+
+    Symmetric with the floor: when enable_max_position is False the ceiling is
+    always active and a target pinned to it bypasses the delta gate.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENABLE_MAX_POSITION,
+        CONF_MAX_POSITION,
+    )
+
+    options = {CONF_MAX_POSITION: 80, CONF_ENABLE_MAX_POSITION: False}
+    special = build_special_positions(options)
+    assert 80 in special
+
+
+def test_build_special_positions_skips_min_floor_when_sun_tracking_only():
+    """Floor is NOT bypassed when enable_min_position=True (sun-tracking-only, conservative v1).
+
+    Conservative v1: only always-enforced limits bypass the delta gate.
+    When the floor only applies during sun-tracking (enable_min_position=True),
+    we cannot determine activeness without sun_valid context, so we do not add it
+    to special_positions.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_ENABLE_MIN_POSITION,
+        CONF_MIN_POSITION,
+    )
+
+    options = {CONF_MIN_POSITION: 25, CONF_ENABLE_MIN_POSITION: True}
+    special = build_special_positions(options)
+    assert 25 not in special


### PR DESCRIPTION
## Summary
A cover whose calculated position falls below its configured min floor (or above its max ceiling) could stick above/below the limit when the move was smaller than the configured `delta_position`. The position delta gate was suppressing the final approach to the floor.

This makes a target pinned to an **always-enforced** min/max position limit bypass the delta gate — the same treatment `0`, `100`, the default position, and the sunset position already receive. So a cover with min 25% and delta 5% now actually moves the last 4% down to 25% instead of stalling at 29%.

Conservative v1: only always-enforced limits (`enable_min_position`/`enable_max_position == False`) bypass the gate. The "only during sun tracking" limit mode is a follow-up.

## Testing
- ✅ 50 passed in the delta/position-limit suites (46 baseline + 4 new); full suite 5362 passed

## Related Issues
Refs #474