### PR TITLE
fix: hold cover on manual-override engage instead of sending default (#809)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -204,6 +204,17 @@ type AdaptiveConfigEntry = ConfigEntry[AdaptiveDataUpdateCoordinator]
 """Config entry whose ``runtime_data`` holds the coordinator instance."""
 
 
+# Skip-record label for a hold-mode dispatch, keyed by the winning control
+# method.  Motion timeout and manual override both hold the cover in place
+# (skip_command=True); the label distinguishes them in diagnostics so a manual
+# hold is not mislabeled as motion (issue #809).  Single source of truth — do
+# not fork a per-method guard block in ``_dispatch_to_cover``.
+_HOLD_SKIP_LABEL: dict[ControlMethod, str] = {
+    ControlMethod.MOTION: "motion_hold",
+    ControlMethod.MANUAL: "manual_override_hold",
+}
+
+
 class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     """Adaptive cover data update coordinator."""
 
@@ -1610,24 +1621,38 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     ) -> tuple[str, str] | None:
         """Send a position command or record a hold-mode skip.
 
-        When the active pipeline result has skip_command=True (hold_position
-        mode during motion timeout), no command is issued. A motion_hold skip
-        record is written instead so diagnostics show why the cover didn't move.
-        All other callers (forced transitions, override clears, window events)
-        bypass this helper and call apply_position directly so they are never
-        blocked by hold mode.
+        When the active pipeline result has skip_command=True (motion-timeout
+        hold_position mode, or a manual-override hold), no command is issued. A
+        hold skip record is written instead so diagnostics show why the cover
+        didn't move; the label reflects the winning control method (motion_hold
+        vs manual_override_hold — issue #809). All other callers (forced
+        transitions, override clears, window events) bypass this helper and call
+        apply_position directly so they are never blocked by hold mode.
         """
         if self._pipeline_result is not None and self._pipeline_result.skip_command:
+            result = self._pipeline_result
+            label = _HOLD_SKIP_LABEL.get(result.control_method, "hold")
+            # Motion holds carry the physical position in ``position`` and leave
+            # held_position None; manual holds keep ``position`` as the would-be
+            # shadow and put the physical position in held_position.  Prefer
+            # held_position when present so the recorded value is the true
+            # physical position for both (byte-identical to the old behaviour
+            # for motion, which has held_position None).
+            held = (
+                result.held_position
+                if result.held_position is not None
+                else result.position
+            )
             self._cmd_svc.record_skipped_action(
                 cover,
-                "motion_hold",
+                label,
                 state,
                 trigger=reason,
                 inverse_state=self._inverse_state,
                 extras={
-                    "held_position": self._pipeline_result.position,
+                    "held_position": held,
                     "would_be_position": state,
-                    "motion_timeout_mode": "hold_position",
+                    "hold_control_method": result.control_method.value,
                 },
             )
             return None

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
@@ -63,6 +63,13 @@ class ManualOverrideHandler(OverrideHandler):
             reason=reason,
             raw_calculated_position=compute_raw_calculated_position(snapshot),
             held_position=held_position,
+            # When the cover's physical position is known, genuinely hold there:
+            # ``position`` stays the would-be shadow for diagnostics, but
+            # skip_command suppresses the dispatch so we don't drive the cover to
+            # the default it merely shadows (issue #809).  When held_position is
+            # None (no feedback) fall through without holding — parity with
+            # motion_timeout's ``current_cover_position is not None`` guard.
+            skip_command=held_position is not None,
         )
 
     def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -153,9 +153,15 @@ class PipelineRegistry:
             if winner.held_position is not None
             else winner.position
         )
-        clamped_position = winner.position
-        if floor_info is not None and floor_pos > effective_winner_pos:
-            clamped_position = floor_pos
+        # A floor "raises" when it sits above where the cover will actually end
+        # up (its effective position).  Key on this — NOT on
+        # ``clamped_position != winner.position`` — so the raise still fires on
+        # the alignment edge where the floor equals the would-be ``position`` but
+        # exceeds the held one (a manual-override hold with position==floor but
+        # held below it must still be lifted; issue #809).
+        floor_raised = floor_info is not None and floor_pos > effective_winner_pos
+        clamped_position = floor_pos if floor_raised else winner.position
+        if floor_raised:
             trace.append(
                 DecisionStep(
                     handler="floor_clamp",
@@ -174,11 +180,7 @@ class PipelineRegistry:
         floor_sources = {info.source for info in active_floors}
         trace = _drop_trace_steps(trace, floor_sources)
         for info in active_floors:
-            if (
-                floor_info is not None
-                and info is floor_info
-                and floor_pos > effective_winner_pos
-            ):
+            if floor_raised and info is floor_info:
                 continue  # this floor *did* win — already emitted as floor_clamp
             trace.append(
                 DecisionStep(
@@ -249,11 +251,15 @@ class PipelineRegistry:
         # The coordinator annotates them via dataclasses.replace()
         # after evaluation so they never appear in the snapshot
         # that handlers can read.
-        if clamped_position != winner.position:
+        if floor_raised:
+            # A floor raise must reach the cover even when the winner is a hold
+            # (manual-override / motion): clear skip_command so the composed
+            # result is dispatched, not suppressed (issue #809 / #534).
             winner = dataclasses.replace(
                 winner,
                 position=clamped_position,
                 floor_clamp_applied=True,
+                skip_command=False,
             )
         # The dedicated tilt-axis overlay (issue #514) wins the tilt field over
         # the generic _MERGEABLE tilt fill — both only fire when the winner's

--- a/tests/test_issue_809_venetian_override_hold.py
+++ b/tests/test_issue_809_venetian_override_hold.py
@@ -1,0 +1,105 @@
+"""Issue #809 — venetian manual-override engage must not open a closed blind.
+
+The reporter's exact scenario: a venetian cover physically closed at 0 (blackout
+scene), a custom_position slot holding pos 0 / tilt 2, ``default_percentage=100``.
+When manual override engages, the pipeline used to dispatch the *would-be default*
+(100 → open_cover) while the log claimed it was "holding 0%".  The handler now
+emits ``skip_command=True`` so the composed result holds the cover, and the
+coordinator dispatch records a ``manual_override_hold`` skip instead of opening.
+
+This exercises the real chain: ManualOverrideHandler → PipelineRegistry →
+``_dispatch_to_cover``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.handlers import ManualOverrideHandler
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
+    DefaultHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+)
+
+from tests.test_pipeline.conftest import make_snapshot
+
+
+def _venetian_engage_snapshot():
+    """Build the reporter's engage snapshot: venetian at 0, slot 0/tilt 2, default 100."""
+    return make_snapshot(
+        cover_type="cover_venetian",
+        manual_override_active=True,
+        direct_sun_valid=False,
+        current_cover_position=0,
+        default_position=100,
+        custom_position_sensors=[
+            CustomPositionSensorState(
+                entity_ids=("binary_sensor.blackout",),
+                is_on=True,
+                position=0,
+                priority=78,
+                min_mode=False,
+                use_my=False,
+                tilt=2,
+                slot=2,
+                active_entity_ids=("binary_sensor.blackout",),
+            )
+        ],
+    )
+
+
+def _make_dispatch_coordinator(pipeline_result):
+    """Minimal coordinator with a pipeline result for _dispatch_to_cover."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._inverse_state = False
+    coord._pipeline_result = pipeline_result
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", None))
+    cmd_svc.record_skipped_action = MagicMock()
+    coord._cmd_svc = cmd_svc
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_override_engage_does_not_drive_venetian_open() -> None:
+    """Engaging manual override on a closed venetian holds — it must not open it."""
+    snap = _venetian_engage_snapshot()
+    registry = PipelineRegistry(
+        [
+            ManualOverrideHandler(),
+            CustomPositionHandler(slot=2, position=0, priority=78, tilt=2),
+            DefaultHandler(),
+        ]
+    )
+    result = registry.evaluate(snap)
+
+    # The manual-override handler wins and produces a genuine hold.
+    assert result.control_method is ControlMethod.MANUAL
+    assert result.skip_command is True
+    assert result.held_position == 0
+    # The resolved-target signature reflects the hold so dispatch suppresses it.
+    assert result.position == 100  # would-be shadow, never dispatched
+
+    # Dispatch the resolved target: it must NOT drive the cover open (state=100).
+    coord = _make_dispatch_coordinator(result)
+    ctx = MagicMock()
+    await coord._dispatch_to_cover("cover.bedroom_bedroom_cover", 100, "solar", ctx)
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    coord._cmd_svc.record_skipped_action.assert_called_once()
+    args, _ = coord._cmd_svc.record_skipped_action.call_args
+    assert args[1] == "manual_override_hold"

--- a/tests/test_manual_override_hold_skip.py
+++ b/tests/test_manual_override_hold_skip.py
@@ -1,0 +1,73 @@
+"""Coordinator dispatch holds and labels a manual-override hold (issue #809).
+
+Mirrors ``tests/test_motion_hold_skip.py`` but for a manual-override hold: when
+the pipeline result is a MANUAL hold (skip_command=True, position=would-be,
+held_position=physical), ``_dispatch_to_cover`` must suppress the command and
+record the skip with a ``manual_override_hold`` label — not ``motion_hold``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+
+def _make_coordinator_with_manual_hold(*, position: int = 100, held: int = 0):
+    """Build a minimal coordinator whose _pipeline_result is a MANUAL hold."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._inverse_state = False
+
+    coord._pipeline_result = PipelineResult(
+        position=position,
+        control_method=ControlMethod.MANUAL,
+        reason=f"manual override active — holding {held}% "
+        f"(default position would be {position}%)",
+        skip_command=True,
+        held_position=held,
+    )
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", None))
+    cmd_svc.record_skipped_action = MagicMock()
+    coord._cmd_svc = cmd_svc
+
+    return coord
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_records_manual_override_hold_and_skips_apply():
+    """A MANUAL hold does not move the cover and records manual_override_hold."""
+    coord = _make_coordinator_with_manual_hold(position=100, held=0)
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.bedroom", 100, "manual_override", ctx)
+
+    coord._cmd_svc.apply_position.assert_not_called()
+    coord._cmd_svc.record_skipped_action.assert_called_once()
+    args, kwargs = coord._cmd_svc.record_skipped_action.call_args
+    assert args[1] == "manual_override_hold"
+    extras = kwargs.get("extras", {})
+    assert extras["held_position"] == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dispatch_manual_override_hold_does_not_mislabel_as_motion():
+    """The manual-override hold must never be recorded as a motion_hold skip."""
+    coord = _make_coordinator_with_manual_hold(position=100, held=0)
+    ctx = MagicMock()
+
+    await coord._dispatch_to_cover("cover.bedroom", 100, "manual_override", ctx)
+
+    args, _ = coord._cmd_svc.record_skipped_action.call_args
+    assert args[1] != "motion_hold"

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -641,6 +641,9 @@ def test_floor_raises_manual_override_held_below_floor() -> None:
     assert winner_step.handler == "manual_override"
     assert result.position == 80
     assert result.floor_clamp_applied is True
+    # The floor raise must reach the cover: a manual-override hold sets
+    # skip_command=True, but the composed floor result clears it (#809/#534).
+    assert result.skip_command is False
     clamp_steps = [
         s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
     ]
@@ -682,9 +685,52 @@ def test_floor_above_held_position_is_inert_under_manual_override() -> None:
     assert winner_step.handler == "manual_override"
     # No clamp: the held physical position (85) is already above the floor (80).
     assert result.floor_clamp_applied is False
+    # The manual-override hold is inert-floor: it genuinely holds the cover, so
+    # skip_command stays set (no floor raise to clear it)  (#809).
+    assert result.skip_command is True
     assert not any(
         s.handler == "floor_clamp" and s.matched for s in result.decision_trace
     )
+
+
+def test_floor_equal_to_would_be_but_above_held_still_raises() -> None:
+    """Alignment edge: floor == would-be position but still above the held one.
+
+    Manual override holds the cover at 0 (physical) while its would-be shadow is
+    the default (100).  A min-mode floor at 100 equals the would-be position but
+    sits far above the held 0 — the floor must still fire (raise the cover to
+    100) and clear the hold, or the blind stays closed forever  (#809/#534).
+    """
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        manual_override_active=True,
+        current_cover_position=0,
+        default_position=100,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=100,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    handlers = [
+        _cp_handler(1, 100),
+        ManualOverrideHandler(),
+    ]
+    registry = _registry_with_custom(handlers)
+    result = registry.evaluate(snap)
+    winner_step = next(
+        s for s in result.decision_trace if s.matched and s.handler != "floor_clamp"
+    )
+    assert winner_step.handler == "manual_override"
+    assert result.position == 100
+    assert result.floor_clamp_applied is True
+    assert result.skip_command is False
 
 
 def test_floor_label_falls_back_to_entity_id_then_template() -> None:

--- a/tests/test_pipeline/test_manual_override_held_position.py
+++ b/tests/test_pipeline/test_manual_override_held_position.py
@@ -380,6 +380,65 @@ def test_handler_reason_string_outside_fov_held_none() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_handler_sets_skip_command_when_held_position_known_outside_fov() -> None:
+    """Override active, sun outside FOV, held position known → hold the cover.
+
+    The handler must emit skip_command=True so dispatch does not drive the cover
+    to the would-be default.  position stays the would-be shadow (100),
+    held_position carries the physical position (0)  (issue #809).
+    """
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=False,
+        current_cover_position=0,
+        default_position=100,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    assert result.skip_command is True
+    assert result.position == 100  # would-be shadow preserved
+    assert result.held_position == 0
+
+
+def test_handler_sets_skip_command_when_held_position_known_in_fov() -> None:
+    """Override active, sun in FOV, held position known → hold the cover.
+
+    skip_command=True; position is the solar would-be (20); held_position is the
+    physical position (50)  (issue #809).
+    """
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=True,
+        calculate_percentage_return=20.0,
+        current_cover_position=50,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    assert result.skip_command is True
+    assert result.position == 20  # solar would-be
+    assert result.held_position == 50
+
+
+def test_handler_no_skip_command_when_held_position_unknown() -> None:
+    """Override active but no physical position reported → do NOT hold.
+
+    With held_position unknown the handler cannot hold at a known position, so
+    skip_command stays False (parity with motion_timeout's guard)  (issue #809).
+    """
+    handler = ManualOverrideHandler()
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=False,
+        current_cover_position=None,
+    )
+    result = handler.evaluate(snap)
+    assert result is not None
+    assert result.skip_command is False
+    assert result.held_position is None
+
+
 def test_sensor_trace_attrs_include_held_position_for_manual_override() -> None:
     """The decision_trace sensor attribute trace includes held_position for manual_override."""
     step_with_held = DecisionStep(


### PR DESCRIPTION
## Summary
On the manual-override **engage** edge the override handler computed its would-be position (`default_percentage`, e.g. 100) and dispatched it, because it never set `skip_command` — so a blackout-closed venetian was driven fully open while the decision trace read "holding 0%". This mirrors motion-hold, which correctly sets `skip_command`.

The fix sets `skip_command` when the held position is known (position stays the would-be shadow per the #608 trace contract), derives the dispatch skip-label from the winning control method via a single mapping (no forked guard block), and clears the hold in the pipeline registry when a floor clamp legitimately raises above the held position (keeps #534's floor-raise green, including the floor==would-be alignment edge).

The reporter's secondary symptom — a several-minute delayed correction after clearing the override — is a consequence of the cover being wrongly opened; once it truly holds at 0 on engage, clearing the override finds it already at target, so there is nothing to gate.

## Testing
- ✅ Full suite: 5499 passing (0 failed)
- New: `tests/test_manual_override_hold_skip.py`, `tests/test_issue_809_venetian_override_hold.py`; extended handler-hold and floor-composition tests
- Regression guards green: #608 held-position contract, #534 floor clamp, #117 reset button, #756 venetian dispatch, motion-hold

## Related Issues
Refs #809