### PR TITLE
fix: pre-fill building profile sensors in create wizard steps (#851)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3728,11 +3728,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             if chosen != _PROFILE_NONE_SENTINEL:
                 profile = self.hass.config_entries.async_get_entry(chosen)
                 if profile is not None:
-                    # Store only the link ID here. The sensor-value merge is
-                    # applied at entry-creation time (async_step_update) so that
-                    # profile values survive subsequent form steps that call
-                    # optional_entities() and overwrite absent keys with None.
                     self.config[CONF_BUILDING_PROFILE_ID] = profile.entry_id
+                    # Eagerly merge the profile's non-empty shared-sensor keys
+                    # so the later create steps render them as suggested defaults
+                    # (issue #851). The unconditional async_step_update merge
+                    # stays the safety net — optional_entities() nulls absent
+                    # keys mid-wizard, and that merge re-fills them at create.
+                    merge_profile_into_config(profile, self.config)
             return await self._route_after_window_config()
 
         profiles = _building_profile_entries(self.hass)
@@ -3791,7 +3793,9 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_weather_override()
         return self.async_show_form(
             step_id="behavior",
-            data_schema=_behavior_schema(self.config),
+            data_schema=self.add_suggested_values_to_schema(
+                _behavior_schema(self.config), self.config
+            ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Position",
                 "position_matching_wiki": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Position-Matching",
@@ -3932,11 +3936,14 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.config.update(user_input)
             # L3 priority 90 → 80 (manual override).
             return await self.async_step_manual_override()
+        suggested = _stringify_templatable(self.config)
         return self.async_show_form(
             step_id="weather_override",
-            data_schema=weather_override_schema(self.hass, self.config),
+            data_schema=self.add_suggested_values_to_schema(
+                weather_override_schema(self.hass, suggested), suggested
+            ),
             description_placeholders=_weather_override_placeholders(
-                self.hass, self.config
+                self.hass, suggested
             ),
         )
 
@@ -3946,9 +3953,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self.optional_entities(_LIGHT_CLOUD_OPTIONAL_KEYS, user_input)
             self.config.update(user_input)
             return await self.async_step_temperature_climate()
+        suggested = _stringify_templatable(self.config)
         return self.async_show_form(
             step_id="light_cloud",
-            data_schema=light_cloud_schema(self.hass, self.config),
+            data_schema=self.add_suggested_values_to_schema(
+                light_cloud_schema(self.hass, suggested), suggested
+            ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides"
             },
@@ -3963,9 +3973,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             if user_input.get(CONF_CLIMATE_MODE) and not user_input.get(
                 CONF_TEMP_ENTITY
             ):
+                suggested = _stringify_templatable(user_input)
                 return self.async_show_form(
                     step_id="temperature_climate",
-                    data_schema=temperature_climate_schema(self.hass, user_input),
+                    data_schema=self.add_suggested_values_to_schema(
+                        temperature_climate_schema(self.hass, suggested), suggested
+                    ),
                     errors={CONF_TEMP_ENTITY: "Required when climate mode is enabled"},
                     description_placeholders={
                         "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Climate-Mode"
@@ -3978,9 +3991,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             ):
                 return await self.async_step_glare_zones()
             return await self.async_step_automation()
+        suggested = _stringify_templatable(self.config)
         return self.async_show_form(
             step_id="temperature_climate",
-            data_schema=temperature_climate_schema(self.hass, self.config),
+            data_schema=self.add_suggested_values_to_schema(
+                temperature_climate_schema(self.hass, suggested), suggested
+            ),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Climate-Mode"
             },

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -10,6 +10,8 @@ Two surfaces:
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -22,12 +24,26 @@ from custom_components.adaptive_cover_pro.const import (
     BUILDING_PROFILE_SENSOR_KEYS,
     CONF_BUILDING_PROFILE_ID,
     CONF_LUX_ENTITY,
+    CONF_OUTSIDETEMP_ENTITY,
     CONF_PROFILE_SENSOR_OVERRIDES,
     CONF_SENSOR_TYPE,
     CONF_WEATHER_ENTITY,
+    CONF_WEATHER_WIND_SPEED_SENSOR,
     DOMAIN,
     CoverType,
 )
+from custom_components.adaptive_cover_pro.profile_link import (
+    merge_profile_into_config,
+)
+
+
+def _suggested_values(schema):
+    """Map each schema key to its ``suggested_value`` (as options-flow prefill)."""
+    return {
+        str(m.schema): m.description.get("suggested_value")
+        for m in schema.schema
+        if hasattr(m, "description") and isinstance(m.description, dict)
+    }
 
 
 def _schema_keys(schema):
@@ -455,3 +471,91 @@ async def test_user_menu_hides_duplicate_when_only_building_profile(
 
     assert result["type"] == "menu"
     assert "duplicate_existing" not in result["menu_options"]
+
+
+# ---------------------------------------------------------------------------
+# Create-wizard profile prefill — issue #851
+# ---------------------------------------------------------------------------
+
+
+def _profile_with_three_categories(hass: HomeAssistant) -> MockConfigEntry:
+    """Profile carrying one sensor key from each of the three step categories."""
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={
+            CONF_OUTSIDETEMP_ENTITY: "sensor.p_temp",
+            CONF_WEATHER_WIND_SPEED_SENSOR: "sensor.p_wind",
+            CONF_LUX_ENTITY: "sensor.p_lux",
+        },
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+    return profile
+
+
+@pytest.mark.integration
+async def test_create_building_profile_eager_copies_sensor_keys(
+    hass: HomeAssistant,
+) -> None:
+    """Selecting a profile in the create wizard eagerly merges its sensor keys.
+
+    Regression for issue #851: later create steps render from ``self.config``,
+    so the profile's values must land there at select time (not only at the
+    finalize safety-net merge), or the pickers render blank.
+    """
+    profile = _profile_with_three_categories(hass)
+
+    flow = ConfigFlowHandler()
+    flow.hass = hass
+    flow.type_blind = CoverType.BLIND
+    flow.setup_mode = "full_setup"
+    flow.config = {}
+    # Isolate the copy: don't route through downstream form steps.
+    flow._route_after_window_config = AsyncMock(return_value={"type": "form"})
+
+    await flow.async_step_building_profile({CONF_BUILDING_PROFILE_ID: profile.entry_id})
+
+    assert flow.config[CONF_BUILDING_PROFILE_ID] == profile.entry_id
+    assert flow.config[CONF_OUTSIDETEMP_ENTITY] == "sensor.p_temp"
+    assert flow.config[CONF_WEATHER_WIND_SPEED_SENSOR] == "sensor.p_wind"
+    assert flow.config[CONF_LUX_ENTITY] == "sensor.p_lux"
+
+
+@pytest.mark.integration
+async def test_create_wizard_prefills_profile_sensor_pickers(
+    hass: HomeAssistant,
+) -> None:
+    """Create-flow sensor steps expose profile values as suggested defaults.
+
+    Regression for issue #851: the create steps must wrap their schema with
+    ``add_suggested_values_to_schema`` (mirroring the options flow), or the
+    pickers render blank even when ``self.config`` holds the value.
+    """
+    profile = _profile_with_three_categories(hass)
+
+    flow = ConfigFlowHandler()
+    flow.hass = hass
+    flow.type_blind = CoverType.BLIND
+    flow.setup_mode = "full_setup"
+    flow.config = {}
+    # Seed the render half only: eager-copy the profile's sensor keys in.
+    merge_profile_into_config(profile, flow.config)
+
+    weather = await flow.async_step_weather_override()
+    assert (
+        _suggested_values(weather["data_schema"]).get(CONF_WEATHER_WIND_SPEED_SENSOR)
+        == "sensor.p_wind"
+    )
+
+    light = await flow.async_step_light_cloud()
+    assert (
+        _suggested_values(light["data_schema"]).get(CONF_LUX_ENTITY) == "sensor.p_lux"
+    )
+
+    temp = await flow.async_step_temperature_climate()
+    assert (
+        _suggested_values(temp["data_schema"]).get(CONF_OUTSIDETEMP_ENTITY)
+        == "sensor.p_temp"
+    )

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -60,6 +60,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_SYNC_SELECT_ALL,
     CONF_INVERSE_STATE,
     CONF_IS_SUNNY_SENSOR,
+    CONF_LUX_ENTITY,
+    CONF_WEATHER_WIND_SPEED_SENSOR,
     CONF_WINDOW_DEPTH,
     CONF_WINDOW_WIDTH,
     CUSTOM_POSITION_SLOTS,
@@ -538,7 +540,11 @@ async def test_full_setup_includes_building_profile_step_when_profile_exists(
     profile = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "My Building", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
-        options={CONF_OUTSIDETEMP_ENTITY: "sensor.outside_temp"},
+        options={
+            CONF_OUTSIDETEMP_ENTITY: "sensor.outside_temp",
+            CONF_WEATHER_WIND_SPEED_SENSOR: "sensor.p_wind",
+            CONF_LUX_ENTITY: "sensor.p_lux",
+        },
         entry_id="test_profile_693",
         title="My Building",
     )
@@ -612,7 +618,11 @@ async def test_full_setup_includes_building_profile_step_when_profile_exists(
 
     opts = result["result"].options
     assert opts.get(CONF_BUILDING_PROFILE_ID) == "test_profile_693"
+    # All three profile-key categories persist through the create-link (issue
+    # #851 / @FredM67's report): outsidetemp, weather-override, and light/cloud.
     assert opts.get(CONF_OUTSIDETEMP_ENTITY) == "sensor.outside_temp"
+    assert opts.get(CONF_WEATHER_WIND_SPEED_SENSOR) == "sensor.p_wind"
+    assert opts.get(CONF_LUX_ENTITY) == "sensor.p_lux"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Summary
Selecting a Building Profile during full setup previously stored only the link ID and deferred the sensor merge to entry-creation, so every wizard step after the profile step rendered from a config that lacked the profile's sensor keys. Fields were blank and threshold unit labels could not resolve. The create steps also never wrapped their schemas with `add_suggested_values_to_schema` (the options flow already does).

This eagerly calls the shared `merge_profile_into_config` helper at profile-select time and wraps the weather/light/temperature/behavior create schemas with suggested values, mirroring the options flow. The `async_step_update` safety-net merge is untouched. The full-wizard integration test was broadened to lock wind/lux/outsidetemp inheritance shut (this also covers the "not inherited after creation" report, which was not reproducible on current develop).

## Testing
- ✅ 511 tests passing (`-k "building_profile or config_flow"`); lint clean

## Related Issues
Refs #851