### PR TITLE
fix: apply default_height in set_position_limits (#792)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -131,7 +131,7 @@ set_position_limits:
     entity:
       integration: adaptive_cover_pro
   fields:
-    default_height:
+    default_percentage:
       name: Default height
       description: "Default cover position when sun is not visible (0–100%)."
       selector:
@@ -207,7 +207,7 @@ set_sunset_sunrise:
   fields:
     sunset_position:
       name: Sunset position
-      description: "Position to move to at end of time window. Null = use default_height."
+      description: "Position to move to at end of time window. Null = use default_percentage."
       selector:
         number:
           min: 0

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -743,17 +743,29 @@ _CUSTOM_SLOT_KEYS = CUSTOM_POSITION_SLOTS
 # ---------------------------------------------------------------------------
 
 
+# Service field names that differ from their internal option key. The canonical
+# service field is now `default_percentage`, matching CONF_DEFAULT_HEIGHT; the
+# older `default_height` wire-format name is kept as a deprecated alias so
+# existing automations keep working (issue #792).
+_SERVICE_FIELD_ALIASES: dict[str, str] = {
+    "default_height": CONF_DEFAULT_HEIGHT,
+}
+
+
 def _build_patch(call_data: dict, allowed_keys: frozenset[str]) -> dict:
     """Extract allowed keys from a service call's data dict.
 
-    Keys whose value is None are included (they signal "clear this option").
-    HA plumbing keys (entity_id, device_id, area_id) are always excluded.
+    Any known field-name alias (_SERVICE_FIELD_ALIASES) is resolved to its
+    internal option key before filtering. Keys whose value is None are included
+    (they signal "clear this option"). HA plumbing keys (entity_id, device_id,
+    area_id) are always excluded.
     """
-    return {
-        k: v
-        for k, v in call_data.items()
-        if k in allowed_keys and k not in _PLUMBING_KEYS
-    }
+    patch: dict = {}
+    for k, v in call_data.items():
+        key = _SERVICE_FIELD_ALIASES.get(k, k)
+        if key in allowed_keys and key not in _PLUMBING_KEYS:
+            patch[key] = v
+    return patch
 
 
 def _validate_fields(patch: dict) -> None:

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2119,7 +2119,7 @@
     "set_position_limits": {
       "description": "Aktualisiert Standardhöhe, Min/Max-Position, Öffnungs-/Schließungsschwelle und inversen Status.",
       "fields": {
-        "default_height": {
+        "default_percentage": {
           "description": "Standardposition der Beschattung wenn Sonne nicht sichtbar ist (0–100%).",
           "name": "Standardhöhe"
         },
@@ -2212,7 +2212,7 @@
           "name": "Sonnenuntergangs-Offset"
         },
         "sunset_position": {
-          "description": "Position zum Bewegen beim Fenster-Ende. Null = default_height verwenden.",
+          "description": "Position zum Bewegen beim Fenster-Ende. Null = default_percentage verwenden.",
           "name": "Sonnenuntergangsposition"
         },
         "sunset_use_my": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1796,7 +1796,7 @@
       "name": "Set position limits",
       "description": "Update default height, min/max position, open/close threshold, and inverse state.",
       "fields": {
-        "default_height": {
+        "default_percentage": {
           "name": "Default height",
           "description": "Default cover position when sun is not visible (0–100%)."
         },
@@ -1836,7 +1836,7 @@
       "fields": {
         "sunset_position": {
           "name": "Sunset position",
-          "description": "Position to move to at end of time window. Null = use default_height."
+          "description": "Position to move to at end of time window. Null = use default_percentage."
         },
         "sunset_offset": {
           "name": "Sunset offset",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2119,7 +2119,7 @@
     "set_position_limits": {
       "description": "Mettre à jour la hauteur par défaut, la position min/max, le seuil d'ouverture/fermeture, et l'état inverse.",
       "fields": {
-        "default_height": {
+        "default_percentage": {
           "description": "Position de protection par défaut lorsque le soleil n'est pas visible (0–100%).",
           "name": "Hauteur par défaut"
         },
@@ -2212,7 +2212,7 @@
           "name": "Décalage du coucher de soleil"
         },
         "sunset_position": {
-          "description": "Position vers laquelle se déplacer à la fin de la fenêtre de temps. Null = utiliser default_height.",
+          "description": "Position vers laquelle se déplacer à la fin de la fenêtre de temps. Null = utiliser default_percentage.",
           "name": "Position du coucher de soleil"
         },
         "sunset_use_my": {

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -83,6 +83,10 @@ from custom_components.adaptive_cover_pro.services.options_service import (
     IDENTITY_KEYS,
     OPTIONS_SERVICE_NAMES,
     _SECTION_CLIMATE,
+    _SECTION_POSITION_LIMITS,
+    _SECTION_SUNSET_SUNRISE,
+    _SERVICE_FIELD_ALIASES,
+    _build_patch,
     _cross_field_validate,
     apply_options_patch,
     validate_options_patch,
@@ -625,16 +629,57 @@ class TestServiceRegistration:
             ), f"Service '{service}' not registered"
 
 
+class TestBuildPatchAliasing:
+    """Unit tests for _build_patch's field-name alias resolution (issue #792)."""
+
+    def test_known_alias_resolves_to_option_key(self):
+        patch = _build_patch({"default_height": 75}, _SECTION_POSITION_LIMITS)
+        assert patch == {CONF_DEFAULT_HEIGHT: 75}
+
+    def test_canonical_key_still_works_unaliased(self):
+        patch = _build_patch({CONF_DEFAULT_HEIGHT: 75}, _SECTION_POSITION_LIMITS)
+        assert patch == {CONF_DEFAULT_HEIGHT: 75}
+
+    def test_unknown_key_still_dropped(self):
+        patch = _build_patch({"not_a_real_field": 1}, _SECTION_POSITION_LIMITS)
+        assert patch == {}
+
+    def test_alias_outside_its_section_still_filtered(self):
+        # default_height's alias resolves to CONF_DEFAULT_HEIGHT; a section that
+        # does not include that key must still drop it.
+        patch = _build_patch({"default_height": 75}, _SECTION_SUNSET_SUNRISE)
+        assert patch == {}
+
+    def test_default_height_alias_is_registered(self):
+        assert _SERVICE_FIELD_ALIASES["default_height"] == CONF_DEFAULT_HEIGHT
+
+
 class TestSetPositionLimits:
     """Integration tests for set_position_limits service."""
 
-    async def test_updates_default_height(self, hass: HomeAssistant):
+    async def test_updates_default_percentage(self, hass: HomeAssistant):
+        """The canonical field name (== CONF_DEFAULT_HEIGHT, 'default_percentage')."""
         await _setup(hass, entry_id="pos_01")
         with (
             patch.object(hass.config_entries, "async_update_entry") as mock_update,
             patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
         ):
             await _call(hass, "set_position_limits", {CONF_DEFAULT_HEIGHT: 75})
+
+        mock_update.assert_called_once()
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_DEFAULT_HEIGHT] == 75
+
+    async def test_updates_default_height_deprecated_alias(self, hass: HomeAssistant):
+        """Issue #792: the pre-rename wire field name 'default_height' must keep
+        working via the deprecated alias, resolving to CONF_DEFAULT_HEIGHT.
+        """
+        await _setup(hass, entry_id="pos_alias_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_position_limits", {"default_height": 75})
 
         mock_update.assert_called_once()
         new_opts = mock_update.call_args[1]["options"]

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -103,3 +103,13 @@ def test_all_registered_services_have_yaml_entry():
     assert (
         not missing
     ), f"Service(s) registered in Python but missing from services.yaml: {sorted(missing)}"
+
+
+def test_set_position_limits_field_is_default_percentage_not_default_height():
+    """Issue #792: the service field name must match the CONF_DEFAULT_HEIGHT option
+    key (``default_percentage``), or _build_patch silently drops it. The old
+    ``default_height`` name is kept working via a deprecated alias, not the yaml.
+    """
+    fields = _load()["set_position_limits"]["fields"]
+    assert "default_percentage" in fields
+    assert "default_height" not in fields


### PR DESCRIPTION
## Summary
The `set_position_limits` service silently dropped `default_height`. The service field name did not match its internal option key (`CONF_DEFAULT_HEIGHT = "default_percentage"`), so `_build_patch` filtered it out before the patch was applied — every other field's wire name coincidentally matched its option key.

I renamed the service field to `default_percentage` (matching the option key) and added a `_SERVICE_FIELD_ALIASES` map so existing automations using the old `default_height` name keep working as a deprecated alias. The field-key rename is synced across en/de/fr translations.

## Testing
- ✅ New guard tests: `TestBuildPatchAliasing` (4 cases) + `test_updates_default_height_deprecated_alias` (literal wire-key repro) + a services.yaml field-name pin
- ✅ Full suite: 5457 passed
- ✅ Translation validator + parity tests green

## Related Issues
Refs #792