### PR TITLE
test: bracket HA support range in CI (floor + stable + dev)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,14 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # Dependabot should not update Home Assistant as that should match the homeassistant key in hacs.json
+      # HA is never a direct dep here — it's pulled in transitively by
+      # pytest-homeassistant-custom-component, whose exact pin decides the tested
+      # HA version. Dependabot bumps that pin weekly (testing group), so the
+      # "stable" CI leg intentionally tracks latest HA ~one week behind release.
+      # The advertised FLOOR (hacs.json `homeassistant`) is tested separately by
+      # the frozen "min" matrix leg in tests.yml (pytest-hacc pinned to 2026.3.x)
+      # — that literal lives in workflow YAML, so Dependabot leaves it alone.
+      # This ignore is a belt-and-suspenders guard against a direct HA pin sneaking in.
       - dependency-name: "homeassistant"
     groups:
       testing:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,11 +55,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Floor — the oldest HA hacs.json promises (2026.3.0). No pytest-hacc
+          # release pins 2026.3.0 exactly; 0.13.317 pins 2026.3.1, the earliest
+          # 2026.3.x and the closest satisfier of the >=2026.3.0 floor. FROZEN:
+          # Dependabot must not bump this (it's ignored in dependabot.yml), or the
+          # floor leg would drift up and stop testing the advertised minimum.
+          - python-version: "3.14"
+            ha-channel: min
+            ha-pin: "0.13.317"
+            experimental: false
+          # Latest stable — what most users run. Tracks HA transitively via the
+          # pytest-hacc pin in requirements-dev.txt, which Dependabot bumps weekly.
           - python-version: "3.14"
             ha-channel: stable
+            ha-pin: ""
             experimental: false
+          # Future — HA core dev tip. Non-blocking early warning for upcoming
+          # breakage; installs latest pytest-hacc + HA @dev on top.
           - python-version: "3.14"
             ha-channel: dev
+            ha-pin: ""
             experimental: true
 
     steps:
@@ -71,14 +86,35 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Floor leg: override the requirements-dev.txt pin with the pytest-hacc
+      # release that pins the oldest supported HA. Runs before the dev-branch
+      # step; the two are mutually exclusive channels so they never collide.
+      - name: Pin HA to floor (min channel only)
+        if: matrix.ha-pin != ''
+        run: uv pip install --system "pytest-homeassistant-custom-component==${{ matrix.ha-pin }}"
+
       - name: Install HA dev branch (dev channel only)
         if: matrix.ha-channel == 'dev'
         run: |
           uv pip install --system --upgrade pytest-homeassistant-custom-component
           uv pip install --system --upgrade git+https://github.com/home-assistant/core.git@dev
 
-      - name: Show HA version
-        run: python -c "from homeassistant.const import __version__; print('HA version:', __version__)"
+      # Print the resolved HA version and hard-fail if it dropped below the floor
+      # advertised in hacs.json — the one invariant tying tested HA to what we
+      # promise HACS users. Every leg tests >= floor (min == floor, stable/dev above).
+      - name: Show HA version & assert >= hacs.json floor
+        run: |
+          python - <<'PY'
+          import json
+          from homeassistant.const import __version__ as ha
+          from packaging.version import Version
+
+          floor = json.load(open("hacs.json"))["homeassistant"]
+          print(f"HA version: {ha}  (hacs.json floor: {floor})")
+          assert Version(ha) >= Version(floor), (
+              f"Tested HA {ha} is below the hacs.json floor {floor}"
+          )
+          PY
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
## Summary
CI only tested one HA version (latest-ish stable, currently 2026.6.4) plus the non-blocking HA `@dev` tip. Nothing verified the **floor** advertised in `hacs.json` (`2026.3.0`), so the minimum-supported claim was untested — code could depend on a post-2026.3 API and CI would stay green.

This brackets the whole support range:

- **New `min` matrix leg (blocking)** — pins `pytest-homeassistant-custom-component==0.13.317`, which pins **HA 2026.3.1** (the earliest 2026.3.x on PyPI; 2026.3.0 itself was never published to that package, and 2026.3.1 satisfies `>=2026.3.0`). Frozen: it's a literal in workflow YAML, so Dependabot can't drift it upward.
- **`stable` leg** — unchanged intent. Still tracks latest HA transitively via the `requirements-dev.txt` pytest-hacc pin that Dependabot bumps weekly. Codecov uploads from this leg only.
- **`dev` leg** — unchanged (non-blocking early warning against HA `@dev`).
- **Floor assertion on every leg** — prints the resolved HA version and hard-fails if it ever drops below the `hacs.json` floor. The one invariant tying tested HA to what HACS users are promised. Uses `packaging` (a hard HA dependency, `packaging>=23.1`).

Also fixes a **misleading `dependabot.yml` comment**: it claimed HA was held to match `hacs.json`, but HA isn't a direct dep there — it rides in via pytest-hacc, which Dependabot bumps weekly. So stable CI has always tracked latest HA, not the floor. The comment now says what actually happens and points at the `min` leg as the floor guard.

All three legs use Python 3.14 (HA 2026.3.1 requires `>=3.14.2`).

## Testing
- ✅ Both YAML files parse
- ✅ `0.13.317` → HA 2026.3.1 confirmed against PyPI
- ✅ Floor assertion dry-run: PASS for 2026.3.1 / 2026.6.4 / dev builds; FAIL for anything `< 2026.3.0`
- ✅ `packaging>=23.1` confirmed a hard HA dependency (present on every leg)
- ⏳ CI itself will confirm the `min` leg's install resolves cleanly (older pytest-hacc downgrades the pytest stack to floor-era versions on top of `requirements-dev.txt`)

## Related Issues
None — CI hardening.