### PR TITLE
fix: gate My-preset resend via real router for unknown-state covers (#779)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -899,33 +899,31 @@ class CoverCommandService:
             logger=self._logger,
         )
 
-    def _same_position_via_target_fallback(self, entity_id: str, position: int) -> bool:
+    def _same_position_via_target_fallback(
+        self,
+        entity_id: str,
+        position: int,
+        context: PositionContext,
+    ) -> bool:
         """Same-position gate fallback for an unresolved current position (issue #779).
 
         Somfy RTS (and any open/close-only cover without genuine position
         feedback) reports HA state ``unknown``/``unavailable`` forever, so
         ``_get_current_position`` always returns ``None`` and the
         same-position gate in ``apply_position`` never sees a genuine
-        reading to compare against — the exact same open/close command gets
-        resent on every update cycle even though the cover was already
-        commanded to (and mechanically at) that state.
+        reading to compare against — the exact same command gets resent on
+        every update cycle even though the cover was already commanded to
+        (and mechanically at) that state.
 
-        Falls back to the last *commanded* target (``get_target``) instead of
-        a live reading:
-
-        - Position-capable axis: ``route_service_call`` sets
-          ``routed_target == state``, so the commanded target mirrors the raw
-          position 1:1. Comparing it against ``position`` directly is
-          equivalent to the normal exact-equality gate — no behavior change.
-        - Open/close-only axis: ``route_service_call`` always snaps
-          ``routed_target`` to the routed endpoint (0 or 100), regardless of
-          the raw ``position`` value. Comparing the commanded target against
-          ``position`` directly would therefore only match when this cycle's
-          calculated position happens to also be a literal 0/100. Instead,
-          compare against the *routed decision* for this cycle's ``position``
-          (the same threshold math ``route_service_call`` applies) so a
-          continuously varying tracking position that still routes to the
-          same hardware action is correctly recognised as a no-op.
+        Falls back to the last *commanded* target (``get_target``) compared
+        against this cycle's *routed decision* rather than the raw
+        ``position``. Delegates to :func:`route_service_call` — the single
+        source of truth for routing — instead of re-deriving the threshold
+        math, so every axis (position-capable, My-preset ``stop_cover``, and
+        open/close endpoint) is compared using the exact same rule that
+        ``_prepare_service_call`` uses to build the outbound command
+        (issue #779 follow-up regression from PR #781, which hand-rolled a
+        partial copy of this math and ignored ``use_my_position``).
 
         Only consulted when ``_current is None``; the delta/time gates and
         reconciliation intentionally keep reading the real (unknown) current
@@ -937,11 +935,16 @@ class CoverCommandService:
 
         caps = self.get_cover_capabilities(entity_id)
         axis = self._policy.select_default_axis(caps)
-        if caps_get(caps, axis.capability_key, default=True):
-            return last_target == position
-
-        routed_position = 100 if position >= self._open_close_threshold else 0
-        return last_target == routed_position
+        plan = route_service_call(
+            entity_id,
+            position,
+            caps,
+            axis=axis,
+            use_my_position=context.use_my_position,
+            open_close_threshold=self._open_close_threshold,
+            endpoint_use_open_close=self._endpoint_use_open_close,
+        )
+        return last_target == plan.routed_target
 
     # ------------------------------------------------------------------ #
     # Primary entry point
@@ -1082,13 +1085,14 @@ class CoverCommandService:
         # _current is None is its own exception (issue #779): Somfy RTS covers
         # (and any open/close-only cover without genuine position feedback) sit
         # at HA state unknown/unavailable forever, so _current never resolves
-        # and this gate would never fire — the same open_cover/close_cover gets
-        # resent every cycle. _same_position_via_target_fallback compares the
-        # last *commanded* target against this cycle's position instead of a
-        # live reading (see its docstring for the position-capable vs.
-        # open/close-only distinction). Delta/time gates and reconciliation
-        # deliberately keep reading the real (unknown) _current — this fallback
-        # is scoped to the same-position gate only.
+        # and this gate would never fire — the same command gets resent every
+        # cycle. _same_position_via_target_fallback compares the last
+        # *commanded* target against this cycle's *routed* decision (via
+        # route_service_call, see its docstring) instead of a live reading, so
+        # position-capable, My-preset stop_cover, and open/close endpoint
+        # covers are all handled by the one routing source of truth. Delta/time
+        # gates and reconciliation deliberately keep reading the real (unknown)
+        # _current — this fallback is scoped to the same-position gate only.
         if (
             not context.sun_just_appeared
             and not force_endpoint
@@ -1104,7 +1108,9 @@ class CoverCommandService:
                 )
                 or (
                     _current is None
-                    and self._same_position_via_target_fallback(entity_id, position)
+                    and self._same_position_via_target_fallback(
+                        entity_id, position, context
+                    )
                 )
             )
         ):

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1066,8 +1066,13 @@ async def test_apply_position_proceeds_when_state_loaded_with_unknown_position(
 # --- same-position exact-equality gate + reconciliation tolerance (issues #507/#567) ---
 
 
-def _ctx_with_special() -> PositionContext:
-    """PositionContext that passes every gate except same-position."""
+def _ctx_with_special(*, use_my_position: bool = False) -> PositionContext:
+    """PositionContext that passes every gate except same-position.
+
+    ``use_my_position=True`` selects the My-preset routing variant (issue
+    #779 follow-up) so tests can exercise the ``stop_cover``/My path through
+    the same shared context builder used by every other test in this file.
+    """
     return PositionContext(
         auto_control=True,
         manual_override=False,
@@ -1075,6 +1080,7 @@ def _ctx_with_special() -> PositionContext:
         min_change=10,
         time_threshold=0,
         special_positions=[0, 100],
+        use_my_position=use_my_position,
     )
 
 
@@ -1894,4 +1900,106 @@ async def test_apply_position_position_capable_current_unknown_uses_raw_target_f
         )
 
     assert (outcome, reason) == ("skipped", "same_position")
+    mock_hass.services.async_call.assert_not_called()
+
+
+# --- same-position gate: My-preset fallback correctness (issue #779 regression
+# from PR #781 — the fallback ignored use_my_position and hand-rolled the
+# open/close threshold math, so a My move collapsed to the same routed
+# decision as a stored full-close target) ---
+
+
+@pytest.mark.asyncio
+async def test_apply_position_my_preset_move_not_suppressed_by_stored_close_target_when_current_unknown(
+    cmd_svc, mock_hass
+):
+    """A My-preset move to a sub-threshold value (e.g. 2%) must not be
+    swallowed by a stored full-close target (0).
+
+    ``_same_position_via_target_fallback`` used to hand-roll
+    ``100 if position >= threshold else 0``, which ignores
+    ``use_my_position`` entirely: a My move to 2% collapsed to the same
+    routed decision (0) as a prior full close, so the gate suppressed the
+    My move as ``same_position`` and the cover never received
+    ``stop_cover``. The fallback must delegate to ``route_service_call``
+    (the single routing source of truth) so a My target routes to its real
+    decision (``stop_cover``, routed_target=2) instead of the hand-rolled
+    open/close snap.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="unknown", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=None),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_my", 0, "solar", _ctx_with_special()
+        )
+        assert (outcome, reason) == ("sent", "close_cover")
+        assert cmd_svc.get_target("cover.rts_my") == 0
+
+        mock_hass.services.async_call.reset_mock()
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.rts_my", 2, "solar", _ctx_with_special(use_my_position=True)
+        )
+
+    assert (outcome2, reason2) == ("sent", "stop_cover")
+
+
+@pytest.mark.asyncio
+async def test_apply_position_repeated_my_preset_suppressed_when_current_unknown(
+    cmd_svc, mock_hass
+):
+    """A second identical My-preset move must be suppressed as
+    ``same_position``, not resent — the residual #779 relay-click bug for
+    the My path.
+
+    ``_same_position_via_target_fallback`` stores the raw My value
+    (``routed_target=state``) but compared it against the hand-rolled
+    ``100 if position >= threshold else 0`` snap, which never matches a
+    mid-range My value — so every cycle re-sent ``stop_cover`` even though
+    the cover was already commanded to the same My preset.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="unknown", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=None),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_my_repeat", 2, "solar", _ctx_with_special(use_my_position=True)
+        )
+        assert (outcome, reason) == ("sent", "stop_cover")
+        assert cmd_svc.get_target("cover.rts_my_repeat") == 2
+
+        mock_hass.services.async_call.reset_mock()
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.rts_my_repeat", 2, "solar", _ctx_with_special(use_my_position=True)
+        )
+
+    assert (outcome2, reason2) == ("skipped", "same_position")
     mock_hass.services.async_call.assert_not_called()


### PR DESCRIPTION
## Summary
Follow-up regression fix for #779. PR #781's same-position fallback for unknown-state covers (Somfy RTS) hand-rolled a partial copy of the routing math (`100 if position >= threshold else 0`) that ignored the `use_my_position` branch. For a cover with a Somfy "My" preset at a mid-range value (e.g. 2%), a My move collapsed to routed `0`, matched the stored full-close target of `0`, and was suppressed as `same_position` — so the shutters never moved. The fallback helper now delegates to `route_service_call` (the same router `_prepare_service_call` uses — single source of truth) and compares the stored target against `plan.routed_target`. This also fixes a residual resend-every-cycle for repeated My moves.

## Testing
- ✅ 84 tests passing in the cover_command suite (82 baseline + 2 new regression tests); PR #781's 3 regression tests remain green

## Related Issues
Refs #779