### PR TITLE
feat: Cover Group entry type — full implementation (#790)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -57,6 +57,7 @@ from .const import (
 )
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
+from .group_coordinator import GroupCoordinator
 from .helpers import (
     copy_legacy_slot_sensors_to_list,
     custom_position_slot_sensors,
@@ -79,6 +80,16 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.COVER,
     Platform.NUMBER,
+]
+# Platform set for cover-group entries (``is_orchestrator = True``). A group
+# exposes aggregate sensors, bulk switches, scene buttons, and the scene
+# select — no proxy cover, number, or binary sensor. Setup and unload must
+# use the same list (load/unload symmetry, the #712/#714 lesson).
+GROUP_PLATFORMS = [
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.BUTTON,
+    Platform.SELECT,
 ]
 CONF_SUN = ["sun.sun"]
 
@@ -134,8 +145,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     # guard stays unambiguous. Register a propagation update-listener so a change
     # to the profile reaches its linked covers, then return without forwarding
     # platforms.
-    if not get_policy(entry.data[CONF_SENSOR_TYPE]).controls_cover:
+    policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+    if not policy.controls_cover:
         entry.async_on_unload(entry.add_update_listener(_async_profile_propagate))
+        return True
+
+    # Cover groups (``is_orchestrator = True``) control covers but are not
+    # geometry-driven: build the GroupCoordinator and forward only the group
+    # platform set — never the sun/geometry coordinator below.
+    if policy.is_orchestrator:
+        group_coordinator = GroupCoordinator(hass, entry)
+        entry.runtime_data = group_coordinator
+        await hass.config_entries.async_forward_entry_setups(entry, GROUP_PLATFORMS)
+        await group_coordinator.async_config_entry_first_refresh()
+        entry.async_on_unload(entry.add_update_listener(_async_group_update_listener))
         return True
 
     coordinator = AdaptiveDataUpdateCoordinator(hass)
@@ -373,13 +396,26 @@ async def async_unload_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) ->
     """Unload a config entry."""
     # Virtual entry types (Building Profile, controls_cover == False) forwarded
     # no platforms in async_setup_entry, so unloading platforms would raise
-    # "Config entry was never loaded!". Mirror the setup short-circuit.
-    if not get_policy(entry.data[CONF_SENSOR_TYPE]).controls_cover:
+    # "Config entry was never loaded!". Mirror the setup short-circuit, and
+    # unload exactly the platform set setup forwarded (groups use their own).
+    policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+    if not policy.controls_cover:
         await async_unload_services(hass)
         return True
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+    platforms = GROUP_PLATFORMS if policy.is_orchestrator else PLATFORMS
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
         await async_unload_services(hass)
     return unload_ok
+
+
+async def _async_group_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload a group entry when its options (membership) change.
+
+    The group holds no long-running state worth preserving across an options
+    edit, so a full reload is the simplest way to re-resolve the roster and
+    rebuild the per-scene entities.
+    """
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -82,14 +82,15 @@ PLATFORMS = [
     Platform.NUMBER,
 ]
 # Platform set for cover-group entries (``is_orchestrator = True``). A group
-# exposes aggregate sensors, bulk switches, scene buttons, and the scene
-# select — no proxy cover, number, or binary sensor. Setup and unload must
-# use the same list (load/unload symmetry, the #712/#714 lesson).
+# exposes aggregate sensors, bulk switches, scene buttons, the scene select,
+# and the opt-in aggregate cover — no number or binary sensor. Setup and
+# unload must use the same list (load/unload symmetry, the #712/#714 lesson).
 GROUP_PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.BUTTON,
     Platform.SELECT,
+    Platform.COVER,
 ]
 CONF_SUN = ["sun.sun"]
 

--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -12,6 +12,7 @@ from .const import (
     CONF_ENABLE_MY_POSITION_ENTITIES,
     CONF_ENTITIES,
     CONF_MY_POSITION_VALUE,
+    CONF_SENSOR_TYPE,
     DEFAULT_ENABLE_MY_POSITION_ENTITIES,
 )
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
@@ -25,6 +26,17 @@ async def async_setup_entry(
 ) -> None:
     """Set up the button platform."""
     coordinator: AdaptiveDataUpdateCoordinator = config_entry.runtime_data
+
+    # Cover groups expose scene + clear-overrides buttons, never the cover set.
+    from .cover_types import get_policy
+
+    if get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        from .group_entities import build_group_buttons
+
+        async_add_entities(
+            build_group_buttons(config_entry.entry_id, hass, config_entry, coordinator)
+        )
+        return
 
     buttons: list[ButtonEntity] = []
 
@@ -69,54 +81,13 @@ class AdaptiveCoverButton(AdaptiveCoverBaseEntity, ButtonEntity):
         return self._button_name
 
     async def async_press(self) -> None:
-        """Handle the button press."""
-        reset_entities = []
-        for entity in self._entities:
-            if self.coordinator.manager.is_cover_manual(entity):
-                _LOGGER.debug("Resetting manual override for: %s", entity)
-                self.coordinator.manager.reset(entity)
-                # Suppress re-detection: cover state events during refresh must
-                # not be treated as a new manual override.
-                self.coordinator._cmd_svc.set_waiting(entity, True)  # noqa: SLF001
-                self.coordinator.cover_state_change = False
-                reset_entities.append(entity)
-            else:
-                _LOGGER.debug(
-                    "Resetting manual override for %s is not needed since it is already auto-controlled",
-                    entity,
-                )
+        """Handle the button press.
 
-        if not reset_entities:
-            return
-
-        # Refresh so the pipeline re-runs without the override active,
-        # producing the correct post-override position (climate, solar,
-        # default — whichever handler wins now).
-        await self.coordinator.async_refresh()
-
-        # Delegate to the shared post-override send path.
-        # Time-window and automatic-control gates live there, along with
-        # force=True so time_delta/position_delta are bypassed for this
-        # intentional user reset.
-        sent = await self.coordinator._async_send_after_override_clear(
-            self.coordinator.state,
-            self.coordinator.config_entry.options,
-            entities=reset_entities,
-            trigger="manual_reset",
-        )
-
-        # Entities not sent to (gated by time window / auto-control, or
-        # skipped inside apply_position) must have wait_for_target cleared so
-        # later cover state events are not silently swallowed.
-        # Entities that were sent already have wait_for_target=True set by
-        # apply_position; leave those untouched.
-        for entity in reset_entities:
-            if entity not in sent:
-                _LOGGER.debug(
-                    "Manual override reset: no position change sent for %s",
-                    entity,
-                )
-                self.coordinator._cmd_svc.set_waiting(entity, False)  # noqa: SLF001
+        The full clear-and-resend sequence lives on the coordinator
+        (``async_reset_manual_overrides``) so this button and the cover-group
+        bulk clear (issue #790) share one path.
+        """
+        await self.coordinator.async_reset_manual_overrides(self._entities)
 
 
 class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -222,6 +222,10 @@ SECTION_CUSTOM_POSITION = "custom_position"
 SECTION_MOTION_OVERRIDE = "motion_override"
 SECTION_PIPELINE_PRIORITIES = "pipeline_priorities"
 SECTION_DEBUG = "debug"
+# Cover-group-only fields (issue #790). Not in COMMON_SECTION_ORDER, so the
+# section never renders in a cover's options flow — it exists so group
+# numeric fields feed OPTION_RANGES / FIELD_VALIDATORS like every other one.
+SECTION_GROUP = "group"
 
 
 # =============================================================================
@@ -1720,6 +1724,23 @@ _GLARE_ZONE_SPECS = _spec(
 # Registry assembly
 # =============================================================================
 
+_GROUP_SPECS = _spec(
+    FieldSpec(
+        const.CONF_GROUP_STAGGER_DELAY,
+        SECTION_GROUP,
+        ValidatorKind.RANGE,
+        rng=const._RANGE_GROUP_STAGGER,
+        default=const.DEFAULT_GROUP_STAGGER_DELAY,
+        make_selector=_number(
+            minimum=const._RANGE_GROUP_STAGGER[0],
+            maximum=const._RANGE_GROUP_STAGGER[1],
+            step=0.5,
+            unit="s",
+        ),
+    ),
+)
+
+
 _ALL_SPEC_GROUPS: tuple[list[FieldSpec], ...] = (
     _GEOMETRY_SPECS,
     _SUN_TRACKING_SPECS,
@@ -1739,6 +1760,7 @@ _ALL_SPEC_GROUPS: tuple[list[FieldSpec], ...] = (
     _MOTION_OVERRIDE_SPECS,
     _PIPELINE_PRIORITY_SPECS,
     _DEBUG_SPECS,
+    _GROUP_SPECS,
 )
 
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,7 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_GROUP_AREA,
     CONF_GROUP_ENABLE_CLIMATE_SENSOR,
     CONF_GROUP_ENABLE_COVER_ENTITY,
     CONF_GROUP_ENABLE_POSITION_SENSOR,
@@ -398,6 +399,10 @@ def _group_membership_schema_dict(hass, *, exclude_entry_id: str | None = None) 
         vol.Optional(CONF_MEMBER_COVERS, default=[]): selector.EntitySelector(
             selector.EntitySelectorConfig(domain="cover", multiple=True)
         ),
+        # LIVE area membership source (issue #790, Phase 4): the effective
+        # rosters are the lists above ∪ the area's covers, tracking registry
+        # changes — not a one-shot copy.
+        vol.Optional(CONF_GROUP_AREA): selector.AreaSelector(),
     }
 
 
@@ -1600,6 +1605,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "group.cover_entity": (
         "Aggregate cover entity exposed — dragging it commands every member"
     ),
+    "group.area": ("Membership tracks area '{area}' — covers there join automatically"),
     "warnings.group_empty": (
         "⚠️ This group has no members — it will not command anything."
     ),
@@ -1706,6 +1712,9 @@ def _build_group_summary(
         lines.append(L["group.stagger"].format(stagger=stagger))
     if config.get(CONF_GROUP_ENABLE_COVER_ENTITY, DEFAULT_GROUP_ENABLE_COVER_ENTITY):
         lines.append(L["group.cover_entity"])
+    area_id = config.get(CONF_GROUP_AREA)
+    if area_id:
+        lines.append(L["group.area"].format(area=area_id))
     return "\n".join(lines)
 
 
@@ -3408,6 +3417,8 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 "name": user_input["name"],
                 **_sanitize_group_membership(self.hass, user_input),
             }
+            if user_input.get(CONF_GROUP_AREA):
+                self.config[CONF_GROUP_AREA] = user_input[CONF_GROUP_AREA]
             self.type_blind = CoverType.GROUP
             return await self.async_step_update()
         return self.async_show_form(
@@ -4596,6 +4607,10 @@ class OptionsFlowHandler(OptionsFlow):
                 own_entry_id=self._config_entry.entry_id,
             )
             self.options.update(sanitized)
+            if user_input.get(CONF_GROUP_AREA):
+                self.options[CONF_GROUP_AREA] = user_input[CONF_GROUP_AREA]
+            else:
+                self.options.pop(CONF_GROUP_AREA, None)
             # A removed member's opt-out entry is stale — prune it in the
             # same save so the arbitration step never lists ghosts.
             opt_out = self.options.get(CONF_GROUP_MEMBER_OPT_OUT)

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,11 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+    CONF_GROUP_ENABLE_COVER_ENTITY,
+    CONF_GROUP_ENABLE_POSITION_SENSOR,
+    CONF_GROUP_ENABLE_STATE_SENSOR,
+    CONF_GROUP_ENABLE_WHO_WON_SENSOR,
     CONF_GROUP_MEMBER_OPT_OUT,
     CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
@@ -174,6 +179,8 @@ from .const import (
     CONF_WINDOW_WIDTH,
     DEFAULT_DELTA_POSITION,
     DEFAULT_DELTA_TIME,
+    DEFAULT_GROUP_ENABLE_COVER_ENTITY,
+    DEFAULT_GROUP_ENABLE_SENSOR,
     DEFAULT_GROUP_STAGGER_DELAY,
     DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MOTION_TIMEOUT,
@@ -1590,6 +1597,9 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
         "place; a member's own safety still wins ties"
     ),
     "group.stagger": "Members commanded {stagger}s apart",
+    "group.cover_entity": (
+        "Aggregate cover entity exposed — dragging it commands every member"
+    ),
     "warnings.group_empty": (
         "⚠️ This group has no members — it will not command anything."
     ),
@@ -1694,6 +1704,8 @@ def _build_group_summary(
     stagger = config.get(CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY)
     if stagger:
         lines.append(L["group.stagger"].format(stagger=stagger))
+    if config.get(CONF_GROUP_ENABLE_COVER_ENTITY, DEFAULT_GROUP_ENABLE_COVER_ENTITY):
+        lines.append(L["group.cover_entity"])
     return "\n".join(lines)
 
 
@@ -4151,6 +4163,7 @@ class OptionsFlowHandler(OptionsFlow):
                 menu_options=[
                     "group_membership",
                     "group_arbitration",
+                    "group_entities",
                     "summary",
                     "done",
                 ],
@@ -4668,6 +4681,46 @@ class OptionsFlowHandler(OptionsFlow):
                 vol.Schema(schema_dict),
                 {CONF_GROUP_STAGGER_DELAY: self.options.get(CONF_GROUP_STAGGER_DELAY)},
             ),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
+            },
+        )
+
+    async def async_step_group_entities(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the group's entity-exposure toggles (issue #790, Phase 3).
+
+        Five booleans: the opt-in aggregate cover (off by default) and the
+        four aggregate sensors (on by default). Saving reloads the entry, so
+        toggles take effect immediately.
+        """
+        if user_input is not None:
+            self.options.update(user_input)
+            return self.async_create_entry(title="", data=self.options)
+
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    CONF_GROUP_ENABLE_COVER_ENTITY,
+                    default=DEFAULT_GROUP_ENABLE_COVER_ENTITY,
+                ): selector.BooleanSelector(),
+                **{
+                    vol.Optional(
+                        key, default=DEFAULT_GROUP_ENABLE_SENSOR
+                    ): selector.BooleanSelector()
+                    for key in (
+                        CONF_GROUP_ENABLE_POSITION_SENSOR,
+                        CONF_GROUP_ENABLE_STATE_SENSOR,
+                        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+                        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+                    )
+                },
+            }
+        )
+        return self.async_show_form(
+            step_id="group_entities",
+            data_schema=self.add_suggested_values_to_schema(schema, self.options),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,8 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
     CONF_FORCE_OVERRIDE_MIN_MODE,
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
@@ -206,7 +208,11 @@ _LOGGER = logging.getLogger(__name__)
 from .cover_types import POLICY_REGISTRY as _POLICY_REGISTRY  # noqa: E402
 from .cover_types import get_policy as _get_policy  # noqa: E402
 
-SENSOR_TYPE_MENU = [k for k in _POLICY_REGISTRY if _get_policy(k).controls_cover]
+SENSOR_TYPE_MENU = [
+    k
+    for k in _POLICY_REGISTRY
+    if _get_policy(k).controls_cover and not _get_policy(k).is_orchestrator
+]
 
 _STANDALONE_SENTINEL = "__standalone__"
 # Sentinel value for the "no profile / unlink" choice in the link selector.
@@ -355,6 +361,66 @@ BUILDING_PROFILE_CREATE_SCHEMA = vol.Schema(
         **building_profile_sensors_schema().schema,
     }
 )
+
+
+def _group_membership_schema_dict(hass, *, exclude_entry_id: str | None = None) -> dict:
+    """Build the two cover-group membership selectors (issue #790).
+
+    ACP members are picked as config entries (an ACP instance may expose no
+    ``cover.`` entity at all when its proxy is off, and one with a proxy must
+    still be orchestrated through its pipeline), generic covers as plain
+    entities. ``_cover_entries`` already excludes profiles and groups, so a
+    group can never nest another group; ``exclude_entry_id`` drops the group
+    itself when editing.
+    """
+    acp_options = [
+        {"value": e.entry_id, "label": e.title}
+        for e in _cover_entries(hass)
+        if e.entry_id != exclude_entry_id
+    ]
+    return {
+        vol.Optional(CONF_MEMBER_ENTRIES, default=[]): selector.SelectSelector(
+            selector.SelectSelectorConfig(options=acp_options, multiple=True)
+        ),
+        vol.Optional(CONF_MEMBER_COVERS, default=[]): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="cover", multiple=True)
+        ),
+    }
+
+
+def _sanitize_group_membership(
+    hass, user_input: dict, *, own_entry_id: str | None = None
+) -> dict[str, list[str]]:
+    """Clean the submitted membership rosters.
+
+    Deduplicates while preserving order, drops the group's own entry id, and
+    drops a generic entity that is already controlled by a selected ACP
+    member — the entry is preferred so the member's pipeline orchestrates the
+    cover instead of it being double-commanded through adopt mode.
+    """
+    member_entries = list(
+        dict.fromkeys(
+            entry_id
+            for entry_id in user_input.get(CONF_MEMBER_ENTRIES, [])
+            if entry_id != own_entry_id
+        )
+    )
+    owned_covers: set[str] = set()
+    for entry_id in member_entries:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is not None:
+            owned_covers.update(entry.options.get(CONF_ENTITIES, []))
+    member_covers = list(
+        dict.fromkeys(
+            entity_id
+            for entity_id in user_input.get(CONF_MEMBER_COVERS, [])
+            if entity_id not in owned_covers
+        )
+    )
+    return {
+        CONF_MEMBER_ENTRIES: member_entries,
+        CONF_MEMBER_COVERS: member_covers,
+    }
 
 
 # The sun-tracking step no longer carries any length field — the shaded distance
@@ -1483,6 +1549,16 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "headers.decision_priority": (
         "**Decision Priority** (highest wins, ✅ active ❌ not configured)"
     ),
+    # --- Cover Group (issue #790) ---
+    "group.header": "**Cover Group**",
+    "group.members": (
+        "Controls {acp_count} ACP member(s) + {generic_count} generic cover(s)"
+    ),
+    "group.member_acp": "- 🪟 {title} (ACP)",
+    "group.member_generic": "- 🪟 {entity} (generic)",
+    "warnings.group_empty": (
+        "⚠️ This group has no members — it will not command anything."
+    ),
 }
 
 
@@ -1545,6 +1621,40 @@ async def _load_summary_labels(hass: HomeAssistant, language: str) -> dict[str, 
     return await hass.async_add_executor_job(_load_summary_labels_sync, language)
 
 
+def _build_group_summary(
+    config: dict,
+    hass: HomeAssistant | None,
+    L: dict[str, str],
+) -> str:
+    """Compact configuration summary for a Cover Group entry (issue #790).
+
+    Header, roster counts, and the member list (ACP member titles resolve
+    only when ``hass`` is available). An empty roster gets a warning — a
+    memberless group commands nothing.
+    """
+    member_entries: list[str] = config.get(CONF_MEMBER_ENTRIES) or []
+    member_covers: list[str] = config.get(CONF_MEMBER_COVERS) or []
+    lines = [L["group.header"], ""]
+    if not member_entries and not member_covers:
+        lines.append(L["warnings.group_empty"])
+        return "\n".join(lines)
+    lines.append(
+        L["group.members"].format(
+            acp_count=len(member_entries), generic_count=len(member_covers)
+        )
+    )
+    if hass is not None:
+        for entry_id in member_entries:
+            entry = hass.config_entries.async_get_entry(entry_id)
+            if entry is not None:
+                lines.append(L["group.member_acp"].format(title=entry.title))
+    lines.extend(
+        L["group.member_generic"].format(entity=entity_id)
+        for entity_id in member_covers
+    )
+    return "\n".join(lines)
+
+
 def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     config: dict,
     sensor_type: str | None,
@@ -1566,6 +1676,12 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     are used, so the output is byte-identical to the pre-i18n strings.
     """
     L = labels or _SUMMARY_LABELS_EN
+
+    # Cover groups render their own compact summary — a group has no cover
+    # chain, geometry, or handler ladder (issue #790).
+    if sensor_type is not None and get_policy(sensor_type).is_orchestrator:
+        return _build_group_summary(config, hass, L)
+
     _ph = L["fragments.template_value"]
     # ---- Gather all values up front ----------------------------------------
     # ``L`` here is the FULL flow bundle (``_SUMMARY_LABELS_EN`` keys + the
@@ -3188,7 +3304,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         choices. The duplicate option only appears when prior entries exist.
         """
         acp_entries = _cover_entries(self.hass)
-        menu_options = ["create_new", "create_building_profile"] + (
+        menu_options = ["create_new", "create_building_profile", "create_group"] + (
             ["duplicate_existing"] if acp_entries else []
         )
         return self.async_show_menu(step_id="user", menu_options=menu_options)
@@ -3222,6 +3338,34 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             data_schema=BUILDING_PROFILE_CREATE_SCHEMA,
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
+            },
+        )
+
+    async def async_step_create_group(self, user_input: dict[str, Any] | None = None):
+        """Create a Cover Group entry from a single combined form (issue #790).
+
+        One step collects the group name together with the two membership
+        rosters (ACP members first, generic covers below), then delegates to
+        the shared finalize (``async_step_update``) — the same path the
+        Building Profile flow uses.
+        """
+        if user_input is not None:
+            self.config = {
+                "name": user_input["name"],
+                **_sanitize_group_membership(self.hass, user_input),
+            }
+            self.type_blind = CoverType.GROUP
+            return await self.async_step_update()
+        return self.async_show_form(
+            step_id="create_group",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("name"): selector.TextSelector(),
+                    **_group_membership_schema_dict(self.hass),
+                }
+            ),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },
         )
 
@@ -3767,10 +3911,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
         # Quick setup skips some steps (e.g. automation) leaving critical keys
         # absent from self.config.  Apply constant-backed defaults so the
-        # coordinator never receives None for gating values (issue #133). A
-        # virtual entry type (Building Profile) builds no coordinator, so it
-        # keeps only the sensor IDs it collected — no cover automation defaults.
-        if get_policy(self.type_blind).controls_cover:
+        # coordinator never receives None for gating values (issue #133).
+        # Virtual entry types skip this: a Building Profile builds no
+        # coordinator, and a cover group builds a GroupCoordinator that reads
+        # none of the cover-automation options — both keep only what their
+        # create step collected.
+        _finalize_policy = get_policy(self.type_blind)
+        if _finalize_policy.controls_cover and not _finalize_policy.is_orchestrator:
             options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
             options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
             options.setdefault(
@@ -3944,6 +4091,23 @@ class OptionsFlowHandler(OptionsFlow):
                     "profile_sensors",
                     "profile_overview",
                     "profile_overrides",
+                    "done",
+                ],
+                description_placeholders={
+                    "instance_name": self._config_entry.title,
+                    "coffee_url": "https://www.buymeacoffee.com/jrhubott",
+                    "profile_line": "",
+                },
+            )
+
+        # Cover groups are orchestrators, not geometry covers — their own
+        # small menu (membership + summary), never the cover categories.
+        if get_policy(self.sensor_type).is_orchestrator:
+            return self.async_show_menu(
+                step_id="init",
+                menu_options=[
+                    "group_membership",
+                    "summary",
                     "done",
                 ],
                 description_placeholders={
@@ -4355,6 +4519,39 @@ class OptionsFlowHandler(OptionsFlow):
             data_schema=schema,
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
+            },
+        )
+
+    async def async_step_group_membership(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit the cover-group membership rosters (issue #790).
+
+        Same one page as the create flow: ACP members first, generic covers
+        below. Saves on submit, mirroring ``profile_sensors``. Sanitization
+        drops duplicates, the group itself, and generic entities owned by a
+        selected ACP member.
+        """
+        if user_input is not None:
+            self.options.update(
+                _sanitize_group_membership(
+                    self.hass,
+                    user_input,
+                    own_entry_id=self._config_entry.entry_id,
+                )
+            )
+            return self.async_create_entry(title="", data=self.options)
+
+        schema = vol.Schema(
+            _group_membership_schema_dict(
+                self.hass, exclude_entry_id=self._config_entry.entry_id
+            )
+        )
+        return self.async_show_form(
+            step_id="group_membership",
+            data_schema=self.add_suggested_values_to_schema(schema, self.options),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },
         )
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -58,6 +58,8 @@ from .const import (
     CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_ENFORCE_DELTA_AT_ENDPOINTS,
     CONF_ENTITIES,
+    CONF_GROUP_MEMBER_OPT_OUT,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_FORCE_OVERRIDE_MIN_MODE,
@@ -172,8 +174,11 @@ from .const import (
     CONF_WINDOW_WIDTH,
     DEFAULT_DELTA_POSITION,
     DEFAULT_DELTA_TIME,
+    DEFAULT_GROUP_STAGGER_DELAY,
     DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MOTION_TIMEOUT,
+    GROUP_SCENE_PRIORITY,
+    OPT_OUT_ALL_SCENES,
     CONF_DEBUG_CATEGORIES,
     CONF_DEBUG_EVENT_BUFFER_SIZE,
     CONF_DEBUG_MODE,
@@ -188,6 +193,7 @@ from .const import (
     MODE2_OPEN_HORIZONTAL_PERCENT,
     DOMAIN,
     CoverType,
+    GroupScene,
     TemplateCombineMode,
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
@@ -421,6 +427,25 @@ def _sanitize_group_membership(
         CONF_MEMBER_ENTRIES: member_entries,
         CONF_MEMBER_COVERS: member_covers,
     }
+
+
+# Transient opt-out multi-select in the group_arbitration step: one field
+# whose option values are "member_id|scene" tokens (labels carry the member
+# title), folded into the persisted CONF_GROUP_MEMBER_OPT_OUT dict on submit.
+# Entry ids are UUID hex (no "|"), so the separator is unambiguous.
+_OPT_OUT_FIELD = "scene_opt_outs"
+_OPT_OUT_TOKEN_SEP = "|"
+
+
+def _group_opt_out_choices() -> list[dict[str, str]]:
+    """Build the opt-out select options: the all-scenes sentinel plus every scene."""
+    return [
+        {"value": OPT_OUT_ALL_SCENES, "label": "All scenes"},
+        *(
+            {"value": str(scene), "label": str(scene).replace("_", " ").title()}
+            for scene in GroupScene
+        ),
+    ]
 
 
 # The sun-tracking step no longer carries any length field — the shaded distance
@@ -1556,6 +1581,15 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     ),
     "group.member_acp": "- 🪟 {title} (ACP)",
     "group.member_generic": "- 🪟 {entity} (generic)",
+    "group.scene_priority": (
+        "Group scenes apply at priority {scene_priority} "
+        "(above manual override, below weather safety)"
+    ),
+    "group.lock": (
+        "🔒 Group lock at priority {lock_priority} — freezes members in "
+        "place; a member's own safety still wins ties"
+    ),
+    "group.stagger": "Members commanded {stagger}s apart",
     "warnings.group_empty": (
         "⚠️ This group has no members — it will not command anything."
     ),
@@ -1652,6 +1686,14 @@ def _build_group_summary(
         L["group.member_generic"].format(entity=entity_id)
         for entity_id in member_covers
     )
+    # Arbitration (Phase 2): priorities from the imported consts, never baked
+    # into the templates.
+    lines.append("")
+    lines.append(L["group.scene_priority"].format(scene_priority=GROUP_SCENE_PRIORITY))
+    lines.append(L["group.lock"].format(lock_priority=CUSTOM_POSITION_SAFETY_PRIORITY))
+    stagger = config.get(CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY)
+    if stagger:
+        lines.append(L["group.stagger"].format(stagger=stagger))
     return "\n".join(lines)
 
 
@@ -4101,12 +4143,14 @@ class OptionsFlowHandler(OptionsFlow):
             )
 
         # Cover groups are orchestrators, not geometry covers — their own
-        # small menu (membership + summary), never the cover categories.
+        # small menu (membership + arbitration + summary), never the cover
+        # categories.
         if get_policy(self.sensor_type).is_orchestrator:
             return self.async_show_menu(
                 step_id="init",
                 menu_options=[
                     "group_membership",
+                    "group_arbitration",
                     "summary",
                     "done",
                 ],
@@ -4533,13 +4577,22 @@ class OptionsFlowHandler(OptionsFlow):
         selected ACP member.
         """
         if user_input is not None:
-            self.options.update(
-                _sanitize_group_membership(
-                    self.hass,
-                    user_input,
-                    own_entry_id=self._config_entry.entry_id,
-                )
+            sanitized = _sanitize_group_membership(
+                self.hass,
+                user_input,
+                own_entry_id=self._config_entry.entry_id,
             )
+            self.options.update(sanitized)
+            # A removed member's opt-out entry is stale — prune it in the
+            # same save so the arbitration step never lists ghosts.
+            opt_out = self.options.get(CONF_GROUP_MEMBER_OPT_OUT)
+            if opt_out:
+                roster = set(sanitized[CONF_MEMBER_ENTRIES])
+                self.options[CONF_GROUP_MEMBER_OPT_OUT] = {
+                    member: scenes
+                    for member, scenes in opt_out.items()
+                    if member in roster
+                }
             return self.async_create_entry(title="", data=self.options)
 
         schema = vol.Schema(
@@ -4550,6 +4603,71 @@ class OptionsFlowHandler(OptionsFlow):
         return self.async_show_form(
             step_id="group_membership",
             data_schema=self.add_suggested_values_to_schema(schema, self.options),
+            description_placeholders={
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
+            },
+        )
+
+    async def async_step_group_arbitration(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Edit stagger and per-member scene opt-out (issue #790, Phase 2).
+
+        Opt-outs use ONE multi-select whose options are ``member|scene``
+        pairs with human labels — the same dynamic-row pattern as the
+        profile-overrides step, so the field itself stays translatable.
+        Unchecked members are pruned so ``CONF_GROUP_MEMBER_OPT_OUT`` holds
+        only members that actually opt out. The group lock ignores opt-out.
+        """
+        member_ids = [
+            entry_id
+            for entry_id in self.options.get(CONF_MEMBER_ENTRIES, [])
+            if self.hass.config_entries.async_get_entry(entry_id) is not None
+        ]
+        if user_input is not None:
+            self.options[CONF_GROUP_STAGGER_DELAY] = user_input.get(
+                CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY
+            )
+            opt_out: dict[str, list[str]] = {}
+            for token in user_input.get(_OPT_OUT_FIELD, []):
+                member_id, _, scene_value = token.partition(_OPT_OUT_TOKEN_SEP)
+                if member_id in member_ids:
+                    opt_out.setdefault(member_id, []).append(scene_value)
+            self.options[CONF_GROUP_MEMBER_OPT_OUT] = opt_out
+            return self.async_create_entry(title="", data=self.options)
+
+        stagger_spec = config_fields.FIELD_SPECS[CONF_GROUP_STAGGER_DELAY]
+        stagger_marker, stagger_selector = stagger_spec.to_marker(
+            self.hass, self.options
+        )
+        current_opt_out = self.options.get(CONF_GROUP_MEMBER_OPT_OUT, {})
+        choices: list[dict[str, str]] = []
+        selected: list[str] = []
+        for member_id in member_ids:
+            entry = self.hass.config_entries.async_get_entry(member_id)
+            for choice in _group_opt_out_choices():
+                token = f"{member_id}{_OPT_OUT_TOKEN_SEP}{choice['value']}"
+                choices.append(
+                    {"value": token, "label": f"{entry.title} — {choice['label']}"}
+                )
+                if choice["value"] in current_opt_out.get(member_id, []):
+                    selected.append(token)
+        schema_dict: dict = {
+            stagger_marker: stagger_selector,
+            vol.Optional(_OPT_OUT_FIELD, default=selected): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=choices,
+                    multiple=True,
+                    mode=selector.SelectSelectorMode.LIST,
+                )
+            ),
+        }
+        return self.async_show_form(
+            step_id="group_arbitration",
+            data_schema=self.add_suggested_values_to_schema(
+                vol.Schema(schema_dict),
+                {CONF_GROUP_STAGGER_DELAY: self.options.get(CONF_GROUP_STAGGER_DELAY)},
+            ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Cover-Groups"
             },

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -104,6 +104,12 @@ CONF_SYNC_SELECT_ALL = "select_all_targets"
 CONF_MEMBER_ENTRIES = "member_entries"  # ACP member config-entry ids
 CONF_MEMBER_COVERS = "member_covers"  # generic cover entity_ids
 
+# Optional area-based membership source (issue #790, Phase 4). LIVE, not a
+# one-shot seed: the effective rosters are the static lists ∪ the area's
+# resolved members (ACP entries with a controlled cover in the area; free
+# ``cover.*`` entities in the area), re-resolved on registry changes.
+CONF_GROUP_AREA = "group_area"
+
 # Per-member scene opt-out, stored on the GROUP entry keyed by member
 # entry_id so a member removal prunes cleanly: {member_id: [scene, ...]}.
 # The sentinel OPT_OUT_ALL_SCENES ("*") opts a member out of every scene.

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -96,6 +96,14 @@ CONF_PROFILE_SENSOR_OVERRIDES = "profile_sensor_overrides"
 # multi-select becomes an exclude list instead of an include list).
 CONF_SYNC_SELECT_ALL = "select_all_targets"
 
+# Cover-group membership rosters, stored on the GROUP entry only (issue #790).
+# Two lists because the member kinds are structural: ACP members are config
+# entries (orchestrated through their own coordinator — an ACP instance may
+# expose no cover entity at all when the proxy is off), generic members are
+# plain ``cover.*`` entity_ids (adopt mode, commanded directly).
+CONF_MEMBER_ENTRIES = "member_entries"  # ACP member config-entry ids
+CONF_MEMBER_COVERS = "member_covers"  # generic cover entity_ids
+
 # Default name prefix used by the config flow when auto-naming a cover from its
 # entity's friendly name (no linked device available) — see config_flow.py's
 # cover_entities auto-fill and async_step_update finalization fallback (#771).
@@ -1406,6 +1414,11 @@ class CoverType(StrEnum):
     # sensor entity IDs that linked covers copy into their own options. Its
     # policy registers no platforms (``controls_cover = False``).
     BUILDING_PROFILE = "cover_building_profile"
+    # Virtual entry type — orchestrates a roster of member covers (ACP
+    # entries + generic ``cover.*`` entities). Controls covers
+    # (``controls_cover = True``) but is not geometry-driven: setup branches
+    # on ``is_orchestrator`` to a ``GroupCoordinator`` (issue #790).
+    GROUP = "cover_group"
 
     @property
     def display_name(self) -> str:
@@ -1423,7 +1436,36 @@ class CoverType(StrEnum):
             self.OSCILLATING_AWNING: "Oscillating Awning",
             self.ROOF_WINDOW: "Roof Window",
             self.BUILDING_PROFILE: "Building Profile",
+            self.GROUP: "Cover Group",
         }[self]
+
+
+class GroupScene(StrEnum):
+    """Built-in cover-group scenes (issue #790, Phase 1).
+
+    Wire-stable identifiers: stored as the group's active-scene state and the
+    scene ``select``/``button`` option values. Each scene is a semantic intent
+    resolved per member cover type via ``CoverTypePolicy.position_for_scene``
+    — never an absolute position shared across a mixed group.
+    """
+
+    ALL_OPEN = "all_open"
+    ALL_CLOSED = "all_closed"
+    PRIVACY = "privacy"
+
+
+class GroupState(StrEnum):
+    """Aggregate open/closed classification of a cover group's members.
+
+    Wire-stable: the group state sensor reports these values. ``MIXED`` covers
+    every non-uniform roster (members disagree, or sit between endpoints);
+    ``UNKNOWN`` means no member position was readable.
+    """
+
+    OPEN = "open"
+    CLOSED = "closed"
+    MIXED = "mixed"
+    UNKNOWN = "unknown"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -104,6 +104,25 @@ CONF_SYNC_SELECT_ALL = "select_all_targets"
 CONF_MEMBER_ENTRIES = "member_entries"  # ACP member config-entry ids
 CONF_MEMBER_COVERS = "member_covers"  # generic cover entity_ids
 
+# Per-member scene opt-out, stored on the GROUP entry keyed by member
+# entry_id so a member removal prunes cleanly: {member_id: [scene, ...]}.
+# The sentinel OPT_OUT_ALL_SCENES ("*") opts a member out of every scene.
+# Enforced group-side at intent-push time (the member handler stays dumb);
+# the group lock ignores opt-out — it is a safety claim on every member.
+CONF_GROUP_MEMBER_OPT_OUT = "group_member_opt_out"
+OPT_OUT_ALL_SCENES = "*"
+
+# Seconds between successive member commands during a group fan-out
+# (scene activation). 0 = simultaneous. Issue #790 Phase 2.
+CONF_GROUP_STAGGER_DELAY = "group_stagger_delay"
+DEFAULT_GROUP_STAGGER_DELAY = 0.0
+_RANGE_GROUP_STAGGER = (0.0, 30.0)
+
+# The scene select's "no scene" option (wire-stable select state). Not a
+# GroupScene member — it is the absence of a scene: choosing it clears the
+# group's claim so members return to their own pipelines.
+GROUP_SCENE_SELECT_AUTO = "auto"
+
 # Default name prefix used by the config flow when auto-naming a cover from its
 # entity's friendly name (no linked device available) — see config_flow.py's
 # cover_entities auto-fill and async_step_update finalization fallback (#771).
@@ -540,6 +559,16 @@ CUSTOM_POSITION_SLOT_NUMBERS: tuple[int, ...] = tuple(
 # semantics: they command the cover outside the start/end time window and
 # bypass the delta-position/delta-time send gates (issue #563).
 CUSTOM_POSITION_SAFETY_PRIORITY = 100
+
+# Cover-group scene intents claim the pipeline at this priority (issue #790,
+# Phase 2): above manual_override (80) so "put the room in Privacy" wins over
+# a stale per-cover manual state, below weather (90) so wind/rain safety on an
+# outdoor member still overrides a group scene. Declared on GroupSceneHandler;
+# the const exists so the config-flow chain summary and tests import it. Not
+# user-overridable (group-injected handler, not one of HANDLER_PRIORITY_CONF).
+# The group lock reuses CUSTOM_POSITION_SAFETY_PRIORITY (100); a member's own
+# safety slot wins ties via handler build order.
+GROUP_SCENE_PRIORITY = 85
 
 
 def _custom_position_slot_keys(n: int) -> dict[str, str]:
@@ -1454,6 +1483,19 @@ class GroupScene(StrEnum):
     PRIVACY = "privacy"
 
 
+class GroupIntentKind(StrEnum):
+    """What a cover-group intent asks of a member's pipeline (issue #790).
+
+    ``SCENE`` — claim the position axis at ``GROUP_SCENE_PRIORITY`` with the
+    member policy's resolution of the intent's scene. ``LOCK`` — freeze the
+    member at ``CUSTOM_POSITION_SAFETY_PRIORITY``: the handler wins the
+    pipeline but sends no command, so the cover holds its position.
+    """
+
+    SCENE = "scene"
+    LOCK = "lock"
+
+
 class GroupState(StrEnum):
     """Aggregate open/closed classification of a cover group's members.
 
@@ -1603,6 +1645,12 @@ class ControlMethod(StrEnum):
 
     GLARE_ZONE = "glare_zone"
     """Glare zone protection active; cover extends to shield a floor zone."""
+
+    GROUP_SCENE = "group_scene"
+    """A cover-group scene intent claims the position (issue #790, Phase 2)."""
+
+    GROUP_LOCK = "group_lock"
+    """A cover-group lock freezes the cover in place (issue #790, Phase 2)."""
 
 
 class SunState(StrEnum):

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -123,6 +123,18 @@ _RANGE_GROUP_STAGGER = (0.0, 30.0)
 # group's claim so members return to their own pipelines.
 GROUP_SCENE_SELECT_AUTO = "auto"
 
+# Entity-exposure toggles for a group entry (issue #790, Phase 3). The
+# aggregate cover entity defaults OFF (dashboard/voice clutter); the sensors
+# default ON. The active-scene sensor, scene controls, and bulk switches are
+# always created (primary control surface, no toggle).
+CONF_GROUP_ENABLE_COVER_ENTITY = "group_enable_cover_entity"
+DEFAULT_GROUP_ENABLE_COVER_ENTITY = False
+CONF_GROUP_ENABLE_POSITION_SENSOR = "group_enable_position_sensor"
+CONF_GROUP_ENABLE_STATE_SENSOR = "group_enable_state_sensor"
+CONF_GROUP_ENABLE_CLIMATE_SENSOR = "group_enable_climate_sensor"
+CONF_GROUP_ENABLE_WHO_WON_SENSOR = "group_enable_who_won_sensor"
+DEFAULT_GROUP_ENABLE_SENSOR = True  # shared default for the four sensor toggles
+
 # Default name prefix used by the config flow when auto-naming a cover from its
 # entity's friendly name (no linked device available) — see config_flow.py's
 # cover_entities auto-fill and async_step_update finalization fallback (#771).
@@ -165,6 +177,9 @@ TRIGGER_PROXY_POSITION = "proxy_managed"
 TRIGGER_PROXY_OPEN = "proxy_open"
 TRIGGER_PROXY_CLOSE = "proxy_close"
 TRIGGER_PROXY_TILT = "proxy_tilt"
+# Cover-group aggregate cover entity commands (issue #790, Phase 3).
+TRIGGER_GROUP_COVER = "group_cover"
+TRIGGER_GROUP_COVER_TILT = "group_cover_tilt"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -117,7 +117,7 @@ from .pipeline.handlers import (
 from .pipeline.floors import effective_floor, gather_active_floors
 from .pipeline.registry import PipelineRegistry
 from .pipeline.snapshot_builder import PipelineSnapshotBuilder
-from .pipeline.types import CustomPositionSensorState
+from .pipeline.types import CustomPositionSensorState, GroupIntent
 from .templates import TemplateResolver
 from .const import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
@@ -332,6 +332,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # each can carry an independent priority configured by the user.
         self._pipeline = self._build_pipeline()
         self._pipeline_result = None
+
+        # Live cover-group intents, one per group entry pushing to this member
+        # (issue #790, Phase 2). Mutable manager-style state: groups write via
+        # set_group_intent(); each snapshot folds effective_group_intent in.
+        self._group_intents: dict[str, GroupIntent] = {}
 
         # Resolved-target signature last handed to the dispatch path (issue
         # #756). The dispatch decision compares the current cycle's resolved
@@ -1268,6 +1273,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             cover_capabilities=getattr(
                 getattr(self, "_snapshot", None), "cover_capabilities", None
             ),
+            group_intent=self.effective_group_intent,
         )
         self._pipeline_result = self._pipeline.evaluate(snapshot)
 
@@ -1668,6 +1674,44 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             return None
         return await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
+
+    def set_group_intent(self, group_id: str, intent: GroupIntent | None) -> None:
+        """Store or remove one cover-group's live intent for this member.
+
+        ``None`` removes the group's claim (scene cleared, lock released, or
+        the group unloaded). The next snapshot folds ``effective_group_intent``
+        in; the caller is responsible for triggering a refresh.
+        """
+        if intent is None:
+            self._group_intents.pop(group_id, None)
+        else:
+            self._group_intents[group_id] = intent
+
+    @property
+    def effective_group_intent(self) -> GroupIntent | None:
+        """The highest-priority live group intent, or None.
+
+        Priority-ranked, not last-write-wins, so a whole-house lock is never
+        silently clobbered by a facade scene from another group (issue #790).
+        """
+        if not self._group_intents:
+            return None
+        return max(self._group_intents.values(), key=lambda intent: intent.priority)
+
+    @property
+    def pipeline_winner_name(self) -> str | None:
+        """Name of the handler that won the last pipeline evaluation.
+
+        The winner is the first ``matched`` step in trace order (handler
+        steps precede synthetic floor/tilt steps). Read by the cover-group
+        who-won sensor; ``None`` before the first evaluation.
+        """
+        result = self._pipeline_result
+        if result is None:
+            return None
+        return next(
+            (step.handler for step in result.decision_trace if step.matched), None
+        )
 
     async def async_reset_manual_overrides(
         self,
@@ -2508,6 +2552,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             cover_capabilities=getattr(
                 getattr(self, "_snapshot", None), "cover_capabilities", None
             ),
+            group_intent=self.effective_group_intent,
         )
         floors = gather_active_floors(snapshot)
         effective_floor_pos, _ = effective_floor(floors)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1669,6 +1669,71 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return None
         return await self._cmd_svc.apply_position(cover, state, reason, context=ctx)
 
+    async def async_reset_manual_overrides(
+        self,
+        entities: list[str] | None = None,
+        *,
+        trigger: str = "manual_reset",
+    ) -> list[str]:
+        """Clear manual override on covers and resend the pipeline position.
+
+        Single authoritative reset sequence shared by the Reset Manual
+        Override button and the cover-group bulk clear (issue #790): clear the
+        override flag, suppress re-detection during the refresh, re-run the
+        pipeline, then delegate to the shared post-override send path. Returns
+        the entities whose override was actually cleared.
+        """
+        covers = (
+            entities
+            if entities is not None
+            else self.config_entry.options.get(CONF_ENTITIES, [])
+        )
+        reset_entities: list[str] = []
+        for entity in covers:
+            if self.manager.is_cover_manual(entity):
+                _LOGGER.debug("Resetting manual override for: %s", entity)
+                self.manager.reset(entity)
+                # Suppress re-detection: cover state events during refresh must
+                # not be treated as a new manual override.
+                self._cmd_svc.set_waiting(entity, True)
+                self.cover_state_change = False
+                reset_entities.append(entity)
+            else:
+                _LOGGER.debug(
+                    "Resetting manual override for %s is not needed since it is already auto-controlled",
+                    entity,
+                )
+
+        if not reset_entities:
+            return []
+
+        # Refresh so the pipeline re-runs without the override active,
+        # producing the correct post-override position (climate, solar,
+        # default — whichever handler wins now).
+        await self.async_refresh()
+
+        # Time-window and automatic-control gates live in the shared send
+        # path, along with force=True so time_delta/position_delta are
+        # bypassed for this intentional reset.
+        sent = await self._async_send_after_override_clear(
+            self.state,
+            self.config_entry.options,
+            entities=reset_entities,
+            trigger=trigger,
+        )
+
+        # Entities not sent to (gated by time window / auto-control, or
+        # skipped inside apply_position) must have wait_for_target cleared so
+        # later cover state events are not silently swallowed.
+        for entity in reset_entities:
+            if entity not in sent:
+                _LOGGER.debug(
+                    "Manual override reset: no position change sent for %s",
+                    entity,
+                )
+                self._cmd_svc.set_waiting(entity, False)
+        return reset_entities
+
     async def _async_send_after_override_clear(
         self,
         state: int,

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -26,7 +26,10 @@ from homeassistant.util import slugify
 from .const import (
     CONF_ENABLE_PROXY_COVER,
     CONF_ENTITIES,
+    CONF_GROUP_ENABLE_COVER_ENTITY,
+    CONF_SENSOR_TYPE,
     DEFAULT_ENABLE_PROXY_COVER,
+    DEFAULT_GROUP_ENABLE_COVER_ENTITY,
     TRIGGER_PROXY_CLOSE,
     TRIGGER_PROXY_OPEN,
     TRIGGER_PROXY_POSITION,
@@ -57,6 +60,20 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up proxy cover entities for an ACP config entry."""
+    # Cover groups expose the opt-in aggregate cover, never a proxy.
+    from .cover_types import get_policy
+
+    if get_policy(entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        if entry.options.get(
+            CONF_GROUP_ENABLE_COVER_ENTITY, DEFAULT_GROUP_ENABLE_COVER_ENTITY
+        ):
+            from .group_entities import build_group_covers
+
+            async_add_entities(
+                build_group_covers(entry.entry_id, hass, entry, entry.runtime_data)
+            )
+        return
+
     if not entry.options.get(CONF_ENABLE_PROXY_COVER, DEFAULT_ENABLE_PROXY_COVER):
         return
 

--- a/custom_components/adaptive_cover_pro/cover_types/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/__init__.py
@@ -21,10 +21,13 @@ from .roof_window import RoofWindowPolicy
 from .tilt import TiltPolicy
 from .venetian import VenetianPolicy
 
-# Virtual entry type — imported LAST so it sorts to the bottom of the
-# cover-type picker (``SENSOR_TYPE_MENU`` follows registration order). It is
-# not a physical cover (``controls_cover = False``).
+# Virtual entry types — imported LAST so they sort to the bottom of
+# registry-derived menus (``SENSOR_TYPE_MENU`` follows registration order).
+# The building profile is not a physical cover (``controls_cover = False``);
+# the group controls covers but is an orchestrator (``is_orchestrator =
+# True``) — both are filtered out of the cover-type picker by capability.
 from .building_profile import BuildingProfilePolicy
+from .group import GroupPolicy
 
 
 def get_policy(cover_type) -> CoverTypePolicy:
@@ -55,6 +58,7 @@ __all__ = [
     "BlindPolicy",
     "BuildingProfilePolicy",
     "CoverTypePolicy",
+    "GroupPolicy",
     "OscillatingAwningPolicy",
     "RoofWindowPolicy",
     "TiltPolicy",

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -24,7 +24,13 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import selector
 
-from ..const import ATTR_POSITION, ATTR_TILT_POSITION, POSITION_CLOSED, POSITION_OPEN
+from ..const import (
+    ATTR_POSITION,
+    ATTR_TILT_POSITION,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    GroupScene,
+)
 from ..helpers import get_open_close_state, should_use_tilt, state_attr
 
 if TYPE_CHECKING:
@@ -163,6 +169,14 @@ class CoverTypePolicy(ABC):
     # cover-only menus, and the setup path can filter them out by capability
     # rather than by branching on the cover-type string.
     controls_cover: ClassVar[bool] = True
+
+    # Whether this policy orchestrates *other* covers instead of driving a
+    # geometry pipeline of its own. Only the cover group sets this ``True``:
+    # it controls covers (``controls_cover = True``) but setup must build a
+    # ``GroupCoordinator`` rather than the sun/geometry coordinator. A second
+    # capability flag keeps that branch off the cover-type string, same as
+    # ``controls_cover`` (issue #790).
+    is_orchestrator: ClassVar[bool] = False
 
     def __init_subclass__(cls, *, register: bool = False, **kwargs: Any) -> None:
         """Auto-register a concrete policy by its ``cover_type``.
@@ -481,6 +495,26 @@ class CoverTypePolicy(ABC):
         if sun_through:
             return POSITION_CLOSED if primary.open_blocks_sun else POSITION_OPEN
         return POSITION_OPEN if primary.open_blocks_sun else POSITION_CLOSED
+
+    def position_for_scene(self, scene: GroupScene) -> int:
+        """Map a cover-group scene to this cover type's primary-axis position.
+
+        Scenes are semantic intents resolved per member (issue #790):
+
+          - ``ALL_OPEN`` / ``ALL_CLOSED`` follow HA cover semantics — 100 =
+            open (blinds raised / awning extended), 0 = closed.
+          - ``PRIVACY`` means maximum coverage, delegated to the existing
+            ``position_for_intent(sun_through=False)`` polymorphism so the
+            awning's open-blocks-sun axis flips the answer.
+
+        Never called on axis-less virtual policies (group, building profile)
+        — the group resolves scenes through each *member's* policy.
+        """
+        if scene is GroupScene.ALL_OPEN:
+            return POSITION_OPEN
+        if scene is GroupScene.ALL_CLOSED:
+            return POSITION_CLOSED
+        return self.position_for_intent(sun_through=False)
 
     def more_protective_position(self, a: int, b: int) -> int:
         """Return whichever of two primary-axis positions blocks more sun.

--- a/custom_components/adaptive_cover_pro/cover_types/group.py
+++ b/custom_components/adaptive_cover_pro/cover_types/group.py
@@ -1,0 +1,34 @@
+"""Cover-group virtual orchestrator entry-type policy (issue #790).
+
+A cover group is not a physical cover: it holds a roster of member covers
+(ACP config entries + generic ``cover.*`` entities) and fans out scenes and
+bulk operations to them at runtime. It *does* control covers
+(``controls_cover = True``) so cover-only filters treat it as an actor, but
+it is not geometry-driven — ``is_orchestrator = True`` routes its config
+entry to a ``GroupCoordinator`` in ``__init__.async_setup_entry`` instead of
+the sun/geometry coordinator, and keeps it out of the cover-type dropdown.
+
+Scene resolution never happens on this policy: the group resolves each scene
+through the *member's* own policy (``position_for_scene``), which is what
+makes mixed blind/awning/venetian groups work.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from ..const import CoverType
+from .base import CoverAxis, CoverTypePolicy
+
+
+class GroupPolicy(CoverTypePolicy, register=True):
+    """Virtual orchestrator entry type driving a roster of member covers."""
+
+    cover_type = CoverType.GROUP
+    controls_cover: ClassVar[bool] = True
+    is_orchestrator: ClassVar[bool] = True
+    axes: ClassVar[tuple[CoverAxis, ...]] = ()
+
+    def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+        """Never called — group setup builds a ``GroupCoordinator``, no engine."""
+        raise NotImplementedError  # pragma: no cover

--- a/custom_components/adaptive_cover_pro/diagnostics/__init__.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/__init__.py
@@ -39,6 +39,58 @@ def _sanitize(obj):
     return obj
 
 
+async def _group_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> dict | None:
+    """Build the cover-group rollup, or None for non-group entries."""
+    from custom_components.adaptive_cover_pro.const import (  # noqa: PLC0415
+        CONF_GROUP_MEMBER_OPT_OUT,
+        CONF_GROUP_STAGGER_DELAY,
+        CONF_MEMBER_COVERS,
+        CONF_SENSOR_TYPE,
+        DEFAULT_GROUP_STAGGER_DELAY,
+    )
+    from custom_components.adaptive_cover_pro.cover_types import (  # noqa: PLC0415
+        get_policy,
+    )
+
+    try:
+        if not get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+            return None
+    except ValueError:
+        return None
+    coordinator = getattr(config_entry, "runtime_data", None)
+    if coordinator is None:
+        return {"status": "unavailable", "reason": "group coordinator not loaded"}
+    if coordinator.data is None:
+        # No aggregates yet (fresh load) — a group refresh reads states only,
+        # never commands covers, so this is side-effect free.
+        await coordinator.async_refresh()
+    aggregates = coordinator.data
+    return {
+        "active_scene": coordinator.active_scene,
+        "group_locked": coordinator.group_locked,
+        "aggregates": {
+            "position": aggregates.position if aggregates else None,
+            "state": aggregates.state if aggregates else None,
+            "member_positions": aggregates.member_positions if aggregates else {},
+        },
+        "member_winners": coordinator.member_winners(),
+        "member_climate_modes": coordinator.member_climate_modes(),
+        "rosters": {
+            "member_entries": [
+                {"entry_id": entry.entry_id, "title": entry.title}
+                for entry, _ in coordinator.resolved_members()
+            ],
+            "member_covers": list(config_entry.options.get(CONF_MEMBER_COVERS, [])),
+        },
+        "opt_out": config_entry.options.get(CONF_GROUP_MEMBER_OPT_OUT, {}),
+        "stagger_delay": config_entry.options.get(
+            CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY
+        ),
+    }
+
+
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, config_entry: ConfigEntry
 ):
@@ -46,6 +98,26 @@ async def async_get_config_entry_diagnostics(
     from custom_components.adaptive_cover_pro.const import (
         DIAG_CACHE_KEY,
     )  # noqa: PLC0415
+
+    # Cover-group entries carry a GroupCoordinator whose ``data`` is the
+    # aggregates dataclass, not a diagnostics payload — the cover path below
+    # would crash on it. Groups get a rollup of per-member SUMMARIES (winner,
+    # position, climate mode) plus the group's own scene/lock/roster state;
+    # full member traces stay on the member entries (issue #790 §4).
+    group_rollup = await _group_diagnostics(hass, config_entry)
+    if group_rollup is not None:
+        return {
+            "title": "Adaptive Cover Pro Configuration",
+            "type": "config_entry",
+            "identifier": config_entry.entry_id,
+            "config_entry_state": config_entry.state.value,
+            "config_entry_version": config_entry.version,
+            "config_entry_minor_version": config_entry.minor_version,
+            "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+            "config_data": dict(config_entry.data),
+            "config_options": dict(config_entry.options),
+            "group": _sanitize(group_rollup),
+        }
 
     # The coordinator lives on entry.runtime_data (the registry every platform
     # reads). Virtual Building-Profile entries have no coordinator, so this is

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -1,0 +1,241 @@
+"""Coordinator for the virtual Cover Group entry type (issue #790, Phase 1).
+
+Orchestrates a roster of member covers:
+
+* **ACP members** (config entries) are commanded through each member's own
+  coordinator (``async_apply_user_position`` / ``async_reset_manual_overrides``
+  / the ``automatic_control`` toggle) so the member's gates, inverse-state,
+  and override semantics all apply.
+* **Generic members** (plain ``cover.*`` entity_ids, "adopt mode") are
+  commanded through a group-owned ``CoverCommandService`` so capability
+  fallback (open/close-only covers), unavailable-cover skips, and no-op
+  suppression come for free.
+
+Phase 1 acts only on explicit user actions (scene buttons/select, bulk
+switches); it never moves covers autonomously, so there is no boot-time
+fan-out path. Scene targets are resolved per member via the member policy's
+``position_for_scene`` — a scene is an intent, not a shared absolute
+position.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DEFAULT_DELTA_POSITION,
+    DEFAULT_DELTA_TIME,
+    DOMAIN,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    CoverType,
+    GroupScene,
+    GroupState,
+)
+from .cover_types import get_policy
+from .managers.cover_command import CoverCommandService
+from .managers.cover_command.state_store import PositionContext
+from .managers.grace_period import GracePeriodManager
+
+_LOGGER = logging.getLogger(__name__)
+
+# Generic ``cover.*`` members carry no ACP geometry; adopt mode drives them as
+# plain HA position covers — the vertical-blind policy's axis semantics
+# (position attribute, open/close fallback, no inversion) are exactly that.
+_ADOPT_COVER_TYPE = CoverType.BLIND
+
+
+@dataclass(frozen=True, slots=True)
+class GroupAggregates:
+    """Aggregate view over the group's member covers, read by the sensors."""
+
+    position: int | None
+    state: GroupState
+    member_positions: dict[str, int | None]
+
+
+class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
+    """Runtime orchestrator for one cover-group config entry."""
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize the group coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_group_{entry.entry_id}",
+            config_entry=entry,
+        )
+        self.entry = entry
+        self.active_scene: GroupScene | None = None
+        self._unsub_state: CALLBACK_TYPE | None = None
+        self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
+        self._grace_mgr = GracePeriodManager(_LOGGER)
+        self._cmd_svc = CoverCommandService(
+            hass,
+            _LOGGER,
+            _ADOPT_COVER_TYPE,
+            self._grace_mgr,
+        )
+
+    # ---- Roster resolution ------------------------------------------------ #
+
+    def resolved_members(self) -> list[tuple[ConfigEntry, object]]:
+        """ACP members whose entry exists and whose coordinator is loaded.
+
+        Every ``runtime_data`` access is null-guarded: during a member reload
+        the attribute is briefly unset, and a removed member's id may linger
+        in the roster until the next options edit. Both are silently skipped —
+        absence is non-membership for this cycle.
+        """
+        members: list[tuple[ConfigEntry, object]] = []
+        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            coordinator = getattr(entry, "runtime_data", None)
+            if coordinator is None:
+                _LOGGER.debug(
+                    "Group %s: member %s has no loaded coordinator; skipping",
+                    self.entry.entry_id,
+                    entry_id,
+                )
+                continue
+            members.append((entry, coordinator))
+        return members
+
+    def member_cover_entities(self) -> list[str]:
+        """All member cover entity_ids: ACP members' covers, then generic."""
+        entities: list[str] = []
+        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            entities.extend(entry.options.get(CONF_ENTITIES, []))
+        entities.extend(self.entry.options.get(CONF_MEMBER_COVERS, []))
+        return entities
+
+    # ---- Fan-out operations ------------------------------------------------ #
+
+    async def async_activate_scene(self, scene: GroupScene) -> None:
+        """Fan a scene out to every member, resolving the target per policy."""
+        trigger = f"group_scene_{scene}"
+        for entry, coordinator in self.resolved_members():
+            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+            target = policy.position_for_scene(scene)
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                await coordinator.async_apply_user_position(
+                    entity_id,
+                    target,
+                    trigger=trigger,
+                )
+        adopt_target = self._adopt_policy.position_for_scene(scene)
+        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            await self._cmd_svc.apply_position(
+                entity_id,
+                adopt_target,
+                trigger,
+                context=self._adopt_context(),
+            )
+        self.active_scene = scene
+        await self.async_refresh()
+
+    async def async_set_automation(self, enabled: bool) -> None:
+        """Bulk-enable/disable sun-tracking automation on every ACP member."""
+        for _entry, coordinator in self.resolved_members():
+            coordinator.automatic_control = enabled
+            await coordinator.async_refresh()
+
+    async def async_clear_overrides(self) -> None:
+        """Clear manual overrides on every ACP member via its shared reset path."""
+        for _entry, coordinator in self.resolved_members():
+            await coordinator.async_reset_manual_overrides(
+                trigger="group_clear_overrides"
+            )
+
+    def _adopt_context(self) -> PositionContext:
+        """Command context for adopt-mode (generic cover) dispatches.
+
+        Scene activation is an explicit user action: ``force=True`` bypasses
+        the delta/time/manual gates (the group has no such config in Phase 1)
+        while the unavailable-cover skip and same-position no-op suppression
+        still apply inside ``apply_position``.
+        """
+        return PositionContext(
+            auto_control=True,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=DEFAULT_DELTA_POSITION,
+            time_threshold=DEFAULT_DELTA_TIME,
+            special_positions=[],
+            force=True,
+            policy=self._adopt_policy,
+        )
+
+    # ---- Aggregates --------------------------------------------------------- #
+
+    async def _async_setup(self) -> None:
+        """Subscribe to member cover state changes to keep aggregates live."""
+        entities = self.member_cover_entities()
+        if entities:
+            self._unsub_state = async_track_state_change_event(
+                self.hass, entities, self._handle_member_state_change
+            )
+
+    @callback
+    def _handle_member_state_change(self, _event: Event) -> None:
+        """Recompute aggregates when any member cover moves."""
+        self.hass.async_create_task(self.async_request_refresh())
+
+    async def async_shutdown(self) -> None:
+        """Tear down listeners and the adopt-mode command service."""
+        if self._unsub_state is not None:
+            self._unsub_state()
+            self._unsub_state = None
+        self._cmd_svc.stop()
+        await super().async_shutdown()
+
+    async def _async_update_data(self) -> GroupAggregates:
+        """Recompute the group position/state aggregates from member covers."""
+        member_positions: dict[str, int | None] = {}
+        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                member_positions[entity_id] = policy.read_axis_value(
+                    self.hass, entity_id, caps=None
+                )
+        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            member_positions[entity_id] = self._adopt_policy.read_axis_value(
+                self.hass, entity_id, caps=None
+            )
+
+        readable = [pos for pos in member_positions.values() if pos is not None]
+        if not readable:
+            return GroupAggregates(
+                position=None,
+                state=GroupState.UNKNOWN,
+                member_positions=member_positions,
+            )
+        if all(pos == POSITION_OPEN for pos in readable):
+            state = GroupState.OPEN
+        elif all(pos == POSITION_CLOSED for pos in readable):
+            state = GroupState.CLOSED
+        else:
+            state = GroupState.MIXED
+        return GroupAggregates(
+            position=int(round(sum(readable) / len(readable))),
+            state=state,
+            member_positions=member_positions,
+        )

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -33,13 +33,17 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_TILT_POSITION,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER, Platform
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_ENTITIES,
+    CONF_GROUP_AREA,
     CONF_GROUP_MEMBER_OPT_OUT,
     CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
@@ -100,6 +104,8 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         self.active_scene: GroupScene | None = None
         self.group_locked: bool = False
         self._unsub_state: CALLBACK_TYPE | None = None
+        self._unsub_registry: list[CALLBACK_TYPE] = []
+        self._roster_snapshot: tuple[tuple[str, ...], tuple[str, ...]] | None = None
         self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
         self._grace_mgr = GracePeriodManager(_LOGGER)
         self._cmd_svc = CoverCommandService(
@@ -111,6 +117,85 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
     # ---- Roster resolution ------------------------------------------------ #
 
+    def _entity_area_id(self, entity_id: str) -> str | None:
+        """Return the entity's area — its own, or inherited from its device."""
+        reg_entry = er.async_get(self.hass).async_get(entity_id)
+        if reg_entry is None:
+            return None
+        if reg_entry.area_id:
+            return reg_entry.area_id
+        if reg_entry.device_id:
+            device = dr.async_get(self.hass).async_get(reg_entry.device_id)
+            if device is not None:
+                return device.area_id
+        return None
+
+    def _cover_entities_in_area(self, area_id: str) -> list[str]:
+        """Every ``cover.`` entity in the area (own or device-inherited)."""
+        ent_reg = er.async_get(self.hass)
+        return [
+            reg_entry.entity_id
+            for reg_entry in ent_reg.entities.values()
+            if reg_entry.domain == Platform.COVER
+            and self._entity_area_id(reg_entry.entity_id) == area_id
+        ]
+
+    def member_entry_ids(self) -> list[str]:
+        """Effective ACP member entry ids: static roster ∪ area members.
+
+        An ACP entry belongs to the area when any of its controlled covers is
+        in it (its own registry area or its device's). Order: static first,
+        area additions after, deduped, self-excluded. With no area set this
+        is exactly the stored roster — static groups are unchanged.
+        """
+        ids = list(
+            dict.fromkeys(
+                entry_id
+                for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, [])
+                if entry_id != self.entry.entry_id
+            )
+        )
+        area_id = self.entry.options.get(CONF_GROUP_AREA)
+        if area_id:
+            from .profile_link import _cover_entries  # noqa: PLC0415
+
+            for entry in _cover_entries(self.hass):
+                if entry.entry_id in ids:
+                    continue
+                if any(
+                    self._entity_area_id(entity_id) == area_id
+                    for entity_id in entry.options.get(CONF_ENTITIES, [])
+                ):
+                    ids.append(entry.entry_id)
+        return ids
+
+    def generic_cover_ids(self) -> list[str]:
+        """Effective generic cover ids: static roster ∪ free area covers.
+
+        A cover controlled by ANY ACP entry is excluded (orchestration wins
+        over adoption), as are ACP's own entities (the proxy covers). Order:
+        static first, area additions after, deduped.
+        """
+        ids = list(dict.fromkeys(self.entry.options.get(CONF_MEMBER_COVERS, [])))
+        area_id = self.entry.options.get(CONF_GROUP_AREA)
+        if area_id:
+            from .profile_link import _cover_entries  # noqa: PLC0415
+
+            owned = {
+                entity_id
+                for entry in _cover_entries(self.hass)
+                for entity_id in entry.options.get(CONF_ENTITIES, [])
+            }
+            ent_reg = er.async_get(self.hass)
+            for entity_id in self._cover_entities_in_area(area_id):
+                if entity_id in ids or entity_id in owned:
+                    continue
+                reg_entry = ent_reg.async_get(entity_id)
+                if reg_entry is not None and reg_entry.platform == DOMAIN:
+                    continue
+                ids.append(entity_id)
+        return ids
+
     def resolved_members(self) -> list[tuple[ConfigEntry, object]]:
         """ACP members whose entry exists and whose coordinator is loaded.
 
@@ -120,7 +205,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         absence is non-membership for this cycle.
         """
         members: list[tuple[ConfigEntry, object]] = []
-        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+        for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
@@ -138,12 +223,12 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     def member_cover_entities(self) -> list[str]:
         """All member cover entity_ids: ACP members' covers, then generic."""
         entities: list[str] = []
-        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+        for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
             entities.extend(entry.options.get(CONF_ENTITIES, []))
-        entities.extend(self.entry.options.get(CONF_MEMBER_COVERS, []))
+        entities.extend(self.generic_cover_ids())
         return entities
 
     # ---- Fan-out operations ------------------------------------------------ #
@@ -188,7 +273,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             await self._stagger_gap(commands)
             commands += 1
             await member_action(entry, coordinator)
-        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+        for entity_id in self.generic_cover_ids():
             await self._stagger_gap(commands)
             commands += 1
             await generic_action(entity_id)
@@ -339,8 +424,8 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
         from .cover_types.base import AXIS_NAME_TILT
 
-        member_ids = self.entry.options.get(CONF_MEMBER_ENTRIES, [])
-        generic = self.entry.options.get(CONF_MEMBER_COVERS, [])
+        member_ids = self.member_entry_ids()
+        generic = self.generic_cover_ids()
         if not member_ids and not generic:
             return False
         for entry_id in member_ids:
@@ -412,12 +497,50 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     # ---- Aggregates --------------------------------------------------------- #
 
     async def _async_setup(self) -> None:
-        """Subscribe to member cover state changes to keep aggregates live."""
+        """Subscribe to member-state and (with an area) registry changes.
+
+        The registry subscriptions keep area membership live: covers moved
+        into or out of the area re-resolve the rosters.
+        """
         entities = self.member_cover_entities()
         if entities:
             self._unsub_state = async_track_state_change_event(
                 self.hass, entities, self._handle_member_state_change
             )
+        if self.entry.options.get(CONF_GROUP_AREA):
+            self._roster_snapshot = self._current_roster_snapshot()
+            self._unsub_registry = [
+                self.hass.bus.async_listen(
+                    er.EVENT_ENTITY_REGISTRY_UPDATED, self._handle_registry_change
+                ),
+                self.hass.bus.async_listen(
+                    ar.EVENT_AREA_REGISTRY_UPDATED, self._handle_registry_change
+                ),
+            ]
+
+    def _current_roster_snapshot(self) -> tuple[tuple[str, ...], tuple[str, ...]]:
+        """Return a comparable snapshot of the effective rosters."""
+        return (tuple(self.member_entry_ids()), tuple(self.generic_cover_ids()))
+
+    @callback
+    def _handle_registry_change(self, _event: Event) -> None:
+        """Reload the group when a registry change alters area membership.
+
+        The changed-guard makes registry chatter free: only an actual roster
+        difference triggers the (single) reload, which rebuilds listeners and
+        per-member entities consistently.
+        """
+        current = self._current_roster_snapshot()
+        if current == self._roster_snapshot:
+            return
+        self._roster_snapshot = current
+        _LOGGER.debug(
+            "Group %s: area membership changed — reloading entry",
+            self.entry.entry_id,
+        )
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(self.entry.entry_id)
+        )
 
     @callback
     def _handle_member_state_change(self, _event: Event) -> None:
@@ -437,13 +560,16 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         if self._unsub_state is not None:
             self._unsub_state()
             self._unsub_state = None
+        for unsub in self._unsub_registry:
+            unsub()
+        self._unsub_registry = []
         self._cmd_svc.stop()
         await super().async_shutdown()
 
     async def _async_update_data(self) -> GroupAggregates:
         """Recompute the group position/state aggregates from member covers."""
         member_positions: dict[str, int | None] = {}
-        for entry_id in self.entry.options.get(CONF_MEMBER_ENTRIES, []):
+        for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
@@ -452,7 +578,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
                 member_positions[entity_id] = policy.read_axis_value(
                     self.hass, entity_id, caps=None
                 )
-        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+        for entity_id in self.generic_cover_ids():
             member_positions[entity_id] = self._adopt_policy.read_axis_value(
                 self.hass, entity_id, caps=None
             )

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -1,25 +1,29 @@
-"""Coordinator for the virtual Cover Group entry type (issue #790, Phase 1).
+"""Coordinator for the virtual Cover Group entry type (issue #790).
 
 Orchestrates a roster of member covers:
 
-* **ACP members** (config entries) are commanded through each member's own
-  coordinator (``async_apply_user_position`` / ``async_reset_manual_overrides``
-  / the ``automatic_control`` toggle) so the member's gates, inverse-state,
-  and override semantics all apply.
-* **Generic members** (plain ``cover.*`` entity_ids, "adopt mode") are
-  commanded through a group-owned ``CoverCommandService`` so capability
-  fallback (open/close-only covers), unavailable-cover skips, and no-op
-  suppression come for free.
+* **ACP members** (config entries): scenes and the group lock are pushed as
+  a :class:`~.pipeline.types.GroupIntent` into each member coordinator
+  (``set_group_intent`` + refresh, Phase 2) — the member's pipeline
+  arbitrates, so weather safety still outranks a scene and a member's own
+  safety slot outranks the group lock. Bulk operations
+  (``async_reset_manual_overrides``, the ``automatic_control`` toggle) call
+  the member's own entry points.
+* **Generic members** (plain ``cover.*`` entity_ids, "adopt mode") have no
+  pipeline: they are commanded directly through a group-owned
+  ``CoverCommandService`` so capability fallback (open/close-only covers),
+  unavailable-cover skips, and no-op suppression come for free.
 
-Phase 1 acts only on explicit user actions (scene buttons/select, bulk
-switches); it never moves covers autonomously, so there is no boot-time
-fan-out path. Scene targets are resolved per member via the member policy's
-``position_for_scene`` — a scene is an intent, not a shared absolute
-position.
+The group acts only on explicit user actions (scene buttons/select, bulk
+switches); it never moves covers autonomously and its intents are not
+persisted, so there is no boot-time fan-out path. Scene targets resolve per
+member via the member policy's ``position_for_scene`` — a scene is an
+intent, not a shared absolute position.
 """
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import logging
 
@@ -30,15 +34,22 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
     CONF_ENTITIES,
+    CONF_GROUP_MEMBER_OPT_OUT,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_SENSOR_TYPE,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
     DEFAULT_DELTA_POSITION,
     DEFAULT_DELTA_TIME,
+    DEFAULT_GROUP_STAGGER_DELAY,
     DOMAIN,
+    GROUP_SCENE_PRIORITY,
+    OPT_OUT_ALL_SCENES,
     POSITION_CLOSED,
     POSITION_OPEN,
     CoverType,
+    GroupIntentKind,
     GroupScene,
     GroupState,
 )
@@ -46,6 +57,7 @@ from .cover_types import get_policy
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
+from .pipeline.types import GroupIntent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,6 +89,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         )
         self.entry = entry
         self.active_scene: GroupScene | None = None
+        self.group_locked: bool = False
         self._unsub_state: CALLBACK_TYPE | None = None
         self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
         self._grace_mgr = GracePeriodManager(_LOGGER)
@@ -126,20 +139,50 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
     # ---- Fan-out operations ------------------------------------------------ #
 
+    def _scene_opted_out(self, member_entry_id: str, scene: GroupScene) -> bool:
+        """Whether the member opted out of this scene (or all scenes)."""
+        opted = self.entry.options.get(CONF_GROUP_MEMBER_OPT_OUT, {}).get(
+            member_entry_id, []
+        )
+        return OPT_OUT_ALL_SCENES in opted or str(scene) in opted
+
+    async def _stagger_gap(self, commands_sent: int) -> None:
+        """Sleep the configured stagger before every command but the first."""
+        stagger = float(
+            self.entry.options.get(
+                CONF_GROUP_STAGGER_DELAY, DEFAULT_GROUP_STAGGER_DELAY
+            )
+        )
+        if commands_sent and stagger > 0:
+            await asyncio.sleep(stagger)
+
     async def async_activate_scene(self, scene: GroupScene) -> None:
-        """Fan a scene out to every member, resolving the target per policy."""
-        trigger = f"group_scene_{scene}"
+        """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
+
+        ACP members get a SCENE intent + refresh — their pipeline arbitrates
+        (weather and member safety still win). Generic members have no
+        pipeline and are commanded directly with the adopt-policy target.
+        Per-member opt-out and the stagger gap apply to both kinds.
+        """
+        intent = GroupIntent(
+            kind=GroupIntentKind.SCENE,
+            scene=scene,
+            priority=GROUP_SCENE_PRIORITY,
+            group_id=self.entry.entry_id,
+        )
+        commands = 0
         for entry, coordinator in self.resolved_members():
-            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
-            target = policy.position_for_scene(scene)
-            for entity_id in entry.options.get(CONF_ENTITIES, []):
-                await coordinator.async_apply_user_position(
-                    entity_id,
-                    target,
-                    trigger=trigger,
-                )
+            if self._scene_opted_out(entry.entry_id, scene):
+                continue
+            await self._stagger_gap(commands)
+            commands += 1
+            coordinator.set_group_intent(self.entry.entry_id, intent)
+            await coordinator.async_request_refresh()
         adopt_target = self._adopt_policy.position_for_scene(scene)
+        trigger = f"group_scene_{scene}"
         for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            await self._stagger_gap(commands)
+            commands += 1
             await self._cmd_svc.apply_position(
                 entity_id,
                 adopt_target,
@@ -148,6 +191,50 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             )
         self.active_scene = scene
         await self.async_refresh()
+
+    async def async_clear_scene(self) -> None:
+        """Release this group's scene claim — members return to their pipeline."""
+        for _entry, coordinator in self.resolved_members():
+            coordinator.set_group_intent(self.entry.entry_id, None)
+            await coordinator.async_request_refresh()
+        self.active_scene = None
+        await self.async_refresh()
+
+    async def async_set_lock(self, locked: bool) -> None:
+        """Push or release the group lock (LOCK intent at safety priority).
+
+        The lock ignores per-scene opt-out — it is a safety claim on every
+        member — and applies immediately (no stagger; nothing moves). On
+        release, an active scene is re-pushed so unlocking returns the room
+        to the scene, not to unmanaged state.
+        """
+        self.group_locked = locked
+        if locked:
+            intent = GroupIntent(
+                kind=GroupIntentKind.LOCK,
+                scene=None,
+                priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+                group_id=self.entry.entry_id,
+            )
+            for _entry, coordinator in self.resolved_members():
+                coordinator.set_group_intent(self.entry.entry_id, intent)
+                await coordinator.async_request_refresh()
+        else:
+            for _entry, coordinator in self.resolved_members():
+                coordinator.set_group_intent(self.entry.entry_id, None)
+                await coordinator.async_request_refresh()
+            if self.active_scene is not None:
+                await self.async_activate_scene(self.active_scene)
+        await self.async_refresh()
+
+    def member_winners(self) -> dict[str, str | None]:
+        """Who-won: each ACP member cover mapped to its pipeline's winner."""
+        winners: dict[str, str | None] = {}
+        for entry, coordinator in self.resolved_members():
+            winner = getattr(coordinator, "pipeline_winner_name", None)
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                winners[entity_id] = winner
+        return winners
 
     async def async_set_automation(self, enabled: bool) -> None:
         """Bulk-enable/disable sun-tracking automation on every ACP member."""
@@ -197,7 +284,15 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         self.hass.async_create_task(self.async_request_refresh())
 
     async def async_shutdown(self) -> None:
-        """Tear down listeners and the adopt-mode command service."""
+        """Tear down listeners, the command service, and any live intents.
+
+        Clearing this group's intent from every member matters on reload and
+        delete: a stale intent would keep claiming the member's pipeline for
+        a group that no longer exists (#712/#714 lifecycle lesson).
+        """
+        for _entry, coordinator in self.resolved_members():
+            coordinator.set_group_intent(self.entry.entry_id, None)
+            await coordinator.async_request_refresh()
         if self._unsub_state is not None:
             self._unsub_state()
             self._unsub_state = None

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -27,7 +27,13 @@ import asyncio
 from dataclasses import dataclass
 import logging
 
+from homeassistant.components.cover import (
+    ATTR_TILT_POSITION,
+    DOMAIN as COVER_DOMAIN,
+    SERVICE_SET_COVER_TILT_POSITION,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -48,12 +54,15 @@ from .const import (
     OPT_OUT_ALL_SCENES,
     POSITION_CLOSED,
     POSITION_OPEN,
+    TRIGGER_GROUP_COVER,
+    TRIGGER_GROUP_COVER_TILT,
     CoverType,
     GroupIntentKind,
     GroupScene,
     GroupState,
 )
 from .cover_types import get_policy
+from .helpers import climate_mode_from_diagnostics
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
@@ -156,6 +165,34 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         if commands_sent and stagger > 0:
             await asyncio.sleep(stagger)
 
+    async def _fan_out_commands(
+        self,
+        member_action,
+        generic_action,
+        *,
+        scene_filter: GroupScene | None = None,
+    ) -> None:
+        """Run one action per ACP member and per generic cover, staggered.
+
+        The single fan-out loop shared by scene activation and the group
+        cover's user commands: roster iteration, per-scene opt-out (when
+        ``scene_filter`` is given), and the stagger gap between successive
+        commands all live here exactly once.
+        """
+        commands = 0
+        for entry, coordinator in self.resolved_members():
+            if scene_filter is not None and self._scene_opted_out(
+                entry.entry_id, scene_filter
+            ):
+                continue
+            await self._stagger_gap(commands)
+            commands += 1
+            await member_action(entry, coordinator)
+        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
+            await self._stagger_gap(commands)
+            commands += 1
+            await generic_action(entity_id)
+
     async def async_activate_scene(self, scene: GroupScene) -> None:
         """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
 
@@ -170,27 +207,82 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             priority=GROUP_SCENE_PRIORITY,
             group_id=self.entry.entry_id,
         )
-        commands = 0
-        for entry, coordinator in self.resolved_members():
-            if self._scene_opted_out(entry.entry_id, scene):
-                continue
-            await self._stagger_gap(commands)
-            commands += 1
-            coordinator.set_group_intent(self.entry.entry_id, intent)
-            await coordinator.async_request_refresh()
         adopt_target = self._adopt_policy.position_for_scene(scene)
         trigger = f"group_scene_{scene}"
-        for entity_id in self.entry.options.get(CONF_MEMBER_COVERS, []):
-            await self._stagger_gap(commands)
-            commands += 1
+
+        async def _member(_entry, coordinator) -> None:
+            coordinator.set_group_intent(self.entry.entry_id, intent)
+            await coordinator.async_request_refresh()
+
+        async def _generic(entity_id: str) -> None:
             await self._cmd_svc.apply_position(
-                entity_id,
-                adopt_target,
-                trigger,
-                context=self._adopt_context(),
+                entity_id, adopt_target, trigger, context=self._adopt_context()
             )
+
+        await self._fan_out_commands(_member, _generic, scene_filter=scene)
         self.active_scene = scene
         await self.async_refresh()
+
+    async def async_set_position(self, position: int) -> None:
+        """Fan a user position out to every member (group cover slider).
+
+        A group-cover drag is a user action: ACP members ride their own
+        user-position path (manual-override engagement and floor clamps
+        apply, exactly like the per-cover proxy); generic covers go through
+        the adopt-mode command service. Stagger applies.
+        """
+
+        async def _member(entry, coordinator) -> None:
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                await coordinator.async_apply_user_position(
+                    entity_id, position, trigger=TRIGGER_GROUP_COVER
+                )
+
+        async def _generic(entity_id: str) -> None:
+            await self._cmd_svc.apply_position(
+                entity_id, position, TRIGGER_GROUP_COVER, context=self._adopt_context()
+            )
+
+        await self._fan_out_commands(_member, _generic)
+        await self.async_refresh()
+
+    async def async_set_tilt(self, tilt: int) -> None:
+        """Fan a user tilt out to every member (group cover tilt slider).
+
+        ACP members ride the dedicated tilt path so dual-axis covers move
+        only their slats (#684); generic covers get the plain tilt service.
+        """
+
+        async def _member(entry, coordinator) -> None:
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                await coordinator.async_apply_user_tilt(
+                    entity_id, tilt, trigger=TRIGGER_GROUP_COVER_TILT
+                )
+
+        async def _generic(entity_id: str) -> None:
+            await self.hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_SET_COVER_TILT_POSITION,
+                {ATTR_ENTITY_ID: entity_id, ATTR_TILT_POSITION: tilt},
+                blocking=False,
+            )
+
+        await self._fan_out_commands(_member, _generic)
+        await self.async_refresh()
+
+    async def async_stop(self) -> None:
+        """Stop every member cover immediately — no stagger, no gates.
+
+        Mirrors the proxy cover's stop: a plain ``cover.stop_cover`` per
+        member entity, ACP and generic alike.
+        """
+        for entity_id in self.member_cover_entities():
+            await self.hass.services.async_call(
+                COVER_DOMAIN,
+                SERVICE_STOP_COVER,
+                {ATTR_ENTITY_ID: entity_id},
+                blocking=False,
+            )
 
     async def async_clear_scene(self) -> None:
         """Release this group's scene claim — members return to their pipeline."""
@@ -235,6 +327,55 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             for entity_id in entry.options.get(CONF_ENTITIES, []):
                 winners[entity_id] = winner
         return winners
+
+    def all_members_tilt(self) -> bool:
+        """Whether every member — ACP and generic — has a tilt axis.
+
+        Gates the group cover's tilt features (issue #790 §3): ACP members
+        are checked via their policy's declared axes, generic covers via the
+        HA ``supported_features`` tilt bit. An empty roster is not tiltable.
+        """
+        from homeassistant.components.cover import CoverEntityFeature
+
+        from .cover_types.base import AXIS_NAME_TILT
+
+        member_ids = self.entry.options.get(CONF_MEMBER_ENTRIES, [])
+        generic = self.entry.options.get(CONF_MEMBER_COVERS, [])
+        if not member_ids and not generic:
+            return False
+        for entry_id in member_ids:
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry is None:
+                continue
+            policy = get_policy(entry.data[CONF_SENSOR_TYPE])
+            if not any(axis.name == AXIS_NAME_TILT for axis in policy.axes):
+                return False
+        for entity_id in generic:
+            state = self.hass.states.get(entity_id)
+            features = (
+                int(state.attributes.get("supported_features", 0)) if state else 0
+            )
+            if not features & CoverEntityFeature.SET_TILT_POSITION:
+                return False
+        return True
+
+    def member_climate_modes(self) -> dict[str, str | None]:
+        """Climate rollup: each ACP member cover mapped to its climate mode.
+
+        Read-only view over the same diagnostics the member's own Climate
+        Status sensor renders — the group shares no climate inputs (that is
+        Building Profile's job); it only reports. Generic covers have no
+        pipeline and are excluded.
+        """
+        modes: dict[str, str | None] = {}
+        for entry, coordinator in self.resolved_members():
+            diagnostics = getattr(
+                getattr(coordinator, "data", None), "diagnostics", None
+            )
+            mode = climate_mode_from_diagnostics(diagnostics)
+            for entity_id in entry.options.get(CONF_ENTITIES, []):
+                modes[entity_id] = mode
+        return modes
 
     async def async_set_automation(self, enabled: bool) -> None:
         """Bulk-enable/disable sun-tracking automation on every ACP member."""

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -12,11 +12,21 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.button import ButtonEntity
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
 
-from .const import GROUP_SCENE_SELECT_AUTO, GroupScene
+from .const import (
+    CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+    CONF_GROUP_ENABLE_POSITION_SENSOR,
+    CONF_GROUP_ENABLE_STATE_SENSOR,
+    CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    DEFAULT_GROUP_ENABLE_SENSOR,
+    GROUP_SCENE_SELECT_AUTO,
+    GroupScene,
+    GroupState,
+)
 from .entity_base import AdaptiveCoverBaseEntity
 from .pipeline.handlers import GroupLockHandler, GroupSceneHandler
 
@@ -173,6 +183,105 @@ class GroupWhoWonSensor(_GroupEntityBase, SensorEntity):
         return {"member_winners": self.coordinator.member_winners()}
 
 
+class GroupClimateSensor(_GroupEntityBase, SensorEntity):
+    """Read-only rollup of member climate modes (issue #790, Phase 3).
+
+    The mode when all reporting members agree, "mixed" when they disagree,
+    None when no member reports one. Values reuse the member Climate Status
+    sensor's wire strings (single-sourced in
+    ``helpers.climate_mode_from_diagnostics``); the group shares no climate
+    inputs — that stays Building Profile territory.
+    """
+
+    _attr_translation_key = "group_climate_mode"
+    _attr_native_unit_of_measurement = ""
+    _attr_icon = "mdi:sun-thermometer-outline"
+
+    # Wire-stable disagreement state, file-private: produced only by this
+    # sensor (distinct concept from GroupState.MIXED, which is positional).
+    _CLIMATE_MIXED = "mixed"
+
+    @property
+    def native_value(self) -> str | None:
+        """The agreed member climate mode, "mixed", or None."""
+        reported = {
+            mode
+            for mode in self.coordinator.member_climate_modes().values()
+            if mode is not None
+        }
+        if not reported:
+            return None
+        if len(reported) == 1:
+            return next(iter(reported))
+        return self._CLIMATE_MIXED
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Per-member climate-mode map."""
+        return {"member_climate_modes": self.coordinator.member_climate_modes()}
+
+
+class AdaptiveGroupCover(_GroupEntityBase, CoverEntity):
+    """Opt-in aggregate cover entity for a group (issue #790, Phase 3).
+
+    Position reads the group aggregates; commands are USER semantics — a
+    dashboard drag, routed exactly like the per-cover proxy (member
+    manual-override engagement and floor clamps apply). Tilt features are
+    exposed only when every member — ACP and generic — has a tilt axis.
+    """
+
+    _attr_translation_key = "group_cover"
+
+    def __init__(self, *args) -> None:
+        """Initialize the aggregate cover."""
+        super().__init__(*args, "group_cover")
+
+    @property
+    def supported_features(self) -> CoverEntityFeature:
+        """Position/open/close/stop always; tilt only for all-tilt rosters."""
+        features = (
+            CoverEntityFeature.OPEN
+            | CoverEntityFeature.CLOSE
+            | CoverEntityFeature.SET_POSITION
+            | CoverEntityFeature.STOP
+        )
+        if self.coordinator.all_members_tilt():
+            features |= CoverEntityFeature.SET_TILT_POSITION
+        return features
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Aggregate (average) member position."""
+        return self.coordinator.data.position
+
+    @property
+    def is_closed(self) -> bool | None:
+        """True when every member reports fully closed."""
+        if self.coordinator.data.state is GroupState.UNKNOWN:
+            return None
+        return self.coordinator.data.state is GroupState.CLOSED
+
+    async def async_set_cover_position(self, **kwargs) -> None:
+        """Fan the requested position out as a user command."""
+        await self.coordinator.async_set_position(int(kwargs["position"]))
+
+    async def async_open_cover(self, **kwargs) -> None:  # noqa: ARG002
+        """Open all members (position 100)."""
+        await self.coordinator.async_set_position(100)
+
+    async def async_close_cover(self, **kwargs) -> None:  # noqa: ARG002
+        """Close all members (position 0)."""
+        await self.coordinator.async_set_position(0)
+
+    async def async_set_cover_tilt_position(self, **kwargs) -> None:
+        """Fan the requested tilt out on the dedicated tilt path."""
+        await self.coordinator.async_set_tilt(int(kwargs["tilt_position"]))
+
+    async def async_stop_cover(self, **kwargs) -> None:  # noqa: ARG002
+        """Stop every member immediately."""
+        await self.coordinator.async_stop()
+
+
 class GroupSceneButton(_GroupEntityBase, ButtonEntity):
     """Activate one built-in scene across the group."""
 
@@ -249,12 +358,23 @@ def build_group_sensors(
 ) -> list[SensorEntity]:
     """Build the aggregate sensors for one group entry."""
     args = (entry_id, hass, config_entry, coordinator)
-    return [
-        GroupPositionSensor(*args, "group_position"),
-        GroupStateSensor(*args, "group_state"),
-        GroupActiveSceneSensor(*args, "group_active_scene"),
-        GroupWhoWonSensor(*args, "group_who_won"),
-    ]
+    options = config_entry.options
+
+    def _enabled(key: str) -> bool:
+        return bool(options.get(key, DEFAULT_GROUP_ENABLE_SENSOR))
+
+    sensors: list[SensorEntity] = []
+    if _enabled(CONF_GROUP_ENABLE_POSITION_SENSOR):
+        sensors.append(GroupPositionSensor(*args, "group_position"))
+    if _enabled(CONF_GROUP_ENABLE_STATE_SENSOR):
+        sensors.append(GroupStateSensor(*args, "group_state"))
+    # Active scene is always exposed — it is the select's state twin.
+    sensors.append(GroupActiveSceneSensor(*args, "group_active_scene"))
+    if _enabled(CONF_GROUP_ENABLE_CLIMATE_SENSOR):
+        sensors.append(GroupClimateSensor(*args, "group_climate_mode"))
+    if _enabled(CONF_GROUP_ENABLE_WHO_WON_SENSOR):
+        sensors.append(GroupWhoWonSensor(*args, "group_who_won"))
+    return sensors
 
 
 def build_group_switches(
@@ -292,3 +412,13 @@ def build_group_selects(
 ) -> list[SelectEntity]:
     """Build the scene-picker select for one group entry."""
     return [GroupSceneSelect(entry_id, hass, config_entry, coordinator)]
+
+
+def build_group_covers(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[CoverEntity]:
+    """Build the opt-in aggregate cover (empty when the toggle is off)."""
+    return [AdaptiveGroupCover(entry_id, hass, config_entry, coordinator)]

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -1,0 +1,231 @@
+"""Entities exposed by a Cover Group entry (issue #790, Phase 1).
+
+One module holds every group entity class plus a per-platform builder, so
+the platform files (``sensor.py`` / ``switch.py`` / ``button.py`` /
+``select.py``) each add a single ``is_orchestrator`` branch and stay free
+of group logic. Unique_ids follow the locked ``f"{entry_id}_{suffix}"``
+contract.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.components.select import SelectEntity
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.switch import SwitchEntity
+
+from .const import GroupScene
+from .entity_base import AdaptiveCoverBaseEntity
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+    from .group_coordinator import GroupCoordinator
+
+# Group entities read GroupCoordinator state, not a cover pipeline.
+# ``AdaptiveCoverBaseEntity`` is coordinator-shape-agnostic (device info,
+# availability gate, render-signature dedup), so it is reused as-is.
+
+
+class _GroupEntityBase(AdaptiveCoverBaseEntity):
+    """Shared init: group coordinator + locked unique_id suffix."""
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: GroupCoordinator,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize with the locked unique_id."""
+        super().__init__(entry_id, hass, config_entry, coordinator)
+        self._attr_unique_id = f"{entry_id}_{unique_id_suffix}"
+
+
+class GroupPositionSensor(_GroupEntityBase, SensorEntity):
+    """Average position across member covers, with per-member attributes."""
+
+    _attr_translation_key = "group_position"
+    _attr_native_unit_of_measurement = "%"
+    _attr_icon = "mdi:page-layout-body"
+
+    @property
+    def native_value(self) -> int | None:
+        """Average of readable member positions."""
+        return self.coordinator.data.position
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Per-member position readings."""
+        return {"member_positions": self.coordinator.data.member_positions}
+
+
+class GroupStateSensor(_GroupEntityBase, SensorEntity):
+    """Aggregate open/closed/mixed classification of the member covers."""
+
+    _attr_translation_key = "group_state"
+    # Text/status sensor: empty unit excludes it from the logbook.
+    _attr_native_unit_of_measurement = ""
+    _attr_icon = "mdi:window-shutter-cog"
+
+    @property
+    def native_value(self) -> str:
+        """Aggregate GroupState classification."""
+        return self.coordinator.data.state
+
+
+class GroupActiveSceneSensor(_GroupEntityBase, SensorEntity):
+    """The last scene activated on this group, if any."""
+
+    _attr_translation_key = "group_active_scene"
+    _attr_native_unit_of_measurement = ""
+    _attr_icon = "mdi:palette-outline"
+
+    @property
+    def native_value(self) -> str | None:
+        """Wire value of the last activated scene, or None."""
+        scene = self.coordinator.active_scene
+        return str(scene) if scene is not None else None
+
+
+class GroupAutomationSwitch(_GroupEntityBase, SwitchEntity):
+    """Bulk-enable/disable sun-tracking automation across all ACP members.
+
+    Reflects the last bulk command sent through this group (defaults to on),
+    not a consensus of member states — members remain individually togglable.
+    """
+
+    _attr_translation_key = "group_automation"
+    _attr_icon = "mdi:cog-clockwise"
+
+    def __init__(self, *args) -> None:
+        """Initialize with automation considered on."""
+        super().__init__(*args, "group_automation")
+        self._attr_is_on = True
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
+        """Bulk-enable automation on all members."""
+        await self.coordinator.async_set_automation(True)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
+        """Bulk-disable automation on all members."""
+        await self.coordinator.async_set_automation(False)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class GroupSceneButton(_GroupEntityBase, ButtonEntity):
+    """Activate one built-in scene across the group."""
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: GroupCoordinator,
+        scene: GroupScene,
+    ) -> None:
+        """Initialize the button for one scene."""
+        super().__init__(
+            entry_id, hass, config_entry, coordinator, f"group_scene_{scene}"
+        )
+        self._scene = scene
+        self._attr_translation_key = f"group_scene_{scene}"
+        self._attr_icon = "mdi:palette"
+
+    async def async_press(self) -> None:
+        """Activate this button's scene across the group."""
+        await self.coordinator.async_activate_scene(self._scene)
+
+
+class GroupClearOverridesButton(_GroupEntityBase, ButtonEntity):
+    """Clear manual overrides on every ACP member of the group."""
+
+    _attr_translation_key = "group_clear_overrides"
+    _attr_icon = "mdi:account-cancel-outline"
+
+    def __init__(self, *args) -> None:
+        """Initialize the clear-overrides button."""
+        super().__init__(*args, "group_clear_overrides")
+
+    async def async_press(self) -> None:
+        """Clear manual overrides on every ACP member."""
+        await self.coordinator.async_clear_overrides()
+
+
+class GroupSceneSelect(_GroupEntityBase, SelectEntity):
+    """Scene picker: selecting an option activates the scene group-wide."""
+
+    _attr_translation_key = "group_scene_select"
+    _attr_icon = "mdi:palette-swatch"
+
+    def __init__(self, *args) -> None:
+        """Initialize the scene picker with the built-in scene options."""
+        super().__init__(*args, "group_scene_select")
+        self._attr_options = [str(scene) for scene in GroupScene]
+
+    @property
+    def current_option(self) -> str | None:
+        """Wire value of the last activated scene, or None."""
+        scene = self.coordinator.active_scene
+        return str(scene) if scene is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Activate the picked scene across the group."""
+        await self.coordinator.async_activate_scene(GroupScene(option))
+        self.async_write_ha_state()
+
+
+def build_group_sensors(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[SensorEntity]:
+    """Build the aggregate sensors for one group entry."""
+    args = (entry_id, hass, config_entry, coordinator)
+    return [
+        GroupPositionSensor(*args, "group_position"),
+        GroupStateSensor(*args, "group_state"),
+        GroupActiveSceneSensor(*args, "group_active_scene"),
+    ]
+
+
+def build_group_switches(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[SwitchEntity]:
+    """Build the bulk switches for one group entry."""
+    return [GroupAutomationSwitch(entry_id, hass, config_entry, coordinator)]
+
+
+def build_group_buttons(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[ButtonEntity]:
+    """Per-scene activate buttons plus the clear-overrides button."""
+    args = (entry_id, hass, config_entry, coordinator)
+    return [
+        *(GroupSceneButton(*args, scene) for scene in GroupScene),
+        GroupClearOverridesButton(*args),
+    ]
+
+
+def build_group_selects(
+    entry_id: str,
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    coordinator: GroupCoordinator,
+) -> list[SelectEntity]:
+    """Build the scene-picker select for one group entry."""
+    return [GroupSceneSelect(entry_id, hass, config_entry, coordinator)]

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -16,8 +16,9 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
 
-from .const import GroupScene
+from .const import GROUP_SCENE_SELECT_AUTO, GroupScene
 from .entity_base import AdaptiveCoverBaseEntity
+from .pipeline.handlers import GroupLockHandler, GroupSceneHandler
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -120,6 +121,58 @@ class GroupAutomationSwitch(_GroupEntityBase, SwitchEntity):
         self.async_write_ha_state()
 
 
+class GroupLockSwitch(_GroupEntityBase, SwitchEntity):
+    """Freeze every member in place via the LOCK intent at safety priority."""
+
+    _attr_translation_key = "group_lock"
+    _attr_icon = "mdi:lock-outline"
+
+    def __init__(self, *args) -> None:
+        """Initialize unlocked."""
+        super().__init__(*args, "group_lock")
+        self._attr_is_on = False
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
+        """Push the lock intent to every member."""
+        await self.coordinator.async_set_lock(True)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
+        """Release the lock (re-pushing an active scene, if any)."""
+        await self.coordinator.async_set_lock(False)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class GroupWhoWonSensor(_GroupEntityBase, SensorEntity):
+    """How many members this group currently drives, with per-member detail.
+
+    A member counts as group-driven when its pipeline's winning handler is
+    one of the group handlers (names imported, never string literals).
+    """
+
+    _attr_translation_key = "group_who_won"
+    _attr_native_unit_of_measurement = "members"
+    _attr_icon = "mdi:scale-balance"
+
+    _GROUP_HANDLER_NAMES = frozenset({GroupSceneHandler.name, GroupLockHandler.name})
+
+    @property
+    def native_value(self) -> int:
+        """Count of members whose pipeline is currently won by this group."""
+        return sum(
+            1
+            for winner in self.coordinator.member_winners().values()
+            if winner in self._GROUP_HANDLER_NAMES
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Per-member winning-handler map."""
+        return {"member_winners": self.coordinator.member_winners()}
+
+
 class GroupSceneButton(_GroupEntityBase, ButtonEntity):
     """Activate one built-in scene across the group."""
 
@@ -166,19 +219,25 @@ class GroupSceneSelect(_GroupEntityBase, SelectEntity):
     _attr_icon = "mdi:palette-swatch"
 
     def __init__(self, *args) -> None:
-        """Initialize the scene picker with the built-in scene options."""
+        """Initialize the scene picker: Auto (no scene) plus the built-ins."""
         super().__init__(*args, "group_scene_select")
-        self._attr_options = [str(scene) for scene in GroupScene]
+        self._attr_options = [
+            GROUP_SCENE_SELECT_AUTO,
+            *(str(scene) for scene in GroupScene),
+        ]
 
     @property
     def current_option(self) -> str | None:
-        """Wire value of the last activated scene, or None."""
+        """Wire value of the active scene; Auto when no scene claims the group."""
         scene = self.coordinator.active_scene
-        return str(scene) if scene is not None else None
+        return str(scene) if scene is not None else GROUP_SCENE_SELECT_AUTO
 
     async def async_select_option(self, option: str) -> None:
-        """Activate the picked scene across the group."""
-        await self.coordinator.async_activate_scene(GroupScene(option))
+        """Activate the picked scene — or release the claim via Auto."""
+        if option == GROUP_SCENE_SELECT_AUTO:
+            await self.coordinator.async_clear_scene()
+        else:
+            await self.coordinator.async_activate_scene(GroupScene(option))
         self.async_write_ha_state()
 
 
@@ -194,6 +253,7 @@ def build_group_sensors(
         GroupPositionSensor(*args, "group_position"),
         GroupStateSensor(*args, "group_state"),
         GroupActiveSceneSensor(*args, "group_active_scene"),
+        GroupWhoWonSensor(*args, "group_who_won"),
     ]
 
 
@@ -204,7 +264,10 @@ def build_group_switches(
     coordinator: GroupCoordinator,
 ) -> list[SwitchEntity]:
     """Build the bulk switches for one group entry."""
-    return [GroupAutomationSwitch(entry_id, hass, config_entry, coordinator)]
+    return [
+        GroupAutomationSwitch(entry_id, hass, config_entry, coordinator),
+        GroupLockSwitch(entry_id, hass, config_entry, coordinator),
+    ]
 
 
 def build_group_buttons(

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -541,3 +541,23 @@ def get_open_close_state(
         return 100
 
     return None
+
+
+def climate_mode_from_diagnostics(diagnostics: dict | None) -> str | None:
+    """Map a coordinator's diagnostics payload to its climate-mode string.
+
+    Single source for the ``summer_mode`` / ``winter_mode`` / ``intermediate``
+    vocabulary — shared by the per-cover Climate Status sensor and the
+    cover-group climate rollup (issue #790, Phase 3). ``None`` when climate
+    mode is off or the diagnostics have not been built yet.
+    """
+    if diagnostics is None:
+        return None
+    data = diagnostics.get("climate_conditions")
+    if data is None:
+        return None
+    if data.get("is_summer"):
+        return "summer_mode"
+    if data.get("is_winter"):
+        return "winter_mode"
+    return "intermediate"

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
@@ -34,6 +34,8 @@ from .cloud_suppression import CloudSuppressionHandler
 from .custom_position import CustomPositionHandler
 from .default import DefaultHandler
 from .glare_zone import GlareZoneHandler
+from .group_lock import GroupLockHandler
+from .group_scene import GroupSceneHandler
 from .manual_override import ManualOverrideHandler
 from .motion_timeout import MotionTimeoutHandler
 from .solar import SolarHandler
@@ -144,6 +146,12 @@ HANDLER_FACTORIES: tuple[HandlerFactory, ...] = (
     _single(GlareZoneHandler),
     _solar_handler,
     _single(DefaultHandler),
+    # Group handlers LAST (issue #790 Phase 2): the registry's priority sort
+    # is stable, so on a 100-tie a member's own custom-position safety slot
+    # (built above) wins over the group lock — physical safety local to the
+    # cover trumps a zone command. Always built; they defer when no intent.
+    _single(GroupSceneHandler),
+    _single(GroupLockHandler),
 )
 
 
@@ -175,6 +183,8 @@ __all__ = [
     "CustomPositionHandler",
     "DefaultHandler",
     "GlareZoneHandler",
+    "GroupLockHandler",
+    "GroupSceneHandler",
     "HandlerFactory",
     "ManualOverrideHandler",
     "MotionTimeoutHandler",

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
@@ -1,0 +1,53 @@
+"""Group lock handler — a cover-group lock freezes the member in place.
+
+Issue #790 Phase 2. Priority 100 (``CUSTOM_POSITION_SAFETY_PRIORITY``): the
+lock outranks everything — including weather — matching the shipped
+semantics of a member's own safety slot. On a 100-tie the member's own
+custom-position safety slot wins: it is built earlier in
+``HANDLER_FACTORIES`` and the registry's priority sort is stable, so
+physical safety local to the cover trumps a zone lock.
+"""
+
+from __future__ import annotations
+
+from ...const import CUSTOM_POSITION_SAFETY_PRIORITY, ControlMethod, GroupIntentKind
+from ..handler import OverrideHandler
+from ..helpers import compute_raw_calculated_position
+from ..types import PipelineResult, PipelineSnapshot
+
+
+class GroupLockHandler(OverrideHandler):
+    """Freeze the cover while a group lock intent is live.
+
+    Reuses the motion-hold shape: the result wins the pipeline (so nothing
+    else can move the cover) and carries ``skip_command=True`` (so nothing is
+    sent) — the cover holds whatever position it is in, with no per-entity
+    target bookkeeping. Deliberately NOT ``is_safety``: no command is emitted,
+    so the safety-target machinery has nothing to track.
+    """
+
+    name = "group_lock"
+    priority = CUSTOM_POSITION_SAFETY_PRIORITY
+
+    def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
+        """Hold the current position while a lock intent is live."""
+        intent = snapshot.group_intent
+        if intent is None or intent.kind is not GroupIntentKind.LOCK:
+            return None
+        held = snapshot.current_cover_position
+        position = held if held is not None else snapshot.default_position
+        return PipelineResult(
+            position=position,
+            control_method=ControlMethod.GROUP_LOCK,
+            reason=(f"group lock from group {intent.group_id} — holding {position}%"),
+            raw_calculated_position=compute_raw_calculated_position(snapshot),
+            held_position=held,
+            skip_command=True,
+            bypass_auto_control=True,
+        )
+
+    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+        """Reason when no lock intent is live."""
+        if snapshot.group_intent is not None:
+            return "group intent is a scene, not a lock"
+        return "no group lock intent"

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_scene.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_scene.py
@@ -1,0 +1,54 @@
+"""Group scene handler — a cover-group's scene intent claims the position.
+
+Issue #790 Phase 2. Priority 85 (``GROUP_SCENE_PRIORITY``): above manual
+override (80) so "put the room in Privacy" wins over a stale per-cover
+manual state, below weather (90) so wind/rain safety on an outdoor member
+still overrides a group scene. Not user-overridable.
+"""
+
+from __future__ import annotations
+
+from ...const import GROUP_SCENE_PRIORITY, ControlMethod, GroupIntentKind
+from ...cover_types import get_policy
+from ..handler import OverrideHandler
+from ..helpers import compute_raw_calculated_position
+from ..types import PipelineResult, PipelineSnapshot
+
+
+class GroupSceneHandler(OverrideHandler):
+    """Apply a live cover-group scene intent, resolved per member policy.
+
+    ``snapshot.group_intent`` is ``None`` for non-members — absence of an
+    intent IS non-membership, so no roster lookup happens here. The scene is
+    an intent, not an absolute position: the member's own policy maps it
+    (``position_for_scene``), which is what makes mixed groups work.
+    """
+
+    name = "group_scene"
+    priority = GROUP_SCENE_PRIORITY
+
+    def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
+        """Return the policy-resolved scene position when a scene intent is live."""
+        intent = snapshot.group_intent
+        if intent is None or intent.kind is not GroupIntentKind.SCENE:
+            return None
+        policy = snapshot.policy or get_policy(snapshot.cover_type)
+        position = policy.position_for_scene(intent.scene)
+        return PipelineResult(
+            position=position,
+            control_method=ControlMethod.GROUP_SCENE,
+            reason=(
+                f"group scene '{intent.scene}' from group {intent.group_id}"
+                f" → {position}%"
+            ),
+            raw_calculated_position=compute_raw_calculated_position(snapshot),
+            # Explicit user intent: runs even with automatic control off —
+            # same semantics as custom-position slots. NOT a safety result.
+            bypass_auto_control=True,
+        )
+
+    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+        """Reason when no scene intent is live."""
+        if snapshot.group_intent is not None:
+            return "group intent is a lock, not a scene"
+        return "no group scene intent"

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -94,6 +94,7 @@ from ..templates import combine_with_mode, is_template_string, render_condition
 from .types import (
     ClimateOptions,
     CustomPositionSensorState,
+    GroupIntent,
     PipelineSnapshot,
 )
 
@@ -322,6 +323,7 @@ class PipelineSnapshotBuilder:
         effective_default: int | None = None,
         is_sunset_active: bool | None = None,
         cover_capabilities: dict | None = None,
+        group_intent: GroupIntent | None = None,
     ) -> PipelineSnapshot:
         """Assemble the per-cycle :class:`PipelineSnapshot`.
 
@@ -413,6 +415,7 @@ class PipelineSnapshotBuilder:
             ),
             current_cover_position=current_cover_position,
             policy=self._policy,
+            group_intent=group_intent,
             minimize_movements=bool(
                 options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS)
             ),

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -5,13 +5,30 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from ..const import ClimateStrategy, ControlMethod
+from ..const import ClimateStrategy, ControlMethod, GroupIntentKind, GroupScene
 
 if TYPE_CHECKING:
     from ..config_types import CoverConfig, GlareZonesConfig
     from ..cover_types.base import CoverTypePolicy
     from ..engine.covers.base import AdaptiveGeneralCover
     from ..state.climate_provider import ClimateReadings
+
+
+@dataclass(frozen=True, slots=True)
+class GroupIntent:
+    """A cover-group's live claim on a member cover (issue #790, Phase 2).
+
+    Pushed by a ``GroupCoordinator`` via the member's ``set_group_intent``;
+    the member folds its highest-priority live intent into each snapshot,
+    where ``GroupSceneHandler`` / ``GroupLockHandler`` read it. ``scene`` is
+    only meaningful for ``kind == SCENE`` — the handler resolves it through
+    the member's own policy, never an absolute shared position.
+    """
+
+    kind: GroupIntentKind
+    scene: GroupScene | None
+    priority: int
+    group_id: str
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +226,12 @@ class PipelineSnapshot:
     # Defaults to ``None`` so test fixtures that build snapshots directly keep
     # working; runtime always populates it via ``coordinator._build_snapshot``.
     policy: CoverTypePolicy | None = None
+
+    # The highest-priority live cover-group intent targeting this member, or
+    # None when no group claims it (issue #790, Phase 2). Read by
+    # GroupSceneHandler / GroupLockHandler; absence of an intent IS
+    # non-membership — the handlers defer without any membership lookup.
+    group_intent: GroupIntent | None = None
 
     # Sun-tracking movement minimization (opt-in). When True, the solar branch
     # quantizes the calculated position into ``max_coverage_steps`` evenly-spaced

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -84,11 +84,19 @@ def _building_profile_entries(hass: HomeAssistant) -> list[ConfigEntry]:
 
 
 def _cover_entries(hass: HomeAssistant) -> list[ConfigEntry]:
-    """Return all physical cover config entries (controls_cover == True)."""
+    """Return all physical cover config entries.
+
+    Filters on capability, never a cover-type string: virtual entry types are
+    excluded — the Building Profile (``controls_cover == False``) and the
+    cover group (``is_orchestrator == True``), which controls covers but is
+    not itself a physical cover. Consumers (duplicate sources, profile link
+    lists, group membership pickers) all want real covers only.
+    """
     return [
         e
         for e in hass.config_entries.async_entries(DOMAIN)
         if get_policy(e.data.get(CONF_SENSOR_TYPE)).controls_cover
+        and not get_policy(e.data.get(CONF_SENSOR_TYPE)).is_orchestrator
     ]
 
 

--- a/custom_components/adaptive_cover_pro/select.py
+++ b/custom_components/adaptive_cover_pro/select.py
@@ -1,0 +1,32 @@
+"""Select platform for the Adaptive Cover Pro integration (issue #790).
+
+Group-only today: the scene picker on Cover Group entries. The platform is
+forwarded only for group entries (``GROUP_PLATFORMS`` in ``__init__``), but
+the capability guard stays so a future forward for cover entries cannot
+accidentally create a select.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import CONF_SENSOR_TYPE
+from .coordinator import AdaptiveConfigEntry
+from .cover_types import get_policy
+from .group_entities import build_group_selects
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: AdaptiveConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the select platform (cover groups only)."""
+    if not get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        return
+    async_add_entities(
+        build_group_selects(
+            config_entry.entry_id, hass, config_entry, config_entry.runtime_data
+        )
+    )

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -1283,6 +1283,17 @@ async def async_setup_entry(
     """Initialize Adaptive Cover Pro config entry."""
     coordinator: AdaptiveDataUpdateCoordinator = config_entry.runtime_data
 
+    # Cover groups expose their own aggregate sensors, never the cover set.
+    from .cover_types import get_policy
+
+    if get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        from .group_entities import build_group_sensors
+
+        async_add_entities(
+            build_group_sensors(config_entry.entry_id, hass, config_entry, coordinator)
+        )
+        return
+
     entities: list[SensorEntity] = []
 
     for spec in _STANDARD_SPECS:

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -686,16 +686,9 @@ def _motion_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
 
 
 def _climate_status_value(s: _ACPDiagnosticSensor) -> str | None:
-    if s.data.diagnostics is None:
-        return None
-    data = s.data.diagnostics.get("climate_conditions")
-    if data is None:
-        return None
-    if data.get("is_summer"):
-        return "summer_mode"
-    if data.get("is_winter"):
-        return "winter_mode"
-    return "intermediate"
+    from .helpers import climate_mode_from_diagnostics
+
+    return climate_mode_from_diagnostics(s.data.diagnostics)
 
 
 def _round_threshold(value: float | str | None) -> float | None:

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1249,3 +1249,116 @@ get_diagnostics:
       selector:
         config_entry:
           integration: adaptive_cover_pro
+
+group_activate_scene:
+  name: "Group: activate scene"
+  description: >-
+    Activates a scene on the targeted cover groups. Scenes ride each member's
+    pipeline (weather safety and member safety still win). Pass "auto" to
+    release the group's scene claim so members return to their own automation.
+    With no target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+  fields:
+    scene:
+      name: Scene
+      description: The scene to activate, or "auto" to release the claim.
+      required: true
+      selector:
+        select:
+          options:
+            - "auto"
+            - "all_open"
+            - "all_closed"
+            - "privacy"
+
+group_set_position:
+  name: "Group: set position"
+  description: >-
+    Moves every member of the targeted cover groups to the given position as a
+    user command (member manual-override engagement and floor clamps apply,
+    like dragging the group cover). With no target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+  fields:
+    position:
+      name: Position
+      description: >-
+        Position (0-100%) to move member covers to. 0% = closed (blinds
+        lowered / awning retracted), 100% = open (blinds raised / awning
+        extended).
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+    tilt:
+      name: Tilt
+      description: Optional slat tilt (0-100%) fanned out on the tilt axis.
+      required: false
+      selector:
+        number:
+          min: 0
+          max: 100
+          unit_of_measurement: "%"
+
+group_lock:
+  name: "Group: lock"
+  description: >-
+    Freezes every member of the targeted cover groups in place at safety
+    priority. A member's own safety trigger still wins ties. With no target,
+    locks all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+
+group_unlock:
+  name: "Group: unlock"
+  description: >-
+    Releases the group lock on the targeted cover groups. An active scene is
+    re-applied; otherwise members return to their own automation. With no
+    target, unlocks all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+
+group_clear_overrides:
+  name: "Group: clear member overrides"
+  description: >-
+    Clears manual overrides on every ACP member of the targeted cover groups
+    and resends each member's pipeline position. With no target, acts on all
+    cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+
+group_set_automation:
+  name: "Group: set automation"
+  description: >-
+    Bulk-enables or disables sun-tracking automation on every ACP member of
+    the targeted cover groups. With no target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+    device:
+      integration: adaptive_cover_pro
+  fields:
+    enabled:
+      name: Enabled
+      description: True to enable member automation, false to disable it.
+      required: true
+      selector:
+        boolean:

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from ..const import DOMAIN
 from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagnostics
+from .group_service import GROUP_SERVICE_NAMES, register_group_services
 from .engage_manual_override_service import (
     ENGAGE_MANUAL_OVERRIDE_SCHEMA,
     async_handle_engage_manual_override,
@@ -59,6 +60,27 @@ def loaded_coordinators(
     }
 
 
+def cover_coordinators(
+    hass: HomeAssistant,
+) -> dict[str, AdaptiveDataUpdateCoordinator]:
+    """``loaded_coordinators`` restricted to real cover coordinators.
+
+    Cover groups also live on ``runtime_data`` but expose none of the cover
+    coordinator's surface — a cover service that walked them would crash
+    (issue #790 Phase 4). The discriminator is the coordinator type itself
+    (not a re-fetched entry) so callers with partially-mocked ``hass`` still
+    resolve. Cover services resolve through this; group services use
+    ``group_service.group_coordinators``.
+    """
+    from ..group_coordinator import GroupCoordinator  # noqa: PLC0415
+
+    return {
+        entry_id: coordinator
+        for entry_id, coordinator in loaded_coordinators(hass).items()
+        if not isinstance(coordinator, GroupCoordinator)
+    }
+
+
 def _resolve_targets(
     hass: HomeAssistant,
     call: ServiceCall,
@@ -76,8 +98,9 @@ def _resolve_targets(
     - area_id targets        → expand device_ids via device registry, then device_id rule
 
     Unmanaged entity_ids (not owned by any ACP coordinator) are silently skipped.
+    Cover groups are excluded — group services have their own resolver.
     """
-    all_coordinators = loaded_coordinators(hass)
+    all_coordinators = cover_coordinators(hass)
 
     entity_ids: list[str] = cv.ensure_list(call.data.get("entity_id"))
     device_ids: list[str] = cv.ensure_list(call.data.get("device_id"))
@@ -244,6 +267,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         schema=ENGAGE_MANUAL_OVERRIDE_SCHEMA,
     )
 
+    register_group_services(hass)
     register_options_services(hass)
 
 
@@ -266,5 +290,7 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "set_tilt")
     hass.services.async_remove(DOMAIN, "stop")
     hass.services.async_remove(DOMAIN, "engage_manual_override")
+    for name in GROUP_SERVICE_NAMES:
+        hass.services.async_remove(DOMAIN, name)
     for name in OPTIONS_SERVICE_NAMES:
         hass.services.async_remove(DOMAIN, name)

--- a/custom_components/adaptive_cover_pro/services/group_service.py
+++ b/custom_components/adaptive_cover_pro/services/group_service.py
@@ -1,0 +1,216 @@
+"""Cover-group domain services (issue #790, Phase 4).
+
+Six thin services over the ``GroupCoordinator``'s public methods so
+automations can drive groups: activate/release scenes, set a group
+position/tilt, lock/unlock, clear member overrides, and bulk-toggle
+automation. Target resolution mirrors the cover services' rules but is
+capability-split: these services act ONLY on group coordinators
+(``is_orchestrator``), never on cover coordinators — and vice versa.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from voluptuous.validators import Coerce, Range
+
+from ..const import DOMAIN, GROUP_SCENE_SELECT_AUTO, GroupScene
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+    from ..group_coordinator import GroupCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+GROUP_SERVICE_NAMES: tuple[str, ...] = (
+    "group_activate_scene",
+    "group_set_position",
+    "group_lock",
+    "group_unlock",
+    "group_clear_overrides",
+    "group_set_automation",
+)
+
+_SCENE_CHOICES: tuple[str, ...] = (
+    GROUP_SCENE_SELECT_AUTO,
+    *(str(scene) for scene in GroupScene),
+)
+
+# Plain schemas (NOT make_entity_service_schema): the target block is
+# optional — an untargeted call fans out to every loaded group, matching
+# integration_enable/disable. extra=ALLOW_EXTRA admits the target keys.
+GROUP_ACTIVATE_SCENE_SCHEMA = vol.Schema(
+    {vol.Required("scene"): vol.In(_SCENE_CHOICES)}, extra=vol.ALLOW_EXTRA
+)
+GROUP_SET_POSITION_SCHEMA = vol.Schema(
+    {
+        vol.Required("position"): vol.All(Coerce(int), Range(min=0, max=100)),
+        vol.Optional("tilt"): vol.All(Coerce(int), Range(min=0, max=100)),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+GROUP_SET_AUTOMATION_SCHEMA = vol.Schema(
+    {vol.Required("enabled"): bool}, extra=vol.ALLOW_EXTRA
+)
+GROUP_NO_FIELDS_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
+
+
+def group_coordinators(hass: HomeAssistant) -> dict[str, GroupCoordinator]:
+    """Map entry_id → coordinator for every loaded cover-group entry.
+
+    Discriminates on the coordinator type (mirror of
+    ``services.cover_coordinators``) — the two service families split the
+    ``loaded_coordinators`` pool exactly in two.
+    """
+    from ..group_coordinator import GroupCoordinator  # noqa: PLC0415
+    from . import loaded_coordinators  # noqa: PLC0415
+
+    return {
+        entry_id: coordinator
+        for entry_id, coordinator in loaded_coordinators(hass).items()
+        if isinstance(coordinator, GroupCoordinator)
+    }
+
+
+def resolve_group_targets(
+    hass: HomeAssistant, call: ServiceCall
+) -> list[GroupCoordinator]:
+    """Resolve a group service call's target block to group coordinators.
+
+    Mirrors ``_resolve_targets``' rules on the group side: no target → every
+    loaded group; entity/device targets resolve through the registries to
+    their owning config entry. Non-group targets are silently skipped.
+    """
+    groups = group_coordinators(hass)
+
+    entity_ids: list[str] = cv.ensure_list(call.data.get("entity_id"))
+    device_ids: list[str] = cv.ensure_list(call.data.get("device_id"))
+    area_ids: list[str] = cv.ensure_list(call.data.get("area_id"))
+
+    if not entity_ids and not device_ids and not area_ids:
+        return list(groups.values())
+
+    if area_ids:
+        dev_reg = dr.async_get(hass)
+        for area_id in area_ids:
+            device_ids.extend(
+                device.id
+                for device in dev_reg.devices.values()
+                if device.area_id == area_id
+            )
+
+    resolved: dict[str, GroupCoordinator] = {}
+    if device_ids:
+        dev_reg = dr.async_get(hass)
+        for device_id in device_ids:
+            device = dev_reg.async_get(device_id)
+            if device is None:
+                continue
+            for entry_id in device.config_entries:
+                if entry_id in groups:
+                    resolved[entry_id] = groups[entry_id]
+
+    ent_reg = er.async_get(hass)
+    for entity_id in entity_ids:
+        reg_entry = ent_reg.async_get(entity_id)
+        if reg_entry is not None and reg_entry.config_entry_id in groups:
+            resolved[reg_entry.config_entry_id] = groups[reg_entry.config_entry_id]
+        else:
+            _LOGGER.debug(
+                "group_service: entity %s is not owned by any cover group — skipping",
+                entity_id,
+            )
+
+    if not resolved:
+        _LOGGER.warning(
+            "group_service: target %s/%s/%s resolved to no cover groups — nothing done",
+            entity_ids,
+            device_ids,
+            area_ids,
+        )
+    return list(resolved.values())
+
+
+async def async_handle_group_activate_scene(call: ServiceCall) -> None:
+    """Activate a scene on the targeted groups — or release it via 'auto'."""
+    scene_value: str = call.data["scene"]
+    for group in resolve_group_targets(call.hass, call):
+        if scene_value == GROUP_SCENE_SELECT_AUTO:
+            await group.async_clear_scene()
+        else:
+            await group.async_activate_scene(GroupScene(scene_value))
+
+
+async def async_handle_group_set_position(call: ServiceCall) -> None:
+    """Fan a user position (and optional tilt) out through the group."""
+    position: int = call.data["position"]
+    tilt: int | None = call.data.get("tilt")
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_position(position)
+        if tilt is not None:
+            await group.async_set_tilt(tilt)
+
+
+async def async_handle_group_lock(call: ServiceCall) -> None:
+    """Push the group lock on the targeted groups."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_lock(True)
+
+
+async def async_handle_group_unlock(call: ServiceCall) -> None:
+    """Release the group lock on the targeted groups."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_lock(False)
+
+
+async def async_handle_group_clear_overrides(call: ServiceCall) -> None:
+    """Clear member manual overrides on the targeted groups."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_clear_overrides()
+
+
+async def async_handle_group_set_automation(call: ServiceCall) -> None:
+    """Bulk-toggle member automation on the targeted groups."""
+    enabled: bool = call.data["enabled"]
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_set_automation(enabled)
+
+
+def register_group_services(hass: HomeAssistant) -> None:
+    """Register the six group services (called from async_setup_services)."""
+    hass.services.async_register(
+        DOMAIN,
+        "group_activate_scene",
+        async_handle_group_activate_scene,
+        schema=GROUP_ACTIVATE_SCENE_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "group_set_position",
+        async_handle_group_set_position,
+        schema=GROUP_SET_POSITION_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, "group_lock", async_handle_group_lock, schema=GROUP_NO_FIELDS_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN, "group_unlock", async_handle_group_unlock, schema=GROUP_NO_FIELDS_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "group_clear_overrides",
+        async_handle_group_clear_overrides,
+        schema=GROUP_NO_FIELDS_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "group_set_automation",
+        async_handle_group_set_automation,
+        schema=GROUP_SET_AUTOMATION_SCHEMA,
+    )

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -56,6 +56,7 @@ from ..const import (
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
     CONF_GLARE_ZONE_PRIORITY,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_HEIGHT_WIN,
     CONF_INTERP,
     CONF_INTERP_END,
@@ -521,6 +522,8 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_CLIMATE_PRIORITY: _range(CONF_CLIMATE_PRIORITY),
     CONF_GLARE_ZONE_PRIORITY: _range(CONF_GLARE_ZONE_PRIORITY),
     CONF_SOLAR_PRIORITY: _range(CONF_SOLAR_PRIORITY),
+    # Cover group (issue #790, Phase 2)
+    CONF_GROUP_STAGGER_DELAY: _range(CONF_GROUP_STAGGER_DELAY),
 }
 
 # ---------------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -257,6 +257,7 @@
     "scene_priority": "Beschattungsgruppen-Szenen gelten mit Priorität {scene_priority} (über manuelle Übersteuerung, unter Wetterschutz)",
     "lock": "🔒 Gruppensperre mit Priorität {lock_priority} — friert Mitglieder an Ort und Stelle ein; die eigene Sicherheit eines Mitglieds gewinnt immer noch Gleichstände",
     "stagger": "Mitglieder mit {stagger}s Abstand befohlen",
-    "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied"
+    "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied",
+    "area": "Mitgliedschaft verfolgt Bereich „{area}\" – Beschattungen dort treten automatisch bei"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -256,6 +256,7 @@
     "member_generic": "- 🪟 {entity} (generic)",
     "scene_priority": "Beschattungsgruppen-Szenen gelten mit Priorität {scene_priority} (über manuelle Übersteuerung, unter Wetterschutz)",
     "lock": "🔒 Gruppensperre mit Priorität {lock_priority} — friert Mitglieder an Ort und Stelle ein; die eigene Sicherheit eines Mitglieds gewinnt immer noch Gleichstände",
-    "stagger": "Mitglieder mit {stagger}s Abstand befohlen"
+    "stagger": "Mitglieder mit {stagger}s Abstand befohlen",
+    "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -253,6 +253,9 @@
     "header": "**Beschattungsgruppe**",
     "members": "Steuert {acp_count} ACP-Mitglied(er) + {generic_count} allgemeine Beschattung(en)",
     "member_acp": "- 🪟 {title} (ACP)",
-    "member_generic": "- 🪟 {entity} (generic)"
+    "member_generic": "- 🪟 {entity} (generic)",
+    "scene_priority": "Beschattungsgruppen-Szenen gelten mit Priorität {scene_priority} (über manuelle Übersteuerung, unter Wetterschutz)",
+    "lock": "🔒 Gruppensperre mit Priorität {lock_priority} — friert Mitglieder an Ort und Stelle ein; die eigene Sicherheit eines Mitglieds gewinnt immer noch Gleichstände",
+    "stagger": "Mitglieder mit {stagger}s Abstand befohlen"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -76,7 +76,8 @@
     "somfy_my_unset": "⚠️ Somfy My-Preset ist für ein oder mehrere Ziele aktiviert, aber My Preset Value ist nicht gesetzt — fällt auf konfiguriertes % zurück.",
     "proxy_no_min": "⚠️ Proxy-Beschattung ist aktiviert, aber kein benutzerdefinierter Positionsslot hat Als Minimum verwenden aktiviert — die verwaltete Beschattung wird nicht begrenzt.",
     "custom_and_no_sensors": "⚠️ Benutzerdefiniert #{slot}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
-    "custom_safety_bypass": "⚠️ Benutzerdefiniert #{slot} hat Sicherheitspriorität ({safety}) – umgeht den Schalter für die automatische Steuerung, die manuelle Übersteuerung und das Start-/Endzeitfenster, kann die Beschattung also auch dann bewegen, wenn die automatische Steuerung AUS ist und außerhalb Ihres Zeitplans. Senken Sie seine Priorität unter {safety}, um diese Gates einzuhalten."
+    "custom_safety_bypass": "⚠️ Benutzerdefiniert #{slot} hat Sicherheitspriorität ({safety}) – umgeht den Schalter für die automatische Steuerung, die manuelle Übersteuerung und das Start-/Endzeitfenster, kann die Beschattung also auch dann bewegen, wenn die automatische Steuerung AUS ist und außerhalb Ihres Zeitplans. Senken Sie seine Priorität unter {safety}, um diese Gates einzuhalten.",
+    "group_empty": "⚠️ Diese Gruppe hat keine Mitglieder – sie wird nichts steuern."
   },
   "motion": {
     "action_hold": "Beschattungen halten aktuelle Position (zurück auf Standard, wenn Sonne FOV verlässt)",
@@ -247,5 +248,11 @@
       "pitch": "Dachneigung {v}° von Horizontal",
       "height_above": "{v}m Dach über Fenster (First-Gate)"
     }
+  },
+  "group": {
+    "header": "**Beschattungsgruppe**",
+    "members": "Steuert {acp_count} ACP-Mitglied(er) + {generic_count} allgemeine Beschattung(en)",
+    "member_acp": "- 🪟 {title} (ACP)",
+    "member_generic": "- 🪟 {entity} (generic)"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -76,7 +76,8 @@
     "somfy_my_unset": "⚠️ Somfy My preset is enabled for one or more targets but My Preset Value is not set — falls back to configured %.",
     "proxy_no_min": "⚠️ Proxy cover is enabled but no custom-position slot has Use as minimum on — the managed cover will not clamp.",
     "custom_and_no_sensors": "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are configured — the template alone activates the slot.",
-    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates."
+    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
+    "group_empty": "⚠️ This group has no members — it will not command anything."
   },
   "motion": {
     "template_source": "occupancy template",
@@ -247,5 +248,11 @@
     "fov": {
       "computed": "Computed FOV ≈ {deg}°/{deg}° ({w} m width, {d} m reveal depth)"
     }
+  },
+  "group": {
+    "header": "**Cover Group**",
+    "members": "Controls {acp_count} ACP member(s) + {generic_count} generic cover(s)",
+    "member_acp": "- 🪟 {title} (ACP)",
+    "member_generic": "- 🪟 {entity} (generic)"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -257,6 +257,7 @@
     "scene_priority": "Group scenes apply at priority {scene_priority} (above manual override, below weather safety)",
     "lock": "🔒 Group lock at priority {lock_priority} — freezes members in place; a member's own safety still wins ties",
     "stagger": "Members commanded {stagger}s apart",
-    "cover_entity": "Aggregate cover entity exposed — dragging it commands every member"
+    "cover_entity": "Aggregate cover entity exposed — dragging it commands every member",
+    "area": "Membership tracks area '{area}' — covers there join automatically"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -256,6 +256,7 @@
     "member_generic": "- 🪟 {entity} (generic)",
     "scene_priority": "Group scenes apply at priority {scene_priority} (above manual override, below weather safety)",
     "lock": "🔒 Group lock at priority {lock_priority} — freezes members in place; a member's own safety still wins ties",
-    "stagger": "Members commanded {stagger}s apart"
+    "stagger": "Members commanded {stagger}s apart",
+    "cover_entity": "Aggregate cover entity exposed — dragging it commands every member"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -253,6 +253,9 @@
     "header": "**Cover Group**",
     "members": "Controls {acp_count} ACP member(s) + {generic_count} generic cover(s)",
     "member_acp": "- 🪟 {title} (ACP)",
-    "member_generic": "- 🪟 {entity} (generic)"
+    "member_generic": "- 🪟 {entity} (generic)",
+    "scene_priority": "Group scenes apply at priority {scene_priority} (above manual override, below weather safety)",
+    "lock": "🔒 Group lock at priority {lock_priority} — freezes members in place; a member's own safety still wins ties",
+    "stagger": "Members commanded {stagger}s apart"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -256,6 +256,7 @@
     "member_generic": "- 🪟 {entity} (générique)",
     "scene_priority": "Les scènes de groupe s'appliquent à la priorité {scene_priority} (au-dessus de la dérogation manuelle, en dessous de la sécurité météo)",
     "lock": "🔒 Verrouillage de groupe à la priorité {lock_priority} — gèle les membres en place ; la sécurité propre d'un membre gagne toujours en cas d'égalité",
-    "stagger": "Membres commandés à {stagger}s d'intervalle"
+    "stagger": "Membres commandés à {stagger}s d'intervalle",
+    "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -253,6 +253,9 @@
     "header": "**Groupe de stores**",
     "members": "Contrôle {acp_count} membre(s) ACP + {generic_count} store(s) générique(s)",
     "member_acp": "- 🪟 {title} (ACP)",
-    "member_generic": "- 🪟 {entity} (générique)"
+    "member_generic": "- 🪟 {entity} (générique)",
+    "scene_priority": "Les scènes de groupe s'appliquent à la priorité {scene_priority} (au-dessus de la dérogation manuelle, en dessous de la sécurité météo)",
+    "lock": "🔒 Verrouillage de groupe à la priorité {lock_priority} — gèle les membres en place ; la sécurité propre d'un membre gagne toujours en cas d'égalité",
+    "stagger": "Membres commandés à {stagger}s d'intervalle"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -76,7 +76,8 @@
     "somfy_my_unset": "⚠️ Préréglage Somfy My est activé pour une ou plusieurs cibles mais Valeur du préréglage My n'est pas définie — revient au % configuré.",
     "proxy_no_min": "⚠️ Store mandataire est activé mais aucun emplacement de position personnalisée n'a Utiliser comme minimum activé — le store géré ne limitera pas.",
     "custom_and_no_sensors": "⚠️ Personnalisé #{slot} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
-    "custom_safety_bypass": "⚠️ L'emplacement personnalisé #{slot} est à la priorité de sécurité ({safety}) — il contourne l'interrupteur de contrôle automatique, la dérogation manuelle et la fenêtre horaire de début/fin, pour que le store puisse se déplacer même quand le contrôle automatique est DÉSACTIVÉ et en dehors de votre horaire. Réduisez sa priorité en dessous de {safety} pour qu'elle respecte ces seuils."
+    "custom_safety_bypass": "⚠️ L'emplacement personnalisé #{slot} est à la priorité de sécurité ({safety}) — il contourne l'interrupteur de contrôle automatique, la dérogation manuelle et la fenêtre horaire de début/fin, pour que le store puisse se déplacer même quand le contrôle automatique est DÉSACTIVÉ et en dehors de votre horaire. Réduisez sa priorité en dessous de {safety} pour qu'elle respecte ces seuils.",
+    "group_empty": "⚠️ Ce groupe n'a pas de membres — il ne commandera rien."
   },
   "motion": {
     "action_hold": "stores maintiennent la position actuelle (reviennent au défaut quand le soleil quitte le FOV)",
@@ -247,5 +248,11 @@
       "pitch": "pente de toit {v}° depuis l'horizontale",
       "height_above": "{v}m de toit au-dessus de la fenêtre (porte de faîtage)"
     }
+  },
+  "group": {
+    "header": "**Groupe de stores**",
+    "members": "Contrôle {acp_count} membre(s) ACP + {generic_count} store(s) générique(s)",
+    "member_acp": "- 🪟 {title} (ACP)",
+    "member_generic": "- 🪟 {entity} (générique)"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -257,6 +257,7 @@
     "scene_priority": "Les scènes de groupe s'appliquent à la priorité {scene_priority} (au-dessus de la dérogation manuelle, en dessous de la sécurité météo)",
     "lock": "🔒 Verrouillage de groupe à la priorité {lock_priority} — gèle les membres en place ; la sécurité propre d'un membre gagne toujours en cas d'égalité",
     "stagger": "Membres commandés à {stagger}s d'intervalle",
-    "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre"
+    "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre",
+    "area": "L'adhésion suit la zone « {area} » — les stores de cette zone rejoignent automatiquement"
   }
 }

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -211,6 +211,15 @@ async def async_setup_entry(
     """Set up the demo switch platform."""
     coordinator: AdaptiveDataUpdateCoordinator = config_entry.runtime_data
 
+    # Cover groups expose the bulk automation switch, never the cover set.
+    if get_policy(config_entry.data.get(CONF_SENSOR_TYPE)).is_orchestrator:
+        from .group_entities import build_group_switches
+
+        async_add_entities(
+            build_group_switches(config_entry.entry_id, hass, config_entry, coordinator)
+        )
+        return
+
     specs: list[_SwitchSpec] = [
         spec for spec in _SWITCH_SPECS if spec.enabled_when(config_entry)
     ]

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -766,11 +766,13 @@
         "data": {
           "name": "Gruppenname",
           "member_entries": "Adaptive-Cover-Pro-Mitglieder",
-          "member_covers": "Allgemeine Beschattungsentitäten"
+          "member_covers": "Allgemeine Beschattungsentitäten",
+          "group_area": "Bereich (Live-Mitgliedschaft)"
         },
         "data_description": {
           "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
-          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen.",
+          "group_area": "Optional: Beschattungen in diesem Bereich treten der Gruppe automatisch bei und die Mitgliedschaft folgt Registrierungsänderungen. Kombiniert mit den obigen Listen."
         }
       }
     },
@@ -1602,11 +1604,13 @@
         "description": "Bearbeiten Sie, welche Beschattungen diese Gruppe steuert. [Weitere Informationen]({learn_more})",
         "data": {
           "member_entries": "Adaptive-Cover-Pro-Mitglieder",
-          "member_covers": "Allgemeine Beschattungsentitäten"
+          "member_covers": "Allgemeine Beschattungsentitäten",
+          "group_area": "Bereich (Live-Mitgliedschaft)"
         },
         "data_description": {
           "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
-          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen.",
+          "group_area": "Optional: Beschattungen in diesem Bereich treten der Gruppe automatisch bei und die Mitgliedschaft folgt Registrierungsänderungen. Kombiniert mit den obigen Listen."
         }
       },
       "group_arbitration": {
@@ -2506,6 +2510,52 @@
         "filename": {
           "name": "Dateipfad",
           "description": "Pfad zur JSON-Datei zum Importieren. Relative Pfade werden relativ zum Konfigurationsverzeichnis von Home Assistant aufgelöst und müssen darin bleiben. Standard: adaptive_cover_pro_export.json."
+        }
+      }
+    },
+    "group_activate_scene": {
+      "name": "Gruppe: Szene aktivieren",
+      "description": "Aktiviert eine Szene auf den angestrebten Beschattungsgruppen oder gibt die Anspruch mit „auto\" frei. Szenen nutzen die Pipeline jedes Mitglieds — Wetter und Mitgliedersicherheit gewinnen immer noch.",
+      "fields": {
+        "scene": {
+          "name": "Szene",
+          "description": "Die Szene zum Aktivieren oder „auto\" um den Anspruch freizugeben."
+        }
+      }
+    },
+    "group_set_position": {
+      "name": "Gruppe: Position festlegen",
+      "description": "Verschiebt alle Mitglieder der angestrebten Beschattungsgruppen zur angegebenen Position als Benutzerbefehl (manuelle Übersteuerung und Positionsgrenzen gelten).",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position (0–100%), zu der Mitgliedsbeschattungen verschoben werden. 0% = geschlossen (Jalousien heruntergefahren / Markise eingefahren), 100% = offen (Jalousien hochgefahren / Markise ausgefahren)."
+        },
+        "tilt": {
+          "name": "Neigung",
+          "description": "Optionale Lamellenneigung (0–100%), ausgebreitet auf der Neigungsachse."
+        }
+      }
+    },
+    "group_lock": {
+      "name": "Gruppe: Sperre",
+      "description": "Friert alle Mitglieder der angestrebten Beschattungsgruppen mit Sicherheitspriorität an Ort und Stelle ein. Das eigene Sicherheitsauslöser eines Mitglieds gewinnt bei Gleichstand."
+    },
+    "group_unlock": {
+      "name": "Gruppe: Entsperren",
+      "description": "Gibt die Gruppensperrung frei. Eine aktive Szene wird erneut angewendet; andernfalls kehren Mitglieder zu ihrer eigenen Automatisierung zurück."
+    },
+    "group_clear_overrides": {
+      "name": "Gruppe: Manuelle Übersteuerungen von Mitgliedern löschen",
+      "description": "Löscht manuelle Übersteuerungen auf jedem ACP-Mitglied der angestrebten Beschattungsgruppen und sendet die Pipeline-Position jedes Mitglieds erneut."
+    },
+    "group_set_automation": {
+      "name": "Gruppe: Automatisierung festlegen",
+      "description": "Aktiviert oder deaktiviert Sonnen-Tracking-Automatisierung in Massen auf jedem ACP-Mitglied der angestrebten Beschattungsgruppen.",
+      "fields": {
+        "enabled": {
+          "name": "Aktiviert",
+          "description": "true zum Aktivieren der Mitgliedersautomatisierung, false zum Deaktivieren."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -6,7 +6,8 @@
         "menu_options": {
           "create_new": "Neue Beschattung erstellen",
           "create_building_profile": "Gebäudeprofil erstellen",
-          "duplicate_existing": "Von vorhandener Beschattung duplizieren"
+          "duplicate_existing": "Von vorhandener Beschattung duplizieren",
+          "create_group": "Beschattungsgruppe erstellen"
         }
       },
       "create_new": {
@@ -758,6 +759,19 @@
         "data_description": {
           "building_profile_id": "Verknüpfe diese Abdeckung mit einem Gebäudeprofil, um seine gemeinsamen gebäudeweiten Sensoren zu erben. Wähle „Keine (nicht verknüpft)\" aus, um die Profilverknüpfung zu überspringen und die Sensoren dieser Abdeckung lokal zu verwalten."
         }
+      },
+      "create_group": {
+        "title": "Beschattungsgruppe erstellen",
+        "description": "Eine Beschattungsgruppe steuert mehrere Beschattungen zusammen: Szenen (Alle offen, Alle geschlossen, Datenschutz), Massenautomatisierungskontrolle und Löschen manueller Übersteuerungen. Wählen Sie Adaptive-Cover-Pro-Instanzen als Mitglieder und fügen Sie einfache Beschattungsentitäten für Beschattungen ohne eigene Instanz hinzu. [Weitere Informationen]({learn_more})",
+        "data": {
+          "name": "Gruppenname",
+          "member_entries": "Adaptive-Cover-Pro-Mitglieder",
+          "member_covers": "Allgemeine Beschattungsentitäten"
+        },
+        "data_description": {
+          "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+        }
       }
     },
     "abort": {
@@ -793,7 +807,8 @@
           "building_profile": "🏢 Gebäudeprofil",
           "profile_sensors": "📡 Gemeinsame Sensoren",
           "profile_overview": "🏢 Profil-Übersicht",
-          "profile_overrides": "🧹 Lokale Übersteuerungen"
+          "profile_overrides": "🧹 Lokale Übersteuerungen",
+          "group_membership": "👥 Gruppenmitglieder"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1579,6 +1594,18 @@
         "data": {
           "clear_overrides": "Ausgewählte Übersteuerungen löschen"
         }
+      },
+      "group_membership": {
+        "title": "Gruppenmitglieder",
+        "description": "Bearbeiten Sie, welche Beschattungen diese Gruppe steuert. [Weitere Informationen]({learn_more})",
+        "data": {
+          "member_entries": "Adaptive-Cover-Pro-Mitglieder",
+          "member_covers": "Allgemeine Beschattungsentitäten"
+        },
+        "data_description": {
+          "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
+          "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
+        }
       }
     },
     "abort": {
@@ -1635,6 +1662,26 @@
       },
       "solar_calculation": {
         "name": "Solarberechnung"
+      },
+      "group_position": {
+        "name": "Gruppenposition"
+      },
+      "group_state": {
+        "name": "Gruppenstatus",
+        "state": {
+          "open": "Offen",
+          "closed": "Geschlossen",
+          "mixed": "Gemischt",
+          "unknown": "Unbekannt"
+        }
+      },
+      "group_active_scene": {
+        "name": "Aktive Szene",
+        "state": {
+          "all_open": "Alle offen",
+          "all_closed": "Alle geschlossen",
+          "privacy": "Datenschutz"
+        }
       }
     },
     "switch": {
@@ -1684,16 +1731,41 @@
           "on": "An",
           "off": "Aus"
         }
+      },
+      "group_automation": {
+        "name": "Gruppenautomatisierung"
       }
     },
     "button": {
       "my_position": {
         "name": "Verwaltete My-Position"
+      },
+      "group_scene_all_open": {
+        "name": "Szene: Alle offen"
+      },
+      "group_scene_all_closed": {
+        "name": "Szene: Alle geschlossen"
+      },
+      "group_scene_privacy": {
+        "name": "Szene: Datenschutz"
+      },
+      "group_clear_overrides": {
+        "name": "Mitglied-Übersteuerungen löschen"
       }
     },
     "number": {
       "my_position_value": {
         "name": "Verwalteter My-Positionswert"
+      }
+    },
+    "select": {
+      "group_scene_select": {
+        "name": "Szene",
+        "state": {
+          "all_open": "Alle offen",
+          "all_closed": "Alle geschlossen",
+          "privacy": "Datenschutz"
+        }
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -809,7 +809,8 @@
           "profile_overview": "🏢 Profil-Übersicht",
           "profile_overrides": "🧹 Lokale Übersteuerungen",
           "group_membership": "👥 Gruppenmitglieder",
-          "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung"
+          "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung",
+          "group_entities": "🧩 Verfügbar gemachte Entitäten"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1619,6 +1620,20 @@
           "group_stagger_delay": "Sekunden zwischen aufeinanderfolgenden Befehlen für Mitglieder während einer Szene. 0 = alle Mitglieder auf einmal befehlen.",
           "scene_opt_outs": "Überprüfte Mitglieder werden für die ausgewählte Szene übersprungen. 'Alle Szenen' überspringt das Mitglied für jede Szene. Die Gruppensperre ignoriert Ausnahmen."
         }
+      },
+      "group_entities": {
+        "title": "Verfügbar gemachte Entitäten",
+        "description": "Wählen Sie, welche aggregierten Entitäten diese Gruppe erstellt. Szenensteuerungen und Gruppenschalter sind immer verfügbar. [Weitere Informationen]({learn_more})",
+        "data": {
+          "group_enable_cover_entity": "Aggregierte Beschattungs-Entität",
+          "group_enable_position_sensor": "Gruppierungspositions-Sensor",
+          "group_enable_state_sensor": "Gruppen-Statussensor",
+          "group_enable_climate_sensor": "Gruppen-Klimamodus-Sensor",
+          "group_enable_who_won_sensor": "Sensor für Gruppenmitglieder"
+        },
+        "data_description": {
+          "group_enable_cover_entity": "Eine einzelne Beschattungs-Entität für Dashboards und Sprachassistenten. Das Ziehen befiehlt jedem Mitglied als Benutzeraktion. Standardmäßig deaktiviert, um Unordnung zu vermeiden."
+        }
       }
     },
     "abort": {
@@ -1698,6 +1713,15 @@
       },
       "group_who_won": {
         "name": "Gruppengesteuerte Mitglieder"
+      },
+      "group_climate_mode": {
+        "name": "Gruppen-Klimamodus",
+        "state": {
+          "summer_mode": "Sommer",
+          "winter_mode": "Winter",
+          "intermediate": "Zwischenmodus",
+          "mixed": "Gemischt"
+        }
       }
     },
     "switch": {
@@ -1786,6 +1810,11 @@
           "privacy": "Datenschutz",
           "auto": "Auto"
         }
+      }
+    },
+    "cover": {
+      "group_cover": {
+        "name": "Gruppenabdeckung"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -808,7 +808,8 @@
           "profile_sensors": "📡 Gemeinsame Sensoren",
           "profile_overview": "🏢 Profil-Übersicht",
           "profile_overrides": "🧹 Lokale Übersteuerungen",
-          "group_membership": "👥 Gruppenmitglieder"
+          "group_membership": "👥 Gruppenmitglieder",
+          "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1606,6 +1607,18 @@
           "member_entries": "Mitglieder werden über ihre eigene Instanz gesteuert, daher gelten Eingaben und Übersteuerungen weiterhin.",
           "member_covers": "Einfache Beschattungen werden direkt mit dem Szenenziel angesteuert. Eine Beschattung, die bereits von einem ausgewählten Mitglied gesteuert wird, wird übersprungen."
         }
+      },
+      "group_arbitration": {
+        "title": "Schiedsverfahren & Zeitplanung",
+        "description": "Beschattungsgruppen-Szenen übersteuern die manuelle Übersteuerung eines Mitglieds, weichen aber dem Wetterschutz; die Gruppensperre übertrumpft alles außer einem Sicherheitsauslöser eines Mitglieds. [Weitere Informationen]({learn_more})",
+        "data": {
+          "group_stagger_delay": "Staffelverzögerung",
+          "scene_opt_outs": "Szenen-Ausnahmen"
+        },
+        "data_description": {
+          "group_stagger_delay": "Sekunden zwischen aufeinanderfolgenden Befehlen für Mitglieder während einer Szene. 0 = alle Mitglieder auf einmal befehlen.",
+          "scene_opt_outs": "Überprüfte Mitglieder werden für die ausgewählte Szene übersprungen. 'Alle Szenen' überspringt das Mitglied für jede Szene. Die Gruppensperre ignoriert Ausnahmen."
+        }
       }
     },
     "abort": {
@@ -1682,6 +1695,9 @@
           "all_closed": "Alle geschlossen",
           "privacy": "Datenschutz"
         }
+      },
+      "group_who_won": {
+        "name": "Gruppengesteuerte Mitglieder"
       }
     },
     "switch": {
@@ -1734,6 +1750,9 @@
       },
       "group_automation": {
         "name": "Gruppenautomatisierung"
+      },
+      "group_lock": {
+        "name": "Gruppensperre"
       }
     },
     "button": {
@@ -1764,7 +1783,8 @@
         "state": {
           "all_open": "Alle offen",
           "all_closed": "Alle geschlossen",
-          "privacy": "Datenschutz"
+          "privacy": "Datenschutz",
+          "auto": "Auto"
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -766,11 +766,13 @@
         "data": {
           "name": "Group name",
           "member_entries": "Adaptive Cover Pro members",
-          "member_covers": "Generic cover entities"
+          "member_covers": "Generic cover entities",
+          "group_area": "Area (live membership)"
         },
         "data_description": {
           "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
-          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped.",
+          "group_area": "Optional: covers in this area join the group automatically and membership tracks registry changes. Combined with the lists above."
         }
       }
     },
@@ -1602,11 +1604,13 @@
         "description": "Edit which covers this group commands. [Learn more]({learn_more})",
         "data": {
           "member_entries": "Adaptive Cover Pro members",
-          "member_covers": "Generic cover entities"
+          "member_covers": "Generic cover entities",
+          "group_area": "Area (live membership)"
         },
         "data_description": {
           "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
-          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped.",
+          "group_area": "Optional: covers in this area join the group automatically and membership tracks registry changes. Combined with the lists above."
         }
       },
       "group_arbitration": {
@@ -2506,6 +2510,52 @@
         "duration": {
           "name": "Duration",
           "description": "Extend an active override by this much, or engage fresh for this long if none is active. Ignored when an end time is set."
+        }
+      }
+    },
+    "group_activate_scene": {
+      "name": "Group: activate scene",
+      "description": "Activates a scene on the targeted cover groups, or releases the claim with 'auto'. Scenes ride each member's pipeline — weather and member safety still win.",
+      "fields": {
+        "scene": {
+          "name": "Scene",
+          "description": "The scene to activate, or 'auto' to release the claim."
+        }
+      }
+    },
+    "group_set_position": {
+      "name": "Group: set position",
+      "description": "Moves every member of the targeted cover groups to the given position as a user command (manual-override engagement and floor clamps apply).",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position (0-100%) to move member covers to. 0% = closed (blinds lowered / awning retracted), 100% = open (blinds raised / awning extended)."
+        },
+        "tilt": {
+          "name": "Tilt",
+          "description": "Optional slat tilt (0-100%) fanned out on the tilt axis."
+        }
+      }
+    },
+    "group_lock": {
+      "name": "Group: lock",
+      "description": "Freezes every member of the targeted cover groups in place at safety priority. A member's own safety trigger still wins ties."
+    },
+    "group_unlock": {
+      "name": "Group: unlock",
+      "description": "Releases the group lock. An active scene is re-applied; otherwise members return to their own automation."
+    },
+    "group_clear_overrides": {
+      "name": "Group: clear member overrides",
+      "description": "Clears manual overrides on every ACP member of the targeted cover groups and resends each member's pipeline position."
+    },
+    "group_set_automation": {
+      "name": "Group: set automation",
+      "description": "Bulk-enables or disables sun-tracking automation on every ACP member of the targeted cover groups.",
+      "fields": {
+        "enabled": {
+          "name": "Enabled",
+          "description": "True to enable member automation, false to disable it."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -809,7 +809,8 @@
           "profile_sensors": "📡 Shared Sensors",
           "profile_overview": "🏢 Profile Overview",
           "profile_overrides": "🧹 Local Overrides",
-          "group_membership": "👥 Group Members"
+          "group_membership": "👥 Group Members",
+          "group_arbitration": "⚖️ Arbitration & Timing"
         }
       },
       "pipeline_priorities": {
@@ -1606,6 +1607,18 @@
           "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
           "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
         }
+      },
+      "group_arbitration": {
+        "title": "Arbitration & Timing",
+        "description": "Group scenes win over a member's manual override but yield to weather safety; the group lock outranks everything except a member's own safety trigger. [Learn more]({learn_more})",
+        "data": {
+          "group_stagger_delay": "Stagger delay",
+          "scene_opt_outs": "Scene opt-outs"
+        },
+        "data_description": {
+          "group_stagger_delay": "Seconds between successive member commands during a scene. 0 = command all members at once.",
+          "scene_opt_outs": "Members checked here are skipped for the selected scene. 'All scenes' skips the member for every scene. The group lock ignores opt-outs."
+        }
       }
     },
     "abort": {
@@ -1682,6 +1695,9 @@
           "all_closed": "All Closed",
           "privacy": "Privacy"
         }
+      },
+      "group_who_won": {
+        "name": "Group-Driven Members"
       }
     },
     "switch": {
@@ -1734,6 +1750,9 @@
       },
       "group_automation": {
         "name": "Group Automation"
+      },
+      "group_lock": {
+        "name": "Group Lock"
       }
     },
     "button": {
@@ -1762,6 +1781,7 @@
       "group_scene_select": {
         "name": "Scene",
         "state": {
+          "auto": "Auto",
           "all_open": "All Open",
           "all_closed": "All Closed",
           "privacy": "Privacy"

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -6,7 +6,8 @@
         "menu_options": {
           "create_new": "Create new cover",
           "create_building_profile": "Create building profile",
-          "duplicate_existing": "Duplicate from existing cover"
+          "duplicate_existing": "Duplicate from existing cover",
+          "create_group": "Create cover group"
         }
       },
       "create_new": {
@@ -758,6 +759,19 @@
         "data_description": {
           "building_profile_id": "Link this cover to a Building Profile to inherit its shared building-level sensors. Select 'None (unlinked)' to skip profile linking and manage this cover's sensors locally."
         }
+      },
+      "create_group": {
+        "title": "Create Cover Group",
+        "description": "A cover group commands a set of covers together: scenes (All Open, All Closed, Privacy), bulk automation control, and clearing manual overrides. Pick Adaptive Cover Pro instances as members, and add plain cover entities for covers without their own instance. [Learn more]({learn_more})",
+        "data": {
+          "name": "Group name",
+          "member_entries": "Adaptive Cover Pro members",
+          "member_covers": "Generic cover entities"
+        },
+        "data_description": {
+          "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+        }
       }
     },
     "abort": {
@@ -794,7 +808,8 @@
           "building_profile": "🏢 Building Profile",
           "profile_sensors": "📡 Shared Sensors",
           "profile_overview": "🏢 Profile Overview",
-          "profile_overrides": "🧹 Local Overrides"
+          "profile_overrides": "🧹 Local Overrides",
+          "group_membership": "👥 Group Members"
         }
       },
       "pipeline_priorities": {
@@ -1579,6 +1594,18 @@
         "data": {
           "clear_overrides": "Clear selected overrides"
         }
+      },
+      "group_membership": {
+        "title": "Group Members",
+        "description": "Edit which covers this group commands. [Learn more]({learn_more})",
+        "data": {
+          "member_entries": "Adaptive Cover Pro members",
+          "member_covers": "Generic cover entities"
+        },
+        "data_description": {
+          "member_entries": "Members are orchestrated through their own instance, so gates and overrides still apply.",
+          "member_covers": "Plain covers are commanded directly with the scene target. A cover already controlled by a selected member is skipped."
+        }
       }
     },
     "abort": {
@@ -1635,6 +1662,26 @@
       },
       "position_forecast": {
         "name": "Position Forecast"
+      },
+      "group_position": {
+        "name": "Group Position"
+      },
+      "group_state": {
+        "name": "Group State",
+        "state": {
+          "open": "Open",
+          "closed": "Closed",
+          "mixed": "Mixed",
+          "unknown": "Unknown"
+        }
+      },
+      "group_active_scene": {
+        "name": "Active Scene",
+        "state": {
+          "all_open": "All Open",
+          "all_closed": "All Closed",
+          "privacy": "Privacy"
+        }
       }
     },
     "switch": {
@@ -1684,16 +1731,41 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "group_automation": {
+        "name": "Group Automation"
       }
     },
     "button": {
       "my_position": {
         "name": "Managed My Position"
+      },
+      "group_scene_all_open": {
+        "name": "Scene: All Open"
+      },
+      "group_scene_all_closed": {
+        "name": "Scene: All Closed"
+      },
+      "group_scene_privacy": {
+        "name": "Scene: Privacy"
+      },
+      "group_clear_overrides": {
+        "name": "Clear Member Overrides"
       }
     },
     "number": {
       "my_position_value": {
         "name": "Managed My Position Value"
+      }
+    },
+    "select": {
+      "group_scene_select": {
+        "name": "Scene",
+        "state": {
+          "all_open": "All Open",
+          "all_closed": "All Closed",
+          "privacy": "Privacy"
+        }
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -810,7 +810,8 @@
           "profile_overview": "🏢 Profile Overview",
           "profile_overrides": "🧹 Local Overrides",
           "group_membership": "👥 Group Members",
-          "group_arbitration": "⚖️ Arbitration & Timing"
+          "group_arbitration": "⚖️ Arbitration & Timing",
+          "group_entities": "🧩 Exposed Entities"
         }
       },
       "pipeline_priorities": {
@@ -1619,6 +1620,20 @@
           "group_stagger_delay": "Seconds between successive member commands during a scene. 0 = command all members at once.",
           "scene_opt_outs": "Members checked here are skipped for the selected scene. 'All scenes' skips the member for every scene. The group lock ignores opt-outs."
         }
+      },
+      "group_entities": {
+        "title": "Exposed Entities",
+        "description": "Choose which aggregate entities this group creates. Scene controls and bulk switches are always available. [Learn more]({learn_more})",
+        "data": {
+          "group_enable_cover_entity": "Aggregate cover entity",
+          "group_enable_position_sensor": "Group position sensor",
+          "group_enable_state_sensor": "Group state sensor",
+          "group_enable_climate_sensor": "Group climate mode sensor",
+          "group_enable_who_won_sensor": "Group-driven members sensor"
+        },
+        "data_description": {
+          "group_enable_cover_entity": "A single cover entity for dashboards and voice assistants. Dragging it commands every member as a user action. Off by default to avoid clutter."
+        }
       }
     },
     "abort": {
@@ -1698,6 +1713,15 @@
       },
       "group_who_won": {
         "name": "Group-Driven Members"
+      },
+      "group_climate_mode": {
+        "name": "Group Climate Mode",
+        "state": {
+          "summer_mode": "Summer",
+          "winter_mode": "Winter",
+          "intermediate": "Intermediate",
+          "mixed": "Mixed"
+        }
       }
     },
     "switch": {
@@ -1786,6 +1810,11 @@
           "all_closed": "All Closed",
           "privacy": "Privacy"
         }
+      }
+    },
+    "cover": {
+      "group_cover": {
+        "name": "Group Cover"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -808,7 +808,8 @@
           "profile_sensors": "📡 Capteurs partagés",
           "profile_overview": "🏢 Aperçu du profil",
           "profile_overrides": "🧹 Dérogations locales",
-          "group_membership": "👥 Membres du groupe"
+          "group_membership": "👥 Membres du groupe",
+          "group_arbitration": "⚖️ Arbitrage & Synchronisation"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1606,6 +1607,18 @@
           "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
           "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
         }
+      },
+      "group_arbitration": {
+        "title": "Arbitrage & Synchronisation",
+        "description": "Les scènes de groupe l'emportent sur la dérogation manuelle d'un membre, mais cèdent à la sécurité météo ; le verrouillage de groupe prime sur tout sauf le déclencheur de sécurité propre d'un membre. [En savoir plus]({learn_more})",
+        "data": {
+          "group_stagger_delay": "Délai d'échelonnement",
+          "scene_opt_outs": "Exclusions de scène"
+        },
+        "data_description": {
+          "group_stagger_delay": "Secondes entre les commandes successives des membres lors d'une scène. 0 = commander tous les membres à la fois.",
+          "scene_opt_outs": "Les membres cochés ici sont ignorés pour la scène sélectionnée. « Toutes les scènes » ignore le membre pour chaque scène. Le verrouillage de groupe ignore les exclusions."
+        }
       }
     },
     "abort": {
@@ -1682,6 +1695,9 @@
           "all_closed": "Tous fermés",
           "privacy": "Confidentialité"
         }
+      },
+      "group_who_won": {
+        "name": "Membres dirigés par le groupe"
       }
     },
     "switch": {
@@ -1734,6 +1750,9 @@
       },
       "group_automation": {
         "name": "Automation du groupe"
+      },
+      "group_lock": {
+        "name": "Verrouillage de groupe"
       }
     },
     "button": {
@@ -1764,7 +1783,8 @@
         "state": {
           "all_open": "Tous ouverts",
           "all_closed": "Tous fermés",
-          "privacy": "Confidentialité"
+          "privacy": "Confidentialité",
+          "auto": "Auto"
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -766,11 +766,13 @@
         "data": {
           "name": "Nom du groupe",
           "member_entries": "Membres Adaptive Cover Pro",
-          "member_covers": "Entités de store génériques"
+          "member_covers": "Entités de store génériques",
+          "group_area": "Zone (adhésion dynamique)"
         },
         "data_description": {
           "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
-          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré.",
+          "group_area": "Optionnel : les stores de cette zone rejoignent le groupe automatiquement et l'adhésion suit les modifications du registre. Combiné avec les listes ci-dessus."
         }
       }
     },
@@ -1602,11 +1604,13 @@
         "description": "Modifiez quels stores ce groupe commande. [En savoir plus]({learn_more})",
         "data": {
           "member_entries": "Membres Adaptive Cover Pro",
-          "member_covers": "Entités de store génériques"
+          "member_covers": "Entités de store génériques",
+          "group_area": "Zone (adhésion dynamique)"
         },
         "data_description": {
           "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
-          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré.",
+          "group_area": "Optionnel : les stores de cette zone rejoignent le groupe automatiquement et l'adhésion suit les modifications du registre. Combiné avec les listes ci-dessus."
         }
       },
       "group_arbitration": {
@@ -2506,6 +2510,52 @@
         "filename": {
           "name": "Chemin du fichier",
           "description": "Chemin du fichier JSON à importer. Les chemins relatifs se résolvent par rapport au répertoire de configuration Home Assistant et doivent rester à l'intérieur. Par défaut adaptive_cover_pro_export.json."
+        }
+      }
+    },
+    "group_activate_scene": {
+      "name": "Groupe : activer la scène",
+      "description": "Active une scène sur les groupes de stores ciblés, ou libère la prise avec « auto ». Les scènes suivent le pipeline de chaque membre — la météo et la sécurité du membre gagnent toujours.",
+      "fields": {
+        "scene": {
+          "name": "Scène",
+          "description": "La scène à activer, ou « auto » pour libérer la prise."
+        }
+      }
+    },
+    "group_set_position": {
+      "name": "Groupe : définir la position",
+      "description": "Déplace chaque membre des groupes de stores ciblés à la position donnée en tant que commande utilisateur (l'engagement de la dérogation manuelle et les pinces limites s'appliquent).",
+      "fields": {
+        "position": {
+          "name": "Position",
+          "description": "Position (0-100%) pour déplacer les stores membres. 0% = fermé (stores baissés / store enroulé rétracté), 100% = ouvert (stores levés / store enroulé déroulé)."
+        },
+        "tilt": {
+          "name": "Inclinaison",
+          "description": "Inclinaison facultative des lames (0-100%) éventée sur l'axe d'inclinaison."
+        }
+      }
+    },
+    "group_lock": {
+      "name": "Groupe : verrouiller",
+      "description": "Gèle chaque membre des groupes de stores ciblés en place à la priorité de sécurité. Le propre déclencheur de sécurité d'un membre gagne toujours les égalités."
+    },
+    "group_unlock": {
+      "name": "Groupe : déverrouiller",
+      "description": "Libère le verrouillage du groupe. Une scène active est réappliquée ; sinon, les membres reviennent à leur propre automatisation."
+    },
+    "group_clear_overrides": {
+      "name": "Groupe : effacer les dérogations des membres",
+      "description": "Efface les dérogations manuelles sur chaque membre ACP des groupes de stores ciblés et renvoie la position du pipeline de chaque membre."
+    },
+    "group_set_automation": {
+      "name": "Groupe : définir l'automatisation",
+      "description": "Active ou désactive en masse l'automatisation du suivi du soleil sur chaque membre ACP des groupes de stores ciblés.",
+      "fields": {
+        "enabled": {
+          "name": "Activé",
+          "description": "True pour activer l'automatisation des membres, false pour la désactiver."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -809,7 +809,8 @@
           "profile_overview": "🏢 Aperçu du profil",
           "profile_overrides": "🧹 Dérogations locales",
           "group_membership": "👥 Membres du groupe",
-          "group_arbitration": "⚖️ Arbitrage & Synchronisation"
+          "group_arbitration": "⚖️ Arbitrage & Synchronisation",
+          "group_entities": "🧩 Entités exposées"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1619,6 +1620,20 @@
           "group_stagger_delay": "Secondes entre les commandes successives des membres lors d'une scène. 0 = commander tous les membres à la fois.",
           "scene_opt_outs": "Les membres cochés ici sont ignorés pour la scène sélectionnée. « Toutes les scènes » ignore le membre pour chaque scène. Le verrouillage de groupe ignore les exclusions."
         }
+      },
+      "group_entities": {
+        "title": "Entités exposées",
+        "description": "Choisissez les entités agrégées que ce groupe crée. Les contrôles de scène et les commutateurs en masse sont toujours disponibles. [En savoir plus]({learn_more})",
+        "data": {
+          "group_enable_cover_entity": "Entité de store agrégée",
+          "group_enable_position_sensor": "Capteur de position du groupe",
+          "group_enable_state_sensor": "Capteur d'état du groupe",
+          "group_enable_climate_sensor": "Capteur de mode climatique du groupe",
+          "group_enable_who_won_sensor": "Capteur de membres pilotés par le groupe"
+        },
+        "data_description": {
+          "group_enable_cover_entity": "Une seule entité de store pour les tableaux de bord et les assistants vocaux. La faire glisser commande chaque membre comme une action utilisateur. Désactivée par défaut pour éviter l'encombrement."
+        }
       }
     },
     "abort": {
@@ -1698,6 +1713,15 @@
       },
       "group_who_won": {
         "name": "Membres dirigés par le groupe"
+      },
+      "group_climate_mode": {
+        "name": "Mode climatique du groupe",
+        "state": {
+          "summer_mode": "Été",
+          "winter_mode": "Hiver",
+          "intermediate": "Intermédiaire",
+          "mixed": "Mixte"
+        }
       }
     },
     "switch": {
@@ -1786,6 +1810,11 @@
           "privacy": "Confidentialité",
           "auto": "Auto"
         }
+      }
+    },
+    "cover": {
+      "group_cover": {
+        "name": "Store du groupe"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -6,7 +6,8 @@
         "menu_options": {
           "create_new": "Créer un nouveau store",
           "create_building_profile": "Créer un profil de bâtiment",
-          "duplicate_existing": "Dupliquer à partir d'un store existant"
+          "duplicate_existing": "Dupliquer à partir d'un store existant",
+          "create_group": "Créer un groupe de stores"
         }
       },
       "create_new": {
@@ -758,6 +759,19 @@
         "data_description": {
           "building_profile_id": "Associez ce volet à un Profil de bâtiment pour hériter de ses capteurs partagés à l'échelle du bâtiment. Sélectionnez « Aucun (non lié) » pour ignorer l'association de profil et gérer les capteurs de ce volet localement."
         }
+      },
+      "create_group": {
+        "title": "Créer un groupe de stores",
+        "description": "Un groupe de stores commande un ensemble de stores ensemble : scènes (Tous ouverts, Tous fermés, Confidentialité), contrôle d'automation en masse et suppression des dérogations manuelles. Sélectionnez les instances Adaptive Cover Pro comme membres, et ajoutez les entités de store simples pour les stores sans leur propre instance. [En savoir plus]({learn_more})",
+        "data": {
+          "name": "Nom du groupe",
+          "member_entries": "Membres Adaptive Cover Pro",
+          "member_covers": "Entités de store génériques"
+        },
+        "data_description": {
+          "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+        }
       }
     },
     "abort": {
@@ -793,7 +807,8 @@
           "building_profile": "🏢 Profil de bâtiment",
           "profile_sensors": "📡 Capteurs partagés",
           "profile_overview": "🏢 Aperçu du profil",
-          "profile_overrides": "🧹 Dérogations locales"
+          "profile_overrides": "🧹 Dérogations locales",
+          "group_membership": "👥 Membres du groupe"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1579,6 +1594,18 @@
         },
         "title": "Profil de bâtiment — Dérogations locales",
         "description": "Capteurs qu'une couverture liée a dérogée, ou définis localement lorsque ce profil les laisse vides. Sélectionnez-en un pour réinitialiser — un capteur dérogaté réhérite la valeur du profil; un capteur local est effacé.\n\n{overrides}"
+      },
+      "group_membership": {
+        "title": "Membres du groupe",
+        "description": "Modifiez quels stores ce groupe commande. [En savoir plus]({learn_more})",
+        "data": {
+          "member_entries": "Membres Adaptive Cover Pro",
+          "member_covers": "Entités de store génériques"
+        },
+        "data_description": {
+          "member_entries": "Les membres sont orchestrés via leur propre instance, donc les portails et dérogations s'appliquent toujours.",
+          "member_covers": "Les stores simples sont commandés directement avec la cible de scène. Un store déjà contrôlé par un membre sélectionné est ignoré."
+        }
       }
     },
     "abort": {
@@ -1635,6 +1662,26 @@
       },
       "solar_calculation": {
         "name": "Calcul solaire"
+      },
+      "group_position": {
+        "name": "Position du groupe"
+      },
+      "group_state": {
+        "name": "État du groupe",
+        "state": {
+          "open": "Ouvert",
+          "closed": "Fermé",
+          "mixed": "Mixte",
+          "unknown": "Inconnu"
+        }
+      },
+      "group_active_scene": {
+        "name": "Scène active",
+        "state": {
+          "all_open": "Tous ouverts",
+          "all_closed": "Tous fermés",
+          "privacy": "Confidentialité"
+        }
       }
     },
     "switch": {
@@ -1684,16 +1731,41 @@
           "on": "Activé",
           "off": "Désactivé"
         }
+      },
+      "group_automation": {
+        "name": "Automation du groupe"
       }
     },
     "button": {
       "my_position": {
         "name": "Position My gérée"
+      },
+      "group_scene_all_open": {
+        "name": "Scène : Tous ouverts"
+      },
+      "group_scene_all_closed": {
+        "name": "Scène : Tous fermés"
+      },
+      "group_scene_privacy": {
+        "name": "Scène : Confidentialité"
+      },
+      "group_clear_overrides": {
+        "name": "Supprimer les dérogations des membres"
       }
     },
     "number": {
       "my_position_value": {
         "name": "Valeur de position My gérée"
+      }
+    },
+    "select": {
+      "group_scene_select": {
+        "name": "Scène",
+        "state": {
+          "all_open": "Tous ouverts",
+          "all_closed": "Tous fermés",
+          "privacy": "Confidentialité"
+        }
       }
     }
   },

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -57,6 +57,7 @@ UNIVERSAL_KEYS: set[str] = {
     "services.set_custom_position.fields.slot.name",  # "Slot" — HA service parameter, language-universal
     "services.set_custom_position.fields.position.name",  # "Position" — HA service parameter, language-universal
     "services.set_position.fields.position.name",  # "Position" — HA service parameter, language-universal
+    "services.group_set_position.fields.position.name",  # "Position" — same in DE/FR
     "entity.select.group_scene_select.state.auto",  # "Auto" — same in DE/FR
 }
 

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -53,6 +53,7 @@ UNIVERSAL_KEYS: set[str] = {
     "config.step.duplicate_configure.data.name",  # "Name" — same in DE/FR
     "config.step.create_building_profile.data.name",  # "Name" — same in DE/FR
     "entity.sensor.decision_trace.state.winter",  # "Winter" — same in DE/FR
+    "entity.sensor.group_climate_mode.state.winter_mode",  # "Winter" — same in DE
     "services.set_custom_position.fields.slot.name",  # "Slot" — HA service parameter, language-universal
     "services.set_custom_position.fields.position.name",  # "Position" — HA service parameter, language-universal
     "services.set_position.fields.position.name",  # "Position" — HA service parameter, language-universal

--- a/scripts/validate_translations.py
+++ b/scripts/validate_translations.py
@@ -56,6 +56,7 @@ UNIVERSAL_KEYS: set[str] = {
     "services.set_custom_position.fields.slot.name",  # "Slot" — HA service parameter, language-universal
     "services.set_custom_position.fields.position.name",  # "Position" — HA service parameter, language-universal
     "services.set_position.fields.position.name",  # "Position" — HA service parameter, language-universal
+    "entity.select.group_scene_select.state.auto",  # "Auto" — same in DE/FR
 }
 
 

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -110,6 +110,7 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
     coord._toggles = ToggleManager()
     coord.automatic_control = False
     coord.entities = [MagicMock()]
+    coord._group_intents = {}
 
     cmd_svc = MagicMock()
     cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3258,3 +3258,20 @@ def test_summary_group_omits_stagger_line_when_zero():
     )
 
     assert "apart" not in summary
+
+
+def test_summary_group_shows_cover_entity_line_when_enabled():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    base = {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []}
+    without = _build_config_summary(base, CoverType.GROUP)
+    assert "Aggregate cover entity" not in without
+
+    with_cover = _build_config_summary(
+        {**base, CONF_GROUP_ENABLE_COVER_ENTITY: True}, CoverType.GROUP
+    )
+    assert "Aggregate cover entity" in with_cover

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3220,3 +3220,41 @@ def test_summary_group_empty_roster_warns():
 
     assert "**Cover Group**" in summary
     assert "no members" in summary
+
+
+def test_summary_group_shows_arbitration_lines():
+    """Phase 2: scene/lock priorities and the stagger, from the imported consts."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_STAGGER_DELAY,
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+        CUSTOM_POSITION_SAFETY_PRIORITY,
+        GROUP_SCENE_PRIORITY,
+    )
+
+    summary = _build_config_summary(
+        {
+            CONF_MEMBER_ENTRIES: ["entry_a"],
+            CONF_MEMBER_COVERS: [],
+            CONF_GROUP_STAGGER_DELAY: 2.5,
+        },
+        CoverType.GROUP,
+    )
+
+    assert f"priority {GROUP_SCENE_PRIORITY}" in summary
+    assert f"priority {CUSTOM_POSITION_SAFETY_PRIORITY}" in summary
+    assert "2.5" in summary
+
+
+def test_summary_group_omits_stagger_line_when_zero():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    summary = _build_config_summary(
+        {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []},
+        CoverType.GROUP,
+    )
+
+    assert "apart" not in summary

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3176,3 +3176,47 @@ def test_summary_building_profile_line_absent_when_unlinked() -> None:
     assert (
         "building profile" not in summary.lower()
     ), "Summary must not mention 'building profile' for an unlinked cover"
+
+
+# ---------------------------------------------------------------------------
+# Cover Group summary (issue #790)
+# ---------------------------------------------------------------------------
+
+
+def test_summary_group_shows_header_and_member_counts():
+    """A group renders its own compact summary, never the cover chain."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    summary = _build_config_summary(
+        {
+            CONF_MEMBER_ENTRIES: ["entry_a", "entry_b"],
+            CONF_MEMBER_COVERS: ["cover.generic"],
+        },
+        CoverType.GROUP,
+    )
+
+    assert "**Cover Group**" in summary
+    assert "2 ACP member(s)" in summary
+    assert "1 generic cover(s)" in summary
+    assert "cover.generic" in summary
+    # None of the cover-chain sections appear for a group.
+    assert "How It Decides" not in summary
+
+
+def test_summary_group_empty_roster_warns():
+    """An empty group is called out — it will not command anything."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    summary = _build_config_summary(
+        {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+        CoverType.GROUP,
+    )
+
+    assert "**Cover Group**" in summary
+    assert "no members" in summary

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3275,3 +3275,20 @@ def test_summary_group_shows_cover_entity_line_when_enabled():
         {**base, CONF_GROUP_ENABLE_COVER_ENTITY: True}, CoverType.GROUP
     )
     assert "Aggregate cover entity" in with_cover
+
+
+def test_summary_group_shows_area_line_when_configured():
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_AREA,
+        CONF_MEMBER_COVERS,
+        CONF_MEMBER_ENTRIES,
+    )
+
+    base = {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []}
+    without = _build_config_summary(base, CoverType.GROUP)
+    assert "area" not in without.lower()
+
+    with_area = _build_config_summary(
+        {**base, CONF_GROUP_AREA: "living_room"}, CoverType.GROUP
+    )
+    assert "living_room" in with_area

--- a/tests/test_cover_types/stub_policy.py
+++ b/tests/test_cover_types/stub_policy.py
@@ -84,12 +84,18 @@ def register_stub_policy(policy_cls: type[CoverTypePolicy]):
 
 # Every real COVER policy plus both stubs. Most invariant tests parametrise
 # over this list so adding a fifth real cover type automatically extends
-# coverage without further edits. Virtual entry types (the building profile,
-# ``controls_cover = False``) are excluded: they have zero axes and register
-# no platforms, so the cover-contract suite must not pull them in. The filter
-# is on the ``controls_cover`` capability, never on a cover-type string.
+# coverage without further edits. Virtual entry types are excluded by
+# capability, never a cover-type string: the building profile
+# (``controls_cover = False``) and the group orchestrator
+# (``is_orchestrator = True``) both declare zero axes, so the cover-axis
+# contract suite must not pull them in — each has its own dedicated suite
+# (``test_building_profile_policy.py`` / ``test_group_policy.py``).
 ALL_POLICIES_WITH_STUBS: tuple[type[CoverTypePolicy], ...] = (
-    *(p for p in POLICY_REGISTRY.values() if p.controls_cover),
+    *(
+        p
+        for p in POLICY_REGISTRY.values()
+        if p.controls_cover and not p.is_orchestrator
+    ),
     StubSingleAxisPolicy,
     StubDualAxisPolicy,
 )

--- a/tests/test_cover_types/test_group_policy.py
+++ b/tests/test_cover_types/test_group_policy.py
@@ -1,0 +1,94 @@
+"""Tests for the virtual ``GroupPolicy`` orchestrator entry type and scenes.
+
+A cover group is a virtual config-entry type that orchestrates a roster of
+member covers. Unlike the building profile it *does* control covers
+(``controls_cover = True``) but it is not geometry-driven — the new
+``is_orchestrator`` ClassVar is the setup discriminator that routes it to a
+``GroupCoordinator`` instead of the sun/geometry pipeline. Scene resolution
+is per-member policy behavior via ``position_for_scene``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.config_flow import SENSOR_TYPE_MENU
+from custom_components.adaptive_cover_pro.const import (
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    CoverType,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.cover_types import (
+    POLICY_REGISTRY,
+    get_policy,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_group_policy_registers() -> None:
+    """The policy is registered and reachable via ``get_policy``."""
+    policy = get_policy(CoverType.GROUP)
+    assert policy.cover_type == CoverType.GROUP
+
+
+def test_group_controls_covers_but_is_orchestrator() -> None:
+    """A group commands covers, but through orchestration, not geometry."""
+    policy = get_policy(CoverType.GROUP)
+    assert policy.controls_cover is True
+    assert policy.is_orchestrator is True
+
+
+def test_group_has_no_axes() -> None:
+    """A group drives members, not an axis of its own."""
+    assert get_policy(CoverType.GROUP).axes == ()
+
+
+def test_group_is_the_only_orchestrator() -> None:
+    """Every other registered policy defaults to ``is_orchestrator = False``."""
+    for key in POLICY_REGISTRY:
+        if key == CoverType.GROUP:
+            continue
+        assert get_policy(key).is_orchestrator is False
+
+
+def test_group_not_in_cover_type_menu() -> None:
+    """The group is its own top-level create option, not a cover-type dropdown
+    entry — ``controls_cover`` alone no longer suffices as the menu filter.
+    """
+    assert CoverType.GROUP not in SENSOR_TYPE_MENU
+    assert all(not get_policy(k).is_orchestrator for k in SENSOR_TYPE_MENU)
+
+
+def test_group_scene_wire_values() -> None:
+    """Scene identifiers are wire-stable (stored in options / select state)."""
+    assert GroupScene.ALL_OPEN == "all_open"
+    assert GroupScene.ALL_CLOSED == "all_closed"
+    assert GroupScene.PRIVACY == "privacy"
+
+
+@pytest.mark.parametrize(
+    ("cover_type", "scene", "expected"),
+    [
+        # ALL_OPEN / ALL_CLOSED are HA cover semantics: 100 = open, 0 = closed
+        # (blinds raised / awning extended vs blinds lowered / awning retracted).
+        (CoverType.BLIND, GroupScene.ALL_OPEN, POSITION_OPEN),
+        (CoverType.BLIND, GroupScene.ALL_CLOSED, POSITION_CLOSED),
+        (CoverType.AWNING, GroupScene.ALL_OPEN, POSITION_OPEN),
+        (CoverType.AWNING, GroupScene.ALL_CLOSED, POSITION_CLOSED),
+        (CoverType.TILT, GroupScene.ALL_OPEN, POSITION_OPEN),
+        (CoverType.VENETIAN, GroupScene.ALL_CLOSED, POSITION_CLOSED),
+        # PRIVACY resolves per-policy to maximum coverage — the existing
+        # ``position_for_intent(sun_through=False)`` polymorphism, so the
+        # awning's open-blocks-sun axis flips the answer.
+        (CoverType.BLIND, GroupScene.PRIVACY, POSITION_CLOSED),
+        (CoverType.AWNING, GroupScene.PRIVACY, POSITION_OPEN),
+        (CoverType.TILT, GroupScene.PRIVACY, POSITION_CLOSED),
+        (CoverType.VENETIAN, GroupScene.PRIVACY, POSITION_CLOSED),
+    ],
+)
+def test_position_for_scene_resolves_per_policy(
+    cover_type: CoverType, scene: GroupScene, expected: int
+) -> None:
+    assert get_policy(cover_type).position_for_scene(scene) == expected

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -98,10 +98,13 @@ async def test_create_group_combined_form_and_entry(hass: HomeAssistant) -> None
     )
     assert result["type"] == "form"
     assert result["step_id"] == "create_group"
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
     assert _schema_keys(result["data_schema"]) == {
         "name",
         CONF_MEMBER_ENTRIES,
         CONF_MEMBER_COVERS,
+        CONF_GROUP_AREA,
     }
     # The ACP-member selector lists existing cover entries.
     values = {
@@ -367,3 +370,51 @@ async def test_group_entities_step_saves_toggles(hass: HomeAssistant) -> None:
     assert result["type"] == "create_entry"
     assert result["data"][CONF_GROUP_ENABLE_COVER_ENTITY] is True
     assert result["data"][CONF_GROUP_ENABLE_STATE_SENSOR] is False
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — area membership picker
+# ---------------------------------------------------------------------------
+
+
+async def test_create_group_offers_and_stores_area(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "create_group"}
+    )
+    assert CONF_GROUP_AREA in _schema_keys(result["data_schema"])
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Area Group", CONF_GROUP_AREA: "living_room"},
+    )
+    assert result["type"] == "create_entry"
+    assert result["result"].options[CONF_GROUP_AREA] == "living_room"
+
+
+async def test_membership_step_updates_and_clears_area(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    group = _add_group(hass, "group_1")
+    hass.config_entries.async_update_entry(
+        group, options={**group.options, CONF_GROUP_AREA: "old_area"}
+    )
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+    result = await flow.async_step_group_membership(
+        {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: [], CONF_GROUP_AREA: "new_area"}
+    )
+    assert result["data"][CONF_GROUP_AREA] == "new_area"
+
+    # Clearing the picker removes the area source entirely.
+    flow2 = OptionsFlowHandler(hass.config_entries.async_get_entry("group_1"))
+    flow2.hass = hass
+    result = await flow2.async_step_group_membership(
+        {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []}
+    )
+    assert CONF_GROUP_AREA not in result["data"]

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -166,7 +166,12 @@ async def test_group_options_flow_shows_group_menu(hass: HomeAssistant) -> None:
     result = await flow.async_step_init()
 
     assert result["type"] == "menu"
-    assert result["menu_options"] == ["group_membership", "summary", "done"]
+    assert result["menu_options"] == [
+        "group_membership",
+        "group_arbitration",
+        "summary",
+        "done",
+    ]
 
 
 async def test_group_membership_step_excludes_self_and_other_groups(
@@ -221,3 +226,101 @@ async def test_cover_entries_excludes_groups(hass: HomeAssistant) -> None:
     entries = _cover_entries(hass)
 
     assert [e.entry_id for e in entries] == ["cover_a"]
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — arbitration step (stagger + per-member opt-out)
+# ---------------------------------------------------------------------------
+
+
+async def test_group_arbitration_step_saves_stagger_and_opt_out(
+    hass: HomeAssistant,
+) -> None:
+    """One page: stagger slider + one opt-out multi-select per ACP member."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_MEMBER_OPT_OUT,
+        CONF_GROUP_STAGGER_DELAY,
+        GroupScene,
+        OPT_OUT_ALL_SCENES,
+    )
+
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+    _add_cover(hass, "cover_b", entities=["cover.b"])
+    group = _add_group(hass, "group_1", member_entries=["cover_a", "cover_b"])
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_arbitration()
+    assert result["type"] == "form"
+    keys = _schema_keys(result["data_schema"])
+    assert keys == {CONF_GROUP_STAGGER_DELAY, "scene_opt_outs"}
+    # One multi-select: per member, the all-scenes sentinel plus every scene,
+    # encoded as "member|scene" with a human label naming the member.
+    opts = _select_options(result["data_schema"], "scene_opt_outs")
+    values = [o["value"] for o in opts]
+    assert values == [
+        *(f"cover_a|{v}" for v in (OPT_OUT_ALL_SCENES, *(str(s) for s in GroupScene))),
+        *(f"cover_b|{v}" for v in (OPT_OUT_ALL_SCENES, *(str(s) for s in GroupScene))),
+    ]
+    assert all("cover_a" in o["label"] for o in opts[:4])
+
+    result = await flow.async_step_group_arbitration(
+        {
+            CONF_GROUP_STAGGER_DELAY: 2.5,
+            "scene_opt_outs": [f"cover_a|{GroupScene.PRIVACY}"],
+        }
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_GROUP_STAGGER_DELAY] == 2.5
+    # Only members with opt-outs are stored.
+    assert result["data"][CONF_GROUP_MEMBER_OPT_OUT] == {
+        "cover_a": [str(GroupScene.PRIVACY)]
+    }
+
+
+async def test_membership_save_prunes_opt_out_of_removed_members(
+    hass: HomeAssistant,
+) -> None:
+    """Removing a member from the roster drops its opt-out entry too."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_MEMBER_OPT_OUT,
+        GroupScene,
+    )
+
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+    _add_cover(hass, "cover_b", entities=["cover.b"])
+    group = _add_group(hass, "group_1", member_entries=["cover_a", "cover_b"])
+    hass.config_entries.async_update_entry(
+        group,
+        options={
+            **group.options,
+            CONF_GROUP_MEMBER_OPT_OUT: {
+                "cover_a": [str(GroupScene.PRIVACY)],
+                "cover_b": [str(GroupScene.ALL_OPEN)],
+            },
+        },
+    )
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_membership(
+        {CONF_MEMBER_ENTRIES: ["cover_a"], CONF_MEMBER_COVERS: []}
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_GROUP_MEMBER_OPT_OUT] == {
+        "cover_a": [str(GroupScene.PRIVACY)]
+    }
+
+
+async def test_stagger_registered_in_option_ranges() -> None:
+    """The stagger range feeds OPTION_RANGES (validators + selectors)."""
+    from custom_components.adaptive_cover_pro.const import (
+        _RANGE_GROUP_STAGGER,
+        CONF_GROUP_STAGGER_DELAY,
+        OPTION_RANGES,
+    )
+
+    assert OPTION_RANGES[CONF_GROUP_STAGGER_DELAY] == _RANGE_GROUP_STAGGER

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -1,0 +1,223 @@
+"""Config-flow surfaces for the Cover Group virtual entry type (issue #790).
+
+Three surfaces:
+- Creating a ``cover_group`` entry is its own top-level menu option whose
+  combined form collects the name plus the two membership rosters (ACP
+  members as config entries, generic covers as entities) on one page.
+- A group's options flow shows a small group menu, never the cover menu.
+- Membership is sanitized on save: duplicates dropped, the group itself
+  cannot be a member, and a generic entity owned by a selected ACP member
+  is dropped in favour of the entry.
+"""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.config_flow import (
+    ConfigFlowHandler,
+    OptionsFlowHandler,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DELTA_POSITION,
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_MOTION_SENSORS,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.profile_link import _cover_entries
+
+pytestmark = pytest.mark.integration
+
+
+def _schema_keys(schema):
+    return {str(marker.schema) for marker in schema.schema}
+
+
+def _select_options(schema, key):
+    for marker, sel in schema.schema.items():
+        if str(marker.schema) == key:
+            return sel.config["options"]
+    raise AssertionError(f"{key} not in schema")
+
+
+def _add_cover(hass, entry_id: str, cover_type=CoverType.BLIND, entities=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: cover_type},
+        options={CONF_ENTITIES: entities or []},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _add_group(hass, entry_id: str, member_entries=None, member_covers=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: member_entries or [],
+            CONF_MEMBER_COVERS: member_covers or [],
+        },
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_user_menu_offers_create_group(hass: HomeAssistant) -> None:
+    """Creating a group is a top-level create choice beside the profile."""
+    handler = ConfigFlowHandler()
+    handler.hass = hass
+
+    result = await handler.async_step_user()
+
+    assert result["type"] == "menu"
+    assert "create_group" in result["menu_options"]
+
+
+async def test_create_group_combined_form_and_entry(hass: HomeAssistant) -> None:
+    """One form: name + the two membership selectors; finalizes a GROUP entry
+    without injecting cover-automation defaults (delta, motion, ...).
+    """
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "create_group"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "create_group"
+    assert _schema_keys(result["data_schema"]) == {
+        "name",
+        CONF_MEMBER_ENTRIES,
+        CONF_MEMBER_COVERS,
+    }
+    # The ACP-member selector lists existing cover entries.
+    values = {
+        o["value"] for o in _select_options(result["data_schema"], CONF_MEMBER_ENTRIES)
+    }
+    assert values == {"cover_a"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "name": "Living Room",
+            CONF_MEMBER_ENTRIES: ["cover_a"],
+            CONF_MEMBER_COVERS: ["cover.generic"],
+        },
+    )
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.GROUP
+    assert entry.options[CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert entry.options[CONF_MEMBER_COVERS] == ["cover.generic"]
+    # A group is not a geometry cover — no cover-automation defaults leak in.
+    assert CONF_DELTA_POSITION not in entry.options
+    assert CONF_MOTION_SENSORS not in entry.options
+
+
+async def test_create_group_drops_covers_owned_by_selected_members(
+    hass: HomeAssistant,
+) -> None:
+    """A generic entity owned by a selected ACP member is dropped (prefer the
+    entry — its pipeline must orchestrate, not be double-commanded), and
+    duplicate ids are deduped.
+    """
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"next_step_id": "create_group"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "name": "G",
+            CONF_MEMBER_ENTRIES: ["cover_a", "cover_a"],
+            CONF_MEMBER_COVERS: ["cover.a", "cover.generic", "cover.generic"],
+        },
+    )
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.options[CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert entry.options[CONF_MEMBER_COVERS] == ["cover.generic"]
+
+
+async def test_group_options_flow_shows_group_menu(hass: HomeAssistant) -> None:
+    """Configure on a group shows the group menu, never the cover categories."""
+    group = _add_group(hass, "group_1")
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_init()
+
+    assert result["type"] == "menu"
+    assert result["menu_options"] == ["group_membership", "summary", "done"]
+
+
+async def test_group_membership_step_excludes_self_and_other_groups(
+    hass: HomeAssistant,
+) -> None:
+    """The ACP-member selector lists real covers only — never the group itself
+    or another group entry.
+    """
+    _add_cover(hass, "cover_a")
+    _add_group(hass, "group_other")
+    group = _add_group(hass, "group_1")
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_membership()
+
+    assert result["type"] == "form"
+    values = {
+        o["value"] for o in _select_options(result["data_schema"], CONF_MEMBER_ENTRIES)
+    }
+    assert values == {"cover_a"}
+
+
+async def test_group_membership_step_saves_sanitized(hass: HomeAssistant) -> None:
+    """Submitting membership sanitizes the rosters and saves the options."""
+    _add_cover(hass, "cover_a", entities=["cover.a"])
+    group = _add_group(hass, "group_1")
+
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_membership(
+        {
+            CONF_MEMBER_ENTRIES: ["cover_a", "group_1"],
+            CONF_MEMBER_COVERS: ["cover.a", "cover.generic"],
+        }
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert result["data"][CONF_MEMBER_COVERS] == ["cover.generic"]
+
+
+async def test_cover_entries_excludes_groups(hass: HomeAssistant) -> None:
+    """_cover_entries means real covers: groups are excluded, so duplicate
+    sources and profile-linkable cover lists never contain a group.
+    """
+    _add_cover(hass, "cover_a")
+    _add_group(hass, "group_1")
+
+    entries = _cover_entries(hass)
+
+    assert [e.entry_id for e in entries] == ["cover_a"]

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -169,6 +169,7 @@ async def test_group_options_flow_shows_group_menu(hass: HomeAssistant) -> None:
     assert result["menu_options"] == [
         "group_membership",
         "group_arbitration",
+        "group_entities",
         "summary",
         "done",
     ]
@@ -324,3 +325,45 @@ async def test_stagger_registered_in_option_ranges() -> None:
     )
 
     assert OPTION_RANGES[CONF_GROUP_STAGGER_DELAY] == _RANGE_GROUP_STAGGER
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — entity-exposure toggles
+# ---------------------------------------------------------------------------
+
+
+async def test_group_entities_step_saves_toggles(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+        CONF_GROUP_ENABLE_POSITION_SENSOR,
+        CONF_GROUP_ENABLE_STATE_SENSOR,
+        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    )
+
+    group = _add_group(hass, "group_1")
+    flow = OptionsFlowHandler(group)
+    flow.hass = hass
+
+    result = await flow.async_step_group_entities()
+    assert result["type"] == "form"
+    assert _schema_keys(result["data_schema"]) == {
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+        CONF_GROUP_ENABLE_POSITION_SENSOR,
+        CONF_GROUP_ENABLE_STATE_SENSOR,
+        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    }
+
+    result = await flow.async_step_group_entities(
+        {
+            CONF_GROUP_ENABLE_COVER_ENTITY: True,
+            CONF_GROUP_ENABLE_POSITION_SENSOR: True,
+            CONF_GROUP_ENABLE_STATE_SENSOR: False,
+            CONF_GROUP_ENABLE_CLIMATE_SENSOR: True,
+            CONF_GROUP_ENABLE_WHO_WON_SENSOR: False,
+        }
+    )
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_GROUP_ENABLE_COVER_ENTITY] is True
+    assert result["data"][CONF_GROUP_ENABLE_STATE_SENSOR] is False

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -1,0 +1,266 @@
+"""Behaviour of the ``GroupCoordinator`` (issue #790, Phase 1).
+
+Covers the three fan-out operations (scene activation, bulk automation,
+bulk override clear), the mid-reload null-guard on member resolution, and
+the position/state aggregates the group sensors read.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    CoverType,
+    GroupScene,
+    GroupState,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+
+pytestmark = pytest.mark.integration
+
+BLIND_ENTITY = "cover.blind1"
+AWNING_ENTITY = "cover.awning1"
+GENERIC_ENTITY = "cover.generic1"
+
+
+def _member_entry(
+    hass, entry_id: str, cover_type: CoverType, entities: list[str]
+) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: cover_type},
+        options={CONF_ENTITIES: entities},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _mock_member_coordinator() -> MagicMock:
+    coord = MagicMock()
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+    coord.async_reset_manual_overrides = AsyncMock(return_value=[])
+    coord.async_refresh = AsyncMock()
+    return coord
+
+
+@pytest.fixture
+def group_setup(hass):
+    """Build a group with a blind member, an awning member, and one generic cover."""
+    blind_entry = _member_entry(hass, "member_blind", CoverType.BLIND, [BLIND_ENTITY])
+    awning_entry = _member_entry(
+        hass, "member_awning", CoverType.AWNING, [AWNING_ENTITY]
+    )
+    blind_coord = _mock_member_coordinator()
+    awning_coord = _mock_member_coordinator()
+    blind_entry.runtime_data = blind_coord
+    awning_entry.runtime_data = awning_coord
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_blind", "member_awning"],
+            CONF_MEMBER_COVERS: [GENERIC_ENTITY],
+        },
+        entry_id="group_01",
+        title="Living Room",
+    )
+    group_entry.add_to_hass(hass)
+
+    coordinator = GroupCoordinator(hass, group_entry)
+    # Adopt-mode command service is real by default; tests that exercise the
+    # adopt fan-out replace it with a mock to observe the calls.
+    coordinator._cmd_svc = MagicMock(
+        apply_position=AsyncMock(return_value=("sent", "")), stop=MagicMock()
+    )
+    return coordinator, blind_coord, awning_coord
+
+
+async def test_member_resolution_skips_unset_runtime_data(hass) -> None:
+    """A member whose entry is mid-reload (runtime_data unset) is skipped."""
+    ok_entry = _member_entry(hass, "member_ok", CoverType.BLIND, [BLIND_ENTITY])
+    ok_coord = _mock_member_coordinator()
+    ok_entry.runtime_data = ok_coord
+    # mid-reload member: entry exists but runtime_data never set
+    _member_entry(hass, "member_reloading", CoverType.BLIND, ["cover.x"])
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            # includes a removed entry id too — must also be skipped
+            CONF_MEMBER_ENTRIES: ["member_ok", "member_reloading", "member_gone"],
+            CONF_MEMBER_COVERS: [],
+        },
+        entry_id="group_02",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+
+    coordinator = GroupCoordinator(hass, group_entry)
+    resolved = coordinator.resolved_members()
+
+    assert [entry.entry_id for entry, _ in resolved] == ["member_ok"]
+    assert resolved[0][1] is ok_coord
+
+
+async def test_activate_scene_resolves_target_per_member_policy(group_setup) -> None:
+    """PRIVACY resolves through each member's own policy: blind 0, awning 100."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+
+    blind_coord.async_apply_user_position.assert_awaited_once_with(
+        BLIND_ENTITY,
+        POSITION_CLOSED,
+        trigger="group_scene_privacy",
+    )
+    awning_coord.async_apply_user_position.assert_awaited_once_with(
+        AWNING_ENTITY,
+        POSITION_OPEN,
+        trigger="group_scene_privacy",
+    )
+
+
+async def test_activate_scene_adopt_commands_generic_covers(group_setup) -> None:
+    """Generic ``cover.*`` members are commanded through the group's own service."""
+    coordinator, _, _ = group_setup
+
+    await coordinator.async_activate_scene(GroupScene.ALL_CLOSED)
+
+    coordinator._cmd_svc.apply_position.assert_awaited_once()
+    args, kwargs = coordinator._cmd_svc.apply_position.await_args
+    assert args[0] == GENERIC_ENTITY
+    assert args[1] == POSITION_CLOSED
+    context = kwargs.get("context") or args[3]
+    assert context.force is True
+    assert context.auto_control is True
+
+
+async def test_activate_scene_records_active_scene(group_setup) -> None:
+    """The last activated scene is recorded for the select/sensor entities."""
+    coordinator, _, _ = group_setup
+    assert coordinator.active_scene is None
+
+    await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+
+    assert coordinator.active_scene is GroupScene.ALL_OPEN
+
+
+async def test_set_automation_flips_member_toggles(group_setup) -> None:
+    """Bulk automation off sets each member's automatic_control and refreshes."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_automation(False)
+
+    for member in (blind_coord, awning_coord):
+        assert member.automatic_control is False
+        member.async_refresh.assert_awaited_once()
+
+    await coordinator.async_set_automation(True)
+    assert blind_coord.automatic_control is True
+
+
+async def test_clear_overrides_delegates_to_members(group_setup) -> None:
+    """Bulk clear rides each member's shared reset path."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_clear_overrides()
+
+    blind_coord.async_reset_manual_overrides.assert_awaited_once_with(
+        trigger="group_clear_overrides"
+    )
+    awning_coord.async_reset_manual_overrides.assert_awaited_once_with(
+        trigger="group_clear_overrides"
+    )
+
+
+async def test_member_cover_entities_union(group_setup) -> None:
+    """ACP members' controlled covers + generic covers, in roster order."""
+    coordinator, _, _ = group_setup
+    assert coordinator.member_cover_entities() == [
+        BLIND_ENTITY,
+        AWNING_ENTITY,
+        GENERIC_ENTITY,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("positions", "expected_state", "expected_position"),
+    [
+        (
+            {BLIND_ENTITY: 100, AWNING_ENTITY: 100, GENERIC_ENTITY: 100},
+            GroupState.OPEN,
+            100,
+        ),
+        ({BLIND_ENTITY: 0, AWNING_ENTITY: 0, GENERIC_ENTITY: 0}, GroupState.CLOSED, 0),
+        (
+            {BLIND_ENTITY: 100, AWNING_ENTITY: 0, GENERIC_ENTITY: 50},
+            GroupState.MIXED,
+            50,
+        ),
+        ({}, GroupState.UNKNOWN, None),
+    ],
+)
+async def test_aggregates(
+    hass, group_setup, positions, expected_state, expected_position
+) -> None:
+    """Aggregate = average of readable member positions + state classification."""
+    coordinator, _, _ = group_setup
+    for entity_id, pos in positions.items():
+        hass.states.async_set(entity_id, "open", {"current_position": pos})
+
+    aggregates = await coordinator._async_update_data()
+
+    assert aggregates.state is expected_state
+    assert aggregates.position == expected_position
+    if positions:
+        assert aggregates.member_positions == positions
+
+
+async def test_member_cover_entities_skips_removed_entries(hass) -> None:
+    """A roster id whose entry was removed contributes no entities anywhere."""
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_gone"],
+            CONF_MEMBER_COVERS: [GENERIC_ENTITY],
+        },
+        entry_id="group_03",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+
+    assert coordinator.member_cover_entities() == [GENERIC_ENTITY]
+    aggregates = await coordinator._async_update_data()
+    assert list(aggregates.member_positions) == [GENERIC_ENTITY]
+
+
+async def test_member_state_change_triggers_refresh(hass, group_setup) -> None:
+    """A member cover state change schedules an aggregate refresh."""
+    coordinator, _, _ = group_setup
+
+    await coordinator._async_setup()
+    assert coordinator._unsub_state is not None
+
+    coordinator.async_request_refresh = AsyncMock()
+    hass.states.async_set(BLIND_ENTITY, "open", {"current_position": 50})
+    await hass.async_block_till_done()
+    coordinator.async_request_refresh.assert_awaited()
+
+    await coordinator.async_shutdown()
+    assert coordinator._unsub_state is None
+    coordinator._cmd_svc.stop.assert_called_once()

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -458,3 +458,120 @@ async def test_unlock_repushes_active_scene(group_setup) -> None:
     ]
     assert pushed and pushed[-1].kind is GroupIntentKind.SCENE
     assert pushed[-1].scene is GroupScene.PRIVACY
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — climate rollup + cover fan-out
+# ---------------------------------------------------------------------------
+
+
+def _set_member_climate(coord: MagicMock, *, is_summer=False, is_winter=False) -> None:
+    coord.data.diagnostics = {
+        "climate_conditions": {"is_summer": is_summer, "is_winter": is_winter}
+    }
+
+
+async def test_member_climate_modes_maps_entities(group_setup) -> None:
+    """Each ACP member's cover entities map to its climate mode; generic
+    covers (no pipeline) are excluded; missing diagnostics → None.
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+    _set_member_climate(blind_coord, is_summer=True)
+    awning_coord.data.diagnostics = None  # climate mode off / not yet built
+
+    modes = coordinator.member_climate_modes()
+
+    assert modes == {
+        BLIND_ENTITY: "summer_mode",
+        AWNING_ENTITY: None,
+    }
+
+
+async def test_member_climate_modes_winter_and_intermediate(group_setup) -> None:
+    coordinator, blind_coord, awning_coord = group_setup
+    _set_member_climate(blind_coord, is_winter=True)
+    _set_member_climate(awning_coord)  # neither flag → intermediate
+
+    modes = coordinator.member_climate_modes()
+
+    assert modes[BLIND_ENTITY] == "winter_mode"
+    assert modes[AWNING_ENTITY] == "intermediate"
+
+
+async def test_set_position_fans_out_user_positions(group_setup) -> None:
+    """A group cover drag is a user action: member user-position path +
+    adopt-mode command for generic covers.
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_position(60)
+
+    blind_coord.async_apply_user_position.assert_awaited_once_with(
+        BLIND_ENTITY, 60, trigger="group_cover"
+    )
+    awning_coord.async_apply_user_position.assert_awaited_once_with(
+        AWNING_ENTITY, 60, trigger="group_cover"
+    )
+    coordinator._cmd_svc.apply_position.assert_awaited_once()
+    args, kwargs = coordinator._cmd_svc.apply_position.await_args
+    assert args[0] == GENERIC_ENTITY
+    assert args[1] == 60
+
+
+async def test_set_position_staggers_commands(hass) -> None:
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = _group_with_options(
+        hass, {CONF_GROUP_STAGGER_DELAY: 2.0}, entry_id="group_12"
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_set_position(50)
+
+    assert sleeper.await_count == 2  # 3 commands → 2 gaps
+    sleeper.assert_awaited_with(2.0)
+
+
+async def test_set_tilt_fans_out_user_tilts(hass, group_setup) -> None:
+    """Tilt rides the dedicated tilt path (#684) for ACP members and the
+    tilt service for generic covers.
+    """
+    from pytest_homeassistant_custom_component.common import async_mock_service
+
+    coordinator, blind_coord, awning_coord = group_setup
+    blind_coord.async_apply_user_tilt = AsyncMock()
+    awning_coord.async_apply_user_tilt = AsyncMock()
+    tilt_calls = async_mock_service(hass, "cover", "set_cover_tilt_position")
+
+    await coordinator.async_set_tilt(30)
+    await hass.async_block_till_done()
+
+    blind_coord.async_apply_user_tilt.assert_awaited_once_with(
+        BLIND_ENTITY, 30, trigger="group_cover_tilt"
+    )
+    awning_coord.async_apply_user_tilt.assert_awaited_once_with(
+        AWNING_ENTITY, 30, trigger="group_cover_tilt"
+    )
+    assert len(tilt_calls) == 1
+    assert tilt_calls[0].data == {
+        "entity_id": GENERIC_ENTITY,
+        "tilt_position": 30,
+    }
+
+
+async def test_stop_calls_stop_service_per_member_cover(hass, group_setup) -> None:
+    from pytest_homeassistant_custom_component.common import async_mock_service
+
+    coordinator, _, _ = group_setup
+    stop_calls = async_mock_service(hass, "cover", "stop_cover")
+
+    await coordinator.async_stop()
+    await hass.async_block_till_done()
+
+    assert [call.data["entity_id"] for call in stop_calls] == [
+        BLIND_ENTITY,
+        AWNING_ENTITY,
+        GENERIC_ENTITY,
+    ]

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -14,17 +14,23 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_ENTITIES,
+    CONF_GROUP_MEMBER_OPT_OUT,
+    CONF_GROUP_STAGGER_DELAY,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_SENSOR_TYPE,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
     DOMAIN,
+    GROUP_SCENE_PRIORITY,
+    OPT_OUT_ALL_SCENES,
     POSITION_CLOSED,
-    POSITION_OPEN,
     CoverType,
+    GroupIntentKind,
     GroupScene,
     GroupState,
 )
 from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
 
 pytestmark = pytest.mark.integration
 
@@ -52,6 +58,7 @@ def _mock_member_coordinator() -> MagicMock:
     coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
     coord.async_reset_manual_overrides = AsyncMock(return_value=[])
     coord.async_refresh = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
     return coord
 
 
@@ -115,22 +122,24 @@ async def test_member_resolution_skips_unset_runtime_data(hass) -> None:
     assert resolved[0][1] is ok_coord
 
 
-async def test_activate_scene_resolves_target_per_member_policy(group_setup) -> None:
-    """PRIVACY resolves through each member's own policy: blind 0, awning 100."""
+async def test_activate_scene_pushes_intent_and_refreshes(group_setup) -> None:
+    """Phase 2: scenes ride the pipeline — intent push + refresh, never the
+    user-position path (which would engage manual override).
+    """
     coordinator, blind_coord, awning_coord = group_setup
 
     await coordinator.async_activate_scene(GroupScene.PRIVACY)
 
-    blind_coord.async_apply_user_position.assert_awaited_once_with(
-        BLIND_ENTITY,
-        POSITION_CLOSED,
-        trigger="group_scene_privacy",
+    expected = GroupIntent(
+        kind=GroupIntentKind.SCENE,
+        scene=GroupScene.PRIVACY,
+        priority=GROUP_SCENE_PRIORITY,
+        group_id="group_01",
     )
-    awning_coord.async_apply_user_position.assert_awaited_once_with(
-        AWNING_ENTITY,
-        POSITION_OPEN,
-        trigger="group_scene_privacy",
-    )
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", expected)
+        member.async_request_refresh.assert_awaited_once()
+        member.async_apply_user_position.assert_not_awaited()
 
 
 async def test_activate_scene_adopt_commands_generic_covers(group_setup) -> None:
@@ -264,3 +273,188 @@ async def test_member_state_change_triggers_refresh(hass, group_setup) -> None:
     await coordinator.async_shutdown()
     assert coordinator._unsub_state is None
     coordinator._cmd_svc.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — intent arbitration, opt-out, stagger, lock, clear, who-won
+# ---------------------------------------------------------------------------
+
+
+def _group_with_options(hass, extra_options, entry_id="group_10"):
+    blind_entry = _member_entry(
+        hass, f"{entry_id}_blind", CoverType.BLIND, [BLIND_ENTITY]
+    )
+    awning_entry = _member_entry(
+        hass, f"{entry_id}_awning", CoverType.AWNING, [AWNING_ENTITY]
+    )
+    blind_coord = _mock_member_coordinator()
+    awning_coord = _mock_member_coordinator()
+    blind_entry.runtime_data = blind_coord
+    awning_entry.runtime_data = awning_coord
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [f"{entry_id}_blind", f"{entry_id}_awning"],
+            CONF_MEMBER_COVERS: [GENERIC_ENTITY],
+            **extra_options,
+        },
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    coordinator._cmd_svc = MagicMock(
+        apply_position=AsyncMock(return_value=("sent", "")), stop=MagicMock()
+    )
+    return coordinator, blind_coord, awning_coord
+
+
+async def test_opt_out_skips_member_for_that_scene_only(hass) -> None:
+    """A member opted out of PRIVACY is skipped for it but included elsewhere."""
+    coordinator, blind_coord, awning_coord = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [str(GroupScene.PRIVACY)]}}
+    )
+
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+    blind_coord.set_group_intent.assert_not_called()
+    awning_coord.set_group_intent.assert_called_once()
+
+    blind_coord.reset_mock()
+    awning_coord.reset_mock()
+    await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+    blind_coord.set_group_intent.assert_called_once()
+    awning_coord.set_group_intent.assert_called_once()
+
+
+async def test_opt_out_star_skips_member_for_all_scenes(hass) -> None:
+    coordinator, blind_coord, _ = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [OPT_OUT_ALL_SCENES]}}
+    )
+
+    await coordinator.async_activate_scene(GroupScene.ALL_CLOSED)
+
+    blind_coord.set_group_intent.assert_not_called()
+
+
+async def test_clear_scene_removes_intents(group_setup) -> None:
+    """Clearing the scene removes this group's claim and refreshes members."""
+    coordinator, blind_coord, awning_coord = group_setup
+    await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+    assert coordinator.active_scene is GroupScene.ALL_OPEN
+
+    for member in (blind_coord, awning_coord):
+        member.reset_mock()
+    await coordinator.async_clear_scene()
+
+    assert coordinator.active_scene is None
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", None)
+        member.async_request_refresh.assert_awaited_once()
+
+
+async def test_lock_pushes_and_clears_lock_intent(group_setup) -> None:
+    """The group lock is a LOCK intent at safety priority on every member."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_lock(True)
+    assert coordinator.group_locked is True
+    expected = GroupIntent(
+        kind=GroupIntentKind.LOCK,
+        scene=None,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        group_id="group_01",
+    )
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", expected)
+
+    for member in (blind_coord, awning_coord):
+        member.reset_mock()
+    await coordinator.async_set_lock(False)
+    assert coordinator.group_locked is False
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", None)
+
+
+async def test_lock_ignores_scene_opt_out(hass) -> None:
+    """Opt-out is per-scene; the lock is a safety claim on every member."""
+    coordinator, blind_coord, _ = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [OPT_OUT_ALL_SCENES]}}
+    )
+
+    await coordinator.async_set_lock(True)
+
+    blind_coord.set_group_intent.assert_called_once()
+
+
+async def test_stagger_spaces_member_commands(hass) -> None:
+    """With a stagger configured, successive commands are spaced apart."""
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = _group_with_options(
+        hass, {CONF_GROUP_STAGGER_DELAY: 1.5}, entry_id="group_11"
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+
+    # 2 ACP members + 1 generic = 3 commands → 2 gaps.
+    assert sleeper.await_count == 2
+    sleeper.assert_awaited_with(1.5)
+
+
+async def test_no_stagger_no_sleep(group_setup) -> None:
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = group_setup
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_activate_scene(GroupScene.ALL_OPEN)
+
+    sleeper.assert_not_awaited()
+
+
+async def test_shutdown_clears_group_intents(group_setup) -> None:
+    """A group being unloaded must not leave stale intents on members."""
+    coordinator, blind_coord, awning_coord = group_setup
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+
+    await coordinator.async_shutdown()
+
+    for member in (blind_coord, awning_coord):
+        assert member.set_group_intent.call_args_list[-1].args == ("group_01", None)
+
+
+async def test_member_winners_maps_entities_to_pipeline_winner(group_setup) -> None:
+    """Who-won: each member cover mapped to its pipeline's winning handler."""
+    coordinator, blind_coord, awning_coord = group_setup
+    blind_coord.pipeline_winner_name = "group_scene"
+    awning_coord.pipeline_winner_name = "weather_override"
+
+    winners = coordinator.member_winners()
+
+    assert winners == {
+        BLIND_ENTITY: "group_scene",
+        AWNING_ENTITY: "weather_override",
+    }
+
+
+async def test_unlock_repushes_active_scene(group_setup) -> None:
+    """Unlocking with a scene active re-pushes the scene, not unmanaged state."""
+    coordinator, blind_coord, _ = group_setup
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+    await coordinator.async_set_lock(True)
+
+    blind_coord.reset_mock()
+    await coordinator.async_set_lock(False)
+
+    pushed = [
+        call.args[1]
+        for call in blind_coord.set_group_intent.call_args_list
+        if call.args[1] is not None
+    ]
+    assert pushed and pushed[-1].kind is GroupIntentKind.SCENE
+    assert pushed[-1].scene is GroupScene.PRIVACY

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -575,3 +575,186 @@ async def test_stop_calls_stop_service_per_member_cover(hass, group_setup) -> No
         AWNING_ENTITY,
         GENERIC_ENTITY,
     ]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — area membership
+# ---------------------------------------------------------------------------
+
+
+def _registry_cover(hass, unique_id, object_id, *, area_id=None, platform="test"):
+    from homeassistant.helpers import entity_registry as er
+
+    reg = er.async_get(hass)
+    entry = reg.async_get_or_create(
+        "cover", platform, unique_id, suggested_object_id=object_id
+    )
+    if area_id is not None:
+        reg.async_update_entity(entry.entity_id, area_id=area_id)
+    return entry.entity_id
+
+
+@pytest.fixture
+def area_setup(hass):
+    """Build an area with one ACP-controlled cover and one free generic
+    cover, plus an out-of-area ACP member for the static roster.
+    """
+    from homeassistant.helpers import area_registry as ar
+
+    area = ar.async_get(hass).async_get_or_create("Living Room")
+
+    acp_cover = _registry_cover(hass, "acp1", "acp_blind", area_id=area.id)
+    generic_cover = _registry_cover(hass, "gen1", "free_cover", area_id=area.id)
+    _registry_cover(hass, "elsewhere", "other_room_cover", area_id=None)
+    # An ACP-owned proxy entity in the area must never be adopted.
+    proxy_cover = _registry_cover(
+        hass, "proxy1", "acp_proxy", area_id=area.id, platform=DOMAIN
+    )
+
+    area_member = _member_entry(hass, "area_member", CoverType.BLIND, [acp_cover])
+    area_member.runtime_data = _mock_member_coordinator()
+    static_member = _member_entry(
+        hass, "static_member", CoverType.AWNING, ["cover.static1"]
+    )
+    static_member.runtime_data = _mock_member_coordinator()
+
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["static_member"],
+            CONF_MEMBER_COVERS: ["cover.static_generic"],
+            CONF_GROUP_AREA: area.id,
+        },
+        entry_id="group_area",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    return coordinator, acp_cover, generic_cover, proxy_cover
+
+
+async def test_area_membership_resolves_acp_entries(area_setup) -> None:
+    """Static roster ∪ ACP entries with a controlled cover in the area."""
+    coordinator, _, _, _ = area_setup
+    assert coordinator.member_entry_ids() == ["static_member", "area_member"]
+
+
+async def test_area_membership_resolves_generic_covers(area_setup) -> None:
+    """Area cover entities join the generic roster — except covers already
+    controlled by an ACP entry (orchestrate wins) and ACP's own proxy
+    entities.
+    """
+    coordinator, acp_cover, generic_cover, proxy_cover = area_setup
+
+    generic = coordinator.generic_cover_ids()
+
+    assert generic == ["cover.static_generic", generic_cover]
+    assert acp_cover not in generic
+    assert proxy_cover not in generic
+
+
+async def test_area_membership_feeds_resolved_members(area_setup) -> None:
+    coordinator, _, _, _ = area_setup
+    resolved_ids = [entry.entry_id for entry, _ in coordinator.resolved_members()]
+    assert resolved_ids == ["static_member", "area_member"]
+
+
+async def test_area_membership_via_device_area(hass) -> None:
+    """An entity with no own area inherits its device's area."""
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+
+    from custom_components.adaptive_cover_pro.const import CONF_GROUP_AREA
+
+    area = ar.async_get(hass).async_get_or_create("Bedroom")
+    helper_entry = MockConfigEntry(domain="test", entry_id="helper")
+    helper_entry.add_to_hass(hass)
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id="helper",
+        identifiers={("test", "dev1")},
+    )
+    dr.async_get(hass).async_update_device(device.id, area_id=area.id)
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "cover",
+        "test",
+        "dev_cover",
+        suggested_object_id="bed_cover",
+        device_id=device.id,
+    )
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: [],
+            CONF_GROUP_AREA: area.id,
+        },
+        entry_id="group_dev_area",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+
+    assert coordinator.generic_cover_ids() == [reg_entry.entity_id]
+
+
+async def test_no_area_behaves_statically(group_setup) -> None:
+    """Without an area, the effective rosters equal the stored rosters."""
+    coordinator, _, _ = group_setup
+    assert coordinator.member_entry_ids() == ["member_blind", "member_awning"]
+    assert coordinator.generic_cover_ids() == [GENERIC_ENTITY]
+
+
+async def test_registry_change_reloads_when_roster_changes(hass, area_setup) -> None:
+    """Moving a cover into the area changes the roster → one entry reload."""
+    from unittest.mock import patch
+
+    coordinator, _, _, _ = area_setup
+    await coordinator._async_setup()
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock:
+        # A registry event with no roster impact must not reload.
+        hass.bus.async_fire(
+            "entity_registry_updated",
+            {"action": "update", "entity_id": "cover.other_room_cover"},
+        )
+        await hass.async_block_till_done()
+        reload_mock.assert_not_awaited()
+
+        # A new free cover appears in the area → roster changes → reload once.
+        from homeassistant.helpers import area_registry as ar
+
+        area = ar.async_get(hass).async_get_or_create("Living Room")
+        _registry_cover(hass, "newgen", "new_free_cover", area_id=area.id)
+        await hass.async_block_till_done()
+        reload_mock.assert_awaited_once_with("group_area")
+
+    await coordinator.async_shutdown()
+
+
+async def test_registry_listener_absent_without_area(hass, group_setup) -> None:
+    """Static-only groups subscribe to no registry events."""
+    from unittest.mock import patch
+
+    coordinator, _, _ = group_setup
+    await coordinator._async_setup()
+
+    with patch.object(hass.config_entries, "async_reload", AsyncMock()) as reload_mock:
+        hass.bus.async_fire(
+            "entity_registry_updated", {"action": "create", "entity_id": "cover.x"}
+        )
+        await hass.async_block_till_done()
+        reload_mock.assert_not_awaited()
+
+    await coordinator.async_shutdown()
+
+
+async def test_entity_area_id_unregistered_entity(group_setup) -> None:
+    """An entity absent from the registry has no area."""
+    coordinator, _, _ = group_setup
+    assert coordinator._entity_area_id("cover.not_registered") is None

--- a/tests/test_group_diagnostics.py
+++ b/tests/test_group_diagnostics.py
@@ -1,0 +1,110 @@
+"""Config-entry diagnostics for cover-group entries (issue #790, Phase 4).
+
+Pins the crash fix: the generic cover path read ``coordinator.data.diagnostics``,
+which a ``GroupCoordinator``'s ``GroupAggregates`` does not have — downloading
+diagnostics for a group entry raised AttributeError. The group branch returns
+a rollup of per-member SUMMARIES (winner + position + climate), never full
+member traces (§4 size mitigation).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_GROUP_STAGGER_DELAY,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+
+pytestmark = pytest.mark.integration
+
+
+async def test_group_entry_diagnostics_rollup(hass) -> None:
+    """A group entry download returns the rollup instead of crashing."""
+    member = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "blind", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: ["cover.blind1"]},
+        entry_id="member_blind",
+        title="Living Blind",
+    )
+    member.add_to_hass(hass)
+    member_coord = MagicMock()
+    member_coord.pipeline_winner_name = "group_scene"
+    member_coord.data.diagnostics = {
+        "climate_conditions": {"is_summer": True, "is_winter": False}
+    }
+    member.runtime_data = member_coord
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_blind"],
+            CONF_MEMBER_COVERS: ["cover.generic1"],
+            CONF_GROUP_STAGGER_DELAY: 1.5,
+        },
+        entry_id="group_01",
+        title="Living Room",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    group_entry.runtime_data = coordinator
+    hass.states.async_set("cover.blind1", "open", {"current_position": 40})
+    hass.states.async_set("cover.generic1", "open", {"current_position": 60})
+    await coordinator.async_refresh()
+    coordinator.active_scene = GroupScene.PRIVACY
+    coordinator.group_locked = True
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, group_entry)
+
+    group = diagnostics["group"]
+    assert group["active_scene"] == "privacy"
+    assert group["group_locked"] is True
+    assert group["aggregates"]["position"] == 50
+    assert group["aggregates"]["member_positions"] == {
+        "cover.blind1": 40,
+        "cover.generic1": 60,
+    }
+    assert group["member_winners"] == {"cover.blind1": "group_scene"}
+    assert group["member_climate_modes"] == {"cover.blind1": "summer_mode"}
+    assert group["stagger_delay"] == 1.5
+    rosters = group["rosters"]
+    assert rosters["member_entries"] == [
+        {"entry_id": "member_blind", "title": "Living Blind"}
+    ]
+    assert rosters["member_covers"] == ["cover.generic1"]
+    # Envelope fields stay consistent with cover diagnostics.
+    assert diagnostics["type"] == "config_entry"
+    assert diagnostics["identifier"] == "group_01"
+
+
+async def test_group_entry_diagnostics_before_first_refresh(hass) -> None:
+    """No aggregates yet → still a valid rollup, no crash, no member commands."""
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+        entry_id="group_02",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    group_entry.runtime_data = GroupCoordinator(hass, group_entry)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, group_entry)
+
+    assert diagnostics["group"]["active_scene"] is None
+    assert diagnostics["group"]["aggregates"]["position"] is None

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -27,6 +27,9 @@ from custom_components.adaptive_cover_pro.group_coordinator import (
     GroupAggregates,
     GroupCoordinator,
 )
+from custom_components.adaptive_cover_pro.const import (
+    GROUP_SCENE_SELECT_AUTO as SCENE_SELECT_AUTO,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -61,6 +64,7 @@ async def test_sensor_platform_builds_group_sensors(hass, group_entry) -> None:
         "group_01_group_position",
         "group_01_group_state",
         "group_01_group_active_scene",
+        "group_01_group_who_won",
     }
 
 
@@ -91,7 +95,10 @@ async def test_switch_platform_builds_group_automation_switch(
     hass, group_entry
 ) -> None:
     entities = await _added_entities(switch, hass, group_entry)
-    assert [e.unique_id for e in entities] == ["group_01_group_automation"]
+    assert [e.unique_id for e in entities] == [
+        "group_01_group_automation",
+        "group_01_group_lock",
+    ]
 
     coordinator = group_entry.runtime_data
     coordinator.async_set_automation = AsyncMock()
@@ -133,10 +140,10 @@ async def test_select_platform_builds_scene_picker(hass, group_entry) -> None:
     assert [e.unique_id for e in entities] == ["group_01_group_scene_select"]
 
     picker = entities[0]
-    assert picker.options == [str(scene) for scene in GroupScene]
+    assert picker.options == [SCENE_SELECT_AUTO, *(str(scene) for scene in GroupScene)]
 
     coordinator = group_entry.runtime_data
-    assert picker.current_option is None
+    assert picker.current_option == SCENE_SELECT_AUTO
     coordinator.active_scene = GroupScene.ALL_CLOSED
     assert picker.current_option == str(GroupScene.ALL_CLOSED)
 
@@ -160,3 +167,61 @@ async def test_select_platform_yields_nothing_for_cover_entry(hass) -> None:
 
     entities = await _added_entities(select, hass, entry)
     assert entities == []
+
+
+async def test_group_lock_switch_drives_lock_intent(hass, group_entry) -> None:
+    """The lock switch pushes/releases the LOCK intent via the coordinator."""
+    coordinator = group_entry.runtime_data
+    coordinator.async_set_lock = AsyncMock()
+    entities = {
+        e.unique_id: e for e in await _added_entities(switch, hass, group_entry)
+    }
+    lock = entities["group_01_group_lock"]
+    lock.async_write_ha_state = MagicMock()
+
+    assert lock.is_on is False  # unlocked by default
+    await lock.async_turn_on()
+    coordinator.async_set_lock.assert_awaited_once_with(True)
+    assert lock.is_on is True
+
+    await lock.async_turn_off()
+    coordinator.async_set_lock.assert_awaited_with(False)
+    assert lock.is_on is False
+
+
+async def test_select_auto_clears_scene(hass, group_entry) -> None:
+    """Choosing Auto releases the scene claim."""
+    coordinator = group_entry.runtime_data
+    coordinator.async_clear_scene = AsyncMock()
+    coordinator.async_activate_scene = AsyncMock()
+    entities = await _added_entities(select, hass, group_entry)
+    picker = entities[0]
+    picker.async_write_ha_state = MagicMock()
+
+    await picker.async_select_option(SCENE_SELECT_AUTO)
+
+    coordinator.async_clear_scene.assert_awaited_once()
+    coordinator.async_activate_scene.assert_not_awaited()
+
+
+async def test_who_won_sensor_reads_member_winners(hass, group_entry) -> None:
+    """State = members currently driven by this group; per-member attributes."""
+    coordinator = group_entry.runtime_data
+    coordinator.member_winners = MagicMock(
+        return_value={
+            "cover.blind1": "group_scene",
+            "cover.awning1": "weather_override",
+            "cover.tilt1": "group_lock",
+        }
+    )
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    who_won = entities["group_01_group_who_won"]
+
+    assert who_won.native_value == 2  # blind (scene) + tilt (lock)
+    assert who_won.extra_state_attributes["member_winners"] == {
+        "cover.blind1": "group_scene",
+        "cover.awning1": "weather_override",
+        "cover.tilt1": "group_lock",
+    }

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -1,0 +1,162 @@
+"""Group entity surfaces (issue #790, Phase 1).
+
+A group entry exposes aggregate sensors, the bulk automation switch, scene
+buttons + clear-overrides button, and the scene-picker select (a NEW
+platform). All unique_ids follow the locked ``f"{entry_id}_{suffix}"``
+contract, and cover entries must not gain any group entity.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro import button, select, sensor, switch
+from custom_components.adaptive_cover_pro.const import (
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+    GroupScene,
+    GroupState,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import (
+    GroupAggregates,
+    GroupCoordinator,
+)
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def group_entry(hass):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: ["cover.g1"]},
+        entry_id="group_01",
+        title="Living Room",
+    )
+    entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, entry)
+    entry.runtime_data = coordinator
+    return entry
+
+
+async def _added_entities(platform_module, hass, entry):
+    added = []
+    await platform_module.async_setup_entry(
+        hass, entry, lambda new, **kwargs: added.extend(new)
+    )
+    return added
+
+
+async def test_sensor_platform_builds_group_sensors(hass, group_entry) -> None:
+    entities = await _added_entities(sensor, hass, group_entry)
+    unique_ids = {e.unique_id for e in entities}
+    assert unique_ids == {
+        "group_01_group_position",
+        "group_01_group_state",
+        "group_01_group_active_scene",
+    }
+
+
+async def test_group_sensor_values(hass, group_entry) -> None:
+    """Sensors render the aggregates and the active scene."""
+    coordinator = group_entry.runtime_data
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    coordinator.active_scene = GroupScene.PRIVACY
+    coordinator.async_set_updated_data(
+        GroupAggregates(
+            position=42,
+            state=GroupState.MIXED,
+            member_positions={"cover.g1": 42},
+        )
+    )
+
+    assert entities["group_01_group_position"].native_value == 42
+    assert entities["group_01_group_position"].extra_state_attributes[
+        "member_positions"
+    ] == {"cover.g1": 42}
+    assert entities["group_01_group_state"].native_value == GroupState.MIXED
+    assert entities["group_01_group_active_scene"].native_value == GroupScene.PRIVACY
+
+
+async def test_switch_platform_builds_group_automation_switch(
+    hass, group_entry
+) -> None:
+    entities = await _added_entities(switch, hass, group_entry)
+    assert [e.unique_id for e in entities] == ["group_01_group_automation"]
+
+    coordinator = group_entry.runtime_data
+    coordinator.async_set_automation = AsyncMock()
+    switch_entity = entities[0]
+    switch_entity.async_write_ha_state = MagicMock()
+
+    assert switch_entity.is_on is True  # default: automation on
+    await switch_entity.async_turn_off()
+    coordinator.async_set_automation.assert_awaited_once_with(False)
+    assert switch_entity.is_on is False
+    await switch_entity.async_turn_on()
+    assert switch_entity.is_on is True
+
+
+async def test_button_platform_builds_scene_and_clear_buttons(
+    hass, group_entry
+) -> None:
+    entities = await _added_entities(button, hass, group_entry)
+    unique_ids = {e.unique_id for e in entities}
+    assert unique_ids == {
+        *(f"group_01_group_scene_{scene}" for scene in GroupScene),
+        "group_01_group_clear_overrides",
+    }
+
+    coordinator = group_entry.runtime_data
+    coordinator.async_activate_scene = AsyncMock()
+    coordinator.async_clear_overrides = AsyncMock()
+    by_id = {e.unique_id: e for e in entities}
+
+    await by_id[f"group_01_group_scene_{GroupScene.ALL_OPEN}"].async_press()
+    coordinator.async_activate_scene.assert_awaited_once_with(GroupScene.ALL_OPEN)
+
+    await by_id["group_01_group_clear_overrides"].async_press()
+    coordinator.async_clear_overrides.assert_awaited_once()
+
+
+async def test_select_platform_builds_scene_picker(hass, group_entry) -> None:
+    entities = await _added_entities(select, hass, group_entry)
+    assert [e.unique_id for e in entities] == ["group_01_group_scene_select"]
+
+    picker = entities[0]
+    assert picker.options == [str(scene) for scene in GroupScene]
+
+    coordinator = group_entry.runtime_data
+    assert picker.current_option is None
+    coordinator.active_scene = GroupScene.ALL_CLOSED
+    assert picker.current_option == str(GroupScene.ALL_CLOSED)
+
+    coordinator.async_activate_scene = AsyncMock()
+    picker.async_write_ha_state = MagicMock()
+    await picker.async_select_option(str(GroupScene.PRIVACY))
+    coordinator.async_activate_scene.assert_awaited_once_with(GroupScene.PRIVACY)
+
+
+async def test_select_platform_yields_nothing_for_cover_entry(hass) -> None:
+    """The select platform is group-only — a cover entry produces no entity."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Blind", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={},
+        entry_id="cover_01",
+        title="Blind",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock()
+
+    entities = await _added_entities(select, hass, entry)
+    assert entities == []

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -64,6 +64,7 @@ async def test_sensor_platform_builds_group_sensors(hass, group_entry) -> None:
         "group_01_group_position",
         "group_01_group_state",
         "group_01_group_active_scene",
+        "group_01_group_climate_mode",
         "group_01_group_who_won",
     }
 
@@ -225,3 +226,244 @@ async def test_who_won_sensor_reads_member_winners(hass, group_entry) -> None:
         "cover.awning1": "weather_override",
         "cover.tilt1": "group_lock",
     }
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — climate rollup sensor, group cover entity, exposure toggles
+# ---------------------------------------------------------------------------
+
+
+async def test_group_climate_sensor_states(hass, group_entry) -> None:
+    """Agree → the mode; disagree → mixed; none reporting → None."""
+    coordinator = group_entry.runtime_data
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    climate = entities["group_01_group_climate_mode"]
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "summer_mode", "cover.b": "summer_mode"}
+    )
+    assert climate.native_value == "summer_mode"
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "summer_mode", "cover.b": "winter_mode"}
+    )
+    assert climate.native_value == "mixed"
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": None, "cover.b": None}
+    )
+    assert climate.native_value is None
+
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "winter_mode", "cover.b": None}
+    )
+    assert climate.native_value == "winter_mode"
+    assert climate.extra_state_attributes["member_climate_modes"] == {
+        "cover.a": "winter_mode",
+        "cover.b": None,
+    }
+
+
+async def test_sensor_platform_includes_climate_by_default(hass, group_entry) -> None:
+    entities = {e.unique_id for e in await _added_entities(sensor, hass, group_entry)}
+    assert "group_01_group_climate_mode" in entities
+
+
+async def test_sensor_toggles_gate_creation(hass) -> None:
+    """Disabled exposure toggles suppress the matching sensors."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_CLIMATE_SENSOR,
+        CONF_GROUP_ENABLE_POSITION_SENSOR,
+        CONF_GROUP_ENABLE_STATE_SENSOR,
+        CONF_GROUP_ENABLE_WHO_WON_SENSOR,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: ["cover.g1"],
+            CONF_GROUP_ENABLE_POSITION_SENSOR: False,
+            CONF_GROUP_ENABLE_STATE_SENSOR: False,
+            CONF_GROUP_ENABLE_CLIMATE_SENSOR: False,
+            CONF_GROUP_ENABLE_WHO_WON_SENSOR: False,
+        },
+        entry_id="group_05",
+        title="G",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = GroupCoordinator(hass, entry)
+
+    entities = {e.unique_id for e in await _added_entities(sensor, hass, entry)}
+
+    # Only the always-on active-scene sensor remains.
+    assert entities == {"group_05_group_active_scene"}
+
+
+async def test_cover_platform_builds_group_cover_only_when_enabled(hass) -> None:
+    from custom_components.adaptive_cover_pro import cover
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_GROUP_ENABLE_COVER_ENTITY,
+    )
+
+    # Default: off — no group cover entity.
+    entry_off = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: ["cover.g1"]},
+        entry_id="group_06",
+        title="G",
+    )
+    entry_off.add_to_hass(hass)
+    entry_off.runtime_data = GroupCoordinator(hass, entry_off)
+    assert await _added_entities(cover, hass, entry_off) == []
+
+    entry_on = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G2", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: ["cover.g1"],
+            CONF_GROUP_ENABLE_COVER_ENTITY: True,
+        },
+        entry_id="group_07",
+        title="G2",
+    )
+    entry_on.add_to_hass(hass)
+    entry_on.runtime_data = GroupCoordinator(hass, entry_on)
+    entities = await _added_entities(cover, hass, entry_on)
+    assert [e.unique_id for e in entities] == ["group_07_group_cover"]
+
+
+async def test_group_cover_reads_aggregates_and_commands(hass, group_entry) -> None:
+    from custom_components.adaptive_cover_pro.group_entities import AdaptiveGroupCover
+
+    coordinator = group_entry.runtime_data
+    group_cover = AdaptiveGroupCover("group_01", hass, group_entry, coordinator)
+    coordinator.async_set_updated_data(
+        GroupAggregates(
+            position=0, state=GroupState.CLOSED, member_positions={"cover.g1": 0}
+        )
+    )
+
+    assert group_cover.current_cover_position == 0
+    assert group_cover.is_closed is True
+
+    coordinator.async_set_position = AsyncMock()
+    coordinator.async_stop = AsyncMock()
+    await group_cover.async_set_cover_position(position=70)
+    coordinator.async_set_position.assert_awaited_once_with(70)
+    await group_cover.async_open_cover()
+    coordinator.async_set_position.assert_awaited_with(100)
+    await group_cover.async_close_cover()
+    coordinator.async_set_position.assert_awaited_with(0)
+    await group_cover.async_stop_cover()
+    coordinator.async_stop.assert_awaited_once()
+
+
+async def test_group_cover_tilt_only_when_all_members_tilt(hass) -> None:
+    """Tilt features appear only when every member (ACP + generic) tilts."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    from custom_components.adaptive_cover_pro.const import CONF_ENTITIES
+    from custom_components.adaptive_cover_pro.group_entities import AdaptiveGroupCover
+
+    # Mixed group: blind member (no tilt axis) → no tilt features.
+    blind_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "b", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: ["cover.b1"]},
+        entry_id="m_blind",
+        title="b",
+    )
+    blind_entry.add_to_hass(hass)
+    blind_entry.runtime_data = MagicMock()
+    mixed = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["m_blind"], CONF_MEMBER_COVERS: []},
+        entry_id="group_08",
+        title="G",
+    )
+    mixed.add_to_hass(hass)
+    mixed_cover = AdaptiveGroupCover(
+        "group_08", hass, mixed, GroupCoordinator(hass, mixed)
+    )
+    assert not mixed_cover.supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+    # All-venetian group + tilt-capable generic → tilt exposed.
+    ven_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "v", CONF_SENSOR_TYPE: CoverType.VENETIAN},
+        options={CONF_ENTITIES: ["cover.v1"]},
+        entry_id="m_ven",
+        title="v",
+    )
+    ven_entry.add_to_hass(hass)
+    ven_entry.runtime_data = MagicMock()
+    hass.states.async_set(
+        "cover.gt1",
+        "open",
+        {"supported_features": int(CoverEntityFeature.SET_TILT_POSITION)},
+    )
+    tilty = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G2", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["m_ven"], CONF_MEMBER_COVERS: ["cover.gt1"]},
+        entry_id="group_09",
+        title="G2",
+    )
+    tilty.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, tilty)
+    tilt_cover = AdaptiveGroupCover("group_09", hass, tilty, coordinator)
+    assert tilt_cover.supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+    coordinator.async_set_tilt = AsyncMock()
+    await tilt_cover.async_set_cover_tilt_position(tilt_position=40)
+    coordinator.async_set_tilt.assert_awaited_once_with(40)
+
+
+async def test_group_cover_edge_cases(hass) -> None:
+    """Empty roster → no tilt; unknown aggregates → is_closed None; generic
+    cover without tilt bit → no tilt; removed member id skipped.
+    """
+    from homeassistant.components.cover import CoverEntityFeature
+
+    from custom_components.adaptive_cover_pro.group_entities import AdaptiveGroupCover
+
+    empty = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "E", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["gone_member"],
+            CONF_MEMBER_COVERS: ["cover.no_tilt"],
+        },
+        entry_id="group_20",
+        title="E",
+    )
+    empty.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, empty)
+    hass.states.async_set("cover.no_tilt", "open", {"supported_features": 0})
+    group_cover = AdaptiveGroupCover("group_20", hass, empty, coordinator)
+
+    # gone_member is skipped; cover.no_tilt lacks the tilt bit → no tilt.
+    assert not group_cover.supported_features & CoverEntityFeature.SET_TILT_POSITION
+
+    coordinator.async_set_updated_data(
+        GroupAggregates(position=None, state=GroupState.UNKNOWN, member_positions={})
+    )
+    assert group_cover.is_closed is None
+
+    # A group with no members at all is not tiltable.
+    bare = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "B", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+        entry_id="group_21",
+        title="B",
+    )
+    bare.add_to_hass(hass)
+    assert GroupCoordinator(hass, bare).all_members_tilt() is False

--- a/tests/test_group_intent.py
+++ b/tests/test_group_intent.py
@@ -1,0 +1,140 @@
+"""GroupIntent types and the member-side intent seam (issue #790, Phase 2).
+
+A group pushes a ``GroupIntent`` into each member coordinator
+(``set_group_intent``); the member holds one live intent per group and folds
+the highest-priority one into its ``PipelineSnapshot`` each cycle, where the
+group pipeline handlers read it.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    GROUP_SCENE_PRIORITY,
+    GroupIntentKind,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+    PipelineSnapshotBuilder,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
+
+pytestmark = pytest.mark.unit
+
+
+def _scene_intent(group_id: str, priority: int = GROUP_SCENE_PRIORITY) -> GroupIntent:
+    return GroupIntent(
+        kind=GroupIntentKind.SCENE,
+        scene=GroupScene.PRIVACY,
+        priority=priority,
+        group_id=group_id,
+    )
+
+
+def test_group_scene_priority_sits_between_manual_and_weather() -> None:
+    """85: above manual override (80), below weather safety (90)."""
+    from custom_components.adaptive_cover_pro.pipeline.handlers import (
+        ManualOverrideHandler,
+        WeatherOverrideHandler,
+    )
+
+    assert ManualOverrideHandler.priority < GROUP_SCENE_PRIORITY
+    assert WeatherOverrideHandler.priority > GROUP_SCENE_PRIORITY
+
+
+def test_group_intent_is_frozen() -> None:
+    intent = _scene_intent("g1")
+    with pytest.raises(AttributeError):
+        intent.priority = 99  # type: ignore[misc]
+
+
+def test_set_group_intent_stores_and_removes_per_group() -> None:
+    coordinator = MagicMock()
+    coordinator._group_intents = {}
+
+    intent = _scene_intent("g1")
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "g1", intent)
+    assert coordinator._group_intents == {"g1": intent}
+
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "g1", None)
+    assert coordinator._group_intents == {}
+    # Removing an absent group is a no-op, not an error.
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "gone", None)
+
+
+def test_effective_group_intent_picks_highest_priority() -> None:
+    """Two groups pushing to one member: the higher-priority intent wins —
+    a whole-house lock is not clobbered by a facade scene.
+    """
+    coordinator = MagicMock()
+    coordinator._group_intents = {}
+
+    scene = _scene_intent("facade")
+    lock = GroupIntent(
+        kind=GroupIntentKind.LOCK,
+        scene=None,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        group_id="house",
+    )
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "facade", scene)
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "house", lock)
+
+    effective = AdaptiveDataUpdateCoordinator.effective_group_intent.fget(coordinator)
+    assert effective is lock
+
+    AdaptiveDataUpdateCoordinator.set_group_intent(coordinator, "house", None)
+    effective = AdaptiveDataUpdateCoordinator.effective_group_intent.fget(coordinator)
+    assert effective is scene
+
+
+def test_effective_group_intent_none_when_empty() -> None:
+    coordinator = MagicMock()
+    coordinator._group_intents = {}
+    assert (
+        AdaptiveDataUpdateCoordinator.effective_group_intent.fget(coordinator) is None
+    )
+
+
+def test_snapshot_builder_accepts_group_intent() -> None:
+    """The builder threads ``group_intent`` into the snapshot (default None)."""
+    params = inspect.signature(PipelineSnapshotBuilder.build).parameters
+    assert "group_intent" in params
+    assert params["group_intent"].default is None
+
+
+def test_pipeline_winner_name_reads_first_matched_step() -> None:
+    """Winner = first matched trace step (handler steps precede synthetic)."""
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.pipeline.types import (
+        DecisionStep,
+        PipelineResult,
+    )
+
+    coordinator = MagicMock()
+    coordinator._pipeline_result = None
+    assert AdaptiveDataUpdateCoordinator.pipeline_winner_name.fget(coordinator) is None
+
+    coordinator._pipeline_result = PipelineResult(
+        position=0,
+        control_method=ControlMethod.GROUP_SCENE,
+        reason="group scene",
+        decision_trace=[
+            DecisionStep(
+                handler="weather_override", matched=False, reason="x", position=None
+            ),
+            DecisionStep(handler="group_scene", matched=True, reason="won", position=0),
+            DecisionStep(handler="floor_clamp", matched=True, reason="y", position=10),
+        ],
+    )
+    assert (
+        AdaptiveDataUpdateCoordinator.pipeline_winner_name.fget(coordinator)
+        == "group_scene"
+    )

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -1,0 +1,268 @@
+"""Cover-group domain services (issue #790, Phase 4).
+
+Six thin services over the GroupCoordinator's public methods, plus the
+resolution split: cover services must never touch a group coordinator
+(pre-existing crash: integration_disable with no target dereferenced
+cover-only attributes on the group), and group services must never touch a
+cover coordinator.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.services import (
+    _resolve_targets,
+    async_setup_services,
+)
+from custom_components.adaptive_cover_pro.services.group_service import (
+    resolve_group_targets,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _add_loaded_entry(hass, entry_id, sensor_type, coordinator, options=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: sensor_type},
+        options=options or {},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    entry.mock_state(
+        hass,
+        __import__(
+            "homeassistant.config_entries", fromlist=["ConfigEntryState"]
+        ).ConfigEntryState.LOADED,
+    )
+    entry.runtime_data = coordinator
+    return entry
+
+
+def _mock_group_coordinator() -> MagicMock:
+    coord = MagicMock(spec=GroupCoordinator)
+    for name in (
+        "async_activate_scene",
+        "async_clear_scene",
+        "async_set_position",
+        "async_set_tilt",
+        "async_set_lock",
+        "async_clear_overrides",
+        "async_set_automation",
+    ):
+        setattr(coord, name, AsyncMock())
+    return coord
+
+
+@pytest.fixture
+def loaded_pair(hass):
+    """One loaded cover entry and one loaded group entry."""
+    cover_coord = MagicMock()
+    cover_coord.entities = ["cover.blind1"]
+    _add_loaded_entry(
+        hass,
+        "cover_entry",
+        CoverType.BLIND,
+        cover_coord,
+        options={CONF_ENTITIES: ["cover.blind1"]},
+    )
+    group_coord = _mock_group_coordinator()
+    _add_loaded_entry(
+        hass,
+        "group_entry",
+        CoverType.GROUP,
+        group_coord,
+        options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []},
+    )
+    return cover_coord, group_coord
+
+
+async def test_cover_target_resolution_excludes_groups(hass, loaded_pair) -> None:
+    """Cover services must never fan out to a group coordinator.
+
+    Pins the pre-existing crash: an untargeted integration_disable walked
+    every loaded coordinator and dereferenced cover-only attributes.
+    """
+    cover_coord, group_coord = loaded_pair
+
+    call = MagicMock()
+    call.data = {}
+    targets = _resolve_targets(hass, call)
+
+    assert cover_coord in targets
+    assert group_coord not in targets
+
+
+async def test_group_target_resolution_no_target_all_groups(hass, loaded_pair) -> None:
+    cover_coord, group_coord = loaded_pair
+
+    call = MagicMock()
+    call.data = {}
+    groups = resolve_group_targets(hass, call)
+
+    assert groups == [group_coord]
+
+
+async def test_group_target_resolution_by_entity(hass, loaded_pair) -> None:
+    """An entity registered to the group entry resolves to that group only."""
+    from homeassistant.helpers import entity_registry as er
+
+    _, group_coord = loaded_pair
+    other_group = _mock_group_coordinator()
+    _add_loaded_entry(hass, "group_other", CoverType.GROUP, other_group)
+
+    reg = er.async_get(hass)
+    reg.async_get_or_create(
+        "select",
+        DOMAIN,
+        "group_entry_group_scene_select",
+        suggested_object_id="living_scene",
+        config_entry=hass.config_entries.async_get_entry("group_entry"),
+    )
+
+    call = MagicMock()
+    call.data = {"entity_id": ["select.living_scene"]}
+    groups = resolve_group_targets(hass, call)
+
+    assert groups == [group_coord]
+
+
+async def test_group_services_drive_coordinator_methods(hass, loaded_pair) -> None:
+    _, group_coord = loaded_pair
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "group_activate_scene",
+        {"scene": str(GroupScene.PRIVACY)},
+        blocking=True,
+    )
+    group_coord.async_activate_scene.assert_awaited_once_with(GroupScene.PRIVACY)
+
+    await hass.services.async_call(
+        DOMAIN, "group_activate_scene", {"scene": "auto"}, blocking=True
+    )
+    group_coord.async_clear_scene.assert_awaited_once()
+
+    await hass.services.async_call(
+        DOMAIN, "group_set_position", {"position": 40, "tilt": 20}, blocking=True
+    )
+    group_coord.async_set_position.assert_awaited_once_with(40)
+    group_coord.async_set_tilt.assert_awaited_once_with(20)
+
+    await hass.services.async_call(DOMAIN, "group_lock", {}, blocking=True)
+    group_coord.async_set_lock.assert_awaited_once_with(True)
+    await hass.services.async_call(DOMAIN, "group_unlock", {}, blocking=True)
+    group_coord.async_set_lock.assert_awaited_with(False)
+
+    await hass.services.async_call(DOMAIN, "group_clear_overrides", {}, blocking=True)
+    group_coord.async_clear_overrides.assert_awaited_once()
+
+    await hass.services.async_call(
+        DOMAIN, "group_set_automation", {"enabled": False}, blocking=True
+    )
+    group_coord.async_set_automation.assert_awaited_once_with(False)
+
+
+async def test_group_set_position_without_tilt_skips_tilt(hass, loaded_pair) -> None:
+    _, group_coord = loaded_pair
+    await async_setup_services(hass)
+
+    await hass.services.async_call(
+        DOMAIN, "group_set_position", {"position": 55}, blocking=True
+    )
+
+    group_coord.async_set_position.assert_awaited_once_with(55)
+    group_coord.async_set_tilt.assert_not_awaited()
+
+
+async def test_group_activate_scene_rejects_unknown_scene(hass, loaded_pair) -> None:
+    import voluptuous as vol
+
+    await async_setup_services(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN, "group_activate_scene", {"scene": "party"}, blocking=True
+        )
+
+
+async def test_group_target_resolution_by_device_and_area(hass, loaded_pair) -> None:
+    """Device and area targets resolve through the registries to the group."""
+    from homeassistant.helpers import area_registry as ar
+    from homeassistant.helpers import device_registry as dr
+
+    _, group_coord = loaded_pair
+    area = ar.async_get(hass).async_get_or_create("Service Area")
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id="group_entry",
+        identifiers={(DOMAIN, "group_entry")},
+    )
+    dr.async_get(hass).async_update_device(device.id, area_id=area.id)
+
+    call = MagicMock()
+    call.data = {"device_id": [device.id]}
+    assert resolve_group_targets(hass, call) == [group_coord]
+
+    call = MagicMock()
+    call.data = {"area_id": [area.id]}
+    assert resolve_group_targets(hass, call) == [group_coord]
+
+
+async def test_group_target_resolution_skips_foreign_targets(hass, loaded_pair) -> None:
+    """A cover-entry entity and an unknown entity resolve to no groups."""
+    from homeassistant.helpers import entity_registry as er
+
+    er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "cover_entry_sensor",
+        suggested_object_id="blind_sensor",
+        config_entry=hass.config_entries.async_get_entry("cover_entry"),
+    )
+
+    call = MagicMock()
+    call.data = {"entity_id": ["sensor.blind_sensor", "cover.nonexistent"]}
+    assert resolve_group_targets(hass, call) == []
+
+
+async def test_group_diagnostics_unloaded_coordinator(hass) -> None:
+    """A group entry with no loaded coordinator reports unavailable, no crash."""
+    from custom_components.adaptive_cover_pro.diagnostics import (
+        async_get_config_entry_diagnostics,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={},
+        entry_id="group_unloaded",
+        title="G",
+    )
+    entry.add_to_hass(hass)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["group"]["status"] == "unavailable"
+
+
+async def test_group_target_resolution_unknown_device(hass, loaded_pair) -> None:
+    """A vanished device id is skipped without error."""
+    call = MagicMock()
+    call.data = {"device_id": ["no_such_device"]}
+    assert resolve_group_targets(hass, call) == []

--- a/tests/test_init_group.py
+++ b/tests/test_init_group.py
@@ -1,0 +1,113 @@
+"""Setup-path and unload-path behaviour for the virtual Cover Group entry type.
+
+A ``cover_group`` config entry orchestrates member covers (issue #790). Its
+policy sets ``is_orchestrator = True``: ``async_setup_entry`` must branch to
+a ``GroupCoordinator`` — never the sun/geometry coordinator — and forward
+only the group platform set. ``async_unload_entry`` must symmetrically
+unload the same platform set (the #712/#714 load/unload-symmetry lesson).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.const import Platform
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro import (
+    GROUP_PLATFORMS,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def _group_entry(entry_id: str) -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={},
+        entry_id=entry_id,
+        title="Living Room",
+    )
+
+
+def test_group_platforms_contents() -> None:
+    """The group forwards exactly its own platform set — no cover/number/binary."""
+    assert [
+        Platform.SENSOR,
+        Platform.SWITCH,
+        Platform.BUTTON,
+        Platform.SELECT,
+    ] == GROUP_PLATFORMS
+
+
+async def test_group_entry_builds_group_coordinator(hass) -> None:
+    """Group setup builds a GroupCoordinator, not the sun/geometry coordinator."""
+    entry = _group_entry("group_01")
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.AdaptiveDataUpdateCoordinator"
+        ) as mock_cover_coord,
+        patch(
+            "custom_components.adaptive_cover_pro.GroupCoordinator"
+        ) as mock_group_coord,
+        patch.object(hass.config_entries, "async_forward_entry_setups") as mock_forward,
+    ):
+        mock_group_coord.return_value.async_config_entry_first_refresh = AsyncMock()
+        result = await async_setup_entry(hass, entry)
+
+    assert result is True
+    mock_cover_coord.assert_not_called()
+    mock_group_coord.assert_called_once_with(hass, entry)
+    assert entry.runtime_data is mock_group_coord.return_value
+    mock_forward.assert_called_once_with(entry, GROUP_PLATFORMS)
+
+
+async def test_group_entry_unloads_group_platforms(hass) -> None:
+    """Group unload must unload GROUP_PLATFORMS — not the cover PLATFORMS list."""
+    entry = _group_entry("group_02")
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(
+            hass.config_entries, "async_unload_platforms", return_value=True
+        ) as mock_unload_platforms,
+        patch("custom_components.adaptive_cover_pro.async_unload_services"),
+    ):
+        result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    mock_unload_platforms.assert_called_once_with(entry, GROUP_PLATFORMS)
+
+
+async def test_group_options_update_reloads_entry(hass) -> None:
+    """Editing the group's options (membership) reloads the entry."""
+    entry = _group_entry("group_03")
+    entry.add_to_hass(hass)
+
+    listeners: list = []
+    entry.add_update_listener = MagicMock(
+        side_effect=lambda listener: listeners.append(listener) or (lambda: None)
+    )
+
+    with (
+        patch("custom_components.adaptive_cover_pro.GroupCoordinator") as mock_coord,
+        patch.object(hass.config_entries, "async_forward_entry_setups"),
+    ):
+        mock_coord.return_value.async_config_entry_first_refresh = AsyncMock()
+        await async_setup_entry(hass, entry)
+
+    assert listeners, "group setup must register an options update listener"
+    with patch.object(hass.config_entries, "async_reload") as mock_reload:
+        await listeners[0](hass, entry)
+    mock_reload.assert_called_once_with(entry.entry_id)

--- a/tests/test_init_group.py
+++ b/tests/test_init_group.py
@@ -40,12 +40,13 @@ def _group_entry(entry_id: str) -> MockConfigEntry:
 
 
 def test_group_platforms_contents() -> None:
-    """The group forwards exactly its own platform set — no cover/number/binary."""
+    """The group forwards exactly its own platform set — no number/binary."""
     assert [
         Platform.SENSOR,
         Platform.SWITCH,
         Platform.BUTTON,
         Platform.SELECT,
+        Platform.COVER,
     ] == GROUP_PLATFORMS
 
 

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -209,14 +209,17 @@ def test_cancel_grace_period_handles_missing_entity():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_manual_override_and_sends_post_refresh_position():
-    """Reset button must reset override, refresh, then delegate to the shared send path.
+async def test_reset_clears_manual_override_and_sends_post_refresh_position():
+    """Reset must clear override, refresh, then delegate to the shared send path.
 
     The shared path (_async_send_after_override_clear) owns force=True and the
-    time-window / auto-control gates.  The button supplies the post-refresh state,
-    the options dict, the target entities, and the "manual_reset" trigger.
+    time-window / auto-control gates.  async_reset_manual_overrides supplies the
+    post-refresh state, the options dict, the target entities, and the
+    "manual_reset" trigger.  (Sequence moved from the button in issue #790.)
     """
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.living_room"
     POST_REFRESH_STATE = 52  # position pipeline returns after override is cleared
@@ -230,11 +233,9 @@ async def test_reset_button_clears_manual_override_and_sends_post_refresh_positi
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # Manager reset must be called before the refresh
     coordinator.manager.reset.assert_called_once_with(entity_id)
@@ -250,9 +251,11 @@ async def test_reset_button_clears_manual_override_and_sends_post_refresh_positi
 
 
 @pytest.mark.asyncio
-async def test_reset_button_suppresses_redetection_during_refresh():
+async def test_reset_suppresses_redetection_during_refresh():
     """wait_for_target must be True while async_refresh runs to block re-detection."""
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.bedroom"
     states_during_refresh = []
@@ -282,25 +285,25 @@ async def test_reset_button_suppresses_redetection_during_refresh():
     coordinator.cover_state_change = False
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # During refresh the suppression flag must be active
     assert states_during_refresh == [True]
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_wait_for_target_when_no_command_sent():
+async def test_reset_clears_wait_for_target_when_no_command_sent():
     """wait_for_target must be False after reset when the shared send path skips the entity.
 
     The shared method (_async_send_after_override_clear) returns a set of sent
     entity_ids.  If an entity is absent (gated by time window, auto-control off,
     or no positioning capability), the button must clear wait_for_target.
     """
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.no_position_support"
 
@@ -313,11 +316,9 @@ async def test_reset_button_clears_wait_for_target_when_no_command_sent():
     coordinator.async_refresh = AsyncMock()
     coordinator.cover_state_change = False
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # Not in sent set — wait_for_target must be cleared so state tracking resumes
     coordinator._cmd_svc.set_waiting.assert_any_call(entity_id, False)
@@ -382,13 +383,15 @@ async def test_reset_if_needed_returns_empty_when_nothing_expired():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_sends_correct_position_with_climate_mode():
-    """Button must pass the post-refresh pipeline position to the shared send path.
+async def test_reset_sends_correct_position_with_climate_mode():
+    """Reset must pass the post-refresh pipeline position to the shared send path.
 
     Covers the climate-mode scenario where ManualOverrideHandler returns solar/default
     but ClimateHandler wins after the override is cleared.
     """
-    from custom_components.adaptive_cover_pro.button import AdaptiveCoverButton
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
 
     entity_id = "cover.climate_room"
     CLIMATE_POSITION = 70  # what ClimateHandler returns after override clears
@@ -404,11 +407,9 @@ async def test_reset_button_sends_correct_position_with_climate_mode():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = AdaptiveCoverButton.__new__(AdaptiveCoverButton)
-    button.coordinator = coordinator
-    button._entities = [entity_id]
-
-    await button.async_press()
+    await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, [entity_id]
+    )
 
     # The state passed to the shared method must be the post-refresh climate position
     call = coordinator._async_send_after_override_clear.call_args

--- a/tests/test_pipeline/conftest.py
+++ b/tests/test_pipeline/conftest.py
@@ -89,6 +89,7 @@ def make_snapshot(
     min_tilt_sun_only: bool = False,
     max_tilt_sun_only: bool = False,
     solar_floor_active: bool = True,
+    group_intent=None,
     # Convenience: configure mock cover
     direct_sun_valid: bool = False,
     calculate_percentage_return: float = 50.0,
@@ -137,4 +138,5 @@ def make_snapshot(
         min_tilt_sun_only=min_tilt_sun_only,
         max_tilt_sun_only=max_tilt_sun_only,
         solar_floor_active=solar_floor_active,
+        group_intent=group_intent,
     )

--- a/tests/test_pipeline/test_group_handlers.py
+++ b/tests/test_pipeline/test_group_handlers.py
@@ -1,0 +1,240 @@
+"""GroupSceneHandler (85) and GroupLockHandler (100) — issue #790 Phase 2.
+
+The group handlers read ``snapshot.group_intent``; ``None`` is the universal
+pass signal (absence of intent IS non-membership). Arbitration contracts:
+weather (90) beats a scene (85); a scene beats manual override (80); a
+member's own custom-position safety slot beats the group lock on 100-ties
+via handler build order (stable sort).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    GROUP_SCENE_PRIORITY,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    ControlMethod,
+    GroupIntentKind,
+    GroupScene,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers import build_handlers
+from custom_components.adaptive_cover_pro.pipeline.handlers.group_lock import (
+    GroupLockHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.group_scene import (
+    GroupSceneHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
+
+from .conftest import make_snapshot
+
+pytestmark = pytest.mark.unit
+
+GROUP_ID = "group_entry_1"
+
+
+def _scene_intent(scene: GroupScene = GroupScene.PRIVACY) -> GroupIntent:
+    return GroupIntent(
+        kind=GroupIntentKind.SCENE,
+        scene=scene,
+        priority=GROUP_SCENE_PRIORITY,
+        group_id=GROUP_ID,
+    )
+
+
+def _lock_intent() -> GroupIntent:
+    return GroupIntent(
+        kind=GroupIntentKind.LOCK,
+        scene=None,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        group_id=GROUP_ID,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GroupSceneHandler
+# ---------------------------------------------------------------------------
+
+
+def test_scene_handler_priority_is_const() -> None:
+    assert GroupSceneHandler.priority == GROUP_SCENE_PRIORITY
+
+
+def test_scene_handler_defers_without_intent() -> None:
+    handler = GroupSceneHandler()
+    assert handler.evaluate(make_snapshot()) is None
+
+
+def test_scene_handler_defers_on_lock_intent() -> None:
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(group_intent=_lock_intent())
+    assert handler.evaluate(snapshot) is None
+
+
+@pytest.mark.parametrize(
+    ("cover_type", "expected"),
+    [
+        ("cover_blind", POSITION_CLOSED),
+        ("cover_awning", POSITION_OPEN),
+    ],
+)
+def test_scene_handler_resolves_position_per_policy(
+    cover_type: str, expected: int
+) -> None:
+    """PRIVACY resolves through the member's own policy, never a shared number."""
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(cover_type=cover_type, group_intent=_scene_intent())
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.position == expected
+    assert result.control_method is ControlMethod.GROUP_SCENE
+    # Explicit user intent: runs even with automatic control off, but it is
+    # NOT a safety result (weather/member-safety still outrank it).
+    assert result.bypass_auto_control is True
+    assert result.is_safety is False
+    assert GROUP_ID in result.reason
+
+
+def test_scene_handler_reason_names_scene() -> None:
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(group_intent=_scene_intent(GroupScene.ALL_OPEN))
+    result = handler.evaluate(snapshot)
+    assert result is not None
+    assert str(GroupScene.ALL_OPEN) in result.reason
+
+
+# ---------------------------------------------------------------------------
+# GroupLockHandler
+# ---------------------------------------------------------------------------
+
+
+def test_lock_handler_priority_is_safety() -> None:
+    assert GroupLockHandler.priority == CUSTOM_POSITION_SAFETY_PRIORITY
+
+
+def test_lock_handler_defers_without_intent_or_on_scene() -> None:
+    handler = GroupLockHandler()
+    assert handler.evaluate(make_snapshot()) is None
+    assert handler.evaluate(make_snapshot(group_intent=_scene_intent())) is None
+
+
+def test_lock_handler_freezes_in_place() -> None:
+    """Lock wins the pipeline but sends nothing — the cover holds position."""
+    handler = GroupLockHandler()
+    snapshot = make_snapshot(group_intent=_lock_intent(), current_cover_position=37)
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.skip_command is True
+    assert result.held_position == 37
+    assert result.position == 37
+    assert result.control_method is ControlMethod.GROUP_LOCK
+    assert GROUP_ID in result.reason
+
+
+def test_lock_handler_without_readable_position_uses_default() -> None:
+    handler = GroupLockHandler()
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        current_cover_position=None,
+        default_position=60,
+    )
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.skip_command is True
+    assert result.position == 60
+
+
+# ---------------------------------------------------------------------------
+# Registry arbitration
+# ---------------------------------------------------------------------------
+
+
+def _registry() -> PipelineRegistry:
+    return PipelineRegistry(build_handlers({}))
+
+
+def test_group_handlers_always_built() -> None:
+    names = [handler.name for handler in build_handlers({})]
+    assert "group_scene" in names
+    assert "group_lock" in names
+    # Tiebreak order: custom-position slots (member safety) must be listed
+    # BEFORE group_lock so the stable priority sort favors the member at 100.
+    # No slots configured in empty options, so pin via the factory tuple order
+    # in the arbitration test below instead.
+
+
+def test_weather_outranks_group_scene() -> None:
+    snapshot = make_snapshot(
+        group_intent=_scene_intent(),
+        weather_override_active=True,
+        weather_override_position=90,
+    )
+    result = _registry().evaluate(snapshot)
+    assert result.control_method is ControlMethod.WEATHER
+
+
+def test_group_scene_outranks_manual_override() -> None:
+    snapshot = make_snapshot(
+        group_intent=_scene_intent(),
+        manual_override_active=True,
+    )
+    result = _registry().evaluate(snapshot)
+    assert result.control_method is ControlMethod.GROUP_SCENE
+
+
+def test_member_safety_slot_beats_group_lock_on_tie() -> None:
+    """Physical safety local to the cover trumps a zone lock at equal priority."""
+    from custom_components.adaptive_cover_pro.const import CUSTOM_POSITION_SLOTS
+    from custom_components.adaptive_cover_pro.pipeline.types import (
+        CustomPositionSensorState,
+    )
+
+    slot_keys = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        slot_keys["sensors"]: ["binary_sensor.wind_alarm"],
+        slot_keys["position"]: 0,
+        slot_keys["priority"]: CUSTOM_POSITION_SAFETY_PRIORITY,
+    }
+    sensor_state = CustomPositionSensorState(
+        entity_ids=("binary_sensor.wind_alarm",),
+        is_on=True,
+        position=0,
+        priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+        min_mode=False,
+        use_my=False,
+        slot=1,
+        active_entity_ids=("binary_sensor.wind_alarm",),
+    )
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        custom_position_sensors=[sensor_state],
+        current_cover_position=50,
+    )
+
+    result = PipelineRegistry(build_handlers(options)).evaluate(snapshot)
+
+    assert result.control_method is ControlMethod.CUSTOM_POSITION
+    assert result.skip_command is False
+
+
+def test_group_lock_wins_over_scene_and_weather() -> None:
+    """Lock at 100 outranks weather (90) — and freezes instead of retracting."""
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        weather_override_active=True,
+        weather_override_position=90,
+        current_cover_position=42,
+    )
+    result = _registry().evaluate(snapshot)
+    assert result.control_method is ControlMethod.GROUP_LOCK
+    assert result.skip_command is True

--- a/tests/test_pipeline_guard.py
+++ b/tests/test_pipeline_guard.py
@@ -15,6 +15,8 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import (
     CloudSuppressionHandler,
     DefaultHandler,
     GlareZoneHandler,
+    GroupLockHandler,
+    GroupSceneHandler,
     ManualOverrideHandler,
     MotionTimeoutHandler,
     SolarHandler,
@@ -26,7 +28,12 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import (
 # user-configurable (1–100; 100 = safety/force-override semantics, issue
 # #563) and cannot be locked to a single value.
 _EXPECTED_PRIORITIES: dict[type, int] = {
+    # Group lock deliberately shares 100 with a member's custom-position
+    # SAFETY slot (excluded from this map); the tie is resolved by handler
+    # build order — member safety first (issue #790 Phase 2).
+    GroupLockHandler: 100,
     WeatherOverrideHandler: 90,
+    GroupSceneHandler: 85,
     ManualOverrideHandler: 80,
     MotionTimeoutHandler: 75,
     CloudSuppressionHandler: 60,

--- a/tests/test_reset_button_time_window.py
+++ b/tests/test_reset_button_time_window.py
@@ -236,13 +236,28 @@ async def test_send_after_override_clear_returns_only_sent_entities():
 
 
 # ---------------------------------------------------------------------------
-# Button path — issue #193 regression tests
+# Shared clear-and-resend sequence — issue #193 regression tests
+#
+# The sequence historically lived in the button's async_press; it moved to
+# AdaptiveDataUpdateCoordinator.async_reset_manual_overrides (issue #790) so
+# the cover-group bulk clear shares it. Tests exercise the method unbound,
+# same pattern as the _async_send_after_override_clear tests above.
 # ---------------------------------------------------------------------------
 
 
+async def _reset_via_coordinator(coordinator, entities):
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    return await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
+        coordinator, entities
+    )
+
+
 @pytest.mark.asyncio
-async def test_reset_button_skips_send_when_outside_time_window():
-    """Pressing Reset outside the active-hours window must clear override but not move the cover.
+async def test_reset_skips_send_when_outside_time_window():
+    """Reset outside the active-hours window must clear override but not move the cover.
 
     Regression test for issue #193: cover was moved to default (100%) even when
     Control Status showed outside_time_window.
@@ -255,23 +270,22 @@ async def test_reset_button_skips_send_when_outside_time_window():
     coordinator.state = 0
     coordinator.config_entry.options = {}
     coordinator.async_refresh = AsyncMock()
-    # The shared method handles the gate; button must delegate to it
+    # The shared send path handles the gate; the reset must delegate to it
     coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    await _reset_via_coordinator(coordinator, [entity_id])
 
     # Override flag must be cleared regardless of time window
     coordinator.manager.reset.assert_called_once_with(entity_id)
-    # No direct apply_position call from the button — it delegates
+    # No direct apply_position call — the send path owns dispatch
     coordinator._cmd_svc.apply_position.assert_not_called()
     # wait_for_target must be unblocked (entity not in sent set)
     coordinator._cmd_svc.set_waiting.assert_any_call(entity_id, False)
 
 
 @pytest.mark.asyncio
-async def test_reset_button_skips_send_when_auto_control_off():
-    """Pressing Reset with Automatic Control OFF must clear override but not move the cover."""
+async def test_reset_skips_send_when_auto_control_off():
+    """Reset with Automatic Control OFF must clear override but not move the cover."""
     entity_id = "cover.bedroom"
 
     coordinator = _make_coordinator(automatic_control=False)
@@ -282,8 +296,7 @@ async def test_reset_button_skips_send_when_auto_control_off():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    await _reset_via_coordinator(coordinator, [entity_id])
 
     coordinator.manager.reset.assert_called_once_with(entity_id)
     coordinator._cmd_svc.apply_position.assert_not_called()
@@ -291,8 +304,8 @@ async def test_reset_button_skips_send_when_auto_control_off():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_delegates_to_shared_method_with_correct_args():
-    """Button must call _async_send_after_override_clear with entities and trigger kwargs."""
+async def test_reset_delegates_to_shared_method_with_correct_args():
+    """The reset must call _async_send_after_override_clear with entities and trigger kwargs."""
     entity_id = "cover.kitchen"
     options = {"some_opt": True}
 
@@ -304,9 +317,9 @@ async def test_reset_button_delegates_to_shared_method_with_correct_args():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    reset = await _reset_via_coordinator(coordinator, [entity_id])
 
+    assert reset == [entity_id]
     coordinator._async_send_after_override_clear.assert_called_once()
     call = coordinator._async_send_after_override_clear.call_args
     assert call[0][0] == 55  # state
@@ -316,7 +329,7 @@ async def test_reset_button_delegates_to_shared_method_with_correct_args():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_clears_wait_for_target_for_unsent_entities():
+async def test_reset_clears_wait_for_target_for_unsent_entities():
     """Entities the shared method did not send to must have wait_for_target cleared."""
     entity_a = "cover.sent"
     entity_b = "cover.not_sent"
@@ -330,10 +343,9 @@ async def test_reset_button_clears_wait_for_target_for_unsent_entities():
     # Simulate: shared method sent to entity_a but not entity_b
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_a})
 
-    button = _make_button(coordinator, [entity_a, entity_b])
-    await button.async_press()
+    await _reset_via_coordinator(coordinator, [entity_a, entity_b])
 
-    # entity_a was sent — apply_position would set waiting=True; button does NOT clear it
+    # entity_a was sent — apply_position would set waiting=True; reset does NOT clear it
     set_waiting_calls = coordinator._cmd_svc.set_waiting.call_args_list
     cleared = [call for call in set_waiting_calls if call.args == (entity_a, False)]
     assert not cleared, "entity_a was sent — wait_for_target must not be cleared"
@@ -342,7 +354,7 @@ async def test_reset_button_clears_wait_for_target_for_unsent_entities():
 
 
 @pytest.mark.asyncio
-async def test_reset_button_happy_path_inside_window():
+async def test_reset_happy_path_inside_window():
     """Inside the window with auto-control on, position must be sent normally."""
     entity_id = "cover.sun_room"
 
@@ -354,13 +366,27 @@ async def test_reset_button_happy_path_inside_window():
     coordinator.async_refresh = AsyncMock()
     coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
 
-    button = _make_button(coordinator, [entity_id])
-    await button.async_press()
+    reset = await _reset_via_coordinator(coordinator, [entity_id])
 
+    assert reset == [entity_id]
     coordinator.manager.reset.assert_called_once_with(entity_id)
     coordinator.async_refresh.assert_called_once()
     coordinator._async_send_after_override_clear.assert_called_once()
-    # entity was sent — button must NOT clear waiting (apply_position set it)
+    # entity was sent — reset must NOT clear waiting (apply_position set it)
     set_waiting_calls = coordinator._cmd_svc.set_waiting.call_args_list
     cleared = [call for call in set_waiting_calls if call.args == (entity_id, False)]
     assert not cleared
+
+
+@pytest.mark.asyncio
+async def test_reset_button_delegates_to_coordinator():
+    """The button is a thin wrapper over the coordinator's shared reset method."""
+    entity_id = "cover.hall"
+
+    coordinator = MagicMock()
+    coordinator.async_reset_manual_overrides = AsyncMock(return_value=[entity_id])
+
+    button = _make_button(coordinator, [entity_id])
+    await button.async_press()
+
+    coordinator.async_reset_manual_overrides.assert_awaited_once_with([entity_id])

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -48,6 +48,7 @@ import custom_components.adaptive_cover_pro.binary_sensor  # noqa: F401
 import custom_components.adaptive_cover_pro.switch  # noqa: F401
 import custom_components.adaptive_cover_pro.button  # noqa: F401
 import custom_components.adaptive_cover_pro.cover  # noqa: F401
+import custom_components.adaptive_cover_pro.select  # noqa: F401
 
 from custom_components.adaptive_cover_pro.sensor import (
     AdaptiveCoverClimateStatusSensor,
@@ -73,6 +74,16 @@ from custom_components.adaptive_cover_pro.button import (
 )
 from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
 from custom_components.adaptive_cover_pro.number import AdaptiveCoverMyPositionNumber
+from custom_components.adaptive_cover_pro.const import GroupScene
+from custom_components.adaptive_cover_pro.group_entities import (
+    GroupActiveSceneSensor,
+    GroupAutomationSwitch,
+    GroupClearOverridesButton,
+    GroupPositionSensor,
+    GroupSceneButton,
+    GroupSceneSelect,
+    GroupStateSensor,
+)
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -245,6 +256,53 @@ ENTITY_FACTORIES: dict[type, object] = {
         coordinator=_make_coordinator(),
         source_entity_id="cover.test_source",
         multi=False,
+    ),
+    # --- group_entities.py (issue #790) ---
+    GroupPositionSensor: lambda: GroupPositionSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_position",
+    ),
+    GroupStateSensor: lambda: GroupStateSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_state",
+    ),
+    GroupActiveSceneSensor: lambda: GroupActiveSceneSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_active_scene",
+    ),
+    GroupAutomationSwitch: lambda: GroupAutomationSwitch(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupSceneButton: lambda: GroupSceneButton(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        GroupScene.ALL_OPEN,
+    ),
+    GroupClearOverridesButton: lambda: GroupClearOverridesButton(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupSceneSelect: lambda: GroupSceneSelect(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
     ),
 }
 

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -76,9 +76,11 @@ from custom_components.adaptive_cover_pro.cover import AdaptiveProxyCover
 from custom_components.adaptive_cover_pro.number import AdaptiveCoverMyPositionNumber
 from custom_components.adaptive_cover_pro.const import GroupScene
 from custom_components.adaptive_cover_pro.group_entities import (
+    AdaptiveGroupCover,
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
     GroupClearOverridesButton,
+    GroupClimateSensor,
     GroupLockSwitch,
     GroupPositionSensor,
     GroupSceneButton,
@@ -318,6 +320,19 @@ ENTITY_FACTORIES: dict[type, object] = {
         _make_config_entry(),
         _make_coordinator(),
         "group_who_won",
+    ),
+    GroupClimateSensor: lambda: GroupClimateSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_climate_mode",
+    ),
+    AdaptiveGroupCover: lambda: AdaptiveGroupCover(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
     ),
 }
 

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -79,10 +79,12 @@ from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
     GroupClearOverridesButton,
+    GroupLockSwitch,
     GroupPositionSensor,
     GroupSceneButton,
     GroupSceneSelect,
     GroupStateSensor,
+    GroupWhoWonSensor,
 )
 
 # ---------------------------------------------------------------------------
@@ -303,6 +305,19 @@ ENTITY_FACTORIES: dict[type, object] = {
         _make_hass(),
         _make_config_entry(),
         _make_coordinator(),
+    ),
+    GroupLockSwitch: lambda: GroupLockSwitch(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupWhoWonSensor: lambda: GroupWhoWonSensor(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+        "group_who_won",
     ),
 }
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
+    GroupClimateSensor,
     GroupLockSwitch,
     GroupPositionSensor,
     GroupStateSensor,
@@ -82,6 +83,7 @@ _GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
         GroupPositionSensor,
         GroupStateSensor,
         GroupActiveSceneSensor,
+        GroupClimateSensor,
         GroupWhoWonSensor,
     )
 )

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -24,8 +24,10 @@ from pathlib import Path
 from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
+    GroupLockSwitch,
     GroupPositionSensor,
     GroupStateSensor,
+    GroupWhoWonSensor,
 )
 from custom_components.adaptive_cover_pro.sensor import (
     _DIAGNOSTIC_SPECS,
@@ -76,10 +78,15 @@ def _class_translation_key(cls: type) -> str:
 
 _GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
     _class_translation_key(cls)
-    for cls in (GroupPositionSensor, GroupStateSensor, GroupActiveSceneSensor)
+    for cls in (
+        GroupPositionSensor,
+        GroupStateSensor,
+        GroupActiveSceneSensor,
+        GroupWhoWonSensor,
+    )
 )
 _GROUP_SWITCH_TRANSLATION_KEYS: frozenset[str] = frozenset(
-    {_class_translation_key(GroupAutomationSwitch)}
+    _class_translation_key(cls) for cls in (GroupAutomationSwitch, GroupLockSwitch)
 )
 
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -21,6 +21,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from custom_components.adaptive_cover_pro.group_entities import (
+    GroupActiveSceneSensor,
+    GroupAutomationSwitch,
+    GroupPositionSensor,
+    GroupStateSensor,
+)
 from custom_components.adaptive_cover_pro.sensor import (
     _DIAGNOSTIC_SPECS,
     _STANDARD_SPECS,
@@ -53,6 +59,28 @@ _EXPECTED_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
 # Switch keys that appear in en.json under entity.switch but are generated
 # dynamically (not in _SWITCH_SPECS) and therefore excluded from the spec check.
 _DYNAMIC_SWITCH_KEYS_PREFIX = "glare_zone_"
+
+# Cover-group entities (issue #790) are class-driven, not spec-driven; their
+# translation_keys come straight from the classes so a rename stays in sync.
+# HA's CachedProperties metaclass rewrites class-level ``_attr_translation_key``
+# into a property whose default lands under ``__attr_translation_key``.
+
+
+def _class_translation_key(cls: type) -> str:
+    value = cls.__dict__.get(
+        "__attr_translation_key", cls.__dict__.get("_attr_translation_key")
+    )
+    assert isinstance(value, str), f"{cls.__name__} has no class translation_key"
+    return value
+
+
+_GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
+    _class_translation_key(cls)
+    for cls in (GroupPositionSensor, GroupStateSensor, GroupActiveSceneSensor)
+)
+_GROUP_SWITCH_TRANSLATION_KEYS: frozenset[str] = frozenset(
+    {_class_translation_key(GroupAutomationSwitch)}
+)
 
 
 class TestSensorSpecTranslationKeys:
@@ -109,7 +137,7 @@ class TestSensorSpecTranslationKeys:
         )
         en_keys = frozenset(_EN_JSON.get("entity", {}).get("sensor", {}).keys())
 
-        orphaned = en_keys - spec_keys
+        orphaned = en_keys - spec_keys - _GROUP_SENSOR_TRANSLATION_KEYS
         assert not orphaned, (
             f"en.json entity.sensor contains entries with no matching sensor spec "
             f"translation_key: {sorted(orphaned)}\n"
@@ -134,7 +162,7 @@ class TestSwitchTranslationKeys:
             k for k in en_switch_keys if not k.startswith(_DYNAMIC_SWITCH_KEYS_PREFIX)
         )
 
-        orphaned = static_en_keys - spec_keys
+        orphaned = static_en_keys - spec_keys - _GROUP_SWITCH_TRANSLATION_KEYS
         assert not orphaned, (
             f"en.json entity.switch contains static entries with no matching "
             f"_SwitchSpec key: {sorted(orphaned)}\n"


### PR DESCRIPTION
## Summary

Complete integration-side implementation of the **Cover Group** feature (#790): a new `cover_group` virtual entry type that orchestrates a roster of member covers (ACP instances and generic `cover.*` entities) on explicit user action, with pipeline arbitration, aggregation, services, diagnostics, and live area membership.

This lands all four design phases as four squash commits. The same four commits already shipped on the `2026.8` release branch (as #797/#802/#803/#804); this PR brings the feature onto `develop` for ongoing integration. The tree is byte-identical to `2026.8`.

## What it adds

A new `create_group` entry type backed by `GroupPolicy` (`is_orchestrator` ClassVar — setup branches to a `GroupCoordinator` by capability, never a cover-type string, so the literal-scan guards stay green). Members can be ACP entries or generic covers; ACP members are always driven through their own coordinator (their gates, inverse-state, and override semantics apply), generic covers through a group-owned adopt-mode `CoverCommandService`.

## Phase breakdown

### Phase 1 — MVP (`69951ab0`, orig #797)
- New `cover_group` entry type + `GroupCoordinator`.
- **Scenes** (All Open / All Closed / Privacy) resolve per member via the `position_for_scene` policy hook.
- **Bulk ops**: group automation switch, clear-overrides button. The reset sequence moved onto the coordinator (`async_reset_manual_overrides`) so button and group share one path.
- **Entities**: aggregate position/state/active-scene sensors, scene buttons, and a new `select` platform (scene picker).
- **Config flow**: one-page two-roster membership (ACP entries + generic covers) with sanitization (dedupe, self-exclusion, member-owned-cover drop), group options menu, summary branch.

### Phase 2 — Pipeline arbitration (`06715232`, orig #802)
- **Intent seam**: groups push a `GroupIntent` (SCENE/LOCK) into member coordinators via `set_group_intent`; each snapshot folds in the member's highest-priority live intent, so a whole-house lock is never clobbered by another group's facade scene.
- **Handlers**: `GroupSceneHandler` (priority **85** — a scene beats a stale manual override; weather safety at 90 still wins) and `GroupLockHandler` (**100**, freezes members via the motion-hold `skip_command` shape). A member's own custom-position safety slot wins 100-ties by build order (pinned by test).
- Scene activation now **arbitrates** rather than engaging a member's manual override. Scene select gains an **Auto** option (releases the claim); new **Group Lock** switch pushes/releases the lock.
- Per-member per-scene opt-out and a stagger delay (0–30 s) on a new Arbitration & Timing page.
- **Observability**: Group-Driven Members sensor (via new `pipeline_winner_name`); group handlers appear in every member's decision trace.

### Phase 3 — Aggregation + exposure (`4448af27`, orig #803)
- **Group Climate Mode sensor** — read-only rollup (agree → that mode; disagree → `mixed`; none → unknown). Summer/winter/intermediate mapping single-sourced into `climate_mode_from_diagnostics`.
- **Opt-in aggregate cover entity** (default **off**): position/open/close ride each ACP member's user-position path; tilt features appear only when every member tilts and fan out on the dedicated tilt path (#684-safe).
- **Shared fan-out** — scenes and the group cover use one staggered loop (roster + opt-out + stagger live once).
- **Exposure toggles** — five booleans on a new Exposed Entities page; `Platform.COVER` joined `GROUP_PLATFORMS` with load/unload symmetry.

### Phase 4 — Services, diagnostics, area membership (`418d3ab4`, orig #804)
- **Six `group_*` services** — `group_activate_scene` (incl. `auto`), `group_set_position` (optional tilt), `group_lock`/`group_unlock`, `group_clear_overrides`, `group_set_automation` — thin wrappers over `GroupCoordinator` with their own target resolver (no target → all groups; entity/device/area targets).
- **Cover/group service split** fixes a latent crash: cover services now resolve through `cover_coordinators()`; previously an untargeted `integration_disable`/`emergency_stop` dereferenced cover-only attributes on a group coordinator.
- **Group diagnostics rollup** — also a crash fix (`GroupAggregates.diagnostics` AttributeError). Groups return active scene, lock state, aggregates, per-member winner/climate summaries, rosters, opt-out, stagger.
- **Live area membership** — optional `group_area`: effective rosters = static lists ∪ the area's covers; registry changes re-resolve and reload only when the roster actually changed.

## Provenance note

Cherry-picked from the four commits merged to `2026.8`. During that merge (a stacked-PR rebase onto a base that had moved past the original `develop`), two adjustments were folded into these commits and are included here:
- **Translation union** in `de.json`/`fr.json` — the new `group_*` service strings coexist with `export_all_config`/`import_config`; full key parity vs `en.json` verified.
- **`services.yaml` device selectors** — added `device: integration: adaptive_cover_pro` to all six group services to satisfy the #824 regression test.

## Testing
- ✅ 5,697 tests passing (`group_coordinator.py`, `group_entities.py`, `group_service.py`, `diagnostics/__init__.py` at 100% coverage)
- Tree byte-identical to `2026.8` (`git diff origin/2026.8 HEAD` empty)

## Related Issues
Refs #790

https://claude.ai/code/session_01MaKMJ9rX3gKCQrBLwqkD3P
