### PR TITLE
fix: escape ICU braces in end_time service description (#793)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -180,7 +180,7 @@ engage_manual_override:
         (no trailing Z or +HH:MM) is treated as UTC, not your local time.
         For local time, use an ISO string with an explicit offset (e.g.
         2026-07-04T22:00:00+02:00) or a template like
-        {{ (now() + timedelta(hours=2)).isoformat() }}. Ignored (falls back
+        '{{' (now() + timedelta(hours=2)).isoformat() '}}'. Ignored (falls back
         to the configured duration) if it is in the past or unparseable.
         Takes precedence over duration.
       required: false

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2358,7 +2358,7 @@
       "fields": {
         "end_time": {
           "name": "Endzeit",
-          "description": "Absolute Zeit, zu der die Übersteuerung enden soll. Ein Wert ohne UTC-Offset (kein nachfolgendes Z oder +HH:MM) wird als UTC behandelt, nicht als Ihre Ortszeit. Für Ortszeit verwenden Sie einen ISO-String mit explizitem Offset (z. B. 2026-07-04T22:00:00+02:00) oder ein Template wie {{ (now() + timedelta(hours=2)).isoformat() }}. Wird ignoriert (Rückfall auf die konfigurierte Dauer), wenn sie in der Vergangenheit liegt oder nicht lesbar ist. Hat Vorrang vor der Dauer."
+          "description": "Absolute Zeit, zu der die Übersteuerung enden soll. Ein Wert ohne UTC-Offset (kein nachfolgendes Z oder +HH:MM) wird als UTC behandelt, nicht als Ihre Ortszeit. Für Ortszeit verwenden Sie einen ISO-String mit explizitem Offset (z. B. 2026-07-04T22:00:00+02:00) oder ein Template wie '{{' (now() + timedelta(hours=2)).isoformat() '}}'. Wird ignoriert (Rückfall auf die konfigurierte Dauer), wenn sie in der Vergangenheit liegt oder nicht lesbar ist. Hat Vorrang vor der Dauer."
         },
         "duration": {
           "name": "Dauer",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -2372,7 +2372,7 @@
       "fields": {
         "end_time": {
           "name": "End time",
-          "description": "Absolute time the override should end. A value with no UTC offset (no trailing Z or +HH:MM) is treated as UTC, not your local time. For local time, use an ISO string with an explicit offset (e.g. 2026-07-04T22:00:00+02:00) or a template like {{ (now() + timedelta(hours=2)).isoformat() }}. Ignored (falls back to the configured duration) if it is in the past or unparseable. Takes precedence over duration."
+          "description": "Absolute time the override should end. A value with no UTC offset (no trailing Z or +HH:MM) is treated as UTC, not your local time. For local time, use an ISO string with an explicit offset (e.g. 2026-07-04T22:00:00+02:00) or a template like '{{' (now() + timedelta(hours=2)).isoformat() '}}'. Ignored (falls back to the configured duration) if it is in the past or unparseable. Takes precedence over duration."
         },
         "duration": {
           "name": "Duration",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2358,7 +2358,7 @@
       "fields": {
         "end_time": {
           "name": "Heure de fin",
-          "description": "Heure absolue à laquelle la dérogation doit se terminer. Une valeur sans décalage UTC (sans Z de fin ou +HH:MM) est traitée comme UTC, pas votre heure locale. Pour l'heure locale, utilisez une chaîne ISO avec un décalage explicite (par exemple 2026-07-04T22:00:00+02:00) ou un modèle comme {{ (now() + timedelta(hours=2)).isoformat() }}. Ignorée (retour à la durée configurée) si elle est passée ou illisible. Prioritaire sur la durée."
+          "description": "Heure absolue à laquelle la dérogation doit se terminer. Une valeur sans décalage UTC (sans Z de fin ou +HH:MM) est traitée comme UTC, pas votre heure locale. Pour l'heure locale, utilisez une chaîne ISO avec un décalage explicite (par exemple 2026-07-04T22:00:00+02:00) ou un modèle comme '{{' (now() + timedelta(hours=2)).isoformat() '}}'. Ignorée (retour à la durée configurée) si elle est passée ou illisible. Prioritaire sur la durée."
         },
         "duration": {
           "name": "Durée",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -425,3 +425,80 @@ def test_no_untranslated_learn_more() -> None:
             f"'[Learn more]' — translate to the target language. "
             f"First offender: {offending[0]!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #793 — service field descriptions must be ICU-safe (no unescaped braces)
+# ---------------------------------------------------------------------------
+
+# HA renders `services` translation text through the frontend's IntlMessageFormat
+# (ICU) parser, which reads `{...}` as a placeholder. A literal Jinja example like
+# `{{ (now()).isoformat() }}` triggers "Translation error: MALFORMED_ARGUMENT" and
+# blanks the whole description. Literal braces must be escaped ICU-style with ASCII
+# single quotes: `'{{'` renders `{{`, `'}}'` renders `}}`.
+
+_ICU_SPECIAL = "{}#|"
+
+
+def _has_unescaped_brace(text: str) -> bool:
+    """Return True if ``text`` contains a `{`/`}` outside ICU apostrophe quoting.
+
+    Mirrors intl-messageformat: a `'` only opens a literal-quote span when the
+    next char is an ICU special char (`{ } # |`) or another `'`; a lone `'`
+    (e.g. French "l'heure") is a literal apostrophe and does not start quoting.
+    """
+    i, n = 0, len(text)
+    in_quote = False
+    while i < n:
+        c = text[i]
+        if c == "'":
+            nxt = text[i + 1] if i + 1 < n else ""
+            if in_quote:
+                if nxt == "'":  # '' -> literal apostrophe
+                    i += 2
+                    continue
+                in_quote = False
+                i += 1
+                continue
+            # not currently quoting
+            if nxt in _ICU_SPECIAL:
+                in_quote = True
+                i += 1
+                continue
+            if nxt == "'":  # '' -> literal apostrophe
+                i += 2
+                continue
+            i += 1  # lone apostrophe, literal
+            continue
+        if not in_quote and c in "{}":
+            return True
+        i += 1
+    return False
+
+
+def _service_field_descriptions(data: dict) -> list[tuple[str, str]]:
+    """Yield (dotpath, description) for every services.*.fields.*.description."""
+    out: list[tuple[str, str]] = []
+    for svc_name, svc in data.get("services", {}).items():
+        for field_name, field in svc.get("fields", {}).items():
+            desc = field.get("description")
+            if isinstance(desc, str):
+                out.append(
+                    (f"services.{svc_name}.fields.{field_name}.description", desc)
+                )
+    return out
+
+
+@pytest.mark.parametrize("lang_file", TRANSLATION_FILES, ids=LANGUAGE_CODES)
+def test_service_field_descriptions_icu_safe(lang_file: Path) -> None:
+    """Service field descriptions must not carry an unescaped ICU brace (#793)."""
+    offending = [
+        path
+        for path, desc in _service_field_descriptions(_load(lang_file))
+        if _has_unescaped_brace(desc)
+    ]
+    assert not offending, (
+        f"{lang_file.name}: {len(offending)} service field description(s) contain "
+        f"an unescaped '{{'/'}}' — escape literal braces ICU-style as '{{{{' … '}}}}' "
+        f"so the frontend does not raise MALFORMED_ARGUMENT. Offenders: {offending}"
+    )


### PR DESCRIPTION
## Summary
The `engage_manual_override` **End time** field showed `Translation error: MALFORMED_ARGUMENT` in the action UI (reported on #793).

HA renders service field descriptions through the frontend's IntlMessageFormat (ICU) parser, which reads `{...}` as a placeholder. The description embedded a literal Jinja template `{{ (now() + timedelta(hours=2)).isoformat() }}` — the unescaped `{{` is invalid ICU, so the whole description was replaced by the error string.

Fix: escape the literal braces ICU-style with single quotes (`'{{'` / `'}}'`) in `services.yaml` and `en/de/fr.json`, so the template renders exactly as before. Purely mechanical, language-agnostic — no re-translation; DE/FR parity intact.

## Testing
- ✅ New guard `test_service_field_descriptions_icu_safe` (en/de/fr) rejects any unescaped `{`/`}` in service field descriptions — RED before, GREEN after
- ✅ 33 `test_translations.py` tests pass; `validate_translations.py --ci` clean
- ✅ 292 service-related tests pass; ruff/black clean

## Related Issues
Refs #793

https://claude.ai/code/session_01ACRNn1xCYRHD6igoar1wMZ