### PR TITLE
feat: generalized set_axes service + axis self-discovery (#725)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -45,6 +45,12 @@ from .helpers import (
 )
 from .config_context_adapter import ConfigContextAdapter
 from .cover_types import CoverTypePolicy, get_policy
+from .cover_types.base import (
+    AXIS_NAME_POSITION,
+    AXIS_NAME_TILT,
+    CoverDescriptor,
+    caps_get,
+)
 from .services.configuration_service import ConfigurationService
 from .const import (
     _LOGGER,
@@ -2784,6 +2790,33 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             entity_id, int(tilt), trigger=trigger, force=force
         )
 
+    async def async_apply_user_axis(
+        self,
+        entity_id: str,
+        axis_name: str,
+        value: int,
+        *,
+        trigger: str,
+        force: bool = False,
+    ) -> tuple[str, str]:
+        """Dispatch a user-initiated axis command to the matching setter (#725).
+
+        Single collapse point behind the ``set_position`` / ``set_tilt`` /
+        ``set_axes`` services: keyed on the ``AXIS_NAME_*`` constant (never a
+        cover-type string), it routes to the existing per-axis entry point so
+        each setter's force / manual-override / dispatch semantics stay
+        bit-identical. Raises ``ValueError`` for an axis name it can't route.
+        """
+        setters = {
+            AXIS_NAME_POSITION: self.async_apply_user_position,
+            AXIS_NAME_TILT: self.async_apply_user_tilt,
+        }
+        setter = setters.get(axis_name)
+        if setter is None:
+            msg = f"Unknown axis {axis_name!r} for {entity_id}"
+            raise ValueError(msg)
+        return await setter(entity_id, value, trigger=trigger, force=force)
+
     async def async_apply_user_stop(
         self,
         entity_id: str,
@@ -2799,6 +2832,29 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """
         self.manager.mark_user_command(entity_id, reason=trigger)
         return await self._cmd_svc.apply_user_stop(entity_id)
+
+    def build_axis_discovery(
+        self, labels: dict[str, str] | None = None
+    ) -> CoverDescriptor:
+        """Assemble the persistent axis/cover self-discovery descriptor (#725).
+
+        Reuses the diagnostics capability read (``read_all_capabilities`` — never
+        re-reads HA features) and rolls up per-axis ``supported`` across every
+        managed cover entity: an axis is supported if ANY member exposes it. The
+        per-axis metadata is delegated to ``policy.describe`` so the payload is
+        cover-type-agnostic — a ninth cover type needs no edit here.
+        """
+        entities = self.entities or []
+        caps_map = self._cover_provider.read_all_capabilities(entities)
+        rolled: dict[str, bool] = {}
+        for axis in self._policy.axes:
+            key = axis.capability_key
+            rolled[key] = (
+                any(caps_get(caps, key) for caps in caps_map.values())
+                if caps_map
+                else True
+            )
+        return self._policy.describe(caps=rolled, labels=labels)
 
     def build_diagnostic_data(self) -> dict:
         """Build diagnostic data from current coordinator state."""

--- a/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
+++ b/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
@@ -31,6 +31,19 @@ these exact keys/values (prefix-stripped). A drift test in
 
 from __future__ import annotations
 
+# --- Axis labels (namespace config_summary.axes.*) --------------------------
+#
+# User-facing names for the controllable axes surfaced by the self-discovery
+# payload (issue #725). Keyed by ``CoverAxis.label_key``. Resolved the same way
+# as the cover-type labels: English base overlaid by whatever translated
+# ``labels`` dict the policy receives. ``summary_i18n/{en,de,fr}.json["axes"]``
+# mirror these keys (prefix-stripped); the drift guard in
+# ``tests/test_policy_summary_i18n.py`` keeps them in lockstep.
+AXIS_LABELS_EN: dict[str, str] = {
+    "axes.position": "Position",
+    "axes.tilt": "Tilt",
+}
+
 # --- Cover-type labels (namespace config_summary.cover_types.*) -------------
 COVER_TYPE_LABELS_EN: dict[str, str] = {
     "cover_types.blind": "Vertical Blind",

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -32,6 +32,7 @@ from ..const import (
     GroupScene,
 )
 from ..helpers import get_open_close_state, should_use_tilt, state_attr
+from ._summary_labels import AXIS_LABELS_EN
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, State
@@ -74,6 +75,13 @@ CAP_HAS_STOP = "has_stop"
 AXIS_NAME_POSITION = "position"
 AXIS_NAME_TILT = "tilt"
 
+# Numeric range + unit every controllable axis exposes today. HA cover
+# position/tilt are 0–100 %. Named here so the discovery surface (#725) and the
+# ``CoverAxis`` field defaults reference one constant instead of a bare literal.
+AXIS_VALUE_MIN = 0
+AXIS_VALUE_MAX = 100
+AXIS_VALUE_UNIT = "%"
+
 
 @dataclass(frozen=True, slots=True)
 class CoverAxis:
@@ -86,6 +94,12 @@ class CoverAxis:
     and the cover-type semantic of "what does fully-open mean". Passing a
     ``CoverAxis`` around eliminates ``cover_type == "cover_tilt"`` checks at
     call sites.
+
+    The trailing fields are self-discovery metadata (#725): ``label_key`` is
+    the i18n key for the axis's user-facing name, and ``value_min`` /
+    ``value_max`` / ``unit`` describe its numeric range. All four carry safe
+    defaults so existing ``CoverAxis`` construction sites (and Liskov-conformant
+    fifth-cover-type policies) keep working unchanged.
     """
 
     name: str
@@ -94,6 +108,10 @@ class CoverAxis:
     state_attr: str
     capability_key: str
     open_blocks_sun: bool
+    label_key: str = ""
+    value_min: int = AXIS_VALUE_MIN
+    value_max: int = AXIS_VALUE_MAX
+    unit: str = AXIS_VALUE_UNIT
 
 
 # Module-level singletons. Each policy declares ``axes`` referencing these so
@@ -109,6 +127,7 @@ POSITION_AXIS = CoverAxis(
     state_attr=STATE_ATTR_POSITION,
     capability_key=CAP_HAS_SET_POSITION,
     open_blocks_sun=False,
+    label_key="axes.position",
 )
 
 POSITION_AXIS_OPEN_BLOCKS_SUN = CoverAxis(
@@ -118,6 +137,7 @@ POSITION_AXIS_OPEN_BLOCKS_SUN = CoverAxis(
     state_attr=STATE_ATTR_POSITION,
     capability_key=CAP_HAS_SET_POSITION,
     open_blocks_sun=True,
+    label_key="axes.position",
 )
 
 TILT_AXIS = CoverAxis(
@@ -127,7 +147,41 @@ TILT_AXIS = CoverAxis(
     state_attr=STATE_ATTR_TILT_POSITION,
     capability_key=CAP_HAS_SET_TILT_POSITION,
     open_blocks_sun=False,
+    label_key="axes.tilt",
 )
+
+
+@dataclass(frozen=True, slots=True)
+class AxisDescriptor:
+    """Self-discovery view of one axis on a specific install (issue #725).
+
+    A flattened, serialisable projection of a ``CoverAxis`` — everything a
+    consumer (the ``cover_discovery`` sensor attribute, the ``set_axes``
+    service, the companion Lovelace card) needs to render and drive an axis
+    without knowing the cover type — plus ``supported``, the per-install
+    rollup of whether the bound cover(s) actually expose the axis.
+    """
+
+    id: str
+    label: str
+    label_key: str
+    min: int
+    max: int
+    unit: str
+    capability_key: str
+    state_attr: str
+    service_attr: str
+    open_blocks_sun: bool
+    supported: bool
+
+
+@dataclass(frozen=True, slots=True)
+class CoverDescriptor:
+    """Self-discovery view of a cover type + its axes (issue #725)."""
+
+    cover_type: str
+    cover_label: str
+    axes: tuple[AxisDescriptor, ...]
 
 
 def caps_get(caps: Any, key: str, default: bool = False) -> bool:
@@ -464,6 +518,62 @@ class CoverTypePolicy(ABC):
         if should_use_tilt(is_tilt_default, caps if caps is not None else {}):
             return TILT_AXIS
         return primary
+
+    def supported_axes(self, caps: Any) -> tuple[CoverAxis, ...]:
+        """Return the declared axes this entity's capabilities actually expose.
+
+        Single source of truth (issue #725) for both the ``set_axes`` service's
+        unsupported-axis rejection and the discovery descriptor's ``supported``
+        flag. Filters ``self.axes`` by each axis's capability flag through
+        ``caps_get`` so no hardcoded ``caps.get("has_X")`` literal leaks out.
+        """
+        return tuple(a for a in self.axes if caps_get(caps, a.capability_key))
+
+    def describe_axis(
+        self,
+        axis: CoverAxis,
+        caps: Any = None,
+        labels: dict[str, str] | None = None,
+    ) -> AxisDescriptor:
+        """Project one ``CoverAxis`` to a serialisable ``AxisDescriptor``.
+
+        ``labels`` overlays translated ``axes.*`` strings on the English base;
+        ``None`` keeps English (back-compat). ``supported`` reflects whether
+        *caps* expose the axis.
+        """
+        label = {**AXIS_LABELS_EN, **(labels or {})}.get(axis.label_key, axis.label_key)
+        return AxisDescriptor(
+            id=axis.name,
+            label=label,
+            label_key=axis.label_key,
+            min=axis.value_min,
+            max=axis.value_max,
+            unit=axis.unit,
+            capability_key=axis.capability_key,
+            state_attr=axis.state_attr,
+            service_attr=axis.service_attr,
+            open_blocks_sun=axis.open_blocks_sun,
+            supported=caps_get(caps, axis.capability_key),
+        )
+
+    def describe(
+        self,
+        caps: Any = None,
+        labels: dict[str, str] | None = None,
+    ) -> CoverDescriptor:
+        """Assemble the self-discovery descriptor for this cover type (#725).
+
+        Cover-type id + localized label + one ``AxisDescriptor`` per declared
+        axis. Every axis appears (so a consumer sees the full axis set); the
+        per-axis ``supported`` flag carries whether *caps* expose it. A ninth
+        cover type inherits this unchanged — the discovery builder never
+        branches on the cover-type string.
+        """
+        return CoverDescriptor(
+            cover_type=self.cover_type,
+            cover_label=self.display_label(labels),
+            axes=tuple(self.describe_axis(a, caps, labels) for a in self.axes),
+        )
 
     def position_axis_supported(self, caps: Any) -> bool:
         """Whether *this entity* exposes the policy's primary (position) axis.

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 import datetime as dt
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from homeassistant.components.sensor import (
@@ -505,6 +505,10 @@ def _control_status_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
         "reason": diagnostics.get("control_state_reason"),
         "automatic_control_enabled": s.coordinator.automatic_control,
         "cover_type": s._cover_type,  # noqa: SLF001 — consumed by Lovelace card to flip cover-fill polarity for awnings
+        # Additive self-discovery descriptor (issue #725): full axis list +
+        # labels + ranges + per-axis supported flags. cover_type above is left
+        # untouched so older card versions are unaffected.
+        "cover_discovery": asdict(s.coordinator.build_axis_discovery()),
     }
 
     time_window = diagnostics.get("time_window", {})

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -159,6 +159,38 @@ set_tilt:
       selector:
         boolean:
 
+set_axes:
+  name: Set axes
+  description: >-
+    Set one or more control axes (position and/or tilt) on the targeted covers
+    in a single call. Each requested axis is dispatched through the same path as
+    set_position / set_tilt. Requesting an axis the cover does not support raises
+    an error. By default the call engages manual override; set force=true to skip
+    manual-override engagement.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    axes:
+      name: Axes
+      description: >-
+        Map of axis targets — include only the axes you want to move. Keys are
+        "position" and/or "tilt"; each value is 0–100%. For example, set position
+        to 60 and tilt to 30.
+      required: true
+      example: '{"position": 60, "tilt": 30}'
+      selector:
+        object:
+    force:
+      name: Force
+      description: >-
+        When true, skip manual-override engagement. Default false — service calls
+        engage manual override like a dashboard slider.
+      required: false
+      default: false
+      selector:
+        boolean:
+
 engage_manual_override:
   name: Engage manual override
   description: >-

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -31,6 +31,7 @@ from .export_service import (
 )
 from .import_service import IMPORT_CONFIG_SCHEMA, async_handle_import_config
 from .options_service import OPTIONS_SERVICE_NAMES, register_options_services
+from .set_axes_service import SET_AXES_SCHEMA, async_handle_set_axes
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
 from .set_tilt_service import SET_TILT_SCHEMA, async_handle_set_tilt
 from .stop_service import async_handle_stop
@@ -259,6 +260,9 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN, "set_tilt", async_handle_set_tilt, schema=SET_TILT_SCHEMA
     )
+    hass.services.async_register(
+        DOMAIN, "set_axes", async_handle_set_axes, schema=SET_AXES_SCHEMA
+    )
     hass.services.async_register(DOMAIN, "stop", async_handle_stop)
     hass.services.async_register(
         DOMAIN,
@@ -288,6 +292,7 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "emergency_stop")
     hass.services.async_remove(DOMAIN, "set_position")
     hass.services.async_remove(DOMAIN, "set_tilt")
+    hass.services.async_remove(DOMAIN, "set_axes")
     hass.services.async_remove(DOMAIN, "stop")
     hass.services.async_remove(DOMAIN, "engage_manual_override")
     for name in GROUP_SERVICE_NAMES:

--- a/custom_components/adaptive_cover_pro/services/set_axes_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_axes_service.py
@@ -1,0 +1,104 @@
+"""set_axes service — dispatches a per-axis target map in one call (issue #725).
+
+Generalizes ``set_position`` / ``set_tilt`` into a single service that accepts
+``axes: {position, tilt}`` plus ``force``. Each requested axis is validated
+against the target entity's ``policy.supported_axes(caps)`` and then dispatched
+through ``Coordinator.async_apply_user_axis`` — the same collapse point the two
+single-axis services now use. Requesting an axis the cover does not support is a
+``ServiceValidationError`` (the issue is explicit: an error, not a no-op).
+
+No cover-type string branching: the supported-axis set and dispatch are keyed on
+the ``AXIS_NAME_*`` constants and ``policy.supported_axes`` / ``describe`` — the
+service works unchanged for a ninth cover type.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+from voluptuous.validators import Coerce, Range
+
+from ..cover_types.base import (
+    AXIS_NAME_POSITION,
+    AXIS_NAME_TILT,
+    AXIS_VALUE_MAX,
+    AXIS_VALUE_MIN,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import ServiceCall
+
+_LOGGER = logging.getLogger(__name__)
+
+_AXIS_VALUE = vol.All(Coerce(int), Range(min=AXIS_VALUE_MIN, max=AXIS_VALUE_MAX))
+
+SET_AXES_SCHEMA = cv.make_entity_service_schema(
+    {
+        vol.Required("axes"): vol.Schema(
+            {
+                vol.Optional(AXIS_NAME_POSITION): _AXIS_VALUE,
+                vol.Optional(AXIS_NAME_TILT): _AXIS_VALUE,
+            }
+        ),
+        vol.Optional("force", default=False): bool,
+    }
+)
+
+
+def _resolve_targets(hass, call):
+    """Thin re-export so tests can patch the local name."""
+    from . import _resolve_targets as _rt  # noqa: PLC0415
+
+    return _rt(hass, call)
+
+
+async def async_handle_set_axes(call: ServiceCall) -> None:
+    """Handle the set_axes service call.
+
+    Resolves targets, validates every requested axis against each target
+    entity's supported axes (raising ``ServiceValidationError`` for an
+    unsupported axis or an empty request), then dispatches each axis through
+    ``coord.async_apply_user_axis``. Validation happens for all targets before
+    any dispatch, so a rejected axis never leaves a partial move behind.
+    """
+    hass = call.hass
+    axes: dict[str, int] = dict(call.data["axes"])
+    force: bool = call.data.get("force", False)
+
+    if not axes:
+        raise ServiceValidationError(
+            "set_axes requires at least one axis in 'axes' (position and/or tilt)"
+        )
+
+    targets = _resolve_targets(hass, call)
+
+    # Validate every (entity, axis) pair up front so an unsupported axis rejects
+    # the whole call rather than dispatching a partial set.
+    resolved: list[tuple] = []
+    for coord, entity_filter in targets.items():
+        entity_ids = (
+            list(entity_filter) if entity_filter is not None else list(coord.entities)
+        )
+        policy = coord._policy  # noqa: SLF001
+        for entity_id in entity_ids:
+            caps = coord._cover_provider.read_single_capabilities(  # noqa: SLF001
+                entity_id
+            )
+            supported = {a.name for a in policy.supported_axes(caps)}
+            for axis_name in axes:
+                if axis_name not in supported:
+                    raise ServiceValidationError(
+                        f"{policy.display_label()} cover {entity_id} does not "
+                        f"support the '{axis_name}' axis"
+                    )
+            resolved.append((coord, entity_id))
+
+    for coord, entity_id in resolved:
+        for axis_name, value in axes.items():
+            await coord.async_apply_user_axis(
+                entity_id, axis_name, int(value), trigger="set_axes", force=force
+            )

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -13,6 +13,8 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 from voluptuous.validators import Coerce, Range
 
+from ..cover_types.base import AXIS_NAME_POSITION
+
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
 
@@ -38,8 +40,9 @@ async def async_handle_set_position(call: ServiceCall) -> None:
 
     Resolves the target block to one or more coordinators (each with an
     optional entity filter), then delegates each command to
-    ``coord.async_apply_user_position`` — the single source of truth for
-    floor clamping, pipeline preemption, and dispatch.
+    ``coord.async_apply_user_axis`` on the position axis — the shared collapse
+    point that routes to ``async_apply_user_position``, the single source of
+    truth for floor clamping, pipeline preemption, and dispatch.
 
     ``force`` (default ``False``) propagates through: when ``False`` the
     service respects force_override / weather and engages manual override
@@ -56,6 +59,10 @@ async def async_handle_set_position(call: ServiceCall) -> None:
             list(entity_filter) if entity_filter is not None else list(coord.entities)
         )
         for entity_id in entity_ids:
-            await coord.async_apply_user_position(
-                entity_id, requested, trigger="set_position", force=force
+            await coord.async_apply_user_axis(
+                entity_id,
+                AXIS_NAME_POSITION,
+                requested,
+                trigger="set_position",
+                force=force,
             )

--- a/custom_components/adaptive_cover_pro/services/set_tilt_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_tilt_service.py
@@ -15,6 +15,8 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 from voluptuous.validators import Coerce, Range
 
+from ..cover_types.base import AXIS_NAME_TILT
+
 if TYPE_CHECKING:
     from homeassistant.core import ServiceCall
 
@@ -40,8 +42,9 @@ async def async_handle_set_tilt(call: ServiceCall) -> None:
 
     Resolves the target block to one or more coordinators (each with an
     optional entity filter), then delegates each command to
-    ``coord.async_apply_user_tilt`` — the single source of truth for tilt-axis
-    dispatch (venetian slats, ``cover_tilt`` position fall-back).
+    ``coord.async_apply_user_axis`` on the tilt axis — the shared collapse point
+    that routes to ``async_apply_user_tilt``, the single source of truth for
+    tilt-axis dispatch (venetian slats, ``cover_tilt`` position fall-back).
 
     ``force`` (default ``False``) propagates through: when ``False`` the service
     engages manual override like a dashboard slider; when ``True`` it skips
@@ -57,6 +60,6 @@ async def async_handle_set_tilt(call: ServiceCall) -> None:
             list(entity_filter) if entity_filter is not None else list(coord.entities)
         )
         for entity_id in entity_ids:
-            await coord.async_apply_user_tilt(
-                entity_id, requested, trigger="set_tilt", force=force
+            await coord.async_apply_user_axis(
+                entity_id, AXIS_NAME_TILT, requested, trigger="set_tilt", force=force
             )

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -275,5 +275,9 @@
     "stagger": "Mitglieder mit {stagger}s Abstand befohlen",
     "cover_entity": "Aggregierte Beschattungs-Entität verfügbar — das Ziehen befiehlt jedem Mitglied",
     "area": "Mitgliedschaft verfolgt Bereich „{area}\" – Beschattungen dort treten automatisch bei"
+  },
+  "axes": {
+    "position": "Position",
+    "tilt": "Neigung"
   }
 }

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -207,6 +207,10 @@
     "sliding_curtain": "Sliding Curtain",
     "louvered_roof": "Louvered Roof"
   },
+  "axes": {
+    "position": "Position",
+    "tilt": "Tilt"
+  },
   "geometry": {
     "window": {
       "tall": "{h}m tall window",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -275,5 +275,9 @@
     "stagger": "Membres commandés à {stagger}s d'intervalle",
     "cover_entity": "Entité de store agrégée exposée — la faire glisser commande chaque membre",
     "area": "L'adhésion suit la zone « {area} » — les stores de cette zone rejoignent automatiquement"
+  },
+  "axes": {
+    "position": "Position",
+    "tilt": "Inclinaison"
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2634,6 +2634,20 @@
           "description": "true zum Aktivieren der Mitgliedersautomatisierung, false zum Deaktivieren."
         }
       }
+    },
+    "set_axes": {
+      "name": "Achsen festlegen",
+      "description": "Legt eine oder mehrere Steuerachsen (Position und/oder Neigung) auf der Beschattung in einem einzigen Aufruf fest. Jede angeforderte Achse wird über denselben Pfad wie set_position / set_tilt versandt. Das Anfordern einer nicht unterstützten Achse verursacht einen Fehler. Standardmäßig aktiviert der Aufruf die manuelle Übersteuerung; setzen Sie force=true, um die Aktivierung der manuellen Übersteuerung zu überspringen.",
+      "fields": {
+        "axes": {
+          "name": "Achsen",
+          "description": "Zuordnung von Achsenzielen — nur die Achsen einschließen, die Sie verschieben möchten. Schlüssel sind \"position\" und/oder \"tilt\"; jeder Wert beträgt 0–100%. Zum Beispiel Position auf 60 und Neigung auf 30 einstellen."
+        },
+        "force": {
+          "name": "Erzwingen",
+          "description": "Wenn wahr, manuelle Übersteuerungsaktivierung überspringen. Vorgabe: falsch — Service-Aufrufe aktivieren die manuelle Übersteuerung wie ein Dashboard-Regler."
+        }
+      }
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -2575,6 +2575,20 @@
         }
       }
     },
+    "set_axes": {
+      "name": "Set axes",
+      "description": "Sets one or more control axes (position and/or tilt) on the cover in a single call. Each requested axis is dispatched through the same path as set_position / set_tilt. Requesting an axis the cover does not support raises an error. By default the call engages manual override; set force=true to skip manual-override engagement.",
+      "fields": {
+        "axes": {
+          "name": "Axes",
+          "description": "Map of axis targets — include only the axes you want to move. Keys are \"position\" and/or \"tilt\"; each value is 0–100%. For example, set position to 60 and tilt to 30."
+        },
+        "force": {
+          "name": "Force",
+          "description": "When true, skip manual-override engagement. Default false — service calls engage manual override like a dashboard slider."
+        }
+      }
+    },
     "engage_manual_override": {
       "name": "Engage manual override",
       "description": "Engages or extends manual override on the targeted covers without moving them — no cover command is sent. With no end time and no duration, the override lasts the configured manual-override duration starting now. Provide an end time for an absolute end, or a duration to extend an active override (or engage fresh for that long if none is active). If both are given, the end time wins.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2634,6 +2634,20 @@
           "description": "True pour activer l'automatisation des membres, false pour la désactiver."
         }
       }
+    },
+    "set_axes": {
+      "name": "Définir les axes",
+      "description": "Définit un ou plusieurs axes de contrôle (position et/ou inclinaison) sur la protection en un seul appel. Chaque axe demandé est transmis via le même chemin que set_position / set_tilt. La demande d'un axe non supporté par la protection génère une erreur. Par défaut, l'appel enclenche la dérogation manuelle ; définissez force=true pour ignorer l'engagement de la dérogation manuelle.",
+      "fields": {
+        "axes": {
+          "name": "Axes",
+          "description": "Carte des cibles d'axe — incluez uniquement les axes que vous voulez déplacer. Les clés sont « position » et/ou « tilt » ; chaque valeur est 0–100 %. Par exemple, définissez la position à 60 et l'inclinaison à 30."
+        },
+        "force": {
+          "name": "Forcer",
+          "description": "Quand vrai, ignorez l'engagement de la dérogation manuelle. Par défaut faux — les appels de service enclenchent la dérogation manuelle comme un curseur du tableau de bord."
+        }
+      }
     }
   }
 }

--- a/tests/services/test_set_position_service.py
+++ b/tests/services/test_set_position_service.py
@@ -55,6 +55,12 @@ def _make_coord(custom_states):
     coord.async_apply_user_position = (
         AdaptiveDataUpdateCoordinator.async_apply_user_position.__get__(coord)
     )
+    # set_position routes through the axis collapse point (issue #725) — bind the
+    # real dispatcher so the service reaches async_apply_user_position as before.
+    coord.async_apply_user_tilt = AsyncMock(return_value=("sent", "tilt"))
+    coord.async_apply_user_axis = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_axis.__get__(coord)
+    )
     return coord, ctx
 
 

--- a/tests/services/test_set_tilt_service.py
+++ b/tests/services/test_set_tilt_service.py
@@ -15,9 +15,20 @@ import voluptuous as vol
 
 
 def _make_coord(*, entities: list[str] | None = None):
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
     coord = MagicMock()
     coord.entities = entities or ["cover.venetian"]
     coord.async_apply_user_tilt = AsyncMock(return_value=("sent", ""))
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
+    # set_tilt now routes through the axis collapse point (issue #725); bind the
+    # real dispatcher so it forwards to the mocked async_apply_user_tilt, keeping
+    # these delegation assertions a true parity guard for the tilt path.
+    coord.async_apply_user_axis = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_axis.__get__(coord)
+    )
     return coord
 
 

--- a/tests/test_config_flow_summary_i18n.py
+++ b/tests/test_config_flow_summary_i18n.py
@@ -31,6 +31,7 @@ from custom_components.adaptive_cover_pro.const import (
     CoverType,
 )
 from custom_components.adaptive_cover_pro.cover_types._summary_labels import (
+    AXIS_LABELS_EN,
     COVER_TYPE_LABELS_EN,
     GEOMETRY_LABELS_EN,
 )
@@ -186,7 +187,12 @@ def test_summary_i18n_en_matches_code_defaults() -> None:
     dicts; the bundle exists as the translation source + drift guard.
     """
     en = _config_summary_flat(_load_json("en.json"))
-    assert en == {**_SUMMARY_LABELS_EN, **COVER_TYPE_LABELS_EN, **GEOMETRY_LABELS_EN}
+    assert en == {
+        **_SUMMARY_LABELS_EN,
+        **COVER_TYPE_LABELS_EN,
+        **GEOMETRY_LABELS_EN,
+        **AXIS_LABELS_EN,
+    }
 
 
 def test_config_summary_placeholder_parity_de_fr() -> None:

--- a/tests/test_coordinator_apply_user_axis.py
+++ b/tests/test_coordinator_apply_user_axis.py
@@ -1,0 +1,69 @@
+"""Tests for the coordinator's ``async_apply_user_axis`` collapse point (#725).
+
+The generalized ``set_axes`` service (and the refactored ``set_position`` /
+``set_tilt`` wrappers) route every user axis command through this single
+dispatch method, keyed on the ``AXIS_NAME_*`` constants. It must delegate to the
+existing per-axis setters unchanged and reject an unknown axis name.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    AXIS_NAME_POSITION,
+    AXIS_NAME_TILT,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _coord() -> MagicMock:
+    """Mock coordinator with the real ``async_apply_user_axis`` bound."""
+    coord = MagicMock()
+    coord.async_apply_user_position = AsyncMock(return_value=("sent", "position"))
+    coord.async_apply_user_tilt = AsyncMock(return_value=("sent", "tilt"))
+    coord.async_apply_user_axis = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_axis.__get__(coord)
+    )
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_position_axis_routes_to_position_setter() -> None:
+    coord = _coord()
+    result = await coord.async_apply_user_axis(
+        "cover.x", AXIS_NAME_POSITION, 40, trigger="set_axes", force=False
+    )
+    coord.async_apply_user_position.assert_awaited_once_with(
+        "cover.x", 40, trigger="set_axes", force=False
+    )
+    coord.async_apply_user_tilt.assert_not_awaited()
+    assert result == ("sent", "position")
+
+
+@pytest.mark.asyncio
+async def test_tilt_axis_routes_to_tilt_setter() -> None:
+    coord = _coord()
+    result = await coord.async_apply_user_axis(
+        "cover.x", AXIS_NAME_TILT, 30, trigger="set_axes", force=True
+    )
+    coord.async_apply_user_tilt.assert_awaited_once_with(
+        "cover.x", 30, trigger="set_axes", force=True
+    )
+    coord.async_apply_user_position.assert_not_awaited()
+    assert result == ("sent", "tilt")
+
+
+@pytest.mark.asyncio
+async def test_unknown_axis_raises() -> None:
+    coord = _coord()
+    with pytest.raises(ValueError, match="Unknown axis"):
+        await coord.async_apply_user_axis("cover.x", "diagonal", 50, trigger="set_axes")
+    coord.async_apply_user_position.assert_not_awaited()
+    coord.async_apply_user_tilt.assert_not_awaited()

--- a/tests/test_coordinator_axis_discovery.py
+++ b/tests/test_coordinator_axis_discovery.py
@@ -1,0 +1,80 @@
+"""Tests for the coordinator's axis self-discovery builder (issue #725).
+
+``build_axis_discovery`` rolls up per-axis capability support across every
+managed cover entity (an axis is supported if ANY member exposes it) and
+delegates the per-axis metadata to the policy's ``describe`` — never re-reading
+HA features or branching on the cover-type string.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.state.snapshot import CoverCapabilities
+
+pytestmark = pytest.mark.unit
+
+
+def _caps(*, position: bool, tilt: bool) -> CoverCapabilities:
+    return CoverCapabilities(
+        has_set_position=position,
+        has_set_tilt_position=tilt,
+        has_open=True,
+        has_close=True,
+    )
+
+
+def _coord(cover_type: str, caps_map: dict[str, CoverCapabilities]) -> MagicMock:
+    coord = MagicMock()
+    coord.entities = list(caps_map)
+    coord._policy = get_policy(cover_type)
+    coord._cover_provider = MagicMock()
+    coord._cover_provider.read_all_capabilities.return_value = caps_map
+    coord.build_axis_discovery = (
+        AdaptiveDataUpdateCoordinator.build_axis_discovery.__get__(coord)
+    )
+    return coord
+
+
+def test_blind_discovery_single_position_axis() -> None:
+    coord = _coord("cover_blind", {"cover.blind": _caps(position=True, tilt=False)})
+    desc = coord.build_axis_discovery()
+    assert desc.cover_type == "cover_blind"
+    assert [a.id for a in desc.axes] == ["position"]
+    assert desc.axes[0].supported is True
+
+
+def test_venetian_discovery_rolls_up_supported_across_members() -> None:
+    """A position-only member + a dual-axis member → both axes supported."""
+    coord = _coord(
+        "cover_venetian",
+        {
+            "cover.a": _caps(position=True, tilt=False),
+            "cover.b": _caps(position=True, tilt=True),
+        },
+    )
+    desc = coord.build_axis_discovery()
+    by_id = {a.id: a for a in desc.axes}
+    assert set(by_id) == {"position", "tilt"}
+    assert by_id["position"].supported is True
+    assert by_id["tilt"].supported is True
+
+
+def test_venetian_discovery_tilt_unsupported_when_no_member_has_it() -> None:
+    coord = _coord(
+        "cover_venetian",
+        {
+            "cover.a": _caps(position=True, tilt=False),
+            "cover.b": _caps(position=True, tilt=False),
+        },
+    )
+    desc = coord.build_axis_discovery()
+    by_id = {a.id: a for a in desc.axes}
+    assert by_id["position"].supported is True
+    assert by_id["tilt"].supported is False

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -85,6 +85,10 @@ class TestCoverAxis:
             state_attr=POSITION_AXIS.state_attr,
             capability_key=POSITION_AXIS.capability_key,
             open_blocks_sun=False,
+            label_key=POSITION_AXIS.label_key,
+            value_min=POSITION_AXIS.value_min,
+            value_max=POSITION_AXIS.value_max,
+            unit=POSITION_AXIS.unit,
         )
         assert twin == POSITION_AXIS
 
@@ -112,6 +116,24 @@ class TestAxisSingletons:
         assert TILT_AXIS.state_attr == STATE_ATTR_TILT_POSITION
         assert TILT_AXIS.capability_key == CAP_HAS_SET_TILT_POSITION
         assert TILT_AXIS.open_blocks_sun is False
+
+    @pytest.mark.unit
+    def test_position_axis_descriptor_fields(self):
+        # Discovery-surface metadata (issue #725): each axis carries a label
+        # i18n key, a numeric range, and a display unit so the self-discovery
+        # payload can be assembled without re-deriving cover-type knowledge.
+        assert POSITION_AXIS.label_key == "axes.position"
+        assert POSITION_AXIS.value_min == 0
+        assert POSITION_AXIS.value_max == 100
+        assert POSITION_AXIS.unit == "%"
+        assert POSITION_AXIS_OPEN_BLOCKS_SUN.label_key == "axes.position"
+
+    @pytest.mark.unit
+    def test_tilt_axis_descriptor_fields(self):
+        assert TILT_AXIS.label_key == "axes.tilt"
+        assert TILT_AXIS.value_min == 0
+        assert TILT_AXIS.value_max == 100
+        assert TILT_AXIS.unit == "%"
 
     @pytest.mark.unit
     def test_awning_position_axis_flips_sun_semantic(self):

--- a/tests/test_cover_types/test_discovery.py
+++ b/tests/test_cover_types/test_discovery.py
@@ -1,0 +1,103 @@
+"""Tests for the policy-owned axis/cover discovery descriptors (issue #725).
+
+``CoverTypePolicy.describe`` assembles a ``CoverDescriptor`` — cover-type id +
+label + one ``AxisDescriptor`` per declared axis — so the self-discovery
+surface (the sensor attribute and the ``set_axes`` service validation) can be
+built generically off ``policy.axes`` without ever branching on a cover-type
+string. ``supported_axes`` filters the declared axes to those a given entity's
+capabilities actually expose; it is the single source of truth for both the
+service's unsupported-axis rejection and each descriptor's ``supported`` flag.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    AxisDescriptor,
+    CoverDescriptor,
+)
+
+from .test_axes import ALL_COVER_TYPES
+
+pytestmark = pytest.mark.unit
+
+_FULL_CAPS = {"has_set_position": True, "has_set_tilt_position": True}
+
+
+@pytest.mark.parametrize("cover_type", ALL_COVER_TYPES)
+def test_describe_round_trips_all_policies(cover_type: str) -> None:
+    """Every cover type round-trips through ``describe`` into a descriptor.
+
+    Parametrised over every registered cover type so a ninth cover type needs
+    zero edits to the discovery builder — it inherits ``describe`` unchanged.
+    """
+    policy = get_policy(cover_type)
+    desc = policy.describe(caps=_FULL_CAPS, labels=None)
+
+    assert isinstance(desc, CoverDescriptor)
+    assert desc.cover_type == cover_type
+    assert desc.cover_label == policy.display_label()
+    assert len(desc.axes) == len(policy.axes)
+
+    for axis_desc, axis in zip(desc.axes, policy.axes, strict=True):
+        assert isinstance(axis_desc, AxisDescriptor)
+        assert axis_desc.id == axis.name
+        assert axis_desc.label_key == axis.label_key
+        assert axis_desc.min == axis.value_min
+        assert axis_desc.max == axis.value_max
+        assert axis_desc.unit == axis.unit
+        assert axis_desc.capability_key == axis.capability_key
+        assert axis_desc.state_attr == axis.state_attr
+        assert axis_desc.service_attr == axis.service_attr
+        assert axis_desc.open_blocks_sun == axis.open_blocks_sun
+        assert axis_desc.supported is True
+
+
+def test_axis_label_resolves_from_english_defaults() -> None:
+    """With ``labels=None`` the English axis label defaults are used."""
+    desc = get_policy("cover_venetian").describe(caps=_FULL_CAPS)
+    by_id = {a.id: a for a in desc.axes}
+    assert by_id["position"].label == "Position"
+    assert by_id["tilt"].label == "Tilt"
+
+
+def test_axis_label_override_wins() -> None:
+    """A translated ``labels`` overlay overrides the English default."""
+    desc = get_policy("cover_venetian").describe(
+        caps=_FULL_CAPS, labels={"axes.tilt": "Lamellenwinkel"}
+    )
+    by_id = {a.id: a for a in desc.axes}
+    assert by_id["tilt"].label == "Lamellenwinkel"
+    # Non-overridden axis keeps the English default.
+    assert by_id["position"].label == "Position"
+
+
+def test_supported_axes_filters_by_caps() -> None:
+    """``describe`` keeps every declared axis but flags ``supported`` per caps.
+
+    For a dual-axis venetian with tilt disabled, both axes still appear in the
+    descriptor, but only the position axis reports ``supported=True``. The
+    separate ``supported_axes`` accessor returns ONLY the caps-supported axes —
+    the set the service validates against.
+    """
+    policy = get_policy("cover_venetian")
+    caps = {"has_set_position": True, "has_set_tilt_position": False}
+
+    desc = policy.describe(caps=caps)
+    by_id = {a.id: a for a in desc.axes}
+    assert set(by_id) == {"position", "tilt"}
+    assert by_id["position"].supported is True
+    assert by_id["tilt"].supported is False
+
+    supported = policy.supported_axes(caps)
+    assert tuple(a.name for a in supported) == ("position",)
+
+
+def test_supported_axes_position_only_blind() -> None:
+    """A position-only blind exposes only the position axis."""
+    policy = get_policy("cover_blind")
+    caps = {"has_set_position": True, "has_set_tilt_position": False}
+    supported = policy.supported_axes(caps)
+    assert tuple(a.name for a in supported) == ("position",)

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -26,7 +26,9 @@ from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.cover_types.base import (
     CAP_HAS_SET_POSITION,
     CAP_HAS_SET_TILT_POSITION,
+    AxisDescriptor,
     CoverAxis,
+    CoverDescriptor,
     CoverTypePolicy,
 )
 
@@ -132,6 +134,59 @@ def test_select_default_axis_returns_cover_axis(policy: CoverTypePolicy) -> None
 def test_axes_tuple_non_empty(policy: CoverTypePolicy) -> None:
     """Every policy declares at least one axis — selecting one must be safe."""
     assert len(policy.axes) >= 1
+
+
+# ---- Discovery descriptors (issue #725) ---------------------------------- #
+
+
+@pytest.mark.unit
+def test_describe_returns_cover_descriptor(policy: CoverTypePolicy) -> None:
+    """``describe`` yields a ``CoverDescriptor`` for any conformant policy.
+
+    Base-class defaults must satisfy this for a stub fifth cover type — no
+    per-policy override required. One ``AxisDescriptor`` per declared axis,
+    each carrying the axis name as its id and ``supported=True`` under full caps.
+    """
+    caps = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: True}
+    desc = policy.describe(caps=caps)
+    assert isinstance(desc, CoverDescriptor)
+    assert desc.cover_type == policy.cover_type
+    assert len(desc.axes) == len(policy.axes)
+    for axis_desc, axis in zip(desc.axes, policy.axes, strict=True):
+        assert isinstance(axis_desc, AxisDescriptor)
+        assert axis_desc.id == axis.name
+        assert axis_desc.supported is True
+
+
+@pytest.mark.unit
+def test_supported_axes_returns_subset(policy: CoverTypePolicy) -> None:
+    """``supported_axes`` returns a subset of declared axes; full caps → all."""
+    caps = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: True}
+    supported = policy.supported_axes(caps)
+    assert set(supported) <= set(policy.axes)
+    assert len(supported) == len(policy.axes)
+
+
+@pytest.mark.unit
+def test_empty_axes_policy_describe_and_supported() -> None:
+    """A policy with zero axes still describes cleanly via base defaults.
+
+    Guards the Liskov contract that a hypothetical axis-less conformant policy
+    (like the virtual entry types) needs no discovery-builder edits: ``describe``
+    returns an empty axis tuple and ``supported_axes`` returns ``()``.
+    """
+
+    class _EmptyAxesPolicy(CoverTypePolicy):
+        cover_type = "cover_empty_stub"
+
+        def build_calc_engine(self, **kwargs):  # type: ignore[override]  # noqa: ARG002
+            return MagicMock()
+
+    policy = _EmptyAxesPolicy()
+    desc = policy.describe(caps={})
+    assert isinstance(desc, CoverDescriptor)
+    assert desc.axes == ()
+    assert policy.supported_axes({}) == ()
 
 
 # ---- Registry-level invariants ------------------------------------------- #

--- a/tests/test_policy_summary_i18n.py
+++ b/tests/test_policy_summary_i18n.py
@@ -27,6 +27,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_TILT_MODE,
 )
 from custom_components.adaptive_cover_pro.cover_types._summary_labels import (
+    AXIS_LABELS_EN,
     COVER_TYPE_LABELS_EN,
     GEOMETRY_LABELS_EN,
 )
@@ -139,4 +140,11 @@ def test_geometry_labels_match_en_json() -> None:
     """``summary_i18n/en.json['geometry']`` == ``GEOMETRY_LABELS_EN``."""
     en = _flatten(_en_config_summary().get("geometry", {}))
     expected = {k.removeprefix("geometry."): v for k, v in GEOMETRY_LABELS_EN.items()}
+    assert en == expected
+
+
+def test_axis_labels_match_en_json() -> None:
+    """``summary_i18n/en.json['axes']`` == ``AXIS_LABELS_EN`` (issue #725)."""
+    en = _flatten(_en_config_summary().get("axes", {}))
+    expected = {k.removeprefix("axes."): v for k, v in AXIS_LABELS_EN.items()}
     assert en == expected

--- a/tests/test_sensor_coverage.py
+++ b/tests/test_sensor_coverage.py
@@ -27,13 +27,23 @@ def _make_config_entry(sensor_type=CoverType.BLIND):
     return entry
 
 
-def _make_coordinator(diagnostics: dict | None = None):
+def _make_coordinator(diagnostics: dict | None = None, cover_type=CoverType.BLIND):
     coord = MagicMock()
     coord.logger = MagicMock()
     data = MagicMock()
     data.diagnostics = diagnostics
     data.states = {}
     coord.data = data
+    # The control-status sensor now surfaces a cover_discovery descriptor built
+    # from the coordinator (issue #725). Provide a real descriptor so
+    # dataclasses.asdict works on the MagicMock coordinator.
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    coord.build_axis_discovery = MagicMock(
+        side_effect=lambda labels=None: get_policy(cover_type).describe(
+            caps={"has_set_position": True, "has_set_tilt_position": True}
+        )
+    )
     return coord
 
 
@@ -410,6 +420,71 @@ def test_control_status_attrs_expose_cover_type(sensor_type):
     attrs = sensor.extra_state_attributes
     assert attrs is not None
     assert attrs.get("cover_type") == sensor_type
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveCoverControlStatusSensor.extra_state_attributes — cover_discovery
+# ---------------------------------------------------------------------------
+# Issue #725: an additive self-discovery descriptor sits alongside the existing
+# cover_type key. Old card versions still read cover_type; new ones read
+# cover_discovery for the full axis list + labels + ranges + supported flags.
+
+
+@pytest.mark.unit
+def test_control_status_attrs_expose_cover_discovery_blind():
+    """A blind exposes cover_discovery with a single position axis; cover_type
+    stays present and unchanged (additive).
+    """
+    coord = _make_coordinator(
+        diagnostics={"control_status": "active"}, cover_type=CoverType.BLIND
+    )
+    entry = _make_config_entry(sensor_type=CoverType.BLIND)
+    sensor = AdaptiveCoverControlStatusSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    # Additive: cover_type still present.
+    assert attrs.get("cover_type") == CoverType.BLIND
+    discovery = attrs.get("cover_discovery")
+    assert discovery is not None
+    assert discovery["cover_type"] == "cover_blind"
+    assert [a["id"] for a in discovery["axes"]] == ["position"]
+    axis = discovery["axes"][0]
+    assert axis["label"] == "Position"
+    assert axis["min"] == 0
+    assert axis["max"] == 100
+    assert axis["unit"] == "%"
+    assert axis["supported"] is True
+
+
+@pytest.mark.unit
+def test_control_status_attrs_expose_cover_discovery_venetian():
+    """A venetian exposes cover_discovery with position + tilt axes."""
+    coord = _make_coordinator(
+        diagnostics={"control_status": "active"}, cover_type=CoverType.VENETIAN
+    )
+    entry = _make_config_entry(sensor_type=CoverType.VENETIAN)
+    sensor = AdaptiveCoverControlStatusSensor(
+        unique_id="test_entry",
+        hass=_make_hass(),
+        config_entry=entry,
+        name="Test",
+        coordinator=coord,
+    )
+    attrs = sensor.extra_state_attributes
+    assert attrs is not None
+    discovery = attrs.get("cover_discovery")
+    assert discovery is not None
+    assert discovery["cover_type"] == "cover_venetian"
+    ids = [a["id"] for a in discovery["axes"]]
+    assert ids == ["position", "tilt"]
+    labels = {a["id"]: a["label"] for a in discovery["axes"]}
+    assert labels == {"position": "Position", "tilt": "Tilt"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services_set_axes.py
+++ b/tests/test_services_set_axes.py
@@ -1,0 +1,231 @@
+"""Tests for the generalized set_axes service (issue #725).
+
+``set_axes`` takes a per-axis target map (``{position, tilt}``) plus ``force``
+and dispatches each requested axis through the coordinator's
+``async_apply_user_axis`` collapse point. It validates every requested axis
+against ``policy.supported_axes(caps)`` for each target entity, raising
+``ServiceValidationError`` for an unsupported axis — the issue is explicit that
+this is an error, not a silent no-op. No cover-type string branching: dispatch
+is keyed on the ``AXIS_NAME_*`` constants.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import voluptuous as vol
+from homeassistant.exceptions import ServiceValidationError
+
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    AXIS_NAME_POSITION,
+    AXIS_NAME_TILT,
+)
+from custom_components.adaptive_cover_pro.state.snapshot import CoverCapabilities
+
+pytestmark = pytest.mark.unit
+
+
+def _make_coord(
+    *,
+    cover_type: str,
+    caps: CoverCapabilities,
+    entities: list[str] | None = None,
+) -> MagicMock:
+    coord = MagicMock()
+    coord.entities = entities or ["cover.test"]
+    coord._policy = get_policy(cover_type)
+    coord._cover_provider = MagicMock()
+    coord._cover_provider.read_single_capabilities.return_value = caps
+    coord.async_apply_user_axis = AsyncMock(return_value=("sent", ""))
+    return coord
+
+
+_DUAL_CAPS = CoverCapabilities(
+    has_set_position=True,
+    has_set_tilt_position=True,
+    has_open=True,
+    has_close=True,
+)
+_POSITION_ONLY_CAPS = CoverCapabilities(
+    has_set_position=True,
+    has_set_tilt_position=False,
+    has_open=True,
+    has_close=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_schema_rejects_missing_axes() -> None:
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        SET_AXES_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_AXES_SCHEMA({"entity_id": ["cover.test"]})
+
+
+def test_schema_accepts_both_axes() -> None:
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        SET_AXES_SCHEMA,
+    )
+
+    result = SET_AXES_SCHEMA(
+        {"axes": {"position": 60, "tilt": 30}, "entity_id": ["cover.test"]}
+    )
+    assert result["axes"]["position"] == 60
+    assert result["axes"]["tilt"] == 30
+
+
+def test_schema_rejects_out_of_range_axis_value() -> None:
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        SET_AXES_SCHEMA,
+    )
+
+    with pytest.raises(vol.Invalid):
+        SET_AXES_SCHEMA({"axes": {"position": 150}, "entity_id": ["cover.test"]})
+
+
+def test_schema_defaults_force_to_false() -> None:
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        SET_AXES_SCHEMA,
+    )
+
+    result = SET_AXES_SCHEMA({"axes": {"position": 50}, "entity_id": ["cover.test"]})
+    assert result.get("force") is False
+
+
+# ---------------------------------------------------------------------------
+# Handler dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sets_both_axes_on_venetian() -> None:
+    """A single call with both axes dispatches each to the collapse point."""
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(
+        cover_type="cover_venetian", caps=_DUAL_CAPS, entities=["cover.venetian"]
+    )
+    call = MagicMock()
+    call.data = {"axes": {"position": 60, "tilt": 30}}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_axes(call)
+
+    awaited = {
+        (c.args[0], c.args[1], c.args[2], c.kwargs.get("force"))
+        for c in coord.async_apply_user_axis.await_args_list
+    }
+    assert awaited == {
+        ("cover.venetian", AXIS_NAME_POSITION, 60, False),
+        ("cover.venetian", AXIS_NAME_TILT, 30, False),
+    }
+
+
+@pytest.mark.asyncio
+async def test_unsupported_axis_raises() -> None:
+    """Requesting tilt on a position-only blind raises ServiceValidationError."""
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(
+        cover_type="cover_blind", caps=_POSITION_ONLY_CAPS, entities=["cover.blind"]
+    )
+    call = MagicMock()
+    call.data = {"axes": {"tilt": 30}}
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+            return_value={coord: None},
+        ),
+        pytest.raises(ServiceValidationError, match="tilt"),
+    ):
+        await async_handle_set_axes(call)
+
+    coord.async_apply_user_axis.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_empty_axes_raises() -> None:
+    """An empty axes map is an error, not a silent no-op."""
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(cover_type="cover_blind", caps=_POSITION_ONLY_CAPS)
+    call = MagicMock()
+    call.data = {"axes": {}}
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+            return_value={coord: None},
+        ),
+        pytest.raises(ServiceValidationError),
+    ):
+        await async_handle_set_axes(call)
+
+    coord.async_apply_user_axis.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_force_propagates() -> None:
+    """force=true reaches the collapse point."""
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(
+        cover_type="cover_blind", caps=_POSITION_ONLY_CAPS, entities=["cover.blind"]
+    )
+    call = MagicMock()
+    call.data = {"axes": {"position": 40}, "force": True}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_axes(call)
+
+    coord.async_apply_user_axis.assert_awaited_once_with(
+        "cover.blind", AXIS_NAME_POSITION, 40, trigger="set_axes", force=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_unsupported_axis_rejected_before_any_dispatch() -> None:
+    """One unsupported axis rejects the whole call — no partial dispatch."""
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(
+        cover_type="cover_blind", caps=_POSITION_ONLY_CAPS, entities=["cover.blind"]
+    )
+    call = MagicMock()
+    call.data = {"axes": {"position": 40, "tilt": 30}}
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+            return_value={coord: None},
+        ),
+        pytest.raises(ServiceValidationError),
+    ):
+        await async_handle_set_axes(call)
+
+    coord.async_apply_user_axis.assert_not_awaited()

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -102,6 +102,12 @@ def _make_coord(
     coord.async_apply_user_position = (
         AdaptiveDataUpdateCoordinator.async_apply_user_position.__get__(coord)
     )
+    # set_position now routes through the axis collapse point (issue #725); bind
+    # the real dispatcher so behavior tests exercise the same path production does.
+    coord.async_apply_user_tilt = AsyncMock(return_value=("sent", "tilt"))
+    coord.async_apply_user_axis = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_axis.__get__(coord)
+    )
 
     return coord
 
@@ -160,6 +166,37 @@ async def test_set_tilt_service_removed_after_all_entries_unloaded(hass) -> None
 # ---------------------------------------------------------------------------
 # Wrapper coverage: thin _resolve_targets re-export
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_position_routes_through_axis_dispatch() -> None:
+    """The set_position handler dispatches on the POSITION axis constant (#725)."""
+    from custom_components.adaptive_cover_pro.cover_types.base import (
+        AXIS_NAME_POSITION,
+    )
+    from custom_components.adaptive_cover_pro.services.set_position_service import (
+        async_handle_set_position,
+    )
+
+    coord = MagicMock()
+    coord.entities = ["cover.blind_a"]
+    coord.async_apply_user_axis = AsyncMock(return_value=("sent", "position"))
+    call = MagicMock()
+    call.data = {"position": 55}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_position_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_position(call)
+
+    coord.async_apply_user_axis.assert_awaited_once_with(
+        "cover.blind_a",
+        AXIS_NAME_POSITION,
+        55,
+        trigger="set_position",
+        force=False,
+    )
 
 
 def test_resolve_targets_wrapper_delegates_to_services_module() -> None:

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -79,6 +79,20 @@ def test_no_service_target_has_a_device_filter():
     )
 
 
+def test_set_axes_service_exists_in_yaml():
+    svc = _load()
+    assert (
+        "set_axes" in svc
+    ), "set_axes service is registered in Python but has no entry in services.yaml"
+
+
+def test_set_axes_has_target_block_and_axes_field():
+    svc = _load()["set_axes"]
+    assert "target" in svc
+    assert svc["target"]["entity"]["integration"] == "adaptive_cover_pro"
+    assert "axes" in svc["fields"]
+
+
 def test_set_position_has_position_field_with_correct_range():
     fields = _load()["set_position"]["fields"]
     assert "position" in fields
@@ -100,6 +114,7 @@ REGISTERED_SERVICES = {
     "emergency_stop",
     "set_position",
     "set_tilt",
+    "set_axes",
     "engage_manual_override",
     # Options services (registered via register_options_services / OPTIONS_SERVICE_NAMES)
     "set_position_limits",

--- a/tests/test_user_command_auto_control_off.py
+++ b/tests/test_user_command_auto_control_off.py
@@ -18,7 +18,7 @@ is issue #293 and is verified in test_issue_293_force_true_auto_off.py.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -104,6 +104,12 @@ def _make_coord():
     )
     coord.async_apply_user_position = (
         AdaptiveDataUpdateCoordinator.async_apply_user_position.__get__(coord)
+    )
+    # set_position routes through the axis collapse point (issue #725) — bind the
+    # real dispatcher so the service still reaches async_apply_user_position.
+    coord.async_apply_user_tilt = AsyncMock(return_value=("sent", "tilt"))
+    coord.async_apply_user_axis = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_axis.__get__(coord)
     )
     return coord
 


### PR DESCRIPTION
## Summary
Adds a generalized `adaptive_cover_pro.set_axes` service that takes a per-axis target map (`position` and/or `tilt`) plus `force`, introspects the target cover's `policy.axes`, rejects unsupported axes with a `ServiceValidationError`, and dispatches each axis through the existing coordinator setters via a new `async_apply_user_axis` collapse point. `set_position` and `set_tilt` become thin wrappers over that same path (behavior unchanged).

Also adds an additive `cover_discovery` attribute on the control-status sensor (right after `cover_type`, so older cards are unaffected). It carries the cover-type id and label plus a per-axis descriptor: id, label, range and unit, capability flag, state/service attrs, and `open_blocks_sun`. It's built from one shared policy assembler that round-trips over every registered cover type, so the forecast work in #724 can consume the same axis descriptors.

New axis-label i18n keys, synced to DE and FR. All existing services and attributes are backward compatible.

## Testing
- ✅ 6053 tests passing (`venv/bin/python -m pytest tests/ -n auto`)

## Related Issues
Refs #725
Relates to #724 (forecast side, shares the axis descriptors) and #723 (terminology consistency).