### PR TITLE
feat: forecast daily-max as climate outdoor-temp source (#547)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -573,6 +573,13 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_options.setdefault(CONF_WEATHER_ENABLED, True)
         new_minor = 6
 
+    # v3.6 → v3.7: added the additive outside_temp_source option (issue #547).
+    # An absent key already reads as "live" (the default), so nothing needs
+    # seeding — this is a no-op minor bump kept only to advance entries sitting
+    # at minor 6 to 7 so they stop re-triggering migration every restart.
+    if new_version == 3 and new_minor < 7:
+        new_minor = 7
+
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor
     )

--- a/custom_components/adaptive_cover_pro/config_dynamic.py
+++ b/custom_components/adaptive_cover_pro/config_dynamic.py
@@ -54,6 +54,7 @@ from .const import (
     CONF_LUX_THRESHOLD,
     CONF_MAX_ELEVATION,
     CONF_MIN_ELEVATION,
+    CONF_OUTSIDE_TEMP_SOURCE,
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
@@ -99,12 +100,14 @@ from .const import (
     DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
     DEFAULT_ENABLE_POSITION_MATCHING,
     DEFAULT_GLARE_ZONE_Z,
+    DEFAULT_OUTSIDE_TEMP_SOURCE,
     DEFAULT_WEATHER_RAIN_THRESHOLD,
     DEFAULT_WEATHER_TIMEOUT,
     DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE,
     DEFAULT_WEATHER_WIND_SPEED_THRESHOLD,
     DEFAULT_TEMPLATE_COMBINE_MODE,
     DEFAULT_WINDOW_AZIMUTH,
+    OutsideTempSource,
     TemplateCombineMode,
 )
 from .unit_system import length_default, length_selector
@@ -535,6 +538,18 @@ def temperature_climate_schema(
         vol.Optional(
             CONF_OUTSIDETEMP_ENTITY, default=vol.UNDEFINED
         ): numeric_selector(),
+        # Outdoor-temp source (issue #547): live (default), forecast daily-max,
+        # or the max of the two. The forecast is fetched from the configured
+        # weather entity — no separate picker.
+        vol.Optional(
+            CONF_OUTSIDE_TEMP_SOURCE, default=DEFAULT_OUTSIDE_TEMP_SOURCE
+        ): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=[m.value for m in OutsideTempSource],
+                mode=selector.SelectSelectorMode.LIST,
+                translation_key="outside_temp_source",
+            )
+        ),
         vol.Optional(
             CONF_PRESENCE_ENTITY, default=vol.UNDEFINED
         ): presence_like_selector(),

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -133,6 +133,7 @@ from .const import (
     MOTION_TIMEOUT_MODE_HOLD,
     MOTION_TIMEOUT_MODE_RETURN,
     CONF_OPEN_CLOSE_THRESHOLD,
+    CONF_OUTSIDE_TEMP_SOURCE,
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_POSITION_TOLERANCE,
@@ -3019,6 +3020,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
             CONF_TEMP_LOW,
             CONF_TEMP_HIGH,
+            CONF_OUTSIDE_TEMP_SOURCE,
             CONF_OUTSIDE_THRESHOLD,
             CONF_TRANSPARENT_BLIND,
             CONF_WINTER_CLOSE_INSULATION,
@@ -3045,6 +3047,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_TEMP_LOW,
             CONF_TEMP_HIGH,
             CONF_OUTSIDETEMP_ENTITY,
+            CONF_OUTSIDE_TEMP_SOURCE,
             CONF_OUTSIDE_THRESHOLD,
             CONF_PRESENCE_ENTITY,
             CONF_PRESENCE_TEMPLATE,
@@ -3077,6 +3080,7 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_TEMP_LOW,
             CONF_TEMP_HIGH,
             CONF_OUTSIDETEMP_ENTITY,
+            CONF_OUTSIDE_TEMP_SOURCE,
             CONF_OUTSIDE_THRESHOLD,
             CONF_PRESENCE_ENTITY,
             CONF_PRESENCE_TEMPLATE,
@@ -3387,8 +3391,10 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     # reconcile/chase behavior; new installs default to off via the schema.
     # 3.3 (issue #563 trailing defect): copy legacy custom_position_sensor_N
     # into the new list key.
+    # 3.7 (issue #547): no-op bump for the additive outside_temp_source option
+    # (absent key reads as "live"); advances stale minor-6 entries.
     # Rollback-safe: every migration block is additive (existing keys retained).
-    MINOR_VERSION = 6
+    MINOR_VERSION = 7
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()

--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -634,6 +634,7 @@ class RuntimeConfig:
     entities: list[str]
     open_close_threshold: int
     event_buffer_size: int
+    outside_temp_source: str
     tracking: TrackingSlice
     manual_override: ManualOverrideSlice
     time_window: TimeWindowSlice
@@ -680,6 +681,7 @@ class RuntimeConfig:
             CONF_MOTION_TEMPLATE_MODE,
             CONF_MOTION_TIMEOUT,
             CONF_OPEN_CLOSE_THRESHOLD,
+            CONF_OUTSIDE_TEMP_SOURCE,
             CONF_POSITION_TOLERANCE,
             CONF_START_ENTITY,
             CONF_START_TIME,
@@ -714,6 +716,7 @@ class RuntimeConfig:
             DEFAULT_MAX_COVERAGE_STEPS,
             DEFAULT_MINIMIZE_MOVEMENTS,
             DEFAULT_MOTION_TIMEOUT,
+            DEFAULT_OUTSIDE_TEMP_SOURCE,
             DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,
             DEFAULT_VENETIAN_MODE,
             DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
@@ -736,6 +739,9 @@ class RuntimeConfig:
             open_close_threshold=options.get(CONF_OPEN_CLOSE_THRESHOLD, 50),
             event_buffer_size=options.get(
                 CONF_DEBUG_EVENT_BUFFER_SIZE, DEFAULT_DEBUG_EVENT_BUFFER_SIZE
+            ),
+            outside_temp_source=options.get(
+                CONF_OUTSIDE_TEMP_SOURCE, DEFAULT_OUTSIDE_TEMP_SOURCE
             ),
             tracking=TrackingSlice(
                 min_change=options.get(CONF_DELTA_POSITION) or 1,

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -519,6 +519,10 @@ CONF_TEMP_ENTITY = "temp_entity"  # indoor temp sensor entity_id
 CONF_TEMP_LOW = "temp_low"  # "cold" threshold, sensor unit (0-90)
 CONF_TEMP_HIGH = "temp_high"  # "hot" threshold, sensor unit (0-90)
 CONF_OUTSIDETEMP_ENTITY = "outside_temp"  # outdoor temp sensor entity_id
+# Which outdoor-temperature reading climate mode uses (issue #547): one of
+# OutsideTempSource — live (default), forecast_max, or max_of_live_and_forecast.
+# Reuses the configured CONF_WEATHER_ENTITY as the forecast source.
+CONF_OUTSIDE_TEMP_SOURCE = "outside_temp_source"
 # Outdoor temp threshold for summer/winter mode switch (range 0-100).
 CONF_OUTSIDE_THRESHOLD = "outside_threshold"
 CONF_PRESENCE_ENTITY = "presence_entity"  # presence/occupancy sensor entity_id
@@ -1490,6 +1494,27 @@ class TemplateCombineMode(StrEnum):
 # custom-position slots, future consumers): additive OR (back-compat).
 DEFAULT_TEMPLATE_COMBINE_MODE = TemplateCombineMode.OR.value
 DEFAULT_MOTION_TEMPLATE_MODE = DEFAULT_TEMPLATE_COMBINE_MODE
+
+
+class OutsideTempSource(StrEnum):
+    """Which outdoor-temperature reading feeds climate mode (issue #547).
+
+    ``LIVE`` (default) preserves today's behaviour — the outdoor sensor state,
+    or the configured weather entity's ``temperature`` attribute (the *current*
+    temp). ``FORECAST_MAX`` uses today's forecast daily high fetched from the
+    configured weather entity via ``weather.get_forecasts`` (falling back to the
+    live read when no forecast is available). ``MAX_OF_LIVE_AND_FORECAST`` takes
+    the larger of the two so a cool morning that will heat up still trips summer
+    close. Wire-stable identifiers stored in the cover's options.
+    """
+
+    LIVE = "live"
+    FORECAST_MAX = "forecast_max"
+    MAX_OF_LIVE_AND_FORECAST = "max_of_live_and_forecast"
+
+
+# Default outdoor-temp source: LIVE, so upgrades are inert (issue #547).
+DEFAULT_OUTSIDE_TEMP_SOURCE = OutsideTempSource.LIVE.value
 
 
 # Defined here (above the ``config_fields`` import at the bottom of this module)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -545,6 +545,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._position_forecast: Forecast | None = None
         self._forecast_unsub: Callable[[], None] | None = None
 
+        # Issue #547: cached forecast daily-high (°) for the configured weather
+        # entity, refreshed on a slow wall-clock cadence by
+        # ``async_recompute_forecast_max`` and fed into the climate read so the
+        # outdoor-temp source switch can source it. ``None`` when the source is
+        # ``live``, no weather entity is configured, or the last fetch failed —
+        # in which case the provider degrades to the live read.
+        self._forecast_max_outside: float | None = None
+        self._forecast_max_unsub: Callable[[], None] | None = None
+
         # Issue #742: cancel handle for the single ``async_call_later`` wake that
         # flips the daytime gate from HOLDING its last-known verdict to the
         # astronomical fallback the moment the grace window expires (otherwise the
@@ -648,6 +657,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # forecast lands on a populated AdaptiveCoverData.  The compute itself
         # runs as a background task so setup never waits for it (issue #437).
         self._start_forecast_scheduler()
+        # Issue #547: outdoor forecast daily-high refresher (separate scheduler
+        # so the position-forecast timer stays a single-writer).
+        self._start_forecast_max_scheduler()
 
     def _start_forecast_scheduler(self) -> None:
         """Kick off the initial forecast compute + periodic recompute timer.
@@ -705,6 +717,44 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             second=0,
         )
 
+    def _start_forecast_max_scheduler(self) -> None:
+        """Kick off the initial outdoor forecast-max fetch + periodic refresh.
+
+        Issue #547: mirrors :meth:`_start_forecast_scheduler` but for the
+        outdoor forecast daily-high. The fetch is a single
+        ``weather.get_forecasts`` service call (cheap vs the position-forecast
+        astral walk) and no-ops on the coordinator side when the source is
+        ``live`` or no weather entity is configured. Idempotent: reuses the
+        existing unsubscribe handle if already scheduled.
+        """
+        from homeassistant.helpers.event import async_track_time_change
+
+        from .const import FORECAST_RECOMPUTE_INTERVAL_MIN
+
+        if self._forecast_max_unsub is not None:
+            return  # already scheduled
+
+        self.config_entry.async_create_background_task(
+            self.hass,
+            self.async_recompute_forecast_max(),
+            name="acp_initial_forecast_max",
+        )
+
+        @callback
+        def _tick_forecast_max(_now: dt.datetime) -> None:
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self.async_recompute_forecast_max(),
+                name="acp_periodic_forecast_max",
+            )
+
+        self._forecast_max_unsub = async_track_time_change(
+            self.hass,
+            _tick_forecast_max,
+            minute=range(0, 60, FORECAST_RECOMPUTE_INTERVAL_MIN),
+            second=0,
+        )
+
     async def async_recompute_forecast(self) -> None:
         """Refresh ``coordinator.data.position_forecast`` via an executor job.
 
@@ -730,6 +780,50 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self.data is not None:
             self.data = replace(self.data, position_forecast=forecast)
             self.async_update_listeners()
+
+    async def async_recompute_forecast_max(self) -> None:
+        """Refresh the cached outdoor forecast daily-high (issue #547).
+
+        Fetches today's forecast high from the configured weather entity via
+        ``weather.get_forecasts`` (type ``daily``) and caches it on
+        ``self._forecast_max_outside`` so the climate read's outdoor-temp
+        source switch can source it.
+
+        Runs only when the outdoor-temp source is not ``live`` AND a weather
+        entity is configured; otherwise the cache is cleared. Every failure
+        path — service error, missing/empty/non-numeric forecast — degrades to
+        ``None`` so the provider falls back to the live read. Hourly-only
+        weather integrations (no daily forecast) therefore degrade to live too.
+        """
+        from .const import (
+            CONF_OUTSIDE_TEMP_SOURCE,
+            CONF_WEATHER_ENTITY,
+            DEFAULT_OUTSIDE_TEMP_SOURCE,
+            OutsideTempSource,
+        )
+
+        options = self.config_entry.options
+        source = options.get(CONF_OUTSIDE_TEMP_SOURCE, DEFAULT_OUTSIDE_TEMP_SOURCE)
+        weather_entity = options.get(CONF_WEATHER_ENTITY)
+        if source == OutsideTempSource.LIVE.value or not weather_entity:
+            self._forecast_max_outside = None
+            return
+
+        try:
+            response = await self.hass.services.async_call(
+                "weather",
+                "get_forecasts",
+                {"type": "daily"},
+                target={"entity_id": weather_entity},
+                blocking=True,
+                return_response=True,
+            )
+            forecasts = (response or {}).get(weather_entity, {}).get("forecast") or []
+            today_high = float(forecasts[0]["temperature"])
+        except Exception:  # noqa: BLE001 — any service/parse failure degrades to live
+            self._forecast_max_outside = None
+            return
+        self._forecast_max_outside = today_high
 
     async def async_check_entity_state_change(
         self, event: Event[EventStateChangedData]
@@ -1244,7 +1338,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Read all climate-related entities (temp, presence, weather, lux, irradiance, cloud).
         # The result is stored in self._weather_readings and passed to PipelineSnapshot
         # so ClimateHandler and CloudSuppressionHandler can self-evaluate.
-        self._weather_readings = self._snapshot_builder.read_climate(options)
+        self._weather_readings = self._snapshot_builder.read_climate(
+            options, forecast_max_outside=self._forecast_max_outside
+        )
 
         # Sensor-health Repair (issue #786): watch the effective indoor temp
         # entity only when climate mode is on (the sensor is otherwise unused,
@@ -2772,6 +2868,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 if _temp_readings is not None
                 else None
             ),
+            outside_temp_source=(
+                _temp_readings.outside_temperature_source
+                if _temp_readings is not None
+                else "live"
+            ),
             check_adaptive_time=self.check_adaptive_time,
             after_start_time=self.after_start_time,
             before_end_time=self.before_end_time,
@@ -3295,6 +3396,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self._forecast_unsub is not None:
             self._forecast_unsub()
             self._forecast_unsub = None
+
+        # Cancel the outdoor forecast daily-high refresher (issue #547).
+        if self._forecast_max_unsub is not None:
+            self._forecast_max_unsub()
+            self._forecast_max_unsub = None
 
         # Cancel the daytime-gate fallback wake (issue #742).
         if self._gate_fallback_unsub is not None:

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -157,6 +157,13 @@ class DiagnosticContext:
     temp_sensor_source: str = "none"
     temp_sensor_area_id: str | None = None
 
+    # issue #547: provenance of the outdoor temperature actually used —
+    # "live", "forecast_max", "max_of_live_and_forecast", or "live_fallback".
+    # Threaded from the cycle's ClimateReadings; surfaced in temperature_details
+    # so a user can see whether climate mode reacted to the forecast or the
+    # live reading.
+    outside_temp_source: str = "live"
+
 
 # ---------------------------------------------------------------------------
 # Strategy label map (moved from coordinator class attribute)
@@ -586,6 +593,7 @@ class DiagnosticsBuilder:
             diagnostics["temperature_details"] = {
                 "inside_temperature": _round_temp(climate_data.inside_temperature),
                 "outside_temperature": _round_temp(climate_data.outside_temperature),
+                "outside_temperature_source": ctx.outside_temp_source,
                 "temp_switch": climate_data.temp_switch,
             }
 

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -53,6 +53,7 @@ from ..const import (
     CONF_MINIMIZE_MOVEMENTS,
     CONF_MOTION_TIMEOUT_MODE,
     CONF_MY_POSITION_VALUE,
+    CONF_OUTSIDE_TEMP_SOURCE,
     CONF_OUTSIDE_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
@@ -88,6 +89,7 @@ from ..const import (
     DEFAULT_MIN_TILT_SUN_ONLY,
     DEFAULT_MINIMIZE_MOVEMENTS,
     DEFAULT_MOTION_TIMEOUT_MODE,
+    DEFAULT_OUTSIDE_TEMP_SOURCE,
     DEFAULT_TEMPLATE_COMBINE_MODE,
 )
 from ..helpers import (
@@ -152,7 +154,9 @@ class PipelineSnapshotBuilder:
 
     # ---- HA reads ---------------------------------------------------------
 
-    def read_climate(self, options: dict) -> ClimateReadings:
+    def read_climate(
+        self, options: dict, *, forecast_max_outside: float | None = None
+    ) -> ClimateReadings:
         """Read all climate-related entities into a fresh ``ClimateReadings``.
 
         Single call to :meth:`ClimateProvider.read` for each update cycle.
@@ -165,6 +169,11 @@ class PipelineSnapshotBuilder:
         lux/irradiance are read whenever cloud suppression is enabled and the
         corresponding entity is configured — even if the climate-mode toggles
         are off.
+
+        ``forecast_max_outside`` is the coordinator's pre-fetched forecast
+        daily-high (issue #547). It is threaded through to the provider so
+        the ``outside_temp_source`` switch can source it; the builder stays
+        stateless (the fetch itself lives on the coordinator).
         """
         cloud_suppression_enabled = bool(options.get(CONF_CLOUD_SUPPRESSION, False))
         lux_entity = options.get(CONF_LUX_ENTITY)
@@ -185,6 +194,10 @@ class PipelineSnapshotBuilder:
                 )
             ),
             outside_entity=options.get(CONF_OUTSIDETEMP_ENTITY),
+            outside_temp_source=options.get(
+                CONF_OUTSIDE_TEMP_SOURCE, DEFAULT_OUTSIDE_TEMP_SOURCE
+            ),
+            forecast_max_outside=forecast_max_outside,
             presence_entity=options.get(CONF_PRESENCE_ENTITY),
             presence_template=options.get(CONF_PRESENCE_TEMPLATE),
             presence_template_mode=options.get(CONF_PRESENCE_TEMPLATE_MODE)

--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -36,6 +36,12 @@ class ClimateReadings:
     inside_temperature_entity_id: str | None = None
     inside_temperature_source: str = "none"
     inside_temperature_area_id: str | None = None
+    # Provenance of the outdoor temperature actually used (issue #547):
+    # "live" (sensor state / weather temp attr), "forecast_max" (pre-fetched
+    # daily high), "max_of_live_and_forecast" (true combine of both), or
+    # "live_fallback" (a forecast source was selected but no numeric forecast
+    # was available). Surfaced in diagnostics.
+    outside_temperature_source: str = "live"
 
 
 class ClimateProvider:
@@ -55,6 +61,8 @@ class ClimateProvider:
         auto_resolve_temp_from_area: bool = True,
         outside_entity: str | None = None,
         weather_entity: str | None = None,
+        outside_temp_source: str = "live",
+        forecast_max_outside: float | None = None,
         weather_condition: list[str] | None = None,
         presence_entity: str | None = None,
         presence_template: str | None = None,
@@ -78,10 +86,17 @@ class ClimateProvider:
             device_id=temp_device_id,
             auto_resolve=auto_resolve_temp_from_area,
         )
+        outside_temperature, outside_temperature_source = (
+            self._read_outside_temperature(
+                outside_entity,
+                weather_entity,
+                outside_temp_source,
+                forecast_max_outside,
+            )
+        )
         return ClimateReadings(
-            outside_temperature=self._read_outside_temperature(
-                outside_entity, weather_entity
-            ),
+            outside_temperature=outside_temperature,
+            outside_temperature_source=outside_temperature_source,
             inside_temperature=self._read_inside_temperature(resolved_temp.entity_id),
             inside_temperature_entity_id=resolved_temp.entity_id,
             inside_temperature_source=resolved_temp.source,
@@ -113,13 +128,67 @@ class ClimateProvider:
         self,
         outside_entity: str | None,
         weather_entity: str | None,
+        source: str = "live",
+        forecast_max_outside: float | None = None,
+    ) -> tuple[float | str | None, str]:
+        """Read outside temperature and its provenance (issue #547).
+
+        Returns a ``(value, source_label)`` tuple. ``source`` selects the
+        strategy; every forecast path degrades to the live read when no
+        numeric forecast is available so climate mode is never stranded:
+
+        - ``live`` → sensor state / weather temp attr, label ``live``.
+        - ``forecast_max`` → the pre-fetched daily high when numeric
+          (label ``forecast_max``), else the live read (label
+          ``live_fallback``).
+        - ``max_of_live_and_forecast`` → ``max(live, forecast)`` when both
+          are numeric (label ``max_of_live_and_forecast``); if only one is
+          available it is used with the matching single-source label.
+        """
+        live_value = self._read_live_outside(outside_entity, weather_entity)
+
+        if source == "live":
+            return live_value, "live"
+
+        forecast = self._coerce_float(forecast_max_outside)
+        live_num = self._coerce_float(live_value)
+
+        if source == "forecast_max":
+            if forecast is not None:
+                return forecast, "forecast_max"
+            return live_value, "live_fallback"
+
+        if source == "max_of_live_and_forecast":
+            if forecast is not None and live_num is not None:
+                return max(live_num, forecast), "max_of_live_and_forecast"
+            if forecast is not None:
+                return forecast, "forecast_max"
+            return live_value, "live_fallback"
+
+        # Unknown/absent source → safe live default.
+        return live_value, "live"
+
+    def _read_live_outside(
+        self,
+        outside_entity: str | None,
+        weather_entity: str | None,
     ) -> float | str | None:
-        """Read outside temperature from entity or weather fallback."""
+        """Live outdoor read: dedicated sensor, else weather temp attr."""
         if outside_entity:
             return get_safe_state(self._hass, outside_entity)
         if weather_entity:
             return state_attr(self._hass, weather_entity, "temperature")
         return None
+
+    @staticmethod
+    def _coerce_float(value: float | str | None) -> float | None:
+        """Coerce a reading to float, or None when non-numeric/unavailable."""
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (ValueError, TypeError):
+            return None
 
     def _read_inside_temperature(
         self,

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -678,7 +678,8 @@
           "presence_template_mode": "Logik der Vorlage \"Presence\"",
           "summer_close_bypass_sun_floor": "Vollständiges Schließen bei Sommerhitze",
           "temp_extreme_heat": "Schwellenwert Extremhitze (außen)",
-          "extreme_heat_position": "Halteposition bei Extremhitze"
+          "extreme_heat_position": "Halteposition bei Extremhitze",
+          "outside_temp_source": "Außentemperatur-Quelle"
         },
         "data_description": {
           "climate_mode": "Aktivieren Sie diese Option, um alle klimagestützten Beschattungssteuerungen zu aktivieren. Wenn deaktiviert, werden alle Einstellungen auf diesem Bildschirm ignoriert und die Beschattung folgt der normalen Sonne/Blendungsverfolgung.",
@@ -695,7 +696,8 @@
           "presence_template_mode": "Wie die Vorlage \"Presence\" sich mit der Entität \"Presence\" oben kombiniert. \"OR\" (Standard) – belegt, wenn die Vorlage wahr ist ODER die Entität aktiv ist. \"AND\" – belegt nur, wenn die Vorlage wahr ist UND die Entität aktiv ist. Ohne eine konfigurierte Entität entscheidet die Vorlage allein in beiden Modi. Hat nur Auswirkungen, wenn oben eine Vorlage \"Presence\" festgelegt ist.",
           "summer_close_bypass_sun_floor": "Bei Aktivierung schließt die Sommerhitze-Blockierung die Beschattung vollständig bis zur globalen Minimalposition und ignoriert die höhere Minimalposition-wenn-Sonne-im-Sichtfeld-Grenze. Verwenden Sie dies für vollständigen Hitzeschutz im Sommer, auch wenn die Sonne direkt auf dem Fenster ist. Hat keine Auswirkungen außerhalb des Sommers, und die Maximalpositionsgrenze gilt weiterhin.",
           "temp_extreme_heat": "Außentemperatur, oberhalb derer die Beschattung den ganzen Tag eine feste Position hält – unabhängig von Sonnenstand, Anwesenheit oder Jahreszeit – und sogar die Winterheizung übersteuert. Leer lassen, um den Extremhitze-Modus zu deaktivieren. **Der Wert wird in der Einheit des Außensensors interpretiert, nicht in der Anzeigeeinheit von Home Assistant.** Akzeptiert eine feste Zahl oder eine Home-Assistant-Jinja2-Vorlage, die zu einer Zahl ausgewertet und in jedem Aktualisierungszyklus neu berechnet wird.",
-          "extreme_heat_position": "Position, die die Beschattung bei Extremhitze hält (0 % = vollständig geschlossen/eingefahren, Standard wenn leer gelassen). Bei Lamellenbehängen ist dies der Lamellenwinkel in Prozent. Die Halteposition berücksichtigt weiterhin Ihre konfigurierten Minimal-/Maximalpositionsgrenzen."
+          "extreme_heat_position": "Position, die die Beschattung bei Extremhitze hält (0 % = vollständig geschlossen/eingefahren, Standard wenn leer gelassen). Bei Lamellenbehängen ist dies der Lamellenwinkel in Prozent. Die Halteposition berücksichtigt weiterhin Ihre konfigurierten Minimal-/Maximalpositionsgrenzen.",
+          "outside_temp_source": "Welche Außentemperatur der Klimamodus verwendet. „Live-Lesung\" (Standard) behält das heutige Verhalten bei – der Außensensor oder die aktuelle Temperatur der Wetter-Entität. „Vorhersage Tagesmaximum\" nutzt das heutige Vorhersage-Maximum der konfigurierten Wetter-Entität (fällt auf die Live-Lesung zurück, wenn keine Vorhersage verfügbar ist). „Höher von Live und Vorhersage\" nimmt den wärmeren Wert, sodass ein kühler Morgen, der sich aufwärmt, auch im Sommer zum Schließen führt. Die Vorhersage wird von der bereits konfigurierten Wetter-Entität abgerufen – keine zusätzliche Auswahl erforderlich."
         }
       },
       "behavior": {
@@ -1506,7 +1508,8 @@
           "presence_template_mode": "Logik der Vorlage \"Presence\"",
           "summer_close_bypass_sun_floor": "Vollständiges Schließen bei Sommerhitze",
           "temp_extreme_heat": "Schwellenwert Extremhitze (außen)",
-          "extreme_heat_position": "Halteposition bei Extremhitze"
+          "extreme_heat_position": "Halteposition bei Extremhitze",
+          "outside_temp_source": "Außentemperatur-Quelle"
         },
         "data_description": {
           "climate_mode": "Aktivieren Sie diese Option, um alle klimagestützten Beschattungssteuerungen zu aktivieren. Wenn deaktiviert, werden alle Einstellungen auf diesem Bildschirm ignoriert und die Beschattung folgt der normalen Sonne/Blendungsverfolgung.",
@@ -1523,7 +1526,8 @@
           "presence_template_mode": "Wie die Vorlage \"Presence\" sich mit der Entität \"Presence\" oben kombiniert. \"OR\" (Standard) – belegt, wenn die Vorlage wahr ist ODER die Entität aktiv ist. \"AND\" – belegt nur, wenn die Vorlage wahr ist UND die Entität aktiv ist. Ohne eine konfigurierte Entität entscheidet die Vorlage allein in beiden Modi. Hat nur Auswirkungen, wenn oben eine Vorlage \"Presence\" festgelegt ist.",
           "summer_close_bypass_sun_floor": "Bei Aktivierung schließt die Sommerhitze-Blockierung die Beschattung vollständig bis zur globalen Minimalposition und ignoriert die höhere Minimalposition-wenn-Sonne-im-Sichtfeld-Grenze. Verwenden Sie dies für vollständigen Hitzeschutz im Sommer, auch wenn die Sonne direkt auf dem Fenster ist. Hat keine Auswirkungen außerhalb des Sommers, und die Maximalpositionsgrenze gilt weiterhin.",
           "temp_extreme_heat": "Außentemperatur, oberhalb derer die Beschattung den ganzen Tag eine feste Position hält – unabhängig von Sonnenstand, Anwesenheit oder Jahreszeit – und sogar die Winterheizung übersteuert. Leer lassen, um den Extremhitze-Modus zu deaktivieren. **Der Wert wird in der Einheit des Außensensors interpretiert, nicht in der Anzeigeeinheit von Home Assistant.** Akzeptiert eine feste Zahl oder eine Home-Assistant-Jinja2-Vorlage, die zu einer Zahl ausgewertet und in jedem Aktualisierungszyklus neu berechnet wird.",
-          "extreme_heat_position": "Position, die die Beschattung bei Extremhitze hält (0 % = vollständig geschlossen/eingefahren, Standard wenn leer gelassen). Bei Lamellenbehängen ist dies der Lamellenwinkel in Prozent. Die Halteposition berücksichtigt weiterhin Ihre konfigurierten Minimal-/Maximalpositionsgrenzen."
+          "extreme_heat_position": "Position, die die Beschattung bei Extremhitze hält (0 % = vollständig geschlossen/eingefahren, Standard wenn leer gelassen). Bei Lamellenbehängen ist dies der Lamellenwinkel in Prozent. Die Halteposition berücksichtigt weiterhin Ihre konfigurierten Minimal-/Maximalpositionsgrenzen.",
+          "outside_temp_source": "Welche Außentemperatur der Klimamodus verwendet. „Live-Lesung\" (Standard) behält das heutige Verhalten bei – der Außensensor oder die aktuelle Temperatur der Wetter-Entität. „Vorhersage Tagesmaximum\" nutzt das heutige Vorhersage-Maximum der konfigurierten Wetter-Entität (fällt auf die Live-Lesung zurück, wenn keine Vorhersage verfügbar ist). „Höher von Live und Vorhersage\" nimmt den wärmeren Wert, sodass ein kühler Morgen, der sich aufwärmt, auch im Sommer zum Schließen führt. Die Vorhersage wird von der bereits konfigurierten Wetter-Entität abgerufen – keine zusätzliche Auswahl erforderlich."
         }
       },
       "behavior": {
@@ -1631,7 +1635,8 @@
           "weather_rain_sensor": "Numerischer Sensor, der Niederschlagsrate meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren.",
           "weather_severe_sensors": "Binärsensoren für schwere Bedingungen (Hagel, Frost, Gewitter usw.). Übersteuerung aktiviert sich, wenn EIN Sensor ‚an' ist. Leer lassen zum Ignorieren.",
           "weather_wind_direction_sensor": "Optional: Trigger Wind-Übersteuerung nur, wenn Wind gegen das Azimut dieses Fensters weht (innerhalb der Richtungstoleranz). Leer lassen, um Übersteuerung allein auf Windgeschwindigkeit zu triggern, unabhängig von der Richtung.",
-          "weather_wind_speed_sensor": "Numerischer Sensor, der Windgeschwindigkeit meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren."
+          "weather_wind_speed_sensor": "Numerischer Sensor, der Windgeschwindigkeit meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren.",
+          "outside_temp_source": "Welche Außentemperatur der Klimamodus für alle verknüpften Beschattungen verwendet. „Live-Lesung\" (Standard) behält das heutige Verhalten bei. „Vorhersage Tagesmaximum\" nutzt das heutige Vorhersage-Maximum der konfigurierten Wetter-Entität (fällt auf Live-Lesung zurück, wenn nicht verfügbar). „Höher von Live und Vorhersage\" nimmt den wärmeren Wert."
         }
       },
       "profile_overview": {
@@ -1949,6 +1954,13 @@
         "bi_part": "Mittig öffnend – zwei Flügel treffen sich in der Mitte",
         "left": "Einflügelig – am linken Rand befestigt, schließt nach rechts",
         "right": "Einflügelig – am rechten Rand befestigt, schließt nach links"
+      }
+    },
+    "outside_temp_source": {
+      "options": {
+        "live": "Live-Lesung (Standard) – aktueller Außensensor oder Wetter-Temperatur",
+        "forecast_max": "Vorhersage Tagesmaximum – heutiges Vorhersage-Maximum der Wetter-Entität",
+        "max_of_live_and_forecast": "Höher von Live und Vorhersage – welcher Wert gerade wärmer ist"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -700,6 +700,7 @@
           "temp_low": "Low temperature threshold",
           "temp_high": "High temperature threshold",
           "outside_temp": "Outside temperature sensor (optional)",
+          "outside_temp_source": "Outdoor temperature source",
           "outside_threshold": "Outside temperature threshold",
           "presence_entity": "Presence entity (optional)",
           "presence_template": "Presence template (optional)",
@@ -717,6 +718,7 @@
           "temp_low": "Indoor (or outdoor, if an outside sensor is configured) temperature below which the season is treated as winter. In winter the cover opens fully when the sun is hitting the window to capture solar heat. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "temp_high": "Indoor (or outdoor, if an outside sensor is configured) temperature above which the season is treated as summer — provided the outside threshold is also exceeded. In summer the cover closes to block heat gain. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "outside_temp": "Optional outdoor temperature sensor. When provided, this reading (rather than the indoor sensor) determines the current season, and the outside threshold guard is applied to prevent summer-close behavior on cold days.",
+          "outside_temp_source": "Which outdoor temperature reading climate mode uses. 'Live reading' (default) keeps today's behavior — the outdoor sensor or the weather entity's current temperature. 'Forecast daily high' uses today's forecast maximum from the configured weather entity (falling back to the live reading when no forecast is available). 'Higher of live and forecast' takes whichever is warmer, so a cool morning that will heat up still triggers summer close. The forecast is fetched from the weather entity you already configured — no extra picker needed.",
           "outside_threshold": "Minimum outdoor temperature required before summer mode activates. Guards against closing covers on a hot indoor day when it is actually cold outside. Only used when an outside temperature sensor is configured. **Value is interpreted in that outside sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "presence_entity": "Optional presence sensor, device tracker, or zone. When someone is home, the cover uses glare-control tracking in intermediate conditions; when nobody is home a simpler summer-closed / winter-open rule applies. Leave blank to always treat the space as occupied.",
           "presence_template": "Optional Home Assistant Jinja2 template that reports occupancy. When it renders truthy (on/true/1) the space counts as occupied; when falsy it is treated as empty. How it combines with the Presence entity above (OR or AND) is set by 'Presence template logic' below; it can stand alone with no entity. Use this for composite occupancy (e.g. anyone home AND awake). A template that is empty or fails to render gives no opinion, so the Presence entity logic decides. Leave empty to disable.",
@@ -1550,6 +1552,7 @@
           "temp_low": "Low temperature threshold",
           "temp_high": "High temperature threshold",
           "outside_temp": "Outside temperature sensor (optional)",
+          "outside_temp_source": "Outdoor temperature source",
           "outside_threshold": "Outside temperature threshold",
           "presence_entity": "Presence entity (optional)",
           "presence_template": "Presence template (optional)",
@@ -1567,6 +1570,7 @@
           "temp_low": "Indoor (or outdoor, if an outside sensor is configured) temperature below which the season is treated as winter. In winter the cover opens fully when the sun is hitting the window to capture solar heat. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "temp_high": "Indoor (or outdoor, if an outside sensor is configured) temperature above which the season is treated as summer — provided the outside threshold is also exceeded. In summer the cover closes to block heat gain. **Value is interpreted in the configured temperature sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "outside_temp": "Optional outdoor temperature sensor. When provided, this reading (rather than the indoor sensor) determines the current season, and the outside threshold guard is applied to prevent summer-close behavior on cold days.",
+          "outside_temp_source": "Which outdoor temperature reading climate mode uses. 'Live reading' (default) keeps today's behavior — the outdoor sensor or the weather entity's current temperature. 'Forecast daily high' uses today's forecast maximum from the configured weather entity (falling back to the live reading when no forecast is available). 'Higher of live and forecast' takes whichever is warmer, so a cool morning that will heat up still triggers summer close. The forecast is fetched from the weather entity you already configured — no extra picker needed.",
           "outside_threshold": "Minimum outdoor temperature required before summer mode activates. Guards against closing covers on a hot indoor day when it is actually cold outside. Only used when an outside temperature sensor is configured. **Value is interpreted in that outside sensor's unit, not Home Assistant's display unit.** Accepts a fixed number or a Home Assistant Jinja2 template that evaluates to a number, re-evaluated each update cycle.",
           "presence_entity": "Optional presence sensor, device tracker, or zone. When someone is home, the cover uses glare-control tracking in intermediate conditions; when nobody is home a simpler summer-closed / winter-open rule applies. Leave blank to always treat the space as occupied.",
           "presence_template": "Optional Home Assistant Jinja2 template that reports occupancy. When it renders truthy (on/true/1) the space counts as occupied; when falsy it is treated as empty. How it combines with the Presence entity above (OR or AND) is set by 'Presence template logic' below; it can stand alone with no entity. Use this for composite occupancy (e.g. anyone home AND awake). A template that is empty or fails to render gives no opinion, so the Presence entity logic decides. Leave empty to disable.",
@@ -1621,6 +1625,7 @@
           "is_sunny_template": "Optional Home Assistant Jinja2 template that decides whether the sun is on the window. Leave empty to disable.",
           "lux_entity": "Optional illuminance sensor (indoor or outdoor) for precise sun detection. Leave empty if you don't have this sensor.",
           "outside_temp": "Optional outdoor temperature sensor. When provided, this reading determines the current season for all linked covers.",
+          "outside_temp_source": "Which outdoor temperature reading climate mode uses for all linked covers. 'Live reading' (default) keeps today's behavior. 'Forecast daily high' uses today's forecast maximum from the configured weather entity (falling back to live when unavailable). 'Higher of live and forecast' takes whichever is warmer.",
           "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). Falls back to astral if unavailable.",
           "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). Falls back to astral if unavailable.",
           "weather_entity": "Optional weather integration used to detect cloud cover. Leave empty to ignore weather state.",
@@ -1899,6 +1904,13 @@
       "options": {
         "or": "OR — occupied if the template is true or a sensor is active (default)",
         "and": "AND — require the template to be true and a sensor active"
+      }
+    },
+    "outside_temp_source": {
+      "options": {
+        "live": "Live reading (default) — current outdoor sensor or weather temperature",
+        "forecast_max": "Forecast daily high — today's forecast maximum from the weather entity",
+        "max_of_live_and_forecast": "Higher of live and forecast — whichever is warmer right now"
       }
     },
     "blind_spot_elevation_mode": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -678,7 +678,8 @@
           "presence_template_mode": "Logique du modèle de présence",
           "summer_close_bypass_sun_floor": "Fermeture complète en cas de chaleur estivale",
           "temp_extreme_heat": "Seuil de chaleur extrême (extérieur)",
-          "extreme_heat_position": "Position de maintien en chaleur extrême"
+          "extreme_heat_position": "Position de maintien en chaleur extrême",
+          "outside_temp_source": "Source de température extérieure"
         },
         "data_description": {
           "climate_mode": "Activez pour activer tout le contrôle du store basé sur le climat. Quand désactivé, tous les paramètres de cet écran sont ignorés et le store suit le suivi solaire/anti-éblouissement normal.",
@@ -695,7 +696,8 @@
           "presence_template_mode": "Comment le modèle de présence se combine avec l'entité de présence ci-dessus. « OU » (par défaut) — occupé lorsque le modèle est vrai OU l'entité est active. « ET » — occupé uniquement lorsque le modèle est vrai ET l'entité est active. Sans entité configurée, le modèle seul décide dans chaque mode. N'a d'effet que lorsqu'un modèle de présence est défini ci-dessus.",
           "summer_close_bypass_sun_floor": "Quand activé, le blocage de la chaleur estivale ferme complètement la protection jusqu'à la position minimale globale, en ignorant le seuil plus élevé de « position minimale lorsque le soleil est dans le champ de vision ». Utilisez ceci pour une protection thermique complète en été, même lorsque le soleil est directement sur la fenêtre. N'a aucun effet en dehors de l'été, et la limite de position maximale s'applique toujours.",
           "temp_extreme_heat": "Température extérieure au-delà de laquelle la protection maintient une position fixe toute la journée — indépendamment de la position du soleil, de la présence ou de la saison — prenant le pas sur le chauffage hivernal. Laisser vide pour désactiver le mode chaleur extrême. **La valeur est interprétée dans l'unité du capteur extérieur, pas l'unité d'affichage de Home Assistant.** Accepte un nombre fixe ou un modèle Jinja2 Home Assistant qui évalue à un nombre, réévalué à chaque cycle de mise à jour.",
-          "extreme_heat_position": "Position que la protection maintient en chaleur extrême (0 % = complètement fermée/rétractée, la valeur par défaut si laissée vide). Pour les protections avec inclinaison, il s'agit du pourcentage d'angle de lamelle. Le maintien respecte toujours vos limites de position minimale/maximale configurées."
+          "extreme_heat_position": "Position que la protection maintient en chaleur extrême (0 % = complètement fermée/rétractée, la valeur par défaut si laissée vide). Pour les protections avec inclinaison, il s'agit du pourcentage d'angle de lamelle. Le maintien respecte toujours vos limites de position minimale/maximale configurées.",
+          "outside_temp_source": "Quelle lecture de température extérieure le mode climatique utilise. « Lecture en temps réel » (défaut) conserve le comportement actuel — le capteur extérieur ou la température actuelle de l'entité météo. « Maximum de prévision journalière » utilise le maximum de prévision d'aujourd'hui à partir de l'entité météo configurée (revenant à la lecture en temps réel quand aucune prévision n'est disponible). « Maximum de lecture en temps réel et prévision » utilise la valeur la plus élevée, de sorte qu'une matinée fraîche qui se réchauffera déclenche toujours la fermeture estivale. La prévision est extraite de l'entité météo que vous avez déjà configurée — aucun sélecteur supplémentaire n'est nécessaire."
         }
       },
       "behavior": {
@@ -1506,7 +1508,8 @@
           "presence_template_mode": "Logique du modèle de présence",
           "summer_close_bypass_sun_floor": "Fermeture complète en cas de chaleur estivale",
           "temp_extreme_heat": "Seuil de chaleur extrême (extérieur)",
-          "extreme_heat_position": "Position de maintien en chaleur extrême"
+          "extreme_heat_position": "Position de maintien en chaleur extrême",
+          "outside_temp_source": "Source de température extérieure"
         },
         "data_description": {
           "climate_mode": "Activez pour activer tout le contrôle du store basé sur le climat. Quand désactivé, tous les paramètres de cet écran sont ignorés et le store suit le suivi solaire/anti-éblouissement normal.",
@@ -1523,7 +1526,8 @@
           "presence_template_mode": "Comment le modèle de présence se combine avec l'entité de présence ci-dessus. « OU » (par défaut) — occupé lorsque le modèle est vrai OU l'entité est active. « ET » — occupé uniquement lorsque le modèle est vrai ET l'entité est active. Sans entité configurée, le modèle seul décide dans chaque mode. N'a d'effet que lorsqu'un modèle de présence est défini ci-dessus.",
           "summer_close_bypass_sun_floor": "Quand activé, le blocage de la chaleur estivale ferme complètement la protection jusqu'à la position minimale globale, en ignorant le seuil plus élevé de « position minimale lorsque le soleil est dans le champ de vision ». Utilisez ceci pour une protection thermique complète en été, même lorsque le soleil est directement sur la fenêtre. N'a aucun effet en dehors de l'été, et la limite de position maximale s'applique toujours.",
           "temp_extreme_heat": "Température extérieure au-delà de laquelle la protection maintient une position fixe toute la journée — indépendamment de la position du soleil, de la présence ou de la saison — prenant le pas sur le chauffage hivernal. Laisser vide pour désactiver le mode chaleur extrême. **La valeur est interprétée dans l'unité du capteur extérieur, pas l'unité d'affichage de Home Assistant.** Accepte un nombre fixe ou un modèle Jinja2 Home Assistant qui évalue à un nombre, réévalué à chaque cycle de mise à jour.",
-          "extreme_heat_position": "Position que la protection maintient en chaleur extrême (0 % = complètement fermée/rétractée, la valeur par défaut si laissée vide). Pour les protections avec inclinaison, il s'agit du pourcentage d'angle de lamelle. Le maintien respecte toujours vos limites de position minimale/maximale configurées."
+          "extreme_heat_position": "Position que la protection maintient en chaleur extrême (0 % = complètement fermée/rétractée, la valeur par défaut si laissée vide). Pour les protections avec inclinaison, il s'agit du pourcentage d'angle de lamelle. Le maintien respecte toujours vos limites de position minimale/maximale configurées.",
+          "outside_temp_source": "Quelle lecture de température extérieure le mode climatique utilise. « Lecture en temps réel » (défaut) conserve le comportement actuel — le capteur extérieur ou la température actuelle de l'entité météo. « Maximum de prévision journalière » utilise le maximum de prévision d'aujourd'hui à partir de l'entité météo configurée (revenant à la lecture en temps réel quand aucune prévision n'est disponible). « Maximum de lecture en temps réel et prévision » utilise la valeur la plus élevée, de sorte qu'une matinée fraîche qui se réchauffera déclenche toujours la fermeture estivale. La prévision est extraite de l'entité météo que vous avez déjà configurée — aucun sélecteur supplémentaire n'est nécessaire."
         }
       },
       "behavior": {
@@ -1631,7 +1635,8 @@
           "weather_rain_sensor": "Capteur numérique signalant le taux de pluie. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer le taux de pluie.",
           "weather_severe_sensors": "Capteurs binaires pour les conditions graves (grêle, gel, tempête, etc.). La dérogation s'active quand N'IMPORTE QUEL capteur est « activé ». Laissez vide pour ignorer.",
           "weather_wind_direction_sensor": "Optionnel : ne déclenchez la dérogation vent que quand le vent souffle vers l'azimut de cette fenêtre (dans la tolérance de direction). Laissez vide pour déclencher uniquement sur la vitesse du vent indépendamment de la direction.",
-          "weather_wind_speed_sensor": "Capteur numérique signalant la vitesse du vent. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer la vitesse du vent."
+          "weather_wind_speed_sensor": "Capteur numérique signalant la vitesse du vent. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer la vitesse du vent.",
+          "outside_temp_source": "Quelle lecture de température extérieure le mode climatique utilise pour toutes les protections liées. « Lecture en temps réel » (défaut) conserve le comportement actuel. « Maximum de prévision journalière » utilise le maximum de prévision d'aujourd'hui à partir de l'entité météo configurée (revenant à la lecture en temps réel quand indisponible). « Maximum de lecture en temps réel et prévision » utilise la valeur la plus élevée."
         }
       },
       "profile_overview": {
@@ -1949,6 +1954,13 @@
         "bi_part": "Ouverture centrale — deux pans se rejoignent au milieu",
         "left": "Un seul pan — ancré à gauche, se ferme vers la droite",
         "right": "Un seul pan — ancré à droite, se ferme vers la gauche"
+      }
+    },
+    "outside_temp_source": {
+      "options": {
+        "live": "Lecture en temps réel (défaut) — capteur extérieur courant ou température météo",
+        "forecast_max": "Maximum de prévision journalière — maximum de prévision d'aujourd'hui de l'entité météo",
+        "max_of_live_and_forecast": "Maximum de lecture en temps réel et prévision — la valeur la plus élevée en ce moment"
       }
     }
   },

--- a/tests/test_climate_cover_data.py
+++ b/tests/test_climate_cover_data.py
@@ -271,3 +271,83 @@ class TestExtremeHeat:
         climate_data = _make_climate()
         assert climate_data.temp_extreme_heat is None
         assert climate_data.extreme_heat_position is None
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: forecast-max outdoor-temp source drives the season logic (#547)
+# ---------------------------------------------------------------------------
+
+
+class TestForecastMaxEndToEnd:
+    """Provider outdoor-temp source flows through into ClimateCoverData.
+
+    Reporter scenario: live 15 C, forecast daily-high 26 C, summer limit 23 C.
+    ``max_of_live_and_forecast`` must trip summer close; ``live`` must not yet.
+    The season properties are source-agnostic — they receive whatever single
+    number the provider produced — so this pins the wiring, not new logic.
+    """
+
+    def _provider(self):
+        from unittest.mock import MagicMock
+
+        from custom_components.adaptive_cover_pro.state.climate_provider import (
+            ClimateProvider,
+        )
+
+        hass = MagicMock()
+        live = MagicMock()
+        live.entity_id = "sensor.outside"
+        live.state = "15.0"
+        live.attributes = {}
+        hass.states.get.return_value = live
+        return ClimateProvider(hass=hass, logger=MagicMock())
+
+    @pytest.mark.unit
+    def test_combined_source_trips_summer(self):
+        provider = self._provider()
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="max_of_live_and_forecast",
+            forecast_max_outside=26.0,
+        )
+        climate_data = _make_climate(
+            temp_switch=True,
+            temp_high=25.0,
+            temp_summer_outside=23.0,
+            outside_temperature=readings.outside_temperature,
+        )
+        assert climate_data.outside_high is True
+        assert climate_data.is_summer is True
+
+    @pytest.mark.unit
+    def test_live_source_does_not_trip_summer(self):
+        provider = self._provider()
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="live",
+            forecast_max_outside=26.0,
+        )
+        climate_data = _make_climate(
+            temp_switch=True,
+            temp_high=25.0,
+            temp_summer_outside=23.0,
+            outside_temperature=readings.outside_temperature,
+        )
+        assert climate_data.outside_high is False
+        assert climate_data.is_summer is False
+
+    @pytest.mark.unit
+    def test_extreme_heat_picks_up_forecast_max(self):
+        """is_extreme_heat keys on outside_temperature, so forecast max feeds it."""
+        provider = self._provider()
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="forecast_max",
+            forecast_max_outside=38.0,
+        )
+        climate_data = _make_climate(
+            temp_switch=False,  # extreme heat ignores temp_switch
+            temp_extreme_heat=35.0,
+            outside_temperature=readings.outside_temperature,
+        )
+        assert climate_data.is_extreme_heat is True

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -250,7 +250,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -286,7 +286,7 @@ async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -299,7 +299,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -326,7 +326,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -363,7 +363,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -405,7 +405,7 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
@@ -428,7 +428,7 @@ async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
@@ -441,7 +441,7 @@ async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -454,7 +454,7 @@ async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
@@ -463,7 +463,7 @@ async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> 
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
     assert entry.version == 3
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 # ---------------------------------------------------------------------------
@@ -485,7 +485,7 @@ async def test_migrate_v3_6_sets_weather_enabled_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=5)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -498,7 +498,7 @@ async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is False
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
@@ -511,7 +511,7 @@ async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
 
 
 async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> None:
@@ -520,7 +520,62 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
     assert entry.version == 3
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
+
+
+# ---------------------------------------------------------------------------
+# Migration: v3.6 → v3.7 — no-op minor bump for the additive outside_temp_source
+# option (issue #547). An absent key already reads as "live" (the default), so
+# nothing needs seeding; the block only advances a stale minor-6 entry to 7.
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
+    """A minor-6 entry advances to minor 7 without altering any option."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180, CONF_WEATHER_ENABLED: True},
+        version=3,
+        minor_version=6,
+    )
+    before = dict(entry.options)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 7
+    # Additive/no-op: no outside_temp_source key seeded, options untouched.
+    assert "outside_temp_source" not in entry.options
+    assert entry.options == before
+
+
+async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
+    """Running the migration twice on a minor-6 entry is stable."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=6,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    first = dict(entry.options)
+    assert entry.minor_version == 7
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 7
+    assert entry.options == first
+
+
+async def test_migrate_v3_6_to_3_7_preserves_explicit_source(
+    hass: HomeAssistant,
+) -> None:
+    """An entry that already set outside_temp_source keeps its value."""
+    entry = _make_entry(
+        hass,
+        {"outside_temp_source": "max_of_live_and_forecast"},
+        version=3,
+        minor_version=6,
+    )
+    await async_migrate_entry(hass, entry)
+    assert entry.options["outside_temp_source"] == "max_of_live_and_forecast"
+    assert entry.minor_version == 7
 
 
 # ---------------------------------------------------------------------------
@@ -549,7 +604,7 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 6
+    assert entry.minor_version == 7
     # No dead key seeded by the v3.4→v3.5 block.
     assert "show_weather_retraction" not in entry.options
     # The only key added across the cascade is the v3.5→v3.6 weather toggle.
@@ -600,13 +655,13 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 6 (the v3.5 → v3.6 block that enables the
-    weather override for pre-existing entries, per issue #719).
+    Currently the highest target is 7 (the v3.6 → v3.7 no-op block that advances
+    entries past the additive outside_temp_source option, per issue #547).
     Raise this assertion whenever a new minor migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 6
+    assert ConfigFlowHandler.MINOR_VERSION == 7
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_flow_outside_temp_source.py
+++ b/tests/test_config_flow_outside_temp_source.py
@@ -1,0 +1,43 @@
+"""Config-flow selector for the outdoor-temp source option (issue #547)."""
+
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+
+from custom_components.adaptive_cover_pro.config_dynamic import (
+    temperature_climate_schema,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_OUTSIDE_TEMP_SOURCE,
+    OutsideTempSource,
+)
+
+
+def _key(schema: vol.Schema, name: str):
+    for k in schema.schema:
+        if str(k) == name:
+            return k
+    return None
+
+
+@pytest.mark.unit
+def test_schema_contains_outside_temp_source_with_default_live():
+    schema = temperature_climate_schema()
+    key = _key(schema, CONF_OUTSIDE_TEMP_SOURCE)
+    assert key is not None, "CONF_OUTSIDE_TEMP_SOURCE missing from climate schema"
+    assert key.default() == OutsideTempSource.LIVE.value
+
+
+@pytest.mark.unit
+def test_selector_offers_three_options():
+    schema = temperature_climate_schema()
+    key = _key(schema, CONF_OUTSIDE_TEMP_SOURCE)
+    selector = schema.schema[key]
+    raw_options = selector.config["options"]
+    option_values = {(o["value"] if isinstance(o, dict) else o) for o in raw_options}
+    assert option_values == {
+        "live",
+        "forecast_max",
+        "max_of_live_and_forecast",
+    }

--- a/tests/test_coordinator_climate_wiring.py
+++ b/tests/test_coordinator_climate_wiring.py
@@ -33,6 +33,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_IS_SUNNY_TEMPLATE_MODE,
     CONF_LUX_ENTITY,
     CONF_LUX_THRESHOLD,
+    CONF_OUTSIDE_TEMP_SOURCE,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
     CONF_PRESENCE_TEMPLATE,
@@ -104,8 +105,10 @@ def _make_coordinator():
             self._builder, self._climate_provider = _make_builder()
             self._weather_readings = None
 
-        def _read_climate_state(self, options):
-            self._weather_readings = self._builder.read_climate(options)
+        def _read_climate_state(self, options, forecast_max_outside=None):
+            self._weather_readings = self._builder.read_climate(
+                options, forecast_max_outside=forecast_max_outside
+            )
 
         @property
         def _toggles(self):
@@ -228,6 +231,32 @@ class TestClimateStateWiring:
         assert kwargs.get("use_cloud_coverage") is True
 
 
+class TestOutsideTempSourceWiring:
+    """Guard forecast-aware outdoor-temp source forwarding (issue #547)."""
+
+    @pytest.mark.unit
+    def test_outside_temp_source_and_forecast_max_forwarded(self):
+        """Source option + pre-fetched forecast max both reach read()."""
+        coord = _make_coordinator()
+        options = {
+            CONF_OUTSIDETEMP_ENTITY: "sensor.outside",
+            CONF_OUTSIDE_TEMP_SOURCE: "max_of_live_and_forecast",
+        }
+        coord._read_climate_state(options, forecast_max_outside=26.0)
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("outside_temp_source") == "max_of_live_and_forecast"
+        assert kwargs.get("forecast_max_outside") == 26.0
+
+    @pytest.mark.unit
+    def test_outside_temp_source_defaults_to_live(self):
+        """Absent option → live, and forecast_max defaults to None."""
+        coord = _make_coordinator()
+        coord._read_climate_state({})
+        _, kwargs = coord._climate_provider.read.call_args
+        assert kwargs.get("outside_temp_source") == "live"
+        assert kwargs.get("forecast_max_outside") is None
+
+
 class TestClimateStateWiringDefaults:
     """Verify graceful fallback when options dict is empty."""
 
@@ -302,8 +331,14 @@ class TestClimateProviderApiCoverage:
     """
 
     # These parameters are intentionally excluded: they are derived by the
-    # coordinator from toggles/flags rather than coming directly from options.
-    _TOGGLE_DERIVED = {"use_lux", "use_irradiance", "use_cloud_coverage"}
+    # coordinator from toggles/flags or supplied as a pre-fetched value
+    # (forecast_max_outside, issue #547) rather than coming directly from options.
+    _TOGGLE_DERIVED = {
+        "use_lux",
+        "use_irradiance",
+        "use_cloud_coverage",
+        "forecast_max_outside",
+    }
 
     # These map from options key → read() kwarg name (non-obvious mappings).
     _OPTIONS_TO_READ_KWARG = {
@@ -311,6 +346,7 @@ class TestClimateProviderApiCoverage:
         CONF_DEVICE_ID: "temp_device_id",
         CONF_AUTO_RESOLVE_TEMP_FROM_AREA: "auto_resolve_temp_from_area",
         CONF_OUTSIDETEMP_ENTITY: "outside_entity",
+        CONF_OUTSIDE_TEMP_SOURCE: "outside_temp_source",
         CONF_PRESENCE_ENTITY: "presence_entity",
         CONF_WEATHER_ENTITY: "weather_entity",
         CONF_WEATHER_STATE: "weather_condition",
@@ -368,6 +404,7 @@ class TestClimateProviderApiCoverage:
             CONF_DEVICE_ID: "device_abc",
             CONF_AUTO_RESOLVE_TEMP_FROM_AREA: True,
             CONF_OUTSIDETEMP_ENTITY: "sensor.outside",
+            CONF_OUTSIDE_TEMP_SOURCE: "max_of_live_and_forecast",
             CONF_PRESENCE_ENTITY: "binary_sensor.pres",
             CONF_WEATHER_ENTITY: "weather.home",
             CONF_WEATHER_STATE: ["sunny"],

--- a/tests/test_coordinator_forecast_max.py
+++ b/tests/test_coordinator_forecast_max.py
@@ -1,0 +1,220 @@
+"""Coordinator forecast daily-max fetch + cache (issue #547).
+
+The coordinator fetches today's forecast high from the configured weather
+entity via ``weather.get_forecasts`` on a slow wall-clock cadence and caches
+it in ``self._forecast_max_outside`` so the climate read can source it. The
+fetch runs only when the outdoor-temp source is not ``live`` AND a weather
+entity is configured; every failure path degrades to ``None`` (the provider
+then falls back to the live read).
+
+Uses the mock-coordinator pattern: the unbound method is invoked on a minimal
+mock carrying just the attributes it touches.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_OUTSIDE_TEMP_SOURCE,
+    CONF_WEATHER_ENTITY,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+
+
+def _make_coordinator(*, options: dict, forecast_response=None, raises=None):
+    """Minimal mock coordinator for the forecast-max fetch method."""
+    coord = MagicMock()
+    coord._forecast_max_outside = None
+    coord.logger = MagicMock()
+
+    entry = MagicMock()
+    entry.options = options
+    coord.config_entry = entry
+
+    async def _async_call(*args, **kwargs):
+        if raises is not None:
+            raise raises
+        return forecast_response
+
+    coord.hass = MagicMock()
+    coord.hass.services.async_call = AsyncMock(side_effect=_async_call)
+    return coord
+
+
+async def _run(coord):
+    await AdaptiveDataUpdateCoordinator.async_recompute_forecast_max(coord)
+
+
+class TestForecastMaxFetch:
+    """The coordinator's forecast daily-high fetch + cache."""
+
+    @pytest.mark.asyncio
+    async def test_caches_today_high_from_daily_forecast(self):
+        """A daily forecast's first entry temperature is cached as the max."""
+        coord = _make_coordinator(
+            options={
+                CONF_OUTSIDE_TEMP_SOURCE: "forecast_max",
+                CONF_WEATHER_ENTITY: "weather.home",
+            },
+            forecast_response={"weather.home": {"forecast": [{"temperature": 26.0}]}},
+        )
+        await _run(coord)
+        assert coord._forecast_max_outside == 26.0
+        coord.hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_fetch_when_source_live(self):
+        """Source ``live`` skips the fetch and clears any stale cache."""
+        coord = _make_coordinator(
+            options={
+                CONF_OUTSIDE_TEMP_SOURCE: "live",
+                CONF_WEATHER_ENTITY: "weather.home",
+            },
+            forecast_response={"weather.home": {"forecast": [{"temperature": 26.0}]}},
+        )
+        coord._forecast_max_outside = 99.0
+        await _run(coord)
+        coord.hass.services.async_call.assert_not_called()
+        assert coord._forecast_max_outside is None
+
+    @pytest.mark.asyncio
+    async def test_no_fetch_when_no_weather_entity(self):
+        """No weather entity → no fetch, cache cleared."""
+        coord = _make_coordinator(
+            options={CONF_OUTSIDE_TEMP_SOURCE: "forecast_max"},
+            forecast_response={},
+        )
+        coord._forecast_max_outside = 12.0
+        await _run(coord)
+        coord.hass.services.async_call.assert_not_called()
+        assert coord._forecast_max_outside is None
+
+    @pytest.mark.asyncio
+    async def test_service_error_degrades_to_none(self):
+        """A service exception leaves the cache at None."""
+        coord = _make_coordinator(
+            options={
+                CONF_OUTSIDE_TEMP_SOURCE: "max_of_live_and_forecast",
+                CONF_WEATHER_ENTITY: "weather.home",
+            },
+            raises=RuntimeError("boom"),
+        )
+        coord._forecast_max_outside = 20.0
+        await _run(coord)
+        assert coord._forecast_max_outside is None
+
+    @pytest.mark.asyncio
+    async def test_empty_forecast_degrades_to_none(self):
+        """An empty forecast list degrades to None."""
+        coord = _make_coordinator(
+            options={
+                CONF_OUTSIDE_TEMP_SOURCE: "forecast_max",
+                CONF_WEATHER_ENTITY: "weather.home",
+            },
+            forecast_response={"weather.home": {"forecast": []}},
+        )
+        await _run(coord)
+        assert coord._forecast_max_outside is None
+
+    @pytest.mark.asyncio
+    async def test_non_numeric_temperature_degrades_to_none(self):
+        """A non-numeric forecast temperature degrades to None."""
+        coord = _make_coordinator(
+            options={
+                CONF_OUTSIDE_TEMP_SOURCE: "forecast_max",
+                CONF_WEATHER_ENTITY: "weather.home",
+            },
+            forecast_response={"weather.home": {"forecast": [{"temperature": "n/a"}]}},
+        )
+        await _run(coord)
+        assert coord._forecast_max_outside is None
+
+    @pytest.mark.asyncio
+    async def test_missing_temperature_key_degrades_to_none(self):
+        """A forecast entry without a temperature key degrades to None."""
+        coord = _make_coordinator(
+            options={
+                CONF_OUTSIDE_TEMP_SOURCE: "forecast_max",
+                CONF_WEATHER_ENTITY: "weather.home",
+            },
+            forecast_response={"weather.home": {"forecast": [{"cloud": 5}]}},
+        )
+        await _run(coord)
+        assert coord._forecast_max_outside is None
+
+
+class TestForecastMaxScheduler:
+    """The wall-clock scheduler that drives the forecast-max refresher."""
+
+    @pytest.mark.asyncio
+    async def test_scheduler_kicks_off_initial_task_and_timer(self, monkeypatch):
+        """One background task + one wall-clock timer are registered."""
+        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+        coord.hass = MagicMock()
+        coord.config_entry = MagicMock()
+        coord._forecast_max_unsub = None
+
+        def _capture_bg(_hass, coro, name=None):  # noqa: ARG001
+            coro.close()
+            return MagicMock(name="task")
+
+        coord.config_entry.async_create_background_task = MagicMock(
+            side_effect=_capture_bg
+        )
+
+        track_calls: list = []
+
+        def _fake_track_time_change(_hass, cb, **kwargs):
+            track_calls.append((cb, kwargs))
+            return MagicMock(name="unsub")
+
+        monkeypatch.setattr(
+            "homeassistant.helpers.event.async_track_time_change",
+            _fake_track_time_change,
+        )
+
+        AdaptiveDataUpdateCoordinator._start_forecast_max_scheduler(coord)
+
+        assert coord.config_entry.async_create_background_task.call_count == 1
+        assert len(track_calls) == 1
+        from custom_components.adaptive_cover_pro.const import (
+            FORECAST_RECOMPUTE_INTERVAL_MIN,
+        )
+
+        cb, kwargs = track_calls[0]
+        assert list(kwargs["minute"]) == list(
+            range(0, 60, FORECAST_RECOMPUTE_INTERVAL_MIN)
+        )
+        assert kwargs["second"] == 0
+        assert getattr(cb, "_hass_callback", False) is True
+        assert coord._forecast_max_unsub is not None
+
+        # Tick fires another background task.
+        import datetime as _dt
+
+        cb(_dt.datetime.now(_dt.UTC))
+        assert coord.config_entry.async_create_background_task.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_scheduler_is_idempotent(self, monkeypatch):
+        """A second call with an existing handle registers nothing new."""
+        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+        coord.hass = MagicMock()
+        coord.config_entry = MagicMock()
+        coord._forecast_max_unsub = MagicMock(name="existing")
+
+        coord.config_entry.async_create_background_task = MagicMock()
+        track_mock = MagicMock(return_value=MagicMock(name="unsub"))
+        monkeypatch.setattr(
+            "homeassistant.helpers.event.async_track_time_change", track_mock
+        )
+
+        AdaptiveDataUpdateCoordinator._start_forecast_max_scheduler(coord)
+
+        assert coord.config_entry.async_create_background_task.call_count == 0
+        assert track_mock.call_count == 0

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -739,6 +739,23 @@ class TestClimateDiagnostics:
             "area_id": "area_bedroom",
         }
 
+    def test_temperature_details_include_outside_temp_source(
+        self, builder: DiagnosticsBuilder
+    ):
+        """Outdoor-temp source provenance surfaces in temperature_details (#547)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+        diag, _ = builder.build(
+            _base_ctx(
+                climate_mode=True,
+                pipeline_result=pr,
+                outside_temp_source="forecast_max",
+            )
+        )
+        assert diag["temperature_details"]["outside_temperature_source"] == (
+            "forecast_max"
+        )
+
     def test_temp_sensor_absent_when_source_none(self, builder: DiagnosticsBuilder):
         """No temp_sensor block when nothing resolved (source none)."""
         cd = self._make_climate_data()

--- a/tests/test_issue_632_daytime_gate.py
+++ b/tests/test_issue_632_daytime_gate.py
@@ -376,6 +376,7 @@ async def test_async_shutdown_cancels_gate_fallback_handle():
     coord._sensor_health = MagicMock()
     coord._cmd_svc = MagicMock()
     coord._forecast_unsub = None
+    coord._forecast_max_unsub = None
     coord._refresh_after_unsub = None
     cancel = MagicMock()
     coord._gate_fallback_unsub = cancel

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -376,3 +376,40 @@ def test_daytime_gate_reads_provided_values() -> None:
     assert rc.time_window.gate_sensors == ["binary_sensor.bright"]
     assert rc.time_window.gate_template == "{{ is_state('sun.sun', 'above_horizon') }}"
     assert rc.time_window.gate_template_mode == "and"
+
+
+# ---------------------------------------------------------------------------
+# Outdoor temperature source (issue #547)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_outside_temp_source_enum_values() -> None:
+    from custom_components.adaptive_cover_pro.const import (
+        DEFAULT_OUTSIDE_TEMP_SOURCE,
+        OutsideTempSource,
+    )
+
+    assert {m.value for m in OutsideTempSource} == {
+        "live",
+        "forecast_max",
+        "max_of_live_and_forecast",
+    }
+    assert DEFAULT_OUTSIDE_TEMP_SOURCE == "live"
+    assert OutsideTempSource.LIVE.value == "live"
+
+
+@pytest.mark.unit
+def test_outside_temp_source_defaults_to_live() -> None:
+    rc = RuntimeConfig.from_options({})
+    assert rc.outside_temp_source == "live"
+
+
+@pytest.mark.unit
+def test_outside_temp_source_reads_set_value() -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_OUTSIDE_TEMP_SOURCE
+
+    rc = RuntimeConfig.from_options(
+        {CONF_OUTSIDE_TEMP_SOURCE: "max_of_live_and_forecast"}
+    )
+    assert rc.outside_temp_source == "max_of_live_and_forecast"

--- a/tests/test_state/test_climate_provider_outside_source.py
+++ b/tests/test_state/test_climate_provider_outside_source.py
@@ -1,0 +1,159 @@
+"""Tests for the forecast-aware outdoor-temp source switch (issue #547).
+
+The single seam is ``ClimateProvider._read_outside_temperature``. The reader
+grows two additive kwargs — ``outside_temp_source`` (``live`` /
+``forecast_max`` / ``max_of_live_and_forecast``) and a pre-fetched
+``forecast_max_outside`` daily-max — and records provenance on
+``ClimateReadings.outside_temperature_source``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.state.climate_provider import (
+    ClimateProvider,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    """Mock HomeAssistant."""
+    h = MagicMock()
+    h.states.get.return_value = None
+    return h
+
+
+@pytest.fixture
+def provider(mock_hass, mock_logger):
+    """ClimateProvider instance."""
+    return ClimateProvider(hass=mock_hass, logger=mock_logger)
+
+
+def _mock_state(entity_id, state, attributes=None):
+    s = MagicMock()
+    s.entity_id = entity_id
+    s.state = state
+    s.attributes = attributes or {}
+    return s
+
+
+class TestOutsideTempSource:
+    """The unified live/forecast source switch."""
+
+    @pytest.mark.unit
+    def test_default_source_is_live(self, provider, mock_hass):
+        """No kwargs → today's live behaviour, source label ``live``."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "22.5")
+        readings = provider.read(outside_entity="sensor.outside")
+        assert readings.outside_temperature == "22.5"
+        assert readings.outside_temperature_source == "live"
+
+    @pytest.mark.unit
+    def test_explicit_live_source(self, provider, mock_hass):
+        """``live`` passed explicitly matches the default."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "18.0")
+        readings = provider.read(
+            outside_entity="sensor.outside", outside_temp_source="live"
+        )
+        assert readings.outside_temperature == "18.0"
+        assert readings.outside_temperature_source == "live"
+
+    @pytest.mark.unit
+    def test_forecast_max_uses_prefetched_value(self, provider, mock_hass):
+        """``forecast_max`` uses the pre-fetched daily max when numeric."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "15.0")
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="forecast_max",
+            forecast_max_outside=26.0,
+        )
+        assert readings.outside_temperature == 26.0
+        assert readings.outside_temperature_source == "forecast_max"
+
+    @pytest.mark.unit
+    def test_forecast_max_falls_back_to_live_when_missing(self, provider, mock_hass):
+        """``forecast_max`` with no forecast → live read, label ``live_fallback``."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "15.0")
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="forecast_max",
+            forecast_max_outside=None,
+        )
+        assert readings.outside_temperature == "15.0"
+        assert readings.outside_temperature_source == "live_fallback"
+
+    @pytest.mark.unit
+    def test_max_of_live_and_forecast_picks_higher(self, provider, mock_hass):
+        """Combined mode returns max(live, forecast) when both numeric."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "15.0")
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="max_of_live_and_forecast",
+            forecast_max_outside=26.0,
+        )
+        assert readings.outside_temperature == 26.0
+        assert readings.outside_temperature_source == "max_of_live_and_forecast"
+
+    @pytest.mark.unit
+    def test_max_of_live_and_forecast_live_higher(self, provider, mock_hass):
+        """Combined mode keeps the live value when it is the higher one."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "30.0")
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="max_of_live_and_forecast",
+            forecast_max_outside=26.0,
+        )
+        assert readings.outside_temperature == 30.0
+        assert readings.outside_temperature_source == "max_of_live_and_forecast"
+
+    @pytest.mark.unit
+    def test_max_of_live_and_forecast_only_forecast(self, provider, mock_hass):
+        """Combined mode with a non-numeric live read uses the forecast max."""
+        mock_hass.states.get.return_value = None  # live unavailable
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="max_of_live_and_forecast",
+            forecast_max_outside=26.0,
+        )
+        assert readings.outside_temperature == 26.0
+        assert readings.outside_temperature_source == "forecast_max"
+
+    @pytest.mark.unit
+    def test_max_of_live_and_forecast_only_live(self, provider, mock_hass):
+        """Combined mode with no forecast falls back to the live read."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "15.0")
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="max_of_live_and_forecast",
+            forecast_max_outside=None,
+        )
+        assert readings.outside_temperature == "15.0"
+        assert readings.outside_temperature_source == "live_fallback"
+
+    @pytest.mark.unit
+    def test_unknown_source_falls_back_to_live(self, provider, mock_hass):
+        """An unrecognized source label degrades to the live read."""
+        mock_hass.states.get.return_value = _mock_state("sensor.outside", "17.0")
+        readings = provider.read(
+            outside_entity="sensor.outside",
+            outside_temp_source="bogus",
+            forecast_max_outside=26.0,
+        )
+        assert readings.outside_temperature == "17.0"
+        assert readings.outside_temperature_source == "live"
+
+    @pytest.mark.unit
+    def test_forecast_max_via_weather_entity_live_fallback(self, provider):
+        """The live fallback still routes through the weather temp attribute."""
+        with patch(
+            "custom_components.adaptive_cover_pro.state.climate_provider.state_attr",
+            return_value=20.0,
+        ):
+            readings = provider.read(
+                weather_entity="weather.home",
+                outside_temp_source="forecast_max",
+                forecast_max_outside=None,
+            )
+        assert readings.outside_temperature == 20.0
+        assert readings.outside_temperature_source == "live_fallback"


### PR DESCRIPTION
## Summary
Adds an **Outdoor temperature source** select for climate mode so it can use today's forecast daily-max instead of only the live outdoor temperature (issue #547). Three modes: `live` (default — unchanged behavior), `forecast_max`, and `max_of_live_and_forecast`.

The forecast daily-max is pulled from the already-configured weather entity via an async `weather.get_forecasts` fetch cached on the coordinator (mirrors the existing position-forecast scheduler), keeping `ClimateProvider.read()` synchronous. Every forecast-unavailable path (no weather entity, service error, empty/non-numeric forecast, hourly-only integrations) degrades to the live reading. `is_extreme_heat` inherits the forecast max automatically. The active source is surfaced in diagnostics via a new `outside_temperature_source` provenance field.

Additive and rollback-safe: new `read()` kwargs default to `live`/`None`, config minor bumped 6→7 with a no-op migration block, `VERSION` stays 3. DE/FR translations synced.

## Testing
- ✅ Full suite green (5996+ passing; translation parity restored)
- New tests: provider source switch, coordinator async forecast fetch/cache, config-flow selector, diagnostics provenance, migration additive/idempotency
- Regression guards green: outside/weather entity forwarding (#134), climate cover data/state, cover-type axes, migration major-stays-3 + minor-reachability

## Related Issues
Refs #547