### PR TITLE
fix: correct develop-build labeling for unshipped CalVer target

### DIFF
--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Compute version
         id: compute
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -51,16 +53,21 @@ jobs:
           # an AwesomeVersion modifier (sorts alphabetically high), and bumping the
           # patch makes the base outrank everything before the modifier is checked.
           BASE=$(jq -r '.version' custom_components/adaptive_cover_pro/manifest.json)
+          CORE=${BASE%%-*}   # strip any -beta.N suffix
           TS=$(date -u +%Y%m%d%H%M)
-          if [[ "$BASE" == *-* ]]; then
-            # Mid-cycle (manifest carries -beta.N): dev of the in-progress release.
-            CORE=${BASE%%-*}
-            VERSION="${CORE}.dev${TS}"
-          else
-            # Clean stable: dev of the NEXT patch, so the build doesn't sort below
-            # the just-shipped stable.
-            IFS=. read -r MAJ MIN PAT <<< "$BASE"
+
+          # Decide the dev base by asking the real question the suffix used to
+          # proxy: has CORE already SHIPPED as a stable (non-prerelease) release?
+          #   - shipped   → dev of the NEXT patch, so it outsorts that stable.
+          #   - unshipped → dev of CORE itself (mid-cycle beta OR bare target).
+          # This is robust to a bare, not-yet-shipped target version on develop
+          # (e.g. the CalVer month rollover sets `YYYY.M.0` with no -beta suffix),
+          # which the old string test mislabeled as `YYYY.M.1.dev`.
+          if gh release view "v${CORE}" --json isPrerelease --jq '.isPrerelease==false' 2>/dev/null | grep -q true; then
+            IFS=. read -r MAJ MIN PAT <<< "$CORE"
             VERSION="${MAJ}.${MIN}.$((PAT + 1)).dev${TS}"
+          else
+            VERSION="${CORE}.dev${TS}"
           fi
           TAG="v${VERSION}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/custom_components/adaptive_cover_pro/manifest.json
+++ b/custom_components/adaptive_cover_pro/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/jrhubott/adaptive-cover-pro/issues",
   "requirements": ["astral", "pandas"],
-  "version": "2026.7.0"
+  "version": "2026.7.0-beta.1"
 }


### PR DESCRIPTION
## Summary
Develop builds were being labeled `2026.7.1.dev...` when they should be `2026.7.0.dev...`.

The `develop-build.yml` workflow decided the dev version by testing for a `-beta` suffix in the manifest: no suffix meant "clean shipped stable", so it bumped the patch to keep the dev build sorting above the stable in AwesomeVersion. The CalVer switch (#760) set a bare `2026.7.0` on develop — an *unshipped target*, not a shipped stable — so the workflow bumped it to `2026.7.1.dev`.

This fix:
- **Hardens the workflow** — replaces the suffix heuristic with the real question it proxied: *has this base already shipped as a stable (non-prerelease) release?* It queries `gh release view` instead of parsing the version string, so a bare, not-yet-shipped target (which recurs at every CalVer month rollover) labels correctly. The patch-bump path is preserved for genuinely-shipped stables.
- **Bumps the manifest** to `2026.7.0-beta.1`, so the current cycle labels right immediately, independent of the workflow change.

The two mislabeled `v2026.7.1.dev*` pre-releases and their tags were already deleted so the corrected `2026.7.0.dev...` build sorts newest on the channel.

## Testing
- ✅ `manifest.json` validates as JSON; `2026.7.0-beta.1` is a format HA already accepts (prior betas used `X.Y.Z-beta.N`)
- ✅ pre-commit (yaml check + prettier) passed on commit
- Workflow change is exercised on the next push to `develop`

## Related Issues
Follows up the CalVer switch (#760)

https://claude.ai/code/session_0189GfMufRXwicEiUvwrY74g