### PR TITLE
fix: allow set_axes position on open/close-only covers (#886)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2901,14 +2901,22 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """
         entities = self.entities or []
         caps_map = self._cover_provider.read_all_capabilities(entities)
-        rolled: dict[str, bool] = {}
+        # Roll up every capability key each axis's drivability consults — its
+        # native flag plus any open/close fallback keys (#886) — so the merged
+        # caps view fed to ``describe`` lets ``is_drivable`` see the fallback.
+        keys: set[str] = set()
         for axis in self._policy.axes:
-            key = axis.capability_key
-            rolled[key] = (
+            keys.add(axis.capability_key)
+            for group in axis.drive_fallbacks:
+                keys.update(group)
+        rolled: dict[str, bool] = {
+            key: (
                 any(caps_get(caps, key) for caps in caps_map.values())
                 if caps_map
                 else True
             )
+            for key in keys
+        }
         return self._policy.describe(caps=rolled, labels=labels)
 
     def build_diagnostic_data(self) -> dict:

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -100,6 +100,17 @@ class CoverAxis:
     ``value_max`` / ``unit`` describe its numeric range. All four carry safe
     defaults so existing ``CoverAxis`` construction sites (and Liskov-conformant
     fifth-cover-type policies) keep working unchanged.
+
+    ``drive_fallbacks`` records the alternative capability sets that let the
+    integration drive this axis even when the native ``capability_key`` is
+    absent. It is an OR-of-ANDs: the axis is drivable if *any* inner group has
+    *all* its capability flags set. The position axis declares
+    ``((CAP_HAS_OPEN, CAP_HAS_CLOSE),)`` because a cover with no
+    ``set_cover_position`` is still moved to its endpoints via
+    ``open_cover`` / ``close_cover`` (see ``routing.route_service_call``); the
+    tilt axis has no fallback, so it stays drivable only with native tilt. This
+    keeps the axis model — not a cover-type string check — the single source of
+    truth for "can this axis be driven" (#886).
     """
 
     name: str
@@ -112,6 +123,23 @@ class CoverAxis:
     value_min: int = AXIS_VALUE_MIN
     value_max: int = AXIS_VALUE_MAX
     unit: str = AXIS_VALUE_UNIT
+    drive_fallbacks: tuple[tuple[str, ...], ...] = ()
+
+    def is_drivable(self, caps: Any) -> bool:
+        """Whether the integration can drive this axis on an entity with *caps*.
+
+        True when the native capability flag is set, or when any
+        ``drive_fallbacks`` group is fully satisfied (e.g. position via
+        ``open_cover`` / ``close_cover`` on a cover lacking
+        ``set_cover_position``). Mirrors ``routing.route_service_call``'s reach,
+        so the ``set_axes`` service and the discovery ``supported`` flag agree
+        with what actually dispatches.
+        """
+        if caps_get(caps, self.capability_key):
+            return True
+        return any(
+            all(caps_get(caps, cap) for cap in group) for group in self.drive_fallbacks
+        )
 
 
 # Module-level singletons. Each policy declares ``axes`` referencing these so
@@ -128,6 +156,7 @@ POSITION_AXIS = CoverAxis(
     capability_key=CAP_HAS_SET_POSITION,
     open_blocks_sun=False,
     label_key="axes.position",
+    drive_fallbacks=((CAP_HAS_OPEN, CAP_HAS_CLOSE),),
 )
 
 POSITION_AXIS_OPEN_BLOCKS_SUN = CoverAxis(
@@ -138,6 +167,7 @@ POSITION_AXIS_OPEN_BLOCKS_SUN = CoverAxis(
     capability_key=CAP_HAS_SET_POSITION,
     open_blocks_sun=True,
     label_key="axes.position",
+    drive_fallbacks=((CAP_HAS_OPEN, CAP_HAS_CLOSE),),
 )
 
 TILT_AXIS = CoverAxis(
@@ -550,10 +580,12 @@ class CoverTypePolicy(ABC):
 
         Single source of truth (issue #725) for both the ``set_axes`` service's
         unsupported-axis rejection and the discovery descriptor's ``supported``
-        flag. Filters ``self.axes`` by each axis's capability flag through
-        ``caps_get`` so no hardcoded ``caps.get("has_X")`` literal leaks out.
+        flag. Filters ``self.axes`` by each axis's ``is_drivable`` check, which
+        honours the open/close fallback so a position-only cover reached via
+        ``open_cover`` / ``close_cover`` is not falsely rejected (#886) — no
+        hardcoded ``caps.get("has_X")`` literal leaks out.
         """
-        return tuple(a for a in self.axes if caps_get(caps, a.capability_key))
+        return tuple(a for a in self.axes if a.is_drivable(caps))
 
     def describe_axis(
         self,
@@ -579,7 +611,7 @@ class CoverTypePolicy(ABC):
             state_attr=axis.state_attr,
             service_attr=axis.service_attr,
             open_blocks_sun=axis.open_blocks_sun,
-            supported=caps_get(caps, axis.capability_key),
+            supported=axis.is_drivable(caps),
         )
 
     def describe(

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -89,6 +89,7 @@ class TestCoverAxis:
             value_min=POSITION_AXIS.value_min,
             value_max=POSITION_AXIS.value_max,
             unit=POSITION_AXIS.unit,
+            drive_fallbacks=POSITION_AXIS.drive_fallbacks,
         )
         assert twin == POSITION_AXIS
 

--- a/tests/test_cover_types/test_discovery.py
+++ b/tests/test_cover_types/test_discovery.py
@@ -101,3 +101,48 @@ def test_supported_axes_position_only_blind() -> None:
     caps = {"has_set_position": True, "has_set_tilt_position": False}
     supported = policy.supported_axes(caps)
     assert tuple(a.name for a in supported) == ("position",)
+
+
+def test_supported_axes_open_close_only_blind_keeps_position() -> None:
+    """A blind with no ``set_position`` but open+close still exposes position.
+
+    Regression for #886: the open/close fallback drives the position axis, so
+    ``supported_axes`` (and the descriptor's ``supported`` flag) must include it.
+    """
+    policy = get_policy("cover_blind")
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    supported = policy.supported_axes(caps)
+    assert tuple(a.name for a in supported) == ("position",)
+
+    by_id = {a.id: a for a in policy.describe(caps=caps).axes}
+    assert by_id["position"].supported is True
+
+
+def test_supported_axes_excludes_position_when_undrivable() -> None:
+    """Neither native position nor open+close → position is not drivable (#886)."""
+    policy = get_policy("cover_blind")
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": False,
+        "has_close": True,
+    }
+    assert policy.supported_axes(caps) == ()
+
+
+def test_tilt_axis_has_no_open_close_fallback() -> None:
+    """Tilt is drivable only with native tilt — open/close does not reach it."""
+    policy = get_policy("cover_venetian")
+    caps = {
+        "has_set_position": True,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    supported = policy.supported_axes(caps)
+    assert tuple(a.name for a in supported) == ("position",)

--- a/tests/test_services_set_axes.py
+++ b/tests/test_services_set_axes.py
@@ -54,6 +54,21 @@ _POSITION_ONLY_CAPS = CoverCapabilities(
     has_open=True,
     has_close=True,
 )
+# Open/close-only cover: no native set_cover_position, but the integration
+# drives the position axis via open_cover/close_cover (#886).
+_OPEN_CLOSE_ONLY_CAPS = CoverCapabilities(
+    has_set_position=False,
+    has_set_tilt_position=False,
+    has_open=True,
+    has_close=True,
+)
+# A cover the integration cannot drive on any axis at all.
+_NO_DRIVE_CAPS = CoverCapabilities(
+    has_set_position=False,
+    has_set_tilt_position=False,
+    has_open=False,
+    has_close=False,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +168,67 @@ async def test_unsupported_axis_raises() -> None:
             return_value={coord: None},
         ),
         pytest.raises(ServiceValidationError, match="tilt"),
+    ):
+        await async_handle_set_axes(call)
+
+    coord.async_apply_user_axis.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_position_axis_on_open_close_only_blind_dispatches() -> None:
+    """Position on an open/close-only blind dispatches — it is not rejected.
+
+    Regression for #886: the companion card's ``set_axes`` call failed with
+    "does not support the 'position' axis" for a vertical blind lacking native
+    ``set_cover_position``, even though the integration drives it via
+    ``open_cover`` / ``close_cover``.
+    """
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(
+        cover_type="cover_blind",
+        caps=_OPEN_CLOSE_ONLY_CAPS,
+        entities=["cover.deck_front_shade"],
+    )
+    call = MagicMock()
+    call.data = {"axes": {"position": 100}}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+        return_value={coord: None},
+    ):
+        await async_handle_set_axes(call)
+
+    coord.async_apply_user_axis.assert_awaited_once_with(
+        "cover.deck_front_shade",
+        AXIS_NAME_POSITION,
+        100,
+        trigger="set_axes",
+        force=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_position_axis_on_undrivable_cover_raises() -> None:
+    """Position on a cover with neither set_position nor open+close still errors."""
+    from custom_components.adaptive_cover_pro.services.set_axes_service import (
+        async_handle_set_axes,
+    )
+
+    coord = _make_coord(
+        cover_type="cover_blind", caps=_NO_DRIVE_CAPS, entities=["cover.blind"]
+    )
+    call = MagicMock()
+    call.data = {"axes": {"position": 50}}
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.services.set_axes_service._resolve_targets",
+            return_value={coord: None},
+        ),
+        pytest.raises(ServiceValidationError, match="position"),
     ):
         await async_handle_set_axes(call)
 


### PR DESCRIPTION
## Summary
Controlling an open/close-only cover (no native `set_cover_position`) from the companion Lovelace Tile Card failed with `Validation error: Vertical Blind cover cover.deck_front_shade does not support the 'position' axis`.

`set_axes` validated each axis via `policy.supported_axes(caps)`, which filtered the position axis out whenever `has_set_position` was false. But the integration drives position on such covers via `open_cover` / `close_cover` (routing fallback), and the single-axis `set_position` service has no such gate — so `set_axes` (used by the card) was stricter than `set_position` and rejected a perfectly drivable axis.

The axis model now records the fallback: `CoverAxis` gains `drive_fallbacks` (OR-of-AND capability groups) and `is_drivable(caps)`. The position axis declares `((has_open, has_close),)`; tilt has none. `supported_axes` and the discovery `supported` flag route through `is_drivable`, so they agree with what actually dispatches. No cover-type string branching — a ninth cover type inherits this unchanged.

## Testing
- ✅ Full suite: 6221 passing
- New regression tests: position dispatches on an open/close-only blind; still errors when the cover has neither `set_position` nor open+close; tilt has no open/close fallback; discovery `supported` flag reflects drivability.

## Related Issues
Refs #886

https://claude.ai/code/session_014T41PeYfDQFQM1q5SDXyAK