### PR TITLE
feat: default group aggregate cover entity to on (#790)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -130,11 +130,13 @@ _RANGE_GROUP_STAGGER = (0.0, 30.0)
 GROUP_SCENE_SELECT_AUTO = "auto"
 
 # Entity-exposure toggles for a group entry (issue #790, Phase 3). The
-# aggregate cover entity defaults OFF (dashboard/voice clutter); the sensors
-# default ON. The active-scene sensor, scene controls, and bulk switches are
-# always created (primary control surface, no toggle).
+# aggregate cover entity defaults ON so a group is controllable as a single
+# cover out of the box; users opt out per-group to reduce dashboard/voice
+# clutter. The sensors also default ON. The active-scene sensor, scene
+# controls, and bulk switches are always created (primary control surface,
+# no toggle).
 CONF_GROUP_ENABLE_COVER_ENTITY = "group_enable_cover_entity"
-DEFAULT_GROUP_ENABLE_COVER_ENTITY = False
+DEFAULT_GROUP_ENABLE_COVER_ENTITY = True
 CONF_GROUP_ENABLE_POSITION_SENSOR = "group_enable_position_sensor"
 CONF_GROUP_ENABLE_STATE_SENSOR = "group_enable_state_sensor"
 CONF_GROUP_ENABLE_CLIMATE_SENSOR = "group_enable_climate_sensor"

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3356,13 +3356,19 @@ def test_summary_group_shows_cover_entity_line_when_enabled():
     )
 
     base = {CONF_MEMBER_ENTRIES: ["entry_a"], CONF_MEMBER_COVERS: []}
-    without = _build_config_summary(base, CoverType.GROUP)
+    without = _build_config_summary(
+        {**base, CONF_GROUP_ENABLE_COVER_ENTITY: False}, CoverType.GROUP
+    )
     assert "Aggregate cover entity" not in without
 
     with_cover = _build_config_summary(
         {**base, CONF_GROUP_ENABLE_COVER_ENTITY: True}, CoverType.GROUP
     )
     assert "Aggregate cover entity" in with_cover
+
+    # Default (key absent) now enables the cover, so the line appears.
+    by_default = _build_config_summary(base, CoverType.GROUP)
+    assert "Aggregate cover entity" in by_default
 
 
 def test_summary_group_shows_area_line_when_configured():

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -327,19 +327,36 @@ async def test_sensor_toggles_gate_creation(hass) -> None:
     assert entities == {"group_05_group_active_scene"}
 
 
-async def test_cover_platform_builds_group_cover_only_when_enabled(hass) -> None:
+async def test_cover_platform_builds_group_cover_per_toggle(hass) -> None:
     from custom_components.adaptive_cover_pro import cover
     from custom_components.adaptive_cover_pro.const import (
         CONF_GROUP_ENABLE_COVER_ENTITY,
     )
 
-    # Default: off — no group cover entity.
-    entry_off = MockConfigEntry(
+    # Default (key absent): on — the aggregate cover entity is built.
+    entry_default = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
         options={CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: ["cover.g1"]},
         entry_id="group_06",
         title="G",
+    )
+    entry_default.add_to_hass(hass)
+    entry_default.runtime_data = GroupCoordinator(hass, entry_default)
+    default_entities = await _added_entities(cover, hass, entry_default)
+    assert [e.unique_id for e in default_entities] == ["group_06_group_cover"]
+
+    # Explicitly disabled — no group cover entity.
+    entry_off = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G3", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [],
+            CONF_MEMBER_COVERS: ["cover.g1"],
+            CONF_GROUP_ENABLE_COVER_ENTITY: False,
+        },
+        entry_id="group_08",
+        title="G3",
     )
     entry_off.add_to_hass(hass)
     entry_off.runtime_data = GroupCoordinator(hass, entry_off)


### PR DESCRIPTION
## Summary
A cover group's aggregate cover entity (issue #790, Phase 3) was opt-in and off by default, so a new group exposed no cover-domain control until the user found the toggle. This flips `DEFAULT_GROUP_ENABLE_COVER_ENTITY` to `True` so every group is controllable as a single proxy cover — over both ACP members and generic HA covers — out of the box. The per-group toggle still lets users opt out to reduce dashboard/voice clutter.

Pure default-constant change: no schema, no migration. Groups that stored the toggle keep their value; groups that never set it gain the cover; a rollback to an older build simply hides it again with no config corruption.

Note: existing groups that never touched the toggle will gain a new `cover.` entity on upgrade — the intended effect, but a visible change for current users.

## Testing
- ✅ 5965 tests passing
- ✅ Ruff + pre-commit clean

## Related Issues
Refs #790

https://claude.ai/code/session_01ND4H5k66USt3L4nud33z4T