### PR TITLE
feat: add export_all_config and import_config services for bulk config management

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -55,6 +55,33 @@ export_config:
         config_entry:
           integration: adaptive_cover_pro
 
+export_all_config:
+  name: Export all configurations
+  description: >-
+    Writes the full options of every ACP cover entry to
+    ``/config/adaptive_cover_pro_export.json`` as a lossless JSON snapshot.
+    The file can then be edited with AI, a script, or regex and re-imported
+    with ``import_config``. Also returns ``{file, count}`` as a service response
+    for confirmation in Developer Tools.
+
+import_config:
+  name: Import configurations
+  description: >-
+    Reads a JSON file previously written by ``export_all_config`` and applies
+    the options of each entry (matched by ``entry_id``) to the live config
+    entries. Internal ``_``-prefixed migration markers are preserved from the
+    current live entry. Returns a per-entry result dict.
+  fields:
+    filename:
+      name: File path
+      description: >-
+        Absolute path to the JSON file to import. Must be inside ``/config/``.
+        Defaults to ``/config/adaptive_cover_pro_export.json``.
+      required: false
+      default: /config/adaptive_cover_pro_export.json
+      selector:
+        text:
+
 set_position:
   name: Set position
   description: >-

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -76,8 +76,10 @@ import_config:
     but absent from the import file will be dropped and reset to its default on
     the next reload. Export first, then edit only the keys you want to change.
 
-    **Note — no validation:** imported values are applied as-is without range or
-    type checking. Invalid values will surface as errors when the entry reloads.
+    **Note — partial validation:** numeric options are checked against their
+    declared min/max bounds and a failing entry is reported as an error without
+    aborting the rest of the import. Non-numeric options (booleans, strings,
+    enums) are applied as-is and may surface errors when the entry reloads.
   fields:
     filename:
       name: File path

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -59,10 +59,10 @@ export_all_config:
   name: Export all configurations
   description: >-
     Writes the full options of every ACP cover entry to
-    ``/config/adaptive_cover_pro_export.json`` as a lossless JSON snapshot.
-    The file can then be edited with AI, a script, or regex and re-imported
-    with ``import_config``. Also returns ``{file, count}`` as a service response
-    for confirmation in Developer Tools.
+    ``adaptive_cover_pro_export.json`` in your HA config directory as a lossless
+    JSON snapshot. The file can then be edited with AI, a script, or regex and
+    re-imported with ``import_config``. Also returns ``{file, count}`` as a
+    service response for confirmation in Developer Tools.
 
 import_config:
   name: Import configurations
@@ -71,14 +71,19 @@ import_config:
     the options of each entry (matched by ``entry_id``) to the live config
     entries. Internal ``_``-prefixed migration markers are preserved from the
     current live entry. Returns a per-entry result dict.
+
+    **Note — full replace:** any public option key present in the live entry
+    but absent from the import file will be dropped and reset to its default on
+    the next reload. Export first, then edit only the keys you want to change.
   fields:
     filename:
       name: File path
       description: >-
-        Absolute path to the JSON file to import. Must be inside ``/config/``.
-        Defaults to ``/config/adaptive_cover_pro_export.json``.
+        Path to the JSON file to import. Relative paths are resolved against the
+        HA config directory. The file must stay inside the config directory.
+        Defaults to ``adaptive_cover_pro_export.json`` (in the config directory).
       required: false
-      default: /config/adaptive_cover_pro_export.json
+      default: adaptive_cover_pro_export.json
       selector:
         text:
 

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -75,6 +75,9 @@ import_config:
     **Note — full replace:** any public option key present in the live entry
     but absent from the import file will be dropped and reset to its default on
     the next reload. Export first, then edit only the keys you want to change.
+
+    **Note — no validation:** imported values are applied as-is without range or
+    type checking. Invalid values will surface as errors when the entry reloads.
   fields:
     filename:
       name: File path

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -22,7 +22,13 @@ from .engage_manual_override_service import (
     ENGAGE_MANUAL_OVERRIDE_SCHEMA,
     async_handle_engage_manual_override,
 )
-from .export_service import EXPORT_CONFIG_SCHEMA, async_handle_export
+from .export_service import (
+    EXPORT_ALL_CONFIG_SCHEMA,
+    EXPORT_CONFIG_SCHEMA,
+    async_handle_export,
+    async_handle_export_all,
+)
+from .import_service import IMPORT_CONFIG_SCHEMA, async_handle_import_config
 from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
 from .set_tilt_service import SET_TILT_SCHEMA, async_handle_set_tilt
@@ -166,6 +172,22 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             schema=GET_DIAGNOSTICS_SCHEMA,
             supports_response=SupportsResponse.ONLY,
         )
+    if not hass.services.has_service(DOMAIN, "export_all_config"):
+        hass.services.async_register(
+            DOMAIN,
+            "export_all_config",
+            async_handle_export_all,
+            schema=EXPORT_ALL_CONFIG_SCHEMA,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
+    if not hass.services.has_service(DOMAIN, "import_config"):
+        hass.services.async_register(
+            DOMAIN,
+            "import_config",
+            async_handle_import_config,
+            schema=IMPORT_CONFIG_SCHEMA,
+            supports_response=SupportsResponse.OPTIONAL,
+        )
 
     async def handle_integration_enable(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
@@ -234,6 +256,8 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     if loaded_coordinators(hass):
         return  # Other entries still active
     hass.services.async_remove(DOMAIN, "export_config")
+    hass.services.async_remove(DOMAIN, "export_all_config")
+    hass.services.async_remove(DOMAIN, "import_config")
     hass.services.async_remove(DOMAIN, "get_diagnostics")
     hass.services.async_remove(DOMAIN, "integration_enable")
     hass.services.async_remove(DOMAIN, "integration_disable")

--- a/custom_components/adaptive_cover_pro/services/export_service.py
+++ b/custom_components/adaptive_cover_pro/services/export_service.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import functools
+import json
 import logging
+import pathlib
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
@@ -52,6 +56,10 @@ EXPORT_CONFIG_SCHEMA = vol.Schema(
         vol.Required("config_entry_id"): str,
     }
 )
+
+EXPORT_ALL_CONFIG_SCHEMA = vol.Schema({})
+
+DEFAULT_EXPORT_PATH = "/config/adaptive_cover_pro_export.json"
 
 
 async def async_handle_export(call: ServiceCall) -> dict:
@@ -123,3 +131,49 @@ async def async_handle_export(call: ServiceCall) -> dict:
             CONF_TILT_MODE: options.get(CONF_TILT_MODE),
         },
     }
+
+
+async def async_handle_export_all(call: ServiceCall) -> dict:
+    """Handle the export_all_config service call.
+
+    Writes all non-virtual ACP cover entries (those with a loaded coordinator) to
+    ``/config/adaptive_cover_pro_export.json`` as a lossless JSON snapshot.  The
+    file is written atomically via the executor so the event loop is never blocked.
+
+    Returns ``{"file": <path>, "count": <n>}`` so the call is also useful in
+    Developer Tools (the response is visible immediately).
+    """
+    from . import (
+        loaded_coordinators,
+    )  # local import avoids circular dependency  # noqa: PLC0415
+
+    hass: HomeAssistant = call.hass
+    coordinators = loaded_coordinators(hass)
+
+    entries = []
+    for entry_id, _coord in coordinators.items():
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None:
+            continue
+        entries.append(
+            {
+                "entry_id": entry_id,
+                "title": entry.title,
+                "options": dict(entry.options),
+            }
+        )
+
+    payload = {
+        "export_version": 1,
+        "exported_at": datetime.now(UTC).isoformat(),
+        "entries": entries,
+    }
+
+    path = pathlib.Path(DEFAULT_EXPORT_PATH)
+    json_text = json.dumps(payload, indent=2, ensure_ascii=False)
+    await hass.async_add_executor_job(
+        functools.partial(path.write_text, json_text, "utf-8")
+    )
+
+    _LOGGER.info("export_all_config: wrote %d entries to %s", len(entries), path)
+    return {"file": str(path), "count": len(entries)}

--- a/custom_components/adaptive_cover_pro/services/export_service.py
+++ b/custom_components/adaptive_cover_pro/services/export_service.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import functools
 import json
 import logging
+import os
 import pathlib
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -59,7 +59,9 @@ EXPORT_CONFIG_SCHEMA = vol.Schema(
 
 EXPORT_ALL_CONFIG_SCHEMA = vol.Schema({})
 
-DEFAULT_EXPORT_PATH = "/config/adaptive_cover_pro_export.json"
+_EXPORT_FILENAME = "adaptive_cover_pro_export.json"
+# Kept as a schema-default hint for the import service (relative filename only).
+DEFAULT_EXPORT_PATH = _EXPORT_FILENAME
 
 
 async def async_handle_export(call: ServiceCall) -> dict:
@@ -137,8 +139,10 @@ async def async_handle_export_all(call: ServiceCall) -> dict:
     """Handle the export_all_config service call.
 
     Writes all non-virtual ACP cover entries (those with a loaded coordinator) to
-    ``/config/adaptive_cover_pro_export.json`` as a lossless JSON snapshot.  The
-    file is written atomically via the executor so the event loop is never blocked.
+    ``<config_dir>/adaptive_cover_pro_export.json`` as a lossless JSON snapshot.
+    The file is written atomically (write to ``.tmp`` then ``os.replace``) via the
+    executor so the event loop is never blocked and a concurrent read never sees a
+    partial file.
 
     Returns ``{"file": <path>, "count": <n>}`` so the call is also useful in
     Developer Tools (the response is visible immediately).
@@ -169,11 +173,15 @@ async def async_handle_export_all(call: ServiceCall) -> dict:
         "entries": entries,
     }
 
-    path = pathlib.Path(DEFAULT_EXPORT_PATH)
+    path = pathlib.Path(hass.config.path(_EXPORT_FILENAME))
     json_text = json.dumps(payload, indent=2, ensure_ascii=False)
-    await hass.async_add_executor_job(
-        functools.partial(path.write_text, json_text, "utf-8")
-    )
+
+    def _atomic_write() -> None:
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json_text, "utf-8")
+        os.replace(tmp, path)
+
+    await hass.async_add_executor_job(_atomic_write)
 
     _LOGGER.info("export_all_config: wrote %d entries to %s", len(entries), path)
     return {"file": str(path), "count": len(entries)}

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -14,7 +14,7 @@ from homeassistant.exceptions import ServiceValidationError
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
-from ..const import DOMAIN
+from ..const import DOMAIN, OPTION_RANGES
 from .export_service import DEFAULT_EXPORT_PATH
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,9 +36,11 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
     are preserved from the current live entry so that version-migration state is
     never overwritten by an older export.
 
-    No range or type validation is performed on imported values — the file is
-    assumed to be a product of ``export_all_config`` and is trusted accordingly.
-    Invalid values will surface as errors when the entry is reloaded.
+    Numeric keys present in ``OPTION_RANGES`` are validated against their
+    declared bounds before the entry is updated; a failed check records
+    ``"error: ..."`` for that entry in the result dict without aborting the
+    rest of the import. Keys absent from ``OPTION_RANGES`` (booleans, strings,
+    enums, and unknown future keys) are accepted as-is.
 
     Returns a per-entry result dict:
         ``{entry_id: "updated" | "skipped" | "error: <msg>"}``
@@ -116,6 +118,27 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
             imported_public = {
                 k: v for k, v in file_opts.items() if not k.startswith("_")
             }
+
+            # Validate numeric keys against their declared OPTION_RANGES bounds.
+            validation_errors: list[str] = []
+            for key, value in imported_public.items():
+                if key not in OPTION_RANGES or value is None:
+                    continue
+                lo, hi = OPTION_RANGES[key]
+                try:
+                    num = float(value)
+                    if not (lo <= num <= hi):
+                        validation_errors.append(
+                            f"{key}={value} out of range [{lo}, {hi}]"
+                        )
+                except (TypeError, ValueError):
+                    validation_errors.append(f"{key}={value!r} is not a valid number")
+            if validation_errors:
+                raise ServiceValidationError(
+                    f"import_config: invalid values for entry '{entry_id}': "
+                    + "; ".join(validation_errors)
+                )
+
             new_options = {**current_internal, **imported_public}
 
             hass.config_entries.async_update_entry(entry, options=new_options)

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -36,12 +36,17 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
     are preserved from the current live entry so that version-migration state is
     never overwritten by an older export.
 
+    No range or type validation is performed on imported values — the file is
+    assumed to be a product of ``export_all_config`` and is trusted accordingly.
+    Invalid values will surface as errors when the entry is reloaded.
+
     Returns a per-entry result dict:
         ``{entry_id: "updated" | "skipped" | "error: <msg>"}``
 
     Raises:
-        ServiceValidationError: if the filename resolves outside ``/config/``, if
-            the file cannot be read, or if the file is not valid JSON.
+        ServiceValidationError: if the filename resolves outside the HA config
+            directory, if the file cannot be read, if the file is not valid JSON,
+            or if the file is not a valid ACP export shape.
 
     """
     hass: HomeAssistant = call.hass

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import pathlib
+from collections import Counter
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
@@ -17,8 +18,6 @@ from ..const import DOMAIN
 from .export_service import DEFAULT_EXPORT_PATH
 
 _LOGGER = logging.getLogger(__name__)
-
-_CONFIG_ROOT = pathlib.Path("/config")
 
 IMPORT_CONFIG_SCHEMA = vol.Schema(
     {
@@ -48,14 +47,21 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
     hass: HomeAssistant = call.hass
     filename: str = call.data["filename"]
 
-    # Path safety: reject traversal outside /config/
-    path = pathlib.Path(filename).resolve()
+    # Resolve relative filenames against the HA config directory.
+    p = pathlib.Path(filename)
+    if not p.is_absolute():
+        p = pathlib.Path(hass.config.config_dir) / p
+
+    # Path safety: reject traversal outside the HA config directory.
+    config_root = pathlib.Path(hass.config.config_dir).resolve()
+    path = p.resolve()
     try:
-        path.relative_to(_CONFIG_ROOT.resolve())
+        path.relative_to(config_root)
     except ValueError as exc:
         raise ServiceValidationError(
-            f"import_config: filename '{filename}' is not inside /config/ — "
-            "only files under /config/ may be imported"
+            f"import_config: filename '{filename}' is not inside the HA config "
+            f"directory ('{config_root}') — only files under the config directory "
+            "may be imported"
         ) from exc
 
     # Read file in executor
@@ -76,7 +82,13 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
             f"import_config: '{path}' is not valid JSON: {exc}"
         ) from exc
 
-    file_entries: list[dict] = data.get("entries", [])
+    if not isinstance(data, dict) or not isinstance(data.get("entries"), list):
+        raise ServiceValidationError(
+            f"import_config: '{path}' is not a valid ACP export "
+            '(expected {{"export_version": 1, "entries": [...]}})'
+        )
+
+    file_entries: list[dict] = data["entries"]
     results: dict[str, str] = {}
 
     for item in file_entries:
@@ -114,10 +126,6 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
         "import_config: processed %d entries from '%s': %s",
         len(file_entries),
         path,
-        {
-            v: sum(1 for r in results.values() if r == v)
-            for v in ("updated", "skipped")
-            if v in results.values()
-        },
+        dict(Counter(results.values())),
     )
     return results

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -1,0 +1,123 @@
+"""Import service for Adaptive Cover Pro — applies a JSON config file to live entries."""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.exceptions import ServiceValidationError
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+from ..const import DOMAIN
+from .export_service import DEFAULT_EXPORT_PATH
+
+_LOGGER = logging.getLogger(__name__)
+
+_CONFIG_ROOT = pathlib.Path("/config")
+
+IMPORT_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Optional("filename", default=DEFAULT_EXPORT_PATH): str,
+    }
+)
+
+
+async def async_handle_import_config(call: ServiceCall) -> dict:
+    """Handle the import_config service call.
+
+    Reads a JSON file previously written by ``export_all_config`` and applies the
+    options of each entry (matched by ``entry_id``) to the live config entries.
+
+    Internal ``_``-prefixed keys (migration markers such as ``_orphan_prune_v1``)
+    are preserved from the current live entry so that version-migration state is
+    never overwritten by an older export.
+
+    Returns a per-entry result dict:
+        ``{entry_id: "updated" | "skipped" | "error: <msg>"}``
+
+    Raises:
+        ServiceValidationError: if the filename resolves outside ``/config/``, if
+            the file cannot be read, or if the file is not valid JSON.
+
+    """
+    hass: HomeAssistant = call.hass
+    filename: str = call.data["filename"]
+
+    # Path safety: reject traversal outside /config/
+    path = pathlib.Path(filename).resolve()
+    try:
+        path.relative_to(_CONFIG_ROOT.resolve())
+    except ValueError as exc:
+        raise ServiceValidationError(
+            f"import_config: filename '{filename}' is not inside /config/ — "
+            "only files under /config/ may be imported"
+        ) from exc
+
+    # Read file in executor
+    def _read() -> str:
+        return path.read_text(encoding="utf-8")
+
+    try:
+        raw = await hass.async_add_executor_job(_read)
+    except OSError as exc:
+        raise ServiceValidationError(
+            f"import_config: cannot read '{path}': {exc}"
+        ) from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ServiceValidationError(
+            f"import_config: '{path}' is not valid JSON: {exc}"
+        ) from exc
+
+    file_entries: list[dict] = data.get("entries", [])
+    results: dict[str, str] = {}
+
+    for item in file_entries:
+        entry_id: str = item.get("entry_id", "")
+        file_opts: dict = item.get("options", {})
+
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            _LOGGER.warning(
+                "import_config: entry_id '%s' not found — skipping", entry_id
+            )
+            results[entry_id] = "skipped"
+            continue
+
+        try:
+            # Preserve current internal (_-prefixed) migration markers
+            current_internal = {
+                k: v for k, v in entry.options.items() if k.startswith("_")
+            }
+            imported_public = {
+                k: v for k, v in file_opts.items() if not k.startswith("_")
+            }
+            new_options = {**current_internal, **imported_public}
+
+            hass.config_entries.async_update_entry(entry, options=new_options)
+            _LOGGER.debug(
+                "import_config: updated entry '%s' (%s)", entry_id, entry.title
+            )
+            results[entry_id] = "updated"
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.exception("import_config: error updating entry '%s'", entry_id)
+            results[entry_id] = f"error: {exc}"
+
+    _LOGGER.info(
+        "import_config: processed %d entries from '%s': %s",
+        len(file_entries),
+        path,
+        {
+            v: sum(1 for r in results.values() if r == v)
+            for v in ("updated", "skipped")
+            if v in results.values()
+        },
+    )
+    return results

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2357,6 +2357,20 @@
           "description": "Verlängert eine aktive Übersteuerung um diesen Betrag oder aktiviert sie neu für diese Dauer, falls keine aktiv ist. Wird ignoriert, wenn eine Endzeit gesetzt ist."
         }
       }
+    },
+    "export_all_config": {
+      "name": "Alle Konfigurationen exportieren",
+      "description": "Schreibt die vollständigen Optionen jedes Adaptive Cover Pro-Konfigurationseintrags in adaptive_cover_pro_export.json im Konfigurationsverzeichnis von Home Assistant als verlustfreien JSON-Snapshot. Gibt den Dateipfad und die Anzahl der Einträge zurück. Bearbeiten Sie die Datei und importieren Sie sie mit Konfigurationen importieren erneut."
+    },
+    "import_config": {
+      "name": "Konfigurationen importieren",
+      "description": "Liest eine JSON-Datei, die zuvor von Alle Konfigurationen exportieren geschrieben wurde, und wendet die Optionen jedes Eintrags (abgeglichen nach Eintrag-ID) auf die aktiven Konfigurationseinträge an. Interne Migrationsmarker werden vom aktuellen Eintrag beibehalten. Numerische Optionen werden gegen ihre Min-/Max-Grenzen überprüft. Ein fehlgeschlagener Eintrag wird gemeldet, ohne den Rest abzubrechen. Jede öffentliche Option, die in der Datei fehlt, wird beim Neuladen auf ihren Standard zurückgesetzt – exportieren Sie zuerst, bearbeiten Sie dann nur, was Sie ändern müssen.",
+      "fields": {
+        "filename": {
+          "name": "Dateipfad",
+          "description": "Pfad zur JSON-Datei zum Importieren. Relative Pfade werden relativ zum Konfigurationsverzeichnis von Home Assistant aufgelöst und müssen darin bleiben. Standard: adaptive_cover_pro_export.json."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1782,6 +1782,20 @@
         }
       }
     },
+    "export_all_config": {
+      "name": "Export all configurations",
+      "description": "Writes the full options of every Adaptive Cover Pro cover entry to adaptive_cover_pro_export.json in your Home Assistant config directory as a lossless JSON snapshot. Returns the file path and entry count. Edit the file and re-import it with Import configurations."
+    },
+    "import_config": {
+      "name": "Import configurations",
+      "description": "Reads a JSON file previously written by Export all configurations and applies each entry's options (matched by entry id) to the live config entries. Internal migration markers are preserved from the current entry. Numeric options are checked against their min/max bounds; a failing entry is reported without aborting the rest. Any public option absent from the file is reset to its default on reload — export first, then edit only what you need to change.",
+      "fields": {
+        "filename": {
+          "name": "File path",
+          "description": "Path to the JSON file to import. Relative paths resolve against the Home Assistant config directory and must stay inside it. Defaults to adaptive_cover_pro_export.json."
+        }
+      }
+    },
     "get_diagnostics": {
       "name": "Get diagnostics",
       "description": "Returns the live diagnostics snapshot for the targeted Adaptive Cover Pro instances — pipeline decision trace, cover positions, climate readings, sun data, and coordinator health.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2357,6 +2357,20 @@
           "description": "Prolonge une dérogation active de cette valeur, ou en engage une nouvelle pour cette durée si aucune n'est active. Ignorée lorsqu'une heure de fin est définie."
         }
       }
+    },
+    "export_all_config": {
+      "name": "Exporter toutes les configurations",
+      "description": "Écrit les options complètes de chaque entrée de protection Adaptive Cover Pro dans adaptive_cover_pro_export.json dans votre répertoire de configuration Home Assistant en tant qu'instantané JSON sans perte. Retourne le chemin du fichier et le nombre d'entrées. Modifiez le fichier et réimportez-le avec Importer les configurations."
+    },
+    "import_config": {
+      "name": "Importer les configurations",
+      "description": "Lit un fichier JSON précédemment écrit par Exporter toutes les configurations et applique les options de chaque entrée (appariées par identifiant d'entrée) aux entrées de configuration actives. Les marqueurs de migration internes sont préservés de l'entrée actuelle. Les options numériques sont vérifiées par rapport à leurs limites min/max ; une entrée défaillante est signalée sans abandonner le reste. Toute option publique absente du fichier est réinitialisée à sa valeur par défaut lors du rechargement — exportez d'abord, puis modifiez uniquement ce que vous devez changer.",
+      "fields": {
+        "filename": {
+          "name": "Chemin du fichier",
+          "description": "Chemin du fichier JSON à importer. Les chemins relatifs se résolvent par rapport au répertoire de configuration Home Assistant et doivent rester à l'intérieur. Par défaut adaptive_cover_pro_export.json."
+        }
+      }
     }
   }
 }

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -332,9 +332,7 @@ class TestImportConfig:
             call.hass = hass
             call.data = {"filename": str(bad_file)}
 
-            with pytest.raises(
-                ServiceValidationError, match="not a valid ACP export"
-            ):
+            with pytest.raises(ServiceValidationError, match="not a valid ACP export"):
                 await async_handle_import_config(call)
 
     @pytest.mark.asyncio
@@ -344,14 +342,14 @@ class TestImportConfig:
             async_handle_import_config,
         )
 
-        entry = _make_entry("id-1", "Blind A", {"azimuth": 90})
+        entry = _make_entry("id-1", "Blind A", {"set_azimuth": 90})
         hass = _make_hass([entry], config_dir=str(tmp_path))
 
         export_path = tmp_path / "import.json"
-        # azimuth valid range is [0, 359]; 999 is out of range
+        # set_azimuth valid range is [0, 359]; 999 is out of range
         self._write_export(
             export_path,
-            [{"entry_id": "id-1", "options": {"azimuth": 999}}],
+            [{"entry_id": "id-1", "options": {"set_azimuth": 999}}],
         )
 
         call = MagicMock()
@@ -361,9 +359,9 @@ class TestImportConfig:
         result = await async_handle_import_config(call)
 
         assert result["id-1"].startswith("error:")
-        assert "azimuth" in result["id-1"]
+        assert "set_azimuth" in result["id-1"]
         # entry options must not have been modified
-        assert entry.options["azimuth"] == 90
+        assert entry.options["set_azimuth"] == 90
 
     @pytest.mark.asyncio
     async def test_mixed_results(self, tmp_path):

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -74,7 +74,7 @@ class TestExportAll:
 
         with (
             patch(
-                "custom_components.adaptive_cover_pro.services.export_service.loaded_coordinators",
+                "custom_components.adaptive_cover_pro.services.loaded_coordinators",
                 return_value=coordinators,
             ),
             patch(
@@ -113,7 +113,7 @@ class TestExportAll:
 
         with (
             patch(
-                "custom_components.adaptive_cover_pro.services.export_service.loaded_coordinators",
+                "custom_components.adaptive_cover_pro.services.loaded_coordinators",
                 return_value={"id-x": MagicMock()},
             ),
             patch(
@@ -141,7 +141,7 @@ class TestExportAll:
 
         with (
             patch(
-                "custom_components.adaptive_cover_pro.services.export_service.loaded_coordinators",
+                "custom_components.adaptive_cover_pro.services.loaded_coordinators",
                 return_value={},
             ),
             patch(
@@ -193,7 +193,11 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        result = await async_handle_import_config(call)
+        with patch(
+            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
+            tmp_path,
+        ):
+            result = await async_handle_import_config(call)
 
         assert result["id-1"] == "updated"
         # azimuth updated, internal key preserved, new key added
@@ -230,7 +234,11 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        await async_handle_import_config(call)
+        with patch(
+            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
+            tmp_path,
+        ):
+            await async_handle_import_config(call)
 
         # File had _orphan_prune_v1=False but live entry had True — live wins
         assert entry.options["_orphan_prune_v1"] is True
@@ -254,7 +262,11 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        result = await async_handle_import_config(call)
+        with patch(
+            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
+            tmp_path,
+        ):
+            result = await async_handle_import_config(call)
 
         assert result["ghost-id"] == "skipped"
 
@@ -356,7 +368,11 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        result = await async_handle_import_config(call)
+        with patch(
+            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
+            tmp_path,
+        ):
+            result = await async_handle_import_config(call)
 
         assert result["id-good"] == "updated"
         assert result["id-ghost"] == "skipped"

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -24,11 +24,16 @@ def _make_entry(
     return entry
 
 
-def _make_hass(entries: list[MagicMock]) -> MagicMock:
-    """Build a minimal hass mock with a config_entries registry."""
+def _make_hass(entries: list[MagicMock], config_dir: str = "/config") -> MagicMock:
+    """Build a minimal hass mock with a config_entries registry and hass.config."""
     hass = MagicMock()
     hass.async_add_executor_job = AsyncMock(
         side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    )
+
+    hass.config.config_dir = config_dir
+    hass.config.path.side_effect = lambda *parts: str(
+        pathlib.Path(config_dir).joinpath(*parts)
     )
 
     entry_map = {e.entry_id: e for e in entries}
@@ -63,27 +68,21 @@ class TestExportAll:
         entry2 = _make_entry(
             "id-2", "Blind B", {"azimuth": 270, "_orphan_prune_v1": True}
         )
-        hass = _make_hass([entry1, entry2])
+        hass = _make_hass([entry1, entry2], config_dir=str(tmp_path))
 
         coord1, coord2 = MagicMock(), MagicMock()
         coordinators = {"id-1": coord1, "id-2": coord2}
 
-        export_path = tmp_path / "adaptive_cover_pro_export.json"
         call = MagicMock()
         call.hass = hass
 
-        with (
-            patch(
-                "custom_components.adaptive_cover_pro.services.loaded_coordinators",
-                return_value=coordinators,
-            ),
-            patch(
-                "custom_components.adaptive_cover_pro.services.export_service.DEFAULT_EXPORT_PATH",
-                str(export_path),
-            ),
+        with patch(
+            "custom_components.adaptive_cover_pro.services.loaded_coordinators",
+            return_value=coordinators,
         ):
             result = await async_handle_export_all(call)
 
+        export_path = tmp_path / "adaptive_cover_pro_export.json"
         assert result["count"] == 2
         assert result["file"] == str(export_path)
 
@@ -106,23 +105,17 @@ class TestExportAll:
             "_orphan_prune_sensors_v2": True,
         }
         entry = _make_entry("id-x", "Test", opts)
-        hass = _make_hass([entry])
-        export_path = tmp_path / "out.json"
+        hass = _make_hass([entry], config_dir=str(tmp_path))
         call = MagicMock()
         call.hass = hass
 
-        with (
-            patch(
-                "custom_components.adaptive_cover_pro.services.loaded_coordinators",
-                return_value={"id-x": MagicMock()},
-            ),
-            patch(
-                "custom_components.adaptive_cover_pro.services.export_service.DEFAULT_EXPORT_PATH",
-                str(export_path),
-            ),
+        with patch(
+            "custom_components.adaptive_cover_pro.services.loaded_coordinators",
+            return_value={"id-x": MagicMock()},
         ):
             await async_handle_export_all(call)
 
+        export_path = tmp_path / "adaptive_cover_pro_export.json"
         data = json.loads(export_path.read_text("utf-8"))
         exported_opts = data["entries"][0]["options"]
         assert exported_opts["_orphan_prune_v1"] is True
@@ -130,28 +123,23 @@ class TestExportAll:
 
     @pytest.mark.asyncio
     async def test_empty_coordinators_writes_empty_entries(self, tmp_path):
+        """An empty coordinator map produces a file with an empty entries list."""
         from custom_components.adaptive_cover_pro.services.export_service import (
             async_handle_export_all,
         )
 
-        hass = _make_hass([])
-        export_path = tmp_path / "out.json"
+        hass = _make_hass([], config_dir=str(tmp_path))
         call = MagicMock()
         call.hass = hass
 
-        with (
-            patch(
-                "custom_components.adaptive_cover_pro.services.loaded_coordinators",
-                return_value={},
-            ),
-            patch(
-                "custom_components.adaptive_cover_pro.services.export_service.DEFAULT_EXPORT_PATH",
-                str(export_path),
-            ),
+        with patch(
+            "custom_components.adaptive_cover_pro.services.loaded_coordinators",
+            return_value={},
         ):
             result = await async_handle_export_all(call)
 
         assert result["count"] == 0
+        export_path = tmp_path / "adaptive_cover_pro_export.json"
         data = json.loads(export_path.read_text("utf-8"))
         assert data["entries"] == []
 
@@ -181,7 +169,7 @@ class TestImportConfig:
 
         live_opts = {"azimuth": 90, "_orphan_prune_v1": True}
         entry = _make_entry("id-1", "Blind A", live_opts)
-        hass = _make_hass([entry])
+        hass = _make_hass([entry], config_dir=str(tmp_path))
 
         export_path = tmp_path / "import.json"
         self._write_export(
@@ -193,19 +181,12 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        with patch(
-            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
-            tmp_path,
-        ):
-            result = await async_handle_import_config(call)
+        result = await async_handle_import_config(call)
 
         assert result["id-1"] == "updated"
-        # azimuth updated, internal key preserved, new key added
         assert entry.options["azimuth"] == 270
         assert entry.options["fov_left"] == 45
         assert entry.options["_orphan_prune_v1"] is True
-        # old _-key from file must NOT overwrite live entry's internal key
-        assert "_orphan_prune_v1" in entry.options
 
     @pytest.mark.asyncio
     async def test_internal_keys_in_file_are_ignored(self, tmp_path):
@@ -217,7 +198,7 @@ class TestImportConfig:
         entry = _make_entry(
             "id-2", "Blind B", {"azimuth": 90, "_orphan_prune_v1": True}
         )
-        hass = _make_hass([entry])
+        hass = _make_hass([entry], config_dir=str(tmp_path))
 
         export_path = tmp_path / "import.json"
         self._write_export(
@@ -234,11 +215,7 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        with patch(
-            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
-            tmp_path,
-        ):
-            await async_handle_import_config(call)
+        await async_handle_import_config(call)
 
         # File had _orphan_prune_v1=False but live entry had True — live wins
         assert entry.options["_orphan_prune_v1"] is True
@@ -251,7 +228,7 @@ class TestImportConfig:
             async_handle_import_config,
         )
 
-        hass = _make_hass([])  # no entries registered
+        hass = _make_hass([], config_dir=str(tmp_path))
         export_path = tmp_path / "import.json"
         self._write_export(
             export_path,
@@ -262,17 +239,13 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        with patch(
-            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
-            tmp_path,
-        ):
-            result = await async_handle_import_config(call)
+        result = await async_handle_import_config(call)
 
         assert result["ghost-id"] == "skipped"
 
     @pytest.mark.asyncio
     async def test_path_traversal_rejected(self, tmp_path):
-        """Filename resolving outside /config/ raises ServiceValidationError."""
+        """Filename resolving outside the config dir raises ServiceValidationError."""
         from homeassistant.exceptions import ServiceValidationError
 
         from custom_components.adaptive_cover_pro.services.import_service import (
@@ -280,10 +253,10 @@ class TestImportConfig:
         )
 
         call = MagicMock()
-        call.hass = _make_hass([])
+        call.hass = _make_hass([], config_dir=str(tmp_path))
         call.data = {"filename": "/etc/passwd"}
 
-        with pytest.raises(ServiceValidationError, match="not inside /config/"):
+        with pytest.raises(ServiceValidationError, match="not inside the HA config"):
             await async_handle_import_config(call)
 
     @pytest.mark.asyncio
@@ -296,10 +269,12 @@ class TestImportConfig:
         )
 
         call = MagicMock()
-        call.hass = _make_hass([])
-        call.data = {"filename": "/config/../etc/shadow"}
+        call.hass = _make_hass([], config_dir=str(tmp_path))
+        # Build a path that starts inside tmp_path but escapes via ..
+        traversal = str(tmp_path / ".." / "etc" / "shadow")
+        call.data = {"filename": traversal}
 
-        with pytest.raises(ServiceValidationError, match="not inside /config/"):
+        with pytest.raises(ServiceValidationError, match="not inside the HA config"):
             await async_handle_import_config(call)
 
     @pytest.mark.asyncio
@@ -311,10 +286,10 @@ class TestImportConfig:
             async_handle_import_config,
         )
 
-        hass = _make_hass([])
+        hass = _make_hass([], config_dir=str(tmp_path))
         call = MagicMock()
         call.hass = hass
-        call.data = {"filename": "/config/does_not_exist_xyz.json"}
+        call.data = {"filename": str(tmp_path / "does_not_exist_xyz.json")}
 
         with pytest.raises(ServiceValidationError, match="cannot read"):
             await async_handle_import_config(call)
@@ -331,19 +306,36 @@ class TestImportConfig:
         bad_file = tmp_path / "bad.json"
         bad_file.write_text("this is not json", encoding="utf-8")
 
-        hass = _make_hass([])
+        hass = _make_hass([], config_dir=str(tmp_path))
         call = MagicMock()
         call.hass = hass
         call.data = {"filename": str(bad_file)}
 
-        with (
-            patch(
-                "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
-                tmp_path,
-            ),
-            pytest.raises(ServiceValidationError, match="not valid JSON"),
-        ):
+        with pytest.raises(ServiceValidationError, match="not valid JSON"):
             await async_handle_import_config(call)
+
+    @pytest.mark.asyncio
+    async def test_wrong_shape_json_raises_validation_error(self, tmp_path):
+        """Valid JSON that is not an ACP export shape raises ServiceValidationError."""
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        for bad_payload in [[], "a string", 42, {"no_entries_key": True}]:
+            bad_file = tmp_path / "wrong_shape.json"
+            bad_file.write_text(json.dumps(bad_payload), encoding="utf-8")
+
+            hass = _make_hass([], config_dir=str(tmp_path))
+            call = MagicMock()
+            call.hass = hass
+            call.data = {"filename": str(bad_file)}
+
+            with pytest.raises(
+                ServiceValidationError, match="not a valid ACP export"
+            ):
+                await async_handle_import_config(call)
 
     @pytest.mark.asyncio
     async def test_mixed_results(self, tmp_path):
@@ -353,7 +345,7 @@ class TestImportConfig:
         )
 
         entry = _make_entry("id-good", "Blind Good", {"azimuth": 90})
-        hass = _make_hass([entry])
+        hass = _make_hass([entry], config_dir=str(tmp_path))
 
         export_path = tmp_path / "import.json"
         self._write_export(
@@ -368,11 +360,7 @@ class TestImportConfig:
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        with patch(
-            "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
-            tmp_path,
-        ):
-            result = await async_handle_import_config(call)
+        result = await async_handle_import_config(call)
 
         assert result["id-good"] == "updated"
         assert result["id-ghost"] == "skipped"

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -338,6 +338,34 @@ class TestImportConfig:
                 await async_handle_import_config(call)
 
     @pytest.mark.asyncio
+    async def test_out_of_range_value_recorded_as_error(self, tmp_path):
+        """A numeric value outside OPTION_RANGES bounds records an error for that entry."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Blind A", {"azimuth": 90})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        # azimuth valid range is [0, 359]; 999 is out of range
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"azimuth": 999}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"].startswith("error:")
+        assert "azimuth" in result["id-1"]
+        # entry options must not have been modified
+        assert entry.options["azimuth"] == 90
+
+    @pytest.mark.asyncio
     async def test_mixed_results(self, tmp_path):
         """One valid entry and one unknown entry produce mixed results dict."""
         from custom_components.adaptive_cover_pro.services.import_service import (

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -1,0 +1,362 @@
+"""Unit tests for export_all_config and import_config services."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(
+    entry_id: str, title: str, options: dict, domain: str = "adaptive_cover_pro"
+) -> MagicMock:
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.title = title
+    entry.options = options
+    entry.domain = domain
+    return entry
+
+
+def _make_hass(entries: list[MagicMock]) -> MagicMock:
+    """Build a minimal hass mock with a config_entries registry."""
+    hass = MagicMock()
+    hass.async_add_executor_job = AsyncMock(
+        side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+    )
+
+    entry_map = {e.entry_id: e for e in entries}
+
+    def _get_entry(entry_id):
+        return entry_map.get(entry_id)
+
+    def _update_entry(entry, *, options):
+        entry.options = options
+
+    hass.config_entries.async_get_entry.side_effect = _get_entry
+    hass.config_entries.async_update_entry.side_effect = _update_entry
+    return hass
+
+
+# ---------------------------------------------------------------------------
+# export_all_config tests
+# ---------------------------------------------------------------------------
+
+
+class TestExportAll:
+    """Tests for async_handle_export_all."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_writes_file_and_returns_count(self, tmp_path):
+        """All loaded coordinators are exported to the file."""
+        from custom_components.adaptive_cover_pro.services.export_service import (
+            async_handle_export_all,
+        )
+
+        entry1 = _make_entry("id-1", "Blind A", {"azimuth": 180, "fov_left": 30})
+        entry2 = _make_entry(
+            "id-2", "Blind B", {"azimuth": 270, "_orphan_prune_v1": True}
+        )
+        hass = _make_hass([entry1, entry2])
+
+        coord1, coord2 = MagicMock(), MagicMock()
+        coordinators = {"id-1": coord1, "id-2": coord2}
+
+        export_path = tmp_path / "adaptive_cover_pro_export.json"
+        call = MagicMock()
+        call.hass = hass
+
+        with (
+            patch(
+                "custom_components.adaptive_cover_pro.services.export_service.loaded_coordinators",
+                return_value=coordinators,
+            ),
+            patch(
+                "custom_components.adaptive_cover_pro.services.export_service.DEFAULT_EXPORT_PATH",
+                str(export_path),
+            ),
+        ):
+            result = await async_handle_export_all(call)
+
+        assert result["count"] == 2
+        assert result["file"] == str(export_path)
+
+        data = json.loads(export_path.read_text("utf-8"))
+        assert data["export_version"] == 1
+        assert len(data["entries"]) == 2
+        ids = {e["entry_id"] for e in data["entries"]}
+        assert ids == {"id-1", "id-2"}
+
+    @pytest.mark.asyncio
+    async def test_internal_keys_included_in_export(self, tmp_path):
+        """Internal _-prefixed keys are exported verbatim (lossless snapshot)."""
+        from custom_components.adaptive_cover_pro.services.export_service import (
+            async_handle_export_all,
+        )
+
+        opts = {
+            "azimuth": 90,
+            "_orphan_prune_v1": True,
+            "_orphan_prune_sensors_v2": True,
+        }
+        entry = _make_entry("id-x", "Test", opts)
+        hass = _make_hass([entry])
+        export_path = tmp_path / "out.json"
+        call = MagicMock()
+        call.hass = hass
+
+        with (
+            patch(
+                "custom_components.adaptive_cover_pro.services.export_service.loaded_coordinators",
+                return_value={"id-x": MagicMock()},
+            ),
+            patch(
+                "custom_components.adaptive_cover_pro.services.export_service.DEFAULT_EXPORT_PATH",
+                str(export_path),
+            ),
+        ):
+            await async_handle_export_all(call)
+
+        data = json.loads(export_path.read_text("utf-8"))
+        exported_opts = data["entries"][0]["options"]
+        assert exported_opts["_orphan_prune_v1"] is True
+        assert exported_opts["_orphan_prune_sensors_v2"] is True
+
+    @pytest.mark.asyncio
+    async def test_empty_coordinators_writes_empty_entries(self, tmp_path):
+        from custom_components.adaptive_cover_pro.services.export_service import (
+            async_handle_export_all,
+        )
+
+        hass = _make_hass([])
+        export_path = tmp_path / "out.json"
+        call = MagicMock()
+        call.hass = hass
+
+        with (
+            patch(
+                "custom_components.adaptive_cover_pro.services.export_service.loaded_coordinators",
+                return_value={},
+            ),
+            patch(
+                "custom_components.adaptive_cover_pro.services.export_service.DEFAULT_EXPORT_PATH",
+                str(export_path),
+            ),
+        ):
+            result = await async_handle_export_all(call)
+
+        assert result["count"] == 0
+        data = json.loads(export_path.read_text("utf-8"))
+        assert data["entries"] == []
+
+
+# ---------------------------------------------------------------------------
+# import_config tests
+# ---------------------------------------------------------------------------
+
+
+class TestImportConfig:
+    """Tests for async_handle_import_config."""
+
+    def _write_export(self, path: pathlib.Path, entries: list[dict]) -> None:
+        payload = {
+            "export_version": 1,
+            "exported_at": "2026-07-02T00:00:00+00:00",
+            "entries": entries,
+        }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+
+    @pytest.mark.asyncio
+    async def test_happy_path_updates_entries(self, tmp_path):
+        """Imported public keys are applied; internal keys from live entry preserved."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        live_opts = {"azimuth": 90, "_orphan_prune_v1": True}
+        entry = _make_entry("id-1", "Blind A", live_opts)
+        hass = _make_hass([entry])
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"azimuth": 270, "fov_left": 45}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"] == "updated"
+        # azimuth updated, internal key preserved, new key added
+        assert entry.options["azimuth"] == 270
+        assert entry.options["fov_left"] == 45
+        assert entry.options["_orphan_prune_v1"] is True
+        # old _-key from file must NOT overwrite live entry's internal key
+        assert "_orphan_prune_v1" in entry.options
+
+    @pytest.mark.asyncio
+    async def test_internal_keys_in_file_are_ignored(self, tmp_path):
+        """_-prefixed keys in the import file are stripped; live entry keeps its own."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry(
+            "id-2", "Blind B", {"azimuth": 90, "_orphan_prune_v1": True}
+        )
+        hass = _make_hass([entry])
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [
+                {
+                    "entry_id": "id-2",
+                    "options": {"azimuth": 180, "_orphan_prune_v1": False},
+                }
+            ],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        await async_handle_import_config(call)
+
+        # File had _orphan_prune_v1=False but live entry had True — live wins
+        assert entry.options["_orphan_prune_v1"] is True
+        assert entry.options["azimuth"] == 180
+
+    @pytest.mark.asyncio
+    async def test_unknown_entry_id_is_skipped(self, tmp_path):
+        """Entry IDs not present in the live HA registry are recorded as 'skipped'."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        hass = _make_hass([])  # no entries registered
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "ghost-id", "options": {"azimuth": 90}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["ghost-id"] == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_rejected(self, tmp_path):
+        """Filename resolving outside /config/ raises ServiceValidationError."""
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        call = MagicMock()
+        call.hass = _make_hass([])
+        call.data = {"filename": "/etc/passwd"}
+
+        with pytest.raises(ServiceValidationError, match="not inside /config/"):
+            await async_handle_import_config(call)
+
+    @pytest.mark.asyncio
+    async def test_path_traversal_via_dotdot_rejected(self, tmp_path):
+        """Path traversal using ../ is resolved and rejected."""
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        call = MagicMock()
+        call.hass = _make_hass([])
+        call.data = {"filename": "/config/../etc/shadow"}
+
+        with pytest.raises(ServiceValidationError, match="not inside /config/"):
+            await async_handle_import_config(call)
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises_validation_error(self, tmp_path):
+        """A filename that does not exist raises ServiceValidationError."""
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        hass = _make_hass([])
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": "/config/does_not_exist_xyz.json"}
+
+        with pytest.raises(ServiceValidationError, match="cannot read"):
+            await async_handle_import_config(call)
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_raises_validation_error(self, tmp_path):
+        """A file containing non-JSON text raises ServiceValidationError."""
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("this is not json", encoding="utf-8")
+
+        hass = _make_hass([])
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(bad_file)}
+
+        with (
+            patch(
+                "custom_components.adaptive_cover_pro.services.import_service._CONFIG_ROOT",
+                tmp_path,
+            ),
+            pytest.raises(ServiceValidationError, match="not valid JSON"),
+        ):
+            await async_handle_import_config(call)
+
+    @pytest.mark.asyncio
+    async def test_mixed_results(self, tmp_path):
+        """One valid entry and one unknown entry produce mixed results dict."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-good", "Blind Good", {"azimuth": 90})
+        hass = _make_hass([entry])
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [
+                {"entry_id": "id-good", "options": {"azimuth": 180}},
+                {"entry_id": "id-ghost", "options": {"azimuth": 45}},
+            ],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-good"] == "updated"
+        assert result["id-ghost"] == "skipped"


### PR DESCRIPTION
## Description

Adds two new integration services that enable a safe, HA-running workflow for
bulk config changes:

- **`export_all_config`** — writes the full `options` dict of every loaded ACP
  cover entry to `/config/adaptive_cover_pro_export.json` as a lossless JSON
  snapshot. Returns `{file, count}` for confirmation in Developer Tools.
- **`import_config`** — reads that file and applies options back to each entry
  matched by `entry_id`. Internal `_`-prefixed migration markers are always
  preserved from the live entry; all public keys are overwritten with the file
  values. Returns `{entry_id: "updated"|"skipped"|"error"}` per entry.

Both services use `SupportsResponse.OPTIONAL` so they are callable from
automations (no response needed) and from Developer Tools (response visible).

## Motivation and Context

The UI has no bulk-edit path. Previously, applying the same option change across
many covers (e.g. setting a custom position sensor on 20+ entries) required
hand-editing `core.config_entries` with HA stopped.

This service pair enables:
1. Call `export_all_config` → JSON file at `/config/adaptive_cover_pro_export.json`
2. Edit with AI, a script, or regex (HA running throughout)
3. Call `import_config` → changes applied; each coordinator reloads normally

- fixes: #799

## How has this been tested?

- Ruff and Black pass on all new/modified files
- Unit tests added in `tests/services/test_export_import_service.py` covering:
  - Happy-path export (file written, count correct, all options present)
  - Internal `_`-prefixed keys included in export (lossless)
  - Empty coordinator list exports empty entries array
  - Happy-path import (public keys updated, internal keys preserved)
  - `_`-prefixed keys in import file are ignored (live entry's internal keys win)
  - Unknown `entry_id` → recorded as `"skipped"`
  - Path traversal via `/etc/passwd` → `ServiceValidationError`
  - Path traversal via `../` → `ServiceValidationError`
  - Missing file → `ServiceValidationError`
  - Invalid JSON → `ServiceValidationError`
  - Mixed results (one updated, one skipped)

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (services.yaml descriptors added)