### PR TITLE
feat: add 'Select all covers' toggle to sync flow (#772)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -136,6 +136,7 @@ from .const import (
     CONF_SUNSET_POS,
     CONF_SUNSET_TIME_ENTITY,
     CONF_SUNSET_TILT,
+    CONF_SYNC_SELECT_ALL,
     CONF_TEMP_ENTITY,
     CONF_TEMP_HIGH,
     CONF_TEMP_LOW,
@@ -4457,7 +4458,16 @@ class OptionsFlowHandler(OptionsFlow):
         ]
 
         if user_input is not None:
-            targets = user_input.get("target_entries", [])
+            # "Select all covers" (#772) turns target_entries into an exclude
+            # list: every same-type other cover is targeted except those
+            # checked. Off, target_entries is the usual explicit include list.
+            if user_input.get(CONF_SYNC_SELECT_ALL):
+                excluded = set(user_input.get("target_entries", []))
+                targets = [
+                    e.entry_id for e in other_entries if e.entry_id not in excluded
+                ]
+            else:
+                targets = user_input.get("target_entries", [])
             if not targets:
                 return await self.async_step_init()
             selected = user_input.get("sync_categories", [])
@@ -4480,6 +4490,9 @@ class OptionsFlowHandler(OptionsFlow):
                             ],
                         )
                     ),
+                    vol.Optional(
+                        CONF_SYNC_SELECT_ALL, default=False
+                    ): selector.BooleanSelector(),
                     vol.Required(
                         "sync_categories", default=[]
                     ): selector.SelectSelector(

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -90,6 +90,11 @@ CONF_BUILDING_PROFILE_ID = (
 # model). Keys NOT in this list track the profile; keys in it keep the cover's
 # own value and are skipped by profile propagation. Absent = no overrides.
 CONF_PROFILE_SENSOR_OVERRIDES = "profile_sensor_overrides"
+# Transient OptionsFlow field for the "Copy to Other Covers" sync step (#772).
+# Never persisted to config_entry.options. When True, the sync targets every
+# same-type other cover except those checked in ``target_entries`` (the
+# multi-select becomes an exclude list instead of an include list).
+CONF_SYNC_SELECT_ALL = "select_all_targets"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1337,7 +1337,12 @@
         "description": "Wählen Sie, auf welche Behänge Sie Einstellungen kopieren möchten, und welche Kategorien synchronisiert werden sollen. Nur ausgewählte Kategorien werden auf Zielbehängen überschrieben.\n\n⚠️ **Azimut ist immer ausgeschlossen** – jeder Behang behält seine eigene Fensterorientierung.",
         "data": {
           "target_entries": "Zielleuchten",
-          "sync_categories": "Zu synchronisierende Kategorien"
+          "sync_categories": "Zu synchronisierende Kategorien",
+          "select_all_targets": "Alle Beschattungen auswählen"
+        },
+        "data_description": {
+          "target_entries": "Beschattungen zum Synchronisieren. Wenn 'Alle Beschattungen auswählen' aus ist, erhalten diese Beschattungen die Einstellungen. Wenn es an ist, sind diese Beschattungen stattdessen von der Synchronisierung ausgeschlossen.",
+          "select_all_targets": "Wenn aktiviert, werden alle anderen Beschattungen dieses Typs synchronisiert; jede oben/unten ausgewählte Beschattung wird aus der Synchronisierung entfernt."
         }
       },
       "summary": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1389,7 +1389,12 @@
         "description": "Choose which covers to copy settings to and which categories to sync. Only selected categories will be overwritten on target covers.\n\n⚠️ **Azimuth is always excluded** — each cover keeps its own window orientation.",
         "data": {
           "target_entries": "Target covers",
+          "select_all_targets": "Select all covers",
           "sync_categories": "Categories to sync"
+        },
+        "data_description": {
+          "target_entries": "Covers to sync to. When 'Select all covers' is off, these are the covers that receive the settings. When it's on, these covers are excluded from the sync instead.",
+          "select_all_targets": "When enabled, all other covers of this type are synced; any cover selected above/below is removed from the sync."
         }
       },
       "summary": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1337,7 +1337,12 @@
         "description": "Choisissez les stores vers lesquels copier les paramètres et les catégories à synchroniser. Seules les catégories sélectionnées seront écrasées sur les stores cibles.\n\n⚠️ **L'azimut est toujours exclu** — chaque store conserve son propre azimut de fenêtre.",
         "data": {
           "target_entries": "Stores cibles",
-          "sync_categories": "Catégories à synchroniser"
+          "sync_categories": "Catégories à synchroniser",
+          "select_all_targets": "Sélectionner toutes les protections"
+        },
+        "data_description": {
+          "target_entries": "Protections à synchroniser. Quand « Sélectionner toutes les protections » est désactivé, ces protections reçoivent les paramètres. Quand c'est activé, elles sont exclues de la synchronisation.",
+          "select_all_targets": "Quand activée, toutes les autres protections de ce type sont synchronisées ; les protections sélectionnées ci-dessus/ci-dessous en sont exclues."
         }
       },
       "summary": {

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -880,6 +880,177 @@ async def test_options_flow_sync_empty_selection_no_abort(hass: HomeAssistant) -
 
 
 # ---------------------------------------------------------------------------
+# Phase 2d-1: Options flow — sync "Select all covers" toggle (issue #772)
+# ---------------------------------------------------------------------------
+
+
+async def _setup_sync_select_all_entries(
+    hass: HomeAssistant,
+    *,
+    source_options: dict | None = None,
+    target1_options: dict | None = None,
+    target2_options: dict | None = None,
+):
+    """Create a source + two same-type target entries for select-all sync tests.
+
+    Only the source is fully set up (options flow requires a loaded entry);
+    targets only need to be registered so they show up in ``other_entries``
+    and can receive ``async_update_entry`` calls.
+    """
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    source = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Sync Select All Source", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(source_options or VERTICAL_OPTIONS),
+        entry_id="sync_sel_all_src",
+        title="Sync Select All Source",
+    )
+    source.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(source.entry_id)
+        await hass.async_block_till_done()
+
+    target1 = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Target One", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(target1_options or VERTICAL_OPTIONS),
+        entry_id="sync_sel_all_t1",
+        title="Target One",
+    )
+    target1.add_to_hass(hass)
+
+    target2 = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Target Two", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(target2_options or VERTICAL_OPTIONS),
+        entry_id="sync_sel_all_t2",
+        title="Target Two",
+    )
+    target2.add_to_hass(hass)
+
+    return source, target1, target2
+
+
+async def _navigate_to_sync_step(hass: HomeAssistant, entry_id: str):
+    """Init the options flow for ``entry_id`` and navigate to the sync step."""
+    result = await hass.config_entries.options.async_init(entry_id)
+    if result["type"] == "menu":
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "sync"}
+        )
+    return result
+
+
+@pytest.mark.integration
+async def test_options_flow_sync_select_all_targets_all_same_type(
+    hass: HomeAssistant,
+) -> None:
+    """Select-all with no exclusions targets every same-type other cover (#772)."""
+    source, target1, target2 = await _setup_sync_select_all_entries(hass)
+
+    result = await _navigate_to_sync_step(hass, source.entry_id)
+    assert result["step_id"] == "sync"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"select_all_targets": True, "sync_categories": ["geometry"]},
+    )
+
+    assert result["step_id"] == "sync_confirm"
+    summary = result["description_placeholders"]["entries_summary"]
+    assert target1.title in summary
+    assert target2.title in summary
+
+
+@pytest.mark.integration
+async def test_sync_select_all_excludes_checked_targets(hass: HomeAssistant) -> None:
+    """Select-all removes any checked cover from the sync; the rest stay targeted (#772).
+
+    The multi-select becomes an *exclude* list when the toggle is on, not an
+    override — a checked cover is removed from the all-covers sync.
+    """
+    source, target1, target2 = await _setup_sync_select_all_entries(hass)
+
+    result = await _navigate_to_sync_step(hass, source.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "select_all_targets": True,
+            "target_entries": [target1.entry_id],
+            "sync_categories": ["geometry"],
+        },
+    )
+
+    assert result["step_id"] == "sync_confirm"
+    summary = result["description_placeholders"]["entries_summary"]
+    assert target1.title not in summary
+    assert target2.title in summary
+
+
+@pytest.mark.integration
+async def test_sync_toggle_off_uses_explicit_targets(hass: HomeAssistant) -> None:
+    """Toggle off keeps target_entries as an explicit include list (today's behavior, #772)."""
+    source, target1, target2 = await _setup_sync_select_all_entries(hass)
+
+    result = await _navigate_to_sync_step(hass, source.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "select_all_targets": False,
+            "target_entries": [target1.entry_id],
+            "sync_categories": ["geometry"],
+        },
+    )
+
+    assert result["step_id"] == "sync_confirm"
+    summary = result["description_placeholders"]["entries_summary"]
+    assert target1.title in summary
+    assert target2.title not in summary
+
+
+@pytest.mark.integration
+async def test_sync_select_all_e2e_copies_geometry_not_per_window_fields(
+    hass: HomeAssistant,
+) -> None:
+    """End-to-end: select-all sync copies geometry, leaves azimuth/entities untouched (#772)."""
+    from tests.ha_helpers import VERTICAL_OPTIONS
+
+    source_options = {**VERTICAL_OPTIONS, CONF_HEIGHT_WIN: 3.5, CONF_AZIMUTH: 180}
+    target_options = {
+        **VERTICAL_OPTIONS,
+        CONF_HEIGHT_WIN: 2.1,
+        CONF_AZIMUTH: 90,
+        CONF_ENTITIES: ["cover.target_blind"],
+    }
+    source, target1, target2 = await _setup_sync_select_all_entries(
+        hass,
+        source_options=source_options,
+        target1_options=target_options,
+        target2_options=target_options,
+    )
+
+    result = await _navigate_to_sync_step(hass, source.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {"select_all_targets": True, "sync_categories": ["geometry"]},
+    )
+    assert result["step_id"] == "sync_confirm"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {"confirm": True}
+    )
+    assert result["type"] in ("form", "menu", "create_entry")
+
+    updated_target1 = hass.config_entries.async_get_entry(target1.entry_id)
+    updated_target2 = hass.config_entries.async_get_entry(target2.entry_id)
+    for updated in (updated_target1, updated_target2):
+        assert updated.options[CONF_HEIGHT_WIN] == 3.5
+        assert updated.options[CONF_AZIMUTH] == 90  # per-window field, untouched
+        assert updated.options[CONF_ENTITIES] == ["cover.target_blind"]  # untouched
+
+
+# ---------------------------------------------------------------------------
 # Module-level helpers: _get_azimuth_edges, _get_geometry_schema,
 #                       _build_glare_zones_schema
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds a "Select all covers" toggle to the OptionsFlow sync ("Copy to Other Covers") step. With the toggle ON, the sync targets every same-type cover and the per-cover multi-select becomes an exclude list — checked covers are removed from the sync. With it OFF, the multi-select is the explicit include list, exactly as before. The toggle is a transient flow field, never persisted; the executor loop and option extraction are untouched. Help text on both fields was updated to describe the include/exclude dual role. Resolves the pain of ticking 24 covers one-by-one.

## Testing
- ✅ 104 passed (sync / config-flow / duplicate-sync suites): 4 new tests covering select-all (no exclusions), select-all with exclusions, toggle-off explicit targets, and an e2e through sync_confirm asserting geometry keys copied and azimuth/entities untouched
- ✅ Translations complete for de/fr; parity + summary-i18n tests pass (45 passed)

## Related Issues
Refs #772

https://claude.ai/code/session_01PSVN8Cmf8qoytRm9P24tVb