### PR TITLE
fix: guard delta_time coercion and correct test fixture type

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -100,6 +100,21 @@ if TYPE_CHECKING:
     from ..state.climate_provider import ClimateProvider, ClimateReadings
 
 
+def _delta_time_minutes(value: object) -> int:
+    """Coerce a ``delta_time`` option to whole minutes.
+
+    Production stores ``CONF_DELTA_TIME`` as a plain int (``NumberSelector``),
+    but a malformed value (e.g. a legacy duration dict) must never crash the
+    whole update cycle downstream — ``anticipated_solar_position`` compares this
+    with ``<=``, and a non-numeric value there raises ``TypeError`` and takes
+    out the coordinator refresh. Anything non-numeric falls back to ``0``
+    (anticipation disabled), the safe no-op.
+    """
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return 0
+    return int(value)
+
+
 class PipelineSnapshotBuilder:
     """Aggregate HA reads + manager state into a :class:`PipelineSnapshot`."""
 
@@ -399,5 +414,5 @@ class PipelineSnapshotBuilder:
             default_tilt=options.get(CONF_DEFAULT_TILT),
             sunset_tilt=options.get(CONF_SUNSET_TILT),
             solar_floor_active=solar_floor_active,
-            time_threshold_minutes=options.get(CONF_DELTA_TIME) or 0,
+            time_threshold_minutes=_delta_time_minutes(options.get(CONF_DELTA_TIME)),
         )

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -77,7 +77,7 @@ VERTICAL_OPTIONS: dict[str, Any] = {
     CONF_RETURN_SUNSET: False,
     CONF_INVERSE_STATE: False,
     CONF_DELTA_POSITION: 5,
-    CONF_DELTA_TIME: {"hours": 0, "minutes": 2, "seconds": 0},
+    CONF_DELTA_TIME: 2,
     CONF_MANUAL_OVERRIDE_DURATION: {"hours": 1, "minutes": 0, "seconds": 0},
     CONF_MANUAL_OVERRIDE_RESET: False,
     CONF_MANUAL_THRESHOLD: 5,

--- a/tests/test_pipeline/test_solar_anticipation.py
+++ b/tests/test_pipeline/test_solar_anticipation.py
@@ -346,3 +346,31 @@ def test_raw_calculated_position_routes_through_anticipation():
 
     assert compute_raw_calculated_position(snap) == anticipated_solar_position(snap)
     assert compute_raw_calculated_position(snap) < compute_solar_position(snap)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (2, 2),
+        (0, 0),
+        (25.0, 25),
+        (None, 0),
+        # Malformed values must never crash the update cycle — a legacy duration
+        # dict (or any non-number) coerces to 0 (anticipation disabled), not a
+        # ``dict``/``str`` that later blows up ``horizon <= 0`` with a TypeError.
+        ({"hours": 0, "minutes": 2, "seconds": 0}, 0),
+        ("nonsense", 0),
+        (True, 0),
+        (False, 0),
+    ],
+)
+def test_delta_time_minutes_coerces_safely(value, expected):
+    from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+        _delta_time_minutes,
+    )
+
+    result = _delta_time_minutes(value)
+    assert result == expected
+    # The whole point of the guard: the result is always ``<=``-comparable.
+    assert result <= 0 or result > 0


### PR DESCRIPTION
## Summary
PR #785's CI failed intermittently in the boot-perf and diagnostics integration tests with `TypeError: '<=' not supported between instances of 'dict' and 'int'`. This was a pre-existing, wall-clock-dependent flake — not a regression from #785:

- The failing tests don't freeze time. When CI ran while the sun was direct-sun-valid at the test location, the solar handler called `anticipated_solar_position`, whose `horizon <= 0` check compared `time_threshold_minutes` against `0`.
- `time_threshold_minutes` was read from `CONF_DELTA_TIME` with no coercion, and `tests/ha_helpers.py` set it to a stale legacy duration dict `{"hours": 0, "minutes": 2, "seconds": 0}` — production stores it as a plain int (`NumberSelector`). So `dict <= 0` threw and took out the whole coordinator refresh (→ `coordinator.data` None → forecast/diagnostics assertions failed).

Two fixes:
- Correct the fixture to `2` (int minutes).
- Add `_delta_time_minutes()` in `snapshot_builder`, coercing any non-numeric `delta_time` to `0` (anticipation disabled) so a malformed option can never crash the update cycle.

## Testing
- ✅ 5450 tests passing
- ✅ `test_boot_perf.py` + `test_diagnostics_integration.py` pass under a frozen midday clock (the exact condition that broke CI)
- ✅ New parametrized guard test for `_delta_time_minutes`
- ✅ ruff + black clean

## Related Issues
Follow-up to #785 CI failure

https://claude.ai/code/session_01FcvSkH1kKcsNh2VUVTyAPJ