### PR TITLE
feat: extend forecast timeline to all axes (project venetian tilt)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -348,6 +348,32 @@ class CoverTypePolicy(ABC):
         """Enrich the pipeline result. Default: identity."""
         return result
 
+    def forecast_secondary_axes(
+        self,
+        *,
+        position: int,  # noqa: ARG002
+        logger,  # noqa: ARG002
+        sol_azi: float,  # noqa: ARG002
+        sol_elev: float,  # noqa: ARG002
+        sun_data,  # noqa: ARG002
+        config,  # noqa: ARG002
+        config_service: ConfigurationService,  # noqa: ARG002
+        options: dict,  # noqa: ARG002
+        minimize_movements: bool,  # noqa: ARG002
+        max_coverage_steps: int,  # noqa: ARG002
+    ) -> dict[str, int]:
+        """Project this cover's non-primary axes at one forecast step (#724).
+
+        The forecast loop calls this alongside the primary ``position`` on each
+        *solar* sample and carries the result in ``ForecastSample.axes`` (keyed
+        by ``CoverAxis.name``). Single-axis covers have no secondary axis to
+        project, so the Liskov-safe default returns an empty map — the forecast
+        asks this polymorphic hook rather than branching on the cover type.
+        Multi-axis policies (venetian) override it, reusing the same tilt math
+        the live path runs so the projected track matches runtime.
+        """
+        return {}
+
     def position_context_overrides(self, result: PipelineResult) -> dict[str, Any]:
         """Extra kwargs for ``PositionContext``. Default: empty."""
         return {}

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -538,6 +538,84 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             return True
         return cover is None or not cover.direct_sun_valid
 
+    def _compose_tilt(
+        self,
+        position: int,
+        *,
+        logger,
+        sol_azi: float,
+        sol_elev: float,
+        sun_data,
+        config,
+        config_service: ConfigurationService,
+        options: dict,
+        minimize_movements: bool,
+        max_coverage_steps: int,
+    ) -> tuple[int, VenetianCoverCalculation]:
+        """Single source of truth for the engine slat angle + minimize quantize.
+
+        Builds the tilt engine, computes the slat angle for ``position``, and
+        applies the movement-minimization quantize (the tilt axis closes at 0%,
+        so full coverage is at zero). Returns ``(tilt, venetian_calc)`` so the
+        live ``post_pipeline_resolve`` can still merge the tilt engine's raw
+        trace (#682) and the forecast hook can take just the scalar. BOTH the
+        live path and the projected forecast flow through this one method, so
+        the tilt geometry never diverges between them (CODING_GUIDELINES.md
+        "No Code Duplication").
+        """
+        venetian_calc = VenetianCoverCalculation(
+            config=config,
+            vert_config=config_service.get_vertical_data(options),
+            tilt_config=config_service.get_tilt_data(options),
+            sun_data=sun_data,
+            sol_azi=sol_azi,
+            sol_elev=sol_elev,
+            logger=logger,
+        )
+        tilt = venetian_calc.tilt_for_position(position)
+        if minimize_movements:
+            tilt = PositionConverter.quantize_to_coverage_steps(
+                tilt,
+                max_coverage_steps,
+                full_coverage_at_zero=not self.axes[1].open_blocks_sun,
+            )
+        return tilt, venetian_calc
+
+    def forecast_secondary_axes(
+        self,
+        *,
+        position: int,
+        logger,
+        sol_azi: float,
+        sol_elev: float,
+        sun_data,
+        config,
+        config_service: ConfigurationService,
+        options: dict,
+        minimize_movements: bool,
+        max_coverage_steps: int,
+    ) -> dict[str, int]:
+        """Project the slat tilt that pairs with ``position`` (#724).
+
+        Delegates to the shared :meth:`_compose_tilt` seam so the forecast
+        strip's tilt track matches the live cover exactly. Returns the tilt
+        keyed by the tilt axis's ``name`` (``self.axes[1].name`` — no hardcoded
+        ``"tilt"`` literal), which the forecast serializer spreads additively.
+        """
+        tilt, _ = self._compose_tilt(
+            position,
+            logger=logger,
+            sol_azi=sol_azi,
+            sol_elev=sol_elev,
+            sun_data=sun_data,
+            config=config,
+            config_service=config_service,
+            options=options,
+            minimize_movements=minimize_movements,
+            max_coverage_steps=max_coverage_steps,
+        )
+        return {self.axes[1].name: tilt}
+
     def post_pipeline_resolve(
         self,
         result: PipelineResult,
@@ -604,16 +682,26 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             self._clear_last_tilt()
             return replace(result, tilt=None)
 
-        venetian_calc = VenetianCoverCalculation(
-            config=config,
-            vert_config=config_service.get_vertical_data(options),
-            tilt_config=config_service.get_tilt_data(options),
-            sun_data=sun_data,
+        # Compose the engine slat angle (+ movement-minimization quantize) via
+        # the shared seam the forecast hook also uses, so the projected tilt
+        # track and the live tilt never diverge. The returned ``venetian_calc``
+        # carries the transient tilt trace the live-only #682 merge needs.
+        tilt, venetian_calc = self._compose_tilt(
+            result.position,
+            logger=logger,
             sol_azi=sol_azi,
             sol_elev=sol_elev,
-            logger=logger,
+            sun_data=sun_data,
+            config=config,
+            config_service=config_service,
+            options=options,
+            minimize_movements=bool(
+                options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS)
+            ),
+            max_coverage_steps=int(
+                options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)
+            ),
         )
-        tilt = venetian_calc.tilt_for_position(result.position)
         # Issue #682: merge the (otherwise transient) tilt engine's raw trace into
         # the position engine's _last_calc_details under a `tilt` sub-key so the
         # live solar_calculation sensor and the diagnostics download surface BOTH
@@ -625,16 +713,6 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         cover_trace = getattr(cover, "_last_calc_details", None)
         if isinstance(cover_trace, dict) and tilt_trace is not None:
             cover_trace[TRACE_KEY_TILT] = tilt_trace
-        # Movement minimization: quantize the slat tilt into the same number of
-        # discrete coverage levels as the carriage position (which the solar
-        # branch already quantized). The tilt axis closes at 0%, so full coverage
-        # is at zero. N=1 → slats fully closed while the sun is in the FOV.
-        if options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS):
-            tilt = PositionConverter.quantize_to_coverage_steps(
-                tilt,
-                int(options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)),
-                full_coverage_at_zero=not self.axes[1].open_blocks_sun,
-            )
         position = result.position
         trace = list(result.decision_trace)
 

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -16,7 +16,7 @@ and roughly where will the cover sit through the rest of the day?*
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 from collections.abc import Callable
@@ -49,13 +49,29 @@ if TYPE_CHECKING:
     from .sun import SunData
 
 
+# Closure that projects a cover-type's non-primary axes at one forecast step.
+# Mirrors the ``cover_factory`` decoupling: the pure sample loop stays free of
+# ``config_service``/``options``/policy plumbing and is trivially stub-testable.
+#   (position, sol_azi, sol_elev, t) -> {axis_name: value}
+# ``t`` is passed for signature symmetry / future time-dependent axes even
+# though venetian tilt is a pure function of the sun geometry + position.
+SecondaryAxisFactory = Callable[[int, float, float, datetime], dict[str, int]]
+
+
 @dataclass(frozen=True, slots=True)
 class ForecastSample:
-    """One (time, position) pair on the forecast strip."""
+    """One (time, position [+ secondary axes]) point on the forecast strip.
+
+    ``position`` is the primary-axis target (the stable wire contract older
+    cards read). ``axes`` carries any non-primary axis projections for
+    multi-axis covers (venetian tilt today), keyed by ``CoverAxis.name`` —
+    empty for single-axis covers so the serialized shape is unchanged (#724).
+    """
 
     t: datetime
     position: int
     handler: str  # "solar" when direct sun is valid at t, else "default"
+    axes: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,7 +98,14 @@ class Forecast:
         """
         return {
             "forecast": [
-                {"t": s.t.isoformat(), "position": s.position, "handler": s.handler}
+                {
+                    "t": s.t.isoformat(),
+                    "position": s.position,
+                    "handler": s.handler,
+                    # Spread the secondary-axis map additively (#724): empty for
+                    # single-axis covers → the pre-#724 keys only.
+                    **s.axes,
+                }
                 for s in self.samples
             ],
             "events": [
@@ -105,6 +128,7 @@ def build_forecast(
     floor_active: bool = True,
     end_of_window_pos: int | None = None,
     end_of_window_time: datetime | None = None,
+    secondary_axis_factory: SecondaryAxisFactory | None = None,
 ) -> Forecast:
     """Compute the forecast for one cover.
 
@@ -136,6 +160,10 @@ def build_forecast(
     until astral sunset, then hand off to the astral sunset position — the same
     two-phase rule the live path uses (delegated to ``compute_effective_default``
     per sample). ``None``/``None`` (default) preserves today's behavior.
+
+    ``secondary_axis_factory`` (issue #724) projects a multi-axis cover's
+    non-primary axes (venetian tilt) alongside each *solar* sample. ``None``
+    (default) — or a single-axis cover — leaves every sample's ``axes`` empty.
     """
     samples = _build_samples(
         sun_data=sun_data,
@@ -148,6 +176,7 @@ def build_forecast(
         floor_active=floor_active,
         end_of_window_pos=end_of_window_pos,
         end_of_window_time=end_of_window_time,
+        secondary_axis_factory=secondary_axis_factory,
     )
     events = _build_events(
         sun_data=sun_data, cover_factory=cover_factory, samples=samples
@@ -167,6 +196,7 @@ def _build_samples(
     floor_active: bool = True,
     end_of_window_pos: int | None = None,
     end_of_window_time: datetime | None = None,
+    secondary_axis_factory: SecondaryAxisFactory | None = None,
 ) -> list[ForecastSample]:
     """Walk the sun_data table at *step_minutes* cadence over the full calendar day.
 
@@ -224,7 +254,15 @@ def _build_samples(
                 policy=policy,
                 floor_active=floor_active,
             )
-            samples.append(ForecastSample(t=t, position=pos, handler="solar"))
+            # Secondary-axis projection (#724) runs on solar samples only —
+            # mirroring the live path, where tilt is meaningful only when the
+            # solar engine drives the position with direct sun on the window.
+            axes: dict[str, int] = {}
+            if secondary_axis_factory is not None:
+                axes = secondary_axis_factory(pos, azi, ele, t)
+            samples.append(
+                ForecastSample(t=t, position=pos, handler="solar", axes=axes)
+            )
         else:
             # Sunset-aware effective default at this sample's projected time,
             # then the same limit treatment the live default branch applies.
@@ -423,6 +461,34 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
                 # No end time configured → the feature cannot fire.
                 eow_pos = None
 
+    # Read once so the value the primitives quantize with is the same one the
+    # secondary-axis closure hands the policy hook (no drift between axes).
+    minimize_movements = bool(
+        options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS)
+    )
+    max_coverage_steps = int(
+        options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)
+    )
+
+    # Secondary-axis projection (#724): build the closure from the polymorphic
+    # policy hook — the shim never branches on the cover type. Single-axis
+    # policies inherit the base no-op returning ``{}``; venetian projects tilt.
+    def make_secondary_axes(
+        position: int, azi: float, ele: float, t: datetime
+    ) -> dict[str, int]:
+        return coord._policy.forecast_secondary_axes(  # noqa: SLF001
+            position=position,
+            logger=coord.logger,
+            sol_azi=azi,
+            sol_elev=ele,
+            sun_data=sun_data,
+            config=config,
+            config_service=coord._config_service,  # noqa: SLF001
+            options=options,
+            minimize_movements=minimize_movements,
+            max_coverage_steps=max_coverage_steps,
+        )
+
     # The coverage direction the primitives need is read from the policy's
     # primary axis (single source of truth), so the shim passes the policy
     # straight through rather than precomputing full_coverage_at_zero.
@@ -432,13 +498,10 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
         config=config,
         policy=coord._policy,  # noqa: SLF001
         now=dt_util.now(),
-        minimize_movements=bool(
-            options.get(CONF_MINIMIZE_MOVEMENTS, DEFAULT_MINIMIZE_MOVEMENTS)
-        ),
-        max_coverage_steps=int(
-            options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)
-        ),
+        minimize_movements=minimize_movements,
+        max_coverage_steps=max_coverage_steps,
         floor_active=not all_positionable,
         end_of_window_pos=eow_pos,
         end_of_window_time=eow_time,
+        secondary_axis_factory=make_secondary_axes,
     )

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -182,6 +182,36 @@ class TestPolicyAxesDeclarations:
         assert get_policy("cover_awning").axes[0].open_blocks_sun is True
 
 
+class TestForecastSecondaryAxesHook:
+    """The polymorphic forecast secondary-axis hook (issue #724).
+
+    Single-axis covers inherit the base no-op returning ``{}`` — the forecast
+    loop asks the hook rather than branching on the cover-type string.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "cover_type",
+        ["cover_blind", "cover_awning", "cover_tilt", "cover_louvered_roof"],
+    )
+    def test_single_axis_policy_returns_no_secondary_axes(self, cover_type):
+        from unittest.mock import MagicMock
+
+        result = get_policy(cover_type).forecast_secondary_axes(
+            position=50,
+            logger=MagicMock(),
+            sol_azi=180.0,
+            sol_elev=30.0,
+            sun_data=MagicMock(),
+            config=MagicMock(),
+            config_service=MagicMock(),
+            options={},
+            minimize_movements=False,
+            max_coverage_steps=1,
+        )
+        assert result == {}
+
+
 # ---------------------------------------------------------------------------
 # select_default_axis — parity with the legacy should_use_tilt routing rule
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -1210,3 +1210,145 @@ class TestVenetianApplyUserTilt:
         ]
         assert len(tilt_calls) == 1, f"expected one tilt call, got {tilt_calls}"
         assert tilt_calls[0].args[2]["tilt_position"] == 90
+
+
+class TestVenetianForecastSecondaryAxes:
+    """VenetianPolicy.forecast_secondary_axes projects the tilt track (#724).
+
+    The forecast hook reuses the same ``_compose_tilt`` seam the live
+    ``post_pipeline_resolve`` runs, so the projected slat angle matches what
+    the cover is actually commanded to at runtime — no duplicated tilt math.
+    """
+
+    def _kwargs(self, **overrides):
+        from tests.cover_helpers import (
+            make_cover_config,
+            make_tilt_config,
+            make_vertical_config,
+        )
+
+        svc = MagicMock()
+        svc.get_vertical_data.return_value = make_vertical_config()
+        svc.get_tilt_data.return_value = make_tilt_config()
+        sun_data = MagicMock()
+        sun_data.timezone = "UTC"
+        kw = {
+            "position": 50,
+            "logger": MagicMock(),
+            "sol_azi": 180.0,
+            "sol_elev": 45.0,
+            "sun_data": sun_data,
+            "config": make_cover_config(),
+            "config_service": svc,
+            "options": {},
+            "minimize_movements": False,
+            "max_coverage_steps": 1,
+        }
+        kw.update(overrides)
+        return kw
+
+    def test_forecast_secondary_axes_returns_tilt_keyed_by_axis_name(self):
+        from custom_components.adaptive_cover_pro.engine.covers import (
+            VenetianCoverCalculation,
+        )
+
+        policy = VenetianPolicy()
+        kw = self._kwargs()
+        result = policy.forecast_secondary_axes(**kw)
+
+        # Keyed by the tilt axis's name (self.axes[1].name == "tilt"), not a
+        # hardcoded literal in the forecast layer.
+        assert set(result) == {policy.axes[1].name}
+        # Value equals the raw engine seam for the identical inputs (parity with
+        # VenetianCoverCalculation.tilt_for_position).
+        calc = VenetianCoverCalculation(
+            config=kw["config"],
+            vert_config=kw["config_service"].get_vertical_data(kw["options"]),
+            tilt_config=kw["config_service"].get_tilt_data(kw["options"]),
+            sun_data=kw["sun_data"],
+            sol_azi=kw["sol_azi"],
+            sol_elev=kw["sol_elev"],
+            logger=kw["logger"],
+        )
+        assert result[policy.axes[1].name] == calc.tilt_for_position(kw["position"])
+
+    def test_forecast_tilt_honors_minimize_movements_quantize(self, monkeypatch):
+        from custom_components.adaptive_cover_pro.engine.covers import (
+            VenetianCoverCalculation,
+        )
+
+        # Force a known intermediate slat angle so the quantize is observable.
+        monkeypatch.setattr(
+            VenetianCoverCalculation,
+            "tilt_for_position",
+            lambda self, position: 70,
+        )
+        policy = VenetianPolicy()
+        result = policy.forecast_secondary_axes(
+            **self._kwargs(minimize_movements=True, max_coverage_steps=1)
+        )
+        # N=1 with full-coverage-at-zero → slats fully closed (tilt 0).
+        assert result["tilt"] == 0
+
+    def test_compose_tilt_matches_post_pipeline_resolve(self):
+        """The forecast tilt equals what post_pipeline_resolve puts on result.tilt.
+
+        Proves both paths flow through the single ``_compose_tilt`` seam — the
+        projected track never diverges from the live decision.
+        """
+        from custom_components.adaptive_cover_pro.const import ControlMethod
+        from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+        policy = VenetianPolicy()
+        kw = self._kwargs(position=50)
+        forecast_tilt = policy.forecast_secondary_axes(**kw)[policy.axes[1].name]
+
+        cover = MagicMock()
+        cover.direct_sun_valid = True
+        live = policy.post_pipeline_resolve(
+            PipelineResult(
+                position=50, control_method=ControlMethod.SOLAR, reason="test"
+            ),
+            logger=kw["logger"],
+            sol_azi=kw["sol_azi"],
+            sol_elev=kw["sol_elev"],
+            sun_data=kw["sun_data"],
+            config=kw["config"],
+            config_service=kw["config_service"],
+            options=kw["options"],
+            cover=cover,
+        )
+        assert forecast_tilt == live.tilt
+
+    def test_compose_tilt_matches_post_pipeline_resolve_with_quantize(self):
+        """Parity must also hold under minimize-movements quantization."""
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_MAX_COVERAGE_STEPS,
+            CONF_MINIMIZE_MOVEMENTS,
+            ControlMethod,
+        )
+        from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+        policy = VenetianPolicy()
+        options = {CONF_MINIMIZE_MOVEMENTS: True, CONF_MAX_COVERAGE_STEPS: 2}
+        kw = self._kwargs(
+            position=50, minimize_movements=True, max_coverage_steps=2, options=options
+        )
+        forecast_tilt = policy.forecast_secondary_axes(**kw)[policy.axes[1].name]
+
+        cover = MagicMock()
+        cover.direct_sun_valid = True
+        live = policy.post_pipeline_resolve(
+            PipelineResult(
+                position=50, control_method=ControlMethod.SOLAR, reason="test"
+            ),
+            logger=kw["logger"],
+            sol_azi=kw["sol_azi"],
+            sol_elev=kw["sol_elev"],
+            sun_data=kw["sun_data"],
+            config=kw["config"],
+            config_service=kw["config_service"],
+            options=options,
+            cover=cover,
+        )
+        assert forecast_tilt == live.tilt

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -447,6 +447,85 @@ class TestForecastToAttrs:
         ]
 
 
+class TestForecastSecondaryAxes:
+    """ForecastSample carries a generic secondary-axis map (issue #724).
+
+    The primary ``position`` scalar is unchanged; multi-axis covers (venetian)
+    project their non-primary axes into ``axes`` keyed by ``CoverAxis.name``.
+    ``to_attrs()`` spreads the map additively so single-axis covers emit a
+    byte-identical wire shape.
+    """
+
+    def test_sample_defaults_to_no_secondary_axes(self):
+        assert ForecastSample(t=_NOW, position=40, handler="default").axes == {}
+
+    def test_to_attrs_spreads_secondary_axes_additively(self):
+        f = Forecast(
+            samples=(
+                ForecastSample(t=_NOW, position=55, handler="solar", axes={"tilt": 30}),
+                ForecastSample(t=_NOW, position=40, handler="default"),
+            ),
+            events=(),
+        )
+        attrs = f.to_attrs()
+        # Non-empty axes → the secondary key is spread into the sample dict.
+        assert attrs["forecast"][0] == {
+            "t": _NOW.isoformat(),
+            "position": 55,
+            "handler": "solar",
+            "tilt": 30,
+        }
+        # Empty axes → no extra keys (byte-identical to the pre-#724 shape).
+        assert attrs["forecast"][1] == {
+            "t": _NOW.isoformat(),
+            "position": 40,
+            "handler": "default",
+        }
+
+    def test_solar_samples_get_secondary_axes_from_factory(self):
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=True, percentage=55),
+            config=_make_config(),
+            policy=_make_policy(),
+            now=_NOW,
+            secondary_axis_factory=lambda pos, azi, ele, t: {"tilt": 30},
+        )
+        solar = [s for s in f.samples if s.handler == "solar"]
+        assert solar  # at least one solar sample was produced
+        assert all(s.axes == {"tilt": 30} for s in solar)
+
+    def test_default_samples_have_no_secondary_axes(self):
+        # A stub factory that would raise if the default branch ever calls it.
+        def _boom(pos, azi, ele, t):  # noqa: ARG001
+            raise AssertionError("factory must not run on default samples")
+
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=False),
+            config=_make_config(),
+            policy=_make_policy(),
+            now=_NOW,
+            secondary_axis_factory=_boom,
+        )
+        assert f.samples
+        assert all(s.axes == {} for s in f.samples)
+
+    def test_no_factory_yields_empty_axes(self):
+        sd = _make_sun_data()
+        f = build_forecast(
+            sun_data=sd,
+            cover_factory=_make_cover_factory(solar_valid=True, percentage=55),
+            config=_make_config(),
+            policy=_make_policy(),
+            now=_NOW,
+        )
+        assert f.samples
+        assert all(s.axes == {} for s in f.samples)
+
+
 # ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
@@ -948,6 +1027,78 @@ class TestForecastShimEndOfWindow:
         _, kwargs = spy.call_args
         assert kwargs["end_of_window_pos"] is None
         assert kwargs["end_of_window_time"] is None
+
+
+class TestForecastShimSecondaryAxes:
+    """build_forecast_for_coord builds the secondary-axis factory from the policy hook (#724).
+
+    The shim never asks "is this venetian" — it wires ``policy.forecast_secondary_axes``
+    into a closure and passes it as ``secondary_axis_factory``. Single-axis
+    policies inherit the base no-op, so the same closure returns ``{}``.
+    """
+
+    def _stub_coord(self, *, policy):
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = {}
+        coord.logger = MagicMock()
+        coord.hass = MagicMock()
+        coord.hass.config.time_zone = "UTC"
+        sun_data = _make_sun_data()
+        coord._sun_provider = MagicMock()
+        coord._sun_provider.create_sun_data = MagicMock(return_value=sun_data)
+        coord._config_service = MagicMock()
+        coord._config_service.get_common_data = MagicMock(return_value=_make_config())
+        coord._policy = policy
+        coord._snapshot = MagicMock()
+        coord._snapshot.cover_capabilities = {}
+        coord._time_mgr = MagicMock()
+        coord._time_mgr.end_time = None
+        return coord, sun_data
+
+    def _run(self, coord):
+        from custom_components.adaptive_cover_pro import forecast as fc_mod
+
+        spy = MagicMock(return_value=MagicMock(name="Forecast"))
+        with patch.object(fc_mod, "build_forecast", spy):
+            fc_mod.build_forecast_for_coord(coord)
+        return spy
+
+    def test_shim_passes_secondary_axis_factory_for_venetian(self):
+        policy = MagicMock()
+        policy.position_axis_supported = MagicMock(return_value=False)
+        policy.forecast_secondary_axes = MagicMock(return_value={"tilt": 30})
+        coord, sun_data = self._stub_coord(policy=policy)
+        spy = self._run(coord)
+        _, kwargs = spy.call_args
+        factory = kwargs["secondary_axis_factory"]
+        assert factory is not None
+        # Calling the closure routes straight to policy.forecast_secondary_axes.
+        assert factory(55, 180.0, 45.0, _NOW) == {"tilt": 30}
+        policy.forecast_secondary_axes.assert_called_once()
+        call_kwargs = policy.forecast_secondary_axes.call_args.kwargs
+        assert call_kwargs["position"] == 55
+        assert call_kwargs["sol_azi"] == 180.0
+        assert call_kwargs["sol_elev"] == 45.0
+        assert call_kwargs["sun_data"] is sun_data
+        assert call_kwargs["config_service"] is coord._config_service
+        assert "minimize_movements" in call_kwargs
+        assert "max_coverage_steps" in call_kwargs
+
+    def test_shim_single_axis_policy_still_passes_factory_returning_empty(self):
+        policy = MagicMock()
+        policy.position_axis_supported = MagicMock(return_value=False)
+        policy.forecast_secondary_axes = MagicMock(return_value={})
+        coord, _ = self._stub_coord(policy=policy)
+        spy = self._run(coord)
+        _, kwargs = spy.call_args
+        factory = kwargs["secondary_axis_factory"]
+        assert factory is not None
+        assert factory(40, 0.0, 0.0, _NOW) == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Extends the forecast timeline to project the secondary axis (venetian tilt) alongside position, building on the #725 CoverAxis model.

- `ForecastSample` grows a generic `axes: dict[str, int]` map keyed by `CoverAxis.name` (not a hardcoded "tilt" field), so it scales to any multi-axis cover.
- New polymorphic `CoverTypePolicy.forecast_secondary_axes` hook (base no-op) fills the map per forecast step. `VenetianPolicy` overrides it, reusing the exact live tilt math via a shared `_compose_tilt` seam that `post_pipeline_resolve` also calls — no duplicated tilt geometry.
- Projection is solar-tracking-only, mirroring the live tilt-suppression rule.
- `to_attrs()` spreads the map additively, so the diagnostics dump and the `position_forecast` sensor inherit the new `tilt` key with no edits, and older cards reading only `position` keep working.
- Card-side rendering of the tilt track is a separate follow-up in the card repo.

## Testing
- ✅ 6068 tests passing (full suite); targeted forecast/venetian/axes suites 276 passing; regression guards green.

## Related Issues
Refs #724