### PR TITLE
feat: expose transit opening/closing state for no-feedback covers

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2916,8 +2916,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # write is caps-confined to open/close-only covers by the shared helper.
         my_position_value = self.config_entry.options.get(CONF_MY_POSITION_VALUE)
         if my_position_value is not None and not was_waiting:
+            # Capture the raw prior position BEFORE set_target overwrites it so
+            # the synthetic direction reflects the move toward My.
+            prior_position = self._cmd_svc.get_current_position(entity_id)
             self._cmd_svc.set_target(entity_id, int(my_position_value))
             self._cmd_svc._record_assumed_if_blind(entity_id, int(my_position_value))
+            # Give the My move a ~45s transit window (open/close-only covers) so
+            # the card renders "Opening…/Closing…". The direction is caps-gated
+            # by the shared helper; begin_transit stamps waiting + sent_at so the
+            # reconciliation timer clears it when the window closes.
+            self._cmd_svc._set_transit_direction_if_blind(
+                entity_id, int(my_position_value), prior_position
+            )
+            self._cmd_svc.begin_transit(
+                entity_id, self._cmd_svc.get_transit_direction(entity_id)
+            )
         return result
 
     def build_axis_discovery(
@@ -2964,6 +2977,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         _covers = {
             eid: {
                 "current_position": _positions.get(eid),
+                "transit_state": self._cmd_svc.get_transit_direction(eid),
                 "available": _positions.get(eid) is not None,
                 "capabilities": (
                     dataclasses.asdict(_caps[eid]) if eid in _caps else None

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -338,8 +338,27 @@ class CoverCommandService:
         return bool(s and s.waiting)
 
     def set_waiting(self, entity_id: str, value: bool) -> None:
-        """Mark an entity as waiting (or no-longer-waiting) for its target."""
-        self.state(entity_id).waiting = value
+        """Mark an entity as waiting (or no-longer-waiting) for its target.
+
+        Clearing ``waiting`` also drops the synthetic transit direction so the
+        opening/closing indicator disappears the moment the transit window
+        closes (the ``transit_states()`` surface is gated on ``waiting``).
+        """
+        s = self.state(entity_id)
+        if value:
+            s.waiting = True
+        else:
+            self._clear_waiting(s)
+
+    def _clear_waiting(self, s: PerEntityState) -> None:
+        """Clear the waiting flag and its synthetic transit direction together.
+
+        Single funnel for every "no longer in transit" site so the
+        opening/closing indicator (``transit_direction``) never outlives the
+        ``waiting`` window it is gated on.
+        """
+        s.waiting = False
+        s.transit_direction = None
 
     def waiting_entities(self) -> list[str]:
         """Return all entities currently in ``waiting=True``."""
@@ -409,6 +428,84 @@ class CoverCommandService:
             return
         if routed_target is not None:
             self.record_assumed_position(entity_id, routed_target)
+
+    # ------------------------------------------------------------------ #
+    # Transit direction (opening/closing indicator) — display-only, for
+    # no-feedback open/close-only covers that report no position and no
+    # opening/closing state. Surfaced only during the transit-timeout window
+    # (gated on ``waiting``) so the companion card can show motion.
+    # ------------------------------------------------------------------ #
+
+    def get_transit_direction(self, entity_id: str) -> str | None:
+        """Return the synthetic travel direction for ``entity_id``, or None.
+
+        ``"opening"`` / ``"closing"`` while ACP believes an open/close-only
+        cover is mid-transit; ``None`` otherwise.
+        """
+        s = self._state.get(entity_id)
+        return None if s is None else s.transit_direction
+
+    def clear_transit_direction(self, entity_id: str) -> None:
+        """Drop any stored synthetic travel direction for ``entity_id``."""
+        s = self._state.get(entity_id)
+        if s is not None:
+            s.transit_direction = None
+
+    def transit_states(self) -> dict[str, str]:
+        """Return ``{entity_id: direction}`` for every cover mid-transit.
+
+        Gated on ``waiting`` so an entry clears exactly when the transit-timeout
+        window closes — a direction recorded on a settled cover is not surfaced.
+        """
+        return {
+            eid: s.transit_direction
+            for eid, s in self._state.items()
+            if s.waiting and s.transit_direction
+        }
+
+    def _set_transit_direction_if_blind(
+        self,
+        entity_id: str,
+        routed_target: int | None,
+        prior_position: int | None,
+        caps: Any | None = None,
+    ) -> None:
+        """Record (or clear) the synthetic travel direction after ACP drives a cover.
+
+        Confined to open/close-only covers (no native position axis): a
+        position-reporting cover animates via % and never gets a synthetic
+        direction, so its stale value is cleared. The direction falls out of a
+        raw target-vs-prior comparison in the same non-inverted display frame as
+        ``cover_positions`` (100=open, 0=closed) — higher target than prior is
+        "opening". Inverse state is NOT applied here.
+        """
+        if caps is None:
+            caps = self.get_cover_capabilities(entity_id)
+        if self._policy.position_axis_supported(caps):
+            self.clear_transit_direction(entity_id)
+            return
+        if routed_target is None or prior_position is None:
+            self.clear_transit_direction(entity_id)
+            return
+        if routed_target > prior_position:
+            self.state(entity_id).transit_direction = "opening"
+        elif routed_target < prior_position:
+            self.state(entity_id).transit_direction = "closing"
+        else:
+            self.clear_transit_direction(entity_id)
+
+    def begin_transit(self, entity_id: str, direction: str | None) -> None:
+        """Open a transit-timeout window with a pre-computed direction.
+
+        Used by the coordinator's user-stop→My path: the My move never flows
+        through ``_prepare_service_call`` (it's a bare ``stop_cover``), so this
+        marks the entity ``waiting`` and stamps ``sent_at`` + ``transit_direction``
+        so the ~45s reconciliation timer runs and the card shows motion.
+        """
+        s = self.state(entity_id)
+        s.waiting = True
+        s.sent_at = dt.datetime.now(dt.UTC)
+        s.transit_direction = direction
 
     # ------------------------------------------------------------------ #
     # Properties
@@ -572,7 +669,7 @@ class CoverCommandService:
         for eid in stale:
             s = self._state[eid]
             s.target = None
-            s.waiting = False
+            self._clear_waiting(s)
             s.retry_count = 0
             s.gave_up = False
         if stale:
@@ -722,7 +819,7 @@ class CoverCommandService:
             # entity is no longer in flight from ACP's perspective — clear
             # the waiting flag so the next reconciliation cycle does not
             # think a fresh command is still travelling.
-            s.waiting = False
+            self._clear_waiting(s)
             s.sent_at = None
             if sent:
                 stopped.append(eid)
@@ -790,6 +887,10 @@ class CoverCommandService:
         else:
             await self._stop_tracker.call_stop_cover(entity_id)
         now = dt.datetime.now(dt.UTC)
+        # Synthetic travel direction: read the raw prior position BEFORE the
+        # target is overwritten so the open/close-only card can show motion
+        # toward My during the transit window.
+        prior_position = self._get_current_position(entity_id)
         s = self.state(entity_id)
         s.target = target
         s.waiting = True
@@ -802,6 +903,7 @@ class CoverCommandService:
         # ``—``. Caps was already fetched above; the helper gates on the policy
         # predicate (no-op for position-capable covers).
         self._record_assumed_if_blind(entity_id, target, caps)
+        self._set_transit_direction_if_blind(entity_id, target, prior_position, caps)
         self._logger.debug(
             "send_my_position: stop_cover sent to %s (My = %d%%)", entity_id, target
         )
@@ -1398,7 +1500,7 @@ class CoverCommandService:
 
         target = s.target
         if self._at_target(reported_position, target):
-            s.waiting = False
+            self._clear_waiting(s)
             s.retry_count = 0
             self._logger.debug(
                 "Target reached for %s (reported=%s target=%s)",
@@ -1466,7 +1568,7 @@ class CoverCommandService:
                             elapsed,
                             self._wait_for_target_timeout_seconds,
                         )
-                        s.waiting = False
+                        self._clear_waiting(s)
                     else:
                         # Cover still expected to be moving
                         continue
@@ -1860,8 +1962,16 @@ class CoverCommandService:
         # override detection, and the grace-period manager all see the same
         # target/timestamp.
         now = dt.datetime.now(dt.UTC)
+        # Synthetic travel direction (open/close-only covers): compute BEFORE the
+        # target is overwritten, from the cover's current raw position vs the
+        # routed target. Uses the command-gate read (no assumed fallback) so the
+        # comparison stays in the raw display frame.
+        prior_position = self._read_position_with_capabilities(entity, caps)
         s = self.state(entity)
         s.target = plan.routed_target
+        self._set_transit_direction_if_blind(
+            entity, plan.routed_target, prior_position, caps
+        )
         # Issue #888: this is the single chokepoint every dispatched command
         # (apply_position + reconciliation) flows through, so refresh the
         # display-only assumed position here. Open/close-only covers with no

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -50,6 +50,15 @@ class PerEntityState:
     # fallback the reported-position surfaces return ONLY when the live HA read
     # is None; NEVER consulted by the command-dispatch gates (§3b).
     assumed_position: int | None = None
+    # Synthetic travel direction for no-feedback covers. Set alongside
+    # ``waiting`` on open/close-only covers (Somfy-RTS-style: no position, no
+    # opening/closing state) so the companion card can render "Opening…" /
+    # "Closing…" during ACP's transit-timeout window. Values: ``"opening"``,
+    # ``"closing"``, or ``None``. Computed in the non-inverted display frame
+    # (100=open, 0=closed) and cleared whenever ``waiting`` clears — the
+    # ``transit_states()`` surface is gated on ``waiting`` so it disappears
+    # exactly when the transit window closes.
+    transit_direction: str | None = None
 
 
 @dataclasses.dataclass

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -342,6 +342,15 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
             # cover_position sensor — map it back so the card stays byte-identical.
             attrs["effective_distance"] = calc_details.get("effective_distance_m")
 
+    # Synthetic opening/closing indicator for no-feedback covers. Present only
+    # while a cover is mid-transit (gated on ``waiting`` inside transit_states),
+    # so the companion card can render "Opening…/Closing…" on covers that report
+    # neither position nor an opening/closing state. Emitted only when non-empty
+    # to keep the attribute set lean.
+    transit = s.coordinator._cmd_svc.transit_states()  # noqa: SLF001
+    if transit:
+        attrs["transit_states"] = transit
+
     snapshot = s.coordinator._snapshot  # noqa: SLF001
     if snapshot and snapshot.cover_positions:
         actual_positions = dict(snapshot.cover_positions)

--- a/tests/test_transit_direction.py
+++ b/tests/test_transit_direction.py
@@ -1,0 +1,265 @@
+"""Transient opening/closing indicator for no-feedback covers.
+
+Somfy-RTS-style open/close-only covers report no position and no
+``opening``/``closing`` state, so the companion card can't show motion. During
+ACP's ~45s transit-timeout window (``PerEntityState.waiting``), surface a
+synthetic travel direction (``opening``/``closing``) so the card can render
+"Opening…/Closing…". Confined to open/close-only covers via the caps gate;
+position-reporting covers animate via % and must always report ``None``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+)
+from tests.test_assumed_position_surface import _setup_open_close_cover
+
+pytestmark = pytest.mark.integration
+
+# Somfy-RTS-style capability mask: OPEN(1) | CLOSE(2) | STOP(8) — no SET_POSITION(4).
+_OPEN_CLOSE_STOP = 1 | 2 | 8
+
+_OPEN_CLOSE_CAPS = {
+    "has_set_position": False,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+_POSITION_CAPS = {
+    "has_set_position": True,
+    "has_set_tilt_position": False,
+    "has_open": True,
+    "has_close": True,
+    "has_stop": True,
+}
+
+
+# ------------------------------------------------------------------ #
+# Unit-level fixtures (direct CoverCommandService construction)
+# ------------------------------------------------------------------ #
+
+
+@pytest.fixture
+def svc():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return CoverCommandService(
+        hass=h,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        check_interval_minutes=1,
+        position_tolerance=3,
+        max_retries=3,
+    )
+
+
+# ------------------------------------------------------------------ #
+# Step 1 — _set_transit_direction_if_blind
+# ------------------------------------------------------------------ #
+
+
+def test_set_transit_direction_closing(svc):
+    svc._set_transit_direction_if_blind(
+        "cover.x", routed_target=50, prior_position=100, caps=_OPEN_CLOSE_CAPS
+    )
+    assert svc.get_transit_direction("cover.x") == "closing"
+
+
+def test_set_transit_direction_opening(svc):
+    svc._set_transit_direction_if_blind(
+        "cover.x", routed_target=50, prior_position=0, caps=_OPEN_CLOSE_CAPS
+    )
+    assert svc.get_transit_direction("cover.x") == "opening"
+
+
+def test_set_transit_direction_equal_is_none(svc):
+    svc._set_transit_direction_if_blind(
+        "cover.x", routed_target=50, prior_position=50, caps=_OPEN_CLOSE_CAPS
+    )
+    assert svc.get_transit_direction("cover.x") is None
+
+
+def test_set_transit_direction_position_capable_cleared(svc):
+    # Seed a stale direction, then a position-capable cover must clear it.
+    svc.state("cover.x").transit_direction = "opening"
+    svc._set_transit_direction_if_blind(
+        "cover.x", routed_target=50, prior_position=100, caps=_POSITION_CAPS
+    )
+    assert svc.get_transit_direction("cover.x") is None
+
+
+def test_set_transit_direction_none_target_cleared(svc):
+    svc.state("cover.x").transit_direction = "opening"
+    svc._set_transit_direction_if_blind(
+        "cover.x", routed_target=None, prior_position=100, caps=_OPEN_CLOSE_CAPS
+    )
+    assert svc.get_transit_direction("cover.x") is None
+
+
+def test_set_transit_direction_none_prior_cleared(svc):
+    svc.state("cover.x").transit_direction = "closing"
+    svc._set_transit_direction_if_blind(
+        "cover.x", routed_target=50, prior_position=None, caps=_OPEN_CLOSE_CAPS
+    )
+    assert svc.get_transit_direction("cover.x") is None
+
+
+# ------------------------------------------------------------------ #
+# Step 2 — transit_states() gated on waiting
+# ------------------------------------------------------------------ #
+
+
+def test_transit_states_only_when_waiting(svc):
+    s = svc.state("cover.x")
+    s.transit_direction = "opening"
+    s.waiting = True
+    assert svc.transit_states() == {"cover.x": "opening"}
+
+
+def test_transit_states_empty_when_not_waiting(svc):
+    s = svc.state("cover.x")
+    s.transit_direction = "opening"
+    s.waiting = False
+    assert svc.transit_states() == {}
+
+
+# ------------------------------------------------------------------ #
+# Step 5 — transit clears when the waiting window times out
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_transit_cleared_on_wait_timeout(svc):
+    now = dt.datetime.now(dt.UTC)
+    s = svc.state("cover.x")
+    s.target = 50
+    s.waiting = True
+    s.transit_direction = "closing"
+    s.sent_at = now - dt.timedelta(seconds=200)  # well past the 45s timeout
+    s.last_progress_at = None
+
+    # Isolate the timeout-clear branch from the position-read machinery.
+    svc._get_current_position = MagicMock(return_value=None)
+    svc._is_cover_in_transit = MagicMock(return_value=False)
+
+    await svc.run_reconciliation_pass(now)
+
+    assert svc.is_waiting_for_target("cover.x") is False
+    assert svc.get_transit_direction("cover.x") is None
+    assert svc.transit_states() == {}
+
+
+# ------------------------------------------------------------------ #
+# Step 3 — async_apply_user_stop gives the My move a transit window
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_user_stop_sets_transit_closing(hass: HomeAssistant) -> None:
+    """A card stop → My on an idle open cover (100) with My=50 shows 'closing'."""
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+
+    # Idle, reporting "open" (prior position 100). Not mid ACP-move.
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+
+    coordinator._cmd_svc._dry_run = True
+    await coordinator.async_apply_user_stop("cover.test_blind", trigger="stop")
+    coordinator._cmd_svc._dry_run = False
+
+    svc = coordinator._cmd_svc
+    assert svc.get_transit_direction("cover.test_blind") == "closing"
+    assert svc.is_waiting_for_target("cover.test_blind") is True
+    assert svc.transit_states()["cover.test_blind"] == "closing"
+
+
+# ------------------------------------------------------------------ #
+# Step 4 — ACP open/close command sets the transit direction
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_prepare_service_call_open_sets_opening(hass: HomeAssistant) -> None:
+    coordinator = await _setup_open_close_cover(hass, my_position=None)
+    hass.states.async_set(
+        "cover.test_blind",
+        "closed",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+    svc = coordinator._cmd_svc
+    # Command fully open → open_cover; prior=0 (closed) → opening.
+    svc._prepare_service_call("cover.test_blind", 100)
+    assert svc.get_transit_direction("cover.test_blind") == "opening"
+
+
+@pytest.mark.asyncio
+async def test_prepare_service_call_close_sets_closing(hass: HomeAssistant) -> None:
+    coordinator = await _setup_open_close_cover(hass, my_position=None)
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+    svc = coordinator._cmd_svc
+    # Command fully closed → close_cover; prior=100 (open) → closing.
+    svc._prepare_service_call("cover.test_blind", 0)
+    assert svc.get_transit_direction("cover.test_blind") == "closing"
+
+
+# ------------------------------------------------------------------ #
+# Step 6 — sensor Cover_Position surfaces transit_states while in transit
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.asyncio
+async def test_sensor_exposes_transit_states_in_transit(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.sensor import _cover_position_attrs
+
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+    coordinator._cmd_svc._dry_run = True
+    await coordinator.async_apply_user_stop("cover.test_blind", trigger="stop")
+    coordinator._cmd_svc._dry_run = False
+    await coordinator.async_refresh()
+
+    sensor = MagicMock()
+    sensor.coordinator = coordinator
+    sensor.data = coordinator.data
+    attrs = _cover_position_attrs(sensor)
+    assert attrs["transit_states"]["cover.test_blind"] == "closing"
+
+
+@pytest.mark.asyncio
+async def test_sensor_omits_transit_states_when_empty(hass: HomeAssistant) -> None:
+    from custom_components.adaptive_cover_pro.sensor import _cover_position_attrs
+
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+    await coordinator.async_refresh()
+
+    sensor = MagicMock()
+    sensor.coordinator = coordinator
+    sensor.data = coordinator.data
+    attrs = _cover_position_attrs(sensor)
+    assert "transit_states" not in attrs


### PR DESCRIPTION
## Summary
Somfy-RTS-style open/close-only covers report no position and no `opening`/`closing` state, so the companion card can't show that a commanded move is in progress. ACP already runs a ~45 s transit-timeout window (`PerEntityState.waiting`, cleared by reconciliation when `elapsed > transit_timeout_seconds`, default 45 s). This surfaces a synthetic travel direction during that window so the card can render "Opening…/Closing…", the way a position cover shows a changing %.

## What it does
- New per-entity `transit_direction` (`opening`/`closing`/`None`), set alongside `waiting` for **open/close-only covers only** (caps-gated; position-reporting covers already animate via %).
- Direction falls out of routed-target-vs-prior-position uniformly: `open_cover` → opening, `close_cover` → closing, `stop_cover`→My → the direction toward My.
- The card-stop→My move also opens a transit window (`begin_transit`) so it shows motion, not just open/close.
- Exposed as a `transit_states: {entity: direction}` attribute on the Cover_Position sensor (only when non-empty) and per-cover `transit_state` in diagnostics.
- Clears exactly when the transit timer clears `waiting` — all `waiting=False` sites funnel through a shared `_clear_waiting` helper.

So a card stop shows `actual_positions` = My and `transit_states` = `closing` for ~45 s, then just My.

Companion card rendering ships separately in `jrhubott/adaptive-cover-pro-card`.

## Testing
- ✅ 6260 tests passing (full suite)
- New `tests/test_transit_direction.py` (14 tests): direction derivation, `transit_states()` gating on `waiting`, stop→My window, open/close direction, timeout clear, sensor attribute presence/absence
- Regression guards green: stop / assumed-position / my_position / manual-override / reconciliation / sensor / diagnostics (436 passed)

## Related Issues
Refs #888