### PR TITLE
fix: use occupancy wording in decision-trace reason strings (#723)

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -786,7 +786,7 @@ class DiagnosticsBuilder:
                 "description": (
                     "Solar-tracking-only projection for the rest of today. "
                     "Holds window geometry constant and walks the sun forward; "
-                    "does NOT model manual override, motion, weather safety, "
+                    "does NOT model manual override, occupancy, weather safety, "
                     "climate, or custom-position handlers. Use it to validate "
                     "sun/FOV geometry and timing, not to explain a specific "
                     "command — see decision_trace for that."

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -40,7 +40,7 @@ class MotionTimeoutHandler(OverrideHandler):
             return PipelineResult(
                 position=held,
                 control_method=ControlMethod.MOTION,
-                reason=f"motion timeout — holding position {held}% (sun in FOV)",
+                reason=f"occupancy timeout — holding position {held}% (sun in FOV)",
                 skip_command=True,
                 raw_calculated_position=compute_raw_calculated_position(snapshot),
             )
@@ -52,12 +52,12 @@ class MotionTimeoutHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.MOTION,
-            reason=f"motion timeout active — {pos_label} {position}%",
+            reason=f"occupancy timeout active — {pos_label} {position}%",
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 
     def describe_skip(self, snapshot: PipelineSnapshot) -> str:
-        """Reason when motion timeout is not active."""
+        """Reason when occupancy timeout is not active."""
         if not snapshot.motion_control_enabled:
-            return "motion control disabled"
-        return "motion timeout not active"
+            return "occupancy detection disabled"
+        return "occupancy timeout not active"

--- a/tests/test_debug_diagnostics.py
+++ b/tests/test_debug_diagnostics.py
@@ -811,13 +811,13 @@ class TestMotionHoldDiagnostics:
         hold_pr = PipelineResult(
             position=42,
             control_method=ControlMethod.MOTION,
-            reason="motion timeout — holding position 42% (sun in FOV)",
+            reason="occupancy timeout — holding position 42% (sun in FOV)",
             skip_command=True,
             decision_trace=[
                 DecisionStep(
                     handler="motion_timeout",
                     matched=True,
-                    reason="motion timeout — holding position 42% (sun in FOV)",
+                    reason="occupancy timeout — holding position 42% (sun in FOV)",
                     position=42,
                 )
             ],

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -319,11 +319,11 @@ class TestPositionExplanation:
         """Motion timeout produces correct explanation."""
         pr = _make_pr(
             control_method=ControlMethod.MOTION,
-            reason="motion timeout active — default position 30%",
+            reason="occupancy timeout active — default position 30%",
             position=30,
         )
         _, explanation = builder.build(_base_ctx(pipeline_result=pr))
-        assert "motion" in explanation.lower()
+        assert "occupancy" in explanation.lower()
         assert "30%" in explanation
 
     def test_manual_override_explanation(self, builder: DiagnosticsBuilder):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -613,8 +613,11 @@ class TestEndToEndIntegration:
             diag_ctx = _build_diagnostic_context(cover, result)
             diag_dict, explanation = DiagnosticsBuilder().build(diag_ctx)
 
+            # control_status is the frozen machine slug (card localizes it); the
+            # human-readable explanation uses occupancy wording (issue #723).
             assert diag_dict["control_status"] == "motion_timeout"
-            assert "motion" in explanation.lower()
+            assert "occupancy" in explanation.lower()
+            assert "motion" not in explanation.lower()
 
     def test_horizontal_awning_sun_tracking(self):
         """Horizontal awning with sun in FOV → SolarHandler wins."""

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -538,7 +538,7 @@ def test_determine_control_status_motion_timeout():
     pipeline_result = PipelineResult(
         position=60,
         control_method=ControlMethod.MOTION,
-        reason="motion timeout active",
+        reason="occupancy timeout active",
     )
 
     ctx = DiagnosticContext(
@@ -618,7 +618,7 @@ def test_state_property_motion_timeout_uses_pipeline_result():
     coordinator._pipeline_result = PipelineResult(
         position=10,
         control_method=ControlMethod.MOTION,
-        reason="motion timeout active — default position 10%",
+        reason="occupancy timeout active — default position 10%",
     )
 
     result = AdaptiveDataUpdateCoordinator.state.fget(coordinator)

--- a/tests/test_motion_hold_skip.py
+++ b/tests/test_motion_hold_skip.py
@@ -23,7 +23,7 @@ def _make_coordinator_with_skip_command(*, skip_command: bool, position: int = 4
     coord._pipeline_result = PipelineResult(
         position=position,
         control_method=ControlMethod.MOTION,
-        reason="motion timeout — holding position 42% (sun in FOV)",
+        reason="occupancy timeout — holding position 42% (sun in FOV)",
         skip_command=skip_command,
     )
 

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -380,6 +380,10 @@ class TestMotionTimeoutHandler:
         result = self.handler.evaluate(snap)
         assert result is not None
         assert result.control_method == ControlMethod.MOTION
+        # issue #723: the decision-trace reason is user-facing and must use
+        # occupancy wording, not "motion".
+        assert result.reason.startswith("occupancy timeout active")
+        assert "motion" not in result.reason.lower()
 
     def test_returns_none_when_inactive(self) -> None:
         """Return None when motion timeout is not active."""
@@ -412,15 +416,17 @@ class TestMotionTimeoutHandler:
         assert result.control_method == ControlMethod.MOTION
 
     def test_describe_skip_motion_control_disabled(self) -> None:
-        """describe_skip returns 'motion control disabled' when switch is off."""
+        """describe_skip returns 'occupancy detection disabled' when switch is off."""
         snap = make_snapshot(motion_timeout_active=True, motion_control_enabled=False)
-        assert self.handler.describe_skip(snap) == "motion control disabled"
+        assert self.handler.describe_skip(snap) == "occupancy detection disabled"
 
     def test_describe_skip_timeout_not_active(self) -> None:
         """describe_skip returns timeout-not-active message when enabled but no timeout."""
         snap = make_snapshot(motion_timeout_active=False, motion_control_enabled=True)
         reason = self.handler.describe_skip(snap)
-        assert "motion" in reason.lower()
+        # issue #723: user-facing reason uses occupancy wording, not "motion".
+        assert "occupancy" in reason.lower()
+        assert "motion" not in reason.lower()
         assert "disabled" not in reason.lower()
 
     def test_priority_is_75(self) -> None:
@@ -453,6 +459,9 @@ class TestMotionTimeoutHandlerHoldMode:
         assert result.position == 42
         assert result.control_method == ControlMethod.MOTION
         assert "hold" in result.reason.lower()
+        # issue #723: hold-mode reason is user-facing → occupancy wording.
+        assert result.reason.startswith("occupancy timeout")
+        assert "motion" not in result.reason.lower()
 
     def test_hold_exits_when_sun_not_valid(self) -> None:
         """hold_position + direct_sun_valid=False → fall through to default position."""

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -626,14 +626,14 @@ class TestBuildPositionExplanation:
         """Motion timeout active → explains default position."""
         pr = _make_pr(
             control_method=ControlMethod.MOTION,
-            reason="motion timeout active — default position 30%",
+            reason="occupancy timeout active — default position 30%",
             position=30,
             default_position=30,
         )
         result = DiagnosticsBuilder._build_position_explanation(
             _base_ctx(pipeline_result=pr)
         )
-        assert "motion" in result.lower()
+        assert "occupancy" in result.lower()
         assert "30%" in result
 
     def test_manual_override(self, builder):


### PR DESCRIPTION
## Summary

Follow-up to the #723 occupancy rename (#878/#880). The rename missed the pipeline `motion_timeout` handler's human-readable `reason` strings, which flow **verbatim** into the card's position explanation and decision trace via `_build_position_explanation` (`builder.py:308` uses `result.reason` as-is). Users still saw **"motion timeout active — …"** on the card after the rename.

### What changed
Reworded the four leaked decision-trace strings in `pipeline/handlers/motion_timeout.py`:
- `"motion timeout active — …"` → `"occupancy timeout active — …"`
- `"motion timeout — holding position …"` → `"occupancy timeout — holding …"`
- `describe_skip` `"motion control disabled"` → `"occupancy detection disabled"`
- `describe_skip` `"motion timeout not active"` → `"occupancy timeout not active"`

Plus the forecast-description override list in `diagnostics/builder.py` (`"…manual override, motion, weather safety…"` → `"…occupancy…"`).

**Frozen, unchanged:** the machine slug `ControlStatus.MOTION_TIMEOUT` (`"motion_timeout"`) — the card localizes that itself (companion-card work in card#178); only the free-text human-readable reasons changed here.

## Testing
- ✅ 6214 tests passing (full suite)
- ✅ TDD: added handler unit-test assertions on the reason wording; the end-to-end `test_integration.py::test_motion_timeout` now verifies the real explanation reads "occupancy timeout active — …" with no "motion" leak
- ✅ ruff + black clean; no translation changes (these are Python-constructed strings, not localized en.json values)

## Related Issues
Refs #723

https://claude.ai/code/session_01APDPu7N3hvp8GkjJes3oED