### PR TITLE
fix: make cover Name field optional in config flow

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import selector
 
 from .const import (
+    ADAPTIVE_NAME_PREFIX,
     BLANK_TIME,
     BLIND_SPOT_ELEV_MODE_ABOVE,
     BLIND_SPOT_SLOTS,
@@ -230,7 +231,7 @@ def _geometry_wiki_link(sensor_type: str | None) -> str:
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Required("name"): selector.TextSelector(),
+        vol.Optional("name"): selector.TextSelector(),
         vol.Optional(CONF_MODE): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=SENSOR_TYPE_MENU, translation_key="mode"
@@ -3238,7 +3239,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                             or entity_entry.name
                             or first_entity_id.split(".")[-1].replace("_", " ").title()
                         )
-                        self.config["name"] = f"Adaptive {entity_name}"
+                        self.config["name"] = f"{ADAPTIVE_NAME_PREFIX} {entity_name}"
 
             entity_ids = self.config.get(CONF_ENTITIES, [])
             devices = await _get_devices_from_entities(self.hass, entity_ids)
@@ -3691,6 +3692,16 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         if self.type_blind is None:
             msg = "type_blind must be set before calling async_step_update"
             raise ValueError(msg)
+
+        # "name" is Optional in CONFIG_SCHEMA (#771) — the cover_entities Pass 1
+        # auto-fill at the top of this class only runs when at least one entity
+        # is selected, so a user who submits zero entities reaches here with no
+        # name ever having been filled in. Building Profiles keep their own
+        # Required name field and never hit this path.
+        if get_policy(self.type_blind).controls_cover and not self.config.get("name"):
+            self.config["name"] = (
+                f"{ADAPTIVE_NAME_PREFIX} {_cover_type_label(self.type_blind)}"
+            )
 
         if self.config.pop("_title_is_device_name", False):
             title = self.config["name"]

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -91,6 +91,11 @@ CONF_BUILDING_PROFILE_ID = (
 # own value and are skipped by profile propagation. Absent = no overrides.
 CONF_PROFILE_SENSOR_OVERRIDES = "profile_sensor_overrides"
 
+# Default name prefix used by the config flow when auto-naming a cover from its
+# entity's friendly name (no linked device available) — see config_flow.py's
+# cover_entities auto-fill and async_step_update finalization fallback (#771).
+ADAPTIVE_NAME_PREFIX = "Adaptive"
+
 
 # =============================================================================
 # 3. Window / Vertical-Blind Geometry

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -14,6 +14,9 @@
         "data": {
           "name": "Name",
           "mode": "Art der Jalousie"
+        },
+        "data_description": {
+          "name": "Optional. Leer lassen und die Integration füllt den Namen automatisch aus: den Namen des verknüpften Geräts, falls eines angeschlossen ist, oder den Anzeigenamen der Beschattungsentität mit dem Präfix \"Adaptive\"."
         }
       },
       "cover_entities": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -14,6 +14,9 @@
         "data": {
           "name": "Name",
           "mode": "Type of blind"
+        },
+        "data_description": {
+          "name": "Optional. Leave blank and the integration fills it in automatically: the linked device's name if one is attached, otherwise the cover entity's friendly name with an \"Adaptive\" prefix."
         }
       },
       "cover_entities": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -14,6 +14,9 @@
         "data": {
           "name": "Nom",
           "mode": "Type de store"
+        },
+        "data_description": {
+          "name": "Optionnel. Laissez vide et l'intégration remplira automatiquement : le nom de l'appareil associé s'il y en a un, sinon le nom convivial de l'entité store avec le préfixe \"Adaptive\"."
         }
       },
       "cover_entities": {

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -2002,6 +2002,25 @@ async def test_options_flow_venetian_geometry_saves_mode(hass: HomeAssistant) ->
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
+async def test_create_new_schema_name_field_is_optional() -> None:
+    """The "name" key in CONFIG_SCHEMA must be Optional, not Required (#771).
+
+    ha-form enforces a voluptuous ``Required`` marker client-side and blocks
+    submission of a blank text field before the request ever reaches the
+    flow handler, so the existing device/entity-name auto-fill logic can
+    never run. The field must be ``Optional`` so a blank "name" can reach
+    Python and trigger the auto-fill.
+    """
+    import voluptuous as vol
+
+    from custom_components.adaptive_cover_pro.config_flow import CONFIG_SCHEMA
+
+    marker = next(k for k in CONFIG_SCHEMA.schema if k == "name")
+    assert isinstance(marker, vol.Optional)
+    assert not isinstance(marker, vol.Required)
+
+
 def _register_cover_with_device(
     hass: HomeAssistant,
     *,
@@ -2207,6 +2226,58 @@ async def test_create_flow_user_typed_name_overrides_device_name(
     # User name wins — device name is ignored
     assert entry.title == "Vertical Blind My Cover"
     assert entry.data["name"] == "My Cover"
+
+
+@pytest.mark.integration
+async def test_create_flow_blank_name_no_entities_gets_fallback_name(
+    hass: HomeAssistant,
+) -> None:
+    """Blank name + zero cover entities selected must not reach finalization
+    with an empty name (#771).
+
+    The auto-fill in ``cover_entities`` Pass 1 only runs when at least one
+    entity is selected; a user can legitimately submit zero entities (add the
+    cover entity later via Configure). Now that "name" is Optional, this
+    combination is reachable via the real UI and must still produce a sane
+    non-empty fallback name/title instead of the malformed
+    ``"Vertical Blind "`` (trailing space) title and empty
+    ``entry.data["name"]``.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"name": "", CONF_MODE: CoverType.BLIND}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "quick_setup"}
+    )
+    assert result["step_id"] == "cover_entities"
+
+    # Zero entities selected — auto-fill in Pass 1 never runs.
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    # No entities → no devices to discover → proceeds straight to geometry.
+    assert result["step_id"] == "geometry"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _VERTICAL_GEOMETRY
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _SUN_TRACKING
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _POSITION
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.data["name"]
+    assert entry.title != "Vertical Blind "
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The Name field was incorrectly marked as required in the config-flow schema, which blocked the documented leave-blank auto-fill behavior. I've changed it to optional so the existing auto-fill logic runs: it sets the cover name to the device name, or the entity's friendly name prefixed with "Adaptive". Added a fallback that sets a sensible name if left blank with no cover entities selected. Added dialog hints (data_description) under the Name field in English, German, and French explaining the behavior, so the UI now matches the wiki documentation.

## Testing
- ✅ 420 config-flow tests passing (incl. 2 new regression tests for schema marker and blank-name fallback)
- ✅ 38 translation parity tests passing

## Related Issues
Refs #771