### PR TITLE
feat: add engage_manual_override service (#793)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -949,6 +949,38 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.state_change = True
         await self.async_refresh()
 
+    async def async_engage_manual_override(
+        self,
+        entity_ids: list[str],
+        *,
+        end_time: dt.datetime | None = None,
+        duration: dt.timedelta | None = None,
+        trigger: str = "engage_manual_override",
+    ) -> None:
+        """Engage or extend manual override on the given covers, without moving them.
+
+        Backs the ``adaptive_cover_pro.engage_manual_override`` service. Engages
+        each cover purely through the override state machine
+        (:meth:`AdaptiveCoverManager.engage_override` — no ``apply_position``,
+        no command), then refreshes once so the ``manual_override`` binary
+        sensor and ``manual_override_end_time`` sensor reflect the new state
+        immediately (mirrors the input-sensor path at
+        :meth:`async_check_manual_override_input_change`).
+
+        Args:
+            entity_ids: Cover entity IDs to engage.
+            end_time: Optional absolute end passed through to the manager.
+            duration: Optional relative extend-by passed through to the manager.
+            trigger: Diagnostic reason label recorded per cover.
+
+        """
+        for entity_id in entity_ids:
+            self.manager.engage_override(
+                entity_id, end_time=end_time, duration=duration, reason=trigger
+            )
+        self.state_change = True
+        await self.async_refresh()
+
     async def async_check_motion_template_change(
         self, event: Event | None, updates: list
     ) -> None:

--- a/custom_components/adaptive_cover_pro/managers/manual_override/expiry.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/expiry.py
@@ -1,0 +1,25 @@
+"""Single source of truth for the manual-override expiry ↔ start-time inverse.
+
+The manual-override *end time* is derived, not stored: a cover's override
+expires at ``manual_control_time[eid] + reset_duration``. Three call sites need
+the same arithmetic and its inverse — the end-time sensor value_fn/attrs, the
+RestoreEntity restore path, and the ``engage_manual_override`` service — so the
+formula lives here and every caller delegates (CODING_GUIDELINES.md §
+"Single-Source-of-Truth Helpers for Repeated Formulas").
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+
+def expiry_for_started_at(
+    started_at: dt.datetime, duration: dt.timedelta
+) -> dt.datetime:
+    """Return the override expiry for a given start time and reset duration."""
+    return started_at + duration
+
+
+def started_at_for_expiry(expiry: dt.datetime, duration: dt.timedelta) -> dt.datetime:
+    """Return the start time that yields ``expiry`` for a given duration (inverse)."""
+    return expiry - duration

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -34,6 +34,7 @@ from .detector import (
     StopToMy,
     UserContextChange,
 )
+from .expiry import expiry_for_started_at, started_at_for_expiry
 from .position_delta import PositionDeltaDetector
 from .secondary_axis import SecondaryAxisCheck
 
@@ -603,27 +604,53 @@ class AdaptiveCoverManager:
         """
         self.manual_control[cover] = True
 
+    def _engage(self, entity_id: str, *, timestamp: dt.datetime, reason: str) -> None:
+        """Engage manual override on one cover without commanding movement.
+
+        Shared engine for the wall-switch / input-sensor path
+        (:meth:`engage_manual_override_from_external`) and the
+        ``engage_manual_override`` service (:meth:`engage_override`) — both
+        delegate here rather than re-implementing the mark/event/edge block
+        (no-duplication rule). Routes through :meth:`_apply_decision` with
+        ``mark_manual=True`` and a ``set_timestamp`` that **overwrites**
+        ``manual_control_time`` with ``timestamp`` (extend semantics — the
+        overwrite lands even when the cover was already manual). Sends no cover
+        command; the not-manual→manual edge fires ``on_engaged`` so any latched
+        target is discarded.
+
+        Args:
+            entity_id: Cover entity ID to engage.
+            timestamp: Value written to ``manual_control_time`` — the derived
+                end time is ``timestamp + reset_duration``.
+            reason: Short label recorded into the diagnostic event buffer.
+
+        """
+        self._apply_decision(
+            entity_id,
+            OverrideDecision(
+                mark_manual=True,
+                event_name="manual_override_set",
+                event_kwargs={
+                    "our_state": None,
+                    "new_position": None,
+                    "reason": reason,
+                },
+            ),
+            set_timestamp=lambda: self.manual_control_time.__setitem__(
+                entity_id, timestamp
+            ),
+        )
+
     def engage_manual_override_from_external(self, reason: str) -> None:
         """Engage manual override on every tracked cover from an external trigger.
 
         Wall-switch / input-sensor path (issue #688): an off→on edge on a
         configured input binary sensor means the user physically operated the
         cover, so ACP pauses auto-control on *every* cover in this instance and
-        drops any latched target. Routes each cover through :meth:`_apply_decision`
-        with ``mark_manual=True`` (sharing the mark/event/edge block rather than
-        re-implementing it — no-duplication rule).
-
-        Two deliberate divergences from :meth:`mark_user_command`:
-
-        * It **must** fire the ``on_engaged`` edge (→ ``discard_target``): unlike
-          the ACP-owned surfaces, this path issues no command afterward, so the
-          latched target has to be discarded or the next cycle would yank the
-          cover back.
-        * Each press **overwrites** ``manual_control_time`` with a fresh ``now``,
-          re-arming the full override duration on every press — the opposite of
-          ``mark_user_command``'s ``setdefault``. ``_apply_decision`` calls
-          ``set_timestamp`` whenever it marks, so the overwrite lands even when
-          the cover was already manual.
+        drops any latched target. Each cover is engaged via :meth:`_engage`
+        with a fresh ``now`` timestamp, re-arming the full override duration on
+        every press (overwrite, not ``setdefault``) and firing the
+        ``on_engaged`` edge on the fresh transition.
 
         Args:
             reason: Short label recorded into the diagnostic event buffer
@@ -632,21 +659,72 @@ class AdaptiveCoverManager:
         """
         now = dt.datetime.now(dt.UTC)
         for entity_id in self.covers:
-            self._apply_decision(
-                entity_id,
-                OverrideDecision(
-                    mark_manual=True,
-                    event_name="manual_override_set",
-                    event_kwargs={
-                        "our_state": None,
-                        "new_position": None,
-                        "reason": reason,
-                    },
-                ),
-                set_timestamp=lambda eid=entity_id: self.manual_control_time.__setitem__(
-                    eid, now
-                ),
-            )
+            self._engage(entity_id, timestamp=now, reason=reason)
+
+    def engage_override(
+        self,
+        entity_id: str,
+        *,
+        end_time: dt.datetime | None = None,
+        duration: dt.timedelta | None = None,
+        reason: str,
+    ) -> None:
+        """Engage or extend manual override on one cover, without moving it.
+
+        Backs the ``adaptive_cover_pro.engage_manual_override`` service. Sends
+        no cover command — engages purely through the override state machine via
+        :meth:`_engage`. Never raises: an invalid ``end_time`` / ``duration``
+        falls through to the next rule.
+
+        Precedence (first valid wins):
+
+        1. ``end_time`` present and strictly in the future → the override ends
+           at ``end_time``; ``duration`` is ignored (logged at debug). A naive
+           ``end_time`` is treated as UTC.
+        2. else ``duration`` positive → EXTEND-BY: if the cover is already under
+           manual override, add ``duration`` to its **current** end; otherwise
+           engage fresh for ``now + duration``.
+        3. else (both absent/invalid) → fall back to ``now + reset_duration``
+           (i.e. ``manual_control_time = now``).
+
+        The chosen target end is converted to the stored start via the SSOT
+        inverse :func:`.expiry.started_at_for_expiry`; the timestamp is
+        overwritten so a later call can move the end.
+
+        Args:
+            entity_id: Cover entity ID to engage.
+            end_time: Optional absolute end (aware or naive-UTC datetime).
+            duration: Optional relative extend-by timedelta.
+            reason: Short label recorded into the diagnostic event buffer.
+
+        """
+        now = dt.datetime.now(dt.UTC)
+        if end_time is not None and end_time.tzinfo is None:
+            end_time = end_time.replace(tzinfo=dt.UTC)
+
+        target_expiry: dt.datetime | None = None
+        if end_time is not None and end_time > now:
+            target_expiry = end_time
+            if duration is not None:
+                self.logger.debug(
+                    "engage_override: both end_time and duration supplied for "
+                    "%s — using end_time, ignoring duration",
+                    entity_id,
+                )
+        elif duration is not None and duration > dt.timedelta(0):
+            if self.is_cover_manual(entity_id):
+                current_end = expiry_for_started_at(
+                    self.manual_control_time[entity_id], self.reset_duration
+                )
+                target_expiry = current_end + duration
+            else:
+                target_expiry = now + duration
+
+        if target_expiry is not None:
+            timestamp = started_at_for_expiry(target_expiry, self.reset_duration)
+        else:
+            timestamp = now
+        self._engage(entity_id, timestamp=timestamp, reason=reason)
 
     def mark_user_command(self, entity_id: str, *, reason: str) -> None:
         """Engage manual override pre-emptively from an ACP-owned surface.

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -48,6 +48,10 @@ from .const import (
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .entity_base import AdaptiveCoverDiagnosticSensorBase, AdaptiveCoverSensorBase
 from .const import ControlMethod
+from .managers.manual_override.expiry import (
+    expiry_for_started_at,
+    started_at_for_expiry,
+)
 from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_sensors,
@@ -248,7 +252,7 @@ class _ManualOverrideEndSensor(_ACPRestorableDiagnosticSensor):
             expiry = dt.datetime.fromisoformat(expiry_iso)
             if expiry <= now:
                 continue
-            started_at = expiry - manager.reset_duration
+            started_at = started_at_for_expiry(expiry, manager.reset_duration)
             manager.manual_control[eid] = True
             manager.manual_control_time[eid] = started_at
             manager._record_event(  # noqa: SLF001
@@ -595,7 +599,7 @@ def _manual_override_end_value(s: _ManualOverrideEndSensor) -> dt.datetime | Non
     if not times:
         return None
     duration = s.coordinator.manager.reset_duration
-    return max(t + duration for t in times.values())
+    return max(expiry_for_started_at(t, duration) for t in times.values())
 
 
 def _manual_override_end_attrs(
@@ -607,7 +611,8 @@ def _manual_override_end_attrs(
     duration = s.coordinator.manager.reset_duration
     return {
         "per_entity": {
-            entity_id: (t + duration).isoformat() for entity_id, t in times.items()
+            entity_id: expiry_for_started_at(t, duration).isoformat()
+            for entity_id, t in times.items()
         }
     }
 

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -122,6 +122,38 @@ set_tilt:
       selector:
         boolean:
 
+engage_manual_override:
+  name: Engage manual override
+  description: >-
+    Engages (or extends) manual override on the targeted covers WITHOUT moving
+    them — no cover command is sent. Use it to pause automatic control and hold
+    the cover where it is. With no end time and no duration, the override lasts
+    the configured manual-override duration starting now. Provide end_time for
+    an absolute end, or duration to extend an active override by that amount
+    (or engage fresh for that long if none is active). If both are given,
+    end_time wins.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    end_time:
+      name: End time
+      description: >-
+        Absolute time the override should end. Ignored (falls back to the
+        configured duration) if it is in the past or unparseable. Takes
+        precedence over duration.
+      required: false
+      selector:
+        datetime:
+    duration:
+      name: Duration
+      description: >-
+        Extend an active override by this much, or engage fresh for this long
+        if none is active. Ignored when end_time is set.
+      required: false
+      selector:
+        duration:
+
 set_position_limits:
   name: Set position limits
   description: >-

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -18,6 +18,10 @@ if TYPE_CHECKING:
 
 from ..const import DOMAIN
 from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagnostics
+from .engage_manual_override_service import (
+    ENGAGE_MANUAL_OVERRIDE_SCHEMA,
+    async_handle_engage_manual_override,
+)
 from .export_service import EXPORT_CONFIG_SCHEMA, async_handle_export
 from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
@@ -211,6 +215,12 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         DOMAIN, "set_tilt", async_handle_set_tilt, schema=SET_TILT_SCHEMA
     )
     hass.services.async_register(DOMAIN, "stop", async_handle_stop)
+    hass.services.async_register(
+        DOMAIN,
+        "engage_manual_override",
+        async_handle_engage_manual_override,
+        schema=ENGAGE_MANUAL_OVERRIDE_SCHEMA,
+    )
 
     register_options_services(hass)
 
@@ -231,5 +241,6 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "set_position")
     hass.services.async_remove(DOMAIN, "set_tilt")
     hass.services.async_remove(DOMAIN, "stop")
+    hass.services.async_remove(DOMAIN, "engage_manual_override")
     for name in OPTIONS_SERVICE_NAMES:
         hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/engage_manual_override_service.py
+++ b/custom_components/adaptive_cover_pro/services/engage_manual_override_service.py
@@ -1,0 +1,125 @@
+"""engage_manual_override service — engage/extend manual override, no movement.
+
+Thin target-resolution + lenient-coercion layer over
+``Coordinator.async_engage_manual_override``, which drives the override state
+machine (no ``apply_position`` — sends NO cover command). Two optional params:
+
+* ``end_time`` — absolute end (datetime or ISO string). Parse failure falls
+  through to the manager, which validates against ``now``.
+* ``duration`` — relative extend-by (duration dict or timedelta). Non-positive
+  or unparseable coerces to ``None``.
+
+The handler does TYPE coercion + tz-normalization only (naive → UTC); it never
+raises on a bad value. Semantic validation against ``now`` lives in the manager.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _accept_any(value):
+    """Passthrough validator — coercion happens leniently in the handler."""
+    return value
+
+
+ENGAGE_MANUAL_OVERRIDE_SCHEMA = cv.make_entity_service_schema(
+    {
+        vol.Optional("end_time"): _accept_any,
+        vol.Optional("duration"): _accept_any,
+    }
+)
+
+
+def _resolve_targets(hass, call):
+    """Thin re-export so tests can patch the local name."""
+    from . import _resolve_targets as _rt  # noqa: PLC0415
+
+    return _rt(hass, call)
+
+
+def _coerce_end_time(value) -> dt.datetime | None:
+    """Coerce a service ``end_time`` value to an aware datetime, or None.
+
+    Accepts a ``datetime`` or a string (ISO / HA datetime). A naive result is
+    treated as UTC (mirrors the tz-normalize precedent in the coordinator). Any
+    parse failure returns ``None`` — the manager then falls through to its
+    default rather than the service raising.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dt.datetime):
+        parsed: dt.datetime | None = value
+    elif isinstance(value, str):
+        parsed = dt_util.parse_datetime(value)
+    else:
+        return None
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed
+
+
+def _coerce_duration(value) -> dt.timedelta | None:
+    """Coerce a service ``duration`` value to a positive timedelta, or None.
+
+    Accepts a ``timedelta`` or a duration dict (``days``/``hours``/``minutes``/
+    ``seconds``). Non-positive or unparseable → ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, dt.timedelta):
+        td = value
+    elif isinstance(value, dict):
+        try:
+            td = dt.timedelta(
+                days=float(value.get("days", 0) or 0),
+                hours=float(value.get("hours", 0) or 0),
+                minutes=float(value.get("minutes", 0) or 0),
+                seconds=float(value.get("seconds", 0) or 0),
+            )
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+    if td <= dt.timedelta(0):
+        return None
+    return td
+
+
+async def async_handle_engage_manual_override(call: ServiceCall) -> None:
+    """Handle the engage_manual_override service call.
+
+    Resolves the target block to one or more coordinators (each with an optional
+    entity filter), coerces the optional ``end_time`` / ``duration`` leniently,
+    then delegates each coordinator to ``async_engage_manual_override`` — which
+    engages via the override state machine and refreshes once. No cover command
+    is sent.
+    """
+    hass = call.hass
+    end_time = _coerce_end_time(call.data.get("end_time"))
+    duration = _coerce_duration(call.data.get("duration"))
+    targets = _resolve_targets(hass, call)
+
+    for coord, entity_filter in targets.items():
+        entity_ids: list[str] = (
+            list(entity_filter) if entity_filter is not None else list(coord.entities)
+        )
+        await coord.async_engage_manual_override(
+            entity_ids,
+            end_time=end_time,
+            duration=duration,
+            trigger="engage_manual_override",
+        )

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2343,6 +2343,20 @@
           "description": "Wenn aktiviert, die Aktivierung der Manuellen Übersteuerung überspringen. Standard: deaktiviert — Dienstaufrufe aktivieren die Manuelle Übersteuerung wie ein Dashboard-Schieberegler."
         }
       }
+    },
+    "engage_manual_override": {
+      "name": "Manuelle Übersteuerung aktivieren",
+      "description": "Aktiviert oder verlängert die Manuelle Übersteuerung für die ausgewählten Beschattungen, ohne sie zu bewegen — es wird kein Beschattungsbefehl gesendet. Ohne Endzeit und ohne Dauer gilt die Übersteuerung für die konfigurierte Dauer der Manuellen Übersteuerung ab jetzt. Geben Sie eine Endzeit für ein absolutes Ende an oder eine Dauer, um eine aktive Übersteuerung zu verlängern (oder neu für diese Dauer zu aktivieren, falls keine aktiv ist). Werden beide angegeben, hat die Endzeit Vorrang.",
+      "fields": {
+        "end_time": {
+          "name": "Endzeit",
+          "description": "Absolute Zeit, zu der die Übersteuerung enden soll. Wird ignoriert (Rückfall auf die konfigurierte Dauer), wenn sie in der Vergangenheit liegt oder nicht lesbar ist. Hat Vorrang vor der Dauer."
+        },
+        "duration": {
+          "name": "Dauer",
+          "description": "Verlängert eine aktive Übersteuerung um diesen Betrag oder aktiviert sie neu für diese Dauer, falls keine aktiv ist. Wird ignoriert, wenn eine Endzeit gesetzt ist."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -2343,6 +2343,20 @@
           "description": "When true, skip manual-override engagement. Default false — service calls engage manual override like a dashboard slider."
         }
       }
+    },
+    "engage_manual_override": {
+      "name": "Engage manual override",
+      "description": "Engages or extends manual override on the targeted covers without moving them — no cover command is sent. With no end time and no duration, the override lasts the configured manual-override duration starting now. Provide an end time for an absolute end, or a duration to extend an active override (or engage fresh for that long if none is active). If both are given, the end time wins.",
+      "fields": {
+        "end_time": {
+          "name": "End time",
+          "description": "Absolute time the override should end. Ignored (falls back to the configured duration) if it is in the past or unparseable. Takes precedence over duration."
+        },
+        "duration": {
+          "name": "Duration",
+          "description": "Extend an active override by this much, or engage fresh for this long if none is active. Ignored when an end time is set."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2343,6 +2343,20 @@
           "description": "Lorsque cette option est activée, ignore l'engagement de dérogation manuelle. Par défaut false — les appels de service engagent la dérogation manuelle comme un curseur du tableau de bord."
         }
       }
+    },
+    "engage_manual_override": {
+      "name": "Engager la dérogation manuelle",
+      "description": "Engage (ou prolonge) la dérogation manuelle sur les protections ciblées sans les déplacer — aucune commande de protection n'est envoyée. Sans heure de fin ni durée, la dérogation dure la durée de dérogation manuelle configurée à partir de maintenant. Indiquez une heure de fin pour une fin absolue, ou une durée pour prolonger une dérogation active (ou en engager une nouvelle pour cette durée si aucune n'est active). Si les deux sont fournies, l'heure de fin l'emporte.",
+      "fields": {
+        "end_time": {
+          "name": "Heure de fin",
+          "description": "Heure absolue à laquelle la dérogation doit se terminer. Ignorée (retour à la durée configurée) si elle est passée ou illisible. Prioritaire sur la durée."
+        },
+        "duration": {
+          "name": "Durée",
+          "description": "Prolonge une dérogation active de cette valeur, ou en engage une nouvelle pour cette durée si aucune n'est active. Ignorée lorsqu'une heure de fin est définie."
+        }
+      }
     }
   }
 }

--- a/tests/services/test_engage_manual_override_service.py
+++ b/tests/services/test_engage_manual_override_service.py
@@ -1,0 +1,168 @@
+"""Tests for the engage_manual_override service handler (issue #793).
+
+The handler does lenient TYPE coercion + tz-normalization only; semantic
+validation against ``now`` lives in the manager. A bad ``end_time`` /
+``duration`` coerces to ``None`` (never raises) and the manager falls back.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.services.engage_manual_override_service import (
+    ENGAGE_MANUAL_OVERRIDE_SCHEMA,
+    _coerce_duration,
+    _coerce_end_time,
+    async_handle_engage_manual_override,
+)
+
+pytestmark = pytest.mark.unit
+
+_PATCH_TARGET = (
+    "custom_components.adaptive_cover_pro.services."
+    "engage_manual_override_service._resolve_targets"
+)
+
+
+def _make_coord() -> MagicMock:
+    coord = MagicMock()
+    coord.entities = ["cover.living_room"]
+    coord.async_engage_manual_override = AsyncMock()
+    return coord
+
+
+async def _run(data: dict) -> MagicMock:
+    coord = _make_coord()
+    call = MagicMock()
+    call.hass = MagicMock()
+    call.data = data
+    with patch(_PATCH_TARGET, return_value={coord: None}):
+        await async_handle_engage_manual_override(call)
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_iso_end_time_parsed_and_passed_through() -> None:
+    coord = await _run({"end_time": "2026-07-02T15:00:00+00:00"})
+    coord.async_engage_manual_override.assert_awaited_once()
+    args, kwargs = coord.async_engage_manual_override.call_args
+    assert args[0] == ["cover.living_room"]
+    assert kwargs["end_time"] == dt.datetime(2026, 7, 2, 15, 0, tzinfo=dt.UTC)
+    assert kwargs["duration"] is None
+
+
+@pytest.mark.asyncio
+async def test_naive_iso_end_time_normalized_to_utc() -> None:
+    coord = await _run({"end_time": "2026-07-02T15:00:00"})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["end_time"] == dt.datetime(2026, 7, 2, 15, 0, tzinfo=dt.UTC)
+
+
+@pytest.mark.asyncio
+async def test_datetime_end_time_passed_through() -> None:
+    end = dt.datetime(2026, 7, 2, 18, 0, tzinfo=dt.UTC)
+    coord = await _run({"end_time": end})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["end_time"] == end
+
+
+@pytest.mark.asyncio
+async def test_garbage_end_time_coerces_to_none() -> None:
+    coord = await _run({"end_time": "not-a-date"})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["end_time"] is None
+    assert kwargs["duration"] is None
+
+
+@pytest.mark.asyncio
+async def test_no_data_passes_none_none() -> None:
+    coord = await _run({})
+    coord.async_engage_manual_override.assert_awaited_once()
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["end_time"] is None
+    assert kwargs["duration"] is None
+
+
+@pytest.mark.asyncio
+async def test_duration_dict_coerced_to_timedelta() -> None:
+    coord = await _run({"duration": {"hours": 1, "minutes": 30}})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["duration"] == dt.timedelta(hours=1, minutes=30)
+    assert kwargs["end_time"] is None
+
+
+@pytest.mark.asyncio
+async def test_zero_duration_coerces_to_none() -> None:
+    coord = await _run({"duration": {"hours": 0, "minutes": 0, "seconds": 0}})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["duration"] is None
+
+
+@pytest.mark.asyncio
+async def test_timedelta_duration_passed_through() -> None:
+    coord = await _run({"duration": dt.timedelta(minutes=45)})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    assert kwargs["duration"] == dt.timedelta(minutes=45)
+
+
+@pytest.mark.asyncio
+async def test_entity_filter_expands_to_all_coordinator_entities() -> None:
+    """A None filter (whole-coordinator) engages every cover the coordinator owns."""
+    coord = _make_coord()
+    coord.entities = ["cover.a", "cover.b"]
+    call = MagicMock()
+    call.hass = MagicMock()
+    call.data = {}
+    with patch(_PATCH_TARGET, return_value={coord: None}):
+        await async_handle_engage_manual_override(call)
+    args, _ = coord.async_engage_manual_override.call_args
+    assert args[0] == ["cover.a", "cover.b"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_entity_filter_passed_through() -> None:
+    coord = _make_coord()
+    coord.entities = ["cover.a", "cover.b"]
+    call = MagicMock()
+    call.hass = MagicMock()
+    call.data = {}
+    with patch(_PATCH_TARGET, return_value={coord: {"cover.a"}}):
+        await async_handle_engage_manual_override(call)
+    args, _ = coord.async_engage_manual_override.call_args
+    assert args[0] == ["cover.a"]
+
+
+# ---------------------------------------------------------------------------
+# Direct coercion-branch coverage
+# ---------------------------------------------------------------------------
+
+
+def test_coerce_end_time_rejects_non_datetime_non_string() -> None:
+    assert _coerce_end_time(12345) is None
+    assert _coerce_end_time(None) is None
+
+
+def test_coerce_duration_rejects_wrong_type_and_bad_dict() -> None:
+    assert _coerce_duration("PT1H") is None
+    assert _coerce_duration(None) is None
+    # Non-numeric dict value → TypeError/ValueError → None (never raises)
+    assert _coerce_duration({"hours": "abc"}) is None
+
+
+def test_coerce_duration_negative_is_none() -> None:
+    assert _coerce_duration(dt.timedelta(seconds=-5)) is None
+
+
+def test_schema_passes_end_time_and_duration_through_untouched() -> None:
+    validated = ENGAGE_MANUAL_OVERRIDE_SCHEMA(
+        {
+            "entity_id": "cover.a",
+            "end_time": "not-a-date",
+            "duration": {"hours": 1},
+        }
+    )
+    assert validated["end_time"] == "not-a-date"
+    assert validated["duration"] == {"hours": 1}

--- a/tests/test_engage_manual_override.py
+++ b/tests/test_engage_manual_override.py
@@ -1,0 +1,236 @@
+"""Tests for the engage/extend manual-override service path (issue #793).
+
+A new ``adaptive_cover_pro.engage_manual_override`` service engages (or extends)
+manual override on targeted covers WITHOUT sending any cover command. These
+tests cover the manager engage method, the SSOT expiry↔start inverse helpers,
+and the coordinator wrapper.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.manual_override import (
+    AdaptiveCoverManager,
+)
+from custom_components.adaptive_cover_pro.managers.manual_override.expiry import (
+    expiry_for_started_at,
+    started_at_for_expiry,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _make_manager(
+    covers: list[str], *, reset_duration: dict[str, int] | None = None
+) -> AdaptiveCoverManager:
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration=reset_duration or {"hours": 2},
+        logger=MagicMock(),
+    )
+    manager.add_covers(covers)
+    return manager
+
+
+# ---------------------------------------------------------------------------
+# SSOT expiry helpers (inverse-helper guard)
+# ---------------------------------------------------------------------------
+
+
+def test_expiry_helpers_are_inverses() -> None:
+    start = dt.datetime(2026, 7, 2, 12, 0, tzinfo=dt.UTC)
+    dur = dt.timedelta(hours=2, minutes=15)
+    expiry = expiry_for_started_at(start, dur)
+    assert expiry == start + dur
+    assert started_at_for_expiry(expiry, dur) == start
+    # Round trip both directions
+    assert expiry_for_started_at(started_at_for_expiry(expiry, dur), dur) == expiry
+
+
+# ---------------------------------------------------------------------------
+# Manager: engage_override with an absolute end_time (no cover command)
+# ---------------------------------------------------------------------------
+
+
+def test_engage_override_absolute_end_time_sets_expiry_no_command() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+    on_engaged = MagicMock()
+    manager.set_transition_callbacks(on_engaged=on_engaged)
+
+    now = dt.datetime.now(dt.UTC)
+    end = now + dt.timedelta(hours=1)
+    manager.engage_override(cover, end_time=end, duration=None, reason="service")
+
+    assert manager.is_cover_manual(cover) is True
+    # stored start = end - reset_duration (the SSOT inverse the sensor uses)
+    expected_start = end - manager.reset_duration
+    assert (
+        abs((manager.manual_control_time[cover] - expected_start).total_seconds()) < 1
+    )
+    on_engaged.assert_called_once_with(cover)
+
+
+def test_engage_override_none_falls_back_to_now() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+
+    before = dt.datetime.now(dt.UTC)
+    manager.engage_override(cover, end_time=None, duration=None, reason="service")
+    after = dt.datetime.now(dt.UTC)
+
+    assert manager.is_cover_manual(cover) is True
+    ts = manager.manual_control_time[cover]
+    assert before <= ts <= after
+
+
+def test_engage_override_past_end_time_falls_back_to_now() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+
+    before = dt.datetime.now(dt.UTC)
+    past = before - dt.timedelta(hours=1)
+    manager.engage_override(cover, end_time=past, duration=None, reason="service")
+    after = dt.datetime.now(dt.UTC)
+
+    ts = manager.manual_control_time[cover]
+    assert before <= ts <= after
+
+
+def test_engage_override_naive_datetime_normalized_utc() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+
+    # naive future datetime — must not raise, treated as UTC
+    end_naive = (dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)).replace(tzinfo=None)
+    manager.engage_override(cover, end_time=end_naive, duration=None, reason="service")
+
+    assert manager.is_cover_manual(cover) is True
+    expected_start = end_naive.replace(tzinfo=dt.UTC) - manager.reset_duration
+    assert (
+        abs((manager.manual_control_time[cover] - expected_start).total_seconds()) < 1
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manager: duration semantics (engage-for + extend-by + precedence)
+# ---------------------------------------------------------------------------
+
+
+def test_engage_override_duration_engages_fresh_for_now_plus_duration() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+
+    now = dt.datetime.now(dt.UTC)
+    manager.engage_override(
+        cover, end_time=None, duration=dt.timedelta(hours=1), reason="service"
+    )
+
+    assert manager.is_cover_manual(cover) is True
+    # end = now + 1h → stored start = now + 1h - 2h = now - 1h
+    end = expiry_for_started_at(
+        manager.manual_control_time[cover], manager.reset_duration
+    )
+    assert abs((end - (now + dt.timedelta(hours=1))).total_seconds()) < 1
+
+
+def test_engage_override_duration_extends_active_override() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+    on_engaged = MagicMock()
+    manager.set_transition_callbacks(on_engaged=on_engaged)
+
+    # Engage fresh for 1h
+    manager.engage_override(
+        cover, end_time=None, duration=dt.timedelta(hours=1), reason="service"
+    )
+    first_end = expiry_for_started_at(
+        manager.manual_control_time[cover], manager.reset_duration
+    )
+    assert on_engaged.call_count == 1
+
+    # Extend by another 1h — end must move to first_end + 1h
+    manager.engage_override(
+        cover, end_time=None, duration=dt.timedelta(hours=1), reason="service"
+    )
+    second_end = expiry_for_started_at(
+        manager.manual_control_time[cover], manager.reset_duration
+    )
+
+    assert abs((second_end - (first_end + dt.timedelta(hours=1))).total_seconds()) < 1
+    # Extending an already-manual cover must NOT re-fire the engaged edge
+    assert on_engaged.call_count == 1
+
+
+def test_engage_override_end_time_takes_precedence_over_duration() -> None:
+    cover = "cover.x"
+    manager = _make_manager([cover], reset_duration={"hours": 2})
+
+    now = dt.datetime.now(dt.UTC)
+    end = now + dt.timedelta(hours=3)
+    manager.engage_override(
+        cover, end_time=end, duration=dt.timedelta(hours=1), reason="service"
+    )
+
+    resolved_end = expiry_for_started_at(
+        manager.manual_control_time[cover], manager.reset_duration
+    )
+    assert abs((resolved_end - end).total_seconds()) < 1
+
+
+def test_engage_override_shares_engine_with_external_path() -> None:
+    """The external input-sensor path must still engage all covers + fire edges."""
+    covers = ["cover.a", "cover.b"]
+    manager = _make_manager(covers)
+    on_engaged = MagicMock()
+    manager.set_transition_callbacks(on_engaged=on_engaged)
+
+    before = dt.datetime.now(dt.UTC)
+    manager.engage_manual_override_from_external(reason="input_sensor")
+
+    for cover in covers:
+        assert manager.is_cover_manual(cover) is True
+        assert manager.manual_control_time[cover] >= before
+    assert on_engaged.call_count == len(covers)
+
+    # Second press re-arms the timer (overwrite) and does not re-fire the edge
+    time.sleep(0.01)
+    first = manager.manual_control_time["cover.a"]
+    manager.engage_manual_override_from_external(reason="input_sensor")
+    assert manager.manual_control_time["cover.a"] > first
+    assert on_engaged.call_count == len(covers)
+
+
+# ---------------------------------------------------------------------------
+# Coordinator wrapper: engage then refresh once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_engage_manual_override_engages_each_then_refreshes() -> None:
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock()
+    coord.entities = ["cover.a", "cover.b"]
+    coord.manager = MagicMock()
+    coord.async_refresh = AsyncMock()
+    coord.async_engage_manual_override = (
+        AdaptiveDataUpdateCoordinator.async_engage_manual_override.__get__(coord)
+    )
+
+    end = dt.datetime.now(dt.UTC) + dt.timedelta(hours=1)
+    await coord.async_engage_manual_override(
+        ["cover.a"], end_time=end, duration=None, trigger="engage_manual_override"
+    )
+
+    coord.manager.engage_override.assert_called_once_with(
+        "cover.a", end_time=end, duration=None, reason="engage_manual_override"
+    )
+    coord.async_refresh.assert_awaited_once()

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -77,6 +77,7 @@ REGISTERED_SERVICES = {
     "emergency_stop",
     "set_position",
     "set_tilt",
+    "engage_manual_override",
     # Options services (registered via register_options_services / OPTIONS_SERVICE_NAMES)
     "set_position_limits",
     "set_sunset_sunrise",


### PR DESCRIPTION
## Summary
Adds `adaptive_cover_pro.engage_manual_override` — a service that engages or extends a manual override on the targeted covers **without moving the cover**. Optional `end_time` (absolute) and `duration` (extend-by an active override, or engage-for that long when none is active) parameters; `end_time` wins when valid, else `duration`, else it falls back to now + the configured default override duration. Parsing is lenient and never raises. The `expiry <-> started_at` formula is extracted into a shared SSOT module reused by the end-time sensor and the restore path.

## Testing
- ✅ 5474 tests passing (full suite), ruff clean, DE/FR translations synced

## Related Issues
Refs #793