### PR TITLE
feat: auto-resolve indoor temp sensor from HA area; exclude from duplicate

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2555,7 +2555,7 @@ async def _get_device_name_for_entity(
     return device_entry.name_by_user or device_entry.name or None
 
 
-_SHARED_OPTIONS_EXCLUDED = frozenset({CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID})
+_SHARED_OPTIONS_EXCLUDED = frozenset({CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID, CONF_TEMP_ENTITY})
 
 # Maps each syncable category (matching options menu names) to its config keys.
 # Used by the sync flow to let users choose which setting groups to copy.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -367,6 +367,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             toggles=self._toggles,
             policy=self._policy,
             config_service=self._config_service,
+            config_entry=self.config_entry,
         )
 
         # Current state snapshot (built at start of each update cycle)

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from ..const import (
     CONF_CLOUD_COVERAGE_ENTITY,
@@ -35,6 +37,7 @@ from ..const import (
     CONF_DEFAULT_HEIGHT,
     CONF_DEFAULT_TILT,
     CONF_DELTA_TIME,
+    CONF_DEVICE_ID,
     CONF_ENABLE_SUN_TRACKING,
     CONF_IRRADIANCE_ENTITY,
     CONF_IRRADIANCE_THRESHOLD,
@@ -90,6 +93,7 @@ from .types import (
 )
 
 if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
     from ..config_types import ConfigContextAdapter
@@ -112,6 +116,7 @@ class PipelineSnapshotBuilder:
         toggles: ToggleManager,
         policy: CoverTypePolicy,
         config_service: ConfigurationService,
+        config_entry: ConfigEntry,
     ) -> None:
         """Bind the builder to its long-lived collaborators."""
         self._hass = hass
@@ -120,6 +125,7 @@ class PipelineSnapshotBuilder:
         self._toggles = toggles
         self._policy = policy
         self._config_service = config_service
+        self._config_entry = config_entry
 
     # ---- HA reads ---------------------------------------------------------
 
@@ -147,7 +153,8 @@ class PipelineSnapshotBuilder:
             cloud_suppression_enabled and irradiance_entity is not None
         )
         return self._climate_provider.read(
-            temp_entity=options.get(CONF_TEMP_ENTITY),
+            temp_entity=options.get(CONF_TEMP_ENTITY)
+            or self._resolve_area_temp_entity(),
             outside_entity=options.get(CONF_OUTSIDETEMP_ENTITY),
             presence_entity=options.get(CONF_PRESENCE_ENTITY),
             presence_template=options.get(CONF_PRESENCE_TEMPLATE),
@@ -169,6 +176,47 @@ class PipelineSnapshotBuilder:
             is_sunny_template_mode=options.get(CONF_IS_SUNNY_TEMPLATE_MODE)
             or DEFAULT_TEMPLATE_COMBINE_MODE,
         )
+
+    def _resolve_area_temp_entity(self) -> str | None:
+        """Return the entity_id of a temperature sensor in the cover's HA area.
+
+        Resolution order:
+        1. Read ``linked_device_id`` from the config entry options.
+        2. Look up that device in the device registry to get its ``area_id``.
+        3. Scan the entity registry for sensor entities with
+           ``device_class == "temperature"`` assigned to the same area.
+        4. Return the first matching entity_id, or ``None`` if any step fails.
+
+        This is called only when ``CONF_TEMP_ENTITY`` is absent or empty from
+        the cover's options, so replacing a sensor in the HA area is picked up
+        automatically on the next update cycle without any user intervention.
+        """
+        linked_device_id: str | None = self._config_entry.options.get(CONF_DEVICE_ID)
+        if not linked_device_id:
+            return None
+
+        device_reg = dr.async_get(self._hass)
+        device_entry = device_reg.async_get(linked_device_id)
+        if device_entry is None or not device_entry.area_id:
+            return None
+
+        area_id: str = device_entry.area_id
+        entity_reg = er.async_get(self._hass)
+
+        for entity in er.async_entries_for_area(entity_reg, area_id):
+            if (
+                entity.domain == "sensor"
+                and entity.device_class == "temperature"
+                and not entity.disabled_by
+            ):
+                self._logger.debug(
+                    "Area temp sensor auto-resolved: %s (area=%s)",
+                    entity.entity_id,
+                    area_id,
+                )
+                return entity.entity_id
+
+        return None
 
     def read_custom_position_sensors(
         self, options: dict


### PR DESCRIPTION
Closes #786

> **Note: not tested yet.** The logic is complete and the diff is clean, but this has not been run against a live HA instance. Integration tests covering the area auto-resolution path and the duplicate-flow exclusion do not yet exist. Please review the approach before merging; a follow-up will add tests once the design is confirmed.

---

## What this does

### 1. Temperature sensor not inherited on duplicate (`config_flow.py`)

`CONF_TEMP_ENTITY` is added to `_SHARED_OPTIONS_EXCLUDED`. When a cover is created by duplicating an existing one, the indoor temperature sensor is no longer copied. Each cover resolves its own sensor independently.

### 2. Auto-resolve indoor temperature sensor from HA Area (`pipeline/snapshot_builder.py`)

`PipelineSnapshotBuilder` now accepts the `config_entry` and implements `_resolve_area_temp_entity()`. When `CONF_TEMP_ENTITY` is absent or empty in the cover's options, the method:

1. Reads `linked_device_id` from the config entry options.
2. Looks up the device in the HA device registry → reads its `area_id`.
3. Scans the entity registry for the first **enabled** `sensor` entity with `device_class == "temperature"` in that area.
4. Returns its `entity_id`, or `None` if any step fails.

`read_climate()` is updated to fall back to this resolved value:

```python
temp_entity=options.get(CONF_TEMP_ENTITY) or self._resolve_area_temp_entity()
```

An explicit `CONF_TEMP_ENTITY` in the options always takes precedence — existing configurations are unaffected.

### 3. Wire-up (`coordinator.py`)

`config_entry=self.config_entry` is passed to `PipelineSnapshotBuilder` at construction.

---

## Behaviour

| Scenario | Result |
|---|---|
| Cover has explicit `temp_entity` set | Used as before — no change |
| Cover has no `temp_entity`, device is in an area with a temp sensor | Auto-resolved every cycle |
| Sensor replaced in the HA area | Picked up on the next update cycle — no user action needed |
| Cover duplicated | `temp_entity` not copied; new cover resolves its own area sensor |
| Cover not attached to a device, or device has no area | `None` — same as today |

---

## Files changed

| File | Change |
|---|---|
| `config_flow.py` | Add `CONF_TEMP_ENTITY` to `_SHARED_OPTIONS_EXCLUDED` |
| `coordinator.py` | Pass `config_entry` to `PipelineSnapshotBuilder` |
| `pipeline/snapshot_builder.py` | Accept `config_entry`; import `dr`/`er`; add `_resolve_area_temp_entity()`; wire into `read_climate()` |
