### PR TITLE
fix: group text sensors show unavailable from empty unit (#843)

### DIFF
--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -79,8 +79,6 @@ class GroupStateSensor(_GroupEntityBase, SensorEntity):
     """Aggregate open/closed/mixed classification of the member covers."""
 
     _attr_translation_key = "group_state"
-    # Text/status sensor: empty unit excludes it from the logbook.
-    _attr_native_unit_of_measurement = ""
     _attr_icon = "mdi:window-shutter-cog"
 
     @property
@@ -93,7 +91,6 @@ class GroupActiveSceneSensor(_GroupEntityBase, SensorEntity):
     """The last scene activated on this group, if any."""
 
     _attr_translation_key = "group_active_scene"
-    _attr_native_unit_of_measurement = ""
     _attr_icon = "mdi:palette-outline"
 
     @property
@@ -194,7 +191,6 @@ class GroupClimateSensor(_GroupEntityBase, SensorEntity):
     """
 
     _attr_translation_key = "group_climate_mode"
-    _attr_native_unit_of_measurement = ""
     _attr_icon = "mdi:sun-thermometer-outline"
 
     # Wire-stable disagreement state, file-private: produced only by this

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -92,6 +92,30 @@ async def test_group_sensor_values(hass, group_entry) -> None:
     assert entities["group_01_group_active_scene"].native_value == GroupScene.PRIVACY
 
 
+@pytest.mark.parametrize(
+    "unique_id",
+    [
+        "group_01_group_state",
+        "group_01_group_active_scene",
+        "group_01_group_climate_mode",
+    ],
+)
+async def test_group_text_sensors_have_no_unit(hass, group_entry, unique_id) -> None:
+    """Text/status group sensors must not set a unit of measurement (issue #843).
+
+    Home Assistant's ``SensorEntity`` raises ``ValueError`` for a non-numeric value
+    when ``native_unit_of_measurement is not None`` — and an empty string ``""`` is
+    not ``None``. That raise aborts the state write and HA marks the entity
+    ``unavailable`` the moment the sensor holds a string (observed live on
+    ``sensor.<group>_group_state``). These sensors return strings, so they carry
+    no unit.
+    """
+    entities = {
+        e.unique_id: e for e in await _added_entities(sensor, hass, group_entry)
+    }
+    assert entities[unique_id].native_unit_of_measurement is None
+
+
 async def test_switch_platform_builds_group_automation_switch(
     hass, group_entry
 ) -> None:


### PR DESCRIPTION
## Summary
The group **Group State**, **Active Scene**, and **Climate Mode** sensors set an empty-string
`native_unit_of_measurement = ""` to hide from the logbook. Home Assistant's `SensorEntity`
raises `ValueError` for a non-numeric value when the unit is not `None` — and `""` is not
`None` — so the state write aborts and the entity is marked **unavailable** the moment it holds
a string.

`Group State` returns a `GroupState` string on every update, so it was unavailable immediately
(observed live). `Active Scene` and `Climate Mode` were latent — `unknown` while their value is
`None`, but they would flip to `unavailable` as soon as they held a real string. Dropping the
empty unit from all three fixes the reported symptom and the two latent cases.

## Testing
- ✅ 76 tests passing (group entities + coordinator + diagnostics + init + services + translation keys)
- New parametrized regression guard asserts the three text sensors carry no unit of measurement.

## Related Issues
Refs #843