### PR TITLE
feat: add device target selector to all service actions (#824)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -9,6 +9,8 @@ stop:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
 
 integration_enable:
   name: Enable integration
@@ -17,6 +19,8 @@ integration_enable:
     are; positioning resumes on the next natural update cycle.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
 
 integration_disable:
@@ -28,6 +32,8 @@ integration_disable:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
 
 emergency_stop:
   name: Emergency stop
@@ -38,6 +44,8 @@ emergency_stop:
     instances and all their covers.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
 
 export_config:
@@ -103,6 +111,8 @@ set_position:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     position:
       name: Position
@@ -136,6 +146,8 @@ set_tilt:
     skip manual-override engagement (matching set_position's force semantics).
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     tilt:
@@ -172,6 +184,8 @@ engage_manual_override:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     end_time:
       name: End time
@@ -202,6 +216,8 @@ set_position_limits:
     threshold, inverse state). Changes are persisted and take effect after reload.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     default_percentage:
@@ -277,6 +293,8 @@ set_sunset_sunrise:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     sunset_position:
       name: Sunset position
@@ -328,6 +346,8 @@ set_automation_timing:
     start_time and start_entity are mutually exclusive; same for end_time/end_entity.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     delta_position:
@@ -387,6 +407,8 @@ set_manual_override:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     manual_override_duration:
       name: Override duration
@@ -428,6 +450,8 @@ set_force_override:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     force_override_sensors:
       name: Force override sensors
@@ -461,6 +485,8 @@ set_custom_position:
     semantics: it acts outside the time window and bypasses delta gates.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     slot:
@@ -535,6 +561,8 @@ set_motion:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     motion_sensors:
       name: Motion sensors
@@ -565,6 +593,8 @@ set_light_cloud:
     cloud coverage threshold, and the cloud suppression toggle.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     weather_entity:
@@ -657,6 +687,8 @@ set_climate:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     climate_mode:
       name: Enable climate mode
@@ -739,6 +771,8 @@ set_weather_safety:
     priority-overrides automatic control to protect covers from damage.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     weather_bypass_auto_control:
@@ -843,6 +877,8 @@ set_sun_tracking:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     enable_sun_tracking:
       name: Enable sun tracking
@@ -932,6 +968,8 @@ set_blind_spot:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     blind_spot:
       name: Enable blind spot
@@ -985,6 +1023,8 @@ set_interpolation:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     interp:
       name: Enable interpolation
@@ -1030,6 +1070,8 @@ set_geometry:
     rejected with an error message.
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     window_height:
@@ -1128,6 +1170,8 @@ set_venetian:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     venetian_mode:
       name: Venetian mode
@@ -1167,6 +1211,8 @@ set_option:
   target:
     entity:
       integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
   fields:
     option:
       name: Option key
@@ -1190,6 +1236,8 @@ get_diagnostics:
     card via hass.callService(..., { return_response: true }).
   target:
     entity:
+      integration: adaptive_cover_pro
+    device:
       integration: adaptive_cover_pro
   fields:
     config_entry_id:

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -56,6 +56,32 @@ def test_set_position_has_target_block():
     assert svc["target"]["entity"]["integration"] == "adaptive_cover_pro"
 
 
+def test_entity_targeted_services_also_offer_device_target():
+    """Every entity-targeted service must also expose a device selector (#824).
+
+    ACP owns no `cover` entities (only sensor/switch/binary_sensor/button), so an
+    `entity: integration:` target picker can only list helper entities. Adding a
+    `device: integration:` selector lets the picker offer the ACP instance device
+    ("Patio Right TV Shade") — the intuitive target — without breaking the call
+    schema, which still accepts entity_id/device_id/area_id.
+    """
+    offenders = []
+    for name, svc in _load().items():
+        target = (svc or {}).get("target")
+        if not isinstance(target, dict) or "entity" not in target:
+            continue  # global / config_entry-based services have no entity target
+        device = target.get("device")
+        if (
+            not isinstance(device, dict)
+            or device.get("integration") != "adaptive_cover_pro"
+        ):
+            offenders.append(name)
+    assert not offenders, (
+        "Entity-targeted services missing a `device: integration: adaptive_cover_pro` "
+        f"target selector (#824): {sorted(offenders)}"
+    )
+
+
 def test_set_position_has_position_field_with_correct_range():
     fields = _load()["set_position"]["fields"]
     assert "position" in fields


### PR DESCRIPTION
## Summary
Adaptive Cover Pro service actions offered "just switches" (helper entities) as targets, never the covers — reported while testing #793.

**Cause:** every entity-targeted service declared only `target: entity: integration: adaptive_cover_pro`. ACP owns no `cover` entities (only sensor/switch/binary_sensor/button), so the entity picker can only ever list helper entities.

**Fix:** add a `device: integration: adaptive_cover_pro` selector alongside `entity:` on all 24 entity-targeted services, so the picker offers the ACP **instance device** (e.g. "Patio Right TV Shade") as the natural target.

- **UI-only, backward compatible** — `cv.make_entity_service_schema` still accepts `entity_id`/`device_id`/`area_id`, and `_resolve_targets` already maps `device_id` → coordinator, so existing automations are unaffected.
- The three config-management services (`export_config`, `export_all_config`, `import_config`) use their own `config_entry`/file model and are intentionally left untouched.

## Testing
- ✅ New guard `test_entity_targeted_services_also_offer_device_target` — RED (24 offenders) before, GREEN after
- ✅ 9 `test_services_yaml_docs.py` tests pass; services.yaml parses cleanly
- ✅ 401 service-related tests pass; ruff/black clean

## Related Issues
Refs #824

https://claude.ai/code/session_01ACRNn1xCYRHD6igoar1wMZ