### PR TITLE
feat: add louvered roof cover type (#830)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -344,6 +344,36 @@ class RoofWindowConfig:
 
 
 @dataclass
+class LouveredRoofConfig:
+    """Configuration specific to louvered (lamella) roofs (#830).
+
+    A louvered roof rotates slats around a horizontal axis lying in a horizontal
+    (or pitched) roof plane — a bioclimatic pergola / "Lamellendach". It reuses
+    the venetian slat geometry (depth, spacing, mode — carried in a sibling
+    ``TiltConfig``) and adds only the roof-plane pitch.
+
+    ``roof_pitch`` is measured FROM HORIZONTAL: ``0`` = flat roof (the default),
+    ``90`` = vertical plane (reduces to the venetian/tilt profile angle exactly).
+    """
+
+    roof_pitch: float = 0.0
+
+    @classmethod
+    def from_options(cls, options: dict) -> LouveredRoofConfig:
+        """Build from a config-entry options dict, applying defaults."""
+        from .const import CONF_ROOF_PITCH, DEFAULT_LOUVERED_ROOF_PITCH
+
+        pitch = options.get(CONF_ROOF_PITCH)
+        return cls(
+            roof_pitch=(
+                float(pitch)
+                if pitch is not None
+                else float(DEFAULT_LOUVERED_ROOF_PITCH)
+            ),
+        )
+
+
+@dataclass
 class TiltConfig:
     """Configuration specific to tilt/venetian blinds."""
 

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -168,6 +168,10 @@ CONF_ROOF_HEIGHT_ABOVE = (
 )
 DEFAULT_ROOF_PITCH = 40  # degrees — typical Velux roof window pitch
 DEFAULT_ROOF_HEIGHT_ABOVE = 0.0  # metres — 0 disables the ridge occlusion gate
+# Louvered (lamella) roof plane pitch default (#830). A louvered roof reuses
+# CONF_ROOF_PITCH / _RANGE_ROOF_PITCH but defaults to a FLAT plane (0° from
+# horizontal), unlike the roof window's 40° glass default.
+DEFAULT_LOUVERED_ROOF_PITCH = 0  # degrees from horizontal — 0 = flat roof
 CONF_FOV_LEFT = "fov_left"  # left half-FOV from azimuth, degrees 0-180
 CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
 DEFAULT_FOV_LEFT = 90  # degrees; matches config flow default
@@ -1460,6 +1464,7 @@ class CoverType(StrEnum):
     VENETIAN = "cover_venetian"
     OSCILLATING_AWNING = "cover_oscillating_awning"
     ROOF_WINDOW = "cover_roof_window"
+    LOUVERED_ROOF = "cover_louvered_roof"
     # Virtual entry type — not a physical cover. Holds shared building-level
     # sensor entity IDs that linked covers copy into their own options. Its
     # policy registers no platforms (``controls_cover = False``).
@@ -1485,6 +1490,7 @@ class CoverType(StrEnum):
             self.VENETIAN: "Venetian",
             self.OSCILLATING_AWNING: "Oscillating Awning",
             self.ROOF_WINDOW: "Roof Window",
+            self.LOUVERED_ROOF: "Louvered Roof",
             self.BUILDING_PROFILE: "Building Profile",
             self.GROUP: "Cover Group",
         }[self]

--- a/custom_components/adaptive_cover_pro/cover_types/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/__init__.py
@@ -20,6 +20,7 @@ from .oscillating_awning import OscillatingAwningPolicy
 from .roof_window import RoofWindowPolicy
 from .tilt import TiltPolicy
 from .venetian import VenetianPolicy
+from .louvered_roof import LouveredRoofPolicy
 
 # Virtual entry types — imported LAST so they sort to the bottom of
 # registry-derived menus (``SENSOR_TYPE_MENU`` follows registration order).
@@ -59,6 +60,7 @@ __all__ = [
     "BuildingProfilePolicy",
     "CoverTypePolicy",
     "GroupPolicy",
+    "LouveredRoofPolicy",
     "OscillatingAwningPolicy",
     "RoofWindowPolicy",
     "TiltPolicy",

--- a/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
+++ b/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
@@ -39,6 +39,7 @@ COVER_TYPE_LABELS_EN: dict[str, str] = {
     "cover_types.oscillating_awning": "Oscillating Awning",
     "cover_types.venetian": "Venetian Blind (Dual-Axis)",
     "cover_types.roof_window": "Roof Window",
+    "cover_types.louvered_roof": "Louvered Roof",
 }
 
 # --- Geometry / physical-dimension templates (namespace config_summary.geometry.*)

--- a/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
@@ -1,0 +1,154 @@
+"""Louvered / lamella roof cover policy (#830).
+
+A louvered roof ("Lamellendach" / bioclimatic pergola) rotates slats around a
+horizontal axis lying in a horizontal or pitched roof plane and reports through
+``set_cover_tilt_position`` — a single tilt axis, exactly like ``cover_tilt``.
+It reuses the venetian slat geometry (depth, spacing, mode) and adds one field:
+the roof-plane ``roof_pitch`` (from horizontal, default 0 = flat).
+
+Modelled on :mod:`tilt` (slat geometry, tilt-capable entity filter, tilt-axis
+declaration) and :mod:`roof_window` (the ``roof_pitch`` selector). No edits to
+the config-flow bodies, options menu, type picker, or registry are needed — the
+type registers itself via ``register=True`` and every config-flow surface
+dispatches through the policy hooks below.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import voluptuous as vol
+from homeassistant.helpers import selector
+
+from ..config_types import LouveredRoofConfig
+from ..const import (
+    CONF_ROOF_PITCH,
+    DEFAULT_LOUVERED_ROOF_PITCH,
+)
+from ..engine.covers import AdaptiveLouveredRoofCover
+from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
+from .base import (
+    CAP_HAS_SET_TILT_POSITION,
+    TILT_AXIS,
+    CoverAxis,
+    CoverTypePolicy,
+    caps_get,
+)
+from .roof_window import _roof_pitch_selector
+from .tilt import (
+    TILT_CAPABLE_ENTITY_FILTER,
+    TILT_SLAT_KEYS,
+    TiltPolicy,
+    geometry_tilt_schema,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from ..engine.covers import AdaptiveGeneralCover
+    from ..services.configuration_service import ConfigurationService
+
+
+def geometry_louvered_roof_schema(hass: HomeAssistant | None = None) -> vol.Schema:
+    """Slat geometry (shared with tilt) plus the roof-plane pitch. ``hass=None`` → metric."""
+    fields = dict(geometry_tilt_schema(hass).schema)
+    fields[vol.Required(CONF_ROOF_PITCH, default=DEFAULT_LOUVERED_ROOF_PITCH)] = (
+        _roof_pitch_selector()
+    )
+    return vol.Schema(fields)
+
+
+# Module-level constant for hass=None (metric) identity, matching the other
+# policies so schema-identity tests keep passing.
+GEOMETRY_LOUVERED_ROOF_SCHEMA = geometry_louvered_roof_schema()
+
+
+class LouveredRoofPolicy(CoverTypePolicy, register=True):
+    """Cover that rotates slats in a horizontal/pitched roof plane (louvered roof)."""
+
+    cover_type = "cover_louvered_roof"
+    axes: ClassVar[tuple[CoverAxis, ...]] = (TILT_AXIS,)
+
+    def wiki_anchor(self) -> str:
+        """Louvered-roof geometry page."""
+        return "Configuration-Louvered-Roof"
+
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
+        """User-facing label for louvered roofs."""
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.louvered_roof"]
+
+    def disallowed_geometry_fields(
+        self,
+        *,
+        vertical_only: set[str],
+        awning_only: set[str],
+        tilt_only: set[str],
+    ) -> list[tuple[set[str], str]]:
+        """Reject vertical-blind and awning geometry; slat geometry is reused."""
+        return [(vertical_only, "vertical blind"), (awning_only, "awning")]
+
+    def geometry_schema(
+        self,
+        hass: HomeAssistant | None = None,
+        options: dict | None = None,  # noqa: ARG002
+    ) -> vol.Schema:
+        """Return the louvered-roof (slat + pitch) geometry schema for the locale."""
+        if hass is None:
+            return GEOMETRY_LOUVERED_ROOF_SCHEMA
+        return geometry_louvered_roof_schema(hass)
+
+    def geometry_slat_keys(self) -> tuple[str, ...]:
+        """Louvered roofs store slat depth and spacing in canonical centimetres."""
+        return TILT_SLAT_KEYS
+
+    def entity_selector_filter(self) -> selector.EntityFilterSelectorConfig:
+        """Require entities that advertise ``set_tilt_position``."""
+        return TILT_CAPABLE_ENTITY_FILTER
+
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
+        """Render the shared slat block, then append the roof-plane pitch."""
+        L = {**GEOMETRY_LABELS_EN, **(labels or {})}
+        lines = TiltPolicy().summary_geometry_lines(config, labels)
+        if (v := config.get(CONF_ROOF_PITCH)) is not None:
+            pitch = L["geometry.roof.pitch"].format(v=v)
+            if lines:
+                lines[0] = f"{lines[0]}, {pitch}"
+            else:
+                lines = [pitch]
+        return lines
+
+    def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:
+        """Warn when no bound entity advertises ``set_tilt_position``."""
+        if not any(
+            caps_get(caps, CAP_HAS_SET_TILT_POSITION) for caps in known.values()
+        ):
+            return [
+                "⚠️ Configured as louvered roof but no bound cover "
+                "advertises set_tilt_position."
+            ]
+        return []
+
+    def build_calc_engine(
+        self,
+        *,
+        logger,
+        sol_azi: float,
+        sol_elev: float,
+        sun_data,
+        config,
+        config_service: ConfigurationService,
+        options: dict,
+    ) -> AdaptiveGeneralCover:
+        """Build an ``AdaptiveLouveredRoofCover`` (slats in a roof plane)."""
+        return AdaptiveLouveredRoofCover(
+            logger=logger,
+            sol_azi=sol_azi,
+            sol_elev=sol_elev,
+            sun_data=sun_data,
+            config=config,
+            tilt_config=config_service.get_tilt_data(options),
+            roof_config=LouveredRoofConfig.from_options(options),
+        )

--- a/custom_components/adaptive_cover_pro/engine/covers/__init__.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import AdaptiveGeneralCover
 from .horizontal import AdaptiveHorizontalCover
+from .louvered_roof import AdaptiveLouveredRoofCover
 from .oscillating import AdaptiveOscillatingCover
 from .roof_window import AdaptiveRoofWindowCover
 from .tilt import AdaptiveTiltCover
@@ -11,6 +12,7 @@ from .vertical import AdaptiveVerticalCover
 __all__ = [
     "AdaptiveGeneralCover",
     "AdaptiveHorizontalCover",
+    "AdaptiveLouveredRoofCover",
     "AdaptiveOscillatingCover",
     "AdaptiveRoofWindowCover",
     "AdaptiveTiltCover",

--- a/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
@@ -1,0 +1,118 @@
+"""Louvered / lamella roof (horizontal-plane slat) calculation (#830).
+
+A louvered roof ("Lamellendach" / bioclimatic pergola) rotates slats around a
+horizontal axis lying in a horizontal or pitched roof plane, and reports through
+``set_cover_tilt_position`` — a single tilt axis, exactly like ``cover_tilt``.
+Geometrically it is the cross-product of two shipped engines:
+
+* the venetian slat cut-off solver (``AdaptiveTiltCover`` — this class's parent,
+  reused unchanged via ``slat_cutoff_angle``), and
+* the pitched-plane sun geometry of the roof window (``roof_cos_aoi`` /
+  ``roof_effective_gamma`` / ``roof_slope_ratio``).
+
+Only three things change relative to the vertical-facade venetian case:
+
+* the profile angle ``beta`` is taken relative to the roof plane —
+  ``beta = arctan|roof_slope_ratio(gamma, elev, roof_pitch)|`` (the vertical
+  case is the ``roof_pitch = 90°`` reduction);
+* the illumination gate requires the sun to strike the working face
+  (``roof_cos_aoi > 0``) rather than a bare above-horizon test;
+* the FOV gate is measured in the tilted roof plane
+  (``roof_effective_gamma``), mirroring the roof window.
+
+Pitch convention (``roof_pitch``, FROM HORIZONTAL):
+
+* ``roof_pitch = 90`` → vertical plane → ``beta`` equals the venetian/tilt
+  profile angle (a true superset).
+* ``roof_pitch = 0`` (default) → flat roof → for aligned sun ``abs(beta)`` is the
+  COMPLEMENT of the vertical case, ``90° − elev`` (the reference plane is the
+  horizontal, not the vertical facade), and the AOI gate is azimuth-independent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ...config_types import LouveredRoofConfig
+from .roof_window import (
+    TRACE_KEY_COS_AOI,
+    TRACE_KEY_ROOF_PITCH_DEG,
+    TRACE_KEY_SLOPE_RATIO,
+    VERTICAL_GLASS_PITCH_DEG,
+    roof_cos_aoi,
+    roof_effective_gamma,
+    roof_slope_ratio,
+)
+from .tilt import AdaptiveTiltCover
+
+
+@dataclass
+class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
+    """Calculate slat tilt for a louvered roof (slats in a horizontal/pitched plane)."""
+
+    roof_config: LouveredRoofConfig = None  # type: ignore[assignment]
+
+    @property
+    def roof_pitch(self) -> float:
+        """Roof-plane pitch from horizontal in degrees (0=flat, 90=vertical)."""
+        return self.roof_config.roof_pitch
+
+    def _cos_aoi(self) -> float:
+        """Cosine of the angle of incidence on the roof plane (``s·n``).
+
+        Positive → the sun strikes the working (outer) face of the slats. At
+        ``roof_pitch = 0`` this is ``sin(elev)`` (azimuth-independent); at
+        ``roof_pitch = 90`` it is ``cos(elev)·cos(gamma)`` (the vertical case).
+        """
+        return float(roof_cos_aoi(self.gamma, self.sol_elev, self.roof_pitch))
+
+    @property
+    def beta(self) -> float:
+        """Profile angle of the sun relative to the roof plane (radians).
+
+        Overrides the vertical-facade profile angle with the roof-plane slope
+        ratio. The magnitude is taken (the sign only encodes up- vs down-slope
+        direction); the slat cut-off solver squares/uses ``tan(beta)`` and the
+        AOI gate handles the sun-behind-face case separately.
+        """
+        return float(
+            np.arctan(abs(roof_slope_ratio(self.gamma, self.sol_elev, self.roof_pitch)))
+        )
+
+    @property
+    def valid_elevation(self) -> bool:
+        """Keep the elevation bounds and additionally require sun on the face.
+
+        Composes the inherited min/max-elevation gate with the tilted-plane AOI
+        illumination test (``cos(AOI) > 0``), mirroring
+        :class:`AdaptiveRoofWindowCover`.
+        """
+        return bool(super().valid_elevation and self._cos_aoi() > 0)
+
+    @property
+    def fov_angle(self) -> float:
+        """FOV azimuth measured in the tilted roof plane (#830, mirrors #212).
+
+        At a vertical plane (``roof_pitch = 90``) this is the raw horizontal
+        gamma (bit-for-bit vertical anchor); below vertical it is the
+        elevation-dependent in-plane azimuth, so the FOV "breathes" with sun
+        height.
+        """
+        if self.roof_pitch == VERTICAL_GLASS_PITCH_DEG:
+            return super().fov_angle
+        return float(roof_effective_gamma(self.gamma, self.sol_elev, self.roof_pitch))
+
+    def calculate_position(self) -> float:
+        """Venetian slat solve on the roof plane, then surface roof trace keys."""
+        result = super().calculate_position()
+        self._last_calc_details = {
+            **self._last_calc_details,
+            TRACE_KEY_ROOF_PITCH_DEG: float(self.roof_pitch),
+            TRACE_KEY_COS_AOI: self._cos_aoi(),
+            TRACE_KEY_SLOPE_RATIO: float(
+                roof_slope_ratio(self.gamma, self.sol_elev, self.roof_pitch)
+            ),
+        }
+        return result

--- a/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
@@ -40,7 +40,7 @@ from math import atan, cos, degrees, radians, sin, tan
 import numpy as np
 
 from ...config_types import RoofWindowConfig
-from .vertical import AdaptiveVerticalCover
+from .vertical import MIN_COS_GAMMA_CLAMP, AdaptiveVerticalCover
 
 # --- Numeric guards (file-local) ---
 # Pitch (from horizontal) at which the glass is vertical and the geometry
@@ -91,6 +91,44 @@ def roof_effective_gamma(gamma, elev, pitch):
     return np.degrees(
         np.arctan2(np.cos(e) * np.sin(g), roof_cos_aoi(gamma, elev, pitch))
     )
+
+
+def roof_slope_ratio(gamma: float, elev: float, pitch: float) -> float:
+    """Down-slope shadow ratio ``(s·t)/(s·n)`` on a plane pitched ``pitch`` from horizontal.
+
+    Single source of truth for the slope-projection math shared by the
+    roof-window drop projection (``_project_drop``) and the louvered-roof
+    profile angle (``beta = arctan|slope_ratio|``).
+
+    Factoring the numerator and denominator by ``cos(elev)·cos Δazi`` expresses
+    the ratio through the vertical foreshortening ``f = tan(elev)/cos(gamma)``::
+
+        (s·t)/(s·n) = (−cosβ + sinβ·f) / (sinβ + cosβ·f)
+
+    which collapses to ``f`` at ``β = 90°`` (vertical plane — the roof-window
+    bit-for-bit regression anchor) and to ``−1/f = −cot(elev)`` at ``β = 0°``,
+    ``gamma = 0`` (flat plane, aligned sun). ``cos(gamma)`` is clamped exactly as
+    the vertical engine clamps it (``MIN_COS_GAMMA_CLAMP``) so the roof-window
+    projection stays byte-for-byte; the tiny ``β`` denominator is clamped by
+    ``MIN_SLOPE_DENOMINATOR`` at the grazing limit.
+    """
+    cos_gamma = float(cos(radians(gamma)))
+    cos_gamma_clamped = max(abs(cos_gamma), MIN_COS_GAMMA_CLAMP) * (
+        1 if cos_gamma >= 0 else -1
+    )
+    f = float(tan(radians(elev))) / cos_gamma_clamped
+    if pitch == VERTICAL_GLASS_PITCH_DEG:
+        return f
+    beta = radians(pitch)
+    sin_b = sin(beta)
+    cos_b = cos(beta)
+    numerator = -cos_b + sin_b * f
+    denominator = sin_b + cos_b * f
+    if abs(denominator) < MIN_SLOPE_DENOMINATOR:
+        denominator = (
+            MIN_SLOPE_DENOMINATOR if denominator >= 0 else -MIN_SLOPE_DENOMINATOR
+        )
+    return numerator / denominator
 
 
 @dataclass
@@ -242,23 +280,14 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
         base_height, cos_gamma, cos_gamma_clamped, path_length = super()._project_drop(
             effective_distance
         )
-        # Vertical foreshortening f = tan(elev)/cos(gamma): the slope ratio at β=90°.
-        f = float(tan(radians(self.sol_elev))) / cos_gamma_clamped
+        # Slope ratio (s·t)/(s·n) via the shared helper — at β=90° it is the
+        # vertical foreshortening f = tan(elev)/cos(gamma) and the vertical drop
+        # is returned unchanged (bit-for-bit anchor).
+        slope_ratio = roof_slope_ratio(self.gamma, self.sol_elev, self.roof_pitch)
+        self._roof_slope_ratio = slope_ratio
         if self.roof_pitch == VERTICAL_GLASS_PITCH_DEG:
-            self._roof_slope_ratio = f
             return base_height, cos_gamma, cos_gamma_clamped, path_length
 
-        beta = radians(self.roof_pitch)
-        sin_b = sin(beta)
-        cos_b = cos(beta)
-        numerator = -cos_b + sin_b * f
-        denominator = sin_b + cos_b * f
-        if abs(denominator) < MIN_SLOPE_DENOMINATOR:
-            denominator = (
-                MIN_SLOPE_DENOMINATOR if denominator >= 0 else -MIN_SLOPE_DENOMINATOR
-            )
-        slope_ratio = numerator / denominator
-        self._roof_slope_ratio = slope_ratio
         slope_drop = abs(effective_distance * slope_ratio)
         return slope_drop, cos_gamma, cos_gamma_clamped, path_length
 

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -21,6 +21,33 @@ from ...position_utils import PositionConverter
 from .base import AdaptiveGeneralCover
 
 
+def slat_cutoff_angle(
+    beta: float, slat_distance: float, depth: float
+) -> tuple[float, float, bool]:
+    """Solve the venetian slat cut-off angle for a profile angle ``beta``.
+
+    Single source of truth for the MDPI cut-off expression
+    (https://www.mdpi.com/1996-1073/13/7/1731) plus its negative-discriminant
+    guard, shared by :class:`AdaptiveTiltCover` (vertical-facade profile angle)
+    and the louvered-roof engine (pitched-plane profile angle). Only ``beta``
+    changes between callers; the slat geometry solve is identical.
+
+    Returns ``(slat_angle_deg, discriminant, negative_discriminant)``:
+
+    * ``negative_discriminant`` is ``True`` when the slat_distance/depth ratio is
+      large relative to ``tan(beta)`` (``sqrt`` of a negative). NumPy would
+      return ``nan`` silently; the caller returns ``0.0`` (closed) instead, so
+      the angle is ``0.0`` in that case.
+    * otherwise the angle is ``2·arctan((tan β + √disc)/(1 + ratio))`` in degrees.
+    """
+    ratio = slat_distance / depth
+    discriminant = (tan(beta) ** 2) - (ratio**2) + 1
+    if discriminant < 0:
+        return 0.0, float(discriminant), True
+    slat = 2 * np.arctan((tan(beta) + np.sqrt(discriminant)) / (1 + ratio))
+    return float(np.rad2deg(slat)), float(discriminant), False
+
+
 @dataclass
 class AdaptiveTiltCover(AdaptiveGeneralCover):
     """Calculate state for tilted blinds."""
@@ -123,9 +150,13 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
 
         # Guard: discriminant can be negative when slat_distance/depth ratio is
         # large relative to tan(beta), making sqrt of a negative.  NumPy returns
-        # nan silently; we return 0.0 (closed) as a safe fallback instead.
-        discriminant = (tan(beta) ** 2) - ((self.slat_distance / self.depth) ** 2) + 1
-        if discriminant < 0:
+        # nan silently; we return 0.0 (closed) as a safe fallback instead. The
+        # cut-off math is shared with the louvered-roof engine via
+        # ``slat_cutoff_angle`` (only ``beta`` differs between them).
+        result, discriminant, negative_discriminant = slat_cutoff_angle(
+            beta, self.slat_distance, self.depth
+        )
+        if negative_discriminant:
             self.logger.debug(
                 "Tilt calc: negative discriminant (%.4f) — returning 0° (closed)",
                 float(discriminant),
@@ -140,11 +171,6 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
                 result=0.0,
             )
             return 0.0
-
-        slat = 2 * np.arctan(
-            (tan(beta) + np.sqrt(discriminant)) / (1 + self.slat_distance / self.depth)
-        )
-        result = np.rad2deg(slat)
 
         # Additional nan guard in case of unexpected floating-point edge cases
         if np.isnan(result):

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -201,7 +201,8 @@
     "tilt": "Jalousie / Neigung",
     "oscillating_awning": "Schwenkmarkise",
     "venetian": "Jalousie (Zwei-Achsen)",
-    "roof_window": "Dachfenster"
+    "roof_window": "Dachfenster",
+    "louvered_roof": "Lamellendach"
   },
   "geometry": {
     "window": {

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -201,7 +201,8 @@
     "tilt": "Venetian / Tilt Blind",
     "oscillating_awning": "Oscillating Awning",
     "venetian": "Venetian Blind (Dual-Axis)",
-    "roof_window": "Roof Window"
+    "roof_window": "Roof Window",
+    "louvered_roof": "Louvered Roof"
   },
   "geometry": {
     "window": {

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -201,7 +201,8 @@
     "tilt": "Store vénitien / inclinaison",
     "oscillating_awning": "Store oscillant",
     "venetian": "Store vénitien (deux axes)",
-    "roof_window": "Fenêtre de toit"
+    "roof_window": "Fenêtre de toit",
+    "louvered_roof": "Toit à lames"
   },
   "geometry": {
     "window": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1830,7 +1830,8 @@
         "cover_tilt": "Dreh-Jalousie",
         "cover_venetian": "Jalousette (zweiachsig)",
         "cover_oscillating_awning": "Gelenkarmmarkise (drop-arm)",
-        "cover_roof_window": "Dachfenster"
+        "cover_roof_window": "Dachfenster",
+        "cover_louvered_roof": "Lamellendach"
       }
     },
     "tilt_mode": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1830,7 +1830,8 @@
         "cover_tilt": "Tilted blind",
         "cover_venetian": "Venetian blind (dual-axis)",
         "cover_oscillating_awning": "Oscillating awning (drop-arm)",
-        "cover_roof_window": "Roof window"
+        "cover_roof_window": "Roof window",
+        "cover_louvered_roof": "Louvered roof"
       }
     },
     "tilt_mode": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1830,7 +1830,8 @@
         "cover_tilt": "Store à inclinaison",
         "cover_venetian": "Store vénitien (double axe)",
         "cover_oscillating_awning": "Store banne à bras articulé",
-        "cover_roof_window": "Fenêtre de toit"
+        "cover_roof_window": "Fenêtre de toit",
+        "cover_louvered_roof": "Toit à lames"
       }
     },
     "tilt_mode": {

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -334,6 +334,23 @@ def test_geometry_tilt_shows_tilt_fields():
     assert "mode1" in summary
 
 
+def test_geometry_louvered_roof_shows_slat_and_pitch_fields():
+    """Louvered roof renders the shared slat block plus the roof-plane pitch."""
+    from custom_components.adaptive_cover_pro.const import CONF_ROOF_PITCH
+
+    cfg = {
+        CONF_TILT_DEPTH: 3.0,
+        CONF_TILT_DISTANCE: 2.0,
+        CONF_TILT_MODE: "mode2",
+        CONF_ROOF_PITCH: 15,
+    }
+    summary = _build_config_summary(cfg, CoverType.LOUVERED_ROOF)
+    assert "slat depth 3.0cm" in summary
+    assert "spacing 2.0cm" in summary
+    assert "roof pitch 15° from horizontal" in summary
+    assert "Louvered Roof" in summary
+
+
 def test_geometry_venetian_shows_retract_threshold_default():
     """Venetian summary includes the upper retract threshold at the default value."""
     summary = _build_config_summary({}, CoverType.VENETIAN)

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -47,6 +47,7 @@ ALL_COVER_TYPES = [
     "cover_tilt",
     "cover_venetian",
     "cover_roof_window",
+    "cover_louvered_roof",
 ]
 
 
@@ -136,6 +137,7 @@ class TestPolicyAxesDeclarations:
             ("cover_awning", (AXIS_NAME_POSITION,)),
             ("cover_tilt", (AXIS_NAME_TILT,)),
             ("cover_venetian", (AXIS_NAME_POSITION, AXIS_NAME_TILT)),
+            ("cover_louvered_roof", (AXIS_NAME_TILT,)),
         ],
     )
     def test_axes_declaration(self, cover_type, expected_axis_names):
@@ -144,7 +146,12 @@ class TestPolicyAxesDeclarations:
 
     @pytest.mark.unit
     def test_blind_tilt_venetian_dont_treat_open_as_sun_blocked(self):
-        for cover_type in ("cover_blind", "cover_tilt", "cover_venetian"):
+        for cover_type in (
+            "cover_blind",
+            "cover_tilt",
+            "cover_venetian",
+            "cover_louvered_roof",
+        ):
             assert get_policy(cover_type).axes[0].open_blocks_sun is False
 
     @pytest.mark.unit
@@ -169,6 +176,7 @@ class TestPolicyAxesDeclarations:
                 "cover_tilt": AXIS_NAME_TILT,
                 "cover_venetian": AXIS_NAME_POSITION,
                 "cover_roof_window": AXIS_NAME_POSITION,
+                "cover_louvered_roof": AXIS_NAME_TILT,
             },
         ),
         (
@@ -180,6 +188,8 @@ class TestPolicyAxesDeclarations:
                 "cover_tilt": AXIS_NAME_TILT,  # cover_tilt always routes tilt
                 "cover_venetian": AXIS_NAME_POSITION,
                 "cover_roof_window": AXIS_NAME_POSITION,
+                # louvered roof is a tilt-axis type like cover_tilt.
+                "cover_louvered_roof": AXIS_NAME_TILT,
             },
         ),
         (
@@ -193,6 +203,7 @@ class TestPolicyAxesDeclarations:
                 "cover_tilt": AXIS_NAME_TILT,
                 "cover_venetian": AXIS_NAME_TILT,
                 "cover_roof_window": AXIS_NAME_TILT,
+                "cover_louvered_roof": AXIS_NAME_TILT,
             },
         ),
     ],
@@ -252,6 +263,7 @@ class TestPositionForIntent:
             ("cover_awning", POSITION_CLOSED, POSITION_OPEN),
             ("cover_tilt", POSITION_OPEN, POSITION_CLOSED),
             ("cover_venetian", POSITION_OPEN, POSITION_CLOSED),
+            ("cover_louvered_roof", POSITION_OPEN, POSITION_CLOSED),
         ],
     )
     def test_intent_map(self, cover_type, sun_through_value, sun_blocked_value):
@@ -451,6 +463,7 @@ def test_is_in_tilt_suppression_uniform_signature(cover_type: str) -> None:
         ("cover_awning", True),
         ("cover_tilt", False),
         ("cover_venetian", False),
+        ("cover_louvered_roof", False),
     ],
 )
 def test_supports_return_to_default_switch(cover_type: str, expected: bool) -> None:
@@ -627,6 +640,7 @@ def test_no_tilt_mode_string_branching_outside_cover_types() -> None:
         ("cover_awning", False),
         ("cover_tilt", False),
         ("cover_venetian", True),
+        ("cover_louvered_roof", False),
     ],
 )
 def test_exposes_dual_axis_sensor(cover_type: str, expected: bool) -> None:
@@ -647,6 +661,7 @@ def test_exposes_dual_axis_sensor(cover_type: str, expected: bool) -> None:
         ("cover_awning", False),
         ("cover_tilt", False),
         ("cover_venetian", True),
+        ("cover_louvered_roof", False),
     ],
 )
 def test_custom_position_includes_tilt(cover_type: str, expected: bool) -> None:
@@ -667,6 +682,7 @@ def test_custom_position_includes_tilt(cover_type: str, expected: bool) -> None:
         ("cover_awning", "Configuration-Horizontal"),
         ("cover_tilt", "Configuration-Tilt"),
         ("cover_venetian", "Venetian-Blinds"),
+        ("cover_louvered_roof", "Configuration-Louvered-Roof"),
     ],
 )
 def test_wiki_anchor(cover_type: str, anchor: str) -> None:
@@ -686,6 +702,7 @@ def test_wiki_anchor(cover_type: str, anchor: str) -> None:
         ("cover_awning", False),
         ("cover_tilt", False),
         ("cover_venetian", True),
+        ("cover_louvered_roof", False),
     ],
 )
 def test_drift_reset_option_is_venetian_only(cover_type: str, expected: bool) -> None:
@@ -742,6 +759,12 @@ class TestLiftTravelMetres:
         svc = self._fake_config_service()
         assert get_policy("cover_tilt").lift_travel_metres(svc, {}) is None
 
+    @pytest.mark.unit
+    def test_louvered_roof_returns_none(self) -> None:
+        # Tilt-axis type — no lift axis, so it inherits the ``None`` default.
+        svc = self._fake_config_service()
+        assert get_policy("cover_louvered_roof").lift_travel_metres(svc, {}) is None
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
@@ -751,6 +774,7 @@ class TestLiftTravelMetres:
         ("cover_awning", "Horizontal Awning"),
         ("cover_tilt", "Venetian / Tilt Blind"),
         ("cover_venetian", "Venetian Blind (Dual-Axis)"),
+        ("cover_louvered_roof", "Louvered Roof"),
     ],
 )
 def test_display_label(cover_type: str, label: str) -> None:

--- a/tests/test_cover_types/test_louvered_roof.py
+++ b/tests/test_cover_types/test_louvered_roof.py
@@ -1,0 +1,170 @@
+"""Policy tests for the louvered (lamella) roof cover type (#830)."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ROOF_PITCH,
+    CONF_TILT_DEPTH,
+    CONF_TILT_DISTANCE,
+    CONF_TILT_MODE,
+)
+from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
+from custom_components.adaptive_cover_pro.const import CoverType
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import AXIS_NAME_TILT
+from custom_components.adaptive_cover_pro.engine.covers import (
+    AdaptiveLouveredRoofCover,
+)
+
+pytestmark = pytest.mark.unit
+
+COVER_TYPE = "cover_louvered_roof"
+
+
+class TestLouveredRoofConfig:
+    """The ``LouveredRoofConfig`` dataclass and the enum member."""
+
+    def test_enum_value(self) -> None:
+        assert CoverType.LOUVERED_ROOF.value == "cover_louvered_roof"
+
+    def test_from_options_defaults_pitch_to_zero(self) -> None:
+        assert LouveredRoofConfig.from_options({}).roof_pitch == 0.0
+
+    def test_from_options_reads_roof_pitch(self) -> None:
+        assert LouveredRoofConfig.from_options({CONF_ROOF_PITCH: 30}).roof_pitch == 30.0
+
+
+def _schema_keys(schema: vol.Schema) -> set[str]:
+    return {(k.schema if isinstance(k, vol.Marker) else k) for k in schema.schema}
+
+
+def _schema_default(schema: vol.Schema, key: str):
+    for marker in schema.schema:
+        name = marker.schema if isinstance(marker, vol.Marker) else marker
+        if name == key and isinstance(marker, vol.Marker):
+            return marker.default() if callable(marker.default) else marker.default
+    raise KeyError(key)
+
+
+class TestLouveredRoofPolicy:
+    """Policy hooks for the louvered-roof cover type."""
+
+    def test_registered(self) -> None:
+        assert get_policy(COVER_TYPE) is not None
+
+    def test_single_tilt_axis(self) -> None:
+        policy = get_policy(COVER_TYPE)
+        assert tuple(a.name for a in policy.axes) == (AXIS_NAME_TILT,)
+
+    def test_tilt_capable_entity_filter(self) -> None:
+        policy = get_policy(COVER_TYPE)
+        filt = policy.entity_selector_filter()
+        assert filt["domain"] == "cover"
+        assert (
+            "cover.CoverEntityFeature.SET_TILT_POSITION" in filt["supported_features"]
+        )
+
+    def test_non_empty_display_label(self) -> None:
+        assert get_policy(COVER_TYPE).display_label()
+
+    def test_wiki_anchor(self) -> None:
+        assert get_policy(COVER_TYPE).wiki_anchor() == "Configuration-Louvered-Roof"
+
+    def test_geometry_schema_has_slat_and_pitch_fields(self) -> None:
+        keys = _schema_keys(get_policy(COVER_TYPE).geometry_schema())
+        assert {
+            CONF_TILT_DEPTH,
+            CONF_TILT_DISTANCE,
+            CONF_TILT_MODE,
+            CONF_ROOF_PITCH,
+        } <= keys
+
+    def test_roof_pitch_defaults_to_zero(self) -> None:
+        schema = get_policy(COVER_TYPE).geometry_schema()
+        assert _schema_default(schema, CONF_ROOF_PITCH) == 0
+
+    def test_disallows_vertical_and_awning_geometry(self) -> None:
+        policy = get_policy(COVER_TYPE)
+        vertical_only = {"distance_shaded_area"}
+        awning_only = {"length_awning"}
+        tilt_only = {"tilt_depth"}
+        rejected = policy.disallowed_geometry_fields(
+            vertical_only=vertical_only,
+            awning_only=awning_only,
+            tilt_only=tilt_only,
+        )
+        rejected_sets = [s for s, _label in rejected]
+        assert vertical_only in rejected_sets
+        assert awning_only in rejected_sets
+        assert tilt_only not in rejected_sets
+
+    def test_capability_warning_when_no_set_tilt_position(self) -> None:
+        policy = get_policy(COVER_TYPE)
+        warnings = policy.cover_capability_warnings(
+            {"cover.x": {"has_set_tilt_position": False}}
+        )
+        assert warnings and "set_tilt_position" in warnings[0]
+        # No warning when at least one entity supports set_tilt_position.
+        assert (
+            policy.cover_capability_warnings(
+                {"cover.x": {"has_set_tilt_position": True}}
+            )
+            == []
+        )
+
+    def test_summary_geometry_lines_include_slat_and_pitch(self) -> None:
+        policy = get_policy(COVER_TYPE)
+        config = {
+            CONF_TILT_DEPTH: 3.0,
+            CONF_TILT_DISTANCE: 2.0,
+            CONF_TILT_MODE: "mode2",
+            CONF_ROOF_PITCH: 15,
+        }
+        lines = policy.summary_geometry_lines(config)
+        joined = " ".join(lines)
+        assert "slat depth 3.0cm" in joined
+        assert "spacing 2.0cm" in joined
+        assert "roof pitch 15° from horizontal" in joined
+
+    def test_geometry_slat_keys(self) -> None:
+        keys = get_policy(COVER_TYPE).geometry_slat_keys()
+        assert CONF_TILT_DEPTH in keys
+        assert CONF_TILT_DISTANCE in keys
+
+    def test_summary_geometry_lines_empty_config(self) -> None:
+        assert get_policy(COVER_TYPE).summary_geometry_lines({}) == []
+
+    def test_summary_geometry_lines_pitch_only(self) -> None:
+        # Roof pitch with no slat fields still renders a pitch-only line.
+        lines = get_policy(COVER_TYPE).summary_geometry_lines({CONF_ROOF_PITCH: 12})
+        assert lines == ["roof pitch 12° from horizontal"]
+
+    def test_geometry_schema_localized_branch(self) -> None:
+        from unittest.mock import MagicMock
+
+        # hass provided → the non-cached (localized) schema-builder branch runs.
+        hass = MagicMock()
+        hass.config.units.length_unit = "m"
+        schema = get_policy(COVER_TYPE).geometry_schema(hass=hass)
+        assert CONF_ROOF_PITCH in _schema_keys(schema)
+
+    def test_build_calc_engine_returns_louvered_engine(self) -> None:
+        from unittest.mock import MagicMock
+
+        policy = get_policy(COVER_TYPE)
+        config_service = MagicMock()
+        config_service.get_tilt_data.return_value = MagicMock()
+        engine = policy.build_calc_engine(
+            logger=MagicMock(),
+            sol_azi=180.0,
+            sol_elev=40.0,
+            sun_data=MagicMock(),
+            config=MagicMock(),
+            config_service=config_service,
+            options={CONF_ROOF_PITCH: 0},
+        )
+        assert isinstance(engine, AdaptiveLouveredRoofCover)
+        assert engine.roof_pitch == 0.0

--- a/tests/test_engine/test_louvered_roof.py
+++ b/tests/test_engine/test_louvered_roof.py
@@ -1,0 +1,299 @@
+"""Engine tests for the louvered (lamella) roof cover type (#830).
+
+The louvered-roof engine is the cross-product of the venetian slat cut-off
+solver and the pitched-plane sun geometry:
+
+* the slat cut-off equation is shared with ``engine/covers/tilt.py`` via the
+  extracted ``slat_cutoff_angle`` helper (this file pins the extraction guard),
+* the profile angle ``beta`` is driven by the roof-plane slope ratio
+  (``roof_slope_ratio``, extracted from ``roof_window._project_drop``),
+* the illumination / FOV gates borrow ``roof_cos_aoi`` / ``roof_effective_gamma``.
+
+The reduction anchors below are hand-computed from first principles, NOT copied
+from the venetian suite.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
+from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
+    AdaptiveLouveredRoofCover,
+)
+from custom_components.adaptive_cover_pro.engine.covers.roof_window import (
+    roof_slope_ratio,
+)
+from custom_components.adaptive_cover_pro.engine.covers.tilt import (
+    AdaptiveTiltCover,
+    slat_cutoff_angle,
+)
+
+from tests.cover_helpers import make_cover_config, make_tilt_config
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _louvered(
+    *,
+    sol_azi: float,
+    sol_elev: float,
+    roof_pitch: float,
+    slat_distance: float = 0.02,
+    depth: float = 0.03,
+    mode: str = "mode2",
+    win_azi: float = 180.0,
+    fov_left: float = 90.0,
+    fov_right: float = 90.0,
+) -> AdaptiveLouveredRoofCover:
+    """Build a louvered-roof engine at an explicit sun/slat geometry."""
+    return AdaptiveLouveredRoofCover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sun_data=MagicMock(),
+        config=make_cover_config(
+            win_azi=win_azi, fov_left=fov_left, fov_right=fov_right
+        ),
+        tilt_config=make_tilt_config(
+            slat_distance=slat_distance, depth=depth, mode=mode
+        ),
+        roof_config=LouveredRoofConfig(roof_pitch=roof_pitch),
+    )
+
+
+def _tilt(
+    *,
+    sol_azi: float,
+    sol_elev: float,
+    slat_distance: float = 0.02,
+    depth: float = 0.03,
+    mode: str = "mode2",
+    win_azi: float = 180.0,
+) -> AdaptiveTiltCover:
+    """Build a plain venetian/tilt engine (the pitch=90 reduction target)."""
+    return AdaptiveTiltCover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sun_data=MagicMock(),
+        config=make_cover_config(win_azi=win_azi, fov_left=90, fov_right=90),
+        tilt_config=make_tilt_config(
+            slat_distance=slat_distance, depth=depth, mode=mode
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extraction guard — slat_cutoff_angle (shared with tilt.py)
+# ---------------------------------------------------------------------------
+
+
+class TestSlatCutoffAngleExtraction:
+    """``slat_cutoff_angle`` returns hand-computed values; tilt delegates to it."""
+
+    def test_matches_hand_computed_positive_discriminant(self) -> None:
+        beta = math.atan(0.893)  # ~0.7289 rad (a venetian anchor profile angle)
+        slat_distance, depth = 0.02, 0.03
+        ratio = slat_distance / depth  # 0.6667
+        result, discriminant, negative = slat_cutoff_angle(beta, slat_distance, depth)
+        # Independent hand formula (the MDPI cut-off expression).
+        expected_disc = math.tan(beta) ** 2 - ratio**2 + 1
+        expected_deg = math.degrees(
+            2 * math.atan((math.tan(beta) + math.sqrt(expected_disc)) / (1 + ratio))
+        )
+        assert negative is False
+        assert discriminant == pytest.approx(expected_disc)
+        assert result == pytest.approx(expected_deg)
+        # Pin the concrete number so a formula drift is caught.
+        assert result == pytest.approx(101.9, abs=0.1)
+
+    def test_negative_discriminant_returns_zero(self) -> None:
+        # tan(beta) small, ratio large → discriminant < 0 → closed fallback.
+        beta = math.radians(5.0)
+        result, discriminant, negative = slat_cutoff_angle(beta, 0.10, 0.02)
+        assert negative is True
+        assert result == 0.0
+        assert discriminant < 0
+
+    def test_tilt_delegates_byte_for_byte(self) -> None:
+        # The tilt engine's slat angle equals the helper driven by tilt's beta.
+        cover = _tilt(sol_azi=200, sol_elev=40, mode="mode2")
+        beta = cover.beta
+        expected, _, _ = slat_cutoff_angle(beta, cover.slat_distance, cover.depth)
+        # Re-run the tilt engine and compare its raw slat angle (safety_margin=0).
+        result = cover.calculate_position()
+        assert result == pytest.approx(expected)
+
+
+# ---------------------------------------------------------------------------
+# Extraction guard — roof_slope_ratio (shared with roof_window.py)
+# ---------------------------------------------------------------------------
+
+
+class TestRoofSlopeRatioExtraction:
+    """``roof_slope_ratio`` returns hand-computed values; anchors at pitch 0/90."""
+
+    def test_pitch_90_returns_f(self) -> None:
+        # Vertical plane: slope ratio == tan(elev)/cos(gamma) (the vertical f).
+        for elev, gamma in [(40, 0), (30, 20), (55, -35)]:
+            f = math.tan(math.radians(elev)) / math.cos(math.radians(gamma))
+            assert roof_slope_ratio(gamma, elev, 90) == pytest.approx(f)
+
+    def test_pitch_0_gamma_0_returns_negative_reciprocal(self) -> None:
+        # Flat roof, aligned sun: slope ratio == -1/f == -cot(elev).
+        for elev in [20, 40, 65]:
+            f = math.tan(math.radians(elev))
+            assert roof_slope_ratio(0, elev, 0) == pytest.approx(-1.0 / f)
+            assert roof_slope_ratio(0, elev, 0) == pytest.approx(
+                -1.0 / math.tan(math.radians(elev))
+            )
+
+
+# ---------------------------------------------------------------------------
+# Reduction anchor 1 — pitch = 90 collapses to the venetian/tilt profile angle
+# ---------------------------------------------------------------------------
+
+
+class TestPitch90ReducesToVenetian:
+    """At vertical pitch the louvered beta equals the tilt beta (true superset)."""
+
+    @pytest.mark.parametrize(
+        ("sol_azi", "sol_elev"),
+        [(180, 40), (200, 30), (160, 55), (210, 15)],
+    )
+    def test_beta_matches_tilt(self, sol_azi: float, sol_elev: float) -> None:
+        louvered = _louvered(sol_azi=sol_azi, sol_elev=sol_elev, roof_pitch=90)
+        tilt = _tilt(sol_azi=sol_azi, sol_elev=sol_elev)
+        # Sun in front (cos(gamma) > 0, elev > 0) so abs() is a no-op.
+        assert louvered.beta == pytest.approx(tilt.beta)
+
+    def test_position_matches_tilt_at_pitch_90(self) -> None:
+        louvered = _louvered(sol_azi=205, sol_elev=35, roof_pitch=90, mode="mode2")
+        tilt = _tilt(sol_azi=205, sol_elev=35, mode="mode2")
+        assert louvered.calculate_position() == pytest.approx(tilt.calculate_position())
+
+
+# ---------------------------------------------------------------------------
+# Reduction anchor 2 — flat roof: abs(beta) == 90° − elev  (complement)
+# ---------------------------------------------------------------------------
+
+
+class TestFlatRoofComplementAnchor:
+    """pitch=0, gamma=0 → the profile angle is the COMPLEMENT of the vertical case.
+
+    Hand derivation (2-D cross-section ⟂ to the slat axis): a flat slat plane
+    has a vertical normal. A sun ray at elevation ``e`` above the horizon makes
+    angle ``90 − e`` with that vertical normal. The venetian solver measures the
+    profile angle from the plane's in-face reference, so beta = 90 − e.
+    """
+
+    @pytest.mark.parametrize("sol_elev", [20, 35, 50, 65])
+    def test_abs_beta_is_complement(self, sol_elev: float) -> None:
+        louvered = _louvered(sol_azi=180, sol_elev=sol_elev, roof_pitch=0)
+        beta_deg = math.degrees(louvered.beta)
+        assert abs(beta_deg) == pytest.approx(90.0 - sol_elev)
+
+
+# ---------------------------------------------------------------------------
+# Reduction anchor 3 — AOI illumination gate
+# ---------------------------------------------------------------------------
+
+
+class TestAoiGate:
+    """The working-face illumination gate borrows ``roof_cos_aoi``."""
+
+    @pytest.mark.parametrize("gamma_azi", [180, 120, 250, 90, 270])
+    def test_flat_roof_valid_iff_above_horizon(self, gamma_azi: float) -> None:
+        # pitch=0: cos_aoi = sin(elev) → azimuth-independent, true iff elev > 0.
+        up = _louvered(sol_azi=gamma_azi, sol_elev=10, roof_pitch=0)
+        down = _louvered(sol_azi=gamma_azi, sol_elev=-5, roof_pitch=0)
+        assert up.valid_elevation is True
+        assert down.valid_elevation is False
+
+    def test_pitched_roof_false_when_cos_aoi_not_positive(self) -> None:
+        # Steep pitch facing south (win_azi=180); sun low in the north
+        # (azimuth 0) → sun strikes the BACK of the plane → cos_aoi <= 0.
+        cover = _louvered(sol_azi=0, sol_elev=10, roof_pitch=80, win_azi=180)
+        assert cover._cos_aoi() <= 0
+        assert cover.valid_elevation is False
+
+    def test_pitched_roof_true_when_sun_on_face(self) -> None:
+        cover = _louvered(sol_azi=180, sol_elev=40, roof_pitch=40, win_azi=180)
+        assert cover._cos_aoi() > 0
+        assert cover.valid_elevation is True
+
+
+# ---------------------------------------------------------------------------
+# Full calculate_position — flat roof vs an independent hand-computed cut-off
+# ---------------------------------------------------------------------------
+
+
+class TestCalculatePositionFlatRoof:
+    """A full solve on a flat roof matches a hand-computed 2-D cut-off angle."""
+
+    def test_flat_roof_slat_angle(self) -> None:
+        sol_elev = 30.0
+        slat_distance, depth, mode = 0.02, 0.03, "mode2"
+        cover = _louvered(
+            sol_azi=180,
+            sol_elev=sol_elev,
+            roof_pitch=0,
+            slat_distance=slat_distance,
+            depth=depth,
+            mode=mode,
+        )
+        # Hand path: flat-roof beta = 90 - elev = 60°, then the MDPI cut-off.
+        beta = math.radians(90.0 - sol_elev)
+        ratio = slat_distance / depth
+        disc = math.tan(beta) ** 2 - ratio**2 + 1
+        expected = math.degrees(
+            2 * math.atan((math.tan(beta) + math.sqrt(disc)) / (1 + ratio))
+        )
+        result = cover.calculate_position()
+        assert not np.isnan(result)
+        assert result == pytest.approx(expected)
+        # Sanity: mode2 caps at 180.
+        assert 0 <= result <= 180
+
+    def test_trace_surfaces_roof_keys(self) -> None:
+        cover = _louvered(sol_azi=180, sol_elev=35, roof_pitch=25)
+        cover.calculate_position()
+        trace = cover._last_calc_details
+        assert trace["roof_pitch_deg"] == pytest.approx(25.0)
+        assert "cos_aoi" in trace
+        assert "slope_ratio" in trace
+        assert "beta_rad" in trace  # inherited from the tilt trace
+
+
+# ---------------------------------------------------------------------------
+# FOV gate — in-plane effective gamma below vertical, raw gamma at vertical
+# ---------------------------------------------------------------------------
+
+
+class TestFovAngle:
+    """``fov_angle`` uses the raw gamma at pitch=90 and the in-plane azimuth below."""
+
+    def test_pitch_90_uses_raw_gamma(self) -> None:
+        cover = _louvered(sol_azi=200, sol_elev=40, roof_pitch=90)
+        assert cover.fov_angle == pytest.approx(cover.gamma)
+
+    def test_below_vertical_uses_effective_gamma(self) -> None:
+        from custom_components.adaptive_cover_pro.engine.covers.roof_window import (
+            roof_effective_gamma,
+        )
+
+        cover = _louvered(sol_azi=200, sol_elev=40, roof_pitch=30)
+        expected = roof_effective_gamma(cover.gamma, cover.sol_elev, 30)
+        assert cover.fov_angle == pytest.approx(expected)
+        # Below vertical the in-plane azimuth widens away from the raw gamma.
+        assert cover.fov_angle != pytest.approx(cover.gamma)


### PR DESCRIPTION
## Summary
New `cover_louvered_roof` cover type for bioclimatic pergolas / Lamellendach — slats rotating in a **horizontal or pitched roof plane** (issue #830). It's the cross-product of two capabilities the codebase already had but never combined: the venetian slat cut-off solver (vertical-plane only) and the roof-window pitched-plane sun geometry (position-axis only, no slat output).

- New single-**tilt-axis** cover type built entirely on the fifth-cover-type contract — nothing outside `cover_types/`, the engine, config dataclass, const, and translations is touched.
- `AdaptiveLouveredRoofCover` reuses the venetian cut-off solver with the profile angle β taken against the roof plane (slat-axis azimuth + `roof_pitch`, default 0 = horizontal), gated by the roof-window angle-of-incidence illumination test.
- Output flows through the tilt axis, so the full pipeline (weather safety, manual override, motion, climate, custom positions, defaults) applies unchanged.
- No duplication: extracted `slat_cutoff_angle` and `roof_slope_ratio` as shared helpers; `AdaptiveTiltCover` and roof-window `_project_drop` delegate to them byte-for-byte.

### Geometry anchors (hand-verified, pinned)
- **pitch = 90° (vertical)** → β reduces to the venetian/tilt case bit-for-bit (true superset).
- **pitch = 0° (flat), γ = 0** → `|β| = 90° − elevation` (complement of the vertical facade; a pure solar-elevation-driven cut-off).
- **AOI gate** → at pitch 0, lit iff elevation > 0 (azimuth-independent); at pitch > 0, gated by `cos_aoi > 0`.

## Testing
- ✅ 5770 passing, 0 failing (full suite)
- ✅ 100% patch coverage on the new engine + policy modules
- ✅ Regression guards green: tilt/venetian cut-off (byte-for-byte after extraction), roof-window β=90 anchors (bit-for-bit), `test_axes.py`, `test_invariants.py`, `test_translations.py`
- ✅ ruff + black + prettier + translation validation clean; DE/FR translations added (Lamellendach / Toit à lames)

## Related Issues
Refs #830

> Note: based on the `next` integration branch; the diff narrows to just the louvered-roof commit once the cover-group work (#827) lands.