### PR TITLE
feat: cover-group pipeline arbitration — Phase 2 (#790)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -222,6 +222,10 @@ SECTION_CUSTOM_POSITION = "custom_position"
 SECTION_MOTION_OVERRIDE = "motion_override"
 SECTION_PIPELINE_PRIORITIES = "pipeline_priorities"
 SECTION_DEBUG = "debug"
+# Cover-group-only fields (issue #790). Not in COMMON_SECTION_ORDER, so the
+# section never renders in a cover's options flow — it exists so group
+# numeric fields feed OPTION_RANGES / FIELD_VALIDATORS like every other one.
+SECTION_GROUP = "group"
 
 
 # =============================================================================
@@ -1720,6 +1724,23 @@ _GLARE_ZONE_SPECS = _spec(
 # Registry assembly
 # =============================================================================
 
+_GROUP_SPECS = _spec(
+    FieldSpec(
+        const.CONF_GROUP_STAGGER_DELAY,
+        SECTION_GROUP,
+        ValidatorKind.RANGE,
+        rng=const._RANGE_GROUP_STAGGER,
+        default=const.DEFAULT_GROUP_STAGGER_DELAY,
+        make_selector=_number(
+            minimum=const._RANGE_GROUP_STAGGER[0],
+            maximum=const._RANGE_GROUP_STAGGER[1],
+            step=0.5,
+            unit="s",
+        ),
+    ),
+)
+
+
 _ALL_SPEC_GROUPS: tuple[list[FieldSpec], ...] = (
     _GEOMETRY_SPECS,
     _SUN_TRACKING_SPECS,
@@ -1739,6 +1760,7 @@ _ALL_SPEC_GROUPS: tuple[list[FieldSpec], ...] = (
     _MOTION_OVERRIDE_SPECS,
     _PIPELINE_PRIORITY_SPECS,
     _DEBUG_SPECS,
+    _GROUP_SPECS,
 )
 
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,8 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_GROUP_MEMBER_OPT_OUT,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_FORCE_OVERRIDE_MIN_MODE,
@@ -172,8 +174,11 @@ from .const import (
     CONF_WINDOW_WIDTH,
     DEFAULT_DELTA_POSITION,
     DEFAULT_DELTA_TIME,
+    DEFAULT_GROUP_STAGGER_DELAY,
     DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MOTION_TIMEOUT,
+    GROUP_SCENE_PRIORITY,
+    OPT_OUT_ALL_SCENES,
     CONF_DEBUG_CATEGORIES,
     CONF_DEBUG_EVENT_BUFFER_SIZE,
     CONF_DEBUG_MODE,
@@ -188,6 +193,7 @@ from .const import (
     MODE2_OPEN_HORIZONTAL_PERCENT,
     DOMAIN,
     CoverType,
+    GroupScene,
     TemplateCombineMode,
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
@@ -421,6 +427,25 @@ def _sanitize_group_membership(
         CONF_MEMBER_ENTRIES: member_entries,
         CONF_MEMBER_COVERS: member_covers,
     }
+
+
+# Transient opt-out multi-select in the group_arbitration step: one field
+# whose option values are "member_id|scene" tokens (labels carry the member
+# title), folded into the persisted CONF_GROUP_MEMBER_OPT_OUT dict on submit.
+# Entry ids are UUID hex (no "|"), so the separator is unambiguous.
+_OPT_OUT_FIELD = "scene_opt_outs"
+_OPT_OUT_TOKEN_SEP = "|"
+
+
+def _group_opt_out_choices() -> list[dict[str, str]]:
+    """Build the opt-out select options: the all-scenes sentinel plus every scene."""
+    return [
+        {"value": OPT_OUT_ALL_SCENES, "label": "All scenes"},
+        *(
+            {"value": str(scene), "label": str(scene).replace("_", " ").title()}
+            for scene in GroupScene
+        ),
+    ]
 
 
 # The sun-tracking step no longer carries any length field — the shaded distance
@@ -1556,6 +1581,15 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     ),
     "group.member_acp": "- 🪟 {title} (ACP)",
     "group.member_generic": "- 🪟 {entity} (generic)",
+    "group.scene_priority": (
+        "Group scenes apply at priority {scene_priority} "
+        "(above manual override, below weather safety)"
+    ),
+    "group.lock": (
+        "🔒 Group lock at priority {lock_priority} — freezes members in "
+        "place; a member's own safety still wins ties"
+    ),
+    "group.stagger": "Members commanded {stagger}s apart",
     "warnings.group_empty": (
         "⚠️ This group has no members — it will not command anything."
     ),
@@ -1652,6 +1686,14 @@ def _build_group_summary(
         L["group.member_generic"].format(entity=entity_id)
         for entity_id in member_covers
     )
+    # Arbitration (Phase 2): priorities from the imported consts, never baked
+    # into the templates.
+    lines.append("")
+    lines.append(L["group.scene_priority"].format(scene_priority=GROUP_SCENE_PRIORITY))
+    lines.append(L["group.lock"].format(lock_priority=CUSTOM_POSITION_SAFETY_PRIORITY))
+    stagger = config.get(CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY)
+    if stagger:
+        lines.append(L["group.stagger"].format(stagger=stagger))
     return "\n".join(lines)
 
 
@@ -4101,12 +4143,14 @@ class OptionsFlowHandler(OptionsFlow):
             )
 
         # Cover groups are orchestrators, not geometry covers — their own
-        # small menu (membership + summary), never the cover categories.
+        # small menu (membership + arbitration + summary), never the cover
+        # categories.
         if get_policy(self.sensor_type).is_orchestrator:
             return self.async_show_menu(
                 step_id="init",
                 menu_options=[
                     "group_membership",
+                    "group_arbitration",
                     "summary",
                     "done",
                 ],
@@ -4533,13 +4577,22 @@ class OptionsFlowHandler(OptionsFlow):
         selected ACP member.
         """
         if user_input is not None:
-            self.options.update(
-                _sanitize_group_membership(
-                    self.hass,
-                    user_input,
-                    own_entry_id=self._config_entry.entry_id,
-                )
+            sanitized = _sanitize_group_membership(
+                self.hass,
+                user_input,
+                own_entry_id=self._config_entry.entry_id,
             )
+            self.options.update(sanitized)
+            # A removed member's opt-out entry is stale — prune it in the
+            # same save so the arbitration step never lists ghosts.
+            opt_out = self.options.get(CONF_GROUP_MEMBER_OPT_OUT)
+            if opt_out:
+                roster = set(sanitized[CONF_MEMBER_ENTRIES])
+                self.options[CONF_GROUP_MEMBER_OPT_OUT] = {
+                    member: scenes
+                    for member, scenes in opt_out.items()
+                    if member in roster
+                }
             return self.async_create_entry(title="", data=self.options)
 
         schema = vol.Schema(
@@ -4550,6 +4603,71 @@ class OptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="group_membership",
             data_schema=self.add_suggested_values_to_schema(schema, self.options),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
+            },
+        )
+
+    async def async_step_group_arbitration(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit stagger and per-member scene opt-out (issue #790, Phase 2).
+
+        Opt-outs use ONE multi-select whose options are ``member|scene``
+        pairs with human labels — the same dynamic-row pattern as the
+        profile-overrides step, so the field itself stays translatable.
+        Unchecked members are pruned so ``CONF_GROUP_MEMBER_OPT_OUT`` holds
+        only members that actually opt out. The group lock ignores opt-out.
+        """
+        member_ids = [
+            entry_id
+            for entry_id in self.options.get(CONF_MEMBER_ENTRIES, [])
+            if self.hass.config_entries.async_get_entry(entry_id) is not None
+        ]
+        if user_input is not None:
+            self.options[CONF_GROUP_STAGGER_DELAY] = user_input.get(
+                CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY
+            )
+            opt_out: dict[str, list[str]] = {}
+            for token in user_input.get(_OPT_OUT_FIELD, []):
+                member_id, _, scene_value = token.partition(_OPT_OUT_TOKEN_SEP)
+                if member_id in member_ids:
+                    opt_out.setdefault(member_id, []).append(scene_value)
+            self.options[CONF_GROUP_MEMBER_OPT_OUT] = opt_out
+            return self.async_create_entry(title="", data=self.options)
+
+        stagger_spec = config_fields.FIELD_SPECS[CONF_GROUP_STAGGER_DELAY]
+        stagger_marker, stagger_selector = stagger_spec.to_marker(
+            self.hass, self.options
+        )
+        current_opt_out = self.options.get(CONF_GROUP_MEMBER_OPT_OUT, {})
+        choices: list[dict[str, str]] = []
+        selected: list[str] = []
+        for member_id in member_ids:
+            entry = self.hass.config_entries.async_get_entry(member_id)
+            for choice in _group_opt_out_choices():
+                token = f"{member_id}{_OPT_OUT_TOKEN_SEP}{choice['value']}"
+                choices.append(
+                    {"value": token, "label": f"{entry.title} — {choice['label']}"}
+                )
+                if choice["value"] in current_opt_out.get(member_id, []):
+                    selected.append(token)
+        schema_dict: dict = {
+            stagger_marker: stagger_selector,
+            vol.Optional(_OPT_OUT_FIELD, default=selected): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=choices,
+                    multiple=True,
+                    mode=selector.SelectSelectorMode.LIST,
+                )
+            ),
+        }
+        return self.async_show_form(
+            step_id="group_arbitration",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(schema_dict),
+                {CONF_GROUP_STAGGER_DELAY: self.options.get(CONF_GROUP_STAGGER_DELAY)},
+            ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -104,6 +104,25 @@ CONF_SYNC_SELECT_ALL = "select_all_targets"
 CONF_MEMBER_ENTRIES = "member_entries"  # ACP member config-entry ids
 CONF_MEMBER_COVERS = "member_covers"  # generic cover entity_ids
 
+# Per-member scene opt-out, stored on the GROUP entry keyed by member
+# entry_id so a member removal prunes cleanly: {member_id: [scene, ...]}.
+# The sentinel OPT_OUT_ALL_SCENES ("*") opts a member out of every scene.
+# Enforced group-side at intent-push time (the member handler stays dumb);
+# the group lock ignores opt-out — it is a safety claim on every member.
+CONF_GROUP_MEMBER_OPT_OUT = "group_member_opt_out"
+OPT_OUT_ALL_SCENES = "*"
+
+# Seconds between successive member commands during a group fan-out
+# (scene activation). 0 = simultaneous. Issue #790 Phase 2.
+CONF_GROUP_STAGGER_DELAY = "group_stagger_delay"
+DEFAULT_GROUP_STAGGER_DELAY = 0.0
+_RANGE_GROUP_STAGGER = (0.0, 30.0)
+
+# The scene select's "no scene" option (wire-stable select state). Not a
+# GroupScene member — it is the absence of a scene: choosing it clears the
+# group's claim so members return to their own pipelines.
+GROUP_SCENE_SELECT_AUTO = "auto"
+
 # Default name prefix used by the config flow when auto-naming a cover from its
 # entity's friendly name (no linked device available) — see config_flow.py's
 # cover_entities auto-fill and async_step_update finalization fallback (#771).
@@ -540,6 +559,16 @@ CUSTOM_POSITION_SLOT_NUMBERS: tuple[int, ...] = tuple(
 # semantics: they command the cover outside the start/end time window and
 # bypass the delta-position/delta-time send gates (issue #563).
 CUSTOM_POSITION_SAFETY_PRIORITY = 100
+
+# Cover-group scene intents claim the pipeline at this priority (issue #790,
+# Phase 2): above manual_override (80) so "put the room in Privacy" wins over
+# a stale per-cover manual state, below weather (90) so wind/rain safety on an
+# outdoor member still overrides a group scene. Declared on GroupSceneHandler;
+# the const exists so the config-flow chain summary and tests import it. Not
+# user-overridable (group-injected handler, not one of HANDLER_PRIORITY_CONF).
+# The group lock reuses CUSTOM_POSITION_SAFETY_PRIORITY (100); a member's own
+# safety slot wins ties via handler build order.
+GROUP_SCENE_PRIORITY = 85
 
 
 def _custom_position_slot_keys(n: int) -> dict[str, str]:
@@ -1454,6 +1483,19 @@ class GroupScene(StrEnum):
     PRIVACY = "privacy"
 
 
+class GroupIntentKind(StrEnum):
+    """What a cover-group intent asks of a member's pipeline (issue #790).
+
+    ``SCENE`` — claim the position axis at ``GROUP_SCENE_PRIORITY`` with the
+    member policy's resolution of the intent's scene. ``LOCK`` — freeze the
+    member at ``CUSTOM_POSITION_SAFETY_PRIORITY``: the handler wins the
+    pipeline but sends no command, so the cover holds its position.
+    """
+
+    SCENE = "scene"
+    LOCK = "lock"
+
+
 class GroupState(StrEnum):
     """Aggregate open/closed classification of a cover group's members.
 
@@ -1603,6 +1645,12 @@ class ControlMethod(StrEnum):
 
     GLARE_ZONE = "glare_zone"
     """Glare zone protection active; cover extends to shield a floor zone."""
+
+    GROUP_SCENE = "group_scene"
+    """A cover-group scene intent claims the position (issue #790, Phase 2)."""
+
+    GROUP_LOCK = "group_lock"
+    """A cover-group lock freezes the cover in place (issue #790, Phase 2)."""
 
 
 class SunState(StrEnum):

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -117,7 +117,7 @@ from .pipeline.handlers import (
 from .pipeline.floors import effective_floor, gather_active_floors
 from .pipeline.registry import PipelineRegistry
 from .pipeline.snapshot_builder import PipelineSnapshotBuilder
-from .pipeline.types import CustomPositionSensorState
+from .pipeline.types import CustomPositionSensorState, GroupIntent
 from .templates import TemplateResolver
 from .const import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
@@ -332,6 +332,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # each can carry an independent priority configured by the user.
         self._pipeline = self._build_pipeline()
         self._pipeline_result = None
+
+        # Live cover-group intents, one per group entry pushing to this member
+        # (issue #790, Phase 2). Mutable manager-style state: groups write via
+        # set_group_intent(); each snapshot folds effective_group_intent in.
+        self._group_intents: dict[str, GroupIntent] = {}
 
         # Resolved-target signature last handed to the dispatch path (issue
         # #756). The dispatch decision compares the current cycle's resolved
@@ -1268,6 +1273,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             cover_capabilities=getattr(
                 getattr(self, "_snapshot", None), "cover_capabilities", None
             ),
+            group_intent=self.effective_group_intent,
         )
         self._pipeline_result = self._pipeline.evaluate(snapshot)
 
@@ -1668,6 +1674,44 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             return None
         return await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
+
+    def set_group_intent(self, group_id: str, intent: GroupIntent | None) -> None:
+        """Store or remove one cover-group's live intent for this member.
+
+        ``None`` removes the group's claim (scene cleared, lock released, or
+        the group unloaded). The next snapshot folds ``effective_group_intent``
+        in; the caller is responsible for triggering a refresh.
+        """
+        if intent is None:
+            self._group_intents.pop(group_id, None)
+        else:
+            self._group_intents[group_id] = intent
+
+    @property
+    def effective_group_intent(self) -> GroupIntent | None:
+        """The highest-priority live group intent, or None.
+
+        Priority-ranked, not last-write-wins, so a whole-house lock is never
+        silently clobbered by a facade scene from another group (issue #790).
+        """
+        if not self._group_intents:
+            return None
+        return max(self._group_intents.values(), key=lambda intent: intent.priority)
+
+    @property
+    def pipeline_winner_name(self) -> str | None:
+        """Name of the handler that won the last pipeline evaluation.
+
+        The winner is the first ``matched`` step in trace order (handler
+        steps precede synthetic floor/tilt steps). Read by the cover-group
+        who-won sensor; ``None`` before the first evaluation.
+        """
+        result = self._pipeline_result
+        if result is None:
+            return None
+        return next(
+            (step.handler for step in result.decision_trace if step.matched), None
+        )
 
     async def async_reset_manual_overrides(
         self,
@@ -2508,6 +2552,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             cover_capabilities=getattr(
                 getattr(self, "_snapshot", None), "cover_capabilities", None
             ),
+            group_intent=self.effective_group_intent,
         )
         floors = gather_active_floors(snapshot)
         effective_floor_pos, _ = effective_floor(floors)

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -1,25 +1,29 @@
-"""Coordinator for the virtual Cover Group entry type (issue #790, Phase 1).
+"""Coordinator for the virtual Cover Group entry type (issue #790).
 
 Orchestrates a roster of member covers:
 
-* **ACP members** (config entries) are commanded through each member's own
-  coordinator (``async_apply_user_position`` / ``async_reset_manual_overrides``
-  / the ``automatic_control`` toggle) so the member's gates, inverse-state,
-  and override semantics all apply.
-* **Generic members** (plain ``cover.*`` entity_ids, "adopt mode") are
-  commanded through a group-owned ``CoverCommandService`` so capability
-  fallback (open/close-only covers), unavailable-cover skips, and no-op
-  suppression come for free.
+* **ACP members** (config entries): scenes and the group lock are pushed as
+  a :class:`~.pipeline.types.GroupIntent` into each member coordinator
+  (``set_group_intent`` + refresh, Phase 2) — the member's pipeline
+  arbitrates, so weather safety still outranks a scene and a member's own
+  safety slot outranks the group lock. Bulk operations
+  (``async_reset_manual_overrides``, the ``automatic_control`` toggle) call
+  the member's own entry points.
+* **Generic members** (plain ``cover.*`` entity_ids, "adopt mode") have no
+  pipeline: they are commanded directly through a group-owned
+  ``CoverCommandService`` so capability fallback (open/close-only covers),
+  unavailable-cover skips, and no-op suppression come for free.
 
-Phase 1 acts only on explicit user actions (scene buttons/select, bulk
-switches); it never moves covers autonomously, so there is no boot-time
-fan-out path. Scene targets are resolved per member via the member policy's
-``position_for_scene`` — a scene is an intent, not a shared absolute
-position.
+The group acts only on explicit user actions (scene buttons/select, bulk
+switches); it never moves covers autonomously and its intents are not
+persisted, so there is no boot-time fan-out path. Scene targets resolve per
+member via the member policy's ``position_for_scene`` — a scene is an
+intent, not a shared absolute position.
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import logging
 
@@ -30,15 +34,22 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_ENTITIES,
+    CONF_GROUP_MEMBER_OPT_OUT,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_SENSOR_TYPE,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
     DEFAULT_DELTA_POSITION,
     DEFAULT_DELTA_TIME,
+    DEFAULT_GROUP_STAGGER_DELAY,
     DOMAIN,
+    GROUP_SCENE_PRIORITY,
+    OPT_OUT_ALL_SCENES,
     POSITION_CLOSED,
     POSITION_OPEN,
     CoverType,
+    GroupIntentKind,
     GroupScene,
     GroupState,
 )
@@ -46,6 +57,7 @@ from .cover_types import get_policy
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
+from .pipeline.types import GroupIntent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,6 +89,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         )
         self.entry = entry
         self.active_scene: GroupScene | None = None
+        self.group_locked: bool = False
         self._unsub_state: CALLBACK_TYPE | None = None
         self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
         self._grace_mgr = GracePeriodManager(_LOGGER)
@@ -126,20 +139,50 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
     # ---- Fan-out operations ------------------------------------------------ #
 
+    def _scene_opted_out(self, member_entry_id: str, scene: GroupScene) -> bool:
+        """Whether the member opted out of this scene (or all scenes)."""
+        opted = self.entry.options.get(CONF_GROUP_MEMBER_OPT_OUT, {}).get(
+            member_entry_id, []
+        )
+        return OPT_OUT_ALL_SCENES in opted or str(scene) in opted
+
+    async def _stagger_gap(self, commands_sent: int) -> None:
+        """Sleep the configured stagger before every command but the first."""
+        stagger = float(
+            self.entry.options.get(
+                CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY
+            )
+        )
+        if commands_sent and stagger > 0:
+            await asyncio.sleep(stagger)
+
     async def async_activate_scene(self, scene: GroupScene) -> None:
-        """Fan a scene out to every member, resolving the target per policy."""
-        trigger = f"group_scene_{scene}"
+        """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
+
+        ACP members get a SCENE intent + refresh — their pipeline arbitrates
+        (weather and member safety still win). Generic members have no
+        pipeline and are commanded directly with the adopt-policy target.
+        Per-member opt-out and the stagger gap apply to both kinds.
+        """
+        intent = GroupIntent(
+            kind=GroupIntentKind.SCENE,
+            scene=scene,
+            priority=GROUP_SCENE_PRIORITY,
+            group_id=self.entry.entry_id,
+        )
+        commands = 0
         for entry, coordinator in self.resolved_members():
-            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
-            target = policy.position_for_scene(scene)
-            for entity_id in entry.options.get(CONF_ENTITIES, []):
-                await coordinator.async_apply_user_position(
-                    entity_id,
-                    target,
-                    trigger=trigger,
-                )
+            if self._scene_opted_out(entry.entry_id, scene):
+                continue
+            await self._stagger_gap(commands)
+            commands += 1
+            coordinator.set_group_intent(self.entry.entry_id, intent)
+            await coordinator.async_request_refresh()
         adopt_target = self._adopt_policy.position_for_scene(scene)
+        trigger = f"group_scene_{scene}"
         for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            await self._stagger_gap(commands)
+            commands += 1
             await self._cmd_svc.apply_position(
                 entity_id,
                 adopt_target,
@@ -148,6 +191,50 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             )
         self.active_scene = scene
         await self.async_refresh()
+
+    async def async_clear_scene(self) -> None:
+        """Release this group's scene claim — members return to their pipeline."""
+        for _entry, coordinator in self.resolved_members():
+            coordinator.set_group_intent(self.entry.entry_id, None)
+            await coordinator.async_request_refresh()
+        self.active_scene = None
+        await self.async_refresh()
+
+    async def async_set_lock(self, locked: bool) -> None:
+        """Push or release the group lock (LOCK intent at safety priority).
+
+        The lock ignores per-scene opt-out — it is a safety claim on every
+        member — and applies immediately (no stagger; nothing moves). On
+        release, an active scene is re-pushed so unlocking returns the room
+        to the scene, not to unmanaged state.
+        """
+        self.group_locked = locked
+        if locked:
+            intent = GroupIntent(
+                kind=GroupIntentKind.LOCK,
+                scene=None,
+                priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+                group_id=self.entry.entry_id,
+            )
+            for _entry, coordinator in self.resolved_members():
+                coordinator.set_group_intent(self.entry.entry_id, intent)
+                await coordinator.async_request_refresh()
+        else:
+            for _entry, coordinator in self.resolved_members():
+                coordinator.set_group_intent(self.entry.entry_id, None)
+                await coordinator.async_request_refresh()
+            if self.active_scene is not None:
+                await self.async_activate_scene(self.active_scene)
+        await self.async_refresh()
+
+    def member_winners(self) -> dict[str, str | None]:
+        """Who-won: each ACP member cover mapped to its pipeline's winner."""
+        winners: dict[str, str | None] = {}
+        for entry, coordinator in self.resolved_members():
+            winner = getattr(coordinator, "pipeline_winner_name", None)
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                winners[entity_id] = winner
+        return winners
 
     async def async_set_automation(self, enabled: bool) -> None:
         """Bulk-enable/disable sun-tracking automation on every ACP member."""
@@ -197,7 +284,15 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         self.hass.async_create_task(self.async_request_refresh())
 
     async def async_shutdown(self) -> None:
-        """Tear down listeners and the adopt-mode command service."""
+        """Tear down listeners, the command service, and any live intents.
+
+        Clearing this group's intent from every member matters on reload and
+        delete: a stale intent would keep claiming the member's pipeline for
+        a group that no longer exists (#712/#714 lifecycle lesson).
+        """
+        for _entry, coordinator in self.resolved_members():
+            coordinator.set_group_intent(self.entry.entry_id, None)
+            await coordinator.async_request_refresh()
         if self._unsub_state is not None:
             self._unsub_state()
             self._unsub_state = None

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -16,8 +16,9 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
 
-from .const import GroupScene
+from .const import GROUP_SCENE_SELECT_AUTO, GroupScene
 from .entity_base import AdaptiveCoverBaseEntity
+from .pipeline.handlers import GroupLockHandler, GroupSceneHandler
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -120,6 +121,58 @@ class GroupAutomationSwitch(_GroupEntityBase, SwitchEntity):
         self.async_write_ha_state()
 
 
+class GroupLockSwitch(_GroupEntityBase, SwitchEntity):
+    """Freeze every member in place via the LOCK intent at safety priority."""
+
+    _attr_translation_key = "group_lock"
+    _attr_icon = "mdi:lock-outline"
+
+    def __init__(self, *args) -> None:
+        """Initialize unlocked."""
+        super().__init__(*args, "group_lock")
+        self._attr_is_on = False
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
+        """Push the lock intent to every member."""
+        await self.coordinator.async_set_lock(True)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
+        """Release the lock (re-pushing an active scene, if any)."""
+        await self.coordinator.async_set_lock(False)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class GroupWhoWonSensor(_GroupEntityBase, SensorEntity):
+    """How many members this group currently drives, with per-member detail.
+
+    A member counts as group-driven when its pipeline's winning handler is
+    one of the group handlers (names imported, never string literals).
+    """
+
+    _attr_translation_key = "group_who_won"
+    _attr_native_unit_of_measurement = "members"
+    _attr_icon = "mdi:scale-balance"
+
+    _GROUP_HANDLER_NAMES = frozenset({GroupSceneHandler.name, GroupLockHandler.name})
+
+    @property
+    def native_value(self) -> int:
+        """Count of members whose pipeline is currently won by this group."""
+        return sum(
+            1
+            for winner in self.coordinator.member_winners().values()
+            if winner in self._GROUP_HANDLER_NAMES
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Per-member winning-handler map."""
+        return {"member_winners": self.coordinator.member_winners()}
+
+
 class GroupSceneButton(_GroupEntityBase, ButtonEntity):
     """Activate one built-in scene across the group."""
 
@@ -166,19 +219,25 @@ class GroupSceneSelect(_GroupEntityBase, SelectEntity):
     _attr_icon = "mdi:palette-swatch"
 
     def __init__(self, *args) -> None:
-        """Initialize the scene picker with the built-in scene options."""
+        """Initialize the scene picker: Auto (no scene) plus the built-ins."""
         super().__init__(*args, "group_scene_select")
-        self._attr_options = [str(scene) for scene in GroupScene]
+        self._attr_options = [
+            GROUP_SCENE_SELECT_AUTO,
+            *(str(scene) for scene in GroupScene),
+        ]
 
     @property
     def current_option(self) -> str | None:
-        """Wire value of the last activated scene, or None."""
+        """Wire value of the active scene; Auto when no scene claims the group."""
         scene = self.coordinator.active_scene
-        return str(scene) if scene is not None else None
+        return str(scene) if scene is not None else GROUP_SCENE_SELECT_AUTO
 
     async def async_select_option(self, option: str) -> None:
-        """Activate the picked scene across the group."""
-        await self.coordinator.async_activate_scene(GroupScene(option))
+        """Activate the picked scene — or release the claim via Auto."""
+        if option == GROUP_SCENE_SELECT_AUTO:
+            await self.coordinator.async_clear_scene()
+        else:
+            await self.coordinator.async_activate_scene(GroupScene(option))
         self.async_write_ha_state()
 
 
@@ -194,6 +253,7 @@ def build_group_sensors(
         GroupPositionSensor(*args, "group_position"),
         GroupStateSensor(*args, "group_state"),
         GroupActiveSceneSensor(*args, "group_active_scene"),
+        GroupWhoWonSensor(*args, "group_who_won"),
     ]
 
 
@@ -204,7 +264,10 @@ def build_group_switches(
     coordinator: GroupCoordinator,
 ) -> list[SwitchEntity]:
     """Build the bulk switches for one group entry."""
-    return [GroupAutomationSwitch(entry_id, hass, config_entry, coordinator)]
+    return [
+        GroupAutomationSwitch(entry_id, hass, config_entry, coordinator),
+        GroupLockSwitch(entry_id, hass, config_entry, coordinator),
+    ]
 
 
 def build_group_buttons(

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
@@ -34,6 +34,8 @@ from .cloud_suppression import CloudSuppressionHandler
 from .custom_position import CustomPositionHandler
 from .default import DefaultHandler
 from .glare_zone import GlareZoneHandler
+from .group_lock import GroupLockHandler
+from .group_scene import GroupSceneHandler
 from .manual_override import ManualOverrideHandler
 from .motion_timeout import MotionTimeoutHandler
 from .solar import SolarHandler
@@ -144,6 +146,12 @@ HANDLER_FACTORIES: tuple[HandlerFactory, ...] = (
     _single(GlareZoneHandler),
     _solar_handler,
     _single(DefaultHandler),
+    # Group handlers LAST (issue #790 Phase 2): the registry's priority sort
+    # is stable, so on a 100-tie a member's own custom-position safety slot
+    # (built above) wins over the group lock — physical safety local to the
+    # cover trumps a zone command. Always built; they defer when no intent.
+    _single(GroupSceneHandler),
+    _single(GroupLockHandler),
 )
 
 
@@ -175,6 +183,8 @@ __all__ = [
     "CustomPositionHandler",
     "DefaultHandler",
     "GlareZoneHandler",
+    "GroupLockHandler",
+    "GroupSceneHandler",
     "HandlerFactory",
     "ManualOverrideHandler",
     "MotionTimeoutHandler",

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
@@ -1,0 +1,53 @@
+"""Group lock handler — a cover-group lock freezes the member in place.
+
+Issue #790 Phase 2. Priority 100 (``CUSTOM_POSITION_SAFETY_PRIORITY``): the
+lock outranks everything — including weather — matching the shipped
+semantics of a member's own safety slot. On a 100-tie the member's own
+custom-position safety slot wins: it is built earlier in
+``HANDLER_FACTORIES`` and the registry's priority sort is stable, so
+physical safety local to the cover trumps a zone lock.
+"""
+
+from __future__ import annotations
+
+from ...const import CUSTOM_POSITION_SAFETY_PRIORITY, ControlMethod, GroupIntentKind
+from ..handler import OverrideHandler
+from ..helpers import compute_raw_calculated_position
+from ..types import PipelineResult, PipelineSnapshot
+
+
+class GroupLockHandler(OverrideHandler):
+    """Freeze the cover while a group lock intent is live.
+
+    Reuses the motion-hold shape: the result wins the pipeline (so nothing
+    else can move the cover) and carries ``skip_command=True`` (so nothing is
+    sent) — the cover holds whatever position it is in, with no per-entity
+    target bookkeeping. Deliberately NOT ``is_safety``: no command is emitted,
+    so the safety-target machinery has nothing to track.
+    """
+
+    name = "group_lock"
+    priority = CUSTOM_POSITION_SAFETY_PRIORITY
+
+    def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
+        """Hold the current position while a lock intent is live."""
+        intent = snapshot.group_intent
+        if intent is None or intent.kind is not GroupIntentKind.LOCK:
+            return None
+        held = snapshot.current_cover_position
+        position = held if held is not None else snapshot.default_position
+        return PipelineResult(
+            position=position,
+            control_method=ControlMethod.GROUP_LOCK,
+            reason=(f"group lock from group {intent.group_id} — holding {position}%"),
+            raw_calculated_position=compute_raw_calculated_position(snapshot),
+            held_position=held,
+            skip_command=True,
+            bypass_auto_control=True,
+        )
+
+    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+        """Reason when no lock intent is live."""
+        if snapshot.group_intent is not None:
+            return "group intent is a scene, not a lock"
+        return "no group lock intent"

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_scene.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_scene.py
@@ -1,0 +1,54 @@
+"""Group scene handler — a cover-group's scene intent claims the position.
+
+Issue #790 Phase 2. Priority 85 (``GROUP_SCENE_PRIORITY``): above manual
+override (80) so "put the room in Privacy" wins over a stale per-cover
+manual state, below weather (90) so wind/rain safety on an outdoor member
+still overrides a group scene. Not user-overridable.
+"""
+
+from __future__ import annotations
+
+from ...const import GROUP_SCENE_PRIORITY, ControlMethod, GroupIntentKind
+from ...cover_types import get_policy
+from ..handler import OverrideHandler
+from ..helpers import compute_raw_calculated_position
+from ..types import PipelineResult, PipelineSnapshot
+
+
+class GroupSceneHandler(OverrideHandler):
+    """Apply a live cover-group scene intent, resolved per member policy.
+
+    ``snapshot.group_intent`` is ``None`` for non-members — absence of an
+    intent IS non-membership, so no roster lookup happens here. The scene is
+    an intent, not an absolute position: the member's own policy maps it
+    (``position_for_scene``), which is what makes mixed groups work.
+    """
+
+    name = "group_scene"
+    priority = GROUP_SCENE_PRIORITY
+
+    def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
+        """Return the policy-resolved scene position when a scene intent is live."""
+        intent = snapshot.group_intent
+        if intent is None or intent.kind is not GroupIntentKind.SCENE:
+            return None
+        policy = snapshot.policy or get_policy(snapshot.cover_type)
+        position = policy.position_for_scene(intent.scene)
+        return PipelineResult(
+            position=position,
+            control_method=ControlMethod.GROUP_SCENE,
+            reason=(
+                f"group scene '{intent.scene}' from group {intent.group_id}"
+                f" → {position}%"
+            ),
+            raw_calculated_position=compute_raw_calculated_position(snapshot),
+            # Explicit user intent: runs even with automatic control off —
+            # same semantics as custom-position slots. NOT a safety result.
+            bypass_auto_control=True,
+        )
+
+    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+        """Reason when no scene intent is live."""
+        if snapshot.group_intent is not None:
+            return "group intent is a lock, not a scene"
+        return "no group scene intent"

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -94,6 +94,7 @@ from ..templates import combine_with_mode, is_template_string, render_condition
 from .types import (
     ClimateOptions,
     CustomPositionSensorState,
+    GroupIntent,
     PipelineSnapshot,
 )
 
@@ -322,6 +323,7 @@ class PipelineSnapshotBuilder:
         effective_default: int | None = None,
         is_sunset_active: bool | None = None,
         cover_capabilities: dict | None = None,
+        group_intent: GroupIntent | None = None,
     ) -> PipelineSnapshot:
         """Assemble the per-cycle :class:`PipelineSnapshot`.
 
@@ -413,6 +415,7 @@ class PipelineSnapshotBuilder:
             ),
             current_cover_position=current_cover_position,
             policy=self._policy,
+            group_intent=group_intent,
             minimize_movements=bool(
                 options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS)
             ),

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -5,13 +5,30 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from ..const import ClimateStrategy, ControlMethod
+from ..const import ClimateStrategy, ControlMethod, GroupIntentKind, GroupScene
 
 if TYPE_CHECKING:
     from ..config_types import CoverConfig, GlareZonesConfig
     from ..cover_types.base import CoverTypePolicy
     from ..engine.covers.base import AdaptiveGeneralCover
     from ..state.climate_provider import ClimateReadings
+
+
+@dataclass(frozen=True, slots=True)
+class GroupIntent:
+    """A cover-group's live claim on a member cover (issue #790, Phase 2).
+
+    Pushed by a ``GroupCoordinator`` via the member's ``set_group_intent``;
+    the member folds its highest-priority live intent into each snapshot,
+    where ``GroupSceneHandler`` / ``GroupLockHandler`` read it. ``scene`` is
+    only meaningful for ``kind == SCENE`` — the handler resolves it through
+    the member's own policy, never an absolute shared position.
+    """
+
+    kind: GroupIntentKind
+    scene: GroupScene | None
+    priority: int
+    group_id: str
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +226,12 @@ class PipelineSnapshot:
     # Defaults to ``None`` so test fixtures that build snapshots directly keep
     # working; runtime always populates it via ``coordinator._build_snapshot``.
     policy: CoverTypePolicy | None = None
+
+    # The highest-priority live cover-group intent targeting this member, or
+    # None when no group claims it (issue #790, Phase 2). Read by
+    # GroupSceneHandler / GroupLockHandler; absence of an intent IS
+    # non-membership — the handlers defer without any membership lookup.
+    group_intent: GroupIntent | None = None
 
     # Sun-tracking movement minimization (opt-in). When True, the solar branch
     # quantizes the calculated position into ``max_coverage_steps`` evenly-spaced

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -56,6 +56,7 @@ from ..const import (
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_GLARE_ZONE_PRIORITY,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_HEIGHT_WIN,
     CONF_INTERP,
     CONF_INTERP_END,
@@ -521,6 +522,8 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_CLIMATE_PRIORITY: _range(CONF_CLIMATE_PRIORITY),
     CONF_GLARE_ZONE_PRIORITY: _range(CONF_GLARE_ZONE_PRIORITY),
     CONF_SOLAR_PRIORITY: _range(CONF_SOLAR_PRIORITY),
+    # Cover group (issue #790, Phase 2)
+    CONF_GROUP_STAGGER_DELAY: _range(CONF_GROUP_STAGGER_DELAY),
 }
 
 # ---------------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -253,6 +253,9 @@
     "header": "**Beschattungsgruppe**",
     "members": "Steuert {acp_count} ACP-Mitglied(er) + {generic_count} allgemeine Beschattung(en)",
     "member_acp": "- 🪟 {title} (ACP)",
-    "member_generic": "- 🪟 {entity} (generic)"
+    "member_generic": "- 🪟 {entity} (generic)",
+    "scene_priority": "Beschattungsgruppen-Szenen gelten mit Priorität {scene_priority} (über manuelle Übersteuerung, unter Wetterschutz)",
+    "lock": "🔒 Gruppensperre mit Priorität {lock_priority} — friert Mitglieder an Ort und Stelle ein; die eigene Sicherheit eines Mitglieds gewinnt immer noch Gleichstände",
+    "stagger": "Mitglieder mit {stagger}s Abstand befohlen"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -253,6 +253,9 @@
     "header": "**Cover Group**",
     "members": "Controls {acp_count} ACP member(s) + {generic_count} generic cover(s)",
     "member_acp": "- 🪟 {title} (ACP)",
-    "member_generic": "- 🪟 {entity} (generic)"
+    "member_generic": "- 🪟 {entity} (generic)",
+    "scene_priority": "Group scenes apply at priority {scene_priority} (above manual override, below weather safety)",
+    "lock": "🔒 Group lock at priority {lock_priority} — freezes members in place; a member's own safety still wins ties",
+    "stagger": "Members commanded {stagger}s apart"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -253,6 +253,9 @@
     "header": "**Groupe de stores**",
     "members": "Contrôle {acp_count} membre(s) ACP + {generic_count} store(s) générique(s)",
     "member_acp": "- 🪟 {title} (ACP)",
-    "member_generic": "- 🪟 {entity} (générique)"
+    "member_generic": "- 🪟 {entity} (générique)",
+    "scene_priority": "Les scènes de groupe s'appliquent à la priorité {scene_priority} (au-dessus de la dérogation manuelle, en dessous de la sécurité météo)",
+    "lock": "🔒 Verrouillage de groupe à la priorité {lock_priority} — gèle les membres en place ; la sécurité propre d'un membre gagne toujours en cas d'égalité",
+    "stagger": "Membres commandés à {stagger}s d'intervalle"
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -808,7 +808,8 @@
           "profile_sensors": "📡 Gemeinsame Sensoren",
           "profile_overview": "🏢 Profil-Übersicht",
           "profile_overrides": "🧹 Lokale Übersteuerungen",
-          "group_membership": "👥 Gruppenmitglieder"
+          "group_membership": "👥 Gruppenmitglieder",
+          "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1606,6 +1607,18 @@
           "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
           "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
         }
+      },
+      "group_arbitration": {
+        "title": "Schiedsverfahren & Zeitplanung",
+        "description": "Beschattungsgruppen-Szenen übersteuern die manuelle Übersteuerung eines Mitglieds, weichen aber dem Wetterschutz; die Gruppensperre übertrumpft alles außer einem Sicherheitsauslöser eines Mitglieds. [Weitere Informationen]({learn_more})",
+        "data": {
+          "group_stagger_delay": "Staffelverzögerung",
+          "scene_opt_outs": "Szenen-Ausnahmen"
+        },
+        "data_description": {
+          "group_stagger_delay": "Sekunden zwischen aufeinanderfolgenden Befehlen für Mitglieder während einer Szene. 0 = alle Mitglieder auf einmal befehlen.",
+          "scene_opt_outs": "Überprüfte Mitglieder werden für die ausgewählte Szene übersprungen. 'Alle Szenen' überspringt das Mitglied für jede Szene. Die Gruppensperre ignoriert Ausnahmen."
+        }
       }
     },
     "abort": {
@@ -1682,6 +1695,9 @@
           "all_closed": "Alle geschlossen",
           "privacy": "Datenschutz"
         }
+      },
+      "group_who_won": {
+        "name": "Gruppengesteuerte Mitglieder"
       }
     },
     "switch": {
@@ -1734,6 +1750,9 @@
       },
       "group_automation": {
         "name": "Gruppenautomatisierung"
+      },
+      "group_lock": {
+        "name": "Gruppensperre"
       }
     },
     "button": {
@@ -1764,7 +1783,8 @@
         "state": {
           "all_open": "Alle offen",
           "all_closed": "Alle geschlossen",
-          "privacy": "Datenschutz"
+          "privacy": "Datenschutz",
+          "auto": "Auto"
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -809,7 +809,8 @@
           "profile_sensors": "📡 Shared Sensors",
           "profile_overview": "🏢 Profile Overview",
           "profile_overrides": "🧹 Local Overrides",
-          "group_membership": "👥 Group Members"
+          "group_membership": "👥 Group Members",
+          "group_arbitration": "⚖️ Arbitration & Timing"
         }
       },
       "pipeline_priorities": {
@@ -1606,6 +1607,18 @@
           "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
           "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
         }
+      },
+      "group_arbitration": {
+        "title": "Arbitration & Timing",
+        "description": "Group scenes win over a member's manual override but yield to weather safety; the group lock outranks everything except a member's own safety trigger. [Learn more]({learn_more})",
+        "data": {
+          "group_stagger_delay": "Stagger delay",
+          "scene_opt_outs": "Scene opt-outs"
+        },
+        "data_description": {
+          "group_stagger_delay": "Seconds between successive member commands during a scene. 0 = command all members at once.",
+          "scene_opt_outs": "Members checked here are skipped for the selected scene. 'All scenes' skips the member for every scene. The group lock ignores opt-outs."
+        }
       }
     },
     "abort": {
@@ -1682,6 +1695,9 @@
           "all_closed": "All Closed",
           "privacy": "Privacy"
         }
+      },
+      "group_who_won": {
+        "name": "Group-Driven Members"
       }
     },
     "switch": {
@@ -1734,6 +1750,9 @@
       },
       "group_automation": {
         "name": "Group Automation"
+      },
+      "group_lock": {
+        "name": "Group Lock"
       }
     },
     "button": {
@@ -1762,6 +1781,7 @@
       "group_scene_select": {
         "name": "Scene",
         "state": {
+          "auto": "Auto",
           "all_open": "All Open",
           "all_closed": "All Closed",
           "privacy": "Privacy"

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -808,7 +808,8 @@
           "profile_sensors": "📡 Capteurs partagés",
           "profile_overview": "🏢 Aperçu du profil",
           "profile_overrides": "🧹 Dérogations locales",
-          "group_membership": "👥 Membres du groupe"
+          "group_membership": "👥 Membres du groupe",
+          "group_arbitration": "⚖️ Arbitrage & Synchronisation"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1606,6 +1607,18 @@
           "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
           "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
         }
+      },
+      "group_arbitration": {
+        "title": "Arbitrage & Synchronisation",
+        "description": "Les scènes de groupe l'emportent sur la dérogation manuelle d'un membre, mais cèdent à la sécurité météo ; le verrouillage de groupe prime sur tout sauf le déclencheur de sécurité propre d'un membre. [En savoir plus]({learn_more})",
+        "data": {
+          "group_stagger_delay": "Délai d'échelonnement",
+          "scene_opt_outs": "Exclusions de scène"
+        },
+        "data_description": {
+          "group_stagger_delay": "Secondes entre les commandes successives des membres lors d'une scène. 0 = commander tous les membres à la fois.",
+          "scene_opt_outs": "Les membres cochés ici sont ignorés pour la scène sélectionnée. « Toutes les scènes » ignore le membre pour chaque scène. Le verrouillage de groupe ignore les exclusions."
+        }
       }
     },
     "abort": {
@@ -1682,6 +1695,9 @@
           "all_closed": "Tous fermés",
           "privacy": "Confidentialité"
         }
+      },
+      "group_who_won": {
+        "name": "Membres dirigés par le groupe"
       }
     },
     "switch": {
@@ -1734,6 +1750,9 @@
       },
       "group_automation": {
         "name": "Automation du groupe"
+      },
+      "group_lock": {
+        "name": "Verrouillage de groupe"
       }
     },
     "button": {
@@ -1764,7 +1783,8 @@
         "state": {
           "all_open": "Tous ouverts",
           "all_closed": "Tous fermés",
-          "privacy": "Confidentialité"
+          "privacy": "Confidentialité",
+          "auto": "Auto"
         }
       }
     }

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -56,6 +56,7 @@ UNIVERSAL_KEYS: set[str] = {
     "services.set_custom_position.fields.slot.name",  # "Slot" — HA service parameter, language-universal
     "services.set_custom_position.fields.position.name",  # "Position" — HA service parameter, language-universal
     "services.set_position.fields.position.name",  # "Position" — HA service parameter, language-universal
+    "entity.select.group_scene_select.state.auto",  # "Auto" — same in DE/FR
 }
 
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -110,6 +110,7 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
     coord._toggles = ToggleManager()
     coord.automatic_control = False
     coord.entities = [MagicMock()]
+    coord._group_intents = {}
 
     cmd_svc = MagicMock()
     cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3220,3 +3220,41 @@ def test_summary_group_empty_roster_warns():
 
     assert "**Cover Group**" in summary
     assert "no members" in summary
+
+
+def test_summary_group_shows_arbitration_lines():
+    """Phase 2: scene/lock priorities and the stagger, from the imported consts."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_STAGGER_DELAY,
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+        CUSTOM_POSITION_SAFETY_PRIORITY,
+        GROUP_SCENE_PRIORITY,
+    )
+
+    summary = _build_config_summary(
+        {
+            CONF_MEMBER_ENTRIES: ["entry_a"],
+            CONF_MEMBER_COVERS: [],
+            CONF_GROUP_STAGGER_DELAY: 2.5,
+        },
+        CoverType.GROUP,
+    )
+
+    assert f"priority {GROUP_SCENE_PRIORITY}" in summary
+    assert f"priority {CUSTOM_POSITION_SAFETY_PRIORITY}" in summary
+    assert "2.5" in summary
+
+
+def test_summary_group_omits_stagger_line_when_zero():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    summary = _build_config_summary(
+        {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []},
+        CoverType.GROUP,
+    )
+
+    assert "apart" not in summary

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -166,7 +166,12 @@ async def test_group_options_flow_shows_group_menu(hass: HomeAssistant) -> None:
     result = await flow.async_step_init()
 
     assert result["type"] == "menu"
-    assert result["menu_options"] == ["group_membership", "summary", "done"]
+    assert result["menu_options"] == [
+        "group_membership",
+        "group_arbitration",
+        "summary",
+        "done",
+    ]
 
 
 async def test_group_membership_step_excludes_self_and_other_groups(
@@ -221,3 +226,101 @@ async def test_cover_entries_excludes_groups(hass: HomeAssistant) -> None:
     entries = _cover_entries(hass)
 
     assert [e.entry_id for e in entries] == ["cover_a"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — arbitration step (stagger + per-member opt-out)
+# ---------------------------------------------------------------------------
+
+
+async def test_group_arbitration_step_saves_stagger_and_opt_out(
+    hass: HomeAssistant,
+) -> None:
+    """One page: stagger slider + one opt-out multi-select per ACP member."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_MEMBER_OPT_OUT,
+        CONF_GROUP_STAGGER_DELAY,
+        GroupScene,
+        OPT_OUT_ALL_SCENES,
+    )
+
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+    _add_cover(hass, "cover_b", entities=["cover.b"])
+    group = _add_group(hass, "group_1", member_entries=["cover_a", "cover_b"])
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_arbitration()
+    assert result["type"] == "form"
+    keys = _schema_keys(result["data_schema"])
+    assert keys == {CONF_GROUP_STAGGER_DELAY, "scene_opt_outs"}
+    # One multi-select: per member, the all-scenes sentinel plus every scene,
+    # encoded as "member|scene" with a human label naming the member.
+    opts = _select_options(result["data_schema"], "scene_opt_outs")
+    values = [o["value"] for o in opts]
+    assert values == [
+        *(f"cover_a|{v}" for v in (OPT_OUT_ALL_SCENES, *(str(s) for s in GroupScene))),
+        *(f"cover_b|{v}" for v in (OPT_OUT_ALL_SCENES, *(str(s) for s in GroupScene))),
+    ]
+    assert all("cover_a" in o["label"] for o in opts[:4])
+
+    result = await flow.async_step_group_arbitration(
+        {
+            CONF_GROUP_STAGGER_DELAY: 2.5,
+            "scene_opt_outs": [f"cover_a|{GroupScene.PRIVACY}"],
+        }
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_GROUP_STAGGER_DELAY] == 2.5
+    # Only members with opt-outs are stored.
+    assert result["data"][CONF_GROUP_MEMBER_OPT_OUT] == {
+        "cover_a": [str(GroupScene.PRIVACY)]
+    }
+
+
+async def test_membership_save_prunes_opt_out_of_removed_members(
+    hass: HomeAssistant,
+) -> None:
+    """Removing a member from the roster drops its opt-out entry too."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_MEMBER_OPT_OUT,
+        GroupScene,
+    )
+
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+    _add_cover(hass, "cover_b", entities=["cover.b"])
+    group = _add_group(hass, "group_1", member_entries=["cover_a", "cover_b"])
+    hass.config_entries.async_update_entry(
+        group,
+        options={
+            **group.options,
+            CONF_GROUP_MEMBER_OPT_OUT: {
+                "cover_a": [str(GroupScene.PRIVACY)],
+                "cover_b": [str(GroupScene.ALL_OPEN)],
+            },
+        },
+    )
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_membership(
+        {CONF_MEMBER_ENTRIES: ["cover_a"], CONF_MEMBER_COVERS: []}
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_GROUP_MEMBER_OPT_OUT] == {
+        "cover_a": [str(GroupScene.PRIVACY)]
+    }
+
+
+async def test_stagger_registered_in_option_ranges() -> None:
+    """The stagger range feeds OPTION_RANGES (validators + selectors)."""
+    from custom_components.adaptive_cover_pro.const import (
+        _RANGE_GROUP_STAGGER,
+        CONF_GROUP_STAGGER_DELAY,
+        OPTION_RANGES,
+    )
+
+    assert OPTION_RANGES[CONF_GROUP_STAGGER_DELAY] == _RANGE_GROUP_STAGGER

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -14,17 +14,23 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENTITIES,
+    CONF_GROUP_MEMBER_OPT_OUT,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_SENSOR_TYPE,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
     DOMAIN,
+    GROUP_SCENE_PRIORITY,
+    OPT_OUT_ALL_SCENES,
     POSITION_CLOSED,
-    POSITION_OPEN,
     CoverType,
+    GroupIntentKind,
     GroupScene,
     GroupState,
 )
 from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
 
 pytestmark = pytest.mark.integration
 
@@ -52,6 +58,7 @@ def _mock_member_coordinator() -> MagicMock:
     coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
     coord.async_reset_manual_overrides = AsyncMock(return_value=[])
     coord.async_refresh = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
     return coord
 
 
@@ -115,22 +122,24 @@ async def test_member_resolution_skips_unset_runtime_data(hass) -> None:
     assert resolved[0][1] is ok_coord
 
 
-async def test_activate_scene_resolves_target_per_member_policy(group_setup) -> None:
-    """PRIVACY resolves through each member's own policy: blind 0, awning 100."""
+async def test_activate_scene_pushes_intent_and_refreshes(group_setup) -> None:
+    """Phase 2: scenes ride the pipeline — intent push + refresh, never the
+    user-position path (which would engage manual override).
+    """
     coordinator, blind_coord, awning_coord = group_setup
 
     await coordinator.async_activate_scene(GroupScene.PRIVACY)
 
-    blind_coord.async_apply_user_position.assert_awaited_once_with(
-        BLIND_ENTITY,
-        POSITION_CLOSED,
-        trigger="group_scene_privacy",
+    expected = GroupIntent(
+        kind=GroupIntentKind.SCENE,
+        scene=GroupScene.PRIVACY,
+        priority=GROUP_SCENE_PRIORITY,
+        group_id="group_01",
     )
-    awning_coord.async_apply_user_position.assert_awaited_once_with(
-        AWNING_ENTITY,
-        POSITION_OPEN,
-        trigger="group_scene_privacy",
-    )
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", expected)
+        member.async_request_refresh.assert_awaited_once()
+        member.async_apply_user_position.assert_not_awaited()
 
 
 async def test_activate_scene_adopt_commands_generic_covers(group_setup) -> None:
@@ -264,3 +273,188 @@ async def test_member_state_change_triggers_refresh(hass, group_setup) -> None:
     await coordinator.async_shutdown()
     assert coordinator._unsub_state is None
     coordinator._cmd_svc.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — intent arbitration, opt-out, stagger, lock, clear, who-won
+# ---------------------------------------------------------------------------
+
+
+def _group_with_options(hass, extra_options, entry_id="group_10"):
+    blind_entry = _member_entry(
+        hass, f"{entry_id}_blind", CoverType.BLIND, [BLIND_ENTITY]
+    )
+    awning_entry = _member_entry(
+        hass, f"{entry_id}_awning", CoverType.AWNING, [AWNING_ENTITY]
+    )
+    blind_coord = _mock_member_coordinator()
+    awning_coord = _mock_member_coordinator()
+    blind_entry.runtime_data = blind_coord
+    awning_entry.runtime_data = awning_coord
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [f"{entry_id}_blind", f"{entry_id}_awning"],
+            CONF_MEMBER_COVERS: [GENERIC_ENTITY],
+            **extra_options,
+        },
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    coordinator._cmd_svc = MagicMock(
+        apply_position=AsyncMock(return_value=("sent", "")), stop=MagicMock()
+    )
+    return coordinator, blind_coord, awning_coord
+
+
+async def test_opt_out_skips_member_for_that_scene_only(hass) -> None:
+    """A member opted out of PRIVACY is skipped for it but included elsewhere."""
+    coordinator, blind_coord, awning_coord = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [str(GroupScene.PRIVACY)]}}
+    )
+
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+    blind_coord.set_group_intent.assert_not_called()
+    awning_coord.set_group_intent.assert_called_once()
+
+    blind_coord.reset_mock()
+    awning_coord.reset_mock()
+    await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+    blind_coord.set_group_intent.assert_called_once()
+    awning_coord.set_group_intent.assert_called_once()
+
+
+async def test_opt_out_star_skips_member_for_all_scenes(hass) -> None:
+    coordinator, blind_coord, _ = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [OPT_OUT_ALL_SCENES]}}
+    )
+
+    await coordinator.async_activate_scene(GroupScene.ALL_CLOSED)
+
+    blind_coord.set_group_intent.assert_not_called()
+
+
+async def test_clear_scene_removes_intents(group_setup) -> None:
+    """Clearing the scene removes this group's claim and refreshes members."""
+    coordinator, blind_coord, awning_coord = group_setup
+    await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+    assert coordinator.active_scene is GroupScene.ALL_OPEN
+
+    for member in (blind_coord, awning_coord):
+        member.reset_mock()
+    await coordinator.async_clear_scene()
+
+    assert coordinator.active_scene is None
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", None)
+        member.async_request_refresh.assert_awaited_once()
+
+
+async def test_lock_pushes_and_clears_lock_intent(group_setup) -> None:
+    """The group lock is a LOCK intent at safety priority on every member."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_lock(True)
+    assert coordinator.group_locked is True
+    expected = GroupIntent(
+        kind=GroupIntentKind.LOCK,
+        scene=None,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        group_id="group_01",
+    )
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", expected)
+
+    for member in (blind_coord, awning_coord):
+        member.reset_mock()
+    await coordinator.async_set_lock(False)
+    assert coordinator.group_locked is False
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", None)
+
+
+async def test_lock_ignores_scene_opt_out(hass) -> None:
+    """Opt-out is per-scene; the lock is a safety claim on every member."""
+    coordinator, blind_coord, _ = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [OPT_OUT_ALL_SCENES]}}
+    )
+
+    await coordinator.async_set_lock(True)
+
+    blind_coord.set_group_intent.assert_called_once()
+
+
+async def test_stagger_spaces_member_commands(hass) -> None:
+    """With a stagger configured, successive commands are spaced apart."""
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = _group_with_options(
+        hass, {CONF_GROUP_STAGGER_DELAY: 1.5}, entry_id="group_11"
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+
+    # 2 ACP members + 1 generic = 3 commands → 2 gaps.
+    assert sleeper.await_count == 2
+    sleeper.assert_awaited_with(1.5)
+
+
+async def test_no_stagger_no_sleep(group_setup) -> None:
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = group_setup
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+
+    sleeper.assert_not_awaited()
+
+
+async def test_shutdown_clears_group_intents(group_setup) -> None:
+    """A group being unloaded must not leave stale intents on members."""
+    coordinator, blind_coord, awning_coord = group_setup
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+
+    await coordinator.async_shutdown()
+
+    for member in (blind_coord, awning_coord):
+        assert member.set_group_intent.call_args_list[-1].args == ("group_01", None)
+
+
+async def test_member_winners_maps_entities_to_pipeline_winner(group_setup) -> None:
+    """Who-won: each member cover mapped to its pipeline's winning handler."""
+    coordinator, blind_coord, awning_coord = group_setup
+    blind_coord.pipeline_winner_name = "group_scene"
+    awning_coord.pipeline_winner_name = "weather_override"
+
+    winners = coordinator.member_winners()
+
+    assert winners == {
+        BLIND_ENTITY: "group_scene",
+        AWNING_ENTITY: "weather_override",
+    }
+
+
+async def test_unlock_repushes_active_scene(group_setup) -> None:
+    """Unlocking with a scene active re-pushes the scene, not unmanaged state."""
+    coordinator, blind_coord, _ = group_setup
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+    await coordinator.async_set_lock(True)
+
+    blind_coord.reset_mock()
+    await coordinator.async_set_lock(False)
+
+    pushed = [
+        call.args[1]
+        for call in blind_coord.set_group_intent.call_args_list
+        if call.args[1] is not None
+    ]
+    assert pushed and pushed[-1].kind is GroupIntentKind.SCENE
+    assert pushed[-1].scene is GroupScene.PRIVACY

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -27,6 +27,9 @@ from custom_components.adaptive_cover_pro.group_coordinator import (
     GroupAggregates,
     GroupCoordinator,
 )
+from custom_components.adaptive_cover_pro.const import (
+    GROUP_SCENE_SELECT_AUTO as SCENE_SELECT_AUTO,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -61,6 +64,7 @@ async def test_sensor_platform_builds_group_sensors(hass, group_entry) -> None:
         "group_01_group_position",
         "group_01_group_state",
         "group_01_group_active_scene",
+        "group_01_group_who_won",
     }
 
 
@@ -91,7 +95,10 @@ async def test_switch_platform_builds_group_automation_switch(
     hass, group_entry
 ) -> None:
     entities = await _added_entities(switch, hass, group_entry)
-    assert [e.unique_id for e in entities] == ["group_01_group_automation"]
+    assert [e.unique_id for e in entities] == [
+        "group_01_group_automation",
+        "group_01_group_lock",
+    ]
 
     coordinator = group_entry.runtime_data
     coordinator.async_set_automation = AsyncMock()
@@ -133,10 +140,10 @@ async def test_select_platform_builds_scene_picker(hass, group_entry) -> None:
     assert [e.unique_id for e in entities] == ["group_01_group_scene_select"]
 
     picker = entities[0]
-    assert picker.options == [str(scene) for scene in GroupScene]
+    assert picker.options == [SCENE_SELECT_AUTO, *(str(scene) for scene in GroupScene)]
 
     coordinator = group_entry.runtime_data
-    assert picker.current_option is None
+    assert picker.current_option == SCENE_SELECT_AUTO
     coordinator.active_scene = GroupScene.ALL_CLOSED
     assert picker.current_option == str(GroupScene.ALL_CLOSED)
 
@@ -160,3 +167,61 @@ async def test_select_platform_yields_nothing_for_cover_entry(hass) -> None:
 
     entities = await _added_entities(select, hass, entry)
     assert entities == []
+
+
+async def test_group_lock_switch_drives_lock_intent(hass, group_entry) -> None:
+    """The lock switch pushes/releases the LOCK intent via the coordinator."""
+    coordinator = group_entry.runtime_data
+    coordinator.async_set_lock = AsyncMock()
+    entities = {
+        e.unique_id: e for e in await _added_entities(switch, hass, group_entry)
+    }
+    lock = entities["group_01_group_lock"]
+    lock.async_write_ha_state = MagicMock()
+
+    assert lock.is_on is False  # unlocked by default
+    await lock.async_turn_on()
+    coordinator.async_set_lock.assert_awaited_once_with(True)
+    assert lock.is_on is True
+
+    await lock.async_turn_off()
+    coordinator.async_set_lock.assert_awaited_with(False)
+    assert lock.is_on is False
+
+
+async def test_select_auto_clears_scene(hass, group_entry) -> None:
+    """Choosing Auto releases the scene claim."""
+    coordinator = group_entry.runtime_data
+    coordinator.async_clear_scene = AsyncMock()
+    coordinator.async_activate_scene = AsyncMock()
+    entities = await _added_entities(select, hass, group_entry)
+    picker = entities[0]
+    picker.async_write_ha_state = MagicMock()
+
+    await picker.async_select_option(SCENE_SELECT_AUTO)
+
+    coordinator.async_clear_scene.assert_awaited_once()
+    coordinator.async_activate_scene.assert_not_awaited()
+
+
+async def test_who_won_sensor_reads_member_winners(hass, group_entry) -> None:
+    """State = members currently driven by this group; per-member attributes."""
+    coordinator = group_entry.runtime_data
+    coordinator.member_winners = MagicMock(
+        return_value={
+            "cover.blind1": "group_scene",
+            "cover.awning1": "weather_override",
+            "cover.tilt1": "group_lock",
+        }
+    )
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    who_won = entities["group_01_group_who_won"]
+
+    assert who_won.native_value == 2  # blind (scene) + tilt (lock)
+    assert who_won.extra_state_attributes["member_winners"] == {
+        "cover.blind1": "group_scene",
+        "cover.awning1": "weather_override",
+        "cover.tilt1": "group_lock",
+    }

--- a/tests/test_group_intent.py
+++ b/tests/test_group_intent.py
@@ -1,0 +1,140 @@
+"""GroupIntent types and the member-side intent seam (issue #790, Phase 2).
+
+A group pushes a ``GroupIntent`` into each member coordinator
+(``set_group_intent``); the member holds one live intent per group and folds
+the highest-priority one into its ``PipelineSnapshot`` each cycle, where the
+group pipeline handlers read it.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    GROUP_SCENE_PRIORITY,
+    GroupIntentKind,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+    PipelineSnapshotBuilder,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
+
+pytestmark = pytest.mark.unit
+
+
+def _scene_intent(group_id: str, priority: int = GROUP_SCENE_PRIORITY) -> GroupIntent:
+    return GroupIntent(
+        kind=GroupIntentKind.SCENE,
+        scene=GroupScene.PRIVACY,
+        priority=priority,
+        group_id=group_id,
+    )
+
+
+def test_group_scene_priority_sits_between_manual_and_weather() -> None:
+    """85: above manual override (80), below weather safety (90)."""
+    from custom_components.adaptive_cover_pro.pipeline.handlers import (
+        ManualOverrideHandler,
+        WeatherOverrideHandler,
+    )
+
+    assert ManualOverrideHandler.priority < GROUP_SCENE_PRIORITY
+    assert WeatherOverrideHandler.priority > GROUP_SCENE_PRIORITY
+
+
+def test_group_intent_is_frozen() -> None:
+    intent = _scene_intent("g1")
+    with pytest.raises(AttributeError):
+        intent.priority = 99  # type: ignore[misc]
+
+
+def test_set_group_intent_stores_and_removes_per_group() -> None:
+    coordinator = MagicMock()
+    coordinator._group_intents = {}
+
+    intent = _scene_intent("g1")
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "g1", intent)
+    assert coordinator._group_intents == {"g1": intent}
+
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "g1", None)
+    assert coordinator._group_intents == {}
+    # Removing an absent group is a no-op, not an error.
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "gone", None)
+
+
+def test_effective_group_intent_picks_highest_priority() -> None:
+    """Two groups pushing to one member: the higher-priority intent wins —
+    a whole-house lock is not clobbered by a facade scene.
+    """
+    coordinator = MagicMock()
+    coordinator._group_intents = {}
+
+    scene = _scene_intent("facade")
+    lock = GroupIntent(
+        kind=GroupIntentKind.LOCK,
+        scene=None,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        group_id="house",
+    )
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "facade", scene)
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "house", lock)
+
+    effective = AdaptiveDataUpdateCoordinator.effective_group_intent.fget(coordinator)
+    assert effective is lock
+
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "house", None)
+    effective = AdaptiveDataUpdateCoordinator.effective_group_intent.fget(coordinator)
+    assert effective is scene
+
+
+def test_effective_group_intent_none_when_empty() -> None:
+    coordinator = MagicMock()
+    coordinator._group_intents = {}
+    assert (
+        AdaptiveDataUpdateCoordinator.effective_group_intent.fget(coordinator) is None
+    )
+
+
+def test_snapshot_builder_accepts_group_intent() -> None:
+    """The builder threads ``group_intent`` into the snapshot (default None)."""
+    params = inspect.signature(PipelineSnapshotBuilder.build).parameters
+    assert "group_intent" in params
+    assert params["group_intent"].default is None
+
+
+def test_pipeline_winner_name_reads_first_matched_step() -> None:
+    """Winner = first matched trace step (handler steps precede synthetic)."""
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.pipeline.types import (
+        DecisionStep,
+        PipelineResult,
+    )
+
+    coordinator = MagicMock()
+    coordinator._pipeline_result = None
+    assert AdaptiveDataUpdateCoordinator.pipeline_winner_name.fget(coordinator) is None
+
+    coordinator._pipeline_result = PipelineResult(
+        position=0,
+        control_method=ControlMethod.GROUP_SCENE,
+        reason="group scene",
+        decision_trace=[
+            DecisionStep(
+                handler="weather_override", matched=False, reason="x", position=None
+            ),
+            DecisionStep(handler="group_scene", matched=True, reason="won", position=0),
+            DecisionStep(handler="floor_clamp", matched=True, reason="y", position=10),
+        ],
+    )
+    assert (
+        AdaptiveDataUpdateCoordinator.pipeline_winner_name.fget(coordinator)
+        == "group_scene"
+    )

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -89,6 +89,7 @@ def make_snapshot(
     min_tilt_sun_only: bool = False,
     max_tilt_sun_only: bool = False,
     solar_floor_active: bool = True,
+    group_intent=None,
     # Convenience: configure mock cover
     direct_sun_valid: bool = False,
     calculate_percentage_return: float = 50.0,
@@ -137,4 +138,5 @@ def make_snapshot(
         min_tilt_sun_only=min_tilt_sun_only,
         max_tilt_sun_only=max_tilt_sun_only,
         solar_floor_active=solar_floor_active,
+        group_intent=group_intent,
     )

--- a/tests/test_pipeline/test_group_handlers.py
+++ b/tests/test_pipeline/test_group_handlers.py
@@ -1,0 +1,240 @@
+"""GroupSceneHandler (85) and GroupLockHandler (100) — issue #790 Phase 2.
+
+The group handlers read ``snapshot.group_intent``; ``None`` is the universal
+pass signal (absence of intent IS non-membership). Arbitration contracts:
+weather (90) beats a scene (85); a scene beats manual override (80); a
+member's own custom-position safety slot beats the group lock on 100-ties
+via handler build order (stable sort).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    GROUP_SCENE_PRIORITY,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    ControlMethod,
+    GroupIntentKind,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers import build_handlers
+from custom_components.adaptive_cover_pro.pipeline.handlers.group_lock import (
+    GroupLockHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.group_scene import (
+    GroupSceneHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
+
+from .conftest import make_snapshot
+
+pytestmark = pytest.mark.unit
+
+GROUP_ID = "group_entry_1"
+
+
+def _scene_intent(scene: GroupScene = GroupScene.PRIVACY) -> GroupIntent:
+    return GroupIntent(
+        kind=GroupIntentKind.SCENE,
+        scene=scene,
+        priority=GROUP_SCENE_PRIORITY,
+        group_id=GROUP_ID,
+    )
+
+
+def _lock_intent() -> GroupIntent:
+    return GroupIntent(
+        kind=GroupIntentKind.LOCK,
+        scene=None,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        group_id=GROUP_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GroupSceneHandler
+# ---------------------------------------------------------------------------
+
+
+def test_scene_handler_priority_is_const() -> None:
+    assert GroupSceneHandler.priority == GROUP_SCENE_PRIORITY
+
+
+def test_scene_handler_defers_without_intent() -> None:
+    handler = GroupSceneHandler()
+    assert handler.evaluate(make_snapshot()) is None
+
+
+def test_scene_handler_defers_on_lock_intent() -> None:
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(group_intent=_lock_intent())
+    assert handler.evaluate(snapshot) is None
+
+
+@pytest.mark.parametrize(
+    ("cover_type", "expected"),
+    [
+        ("cover_blind", POSITION_CLOSED),
+        ("cover_awning", POSITION_OPEN),
+    ],
+)
+def test_scene_handler_resolves_position_per_policy(
+    cover_type: str, expected: int
+) -> None:
+    """PRIVACY resolves through the member's own policy, never a shared number."""
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(cover_type=cover_type, group_intent=_scene_intent())
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.position == expected
+    assert result.control_method is ControlMethod.GROUP_SCENE
+    # Explicit user intent: runs even with automatic control off, but it is
+    # NOT a safety result (weather/member-safety still outrank it).
+    assert result.bypass_auto_control is True
+    assert result.is_safety is False
+    assert GROUP_ID in result.reason
+
+
+def test_scene_handler_reason_names_scene() -> None:
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(group_intent=_scene_intent(GroupScene.ALL_OPEN))
+    result = handler.evaluate(snapshot)
+    assert result is not None
+    assert str(GroupScene.ALL_OPEN) in result.reason
+
+
+# ---------------------------------------------------------------------------
+# GroupLockHandler
+# ---------------------------------------------------------------------------
+
+
+def test_lock_handler_priority_is_safety() -> None:
+    assert GroupLockHandler.priority == CUSTOM_POSITION_SAFETY_PRIORITY
+
+
+def test_lock_handler_defers_without_intent_or_on_scene() -> None:
+    handler = GroupLockHandler()
+    assert handler.evaluate(make_snapshot()) is None
+    assert handler.evaluate(make_snapshot(group_intent=_scene_intent())) is None
+
+
+def test_lock_handler_freezes_in_place() -> None:
+    """Lock wins the pipeline but sends nothing — the cover holds position."""
+    handler = GroupLockHandler()
+    snapshot = make_snapshot(group_intent=_lock_intent(), current_cover_position=37)
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.skip_command is True
+    assert result.held_position == 37
+    assert result.position == 37
+    assert result.control_method is ControlMethod.GROUP_LOCK
+    assert GROUP_ID in result.reason
+
+
+def test_lock_handler_without_readable_position_uses_default() -> None:
+    handler = GroupLockHandler()
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        current_cover_position=None,
+        default_position=60,
+    )
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.skip_command is True
+    assert result.position == 60
+
+
+# ---------------------------------------------------------------------------
+# Registry arbitration
+# ---------------------------------------------------------------------------
+
+
+def _registry() -> PipelineRegistry:
+    return PipelineRegistry(build_handlers({}))
+
+
+def test_group_handlers_always_built() -> None:
+    names = [handler.name for handler in build_handlers({})]
+    assert "group_scene" in names
+    assert "group_lock" in names
+    # Tiebreak order: custom-position slots (member safety) must be listed
+    # BEFORE group_lock so the stable priority sort favors the member at 100.
+    # No slots configured in empty options, so pin via the factory tuple order
+    # in the arbitration test below instead.
+
+
+def test_weather_outranks_group_scene() -> None:
+    snapshot = make_snapshot(
+        group_intent=_scene_intent(),
+        weather_override_active=True,
+        weather_override_position=90,
+    )
+    result = _registry().evaluate(snapshot)
+    assert result.control_method is ControlMethod.WEATHER
+
+
+def test_group_scene_outranks_manual_override() -> None:
+    snapshot = make_snapshot(
+        group_intent=_scene_intent(),
+        manual_override_active=True,
+    )
+    result = _registry().evaluate(snapshot)
+    assert result.control_method is ControlMethod.GROUP_SCENE
+
+
+def test_member_safety_slot_beats_group_lock_on_tie() -> None:
+    """Physical safety local to the cover trumps a zone lock at equal priority."""
+    from custom_components.adaptive_cover_pro.const import CUSTOM_POSITION_SLOTS
+    from custom_components.adaptive_cover_pro.pipeline.types import (
+        CustomPositionSensorState,
+    )
+
+    slot_keys = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        slot_keys["sensors"]: ["binary_sensor.wind_alarm"],
+        slot_keys["position"]: 0,
+        slot_keys["priority"]: CUSTOM_POSITION_SAFETY_PRIORITY,
+    }
+    sensor_state = CustomPositionSensorState(
+        entity_ids=("binary_sensor.wind_alarm",),
+        is_on=True,
+        position=0,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        min_mode=False,
+        use_my=False,
+        slot=1,
+        active_entity_ids=("binary_sensor.wind_alarm",),
+    )
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        custom_position_sensors=[sensor_state],
+        current_cover_position=50,
+    )
+
+    result = PipelineRegistry(build_handlers(options)).evaluate(snapshot)
+
+    assert result.control_method is ControlMethod.CUSTOM_POSITION
+    assert result.skip_command is False
+
+
+def test_group_lock_wins_over_scene_and_weather() -> None:
+    """Lock at 100 outranks weather (90) — and freezes instead of retracting."""
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        weather_override_active=True,
+        weather_override_position=90,
+        current_cover_position=42,
+    )
+    result = _registry().evaluate(snapshot)
+    assert result.control_method is ControlMethod.GROUP_LOCK
+    assert result.skip_command is True

--- a/tests/test_pipeline_guard.py
+++ b/tests/test_pipeline_guard.py
@@ -15,6 +15,8 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import (
     CloudSuppressionHandler,
     DefaultHandler,
     GlareZoneHandler,
+    GroupLockHandler,
+    GroupSceneHandler,
     ManualOverrideHandler,
     MotionTimeoutHandler,
     SolarHandler,
@@ -26,7 +28,12 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import (
 # user-configurable (1–100; 100 = safety/force-override semantics, issue
 # #563) and cannot be locked to a single value.
 _EXPECTED_PRIORITIES: dict[type, int] = {
+    # Group lock deliberately shares 100 with a member's custom-position
+    # SAFETY slot (excluded from this map); the tie is resolved by handler
+    # build order — member safety first (issue #790 Phase 2).
+    GroupLockHandler: 100,
     WeatherOverrideHandler: 90,
+    GroupSceneHandler: 85,
     ManualOverrideHandler: 80,
     MotionTimeoutHandler: 75,
     CloudSuppressionHandler: 60,

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -79,10 +79,12 @@ from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
     GroupClearOverridesButton,
+    GroupLockSwitch,
     GroupPositionSensor,
     GroupSceneButton,
     GroupSceneSelect,
     GroupStateSensor,
+    GroupWhoWonSensor,
 )
 
 # ---------------------------------------------------------------------------
@@ -303,6 +305,19 @@ ENTITY_FACTORIES: dict[type, object] = {
         _make_hass(),
         _make_config_entry(),
         _make_coordinator(),
+    ),
+    GroupLockSwitch: lambda: GroupLockSwitch(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupWhoWonSensor: lambda: GroupWhoWonSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_who_won",
     ),
 }
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -24,8 +24,10 @@ from pathlib import Path
 from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
+    GroupLockSwitch,
     GroupPositionSensor,
     GroupStateSensor,
+    GroupWhoWonSensor,
 )
 from custom_components.adaptive_cover_pro.sensor import (
     _DIAGNOSTIC_SPECS,
@@ -76,10 +78,15 @@ def _class_translation_key(cls: type) -> str:
 
 _GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
     _class_translation_key(cls)
-    for cls in (GroupPositionSensor, GroupStateSensor, GroupActiveSceneSensor)
+    for cls in (
+        GroupPositionSensor,
+        GroupStateSensor,
+        GroupActiveSceneSensor,
+        GroupWhoWonSensor,
+    )
 )
 _GROUP_SWITCH_TRANSLATION_KEYS: frozenset[str] = frozenset(
-    {_class_translation_key(GroupAutomationSwitch)}
+    _class_translation_key(cls) for cls in (GroupAutomationSwitch, GroupLockSwitch)
 )
 
 


### PR DESCRIPTION
## Summary
Phase 2 of #790, stacked on #797: group scenes and the new group lock now ride each member's pipeline instead of the user-position path.

- **Intent seam**: groups push a `GroupIntent` (SCENE/LOCK) into member coordinators via `set_group_intent`; each snapshot folds the member's highest-priority live intent in, so a whole-house lock is never clobbered by a facade scene from another group.
- **Handlers**: `GroupSceneHandler` at priority **85** (a scene beats a stale manual override; weather safety at 90 still beats a scene) and `GroupLockHandler` at **100**, freezing members in place via the motion-hold `skip_command` shape. A member's own custom-position safety slot wins 100-ties by handler build order — pinned by test.
- **Behavior change from Phase 1** (intentional): scene activation no longer engages a member's manual override — it arbitrates. The scene select gains an **Auto** option that releases the group's claim; the new **Group Lock** switch pushes/releases the lock, re-pushing an active scene on unlock; group unload/reload clears its intents from every member.
- **Config**: per-member per-scene opt-out (enforced group-side; the lock ignores it) and a stagger delay (0–30 s) between member commands, on a new Arbitration & Timing options page. Stagger range feeds `OPTION_RANGES`/`FIELD_VALIDATORS`.
- **Observability**: new Group-Driven Members sensor (per-member winning-handler attributes via the new `pipeline_winner_name` property); group handlers appear in every member's decision trace; group summary shows the priorities and stagger.
- **Translations** synced to DE/FR (parity locks green).

Note: the plan originally called for adding Group scene/lock anchors to each cover's Decision Priority chain summary; that was dropped — a member's options cannot know group membership, so a static ✅/❌ would mislead. The member's Decision Trace sensor shows the group handlers truthfully at runtime.

Phases 3–4 (aggregate cover entity, group services, area auto-membership) remain open on the issue.

## Testing
- ✅ 5,583 tests passing (42 new; `group_coordinator.py` and both handlers at 100% coverage)

## Related Issues
Refs #790

https://claude.ai/code/session_01D2VimyDNsSA3TZUWy76ZLH