### PR TITLE
fix: gate same-position resend for open/close-only covers stuck at unknown state

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -899,6 +899,50 @@ class CoverCommandService:
             logger=self._logger,
         )
 
+    def _same_position_via_target_fallback(self, entity_id: str, position: int) -> bool:
+        """Same-position gate fallback for an unresolved current position (issue #779).
+
+        Somfy RTS (and any open/close-only cover without genuine position
+        feedback) reports HA state ``unknown``/``unavailable`` forever, so
+        ``_get_current_position`` always returns ``None`` and the
+        same-position gate in ``apply_position`` never sees a genuine
+        reading to compare against — the exact same open/close command gets
+        resent on every update cycle even though the cover was already
+        commanded to (and mechanically at) that state.
+
+        Falls back to the last *commanded* target (``get_target``) instead of
+        a live reading:
+
+        - Position-capable axis: ``route_service_call`` sets
+          ``routed_target == state``, so the commanded target mirrors the raw
+          position 1:1. Comparing it against ``position`` directly is
+          equivalent to the normal exact-equality gate — no behavior change.
+        - Open/close-only axis: ``route_service_call`` always snaps
+          ``routed_target`` to the routed endpoint (0 or 100), regardless of
+          the raw ``position`` value. Comparing the commanded target against
+          ``position`` directly would therefore only match when this cycle's
+          calculated position happens to also be a literal 0/100. Instead,
+          compare against the *routed decision* for this cycle's ``position``
+          (the same threshold math ``route_service_call`` applies) so a
+          continuously varying tracking position that still routes to the
+          same hardware action is correctly recognised as a no-op.
+
+        Only consulted when ``_current is None``; the delta/time gates and
+        reconciliation intentionally keep reading the real (unknown) current
+        position and are untouched by this fallback.
+        """
+        last_target = self.get_target(entity_id)
+        if last_target is None:
+            return False
+
+        caps = self.get_cover_capabilities(entity_id)
+        axis = self._policy.select_default_axis(caps)
+        if caps_get(caps, axis.capability_key, default=True):
+            return last_target == position
+
+        routed_position = 100 if position >= self._open_close_threshold else 0
+        return last_target == routed_position
+
     # ------------------------------------------------------------------ #
     # Primary entry point
     # ------------------------------------------------------------------ #
@@ -1034,13 +1078,34 @@ class CoverCommandService:
         # through to routing so close_cover/open_cover fires. Idempotency for
         # that case is owned by the HA-state mechanical-stop check above, not by
         # tolerance, so the gap can't be reintroduced here.
+        #
+        # _current is None is its own exception (issue #779): Somfy RTS covers
+        # (and any open/close-only cover without genuine position feedback) sit
+        # at HA state unknown/unavailable forever, so _current never resolves
+        # and this gate would never fire — the same open_cover/close_cover gets
+        # resent every cycle. _same_position_via_target_fallback compares the
+        # last *commanded* target against this cycle's position instead of a
+        # live reading (see its docstring for the position-capable vs.
+        # open/close-only distinction). Delta/time gates and reconciliation
+        # deliberately keep reading the real (unknown) _current — this fallback
+        # is scoped to the same-position gate only.
         if (
             not context.sun_just_appeared
             and not force_endpoint
-            and _current is not None
             and (
-                _current == position
-                or (position in (0, 100) and self._at_target(_current, position))
+                (
+                    _current is not None
+                    and (
+                        _current == position
+                        or (
+                            position in (0, 100) and self._at_target(_current, position)
+                        )
+                    )
+                )
+                or (
+                    _current is None
+                    and self._same_position_via_target_fallback(entity_id, position)
+                )
             )
         ):
             if context.policy is not None and context.tilt is not None:

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1761,3 +1761,137 @@ async def test_reconcile_gives_up_on_unreachable_target(mock_hass, logger, grace
     mock_hass.services.async_call.assert_not_called()
     assert svc.state("cover.unreachable").gave_up is True
     assert svc.state("cover.unreachable").retry_count == 2  # not incremented
+
+
+# --- same-position gate: unknown current position fallback (issue #779) ---
+
+
+@pytest.mark.asyncio
+async def test_apply_position_same_position_gate_uses_last_target_when_current_unknown(
+    cmd_svc, mock_hass
+):
+    """Issue #779: Somfy RTS covers sit at HA state unknown/unavailable forever,
+    so _get_current_position always returns None and the same-position gate
+    never fires — open_cover/close_cover gets resent every cycle even though
+    the cover was already commanded to that state.
+
+    First call (current unknown, no prior target): must proceed and send
+    close_cover, recording routed_target=0 as the commanded target. Second
+    call with the same continuously-computed position (30, which is not
+    itself an endpoint but still routes to close_cover) must be recognised
+    as a no-op via the routed-decision fallback and skipped as
+    same_position.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="unknown", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=None),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts", 30, "solar", _ctx_with_special()
+        )
+        assert (outcome, reason) == ("sent", "close_cover")
+        assert cmd_svc.get_target("cover.rts") == 0
+
+        mock_hass.services.async_call.reset_mock()
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.rts", 30, "solar", _ctx_with_special()
+        )
+
+    assert (outcome2, reason2) == ("skipped", "same_position")
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_same_position_gate_literal_endpoint_when_current_unknown(
+    cmd_svc, mock_hass
+):
+    """Issue #779 boundary case: raw position is itself a literal endpoint (0).
+
+    Confirms the amended fallback still suppresses the resend in the
+    "parked at a literal 0/100 default" case that the reporter's original
+    (unamended) proposal handled, not just the general mid-range case
+    covered above.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="unknown", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=None),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_endpoint", 0, "solar", _ctx_with_special()
+        )
+        assert (outcome, reason) == ("sent", "close_cover")
+        assert cmd_svc.get_target("cover.rts_endpoint") == 0
+
+        mock_hass.services.async_call.reset_mock()
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.rts_endpoint", 0, "solar", _ctx_with_special()
+        )
+
+    assert (outcome2, reason2) == ("skipped", "same_position")
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_position_capable_current_unknown_uses_raw_target_fallback(
+    cmd_svc, mock_hass
+):
+    """Position-capable axis: no regression from the issue #779 fallback.
+
+    For a position-capable axis, routed_target == the raw commanded position
+    (see route_service_call), so the fallback must compare the last
+    commanded target against ``position`` directly (no routed-decision
+    translation) — the same outcome as if ``_current`` had been read
+    successfully.
+    """
+    mock_hass.states.get.return_value = MagicMock(
+        state="unknown", attributes={"current_position": None}
+    )
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": True,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    cmd_svc.set_target("cover.rts_pos", 42)
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=None),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_pos", 42, "solar", _ctx_with_special()
+        )
+
+    assert (outcome, reason) == ("skipped", "same_position")
+    mock_hass.services.async_call.assert_not_called()


### PR DESCRIPTION
## Summary
Covers that never report their position back to HA (Somfy RTS is the canonical case) sit at state `unknown`, so `_get_current_position` returns `None` and the same-position gate in `apply_position()` never fired. ACP resent `open_cover`/`close_cover` on every update cycle even though the cover was already at target. This falls back to the last commanded target (`get_target`) when `_current` is None: for open/close-only axes it compares against the routed 0/100 decision (`100 if position >= threshold else 0`), and position-capable axes use raw equality. Delta and time gates keep using the real `_current`.

## Testing
- ✅ 5398 tests passing (135 in the cover_command suite, including 3 new regression tests)

## Related Issues
Refs #779