### PR TITLE
fix: unbreak develop CI (Hassfest translations + black formatting)

### DIFF
--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1655,8 +1655,7 @@
           "weather_rain_sensor": "Numerischer Sensor, der Niederschlagsrate meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren.",
           "weather_severe_sensors": "Binärsensoren für schwere Bedingungen (Hagel, Frost, Gewitter usw.). Übersteuerung aktiviert sich, wenn EIN Sensor ‚an' ist. Leer lassen zum Ignorieren.",
           "weather_wind_direction_sensor": "Optional: Trigger Wind-Übersteuerung nur, wenn Wind gegen das Azimut dieses Fensters weht (innerhalb der Richtungstoleranz). Leer lassen, um Übersteuerung allein auf Windgeschwindigkeit zu triggern, unabhängig von der Richtung.",
-          "weather_wind_speed_sensor": "Numerischer Sensor, der Windgeschwindigkeit meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren.",
-          "outside_temp_source": "Welche Außentemperatur der Klimamodus für alle verknüpften Beschattungen verwendet. „Live-Lesung\" (Standard) behält das heutige Verhalten bei. „Vorhersage Tagesmaximum\" nutzt das heutige Vorhersage-Maximum der konfigurierten Wetter-Entität (fällt auf Live-Lesung zurück, wenn nicht verfügbar). „Höher von Live und Vorhersage\" nimmt den wärmeren Wert."
+          "weather_wind_speed_sensor": "Numerischer Sensor, der Windgeschwindigkeit meldet. Übersteuerung aktiviert sich, wenn der Wert den Schwellwert erfüllt oder überschreitet. Leer lassen zum Ignorieren."
         }
       },
       "profile_overview": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1645,7 +1645,6 @@
           "is_sunny_template": "Optional Home Assistant Jinja2 template that decides whether the sun is on the window. Leave empty to disable.",
           "lux_entity": "Optional illuminance sensor (indoor or outdoor) for precise sun detection. Leave empty if you don't have this sensor.",
           "outside_temp": "Optional outdoor temperature sensor. When provided, this reading determines the current season for all linked covers.",
-          "outside_temp_source": "Which outdoor temperature reading climate mode uses for all linked covers. 'Live reading' (default) keeps today's behavior. 'Forecast daily high' uses today's forecast maximum from the configured weather entity (falling back to live when unavailable). 'Higher of live and forecast' takes whichever is warmer.",
           "sunrise_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunrise at -4° elevation'). Falls back to astral if unavailable.",
           "sunset_time_entity": "Optional entity whose state is a datetime (e.g. Sun2 'sunset at -4° elevation'). Falls back to astral if unavailable.",
           "weather_entity": "Optional weather integration used to detect cloud cover. Leave empty to ignore weather state.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1655,8 +1655,7 @@
           "weather_rain_sensor": "Capteur numérique signalant le taux de pluie. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer le taux de pluie.",
           "weather_severe_sensors": "Capteurs binaires pour les conditions graves (grêle, gel, tempête, etc.). La dérogation s'active quand N'IMPORTE QUEL capteur est « activé ». Laissez vide pour ignorer.",
           "weather_wind_direction_sensor": "Optionnel : ne déclenchez la dérogation vent que quand le vent souffle vers l'azimut de cette fenêtre (dans la tolérance de direction). Laissez vide pour déclencher uniquement sur la vitesse du vent indépendamment de la direction.",
-          "weather_wind_speed_sensor": "Capteur numérique signalant la vitesse du vent. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer la vitesse du vent.",
-          "outside_temp_source": "Quelle lecture de température extérieure le mode climatique utilise pour toutes les protections liées. « Lecture en temps réel » (défaut) conserve le comportement actuel. « Maximum de prévision journalière » utilise le maximum de prévision d'aujourd'hui à partir de l'entité météo configurée (revenant à la lecture en temps réel quand indisponible). « Maximum de lecture en temps réel et prévision » utilise la valeur la plus élevée."
+          "weather_wind_speed_sensor": "Capteur numérique signalant la vitesse du vent. La dérogation s'active quand la valeur atteint ou dépasse le seuil. Laissez vide pour ignorer la vitesse du vent."
         }
       },
       "profile_overview": {

--- a/tests/test_duplicate_sync.py
+++ b/tests/test_duplicate_sync.py
@@ -500,17 +500,13 @@ class TestMinimizeMovementsAutomationSyncMove:
     never updated to follow — they were still sitting in sun_tracking.
     """
 
-    @pytest.mark.parametrize(
-        "key", [CONF_MINIMIZE_MOVEMENTS, CONF_MAX_COVERAGE_STEPS]
-    )
+    @pytest.mark.parametrize("key", [CONF_MINIMIZE_MOVEMENTS, CONF_MAX_COVERAGE_STEPS])
     def test_minimize_movements_and_max_coverage_steps_in_automation_category(
         self, key
     ):
         assert key in SYNC_CATEGORIES["automation"]
 
-    @pytest.mark.parametrize(
-        "key", [CONF_MINIMIZE_MOVEMENTS, CONF_MAX_COVERAGE_STEPS]
-    )
+    @pytest.mark.parametrize("key", [CONF_MINIMIZE_MOVEMENTS, CONF_MAX_COVERAGE_STEPS])
     def test_minimize_movements_and_max_coverage_steps_not_in_sun_tracking_category(
         self, key
     ):
@@ -533,9 +529,7 @@ class TestMinimizeMovementsAutomationSyncMove:
         assert result[CONF_ENABLE_BLIND_SPOT] is True
 
     def test_syncing_automation_copies_minimize_movements_and_max_coverage_steps(self):
-        entry = _make_entry(
-            {CONF_MINIMIZE_MOVEMENTS: True, CONF_MAX_COVERAGE_STEPS: 4}
-        )
+        entry = _make_entry({CONF_MINIMIZE_MOVEMENTS: True, CONF_MAX_COVERAGE_STEPS: 4})
         result = _extract_shared_options(entry, ["automation"])
         assert result[CONF_MINIMIZE_MOVEMENTS] is True
         assert result[CONF_MAX_COVERAGE_STEPS] == 4


### PR DESCRIPTION
## Summary
Two independent, pre-existing CI breakages on `develop` — both unrelated to any feature work — were turning every run red and blocking in-flight PRs (e.g. #548). This unbreaks both.

### 1. Hassfest — orphaned translation key
Hassfest Translations validation has failed on **every `develop` run** since the `outside_temp_source` feature (#547) shipped:

```
[ERROR] [TRANSLATIONS] Invalid translations/en.json: data_description key
outside_temp_source is not in data for dictionary value @ data['options'].
```

The `options.profile_sensors` step carried an `outside_temp_source` entry in its `data_description`, but the field itself only exists in the `temperature_climate` step's schema. `profile_sensors` has the `outside_temp` sensor picker, not `outside_temp_source`. Removed the orphaned key from `en/de/fr.json`. No user-facing field is lost — the description was never rendered because the field isn't in that step.

### 2. Lint — black formatting
`tests/test_duplicate_sync.py` has failed `black --check` since #865, blocking the Lint job on every run. Applied black (collapses a few parametrize/call lines that fit on one line). Purely formatting.

## Testing
- ✅ Hassfest passes locally (no orphaned `data_description` keys remain in any config/options step across en/de/fr)
- ✅ `black --check .` clean repo-wide (413 files)
- ✅ `ruff check` clean
- ✅ 33 translation tests passing; `./scripts/validate_translations.py --ci` passes

## Related Issues
Refs #547, #865

https://claude.ai/code/session_01Jn7V5WAkD8HSPNwAqgePBY