### PR TITLE
feat: record stop_cover origin context in manual override event

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -961,6 +961,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             return
 
+        # Capture the stop_cover call's originating HA context (issue #875) so
+        # the recorded manual_override_set event is self-attributing —
+        # distinguishing a legitimate external stop from a spurious/descendant
+        # one without needing the HA logbook.
         for entity_id in tracked:
             # On the not-manual→manual edge the manager fires on_engaged →
             # discard_target (issue #215/#216); see set_transition_callbacks.
@@ -968,6 +972,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 entity_id,
                 int(my_position_value),
                 self._cmd_svc.is_waiting_for_target,
+                context_user_id=event.context.user_id if event.context else None,
+                context_id=event.context.id if event.context else None,
+                context_parent_id=event.context.parent_id if event.context else None,
             )
             # Update target so the next reconciliation compares against
             # My rather than the stale calculated state.

--- a/custom_components/adaptive_cover_pro/managers/manual_override/detector.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/detector.py
@@ -87,11 +87,23 @@ class UserContextChange:
 
 @dataclass(frozen=True, slots=True)
 class StopToMy:
-    """Input for the stop-service channel (user stop_cover to the 'My' preset)."""
+    """Input for the stop-service channel (user stop_cover to the 'My' preset).
+
+    ``context_user_id``/``context_id``/``context_parent_id`` carry the
+    originating HA ``Context`` of the ``cover.stop_cover`` call (issue #875)
+    so the recorded ``manual_override_set`` event is self-attributing —
+    distinguishing a legitimate external stop from a spurious/descendant one
+    without needing the HA logbook. All default to ``None`` for callers that
+    don't have a context (e.g. existing unit tests constructing ``StopToMy``
+    directly).
+    """
 
     entity_id: str
     my_position_value: int
     is_waiting: Callable[[str], bool]
+    context_user_id: str | None = None
+    context_id: str | None = None
+    context_parent_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -110,6 +122,24 @@ class DetectorConfig:
     ignore_external: bool
 
 
+def _format_context_suffix(
+    context_user_id: str | None,
+    context_id: str | None,
+    context_parent_id: str | None = None,
+) -> str:
+    """Render the '(context user_id=..., id=...)' suffix.
+
+    Shared by every override reason that records its originating HA context
+    (issue #875). ``context_parent_id`` is appended only when the caller has
+    one to report, so :func:`default_user_context_decision` (which doesn't
+    track it) keeps its existing reason text unchanged.
+    """
+    parts = [f"user_id={context_user_id}", f"id={context_id}"]
+    if context_parent_id is not None:
+        parts.append(f"parent_id={context_parent_id}")
+    return f"(context {', '.join(parts)})"
+
+
 def default_user_context_decision(change: UserContextChange) -> OverrideDecision:
     """Today's behaviour: a confirmed user-context change marks manual override."""
     return OverrideDecision(
@@ -119,8 +149,8 @@ def default_user_context_decision(change: UserContextChange) -> OverrideDecision
             "our_state": None,
             "new_position": None,
             "reason": (
-                f"user-initiated state change "
-                f"(context user_id={change.context_user_id}, id={change.context_id})"
+                "user-initiated state change "
+                + _format_context_suffix(change.context_user_id, change.context_id)
             ),
         },
     )
@@ -130,7 +160,9 @@ def default_stop_to_my_decision(stop: StopToMy) -> OverrideDecision | None:
     """Today's behaviour: stop_cover to 'My' marks manual unless mid-command.
 
     Returns ``None`` when the cover is still moving toward a commanded target
-    (the stop is the cover reaching that target, not a user touch).
+    (the stop is the cover reaching that target, not a user touch). The
+    recorded reason embeds the originating HA context (issue #875) so this
+    class of report is self-attributing without needing the HA logbook.
     """
     if stop.is_waiting(stop.entity_id):
         return None
@@ -140,7 +172,12 @@ def default_stop_to_my_decision(stop: StopToMy) -> OverrideDecision | None:
         event_kwargs={
             "our_state": stop.my_position_value,
             "new_position": stop.my_position_value,
-            "reason": "user stop_cover to My position",
+            "reason": (
+                "user stop_cover to My position "
+                + _format_context_suffix(
+                    stop.context_user_id, stop.context_id, stop.context_parent_id
+                )
+            ),
         },
     )
 

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -519,6 +519,10 @@ class AdaptiveCoverManager:
         entity_id: str,
         my_position_value: int,
         is_waiting,
+        *,
+        context_user_id: str | None = None,
+        context_id: str | None = None,
+        context_parent_id: str | None = None,
     ) -> None:
         """Mark manual override when a user-initiated cover.stop_cover is detected.
 
@@ -532,6 +536,10 @@ class AdaptiveCoverManager:
             my_position_value: The position (0–100) the My preset represents.
             is_waiting:       Callable(entity_id) -> bool from
                               CoverCommandService.
+            context_user_id:  user_id of the stop_cover call's originating HA
+                              Context, if any (issue #875 diagnostic capture).
+            context_id:       id of the stop_cover call's originating HA Context.
+            context_parent_id: parent_id of the originating HA Context, if any.
 
         """
         if entity_id not in self.covers:
@@ -541,6 +549,9 @@ class AdaptiveCoverManager:
                 entity_id=entity_id,
                 my_position_value=my_position_value,
                 is_waiting=is_waiting,
+                context_user_id=context_user_id,
+                context_id=context_id,
+                context_parent_id=context_parent_id,
             )
         )
         if decision is None:

--- a/tests/test_my_position.py
+++ b/tests/test_my_position.py
@@ -657,11 +657,15 @@ class TestCoverServiceCallHandler:
     fires → manual override is set (or not) based on context id and config.
     """
 
-    def _make_event(self, entity_id, context_id=None):
+    def _make_event(self, entity_id, context_id=None, user_id=None):
         """Build a mock EVENT_CALL_SERVICE event for cover.stop_cover."""
         from homeassistant.core import Context
 
-        ctx = Context(id=context_id) if context_id else Context()
+        ctx = (
+            Context(id=context_id, user_id=user_id)
+            if context_id or user_id
+            else Context()
+        )
         event = MagicMock()
         event.data = {
             "domain": "cover",
@@ -706,6 +710,62 @@ class TestCoverServiceCallHandler:
 
         assert mgr.manual_control.get("cover.somfy") is True
         coord._cmd_svc.set_target.assert_called_with("cover.somfy", 50)
+
+    @pytest.mark.asyncio
+    async def test_user_stop_records_originating_context(self, mock_hass):
+        """Issue #875: a genuine external stop_cover records the originating
+        HA context (user_id / context id) on the manual_override_set event,
+        so a later report can distinguish a legitimate external stop from a
+        spurious/descendant call.
+        """
+        from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+            EventBuffer,
+        )
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            AdaptiveCoverManager,
+        )
+
+        event_buffer = EventBuffer(maxlen=50)
+        mgr = AdaptiveCoverManager(
+            hass=mock_hass,
+            reset_duration={"minutes": 15},
+            logger=MagicMock(),
+            event_buffer=event_buffer,
+        )
+        mgr.add_covers(["cover.somfy"])
+
+        coord = MagicMock()
+        coord.manual_toggle = True
+        coord.automatic_control = True
+        coord.manual_ignore_external = False
+        coord.entities = ["cover.somfy"]
+        coord.manager = mgr
+        coord.config_entry.options = {"my_position_value": 50}
+        coord._cmd_svc.was_acp_stop_context = MagicMock(return_value=False)
+        coord.logger = MagicMock()
+        coord._cmd_svc.is_waiting_for_target = MagicMock(return_value=False)
+
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        # A genuine external stop while ACP is idle — non-ACP context with a
+        # real HA user_id, mirroring Incident A in issue #875 (cover idle,
+        # stop arrives on the service-call channel).
+        event = self._make_event("cover.somfy", context_id="ctx-abc", user_id="u1")
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(coord, event)
+
+        assert mgr.manual_control.get("cover.somfy") is True
+        events = event_buffer.snapshot()
+        assert len(events) == 1
+        assert events[0]["event"] == "manual_override_set"
+        reason = events[0]["reason"]
+        assert (
+            "u1" in reason
+        ), f"expected originating context user_id 'u1' in recorded reason, got: {reason!r}"
+        assert (
+            "ctx-abc" in reason
+        ), f"expected originating context id 'ctx-abc' in recorded reason, got: {reason!r}"
 
     @pytest.mark.asyncio
     async def test_acp_originated_stop_does_not_set_override(self, mock_hass):


### PR DESCRIPTION
## Summary
When a `cover.stop_cover` service call is detected as a user "My position" manual override, the recorded `manual_override_set` diagnostics event now captures the originating HA `Context` (user_id / id / parent_id) of that call. This makes the event self-attributing, so a phantom-trigger report (issue #875) can be told apart from a legitimate external stop without needing the HA logbook. A shared `_format_context_suffix()` helper renders the context, reused by the existing `default_user_context_decision` path (its output is unchanged). Detection behavior is unchanged — no suppression or transit guard was added; only the recorded `reason` gains context.

## Testing
- ✅ 6203 tests passing (full suite, `pytest tests/ -n auto`)
- ✅ New test `test_user_stop_records_originating_context` in `tests/test_my_position.py`; regression guards `test_services_stop.py`, `test_manual_ignore_external.py`, `test_false_manual_override_on_automation.py` green

## Related Issues
Refs #875