### PR TITLE
feat: add set_occupancy service, deprecate set_motion (#723)

### DIFF
--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -562,8 +562,11 @@ set_custom_position:
         boolean:
 
 set_motion:
-  name: Set occupancy settings
-  description: Update occupancy sensors and occupancy timeout. Pass an empty list to disable occupancy detection.
+  name: Set occupancy settings (deprecated)
+  description: >-
+    Deprecated — use set_occupancy instead. Update occupancy sensors and
+    occupancy timeout. Pass an empty list to disable occupancy detection. This
+    service keeps working but will be removed in a future major release.
   target:
     entity:
       integration: adaptive_cover_pro
@@ -580,6 +583,45 @@ set_motion:
             - presence
           multiple: true
     motion_timeout:
+      name: Occupancy timeout
+      description: "Seconds to wait after occupancy clears before applying the occupancy-timeout position (30–3600)."
+      selector:
+        number:
+          min: 30
+          max: 3600
+          step: 30
+          mode: slider
+          unit_of_measurement: seconds
+
+set_occupancy:
+  name: Set occupancy settings
+  description: >-
+    Update the occupancy sensors, media players, and timeout that drive
+    occupancy detection. Pass an empty list to disable a source. Replaces the
+    deprecated set_motion service.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    occupancy_sensors:
+      name: Occupancy sensors
+      description: "Binary sensors (motion/occupancy/presence device classes) that indicate occupancy. Empty list = disable."
+      selector:
+        entity:
+          domain: binary_sensor
+          device_class:
+            - motion
+            - occupancy
+            - presence
+          multiple: true
+    occupancy_media_players:
+      name: Occupancy media players
+      description: "Media players treated as occupancy — any player that is not off counts as occupied. Empty list = disable."
+      selector:
+        entity:
+          domain: media_player
+          multiple: true
+    occupancy_timeout:
       name: Occupancy timeout
       description: "Seconds to wait after occupancy clears before applying the occupancy-timeout position (30–3600)."
       selector:

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -838,6 +838,13 @@ _CUSTOM_SLOT_KEYS = CUSTOM_POSITION_SLOTS
 # existing automations keep working (issue #792).
 _SERVICE_FIELD_ALIASES: dict[str, str] = {
     "default_height": CONF_DEFAULT_HEIGHT,
+    # issue #723: set_occupancy is the renamed API for the occupancy-detection
+    # feature. Its occupancy_* wire fields resolve to the frozen CONF_MOTION_*
+    # option keys so the new service shares set_motion's handler with no
+    # duplication; set_motion keeps working via its own field names.
+    "occupancy_sensors": CONF_MOTION_SENSORS,
+    "occupancy_media_players": CONF_MOTION_MEDIA_PLAYERS,
+    "occupancy_timeout": CONF_MOTION_TIMEOUT,
 }
 
 
@@ -1254,9 +1261,24 @@ def register_options_services(hass: HomeAssistant) -> None:
     # DEPRECATED (issue #563): kept one release so existing automations don't
     # hit service-not-found; routes onto custom-position slot 5.
     hass.services.async_register(DOMAIN, "set_force_override", _force_override_shim)
-    hass.services.async_register(
-        DOMAIN, "set_motion", _section_handler(_SECTION_MOTION)
-    )
+
+    # issue #723: set_occupancy is the current name for the occupancy-detection
+    # service; set_motion is deprecated but kept working. Both delegate to the
+    # SAME section handler — set_occupancy's occupancy_* fields resolve to the
+    # CONF_MOTION_* option keys via _SERVICE_FIELD_ALIASES. set_motion only adds
+    # a deprecation-warning side effect.
+    _motion_handler = _section_handler(_SECTION_MOTION)
+
+    async def _set_motion_deprecated(call: ServiceCall) -> None:
+        _LOGGER.warning(
+            "adaptive_cover_pro.set_motion is deprecated (issue #723); use "
+            "set_occupancy with occupancy_sensors / occupancy_timeout / "
+            "occupancy_media_players instead. set_motion keeps working for now."
+        )
+        await _motion_handler(call)
+
+    hass.services.async_register(DOMAIN, "set_motion", _set_motion_deprecated)
+    hass.services.async_register(DOMAIN, "set_occupancy", _motion_handler)
     hass.services.async_register(
         DOMAIN, "set_light_cloud", _section_handler(_SECTION_LIGHT_CLOUD)
     )
@@ -1302,6 +1324,7 @@ OPTIONS_SERVICE_NAMES: tuple[str, ...] = (
     "set_force_override",
     "set_custom_position",
     "set_motion",
+    "set_occupancy",
     "set_light_cloud",
     "set_climate",
     "set_weather_safety",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -2352,7 +2352,7 @@
       "name": "Einstellungen für manuelle Übersteuerung festlegen"
     },
     "set_motion": {
-      "description": "Aktualisieren Sie Belegungssensoren und Belegungs-Timeout.",
+      "description": "Veraltet – stattdessen set_occupancy verwenden. Aktualisieren Sie Belegungssensoren und Belegungs-Timeout.",
       "fields": {
         "motion_sensors": {
           "description": "Binärsensoren, die Belegung anzeigen. Leere Liste = Belegungserkennung deaktivieren.",
@@ -2363,7 +2363,7 @@
           "name": "Belegungs-Timeout"
         }
       },
-      "name": "Belegungseinstellungen festlegen"
+      "name": "Belegungseinstellungen festlegen (veraltet)"
     },
     "set_option": {
       "description": "Generischer Ausweg — aktualisiert jede unterstützte Option nach Schlüsselnamen. Identitätsschlüssel werden abgelehnt.",
@@ -2692,6 +2692,24 @@
         "force": {
           "name": "Erzwingen",
           "description": "Wenn wahr, manuelle Übersteuerungsaktivierung überspringen. Vorgabe: falsch — Service-Aufrufe aktivieren die manuelle Übersteuerung wie ein Dashboard-Regler."
+        }
+      }
+    },
+    "set_occupancy": {
+      "name": "Belegungseinstellungen festlegen",
+      "description": "Aktualisieren Sie die Belegungssensoren, Belegungs-Medienplayer und das Timeout, die die Belegungserkennung antreiben. Ersetzt den veralteten set_motion-Service.",
+      "fields": {
+        "occupancy_sensors": {
+          "name": "Belegungssensoren",
+          "description": "Binärsensoren, die Belegung anzeigen. Leere Liste = Belegungserkennung deaktivieren."
+        },
+        "occupancy_media_players": {
+          "name": "Belegungs-Medienplayer",
+          "description": "Medienplayer, die als Belegung behandelt werden – jeder Player, der nicht ausgeschaltet ist, wird als besetzt gezählt. Leere Liste = deaktivieren."
+        },
+        "occupancy_timeout": {
+          "name": "Belegungs-Timeout",
+          "description": "Sekunden zum Warten, nachdem die Belegung endet, bevor die Belegungs-Timeout-Position angewendet wird (30–3600)."
         }
       }
     }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -2246,14 +2246,32 @@
       }
     },
     "set_motion": {
-      "name": "Set occupancy settings",
-      "description": "Update occupancy sensors and occupancy timeout.",
+      "name": "Set occupancy settings (deprecated)",
+      "description": "Deprecated — use set_occupancy instead. Update occupancy sensors and occupancy timeout.",
       "fields": {
         "motion_sensors": {
           "name": "Occupancy sensors",
           "description": "Binary sensors indicating occupancy. Empty list = disable occupancy detection."
         },
         "motion_timeout": {
+          "name": "Occupancy timeout",
+          "description": "Seconds to wait after occupancy clears before applying occupancy-timeout position (30–3600)."
+        }
+      }
+    },
+    "set_occupancy": {
+      "name": "Set occupancy settings",
+      "description": "Update the occupancy sensors, media players, and timeout that drive occupancy detection. Replaces the deprecated set_motion service.",
+      "fields": {
+        "occupancy_sensors": {
+          "name": "Occupancy sensors",
+          "description": "Binary sensors indicating occupancy. Empty list = disable occupancy detection."
+        },
+        "occupancy_media_players": {
+          "name": "Occupancy media players",
+          "description": "Media players treated as occupancy — any player that is not off counts as occupied. Empty list = disable."
+        },
+        "occupancy_timeout": {
           "name": "Occupancy timeout",
           "description": "Seconds to wait after occupancy clears before applying occupancy-timeout position (30–3600)."
         }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -2352,7 +2352,7 @@
       "name": "Définir les paramètres de la dérogation manuelle"
     },
     "set_motion": {
-      "description": "Définir manuellement l'état de la détection d'occupation",
+      "description": "Obsolète — utilisez plutôt set_occupancy. Mettre à jour les capteurs d'occupation et le délai d'occupation.",
       "fields": {
         "motion_sensors": {
           "description": "Capteurs d'occupation à définir",
@@ -2363,7 +2363,7 @@
           "name": "Délai d'occupation"
         }
       },
-      "name": "Définir la détection d'occupation"
+      "name": "Paramètres d'occupation (obsolète)"
     },
     "set_option": {
       "description": "Échappatoire générique — mettre à jour n'importe quelle option unique supportée par clé de nom. Les clés d'identité sont rejetées.",
@@ -2692,6 +2692,24 @@
         "force": {
           "name": "Forcer",
           "description": "Quand vrai, ignorez l'engagement de la dérogation manuelle. Par défaut faux — les appels de service enclenchent la dérogation manuelle comme un curseur du tableau de bord."
+        }
+      }
+    },
+    "set_occupancy": {
+      "name": "Paramètres d'occupation",
+      "description": "Mettez à jour les capteurs d'occupation, les lecteurs multimédias et le délai qui pilotent la détection d'occupation. Remplace le service set_motion obsolète.",
+      "fields": {
+        "occupancy_sensors": {
+          "name": "Capteurs d'occupation",
+          "description": "Capteurs binaires indiquant l'occupation. Liste vide = désactiver la détection d'occupation."
+        },
+        "occupancy_media_players": {
+          "name": "Lecteurs multimédias (occupation)",
+          "description": "Lecteurs multimédias traités comme occupation — tout lecteur qui n'est pas arrêté compte comme occupé. Liste vide = désactiver."
+        },
+        "occupancy_timeout": {
+          "name": "Délai d'occupation",
+          "description": "Secondes à attendre après que l'occupation disparaisse avant d'appliquer la position du délai d'occupation (30–3600)."
         }
       }
     }

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -45,6 +46,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MAX_POSITION,
     CONF_MIN_POSITION,
+    CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
     CONF_DISTANCE,
     CONF_HEIGHT_WIN,
@@ -83,6 +85,7 @@ from custom_components.adaptive_cover_pro.services.options_service import (
     IDENTITY_KEYS,
     OPTIONS_SERVICE_NAMES,
     _SECTION_CLIMATE,
+    _SECTION_MOTION,
     _SECTION_POSITION_LIMITS,
     _SECTION_SUNSET_SUNRISE,
     _SERVICE_FIELD_ALIASES,
@@ -703,6 +706,7 @@ class TestServiceRegistration:
             "set_force_override",
             "set_custom_position",
             "set_motion",
+            "set_occupancy",
             "set_light_cloud",
             "set_climate",
             "set_weather_safety",
@@ -741,6 +745,31 @@ class TestBuildPatchAliasing:
 
     def test_default_height_alias_is_registered(self):
         assert _SERVICE_FIELD_ALIASES["default_height"] == CONF_DEFAULT_HEIGHT
+
+    def test_occupancy_timeout_alias_resolves(self):
+        # issue #723: set_occupancy's occupancy_timeout maps to CONF_MOTION_TIMEOUT.
+        patch_ = _build_patch({"occupancy_timeout": 600}, _SECTION_MOTION)
+        assert patch_ == {CONF_MOTION_TIMEOUT: 600}
+
+    def test_occupancy_sensors_alias_resolves(self):
+        patch_ = _build_patch(
+            {"occupancy_sensors": ["binary_sensor.a"]}, _SECTION_MOTION
+        )
+        assert patch_ == {CONF_MOTION_SENSORS: ["binary_sensor.a"]}
+
+    def test_occupancy_media_players_alias_resolves(self):
+        patch_ = _build_patch(
+            {"occupancy_media_players": ["media_player.tv"]}, _SECTION_MOTION
+        )
+        assert patch_ == {CONF_MOTION_MEDIA_PLAYERS: ["media_player.tv"]}
+
+    def test_occupancy_aliases_are_registered(self):
+        assert _SERVICE_FIELD_ALIASES["occupancy_sensors"] == CONF_MOTION_SENSORS
+        assert _SERVICE_FIELD_ALIASES["occupancy_timeout"] == CONF_MOTION_TIMEOUT
+        assert (
+            _SERVICE_FIELD_ALIASES["occupancy_media_players"]
+            == CONF_MOTION_MEDIA_PLAYERS
+        )
 
 
 class TestSetPositionLimits:
@@ -1204,6 +1233,97 @@ class TestSetMotion:
         await _setup(hass, entry_id="mot_err_01")
         with pytest.raises((ServiceValidationError, Exception)):
             await _call(hass, "set_motion", {CONF_MOTION_TIMEOUT: 10})  # below 30
+
+    async def test_emits_deprecation_warning(
+        self, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    ):
+        # issue #723: set_motion still works but logs a deprecation warning
+        # steering users to set_occupancy.
+        await _setup(hass, entry_id="mot_dep_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry"),
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING),
+        ):
+            await _call(hass, "set_motion", {CONF_MOTION_TIMEOUT: 600})
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any(
+            "set_motion is deprecated" in r.message and "set_occupancy" in r.message
+            for r in warnings
+        ), f"expected set_motion deprecation warning, got: {[r.message for r in warnings]}"
+
+
+class TestSetOccupancy:
+    """Integration tests for the set_occupancy service (issue #723).
+
+    set_occupancy is the renamed API for the occupancy-detection feature; it
+    delegates to the same section handler as set_motion via field-name aliases,
+    writing the same CONF_MOTION_* option keys.
+    """
+
+    async def test_updates_timeout(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="occ_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(hass, "set_occupancy", {"occupancy_timeout": 600})
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MOTION_TIMEOUT] == 600
+
+    async def test_sensors_replace_semantics(self, hass: HomeAssistant):
+        opts = {**VERTICAL_OPTIONS, CONF_MOTION_SENSORS: ["binary_sensor.a"]}
+        await _setup(hass, entry_id="occ_list_01", options=opts)
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_occupancy",
+                {"occupancy_sensors": ["binary_sensor.b", "binary_sensor.c"]},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MOTION_SENSORS] == ["binary_sensor.b", "binary_sensor.c"]
+
+    async def test_updates_media_players(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="occ_mp_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_occupancy",
+                {"occupancy_media_players": ["media_player.tv"]},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts[CONF_MOTION_MEDIA_PLAYERS] == ["media_player.tv"]
+
+    async def test_invalid_timeout_rejected(self, hass: HomeAssistant):
+        await _setup(hass, entry_id="occ_err_01")
+        with pytest.raises((ServiceValidationError, Exception)):
+            await _call(hass, "set_occupancy", {"occupancy_timeout": 10})  # below 30
+
+    async def test_no_deprecation_warning(
+        self, hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    ):
+        # set_occupancy is the current API — it must NOT log a deprecation warning.
+        await _setup(hass, entry_id="occ_nodep_01")
+        with (
+            patch.object(hass.config_entries, "async_update_entry"),
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+            caplog.at_level(logging.WARNING),
+        ):
+            await _call(hass, "set_occupancy", {"occupancy_timeout": 600})
+
+        assert not any(
+            "deprecated" in r.message for r in caplog.records
+        ), "set_occupancy must not emit a deprecation warning"
 
 
 class TestSetLightCloud:

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -124,6 +124,7 @@ REGISTERED_SERVICES = {
     "set_force_override",
     "set_custom_position",
     "set_motion",
+    "set_occupancy",
     "set_light_cloud",
     "set_climate",
     "set_weather_safety",
@@ -142,6 +143,18 @@ def test_all_registered_services_have_yaml_entry():
     assert (
         not missing
     ), f"Service(s) registered in Python but missing from services.yaml: {sorted(missing)}"
+
+
+def test_set_occupancy_fields_are_occupancy_prefixed():
+    """Issue #723: set_occupancy exposes occupancy_* wire fields (aliased to the
+    frozen CONF_MOTION_* option keys). The yaml must NOT expose motion_* keys —
+    set_motion keeps those; set_occupancy is the renamed API.
+    """
+    fields = _load()["set_occupancy"]["fields"]
+    assert "occupancy_sensors" in fields
+    assert "occupancy_timeout" in fields
+    assert "occupancy_media_players" in fields
+    assert not any(k.startswith("motion_") for k in fields)
 
 
 def test_set_position_limits_field_is_default_percentage_not_default_height():


### PR DESCRIPTION
## Summary

PR 2 of 2 for #723 — the service API layer, completing the "Motion Override" → "Occupancy Detection" rename. Follows [#878](https://github.com/jrhubott/adaptive-cover-pro/pull/878) (display strings).

Adds a **`set_occupancy`** service as the current name for the occupancy-detection feature. It takes `occupancy_sensors` / `occupancy_media_players` / `occupancy_timeout` and **delegates to the exact same section handler as `set_motion`** — the `occupancy_*` wire fields resolve to the frozen `CONF_MOTION_*` option keys through the existing `_SERVICE_FIELD_ALIASES` mechanism (the same hook issue #792 uses for `default_height`). One handler body, no duplication.

**`set_motion` keeps working unchanged** but now logs a deprecation warning on each call pointing users to `set_occupancy` — matching the repo's existing `set_force_override` deprecation pattern. Signal-only; the option writes are identical, so existing automations keep working. Removal is deferred to a future major release (never-break-automations rule).

`set_occupancy` also exposes `occupancy_media_players`, which `set_motion` never surfaced via its service — the new API is a superset.

**No config-entry migration, no `VERSION` bump** — services + an optional warning only.

### What changed
- **`options_service.py`** — two `occupancy_*` aliases; `set_occupancy` registered on the shared `_motion_handler`; `set_motion` wrapped in a `_set_motion_deprecated` warning shim; `set_occupancy` added to `OPTIONS_SERVICE_NAMES`.
- **`services.yaml` + `translations/en.json`** — new `set_occupancy` block; `set_motion` marked deprecated.
- **DE/FR** synced for the new keys (Belegung / occupation, kept distinct from Climate "Presence").
- **Tests** — `TestSetOccupancy` (timeout/sensors/media-players/invalid/no-warning), alias unit tests, and a `set_motion` deprecation-warning test.

## Testing
- ✅ 6214 tests passing (full suite; +11 new)
- ✅ `set_motion` behavior guards, service-registration, and yaml-docs parity all green
- ✅ `validate_translations.py --ci`, ruff, black clean

## Related Issues
Refs #723 — closes out the 2-PR effort once merged.

https://claude.ai/code/session_01APDPu7N3hvp8GkjJes3oED