### PR TITLE
feat: put Select-all toggle first in sync step, clarify cover label (#772)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4492,6 +4492,9 @@ class OptionsFlowHandler(OptionsFlow):
             step_id="sync",
             data_schema=vol.Schema(
                 {
+                    vol.Optional(
+                        CONF_SYNC_SELECT_ALL, default=False
+                    ): selector.BooleanSelector(),
                     vol.Required("target_entries", default=[]): selector.SelectSelector(
                         selector.SelectSelectorConfig(
                             multiple=True,
@@ -4501,9 +4504,6 @@ class OptionsFlowHandler(OptionsFlow):
                             ],
                         )
                     ),
-                    vol.Optional(
-                        CONF_SYNC_SELECT_ALL, default=False
-                    ): selector.BooleanSelector(),
                     vol.Required(
                         "sync_categories", default=[]
                     ): selector.SelectSelector(

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1343,7 +1343,7 @@
         "title": "Einstellungen auf andere Behänge kopieren",
         "description": "Wählen Sie, auf welche Behänge Sie Einstellungen kopieren möchten, und welche Kategorien synchronisiert werden sollen. Nur ausgewählte Kategorien werden auf Zielbehängen überschrieben.\n\n⚠️ **Azimut ist immer ausgeschlossen** – jeder Behang behält seine eigene Fensterorientierung.",
         "data": {
-          "target_entries": "Zielleuchten",
+          "target_entries": "Ziel-/ausgeschlossene Beschattungen",
           "sync_categories": "Zu synchronisierende Kategorien",
           "select_all_targets": "Alle Beschattungen auswählen"
         },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1395,7 +1395,7 @@
         "title": "Copy Settings to Other Covers",
         "description": "Choose which covers to copy settings to and which categories to sync. Only selected categories will be overwritten on target covers.\n\n⚠️ **Azimuth is always excluded** — each cover keeps its own window orientation.",
         "data": {
-          "target_entries": "Target covers",
+          "target_entries": "Target/excluded covers",
           "select_all_targets": "Select all covers",
           "sync_categories": "Categories to sync"
         },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1343,7 +1343,7 @@
         "title": "Copier les paramètres vers d'autres stores",
         "description": "Choisissez les stores vers lesquels copier les paramètres et les catégories à synchroniser. Seules les catégories sélectionnées seront écrasées sur les stores cibles.\n\n⚠️ **L'azimut est toujours exclu** — chaque store conserve son propre azimut de fenêtre.",
         "data": {
-          "target_entries": "Stores cibles",
+          "target_entries": "Stores cibles/exclus",
           "sync_categories": "Catégories à synchroniser",
           "select_all_targets": "Sélectionner toutes les protections"
         },

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -57,6 +57,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_END_TIME,
     CONF_SUNRISE_OFFSET,
     CONF_SUNSET_OFFSET,
+    CONF_SYNC_SELECT_ALL,
     CONF_INVERSE_STATE,
     CONF_IS_SUNNY_SENSOR,
     CONF_WINDOW_DEPTH,
@@ -1007,6 +1008,22 @@ async def test_sync_toggle_off_uses_explicit_targets(hass: HomeAssistant) -> Non
     summary = result["description_placeholders"]["entries_summary"]
     assert target1.title in summary
     assert target2.title not in summary
+
+
+@pytest.mark.integration
+async def test_sync_step_toggle_field_rendered_first(hass: HomeAssistant) -> None:
+    """The 'Select all covers' toggle renders above the cover list (#772 follow-up)."""
+    source, target1, target2 = await _setup_sync_select_all_entries(hass)
+
+    result = await _navigate_to_sync_step(hass, source.entry_id)
+    assert result["step_id"] == "sync"
+
+    field_names = [str(key) for key in result["data_schema"].schema]
+
+    toggle_index = field_names.index(CONF_SYNC_SELECT_ALL)
+    targets_index = field_names.index("target_entries")
+
+    assert toggle_index < targets_index
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
Follow-up to #774 addressing @FredM67's two refinement suggestions on #772:
- The "Select all covers" toggle now renders **first** in the sync step, above the per-cover list, so you decide select-all-vs-hand-pick before scanning the list.
- The cover-selection field is relabelled **"Target/excluded covers"** (EN) so the include/exclude duality is visible in the label itself, not just the help text. DE/FR synced — FR uses "Stores cibles/exclus" per the reporter's suggestion; DE's stale "Zielleuchten" mistranslation is corrected.

Pure UI/label change — no sync logic touched (the schema handler reads values by key name, not position).

## Testing
- ✅ New regression test `test_sync_step_toggle_field_rendered_first` locks the schema field order
- ✅ Full config-flow + translation sweep green (105 passed); translation validator passes

## Related Issues
Refs #772

https://claude.ai/code/session_017aY47sF37BQ4HztXpjr2h4