### PR TITLE
fix: show My position on assumed-state covers reporting open/closed (#888)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import voluptuous as vol
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
@@ -720,11 +721,14 @@ class CoverTypePolicy(ABC):
         handling, and the position-capability check inside ``_prepare_service_call``.
 
         ``assumed`` (issue #888) is a display-only fallback surfaced ONLY on the
-        open/close-only branch, and ONLY after the live open/close read yields
-        ``None``. A real numeric/open/closed read always wins and is never
-        masked; a position-capable cover never reaches the fallback. Callers on
-        the command-dispatch read path leave ``assumed=None`` so the gates stay
-        raw (§3b) — only the reported-position surfaces pass it.
+        open/close-only branch. It wins in two cases: after the live open/close
+        read yields ``None``, and — for an ``assumed_state`` cover (issue #888
+        follow-up) — over the open/close mapping itself, because for such covers
+        ``open``/``closed`` is the last-command direction, not a real position.
+        On a non-assumed open/close cover a real open/closed read still wins and
+        is never masked; a position-capable cover never reaches the fallback.
+        Callers on the command-dispatch read path leave ``assumed=None`` so the
+        gates stay raw (§3b) — only the reported-position surfaces pass it.
         """
         axis = self.select_default_axis(caps)
         if _caps_get(caps, axis.capability_key, default=True):
@@ -732,6 +736,15 @@ class CoverTypePolicy(ABC):
                 return state_obj.attributes.get(axis.state_attr)
             return state_attr(hass, entity, axis.state_attr)
         live = get_open_close_state(hass, entity, state_obj=state_obj)
+        if assumed is not None:
+            st = state_obj if state_obj is not None else hass.states.get(entity)
+            if st is not None and st.attributes.get(ATTR_ASSUMED_STATE):
+                # Issue #888 follow-up: for an assumed-state cover, open/closed is
+                # the last-command direction, not a real position. A recorded
+                # high-confidence assumed value (a My arrival) is more specific, so
+                # surface it over the open/close mapping. Invalidation (manual-override
+                # transition + per-command refresh) keeps it from going stale.
+                return assumed
         if live is None and assumed is not None:
             return assumed
         return live

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -425,17 +425,21 @@ class AdaptiveCoverManager:
         new_position = policy.read_axis_value(
             self.hass, entity_id, caps, state_obj=new_state
         )
-        # Issue #888: a genuine numeric position read supersedes any display-only
-        # assumed value, so drop it. Reads that resolve to None (the Somfy-RTS
-        # unknown state that made the assumed value necessary) leave it intact.
-        if new_position is not None:
-            self._invalidate_assumed(entity_id)
         old_state_obj = getattr(event, "old_state", None)
         old_position = (
             policy.read_axis_value(self.hass, entity_id, caps, state_obj=old_state_obj)
             if old_state_obj is not None
             else None
         )
+        # Issue #888 follow-up: drop the display-only assumed value only on a
+        # GENUINE position transition. For assumed-state open/close covers (Somfy
+        # RTS) "open"/"closed" is the last-command signal; a same-value re-report
+        # ("open"→"open") must NOT wipe the assumed My value, or the card snaps
+        # back off My. A real move to a different endpoint (or a differing numeric
+        # read) still supersedes it. Both reads above pass no ``assumed`` so they
+        # compare raw open/close values (§3b), never the assumed fallback.
+        if new_position is not None and new_position != old_position:
+            self._invalidate_assumed(entity_id)
 
         now = dt.datetime.now(dt.UTC)
         ctx_obj = getattr(new_state, "context", None)

--- a/tests/test_assumed_position_surface.py
+++ b/tests/test_assumed_position_surface.py
@@ -139,6 +139,107 @@ async def test_assumed_cleared_on_real_state_change(hass: HomeAssistant) -> None
 
 
 @pytest.mark.asyncio
+async def test_assumed_survives_same_state_re_report(hass: HomeAssistant) -> None:
+    """A same-value re-report ("open"→"open") must NOT wipe the assumed value.
+
+    Issue #888 follow-up: an assumed-state Somfy-RTS cover reports HA state
+    "open" (the last-command direction). Any incidental state re-report of the
+    same value must leave the display-only assumed My value intact — otherwise
+    the card snaps back off My.
+    """
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    coordinator.manager.add_covers(["cover.test_blind"])
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 50)
+
+    old_state = MagicMock()
+    old_state.state = "open"
+    old_state.attributes = {"assumed_state": True}
+    new_state = MagicMock()
+    new_state.state = "open"
+    new_state.attributes = {"assumed_state": True}
+    new_state.context = None
+    new_state.last_updated = None
+    event = MagicMock()
+    event.entity_id = "cover.test_blind"
+    event.new_state = new_state
+    event.old_state = old_state
+
+    # our_state matches the raw open read (100) so no manual override engages.
+    coordinator.manager.handle_state_change(
+        event,
+        100,
+        coordinator._policy,
+        False,
+        lambda _e: False,
+        5,
+    )
+
+    assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") == 50
+
+
+@pytest.mark.asyncio
+async def test_assumed_cleared_on_open_close_transition(hass: HomeAssistant) -> None:
+    """A genuine endpoint transition ("open"→"closed") still clears the assumed value."""
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    coordinator.manager.add_covers(["cover.test_blind"])
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 50)
+
+    old_state = MagicMock()
+    old_state.state = "open"
+    old_state.attributes = {"assumed_state": True}
+    new_state = MagicMock()
+    new_state.state = "closed"
+    new_state.attributes = {"assumed_state": True}
+    new_state.context = None
+    new_state.last_updated = None
+    event = MagicMock()
+    event.entity_id = "cover.test_blind"
+    event.new_state = new_state
+    event.old_state = old_state
+
+    coordinator.manager.handle_state_change(
+        event,
+        0,
+        coordinator._policy,
+        False,
+        lambda _e: False,
+        5,
+    )
+
+    assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") is None
+
+
+@pytest.mark.asyncio
+async def test_actual_positions_shows_my_for_assumed_state_cover_reporting_open(
+    hass: HomeAssistant,
+) -> None:
+    """The live Deck scenario: an assumed-state cover reporting "open" shows My.
+
+    The most common assumed-state cover (Somfy RTS) reports HA state "open"
+    (assumed_state=True) after a stop→My, which get_open_close_state would map
+    to 100. With a recorded assumed My value, both display surfaces must show
+    50, not the open-derived 100.
+    """
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+
+    # The cover reports "open" with assumed_state=True (last-command direction).
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 50)
+
+    # Diagnostics surface (build_diagnostic_data → read_positions).
+    diag = coordinator.build_diagnostic_data()
+    assert diag["covers"]["cover.test_blind"]["current_position"] == 50
+
+    # Sensor surface: snapshot.cover_positions, rebuilt on the next update cycle.
+    await coordinator.async_refresh()
+    assert coordinator._snapshot.cover_positions["cover.test_blind"] == 50
+
+
+@pytest.mark.asyncio
 async def test_assumed_cleared_on_native_position_command(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -427,6 +427,20 @@ class TestReadAxisValue:
         assert policy.read_axis_value(live_open, "cover.somfy", caps, assumed=50) == 100
 
     @pytest.mark.unit
+    def test_read_axis_value_assumed_wins_for_assumed_state_open(self):
+        # Issue #888 follow-up: a Somfy-RTS assumed-state cover reports HA state
+        # "open" (the last-command direction), which get_open_close_state maps to
+        # 100 — but that is NOT a real position. A recorded assumed My value (50)
+        # is more specific and must win over the open/close mapping.
+        caps = {"has_set_position": False, "has_set_tilt_position": False}
+        policy = get_policy("cover_blind")
+
+        assumed_open = _hass_with_state({"assumed_state": True}, state="open")
+        assert (
+            policy.read_axis_value(assumed_open, "cover.somfy", caps, assumed=50) == 50
+        )
+
+    @pytest.mark.unit
     def test_read_axis_value_assumed_ignored_for_position_capable(self):
         # A position-capable cover never returns the assumed value: its live read
         # (here None because the attribute is absent) is authoritative and must


### PR DESCRIPTION
## Summary
Follow-up to #888. The assumed-position display shipped in #888 only surfaced the My value for covers that report an `unknown` state. The common real-world case, a Somfy-RTS-style `assumed_state` cover (verified live on a user's "Deck Front Shade"), reports HA state `open` or `closed`, which ACP maps to 100/0. That broke the feature two ways:

1. `read_axis_value` returned the open/close-derived value (100 for `open`), which is not `None`, so it **masked** the recorded assumed My value (50).
2. `handle_state_change` wiped the assumed value on **any** non-`None` read, so any state re-report cleared it.

Net effect: after a stop→My the card kept showing 100%, never the My value.

## Fix
- **`cover_types/base.py:read_axis_value`** — for `assumed_state` covers, the recorded assumed value now wins over the open/close mapping. For such covers `open`/`closed` is the last-command direction, not a real position. Gated strictly on the entity's `assumed_state` attribute, so non-assumed open/close covers keep "real read wins" unchanged.
- **`managers/manual_override/manager.py:handle_state_change`** — the assumed value is invalidated only on a genuine position transition (`new != old`), not on every non-`None` read. A same-value `open`→`open` re-report no longer wipes it. Both reads stay raw (no `assumed` passed), so the command-gate path (§3b) is untouched.

## Testing
- ✅ 6241 tests passing (full suite)
- Regression guards green: the existing non-assumed "real open read wins" axis test is unchanged, plus #875/#591/#809 manual-override suites (313 passed in the guard set)
- New: assumed-state read precedence, same-state re-report survival, open→closed transition clears, and an end-to-end test reproducing the Deck scenario (cover reports `open`, card shows 50 not 100)

## Related Issues
Refs #888