### PR TITLE
feat: cover-group aggregation + exposure — Phase 3 (#790)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -82,14 +82,15 @@ PLATFORMS = [
     Platform.NUMBER,
 ]
 # Platform set for cover-group entries (``is_orchestrator = True``). A group
-# exposes aggregate sensors, bulk switches, scene buttons, and the scene
-# select — no proxy cover, number, or binary sensor. Setup and unload must
-# use the same list (load/unload symmetry, the #712/#714 lesson).
+# exposes aggregate sensors, bulk switches, scene buttons, the scene select,
+# and the opt-in aggregate cover — no number or binary sensor. Setup and
+# unload must use the same list (load/unload symmetry, the #712/#714 lesson).
 GROUP_PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.BUTTON,
     Platform.SELECT,
+    Platform.COVER,
 ]
 CONF_SUN = ["sun.sun"]
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,11 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+    CONF_GROUP_ENABLE_COVER_ENTITY,
+    CONF_GROUP_ENABLE_POSITION_SENSOR,
+    CONF_GROUP_ENABLE_STATE_SENSOR,
+    CONF_GROUP_ENABLE_WHO_WON_SENSOR,
     CONF_GROUP_MEMBER_OPT_OUT,
     CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
@@ -174,6 +179,8 @@ from .const import (
     CONF_WINDOW_WIDTH,
     DEFAULT_DELTA_POSITION,
     DEFAULT_DELTA_TIME,
+    DEFAULT_GROUP_ENABLE_COVER_ENTITY,
+    DEFAULT_GROUP_ENABLE_SENSOR,
     DEFAULT_GROUP_STAGGER_DELAY,
     DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MOTION_TIMEOUT,
@@ -1590,6 +1597,9 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
         "place; a member's own safety still wins ties"
     ),
     "group.stagger": "Members commanded {stagger}s apart",
+    "group.cover_entity": (
+        "Aggregate cover entity exposed — dragging it commands every member"
+    ),
     "warnings.group_empty": (
         "⚠️ This group has no members — it will not command anything."
     ),
@@ -1694,6 +1704,8 @@ def _build_group_summary(
     stagger = config.get(CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY)
     if stagger:
         lines.append(L["group.stagger"].format(stagger=stagger))
+    if config.get(CONF_GROUP_ENABLE_COVER_ENTITY, DEFAULT_GROUP_ENABLE_COVER_ENTITY):
+        lines.append(L["group.cover_entity"])
     return "\n".join(lines)
 
 
@@ -4151,6 +4163,7 @@ class OptionsFlowHandler(OptionsFlow):
                 menu_options=[
                     "group_membership",
                     "group_arbitration",
+                    "group_entities",
                     "summary",
                     "done",
                 ],
@@ -4668,6 +4681,46 @@ class OptionsFlowHandler(OptionsFlow):
                 vol.Schema(schema_dict),
                 {CONF_GROUP_STAGGER_DELAY: self.options.get(CONF_GROUP_STAGGER_DELAY)},
             ),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
+            },
+        )
+
+    async def async_step_group_entities(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the group's entity-exposure toggles (issue #790, Phase 3).
+
+        Five booleans: the opt-in aggregate cover (off by default) and the
+        four aggregate sensors (on by default). Saving reloads the entry, so
+        toggles take effect immediately.
+        """
+        if user_input is not None:
+            self.options.update(user_input)
+            return self.async_create_entry(title="", data=self.options)
+
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_GROUP_ENABLE_COVER_ENTITY,
+                    default=DEFAULT_GROUP_ENABLE_COVER_ENTITY,
+                ): selector.BooleanSelector(),
+                **{
+                    vol.Optional(
+                        key, default=DEFAULT_GROUP_ENABLE_SENSOR
+                    ): selector.BooleanSelector()
+                    for key in (
+                        CONF_GROUP_ENABLE_POSITION_SENSOR,
+                        CONF_GROUP_ENABLE_STATE_SENSOR,
+                        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+                        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+                    )
+                },
+            }
+        )
+        return self.async_show_form(
+            step_id="group_entities",
+            data_schema=self.add_suggested_values_to_schema(schema, self.options),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -123,6 +123,18 @@ _RANGE_GROUP_STAGGER = (0.0, 30.0)
 # group's claim so members return to their own pipelines.
 GROUP_SCENE_SELECT_AUTO = "auto"
 
+# Entity-exposure toggles for a group entry (issue #790, Phase 3). The
+# aggregate cover entity defaults OFF (dashboard/voice clutter); the sensors
+# default ON. The active-scene sensor, scene controls, and bulk switches are
+# always created (primary control surface, no toggle).
+CONF_GROUP_ENABLE_COVER_ENTITY = "group_enable_cover_entity"
+DEFAULT_GROUP_ENABLE_COVER_ENTITY = False
+CONF_GROUP_ENABLE_POSITION_SENSOR = "group_enable_position_sensor"
+CONF_GROUP_ENABLE_STATE_SENSOR = "group_enable_state_sensor"
+CONF_GROUP_ENABLE_CLIMATE_SENSOR = "group_enable_climate_sensor"
+CONF_GROUP_ENABLE_WHO_WON_SENSOR = "group_enable_who_won_sensor"
+DEFAULT_GROUP_ENABLE_SENSOR = True  # shared default for the four sensor toggles
+
 # Default name prefix used by the config flow when auto-naming a cover from its
 # entity's friendly name (no linked device available) — see config_flow.py's
 # cover_entities auto-fill and async_step_update finalization fallback (#771).
@@ -165,6 +177,9 @@ TRIGGER_PROXY_POSITION = "proxy_managed"
 TRIGGER_PROXY_OPEN = "proxy_open"
 TRIGGER_PROXY_CLOSE = "proxy_close"
 TRIGGER_PROXY_TILT = "proxy_tilt"
+# Cover-group aggregate cover entity commands (issue #790, Phase 3).
+TRIGGER_GROUP_COVER = "group_cover"
+TRIGGER_GROUP_COVER_TILT = "group_cover_tilt"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -26,7 +26,10 @@ from homeassistant.util import slugify
 from .const import (
     CONF_ENABLE_PROXY_COVER,
     CONF_ENTITIES,
+    CONF_GROUP_ENABLE_COVER_ENTITY,
+    CONF_SENSOR_TYPE,
     DEFAULT_ENABLE_PROXY_COVER,
+    DEFAULT_GROUP_ENABLE_COVER_ENTITY,
     TRIGGER_PROXY_CLOSE,
     TRIGGER_PROXY_OPEN,
     TRIGGER_PROXY_POSITION,
@@ -57,6 +60,20 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up proxy cover entities for an ACP config entry."""
+    # Cover groups expose the opt-in aggregate cover, never a proxy.
+    from .cover_types import get_policy
+
+    if get_policy(entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        if entry.options.get(
+            CONF_GROUP_ENABLE_COVER_ENTITY, DEFAULT_GROUP_ENABLE_COVER_ENTITY
+        ):
+            from .group_entities import build_group_covers
+
+            async_add_entities(
+                build_group_covers(entry.entry_id, hass, entry, entry.runtime_data)
+            )
+        return
+
     if not entry.options.get(CONF_ENABLE_PROXY_COVER, DEFAULT_ENABLE_PROXY_COVER):
         return
 

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -27,7 +27,13 @@ import asyncio
 from dataclasses import dataclass
 import logging
 
+from homeassistant.components.cover import (
+    ATTR_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_SET_COVER_TILT_POSITION,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -48,12 +54,15 @@ from .const import (
     OPT_OUT_ALL_SCENES,
     POSITION_CLOSED,
     POSITION_OPEN,
+    TRIGGER_GROUP_COVER,
+    TRIGGER_GROUP_COVER_TILT,
     CoverType,
     GroupIntentKind,
     GroupScene,
     GroupState,
 )
 from .cover_types import get_policy
+from .helpers import climate_mode_from_diagnostics
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
@@ -156,6 +165,34 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         if commands_sent and stagger > 0:
             await asyncio.sleep(stagger)
 
+    async def _fan_out_commands(
+        self,
+        member_action,
+        generic_action,
+        *,
+        scene_filter: GroupScene | None = None,
+    ) -> None:
+        """Run one action per ACP member and per generic cover, staggered.
+
+        The single fan-out loop shared by scene activation and the group
+        cover's user commands: roster iteration, per-scene opt-out (when
+        ``scene_filter`` is given), and the stagger gap between successive
+        commands all live here exactly once.
+        """
+        commands = 0
+        for entry, coordinator in self.resolved_members():
+            if scene_filter is not None and self._scene_opted_out(
+                entry.entry_id, scene_filter
+            ):
+                continue
+            await self._stagger_gap(commands)
+            commands += 1
+            await member_action(entry, coordinator)
+        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            await self._stagger_gap(commands)
+            commands += 1
+            await generic_action(entity_id)
+
     async def async_activate_scene(self, scene: GroupScene) -> None:
         """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
 
@@ -170,27 +207,82 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             priority=GROUP_SCENE_PRIORITY,
             group_id=self.entry.entry_id,
         )
-        commands = 0
-        for entry, coordinator in self.resolved_members():
-            if self._scene_opted_out(entry.entry_id, scene):
-                continue
-            await self._stagger_gap(commands)
-            commands += 1
-            coordinator.set_group_intent(self.entry.entry_id, intent)
-            await coordinator.async_request_refresh()
         adopt_target = self._adopt_policy.position_for_scene(scene)
         trigger = f"group_scene_{scene}"
-        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
-            await self._stagger_gap(commands)
-            commands += 1
+
+        async def _member(_entry, coordinator) -> None:
+            coordinator.set_group_intent(self.entry.entry_id, intent)
+            await coordinator.async_request_refresh()
+
+        async def _generic(entity_id: str) -> None:
             await self._cmd_svc.apply_position(
-                entity_id,
-                adopt_target,
-                trigger,
-                context=self._adopt_context(),
+                entity_id, adopt_target, trigger, context=self._adopt_context()
             )
+
+        await self._fan_out_commands(_member, _generic, scene_filter=scene)
         self.active_scene = scene
         await self.async_refresh()
+
+    async def async_set_position(self, position: int) -> None:
+        """Fan a user position out to every member (group cover slider).
+
+        A group-cover drag is a user action: ACP members ride their own
+        user-position path (manual-override engagement and floor clamps
+        apply, exactly like the per-cover proxy); generic covers go through
+        the adopt-mode command service. Stagger applies.
+        """
+
+        async def _member(entry, coordinator) -> None:
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                await coordinator.async_apply_user_position(
+                    entity_id, position, trigger=TRIGGER_GROUP_COVER
+                )
+
+        async def _generic(entity_id: str) -> None:
+            await self._cmd_svc.apply_position(
+                entity_id, position, TRIGGER_GROUP_COVER, context=self._adopt_context()
+            )
+
+        await self._fan_out_commands(_member, _generic)
+        await self.async_refresh()
+
+    async def async_set_tilt(self, tilt: int) -> None:
+        """Fan a user tilt out to every member (group cover tilt slider).
+
+        ACP members ride the dedicated tilt path so dual-axis covers move
+        only their slats (#684); generic covers get the plain tilt service.
+        """
+
+        async def _member(entry, coordinator) -> None:
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                await coordinator.async_apply_user_tilt(
+                    entity_id, tilt, trigger=TRIGGER_GROUP_COVER_TILT
+                )
+
+        async def _generic(entity_id: str) -> None:
+            await self.hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_SET_COVER_TILT_POSITION,
+                {ATTR_ENTITY_ID: entity_id, ATTR_TILT_POSITION: tilt},
+                blocking=False,
+            )
+
+        await self._fan_out_commands(_member, _generic)
+        await self.async_refresh()
+
+    async def async_stop(self) -> None:
+        """Stop every member cover immediately — no stagger, no gates.
+
+        Mirrors the proxy cover's stop: a plain ``cover.stop_cover`` per
+        member entity, ACP and generic alike.
+        """
+        for entity_id in self.member_cover_entities():
+            await self.hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_STOP_COVER,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=False,
+            )
 
     async def async_clear_scene(self) -> None:
         """Release this group's scene claim — members return to their pipeline."""
@@ -235,6 +327,55 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             for entity_id in entry.options.get(CONF_ENTITIES, []):
                 winners[entity_id] = winner
         return winners
+
+    def all_members_tilt(self) -> bool:
+        """Whether every member — ACP and generic — has a tilt axis.
+
+        Gates the group cover's tilt features (issue #790 §3): ACP members
+        are checked via their policy's declared axes, generic covers via the
+        HA ``supported_features`` tilt bit. An empty roster is not tiltable.
+        """
+        from homeassistant.components.cover import CoverEntityFeature
+
+        from .cover_types.base import AXIS_NAME_TILT
+
+        member_ids = self.entry.options.get(CONF_MEMBER_ENTRIES, [])
+        generic = self.entry.options.get(CONF_MEMBER_COVERS, [])
+        if not member_ids and not generic:
+            return False
+        for entry_id in member_ids:
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+            if not any(axis.name == AXIS_NAME_TILT for axis in policy.axes):
+                return False
+        for entity_id in generic:
+            state = self.hass.states.get(entity_id)
+            features = (
+                int(state.attributes.get("supported_features", 0)) if state else 0
+            )
+            if not features & CoverEntityFeature.SET_TILT_POSITION:
+                return False
+        return True
+
+    def member_climate_modes(self) -> dict[str, str | None]:
+        """Climate rollup: each ACP member cover mapped to its climate mode.
+
+        Read-only view over the same diagnostics the member's own Climate
+        Status sensor renders — the group shares no climate inputs (that is
+        Building Profile's job); it only reports. Generic covers have no
+        pipeline and are excluded.
+        """
+        modes: dict[str, str | None] = {}
+        for entry, coordinator in self.resolved_members():
+            diagnostics = getattr(
+                getattr(coordinator, "data", None), "diagnostics", None
+            )
+            mode = climate_mode_from_diagnostics(diagnostics)
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                modes[entity_id] = mode
+        return modes
 
     async def async_set_automation(self, enabled: bool) -> None:
         """Bulk-enable/disable sun-tracking automation on every ACP member."""

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -12,11 +12,21 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
 
-from .const import GROUP_SCENE_SELECT_AUTO, GroupScene
+from .const import (
+    CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+    CONF_GROUP_ENABLE_POSITION_SENSOR,
+    CONF_GROUP_ENABLE_STATE_SENSOR,
+    CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    DEFAULT_GROUP_ENABLE_SENSOR,
+    GROUP_SCENE_SELECT_AUTO,
+    GroupScene,
+    GroupState,
+)
 from .entity_base import AdaptiveCoverBaseEntity
 from .pipeline.handlers import GroupLockHandler, GroupSceneHandler
 
@@ -173,6 +183,105 @@ class GroupWhoWonSensor(_GroupEntityBase, SensorEntity):
         return {"member_winners": self.coordinator.member_winners()}
 
 
+class GroupClimateSensor(_GroupEntityBase, SensorEntity):
+    """Read-only rollup of member climate modes (issue #790, Phase 3).
+
+    The mode when all reporting members agree, "mixed" when they disagree,
+    None when no member reports one. Values reuse the member Climate Status
+    sensor's wire strings (single-sourced in
+    ``helpers.climate_mode_from_diagnostics``); the group shares no climate
+    inputs — that stays Building Profile territory.
+    """
+
+    _attr_translation_key = "group_climate_mode"
+    _attr_native_unit_of_measurement = ""
+    _attr_icon = "mdi:sun-thermometer-outline"
+
+    # Wire-stable disagreement state, file-private: produced only by this
+    # sensor (distinct concept from GroupState.MIXED, which is positional).
+    _CLIMATE_MIXED = "mixed"
+
+    @property
+    def native_value(self) -> str | None:
+        """The agreed member climate mode, "mixed", or None."""
+        reported = {
+            mode
+            for mode in self.coordinator.member_climate_modes().values()
+            if mode is not None
+        }
+        if not reported:
+            return None
+        if len(reported) == 1:
+            return next(iter(reported))
+        return self._CLIMATE_MIXED
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Per-member climate-mode map."""
+        return {"member_climate_modes": self.coordinator.member_climate_modes()}
+
+
+class AdaptiveGroupCover(_GroupEntityBase, CoverEntity):
+    """Opt-in aggregate cover entity for a group (issue #790, Phase 3).
+
+    Position reads the group aggregates; commands are USER semantics — a
+    dashboard drag, routed exactly like the per-cover proxy (member
+    manual-override engagement and floor clamps apply). Tilt features are
+    exposed only when every member — ACP and generic — has a tilt axis.
+    """
+
+    _attr_translation_key = "group_cover"
+
+    def __init__(self, *args) -> None:
+        """Initialize the aggregate cover."""
+        super().__init__(*args, "group_cover")
+
+    @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Position/open/close/stop always; tilt only for all-tilt rosters."""
+        features = (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.STOP
+        )
+        if self.coordinator.all_members_tilt():
+            features |= CoverEntityFeature.SET_TILT_POSITION
+        return features
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Aggregate (average) member position."""
+        return self.coordinator.data.position
+
+    @property
+    def is_closed(self) -> bool | None:
+        """True when every member reports fully closed."""
+        if self.coordinator.data.state is GroupState.UNKNOWN:
+            return None
+        return self.coordinator.data.state is GroupState.CLOSED
+
+    async def async_set_cover_position(self, **kwargs) -> None:
+        """Fan the requested position out as a user command."""
+        await self.coordinator.async_set_position(int(kwargs["position"]))
+
+    async def async_open_cover(self, **kwargs) -> None:  # noqa: ARG002
+        """Open all members (position 100)."""
+        await self.coordinator.async_set_position(100)
+
+    async def async_close_cover(self, **kwargs) -> None:  # noqa: ARG002
+        """Close all members (position 0)."""
+        await self.coordinator.async_set_position(0)
+
+    async def async_set_cover_tilt_position(self, **kwargs) -> None:
+        """Fan the requested tilt out on the dedicated tilt path."""
+        await self.coordinator.async_set_tilt(int(kwargs["tilt_position"]))
+
+    async def async_stop_cover(self, **kwargs) -> None:  # noqa: ARG002
+        """Stop every member immediately."""
+        await self.coordinator.async_stop()
+
+
 class GroupSceneButton(_GroupEntityBase, ButtonEntity):
     """Activate one built-in scene across the group."""
 
@@ -249,12 +358,23 @@ def build_group_sensors(
 ) -> list[SensorEntity]:
     """Build the aggregate sensors for one group entry."""
     args = (entry_id, hass, config_entry, coordinator)
-    return [
-        GroupPositionSensor(*args, "group_position"),
-        GroupStateSensor(*args, "group_state"),
-        GroupActiveSceneSensor(*args, "group_active_scene"),
-        GroupWhoWonSensor(*args, "group_who_won"),
-    ]
+    options = config_entry.options
+
+    def _enabled(key: str) -> bool:
+        return bool(options.get(key, DEFAULT_GROUP_ENABLE_SENSOR))
+
+    sensors: list[SensorEntity] = []
+    if _enabled(CONF_GROUP_ENABLE_POSITION_SENSOR):
+        sensors.append(GroupPositionSensor(*args, "group_position"))
+    if _enabled(CONF_GROUP_ENABLE_STATE_SENSOR):
+        sensors.append(GroupStateSensor(*args, "group_state"))
+    # Active scene is always exposed — it is the select's state twin.
+    sensors.append(GroupActiveSceneSensor(*args, "group_active_scene"))
+    if _enabled(CONF_GROUP_ENABLE_CLIMATE_SENSOR):
+        sensors.append(GroupClimateSensor(*args, "group_climate_mode"))
+    if _enabled(CONF_GROUP_ENABLE_WHO_WON_SENSOR):
+        sensors.append(GroupWhoWonSensor(*args, "group_who_won"))
+    return sensors
 
 
 def build_group_switches(
@@ -292,3 +412,13 @@ def build_group_selects(
 ) -> list[SelectEntity]:
     """Build the scene-picker select for one group entry."""
     return [GroupSceneSelect(entry_id, hass, config_entry, coordinator)]
+
+
+def build_group_covers(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[CoverEntity]:
+    """Build the opt-in aggregate cover (empty when the toggle is off)."""
+    return [AdaptiveGroupCover(entry_id, hass, config_entry, coordinator)]

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -541,3 +541,23 @@ def get_open_close_state(
         return 100
 
     return None
+
+
+def climate_mode_from_diagnostics(diagnostics: dict | None) -> str | None:
+    """Map a coordinator's diagnostics payload to its climate-mode string.
+
+    Single source for the ``summer_mode`` / ``winter_mode`` / ``intermediate``
+    vocabulary — shared by the per-cover Climate Status sensor and the
+    cover-group climate rollup (issue #790, Phase 3). ``None`` when climate
+    mode is off or the diagnostics have not been built yet.
+    """
+    if diagnostics is None:
+        return None
+    data = diagnostics.get("climate_conditions")
+    if data is None:
+        return None
+    if data.get("is_summer"):
+        return "summer_mode"
+    if data.get("is_winter"):
+        return "winter_mode"
+    return "intermediate"

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -686,16 +686,9 @@ def _motion_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
 
 
 def _climate_status_value(s: _ACPDiagnosticSensor) -> str | None:
-    if s.data.diagnostics is None:
-        return None
-    data = s.data.diagnostics.get("climate_conditions")
-    if data is None:
-        return None
-    if data.get("is_summer"):
-        return "summer_mode"
-    if data.get("is_winter"):
-        return "winter_mode"
-    return "intermediate"
+    from .helpers import climate_mode_from_diagnostics
+
+    return climate_mode_from_diagnostics(s.data.diagnostics)
 
 
 def _round_threshold(value: float | str | None) -> float | None:

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -256,6 +256,7 @@
     "member_generic": "- 🪟 {entity} (generic)",
     "scene_priority": "Beschattungsgruppen-Szenen gelten mit Priorität {scene_priority} (über manuelle Übersteuerung, unter Wetterschutz)",
     "lock": "🔒 Gruppensperre mit Priorität {lock_priority} — friert Mitglieder an Ort und Stelle ein; die eigene Sicherheit eines Mitglieds gewinnt immer noch Gleichstände",
-    "stagger": "Mitglieder mit {stagger}s Abstand befohlen"
+    "stagger": "Mitglieder mit {stagger}s Abstand befohlen",
+    "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -256,6 +256,7 @@
     "member_generic": "- 🪟 {entity} (generic)",
     "scene_priority": "Group scenes apply at priority {scene_priority} (above manual override, below weather safety)",
     "lock": "🔒 Group lock at priority {lock_priority} — freezes members in place; a member's own safety still wins ties",
-    "stagger": "Members commanded {stagger}s apart"
+    "stagger": "Members commanded {stagger}s apart",
+    "cover_entity": "Aggregate cover entity exposed — dragging it commands every member"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -256,6 +256,7 @@
     "member_generic": "- 🪟 {entity} (générique)",
     "scene_priority": "Les scènes de groupe s'appliquent à la priorité {scene_priority} (au-dessus de la dérogation manuelle, en dessous de la sécurité météo)",
     "lock": "🔒 Verrouillage de groupe à la priorité {lock_priority} — gèle les membres en place ; la sécurité propre d'un membre gagne toujours en cas d'égalité",
-    "stagger": "Membres commandés à {stagger}s d'intervalle"
+    "stagger": "Membres commandés à {stagger}s d'intervalle",
+    "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre"
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -809,7 +809,8 @@
           "profile_overview": "🏢 Profil-Übersicht",
           "profile_overrides": "🧹 Lokale Übersteuerungen",
           "group_membership": "👥 Gruppenmitglieder",
-          "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung"
+          "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung",
+          "group_entities": "🧩 Verfügbar gemachte Entitäten"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1619,6 +1620,20 @@
           "group_stagger_delay": "Sekunden zwischen aufeinanderfolgenden Befehlen für Mitglieder während einer Szene. 0 = alle Mitglieder auf einmal befehlen.",
           "scene_opt_outs": "Überprüfte Mitglieder werden für die ausgewählte Szene übersprungen. 'Alle Szenen' überspringt das Mitglied für jede Szene. Die Gruppensperre ignoriert Ausnahmen."
         }
+      },
+      "group_entities": {
+        "title": "Verfügbar gemachte Entitäten",
+        "description": "Wählen Sie, welche aggregierten Entitäten diese Gruppe erstellt. Szenensteuerungen und Gruppenschalter sind immer verfügbar. [Weitere Informationen]({learn_more})",
+        "data": {
+          "group_enable_cover_entity": "Aggregierte Beschattungs-Entität",
+          "group_enable_position_sensor": "Gruppierungspositions-Sensor",
+          "group_enable_state_sensor": "Gruppen-Statussensor",
+          "group_enable_climate_sensor": "Gruppen-Klimamodus-Sensor",
+          "group_enable_who_won_sensor": "Sensor für Gruppenmitglieder"
+        },
+        "data_description": {
+          "group_enable_cover_entity": "Eine einzelne Beschattungs-Entität für Dashboards und Sprachassistenten. Das Ziehen befiehlt jedem Mitglied als Benutzeraktion. Standardmäßig deaktiviert, um Unordnung zu vermeiden."
+        }
       }
     },
     "abort": {
@@ -1698,6 +1713,15 @@
       },
       "group_who_won": {
         "name": "Gruppengesteuerte Mitglieder"
+      },
+      "group_climate_mode": {
+        "name": "Gruppen-Klimamodus",
+        "state": {
+          "summer_mode": "Sommer",
+          "winter_mode": "Winter",
+          "intermediate": "Zwischenmodus",
+          "mixed": "Gemischt"
+        }
       }
     },
     "switch": {
@@ -1786,6 +1810,11 @@
           "privacy": "Datenschutz",
           "auto": "Auto"
         }
+      }
+    },
+    "cover": {
+      "group_cover": {
+        "name": "Gruppenabdeckung"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -810,7 +810,8 @@
           "profile_overview": "🏢 Profile Overview",
           "profile_overrides": "🧹 Local Overrides",
           "group_membership": "👥 Group Members",
-          "group_arbitration": "⚖️ Arbitration & Timing"
+          "group_arbitration": "⚖️ Arbitration & Timing",
+          "group_entities": "🧩 Exposed Entities"
         }
       },
       "pipeline_priorities": {
@@ -1619,6 +1620,20 @@
           "group_stagger_delay": "Seconds between successive member commands during a scene. 0 = command all members at once.",
           "scene_opt_outs": "Members checked here are skipped for the selected scene. 'All scenes' skips the member for every scene. The group lock ignores opt-outs."
         }
+      },
+      "group_entities": {
+        "title": "Exposed Entities",
+        "description": "Choose which aggregate entities this group creates. Scene controls and bulk switches are always available. [Learn more]({learn_more})",
+        "data": {
+          "group_enable_cover_entity": "Aggregate cover entity",
+          "group_enable_position_sensor": "Group position sensor",
+          "group_enable_state_sensor": "Group state sensor",
+          "group_enable_climate_sensor": "Group climate mode sensor",
+          "group_enable_who_won_sensor": "Group-driven members sensor"
+        },
+        "data_description": {
+          "group_enable_cover_entity": "A single cover entity for dashboards and voice assistants. Dragging it commands every member as a user action. Off by default to avoid clutter."
+        }
       }
     },
     "abort": {
@@ -1698,6 +1713,15 @@
       },
       "group_who_won": {
         "name": "Group-Driven Members"
+      },
+      "group_climate_mode": {
+        "name": "Group Climate Mode",
+        "state": {
+          "summer_mode": "Summer",
+          "winter_mode": "Winter",
+          "intermediate": "Intermediate",
+          "mixed": "Mixed"
+        }
       }
     },
     "switch": {
@@ -1786,6 +1810,11 @@
           "all_closed": "All Closed",
           "privacy": "Privacy"
         }
+      }
+    },
+    "cover": {
+      "group_cover": {
+        "name": "Group Cover"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -809,7 +809,8 @@
           "profile_overview": "🏢 Aperçu du profil",
           "profile_overrides": "🧹 Dérogations locales",
           "group_membership": "👥 Membres du groupe",
-          "group_arbitration": "⚖️ Arbitrage & Synchronisation"
+          "group_arbitration": "⚖️ Arbitrage & Synchronisation",
+          "group_entities": "🧩 Entités exposées"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1619,6 +1620,20 @@
           "group_stagger_delay": "Secondes entre les commandes successives des membres lors d'une scène. 0 = commander tous les membres à la fois.",
           "scene_opt_outs": "Les membres cochés ici sont ignorés pour la scène sélectionnée. « Toutes les scènes » ignore le membre pour chaque scène. Le verrouillage de groupe ignore les exclusions."
         }
+      },
+      "group_entities": {
+        "title": "Entités exposées",
+        "description": "Choisissez les entités agrégées que ce groupe crée. Les contrôles de scène et les commutateurs en masse sont toujours disponibles. [En savoir plus]({learn_more})",
+        "data": {
+          "group_enable_cover_entity": "Entité de store agrégée",
+          "group_enable_position_sensor": "Capteur de position du groupe",
+          "group_enable_state_sensor": "Capteur d'état du groupe",
+          "group_enable_climate_sensor": "Capteur de mode climatique du groupe",
+          "group_enable_who_won_sensor": "Capteur de membres pilotés par le groupe"
+        },
+        "data_description": {
+          "group_enable_cover_entity": "Une seule entité de store pour les tableaux de bord et les assistants vocaux. La faire glisser commande chaque membre comme une action utilisateur. Désactivée par défaut pour éviter l'encombrement."
+        }
       }
     },
     "abort": {
@@ -1698,6 +1713,15 @@
       },
       "group_who_won": {
         "name": "Membres dirigés par le groupe"
+      },
+      "group_climate_mode": {
+        "name": "Mode climatique du groupe",
+        "state": {
+          "summer_mode": "Été",
+          "winter_mode": "Hiver",
+          "intermediate": "Intermédiaire",
+          "mixed": "Mixte"
+        }
       }
     },
     "switch": {
@@ -1786,6 +1810,11 @@
           "privacy": "Confidentialité",
           "auto": "Auto"
         }
+      }
+    },
+    "cover": {
+      "group_cover": {
+        "name": "Store du groupe"
       }
     }
   },

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -53,6 +53,7 @@ UNIVERSAL_KEYS: set[str] = {
     "config.step.duplicate_configure.data.name",  # "Name" — same in DE/FR
     "config.step.create_building_profile.data.name",  # "Name" — same in DE/FR
     "entity.sensor.decision_trace.state.winter",  # "Winter" — same in DE/FR
+    "entity.sensor.group_climate_mode.state.winter_mode",  # "Winter" — same in DE
     "services.set_custom_position.fields.slot.name",  # "Slot" — HA service parameter, language-universal
     "services.set_custom_position.fields.position.name",  # "Position" — HA service parameter, language-universal
     "services.set_position.fields.position.name",  # "Position" — HA service parameter, language-universal

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3258,3 +3258,20 @@ def test_summary_group_omits_stagger_line_when_zero():
     )
 
     assert "apart" not in summary
+
+
+def test_summary_group_shows_cover_entity_line_when_enabled():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    base = {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []}
+    without = _build_config_summary(base, CoverType.GROUP)
+    assert "Aggregate cover entity" not in without
+
+    with_cover = _build_config_summary(
+        {**base, CONF_GROUP_ENABLE_COVER_ENTITY: True}, CoverType.GROUP
+    )
+    assert "Aggregate cover entity" in with_cover

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -169,6 +169,7 @@ async def test_group_options_flow_shows_group_menu(hass: HomeAssistant) -> None:
     assert result["menu_options"] == [
         "group_membership",
         "group_arbitration",
+        "group_entities",
         "summary",
         "done",
     ]
@@ -324,3 +325,45 @@ async def test_stagger_registered_in_option_ranges() -> None:
     )
 
     assert OPTION_RANGES[CONF_GROUP_STAGGER_DELAY] == _RANGE_GROUP_STAGGER
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — entity-exposure toggles
+# ---------------------------------------------------------------------------
+
+
+async def test_group_entities_step_saves_toggles(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+        CONF_GROUP_ENABLE_POSITION_SENSOR,
+        CONF_GROUP_ENABLE_STATE_SENSOR,
+        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    )
+
+    group = _add_group(hass, "group_1")
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_entities()
+    assert result["type"] == "form"
+    assert _schema_keys(result["data_schema"]) == {
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+        CONF_GROUP_ENABLE_POSITION_SENSOR,
+        CONF_GROUP_ENABLE_STATE_SENSOR,
+        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    }
+
+    result = await flow.async_step_group_entities(
+        {
+            CONF_GROUP_ENABLE_COVER_ENTITY: True,
+            CONF_GROUP_ENABLE_POSITION_SENSOR: True,
+            CONF_GROUP_ENABLE_STATE_SENSOR: False,
+            CONF_GROUP_ENABLE_CLIMATE_SENSOR: True,
+            CONF_GROUP_ENABLE_WHO_WON_SENSOR: False,
+        }
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_GROUP_ENABLE_COVER_ENTITY] is True
+    assert result["data"][CONF_GROUP_ENABLE_STATE_SENSOR] is False

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -458,3 +458,120 @@ async def test_unlock_repushes_active_scene(group_setup) -> None:
     ]
     assert pushed and pushed[-1].kind is GroupIntentKind.SCENE
     assert pushed[-1].scene is GroupScene.PRIVACY
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — climate rollup + cover fan-out
+# ---------------------------------------------------------------------------
+
+
+def _set_member_climate(coord: MagicMock, *, is_summer=False, is_winter=False) -> None:
+    coord.data.diagnostics = {
+        "climate_conditions": {"is_summer": is_summer, "is_winter": is_winter}
+    }
+
+
+async def test_member_climate_modes_maps_entities(group_setup) -> None:
+    """Each ACP member's cover entities map to its climate mode; generic
+    covers (no pipeline) are excluded; missing diagnostics → None.
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+    _set_member_climate(blind_coord, is_summer=True)
+    awning_coord.data.diagnostics = None  # climate mode off / not yet built
+
+    modes = coordinator.member_climate_modes()
+
+    assert modes == {
+        BLIND_ENTITY: "summer_mode",
+        AWNING_ENTITY: None,
+    }
+
+
+async def test_member_climate_modes_winter_and_intermediate(group_setup) -> None:
+    coordinator, blind_coord, awning_coord = group_setup
+    _set_member_climate(blind_coord, is_winter=True)
+    _set_member_climate(awning_coord)  # neither flag → intermediate
+
+    modes = coordinator.member_climate_modes()
+
+    assert modes[BLIND_ENTITY] == "winter_mode"
+    assert modes[AWNING_ENTITY] == "intermediate"
+
+
+async def test_set_position_fans_out_user_positions(group_setup) -> None:
+    """A group cover drag is a user action: member user-position path +
+    adopt-mode command for generic covers.
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_position(60)
+
+    blind_coord.async_apply_user_position.assert_awaited_once_with(
+        BLIND_ENTITY, 60, trigger="group_cover"
+    )
+    awning_coord.async_apply_user_position.assert_awaited_once_with(
+        AWNING_ENTITY, 60, trigger="group_cover"
+    )
+    coordinator._cmd_svc.apply_position.assert_awaited_once()
+    args, kwargs = coordinator._cmd_svc.apply_position.await_args
+    assert args[0] == GENERIC_ENTITY
+    assert args[1] == 60
+
+
+async def test_set_position_staggers_commands(hass) -> None:
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = _group_with_options(
+        hass, {CONF_GROUP_STAGGER_DELAY: 2.0}, entry_id="group_12"
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_set_position(50)
+
+    assert sleeper.await_count == 2  # 3 commands → 2 gaps
+    sleeper.assert_awaited_with(2.0)
+
+
+async def test_set_tilt_fans_out_user_tilts(hass, group_setup) -> None:
+    """Tilt rides the dedicated tilt path (#684) for ACP members and the
+    tilt service for generic covers.
+    """
+    from pytest_homeassistant_custom_component.common import async_mock_service
+
+    coordinator, blind_coord, awning_coord = group_setup
+    blind_coord.async_apply_user_tilt = AsyncMock()
+    awning_coord.async_apply_user_tilt = AsyncMock()
+    tilt_calls = async_mock_service(hass, "cover", "set_cover_tilt_position")
+
+    await coordinator.async_set_tilt(30)
+    await hass.async_block_till_done()
+
+    blind_coord.async_apply_user_tilt.assert_awaited_once_with(
+        BLIND_ENTITY, 30, trigger="group_cover_tilt"
+    )
+    awning_coord.async_apply_user_tilt.assert_awaited_once_with(
+        AWNING_ENTITY, 30, trigger="group_cover_tilt"
+    )
+    assert len(tilt_calls) == 1
+    assert tilt_calls[0].data == {
+        "entity_id": GENERIC_ENTITY,
+        "tilt_position": 30,
+    }
+
+
+async def test_stop_calls_stop_service_per_member_cover(hass, group_setup) -> None:
+    from pytest_homeassistant_custom_component.common import async_mock_service
+
+    coordinator, _, _ = group_setup
+    stop_calls = async_mock_service(hass, "cover", "stop_cover")
+
+    await coordinator.async_stop()
+    await hass.async_block_till_done()
+
+    assert [call.data["entity_id"] for call in stop_calls] == [
+        BLIND_ENTITY,
+        AWNING_ENTITY,
+        GENERIC_ENTITY,
+    ]

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -64,6 +64,7 @@ async def test_sensor_platform_builds_group_sensors(hass, group_entry) -> None:
         "group_01_group_position",
         "group_01_group_state",
         "group_01_group_active_scene",
+        "group_01_group_climate_mode",
         "group_01_group_who_won",
     }
 
@@ -225,3 +226,244 @@ async def test_who_won_sensor_reads_member_winners(hass, group_entry) -> None:
         "cover.awning1": "weather_override",
         "cover.tilt1": "group_lock",
     }
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — climate rollup sensor, group cover entity, exposure toggles
+# ---------------------------------------------------------------------------
+
+
+async def test_group_climate_sensor_states(hass, group_entry) -> None:
+    """Agree → the mode; disagree → mixed; none reporting → None."""
+    coordinator = group_entry.runtime_data
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    climate = entities["group_01_group_climate_mode"]
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "summer_mode", "cover.b": "summer_mode"}
+    )
+    assert climate.native_value == "summer_mode"
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "summer_mode", "cover.b": "winter_mode"}
+    )
+    assert climate.native_value == "mixed"
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": None, "cover.b": None}
+    )
+    assert climate.native_value is None
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "winter_mode", "cover.b": None}
+    )
+    assert climate.native_value == "winter_mode"
+    assert climate.extra_state_attributes["member_climate_modes"] == {
+        "cover.a": "winter_mode",
+        "cover.b": None,
+    }
+
+
+async def test_sensor_platform_includes_climate_by_default(hass, group_entry) -> None:
+    entities = {e.unique_id for e in await _added_entities(sensor, hass, group_entry)}
+    assert "group_01_group_climate_mode" in entities
+
+
+async def test_sensor_toggles_gate_creation(hass) -> None:
+    """Disabled exposure toggles suppress the matching sensors."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+        CONF_GROUP_ENABLE_POSITION_SENSOR,
+        CONF_GROUP_ENABLE_STATE_SENSOR,
+        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: ["cover.g1"],
+            CONF_GROUP_ENABLE_POSITION_SENSOR: False,
+            CONF_GROUP_ENABLE_STATE_SENSOR: False,
+            CONF_GROUP_ENABLE_CLIMATE_SENSOR: False,
+            CONF_GROUP_ENABLE_WHO_WON_SENSOR: False,
+        },
+        entry_id="group_05",
+        title="G",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = GroupCoordinator(hass, entry)
+
+    entities = {e.unique_id for e in await _added_entities(sensor, hass, entry)}
+
+    # Only the always-on active-scene sensor remains.
+    assert entities == {"group_05_group_active_scene"}
+
+
+async def test_cover_platform_builds_group_cover_only_when_enabled(hass) -> None:
+    from custom_components.adaptive_cover_pro import cover
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+    )
+
+    # Default: off — no group cover entity.
+    entry_off = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: ["cover.g1"]},
+        entry_id="group_06",
+        title="G",
+    )
+    entry_off.add_to_hass(hass)
+    entry_off.runtime_data = GroupCoordinator(hass, entry_off)
+    assert await _added_entities(cover, hass, entry_off) == []
+
+    entry_on = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G2", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: ["cover.g1"],
+            CONF_GROUP_ENABLE_COVER_ENTITY: True,
+        },
+        entry_id="group_07",
+        title="G2",
+    )
+    entry_on.add_to_hass(hass)
+    entry_on.runtime_data = GroupCoordinator(hass, entry_on)
+    entities = await _added_entities(cover, hass, entry_on)
+    assert [e.unique_id for e in entities] == ["group_07_group_cover"]
+
+
+async def test_group_cover_reads_aggregates_and_commands(hass, group_entry) -> None:
+    from custom_components.adaptive_cover_pro.group_entities import AdaptiveGroupCover
+
+    coordinator = group_entry.runtime_data
+    group_cover = AdaptiveGroupCover("group_01", hass, group_entry, coordinator)
+    coordinator.async_set_updated_data(
+        GroupAggregates(
+            position=0, state=GroupState.CLOSED, member_positions={"cover.g1": 0}
+        )
+    )
+
+    assert group_cover.current_cover_position == 0
+    assert group_cover.is_closed is True
+
+    coordinator.async_set_position = AsyncMock()
+    coordinator.async_stop = AsyncMock()
+    await group_cover.async_set_cover_position(position=70)
+    coordinator.async_set_position.assert_awaited_once_with(70)
+    await group_cover.async_open_cover()
+    coordinator.async_set_position.assert_awaited_with(100)
+    await group_cover.async_close_cover()
+    coordinator.async_set_position.assert_awaited_with(0)
+    await group_cover.async_stop_cover()
+    coordinator.async_stop.assert_awaited_once()
+
+
+async def test_group_cover_tilt_only_when_all_members_tilt(hass) -> None:
+    """Tilt features appear only when every member (ACP + generic) tilts."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES
+    from custom_components.adaptive_cover_pro.group_entities import AdaptiveGroupCover
+
+    # Mixed group: blind member (no tilt axis) → no tilt features.
+    blind_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "b", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: ["cover.b1"]},
+        entry_id="m_blind",
+        title="b",
+    )
+    blind_entry.add_to_hass(hass)
+    blind_entry.runtime_data = MagicMock()
+    mixed = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["m_blind"], CONF_MEMBER_COVERS: []},
+        entry_id="group_08",
+        title="G",
+    )
+    mixed.add_to_hass(hass)
+    mixed_cover = AdaptiveGroupCover(
+        "group_08", hass, mixed, GroupCoordinator(hass, mixed)
+    )
+    assert not mixed_cover.supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+    # All-venetian group + tilt-capable generic → tilt exposed.
+    ven_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "v", CONF_SENSOR_TYPE: CoverType.VENETIAN},
+        options={CONF_ENTITIES: ["cover.v1"]},
+        entry_id="m_ven",
+        title="v",
+    )
+    ven_entry.add_to_hass(hass)
+    ven_entry.runtime_data = MagicMock()
+    hass.states.async_set(
+        "cover.gt1",
+        "open",
+        {"supported_features": int(CoverEntityFeature.SET_TILT_POSITION)},
+    )
+    tilty = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G2", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["m_ven"], CONF_MEMBER_COVERS: ["cover.gt1"]},
+        entry_id="group_09",
+        title="G2",
+    )
+    tilty.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, tilty)
+    tilt_cover = AdaptiveGroupCover("group_09", hass, tilty, coordinator)
+    assert tilt_cover.supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+    coordinator.async_set_tilt = AsyncMock()
+    await tilt_cover.async_set_cover_tilt_position(tilt_position=40)
+    coordinator.async_set_tilt.assert_awaited_once_with(40)
+
+
+async def test_group_cover_edge_cases(hass) -> None:
+    """Empty roster → no tilt; unknown aggregates → is_closed None; generic
+    cover without tilt bit → no tilt; removed member id skipped.
+    """
+    from homeassistant.components.cover import CoverEntityFeature
+
+    from custom_components.adaptive_cover_pro.group_entities import AdaptiveGroupCover
+
+    empty = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "E", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["gone_member"],
+            CONF_MEMBER_COVERS: ["cover.no_tilt"],
+        },
+        entry_id="group_20",
+        title="E",
+    )
+    empty.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, empty)
+    hass.states.async_set("cover.no_tilt", "open", {"supported_features": 0})
+    group_cover = AdaptiveGroupCover("group_20", hass, empty, coordinator)
+
+    # gone_member is skipped; cover.no_tilt lacks the tilt bit → no tilt.
+    assert not group_cover.supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+    coordinator.async_set_updated_data(
+        GroupAggregates(position=None, state=GroupState.UNKNOWN, member_positions={})
+    )
+    assert group_cover.is_closed is None
+
+    # A group with no members at all is not tiltable.
+    bare = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "B", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+        entry_id="group_21",
+        title="B",
+    )
+    bare.add_to_hass(hass)
+    assert GroupCoordinator(hass, bare).all_members_tilt() is False

--- a/tests/test_init_group.py
+++ b/tests/test_init_group.py
@@ -40,12 +40,13 @@ def _group_entry(entry_id: str) -> MockConfigEntry:
 
 
 def test_group_platforms_contents() -> None:
-    """The group forwards exactly its own platform set — no cover/number/binary."""
+    """The group forwards exactly its own platform set — no number/binary."""
     assert [
         Platform.SENSOR,
         Platform.SWITCH,
         Platform.BUTTON,
         Platform.SELECT,
+        Platform.COVER,
     ] == GROUP_PLATFORMS
 
 

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -76,9 +76,11 @@ from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
 from custom_components.adaptive_cover_pro.number import AdaptiveCoverMyPositionNumber
 from custom_components.adaptive_cover_pro.const import GroupScene
 from custom_components.adaptive_cover_pro.group_entities import (
+    AdaptiveGroupCover,
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
     GroupClearOverridesButton,
+    GroupClimateSensor,
     GroupLockSwitch,
     GroupPositionSensor,
     GroupSceneButton,
@@ -318,6 +320,19 @@ ENTITY_FACTORIES: dict[type, object] = {
         _make_config_entry(),
         _make_coordinator(),
         "group_who_won",
+    ),
+    GroupClimateSensor: lambda: GroupClimateSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_climate_mode",
+    ),
+    AdaptiveGroupCover: lambda: AdaptiveGroupCover(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
     ),
 }
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
+    GroupClimateSensor,
     GroupLockSwitch,
     GroupPositionSensor,
     GroupStateSensor,
@@ -82,6 +83,7 @@ _GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
         GroupPositionSensor,
         GroupStateSensor,
         GroupActiveSceneSensor,
+        GroupClimateSensor,
         GroupWhoWonSensor,
     )
 )


### PR DESCRIPTION
## Summary
Phase 3 of #790, stacked on #802 (which stacks on #797): aggregation and exposure polish.

- **Group Climate Mode sensor** — read-only rollup of member climate modes: the mode when all reporting members agree, `mixed` when they disagree, unknown when none report. The summer/winter/intermediate mapping moved into a shared `climate_mode_from_diagnostics` helper used by both the member Climate Status sensor and this rollup, so the vocabulary is single-sourced. The group still shares no climate *inputs* — that remains Building Profile territory.
- **Opt-in aggregate cover entity** (default **off**): position/open/close commands are user semantics, riding each ACP member's own user-position path exactly like the per-cover proxy (manual-override engagement and floor clamps apply) and the adopt-mode command service for generic covers, with the configured stagger; stop is immediate per member. **Tilt features appear only when every member tilts** — ACP members via their policy's declared axes, generic covers via the HA `supported_features` bit — and fan out on the dedicated tilt path (#684-safe).
- **Shared fan-out** — scene activation and the group cover's commands now use one staggered fan-out loop (roster + opt-out + stagger live exactly once).
- **Exposure toggles** — five booleans on a new Exposed Entities options page: the aggregate cover (off) and the four aggregate sensors (on). Active-scene sensor, scene controls, and bulk switches stay always-on. `Platform.COVER` joined `GROUP_PLATFORMS` with load/unload symmetry.
- **Summary + translations** — the group summary notes the aggregate cover when enabled; EN strings synced to DE/FR (all parity locks green).

Phase 4 (group services, area auto-membership, diagnostics rollup) remains open on the issue.

## Testing
- ✅ 5,600 tests passing (17 new; `group_coordinator.py` and `group_entities.py` at 100% coverage)

## Related Issues
Refs #790

https://claude.ai/code/session_01D2VimyDNsSA3TZUWy76ZLH