### PR TITLE
fix: gate custom-position auto-control bypass to safety slot (#767)

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -106,6 +106,12 @@ class CustomPositionHandler(OverrideHandler):
                         return None
                     raw = compute_raw_calculated_position(snapshot)
                     trigger = self._trigger_label(state)
+                    # Issue #767: only the priority-100 safety slot bypasses the
+                    # Automatic-Control-OFF gate. Ordinary slots respect the switch.
+                    bypass_auto_control = self._is_safety
+                    bypass_note = (
+                        " [bypasses automatic control]" if bypass_auto_control else ""
+                    )
                     # "Use My" path: route through the cover's hardware-stored My preset.
                     # my_position_value acts as both the target and the reason annotation.
                     # min_mode is ignored — My is hardware-pinned; floor semantics don't apply.
@@ -115,13 +121,13 @@ class CustomPositionHandler(OverrideHandler):
                             position=pos,
                             tilt=self._tilt,
                             use_my_position=True,
-                            bypass_auto_control=True,
+                            bypass_auto_control=bypass_auto_control,
                             is_safety=self._is_safety,
                             control_method=ControlMethod.CUSTOM_POSITION,
                             reason=(
                                 f"custom position #{self._slot} active ({trigger})"
                                 f" — use My position ({pos}%)"
-                                " [bypasses automatic control]"
+                                f"{bypass_note}"
                             ),
                             raw_calculated_position=raw,
                             custom_position_active_slot=self._slot,
@@ -134,13 +140,13 @@ class CustomPositionHandler(OverrideHandler):
                     return PipelineResult(
                         position=pos,
                         tilt=self._tilt,
-                        bypass_auto_control=True,
+                        bypass_auto_control=bypass_auto_control,
                         is_safety=self._is_safety,
                         control_method=ControlMethod.CUSTOM_POSITION,
                         reason=(
                             f"custom position #{self._slot} active ({trigger})"
                             f" — position {pos}%"
-                            " [bypasses automatic control]"
+                            f"{bypass_note}"
                         ),
                         raw_calculated_position=raw,
                         custom_position_active_slot=self._slot,

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -79,14 +79,27 @@ from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 # ---------------------------------------------------------------------------
 
 
-def _make_pipeline_result(bypass: bool) -> PipelineResult:
-    """SOLAR result, or a safety-priority custom-position result when bypass=True."""
+def _make_pipeline_result(
+    bypass: bool, *, is_safety: bool | None = None
+) -> PipelineResult:
+    """SOLAR result, or a custom-position result when it bypasses or is safety.
+
+    ``is_safety`` defaults to ``bypass`` so existing call sites keep modeling a
+    safety-priority custom position (both flags set together). Pass it
+    explicitly to decouple the two — e.g. a non-safety slot (issue #767) that
+    bypasses nothing, or a safety target that does not set ``bypass``.
+    """
+    if is_safety is None:
+        is_safety = bypass
+    is_custom = bypass or is_safety
     return PipelineResult(
         position=50,
-        control_method=ControlMethod.CUSTOM_POSITION if bypass else ControlMethod.SOLAR,
-        reason="custom position #5 active" if bypass else "solar",
+        control_method=(
+            ControlMethod.CUSTOM_POSITION if is_custom else ControlMethod.SOLAR
+        ),
+        reason="custom position #5 active" if is_custom else "solar",
         bypass_auto_control=bypass,
-        is_safety=bypass,
+        is_safety=is_safety,
     )
 
 
@@ -197,6 +210,24 @@ async def _trigger_manual_override_expiry(coord):
 
 async def _trigger_state_change_safety_custom_position(coord):
     coord._pipeline_result = _make_pipeline_result(bypass=True)
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.is_active = True
+    coord._check_sun_validity_transition = MagicMock(return_value=False)
+    coord.state_change = True
+    coord._last_state_change_entity = None
+    coord._custom_position_template_trigger = False
+    await coord.async_handle_state_change(50, {})
+
+
+async def _trigger_state_change_non_safety_custom_position(coord):
+    """Trigger: a default-priority (77) custom position is the active winner.
+
+    Issue #767: a non-safety custom position must respect Automatic Control.
+    With no fresh sensor edge and is_safety=False, the coordinator must NOT
+    force the command through when automatic_control=False — the slot's
+    bypass_auto_control flag does not earn it coordinator-level force treatment.
+    """
+    coord._pipeline_result = _make_pipeline_result(bypass=True, is_safety=False)
     coord._time_mgr = MagicMock()
     coord._time_mgr.is_active = True
     coord._check_sun_validity_transition = MagicMock(return_value=False)
@@ -420,6 +451,17 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
         is_safety_target=True,
         setup=lambda _: None,
         trigger=_trigger_state_change_safety_custom_position,
+    ),
+    MatrixCase(
+        # Issue #767: a default-priority (77) custom position is non-safety.
+        # When automatic_control=False and no fresh sensor edge fired, the
+        # coordinator must NOT force it through and must NOT tag it as a safety
+        # target — it follows the Automatic Control switch like any other slot.
+        id="state_change_non_safety_custom_position",
+        is_safety_bypass=False,
+        is_safety_target=False,
+        setup=lambda _: None,
+        trigger=_trigger_state_change_non_safety_custom_position,
     ),
     MatrixCase(
         id="state_change_weather_bypass",

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -454,61 +454,110 @@ class TestMinimumPositionMode:
 
 
 # ---------------------------------------------------------------------------
-# bypass_auto_control — custom positions always bypass delta gates
+# bypass_auto_control — gated on safety priority (issue #767)
 # ---------------------------------------------------------------------------
 
 
 class TestBypassAutoControl:
-    """CustomPositionHandler must set bypass_auto_control=True on every active result."""
+    """CustomPositionHandler gates bypass_auto_control on safety priority (#767).
 
-    def test_bypass_flag_set_normal_path(self) -> None:
-        """Normal position path sets bypass_auto_control=True."""
+    Only a priority-100 (safety) slot bypasses Automatic Control; a
+    default-priority (77) slot respects the switch like any other handler.
+    """
+
+    def test_no_bypass_normal_path_non_safety(self) -> None:
+        """A default-priority (77) slot does NOT bypass automatic control."""
         snapshot = make_snapshot(
-            custom_position_sensors=[_make_state(_ENTITY, True, 50, 77, False, False)]
+            custom_position_sensors=[
+                _make_state(_ENTITY, True, 50, _DEFAULT_PRIORITY, False, False)
+            ]
         )
         result = _handler(position=50).evaluate(snapshot)
+        assert result is not None
+        assert result.bypass_auto_control is False
+
+    def test_bypass_set_normal_path_safety(self) -> None:
+        """A safety-priority (100) slot bypasses automatic control."""
+        snapshot = make_snapshot(
+            custom_position_sensors=[
+                _make_state(
+                    _ENTITY, True, 50, CUSTOM_POSITION_SAFETY_PRIORITY, False, False
+                )
+            ]
+        )
+        result = _handler(
+            position=50, priority=CUSTOM_POSITION_SAFETY_PRIORITY
+        ).evaluate(snapshot)
         assert result is not None
         assert result.bypass_auto_control is True
 
     def test_bypass_flag_min_mode_defers(self) -> None:
         """Min-mode handler defers (returns None) — bypass is moot since no
         result is produced. The floor-clamp composition pass in the registry
-        carries the bypass forward via the lower-priority winner.
+        carries the winner forward via the lower-priority handler.
         """
         snapshot = make_snapshot(
-            custom_position_sensors=[_make_state(_ENTITY, True, 30, 77, True, False)],
+            custom_position_sensors=[
+                _make_state(_ENTITY, True, 30, _DEFAULT_PRIORITY, True, False)
+            ],
             calculate_percentage_return=50.0,
         )
         result = _handler(position=30).evaluate(snapshot)
         assert result is None
 
-    def test_bypass_flag_set_use_my_path(self) -> None:
-        """Use-My path sets bypass_auto_control=True."""
+    def test_no_bypass_use_my_path_non_safety(self) -> None:
+        """The use-My path of a default-priority slot does NOT bypass automatic control."""
         snapshot = make_snapshot(
-            custom_position_sensors=[_make_state(_ENTITY, True, 50, 77, False, True)],
+            custom_position_sensors=[
+                _make_state(_ENTITY, True, 50, _DEFAULT_PRIORITY, False, True)
+            ],
             my_position_value=30,
         )
         result = _handler(position=50).evaluate(snapshot)
         assert result is not None
         assert result.use_my_position is True
+        assert result.bypass_auto_control is False
+
+    def test_bypass_set_use_my_path_safety(self) -> None:
+        """The use-My path of a safety-priority slot bypasses automatic control."""
+        snapshot = make_snapshot(
+            custom_position_sensors=[
+                _make_state(
+                    _ENTITY, True, 50, CUSTOM_POSITION_SAFETY_PRIORITY, False, True
+                )
+            ],
+            my_position_value=30,
+        )
+        result = _handler(
+            position=50, priority=CUSTOM_POSITION_SAFETY_PRIORITY
+        ).evaluate(snapshot)
+        assert result is not None
+        assert result.use_my_position is True
         assert result.bypass_auto_control is True
 
-    def test_reason_includes_bypass_text_normal_path(self) -> None:
-        """Reason string includes '[bypasses automatic control]' on normal path."""
+    def test_reason_omits_bypass_text_non_safety(self) -> None:
+        """A default-priority slot reason omits the bypass annotation."""
         snapshot = make_snapshot(
-            custom_position_sensors=[_make_state(_ENTITY, True, 50, 77, False, False)]
+            custom_position_sensors=[
+                _make_state(_ENTITY, True, 50, _DEFAULT_PRIORITY, False, False)
+            ]
         )
         result = _handler(position=50).evaluate(snapshot)
         assert result is not None
-        assert "[bypasses automatic control]" in result.reason
+        assert "[bypasses automatic control]" not in result.reason
 
-    def test_reason_includes_bypass_text_use_my_path(self) -> None:
-        """Reason string includes '[bypasses automatic control]' on use-My path."""
+    def test_reason_includes_bypass_text_safety(self) -> None:
+        """A safety-priority slot reason includes '[bypasses automatic control]'."""
         snapshot = make_snapshot(
-            custom_position_sensors=[_make_state(_ENTITY, True, 50, 77, False, True)],
-            my_position_value=30,
+            custom_position_sensors=[
+                _make_state(
+                    _ENTITY, True, 50, CUSTOM_POSITION_SAFETY_PRIORITY, False, False
+                )
+            ]
         )
-        result = _handler(position=50).evaluate(snapshot)
+        result = _handler(
+            position=50, priority=CUSTOM_POSITION_SAFETY_PRIORITY
+        ).evaluate(snapshot)
         assert result is not None
         assert "[bypasses automatic control]" in result.reason
 

--- a/tests/test_safety_override_bypass.py
+++ b/tests/test_safety_override_bypass.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 
-from custom_components.adaptive_cover_pro.const import DEFAULT_CUSTOM_POSITION_PRIORITY
+from custom_components.adaptive_cover_pro.const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+)
 from custom_components.adaptive_cover_pro.const import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     DefaultHandler,
@@ -550,23 +553,35 @@ _CP_ENTITY = "binary_sensor.cp_scene"
 
 
 class TestCustomPositionBypass:
-    """CustomPositionHandler must set bypass_auto_control=True unconditionally."""
+    """CustomPositionHandler gates bypass_auto_control on safety priority (#767).
 
-    def _handler(self, position: int = 50) -> CustomPositionHandler:
+    Only a priority-100 (safety) slot bypasses Automatic Control; a
+    default-priority (77) slot follows the switch like any other handler.
+    """
+
+    def _handler(
+        self,
+        position: int = 50,
+        priority: int = CUSTOM_POSITION_SAFETY_PRIORITY,
+    ) -> CustomPositionHandler:
         return CustomPositionHandler(
             slot=1,
             position=position,
-            priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+            priority=priority,
         )
 
-    def _snapshot_on(self, position: int = 50) -> object:
+    def _snapshot_on(
+        self,
+        position: int = 50,
+        priority: int = CUSTOM_POSITION_SAFETY_PRIORITY,
+    ) -> object:
         return make_snapshot(
             custom_position_sensors=[
                 CustomPositionSensorState(
                     entity_ids=(_CP_ENTITY,),
                     is_on=True,
                     position=position,
-                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+                    priority=priority,
                     min_mode=False,
                     use_my=False,
                     slot=1,
@@ -576,16 +591,32 @@ class TestCustomPositionBypass:
         )
 
     def test_bypass_flag_set(self) -> None:
-        """Handler result has bypass_auto_control=True when sensor is on."""
+        """A safety-priority slot sets bypass_auto_control=True when sensor is on."""
         result = self._handler().evaluate(self._snapshot_on())
         assert result is not None
         assert result.bypass_auto_control is True
 
+    def test_non_safety_slot_does_not_bypass(self) -> None:
+        """A default-priority (77) slot does NOT bypass automatic control (#767)."""
+        result = self._handler(priority=DEFAULT_CUSTOM_POSITION_PRIORITY).evaluate(
+            self._snapshot_on(priority=DEFAULT_CUSTOM_POSITION_PRIORITY)
+        )
+        assert result is not None
+        assert result.bypass_auto_control is False
+
     def test_reason_includes_bypass_text(self) -> None:
-        """Reason string includes '[bypasses automatic control]' when sensor is on."""
+        """Safety-slot reason includes '[bypasses automatic control]' when sensor is on."""
         result = self._handler().evaluate(self._snapshot_on())
         assert result is not None
         assert "[bypasses automatic control]" in result.reason
+
+    def test_non_safety_reason_omits_bypass_text(self) -> None:
+        """A default-priority slot reason omits the bypass annotation (#767)."""
+        result = self._handler(priority=DEFAULT_CUSTOM_POSITION_PRIORITY).evaluate(
+            self._snapshot_on(priority=DEFAULT_CUSTOM_POSITION_PRIORITY)
+        )
+        assert result is not None
+        assert "[bypasses automatic control]" not in result.reason
 
     def test_sensor_off_returns_none(self) -> None:
         """No result when sensor is off — bypass flag irrelevant."""

--- a/tests/test_safety_priority_custom_position.py
+++ b/tests/test_safety_priority_custom_position.py
@@ -13,13 +13,18 @@ force-override sensor scenarios:
 - reason/diagnostics reflect the active sensors
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
     CUSTOM_POSITION_SAFETY_PRIORITY,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
     ControlMethod,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
 )
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
     CustomPositionHandler,
@@ -106,6 +111,88 @@ def _safety_registry(position: int = 90) -> PipelineRegistry:
             ManualOverrideHandler(),
             DefaultHandler(),
         ]
+    )
+
+
+def _non_safety_state(
+    is_on: bool,
+    *,
+    position: int = 90,
+    active: tuple[str, ...] = (),
+    use_my: bool = False,
+) -> CustomPositionSensorState:
+    """Pre-built slot-5 state at the default (non-safety) priority 77."""
+    return CustomPositionSensorState(
+        entity_ids=("binary_sensor.rain", "binary_sensor.wind"),
+        is_on=is_on,
+        position=position,
+        priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+        min_mode=False,
+        use_my=use_my,
+        slot=_SLOT,
+        active_entity_ids=active,
+    )
+
+
+def _non_safety_registry(position: int = 90) -> PipelineRegistry:
+    return PipelineRegistry(
+        [
+            CustomPositionHandler(
+                slot=_SLOT,
+                position=position,
+                priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+            ),
+            ManualOverrideHandler(),
+            DefaultHandler(),
+        ]
+    )
+
+
+def _command_service() -> tuple[CoverCommandService, MagicMock]:
+    """Build a real CoverCommandService over a mock hass (mirrors the force-gate suite)."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+    )
+    svc._enabled = True
+    return svc, hass
+
+
+def _gate_context(result, *, auto_control: bool = False) -> PositionContext:
+    """PositionContext mirroring how the coordinator forwards a pipeline result.
+
+    The two auto-control bypass channels (is_safety / bypass_auto_control) are
+    sourced straight from the pipeline result so the service gate sees exactly
+    what the handler produced.
+    """
+    return PositionContext(
+        auto_control=auto_control,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=1,
+        time_threshold=0,
+        special_positions=[0, 100],
+        force=True,
+        is_safety=result.is_safety,
+        bypass_auto_control=result.bypass_auto_control,
+    )
+
+
+def _patch_caps():
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value={
+            "has_set_position": True,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
     )
 
 
@@ -312,6 +399,100 @@ def test_decision_trace_names_safety_slot():
     matched = [s for s in result.decision_trace if s.matched]
     assert len(matched) == 1
     assert matched[0].handler == f"custom_position_{_SLOT}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #767: only the priority-100 safety slot bypasses Automatic-Control-OFF
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_non_safety_slot_does_not_bypass_auto_control():
+    """A default-priority (77) slot wins but must NOT bypass automatic control."""
+    registry = _non_safety_registry(position=90)
+    snapshot = make_snapshot(
+        custom_position_sensors=[
+            _non_safety_state(True, active=("binary_sensor.rain",))
+        ],
+    )
+
+    result = registry.evaluate(snapshot)
+
+    assert result.control_method == ControlMethod.CUSTOM_POSITION
+    assert result.position == 90
+    assert result.is_safety is False
+    assert result.bypass_auto_control is False
+    assert "[bypasses automatic control]" not in result.reason
+
+
+@pytest.mark.unit
+def test_use_my_non_safety_slot_does_not_bypass_auto_control():
+    """The use-My branch of a non-safety slot must also respect automatic control."""
+    registry = _non_safety_registry(position=90)
+    snapshot = make_snapshot(
+        custom_position_sensors=[
+            _non_safety_state(True, use_my=True, active=("binary_sensor.rain",))
+        ],
+        my_position_value=42,
+    )
+
+    result = registry.evaluate(snapshot)
+
+    assert result.use_my_position is True
+    assert result.is_safety is False
+    assert result.bypass_auto_control is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_non_safety_slot_skipped_by_auto_control_gate():
+    """End-to-end: a non-safety slot is blocked by the auto-control-off gate."""
+    registry = _non_safety_registry(position=90)
+    snapshot = make_snapshot(
+        custom_position_sensors=[
+            _non_safety_state(True, active=("binary_sensor.rain",))
+        ],
+    )
+    result = registry.evaluate(snapshot)
+
+    svc, hass = _command_service()
+    with _patch_caps():
+        outcome, detail = await svc.apply_position(
+            "cover.test",
+            result.position,
+            "custom_position",
+            _gate_context(result),
+        )
+
+    assert outcome == "skipped"
+    assert detail == "auto_control_off"
+    hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_safety_slot_still_bypasses_auto_control_gate():
+    """Regression guard: the priority-100 safety slot still bypasses the gate."""
+    registry = _safety_registry(position=0)
+    snapshot = make_snapshot(
+        custom_position_sensors=[
+            _safety_state(True, position=0, active=("binary_sensor.rain",))
+        ],
+    )
+    result = registry.evaluate(snapshot)
+    assert result.bypass_auto_control is True
+
+    svc, hass = _command_service()
+    with _patch_caps(), patch.object(svc, "_get_current_position", return_value=50):
+        outcome, _detail = await svc.apply_position(
+            "cover.test",
+            0,
+            "custom_position",
+            _gate_context(result),
+        )
+
+    assert outcome == "sent"
+    hass.services.async_call.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Non-safety custom-position slots (priority <100) hardcoded `bypass_auto_control=True`, so they opened covers even when Automatic Control was OFF. The #711 advice to lower the slot priority below 100 did not help because the bypass was not priority-gated. The fix derives the bypass from `_is_safety`, so only the priority-100 safety slot bypasses the auto-control gate; ordinary slots are now skipped with reason `auto_control_off`. Confirmed against the reporter's attached diagnostics.

Note: this is a behavior change. Non-safety slots will now stop firing while Automatic Control is OFF. Users who want a slot to always act should move it to priority 100.

## Testing
- ✅ 5371 tests passing

## Related Issues
Refs #767