### PR TITLE
feat: auto-resolve indoor temp sensor from HA area (#786)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_dynamic.py
+++ b/custom_components/adaptive_cover_pro/config_dynamic.py
@@ -29,6 +29,7 @@ from .const import (
     BLIND_SPOT_SLOT_NUMBERS,
     BLIND_SPOT_SLOTS,
     BUILDING_PROFILE_SENSOR_KEYS,
+    CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
     CONF_AZIMUTH,
     CONF_CLIMATE_MODE,
     CONF_CLOUD_COVERAGE_ENTITY,
@@ -93,6 +94,7 @@ from .const import (
     CONF_WINTER_CLOSE_INSULATION,
     DEFAULT_BLIND_SPOT_ELEVATION_MODE,
     DEFAULT_CLOUD_COVERAGE_THRESHOLD,
+    DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
     DEFAULT_ENABLE_POSITION_MATCHING,
     DEFAULT_GLARE_ZONE_Z,
     DEFAULT_WEATHER_RAIN_THRESHOLD,
@@ -524,6 +526,10 @@ def temperature_climate_schema(
         vol.Optional(CONF_TEMP_ENTITY): selector.EntitySelector(
             selector.EntityFilterSelectorConfig(domain=["climate", "sensor"])
         ),
+        vol.Optional(
+            CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
+            default=DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
+        ): selector.BooleanSelector(),
         vol.Optional(
             CONF_OUTSIDETEMP_ENTITY, default=vol.UNDEFINED
         ): numeric_selector(),

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -25,9 +25,11 @@ from .const import (
     BLANK_TIME,
     BLIND_SPOT_ELEV_MODE_ABOVE,
     BLIND_SPOT_SLOTS,
+    DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
     DEFAULT_BLIND_SPOT_ELEVATION_MODE,
     LIGHT_CLOUD_SENSOR_KEYS,
     WEATHER_OVERRIDE_SENSOR_KEYS,
+    CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
     CONF_AWNING_ANGLE,
     CONF_AZIMUTH,
     CONF_BUILDING_PROFILE_ID,
@@ -1449,6 +1451,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "rules.climate": ("🌡️ Climate mode: adjusts strategy for heating/cooling{detail}"),
     "climate.comfort_range": "comfort range {lo}–{hi}°C",
     "climate.using": "using {entity}",
+    "climate.using_area": "using area temperature sensor",
     "climate.outside_thresh": "outside: {entity} > {thresh}°C",
     "climate.outside": "outside: {entity}",
     "climate.weather": "weather: {entity}",
@@ -2239,6 +2242,12 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             )
         if temp_entity:
             cl_parts.append(L["climate.using"].format(entity=temp_entity))
+        elif config.get(
+            CONF_AUTO_RESOLVE_TEMP_FROM_AREA, DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA
+        ):
+            # No explicit sensor but area auto-resolution is on (#786): the
+            # effective sensor comes from the cover's HA area at runtime.
+            cl_parts.append(L["climate.using_area"])
         outside = config.get(CONF_OUTSIDETEMP_ENTITY)
         if outside:
             out_thresh = config.get(CONF_OUTSIDE_THRESHOLD)
@@ -2750,7 +2759,9 @@ async def _get_device_name_for_entity(
     return device_entry.name_by_user or device_entry.name or None
 
 
-_SHARED_OPTIONS_EXCLUDED = frozenset({CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID})
+_SHARED_OPTIONS_EXCLUDED = frozenset(
+    {CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID, CONF_TEMP_ENTITY}
+)
 
 # Maps each syncable category (matching options menu names) to its config keys.
 # Used by the sync flow to let users choose which setting groups to copy.
@@ -2986,6 +2997,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
     "temperature_climate_values": frozenset(
         {
             CONF_CLIMATE_MODE,
+            CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
             CONF_TEMP_LOW,
             CONF_TEMP_HIGH,
             CONF_OUTSIDE_THRESHOLD,
@@ -3007,6 +3019,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
     "temperature_climate": frozenset(
         {
             CONF_CLIMATE_MODE,
+            CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
             CONF_TEMP_ENTITY,
             CONF_TEMP_LOW,
             CONF_TEMP_HIGH,
@@ -3036,6 +3049,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_IS_SUNNY_TEMPLATE,
             CONF_IS_SUNNY_TEMPLATE_MODE,
             CONF_CLIMATE_MODE,
+            CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
             CONF_TEMP_ENTITY,
             CONF_TEMP_LOW,
             CONF_TEMP_HIGH,

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -532,6 +532,17 @@ CONF_WINTER_CLOSE_INSULATION = "winter_close_insulation"
 # True to let summer climate-close ignore the sun-in-FOV min floor
 # (min_position_sun_tracking) and reach the global min_position instead.
 CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR = "summer_close_bypass_sun_floor"
+# When no explicit CONF_TEMP_ENTITY is set, fall back to the cover's HA area
+# configured temperature entity (issue #786). Defaults True (opt-out).
+CONF_AUTO_RESOLVE_TEMP_FROM_AREA = "auto_resolve_temp_from_area"
+DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA = True
+
+# Repair issue id (issue_registry) raised when the effective indoor temperature
+# sensor stays unavailable/missing beyond the debounce window (issue #786).
+ISSUE_TEMP_SENSOR_UNAVAILABLE = "temp_sensor_unavailable"
+# Generous debounce so integration restarts / device re-adds don't nag before
+# a genuinely dead sensor is flagged.
+DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS = 900.0
 
 STRATEGY_MODE_BASIC = "basic"  # geometry only, no climate inputs
 STRATEGY_MODE_CLIMATE = "climate"  # climate-aware (temps/presence/weather)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -87,6 +87,7 @@ from .const import (
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     DIAG_CACHE_KEY,
     DOMAIN,
+    ISSUE_TEMP_SENSOR_UNAVAILABLE,
     LOGGER,
     POSITION_TOLERANCE_PERCENT,
     STARTUP_GRACE_PERIOD_SECONDS,
@@ -106,6 +107,7 @@ from .managers.manual_override import (
     inverse_state,
 )
 from .managers.motion import MotionManager
+from .managers.sensor_health import SensorHealthManager
 from .managers.weather import WeatherManager
 from .managers.time_window import TimeWindowManager
 from .managers.toggles import ToggleManager
@@ -327,6 +329,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Weather override tracking
         self._weather_mgr = WeatherManager(
             hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+        )
+        # Sensor-health Repairs (issue #786): raise an informational Repair when
+        # the effective indoor temperature sensor stays unavailable past a
+        # generous debounce, and clear it on recovery. Entity-agnostic — this PR
+        # wires only the temp sensor.
+        self._sensor_health = SensorHealthManager(self.hass, self.logger, domain=DOMAIN)
+        self._temp_issue_key = (
+            f"{ISSUE_TEMP_SENSOR_UNAVAILABLE}_{self.config_entry.entry_id}"
         )
         # Override pipeline — custom position handlers are created per-slot so
         # each can carry an independent priority configured by the user.
@@ -1235,6 +1245,31 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # The result is stored in self._weather_readings and passed to PipelineSnapshot
         # so ClimateHandler and CloudSuppressionHandler can self-evaluate.
         self._weather_readings = self._snapshot_builder.read_climate(options)
+
+        # Sensor-health Repair (issue #786): watch the effective indoor temp
+        # entity only when climate mode is on (the sensor is otherwise unused,
+        # so an unavailable one is not worth nagging about). Watching the
+        # resolved effective entity covers both explicit and area-resolved
+        # cases. Fail-open: never let this raise into the update cycle.
+        try:
+            climate_on = bool(options.get(CONF_CLIMATE_MODE, False))
+            effective_temp = (
+                self._weather_readings.inside_temperature_entity_id
+                if climate_on
+                else None
+            )
+            self._sensor_health.update_watch(
+                self._temp_issue_key,
+                effective_temp,
+                translation_key=ISSUE_TEMP_SENSOR_UNAVAILABLE,
+                placeholders={
+                    "entity_id": effective_temp or "",
+                    "name": self.config_entry.data.get("name", "") or "",
+                },
+            )
+            self._sensor_health.evaluate()
+        except Exception:  # noqa: BLE001 — health check must never break the cycle
+            self.logger.debug("Sensor-health evaluation failed", exc_info=True)
 
         # Compute the effective default position from astronomical sunset/sunrise.
         # This is the single source of truth — all pipeline handlers use it via
@@ -2715,12 +2750,28 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         _last_success_time = self._last_update_success_time
         _last_exc = self.last_exception
 
+        _temp_readings = self._weather_readings
         ctx = DiagnosticContext(
             pos_sun=self.pos_sun,
             cover=self._cover_data,
             position_forecast=self._position_forecast,
             pipeline_result=result,
             climate_mode=self._climate_mode,
+            temp_sensor_entity_id=(
+                _temp_readings.inside_temperature_entity_id
+                if _temp_readings is not None
+                else None
+            ),
+            temp_sensor_source=(
+                _temp_readings.inside_temperature_source
+                if _temp_readings is not None
+                else "none"
+            ),
+            temp_sensor_area_id=(
+                _temp_readings.inside_temperature_area_id
+                if _temp_readings is not None
+                else None
+            ),
             check_adaptive_time=self.check_adaptive_time,
             after_start_time=self.after_start_time,
             before_end_time=self.before_end_time,
@@ -3233,6 +3284,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         # Cancel weather clear-delay timeout task
         self._cancel_weather_timeout()
+
+        # Cancel any in-flight sensor-health debounce timers (issue #786).
+        self._sensor_health.shutdown()
 
         # Stop cover command service reconciliation timer
         self._cmd_svc.stop()

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -148,6 +148,15 @@ class DiagnosticContext:
     # default_position diagnostics block to disambiguate sunset-vs-eow.
     end_of_window_active: bool = False
 
+    # issue #786: the effective indoor temperature sensor and its provenance,
+    # threaded from the cycle's ClimateReadings. ``source`` is "explicit" /
+    # "area" / "none"; ``area_id`` is set only for the "area" source. Surfaced
+    # in the climate block so a user can see why a cover reacts to a sensor
+    # they never configured on it.
+    temp_sensor_entity_id: str | None = None
+    temp_sensor_source: str = "none"
+    temp_sensor_area_id: str | None = None
+
 
 # ---------------------------------------------------------------------------
 # Strategy label map (moved from coordinator class attribute)
@@ -542,6 +551,18 @@ class DiagnosticsBuilder:
     def _build_climate(ctx: DiagnosticContext) -> dict:
         """Build climate mode diagnostics."""
         diagnostics: dict = {}
+
+        # Effective indoor temp sensor + provenance (issue #786). Surfaced
+        # whenever a sensor resolved (explicit or auto-resolved from the area)
+        # so a user can trace why a cover reacts to a sensor they never
+        # configured on it. Absent when nothing resolved (source "none").
+        if ctx.temp_sensor_source and ctx.temp_sensor_source != "none":
+            diagnostics["temp_sensor"] = {
+                "entity_id": ctx.temp_sensor_entity_id,
+                "source": ctx.temp_sensor_source,
+                "area_id": ctx.temp_sensor_area_id,
+            }
+
         result = ctx.pipeline_result
         if ctx.climate_mode and result is not None and result.climate_data is not None:
             climate_data = result.climate_data

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -36,7 +36,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER, Platform
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import area_registry as ar
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -71,6 +70,7 @@ from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
 from .pipeline.types import GroupIntent
+from .state.area_resolver import device_area_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -118,17 +118,19 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     # ---- Roster resolution ------------------------------------------------ #
 
     def _entity_area_id(self, entity_id: str) -> str | None:
-        """Return the entity's area — its own, or inherited from its device."""
+        """Return the entity's area — its own, or inherited from its device.
+
+        The device→area hop delegates to the shared
+        :func:`state.area_resolver.device_area_id` helper so the registry
+        lookup lives in exactly one place (also used by the area-based temp
+        sensor resolver, issue #786).
+        """
         reg_entry = er.async_get(self.hass).async_get(entity_id)
         if reg_entry is None:
             return None
         if reg_entry.area_id:
             return reg_entry.area_id
-        if reg_entry.device_id:
-            device = dr.async_get(self.hass).async_get(reg_entry.device_id)
-            if device is not None:
-                return device.area_id
-        return None
+        return device_area_id(self.hass, reg_entry.device_id)
 
     def _cover_entities_in_area(self, area_id: str) -> list[str]:
         """Every ``cover.`` entity in the area (own or device-inherited)."""

--- a/custom_components/adaptive_cover_pro/managers/sensor_health.py
+++ b/custom_components/adaptive_cover_pro/managers/sensor_health.py
@@ -1,0 +1,162 @@
+"""Generic sensor-health Repair manager (issue #786).
+
+Watches a registry of ``{issue_key -> entity_id}`` and raises an informational
+Home Assistant Repair when a watched sensor stays unavailable (or missing from
+the state machine) past a debounce window — then clears the Repair once it
+recovers. The debounce is generous so integration restarts and device re-adds
+do not nag the user before a genuinely dead sensor is flagged.
+
+The manager is deliberately entity-agnostic: wiring a new sensor is a single
+``update_watch`` call with its own ``issue_key`` and ``translation_key`` — no
+per-sensor branching here (no-duplication rule). This PR wires only the
+effective indoor temperature entity, but motion/wind/humidity could register
+the same way later.
+
+Side-effect ownership: this is a manager (it holds per-instance state and
+orchestrates the Repair lifecycle). The resolution *read* stays in the
+``state/`` boundary (``AreaSensorResolver``); the manager only reacts to the
+already-resolved effective entity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import issue_registry as ir
+
+from ..const import DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS
+from .common import TimeoutController
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from homeassistant.core import HomeAssistant
+
+# HA state strings that count as "no real value" for a watched entity.
+_UNHEALTHY_STATES = ("unavailable", "unknown", None)
+
+
+@dataclass(frozen=True, slots=True)
+class _Watch:
+    """One watched entity and the Repair metadata to raise for it."""
+
+    entity_id: str
+    translation_key: str
+    placeholders: dict[str, str] = field(default_factory=dict)
+
+
+class SensorHealthManager:
+    """Raise/clear informational Repairs for unhealthy watched sensors."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: Logger,
+        *,
+        domain: str,
+        debounce_seconds: float = DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS,
+    ) -> None:
+        """Bind the manager to hass and the integration domain."""
+        self._hass = hass
+        self._logger = logger
+        self._domain = domain
+        self._debounce = debounce_seconds
+        self._watched: dict[str, _Watch] = {}
+        self._timers: dict[str, TimeoutController] = {}
+        self._active: set[str] = set()
+
+    # -- registration -------------------------------------------------------
+
+    def update_watch(
+        self,
+        issue_key: str,
+        entity_id: str | None,
+        *,
+        translation_key: str,
+        placeholders: dict[str, str] | None = None,
+    ) -> None:
+        """Register / replace / clear the entity watched under ``issue_key``.
+
+        ``entity_id`` of ``None`` unwatches the key and clears any pending timer
+        or active Repair — the effective sensor became unset.
+        """
+        if not entity_id:
+            self._unwatch(issue_key)
+            return
+        self._watched[issue_key] = _Watch(
+            entity_id=entity_id,
+            translation_key=translation_key,
+            placeholders=dict(placeholders or {}),
+        )
+
+    # -- per-cycle evaluation ----------------------------------------------
+
+    def evaluate(self) -> None:
+        """Re-check every watched entity's health once per update cycle."""
+        for issue_key, watch in list(self._watched.items()):
+            if self._is_healthy(watch.entity_id):
+                self._recover(issue_key)
+            else:
+                self._schedule(issue_key, watch)
+
+    def _is_healthy(self, entity_id: str) -> bool:
+        """Return True iff the watched entity has a real (non-null) state."""
+        state = self._hass.states.get(entity_id)
+        if state is None:
+            return False
+        return state.state not in _UNHEALTHY_STATES
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def _schedule(self, issue_key: str, watch: _Watch) -> None:
+        """Start (once) the debounce timer that will raise the Repair."""
+        if issue_key in self._active:
+            return  # already raised — nothing to debounce
+        timer = self._timers.get(issue_key)
+        if timer is not None and timer.is_running:
+            return  # debounce already in flight
+        timer = TimeoutController(self._logger, label=f"sensor health {issue_key}")
+        self._timers[issue_key] = timer
+        timer.start(self._debounce, lambda: self._raise(issue_key, watch))
+
+    async def _raise(self, issue_key: str, watch: _Watch) -> None:
+        """Raise the Repair — but only if still unhealthy at expiry."""
+        if self._is_healthy(watch.entity_id):
+            return
+        ir.async_create_issue(
+            self._hass,
+            self._domain,
+            issue_key,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=watch.translation_key,
+            translation_placeholders=watch.placeholders,
+        )
+        self._active.add(issue_key)
+
+    def _recover(self, issue_key: str) -> None:
+        """Cancel any pending debounce and clear an active Repair."""
+        self._cancel_timer(issue_key)
+        self._delete_issue(issue_key)
+
+    def _unwatch(self, issue_key: str) -> None:
+        """Stop watching a key and clear its timer + Repair."""
+        self._watched.pop(issue_key, None)
+        self._cancel_timer(issue_key)
+        self._delete_issue(issue_key)
+
+    def _cancel_timer(self, issue_key: str) -> None:
+        timer = self._timers.pop(issue_key, None)
+        if timer is not None:
+            timer.cancel()
+
+    def _delete_issue(self, issue_key: str) -> None:
+        if issue_key in self._active:
+            ir.async_delete_issue(self._hass, self._domain, issue_key)
+            self._active.discard(issue_key)
+
+    def shutdown(self) -> None:
+        """Cancel all in-flight debounce timers (on reload / unload)."""
+        for issue_key in list(self._timers):
+            self._cancel_timer(issue_key)

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -28,6 +28,7 @@ from collections.abc import Callable
 from homeassistant.const import ATTR_FRIENDLY_NAME
 
 from ..const import (
+    CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
     CONF_CLOUD_COVERAGE_ENTITY,
     CONF_CLOUD_COVERAGE_THRESHOLD,
     CONF_CLOUD_SUPPRESSION,
@@ -35,6 +36,7 @@ from ..const import (
     CONF_DEFAULT_HEIGHT,
     CONF_DEFAULT_TILT,
     CONF_DELTA_TIME,
+    CONF_DEVICE_ID,
     CONF_ENABLE_SUN_TRACKING,
     CONF_IRRADIANCE_ENTITY,
     CONF_IRRADIANCE_THRESHOLD,
@@ -73,6 +75,7 @@ from ..const import (
     CONF_WEATHER_STATE,
     CONF_WINTER_CLOSE_INSULATION,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
     DEFAULT_CUSTOM_POSITION_ENABLED,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_CUSTOM_POSITION_TILT_ONLY,
@@ -172,6 +175,13 @@ class PipelineSnapshotBuilder:
         )
         return self._climate_provider.read(
             temp_entity=options.get(CONF_TEMP_ENTITY),
+            temp_device_id=options.get(CONF_DEVICE_ID),
+            auto_resolve_temp_from_area=bool(
+                options.get(
+                    CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
+                    DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
+                )
+            ),
             outside_entity=options.get(CONF_OUTSIDETEMP_ENTITY),
             presence_entity=options.get(CONF_PRESENCE_ENTITY),
             presence_template=options.get(CONF_PRESENCE_TEMPLATE),

--- a/custom_components/adaptive_cover_pro/repairs.py
+++ b/custom_components/adaptive_cover_pro/repairs.py
@@ -1,0 +1,28 @@
+"""Repairs platform for Adaptive Cover Pro (issue #786).
+
+The integration raises only *informational* Repairs (``is_fixable=False``) via
+``SensorHealthManager`` — e.g. an indoor temperature sensor that has stayed
+unavailable past the debounce window. Home Assistant renders these directly
+from the ``issues`` translation block; a non-fixable issue never triggers a fix
+flow, so this platform exists only to satisfy the repairs-platform contract and
+return a no-op confirm flow should an issue ever be marked fixable.
+"""
+
+from __future__ import annotations
+
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict | None,
+) -> RepairsFlow:
+    """Return a confirm-only fix flow.
+
+    All issues this integration raises are informational (``is_fixable=False``)
+    and never reach this hook; a plain :class:`ConfirmRepairFlow` is the safe
+    default if that ever changes.
+    """
+    return ConfirmRepairFlow()

--- a/custom_components/adaptive_cover_pro/state/area_resolver.py
+++ b/custom_components/adaptive_cover_pro/state/area_resolver.py
@@ -1,0 +1,101 @@
+"""Area-based sensor resolution — cover area → configured sensor entity.
+
+Part of the ``state/`` boundary: this is the only place the device and area
+registries are read to derive a cover's indoor temperature sensor from its
+Home Assistant area (issue #786). Home Assistant's area registry stores a
+per-area ``temperature_entity_id`` (added HA 2024.11); when a cover has no
+explicit temp sensor configured, we fall back to its area's configured one.
+
+The resolver is named generically (``resolve_temperature_entity``) so a future
+device-class-scan resolver for motion/wind can be a sibling method — but only
+temperature is implemented today, because the area registry exposes only
+``temperature_entity_id`` / ``humidity_entity_id`` and no motion/wind field.
+
+Fail-open: any missing hop (no device, device has no area, area has no
+temperature entity) resolves to ``None`` — identical to "no sensor configured"
+— and never raises into the update cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import device_registry as dr
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+# Provenance of a resolved sensor entity — surfaced in diagnostics and the
+# config summary so a user can see why a cover reacts to a sensor they never
+# configured on it.
+SENSOR_SOURCE_EXPLICIT = "explicit"
+SENSOR_SOURCE_AREA = "area"
+SENSOR_SOURCE_NONE = "none"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSensor:
+    """A resolved sensor entity and where it came from.
+
+    ``entity_id`` is the effective entity (``None`` when nothing resolved).
+    ``source`` is one of :data:`SENSOR_SOURCE_EXPLICIT` / ``_AREA`` / ``_NONE``.
+    ``area_id`` is the area the entity was resolved from (only set for the
+    ``area`` source).
+    """
+
+    entity_id: str | None
+    source: str
+    area_id: str | None
+
+
+def device_area_id(hass: HomeAssistant, device_id: str | None) -> str | None:
+    """Return the area a device belongs to, or ``None``.
+
+    Shared device→area lookup used by both :class:`AreaSensorResolver` and the
+    cover-group coordinator's entity→area resolution, so the registry hop lives
+    in exactly one place. Fail-open: an unknown or unlinked device yields
+    ``None``.
+    """
+    if not device_id:
+        return None
+    device = dr.async_get(hass).async_get(device_id)
+    if device is None:
+        return None
+    return device.area_id
+
+
+class AreaSensorResolver:
+    """Resolve a cover's sensor entity from explicit config or its HA area."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Bind the resolver to the Home Assistant instance."""
+        self._hass = hass
+
+    def resolve_temperature_entity(
+        self,
+        *,
+        explicit_entity: str | None,
+        device_id: str | None,
+        auto_resolve: bool = True,
+    ) -> ResolvedSensor:
+        """Resolve the effective indoor temperature entity for a cover.
+
+        Precedence: an explicit ``explicit_entity`` (the configured
+        ``CONF_TEMP_ENTITY``) always wins. Otherwise, when ``auto_resolve`` is
+        on, follow ``device_id`` → area → the area's configured
+        ``temperature_entity_id``. Any missing hop yields a ``None`` /
+        :data:`SENSOR_SOURCE_NONE` result.
+        """
+        if explicit_entity:
+            return ResolvedSensor(explicit_entity, SENSOR_SOURCE_EXPLICIT, None)
+        if not auto_resolve:
+            return ResolvedSensor(None, SENSOR_SOURCE_NONE, None)
+        area_id = device_area_id(self._hass, device_id)
+        if area_id:
+            area = ar.async_get(self._hass).async_get_area(area_id)
+            temp_entity = getattr(area, "temperature_entity_id", None)
+            if temp_entity:
+                return ResolvedSensor(temp_entity, SENSOR_SOURCE_AREA, area_id)
+        return ResolvedSensor(None, SENSOR_SOURCE_NONE, None)

--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from ..const import DEFAULT_TEMPLATE_COMBINE_MODE
 from ..helpers import get_domain, get_safe_state, is_entity_active, state_attr
 from ..templates import fold_condition_template
+from .area_resolver import AreaSensorResolver
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -28,6 +29,13 @@ class ClimateReadings:
     lux_below_threshold: bool
     irradiance_below_threshold: bool
     cloud_coverage_above_threshold: bool
+    # Effective indoor temperature entity actually read, and its provenance
+    # (issue #786): "explicit" (configured), "area" (auto-resolved from the
+    # cover's HA area), or "none". ``inside_temperature_area_id`` is set only
+    # for the "area" source. Surfaced in diagnostics + config summary.
+    inside_temperature_entity_id: str | None = None
+    inside_temperature_source: str = "none"
+    inside_temperature_area_id: str | None = None
 
 
 class ClimateProvider:
@@ -37,11 +45,14 @@ class ClimateProvider:
         """Initialize with HA instance and logger."""
         self._hass = hass
         self._logger = logger
+        self._area_resolver = AreaSensorResolver(hass)
 
     def read(
         self,
         *,
         temp_entity: str | None = None,
+        temp_device_id: str | None = None,
+        auto_resolve_temp_from_area: bool = True,
         outside_entity: str | None = None,
         weather_entity: str | None = None,
         weather_condition: list[str] | None = None,
@@ -62,11 +73,19 @@ class ClimateProvider:
         is_sunny_template_mode: str = DEFAULT_TEMPLATE_COMBINE_MODE,
     ) -> ClimateReadings:
         """Read all climate entities and return a frozen snapshot."""
+        resolved_temp = self._area_resolver.resolve_temperature_entity(
+            explicit_entity=temp_entity,
+            device_id=temp_device_id,
+            auto_resolve=auto_resolve_temp_from_area,
+        )
         return ClimateReadings(
             outside_temperature=self._read_outside_temperature(
                 outside_entity, weather_entity
             ),
-            inside_temperature=self._read_inside_temperature(temp_entity),
+            inside_temperature=self._read_inside_temperature(resolved_temp.entity_id),
+            inside_temperature_entity_id=resolved_temp.entity_id,
+            inside_temperature_source=resolved_temp.source,
+            inside_temperature_area_id=resolved_temp.area_id,
             is_presence=self._read_presence(
                 presence_entity, presence_template, presence_template_mode
             ),

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -106,6 +106,7 @@
   "climate": {
     "comfort_range": "Komfortbereich {lo}–{hi}°C",
     "using": "mit {entity}",
+    "using_area": "mit Bereichs-Temperatursensor",
     "outside_thresh": "außen: {entity} > {thresh}°C",
     "outside": "außen: {entity}",
     "weather": "Wetter: {entity}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -106,6 +106,7 @@
   "climate": {
     "comfort_range": "comfort range {lo}–{hi}°C",
     "using": "using {entity}",
+    "using_area": "using area temperature sensor",
     "outside_thresh": "outside: {entity} > {thresh}°C",
     "outside": "outside: {entity}",
     "weather": "weather: {entity}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -106,6 +106,7 @@
   "climate": {
     "comfort_range": "plage de confort {lo}–{hi}°C",
     "using": "utilisant {entity}",
+    "using_area": "utilisant le capteur de température de la zone",
     "outside_thresh": "extérieur : {entity} > {thresh}°C",
     "outside": "extérieur : {entity}",
     "weather": "météo : {entity}",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1,5 +1,11 @@
 {
   "title": "Adaptive Cover Pro",
+  "issues": {
+    "temp_sensor_unavailable": {
+      "title": "Innentemperatursensor nicht verfügbar",
+      "description": "Der vom Klimamodus auf **{name}** verwendete Innentemperatursensor `{entity_id}` ist seit einiger Zeit nicht verfügbar. Klimaentscheidungen laufen möglicherweise ohne aktuellen Innenmesswert. Prüfe, ob das Gerät des Sensors online ist, oder wähle einen anderen Sensor (oder deaktiviere die automatische Ermittlung aus dem Bereich) in den Temperatur- & Klimaoptionen der Abdeckung."
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -660,6 +666,7 @@
         "data": {
           "climate_mode": "Klimamodus aktivieren",
           "temp_entity": "Innere Temperaturentität",
+          "auto_resolve_temp_from_area": "Temperatursensor automatisch aus Bereich ermitteln",
           "temp_low": "Unterer Temperaturschwellwert",
           "temp_high": "Oberer Temperaturschwellwert",
           "outside_temp": "Außentemperatursensor (optional)",
@@ -674,6 +681,7 @@
         "data_description": {
           "climate_mode": "Aktivieren Sie diese Option, um alle klimagestützten Beschattungssteuerungen zu aktivieren. Wenn deaktiviert, werden alle Einstellungen auf diesem Bildschirm ignoriert und die Beschattung folgt der normalen Sonne/Blendungsverfolgung.",
           "temp_entity": "Ein Klima-Thermostat oder Temperatursensor, der die Innentemperatur misst und zur Bestimmung der aktuellen Jahreszeit (Winter/Sommer/Zwischensaison) verwendet wird. Erforderlich, wenn der Klimamodus aktiviert ist.",
+          "auto_resolve_temp_from_area": "Wenn oben keine innere Temperaturentität gesetzt ist, wird auf den Temperatursensor zurückgegriffen, der für den Home-Assistant-Bereich dieser Abdeckung konfiguriert ist. So lässt sich eine Abdeckung über mehrere Räume duplizieren, ohne für jeden einen Sensor auszuwählen. Die oben angegebene Entität hat immer Vorrang. Ausschalten, um den Sensor unbelegt zu lassen, wenn keiner gewählt ist.",
           "temp_low": "Innentemperatur (oder Außentemperatur, falls ein Außensensor konfiguriert ist), unter der die Jahreszeit als Winter behandelt wird. Im Winter öffnet sich die Beschattung vollständig, wenn die Sonne auf das Fenster scheint, um Sonnenwärme zu nutzen. **Der Wert wird in der Einheit des konfigurierten Temperatursensors interpretiert, nicht in der Anzeigeeinheit von Home Assistant.** Akzeptiert eine feste Zahl oder eine Home Assistant Jinja2-Vorlage, die eine Zahl ergibt und bei jedem Update neu bewertet wird.",
           "temp_high": "Innentemperatur (oder Außentemperatur, falls ein Außensensor konfiguriert ist), ab der die Jahreszeit als Sommer behandelt wird – vorausgesetzt, auch die Außenschwelle wird überschritten. Im Sommer schließt sich die Beschattung, um Wärmeeintrag zu blockieren. **Der Wert wird in der Einheit des konfigurierten Temperatursensors interpretiert, nicht in der Anzeigeeinheit von Home Assistant.** Akzeptiert eine feste Zahl oder eine Home Assistant Jinja2-Vorlage, die eine Zahl ergibt und bei jedem Update neu bewertet wird.",
           "outside_temp": "Optionaler Außentemperatursensor. Wenn bereitgestellt, bestimmt diese Messung (nicht der Innensensor) die aktuelle Jahreszeit, und die Außenschwellenwertschutz wird angewendet, um ein Sommerschluss-Verhalten an kalten Tagen zu verhindern.",
@@ -1482,6 +1490,7 @@
         "data": {
           "climate_mode": "Klimamodus aktivieren",
           "temp_entity": "Innere Temperaturentität",
+          "auto_resolve_temp_from_area": "Temperatursensor automatisch aus Bereich ermitteln",
           "temp_low": "Unterer Temperaturschwellwert",
           "temp_high": "Oberer Temperaturschwellwert",
           "outside_temp": "Außentemperatursensor (optional)",
@@ -1496,6 +1505,7 @@
         "data_description": {
           "climate_mode": "Aktivieren Sie diese Option, um alle klimagestützten Beschattungssteuerungen zu aktivieren. Wenn deaktiviert, werden alle Einstellungen auf diesem Bildschirm ignoriert und die Beschattung folgt der normalen Sonne/Blendungsverfolgung.",
           "temp_entity": "Ein Klima-Thermostat oder Temperatursensor, der die Innentemperatur misst und zur Bestimmung der aktuellen Jahreszeit (Winter/Sommer/Zwischensaison) verwendet wird. Erforderlich, wenn der Klimamodus aktiviert ist.",
+          "auto_resolve_temp_from_area": "Wenn oben keine innere Temperaturentität gesetzt ist, wird auf den Temperatursensor zurückgegriffen, der für den Home-Assistant-Bereich dieser Abdeckung konfiguriert ist. So lässt sich eine Abdeckung über mehrere Räume duplizieren, ohne für jeden einen Sensor auszuwählen. Die oben angegebene Entität hat immer Vorrang. Ausschalten, um den Sensor unbelegt zu lassen, wenn keiner gewählt ist.",
           "temp_low": "Innentemperatur (oder Außentemperatur, falls ein Außensensor konfiguriert ist), unter der die Jahreszeit als Winter behandelt wird. Im Winter öffnet sich die Beschattung vollständig, wenn die Sonne auf das Fenster scheint, um Sonnenwärme zu nutzen. **Der Wert wird in der Einheit des konfigurierten Temperatursensors interpretiert, nicht in der Anzeigeeinheit von Home Assistant.** Akzeptiert eine feste Zahl oder eine Home Assistant Jinja2-Vorlage, die eine Zahl ergibt und bei jedem Update neu bewertet wird.",
           "temp_high": "Innentemperatur (oder Außentemperatur, falls ein Außensensor konfiguriert ist), ab der die Jahreszeit als Sommer behandelt wird – vorausgesetzt, auch die Außenschwelle wird überschritten. Im Sommer schließt sich die Beschattung, um Wärmeeintrag zu blockieren. **Der Wert wird in der Einheit des konfigurierten Temperatursensors interpretiert, nicht in der Anzeigeeinheit von Home Assistant.** Akzeptiert eine feste Zahl oder eine Home Assistant Jinja2-Vorlage, die eine Zahl ergibt und bei jedem Update neu bewertet wird.",
           "outside_temp": "Optionaler Außentemperatursensor. Wenn bereitgestellt, bestimmt diese Messung (nicht der Innensensor) die aktuelle Jahreszeit, und die Außenschwellenwertschutz wird angewendet, um ein Sommerschluss-Verhalten an kalten Tagen zu verhindern.",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1,5 +1,11 @@
 {
   "title": "Adaptive Cover Pro",
+  "issues": {
+    "temp_sensor_unavailable": {
+      "title": "Indoor temperature sensor unavailable",
+      "description": "The indoor temperature sensor `{entity_id}` used by climate mode on **{name}** has been unavailable for a while. Climate decisions may be running without a current indoor reading. Check that the sensor's device is online, or set a different sensor (or turn off area auto-resolution) in the cover's Temperature & Climate options."
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -690,6 +696,7 @@
         "data": {
           "climate_mode": "Enable climate mode",
           "temp_entity": "Inside temperature entity",
+          "auto_resolve_temp_from_area": "Auto-resolve temperature sensor from area",
           "temp_low": "Low temperature threshold",
           "temp_high": "High temperature threshold",
           "outside_temp": "Outside temperature sensor (optional)",
@@ -704,6 +711,7 @@
         "data_description": {
           "climate_mode": "Turn on to enable all climate-based cover control. When off, all settings on this screen are ignored and the cover follows normal sun/glare tracking.",
           "temp_entity": "A climate thermostat or temperature sensor that measures the indoor temperature used to determine the current season (winter/summer/intermediate). Required when climate mode is enabled.",
+          "auto_resolve_temp_from_area": "When no inside temperature entity is set above, fall back to the temperature sensor configured on this cover's Home Assistant area. Lets you duplicate a cover across rooms without picking a sensor for each. The explicit entity above always wins. Turn off to leave the sensor unset when none is chosen.",
           "temp_low": "Indoor (or outdoor, if an outside sensor is configured) temperature below which the season is treated as winter. In winter the cover opens fully when the sun is hitting the window to capture solar heat. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "temp_high": "Indoor (or outdoor, if an outside sensor is configured) temperature above which the season is treated as summer — provided the outside threshold is also exceeded. In summer the cover closes to block heat gain. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "outside_temp": "Optional outdoor temperature sensor. When provided, this reading (rather than the indoor sensor) determines the current season, and the outside threshold guard is applied to prevent summer-close behavior on cold days.",
@@ -1534,6 +1542,7 @@
         "data": {
           "climate_mode": "Enable climate mode",
           "temp_entity": "Inside temperature entity",
+          "auto_resolve_temp_from_area": "Auto-resolve temperature sensor from area",
           "temp_low": "Low temperature threshold",
           "temp_high": "High temperature threshold",
           "outside_temp": "Outside temperature sensor (optional)",
@@ -1548,6 +1557,7 @@
         "data_description": {
           "climate_mode": "Turn on to enable all climate-based cover control. When off, all settings on this screen are ignored and the cover follows normal sun/glare tracking.",
           "temp_entity": "A climate thermostat or temperature sensor that measures the indoor temperature used to determine the current season (winter/summer/intermediate). Required when climate mode is enabled.",
+          "auto_resolve_temp_from_area": "When no inside temperature entity is set above, fall back to the temperature sensor configured on this cover's Home Assistant area. Lets you duplicate a cover across rooms without picking a sensor for each. The explicit entity above always wins. Turn off to leave the sensor unset when none is chosen.",
           "temp_low": "Indoor (or outdoor, if an outside sensor is configured) temperature below which the season is treated as winter. In winter the cover opens fully when the sun is hitting the window to capture solar heat. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "temp_high": "Indoor (or outdoor, if an outside sensor is configured) temperature above which the season is treated as summer — provided the outside threshold is also exceeded. In summer the cover closes to block heat gain. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "outside_temp": "Optional outdoor temperature sensor. When provided, this reading (rather than the indoor sensor) determines the current season, and the outside threshold guard is applied to prevent summer-close behavior on cold days.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1,5 +1,11 @@
 {
   "title": "Adaptive Cover Pro",
+  "issues": {
+    "temp_sensor_unavailable": {
+      "title": "Capteur de température intérieure indisponible",
+      "description": "Le capteur de température intérieure `{entity_id}` utilisé par le mode climatique sur **{name}** est indisponible depuis un moment. Les décisions climatiques s'exécutent peut-être sans relevé intérieur à jour. Vérifiez que l'appareil du capteur est en ligne, ou choisissez un autre capteur (ou désactivez la résolution automatique depuis la zone) dans les options Température et Climat de la couverture."
+    }
+  },
   "config": {
     "step": {
       "user": {
@@ -660,6 +666,7 @@
         "data": {
           "climate_mode": "Activer le mode climatique",
           "temp_entity": "Entité de température intérieure",
+          "auto_resolve_temp_from_area": "Résoudre automatiquement le capteur de température depuis la zone",
           "temp_low": "Seuil de température basse",
           "temp_high": "Seuil de température haute",
           "outside_temp": "Capteur de température extérieure (optionnel)",
@@ -674,6 +681,7 @@
         "data_description": {
           "climate_mode": "Activez pour activer tout le contrôle du store basé sur le climat. Quand désactivé, tous les paramètres de cet écran sont ignorés et le store suit le suivi solaire/anti-éblouissement normal.",
           "temp_entity": "Un thermostat ou capteur de température mesurant la température intérieure utilisée pour déterminer la saison actuelle (hiver/été/intermédiaire). Requis quand le mode climatique est activé.",
+          "auto_resolve_temp_from_area": "Quand aucune entité de température intérieure n'est définie ci-dessus, utiliser en repli le capteur de température configuré sur la zone Home Assistant de cette couverture. Cela permet de dupliquer une couverture entre plusieurs pièces sans choisir un capteur pour chacune. L'entité ci-dessus est toujours prioritaire. Désactiver pour laisser le capteur non défini si aucun n'est choisi.",
           "temp_low": "Température intérieure (ou extérieure, si un capteur extérieur est configuré) en dessous de laquelle la saison est traitée comme l'hiver. En hiver, la protection s'ouvre complètement quand le soleil frappe la fenêtre pour capter la chaleur solaire. **La valeur est interprétée dans l'unité du capteur de température configuré, non dans l'unité d'affichage Home Assistant.** Accepte un nombre fixe ou un modèle Jinja2 Home Assistant qui évalue à un nombre, réévalué à chaque cycle de mise à jour.",
           "temp_high": "Température intérieure (ou extérieure, si un capteur extérieur est configuré) au-dessus de laquelle la saison est traitée comme l'été — pourvu que le seuil extérieur soit également dépassé. En été, la protection se ferme pour bloquer les gains de chaleur. **La valeur est interprétée dans l'unité du capteur de température configuré, non dans l'unité d'affichage Home Assistant.** Accepte un nombre fixe ou un modèle Jinja2 Home Assistant qui évalue à un nombre, réévalué à chaque cycle de mise à jour.",
           "outside_temp": "Capteur de température extérieure optionnel. Quand configuré, cette valeur (plutôt que le capteur intérieur) détermine la saison actuelle, et le seuil extérieur est appliqué pour éviter que le store se ferme comme en été lors d'une journée intérieure chaude mais extérieure froide.",
@@ -1482,6 +1490,7 @@
         "data": {
           "climate_mode": "Activer le mode climatique",
           "temp_entity": "Entité de température intérieure",
+          "auto_resolve_temp_from_area": "Résoudre automatiquement le capteur de température depuis la zone",
           "temp_low": "Seuil de température basse",
           "temp_high": "Seuil de température haute",
           "outside_temp": "Capteur de température extérieure (optionnel)",
@@ -1496,6 +1505,7 @@
         "data_description": {
           "climate_mode": "Activez pour activer tout le contrôle du store basé sur le climat. Quand désactivé, tous les paramètres de cet écran sont ignorés et le store suit le suivi solaire/anti-éblouissement normal.",
           "temp_entity": "Un thermostat ou capteur de température mesurant la température intérieure utilisée pour déterminer la saison actuelle (hiver/été/intermédiaire). Requis quand le mode climatique est activé.",
+          "auto_resolve_temp_from_area": "Quand aucune entité de température intérieure n'est définie ci-dessus, utiliser en repli le capteur de température configuré sur la zone Home Assistant de cette couverture. Cela permet de dupliquer une couverture entre plusieurs pièces sans choisir un capteur pour chacune. L'entité ci-dessus est toujours prioritaire. Désactiver pour laisser le capteur non défini si aucun n'est choisi.",
           "temp_low": "Température intérieure (ou extérieure, si un capteur extérieur est configuré) en dessous de laquelle la saison est traitée comme l'hiver. En hiver, la protection s'ouvre complètement quand le soleil frappe la fenêtre pour capter la chaleur solaire. **La valeur est interprétée dans l'unité du capteur de température configuré, non dans l'unité d'affichage Home Assistant.** Accepte un nombre fixe ou un modèle Jinja2 Home Assistant qui évalue à un nombre, réévalué à chaque cycle de mise à jour.",
           "temp_high": "Température intérieure (ou extérieure, si un capteur extérieur est configuré) au-dessus de laquelle la saison est traitée comme l'été — pourvu que le seuil extérieur soit également dépassé. En été, la protection se ferme pour bloquer les gains de chaleur. **La valeur est interprétée dans l'unité du capteur de température configuré, non dans l'unité d'affichage Home Assistant.** Accepte un nombre fixe ou un modèle Jinja2 Home Assistant qui évalue à un nombre, réévalué à chaque cycle de mise à jour.",
           "outside_temp": "Capteur de température extérieure optionnel. Quand configuré, cette valeur (plutôt que le capteur intérieur) détermine la saison actuelle, et le seuil extérieur est appliqué pour éviter que le store se ferme comme en été lors d'une journée intérieure chaude mais extérieure froide.",

--- a/tests/test_area_temp_resolution.py
+++ b/tests/test_area_temp_resolution.py
@@ -1,0 +1,138 @@
+"""Tests for AreaSensorResolver — cover area → indoor temp sensor (issue #786).
+
+The resolver lives in the ``state/`` boundary and is the only place the
+device/area registries are read for temperature resolution. Explicit config
+always wins; the area's configured ``temperature_entity_id`` is the fallback.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.state.area_resolver import (
+    AreaSensorResolver,
+    ResolvedSensor,
+    SENSOR_SOURCE_AREA,
+    SENSOR_SOURCE_EXPLICIT,
+    SENSOR_SOURCE_NONE,
+)
+
+_MOD = "custom_components.adaptive_cover_pro.state.area_resolver"
+
+
+def _patch_registries(*, device_area_id=None, area_temp_entity=None):
+    """Patch the device + area registries the resolver reads.
+
+    ``device_area_id`` is the area a device belongs to (None = no device / no
+    area). ``area_temp_entity`` is the area's configured temperature entity
+    (None = area has none configured).
+    """
+    device = MagicMock()
+    device.area_id = device_area_id
+    device_reg = MagicMock()
+    device_reg.async_get.return_value = device if device_area_id is not None else None
+
+    area = MagicMock()
+    area.temperature_entity_id = area_temp_entity
+    area_reg = MagicMock()
+    area_reg.async_get_area.return_value = area if device_area_id is not None else None
+
+    return (
+        patch(f"{_MOD}.dr.async_get", return_value=device_reg),
+        patch(f"{_MOD}.ar.async_get", return_value=area_reg),
+    )
+
+
+@pytest.fixture
+def hass():
+    """Minimal mock HomeAssistant — registries are patched per test."""
+    return MagicMock()
+
+
+class TestResolveTemperatureEntity:
+    """Explicit-wins precedence and area fallback for the temp sensor."""
+
+    @pytest.mark.unit
+    def test_explicit_temp_entity_wins_over_area(self, hass):
+        """An explicit CONF_TEMP_ENTITY always wins; the area is never read."""
+        dev_patch, area_patch = _patch_registries(
+            device_area_id="area_bedroom", area_temp_entity="sensor.area_temp"
+        )
+        resolver = AreaSensorResolver(hass)
+        with dev_patch as dev, area_patch as area:
+            result = resolver.resolve_temperature_entity(
+                explicit_entity="sensor.explicit_temp",
+                device_id="device_1",
+            )
+        assert result == ResolvedSensor(
+            entity_id="sensor.explicit_temp",
+            source=SENSOR_SOURCE_EXPLICIT,
+            area_id=None,
+        )
+        # Explicit short-circuits — registries untouched.
+        dev.assert_not_called()
+        area.assert_not_called()
+
+    @pytest.mark.unit
+    def test_area_temp_resolved_when_no_explicit(self, hass):
+        """No explicit entity → resolve the area's configured temperature entity."""
+        dev_patch, area_patch = _patch_registries(
+            device_area_id="area_bedroom", area_temp_entity="sensor.bedroom_temp"
+        )
+        resolver = AreaSensorResolver(hass)
+        with dev_patch, area_patch:
+            result = resolver.resolve_temperature_entity(
+                explicit_entity=None,
+                device_id="device_1",
+            )
+        assert result == ResolvedSensor(
+            entity_id="sensor.bedroom_temp",
+            source=SENSOR_SOURCE_AREA,
+            area_id="area_bedroom",
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("device_id", "device_area_id", "area_temp_entity"),
+        [
+            (None, None, None),  # no device linked
+            ("device_1", None, None),  # device has no area
+            ("device_1", "area_bedroom", None),  # area has no temp entity
+        ],
+        ids=["no_device", "no_area", "no_temp_entity"],
+    )
+    def test_falls_through_to_none(
+        self, hass, device_id, device_area_id, area_temp_entity
+    ):
+        """Any missing hop → None / source none, matching 'no sensor' today."""
+        dev_patch, area_patch = _patch_registries(
+            device_area_id=device_area_id, area_temp_entity=area_temp_entity
+        )
+        resolver = AreaSensorResolver(hass)
+        with dev_patch, area_patch:
+            result = resolver.resolve_temperature_entity(
+                explicit_entity=None,
+                device_id=device_id,
+            )
+        assert result == ResolvedSensor(
+            entity_id=None, source=SENSOR_SOURCE_NONE, area_id=None
+        )
+
+    @pytest.mark.unit
+    def test_auto_resolve_disabled_skips_area(self, hass):
+        """With auto_resolve off and no explicit entity → None (opt-out)."""
+        dev_patch, area_patch = _patch_registries(
+            device_area_id="area_bedroom", area_temp_entity="sensor.bedroom_temp"
+        )
+        resolver = AreaSensorResolver(hass)
+        with dev_patch as dev, area_patch as area:
+            result = resolver.resolve_temperature_entity(
+                explicit_entity=None,
+                device_id="device_1",
+                auto_resolve=False,
+            )
+        assert result == ResolvedSensor(
+            entity_id=None, source=SENSOR_SOURCE_NONE, area_id=None
+        )
+        dev.assert_not_called()
+        area.assert_not_called()

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -19,6 +19,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_BLIND_SPOT_ELEVATION,
     CONF_MY_POSITION_VALUE,
     CONF_SUNSET_USE_MY,
+    CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
     CONF_BLIND_SPOT_LEFT,
     CONF_BLIND_SPOT_RIGHT,
     CONF_CLIMATE_MODE,
@@ -955,6 +956,42 @@ def test_climate_mode_shown():
     assert "16" in summary
     assert "24" in summary
     assert "sensor.temp" in summary
+
+
+def test_climate_line_shows_area_resolved_sensor():
+    """With no explicit temp sensor and auto-resolve on, the climate line notes
+    the sensor is taken from the cover's area (issue #786).
+    """
+    cfg = {
+        CONF_CLIMATE_MODE: True,
+        CONF_TEMP_LOW: 16,
+        CONF_TEMP_HIGH: 24,
+        # No CONF_TEMP_ENTITY; auto-resolve defaults on.
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "area temperature sensor" in summary
+    assert "using sensor." not in summary
+
+
+def test_climate_line_area_resolve_suppressed_when_explicit_sensor():
+    """An explicit temp sensor takes precedence — no area note."""
+    cfg = {
+        CONF_CLIMATE_MODE: True,
+        CONF_TEMP_ENTITY: "sensor.explicit",
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "sensor.explicit" in summary
+    assert "area temperature sensor" not in summary
+
+
+def test_climate_line_no_area_note_when_auto_resolve_disabled():
+    """Auto-resolve off and no explicit sensor → no area note."""
+    cfg = {
+        CONF_CLIMATE_MODE: True,
+        CONF_AUTO_RESOLVE_TEMP_FROM_AREA: False,
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "area temperature sensor" not in summary
 
 
 def test_climate_weather_entity_shown():

--- a/tests/test_coordinator_climate_wiring.py
+++ b/tests/test_coordinator_climate_wiring.py
@@ -19,10 +19,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
     CONF_CLOUD_COVERAGE_ENTITY,
     CONF_CLOUD_COVERAGE_THRESHOLD,
     CONF_CLOUD_SUPPRESSION,
     CONF_CLOUDY_POSITION,
+    CONF_DEVICE_ID,
     CONF_IRRADIANCE_ENTITY,
     CONF_IRRADIANCE_THRESHOLD,
     CONF_IS_SUNNY_SENSOR,
@@ -304,6 +306,8 @@ class TestClimateProviderApiCoverage:
     # These map from options key → read() kwarg name (non-obvious mappings).
     _OPTIONS_TO_READ_KWARG = {
         CONF_TEMP_ENTITY: "temp_entity",
+        CONF_DEVICE_ID: "temp_device_id",
+        CONF_AUTO_RESOLVE_TEMP_FROM_AREA: "auto_resolve_temp_from_area",
         CONF_OUTSIDETEMP_ENTITY: "outside_entity",
         CONF_PRESENCE_ENTITY: "presence_entity",
         CONF_WEATHER_ENTITY: "weather_entity",
@@ -359,6 +363,8 @@ class TestClimateProviderApiCoverage:
         # Build options from the canonical options→kwarg map
         options = {
             CONF_TEMP_ENTITY: "sensor.temp",
+            CONF_DEVICE_ID: "device_abc",
+            CONF_AUTO_RESOLVE_TEMP_FROM_AREA: True,
             CONF_OUTSIDETEMP_ENTITY: "sensor.outside",
             CONF_PRESENCE_ENTITY: "binary_sensor.pres",
             CONF_WEATHER_ENTITY: "weather.home",

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -718,6 +718,40 @@ class TestClimateDiagnostics:
         assert "cloud_coverage_above_threshold" in conditions
         assert conditions["cloud_coverage_above_threshold"] is False
 
+    def test_climate_diagnostics_include_resolved_temp_sensor(
+        self, builder: DiagnosticsBuilder
+    ):
+        """Area-resolved temp sensor + provenance surface in climate diagnostics (#786)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+        diag, _ = builder.build(
+            _base_ctx(
+                climate_mode=True,
+                pipeline_result=pr,
+                temp_sensor_entity_id="sensor.bedroom_temp",
+                temp_sensor_source="area",
+                temp_sensor_area_id="area_bedroom",
+            )
+        )
+        assert diag["temp_sensor"] == {
+            "entity_id": "sensor.bedroom_temp",
+            "source": "area",
+            "area_id": "area_bedroom",
+        }
+
+    def test_temp_sensor_absent_when_source_none(self, builder: DiagnosticsBuilder):
+        """No temp_sensor block when nothing resolved (source none)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+        diag, _ = builder.build(
+            _base_ctx(
+                climate_mode=True,
+                pipeline_result=pr,
+                temp_sensor_source="none",
+            )
+        )
+        assert "temp_sensor" not in diag
+
     def test_climate_conditions_cloud_coverage_true_when_active(
         self, builder: DiagnosticsBuilder
     ):

--- a/tests/test_duplicate_sync.py
+++ b/tests/test_duplicate_sync.py
@@ -83,6 +83,19 @@ class TestExtractSharedOptions:
         result = _extract_shared_options(entry)
         assert CONF_DEVICE_ID not in result
 
+    def test_duplicate_flow_drops_temp_entity(self):
+        """Duplicating a cover must not copy the per-room indoor temp sensor (#786).
+
+        The temp sensor is room-specific; a clone in another area should not
+        inherit the source cover's sensor. Area auto-resolution fills the gap.
+        """
+        entry = _make_entry(
+            {CONF_TEMP_ENTITY: "sensor.bedroom_temp", CONF_HEIGHT_WIN: 2.1}
+        )
+        result = _extract_shared_options(entry)
+        assert CONF_TEMP_ENTITY not in result
+        assert result[CONF_HEIGHT_WIN] == 2.1
+
     def test_includes_window_dimensions(self):
         """Verify window dimension options are included in the returned dict."""
         entry = _make_entry({CONF_HEIGHT_WIN: 2.1, CONF_AZIMUTH: 180})

--- a/tests/test_issue_632_daytime_gate.py
+++ b/tests/test_issue_632_daytime_gate.py
@@ -373,6 +373,7 @@ async def test_async_shutdown_cancels_gate_fallback_handle():
     coord._grace_mgr = MagicMock()
     coord._cancel_motion_timeout = MagicMock()
     coord._cancel_weather_timeout = MagicMock()
+    coord._sensor_health = MagicMock()
     coord._cmd_svc = MagicMock()
     coord._forecast_unsub = None
     coord._refresh_after_unsub = None

--- a/tests/test_managers/test_sensor_health_repairs.py
+++ b/tests/test_managers/test_sensor_health_repairs.py
@@ -1,0 +1,152 @@
+"""Tests for SensorHealthManager — Repair on sustained sensor unavailability (#786).
+
+The manager is entity-agnostic: it watches an ``{issue_key -> entity_id}``
+registry, debounces via ``TimeoutController`` so restarts / device re-adds don't
+nag, and raises/clears an informational Repair via the issue registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.sensor_health import (
+    SensorHealthManager,
+)
+
+pytestmark = pytest.mark.unit
+
+_MOD = "custom_components.adaptive_cover_pro.managers.sensor_health"
+_ISSUE_KEY = "temp_sensor_unavailable_entry1"
+_TRANSLATION_KEY = "temp_sensor_unavailable"
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test.sensor_health")
+
+
+def _make_hass(state):
+    """Mock hass whose states.get returns ``state`` (a mock or None)."""
+    hass = MagicMock()
+    hass.states.get.return_value = state
+    return hass
+
+
+def _state(value):
+    s = MagicMock()
+    s.state = value
+    return s
+
+
+async def _drain():
+    """Let the debounce task run (seconds=0)."""
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+
+class TestSensorHealthManager:
+    """Raise-on-sustained-unavailable, debounce, clear-on-recovery."""
+
+    async def test_repair_raised_on_sustained_unavailable(self, logger):
+        """An entity that stays unavailable past debounce raises the Repair."""
+        hass = _make_hass(_state("unavailable"))
+        mgr = SensorHealthManager(
+            hass, logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_watch(
+            _ISSUE_KEY, "sensor.bedroom_temp", translation_key=_TRANSLATION_KEY
+        )
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            mgr.evaluate()
+            await _drain()
+        create.assert_called_once()
+        # issue_id is the issue_key; informational (not fixable).
+        _args, kwargs = create.call_args
+        assert kwargs.get("is_fixable") is False
+        assert kwargs.get("translation_key") == _TRANSLATION_KEY
+
+    async def test_no_repair_on_transient_blip(self, logger):
+        """Unavailable then recovers before debounce → no Repair (debounce gate)."""
+        hass = _make_hass(_state("unavailable"))
+        mgr = SensorHealthManager(
+            hass, logger, domain="adaptive_cover_pro", debounce_seconds=100
+        )
+        mgr.update_watch(
+            _ISSUE_KEY, "sensor.bedroom_temp", translation_key=_TRANSLATION_KEY
+        )
+        with (
+            patch(f"{_MOD}.ir.async_create_issue") as create,
+            patch(f"{_MOD}.ir.async_delete_issue"),
+        ):
+            mgr.evaluate()  # starts the (long) debounce timer
+            hass.states.get.return_value = _state("21.0")  # recovered
+            mgr.evaluate()  # cancels the pending timer
+            await _drain()
+        create.assert_not_called()
+
+    async def test_repair_cleared_on_recovery(self, logger):
+        """A raised Repair is deleted once the entity recovers."""
+        hass = _make_hass(_state("unavailable"))
+        mgr = SensorHealthManager(
+            hass, logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_watch(
+            _ISSUE_KEY, "sensor.bedroom_temp", translation_key=_TRANSLATION_KEY
+        )
+        with (
+            patch(f"{_MOD}.ir.async_create_issue"),
+            patch(f"{_MOD}.ir.async_delete_issue") as delete,
+        ):
+            mgr.evaluate()
+            await _drain()
+            hass.states.get.return_value = _state("21.0")  # recovered
+            mgr.evaluate()
+        delete.assert_called_once()
+
+    async def test_missing_from_registry_triggers_repair(self, logger):
+        """An entity with no state at all (missing) is treated as unhealthy."""
+        hass = _make_hass(None)
+        mgr = SensorHealthManager(
+            hass, logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_watch(_ISSUE_KEY, "sensor.gone", translation_key=_TRANSLATION_KEY)
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            mgr.evaluate()
+            await _drain()
+        create.assert_called_once()
+
+    async def test_healthy_entity_never_raises(self, logger):
+        """A healthy entity never schedules or raises anything."""
+        hass = _make_hass(_state("21.0"))
+        mgr = SensorHealthManager(
+            hass, logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_watch(
+            _ISSUE_KEY, "sensor.bedroom_temp", translation_key=_TRANSLATION_KEY
+        )
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            mgr.evaluate()
+            await _drain()
+        create.assert_not_called()
+
+    async def test_unwatch_clears_issue_and_timer(self, logger):
+        """Clearing the watch (entity_id None) deletes any active Repair."""
+        hass = _make_hass(_state("unavailable"))
+        mgr = SensorHealthManager(
+            hass, logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_watch(
+            _ISSUE_KEY, "sensor.bedroom_temp", translation_key=_TRANSLATION_KEY
+        )
+        with (
+            patch(f"{_MOD}.ir.async_create_issue"),
+            patch(f"{_MOD}.ir.async_delete_issue") as delete,
+        ):
+            mgr.evaluate()
+            await _drain()
+            mgr.update_watch(_ISSUE_KEY, None, translation_key=_TRANSLATION_KEY)
+        delete.assert_called_once()

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -808,6 +808,7 @@ class TestPositionExplanationChangeDetection:
         coord._cover_data = _make_cover()
         coord._position_forecast = None
         coord._climate_mode = False
+        coord._weather_readings = None
         coord._pipeline_result = _make_pr()
         type(coord).check_adaptive_time = PropertyMock(return_value=True)
         type(coord).after_start_time = PropertyMock(return_value=True)

--- a/tests/test_state/test_climate_provider.py
+++ b/tests/test_state/test_climate_provider.py
@@ -108,6 +108,81 @@ class TestInsideTemperature:
 
 
 # ---------------------------------------------------------------------------
+# Resolved temperature source (issue #786)
+# ---------------------------------------------------------------------------
+
+
+def _patch_area(*, device_area_id=None, area_temp_entity=None):
+    """Patch the device + area registries the AreaSensorResolver reads."""
+    device = MagicMock()
+    device.area_id = device_area_id
+    device_reg = MagicMock()
+    device_reg.async_get.return_value = device if device_area_id is not None else None
+    area = MagicMock()
+    area.temperature_entity_id = area_temp_entity
+    area_reg = MagicMock()
+    area_reg.async_get_area.return_value = area if device_area_id is not None else None
+    mod = "custom_components.adaptive_cover_pro.state.area_resolver"
+    return (
+        patch(f"{mod}.dr.async_get", return_value=device_reg),
+        patch(f"{mod}.ar.async_get", return_value=area_reg),
+    )
+
+
+class TestResolvedTempSource:
+    """ClimateReadings carries the resolved temp entity_id + provenance."""
+
+    @pytest.mark.unit
+    def test_explicit_source(self, provider, mock_hass):
+        """Explicit temp entity → source 'explicit', entity surfaced."""
+        mock_hass.states.get.return_value = _mock_state("sensor.temp", "23.0")
+        readings = provider.read(temp_entity="sensor.temp", temp_device_id="dev1")
+        assert readings.inside_temperature == "23.0"
+        assert readings.inside_temperature_entity_id == "sensor.temp"
+        assert readings.inside_temperature_source == "explicit"
+
+    @pytest.mark.unit
+    def test_area_resolved_source(self, provider, mock_hass):
+        """No explicit entity → area's temp entity resolved and read."""
+        mock_hass.states.get.return_value = _mock_state("sensor.bedroom_temp", "19.5")
+        dev_patch, area_patch = _patch_area(
+            device_area_id="area_bedroom", area_temp_entity="sensor.bedroom_temp"
+        )
+        with dev_patch, area_patch:
+            readings = provider.read(temp_entity=None, temp_device_id="dev1")
+        assert readings.inside_temperature == "19.5"
+        assert readings.inside_temperature_entity_id == "sensor.bedroom_temp"
+        assert readings.inside_temperature_source == "area"
+
+    @pytest.mark.unit
+    def test_none_source_when_unresolved(self, provider):
+        """No explicit entity and no area temp → source 'none'."""
+        dev_patch, area_patch = _patch_area(device_area_id=None)
+        with dev_patch, area_patch:
+            readings = provider.read(temp_entity=None, temp_device_id="dev1")
+        assert readings.inside_temperature is None
+        assert readings.inside_temperature_entity_id is None
+        assert readings.inside_temperature_source == "none"
+
+    @pytest.mark.unit
+    def test_auto_resolve_disabled_skips_area(self, provider, mock_hass):
+        """auto_resolve off → area sensor ignored, source 'none'."""
+        mock_hass.states.get.return_value = _mock_state("sensor.bedroom_temp", "19.5")
+        dev_patch, area_patch = _patch_area(
+            device_area_id="area_bedroom", area_temp_entity="sensor.bedroom_temp"
+        )
+        with dev_patch, area_patch:
+            readings = provider.read(
+                temp_entity=None,
+                temp_device_id="dev1",
+                auto_resolve_temp_from_area=False,
+            )
+        assert readings.inside_temperature is None
+        assert readings.inside_temperature_entity_id is None
+        assert readings.inside_temperature_source == "none"
+
+
+# ---------------------------------------------------------------------------
 # Presence
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -44,6 +44,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_DRY_RUN,
     CONF_ENABLE_GLARE_ZONES,
     CONF_ENTITIES,
+    CONF_TEMP_ENTITY,
 )
 
 # Options intentionally in the Duplicate flow (copy-all) but NOT in selective sync.
@@ -142,15 +143,23 @@ class TestSyncCoverage:
         )
 
     def test_shared_options_excluded_is_exact(self):
-        """_SHARED_OPTIONS_EXCLUDED must stay exactly {CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID}.
+        """_SHARED_OPTIONS_EXCLUDED must stay exactly the per-window key set.
 
         Catches an option accidentally added to the exclusion set, which would
         silently drop it from the Duplicate flow as well as selective sync.
         If you genuinely need a new per-window exclusion, update this assertion
         with an explanation comment.
+
+        CONF_TEMP_ENTITY (issue #786): the indoor temperature sensor is
+        per-room, so duplicating a cover must not copy it — area
+        auto-resolution fills it in for the clone instead. It is still
+        available via explicit selective sync (temperature_climate_sensors
+        category), so it also lives in SYNC_CATEGORIES; that intentional
+        dual-membership is exempted in
+        ``test_shared_options_excluded_not_in_sync_categories``.
         """
         assert (
-            frozenset({CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID})
+            frozenset({CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID, CONF_TEMP_ENTITY})
             == _SHARED_OPTIONS_EXCLUDED
         )
 
@@ -171,11 +180,21 @@ class TestSyncCoverage:
     def test_shared_options_excluded_not_in_sync_categories(self):
         """Per-window excluded keys must not appear in SYNC_CATEGORIES either.
 
-        These keys are intentionally skipped in both flows; putting them in
-        SYNC_CATEGORIES would be contradictory.
+        These keys are intentionally skipped in the blanket Duplicate flow;
+        putting them in SYNC_CATEGORIES would normally be contradictory.
+
+        CONF_TEMP_ENTITY (issue #786) is the one deliberate exception: it is
+        excluded from Duplicate (a clone should not inherit the source room's
+        indoor temperature sensor — area auto-resolution fills it in) yet stays
+        in the temperature_climate_sensors category so a user can still copy it
+        via explicit selective sync. Those are two distinct user actions, so
+        the dual-membership is intentional.
         """
         all_sync_keys = frozenset().union(*SYNC_CATEGORIES.values())
-        overlap = _SHARED_OPTIONS_EXCLUDED & all_sync_keys
+        _INTENTIONAL_DUAL_MEMBERSHIP = frozenset({CONF_TEMP_ENTITY})
+        overlap = (
+            _SHARED_OPTIONS_EXCLUDED & all_sync_keys
+        ) - _INTENTIONAL_DUAL_MEMBERSHIP
 
         assert not overlap, (
             f"Keys in _SHARED_OPTIONS_EXCLUDED are also in SYNC_CATEGORIES: {sorted(overlap)}.\n"


### PR DESCRIPTION
## Summary
Auto-resolves the indoor temperature sensor from the cover's Home Assistant area, per the direction in #786 from @pkolbus. A cover with no explicit `temp_entity` now falls back to the temperature entity configured on its HA area (`device -> area -> AreaEntry.temperature_entity_id`), rather than a `device_class` scan. Explicit `CONF_TEMP_ENTITY` always wins. Gated by a new `auto_resolve_temp_from_area` toggle (default on, per-install opt-out).

Also: duplicating a cover no longer copies the temperature sensor (Part A), so a clone resolves its own room. The resolved entity and its provenance (explicit/area/none) surface in diagnostics and the config summary. A new generic `SensorHealthManager` raises an informational HA Repair when the effective sensor stays unavailable past a generous debounce, clearing on recovery, instead of silently overriding.

All HA registry reads live in the `state/` boundary; the pure engine gains no HA imports; `snapshot_builder` only threads `device_id` through. Temperature-only for now (HA area registry exposes only temperature/humidity); the resolver is built so motion/wind can be added later.

## Testing
- ✅ 5921 tests passing
- ✅ Ruff + black clean; DE/FR translation parity green

## Related Issues
Refs #786