### PR TITLE
fix: move minimize_movements and max_coverage_steps to automation sync category

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2815,8 +2815,6 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_MIN_ELEVATION,
             CONF_MAX_ELEVATION,
             CONF_ENABLE_BLIND_SPOT,
-            CONF_MINIMIZE_MOVEMENTS,
-            CONF_MAX_COVERAGE_STEPS,
         }
     ),
     "blind_spot": frozenset(
@@ -2870,6 +2868,10 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             CONF_START_ENTITY,
             CONF_END_TIME,
             CONF_END_ENTITY,
+            # Movement throttle — lives on the automation UI step alongside
+            # delta_position/delta_time, so it syncs with that category (#862).
+            CONF_MINIMIZE_MOVEMENTS,
+            CONF_MAX_COVERAGE_STEPS,
         }
     ),
     "manual_override": frozenset(


### PR DESCRIPTION
Fixes #862

## What changed

Moved `CONF_MINIMIZE_MOVEMENTS` and `CONF_MAX_COVERAGE_STEPS` from `SYNC_CATEGORIES["sun_tracking"]` to `SYNC_CATEGORIES["automation"]` in `config_flow.py`.

## Why

Both settings live on the Motion & Schedules (automation) config step in the UI, right next to `delta_position` and `delta_time`. Users selecting the Schedule & Timing category in the sync dialog expect all settings from that step to be copied, but these two keys were silently skipped because they were filed under `sun_tracking` instead.

## Testing

Select the Schedule & Timing sync category: `minimize_movements` and `max_coverage_steps` are now included in the copy.
Selecting only Sun Tracking no longer copies those two keys (they were misplaced there).