### PR TITLE
fix: honor min interval on routine solar cycles (#853)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2158,13 +2158,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self._pipeline_result is not None
             and self._pipeline_result.floor_clamp_applied
         )
+        # target_changed alone must not defeat the user's delta_position/
+        # delta_time throttle for routine solar/climate tracking (issue #853)
+        # — only force the bypass when the resolved target already carries
+        # override/safety semantics, matching the same delta-gate invariant
+        # documented on _pipeline_bypasses_auto_control (issue #290).
+        target_changed_override = target_changed and (
+            is_safety or self._pipeline_bypasses_auto_control
+        )
         use_force = (
             is_safety
             or safety_release
             or custom_position_sensor_triggered
             or custom_position_released
             or floor_clamp
-            or target_changed
+            or target_changed_override
         )
         if custom_position_released or safety_release:
             reason = "custom_position_released"

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -168,6 +168,34 @@ class TestStateChangeWithSolarTracking:
         )
 
     @pytest.mark.asyncio
+    async def test_solar_target_changed_does_not_force_bypass(self):
+        """A plain SOLAR result with target_changed=True must still call
+        _build_position_context with force=False (issue #853) — routine solar
+        tracking must stay subject to delta_position/delta_time, only
+        override/safety results may bypass on a resolved-target change.
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        result = _make_pipeline_result(
+            position=55, control_method=ControlMethod.SOLAR, bypass_auto_control=False
+        )
+        coordinator = _make_coordinator(entities=["cover.test"], pipeline_result=result)
+
+        await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+            coordinator, state=55, options={}, target_changed=True
+        )
+
+        coordinator._build_position_context.assert_called_once_with(
+            "cover.test",
+            {},
+            force=False,
+            is_safety=False,
+            sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
+        )
+
+    @pytest.mark.asyncio
     async def test_state_change_flag_cleared_after_handling(self):
         """state_change flag must be cleared after async_handle_state_change."""
         from custom_components.adaptive_cover_pro.coordinator import (


### PR DESCRIPTION
## Summary
Fixes #853 where the configured "Minimum interval between position changes" (delta_time) was ignored during routine solar/cloud tracking.

The #756 fix OR'd `target_changed` unconditionally into `use_force` in `coordinator.py::async_handle_state_change`. Because `target_changed` is derived from a signature that embeds the computed position, it went true on almost every tracking cycle, forcing past the delta_position/delta_time gates and the manual-override check.

This scopes `target_changed`'s force contribution to safety/override results only (`is_safety or self._pipeline_bypasses_auto_control`). Routine solar/climate cycles now go back through the throttle. The separate `elif target_changed` dispatch-recovery branch is untouched, so #756's lost-edge recovery still fires.

## Testing
- ✅ Added `test_solar_target_changed_does_not_force_bypass` (RED confirmed, then GREEN)
- ✅ 86 regression-guard tests passing (#756, #275/#348 sensor bypass, #616 anticipation, solar tracking)
- ✅ Full suite green (2 unrelated perf-timing flakes pass standalone)

## Related Issues
Refs #853