### PR TITLE
feat: add Cover Group entry type — Phase 1 MVP (#790)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -57,6 +57,7 @@ from .const import (
 )
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
+from .group_coordinator import GroupCoordinator
 from .helpers import (
     copy_legacy_slot_sensors_to_list,
     custom_position_slot_sensors,
@@ -79,6 +80,16 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.COVER,
     Platform.NUMBER,
+]
+# Platform set for cover-group entries (``is_orchestrator = True``). A group
+# exposes aggregate sensors, bulk switches, scene buttons, and the scene
+# select — no proxy cover, number, or binary sensor. Setup and unload must
+# use the same list (load/unload symmetry, the #712/#714 lesson).
+GROUP_PLATFORMS = [
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.BUTTON,
+    Platform.SELECT,
 ]
 CONF_SUN = ["sun.sun"]
 
@@ -134,8 +145,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     # guard stays unambiguous. Register a propagation update-listener so a change
     # to the profile reaches its linked covers, then return without forwarding
     # platforms.
-    if not get_policy(entry.data[CONF_SENSOR_TYPE]).controls_cover:
+    policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+    if not policy.controls_cover:
         entry.async_on_unload(entry.add_update_listener(_async_profile_propagate))
+        return True
+
+    # Cover groups (``is_orchestrator = True``) control covers but are not
+    # geometry-driven: build the GroupCoordinator and forward only the group
+    # platform set — never the sun/geometry coordinator below.
+    if policy.is_orchestrator:
+        group_coordinator = GroupCoordinator(hass, entry)
+        entry.runtime_data = group_coordinator
+        await hass.config_entries.async_forward_entry_setups(entry, GROUP_PLATFORMS)
+        await group_coordinator.async_config_entry_first_refresh()
+        entry.async_on_unload(entry.add_update_listener(_async_group_update_listener))
         return True
 
     coordinator = AdaptiveDataUpdateCoordinator(hass)
@@ -373,13 +396,26 @@ async def async_unload_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) ->
     """Unload a config entry."""
     # Virtual entry types (Building Profile, controls_cover == False) forwarded
     # no platforms in async_setup_entry, so unloading platforms would raise
-    # "Config entry was never loaded!". Mirror the setup short-circuit.
-    if not get_policy(entry.data[CONF_SENSOR_TYPE]).controls_cover:
+    # "Config entry was never loaded!". Mirror the setup short-circuit, and
+    # unload exactly the platform set setup forwarded (groups use their own).
+    policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+    if not policy.controls_cover:
         await async_unload_services(hass)
         return True
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+    platforms = GROUP_PLATFORMS if policy.is_orchestrator else PLATFORMS
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
         await async_unload_services(hass)
     return unload_ok
+
+
+async def _async_group_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload a group entry when its options (membership) change.
+
+    The group holds no long-running state worth preserving across an options
+    edit, so a full reload is the simplest way to re-resolve the roster and
+    rebuild the per-scene entities.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -12,6 +12,7 @@ from .const import (
     CONF_ENABLE_MY_POSITION_ENTITIES,
     CONF_ENTITIES,
     CONF_MY_POSITION_VALUE,
+    CONF_SENSOR_TYPE,
     DEFAULT_ENABLE_MY_POSITION_ENTITIES,
 )
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
@@ -25,6 +26,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up the button platform."""
     coordinator: AdaptiveDataUpdateCoordinator = config_entry.runtime_data
+
+    # Cover groups expose scene + clear-overrides buttons, never the cover set.
+    from .cover_types import get_policy
+
+    if get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        from .group_entities import build_group_buttons
+
+        async_add_entities(
+            build_group_buttons(config_entry.entry_id, hass, config_entry, coordinator)
+        )
+        return
 
     buttons: list[ButtonEntity] = []
 
@@ -69,54 +81,13 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
         return self._button_name
 
     async def async_press(self) -> None:
-        """Handle the button press."""
-        reset_entities = []
-        for entity in self._entities:
-            if self.coordinator.manager.is_cover_manual(entity):
-                _LOGGER.debug("Resetting manual override for: %s", entity)
-                self.coordinator.manager.reset(entity)
-                # Suppress re-detection: cover state events during refresh must
-                # not be treated as a new manual override.
-                self.coordinator._cmd_svc.set_waiting(entity, True)  # noqa: SLF001
-                self.coordinator.cover_state_change = False
-                reset_entities.append(entity)
-            else:
-                _LOGGER.debug(
-                    "Resetting manual override for %s is not needed since it is already auto-controlled",
-                    entity,
-                )
+        """Handle the button press.
 
-        if not reset_entities:
-            return
-
-        # Refresh so the pipeline re-runs without the override active,
-        # producing the correct post-override position (climate, solar,
-        # default — whichever handler wins now).
-        await self.coordinator.async_refresh()
-
-        # Delegate to the shared post-override send path.
-        # Time-window and automatic-control gates live there, along with
-        # force=True so time_delta/position_delta are bypassed for this
-        # intentional user reset.
-        sent = await self.coordinator._async_send_after_override_clear(
-            self.coordinator.state,
-            self.coordinator.config_entry.options,
-            entities=reset_entities,
-            trigger="manual_reset",
-        )
-
-        # Entities not sent to (gated by time window / auto-control, or
-        # skipped inside apply_position) must have wait_for_target cleared so
-        # later cover state events are not silently swallowed.
-        # Entities that were sent already have wait_for_target=True set by
-        # apply_position; leave those untouched.
-        for entity in reset_entities:
-            if entity not in sent:
-                _LOGGER.debug(
-                    "Manual override reset: no position change sent for %s",
-                    entity,
-                )
-                self.coordinator._cmd_svc.set_waiting(entity, False)  # noqa: SLF001
+        The full clear-and-resend sequence lives on the coordinator
+        (``async_reset_manual_overrides``) so this button and the cover-group
+        bulk clear (issue #790) share one path.
+        """
+        await self.coordinator.async_reset_manual_overrides(self._entities)
 
 
 class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,8 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
     CONF_FORCE_OVERRIDE_MIN_MODE,
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
@@ -206,7 +208,11 @@ _LOGGER = logging.getLogger(__name__)
 from .cover_types import POLICY_REGISTRY as _POLICY_REGISTRY  # noqa: E402
 from .cover_types import get_policy as _get_policy  # noqa: E402
 
-SENSOR_TYPE_MENU = [k for k in _POLICY_REGISTRY if _get_policy(k).controls_cover]
+SENSOR_TYPE_MENU = [
+    k
+    for k in _POLICY_REGISTRY
+    if _get_policy(k).controls_cover and not _get_policy(k).is_orchestrator
+]
 
 _STANDALONE_SENTINEL = "__standalone__"
 # Sentinel value for the "no profile / unlink" choice in the link selector.
@@ -355,6 +361,66 @@ BUILDING_PROFILE_CREATE_SCHEMA = vol.Schema(
         **building_profile_sensors_schema().schema,
     }
 )
+
+
+def _group_membership_schema_dict(hass, *, exclude_entry_id: str | None = None) -> dict:
+    """Build the two cover-group membership selectors (issue #790).
+
+    ACP members are picked as config entries (an ACP instance may expose no
+    ``cover.`` entity at all when its proxy is off, and one with a proxy must
+    still be orchestrated through its pipeline), generic covers as plain
+    entities. ``_cover_entries`` already excludes profiles and groups, so a
+    group can never nest another group; ``exclude_entry_id`` drops the group
+    itself when editing.
+    """
+    acp_options = [
+        {"value": e.entry_id, "label": e.title}
+        for e in _cover_entries(hass)
+        if e.entry_id != exclude_entry_id
+    ]
+    return {
+        vol.Optional(CONF_MEMBER_ENTRIES, default=[]): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=acp_options, multiple=True)
+        ),
+        vol.Optional(CONF_MEMBER_COVERS, default=[]): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="cover", multiple=True)
+        ),
+    }
+
+
+def _sanitize_group_membership(
+    hass, user_input: dict, *, own_entry_id: str | None = None
+) -> dict[str, list[str]]:
+    """Clean the submitted membership rosters.
+
+    Deduplicates while preserving order, drops the group's own entry id, and
+    drops a generic entity that is already controlled by a selected ACP
+    member — the entry is preferred so the member's pipeline orchestrates the
+    cover instead of it being double-commanded through adopt mode.
+    """
+    member_entries = list(
+        dict.fromkeys(
+            entry_id
+            for entry_id in user_input.get(CONF_MEMBER_ENTRIES, [])
+            if entry_id != own_entry_id
+        )
+    )
+    owned_covers: set[str] = set()
+    for entry_id in member_entries:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is not None:
+            owned_covers.update(entry.options.get(CONF_ENTITIES, []))
+    member_covers = list(
+        dict.fromkeys(
+            entity_id
+            for entity_id in user_input.get(CONF_MEMBER_COVERS, [])
+            if entity_id not in owned_covers
+        )
+    )
+    return {
+        CONF_MEMBER_ENTRIES: member_entries,
+        CONF_MEMBER_COVERS: member_covers,
+    }
 
 
 # The sun-tracking step no longer carries any length field — the shaded distance
@@ -1483,6 +1549,16 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "headers.decision_priority": (
         "**Decision Priority** (highest wins, ✅ active ❌ not configured)"
     ),
+    # --- Cover Group (issue #790) ---
+    "group.header": "**Cover Group**",
+    "group.members": (
+        "Controls {acp_count} ACP member(s) + {generic_count} generic cover(s)"
+    ),
+    "group.member_acp": "- 🪟 {title} (ACP)",
+    "group.member_generic": "- 🪟 {entity} (generic)",
+    "warnings.group_empty": (
+        "⚠️ This group has no members — it will not command anything."
+    ),
 }
 
 
@@ -1545,6 +1621,40 @@ async def _load_summary_labels(hass: HomeAssistant, language: str) -> dict[str, 
     return await hass.async_add_executor_job(_load_summary_labels_sync, language)
 
 
+def _build_group_summary(
+    config: dict,
+    hass: HomeAssistant | None,
+    L: dict[str, str],
+) -> str:
+    """Compact configuration summary for a Cover Group entry (issue #790).
+
+    Header, roster counts, and the member list (ACP member titles resolve
+    only when ``hass`` is available). An empty roster gets a warning — a
+    memberless group commands nothing.
+    """
+    member_entries: list[str] = config.get(CONF_MEMBER_ENTRIES) or []
+    member_covers: list[str] = config.get(CONF_MEMBER_COVERS) or []
+    lines = [L["group.header"], ""]
+    if not member_entries and not member_covers:
+        lines.append(L["warnings.group_empty"])
+        return "\n".join(lines)
+    lines.append(
+        L["group.members"].format(
+            acp_count=len(member_entries), generic_count=len(member_covers)
+        )
+    )
+    if hass is not None:
+        for entry_id in member_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry is not None:
+                lines.append(L["group.member_acp"].format(title=entry.title))
+    lines.extend(
+        L["group.member_generic"].format(entity=entity_id)
+        for entity_id in member_covers
+    )
+    return "\n".join(lines)
+
+
 def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     config: dict,
     sensor_type: str | None,
@@ -1566,6 +1676,12 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     are used, so the output is byte-identical to the pre-i18n strings.
     """
     L = labels or _SUMMARY_LABELS_EN
+
+    # Cover groups render their own compact summary — a group has no cover
+    # chain, geometry, or handler ladder (issue #790).
+    if sensor_type is not None and get_policy(sensor_type).is_orchestrator:
+        return _build_group_summary(config, hass, L)
+
     _ph = L["fragments.template_value"]
     # ---- Gather all values up front ----------------------------------------
     # ``L`` here is the FULL flow bundle (``_SUMMARY_LABELS_EN`` keys + the
@@ -3188,7 +3304,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         choices. The duplicate option only appears when prior entries exist.
         """
         acp_entries = _cover_entries(self.hass)
-        menu_options = ["create_new", "create_building_profile"] + (
+        menu_options = ["create_new", "create_building_profile", "create_group"] + (
             ["duplicate_existing"] if acp_entries else []
         )
         return self.async_show_menu(step_id="user", menu_options=menu_options)
@@ -3222,6 +3338,34 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=BUILDING_PROFILE_CREATE_SCHEMA,
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
+            },
+        )
+
+    async def async_step_create_group(self, user_input: dict[str, Any] | None = None):
+        """Create a Cover Group entry from a single combined form (issue #790).
+
+        One step collects the group name together with the two membership
+        rosters (ACP members first, generic covers below), then delegates to
+        the shared finalize (``async_step_update``) — the same path the
+        Building Profile flow uses.
+        """
+        if user_input is not None:
+            self.config = {
+                "name": user_input["name"],
+                **_sanitize_group_membership(self.hass, user_input),
+            }
+            self.type_blind = CoverType.GROUP
+            return await self.async_step_update()
+        return self.async_show_form(
+            step_id="create_group",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("name"): selector.TextSelector(),
+                    **_group_membership_schema_dict(self.hass),
+                }
+            ),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },
         )
 
@@ -3767,10 +3911,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
         # Quick setup skips some steps (e.g. automation) leaving critical keys
         # absent from self.config.  Apply constant-backed defaults so the
-        # coordinator never receives None for gating values (issue #133). A
-        # virtual entry type (Building Profile) builds no coordinator, so it
-        # keeps only the sensor IDs it collected — no cover automation defaults.
-        if get_policy(self.type_blind).controls_cover:
+        # coordinator never receives None for gating values (issue #133).
+        # Virtual entry types skip this: a Building Profile builds no
+        # coordinator, and a cover group builds a GroupCoordinator that reads
+        # none of the cover-automation options — both keep only what their
+        # create step collected.
+        _finalize_policy = get_policy(self.type_blind)
+        if _finalize_policy.controls_cover and not _finalize_policy.is_orchestrator:
             options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
             options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
             options.setdefault(
@@ -3944,6 +4091,23 @@ class OptionsFlowHandler(OptionsFlow):
                     "profile_sensors",
                     "profile_overview",
                     "profile_overrides",
+                    "done",
+                ],
+                description_placeholders={
+                    "instance_name": self._config_entry.title,
+                    "coffee_url": "https://www.buymeacoffee.com/jrhubott",
+                    "profile_line": "",
+                },
+            )
+
+        # Cover groups are orchestrators, not geometry covers — their own
+        # small menu (membership + summary), never the cover categories.
+        if get_policy(self.sensor_type).is_orchestrator:
+            return self.async_show_menu(
+                step_id="init",
+                menu_options=[
+                    "group_membership",
+                    "summary",
                     "done",
                 ],
                 description_placeholders={
@@ -4355,6 +4519,39 @@ class OptionsFlowHandler(OptionsFlow):
             data_schema=schema,
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
+            },
+        )
+
+    async def async_step_group_membership(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the cover-group membership rosters (issue #790).
+
+        Same one page as the create flow: ACP members first, generic covers
+        below. Saves on submit, mirroring ``profile_sensors``. Sanitization
+        drops duplicates, the group itself, and generic entities owned by a
+        selected ACP member.
+        """
+        if user_input is not None:
+            self.options.update(
+                _sanitize_group_membership(
+                    self.hass,
+                    user_input,
+                    own_entry_id=self._config_entry.entry_id,
+                )
+            )
+            return self.async_create_entry(title="", data=self.options)
+
+        schema = vol.Schema(
+            _group_membership_schema_dict(
+                self.hass, exclude_entry_id=self._config_entry.entry_id
+            )
+        )
+        return self.async_show_form(
+            step_id="group_membership",
+            data_schema=self.add_suggested_values_to_schema(schema, self.options),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },
         )
 

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -96,6 +96,14 @@ CONF_PROFILE_SENSOR_OVERRIDES = "profile_sensor_overrides"
 # multi-select becomes an exclude list instead of an include list).
 CONF_SYNC_SELECT_ALL = "select_all_targets"
 
+# Cover-group membership rosters, stored on the GROUP entry only (issue #790).
+# Two lists because the member kinds are structural: ACP members are config
+# entries (orchestrated through their own coordinator — an ACP instance may
+# expose no cover entity at all when the proxy is off), generic members are
+# plain ``cover.*`` entity_ids (adopt mode, commanded directly).
+CONF_MEMBER_ENTRIES = "member_entries"  # ACP member config-entry ids
+CONF_MEMBER_COVERS = "member_covers"  # generic cover entity_ids
+
 # Default name prefix used by the config flow when auto-naming a cover from its
 # entity's friendly name (no linked device available) — see config_flow.py's
 # cover_entities auto-fill and async_step_update finalization fallback (#771).
@@ -1366,6 +1374,11 @@ class CoverType(StrEnum):
     # sensor entity IDs that linked covers copy into their own options. Its
     # policy registers no platforms (``controls_cover = False``).
     BUILDING_PROFILE = "cover_building_profile"
+    # Virtual entry type — orchestrates a roster of member covers (ACP
+    # entries + generic ``cover.*`` entities). Controls covers
+    # (``controls_cover = True``) but is not geometry-driven: setup branches
+    # on ``is_orchestrator`` to a ``GroupCoordinator`` (issue #790).
+    GROUP = "cover_group"
 
     @property
     def display_name(self) -> str:
@@ -1383,7 +1396,36 @@ class CoverType(StrEnum):
             self.OSCILLATING_AWNING: "Oscillating Awning",
             self.ROOF_WINDOW: "Roof Window",
             self.BUILDING_PROFILE: "Building Profile",
+            self.GROUP: "Cover Group",
         }[self]
+
+
+class GroupScene(StrEnum):
+    """Built-in cover-group scenes (issue #790, Phase 1).
+
+    Wire-stable identifiers: stored as the group's active-scene state and the
+    scene ``select``/``button`` option values. Each scene is a semantic intent
+    resolved per member cover type via ``CoverTypePolicy.position_for_scene``
+    — never an absolute position shared across a mixed group.
+    """
+
+    ALL_OPEN = "all_open"
+    ALL_CLOSED = "all_closed"
+    PRIVACY = "privacy"
+
+
+class GroupState(StrEnum):
+    """Aggregate open/closed classification of a cover group's members.
+
+    Wire-stable: the group state sensor reports these values. ``MIXED`` covers
+    every non-uniform roster (members disagree, or sit between endpoints);
+    ``UNKNOWN`` means no member position was readable.
+    """
+
+    OPEN = "open"
+    CLOSED = "closed"
+    MIXED = "mixed"
+    UNKNOWN = "unknown"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1632,6 +1632,71 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return None
         return await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
 
+    async def async_reset_manual_overrides(
+        self,
+        entities: list[str] | None = None,
+        *,
+        trigger: str = "manual_reset",
+    ) -> list[str]:
+        """Clear manual override on covers and resend the pipeline position.
+
+        Single authoritative reset sequence shared by the Reset Manual
+        Override button and the cover-group bulk clear (issue #790): clear the
+        override flag, suppress re-detection during the refresh, re-run the
+        pipeline, then delegate to the shared post-override send path. Returns
+        the entities whose override was actually cleared.
+        """
+        covers = (
+            entities
+            if entities is not None
+            else self.config_entry.options.get(CONF_ENTITIES, [])
+        )
+        reset_entities: list[str] = []
+        for entity in covers:
+            if self.manager.is_cover_manual(entity):
+                _LOGGER.debug("Resetting manual override for: %s", entity)
+                self.manager.reset(entity)
+                # Suppress re-detection: cover state events during refresh must
+                # not be treated as a new manual override.
+                self._cmd_svc.set_waiting(entity, True)
+                self.cover_state_change = False
+                reset_entities.append(entity)
+            else:
+                _LOGGER.debug(
+                    "Resetting manual override for %s is not needed since it is already auto-controlled",
+                    entity,
+                )
+
+        if not reset_entities:
+            return []
+
+        # Refresh so the pipeline re-runs without the override active,
+        # producing the correct post-override position (climate, solar,
+        # default — whichever handler wins now).
+        await self.async_refresh()
+
+        # Time-window and automatic-control gates live in the shared send
+        # path, along with force=True so time_delta/position_delta are
+        # bypassed for this intentional reset.
+        sent = await self._async_send_after_override_clear(
+            self.state,
+            self.config_entry.options,
+            entities=reset_entities,
+            trigger=trigger,
+        )
+
+        # Entities not sent to (gated by time window / auto-control, or
+        # skipped inside apply_position) must have wait_for_target cleared so
+        # later cover state events are not silently swallowed.
+        for entity in reset_entities:
+            if entity not in sent:
+                _LOGGER.debug(
+                    "Manual override reset: no position change sent for %s",
+                    entity,
+                )
+                self._cmd_svc.set_waiting(entity, False)
+        return reset_entities
+
     async def _async_send_after_override_clear(
         self,
         state: int,

--- a/custom_components/adaptive_cover_pro/cover_types/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/__init__.py
@@ -21,10 +21,13 @@ from .roof_window import RoofWindowPolicy
 from .tilt import TiltPolicy
 from .venetian import VenetianPolicy
 
-# Virtual entry type — imported LAST so it sorts to the bottom of the
-# cover-type picker (``SENSOR_TYPE_MENU`` follows registration order). It is
-# not a physical cover (``controls_cover = False``).
+# Virtual entry types — imported LAST so they sort to the bottom of
+# registry-derived menus (``SENSOR_TYPE_MENU`` follows registration order).
+# The building profile is not a physical cover (``controls_cover = False``);
+# the group controls covers but is an orchestrator (``is_orchestrator =
+# True``) — both are filtered out of the cover-type picker by capability.
 from .building_profile import BuildingProfilePolicy
+from .group import GroupPolicy
 
 
 def get_policy(cover_type) -> CoverTypePolicy:
@@ -55,6 +58,7 @@ __all__ = [
     "BlindPolicy",
     "BuildingProfilePolicy",
     "CoverTypePolicy",
+    "GroupPolicy",
     "OscillatingAwningPolicy",
     "RoofWindowPolicy",
     "TiltPolicy",

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -24,7 +24,13 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import selector
 
-from ..const import ATTR_POSITION, ATTR_TILT_POSITION, POSITION_CLOSED, POSITION_OPEN
+from ..const import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    GroupScene,
+)
 from ..helpers import get_open_close_state, should_use_tilt, state_attr
 
 if TYPE_CHECKING:
@@ -163,6 +169,14 @@ class CoverTypePolicy(ABC):
     # cover-only menus, and the setup path can filter them out by capability
     # rather than by branching on the cover-type string.
     controls_cover: ClassVar[bool] = True
+
+    # Whether this policy orchestrates *other* covers instead of driving a
+    # geometry pipeline of its own. Only the cover group sets this ``True``:
+    # it controls covers (``controls_cover = True``) but setup must build a
+    # ``GroupCoordinator`` rather than the sun/geometry coordinator. A second
+    # capability flag keeps that branch off the cover-type string, same as
+    # ``controls_cover`` (issue #790).
+    is_orchestrator: ClassVar[bool] = False
 
     def __init_subclass__(cls, *, register: bool = False, **kwargs: Any) -> None:
         """Auto-register a concrete policy by its ``cover_type``.
@@ -481,6 +495,26 @@ class CoverTypePolicy(ABC):
         if sun_through:
             return POSITION_CLOSED if primary.open_blocks_sun else POSITION_OPEN
         return POSITION_OPEN if primary.open_blocks_sun else POSITION_CLOSED
+
+    def position_for_scene(self, scene: GroupScene) -> int:
+        """Map a cover-group scene to this cover type's primary-axis position.
+
+        Scenes are semantic intents resolved per member (issue #790):
+
+          - ``ALL_OPEN`` / ``ALL_CLOSED`` follow HA cover semantics — 100 =
+            open (blinds raised / awning extended), 0 = closed.
+          - ``PRIVACY`` means maximum coverage, delegated to the existing
+            ``position_for_intent(sun_through=False)`` polymorphism so the
+            awning's open-blocks-sun axis flips the answer.
+
+        Never called on axis-less virtual policies (group, building profile)
+        — the group resolves scenes through each *member's* policy.
+        """
+        if scene is GroupScene.ALL_OPEN:
+            return POSITION_OPEN
+        if scene is GroupScene.ALL_CLOSED:
+            return POSITION_CLOSED
+        return self.position_for_intent(sun_through=False)
 
     def more_protective_position(self, a: int, b: int) -> int:
         """Return whichever of two primary-axis positions blocks more sun.

--- a/custom_components/adaptive_cover_pro/cover_types/group.py
+++ b/custom_components/adaptive_cover_pro/cover_types/group.py
@@ -1,0 +1,34 @@
+"""Cover-group virtual orchestrator entry-type policy (issue #790).
+
+A cover group is not a physical cover: it holds a roster of member covers
+(ACP config entries + generic ``cover.*`` entities) and fans out scenes and
+bulk operations to them at runtime. It *does* control covers
+(``controls_cover = True``) so cover-only filters treat it as an actor, but
+it is not geometry-driven — ``is_orchestrator = True`` routes its config
+entry to a ``GroupCoordinator`` in ``__init__.async_setup_entry`` instead of
+the sun/geometry coordinator, and keeps it out of the cover-type dropdown.
+
+Scene resolution never happens on this policy: the group resolves each scene
+through the *member's* own policy (``position_for_scene``), which is what
+makes mixed blind/awning/venetian groups work.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ..const import CoverType
+from .base import CoverAxis, CoverTypePolicy
+
+
+class GroupPolicy(CoverTypePolicy, register=True):
+    """Virtual orchestrator entry type driving a roster of member covers."""
+
+    cover_type = CoverType.GROUP
+    controls_cover: ClassVar[bool] = True
+    is_orchestrator: ClassVar[bool] = True
+    axes: ClassVar[tuple[CoverAxis, ...]] = ()
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+        """Never called — group setup builds a ``GroupCoordinator``, no engine."""
+        raise NotImplementedError  # pragma: no cover

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -1,0 +1,241 @@
+"""Coordinator for the virtual Cover Group entry type (issue #790, Phase 1).
+
+Orchestrates a roster of member covers:
+
+* **ACP members** (config entries) are commanded through each member's own
+  coordinator (``async_apply_user_position`` / ``async_reset_manual_overrides``
+  / the ``automatic_control`` toggle) so the member's gates, inverse-state,
+  and override semantics all apply.
+* **Generic members** (plain ``cover.*`` entity_ids, "adopt mode") are
+  commanded through a group-owned ``CoverCommandService`` so capability
+  fallback (open/close-only covers), unavailable-cover skips, and no-op
+  suppression come for free.
+
+Phase 1 acts only on explicit user actions (scene buttons/select, bulk
+switches); it never moves covers autonomously, so there is no boot-time
+fan-out path. Scene targets are resolved per member via the member policy's
+``position_for_scene`` — a scene is an intent, not a shared absolute
+position.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DEFAULT_DELTA_POSITION,
+    DEFAULT_DELTA_TIME,
+    DOMAIN,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    CoverType,
+    GroupScene,
+    GroupState,
+)
+from .cover_types import get_policy
+from .managers.cover_command import CoverCommandService
+from .managers.cover_command.state_store import PositionContext
+from .managers.grace_period import GracePeriodManager
+
+_LOGGER = logging.getLogger(__name__)
+
+# Generic ``cover.*`` members carry no ACP geometry; adopt mode drives them as
+# plain HA position covers — the vertical-blind policy's axis semantics
+# (position attribute, open/close fallback, no inversion) are exactly that.
+_ADOPT_COVER_TYPE = CoverType.BLIND
+
+
+@dataclass(frozen=True, slots=True)
+class GroupAggregates:
+    """Aggregate view over the group's member covers, read by the sensors."""
+
+    position: int | None
+    state: GroupState
+    member_positions: dict[str, int | None]
+
+
+class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
+    """Runtime orchestrator for one cover-group config entry."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the group coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_group_{entry.entry_id}",
+            config_entry=entry,
+        )
+        self.entry = entry
+        self.active_scene: GroupScene | None = None
+        self._unsub_state: CALLBACK_TYPE | None = None
+        self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
+        self._grace_mgr = GracePeriodManager(_LOGGER)
+        self._cmd_svc = CoverCommandService(
+            hass,
+            _LOGGER,
+            _ADOPT_COVER_TYPE,
+            self._grace_mgr,
+        )
+
+    # ---- Roster resolution ------------------------------------------------ #
+
+    def resolved_members(self) -> list[tuple[ConfigEntry, object]]:
+        """ACP members whose entry exists and whose coordinator is loaded.
+
+        Every ``runtime_data`` access is null-guarded: during a member reload
+        the attribute is briefly unset, and a removed member's id may linger
+        in the roster until the next options edit. Both are silently skipped —
+        absence is non-membership for this cycle.
+        """
+        members: list[tuple[ConfigEntry, object]] = []
+        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            coordinator = getattr(entry, "runtime_data", None)
+            if coordinator is None:
+                _LOGGER.debug(
+                    "Group %s: member %s has no loaded coordinator; skipping",
+                    self.entry.entry_id,
+                    entry_id,
+                )
+                continue
+            members.append((entry, coordinator))
+        return members
+
+    def member_cover_entities(self) -> list[str]:
+        """All member cover entity_ids: ACP members' covers, then generic."""
+        entities: list[str] = []
+        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            entities.extend(entry.options.get(CONF_ENTITIES, []))
+        entities.extend(self.entry.options.get(CONF_MEMBER_COVERS, []))
+        return entities
+
+    # ---- Fan-out operations ------------------------------------------------ #
+
+    async def async_activate_scene(self, scene: GroupScene) -> None:
+        """Fan a scene out to every member, resolving the target per policy."""
+        trigger = f"group_scene_{scene}"
+        for entry, coordinator in self.resolved_members():
+            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+            target = policy.position_for_scene(scene)
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                await coordinator.async_apply_user_position(
+                    entity_id,
+                    target,
+                    trigger=trigger,
+                )
+        adopt_target = self._adopt_policy.position_for_scene(scene)
+        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            await self._cmd_svc.apply_position(
+                entity_id,
+                adopt_target,
+                trigger,
+                context=self._adopt_context(),
+            )
+        self.active_scene = scene
+        await self.async_refresh()
+
+    async def async_set_automation(self, enabled: bool) -> None:
+        """Bulk-enable/disable sun-tracking automation on every ACP member."""
+        for _entry, coordinator in self.resolved_members():
+            coordinator.automatic_control = enabled
+            await coordinator.async_refresh()
+
+    async def async_clear_overrides(self) -> None:
+        """Clear manual overrides on every ACP member via its shared reset path."""
+        for _entry, coordinator in self.resolved_members():
+            await coordinator.async_reset_manual_overrides(
+                trigger="group_clear_overrides"
+            )
+
+    def _adopt_context(self) -> PositionContext:
+        """Command context for adopt-mode (generic cover) dispatches.
+
+        Scene activation is an explicit user action: ``force=True`` bypasses
+        the delta/time/manual gates (the group has no such config in Phase 1)
+        while the unavailable-cover skip and same-position no-op suppression
+        still apply inside ``apply_position``.
+        """
+        return PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=DEFAULT_DELTA_POSITION,
+            time_threshold=DEFAULT_DELTA_TIME,
+            special_positions=[],
+            force=True,
+            policy=self._adopt_policy,
+        )
+
+    # ---- Aggregates --------------------------------------------------------- #
+
+    async def _async_setup(self) -> None:
+        """Subscribe to member cover state changes to keep aggregates live."""
+        entities = self.member_cover_entities()
+        if entities:
+            self._unsub_state = async_track_state_change_event(
+                self.hass, entities, self._handle_member_state_change
+            )
+
+    @callback
+    def _handle_member_state_change(self, _event: Event) -> None:
+        """Recompute aggregates when any member cover moves."""
+        self.hass.async_create_task(self.async_request_refresh())
+
+    async def async_shutdown(self) -> None:
+        """Tear down listeners and the adopt-mode command service."""
+        if self._unsub_state is not None:
+            self._unsub_state()
+            self._unsub_state = None
+        self._cmd_svc.stop()
+        await super().async_shutdown()
+
+    async def _async_update_data(self) -> GroupAggregates:
+        """Recompute the group position/state aggregates from member covers."""
+        member_positions: dict[str, int | None] = {}
+        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                member_positions[entity_id] = policy.read_axis_value(
+                    self.hass, entity_id, caps=None
+                )
+        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            member_positions[entity_id] = self._adopt_policy.read_axis_value(
+                self.hass, entity_id, caps=None
+            )
+
+        readable = [pos for pos in member_positions.values() if pos is not None]
+        if not readable:
+            return GroupAggregates(
+                position=None,
+                state=GroupState.UNKNOWN,
+                member_positions=member_positions,
+            )
+        if all(pos == POSITION_OPEN for pos in readable):
+            state = GroupState.OPEN
+        elif all(pos == POSITION_CLOSED for pos in readable):
+            state = GroupState.CLOSED
+        else:
+            state = GroupState.MIXED
+        return GroupAggregates(
+            position=int(round(sum(readable) / len(readable))),
+            state=state,
+            member_positions=member_positions,
+        )

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -1,0 +1,231 @@
+"""Entities exposed by a Cover Group entry (issue #790, Phase 1).
+
+One module holds every group entity class plus a per-platform builder, so
+the platform files (``sensor.py`` / ``switch.py`` / ``button.py`` /
+``select.py``) each add a single ``is_orchestrator`` branch and stay free
+of group logic. Unique_ids follow the locked ``f"{entry_id}_{suffix}"``
+contract.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.components.select import SelectEntity
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.switch import SwitchEntity
+
+from .const import GroupScene
+from .entity_base import AdaptiveCoverBaseEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+    from .group_coordinator import GroupCoordinator
+
+# Group entities read GroupCoordinator state, not a cover pipeline.
+# ``AdaptiveCoverBaseEntity`` is coordinator-shape-agnostic (device info,
+# availability gate, render-signature dedup), so it is reused as-is.
+
+
+class _GroupEntityBase(AdaptiveCoverBaseEntity):
+    """Shared init: group coordinator + locked unique_id suffix."""
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: GroupCoordinator,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize with the locked unique_id."""
+        super().__init__(entry_id, hass, config_entry, coordinator)
+        self._attr_unique_id = f"{entry_id}_{unique_id_suffix}"
+
+
+class GroupPositionSensor(_GroupEntityBase, SensorEntity):
+    """Average position across member covers, with per-member attributes."""
+
+    _attr_translation_key = "group_position"
+    _attr_native_unit_of_measurement = "%"
+    _attr_icon = "mdi:page-layout-body"
+
+    @property
+    def native_value(self) -> int | None:
+        """Average of readable member positions."""
+        return self.coordinator.data.position
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Per-member position readings."""
+        return {"member_positions": self.coordinator.data.member_positions}
+
+
+class GroupStateSensor(_GroupEntityBase, SensorEntity):
+    """Aggregate open/closed/mixed classification of the member covers."""
+
+    _attr_translation_key = "group_state"
+    # Text/status sensor: empty unit excludes it from the logbook.
+    _attr_native_unit_of_measurement = ""
+    _attr_icon = "mdi:window-shutter-cog"
+
+    @property
+    def native_value(self) -> str:
+        """Aggregate GroupState classification."""
+        return self.coordinator.data.state
+
+
+class GroupActiveSceneSensor(_GroupEntityBase, SensorEntity):
+    """The last scene activated on this group, if any."""
+
+    _attr_translation_key = "group_active_scene"
+    _attr_native_unit_of_measurement = ""
+    _attr_icon = "mdi:palette-outline"
+
+    @property
+    def native_value(self) -> str | None:
+        """Wire value of the last activated scene, or None."""
+        scene = self.coordinator.active_scene
+        return str(scene) if scene is not None else None
+
+
+class GroupAutomationSwitch(_GroupEntityBase, SwitchEntity):
+    """Bulk-enable/disable sun-tracking automation across all ACP members.
+
+    Reflects the last bulk command sent through this group (defaults to on),
+    not a consensus of member states — members remain individually togglable.
+    """
+
+    _attr_translation_key = "group_automation"
+    _attr_icon = "mdi:cog-clockwise"
+
+    def __init__(self, *args) -> None:
+        """Initialize with automation considered on."""
+        super().__init__(*args, "group_automation")
+        self._attr_is_on = True
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
+        """Bulk-enable automation on all members."""
+        await self.coordinator.async_set_automation(True)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
+        """Bulk-disable automation on all members."""
+        await self.coordinator.async_set_automation(False)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class GroupSceneButton(_GroupEntityBase, ButtonEntity):
+    """Activate one built-in scene across the group."""
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: GroupCoordinator,
+        scene: GroupScene,
+    ) -> None:
+        """Initialize the button for one scene."""
+        super().__init__(
+            entry_id, hass, config_entry, coordinator, f"group_scene_{scene}"
+        )
+        self._scene = scene
+        self._attr_translation_key = f"group_scene_{scene}"
+        self._attr_icon = "mdi:palette"
+
+    async def async_press(self) -> None:
+        """Activate this button's scene across the group."""
+        await self.coordinator.async_activate_scene(self._scene)
+
+
+class GroupClearOverridesButton(_GroupEntityBase, ButtonEntity):
+    """Clear manual overrides on every ACP member of the group."""
+
+    _attr_translation_key = "group_clear_overrides"
+    _attr_icon = "mdi:account-cancel-outline"
+
+    def __init__(self, *args) -> None:
+        """Initialize the clear-overrides button."""
+        super().__init__(*args, "group_clear_overrides")
+
+    async def async_press(self) -> None:
+        """Clear manual overrides on every ACP member."""
+        await self.coordinator.async_clear_overrides()
+
+
+class GroupSceneSelect(_GroupEntityBase, SelectEntity):
+    """Scene picker: selecting an option activates the scene group-wide."""
+
+    _attr_translation_key = "group_scene_select"
+    _attr_icon = "mdi:palette-swatch"
+
+    def __init__(self, *args) -> None:
+        """Initialize the scene picker with the built-in scene options."""
+        super().__init__(*args, "group_scene_select")
+        self._attr_options = [str(scene) for scene in GroupScene]
+
+    @property
+    def current_option(self) -> str | None:
+        """Wire value of the last activated scene, or None."""
+        scene = self.coordinator.active_scene
+        return str(scene) if scene is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Activate the picked scene across the group."""
+        await self.coordinator.async_activate_scene(GroupScene(option))
+        self.async_write_ha_state()
+
+
+def build_group_sensors(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[SensorEntity]:
+    """Build the aggregate sensors for one group entry."""
+    args = (entry_id, hass, config_entry, coordinator)
+    return [
+        GroupPositionSensor(*args, "group_position"),
+        GroupStateSensor(*args, "group_state"),
+        GroupActiveSceneSensor(*args, "group_active_scene"),
+    ]
+
+
+def build_group_switches(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[SwitchEntity]:
+    """Build the bulk switches for one group entry."""
+    return [GroupAutomationSwitch(entry_id, hass, config_entry, coordinator)]
+
+
+def build_group_buttons(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[ButtonEntity]:
+    """Per-scene activate buttons plus the clear-overrides button."""
+    args = (entry_id, hass, config_entry, coordinator)
+    return [
+        *(GroupSceneButton(*args, scene) for scene in GroupScene),
+        GroupClearOverridesButton(*args),
+    ]
+
+
+def build_group_selects(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[SelectEntity]:
+    """Build the scene-picker select for one group entry."""
+    return [GroupSceneSelect(entry_id, hass, config_entry, coordinator)]

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -84,11 +84,19 @@ def _building_profile_entries(hass: HomeAssistant) -> list[ConfigEntry]:
 
 
 def _cover_entries(hass: HomeAssistant) -> list[ConfigEntry]:
-    """Return all physical cover config entries (controls_cover == True)."""
+    """Return all physical cover config entries.
+
+    Filters on capability, never a cover-type string: virtual entry types are
+    excluded — the Building Profile (``controls_cover == False``) and the
+    cover group (``is_orchestrator == True``), which controls covers but is
+    not itself a physical cover. Consumers (duplicate sources, profile link
+    lists, group membership pickers) all want real covers only.
+    """
     return [
         e
         for e in hass.config_entries.async_entries(DOMAIN)
         if get_policy(e.data.get(CONF_SENSOR_TYPE)).controls_cover
+        and not get_policy(e.data.get(CONF_SENSOR_TYPE)).is_orchestrator
     ]
 
 

--- a/custom_components/adaptive_cover_pro/select.py
+++ b/custom_components/adaptive_cover_pro/select.py
@@ -1,0 +1,32 @@
+"""Select platform for the Adaptive Cover Pro integration (issue #790).
+
+Group-only today: the scene picker on Cover Group entries. The platform is
+forwarded only for group entries (``GROUP_PLATFORMS`` in ``__init__``), but
+the capability guard stays so a future forward for cover entries cannot
+accidentally create a select.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_SENSOR_TYPE
+from .coordinator import AdaptiveConfigEntry
+from .cover_types import get_policy
+from .group_entities import build_group_selects
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: AdaptiveConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the select platform (cover groups only)."""
+    if not get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        return
+    async_add_entities(
+        build_group_selects(
+            config_entry.entry_id, hass, config_entry, config_entry.runtime_data
+        )
+    )

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -1283,6 +1283,17 @@ async def async_setup_entry(
     """Initialize Adaptive Cover Pro config entry."""
     coordinator: AdaptiveDataUpdateCoordinator = config_entry.runtime_data
 
+    # Cover groups expose their own aggregate sensors, never the cover set.
+    from .cover_types import get_policy
+
+    if get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        from .group_entities import build_group_sensors
+
+        async_add_entities(
+            build_group_sensors(config_entry.entry_id, hass, config_entry, coordinator)
+        )
+        return
+
     entities: list[SensorEntity] = []
 
     for spec in _STANDARD_SPECS:

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -76,7 +76,8 @@
     "somfy_my_unset": "⚠️ Somfy My-Preset ist für ein oder mehrere Ziele aktiviert, aber My Preset Value ist nicht gesetzt — fällt auf konfiguriertes % zurück.",
     "proxy_no_min": "⚠️ Proxy-Beschattung ist aktiviert, aber kein benutzerdefinierter Positionsslot hat Als Minimum verwenden aktiviert — die verwaltete Beschattung wird nicht begrenzt.",
     "custom_and_no_sensors": "⚠️ Benutzerdefiniert #{slot}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
-    "custom_safety_bypass": "⚠️ Benutzerdefiniert #{slot} hat Sicherheitspriorität ({safety}) – umgeht den Schalter für die automatische Steuerung, die manuelle Übersteuerung und das Start-/Endzeitfenster, kann die Beschattung also auch dann bewegen, wenn die automatische Steuerung AUS ist und außerhalb Ihres Zeitplans. Senken Sie seine Priorität unter {safety}, um diese Gates einzuhalten."
+    "custom_safety_bypass": "⚠️ Benutzerdefiniert #{slot} hat Sicherheitspriorität ({safety}) – umgeht den Schalter für die automatische Steuerung, die manuelle Übersteuerung und das Start-/Endzeitfenster, kann die Beschattung also auch dann bewegen, wenn die automatische Steuerung AUS ist und außerhalb Ihres Zeitplans. Senken Sie seine Priorität unter {safety}, um diese Gates einzuhalten.",
+    "group_empty": "⚠️ Diese Gruppe hat keine Mitglieder – sie wird nichts steuern."
   },
   "motion": {
     "action_hold": "Beschattungen halten aktuelle Position (zurück auf Standard, wenn Sonne FOV verlässt)",
@@ -246,5 +247,11 @@
       "pitch": "Dachneigung {v}° von Horizontal",
       "height_above": "{v}m Dach über Fenster (First-Gate)"
     }
+  },
+  "group": {
+    "header": "**Beschattungsgruppe**",
+    "members": "Steuert {acp_count} ACP-Mitglied(er) + {generic_count} allgemeine Beschattung(en)",
+    "member_acp": "- 🪟 {title} (ACP)",
+    "member_generic": "- 🪟 {entity} (generic)"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -76,7 +76,8 @@
     "somfy_my_unset": "⚠️ Somfy My preset is enabled for one or more targets but My Preset Value is not set — falls back to configured %.",
     "proxy_no_min": "⚠️ Proxy cover is enabled but no custom-position slot has Use as minimum on — the managed cover will not clamp.",
     "custom_and_no_sensors": "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are configured — the template alone activates the slot.",
-    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates."
+    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
+    "group_empty": "⚠️ This group has no members — it will not command anything."
   },
   "motion": {
     "template_source": "occupancy template",
@@ -246,5 +247,11 @@
     "fov": {
       "computed": "Computed FOV ≈ {deg}°/{deg}° ({w} m width, {d} m reveal depth)"
     }
+  },
+  "group": {
+    "header": "**Cover Group**",
+    "members": "Controls {acp_count} ACP member(s) + {generic_count} generic cover(s)",
+    "member_acp": "- 🪟 {title} (ACP)",
+    "member_generic": "- 🪟 {entity} (generic)"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -76,7 +76,8 @@
     "somfy_my_unset": "⚠️ Préréglage Somfy My est activé pour une ou plusieurs cibles mais Valeur du préréglage My n'est pas définie — revient au % configuré.",
     "proxy_no_min": "⚠️ Store mandataire est activé mais aucun emplacement de position personnalisée n'a Utiliser comme minimum activé — le store géré ne limitera pas.",
     "custom_and_no_sensors": "⚠️ Personnalisé #{slot} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
-    "custom_safety_bypass": "⚠️ L'emplacement personnalisé #{slot} est à la priorité de sécurité ({safety}) — il contourne l'interrupteur de contrôle automatique, la dérogation manuelle et la fenêtre horaire de début/fin, pour que le store puisse se déplacer même quand le contrôle automatique est DÉSACTIVÉ et en dehors de votre horaire. Réduisez sa priorité en dessous de {safety} pour qu'elle respecte ces seuils."
+    "custom_safety_bypass": "⚠️ L'emplacement personnalisé #{slot} est à la priorité de sécurité ({safety}) — il contourne l'interrupteur de contrôle automatique, la dérogation manuelle et la fenêtre horaire de début/fin, pour que le store puisse se déplacer même quand le contrôle automatique est DÉSACTIVÉ et en dehors de votre horaire. Réduisez sa priorité en dessous de {safety} pour qu'elle respecte ces seuils.",
+    "group_empty": "⚠️ Ce groupe n'a pas de membres — il ne commandera rien."
   },
   "motion": {
     "action_hold": "stores maintiennent la position actuelle (reviennent au défaut quand le soleil quitte le FOV)",
@@ -246,5 +247,11 @@
       "pitch": "pente de toit {v}° depuis l'horizontale",
       "height_above": "{v}m de toit au-dessus de la fenêtre (porte de faîtage)"
     }
+  },
+  "group": {
+    "header": "**Groupe de stores**",
+    "members": "Contrôle {acp_count} membre(s) ACP + {generic_count} store(s) générique(s)",
+    "member_acp": "- 🪟 {title} (ACP)",
+    "member_generic": "- 🪟 {entity} (générique)"
   }
 }

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -211,6 +211,15 @@ async def async_setup_entry(
     """Set up the demo switch platform."""
     coordinator: AdaptiveDataUpdateCoordinator = config_entry.runtime_data
 
+    # Cover groups expose the bulk automation switch, never the cover set.
+    if get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        from .group_entities import build_group_switches
+
+        async_add_entities(
+            build_group_switches(config_entry.entry_id, hass, config_entry, coordinator)
+        )
+        return
+
     specs: list[_SwitchSpec] = [
         spec for spec in _SWITCH_SPECS if spec.enabled_when(config_entry)
     ]

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -6,7 +6,8 @@
         "menu_options": {
           "create_new": "Neue Beschattung erstellen",
           "create_building_profile": "Gebäudeprofil erstellen",
-          "duplicate_existing": "Von vorhandener Beschattung duplizieren"
+          "duplicate_existing": "Von vorhandener Beschattung duplizieren",
+          "create_group": "Beschattungsgruppe erstellen"
         }
       },
       "create_new": {
@@ -750,6 +751,19 @@
         "data_description": {
           "building_profile_id": "Verknüpfe diese Abdeckung mit einem Gebäudeprofil, um seine gemeinsamen gebäudeweiten Sensoren zu erben. Wähle „Keine (nicht verknüpft)\" aus, um die Profilverknüpfung zu überspringen und die Sensoren dieser Abdeckung lokal zu verwalten."
         }
+      },
+      "create_group": {
+        "title": "Beschattungsgruppe erstellen",
+        "description": "Eine Beschattungsgruppe steuert mehrere Beschattungen zusammen: Szenen (Alle offen, Alle geschlossen, Datenschutz), Massenautomatisierungskontrolle und Löschen manueller Übersteuerungen. Wählen Sie Adaptive-Cover-Pro-Instanzen als Mitglieder und fügen Sie einfache Beschattungsentitäten für Beschattungen ohne eigene Instanz hinzu. [Weitere Informationen]({learn_more})",
+        "data": {
+          "name": "Gruppenname",
+          "member_entries": "Adaptive-Cover-Pro-Mitglieder",
+          "member_covers": "Allgemeine Beschattungsentitäten"
+        },
+        "data_description": {
+          "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+        }
       }
     },
     "abort": {
@@ -785,7 +799,8 @@
           "building_profile": "🏢 Gebäudeprofil",
           "profile_sensors": "📡 Gemeinsame Sensoren",
           "profile_overview": "🏢 Profil-Übersicht",
-          "profile_overrides": "🧹 Lokale Übersteuerungen"
+          "profile_overrides": "🧹 Lokale Übersteuerungen",
+          "group_membership": "👥 Gruppenmitglieder"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1563,6 +1578,18 @@
         "data": {
           "clear_overrides": "Ausgewählte Übersteuerungen löschen"
         }
+      },
+      "group_membership": {
+        "title": "Gruppenmitglieder",
+        "description": "Bearbeiten Sie, welche Beschattungen diese Gruppe steuert. [Weitere Informationen]({learn_more})",
+        "data": {
+          "member_entries": "Adaptive-Cover-Pro-Mitglieder",
+          "member_covers": "Allgemeine Beschattungsentitäten"
+        },
+        "data_description": {
+          "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+        }
       }
     },
     "abort": {
@@ -1619,6 +1646,26 @@
       },
       "solar_calculation": {
         "name": "Solarberechnung"
+      },
+      "group_position": {
+        "name": "Gruppenposition"
+      },
+      "group_state": {
+        "name": "Gruppenstatus",
+        "state": {
+          "open": "Offen",
+          "closed": "Geschlossen",
+          "mixed": "Gemischt",
+          "unknown": "Unbekannt"
+        }
+      },
+      "group_active_scene": {
+        "name": "Aktive Szene",
+        "state": {
+          "all_open": "Alle offen",
+          "all_closed": "Alle geschlossen",
+          "privacy": "Datenschutz"
+        }
       }
     },
     "switch": {
@@ -1668,16 +1715,41 @@
           "on": "An",
           "off": "Aus"
         }
+      },
+      "group_automation": {
+        "name": "Gruppenautomatisierung"
       }
     },
     "button": {
       "my_position": {
         "name": "Verwaltete My-Position"
+      },
+      "group_scene_all_open": {
+        "name": "Szene: Alle offen"
+      },
+      "group_scene_all_closed": {
+        "name": "Szene: Alle geschlossen"
+      },
+      "group_scene_privacy": {
+        "name": "Szene: Datenschutz"
+      },
+      "group_clear_overrides": {
+        "name": "Mitglied-Übersteuerungen löschen"
       }
     },
     "number": {
       "my_position_value": {
         "name": "Verwalteter My-Positionswert"
+      }
+    },
+    "select": {
+      "group_scene_select": {
+        "name": "Szene",
+        "state": {
+          "all_open": "Alle offen",
+          "all_closed": "Alle geschlossen",
+          "privacy": "Datenschutz"
+        }
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -6,7 +6,8 @@
         "menu_options": {
           "create_new": "Create new cover",
           "create_building_profile": "Create building profile",
-          "duplicate_existing": "Duplicate from existing cover"
+          "duplicate_existing": "Duplicate from existing cover",
+          "create_group": "Create cover group"
         }
       },
       "create_new": {
@@ -750,6 +751,19 @@
         "data_description": {
           "building_profile_id": "Link this cover to a Building Profile to inherit its shared building-level sensors. Select 'None (unlinked)' to skip profile linking and manage this cover's sensors locally."
         }
+      },
+      "create_group": {
+        "title": "Create Cover Group",
+        "description": "A cover group commands a set of covers together: scenes (All Open, All Closed, Privacy), bulk automation control, and clearing manual overrides. Pick Adaptive Cover Pro instances as members, and add plain cover entities for covers without their own instance. [Learn more]({learn_more})",
+        "data": {
+          "name": "Group name",
+          "member_entries": "Adaptive Cover Pro members",
+          "member_covers": "Generic cover entities"
+        },
+        "data_description": {
+          "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+        }
       }
     },
     "abort": {
@@ -786,7 +800,8 @@
           "building_profile": "🏢 Building Profile",
           "profile_sensors": "📡 Shared Sensors",
           "profile_overview": "🏢 Profile Overview",
-          "profile_overrides": "🧹 Local Overrides"
+          "profile_overrides": "🧹 Local Overrides",
+          "group_membership": "👥 Group Members"
         }
       },
       "pipeline_priorities": {
@@ -1563,6 +1578,18 @@
         "data": {
           "clear_overrides": "Clear selected overrides"
         }
+      },
+      "group_membership": {
+        "title": "Group Members",
+        "description": "Edit which covers this group commands. [Learn more]({learn_more})",
+        "data": {
+          "member_entries": "Adaptive Cover Pro members",
+          "member_covers": "Generic cover entities"
+        },
+        "data_description": {
+          "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+        }
       }
     },
     "abort": {
@@ -1619,6 +1646,26 @@
       },
       "position_forecast": {
         "name": "Position Forecast"
+      },
+      "group_position": {
+        "name": "Group Position"
+      },
+      "group_state": {
+        "name": "Group State",
+        "state": {
+          "open": "Open",
+          "closed": "Closed",
+          "mixed": "Mixed",
+          "unknown": "Unknown"
+        }
+      },
+      "group_active_scene": {
+        "name": "Active Scene",
+        "state": {
+          "all_open": "All Open",
+          "all_closed": "All Closed",
+          "privacy": "Privacy"
+        }
       }
     },
     "switch": {
@@ -1668,16 +1715,41 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "group_automation": {
+        "name": "Group Automation"
       }
     },
     "button": {
       "my_position": {
         "name": "Managed My Position"
+      },
+      "group_scene_all_open": {
+        "name": "Scene: All Open"
+      },
+      "group_scene_all_closed": {
+        "name": "Scene: All Closed"
+      },
+      "group_scene_privacy": {
+        "name": "Scene: Privacy"
+      },
+      "group_clear_overrides": {
+        "name": "Clear Member Overrides"
       }
     },
     "number": {
       "my_position_value": {
         "name": "Managed My Position Value"
+      }
+    },
+    "select": {
+      "group_scene_select": {
+        "name": "Scene",
+        "state": {
+          "all_open": "All Open",
+          "all_closed": "All Closed",
+          "privacy": "Privacy"
+        }
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -6,7 +6,8 @@
         "menu_options": {
           "create_new": "Créer un nouveau store",
           "create_building_profile": "Créer un profil de bâtiment",
-          "duplicate_existing": "Dupliquer à partir d'un store existant"
+          "duplicate_existing": "Dupliquer à partir d'un store existant",
+          "create_group": "Créer un groupe de stores"
         }
       },
       "create_new": {
@@ -750,6 +751,19 @@
         "data_description": {
           "building_profile_id": "Associez ce volet à un Profil de bâtiment pour hériter de ses capteurs partagés à l'échelle du bâtiment. Sélectionnez « Aucun (non lié) » pour ignorer l'association de profil et gérer les capteurs de ce volet localement."
         }
+      },
+      "create_group": {
+        "title": "Créer un groupe de stores",
+        "description": "Un groupe de stores commande un ensemble de stores ensemble : scènes (Tous ouverts, Tous fermés, Confidentialité), contrôle d'automation en masse et suppression des dérogations manuelles. Sélectionnez les instances Adaptive Cover Pro comme membres, et ajoutez les entités de store simples pour les stores sans leur propre instance. [En savoir plus]({learn_more})",
+        "data": {
+          "name": "Nom du groupe",
+          "member_entries": "Membres Adaptive Cover Pro",
+          "member_covers": "Entités de store génériques"
+        },
+        "data_description": {
+          "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+        }
       }
     },
     "abort": {
@@ -785,7 +799,8 @@
           "building_profile": "🏢 Profil de bâtiment",
           "profile_sensors": "📡 Capteurs partagés",
           "profile_overview": "🏢 Aperçu du profil",
-          "profile_overrides": "🧹 Dérogations locales"
+          "profile_overrides": "🧹 Dérogations locales",
+          "group_membership": "👥 Membres du groupe"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1563,6 +1578,18 @@
         },
         "title": "Profil de bâtiment — Dérogations locales",
         "description": "Capteurs qu'une couverture liée a dérogée, ou définis localement lorsque ce profil les laisse vides. Sélectionnez-en un pour réinitialiser — un capteur dérogaté réhérite la valeur du profil; un capteur local est effacé.\n\n{overrides}"
+      },
+      "group_membership": {
+        "title": "Membres du groupe",
+        "description": "Modifiez quels stores ce groupe commande. [En savoir plus]({learn_more})",
+        "data": {
+          "member_entries": "Membres Adaptive Cover Pro",
+          "member_covers": "Entités de store génériques"
+        },
+        "data_description": {
+          "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+        }
       }
     },
     "abort": {
@@ -1619,6 +1646,26 @@
       },
       "solar_calculation": {
         "name": "Calcul solaire"
+      },
+      "group_position": {
+        "name": "Position du groupe"
+      },
+      "group_state": {
+        "name": "État du groupe",
+        "state": {
+          "open": "Ouvert",
+          "closed": "Fermé",
+          "mixed": "Mixte",
+          "unknown": "Inconnu"
+        }
+      },
+      "group_active_scene": {
+        "name": "Scène active",
+        "state": {
+          "all_open": "Tous ouverts",
+          "all_closed": "Tous fermés",
+          "privacy": "Confidentialité"
+        }
       }
     },
     "switch": {
@@ -1668,16 +1715,41 @@
           "on": "Activé",
           "off": "Désactivé"
         }
+      },
+      "group_automation": {
+        "name": "Automation du groupe"
       }
     },
     "button": {
       "my_position": {
         "name": "Position My gérée"
+      },
+      "group_scene_all_open": {
+        "name": "Scène : Tous ouverts"
+      },
+      "group_scene_all_closed": {
+        "name": "Scène : Tous fermés"
+      },
+      "group_scene_privacy": {
+        "name": "Scène : Confidentialité"
+      },
+      "group_clear_overrides": {
+        "name": "Supprimer les dérogations des membres"
       }
     },
     "number": {
       "my_position_value": {
         "name": "Valeur de position My gérée"
+      }
+    },
+    "select": {
+      "group_scene_select": {
+        "name": "Scène",
+        "state": {
+          "all_open": "Tous ouverts",
+          "all_closed": "Tous fermés",
+          "privacy": "Confidentialité"
+        }
       }
     }
   },

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3176,3 +3176,47 @@ def test_summary_building_profile_line_absent_when_unlinked() -> None:
     assert (
         "building profile" not in summary.lower()
     ), "Summary must not mention 'building profile' for an unlinked cover"
+
+
+# ---------------------------------------------------------------------------
+# Cover Group summary (issue #790)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_group_shows_header_and_member_counts():
+    """A group renders its own compact summary, never the cover chain."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    summary = _build_config_summary(
+        {
+            CONF_MEMBER_ENTRIES: ["entry_a", "entry_b"],
+            CONF_MEMBER_COVERS: ["cover.generic"],
+        },
+        CoverType.GROUP,
+    )
+
+    assert "**Cover Group**" in summary
+    assert "2 ACP member(s)" in summary
+    assert "1 generic cover(s)" in summary
+    assert "cover.generic" in summary
+    # None of the cover-chain sections appear for a group.
+    assert "How It Decides" not in summary
+
+
+def test_summary_group_empty_roster_warns():
+    """An empty group is called out — it will not command anything."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    summary = _build_config_summary(
+        {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+        CoverType.GROUP,
+    )
+
+    assert "**Cover Group**" in summary
+    assert "no members" in summary

--- a/tests/test_cover_types/stub_policy.py
+++ b/tests/test_cover_types/stub_policy.py
@@ -84,12 +84,18 @@ def register_stub_policy(policy_cls: type[CoverTypePolicy]):
 
 # Every real COVER policy plus both stubs. Most invariant tests parametrise
 # over this list so adding a fifth real cover type automatically extends
-# coverage without further edits. Virtual entry types (the building profile,
-# ``controls_cover = False``) are excluded: they have zero axes and register
-# no platforms, so the cover-contract suite must not pull them in. The filter
-# is on the ``controls_cover`` capability, never on a cover-type string.
+# coverage without further edits. Virtual entry types are excluded by
+# capability, never a cover-type string: the building profile
+# (``controls_cover = False``) and the group orchestrator
+# (``is_orchestrator = True``) both declare zero axes, so the cover-axis
+# contract suite must not pull them in — each has its own dedicated suite
+# (``test_building_profile_policy.py`` / ``test_group_policy.py``).
 ALL_POLICIES_WITH_STUBS: tuple[type[CoverTypePolicy], ...] = (
-    *(p for p in POLICY_REGISTRY.values() if p.controls_cover),
+    *(
+        p
+        for p in POLICY_REGISTRY.values()
+        if p.controls_cover and not p.is_orchestrator
+    ),
     StubSingleAxisPolicy,
     StubDualAxisPolicy,
 )

--- a/tests/test_cover_types/test_group_policy.py
+++ b/tests/test_cover_types/test_group_policy.py
@@ -1,0 +1,94 @@
+"""Tests for the virtual ``GroupPolicy`` orchestrator entry type and scenes.
+
+A cover group is a virtual config-entry type that orchestrates a roster of
+member covers. Unlike the building profile it *does* control covers
+(``controls_cover = True``) but it is not geometry-driven — the new
+``is_orchestrator`` ClassVar is the setup discriminator that routes it to a
+``GroupCoordinator`` instead of the sun/geometry pipeline. Scene resolution
+is per-member policy behavior via ``position_for_scene``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.config_flow import SENSOR_TYPE_MENU
+from custom_components.adaptive_cover_pro.const import (
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    CoverType,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.cover_types import (
+    POLICY_REGISTRY,
+    get_policy,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_group_policy_registers() -> None:
+    """The policy is registered and reachable via ``get_policy``."""
+    policy = get_policy(CoverType.GROUP)
+    assert policy.cover_type == CoverType.GROUP
+
+
+def test_group_controls_covers_but_is_orchestrator() -> None:
+    """A group commands covers, but through orchestration, not geometry."""
+    policy = get_policy(CoverType.GROUP)
+    assert policy.controls_cover is True
+    assert policy.is_orchestrator is True
+
+
+def test_group_has_no_axes() -> None:
+    """A group drives members, not an axis of its own."""
+    assert get_policy(CoverType.GROUP).axes == ()
+
+
+def test_group_is_the_only_orchestrator() -> None:
+    """Every other registered policy defaults to ``is_orchestrator = False``."""
+    for key in POLICY_REGISTRY:
+        if key == CoverType.GROUP:
+            continue
+        assert get_policy(key).is_orchestrator is False
+
+
+def test_group_not_in_cover_type_menu() -> None:
+    """The group is its own top-level create option, not a cover-type dropdown
+    entry — ``controls_cover`` alone no longer suffices as the menu filter.
+    """
+    assert CoverType.GROUP not in SENSOR_TYPE_MENU
+    assert all(not get_policy(k).is_orchestrator for k in SENSOR_TYPE_MENU)
+
+
+def test_group_scene_wire_values() -> None:
+    """Scene identifiers are wire-stable (stored in options / select state)."""
+    assert GroupScene.ALL_OPEN == "all_open"
+    assert GroupScene.ALL_CLOSED == "all_closed"
+    assert GroupScene.PRIVACY == "privacy"
+
+
+@pytest.mark.parametrize(
+    ("cover_type", "scene", "expected"),
+    [
+        # ALL_OPEN / ALL_CLOSED are HA cover semantics: 100 = open, 0 = closed
+        # (blinds raised / awning extended vs blinds lowered / awning retracted).
+        (CoverType.BLIND, GroupScene.ALL_OPEN, POSITION_OPEN),
+        (CoverType.BLIND, GroupScene.ALL_CLOSED, POSITION_CLOSED),
+        (CoverType.AWNING, GroupScene.ALL_OPEN, POSITION_OPEN),
+        (CoverType.AWNING, GroupScene.ALL_CLOSED, POSITION_CLOSED),
+        (CoverType.TILT, GroupScene.ALL_OPEN, POSITION_OPEN),
+        (CoverType.VENETIAN, GroupScene.ALL_CLOSED, POSITION_CLOSED),
+        # PRIVACY resolves per-policy to maximum coverage — the existing
+        # ``position_for_intent(sun_through=False)`` polymorphism, so the
+        # awning's open-blocks-sun axis flips the answer.
+        (CoverType.BLIND, GroupScene.PRIVACY, POSITION_CLOSED),
+        (CoverType.AWNING, GroupScene.PRIVACY, POSITION_OPEN),
+        (CoverType.TILT, GroupScene.PRIVACY, POSITION_CLOSED),
+        (CoverType.VENETIAN, GroupScene.PRIVACY, POSITION_CLOSED),
+    ],
+)
+def test_position_for_scene_resolves_per_policy(
+    cover_type: CoverType, scene: GroupScene, expected: int
+) -> None:
+    assert get_policy(cover_type).position_for_scene(scene) == expected

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -1,0 +1,223 @@
+"""Config-flow surfaces for the Cover Group virtual entry type (issue #790).
+
+Three surfaces:
+- Creating a ``cover_group`` entry is its own top-level menu option whose
+  combined form collects the name plus the two membership rosters (ACP
+  members as config entries, generic covers as entities) on one page.
+- A group's options flow shows a small group menu, never the cover menu.
+- Membership is sanitized on save: duplicates dropped, the group itself
+  cannot be a member, and a generic entity owned by a selected ACP member
+  is dropped in favour of the entry.
+"""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.config_flow import (
+    ConfigFlowHandler,
+    OptionsFlowHandler,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DELTA_POSITION,
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_MOTION_SENSORS,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.profile_link import _cover_entries
+
+pytestmark = pytest.mark.integration
+
+
+def _schema_keys(schema):
+    return {str(marker.schema) for marker in schema.schema}
+
+
+def _select_options(schema, key):
+    for marker, sel in schema.schema.items():
+        if str(marker.schema) == key:
+            return sel.config["options"]
+    raise AssertionError(f"{key} not in schema")
+
+
+def _add_cover(hass, entry_id: str, cover_type=CoverType.BLIND, entities=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: cover_type},
+        options={CONF_ENTITIES: entities or []},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _add_group(hass, entry_id: str, member_entries=None, member_covers=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: member_entries or [],
+            CONF_MEMBER_COVERS: member_covers or [],
+        },
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_user_menu_offers_create_group(hass: HomeAssistant) -> None:
+    """Creating a group is a top-level create choice beside the profile."""
+    handler = ConfigFlowHandler()
+    handler.hass = hass
+
+    result = await handler.async_step_user()
+
+    assert result["type"] == "menu"
+    assert "create_group" in result["menu_options"]
+
+
+async def test_create_group_combined_form_and_entry(hass: HomeAssistant) -> None:
+    """One form: name + the two membership selectors; finalizes a GROUP entry
+    without injecting cover-automation defaults (delta, motion, ...).
+    """
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "create_group"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "create_group"
+    assert _schema_keys(result["data_schema"]) == {
+        "name",
+        CONF_MEMBER_ENTRIES,
+        CONF_MEMBER_COVERS,
+    }
+    # The ACP-member selector lists existing cover entries.
+    values = {
+        o["value"] for o in _select_options(result["data_schema"], CONF_MEMBER_ENTRIES)
+    }
+    assert values == {"cover_a"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "name": "Living Room",
+            CONF_MEMBER_ENTRIES: ["cover_a"],
+            CONF_MEMBER_COVERS: ["cover.generic"],
+        },
+    )
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.GROUP
+    assert entry.options[CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert entry.options[CONF_MEMBER_COVERS] == ["cover.generic"]
+    # A group is not a geometry cover — no cover-automation defaults leak in.
+    assert CONF_DELTA_POSITION not in entry.options
+    assert CONF_MOTION_SENSORS not in entry.options
+
+
+async def test_create_group_drops_covers_owned_by_selected_members(
+    hass: HomeAssistant,
+) -> None:
+    """A generic entity owned by a selected ACP member is dropped (prefer the
+    entry — its pipeline must orchestrate, not be double-commanded), and
+    duplicate ids are deduped.
+    """
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "create_group"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "name": "G",
+            CONF_MEMBER_ENTRIES: ["cover_a", "cover_a"],
+            CONF_MEMBER_COVERS: ["cover.a", "cover.generic", "cover.generic"],
+        },
+    )
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.options[CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert entry.options[CONF_MEMBER_COVERS] == ["cover.generic"]
+
+
+async def test_group_options_flow_shows_group_menu(hass: HomeAssistant) -> None:
+    """Configure on a group shows the group menu, never the cover categories."""
+    group = _add_group(hass, "group_1")
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == "menu"
+    assert result["menu_options"] == ["group_membership", "summary", "done"]
+
+
+async def test_group_membership_step_excludes_self_and_other_groups(
+    hass: HomeAssistant,
+) -> None:
+    """The ACP-member selector lists real covers only — never the group itself
+    or another group entry.
+    """
+    _add_cover(hass, "cover_a")
+    _add_group(hass, "group_other")
+    group = _add_group(hass, "group_1")
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_membership()
+
+    assert result["type"] == "form"
+    values = {
+        o["value"] for o in _select_options(result["data_schema"], CONF_MEMBER_ENTRIES)
+    }
+    assert values == {"cover_a"}
+
+
+async def test_group_membership_step_saves_sanitized(hass: HomeAssistant) -> None:
+    """Submitting membership sanitizes the rosters and saves the options."""
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+    group = _add_group(hass, "group_1")
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_membership(
+        {
+            CONF_MEMBER_ENTRIES: ["cover_a", "group_1"],
+            CONF_MEMBER_COVERS: ["cover.a", "cover.generic"],
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert result["data"][CONF_MEMBER_COVERS] == ["cover.generic"]
+
+
+async def test_cover_entries_excludes_groups(hass: HomeAssistant) -> None:
+    """_cover_entries means real covers: groups are excluded, so duplicate
+    sources and profile-linkable cover lists never contain a group.
+    """
+    _add_cover(hass, "cover_a")
+    _add_group(hass, "group_1")
+
+    entries = _cover_entries(hass)
+
+    assert [e.entry_id for e in entries] == ["cover_a"]

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -1,0 +1,266 @@
+"""Behaviour of the ``GroupCoordinator`` (issue #790, Phase 1).
+
+Covers the three fan-out operations (scene activation, bulk automation,
+bulk override clear), the mid-reload null-guard on member resolution, and
+the position/state aggregates the group sensors read.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    CoverType,
+    GroupScene,
+    GroupState,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+
+pytestmark = pytest.mark.integration
+
+BLIND_ENTITY = "cover.blind1"
+AWNING_ENTITY = "cover.awning1"
+GENERIC_ENTITY = "cover.generic1"
+
+
+def _member_entry(
+    hass, entry_id: str, cover_type: CoverType, entities: list[str]
+) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: cover_type},
+        options={CONF_ENTITIES: entities},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _mock_member_coordinator() -> MagicMock:
+    coord = MagicMock()
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+    coord.async_reset_manual_overrides = AsyncMock(return_value=[])
+    coord.async_refresh = AsyncMock()
+    return coord
+
+
+@pytest.fixture
+def group_setup(hass):
+    """Build a group with a blind member, an awning member, and one generic cover."""
+    blind_entry = _member_entry(hass, "member_blind", CoverType.BLIND, [BLIND_ENTITY])
+    awning_entry = _member_entry(
+        hass, "member_awning", CoverType.AWNING, [AWNING_ENTITY]
+    )
+    blind_coord = _mock_member_coordinator()
+    awning_coord = _mock_member_coordinator()
+    blind_entry.runtime_data = blind_coord
+    awning_entry.runtime_data = awning_coord
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_blind", "member_awning"],
+            CONF_MEMBER_COVERS: [GENERIC_ENTITY],
+        },
+        entry_id="group_01",
+        title="Living Room",
+    )
+    group_entry.add_to_hass(hass)
+
+    coordinator = GroupCoordinator(hass, group_entry)
+    # Adopt-mode command service is real by default; tests that exercise the
+    # adopt fan-out replace it with a mock to observe the calls.
+    coordinator._cmd_svc = MagicMock(
+        apply_position=AsyncMock(return_value=("sent", "")), stop=MagicMock()
+    )
+    return coordinator, blind_coord, awning_coord
+
+
+async def test_member_resolution_skips_unset_runtime_data(hass) -> None:
+    """A member whose entry is mid-reload (runtime_data unset) is skipped."""
+    ok_entry = _member_entry(hass, "member_ok", CoverType.BLIND, [BLIND_ENTITY])
+    ok_coord = _mock_member_coordinator()
+    ok_entry.runtime_data = ok_coord
+    # mid-reload member: entry exists but runtime_data never set
+    _member_entry(hass, "member_reloading", CoverType.BLIND, ["cover.x"])
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            # includes a removed entry id too — must also be skipped
+            CONF_MEMBER_ENTRIES: ["member_ok", "member_reloading", "member_gone"],
+            CONF_MEMBER_COVERS: [],
+        },
+        entry_id="group_02",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+
+    coordinator = GroupCoordinator(hass, group_entry)
+    resolved = coordinator.resolved_members()
+
+    assert [entry.entry_id for entry, _ in resolved] == ["member_ok"]
+    assert resolved[0][1] is ok_coord
+
+
+async def test_activate_scene_resolves_target_per_member_policy(group_setup) -> None:
+    """PRIVACY resolves through each member's own policy: blind 0, awning 100."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+
+    blind_coord.async_apply_user_position.assert_awaited_once_with(
+        BLIND_ENTITY,
+        POSITION_CLOSED,
+        trigger="group_scene_privacy",
+    )
+    awning_coord.async_apply_user_position.assert_awaited_once_with(
+        AWNING_ENTITY,
+        POSITION_OPEN,
+        trigger="group_scene_privacy",
+    )
+
+
+async def test_activate_scene_adopt_commands_generic_covers(group_setup) -> None:
+    """Generic ``cover.*`` members are commanded through the group's own service."""
+    coordinator, _, _ = group_setup
+
+    await coordinator.async_activate_scene(GroupScene.ALL_CLOSED)
+
+    coordinator._cmd_svc.apply_position.assert_awaited_once()
+    args, kwargs = coordinator._cmd_svc.apply_position.await_args
+    assert args[0] == GENERIC_ENTITY
+    assert args[1] == POSITION_CLOSED
+    context = kwargs.get("context") or args[3]
+    assert context.force is True
+    assert context.auto_control is True
+
+
+async def test_activate_scene_records_active_scene(group_setup) -> None:
+    """The last activated scene is recorded for the select/sensor entities."""
+    coordinator, _, _ = group_setup
+    assert coordinator.active_scene is None
+
+    await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+
+    assert coordinator.active_scene is GroupScene.ALL_OPEN
+
+
+async def test_set_automation_flips_member_toggles(group_setup) -> None:
+    """Bulk automation off sets each member's automatic_control and refreshes."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_automation(False)
+
+    for member in (blind_coord, awning_coord):
+        assert member.automatic_control is False
+        member.async_refresh.assert_awaited_once()
+
+    await coordinator.async_set_automation(True)
+    assert blind_coord.automatic_control is True
+
+
+async def test_clear_overrides_delegates_to_members(group_setup) -> None:
+    """Bulk clear rides each member's shared reset path."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_clear_overrides()
+
+    blind_coord.async_reset_manual_overrides.assert_awaited_once_with(
+        trigger="group_clear_overrides"
+    )
+    awning_coord.async_reset_manual_overrides.assert_awaited_once_with(
+        trigger="group_clear_overrides"
+    )
+
+
+async def test_member_cover_entities_union(group_setup) -> None:
+    """ACP members' controlled covers + generic covers, in roster order."""
+    coordinator, _, _ = group_setup
+    assert coordinator.member_cover_entities() == [
+        BLIND_ENTITY,
+        AWNING_ENTITY,
+        GENERIC_ENTITY,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("positions", "expected_state", "expected_position"),
+    [
+        (
+            {BLIND_ENTITY: 100, AWNING_ENTITY: 100, GENERIC_ENTITY: 100},
+            GroupState.OPEN,
+            100,
+        ),
+        ({BLIND_ENTITY: 0, AWNING_ENTITY: 0, GENERIC_ENTITY: 0}, GroupState.CLOSED, 0),
+        (
+            {BLIND_ENTITY: 100, AWNING_ENTITY: 0, GENERIC_ENTITY: 50},
+            GroupState.MIXED,
+            50,
+        ),
+        ({}, GroupState.UNKNOWN, None),
+    ],
+)
+async def test_aggregates(
+    hass, group_setup, positions, expected_state, expected_position
+) -> None:
+    """Aggregate = average of readable member positions + state classification."""
+    coordinator, _, _ = group_setup
+    for entity_id, pos in positions.items():
+        hass.states.async_set(entity_id, "open", {"current_position": pos})
+
+    aggregates = await coordinator._async_update_data()
+
+    assert aggregates.state is expected_state
+    assert aggregates.position == expected_position
+    if positions:
+        assert aggregates.member_positions == positions
+
+
+async def test_member_cover_entities_skips_removed_entries(hass) -> None:
+    """A roster id whose entry was removed contributes no entities anywhere."""
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_gone"],
+            CONF_MEMBER_COVERS: [GENERIC_ENTITY],
+        },
+        entry_id="group_03",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+
+    assert coordinator.member_cover_entities() == [GENERIC_ENTITY]
+    aggregates = await coordinator._async_update_data()
+    assert list(aggregates.member_positions) == [GENERIC_ENTITY]
+
+
+async def test_member_state_change_triggers_refresh(hass, group_setup) -> None:
+    """A member cover state change schedules an aggregate refresh."""
+    coordinator, _, _ = group_setup
+
+    await coordinator._async_setup()
+    assert coordinator._unsub_state is not None
+
+    coordinator.async_request_refresh = AsyncMock()
+    hass.states.async_set(BLIND_ENTITY, "open", {"current_position": 50})
+    await hass.async_block_till_done()
+    coordinator.async_request_refresh.assert_awaited()
+
+    await coordinator.async_shutdown()
+    assert coordinator._unsub_state is None
+    coordinator._cmd_svc.stop.assert_called_once()

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -1,0 +1,162 @@
+"""Group entity surfaces (issue #790, Phase 1).
+
+A group entry exposes aggregate sensors, the bulk automation switch, scene
+buttons + clear-overrides button, and the scene-picker select (a NEW
+platform). All unique_ids follow the locked ``f"{entry_id}_{suffix}"``
+contract, and cover entries must not gain any group entity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro import button, select, sensor, switch
+from custom_components.adaptive_cover_pro.const import (
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+    GroupScene,
+    GroupState,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import (
+    GroupAggregates,
+    GroupCoordinator,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def group_entry(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: ["cover.g1"]},
+        entry_id="group_01",
+        title="Living Room",
+    )
+    entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, entry)
+    entry.runtime_data = coordinator
+    return entry
+
+
+async def _added_entities(platform_module, hass, entry):
+    added = []
+    await platform_module.async_setup_entry(
+        hass, entry, lambda new, **kwargs: added.extend(new)
+    )
+    return added
+
+
+async def test_sensor_platform_builds_group_sensors(hass, group_entry) -> None:
+    entities = await _added_entities(sensor, hass, group_entry)
+    unique_ids = {e.unique_id for e in entities}
+    assert unique_ids == {
+        "group_01_group_position",
+        "group_01_group_state",
+        "group_01_group_active_scene",
+    }
+
+
+async def test_group_sensor_values(hass, group_entry) -> None:
+    """Sensors render the aggregates and the active scene."""
+    coordinator = group_entry.runtime_data
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    coordinator.active_scene = GroupScene.PRIVACY
+    coordinator.async_set_updated_data(
+        GroupAggregates(
+            position=42,
+            state=GroupState.MIXED,
+            member_positions={"cover.g1": 42},
+        )
+    )
+
+    assert entities["group_01_group_position"].native_value == 42
+    assert entities["group_01_group_position"].extra_state_attributes[
+        "member_positions"
+    ] == {"cover.g1": 42}
+    assert entities["group_01_group_state"].native_value == GroupState.MIXED
+    assert entities["group_01_group_active_scene"].native_value == GroupScene.PRIVACY
+
+
+async def test_switch_platform_builds_group_automation_switch(
+    hass, group_entry
+) -> None:
+    entities = await _added_entities(switch, hass, group_entry)
+    assert [e.unique_id for e in entities] == ["group_01_group_automation"]
+
+    coordinator = group_entry.runtime_data
+    coordinator.async_set_automation = AsyncMock()
+    switch_entity = entities[0]
+    switch_entity.async_write_ha_state = MagicMock()
+
+    assert switch_entity.is_on is True  # default: automation on
+    await switch_entity.async_turn_off()
+    coordinator.async_set_automation.assert_awaited_once_with(False)
+    assert switch_entity.is_on is False
+    await switch_entity.async_turn_on()
+    assert switch_entity.is_on is True
+
+
+async def test_button_platform_builds_scene_and_clear_buttons(
+    hass, group_entry
+) -> None:
+    entities = await _added_entities(button, hass, group_entry)
+    unique_ids = {e.unique_id for e in entities}
+    assert unique_ids == {
+        *(f"group_01_group_scene_{scene}" for scene in GroupScene),
+        "group_01_group_clear_overrides",
+    }
+
+    coordinator = group_entry.runtime_data
+    coordinator.async_activate_scene = AsyncMock()
+    coordinator.async_clear_overrides = AsyncMock()
+    by_id = {e.unique_id: e for e in entities}
+
+    await by_id[f"group_01_group_scene_{GroupScene.ALL_OPEN}"].async_press()
+    coordinator.async_activate_scene.assert_awaited_once_with(GroupScene.ALL_OPEN)
+
+    await by_id["group_01_group_clear_overrides"].async_press()
+    coordinator.async_clear_overrides.assert_awaited_once()
+
+
+async def test_select_platform_builds_scene_picker(hass, group_entry) -> None:
+    entities = await _added_entities(select, hass, group_entry)
+    assert [e.unique_id for e in entities] == ["group_01_group_scene_select"]
+
+    picker = entities[0]
+    assert picker.options == [str(scene) for scene in GroupScene]
+
+    coordinator = group_entry.runtime_data
+    assert picker.current_option is None
+    coordinator.active_scene = GroupScene.ALL_CLOSED
+    assert picker.current_option == str(GroupScene.ALL_CLOSED)
+
+    coordinator.async_activate_scene = AsyncMock()
+    picker.async_write_ha_state = MagicMock()
+    await picker.async_select_option(str(GroupScene.PRIVACY))
+    coordinator.async_activate_scene.assert_awaited_once_with(GroupScene.PRIVACY)
+
+
+async def test_select_platform_yields_nothing_for_cover_entry(hass) -> None:
+    """The select platform is group-only — a cover entry produces no entity."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Blind", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={},
+        entry_id="cover_01",
+        title="Blind",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock()
+
+    entities = await _added_entities(select, hass, entry)
+    assert entities == []

--- a/tests/test_init_group.py
+++ b/tests/test_init_group.py
@@ -1,0 +1,113 @@
+"""Setup-path and unload-path behaviour for the virtual Cover Group entry type.
+
+A ``cover_group`` config entry orchestrates member covers (issue #790). Its
+policy sets ``is_orchestrator = True``: ``async_setup_entry`` must branch to
+a ``GroupCoordinator`` — never the sun/geometry coordinator — and forward
+only the group platform set. ``async_unload_entry`` must symmetrically
+unload the same platform set (the #712/#714 load/unload-symmetry lesson).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import Platform
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro import (
+    GROUP_PLATFORMS,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _group_entry(entry_id: str) -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={},
+        entry_id=entry_id,
+        title="Living Room",
+    )
+
+
+def test_group_platforms_contents() -> None:
+    """The group forwards exactly its own platform set — no cover/number/binary."""
+    assert [
+        Platform.SENSOR,
+        Platform.SWITCH,
+        Platform.BUTTON,
+        Platform.SELECT,
+    ] == GROUP_PLATFORMS
+
+
+async def test_group_entry_builds_group_coordinator(hass) -> None:
+    """Group setup builds a GroupCoordinator, not the sun/geometry coordinator."""
+    entry = _group_entry("group_01")
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.AdaptiveDataUpdateCoordinator"
+        ) as mock_cover_coord,
+        patch(
+            "custom_components.adaptive_cover_pro.GroupCoordinator"
+        ) as mock_group_coord,
+        patch.object(hass.config_entries, "async_forward_entry_setups") as mock_forward,
+    ):
+        mock_group_coord.return_value.async_config_entry_first_refresh = AsyncMock()
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    mock_cover_coord.assert_not_called()
+    mock_group_coord.assert_called_once_with(hass, entry)
+    assert entry.runtime_data is mock_group_coord.return_value
+    mock_forward.assert_called_once_with(entry, GROUP_PLATFORMS)
+
+
+async def test_group_entry_unloads_group_platforms(hass) -> None:
+    """Group unload must unload GROUP_PLATFORMS — not the cover PLATFORMS list."""
+    entry = _group_entry("group_02")
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            hass.config_entries, "async_unload_platforms", return_value=True
+        ) as mock_unload_platforms,
+        patch("custom_components.adaptive_cover_pro.async_unload_services"),
+    ):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    mock_unload_platforms.assert_called_once_with(entry, GROUP_PLATFORMS)
+
+
+async def test_group_options_update_reloads_entry(hass) -> None:
+    """Editing the group's options (membership) reloads the entry."""
+    entry = _group_entry("group_03")
+    entry.add_to_hass(hass)
+
+    listeners: list = []
+    entry.add_update_listener = MagicMock(
+        side_effect=lambda listener: listeners.append(listener) or (lambda: None)
+    )
+
+    with (
+        patch("custom_components.adaptive_cover_pro.GroupCoordinator") as mock_coord,
+        patch.object(hass.config_entries, "async_forward_entry_setups"),
+    ):
+        mock_coord.return_value.async_config_entry_first_refresh = AsyncMock()
+        await async_setup_entry(hass, entry)
+
+    assert listeners, "group setup must register an options update listener"
+    with patch.object(hass.config_entries, "async_reload") as mock_reload:
+        await listeners[0](hass, entry)
+    mock_reload.assert_called_once_with(entry.entry_id)

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -209,14 +209,17 @@ def test_cancel_grace_period_handles_missing_entity():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_manual_override_and_sends_post_refresh_position():
-    """Reset button must reset override, refresh, then delegate to the shared send path.
+async def test_reset_clears_manual_override_and_sends_post_refresh_position():
+    """Reset must clear override, refresh, then delegate to the shared send path.
 
     The shared path (_async_send_after_override_clear) owns force=True and the
-    time-window / auto-control gates.  The button supplies the post-refresh state,
-    the options dict, the target entities, and the "manual_reset" trigger.
+    time-window / auto-control gates.  async_reset_manual_overrides supplies the
+    post-refresh state, the options dict, the target entities, and the
+    "manual_reset" trigger.  (Sequence moved from the button in issue #790.)
     """
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.living_room"
     POST_REFRESH_STATE = 52  # position pipeline returns after override is cleared
@@ -230,11 +233,9 @@ async def test_reset_button_clears_manual_override_and_sends_post_refresh_positi
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # Manager reset must be called before the refresh
     coordinator.manager.reset.assert_called_once_with(entity_id)
@@ -250,9 +251,11 @@ async def test_reset_button_clears_manual_override_and_sends_post_refresh_positi
 
 
 @pytest.mark.asyncio
-async def test_reset_button_suppresses_redetection_during_refresh():
+async def test_reset_suppresses_redetection_during_refresh():
     """wait_for_target must be True while async_refresh runs to block re-detection."""
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.bedroom"
     states_during_refresh = []
@@ -282,25 +285,25 @@ async def test_reset_button_suppresses_redetection_during_refresh():
     coordinator.cover_state_change = False
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # During refresh the suppression flag must be active
     assert states_during_refresh == [True]
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_wait_for_target_when_no_command_sent():
+async def test_reset_clears_wait_for_target_when_no_command_sent():
     """wait_for_target must be False after reset when the shared send path skips the entity.
 
     The shared method (_async_send_after_override_clear) returns a set of sent
     entity_ids.  If an entity is absent (gated by time window, auto-control off,
     or no positioning capability), the button must clear wait_for_target.
     """
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.no_position_support"
 
@@ -313,11 +316,9 @@ async def test_reset_button_clears_wait_for_target_when_no_command_sent():
     coordinator.async_refresh = AsyncMock()
     coordinator.cover_state_change = False
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # Not in sent set — wait_for_target must be cleared so state tracking resumes
     coordinator._cmd_svc.set_waiting.assert_any_call(entity_id, False)
@@ -382,13 +383,15 @@ async def test_reset_if_needed_returns_empty_when_nothing_expired():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_sends_correct_position_with_climate_mode():
-    """Button must pass the post-refresh pipeline position to the shared send path.
+async def test_reset_sends_correct_position_with_climate_mode():
+    """Reset must pass the post-refresh pipeline position to the shared send path.
 
     Covers the climate-mode scenario where ManualOverrideHandler returns solar/default
     but ClimateHandler wins after the override is cleared.
     """
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.climate_room"
     CLIMATE_POSITION = 70  # what ClimateHandler returns after override clears
@@ -404,11 +407,9 @@ async def test_reset_button_sends_correct_position_with_climate_mode():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # The state passed to the shared method must be the post-refresh climate position
     call = coordinator._async_send_after_override_clear.call_args

--- a/tests/test_reset_button_time_window.py
+++ b/tests/test_reset_button_time_window.py
@@ -236,13 +236,28 @@ async def test_send_after_override_clear_returns_only_sent_entities():
 
 
 # ---------------------------------------------------------------------------
-# Button path — issue #193 regression tests
+# Shared clear-and-resend sequence — issue #193 regression tests
+#
+# The sequence historically lived in the button's async_press; it moved to
+# AdaptiveDataUpdateCoordinator.async_reset_manual_overrides (issue #790) so
+# the cover-group bulk clear shares it. Tests exercise the method unbound,
+# same pattern as the _async_send_after_override_clear tests above.
 # ---------------------------------------------------------------------------
 
 
+async def _reset_via_coordinator(coordinator, entities):
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    return await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, entities
+    )
+
+
 @pytest.mark.asyncio
-async def test_reset_button_skips_send_when_outside_time_window():
-    """Pressing Reset outside the active-hours window must clear override but not move the cover.
+async def test_reset_skips_send_when_outside_time_window():
+    """Reset outside the active-hours window must clear override but not move the cover.
 
     Regression test for issue #193: cover was moved to default (100%) even when
     Control Status showed outside_time_window.
@@ -255,23 +270,22 @@ async def test_reset_button_skips_send_when_outside_time_window():
     coordinator.state = 0
     coordinator.config_entry.options = {}
     coordinator.async_refresh = AsyncMock()
-    # The shared method handles the gate; button must delegate to it
+    # The shared send path handles the gate; the reset must delegate to it
     coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    await _reset_via_coordinator(coordinator, [entity_id])
 
     # Override flag must be cleared regardless of time window
     coordinator.manager.reset.assert_called_once_with(entity_id)
-    # No direct apply_position call from the button — it delegates
+    # No direct apply_position call — the send path owns dispatch
     coordinator._cmd_svc.apply_position.assert_not_called()
     # wait_for_target must be unblocked (entity not in sent set)
     coordinator._cmd_svc.set_waiting.assert_any_call(entity_id, False)
 
 
 @pytest.mark.asyncio
-async def test_reset_button_skips_send_when_auto_control_off():
-    """Pressing Reset with Automatic Control OFF must clear override but not move the cover."""
+async def test_reset_skips_send_when_auto_control_off():
+    """Reset with Automatic Control OFF must clear override but not move the cover."""
     entity_id = "cover.bedroom"
 
     coordinator = _make_coordinator(automatic_control=False)
@@ -282,8 +296,7 @@ async def test_reset_button_skips_send_when_auto_control_off():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    await _reset_via_coordinator(coordinator, [entity_id])
 
     coordinator.manager.reset.assert_called_once_with(entity_id)
     coordinator._cmd_svc.apply_position.assert_not_called()
@@ -291,8 +304,8 @@ async def test_reset_button_skips_send_when_auto_control_off():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_delegates_to_shared_method_with_correct_args():
-    """Button must call _async_send_after_override_clear with entities and trigger kwargs."""
+async def test_reset_delegates_to_shared_method_with_correct_args():
+    """The reset must call _async_send_after_override_clear with entities and trigger kwargs."""
     entity_id = "cover.kitchen"
     options = {"some_opt": True}
 
@@ -304,9 +317,9 @@ async def test_reset_button_delegates_to_shared_method_with_correct_args():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    reset = await _reset_via_coordinator(coordinator, [entity_id])
 
+    assert reset == [entity_id]
     coordinator._async_send_after_override_clear.assert_called_once()
     call = coordinator._async_send_after_override_clear.call_args
     assert call[0][0] == 55  # state
@@ -316,7 +329,7 @@ async def test_reset_button_delegates_to_shared_method_with_correct_args():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_wait_for_target_for_unsent_entities():
+async def test_reset_clears_wait_for_target_for_unsent_entities():
     """Entities the shared method did not send to must have wait_for_target cleared."""
     entity_a = "cover.sent"
     entity_b = "cover.not_sent"
@@ -330,10 +343,9 @@ async def test_reset_button_clears_wait_for_target_for_unsent_entities():
     # Simulate: shared method sent to entity_a but not entity_b
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_a})
 
-    button = _make_button(coordinator, [entity_a, entity_b])
-    await button.async_press()
+    await _reset_via_coordinator(coordinator, [entity_a, entity_b])
 
-    # entity_a was sent — apply_position would set waiting=True; button does NOT clear it
+    # entity_a was sent — apply_position would set waiting=True; reset does NOT clear it
     set_waiting_calls = coordinator._cmd_svc.set_waiting.call_args_list
     cleared = [call for call in set_waiting_calls if call.args == (entity_a, False)]
     assert not cleared, "entity_a was sent — wait_for_target must not be cleared"
@@ -342,7 +354,7 @@ async def test_reset_button_clears_wait_for_target_for_unsent_entities():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_happy_path_inside_window():
+async def test_reset_happy_path_inside_window():
     """Inside the window with auto-control on, position must be sent normally."""
     entity_id = "cover.sun_room"
 
@@ -354,13 +366,27 @@ async def test_reset_button_happy_path_inside_window():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    reset = await _reset_via_coordinator(coordinator, [entity_id])
 
+    assert reset == [entity_id]
     coordinator.manager.reset.assert_called_once_with(entity_id)
     coordinator.async_refresh.assert_called_once()
     coordinator._async_send_after_override_clear.assert_called_once()
-    # entity was sent — button must NOT clear waiting (apply_position set it)
+    # entity was sent — reset must NOT clear waiting (apply_position set it)
     set_waiting_calls = coordinator._cmd_svc.set_waiting.call_args_list
     cleared = [call for call in set_waiting_calls if call.args == (entity_id, False)]
     assert not cleared
+
+
+@pytest.mark.asyncio
+async def test_reset_button_delegates_to_coordinator():
+    """The button is a thin wrapper over the coordinator's shared reset method."""
+    entity_id = "cover.hall"
+
+    coordinator = MagicMock()
+    coordinator.async_reset_manual_overrides = AsyncMock(return_value=[entity_id])
+
+    button = _make_button(coordinator, [entity_id])
+    await button.async_press()
+
+    coordinator.async_reset_manual_overrides.assert_awaited_once_with([entity_id])

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -48,6 +48,7 @@ import custom_components.adaptive_cover_pro.binary_sensor  # noqa: F401
 import custom_components.adaptive_cover_pro.switch  # noqa: F401
 import custom_components.adaptive_cover_pro.button  # noqa: F401
 import custom_components.adaptive_cover_pro.cover  # noqa: F401
+import custom_components.adaptive_cover_pro.select  # noqa: F401
 
 from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverClimateStatusSensor,
@@ -73,6 +74,16 @@ from custom_components.adaptive_cover_pro.button import (
 )
 from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
 from custom_components.adaptive_cover_pro.number import AdaptiveCoverMyPositionNumber
+from custom_components.adaptive_cover_pro.const import GroupScene
+from custom_components.adaptive_cover_pro.group_entities import (
+    GroupActiveSceneSensor,
+    GroupAutomationSwitch,
+    GroupClearOverridesButton,
+    GroupPositionSensor,
+    GroupSceneButton,
+    GroupSceneSelect,
+    GroupStateSensor,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -245,6 +256,53 @@ ENTITY_FACTORIES: dict[type, object] = {
         coordinator=_make_coordinator(),
         source_entity_id="cover.test_source",
         multi=False,
+    ),
+    # --- group_entities.py (issue #790) ---
+    GroupPositionSensor: lambda: GroupPositionSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_position",
+    ),
+    GroupStateSensor: lambda: GroupStateSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_state",
+    ),
+    GroupActiveSceneSensor: lambda: GroupActiveSceneSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_active_scene",
+    ),
+    GroupAutomationSwitch: lambda: GroupAutomationSwitch(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupSceneButton: lambda: GroupSceneButton(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        GroupScene.ALL_OPEN,
+    ),
+    GroupClearOverridesButton: lambda: GroupClearOverridesButton(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupSceneSelect: lambda: GroupSceneSelect(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
     ),
 }
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -21,6 +21,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from custom_components.adaptive_cover_pro.group_entities import (
+    GroupActiveSceneSensor,
+    GroupAutomationSwitch,
+    GroupPositionSensor,
+    GroupStateSensor,
+)
 from custom_components.adaptive_cover_pro.sensor import (
     _DIAGNOSTIC_SPECS,
     _STANDARD_SPECS,
@@ -53,6 +59,28 @@ _EXPECTED_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
 # Switch keys that appear in en.json under entity.switch but are generated
 # dynamically (not in _SWITCH_SPECS) and therefore excluded from the spec check.
 _DYNAMIC_SWITCH_KEYS_PREFIX = "glare_zone_"
+
+# Cover-group entities (issue #790) are class-driven, not spec-driven; their
+# translation_keys come straight from the classes so a rename stays in sync.
+# HA's CachedProperties metaclass rewrites class-level ``_attr_translation_key``
+# into a property whose default lands under ``__attr_translation_key``.
+
+
+def _class_translation_key(cls: type) -> str:
+    value = cls.__dict__.get(
+        "__attr_translation_key", cls.__dict__.get("_attr_translation_key")
+    )
+    assert isinstance(value, str), f"{cls.__name__} has no class translation_key"
+    return value
+
+
+_GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
+    _class_translation_key(cls)
+    for cls in (GroupPositionSensor, GroupStateSensor, GroupActiveSceneSensor)
+)
+_GROUP_SWITCH_TRANSLATION_KEYS: frozenset[str] = frozenset(
+    {_class_translation_key(GroupAutomationSwitch)}
+)
 
 
 class TestSensorSpecTranslationKeys:
@@ -109,7 +137,7 @@ class TestSensorSpecTranslationKeys:
         )
         en_keys = frozenset(_EN_JSON.get("entity", {}).get("sensor", {}).keys())
 
-        orphaned = en_keys - spec_keys
+        orphaned = en_keys - spec_keys - _GROUP_SENSOR_TRANSLATION_KEYS
         assert not orphaned, (
             f"en.json entity.sensor contains entries with no matching sensor spec "
             f"translation_key: {sorted(orphaned)}\n"
@@ -134,7 +162,7 @@ class TestSwitchTranslationKeys:
             k for k in en_switch_keys if not k.startswith(_DYNAMIC_SWITCH_KEYS_PREFIX)
         )
 
-        orphaned = static_en_keys - spec_keys
+        orphaned = static_en_keys - spec_keys - _GROUP_SWITCH_TRANSLATION_KEYS
         assert not orphaned, (
             f"en.json entity.switch contains static entries with no matching "
             f"_SwitchSpec key: {sorted(orphaned)}\n"


### PR DESCRIPTION
## Summary
Phase 1 (MVP) of the Cover Group design from #790: a new `cover_group` virtual entry type that orchestrates a roster of member covers on explicit user action.

- **New entry type**: `GroupPolicy` with a new `is_orchestrator` ClassVar on the policy base — setup branches to a `GroupCoordinator` by capability, never a cover-type string (literal-scan guards stay green).
- **Scenes** (All Open / All Closed / Privacy) resolve per member via the new `position_for_scene` policy hook: ACP members are commanded through their own coordinator's user-position path (their gates, inverse-state, and override semantics apply); generic `cover.*` members go through a group-owned `CoverCommandService` (adopt mode: capability fallback, unavailable-skip, no-op suppression).
- **Bulk operations**: group automation switch (fan-out to member `automatic_control`), clear-overrides button. The reset sequence moved from the button onto the coordinator (`async_reset_manual_overrides`) so the button and the group share one path.
- **Entities**: aggregate group position/state/active-scene sensors, scene buttons, and a NEW `select` platform with the scene picker.
- **Config flow**: `create_group` top-level create option, one-page two-roster membership (ACP entries + generic covers) with sanitization (dedupe, self-exclusion, member-owned-cover drop), group options menu, group config-summary branch.
- **Translations**: EN strings added and synced to DE/FR (incl. the `summary_i18n` bundle; all parity locks green).

Phase 2+ (pipeline arbitration via `GroupOverrideHandler`, group lock, `group_*` services, stagger/startup grace, aggregate cover entity) intentionally deferred per the issue's phasing.

## Testing
- ✅ 5,541 tests passing (77 new group tests; `group_coordinator.py` at 100% coverage)

## Related Issues
Refs #790

https://claude.ai/code/session_01D2VimyDNsSA3TZUWy76ZLH