### PR TITLE
feat: surface My-position value as reported position on stop->My (#888)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -491,6 +491,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # ACP-issued context ids from genuine user actions.
         self.manager.set_transition_callbacks(on_engaged=self._cmd_svc.discard_target)
         self.manager.set_acp_context_predicate(self._cmd_svc.was_acp_position_context)
+        # Issue #888: drop the display-only assumed position when the override
+        # resets or a real numeric position read arrives.
+        self.manager.set_assumed_invalidator(self._cmd_svc.clear_assumed_position)
 
         # Late-bind cover-type policy dependencies (e.g. VenetianPolicy
         # constructs its DualAxisSequencer here once cmd_svc + grace_mgr are
@@ -968,7 +971,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         for entity_id in tracked:
             # On the not-manual→manual edge the manager fires on_engaged →
             # discard_target (issue #215/#216); see set_transition_callbacks.
-            self.manager.handle_stop_service_call(
+            engaged = self.manager.handle_stop_service_call(
                 entity_id,
                 int(my_position_value),
                 self._cmd_svc.is_waiting_for_target,
@@ -979,6 +982,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # Update target so the next reconciliation compares against
             # My rather than the stale calculated state.
             self._cmd_svc.set_target(entity_id, int(my_position_value))
+            # Issue #888: when the stop actually engaged the #875 override (not a
+            # mid-move stop), record My as the display-only assumed position so
+            # the card shows My. Confined to covers with no native position axis
+            # by the shared helper's caps predicate; the my_position_value gate
+            # above already restricts this to configured-My instances.
+            if engaged:
+                self._cmd_svc._record_assumed_if_blind(
+                    entity_id, int(my_position_value)
+                )
 
     async def async_check_weather_state_change(
         self, event: Event[EventStateChangedData]
@@ -1564,7 +1576,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             ),
             climate=None,  # Populated later when climate mode data is read
             cover_positions=self._cover_provider.read_positions(
-                self.entities, self._policy
+                self.entities,
+                self._policy,
+                assumed=self._cmd_svc.get_assumed_position,
             ),
             cover_capabilities=self._cover_provider.read_all_capabilities(
                 self.entities
@@ -2925,7 +2939,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         # Live cover positions and capabilities
         cover_entities = self.entities or []
-        _positions = self._cover_provider.read_positions(cover_entities, self._policy)
+        _positions = self._cover_provider.read_positions(
+            cover_entities, self._policy, assumed=self._cmd_svc.get_assumed_position
+        )
         _caps = self._cover_provider.read_all_capabilities(cover_entities)
         _covers = {
             eid: {

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -709,6 +709,7 @@ class CoverTypePolicy(ABC):
         caps: Any,
         *,
         state_obj: State | None = None,
+        assumed: int | None = None,
     ) -> int | None:
         """Read the current value on the axis this policy targets by default.
 
@@ -717,13 +718,23 @@ class CoverTypePolicy(ABC):
         ``CoverCommandService._read_position_with_capabilities``,
         ``CoverProvider.read_positions``, manual_override state-change
         handling, and the position-capability check inside ``_prepare_service_call``.
+
+        ``assumed`` (issue #888) is a display-only fallback surfaced ONLY on the
+        open/close-only branch, and ONLY after the live open/close read yields
+        ``None``. A real numeric/open/closed read always wins and is never
+        masked; a position-capable cover never reaches the fallback. Callers on
+        the command-dispatch read path leave ``assumed=None`` so the gates stay
+        raw (§3b) — only the reported-position surfaces pass it.
         """
         axis = self.select_default_axis(caps)
         if _caps_get(caps, axis.capability_key, default=True):
             if state_obj is not None:
                 return state_obj.attributes.get(axis.state_attr)
             return state_attr(hass, entity, axis.state_attr)
-        return get_open_close_state(hass, entity, state_obj=state_obj)
+        live = get_open_close_state(hass, entity, state_obj=state_obj)
+        if live is None and assumed is not None:
+            return assumed
+        return live
 
     # ---- Declarative section configuration ----------------------------- #
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -356,6 +356,61 @@ class CoverCommandService:
             s.is_safety = False
 
     # ------------------------------------------------------------------ #
+    # Assumed display position (issue #888) — display-only fallback for
+    # open/close-only covers with no native position feedback.
+    # ------------------------------------------------------------------ #
+
+    def get_assumed_position(self, entity_id: str) -> int | None:
+        """Return the assumed display position for ``entity_id``, or None.
+
+        Display-only (issue #888): the reported-position surfaces
+        (``CoverProvider.read_positions``) fall back to this ONLY when the live
+        HA read is None. NEVER consulted by the command-dispatch read path
+        (``_read_position_with_capabilities`` / ``get_current_position``) — see
+        §3b — so the delta / same-position / endpoint gates stay raw.
+        """
+        s = self._state.get(entity_id)
+        return None if s is None else s.assumed_position
+
+    def record_assumed_position(self, entity_id: str, value: int) -> None:
+        """Store an assumed display position for ``entity_id``."""
+        self.state(entity_id).assumed_position = value
+
+    def clear_assumed_position(self, entity_id: str) -> None:
+        """Drop any stored assumed display position for ``entity_id``."""
+        s = self._state.get(entity_id)
+        if s is not None:
+            s.assumed_position = None
+
+    def _record_assumed_if_blind(
+        self, entity_id: str, routed_target: int | None, caps: Any | None = None
+    ) -> None:
+        """Record (or clear) the assumed display position after ACP drives a cover.
+
+        Single shared write for both My paths (``send_my_position`` and the
+        command-sent tail of ``apply_position``) and the coordinator's external
+        stop→My path. Gated on ``not policy.position_axis_supported(caps)`` so
+        the assumed value is confined to open/close-only covers that report no
+        native position:
+
+        - open/close-only cover → stash ``routed_target`` as the assumed value
+          (the routed My target, or the routed open/close endpoint).
+        - position-capable cover → clear any stale assumed value so a real read
+          can never be masked (dedupes the clear-on-native-command path).
+
+        Never touches the command-dispatch read path (§3b); recording happens
+        only after the command has already dispatched, so this cycle's gates —
+        which read raw HA state — are unaffected.
+        """
+        if caps is None:
+            caps = self.get_cover_capabilities(entity_id)
+        if self._policy.position_axis_supported(caps):
+            self.clear_assumed_position(entity_id)
+            return
+        if routed_target is not None:
+            self.record_assumed_position(entity_id, routed_target)
+
+    # ------------------------------------------------------------------ #
     # Properties
     # ------------------------------------------------------------------ #
 
@@ -742,6 +797,11 @@ class CoverCommandService:
         s.last_progress_at = None
         s.retry_count = 0
         s.gave_up = False
+        # Issue #888: on covers with no native position axis, stash the My value
+        # as the display-only assumed position so the card shows My rather than
+        # ``—``. Caps was already fetched above; the helper gates on the policy
+        # predicate (no-op for position-capable covers).
+        self._record_assumed_if_blind(entity_id, target, caps)
         self._logger.debug(
             "send_my_position: stop_cover sent to %s (My = %d%%)", entity_id, target
         )
@@ -1802,6 +1862,16 @@ class CoverCommandService:
         now = dt.datetime.now(dt.UTC)
         s = self.state(entity)
         s.target = plan.routed_target
+        # Issue #888: this is the single chokepoint every dispatched command
+        # (apply_position + reconciliation) flows through, so refresh the
+        # display-only assumed position here. Open/close-only covers with no
+        # native feedback (Somfy RTS) stash the routed target so the card shows
+        # where ACP drove them; position-capable covers clear any stale assumed
+        # value (dedupes clear-on-native-command). It only writes/clears the
+        # assumed store — never read by the gates, which already ran — so §3b
+        # holds. Runs before the dry-run early return so a dry-run cycle keeps
+        # the display honest too.
+        self._record_assumed_if_blind(entity, plan.routed_target, caps)
         s.waiting = True
         s.sent_at = now
         s.last_progress_at = None

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -44,6 +44,12 @@ class PerEntityState:
     gave_up: bool = False
     is_safety: bool = False
     last_reconcile_at: dt.datetime | None = None
+    # Display-only assumed position (issue #888). Set on covers with no native
+    # position axis (Somfy-RTS-style open/close-only) when ACP drives them — an
+    # ACP My move or an external stop that engaged the #875 override. A pure
+    # fallback the reported-position surfaces return ONLY when the live HA read
+    # is None; NEVER consulted by the command-dispatch gates (§3b).
+    assumed_position: int | None = None
 
 
 @dataclasses.dataclass

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -128,6 +128,11 @@ class AdaptiveCoverManager:
         # ACP-origin predicate over a context id; the coordinator wires the
         # real one. Default treats nothing as ACP-originated.
         self._is_acp_context_fn: Callable[[str | None], bool] = lambda _cid: False
+        # Display-only assumed-position invalidator (issue #888). The coordinator
+        # wires this to ``CoverCommandService.clear_assumed_position`` so the
+        # stashed My/assumed value is dropped the moment the override resets or a
+        # real numeric position read arrives. Default is a no-op.
+        self._invalidate_assumed: Callable[[str], None] = lambda _eid: None
 
     # --- wiring -----------------------------------------------------------
 
@@ -144,6 +149,10 @@ class AdaptiveCoverManager:
     def set_acp_context_predicate(self, fn: Callable[[str | None], bool]) -> None:
         """Register the predicate that recognises ACP-originated context ids."""
         self._is_acp_context_fn = fn
+
+    def set_assumed_invalidator(self, fn: Callable[[str], None]) -> None:
+        """Register the callback that drops a cover's assumed display position (#888)."""
+        self._invalidate_assumed = fn
 
     def update_config(self, config: DetectorConfig) -> None:
         """Apply an options change at runtime (no reload).
@@ -416,6 +425,11 @@ class AdaptiveCoverManager:
         new_position = policy.read_axis_value(
             self.hass, entity_id, caps, state_obj=new_state
         )
+        # Issue #888: a genuine numeric position read supersedes any display-only
+        # assumed value, so drop it. Reads that resolve to None (the Somfy-RTS
+        # unknown state that made the assumed value necessary) leave it intact.
+        if new_position is not None:
+            self._invalidate_assumed(entity_id)
         old_state_obj = getattr(event, "old_state", None)
         old_position = (
             policy.read_axis_value(self.hass, entity_id, caps, state_obj=old_state_obj)
@@ -523,7 +537,7 @@ class AdaptiveCoverManager:
         context_user_id: str | None = None,
         context_id: str | None = None,
         context_parent_id: str | None = None,
-    ) -> None:
+    ) -> bool:
         """Mark manual override when a user-initiated cover.stop_cover is detected.
 
         Delegates to the active detector's ``on_stop_to_my`` hook (default: mark
@@ -541,9 +555,15 @@ class AdaptiveCoverManager:
             context_id:       id of the stop_cover call's originating HA Context.
             context_parent_id: parent_id of the originating HA Context, if any.
 
+        Returns:
+            True when the stop engaged the manual override (the cover is taken to
+            be at My), False when it was ignored (untracked, or the #875
+            wait-for-target gate declined). The coordinator uses this to decide
+            whether to record the display-only assumed My position (#888).
+
         """
         if entity_id not in self.covers:
-            return
+            return False
         decision = self._detector.on_stop_to_my(
             StopToMy(
                 entity_id=entity_id,
@@ -559,7 +579,7 @@ class AdaptiveCoverManager:
                 "handle_stop_service_call: ignoring stop for %s — wait_for_target active",
                 entity_id,
             )
-            return
+            return False
         self.logger.debug(
             "Manual override via user stop_cover for %s (My position = %d%%)",
             entity_id,
@@ -572,6 +592,7 @@ class AdaptiveCoverManager:
                 entity_id, dt.datetime.now(dt.UTC)
             ),
         )
+        return True
 
     def set_last_updated(self, entity_id, new_state, allow_reset):
         """Set last updated time for manual control.
@@ -811,6 +832,9 @@ class AdaptiveCoverManager:
         """
         self.manual_control[entity_id] = False
         self.manual_control_time.pop(entity_id, None)
+        # Issue #888: the assumed My/display position was a stand-in while the
+        # override held the cover; clearing the override retires it too.
+        self._invalidate_assumed(entity_id)
         self.logger.debug("Reset manual override for %s", entity_id)
         self._record_event(
             entity_id,

--- a/custom_components/adaptive_cover_pro/state/cover_provider.py
+++ b/custom_components/adaptive_cover_pro/state/cover_provider.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from ..cover_types.base import (
@@ -36,18 +37,32 @@ class CoverProvider:
         self.logger = logger
 
     def read_positions(
-        self, entities: list[str], policy: CoverTypePolicy
+        self,
+        entities: list[str],
+        policy: CoverTypePolicy,
+        assumed: Callable[[str], int | None] | None = None,
     ) -> dict[str, int | None]:
         """Read current positions for all managed cover entities.
 
         Delegates the per-entity axis routing to ``policy.read_axis_value`` so
         the same "pick the axis, fall back to open/close" rule used by
         ``CoverCommandService`` lives in exactly one place.
+
+        ``assumed`` (issue #888) is a per-entity lookup for the display-only
+        assumed position. When supplied, its value is passed through to
+        ``read_axis_value``, which surfaces it ONLY on the open/close-only
+        branch when the live read is None. This is a reported-position surface,
+        never the command-dispatch read path — so it never affects the gates.
         """
         positions: dict[str, int | None] = {}
         for entity in entities:
             caps = self.read_single_capabilities(entity)
-            positions[entity] = policy.read_axis_value(self._hass, entity, caps)
+            positions[entity] = policy.read_axis_value(
+                self._hass,
+                entity,
+                caps,
+                assumed=assumed(entity) if assumed is not None else None,
+            )
         return positions
 
     def read_single_capabilities(self, entity: str) -> CoverCapabilities:

--- a/tests/test_assumed_position_surface.py
+++ b/tests/test_assumed_position_surface.py
@@ -1,0 +1,161 @@
+"""End-to-end: assumed My position surfaces on the display for RTS covers (#888).
+
+An open/close-only cover (Somfy RTS: OPEN|CLOSE|STOP, no SET_POSITION) reports
+no numeric position, so the reported-position surfaces render ``—``. After ACP
+drives it to its hardware "My" preset, both display surfaces — the cover-position
+sensor's ``actual_positions`` (from ``snapshot.cover_positions``) and the
+diagnostics ``current_position`` — must fall back to ``my_position_value``.
+
+Also covers invalidation (Step 7): the assumed value is dropped on override
+reset, on a real numeric state change, and on a native-position command.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_MY_POSITION_VALUE,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+pytestmark = pytest.mark.integration
+
+# Somfy-RTS-style capability mask: OPEN(1) | CLOSE(2) | STOP(8) — no SET_POSITION(4).
+_OPEN_CLOSE_STOP = 1 | 2 | 8
+
+
+async def _setup_open_close_cover(
+    hass: HomeAssistant, *, my_position: int | None = 50, entry_id: str = "assumed_01"
+):
+    """Set up one open/close-only (assumed-state) blind with an unknown position."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    hass.states.async_set(
+        "cover.test_blind",
+        "unknown",
+        {"supported_features": _OPEN_CLOSE_STOP},
+    )
+
+    opts = dict(VERTICAL_OPTIONS)
+    if my_position is not None:
+        opts[CONF_MY_POSITION_VALUE] = my_position
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Assumed", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=opts,
+        entry_id=entry_id,
+        title="Assumed",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry.runtime_data
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — both display surfaces fall back to the assumed My value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_actual_positions_shows_my_after_acp_move(hass: HomeAssistant) -> None:
+    """After an ACP My move, diagnostics + the snapshot report my_position_value."""
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+
+    # ACP drives the cover to My. dry_run keeps the real cover.stop_cover service
+    # (unregistered in this bare hass) from firing while still recording state.
+    coordinator._cmd_svc._dry_run = True
+    await coordinator._cmd_svc.send_my_position("cover.test_blind", 50)
+    coordinator._cmd_svc._dry_run = False
+
+    # Diagnostics surface (build_diagnostic_data → read_positions).
+    diag = coordinator.build_diagnostic_data()
+    assert diag["covers"]["cover.test_blind"]["current_position"] == 50
+
+    # Sensor surface: snapshot.cover_positions, rebuilt on the next update cycle.
+    await coordinator.async_refresh()
+    assert coordinator._snapshot.cover_positions["cover.test_blind"] == 50
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — invalidation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_assumed_cleared_on_override_reset(hass: HomeAssistant) -> None:
+    """Resetting the manual override drops the assumed display position."""
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 50)
+
+    coordinator.manager.reset("cover.test_blind")
+
+    assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") is None
+
+
+@pytest.mark.asyncio
+async def test_assumed_cleared_on_real_state_change(hass: HomeAssistant) -> None:
+    """A real numeric position read invalidates the stale assumed value.
+
+    Uses a read that matches ``our_state`` so no manual override engages — this
+    isolates the explicit invalidation, rather than the incidental
+    ``discard_target`` that a detected override would trigger.
+    """
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    coordinator.manager.add_covers(["cover.test_blind"])
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 50)
+
+    # A state-change event carrying a genuine open read (100), matching the
+    # expected position so the position-delta detector marks no override.
+    new_state = MagicMock()
+    new_state.state = "open"
+    new_state.attributes = {}
+    new_state.context = None
+    new_state.last_updated = None
+    event = MagicMock()
+    event.entity_id = "cover.test_blind"
+    event.new_state = new_state
+    event.old_state = None
+
+    coordinator.manager.handle_state_change(
+        event,
+        100,
+        coordinator._policy,
+        False,
+        lambda _e: False,
+        5,
+    )
+
+    assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") is None
+
+
+@pytest.mark.asyncio
+async def test_assumed_cleared_on_native_position_command(
+    hass: HomeAssistant,
+) -> None:
+    """A native set_position command clears any stale assumed value."""
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 50)
+
+    # The cover now reports a native position axis (SET_POSITION added).
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"current_position": 40, "supported_features": _OPEN_CLOSE_STOP | 4},
+    )
+    coordinator._cmd_svc._dry_run = True
+    ctx = coordinator._build_position_context(
+        "cover.test_blind", dict(VERTICAL_OPTIONS), force=True
+    )
+    await coordinator._cmd_svc.apply_position("cover.test_blind", 30, "solar", ctx)
+
+    assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") is None

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -412,6 +412,32 @@ class TestReadAxisValue:
         result = get_policy("cover_blind").read_axis_value(hass, "cover.blind", caps)
         assert result == 25
 
+    @pytest.mark.unit
+    def test_read_axis_value_assumed_fallback_open_close_only(self):
+        # Issue #888: an open/close-only cover whose live state is unknown falls
+        # back to the assumed display value — but a real open/closed read always
+        # wins over the assumed value.
+        caps = {"has_set_position": False, "has_set_tilt_position": False}
+        policy = get_policy("cover_blind")
+
+        unknown = _hass_with_state({}, state="unknown")
+        assert policy.read_axis_value(unknown, "cover.somfy", caps, assumed=50) == 50
+
+        live_open = _hass_with_state({}, state="open")
+        assert policy.read_axis_value(live_open, "cover.somfy", caps, assumed=50) == 100
+
+    @pytest.mark.unit
+    def test_read_axis_value_assumed_ignored_for_position_capable(self):
+        # A position-capable cover never returns the assumed value: its live read
+        # (here None because the attribute is absent) is authoritative and must
+        # not be masked by an assumed fallback.
+        hass = _hass_with_state({}, state="unknown")
+        caps = {"has_set_position": True, "has_set_tilt_position": False}
+        result = get_policy("cover_blind").read_axis_value(
+            hass, "cover.blind", caps, assumed=50
+        )
+        assert result is None
+
 
 # ---------------------------------------------------------------------------
 # position_axis_supported — does this entity expose the policy's primary axis?

--- a/tests/test_managers/test_cover_command_assumed_position.py
+++ b/tests/test_managers/test_cover_command_assumed_position.py
@@ -1,0 +1,110 @@
+"""Assumed-position store + display surfacing for open/close-only covers (#888).
+
+An assumed-state / open-close-only cover (e.g. Somfy RTS) never reports a
+numeric position, so the companion card renders ``—``. When ACP drives such a
+cover — an ACP My move, or an external stop that engages the #875 override —
+we stash the routed target as a *display-only* assumed position that the
+reported-position surfaces fall back to ONLY when the live HA read is None.
+
+Binding invariant §3b: the assumed value must NEVER enter the command-dispatch
+read path (``get_current_position`` / ``_read_position_with_capabilities``);
+those keep reading raw HA state so the delta / same-position / endpoint gates
+are unaffected.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+)
+from custom_components.adaptive_cover_pro.state.cover_provider import CoverProvider
+
+_OPEN_CLOSE_ONLY = {
+    "has_set_position": False,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+
+
+@pytest.fixture
+def mock_hass():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return h
+
+
+@pytest.fixture
+def svc(mock_hass):
+    return CoverCommandService(
+        hass=mock_hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        check_interval_minutes=1,
+        position_tolerance=3,
+        max_retries=3,
+    )
+
+
+def _unknown_state(mock_hass) -> None:
+    state_obj = MagicMock()
+    state_obj.state = "unknown"
+    state_obj.attributes = {}
+    mock_hass.states.get.return_value = state_obj
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — the per-entity assumed-position store
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_record_and_clear_assumed_position(svc):
+    """Record → get → clear round-trips through PerEntityState.assumed_position."""
+    entity = "cover.somfy"
+    assert svc.get_assumed_position(entity) is None
+    svc.record_assumed_position(entity, 50)
+    assert svc.get_assumed_position(entity) == 50
+    svc.clear_assumed_position(entity)
+    assert svc.get_assumed_position(entity) is None
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — display carries assumed; the command gate does not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_read_positions_surfaces_assumed(mock_hass):
+    """read_positions(..., assumed=fn) returns the assumed value when live is None."""
+    _unknown_state(mock_hass)
+    provider = CoverProvider(mock_hass, MagicMock())
+    policy = get_policy("cover_blind")
+    with patch(
+        "custom_components.adaptive_cover_pro.state.cover_provider.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        positions = provider.read_positions(
+            ["cover.somfy"], policy, assumed=lambda _e: 50
+        )
+    assert positions == {"cover.somfy": 50}
+
+
+@pytest.mark.unit
+def test_get_current_position_stays_raw(svc, mock_hass):
+    """§3b: the command-dispatch read never sees the assumed value."""
+    _unknown_state(mock_hass)
+    svc.record_assumed_position("cover.somfy", 50)
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        assert svc.get_current_position("cover.somfy") is None

--- a/tests/test_manual_override_hold_skip.py
+++ b/tests/test_manual_override_hold_skip.py
@@ -8,12 +8,22 @@ record the skip with a ``manual_override_hold`` label — not ``motion_hold``.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers import (
+    ManualOverrideHandler,
+)
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.state.cover_provider import CoverProvider
+
+from tests.test_pipeline.conftest import make_snapshot
 
 
 def _make_coordinator_with_manual_hold(*, position: int = 100, held: int = 0):
@@ -71,3 +81,88 @@ async def test_dispatch_manual_override_hold_does_not_mislabel_as_motion():
 
     args, _ = coord._cmd_svc.record_skipped_action.call_args
     assert args[1] != "motion_hold"
+
+
+# ---------------------------------------------------------------------------
+# Issue #888: the assumed My value feeds the #809 hold on open/close-only covers
+# ---------------------------------------------------------------------------
+
+
+def _cmd_svc_with_assumed(hass) -> CoverCommandService:
+    return CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        check_interval_minutes=1,
+        position_tolerance=3,
+        max_retries=3,
+    )
+
+
+@pytest.mark.unit
+def test_hold_at_assumed_my_on_open_close_cover():
+    """An open/close-only cover under override holds at its assumed My value.
+
+    The assumed My position flows through ``read_positions`` into the snapshot's
+    ``current_cover_position``, so ``ManualOverrideHandler`` holds there
+    (skip_command=True) instead of surfacing ``—``. A position-reporting cover
+    is unaffected: its real read always wins over any assumed value.
+    """
+    hass = MagicMock()
+    unknown = MagicMock()
+    unknown.state = "unknown"
+    unknown.attributes = {}
+    hass.states.get.return_value = unknown
+
+    cmd_svc = _cmd_svc_with_assumed(hass)
+    cmd_svc.record_assumed_position("cover.somfy", 50)
+    provider = CoverProvider(hass, MagicMock())
+    policy = get_policy("cover_blind")
+
+    open_close_only = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    with patch(
+        "custom_components.adaptive_cover_pro.state.cover_provider.check_cover_features",
+        return_value=open_close_only,
+    ):
+        positions = provider.read_positions(
+            ["cover.somfy"], policy, assumed=cmd_svc.get_assumed_position
+        )
+    assert positions["cover.somfy"] == 50
+
+    snap = make_snapshot(
+        manual_override_active=True,
+        direct_sun_valid=False,
+        current_cover_position=positions["cover.somfy"],
+        default_position=0,
+    )
+    result = ManualOverrideHandler().evaluate(snap)
+    assert result is not None
+    assert result.held_position == 50
+    assert result.skip_command is True
+
+    # Position-reporting cover: a real read wins over any assumed value.
+    reporting = MagicMock()
+    reporting.state = "open"
+    reporting.attributes = {"current_position": 30}
+    hass.states.get.return_value = reporting
+    position_capable = {
+        "has_set_position": True,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    with patch(
+        "custom_components.adaptive_cover_pro.state.cover_provider.check_cover_features",
+        return_value=position_capable,
+    ):
+        positions2 = provider.read_positions(
+            ["cover.somfy"], policy, assumed=lambda _e: 50
+        )
+    assert positions2["cover.somfy"] == 30

--- a/tests/test_my_position.py
+++ b/tests/test_my_position.py
@@ -193,6 +193,24 @@ class TestSendMyPosition:
             "cover", "stop_cover", {"entity_id": "cover.somfy"}, context=ANY
         )
 
+    @pytest.mark.asyncio
+    async def test_acp_my_move_records_assumed_position(self, svc, mock_hass):
+        """Issue #888: an ACP My move on an open/close-only cover records the
+        assumed display position so the card can show My instead of ``—``.
+        """
+        with _patch_caps_my(has_set_position=False, has_stop=True):
+            await svc.send_my_position("cover.somfy", 50)
+
+        assert svc.get_assumed_position("cover.somfy") == 50
+
+    @pytest.mark.asyncio
+    async def test_no_assumed_recorded_for_position_capable(self, svc, mock_hass):
+        """A position-capable cover has a real read, so no assumed value is stored."""
+        with _patch_caps_my(has_set_position=True, has_stop=True):
+            await svc.send_my_position("cover.somfy", 50)
+
+        assert svc.get_assumed_position("cover.somfy") is None
+
 
 # ---------------------------------------------------------------------------
 # _prepare_service_call — My-position routing

--- a/tests/test_services_stop.py
+++ b/tests/test_services_stop.py
@@ -196,6 +196,156 @@ async def test_acp_stop_service_bypasses_manual_ignore_external_gate() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Issue #888: external stop→My records the display-only assumed position,
+# gated by a configured My value + the #875 wait-for-target guard.
+# ---------------------------------------------------------------------------
+
+
+def _make_coord_for_assumed(
+    *,
+    my_position: int | None,
+    manual_ignore_external: bool = False,
+    engaged: bool = True,
+):
+    """Coordinator mock with a real CoverCommandService for assumed-position tests."""
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+    )
+
+    coord = MagicMock()
+    coord.manual_toggle = True
+    coord.automatic_control = True
+    coord.manual_ignore_external = manual_ignore_external
+    coord.entities = ["cover.test_blind"]
+    coord.logger = MagicMock()
+    coord._manual_gate_closed_log = MagicMock()
+
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    cmd_svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        check_interval_minutes=1,
+        position_tolerance=3,
+        max_retries=3,
+    )
+    coord._cmd_svc = cmd_svc
+
+    coord.manager = MagicMock()
+    coord.manager.handle_stop_service_call = MagicMock(return_value=engaged)
+
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = (
+        {} if my_position is None else {"my_position_value": my_position}
+    )
+    return coord
+
+
+def _stop_event(entity_id: str = "cover.test_blind"):
+    from homeassistant.core import Context, Event
+
+    ctx = Context()
+    return Event(
+        "call_service",
+        {
+            "domain": "cover",
+            "service": "stop_cover",
+            "service_data": {"entity_id": entity_id},
+            "context": ctx,
+        },
+        context=ctx,
+    )
+
+
+_OPEN_CLOSE_ONLY = {
+    "has_set_position": False,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+
+
+@pytest.mark.asyncio
+async def test_external_stop_records_assumed_when_my_configured() -> None:
+    """A real external stop→My on an open/close-only cover records assumed=My."""
+    from unittest.mock import patch
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = _make_coord_for_assumed(my_position=50, engaged=True)
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+            coord, _stop_event()
+        )
+
+    assert coord._cmd_svc.get_assumed_position("cover.test_blind") == 50
+
+
+@pytest.mark.asyncio
+async def test_external_stop_no_assumed_when_my_unset() -> None:
+    """No My configured → the whole path early-returns, no assumed recorded."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = _make_coord_for_assumed(my_position=None, engaged=True)
+    await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+        coord, _stop_event()
+    )
+
+    assert coord._cmd_svc.get_assumed_position("cover.test_blind") is None
+    coord.manager.handle_stop_service_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_external_stop_no_assumed_when_waiting() -> None:
+    """A mid-move stop (override declined) records no assumed position."""
+    from unittest.mock import patch
+
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = _make_coord_for_assumed(my_position=50, engaged=False)
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+            coord, _stop_event()
+        )
+
+    assert coord._cmd_svc.get_assumed_position("cover.test_blind") is None
+
+
+@pytest.mark.asyncio
+async def test_external_stop_no_assumed_when_ignore_external() -> None:
+    """manual_ignore_external → external stop ignored, no assumed recorded."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = _make_coord_for_assumed(
+        my_position=50, manual_ignore_external=True, engaged=True
+    )
+    await AdaptiveDataUpdateCoordinator.async_check_cover_service_call(
+        coord, _stop_event()
+    )
+
+    assert coord._cmd_svc.get_assumed_position("cover.test_blind") is None
+    coord.manager.handle_stop_service_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Step 10: services.yaml documents the stop service
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Covers that report no native position (Somfy-RTS-style open/close-only) now surface a display-only assumed position, the routed My/endpoint target, so the companion card's `actual_positions` attribute shows a value instead of a dash after the cover lands on its My preset.

It's a pure fallback: a real numeric position read always wins and is never masked. It's caps-gated (never branches on a cover-type string) and it never enters the command-dispatch read path, so open, close, and stop commands always dispatch on their own merits regardless of any stored assumed position.

Gated entirely on `my_position_value` being configured, plus the existing #875 override gates on the external-stop path. No new config option and no user-facing string. No change needed in the companion card, which already reads `actual_positions`.

## Testing
- 6237 tests passing (full suite), all named regression guards green (#875, #591, #809 paths)

## Related Issues
Refs #888