### PR TITLE
ci: add deprecation-check CI task for HA helpers (#815)

### DIFF
--- a/.github/workflows/deprecated-ha-helpers.yml
+++ b/.github/workflows/deprecated-ha-helpers.yml
@@ -1,0 +1,35 @@
+name: Deprecated HA Helpers
+
+# Standalone CI task that fails if the integration references a deprecated Home
+# Assistant helper (see scripts/check_deprecated_ha_helpers.py). Kept separate
+# from the unit-test workflow so a flagged deprecation surfaces as its own check
+# rather than a failing unit test, and so it runs version-independently (no HA
+# core install needed — the scan is pure ast). Seeded by issue #815.
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - develop
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Deprecation Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Check for deprecated Home Assistant helper usage
+        run: python scripts/check_deprecated_ha_helpers.py

--- a/scripts/check_deprecated_ha_helpers.py
+++ b/scripts/check_deprecated_ha_helpers.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Fail if the integration references a deprecated Home Assistant helper.
+
+Home Assistant marks helpers scheduled for removal with ``@deprecated_function``
+/ ``@deprecated_class``. Calling one emits a WARNING *log* record — not a Python
+``warnings`` warning, so ``pytest -W error`` never catches it — and, for custom
+integrations, asks the user to file a bug. Issue #815 was exactly this:
+``state/sun_provider.py`` called the deprecated
+``homeassistant.helpers.sun.get_astral_location`` on every update cycle,
+spamming a user's log with 461 warnings.
+
+This is a standalone CI check (wired in
+``.github/workflows/deprecated-ha-helpers.yml``) rather than a unit test, on
+purpose:
+
+* It is independent of the installed HA version. The pinned test HA
+  (``pytest-homeassistant-custom-component``) may predate a given deprecation,
+  which would let a runtime check pass green while the offending call is present
+  — this static scan bites regardless.
+* It keeps the deprecation gate out of the unit-test suite, so a flagged
+  deprecation shows up as its own CI task instead of a failing unit test.
+
+It parses each source file with the ``ast`` module, so a denylisted name that
+appears only in a docstring or comment does not trip it (the #815 fix keeps
+``get_astral_location`` in an explanatory docstring).
+
+Run locally::
+
+    python scripts/check_deprecated_ha_helpers.py
+
+Extend the denylist as HA announces removals in the developer blog's deprecation
+notices — record the successor API and the removal version so the failure
+message tells a maintainer exactly what to switch to.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+# Deprecated Home Assistant helper symbols the integration must not reference.
+#   symbol -> (recommended replacement, breaks_in_ha_version)
+DEPRECATED_HA_HELPERS: dict[str, tuple[str, str]] = {
+    "get_astral_location": (
+        "homeassistant.helpers.sun.get_astral_observer",
+        "2027.7",
+    ),
+}
+
+SOURCE_ROOT = (
+    Path(__file__).resolve().parent.parent / "custom_components" / "adaptive_cover_pro"
+)
+
+
+def _referenced_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.Name):
+            names.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            names.add(node.attr)
+    return names
+
+
+def find_offenders(root: Path) -> list[tuple[str, str]]:
+    offenders: list[tuple[str, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        used = _referenced_names(tree)
+        offenders.extend(
+            (str(path.relative_to(root)), symbol)
+            for symbol in DEPRECATED_HA_HELPERS
+            if symbol in used
+        )
+    return offenders
+
+
+def main() -> int:
+    offenders = find_offenders(SOURCE_ROOT)
+    if not offenders:
+        print("OK: no deprecated Home Assistant helper references found.")
+        return 0
+    print("Deprecated Home Assistant helper reference(s) found:")
+    for rel, symbol in offenders:
+        replacement, breaks_in = DEPRECATED_HA_HELPERS[symbol]
+        print(f"  {rel}: {symbol} -> {replacement} (removed in HA {breaks_in})")
+    print(
+        "\nReplace each call with its documented successor. Edit the denylist in "
+        "scripts/check_deprecated_ha_helpers.py to add newly deprecated symbols."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Adds a **standalone CI task** that fails if the integration references a deprecated Home Assistant helper (like the `get_astral_location` call behind #815), so a reintroduced call is caught by CI instead of a user's log — and as its **own check, not a failing unit test**.

- **`scripts/check_deprecated_ha_helpers.py`** — a version-independent AST scan of `custom_components/adaptive_cover_pro` against a denylist of deprecated HA symbols (seeded with `get_astral_location` → `get_astral_observer`, removed in HA 2027.7). AST-based, so a symbol that appears only in a docstring/comment does **not** trip it — the #815 fix keeps `get_astral_location` in an explanatory docstring. Runs locally: `python scripts/check_deprecated_ha_helpers.py`.
- **`.github/workflows/deprecated-ha-helpers.yml`** — a dedicated `Deprecation Check` job on push/PR. Pure stdlib, no HA core install, so it's fast and independent of the pinned test-HA version.

### Why a separate CI task (not a unit test)
The pinned test HA predates the deprecation, so a runtime/unit test would pass green today and miss a reintroduction until the pin advances. This static scan bites regardless, and living in its own workflow keeps the deprecation gate out of the unit-test run.

## ⚠️ Ordering
The check is **red on `develop` until the #815 fix (PR #817) lands** and this branch is rebased — failing while the deprecated call still exists is the check working as designed. Merge order: **#817 first, then this.**

## Testing
- ✅ `scripts/check_deprecated_ha_helpers.py` verified: exit 1 on develop (flags `state/sun_provider.py: get_astral_location`); exit 0 once #817's fix is applied, including that the fix's docstring mention does not trip it.
- ✅ ruff + black clean; workflow YAML validated.

## Related Issues
Refs #815

https://claude.ai/code/session_016n4DEgBSLhJ4sUHUZ4x2PZ