### PR TITLE
fix: allow max_position of 0 for close-only covers (#806)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -581,7 +581,14 @@ _POSITION_SPECS = _spec(
         ValidatorKind.RANGE,
         rng=const._RANGE_MAX_POSITION,
         default=100,
-        make_selector=_number(minimum=1, maximum=100, step=1, unit="%"),
+        # Selector bounds derive from the range so 0 ("always closed", #806) can't
+        # drift back out of sync with the validator.
+        make_selector=_number(
+            minimum=const._RANGE_MAX_POSITION[0],
+            maximum=const._RANGE_MAX_POSITION[1],
+            step=1,
+            unit="%",
+        ),
     ),
     FieldSpec(
         CONF_ENABLE_MIN_POSITION,

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -411,7 +411,7 @@ POSITION_SCHEMA = vol.Schema(
         ): selector.BooleanSelector(),
         vol.Optional(CONF_MAX_POSITION, default=100): selector.NumberSelector(
             selector.NumberSelectorConfig(
-                min=1,
+                min=0,
                 max=100,
                 step=1,
                 mode=selector.NumberSelectorMode.SLIDER,

--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -210,7 +210,11 @@ class CoverConfig:
                 CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET)
             )
             or 0,
-            max_pos=options.get(CONF_MAX_POSITION) or 100,
+            max_pos=(  # no `or` — 0 ("always closed", #806) must survive, not fall back to 100
+                options[CONF_MAX_POSITION]
+                if options.get(CONF_MAX_POSITION) is not None
+                else 100
+            ),
             min_pos=options.get(CONF_MIN_POSITION) or 0,
             max_pos_sun_only=options.get(CONF_ENABLE_MAX_POSITION, False),
             min_pos_sun_only=options.get(CONF_ENABLE_MIN_POSITION, False),

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -217,7 +217,7 @@ MAX_VENETIAN_TILT_SAFETY_MARGIN = 1.0
 # flags (some covers report 0=open instead of 0=closed), and the two named
 # fixed points POSITION_CLOSED / POSITION_OPEN used widely in calc code.
 
-CONF_MAX_POSITION = "max_position"  # upper clamp on commanded position (1-100)
+CONF_MAX_POSITION = "max_position"  # upper clamp on commanded position (0-100)
 CONF_MIN_POSITION = "min_position"  # lower clamp on commanded position (0-99)
 # Optional separate floor that applies only during sun tracking (0-99, optional).
 # When set, overrides CONF_MIN_POSITION for sun-tracking paths only.
@@ -1269,7 +1269,7 @@ _RANGE_BLIND_SPOT_ELEVATION = (0, 90)  # CONF_BLIND_SPOT_ELEVATION, degrees
 
 # Position limits & sunset.
 _RANGE_DEFAULT_HEIGHT = (0, 100)  # CONF_DEFAULT_HEIGHT, percent
-_RANGE_MAX_POSITION = (1, 100)  # CONF_MAX_POSITION, percent
+_RANGE_MAX_POSITION = (0, 100)  # CONF_MAX_POSITION, percent (0 = always closed, #806)
 _RANGE_MIN_POSITION = (0, 99)  # CONF_MIN_POSITION, percent
 _RANGE_SUNSET_POS = (0, 100)  # CONF_SUNSET_POS, percent
 _RANGE_END_OF_WINDOW_POS = (0, 100)  # CONF_END_OF_WINDOW_POS, percent

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -194,10 +194,10 @@ set_position_limits:
         boolean:
     max_position:
       name: Maximum position
-      description: "Maximum position the cover may move to (1–100%)."
+      description: "Maximum position the cover may move to (0–100%; 0 = always closed)."
       selector:
         number:
-          min: 1
+          min: 0
           max: 100
           step: 1
           mode: slider

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2148,7 +2148,7 @@
           "name": "Inverser Status"
         },
         "max_position": {
-          "description": "Maximale Position, zu der sich die Beschattung bewegen kann (1–100%).",
+          "description": "Maximale Position, zu der sich die Beschattung bewegen kann (0–100%; 0 = immer geschlossen).",
           "name": "Maximale Position"
         },
         "min_position": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1822,7 +1822,7 @@
         },
         "max_position": {
           "name": "Maximum position",
-          "description": "Maximum position the cover may move to (1–100%)."
+          "description": "Maximum position the cover may move to (0–100%; 0 = always closed)."
         },
         "enable_max_position": {
           "name": "Enable max position only during tracking",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2148,7 +2148,7 @@
           "name": "État inverse"
         },
         "max_position": {
-          "description": "Position maximale vers laquelle la protection peut se déplacer (1–100%).",
+          "description": "Position maximale vers laquelle la protection peut se déplacer (0–100%; 0 = toujours fermé).",
           "name": "Position maximale"
         },
         "min_position": {

--- a/tests/test_max_position_zero.py
+++ b/tests/test_max_position_zero.py
@@ -1,0 +1,88 @@
+"""Issue #806: Maximum Position must accept 0.
+
+A roof-window impulse motor can only be fully open or fully closed, so the user
+needs ``max_position = 0`` ("always keep it closed") — a value the field's help
+text already advertises as in-range (0-100%). Four sites conspired to reject it:
+the shared range constant floored at 1, both rendered selectors floored at 1, and
+``CoverConfig.from_options`` coerced a stored 0 back to 100 via ``or 100``.
+
+These are the regression guards for all four fix points, plus a characterization
+test proving ``max_pos = 0`` is semantically valid downstream (forces closed).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro import config_fields as cf
+from custom_components.adaptive_cover_pro.config_flow import POSITION_SCHEMA
+from custom_components.adaptive_cover_pro.config_types import CoverConfig
+from custom_components.adaptive_cover_pro.const import CONF_MAX_POSITION, OPTION_RANGES
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.position_utils import PositionConverter
+from custom_components.adaptive_cover_pro.services.options_service import (
+    FIELD_VALIDATORS,
+)
+
+
+def _selector_min(schema, key) -> float:
+    """Return the ``min`` of the NumberSelector for ``key`` in *schema*."""
+    for marker, value in schema.schema.items():
+        if str(marker) == key:
+            return value.config["min"]
+    raise AssertionError(f"key {key!r} not found in schema")
+
+
+@pytest.mark.unit
+def test_option_ranges_max_position_allows_zero() -> None:
+    """The single-source range constant floors at 0, not 1 (drives the validator)."""
+    assert OPTION_RANGES[CONF_MAX_POSITION] == (0, 100)
+
+
+@pytest.mark.unit
+def test_field_validator_accepts_max_position_zero() -> None:
+    """The service/API validation path accepts 0 without raising."""
+    FIELD_VALIDATORS[CONF_MAX_POSITION](0)  # should not raise
+
+
+@pytest.mark.unit
+def test_config_flow_position_schema_max_selector_floors_at_zero() -> None:
+    """The config-flow POSITION_SCHEMA slider lets the user pick 0."""
+    assert _selector_min(POSITION_SCHEMA, CONF_MAX_POSITION) == 0
+
+
+@pytest.mark.unit
+def test_options_flow_section_schema_max_selector_floors_at_zero() -> None:
+    """The rendered options-flow position section slider lets the user pick 0."""
+    schema = get_policy("cover_blind").build_section_schema(cf.SECTION_POSITION)
+    assert _selector_min(schema, CONF_MAX_POSITION) == 0
+
+
+@pytest.mark.unit
+def test_cover_config_preserves_max_position_zero() -> None:
+    """A stored 0 survives ``from_options`` instead of being coerced to 100."""
+    config = CoverConfig.from_options({CONF_MAX_POSITION: 0})
+    assert config.max_pos == 0
+
+
+@pytest.mark.unit
+def test_cover_config_defaults_max_position_when_absent() -> None:
+    """Omitting the key still falls back to the 100 default (guards the fix)."""
+    config = CoverConfig.from_options({})
+    assert config.max_pos == 100
+
+
+@pytest.mark.unit
+def test_apply_limits_max_position_zero_forces_closed(
+    mock_sun_data, mock_logger
+) -> None:
+    """max_pos=0 clamps any commanded value to fully closed (semantics check)."""
+    result = PositionConverter.apply_limits(
+        value=80,
+        min_pos=0,
+        max_pos=0,
+        apply_min=False,
+        apply_max=False,  # always enforce
+        sun_valid=True,
+    )
+    assert result == 0

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -214,7 +214,10 @@ class TestFieldValidators:
             (CONF_DEFAULT_HEIGHT, 100),
             (CONF_MIN_POSITION, 0),
             (CONF_MIN_POSITION, 99),
-            (CONF_MAX_POSITION, 1),
+            (
+                CONF_MAX_POSITION,
+                0,
+            ),  # issue #806: 0 = "always closed" (roof-window impulse motor)
             (CONF_MAX_POSITION, 100),
             (CONF_AZIMUTH, 0),
             (CONF_AZIMUTH, 359),


### PR DESCRIPTION
## Summary
Issue #806: an impulse-motor roof window (Roto / Fibaro Roller Shutter 3) can only go fully open or fully closed — no intermediate positions. Its user needs `max_position = 0` ("always keep it closed for shading"), but the **Maximum Position** field rejected `0` even though its help text advertises a 0–100% range.

Root cause was four sites that floored the max at `1`, plus a downstream falsy-coercion bug:
- `const._RANGE_MAX_POSITION = (1, 100)` — drove `OPTION_RANGES` → the service/API validator.
- `config_flow.POSITION_SCHEMA` selector `min=1` — the config-flow slider.
- `config_fields` FieldSpec selector `minimum=1` — the rendered options-flow slider.
- `CoverConfig.from_options` used `max_pos = options.get(...) or 100`, so a stored `0` (falsy) silently became `100`.

Fix:
- Widen `_RANGE_MAX_POSITION` to `(0, 100)`.
- Floor both rendered selectors at 0 — the `config_fields` selector now derives its bounds from `_RANGE_MAX_POSITION` so the validator and selector can't drift apart again.
- Replace the `or 100` coercion with an explicit `is not None` check (mirrors the sibling `min_pos_sun_tracking` pattern).
- Fix the `set_position_limits` service description + selector `min`, and the `CONF_MAX_POSITION` doc comment.

Downstream clamping in `position_utils` already forces the cover closed for `max_pos = 0`, so no calc-engine change was needed. Config-flow help text already read "0-100%".

## Testing
- ✅ New `tests/test_max_position_zero.py` (7 guards: range constant, validator, both selectors, `from_options` preserves 0 and still defaults to 100 when absent, and downstream forces-closed semantics)
- ✅ Extended `test_services_options` valid-cases to pin `max_position=0`
- ✅ DE/FR translations synced (validator + `test_translations.py` green)
- ✅ Full suite: 5524 passed; ruff clean

## Related Issues
Refs #806

https://claude.ai/code/session_013tycoYXfBBVMxMx58GoaC1