### PR TITLE
fix: drop deprecated get_astral_location (#815)

### DIFF
--- a/custom_components/adaptive_cover_pro/state/sun_provider.py
+++ b/custom_components/adaptive_cover_pro/state/sun_provider.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers.sun import get_astral_location
+from astral import LocationInfo
+from astral.location import Location
 
 from ..sun import SunData
 
@@ -28,6 +29,25 @@ class SunProvider:
         Returns:
             SunData instance with location and elevation from HA config.
 
+        Note:
+            Builds the astral ``Location`` directly instead of calling HA's
+            ``homeassistant.helpers.sun.get_astral_location`` — that helper is
+            deprecated (breaks in HA 2027.7) in favor of
+            ``get_astral_observer``, which returns a bare ``Observer`` with no
+            ``.solar_azimuth``/``.solar_elevation``/``.sunset``/``.sunrise``
+            methods and would require a larger rewrite of ``SunData``. This
+            inlines exactly ``get_astral_location``'s own (non-deprecated)
+            body. See issue #815.
+
         """
-        location, elevation = get_astral_location(self._hass)
+        location = Location(
+            LocationInfo(
+                "",
+                "",
+                str(self._hass.config.time_zone),
+                self._hass.config.latitude,
+                self._hass.config.longitude,
+            )
+        )
+        elevation = self._hass.config.elevation
         return SunData(timezone, location, elevation)

--- a/tests/test_state/test_sun_provider.py
+++ b/tests/test_state/test_sun_provider.py
@@ -1,65 +1,67 @@
 """Tests for the SunProvider state provider."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.state import sun_provider
 from custom_components.adaptive_cover_pro.state.sun_provider import SunProvider
 from custom_components.adaptive_cover_pro.sun import SunData
 
 
 @pytest.fixture
 def mock_hass():
-    """Return a mock HomeAssistant instance."""
-    return MagicMock()
+    """Return a mock HomeAssistant instance with real config values.
+
+    ``sun_provider.create_sun_data`` builds an astral ``Location`` directly
+    from ``hass.config`` (see #815), so latitude/longitude/elevation/time_zone
+    must be real values — an astral ``LocationInfo``/``Location`` raises on
+    plain ``MagicMock`` attributes.
+    """
+    hass = MagicMock()
+    hass.config.latitude = 52.0
+    hass.config.longitude = 13.0
+    hass.config.elevation = 100.0
+    hass.config.time_zone = "Europe/Berlin"
+    return hass
 
 
 class TestSunProvider:
     """Tests for SunProvider."""
 
     def test_create_sun_data_returns_sun_data(self, mock_hass):
-        """SunProvider.create_sun_data returns a SunData instance."""
-        with patch(
-            "custom_components.adaptive_cover_pro.state.sun_provider.get_astral_location"
-        ) as mock_get_loc:
-            mock_location = MagicMock()
-            mock_get_loc.return_value = (mock_location, 100.0)
+        """SunProvider.create_sun_data returns a SunData instance built from hass.config."""
+        provider = SunProvider(hass=mock_hass)
+        result = provider.create_sun_data("Europe/Berlin")
 
-            provider = SunProvider(hass=mock_hass)
-            result = provider.create_sun_data("Europe/Berlin")
+        assert isinstance(result, SunData)
+        assert result.timezone == "Europe/Berlin"
+        assert result.location.latitude == 52.0
+        assert result.location.longitude == 13.0
+        assert result.elevation == 100.0
 
-            assert isinstance(result, SunData)
-            assert result.timezone == "Europe/Berlin"
-            assert result.location is mock_location
-            assert result.elevation == 100.0
-            mock_get_loc.assert_called_once_with(mock_hass)
+    def test_create_sun_data_passes_hass_config_to_location(self, mock_hass):
+        """SunProvider reads latitude/longitude/elevation straight from hass.config."""
+        mock_hass.config.latitude = 40.7
+        mock_hass.config.longitude = -74.0
+        mock_hass.config.elevation = 10.0
 
-    def test_create_sun_data_passes_hass_to_get_astral_location(self, mock_hass):
-        """SunProvider passes its mock_hass instance to get_astral_location."""
-        with patch(
-            "custom_components.adaptive_cover_pro.state.sun_provider.get_astral_location"
-        ) as mock_get_loc:
-            mock_get_loc.return_value = (MagicMock(), 0.0)
+        provider = SunProvider(hass=mock_hass)
+        result = provider.create_sun_data("America/New_York")
 
-            provider = SunProvider(hass=mock_hass)
-            provider.create_sun_data("UTC")
-
-            mock_get_loc.assert_called_once_with(mock_hass)
+        assert result.location.latitude == 40.7
+        assert result.location.longitude == -74.0
+        assert result.elevation == 10.0
 
     def test_create_sun_data_different_timezones(self, mock_hass):
         """SunProvider can create SunData with different timezones."""
-        with patch(
-            "custom_components.adaptive_cover_pro.state.sun_provider.get_astral_location"
-        ) as mock_get_loc:
-            mock_get_loc.return_value = (MagicMock(), 50.0)
+        provider = SunProvider(hass=mock_hass)
 
-            provider = SunProvider(hass=mock_hass)
+        utc_data = provider.create_sun_data("UTC")
+        assert utc_data.timezone == "UTC"
 
-            utc_data = provider.create_sun_data("UTC")
-            assert utc_data.timezone == "UTC"
-
-            berlin_data = provider.create_sun_data("Europe/Berlin")
-            assert berlin_data.timezone == "Europe/Berlin"
+        berlin_data = provider.create_sun_data("Europe/Berlin")
+        assert berlin_data.timezone == "Europe/Berlin"
 
     def test_sun_data_no_hass_dependency(self):
         """SunData itself has no HomeAssistant dependency."""
@@ -69,3 +71,29 @@ class TestSunProvider:
         assert sun_data.timezone == "UTC"
         assert sun_data.location is mock_location
         assert sun_data.elevation == 42.0
+
+    def test_create_sun_data_does_not_call_get_astral_location(self, mock_hass):
+        """SunProvider must not use HA's deprecated get_astral_location (#815).
+
+        The old implementation imported ``get_astral_location`` via
+        ``from homeassistant.helpers.sun import get_astral_location``. That
+        import (and the deprecated call) must be gone entirely, not merely
+        unused.
+        """
+        assert not hasattr(sun_provider, "get_astral_location")
+
+        provider = SunProvider(hass=mock_hass)
+        provider.create_sun_data("Europe/Berlin")
+
+        # Still doesn't exist post-call — nothing lazily re-imports it.
+        assert not hasattr(sun_provider, "get_astral_location")
+
+    def test_create_sun_data_builds_location_from_hass_config(self, mock_hass):
+        """SunProvider builds the astral Location directly from hass.config (#815)."""
+        provider = SunProvider(hass=mock_hass)
+        result = provider.create_sun_data("Europe/Berlin")
+
+        assert isinstance(result, SunData)
+        assert result.location.latitude == 52.0
+        assert result.location.longitude == 13.0
+        assert result.elevation == 100.0


### PR DESCRIPTION
## Summary
HA's `get_astral_location` is deprecated (removed in HA Core 2027.7) and was called once per coordinator update cycle, producing repeated log warnings (461 for the reporter). This inlines the helper's own non-deprecated body — building the astral `Location` directly from `hass.config` — so the `SunData` contract and all sun calculations are unchanged, with no min-HA-version bump.

## Testing
- ✅ Full suite: 5527 passing (2 new tests guarding against reintroducing the deprecated call)

## Related Issues
Refs #815