### PR TITLE
docs: state UTC handling of engage_manual_override end_time (#793)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -139,9 +139,13 @@ engage_manual_override:
     end_time:
       name: End time
       description: >-
-        Absolute time the override should end. Ignored (falls back to the
-        configured duration) if it is in the past or unparseable. Takes
-        precedence over duration.
+        Absolute time the override should end. A value with no UTC offset
+        (no trailing Z or +HH:MM) is treated as UTC, not your local time.
+        For local time, use an ISO string with an explicit offset (e.g.
+        2026-07-04T22:00:00+02:00) or a template like
+        {{ (now() + timedelta(hours=2)).isoformat() }}. Ignored (falls back
+        to the configured duration) if it is in the past or unparseable.
+        Takes precedence over duration.
       required: false
       selector:
         datetime:

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2354,7 +2354,7 @@
       "fields": {
         "end_time": {
           "name": "Endzeit",
-          "description": "Absolute Zeit, zu der die Übersteuerung enden soll. Wird ignoriert (Rückfall auf die konfigurierte Dauer), wenn sie in der Vergangenheit liegt oder nicht lesbar ist. Hat Vorrang vor der Dauer."
+          "description": "Absolute Zeit, zu der die Übersteuerung enden soll. Ein Wert ohne UTC-Offset (kein nachfolgendes Z oder +HH:MM) wird als UTC behandelt, nicht als Ihre Ortszeit. Für Ortszeit verwenden Sie einen ISO-String mit explizitem Offset (z. B. 2026-07-04T22:00:00+02:00) oder ein Template wie {{ (now() + timedelta(hours=2)).isoformat() }}. Wird ignoriert (Rückfall auf die konfigurierte Dauer), wenn sie in der Vergangenheit liegt oder nicht lesbar ist. Hat Vorrang vor der Dauer."
         },
         "duration": {
           "name": "Dauer",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -2354,7 +2354,7 @@
       "fields": {
         "end_time": {
           "name": "End time",
-          "description": "Absolute time the override should end. Ignored (falls back to the configured duration) if it is in the past or unparseable. Takes precedence over duration."
+          "description": "Absolute time the override should end. A value with no UTC offset (no trailing Z or +HH:MM) is treated as UTC, not your local time. For local time, use an ISO string with an explicit offset (e.g. 2026-07-04T22:00:00+02:00) or a template like {{ (now() + timedelta(hours=2)).isoformat() }}. Ignored (falls back to the configured duration) if it is in the past or unparseable. Takes precedence over duration."
         },
         "duration": {
           "name": "Duration",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2354,7 +2354,7 @@
       "fields": {
         "end_time": {
           "name": "Heure de fin",
-          "description": "Heure absolue à laquelle la dérogation doit se terminer. Ignorée (retour à la durée configurée) si elle est passée ou illisible. Prioritaire sur la durée."
+          "description": "Heure absolue à laquelle la dérogation doit se terminer. Une valeur sans décalage UTC (sans Z de fin ou +HH:MM) est traitée comme UTC, pas votre heure locale. Pour l'heure locale, utilisez une chaîne ISO avec un décalage explicite (par exemple 2026-07-04T22:00:00+02:00) ou un modèle comme {{ (now() + timedelta(hours=2)).isoformat() }}. Ignorée (retour à la durée configurée) si elle est passée ou illisible. Prioritaire sur la durée."
         },
         "duration": {
           "name": "Durée",

--- a/tests/services/test_engage_manual_override_service.py
+++ b/tests/services/test_engage_manual_override_service.py
@@ -55,6 +55,15 @@ async def test_iso_end_time_parsed_and_passed_through() -> None:
 
 
 @pytest.mark.asyncio
+async def test_offset_end_time_preserved_as_correct_absolute_instant() -> None:
+    """A non-UTC offset is preserved (not re-stamped), landing at the right instant."""
+    coord = await _run({"end_time": "2026-07-04T22:00:00+02:00"})
+    _, kwargs = coord.async_engage_manual_override.call_args
+    # 22:00 +02:00 == 20:00 UTC
+    assert kwargs["end_time"] == dt.datetime(2026, 7, 4, 20, 0, tzinfo=dt.UTC)
+
+
+@pytest.mark.asyncio
 async def test_naive_iso_end_time_normalized_to_utc() -> None:
     coord = await _run({"end_time": "2026-07-02T15:00:00"})
     _, kwargs = coord.async_engage_manual_override.call_args


### PR DESCRIPTION
## Summary
The end_time field of adaptive_cover_pro.engage_manual_override treats a value with no UTC offset as UTC, and the HA datetime picker submits naive values, so a non-UTC user gets a silently shifted expiry (reported by @Nipal33 on #793). I documented the UTC interpretation in the end_time field description (services.yaml + en/de/fr translations), showed how to pass local time (offset ISO string or a {{ (now() + timedelta(hours=2)).isoformat() }} template), and added a test pinning that a +02:00 offset string round-trips to the correct absolute instant. Detailed wiki coverage of the service (engage vs. extend semantics, timezone behavior, worked examples) was published separately: https://github.com/jrhubott/adaptive-cover-pro/wiki/Runtime-Configuration-Services#engage_manual_override

## Testing
- ✅ 78 tests passing (engage_manual_override service + manager, services.yaml docs, translations parity, summary i18n)

## Related Issues
Refs #793

https://claude.ai/code/session_01NmLNeFVV8iHVbU2WDndZwr