### PR TITLE
ci: dedup setup, add ruff gate, uv installs, drop dup develop run

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -1,0 +1,30 @@
+name: Set up Python + dev deps
+description: >-
+  Set up Python and install the project's dev requirements with uv (fast,
+  cached). Single source for the setup boilerplate shared by the test and
+  notebook jobs. Channel-specific extras (e.g. the HA dev branch) stay in the
+  caller.
+
+inputs:
+  python-version:
+    description: Python version to set up
+    required: false
+    default: "3.14"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+        cache-dependency-glob: requirements-dev.txt
+
+    - name: Install dev requirements
+      shell: bash
+      run: uv pip install --system -r requirements-dev.txt

--- a/.github/workflows/notebook-validation.yml
+++ b/.github/workflows/notebook-validation.yml
@@ -36,17 +36,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.14"
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+      - name: Set up Python + dev deps
+        uses: ./.github/actions/setup-python-deps
 
       - name: Execute notebook
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,12 @@ on:
   workflow_call:
   pull_request:
   push:
+    # `develop` is intentionally omitted: develop-build.yml runs this workflow
+    # via workflow_call on every develop push, so a `push: develop` trigger here
+    # would run the full matrix a second time. PRs into develop still run via
+    # `pull_request`; `main` pushes run directly.
     branches:
       - main
-      - develop
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,9 +18,8 @@ concurrency:
 
 jobs:
   lint:
-    name: Format check (Black)
+    name: Lint (Ruff + Black)
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -26,11 +28,21 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
 
-      - name: Install Black
-        run: pip install "black~=26.5"
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: requirements-dev.txt
+
+      # Install only the linters, pinned via requirements-dev.txt as a
+      # constraints file — no HA core needed, so this stays fast, and the
+      # versions never drift from the source of truth.
+      - name: Install linters
+        run: uv pip install --system -c requirements-dev.txt ruff black
+
+      - name: Run ruff check
+        run: ruff check .
 
       - name: Run black --check
         run: black --check .
@@ -54,26 +66,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+      - name: Set up Python + dev deps
+        uses: ./.github/actions/setup-python-deps
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: requirements-dev.txt
 
-      - name: Install dependencies (stable — HA 2026.3.1)
-        if: matrix.ha-channel == 'stable'
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-
-      - name: Install dependencies (dev — HA dev branch)
+      - name: Install HA dev branch (dev channel only)
         if: matrix.ha-channel == 'dev'
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
-          pip install --upgrade --no-cache-dir pytest-homeassistant-custom-component
-          pip install --upgrade --no-cache-dir git+https://github.com/home-assistant/core.git@dev
+          uv pip install --system --upgrade pytest-homeassistant-custom-component
+          uv pip install --system --upgrade git+https://github.com/home-assistant/core.git@dev
 
       - name: Show HA version
         run: python -c "from homeassistant.const import __version__; print('HA version:', __version__)"


### PR DESCRIPTION
## Summary
Reviews the CI workflows for duplication and speed:

- **Kill duplicate test runs on `develop`.** `tests.yml` triggered on `push: develop` *and* was invoked by `develop-build.yml` via `workflow_call` — every develop push ran the full matrix twice. Dropped `develop` from `tests.yml` push triggers (PRs still run via `pull_request`; direct develop pushes run through the Develop Build gate).
- **Enforce Ruff in CI.** Ruff is the project's primary linter but CI never ran it, and the Black job was `continue-on-error`. The lint job is now a blocking **Ruff + Black** gate. Linter versions come from `requirements-dev.txt` via a `uv` constraints install instead of the hardcoded `black~=26.5` pin.
- **Faster installs with `uv`.** New composite action `.github/actions/setup-python-deps` (setup-python + cached `uv` + `uv pip install -r requirements-dev.txt`), reused by the test and notebook jobs — removes the copy-pasted setup boilerplate.

## Testing
- ✅ `ruff check .` and `black --check .` clean on the current tree (new gate passes)
- ✅ All workflow/action YAML parses
- No Python source changed, so the pytest suite is unaffected

## Notes
Landing on `main` per the hotfix flow; I'll forward-merge `main` → `develop` after this merges.

https://claude.ai/code/session_01V1aspun4DaZ6HyL8PKYzwB