### PR TITLE
fix: correct end-time summary label to say default, not sunset (#820)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1393,7 +1393,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "timing.after_sunrise": (
         "{indent}🌄 After sunrise{ann} → {default_pos}% (tracking resumes)."
     ),
-    "timing.return_sunset": "{indent}🔚 Return to sunset position at end time: on",
+    "timing.return_sunset": "{indent}🔚 Move to default position at end time: on",
     "timing.end_of_window": (
         "{indent}🔚 End-of-window position → {target} from end time until sunset "
         "(then the sunset position applies, if set)."

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -149,7 +149,7 @@
     "label_end_or_sunset": "Endzeit/Sonnenuntergang",
     "label_sunset": "Sonnenuntergang",
     "after_sunrise": "{indent}🌄 Nach Sonnenaufgang{ann} → {default_pos}% (Verfolgung fortgesetzt).",
-    "return_sunset": "{indent}🔚 Zurück zur Sonnenuntergangsposition bei Endzeit: aktiviert",
+    "return_sunset": "{indent}🔚 Zur Standardposition bei Endzeit: aktiviert",
     "end_of_window": "{indent}🔚 Position bei Fensterende → {target} von der Endzeit bis zum Sonnenuntergang (danach gilt die Sonnenuntergangsposition, falls gesetzt).",
     "end_of_window_needs_return": "{indent}⚠️ Position bei Fensterende ist gesetzt, aber \"Abdeckungen bei Erreichen der Endzeit bewegen\" ist AUS — sie wird nicht angewendet. Schalte diese Option ein.",
     "gate_sensors": "{indent}🌗 Tageslicht-Gate: {sensors} entscheiden über Tag vs. Dunkelheit.",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -149,7 +149,7 @@
     "label_end_or_sunset": "end time/sunset",
     "label_sunset": "sunset",
     "after_sunrise": "{indent}🌄 After sunrise{ann} → {default_pos}% (tracking resumes).",
-    "return_sunset": "{indent}🔚 Return to sunset position at end time: on",
+    "return_sunset": "{indent}🔚 Move to default position at end time: on",
     "end_of_window": "{indent}🔚 End-of-window position → {target} from end time until sunset (then the sunset position applies, if set).",
     "end_of_window_needs_return": "{indent}⚠️ End-of-window position is set but \"Move covers when end time is reached\" is OFF — it will not be applied. Turn that toggle on.",
     "gate_sensors": "{indent}🌗 Daytime gate: {sensors} decide day vs dark.",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -149,7 +149,7 @@
     "label_end_or_sunset": "heure de fin/coucher",
     "label_sunset": "coucher",
     "after_sunrise": "{indent}🌄 Après lever{ann} → {default_pos}% (suivi reprend).",
-    "return_sunset": "{indent}🔚 Retour à la position coucher à l'heure de fin : activé",
+    "return_sunset": "{indent}🔚 Aller à la position par défaut à l'heure de fin : activé",
     "end_of_window": "{indent}🔚 Position de fin de fenêtre → {target} de l'heure de fin jusqu'au coucher (puis la position coucher s'applique, si définie).",
     "end_of_window_needs_return": "{indent}⚠️ La position de fin de fenêtre est définie mais « Déplacer les couvertures à l'heure de fin » est DÉSACTIVÉ — elle ne sera pas appliquée. Activez cette option.",
     "gate_sensors": "{indent}🌗 Filtre de jour : {sensors} décident le jour par rapport à l'obscurité.",


### PR DESCRIPTION
## Summary
The config-summary line for `return_sunset` read **"Return to sunset position at end time"**, but the option actually sends the *effective default* position at end time — which is the sunset position only after astronomical sunset, otherwise the normal default. Surfaced by #820, where the wording reinforced a mistaken expectation that the cover moves to the sunset position at end time.

I reworded the label to **"Move to default position at end time"**, matching the option's own name ("Move covers to current default position when end time is reached") and its `en.json` description, and synced DE/FR. No behavior change — summary text only.

## Testing
- ✅ 45 passing (test_translations, test_config_flow_summary_i18n, test_policy_summary_i18n) — includes the byte-identical en parity lock and DE/FR placeholder parity
- ✅ `validate_translations.py --ci` clean

## Related Issues
Refs #820

https://claude.ai/code/session_01ACRNn1xCYRHD6igoar1wMZ