### PR TITLE
fix: apply venetian tilt immediately on forced handler transition (#770)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -694,16 +694,39 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         entity_id: str,
         *,
         current_position: int | None,
-        context: Any,  # noqa: ARG002
+        context: Any,
         reason: str,
     ) -> None:
-        """Send a tilt-only update when the position axis won't fire this cycle."""
+        """Send a tilt-only update when the position axis won't fire this cycle.
+
+        Routine tracking cycles that land inside the prior sequence's
+        back-rotate suppression window defer the tilt (issue #756). A forced
+        handler transition (``context.force`` — e.g. ``custom_position_released``)
+        is new handler intent rather than motor back-rotate drift, so it
+        bypasses that deferral and sends the full new tilt immediately — but
+        only once the carriage has stopped moving, preserving the mid-travel
+        suppression guard (issue #770).
+        """
         if self._sequencer is None:
             return
         if self._last_tilt is None:
             return
         tilt_target = self._resolve_skip_above_tilt(current_position, self._last_tilt)
         if self._sequencer.is_in_suppression(entity_id):
+            if context.force and not self._sequencer.is_carriage_moving(entity_id):
+                # Issue #770: a forced handler transition (e.g.
+                # custom_position_released) is new handler intent, not motor
+                # back-rotate drift. Send the full new tilt immediately rather
+                # than deferring it — but only once the carriage has stopped
+                # moving, so tier (a) of the suppression cap still holds.
+                await self._sequencer.update_tilt_only(
+                    entity_id,
+                    tilt_target=tilt_target,
+                    current_position=current_position,
+                    reason=reason,
+                    force=True,
+                )
+                return
             # Issue #756: a tilt-only update that lands inside the prior
             # sequence's back-rotate suppression window cannot send yet. Record
             # the deferred tilt and schedule a single wake at suppression expiry

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -283,6 +283,19 @@ class DualAxisSequencer:
             return False
         return self._seconds_since(ts) < VENETIAN_TILT_SUPPRESSION_SECONDS
 
+    def is_carriage_moving(self, entity_id: str) -> bool:
+        """Return whether the carriage is physically mid-travel.
+
+        Reads ``cover.state`` via the injected ``get_state`` callback and
+        reports True only while the motor is actively ``opening``/``closing``.
+        Single source of truth for the "carriage still settling" check, shared
+        by ``is_in_suppression_with_cap`` tier (a) and the forced-transition
+        tilt bypass (issue #770).
+        """
+        if self._get_state is None:
+            return False
+        return is_state_in_transit(self._get_state(entity_id))
+
     def suppression_remaining_seconds(self, entity_id: str) -> float | None:
         """Seconds until the back-rotate suppression window closes (issue #756).
 
@@ -354,10 +367,8 @@ class DualAxisSequencer:
         """
         if not self.is_in_suppression(entity_id):
             return False
-        if self._get_state is not None:
-            state = self._get_state(entity_id)
-            if is_state_in_transit(state):
-                return True
+        if self.is_carriage_moving(entity_id):
+            return True
         # (b) Command-grace tail anchored to stamp_position_command.
         stamp = self._suppression_at.get(entity_id)
         if stamp is not None and (

--- a/tests/test_issue_756_venetian_tilt_tail.py
+++ b/tests/test_issue_756_venetian_tilt_tail.py
@@ -14,6 +14,7 @@ sends.
 from __future__ import annotations
 
 import datetime as dt
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -84,7 +85,7 @@ async def test_tilt_deferred_and_refresh_scheduled_during_suppression(
     await policy.maybe_update_tilt_only(
         _ENTITY,
         current_position=0,
-        context=MagicMock(),
+        context=SimpleNamespace(force=False),
         reason="custom_position",
     )
 
@@ -109,7 +110,7 @@ async def test_pending_tilt_fires_and_clears_after_suppression_expires(
     await policy.maybe_update_tilt_only(
         _ENTITY,
         current_position=0,
-        context=MagicMock(),
+        context=SimpleNamespace(force=False),
         reason="custom_position",
     )
     assert policy.has_pending_secondary_axis(_ENTITY) is True
@@ -123,7 +124,7 @@ async def test_pending_tilt_fires_and_clears_after_suppression_expires(
     await policy.maybe_update_tilt_only(
         _ENTITY,
         current_position=0,
-        context=MagicMock(),
+        context=SimpleNamespace(force=False),
         reason="custom_position",
     )
 

--- a/tests/test_issue_770_venetian_forced_tilt.py
+++ b/tests/test_issue_770_venetian_forced_tilt.py
@@ -1,0 +1,147 @@
+"""Issue #770 — venetian forced-transition tilt bypass.
+
+On a handler transition that releases a custom position back to solar, the
+coordinator forces the **position** command (``force=True``, reason
+``custom_position_released``) so it bypasses the time/position delta gates. The
+**tilt** axis is driven separately by ``VenetianPolicy.maybe_update_tilt_only``,
+invoked from the ``same_position`` skip branch. Before this fix that method
+ignored the ``context`` it was handed and, while the prior sequence's 90 s
+back-rotate suppression window was still open, **deferred** the tilt (issue #756)
+instead of sending the new handler's full target.
+
+The fix: when the call is a forced handler transition (``context.force``) AND the
+carriage is not physically mid-travel, bypass the suppression *deferral* and send
+the tilt immediately via ``update_tilt_only(..., force=True)``. The #756 deferral
+stays the default for non-forced (routine tracking) cycles, and a forced
+transition still defers while the carriage is actively moving.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.cover_types import VenetianPolicy
+
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
+
+_ENTITY = "cover.bedroom"
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return h
+
+
+@pytest.fixture
+def schedule_refresh_after():
+    return MagicMock()
+
+
+def _make_policy(hass, schedule_refresh_after, *, get_state=None):
+    p = VenetianPolicy()
+    attach_kwargs = {
+        "hass": hass,
+        "logger": MagicMock(),
+        "grace_mgr": MagicMock(),
+        "get_current_position": lambda eid: 0,
+        "set_commanded_position": MagicMock(),
+        "position_tolerance": 5,
+        "is_dry_run": lambda: True,
+        "schedule_refresh_after": schedule_refresh_after,
+    }
+    if get_state is not None:
+        attach_kwargs["get_state"] = get_state
+    p.attach(**attach_kwargs)
+    return p
+
+
+@pytest.fixture
+def policy(hass, schedule_refresh_after):
+    return _make_policy(hass, schedule_refresh_after)
+
+
+@pytest.mark.asyncio
+async def test_forced_transition_bypasses_suppression_deferral(
+    policy, schedule_refresh_after
+):
+    """A forced handler transition sends the full new tilt immediately even
+    inside the back-rotate suppression window, instead of deferring it (#756).
+    """
+    policy._last_tilt = 100
+    # Open the back-rotate suppression window (fresh position command stamp).
+    policy._sequencer.stamp_position_command(_ENTITY)
+    assert policy._sequencer.is_in_suppression(_ENTITY)
+
+    send_spy = AsyncMock()
+    record_spy = MagicMock()
+    policy._sequencer.update_tilt_only = send_spy
+    policy._sequencer.record_pending_tilt = record_spy
+
+    await policy.maybe_update_tilt_only(
+        _ENTITY,
+        current_position=0,
+        context=SimpleNamespace(force=True),
+        reason="custom_position_released",
+    )
+
+    send_spy.assert_awaited_once()
+    assert send_spy.await_args.kwargs["force"] is True
+    assert send_spy.await_args.kwargs["tilt_target"] == 100
+    record_spy.assert_not_called()
+    schedule_refresh_after.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_forced_cycle_still_defers(policy, schedule_refresh_after):
+    """A routine (non-forced) tracking cycle inside suppression still defers the
+    tilt (issue #756 regression guard): pending is set and a refresh scheduled.
+    """
+    policy._last_tilt = 100
+    policy._sequencer.stamp_position_command(_ENTITY)
+    assert policy._sequencer.is_in_suppression(_ENTITY)
+
+    send_spy = AsyncMock()
+    policy._sequencer.update_tilt_only = send_spy
+
+    await policy.maybe_update_tilt_only(
+        _ENTITY,
+        current_position=0,
+        context=SimpleNamespace(force=False),
+        reason="solar",
+    )
+
+    send_spy.assert_not_awaited()
+    assert policy.has_pending_secondary_axis(_ENTITY) is True
+    schedule_refresh_after.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_forced_transition_defers_while_carriage_moving(
+    hass, schedule_refresh_after
+):
+    """A forced transition still defers while the carriage is physically
+    mid-travel — tier (a) of the suppression cap must hold even under force.
+    """
+    policy = _make_policy(hass, schedule_refresh_after, get_state=lambda eid: "closing")
+    policy._last_tilt = 100
+    policy._sequencer.stamp_position_command(_ENTITY)
+    assert policy._sequencer.is_carriage_moving(_ENTITY) is True
+
+    send_spy = AsyncMock()
+    policy._sequencer.update_tilt_only = send_spy
+
+    await policy.maybe_update_tilt_only(
+        _ENTITY,
+        current_position=0,
+        context=SimpleNamespace(force=True),
+        reason="custom_position_released",
+    )
+
+    send_spy.assert_not_awaited()
+    assert policy.has_pending_secondary_axis(_ENTITY) is True
+    schedule_refresh_after.assert_called_once()


### PR DESCRIPTION
## Summary
On a `custom_position → solar` handler release for a venetian cover, the coordinator forces only the position command, which correctly skips as `same_position` (0→0). The tilt axis ran through `VenetianPolicy.maybe_update_tilt_only`, which ignored the `force` context and deferred the new slat tilt inside the 90s back-rotate suppression window (issue #756). The new handler's tilt (e.g. 0→100) landed up to 90s late, or was lost entirely if the controlling handler changed again first.

The fix honors `context.force`: a forced handler transition now sends the tilt immediately via the existing `update_tilt_only(force=True)` path — unless the carriage is mid-travel (`is_carriage_moving`), in which case it still defers so an in-flight position move is never interrupted. Routine (non-forced) tracking cycles keep the #756 deferral as the default. A new public `is_carriage_moving` predicate is shared between the policy bypass and `is_in_suppression_with_cap` tier (a) to avoid duplication.

Confirmed against the reporter's diagnostics (1318.json): the identical transition failed at 06:08:13 (22.8s into the window — tilt deferred then lost) but succeeded at 11:16:37 (93.0s — window expired, tilt sent immediately). The only variable was the suppression window.

## Testing
- ✅ New `tests/test_issue_770_venetian_forced_tilt.py` — forced bypass sends immediately; non-forced still defers (#756 guard); forced still defers while carriage moving
- ✅ `tests/test_issue_756_venetian_tilt_tail.py` updated to explicit non-forced context (regression guard for #756)
- ✅ 789 passed across the affected venetian/cover-type suites; ruff clean

## Related Issues
Refs #770

https://claude.ai/code/session_01JCBCXcXPFwqfNG7c8jqLRZ