### PR TITLE
chore: add required hardware fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -21,6 +21,8 @@ body:
           required: true
         - label: This report covers a single bug (open a separate issue for each additional bug).
           required: true
+        - label: I have checked the [Hardware Compatibility wiki page](https://github.com/jrhubott/adaptive-cover-pro/wiki/Hardware-Compatibility) for my cover's required settings.
+          required: true
         - label: I have attached the diagnostics file as an upload (drag-and-drop the JSON file into the Diagnostics field below — do **not** paste its contents). See [Downloading Diagnostics](https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Debug-Diagnostics#downloading-diagnostics).
           required: true
 
@@ -50,7 +52,34 @@ body:
       description: "Vertical blind, horizontal awning, or venetian/tilt."
       placeholder: "e.g. Vertical blind"
     validations:
-      required: false
+      required: true
+
+  - type: input
+    id: cover_brand
+    attributes:
+      label: Cover brand
+      description: "The manufacturer of the cover or motor."
+      placeholder: "e.g. Somfy"
+    validations:
+      required: true
+
+  - type: input
+    id: cover_model
+    attributes:
+      label: Cover model
+      description: "The model of the cover, motor, or controller."
+      placeholder: "e.g. Sonesse 30 WireFree"
+    validations:
+      required: true
+
+  - type: input
+    id: communication_protocol
+    attributes:
+      label: Communication protocol
+      description: "How Home Assistant talks to the cover."
+      placeholder: "e.g. Zigbee, Z-Wave, KNX, RTS/RF, Wi-Fi, Matter"
+    validations:
+      required: true
 
   - type: textarea
     attributes:


### PR DESCRIPTION
## Summary
Adds required hardware context to the bug report issue form so reports arrive with enough detail to triage:
- New required **Hardware Compatibility** checklist item linking to the [wiki page](https://github.com/jrhubott/adaptive-cover-pro/wiki/Hardware-Compatibility).
- New required **Cover brand**, **Cover model**, and **Communication protocol** fields.
- Made the existing **Cover type** field required.

## Testing
- ✅ YAML validates (`yaml.safe_load`)
- ✅ pre-commit `check yaml` + prettier passed

## Related Issues
None.

https://claude.ai/code/session_01UrHyLaeMyHUmuo3Lhszs7r