### PR TITLE
feat: cover-group services, diagnostics, area membership — Phase 4 (#790)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,7 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_GROUP_AREA,
     CONF_GROUP_ENABLE_CLIMATE_SENSOR,
     CONF_GROUP_ENABLE_COVER_ENTITY,
     CONF_GROUP_ENABLE_POSITION_SENSOR,
@@ -398,6 +399,10 @@ def _group_membership_schema_dict(hass, *, exclude_entry_id: str | None = None) 
         vol.Optional(CONF_MEMBER_COVERS, default=[]): selector.EntitySelector(
             selector.EntitySelectorConfig(domain="cover", multiple=True)
         ),
+        # LIVE area membership source (issue #790, Phase 4): the effective
+        # rosters are the lists above ∪ the area's covers, tracking registry
+        # changes — not a one-shot copy.
+        vol.Optional(CONF_GROUP_AREA): selector.AreaSelector(),
     }
 
 
@@ -1600,6 +1605,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "group.cover_entity": (
         "Aggregate cover entity exposed — dragging it commands every member"
     ),
+    "group.area": ("Membership tracks area '{area}' — covers there join automatically"),
     "warnings.group_empty": (
         "⚠️ This group has no members — it will not command anything."
     ),
@@ -1706,6 +1712,9 @@ def _build_group_summary(
         lines.append(L["group.stagger"].format(stagger=stagger))
     if config.get(CONF_GROUP_ENABLE_COVER_ENTITY, DEFAULT_GROUP_ENABLE_COVER_ENTITY):
         lines.append(L["group.cover_entity"])
+    area_id = config.get(CONF_GROUP_AREA)
+    if area_id:
+        lines.append(L["group.area"].format(area=area_id))
     return "\n".join(lines)
 
 
@@ -3408,6 +3417,8 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 "name": user_input["name"],
                 **_sanitize_group_membership(self.hass, user_input),
             }
+            if user_input.get(CONF_GROUP_AREA):
+                self.config[CONF_GROUP_AREA] = user_input[CONF_GROUP_AREA]
             self.type_blind = CoverType.GROUP
             return await self.async_step_update()
         return self.async_show_form(
@@ -4596,6 +4607,10 @@ class OptionsFlowHandler(OptionsFlow):
                 own_entry_id=self._config_entry.entry_id,
             )
             self.options.update(sanitized)
+            if user_input.get(CONF_GROUP_AREA):
+                self.options[CONF_GROUP_AREA] = user_input[CONF_GROUP_AREA]
+            else:
+                self.options.pop(CONF_GROUP_AREA, None)
             # A removed member's opt-out entry is stale — prune it in the
             # same save so the arbitration step never lists ghosts.
             opt_out = self.options.get(CONF_GROUP_MEMBER_OPT_OUT)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -104,6 +104,12 @@ CONF_SYNC_SELECT_ALL = "select_all_targets"
 CONF_MEMBER_ENTRIES = "member_entries"  # ACP member config-entry ids
 CONF_MEMBER_COVERS = "member_covers"  # generic cover entity_ids
 
+# Optional area-based membership source (issue #790, Phase 4). LIVE, not a
+# one-shot seed: the effective rosters are the static lists ∪ the area's
+# resolved members (ACP entries with a controlled cover in the area; free
+# ``cover.*`` entities in the area), re-resolved on registry changes.
+CONF_GROUP_AREA = "group_area"
+
 # Per-member scene opt-out, stored on the GROUP entry keyed by member
 # entry_id so a member removal prunes cleanly: {member_id: [scene, ...]}.
 # The sentinel OPT_OUT_ALL_SCENES ("*") opts a member out of every scene.

--- a/custom_components/adaptive_cover_pro/diagnostics/__init__.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/__init__.py
@@ -39,6 +39,58 @@ def _sanitize(obj):
     return obj
 
 
+async def _group_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict | None:
+    """Build the cover-group rollup, or None for non-group entries."""
+    from custom_components.adaptive_cover_pro.const import (  # noqa: PLC0415
+        CONF_GROUP_MEMBER_OPT_OUT,
+        CONF_GROUP_STAGGER_DELAY,
+        CONF_MEMBER_COVERS,
+        CONF_SENSOR_TYPE,
+        DEFAULT_GROUP_STAGGER_DELAY,
+    )
+    from custom_components.adaptive_cover_pro.cover_types import (  # noqa: PLC0415
+        get_policy,
+    )
+
+    try:
+        if not get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+            return None
+    except ValueError:
+        return None
+    coordinator = getattr(config_entry, "runtime_data", None)
+    if coordinator is None:
+        return {"status": "unavailable", "reason": "group coordinator not loaded"}
+    if coordinator.data is None:
+        # No aggregates yet (fresh load) — a group refresh reads states only,
+        # never commands covers, so this is side-effect free.
+        await coordinator.async_refresh()
+    aggregates = coordinator.data
+    return {
+        "active_scene": coordinator.active_scene,
+        "group_locked": coordinator.group_locked,
+        "aggregates": {
+            "position": aggregates.position if aggregates else None,
+            "state": aggregates.state if aggregates else None,
+            "member_positions": aggregates.member_positions if aggregates else {},
+        },
+        "member_winners": coordinator.member_winners(),
+        "member_climate_modes": coordinator.member_climate_modes(),
+        "rosters": {
+            "member_entries": [
+                {"entry_id": entry.entry_id, "title": entry.title}
+                for entry, _ in coordinator.resolved_members()
+            ],
+            "member_covers": list(config_entry.options.get(CONF_MEMBER_COVERS, [])),
+        },
+        "opt_out": config_entry.options.get(CONF_GROUP_MEMBER_OPT_OUT, {}),
+        "stagger_delay": config_entry.options.get(
+            CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY
+        ),
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ):
@@ -46,6 +98,26 @@ async def async_get_config_entry_diagnostics(
     from custom_components.adaptive_cover_pro.const import (
         DIAG_CACHE_KEY,
     )  # noqa: PLC0415
+
+    # Cover-group entries carry a GroupCoordinator whose ``data`` is the
+    # aggregates dataclass, not a diagnostics payload — the cover path below
+    # would crash on it. Groups get a rollup of per-member SUMMARIES (winner,
+    # position, climate mode) plus the group's own scene/lock/roster state;
+    # full member traces stay on the member entries (issue #790 §4).
+    group_rollup = await _group_diagnostics(hass, config_entry)
+    if group_rollup is not None:
+        return {
+            "title": "Adaptive Cover Pro Configuration",
+            "type": "config_entry",
+            "identifier": config_entry.entry_id,
+            "config_entry_state": config_entry.state.value,
+            "config_entry_version": config_entry.version,
+            "config_entry_minor_version": config_entry.minor_version,
+            "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+            "config_data": dict(config_entry.data),
+            "config_options": dict(config_entry.options),
+            "group": _sanitize(group_rollup),
+        }
 
     # The coordinator lives on entry.runtime_data (the registry every platform
     # reads). Virtual Building-Profile entries have no coordinator, so this is

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -33,13 +33,17 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER, Platform
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_ENTITIES,
+    CONF_GROUP_AREA,
     CONF_GROUP_MEMBER_OPT_OUT,
     CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
@@ -100,6 +104,8 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         self.active_scene: GroupScene | None = None
         self.group_locked: bool = False
         self._unsub_state: CALLBACK_TYPE | None = None
+        self._unsub_registry: list[CALLBACK_TYPE] = []
+        self._roster_snapshot: tuple[tuple[str, ...], tuple[str, ...]] | None = None
         self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
         self._grace_mgr = GracePeriodManager(_LOGGER)
         self._cmd_svc = CoverCommandService(
@@ -111,6 +117,85 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
     # ---- Roster resolution ------------------------------------------------ #
 
+    def _entity_area_id(self, entity_id: str) -> str | None:
+        """Return the entity's area — its own, or inherited from its device."""
+        reg_entry = er.async_get(self.hass).async_get(entity_id)
+        if reg_entry is None:
+            return None
+        if reg_entry.area_id:
+            return reg_entry.area_id
+        if reg_entry.device_id:
+            device = dr.async_get(self.hass).async_get(reg_entry.device_id)
+            if device is not None:
+                return device.area_id
+        return None
+
+    def _cover_entities_in_area(self, area_id: str) -> list[str]:
+        """Every ``cover.`` entity in the area (own or device-inherited)."""
+        ent_reg = er.async_get(self.hass)
+        return [
+            reg_entry.entity_id
+            for reg_entry in ent_reg.entities.values()
+            if reg_entry.domain == Platform.COVER
+            and self._entity_area_id(reg_entry.entity_id) == area_id
+        ]
+
+    def member_entry_ids(self) -> list[str]:
+        """Effective ACP member entry ids: static roster ∪ area members.
+
+        An ACP entry belongs to the area when any of its controlled covers is
+        in it (its own registry area or its device's). Order: static first,
+        area additions after, deduped, self-excluded. With no area set this
+        is exactly the stored roster — static groups are unchanged.
+        """
+        ids = list(
+            dict.fromkeys(
+                entry_id
+                for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, [])
+                if entry_id != self.entry.entry_id
+            )
+        )
+        area_id = self.entry.options.get(CONF_GROUP_AREA)
+        if area_id:
+            from .profile_link import _cover_entries  # noqa: PLC0415
+
+            for entry in _cover_entries(self.hass):
+                if entry.entry_id in ids:
+                    continue
+                if any(
+                    self._entity_area_id(entity_id) == area_id
+                    for entity_id in entry.options.get(CONF_ENTITIES, [])
+                ):
+                    ids.append(entry.entry_id)
+        return ids
+
+    def generic_cover_ids(self) -> list[str]:
+        """Effective generic cover ids: static roster ∪ free area covers.
+
+        A cover controlled by ANY ACP entry is excluded (orchestration wins
+        over adoption), as are ACP's own entities (the proxy covers). Order:
+        static first, area additions after, deduped.
+        """
+        ids = list(dict.fromkeys(self.entry.options.get(CONF_MEMBER_COVERS, [])))
+        area_id = self.entry.options.get(CONF_GROUP_AREA)
+        if area_id:
+            from .profile_link import _cover_entries  # noqa: PLC0415
+
+            owned = {
+                entity_id
+                for entry in _cover_entries(self.hass)
+                for entity_id in entry.options.get(CONF_ENTITIES, [])
+            }
+            ent_reg = er.async_get(self.hass)
+            for entity_id in self._cover_entities_in_area(area_id):
+                if entity_id in ids or entity_id in owned:
+                    continue
+                reg_entry = ent_reg.async_get(entity_id)
+                if reg_entry is not None and reg_entry.platform == DOMAIN:
+                    continue
+                ids.append(entity_id)
+        return ids
+
     def resolved_members(self) -> list[tuple[ConfigEntry, object]]:
         """ACP members whose entry exists and whose coordinator is loaded.
 
@@ -120,7 +205,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         absence is non-membership for this cycle.
         """
         members: list[tuple[ConfigEntry, object]] = []
-        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+        for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
@@ -138,12 +223,12 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     def member_cover_entities(self) -> list[str]:
         """All member cover entity_ids: ACP members' covers, then generic."""
         entities: list[str] = []
-        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+        for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
             entities.extend(entry.options.get(CONF_ENTITIES, []))
-        entities.extend(self.entry.options.get(CONF_MEMBER_COVERS, []))
+        entities.extend(self.generic_cover_ids())
         return entities
 
     # ---- Fan-out operations ------------------------------------------------ #
@@ -188,7 +273,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             await self._stagger_gap(commands)
             commands += 1
             await member_action(entry, coordinator)
-        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+        for entity_id in self.generic_cover_ids():
             await self._stagger_gap(commands)
             commands += 1
             await generic_action(entity_id)
@@ -339,8 +424,8 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
         from .cover_types.base import AXIS_NAME_TILT
 
-        member_ids = self.entry.options.get(CONF_MEMBER_ENTRIES, [])
-        generic = self.entry.options.get(CONF_MEMBER_COVERS, [])
+        member_ids = self.member_entry_ids()
+        generic = self.generic_cover_ids()
         if not member_ids and not generic:
             return False
         for entry_id in member_ids:
@@ -412,12 +497,50 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     # ---- Aggregates --------------------------------------------------------- #
 
     async def _async_setup(self) -> None:
-        """Subscribe to member cover state changes to keep aggregates live."""
+        """Subscribe to member-state and (with an area) registry changes.
+
+        The registry subscriptions keep area membership live: covers moved
+        into or out of the area re-resolve the rosters.
+        """
         entities = self.member_cover_entities()
         if entities:
             self._unsub_state = async_track_state_change_event(
                 self.hass, entities, self._handle_member_state_change
             )
+        if self.entry.options.get(CONF_GROUP_AREA):
+            self._roster_snapshot = self._current_roster_snapshot()
+            self._unsub_registry = [
+                self.hass.bus.async_listen(
+                    er.EVENT_ENTITY_REGISTRY_UPDATED, self._handle_registry_change
+                ),
+                self.hass.bus.async_listen(
+                    ar.EVENT_AREA_REGISTRY_UPDATED, self._handle_registry_change
+                ),
+            ]
+
+    def _current_roster_snapshot(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        """Return a comparable snapshot of the effective rosters."""
+        return (tuple(self.member_entry_ids()), tuple(self.generic_cover_ids()))
+
+    @callback
+    def _handle_registry_change(self, _event: Event) -> None:
+        """Reload the group when a registry change alters area membership.
+
+        The changed-guard makes registry chatter free: only an actual roster
+        difference triggers the (single) reload, which rebuilds listeners and
+        per-member entities consistently.
+        """
+        current = self._current_roster_snapshot()
+        if current == self._roster_snapshot:
+            return
+        self._roster_snapshot = current
+        _LOGGER.debug(
+            "Group %s: area membership changed — reloading entry",
+            self.entry.entry_id,
+        )
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self.entry.entry_id)
+        )
 
     @callback
     def _handle_member_state_change(self, _event: Event) -> None:
@@ -437,13 +560,16 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         if self._unsub_state is not None:
             self._unsub_state()
             self._unsub_state = None
+        for unsub in self._unsub_registry:
+            unsub()
+        self._unsub_registry = []
         self._cmd_svc.stop()
         await super().async_shutdown()
 
     async def _async_update_data(self) -> GroupAggregates:
         """Recompute the group position/state aggregates from member covers."""
         member_positions: dict[str, int | None] = {}
-        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+        for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
@@ -452,7 +578,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
                 member_positions[entity_id] = policy.read_axis_value(
                     self.hass, entity_id, caps=None
                 )
-        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+        for entity_id in self.generic_cover_ids():
             member_positions[entity_id] = self._adopt_policy.read_axis_value(
                 self.hass, entity_id, caps=None
             )

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1249,3 +1249,116 @@ get_diagnostics:
       selector:
         config_entry:
           integration: adaptive_cover_pro
+
+group_activate_scene:
+  name: "Group: activate scene"
+  description: >-
+    Activates a scene on the targeted cover groups. Scenes ride each member's
+    pipeline (weather safety and member safety still win). Pass "auto" to
+    release the group's scene claim so members return to their own automation.
+    With no target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+  fields:
+    scene:
+      name: Scene
+      description: The scene to activate, or "auto" to release the claim.
+      required: true
+      selector:
+        select:
+          options:
+            - "auto"
+            - "all_open"
+            - "all_closed"
+            - "privacy"
+
+group_set_position:
+  name: "Group: set position"
+  description: >-
+    Moves every member of the targeted cover groups to the given position as a
+    user command (member manual-override engagement and floor clamps apply,
+    like dragging the group cover). With no target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+  fields:
+    position:
+      name: Position
+      description: >-
+        Position (0-100%) to move member covers to. 0% = closed (blinds
+        lowered / awning retracted), 100% = open (blinds raised / awning
+        extended).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    tilt:
+      name: Tilt
+      description: Optional slat tilt (0-100%) fanned out on the tilt axis.
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+
+group_lock:
+  name: "Group: lock"
+  description: >-
+    Freezes every member of the targeted cover groups in place at safety
+    priority. A member's own safety trigger still wins ties. With no target,
+    locks all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+
+group_unlock:
+  name: "Group: unlock"
+  description: >-
+    Releases the group lock on the targeted cover groups. An active scene is
+    re-applied; otherwise members return to their own automation. With no
+    target, unlocks all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+
+group_clear_overrides:
+  name: "Group: clear member overrides"
+  description: >-
+    Clears manual overrides on every ACP member of the targeted cover groups
+    and resends each member's pipeline position. With no target, acts on all
+    cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+
+group_set_automation:
+  name: "Group: set automation"
+  description: >-
+    Bulk-enables or disables sun-tracking automation on every ACP member of
+    the targeted cover groups. With no target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+  fields:
+    enabled:
+      name: Enabled
+      description: True to enable member automation, false to disable it.
+      required: true
+      selector:
+        boolean:

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from ..const import DOMAIN
 from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagnostics
+from .group_service import GROUP_SERVICE_NAMES, register_group_services
 from .engage_manual_override_service import (
     ENGAGE_MANUAL_OVERRIDE_SCHEMA,
     async_handle_engage_manual_override,
@@ -59,6 +60,27 @@ def loaded_coordinators(
     }
 
 
+def cover_coordinators(
+    hass: HomeAssistant,
+) -> dict[str, AdaptiveDataUpdateCoordinator]:
+    """``loaded_coordinators`` restricted to real cover coordinators.
+
+    Cover groups also live on ``runtime_data`` but expose none of the cover
+    coordinator's surface — a cover service that walked them would crash
+    (issue #790 Phase 4). The discriminator is the coordinator type itself
+    (not a re-fetched entry) so callers with partially-mocked ``hass`` still
+    resolve. Cover services resolve through this; group services use
+    ``group_service.group_coordinators``.
+    """
+    from ..group_coordinator import GroupCoordinator  # noqa: PLC0415
+
+    return {
+        entry_id: coordinator
+        for entry_id, coordinator in loaded_coordinators(hass).items()
+        if not isinstance(coordinator, GroupCoordinator)
+    }
+
+
 def _resolve_targets(
     hass: HomeAssistant,
     call: ServiceCall,
@@ -76,8 +98,9 @@ def _resolve_targets(
     - area_id targets        → expand device_ids via device registry, then device_id rule
 
     Unmanaged entity_ids (not owned by any ACP coordinator) are silently skipped.
+    Cover groups are excluded — group services have their own resolver.
     """
-    all_coordinators = loaded_coordinators(hass)
+    all_coordinators = cover_coordinators(hass)
 
     entity_ids: list[str] = cv.ensure_list(call.data.get("entity_id"))
     device_ids: list[str] = cv.ensure_list(call.data.get("device_id"))
@@ -244,6 +267,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         schema=ENGAGE_MANUAL_OVERRIDE_SCHEMA,
     )
 
+    register_group_services(hass)
     register_options_services(hass)
 
 
@@ -266,5 +290,7 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "set_tilt")
     hass.services.async_remove(DOMAIN, "stop")
     hass.services.async_remove(DOMAIN, "engage_manual_override")
+    for name in GROUP_SERVICE_NAMES:
+        hass.services.async_remove(DOMAIN, name)
     for name in OPTIONS_SERVICE_NAMES:
         hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/group_service.py
+++ b/custom_components/adaptive_cover_pro/services/group_service.py
@@ -1,0 +1,216 @@
+"""Cover-group domain services (issue #790, Phase 4).
+
+Six thin services over the ``GroupCoordinator``'s public methods so
+automations can drive groups: activate/release scenes, set a group
+position/tilt, lock/unlock, clear member overrides, and bulk-toggle
+automation. Target resolution mirrors the cover services' rules but is
+capability-split: these services act ONLY on group coordinators
+(``is_orchestrator``), never on cover coordinators — and vice versa.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from voluptuous.validators import Coerce, Range
+
+from ..const import DOMAIN, GROUP_SCENE_SELECT_AUTO, GroupScene
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+    from ..group_coordinator import GroupCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+GROUP_SERVICE_NAMES: tuple[str, ...] = (
+    "group_activate_scene",
+    "group_set_position",
+    "group_lock",
+    "group_unlock",
+    "group_clear_overrides",
+    "group_set_automation",
+)
+
+_SCENE_CHOICES: tuple[str, ...] = (
+    GROUP_SCENE_SELECT_AUTO,
+    *(str(scene) for scene in GroupScene),
+)
+
+# Plain schemas (NOT make_entity_service_schema): the target block is
+# optional — an untargeted call fans out to every loaded group, matching
+# integration_enable/disable. extra=ALLOW_EXTRA admits the target keys.
+GROUP_ACTIVATE_SCENE_SCHEMA = vol.Schema(
+    {vol.Required("scene"): vol.In(_SCENE_CHOICES)}, extra=vol.ALLOW_EXTRA
+)
+GROUP_SET_POSITION_SCHEMA = vol.Schema(
+    {
+        vol.Required("position"): vol.All(Coerce(int), Range(min=0, max=100)),
+        vol.Optional("tilt"): vol.All(Coerce(int), Range(min=0, max=100)),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+GROUP_SET_AUTOMATION_SCHEMA = vol.Schema(
+    {vol.Required("enabled"): bool}, extra=vol.ALLOW_EXTRA
+)
+GROUP_NO_FIELDS_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+
+
+def group_coordinators(hass: HomeAssistant) -> dict[str, GroupCoordinator]:
+    """Map entry_id → coordinator for every loaded cover-group entry.
+
+    Discriminates on the coordinator type (mirror of
+    ``services.cover_coordinators``) — the two service families split the
+    ``loaded_coordinators`` pool exactly in two.
+    """
+    from ..group_coordinator import GroupCoordinator  # noqa: PLC0415
+    from . import loaded_coordinators  # noqa: PLC0415
+
+    return {
+        entry_id: coordinator
+        for entry_id, coordinator in loaded_coordinators(hass).items()
+        if isinstance(coordinator, GroupCoordinator)
+    }
+
+
+def resolve_group_targets(
+    hass: HomeAssistant, call: ServiceCall
+) -> list[GroupCoordinator]:
+    """Resolve a group service call's target block to group coordinators.
+
+    Mirrors ``_resolve_targets``' rules on the group side: no target → every
+    loaded group; entity/device targets resolve through the registries to
+    their owning config entry. Non-group targets are silently skipped.
+    """
+    groups = group_coordinators(hass)
+
+    entity_ids: list[str] = cv.ensure_list(call.data.get("entity_id"))
+    device_ids: list[str] = cv.ensure_list(call.data.get("device_id"))
+    area_ids: list[str] = cv.ensure_list(call.data.get("area_id"))
+
+    if not entity_ids and not device_ids and not area_ids:
+        return list(groups.values())
+
+    if area_ids:
+        dev_reg = dr.async_get(hass)
+        for area_id in area_ids:
+            device_ids.extend(
+                device.id
+                for device in dev_reg.devices.values()
+                if device.area_id == area_id
+            )
+
+    resolved: dict[str, GroupCoordinator] = {}
+    if device_ids:
+        dev_reg = dr.async_get(hass)
+        for device_id in device_ids:
+            device = dev_reg.async_get(device_id)
+            if device is None:
+                continue
+            for entry_id in device.config_entries:
+                if entry_id in groups:
+                    resolved[entry_id] = groups[entry_id]
+
+    ent_reg = er.async_get(hass)
+    for entity_id in entity_ids:
+        reg_entry = ent_reg.async_get(entity_id)
+        if reg_entry is not None and reg_entry.config_entry_id in groups:
+            resolved[reg_entry.config_entry_id] = groups[reg_entry.config_entry_id]
+        else:
+            _LOGGER.debug(
+                "group_service: entity %s is not owned by any cover group — skipping",
+                entity_id,
+            )
+
+    if not resolved:
+        _LOGGER.warning(
+            "group_service: target %s/%s/%s resolved to no cover groups — nothing done",
+            entity_ids,
+            device_ids,
+            area_ids,
+        )
+    return list(resolved.values())
+
+
+async def async_handle_group_activate_scene(call: ServiceCall) -> None:
+    """Activate a scene on the targeted groups — or release it via 'auto'."""
+    scene_value: str = call.data["scene"]
+    for group in resolve_group_targets(call.hass, call):
+        if scene_value == GROUP_SCENE_SELECT_AUTO:
+            await group.async_clear_scene()
+        else:
+            await group.async_activate_scene(GroupScene(scene_value))
+
+
+async def async_handle_group_set_position(call: ServiceCall) -> None:
+    """Fan a user position (and optional tilt) out through the group."""
+    position: int = call.data["position"]
+    tilt: int | None = call.data.get("tilt")
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_position(position)
+        if tilt is not None:
+            await group.async_set_tilt(tilt)
+
+
+async def async_handle_group_lock(call: ServiceCall) -> None:
+    """Push the group lock on the targeted groups."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_lock(True)
+
+
+async def async_handle_group_unlock(call: ServiceCall) -> None:
+    """Release the group lock on the targeted groups."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_lock(False)
+
+
+async def async_handle_group_clear_overrides(call: ServiceCall) -> None:
+    """Clear member manual overrides on the targeted groups."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_clear_overrides()
+
+
+async def async_handle_group_set_automation(call: ServiceCall) -> None:
+    """Bulk-toggle member automation on the targeted groups."""
+    enabled: bool = call.data["enabled"]
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_automation(enabled)
+
+
+def register_group_services(hass: HomeAssistant) -> None:
+    """Register the six group services (called from async_setup_services)."""
+    hass.services.async_register(
+        DOMAIN,
+        "group_activate_scene",
+        async_handle_group_activate_scene,
+        schema=GROUP_ACTIVATE_SCENE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "group_set_position",
+        async_handle_group_set_position,
+        schema=GROUP_SET_POSITION_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, "group_lock", async_handle_group_lock, schema=GROUP_NO_FIELDS_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, "group_unlock", async_handle_group_unlock, schema=GROUP_NO_FIELDS_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "group_clear_overrides",
+        async_handle_group_clear_overrides,
+        schema=GROUP_NO_FIELDS_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "group_set_automation",
+        async_handle_group_set_automation,
+        schema=GROUP_SET_AUTOMATION_SCHEMA,
+    )

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -257,6 +257,7 @@
     "scene_priority": "Beschattungsgruppen-Szenen gelten mit Priorität {scene_priority} (über manuelle Übersteuerung, unter Wetterschutz)",
     "lock": "🔒 Gruppensperre mit Priorität {lock_priority} — friert Mitglieder an Ort und Stelle ein; die eigene Sicherheit eines Mitglieds gewinnt immer noch Gleichstände",
     "stagger": "Mitglieder mit {stagger}s Abstand befohlen",
-    "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied"
+    "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied",
+    "area": "Mitgliedschaft verfolgt Bereich „{area}\" – Beschattungen dort treten automatisch bei"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -257,6 +257,7 @@
     "scene_priority": "Group scenes apply at priority {scene_priority} (above manual override, below weather safety)",
     "lock": "🔒 Group lock at priority {lock_priority} — freezes members in place; a member's own safety still wins ties",
     "stagger": "Members commanded {stagger}s apart",
-    "cover_entity": "Aggregate cover entity exposed — dragging it commands every member"
+    "cover_entity": "Aggregate cover entity exposed — dragging it commands every member",
+    "area": "Membership tracks area '{area}' — covers there join automatically"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -257,6 +257,7 @@
     "scene_priority": "Les scènes de groupe s'appliquent à la priorité {scene_priority} (au-dessus de la dérogation manuelle, en dessous de la sécurité météo)",
     "lock": "🔒 Verrouillage de groupe à la priorité {lock_priority} — gèle les membres en place ; la sécurité propre d'un membre gagne toujours en cas d'égalité",
     "stagger": "Membres commandés à {stagger}s d'intervalle",
-    "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre"
+    "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre",
+    "area": "L'adhésion suit la zone « {area} » — les stores de cette zone rejoignent automatiquement"
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -766,11 +766,13 @@
         "data": {
           "name": "Gruppenname",
           "member_entries": "Adaptive-Cover-Pro-Mitglieder",
-          "member_covers": "Allgemeine Beschattungsentitäten"
+          "member_covers": "Allgemeine Beschattungsentitäten",
+          "group_area": "Bereich (Live-Mitgliedschaft)"
         },
         "data_description": {
           "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
-          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen.",
+          "group_area": "Optional: Beschattungen in diesem Bereich treten der Gruppe automatisch bei und die Mitgliedschaft folgt Registrierungsänderungen. Kombiniert mit den obigen Listen."
         }
       }
     },
@@ -1602,11 +1604,13 @@
         "description": "Bearbeiten Sie, welche Beschattungen diese Gruppe steuert. [Weitere Informationen]({learn_more})",
         "data": {
           "member_entries": "Adaptive-Cover-Pro-Mitglieder",
-          "member_covers": "Allgemeine Beschattungsentitäten"
+          "member_covers": "Allgemeine Beschattungsentitäten",
+          "group_area": "Bereich (Live-Mitgliedschaft)"
         },
         "data_description": {
           "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
-          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen.",
+          "group_area": "Optional: Beschattungen in diesem Bereich treten der Gruppe automatisch bei und die Mitgliedschaft folgt Registrierungsänderungen. Kombiniert mit den obigen Listen."
         }
       },
       "group_arbitration": {
@@ -2506,6 +2510,52 @@
         "filename": {
           "name": "Dateipfad",
           "description": "Pfad zur JSON-Datei zum Importieren. Relative Pfade werden relativ zum Konfigurationsverzeichnis von Home Assistant aufgelöst und müssen darin bleiben. Standard: adaptive_cover_pro_export.json."
+        }
+      }
+    },
+    "group_activate_scene": {
+      "name": "Gruppe: Szene aktivieren",
+      "description": "Aktiviert eine Szene auf den angestrebten Beschattungsgruppen oder gibt die Anspruch mit „auto\" frei. Szenen nutzen die Pipeline jedes Mitglieds — Wetter und Mitgliedersicherheit gewinnen immer noch.",
+      "fields": {
+        "scene": {
+          "name": "Szene",
+          "description": "Die Szene zum Aktivieren oder „auto\" um den Anspruch freizugeben."
+        }
+      }
+    },
+    "group_set_position": {
+      "name": "Gruppe: Position festlegen",
+      "description": "Verschiebt alle Mitglieder der angestrebten Beschattungsgruppen zur angegebenen Position als Benutzerbefehl (manuelle Übersteuerung und Positionsgrenzen gelten).",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position (0–100%), zu der Mitgliedsbeschattungen verschoben werden. 0% = geschlossen (Jalousien heruntergefahren / Markise eingefahren), 100% = offen (Jalousien hochgefahren / Markise ausgefahren)."
+        },
+        "tilt": {
+          "name": "Neigung",
+          "description": "Optionale Lamellenneigung (0–100%), ausgebreitet auf der Neigungsachse."
+        }
+      }
+    },
+    "group_lock": {
+      "name": "Gruppe: Sperre",
+      "description": "Friert alle Mitglieder der angestrebten Beschattungsgruppen mit Sicherheitspriorität an Ort und Stelle ein. Das eigene Sicherheitsauslöser eines Mitglieds gewinnt bei Gleichstand."
+    },
+    "group_unlock": {
+      "name": "Gruppe: Entsperren",
+      "description": "Gibt die Gruppensperrung frei. Eine aktive Szene wird erneut angewendet; andernfalls kehren Mitglieder zu ihrer eigenen Automatisierung zurück."
+    },
+    "group_clear_overrides": {
+      "name": "Gruppe: Manuelle Übersteuerungen von Mitgliedern löschen",
+      "description": "Löscht manuelle Übersteuerungen auf jedem ACP-Mitglied der angestrebten Beschattungsgruppen und sendet die Pipeline-Position jedes Mitglieds erneut."
+    },
+    "group_set_automation": {
+      "name": "Gruppe: Automatisierung festlegen",
+      "description": "Aktiviert oder deaktiviert Sonnen-Tracking-Automatisierung in Massen auf jedem ACP-Mitglied der angestrebten Beschattungsgruppen.",
+      "fields": {
+        "enabled": {
+          "name": "Aktiviert",
+          "description": "true zum Aktivieren der Mitgliedersautomatisierung, false zum Deaktivieren."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -766,11 +766,13 @@
         "data": {
           "name": "Group name",
           "member_entries": "Adaptive Cover Pro members",
-          "member_covers": "Generic cover entities"
+          "member_covers": "Generic cover entities",
+          "group_area": "Area (live membership)"
         },
         "data_description": {
           "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
-          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped.",
+          "group_area": "Optional: covers in this area join the group automatically and membership tracks registry changes. Combined with the lists above."
         }
       }
     },
@@ -1602,11 +1604,13 @@
         "description": "Edit which covers this group commands. [Learn more]({learn_more})",
         "data": {
           "member_entries": "Adaptive Cover Pro members",
-          "member_covers": "Generic cover entities"
+          "member_covers": "Generic cover entities",
+          "group_area": "Area (live membership)"
         },
         "data_description": {
           "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
-          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped.",
+          "group_area": "Optional: covers in this area join the group automatically and membership tracks registry changes. Combined with the lists above."
         }
       },
       "group_arbitration": {
@@ -2506,6 +2510,52 @@
         "duration": {
           "name": "Duration",
           "description": "Extend an active override by this much, or engage fresh for this long if none is active. Ignored when an end time is set."
+        }
+      }
+    },
+    "group_activate_scene": {
+      "name": "Group: activate scene",
+      "description": "Activates a scene on the targeted cover groups, or releases the claim with 'auto'. Scenes ride each member's pipeline — weather and member safety still win.",
+      "fields": {
+        "scene": {
+          "name": "Scene",
+          "description": "The scene to activate, or 'auto' to release the claim."
+        }
+      }
+    },
+    "group_set_position": {
+      "name": "Group: set position",
+      "description": "Moves every member of the targeted cover groups to the given position as a user command (manual-override engagement and floor clamps apply).",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position (0-100%) to move member covers to. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended)."
+        },
+        "tilt": {
+          "name": "Tilt",
+          "description": "Optional slat tilt (0-100%) fanned out on the tilt axis."
+        }
+      }
+    },
+    "group_lock": {
+      "name": "Group: lock",
+      "description": "Freezes every member of the targeted cover groups in place at safety priority. A member's own safety trigger still wins ties."
+    },
+    "group_unlock": {
+      "name": "Group: unlock",
+      "description": "Releases the group lock. An active scene is re-applied; otherwise members return to their own automation."
+    },
+    "group_clear_overrides": {
+      "name": "Group: clear member overrides",
+      "description": "Clears manual overrides on every ACP member of the targeted cover groups and resends each member's pipeline position."
+    },
+    "group_set_automation": {
+      "name": "Group: set automation",
+      "description": "Bulk-enables or disables sun-tracking automation on every ACP member of the targeted cover groups.",
+      "fields": {
+        "enabled": {
+          "name": "Enabled",
+          "description": "True to enable member automation, false to disable it."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -766,11 +766,13 @@
         "data": {
           "name": "Nom du groupe",
           "member_entries": "Membres Adaptive Cover Pro",
-          "member_covers": "Entités de store génériques"
+          "member_covers": "Entités de store génériques",
+          "group_area": "Zone (adhésion dynamique)"
         },
         "data_description": {
           "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
-          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré.",
+          "group_area": "Optionnel : les stores de cette zone rejoignent le groupe automatiquement et l'adhésion suit les modifications du registre. Combiné avec les listes ci-dessus."
         }
       }
     },
@@ -1602,11 +1604,13 @@
         "description": "Modifiez quels stores ce groupe commande. [En savoir plus]({learn_more})",
         "data": {
           "member_entries": "Membres Adaptive Cover Pro",
-          "member_covers": "Entités de store génériques"
+          "member_covers": "Entités de store génériques",
+          "group_area": "Zone (adhésion dynamique)"
         },
         "data_description": {
           "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
-          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré.",
+          "group_area": "Optionnel : les stores de cette zone rejoignent le groupe automatiquement et l'adhésion suit les modifications du registre. Combiné avec les listes ci-dessus."
         }
       },
       "group_arbitration": {
@@ -2506,6 +2510,52 @@
         "filename": {
           "name": "Chemin du fichier",
           "description": "Chemin du fichier JSON à importer. Les chemins relatifs se résolvent par rapport au répertoire de configuration Home Assistant et doivent rester à l'intérieur. Par défaut adaptive_cover_pro_export.json."
+        }
+      }
+    },
+    "group_activate_scene": {
+      "name": "Groupe : activer la scène",
+      "description": "Active une scène sur les groupes de stores ciblés, ou libère la prise avec « auto ». Les scènes suivent le pipeline de chaque membre — la météo et la sécurité du membre gagnent toujours.",
+      "fields": {
+        "scene": {
+          "name": "Scène",
+          "description": "La scène à activer, ou « auto » pour libérer la prise."
+        }
+      }
+    },
+    "group_set_position": {
+      "name": "Groupe : définir la position",
+      "description": "Déplace chaque membre des groupes de stores ciblés à la position donnée en tant que commande utilisateur (l'engagement de la dérogation manuelle et les pinces limites s'appliquent).",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position (0-100%) pour déplacer les stores membres. 0% = fermé (stores baissés / store enroulé rétracté), 100% = ouvert (stores levés / store enroulé déroulé)."
+        },
+        "tilt": {
+          "name": "Inclinaison",
+          "description": "Inclinaison facultative des lames (0-100%) éventée sur l'axe d'inclinaison."
+        }
+      }
+    },
+    "group_lock": {
+      "name": "Groupe : verrouiller",
+      "description": "Gèle chaque membre des groupes de stores ciblés en place à la priorité de sécurité. Le propre déclencheur de sécurité d'un membre gagne toujours les égalités."
+    },
+    "group_unlock": {
+      "name": "Groupe : déverrouiller",
+      "description": "Libère le verrouillage du groupe. Une scène active est réappliquée ; sinon, les membres reviennent à leur propre automatisation."
+    },
+    "group_clear_overrides": {
+      "name": "Groupe : effacer les dérogations des membres",
+      "description": "Efface les dérogations manuelles sur chaque membre ACP des groupes de stores ciblés et renvoie la position du pipeline de chaque membre."
+    },
+    "group_set_automation": {
+      "name": "Groupe : définir l'automatisation",
+      "description": "Active ou désactive en masse l'automatisation du suivi du soleil sur chaque membre ACP des groupes de stores ciblés.",
+      "fields": {
+        "enabled": {
+          "name": "Activé",
+          "description": "True pour activer l'automatisation des membres, false pour la désactiver."
         }
       }
     }

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -57,6 +57,7 @@ UNIVERSAL_KEYS: set[str] = {
     "services.set_custom_position.fields.slot.name",  # "Slot" — HA service parameter, language-universal
     "services.set_custom_position.fields.position.name",  # "Position" — HA service parameter, language-universal
     "services.set_position.fields.position.name",  # "Position" — HA service parameter, language-universal
+    "services.group_set_position.fields.position.name",  # "Position" — same in DE/FR
     "entity.select.group_scene_select.state.auto",  # "Auto" — same in DE/FR
 }
 

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3275,3 +3275,20 @@ def test_summary_group_shows_cover_entity_line_when_enabled():
         {**base, CONF_GROUP_ENABLE_COVER_ENTITY: True}, CoverType.GROUP
     )
     assert "Aggregate cover entity" in with_cover
+
+
+def test_summary_group_shows_area_line_when_configured():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_AREA,
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    base = {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []}
+    without = _build_config_summary(base, CoverType.GROUP)
+    assert "area" not in without.lower()
+
+    with_area = _build_config_summary(
+        {**base, CONF_GROUP_AREA: "living_room"}, CoverType.GROUP
+    )
+    assert "living_room" in with_area

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -98,10 +98,13 @@ async def test_create_group_combined_form_and_entry(hass: HomeAssistant) -> None
     )
     assert result["type"] == "form"
     assert result["step_id"] == "create_group"
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
     assert _schema_keys(result["data_schema"]) == {
         "name",
         CONF_MEMBER_ENTRIES,
         CONF_MEMBER_COVERS,
+        CONF_GROUP_AREA,
     }
     # The ACP-member selector lists existing cover entries.
     values = {
@@ -367,3 +370,51 @@ async def test_group_entities_step_saves_toggles(hass: HomeAssistant) -> None:
     assert result["type"] == "create_entry"
     assert result["data"][CONF_GROUP_ENABLE_COVER_ENTITY] is True
     assert result["data"][CONF_GROUP_ENABLE_STATE_SENSOR] is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — area membership picker
+# ---------------------------------------------------------------------------
+
+
+async def test_create_group_offers_and_stores_area(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "create_group"}
+    )
+    assert CONF_GROUP_AREA in _schema_keys(result["data_schema"])
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Area Group", CONF_GROUP_AREA: "living_room"},
+    )
+    assert result["type"] == "create_entry"
+    assert result["result"].options[CONF_GROUP_AREA] == "living_room"
+
+
+async def test_membership_step_updates_and_clears_area(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    group = _add_group(hass, "group_1")
+    hass.config_entries.async_update_entry(
+        group, options={**group.options, CONF_GROUP_AREA: "old_area"}
+    )
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+    result = await flow.async_step_group_membership(
+        {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: [], CONF_GROUP_AREA: "new_area"}
+    )
+    assert result["data"][CONF_GROUP_AREA] == "new_area"
+
+    # Clearing the picker removes the area source entirely.
+    flow2 = OptionsFlowHandler(hass.config_entries.async_get_entry("group_1"))
+    flow2.hass = hass
+    result = await flow2.async_step_group_membership(
+        {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []}
+    )
+    assert CONF_GROUP_AREA not in result["data"]

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -575,3 +575,186 @@ async def test_stop_calls_stop_service_per_member_cover(hass, group_setup) -> No
         AWNING_ENTITY,
         GENERIC_ENTITY,
     ]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — area membership
+# ---------------------------------------------------------------------------
+
+
+def _registry_cover(hass, unique_id, object_id, *, area_id=None, platform="test"):
+    from homeassistant.helpers import entity_registry as er
+
+    reg = er.async_get(hass)
+    entry = reg.async_get_or_create(
+        "cover", platform, unique_id, suggested_object_id=object_id
+    )
+    if area_id is not None:
+        reg.async_update_entity(entry.entity_id, area_id=area_id)
+    return entry.entity_id
+
+
+@pytest.fixture
+def area_setup(hass):
+    """Build an area with one ACP-controlled cover and one free generic
+    cover, plus an out-of-area ACP member for the static roster.
+    """
+    from homeassistant.helpers import area_registry as ar
+
+    area = ar.async_get(hass).async_get_or_create("Living Room")
+
+    acp_cover = _registry_cover(hass, "acp1", "acp_blind", area_id=area.id)
+    generic_cover = _registry_cover(hass, "gen1", "free_cover", area_id=area.id)
+    _registry_cover(hass, "elsewhere", "other_room_cover", area_id=None)
+    # An ACP-owned proxy entity in the area must never be adopted.
+    proxy_cover = _registry_cover(
+        hass, "proxy1", "acp_proxy", area_id=area.id, platform=DOMAIN
+    )
+
+    area_member = _member_entry(hass, "area_member", CoverType.BLIND, [acp_cover])
+    area_member.runtime_data = _mock_member_coordinator()
+    static_member = _member_entry(
+        hass, "static_member", CoverType.AWNING, ["cover.static1"]
+    )
+    static_member.runtime_data = _mock_member_coordinator()
+
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["static_member"],
+            CONF_MEMBER_COVERS: ["cover.static_generic"],
+            CONF_GROUP_AREA: area.id,
+        },
+        entry_id="group_area",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    return coordinator, acp_cover, generic_cover, proxy_cover
+
+
+async def test_area_membership_resolves_acp_entries(area_setup) -> None:
+    """Static roster ∪ ACP entries with a controlled cover in the area."""
+    coordinator, _, _, _ = area_setup
+    assert coordinator.member_entry_ids() == ["static_member", "area_member"]
+
+
+async def test_area_membership_resolves_generic_covers(area_setup) -> None:
+    """Area cover entities join the generic roster — except covers already
+    controlled by an ACP entry (orchestrate wins) and ACP's own proxy
+    entities.
+    """
+    coordinator, acp_cover, generic_cover, proxy_cover = area_setup
+
+    generic = coordinator.generic_cover_ids()
+
+    assert generic == ["cover.static_generic", generic_cover]
+    assert acp_cover not in generic
+    assert proxy_cover not in generic
+
+
+async def test_area_membership_feeds_resolved_members(area_setup) -> None:
+    coordinator, _, _, _ = area_setup
+    resolved_ids = [entry.entry_id for entry, _ in coordinator.resolved_members()]
+    assert resolved_ids == ["static_member", "area_member"]
+
+
+async def test_area_membership_via_device_area(hass) -> None:
+    """An entity with no own area inherits its device's area."""
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    area = ar.async_get(hass).async_get_or_create("Bedroom")
+    helper_entry = MockConfigEntry(domain="test", entry_id="helper")
+    helper_entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id="helper",
+        identifiers={("test", "dev1")},
+    )
+    dr.async_get(hass).async_update_device(device.id, area_id=area.id)
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "cover",
+        "test",
+        "dev_cover",
+        suggested_object_id="bed_cover",
+        device_id=device.id,
+    )
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: [],
+            CONF_GROUP_AREA: area.id,
+        },
+        entry_id="group_dev_area",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+
+    assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
+
+
+async def test_no_area_behaves_statically(group_setup) -> None:
+    """Without an area, the effective rosters equal the stored rosters."""
+    coordinator, _, _ = group_setup
+    assert coordinator.member_entry_ids() == ["member_blind", "member_awning"]
+    assert coordinator.generic_cover_ids() == [GENERIC_ENTITY]
+
+
+async def test_registry_change_reloads_when_roster_changes(hass, area_setup) -> None:
+    """Moving a cover into the area changes the roster → one entry reload."""
+    from unittest.mock import patch
+
+    coordinator, _, _, _ = area_setup
+    await coordinator._async_setup()
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock:
+        # A registry event with no roster impact must not reload.
+        hass.bus.async_fire(
+            "entity_registry_updated",
+            {"action": "update", "entity_id": "cover.other_room_cover"},
+        )
+        await hass.async_block_till_done()
+        reload_mock.assert_not_awaited()
+
+        # A new free cover appears in the area → roster changes → reload once.
+        from homeassistant.helpers import area_registry as ar
+
+        area = ar.async_get(hass).async_get_or_create("Living Room")
+        _registry_cover(hass, "newgen", "new_free_cover", area_id=area.id)
+        await hass.async_block_till_done()
+        reload_mock.assert_awaited_once_with("group_area")
+
+    await coordinator.async_shutdown()
+
+
+async def test_registry_listener_absent_without_area(hass, group_setup) -> None:
+    """Static-only groups subscribe to no registry events."""
+    from unittest.mock import patch
+
+    coordinator, _, _ = group_setup
+    await coordinator._async_setup()
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock:
+        hass.bus.async_fire(
+            "entity_registry_updated", {"action": "create", "entity_id": "cover.x"}
+        )
+        await hass.async_block_till_done()
+        reload_mock.assert_not_awaited()
+
+    await coordinator.async_shutdown()
+
+
+async def test_entity_area_id_unregistered_entity(group_setup) -> None:
+    """An entity absent from the registry has no area."""
+    coordinator, _, _ = group_setup
+    assert coordinator._entity_area_id("cover.not_registered") is None

--- a/tests/test_group_diagnostics.py
+++ b/tests/test_group_diagnostics.py
@@ -1,0 +1,110 @@
+"""Config-entry diagnostics for cover-group entries (issue #790, Phase 4).
+
+Pins the crash fix: the generic cover path read ``coordinator.data.diagnostics``,
+which a ``GroupCoordinator``'s ``GroupAggregates`` does not have — downloading
+diagnostics for a group entry raised AttributeError. The group branch returns
+a rollup of per-member SUMMARIES (winner + position + climate), never full
+member traces (§4 size mitigation).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_GROUP_STAGGER_DELAY,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+
+pytestmark = pytest.mark.integration
+
+
+async def test_group_entry_diagnostics_rollup(hass) -> None:
+    """A group entry download returns the rollup instead of crashing."""
+    member = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "blind", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: ["cover.blind1"]},
+        entry_id="member_blind",
+        title="Living Blind",
+    )
+    member.add_to_hass(hass)
+    member_coord = MagicMock()
+    member_coord.pipeline_winner_name = "group_scene"
+    member_coord.data.diagnostics = {
+        "climate_conditions": {"is_summer": True, "is_winter": False}
+    }
+    member.runtime_data = member_coord
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_blind"],
+            CONF_MEMBER_COVERS: ["cover.generic1"],
+            CONF_GROUP_STAGGER_DELAY: 1.5,
+        },
+        entry_id="group_01",
+        title="Living Room",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    group_entry.runtime_data = coordinator
+    hass.states.async_set("cover.blind1", "open", {"current_position": 40})
+    hass.states.async_set("cover.generic1", "open", {"current_position": 60})
+    await coordinator.async_refresh()
+    coordinator.active_scene = GroupScene.PRIVACY
+    coordinator.group_locked = True
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, group_entry)
+
+    group = diagnostics["group"]
+    assert group["active_scene"] == "privacy"
+    assert group["group_locked"] is True
+    assert group["aggregates"]["position"] == 50
+    assert group["aggregates"]["member_positions"] == {
+        "cover.blind1": 40,
+        "cover.generic1": 60,
+    }
+    assert group["member_winners"] == {"cover.blind1": "group_scene"}
+    assert group["member_climate_modes"] == {"cover.blind1": "summer_mode"}
+    assert group["stagger_delay"] == 1.5
+    rosters = group["rosters"]
+    assert rosters["member_entries"] == [
+        {"entry_id": "member_blind", "title": "Living Blind"}
+    ]
+    assert rosters["member_covers"] == ["cover.generic1"]
+    # Envelope fields stay consistent with cover diagnostics.
+    assert diagnostics["type"] == "config_entry"
+    assert diagnostics["identifier"] == "group_01"
+
+
+async def test_group_entry_diagnostics_before_first_refresh(hass) -> None:
+    """No aggregates yet → still a valid rollup, no crash, no member commands."""
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+        entry_id="group_02",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    group_entry.runtime_data = GroupCoordinator(hass, group_entry)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, group_entry)
+
+    assert diagnostics["group"]["active_scene"] is None
+    assert diagnostics["group"]["aggregates"]["position"] is None

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -1,0 +1,268 @@
+"""Cover-group domain services (issue #790, Phase 4).
+
+Six thin services over the GroupCoordinator's public methods, plus the
+resolution split: cover services must never touch a group coordinator
+(pre-existing crash: integration_disable with no target dereferenced
+cover-only attributes on the group), and group services must never touch a
+cover coordinator.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.services import (
+    _resolve_targets,
+    async_setup_services,
+)
+from custom_components.adaptive_cover_pro.services.group_service import (
+    resolve_group_targets,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _add_loaded_entry(hass, entry_id, sensor_type, coordinator, options=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: sensor_type},
+        options=options or {},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    entry.mock_state(
+        hass,
+        __import__(
+            "homeassistant.config_entries", fromlist=["ConfigEntryState"]
+        ).ConfigEntryState.LOADED,
+    )
+    entry.runtime_data = coordinator
+    return entry
+
+
+def _mock_group_coordinator() -> MagicMock:
+    coord = MagicMock(spec=GroupCoordinator)
+    for name in (
+        "async_activate_scene",
+        "async_clear_scene",
+        "async_set_position",
+        "async_set_tilt",
+        "async_set_lock",
+        "async_clear_overrides",
+        "async_set_automation",
+    ):
+        setattr(coord, name, AsyncMock())
+    return coord
+
+
+@pytest.fixture
+def loaded_pair(hass):
+    """One loaded cover entry and one loaded group entry."""
+    cover_coord = MagicMock()
+    cover_coord.entities = ["cover.blind1"]
+    _add_loaded_entry(
+        hass,
+        "cover_entry",
+        CoverType.BLIND,
+        cover_coord,
+        options={CONF_ENTITIES: ["cover.blind1"]},
+    )
+    group_coord = _mock_group_coordinator()
+    _add_loaded_entry(
+        hass,
+        "group_entry",
+        CoverType.GROUP,
+        group_coord,
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+    )
+    return cover_coord, group_coord
+
+
+async def test_cover_target_resolution_excludes_groups(hass, loaded_pair) -> None:
+    """Cover services must never fan out to a group coordinator.
+
+    Pins the pre-existing crash: an untargeted integration_disable walked
+    every loaded coordinator and dereferenced cover-only attributes.
+    """
+    cover_coord, group_coord = loaded_pair
+
+    call = MagicMock()
+    call.data = {}
+    targets = _resolve_targets(hass, call)
+
+    assert cover_coord in targets
+    assert group_coord not in targets
+
+
+async def test_group_target_resolution_no_target_all_groups(hass, loaded_pair) -> None:
+    cover_coord, group_coord = loaded_pair
+
+    call = MagicMock()
+    call.data = {}
+    groups = resolve_group_targets(hass, call)
+
+    assert groups == [group_coord]
+
+
+async def test_group_target_resolution_by_entity(hass, loaded_pair) -> None:
+    """An entity registered to the group entry resolves to that group only."""
+    from homeassistant.helpers import entity_registry as er
+
+    _, group_coord = loaded_pair
+    other_group = _mock_group_coordinator()
+    _add_loaded_entry(hass, "group_other", CoverType.GROUP, other_group)
+
+    reg = er.async_get(hass)
+    reg.async_get_or_create(
+        "select",
+        DOMAIN,
+        "group_entry_group_scene_select",
+        suggested_object_id="living_scene",
+        config_entry=hass.config_entries.async_get_entry("group_entry"),
+    )
+
+    call = MagicMock()
+    call.data = {"entity_id": ["select.living_scene"]}
+    groups = resolve_group_targets(hass, call)
+
+    assert groups == [group_coord]
+
+
+async def test_group_services_drive_coordinator_methods(hass, loaded_pair) -> None:
+    _, group_coord = loaded_pair
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "group_activate_scene",
+        {"scene": str(GroupScene.PRIVACY)},
+        blocking=True,
+    )
+    group_coord.async_activate_scene.assert_awaited_once_with(GroupScene.PRIVACY)
+
+    await hass.services.async_call(
+        DOMAIN, "group_activate_scene", {"scene": "auto"}, blocking=True
+    )
+    group_coord.async_clear_scene.assert_awaited_once()
+
+    await hass.services.async_call(
+        DOMAIN, "group_set_position", {"position": 40, "tilt": 20}, blocking=True
+    )
+    group_coord.async_set_position.assert_awaited_once_with(40)
+    group_coord.async_set_tilt.assert_awaited_once_with(20)
+
+    await hass.services.async_call(DOMAIN, "group_lock", {}, blocking=True)
+    group_coord.async_set_lock.assert_awaited_once_with(True)
+    await hass.services.async_call(DOMAIN, "group_unlock", {}, blocking=True)
+    group_coord.async_set_lock.assert_awaited_with(False)
+
+    await hass.services.async_call(DOMAIN, "group_clear_overrides", {}, blocking=True)
+    group_coord.async_clear_overrides.assert_awaited_once()
+
+    await hass.services.async_call(
+        DOMAIN, "group_set_automation", {"enabled": False}, blocking=True
+    )
+    group_coord.async_set_automation.assert_awaited_once_with(False)
+
+
+async def test_group_set_position_without_tilt_skips_tilt(hass, loaded_pair) -> None:
+    _, group_coord = loaded_pair
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN, "group_set_position", {"position": 55}, blocking=True
+    )
+
+    group_coord.async_set_position.assert_awaited_once_with(55)
+    group_coord.async_set_tilt.assert_not_awaited()
+
+
+async def test_group_activate_scene_rejects_unknown_scene(hass, loaded_pair) -> None:
+    import voluptuous as vol
+
+    await async_setup_services(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN, "group_activate_scene", {"scene": "party"}, blocking=True
+        )
+
+
+async def test_group_target_resolution_by_device_and_area(hass, loaded_pair) -> None:
+    """Device and area targets resolve through the registries to the group."""
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+
+    _, group_coord = loaded_pair
+    area = ar.async_get(hass).async_get_or_create("Service Area")
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id="group_entry",
+        identifiers={(DOMAIN, "group_entry")},
+    )
+    dr.async_get(hass).async_update_device(device.id, area_id=area.id)
+
+    call = MagicMock()
+    call.data = {"device_id": [device.id]}
+    assert resolve_group_targets(hass, call) == [group_coord]
+
+    call = MagicMock()
+    call.data = {"area_id": [area.id]}
+    assert resolve_group_targets(hass, call) == [group_coord]
+
+
+async def test_group_target_resolution_skips_foreign_targets(hass, loaded_pair) -> None:
+    """A cover-entry entity and an unknown entity resolve to no groups."""
+    from homeassistant.helpers import entity_registry as er
+
+    er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "cover_entry_sensor",
+        suggested_object_id="blind_sensor",
+        config_entry=hass.config_entries.async_get_entry("cover_entry"),
+    )
+
+    call = MagicMock()
+    call.data = {"entity_id": ["sensor.blind_sensor", "cover.nonexistent"]}
+    assert resolve_group_targets(hass, call) == []
+
+
+async def test_group_diagnostics_unloaded_coordinator(hass) -> None:
+    """A group entry with no loaded coordinator reports unavailable, no crash."""
+    from custom_components.adaptive_cover_pro.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={},
+        entry_id="group_unloaded",
+        title="G",
+    )
+    entry.add_to_hass(hass)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["group"]["status"] == "unavailable"
+
+
+async def test_group_target_resolution_unknown_device(hass, loaded_pair) -> None:
+    """A vanished device id is skipped without error."""
+    call = MagicMock()
+    call.data = {"device_id": ["no_such_device"]}
+    assert resolve_group_targets(hass, call) == []


### PR DESCRIPTION
## Summary
Phase 4 of #790 — the final phase of the cover-group design, stacked on #803.

- **Six `group_*` domain services** — `group_activate_scene` (incl. `auto` to release the claim), `group_set_position` (optional tilt), `group_lock`/`group_unlock`, `group_clear_overrides`, `group_set_automation` — thin wrappers over the `GroupCoordinator`, with their own target resolver (no target → all groups; entity/device/area targets via the registries). Deviations from the issue's §6.8, deliberate: `group_reset_default` dropped (no clean per-member semantic exists) and per-service `members` subsets dropped (per-member exclusions already exist via opt-out).
- **Cover/group service split fixes a latent crash**: cover services now resolve through `cover_coordinators()` — previously an untargeted `integration_disable`/`emergency_stop` walked every loaded coordinator and dereferenced cover-only attributes on a group coordinator (AttributeError since Phase 1).
- **Group diagnostics rollup** — also a crash fix: downloading diagnostics for a group entry hit `GroupAggregates.diagnostics` (AttributeError). Groups now return active scene, lock state, aggregates, per-member winner/climate **summaries** (full traces stay on member entries, §4 size mitigation), rosters, opt-out, and stagger, in the standard envelope.
- **Live area membership** — optional `group_area`: effective rosters = static lists ∪ the area's covers (ACP entries whose controlled cover is in the area — own or device-inherited; free `cover.*` entities, excluding ACP-controlled covers and ACP proxy entities). Registry changes re-resolve and reload the entry only when the roster actually changed. This subsumes the issue's seed-from-area convenience with one live concept. Label-based membership deferred.
- Area picker on the create + membership pages, summary area line, `services.yaml` definitions, translations synced to DE/FR.

Of the issue's Phase 4 list, multi-group conflict resolution shipped in Phase 2 and the companion-card group view is a separate repo (§7.6) — with this PR the integration side of #790 is complete.

## Testing
- ✅ 5,623 tests passing (16 new; `group_service.py`, `group_coordinator.py`, and `diagnostics/__init__.py` at 100% coverage)

## Related Issues
Refs #790

https://claude.ai/code/session_01D2VimyDNsSA3TZUWy76ZLH