### PR TITLE
fix: record My on ACP stop service so the card shows it (#888)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2898,9 +2898,27 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         counter-command the cover) then dispatches an ACP-context-stamped
         ``cover.stop_cover`` via :meth:`CoverCommandService.apply_user_stop`.
         Stop is unconditional — no pipeline preemption check.
+
+        Issue #888 follow-up: the ACP ``stop`` service (the card's stop button)
+        lands a My-configured open/close-only cover on its hardware My preset,
+        just like an external ``cover.stop_cover`` — but the external-stop
+        detector (:meth:`async_check_cover_service_call`) ignores ACP-originated
+        stops (``was_acp_stop_context``), so record My here instead. Mirrors the
+        external path's ``is_waiting_for_target`` guard: a stop mid ACP-move is a
+        halt, not a My landing.
         """
+        # Capture waiting BEFORE mark_user_command, which discards the in-flight
+        # target. was_waiting means ACP was mid its-own-move.
+        was_waiting = self._cmd_svc.is_waiting_for_target(entity_id)
         self.manager.mark_user_command(entity_id, reason=trigger)
-        return await self._cmd_svc.apply_user_stop(entity_id)
+        result = await self._cmd_svc.apply_user_stop(entity_id)
+        # set_target so reconciliation/hold compares against My; the assumed
+        # write is caps-confined to open/close-only covers by the shared helper.
+        my_position_value = self.config_entry.options.get(CONF_MY_POSITION_VALUE)
+        if my_position_value is not None and not was_waiting:
+            self._cmd_svc.set_target(entity_id, int(my_position_value))
+            self._cmd_svc._record_assumed_if_blind(entity_id, int(my_position_value))
+        return result
 
     def build_axis_discovery(
         self, labels: dict[str, str] | None = None

--- a/tests/test_assumed_position_surface.py
+++ b/tests/test_assumed_position_surface.py
@@ -86,6 +86,41 @@ async def test_actual_positions_shows_my_after_acp_move(hass: HomeAssistant) -> 
     assert coordinator._snapshot.cover_positions["cover.test_blind"] == 50
 
 
+@pytest.mark.asyncio
+async def test_actual_positions_shows_my_after_user_stop(
+    hass: HomeAssistant,
+) -> None:
+    """Issue #888 follow-up: the card's stop service surfaces My on the display.
+
+    An assumed-state open/close-only cover reporting "open" — after the ACP
+    `stop` service (``async_apply_user_stop``) lands it on its hardware My
+    preset — must show ``my_position_value`` on both display surfaces, exactly
+    like the external stop→My path.
+    """
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+
+    # The cover reports "open" with assumed_state=True (last-command direction).
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+
+    # The card stop button routes here. dry_run keeps the (unregistered)
+    # cover.stop_cover service from firing while still recording state.
+    coordinator._cmd_svc._dry_run = True
+    await coordinator.async_apply_user_stop("cover.test_blind", trigger="stop")
+    coordinator._cmd_svc._dry_run = False
+
+    # Diagnostics surface (build_diagnostic_data → read_positions).
+    diag = coordinator.build_diagnostic_data()
+    assert diag["covers"]["cover.test_blind"]["current_position"] == 50
+
+    # Sensor surface: snapshot.cover_positions, rebuilt on the next update cycle.
+    await coordinator.async_refresh()
+    assert coordinator._snapshot.cover_positions["cover.test_blind"] == 50
+
+
 # ---------------------------------------------------------------------------
 # Step 7 — invalidation
 # ---------------------------------------------------------------------------

--- a/tests/test_services_stop.py
+++ b/tests/test_services_stop.py
@@ -346,6 +346,104 @@ async def test_external_stop_no_assumed_when_ignore_external() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Issue #888 follow-up: the ACP `stop` service (card stop button) records My
+# for open/close-only covers, mirroring the external stop→My path above.
+# ---------------------------------------------------------------------------
+
+
+_POSITION_CAPABLE = {
+    "has_set_position": True,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+
+
+def _bind_user_stop(coord):
+    """Bind the real async_apply_user_stop onto a coord with a real cmd_svc."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord.async_apply_user_stop = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_stop.__get__(coord)
+    )
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_user_stop_records_my_when_idle() -> None:
+    """ACP stop on an idle open/close-only cover records assumed=My and target=My."""
+    from unittest.mock import patch
+
+    coord = _bind_user_stop(_make_coord_for_assumed(my_position=50))
+    entity_id = "cover.test_blind"
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await coord.async_apply_user_stop(entity_id, trigger="stop")
+
+    assert coord._cmd_svc.get_assumed_position(entity_id) == 50
+    assert coord._cmd_svc.get_target(entity_id) == 50
+
+
+@pytest.mark.asyncio
+async def test_user_stop_no_my_when_waiting() -> None:
+    """A stop mid ACP-move (waiting) is a halt, not a My landing — no assumed."""
+    from unittest.mock import patch
+
+    coord = _bind_user_stop(_make_coord_for_assumed(my_position=50))
+    entity_id = "cover.test_blind"
+    coord._cmd_svc.set_waiting(entity_id, True)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await coord.async_apply_user_stop(entity_id, trigger="stop")
+
+    assert coord._cmd_svc.get_assumed_position(entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_user_stop_no_my_when_unconfigured() -> None:
+    """No My configured → the stop records no assumed position."""
+    from unittest.mock import patch
+
+    coord = _bind_user_stop(_make_coord_for_assumed(my_position=None))
+    entity_id = "cover.test_blind"
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_OPEN_CLOSE_ONLY,
+    ):
+        await coord.async_apply_user_stop(entity_id, trigger="stop")
+
+    assert coord._cmd_svc.get_assumed_position(entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_user_stop_position_capable_clears_assumed() -> None:
+    """A position-capable cover clears any stale assumed value (caps helper)."""
+    from unittest.mock import patch
+
+    coord = _bind_user_stop(_make_coord_for_assumed(my_position=50))
+    entity_id = "cover.test_blind"
+    coord._cmd_svc.record_assumed_position(entity_id, 50)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value=_POSITION_CAPABLE,
+    ):
+        await coord.async_apply_user_stop(entity_id, trigger="stop")
+
+    assert coord._cmd_svc.get_assumed_position(entity_id) is None
+
+
+# ---------------------------------------------------------------------------
 # Step 10: services.yaml documents the stop service
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Third follow-up to #888. The companion card's stop button calls the ACP service `adaptive_cover_pro.stop`, which routes to `coordinator.async_apply_user_stop`. For a Somfy-RTS-style open/close-only cover with a configured `my_position_value`, pressing stop lands the cover on its hardware My preset, but that path only engaged a manual override and fired an **ACP-context-stamped** `cover.stop_cover`. The external stop→My detector (`async_check_cover_service_call`, #888) deliberately skips ACP-stamped stops (`was_acp_stop_context`), and the stop service itself never recorded My. Net effect: the card kept showing 0/100 after a card stop, never the My value.

## Fix (Option A)
`async_apply_user_stop` now, when `my_position_value` is configured **and** ACP was not mid its-own-move, sets the target to My and records the display-only assumed position:
- `was_waiting` is captured **before** `mark_user_command` (which discards the in-flight target). The guard mirrors the external path's `default_stop_to_my_decision` (`if is_waiting: return None`), so a stop that halts an ACP move is not misread as a My landing.
- `set_target(My)` so reconciliation/hold compares against My.
- `_record_assumed_if_blind(My)` records the assumed value, caps-confined to open/close-only covers (position-capable covers get any stale assumed value cleared).

No new config option, no translations. Relies on the #890 read precedence (assumed wins over the open/closed mapping for `assumed_state` covers) already on develop.

## Testing
- ✅ 6246 tests passing (full suite)
- New: records My when idle; no My when `was_waiting`; no My when unconfigured; position-capable clears; end-to-end `actual_positions` shows My after the ACP stop service
- Regression guards green: #888/#875 stop and manual-override suites (146 passed)

## Related Issues
Refs #888