### PR TITLE
fix: activate blind spot slot 2/3 when left edge is 0 (#868)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_dynamic.py
+++ b/custom_components/adaptive_cover_pro/config_dynamic.py
@@ -331,9 +331,16 @@ def blind_spot_schema(options: dict | None = None) -> vol.Schema:
     (issue #852) derives its clamp bounds from the same call.
 
     Slot 1 reuses the legacy unsuffixed keys and keeps its ``Required``
-    defaults (0/1) so its form is byte-for-byte unchanged. Slots 2/3 are
-    ``Optional`` sliders with no default, so an unconfigured slot stays absent
-    (``None``-preserving) and therefore inactive.
+    defaults (0/1) so its form is byte-for-byte unchanged. Slots 2/3's left
+    marker also gets ``default=0`` (mirroring slot 1) — HA validates
+    submitted form data against this schema before the step handler runs,
+    and a frontend slider resting at its minimum value (0) may never appear
+    in the raw payload; without a default, ``vol.Optional`` drops an absent
+    key entirely instead of backfilling it, silently losing a brand-new
+    slot's left edge (issue #868). Slot 2/3's right marker stays a
+    default-less ``Optional`` so an unconfigured slot's right edge remains
+    genuinely absent — ``_make_blind_spot``'s "both edges present" gate still
+    keeps a truly untouched slot inactive.
     """
     edges = blind_spot_edges(options)
 
@@ -355,7 +362,7 @@ def blind_spot_schema(options: dict | None = None) -> vol.Schema:
             left_marker = vol.Required(keys["left"], default=0)
             right_marker = vol.Required(keys["right"], default=1)
         else:
-            left_marker = vol.Optional(keys["left"])
+            left_marker = vol.Optional(keys["left"], default=0)
             right_marker = vol.Optional(keys["right"])
         schema[left_marker] = _slider(0, edges - 1)
         schema[right_marker] = _slider(1, edges)

--- a/tests/test_blind_spot_config_flow.py
+++ b/tests/test_blind_spot_config_flow.py
@@ -30,6 +30,35 @@ def test_schema_renders_all_slot_keys():
     assert "blind_spot_right_3" in keys
 
 
+def test_slot_2_left_survives_omission_when_right_is_configured():
+    """A submission that configures slot 2's right edge but never touches
+    its left slider (at rest = 0) must not silently drop the slot's left
+    edge. Regression for issue #868 — HA's data_entry_flow validates
+    user_input against data_schema before the step handler runs, and
+    vol.Optional(key) with no default leaves an absent key absent.
+    """
+    schema = blind_spot_schema({"fov_left": 45, "fov_right": 45})
+    validated = schema(
+        {"blind_spot_left": 0, "blind_spot_right": 10, "blind_spot_right_2": 90}
+    )
+    assert validated.get("blind_spot_left_2") == 0
+
+
+def test_slot_2_stays_inactive_when_completely_untouched():
+    """The new left default must not spuriously activate an unconfigured
+    slot 2/3 — right stays absent, so _make_blind_spot's guard still wins.
+    """
+    schema = blind_spot_schema({"fov_left": 45, "fov_right": 45})
+    validated = schema({"blind_spot_left": 0, "blind_spot_right": 10})
+    assert validated.get("blind_spot_left_2") == 0  # new default present
+    assert "blind_spot_right_2" not in validated  # still genuinely absent
+
+    from custom_components.adaptive_cover_pro.config_types import CoverConfig
+
+    config = CoverConfig.from_options({"blind_spot": True, **validated})
+    assert len(config.blind_spots) == 1  # slot 2 did NOT activate
+
+
 def test_per_slot_left_right_errors():
     from custom_components.adaptive_cover_pro.config_flow import (
         _blind_spot_step_errors,

--- a/tests/test_config_types_blind_spots.py
+++ b/tests/test_config_types_blind_spots.py
@@ -63,3 +63,20 @@ def test_incomplete_slot_skipped():
         }
     )
     assert len(config.blind_spots) == 1
+
+
+def test_slot_left_zero_is_not_treated_as_missing():
+    """left=0 is a valid edge value, not an 'unset' sentinel (issue #868)."""
+    config = CoverConfig.from_options(
+        {
+            "blind_spot": True,
+            "blind_spot_left": 0,
+            "blind_spot_right": 30,
+            "blind_spot_left_2": 0,
+            "blind_spot_right_2": 60,
+            "blind_spot_elevation_2": 5,
+        }
+    )
+    assert len(config.blind_spots) == 2
+    assert config.blind_spots[1].left == 0
+    assert config.blind_spots[1].right == 60


### PR DESCRIPTION
## Summary
Slot 2/3's left edge in `blind_spot_schema()` was a default-less `vol.Optional`, while slot 1 uses `vol.Required(default=0)`. HA validates submitted form data against the schema before the step handler runs, and a slider resting at its minimum value (0) can be absent from the payload — a default-less `vol.Optional` then drops the key entirely instead of backfilling it, so a brand-new full-width blind-spot slot (left=0) never got written to options and stayed inactive.

Fix: give slot 2/3's left marker `default=0`, mirroring slot 1. The right marker stays default-less on purpose so a genuinely untouched slot still reads as inactive (`_make_blind_spot`'s "both edges present" gate). The `any()` union and the `_make_blind_spot` None-guard were investigated and left unchanged — both are correct.

## Testing
- ✅ Full suite: 6116 tests passing
- Added `test_slot_2_left_survives_omission_when_right_is_configured` (RED reproducer), `test_slot_2_stays_inactive_when_completely_untouched` (anti-regression), and `test_slot_left_zero_is_not_treated_as_missing` (documents that 0 is a valid, non-falsy edge)

## Related Issues
Refs #868