### PR TITLE
fix: clamp blind spot slots to FOV span on geometry save (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_dynamic.py
+++ b/custom_components/adaptive_cover_pro/config_dynamic.py
@@ -266,19 +266,69 @@ def sun_tracking_schema(hass: HomeAssistant | None = None) -> vol.Schema:
     )
 
 
+def blind_spot_edges(options: dict | None = None) -> int:
+    """Return the blind-spot azimuth span: ``fov_left + fov_right``.
+
+    Each side defaults to 90 when absent, matching the legacy in-step
+    construction (a cover created before the FOV fields are saved). This is
+    the single source for the formula: ``blind_spot_schema`` derives its
+    slider bounds from it, and ``clamp_blind_spots_to_fov`` (issue #852) uses
+    the identical value to re-clamp stored slots when the FOV narrows — the
+    two must never drift apart on this arithmetic.
+    """
+    opts = options or {}
+    return int(opts.get(CONF_FOV_LEFT, 90)) + int(opts.get(CONF_FOV_RIGHT, 90))
+
+
+def clamp_blind_spots_to_fov(options: dict) -> dict:
+    """Re-clamp stored blind-spot slot offsets to the current FOV span.
+
+    Blind-spot left/right are azimuth offsets *within* the FOV span
+    (``blind_spot_edges``), consumed raw at runtime. Nothing re-clamps them
+    when ``fov_left``/``fov_right`` narrow on the geometry step, so a slot
+    saved under a wider FOV can be left exceeding the new span — silently
+    disagreeing with the options-flow slider (max = the new edges) and
+    mis-shaping the wedge at runtime (issue #852).
+
+    Call this right after any options/config update that changes
+    ``CONF_FOV_LEFT``/``CONF_FOV_RIGHT`` (the geometry-step save sites in
+    ``config_flow.py``, plus the geometry sync-merge). Bounds mirror
+    ``blind_spot_schema`` exactly (``0 <= left <= edges-1``,
+    ``1 <= right <= edges``), sourced from the same ``blind_spot_edges`` call
+    so schema and clamp can never disagree.
+
+    Mutates *options* in place (and returns it) for every slot in
+    ``BLIND_SPOT_SLOTS``. A slot key that is absent or explicitly ``None`` is
+    left untouched — an unconfigured slot must stay inactive, never coerced
+    into existence by the clamp.
+    """
+    edges = blind_spot_edges(options)
+    left_max = edges - 1
+    right_max = edges
+    for keys in BLIND_SPOT_SLOTS.values():
+        left = options.get(keys["left"])
+        if left is not None:
+            options[keys["left"]] = min(int(left), left_max)
+        right = options.get(keys["right"])
+        if right is not None:
+            options[keys["right"]] = min(int(right), right_max)
+    return options
+
+
 def blind_spot_schema(options: dict | None = None) -> vol.Schema:
     """Blind-spot wedge schema for up to 3 slots (issue #701).
 
     ``edges = fov_left + fov_right`` (defaulting to 90+90) sets the maximum
-    left/right azimuth offset, matching the legacy in-step construction.
+    left/right azimuth offset, matching the legacy in-step construction. The
+    formula is single-sourced in ``blind_spot_edges`` — ``clamp_blind_spots_to_fov``
+    (issue #852) derives its clamp bounds from the same call.
 
     Slot 1 reuses the legacy unsuffixed keys and keeps its ``Required``
     defaults (0/1) so its form is byte-for-byte unchanged. Slots 2/3 are
     ``Optional`` sliders with no default, so an unconfigured slot stays absent
     (``None``-preserving) and therefore inactive.
     """
-    opts = options or {}
-    edges = int(opts.get(CONF_FOV_LEFT, 90)) + int(opts.get(CONF_FOV_RIGHT, 90))
+    edges = blind_spot_edges(options)
 
     def _slider(min_v: int, max_v: int, *, step: int | None = None):
         cfg: dict = {

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -271,6 +271,7 @@ from .config_dynamic import (  # noqa: E402
     behavior_schema as _behavior_schema,
     blind_spot_schema,
     building_profile_sensors_schema,
+    clamp_blind_spots_to_fov,
     glare_zones_schema as _glare_zones_schema,
     light_cloud_schema,
     sun_tracking_schema,
@@ -3324,6 +3325,10 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             if _resolve_fov_compute_submit(self.type_blind, canonical, canonical):
                 return self._show_geometry_form(canonical)
             self.config.update(canonical)
+            # Defensive parity with the options-flow save (issue #852): blind
+            # spots aren't configured yet this early in the create flow, so
+            # this is normally a no-op, but keeps both save sites identical.
+            clamp_blind_spots_to_fov(self.config)
             return await self.async_step_sun_tracking()
 
         return self._show_geometry_form(self.config)
@@ -4067,6 +4072,9 @@ class OptionsFlowHandler(OptionsFlow):
             if _resolve_fov_compute_submit(self.sensor_type, canonical, canonical):
                 return self._show_geometry_form(canonical)
             self.options.update(canonical)
+            # A narrower FOV can strand stale blind-spot slots past the new
+            # span (issue #852); re-clamp right after the FOV lands.
+            clamp_blind_spots_to_fov(self.options)
             return await self.async_step_init()
 
         return self._show_geometry_form(self.options)
@@ -4572,9 +4580,12 @@ class OptionsFlowHandler(OptionsFlow):
                 for entry_id in self.selected_sync_targets:
                     target = self.hass.config_entries.async_get_entry(entry_id)
                     if target:
+                        merged_options = clamp_blind_spots_to_fov(
+                            {**target.options, **shared_options}
+                        )
                         self.hass.config_entries.async_update_entry(
                             target,
-                            options={**target.options, **shared_options},
+                            options=merged_options,
                         )
             return await self.async_step_init()
 

--- a/tests/test_blind_spot_clamp.py
+++ b/tests/test_blind_spot_clamp.py
@@ -1,0 +1,148 @@
+"""Blind-spot slots re-clamped to a narrowed FOV span (issue #852).
+
+Blind-spot left/right are azimuth offsets *within* the FOV span
+(``edges = fov_left + fov_right``). Narrowing the FOV on the geometry step
+never re-clamped stored slot values, leaving out-of-range wedges (e.g.
+``blind_spot_right=172`` under a new ``edges=150``) whose stored value silently
+disagreed with the options-flow slider (max = new edges). ``clamp_blind_spots_to_fov``
+is the single shared helper that fixes stored values in place; ``blind_spot_edges``
+is the single-sourced ``fov_left + fov_right`` formula it (and ``blind_spot_schema``)
+both delegate to.
+"""
+
+from custom_components.adaptive_cover_pro.config_dynamic import (
+    blind_spot_edges,
+    clamp_blind_spots_to_fov,
+)
+from custom_components.adaptive_cover_pro.const import (
+    BLIND_SPOT_SLOTS,
+    CONF_FOV_LEFT,
+    CONF_FOV_RIGHT,
+)
+
+# ----------------------------------------------------------------------------
+# blind_spot_edges
+# ----------------------------------------------------------------------------
+
+
+def test_blind_spot_edges_sums_fov():
+    assert blind_spot_edges({CONF_FOV_LEFT: 75, CONF_FOV_RIGHT: 75}) == 150
+
+
+def test_blind_spot_edges_defaults_to_90_90_when_absent():
+    assert blind_spot_edges({}) == 180
+    assert blind_spot_edges(None) == 180
+
+
+# ----------------------------------------------------------------------------
+# clamp_blind_spots_to_fov
+# ----------------------------------------------------------------------------
+
+
+def test_over_range_right_clamped_to_new_edges():
+    # fov 86/86 (edges=172) narrowed to fov 75/75 (edges=150).
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_left": 0,
+        "blind_spot_right": 172,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result["blind_spot_right"] == 150
+
+
+def test_over_range_left_clamped_to_edges_minus_one():
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_left": 155,
+        "blind_spot_right": 172,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result["blind_spot_left"] == 149  # edges(150) - 1
+    assert result["blind_spot_right"] == 150
+
+
+def test_in_range_values_left_unchanged():
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_left": 10,
+        "blind_spot_right": 30,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result["blind_spot_left"] == 10
+    assert result["blind_spot_right"] == 30
+
+
+def test_absent_slot_keys_untouched_no_keyerror():
+    options = {CONF_FOV_LEFT: 75, CONF_FOV_RIGHT: 75}
+    result = clamp_blind_spots_to_fov(options)
+    assert "blind_spot_left" not in result
+    assert "blind_spot_right" not in result
+
+
+def test_none_slot_values_not_coerced():
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_left": None,
+        "blind_spot_right": None,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result["blind_spot_left"] is None
+    assert result["blind_spot_right"] is None
+
+
+def test_ordering_preserved_after_clamp():
+    # A slot pinned near the OLD edges must still satisfy right > left once
+    # both are clamped to the new (narrower) edges.
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_left": 170,
+        "blind_spot_right": 172,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result["blind_spot_right"] > result["blind_spot_left"]
+    assert result["blind_spot_left"] == 149
+    assert result["blind_spot_right"] == 150
+
+
+def test_suffixed_slot_2_and_3_clamp_too():
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_left_2": 0,
+        "blind_spot_right_2": 172,
+        "blind_spot_left_3": 149,
+        "blind_spot_right_3": 172,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result["blind_spot_right_2"] == 150
+    assert result["blind_spot_left_3"] == 149  # already at the new cap
+    assert result["blind_spot_right_3"] == 150
+
+
+def test_iterates_every_real_slot_defined_in_const():
+    # Data-driven: every slot in BLIND_SPOT_SLOTS gets its left/right clamped,
+    # not just a hardcoded subset.
+    options = {CONF_FOV_LEFT: 10, CONF_FOV_RIGHT: 10}  # edges=20
+    for keys in BLIND_SPOT_SLOTS.values():
+        options[keys["left"]] = 100
+        options[keys["right"]] = 100
+    result = clamp_blind_spots_to_fov(options)
+    for keys in BLIND_SPOT_SLOTS.values():
+        assert result[keys["left"]] == 19
+        assert result[keys["right"]] == 20
+
+
+def test_returns_same_mapping_mutated_in_place():
+    options = {
+        CONF_FOV_LEFT: 75,
+        CONF_FOV_RIGHT: 75,
+        "blind_spot_right": 172,
+    }
+    result = clamp_blind_spots_to_fov(options)
+    assert result is options
+    assert options["blind_spot_right"] == 150

--- a/tests/test_blind_spot_config_flow.py
+++ b/tests/test_blind_spot_config_flow.py
@@ -1,6 +1,16 @@
 """Config-flow blind-spot multi-slot rendering + per-slot validation (#701)."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
 from custom_components.adaptive_cover_pro.config_dynamic import blind_spot_schema
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_BLIND_SPOT,
+    CONF_FOV_LEFT,
+    CONF_FOV_RIGHT,
+    CoverType,
+)
 
 
 def _schema_keys(schema) -> set[str]:
@@ -39,3 +49,51 @@ def test_per_slot_left_right_errors():
 
     # Absent slot keys → no error.
     assert _blind_spot_step_errors({"blind_spot_left": 5}) == {}
+
+
+# ----------------------------------------------------------------------------
+# Geometry-save clamp (#852): narrowing the FOV on the geometry step must
+# re-clamp stale blind-spot slot values, not leave them stranded past the new
+# span's slider max.
+# ----------------------------------------------------------------------------
+
+
+def _options_flow(options: dict, sensor_type=CoverType.BLIND):
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    entry = MagicMock()
+    entry.options = dict(options)
+    entry.data = {"sensor_type": sensor_type}
+    flow = OptionsFlowHandler(entry)
+    flow.hass = MagicMock()
+    flow.hass.states.get.return_value = None
+    flow.sensor_type = sensor_type
+    flow.options = dict(options)
+    flow.async_step_init = AsyncMock(return_value={"type": "menu"})
+    return flow
+
+
+@pytest.mark.asyncio
+async def test_geometry_save_clamps_stale_blind_spot_to_narrowed_fov():
+    # Starting FOV 86/86 (edges=172) with an enabled blind-spot slot pinned at
+    # the old edge; narrowing to 75/75 (edges=150) must clamp the stored
+    # right value down to the new max instead of leaving it stranded at 172.
+    flow = _options_flow(
+        {
+            CONF_FOV_LEFT: 86,
+            CONF_FOV_RIGHT: 86,
+            CONF_ENABLE_BLIND_SPOT: True,
+            "blind_spot_left": 0,
+            "blind_spot_right": 172,
+        }
+    )
+    result = await flow.async_step_geometry(
+        {
+            CONF_FOV_LEFT: 75,
+            CONF_FOV_RIGHT: 75,
+            "distance_shaded_area": 0.5,
+        }
+    )
+    assert result["type"] == "menu"  # advanced (saved)
+    assert flow.options["blind_spot_right"] == 150
+    assert flow.options["blind_spot_left"] == 0  # already in range, unchanged


### PR DESCRIPTION
## Summary
Blind-spot slot left/right values are azimuth offsets within the FOV span (`fov_left + fov_right`), but nothing re-clamped them when the options-flow geometry step narrowed the FOV. A slot saved under a wider FOV could exceed the new span, silently disagreeing with the options slider (max = new edges) and mis-shaping the runtime wedge. The reporter framed it as a duplication bug, but the duplicate form does not expose FOV, so the real defect is the geometry-save path and it affects any cover.

Fix: a single shared `clamp_blind_spots_to_fov` helper (bounds from the same `blind_spot_edges` call the slider schema uses), applied at the three FOV-change save sites (options-flow geometry, create-flow geometry, sync-confirm merge). The duplication path is intentionally untouched.

## Testing
- ✅ 5569 tests passing on main

## Related Issues
Refs #852

Cherry-picked from #855 for a hotfix release.

https://claude.ai/code/session_01TspW41sUi2YN4tFYbR3aHB