### PR TITLE
feat: refine louvered roof objective, slat cap, config form (#830)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_dynamic.py
+++ b/custom_components/adaptive_cover_pro/config_dynamic.py
@@ -188,7 +188,9 @@ def _condition_template_schema(template_key: str, mode_key: str) -> dict:
     }
 
 
-def window_facing_schema(hass: HomeAssistant | None = None) -> vol.Schema:
+def window_facing_schema(
+    hass: HomeAssistant | None = None, *, include_distance: bool = True
+) -> vol.Schema:
     """Per-window facing fields: azimuth + FOV left/right + shaded distance.
 
     Single definition of the four fields relocated from the sun-tracking step to
@@ -196,47 +198,51 @@ def window_facing_schema(hass: HomeAssistant | None = None) -> vol.Schema:
     they sit beside the window width/depth the FOV button derives from. Only
     ``CONF_DISTANCE`` is unit-dependent; azimuth and FOV are angles. ``min_m=0.0``
     keeps a flush shaded distance of 0 valid (#427).
+
+    ``include_distance=False`` omits the ``CONF_DISTANCE`` marker for cover types
+    whose engine never reads it (the tilt-only louvered roof, #830); the default
+    keeps it so every existing caller is unchanged.
     """
-    return vol.Schema(
-        {
-            vol.Required(
-                CONF_AZIMUTH, default=DEFAULT_WINDOW_AZIMUTH
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0,
-                    max=359,
-                    mode=selector.NumberSelectorMode.SLIDER,
-                    unit_of_measurement="°",
-                )
-            ),
-            vol.Required(CONF_FOV_LEFT, default=90): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0,
-                    max=180,
-                    step=1,
-                    mode=selector.NumberSelectorMode.SLIDER,
-                    unit_of_measurement="°",
-                )
-            ),
-            vol.Required(CONF_FOV_RIGHT, default=90): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0,
-                    max=180,
-                    step=1,
-                    mode=selector.NumberSelectorMode.SLIDER,
-                    unit_of_measurement="°",
-                )
-            ),
-            vol.Required(
-                CONF_DISTANCE, default=length_default(0.5, hass)
-            ): length_selector(
+    fields: dict = {
+        vol.Required(
+            CONF_AZIMUTH, default=DEFAULT_WINDOW_AZIMUTH
+        ): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0,
+                max=359,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="°",
+            )
+        ),
+        vol.Required(CONF_FOV_LEFT, default=90): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0,
+                max=180,
+                step=1,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="°",
+            )
+        ),
+        vol.Required(CONF_FOV_RIGHT, default=90): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0,
+                max=180,
+                step=1,
+                mode=selector.NumberSelectorMode.SLIDER,
+                unit_of_measurement="°",
+            )
+        ),
+    }
+    if include_distance:
+        fields[vol.Required(CONF_DISTANCE, default=length_default(0.5, hass))] = (
+            length_selector(
                 hass,
                 min_m=0.0,
                 max_m=50,
                 metric_step=0.1,
-            ),
-        }
-    )
+            )
+        )
+    return vol.Schema(fields)
 
 
 def sun_tracking_schema(hass: HomeAssistant | None = None) -> vol.Schema:

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3281,7 +3281,11 @@ def _get_geometry_schema(
     # derives from. Routed through the policy so no cover-type string branch
     # leaks in.
     base = policy.geometry_schema(hass, options)
-    base = base.extend(window_facing_schema(hass).schema)
+    base = base.extend(
+        window_facing_schema(
+            hass, include_distance=policy.includes_shaded_distance()
+        ).schema
+    )
     return policy.fov_compute_schema(base)
 
 
@@ -3293,16 +3297,21 @@ def _geometry_unit_keys(
     ``length_keys`` are option keys stored in canonical metres,
     ``slat_keys`` in canonical centimetres. Empty tuples for unknown types.
 
-    ``CONF_DISTANCE`` (shaded area) is appended centrally for every cover type —
-    it moved from the sun-tracking step to the geometry step (#778) and is stored
-    in canonical metres like the other window lengths.
+    ``CONF_DISTANCE`` (shaded area) is appended for every cover type whose policy
+    includes the shaded-distance field — it moved from the sun-tracking step to
+    the geometry step (#778) and is stored in canonical metres like the other
+    window lengths. Types that hide it (the tilt-only louvered roof, #830) omit
+    it here too so the unit-conversion keys stay in step with the rendered form.
     """
     cls = POLICY_REGISTRY.get(sensor_type) if sensor_type is not None else None
     if cls is None:
         return ((), ())
     policy = get_policy(sensor_type)
+    length_keys = policy.geometry_length_keys()
+    if policy.includes_shaded_distance():
+        length_keys = (*length_keys, CONF_DISTANCE)
     return (
-        (*policy.geometry_length_keys(), CONF_DISTANCE),
+        length_keys,
         policy.geometry_slat_keys(),
     )
 

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -199,6 +199,12 @@ DEFAULT_LOUVERED_ROOF_PITCH = 0  # degrees from horizontal — 0 = flat roof
 # max. When set it becomes BOTH the clamp ceiling AND the tilt%→angle denominator.
 CONF_MAX_SLAT_ANGLE = "max_slat_angle"  # degrees; 0 = use tilt-mode max
 DEFAULT_MAX_SLAT_ANGLE = 0  # 0 sentinel → tilt mode's 90/180
+# Louvered-roof slat geometry defaults (#830 follow-up). Pergola lamellae are
+# far larger than interior venetian slats (whose defaults stay 3.0/2.0 cm), so
+# the louvered schema overrides these two markers only. Values are the #830
+# reference rig (17 cm deep, 15 cm apart → 0.88 spacing ratio), in canonical cm.
+DEFAULT_LOUVERED_SLAT_DEPTH_CM = 17.0  # CONF_TILT_DEPTH default for louvered roofs
+DEFAULT_LOUVERED_SLAT_DISTANCE_CM = 15.0  # CONF_TILT_DISTANCE default, louvered roofs
 CONF_FOV_LEFT = "fov_left"  # left half-FOV from azimuth, degrees 0-180
 CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
 DEFAULT_FOV_LEFT = 90  # degrees; matches config flow default
@@ -268,8 +274,8 @@ OSCILLATING_ARC_SCAN_SAMPLES = 1801
 # =============================================================================
 # Slat dimensions used to compute tilt angle, plus min/max tilt clamps.
 
-CONF_TILT_DEPTH = "slat_depth"  # slat depth, cm (range 0.1-15.0)
-CONF_TILT_DISTANCE = "slat_distance"  # vertical slat spacing, cm (0.1-15.0)
+CONF_TILT_DEPTH = "slat_depth"  # slat depth, cm (range 0.1-30.0)
+CONF_TILT_DISTANCE = "slat_distance"  # vertical slat spacing, cm (0.1-30.0)
 CONF_TILT_MODE = "tilt_mode"  # tilt strategy identifier
 CONF_TILT_ANGLE_0 = "tilt_angle_0"  # raw slat angle at 0% tilt, degrees
 CONF_TILT_ANGLE_100 = "tilt_angle_100"  # raw slat angle at 100% tilt, degrees
@@ -1405,8 +1411,8 @@ _RANGE_ROOF_HEIGHT_ABOVE = (0.0, 10.0)  # CONF_ROOF_HEIGHT_ABOVE, metres
 _RANGE_MAX_SLAT_ANGLE = (0, 180)  # CONF_MAX_SLAT_ANGLE, degrees (0 = use tilt mode)
 
 # Geometry — tilt / venetian slats.
-_RANGE_TILT_DEPTH = (0.1, 15.0)  # CONF_TILT_DEPTH, cm
-_RANGE_TILT_DISTANCE = (0.1, 15.0)  # CONF_TILT_DISTANCE, cm
+_RANGE_TILT_DEPTH = (0.1, 30.0)  # CONF_TILT_DEPTH, cm (raised to 300 mm for #830)
+_RANGE_TILT_DISTANCE = (0.1, 30.0)  # CONF_TILT_DISTANCE, cm (raised to 300 mm, #830)
 _RANGE_MAX_TILT = (0, 100)  # CONF_MAX_TILT, percent
 _RANGE_MIN_TILT = (0, 100)  # CONF_MIN_TILT, percent
 _RANGE_VENETIAN_TILT_SAFETY_MARGIN = (

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -804,7 +804,11 @@ class CoverTypePolicy(ABC):
             # button is NOT added here — it is a transient toggle layered on in
             # ``config_flow._get_geometry_schema`` only, never a persisted key.
             base = self.geometry_schema(hass, opts)
-            base = base.extend(cd.window_facing_schema(hass).schema)
+            base = base.extend(
+                cd.window_facing_schema(
+                    hass, include_distance=self.includes_shaded_distance()
+                ).schema
+            )
         elif name == cf.SECTION_SUN_TRACKING:
             base = cd.sun_tracking_schema(hass)
         elif name == cf.SECTION_BLIND_SPOT:
@@ -936,6 +940,18 @@ class CoverTypePolicy(ABC):
         ignores both — passing them is backward-compatible.
         """
         return vol.Schema({})
+
+    def includes_shaded_distance(self) -> bool:
+        """Whether the shared ``CONF_DISTANCE`` (shaded distance) field applies.
+
+        The per-window shaded-distance field composes onto every geometry
+        schema through ``window_facing_schema``. Cover types whose engine
+        never reads it (the tilt-only louvered roof) override this to
+        ``False`` so the inert marker is omitted from the form and from
+        ``live_option_keys`` / the geometry unit-key set. Default ``True`` —
+        every other type keeps the field.
+        """
+        return True
 
     def geometry_length_keys(self) -> tuple[str, ...]:
         """Return option keys stored as canonical metres.

--- a/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
@@ -136,6 +136,15 @@ class LouveredRoofPolicy(CoverTypePolicy, register=True):
             return GEOMETRY_LOUVERED_ROOF_SCHEMA
         return geometry_louvered_roof_schema(hass)
 
+    def includes_shaded_distance(self) -> bool:
+        """Hide the shared shaded-distance field (#830).
+
+        The tilt-only louvered engine derives its slat angle from sun geometry
+        and slat depth/spacing alone — ``CONF_DISTANCE`` is inert — so the field
+        is omitted from the geometry form and its unit/length key set.
+        """
+        return False
+
     def geometry_slat_keys(self) -> tuple[str, ...]:
         """Louvered roofs store slat depth and spacing in canonical centimetres."""
         return TILT_SLAT_KEYS

--- a/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
@@ -24,11 +24,16 @@ from ..config_types import LouveredRoofConfig
 from ..const import (
     CONF_MAX_SLAT_ANGLE,
     CONF_ROOF_PITCH,
+    CONF_TILT_DEPTH,
+    CONF_TILT_DISTANCE,
     DEFAULT_LOUVERED_ROOF_PITCH,
+    DEFAULT_LOUVERED_SLAT_DEPTH_CM,
+    DEFAULT_LOUVERED_SLAT_DISTANCE_CM,
     DEFAULT_MAX_SLAT_ANGLE,
     OPTION_RANGES,
 )
 from ..engine.covers import AdaptiveLouveredRoofCover
+from ..unit_system import slat_default
 from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from .base import (
     CAP_HAS_SET_TILT_POSITION,
@@ -69,6 +74,19 @@ def _max_slat_angle_selector() -> selector.NumberSelector:
 def geometry_louvered_roof_schema(hass: HomeAssistant | None = None) -> vol.Schema:
     """Slat geometry (shared with tilt) plus the roof-plane pitch. ``hass=None`` → metric."""
     fields = dict(geometry_tilt_schema(hass).schema)
+    # Override the shared slat defaults with pergola-scale dimensions. The tilt
+    # schema stores interior venetian defaults (3.0/2.0 cm); a louvered roof's
+    # lamellae are much larger, so swap the two slat markers for the #830 rig
+    # (17/15 cm). Re-key the markers (a dict assignment keeps the original key
+    # object, so pop the old marker before inserting the new default).
+    for slat_key, default_cm in (
+        (CONF_TILT_DEPTH, DEFAULT_LOUVERED_SLAT_DEPTH_CM),
+        (CONF_TILT_DISTANCE, DEFAULT_LOUVERED_SLAT_DISTANCE_CM),
+    ):
+        slat_selector = fields.pop(vol.Required(slat_key))
+        fields[vol.Required(slat_key, default=slat_default(default_cm, hass))] = (
+            slat_selector
+        )
     fields[vol.Required(CONF_ROOF_PITCH, default=DEFAULT_LOUVERED_ROOF_PITCH)] = (
         _roof_pitch_selector()
     )

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -52,11 +52,11 @@ def geometry_tilt_schema(hass: HomeAssistant | None = None) -> vol.Schema:
         {
             vol.Required(
                 CONF_TILT_DEPTH, default=slat_default(_DEFAULT_TILT_DEPTH_CM, hass)
-            ): slat_selector(hass, min_cm=0.1, max_cm=15),
+            ): slat_selector(hass, min_cm=0.1, max_cm=30),
             vol.Required(
                 CONF_TILT_DISTANCE,
                 default=slat_default(_DEFAULT_TILT_DISTANCE_CM, hass),
-            ): slat_selector(hass, min_cm=0.1, max_cm=15),
+            ): slat_selector(hass, min_cm=0.1, max_cm=30),
             vol.Required(CONF_TILT_MODE, default="mode2"): selector.SelectSelector(
                 selector.SelectSelectorConfig(
                     options=["mode1", "mode2", "specify_angles"],

--- a/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 import numpy as np
 
 from ...config_types import LouveredRoofConfig
+from ...const import TILT_HORIZONTAL_DEG
 from .roof_window import (
     TRACE_KEY_COS_AOI,
     TRACE_KEY_ROOF_PITCH_DEG,
@@ -100,10 +101,27 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
         return bool(float(np.cos(np.radians(self.gamma))) < 0)
 
     def _resolve_slat_angle(self, cutoff_angle: float) -> float:
-        """Realize the far-side cut-off as the flipped face past the 90° turnover."""
+        """Realize the MAX-OPENING slat angle (closest to vertical) that blocks.
+
+        Unlike the interior venetian — which drives to the steepest cut-off to
+        maximize shading — the bioclimatic roof wants the slats as OPEN as
+        possible (closest to vertical/90°) while the direct beam is still
+        blocked. The geometric max-opening inclination from vertical is the
+        closed-form ``i = max(0, 90° − cutoff)`` (derived from the roof-fin
+        shadow-overlap condition); the physical slat angle is ``90° + i`` on the
+        facing side and ``90° − i`` on the far side. Once the slats self-block
+        (``cutoff ≥ 90°``) ``i`` is 0 and the angle clamps to fully open (90°).
+
+        The ``roof_pitch = 90°`` vertical reduction returns the raw cut-off
+        unchanged so the venetian anchor stays byte-for-byte (the far side never
+        fires there — lit sun always satisfies ``cos(gamma) > 0``).
+        """
+        if self.roof_pitch == VERTICAL_GLASS_PITCH_DEG:
+            return cutoff_angle
+        inclination = max(0.0, TILT_HORIZONTAL_DEG - cutoff_angle)
         if self._is_far_side():
-            return 180.0 - cutoff_angle
-        return cutoff_angle
+            return TILT_HORIZONTAL_DEG - inclination
+        return TILT_HORIZONTAL_DEG + inclination
 
     def _effective_max_degrees(self) -> int:
         """Honour a configured physical ``max_slat_angle`` over the tilt-mode max.

--- a/tests/test_cover_types/test_louvered_roof.py
+++ b/tests/test_cover_types/test_louvered_roof.py
@@ -240,6 +240,35 @@ class TestLouveredRoofPolicy:
         assert DEFAULT_LOUVERED_SLAT_DEPTH_CM == 17.0
         assert DEFAULT_LOUVERED_SLAT_DISTANCE_CM == 15.0
 
+    def test_includes_shaded_distance_false(self) -> None:
+        # The tilt-only louvered engine never reads the shaded-distance field,
+        # so the policy hides it (#830 follow-up). A vertical blind still shows it.
+        assert get_policy(COVER_TYPE).includes_shaded_distance() is False
+        assert get_policy("cover_blind").includes_shaded_distance() is True
+
+    def test_composed_geometry_schema_omits_shaded_distance(self) -> None:
+        # The shared window-facing bundle is composed onto every geometry schema
+        # via _get_geometry_schema; for louvered the shaded-distance marker must
+        # be dropped, while every other type keeps it.
+        from custom_components.adaptive_cover_pro import config_flow as cf
+        from custom_components.adaptive_cover_pro.const import CONF_DISTANCE
+
+        louvered_keys = _schema_keys(cf._get_geometry_schema(COVER_TYPE))
+        assert CONF_DISTANCE not in louvered_keys
+
+        blind_keys = _schema_keys(cf._get_geometry_schema("cover_blind"))
+        assert CONF_DISTANCE in blind_keys
+
+    def test_geometry_unit_keys_omit_shaded_distance(self) -> None:
+        from custom_components.adaptive_cover_pro import config_flow as cf
+        from custom_components.adaptive_cover_pro.const import CONF_DISTANCE
+
+        louvered_length_keys, _ = cf._geometry_unit_keys(COVER_TYPE)
+        assert CONF_DISTANCE not in louvered_length_keys
+
+        blind_length_keys, _ = cf._geometry_unit_keys("cover_blind")
+        assert CONF_DISTANCE in blind_length_keys
+
     def test_build_calc_engine_returns_louvered_engine(self) -> None:
         from unittest.mock import MagicMock
 

--- a/tests/test_cover_types/test_louvered_roof.py
+++ b/tests/test_cover_types/test_louvered_roof.py
@@ -58,6 +58,26 @@ def _schema_default(schema: vol.Schema, key: str):
     raise KeyError(key)
 
 
+def _schema_value_validator(schema: vol.Schema, key: str):
+    for marker, value in schema.schema.items():
+        name = marker.schema if isinstance(marker, vol.Marker) else marker
+        if name == key:
+            return value
+    raise KeyError(key)
+
+
+def test_tilt_schema_accepts_value_at_raised_slat_cap() -> None:
+    # The shared slat depth/spacing cap was raised to 30 cm globally, so the
+    # interior tilt/venetian schema must validate a value at the new cap too.
+    from custom_components.adaptive_cover_pro.cover_types.tilt import (
+        geometry_tilt_schema,
+    )
+
+    schema = geometry_tilt_schema()
+    depth_validator = _schema_value_validator(schema, CONF_TILT_DEPTH)
+    assert depth_validator(30.0) == 30.0
+
+
 class TestLouveredRoofPolicy:
     """Policy hooks for the louvered-roof cover type."""
 
@@ -191,6 +211,34 @@ class TestLouveredRoofPolicy:
         hass.config.units.length_unit = "m"
         schema = get_policy(COVER_TYPE).geometry_schema(hass=hass)
         assert CONF_ROOF_PITCH in _schema_keys(schema)
+
+    def test_louvered_schema_accepts_pergola_scale_slats(self) -> None:
+        # Pergola slats are much larger than interior venetian blinds. The
+        # louvered geometry schema must validate a 17 cm depth / 15 cm spacing
+        # rig (the reference installation from #830). The old 15 cm cap
+        # rejected the 17 cm depth.
+        schema = get_policy(COVER_TYPE).geometry_schema()
+        depth_validator = _schema_value_validator(schema, CONF_TILT_DEPTH)
+        distance_validator = _schema_value_validator(schema, CONF_TILT_DISTANCE)
+        assert depth_validator(17.0) == 17.0
+        assert distance_validator(15.0) == 15.0
+
+    def test_louvered_slat_defaults_are_pergola_scale(self) -> None:
+        from custom_components.adaptive_cover_pro.const import (
+            DEFAULT_LOUVERED_SLAT_DEPTH_CM,
+            DEFAULT_LOUVERED_SLAT_DISTANCE_CM,
+        )
+
+        schema = get_policy(COVER_TYPE).geometry_schema()
+        assert (
+            _schema_default(schema, CONF_TILT_DEPTH) == DEFAULT_LOUVERED_SLAT_DEPTH_CM
+        )
+        assert (
+            _schema_default(schema, CONF_TILT_DISTANCE)
+            == DEFAULT_LOUVERED_SLAT_DISTANCE_CM
+        )
+        assert DEFAULT_LOUVERED_SLAT_DEPTH_CM == 17.0
+        assert DEFAULT_LOUVERED_SLAT_DISTANCE_CM == 15.0
 
     def test_build_calc_engine_returns_louvered_engine(self) -> None:
         from unittest.mock import MagicMock

--- a/tests/test_engine/test_louvered_roof.py
+++ b/tests/test_engine/test_louvered_roof.py
@@ -245,6 +245,10 @@ class TestCalculatePositionFlatRoof:
     """A full solve on a flat roof matches a hand-computed 2-D cut-off angle."""
 
     def test_flat_roof_slat_angle(self) -> None:
+        # Max-opening objective: a low near-side sun whose raw MDPI cut-off runs
+        # PAST vertical (≥ 90°) means the slats already self-block, so the roof
+        # drives to fully OPEN (90°) — not the steep 130.5° interior-venetian
+        # cut-off the old objective produced.
         sol_elev = 30.0
         slat_distance, depth, mode = 0.02, 0.03, "mode2"
         cover = _louvered(
@@ -255,16 +259,17 @@ class TestCalculatePositionFlatRoof:
             depth=depth,
             mode=mode,
         )
-        # Hand path: flat-roof beta = 90 - elev = 60°, then the MDPI cut-off.
+        # Hand path: flat-roof beta = 90 - elev = 60°; the MDPI cut-off is > 90.
         beta = math.radians(90.0 - sol_elev)
         ratio = slat_distance / depth
         disc = math.tan(beta) ** 2 - ratio**2 + 1
-        expected = math.degrees(
+        cutoff = math.degrees(
             2 * math.atan((math.tan(beta) + math.sqrt(disc)) / (1 + ratio))
         )
+        assert cutoff > 90.0  # precondition: raw cut-off past vertical
         result = cover.calculate_position()
         assert not np.isnan(result)
-        assert result == pytest.approx(expected)
+        assert result == pytest.approx(90.0)  # max-opening clamp, not the cut-off
         # Sanity: mode2 caps at 180.
         assert 0 <= result <= 180
 
@@ -303,17 +308,20 @@ class TestFarSideFlip:
         near_angle = near.calculate_position()
         far_angle = far.calculate_position()
 
-        # The two physical slat angles mirror across the 90° turnover.
+        # The two physical slat angles still mirror across the 90° turnover.
         assert near_angle + far_angle == pytest.approx(180.0)
 
-        # Near side is the unchanged raw MDPI cut-off (the pre-fix behaviour).
+        # Max-opening objective: the raw cut-off is < 90 here, so the facing side
+        # opens PAST vertical to 180 − cut-off while the far side rests at the
+        # cut-off itself — the near/far roles invert vs the old steep objective.
         beta = math.atan(abs(roof_slope_ratio(60.0, elev, 0)))
         raw, _, _ = slat_cutoff_angle(beta, near.slat_distance, near.depth)
-        assert near_angle == pytest.approx(raw)
-        assert far_angle == pytest.approx(180.0 - raw)
+        assert raw < 90.0
+        assert near_angle == pytest.approx(180.0 - raw)
+        assert far_angle == pytest.approx(raw)
         # Pin the concrete numbers so a formula drift is caught.
-        assert near_angle == pytest.approx(85.9, abs=0.1)
-        assert far_angle == pytest.approx(94.1, abs=0.1)
+        assert near_angle == pytest.approx(94.1, abs=0.1)
+        assert far_angle == pytest.approx(85.9, abs=0.1)
 
     def test_no_flip_at_pitch_90_near_side(self) -> None:
         # At vertical pitch the lit sun is always near side (cos_aoi needs
@@ -324,11 +332,14 @@ class TestFarSideFlip:
         assert louvered.calculate_position() == pytest.approx(tilt.calculate_position())
         assert louvered._last_calc_details["louvered_far_side_branch"] is False
 
-    def test_mode1_far_side_clamps_to_open(self) -> None:
-        # Mode1 caps at 90°; a far-side angle (> 90) clamps to fully open (90).
-        far = _louvered(sol_azi=60, sol_elev=40, roof_pitch=0, mode="mode1")
-        assert far.gamma == pytest.approx(120.0)
-        assert far.calculate_position() == pytest.approx(90.0)
+    def test_mode1_near_side_clamps_to_open(self) -> None:
+        # Mode1 caps at 90°. Under the max-opening objective the NEAR (facing)
+        # side opens PAST vertical (> 90) whenever the raw cut-off is < 90, so it
+        # clamps to fully open (90). (The far side now rests at/below 90 instead,
+        # inverting the old behaviour where the far side was the one clamping.)
+        near = _louvered(sol_azi=120, sol_elev=40, roof_pitch=0, mode="mode1")
+        assert near.gamma == pytest.approx(60.0)
+        assert near.calculate_position() == pytest.approx(90.0)
 
     def test_trace_far_side_branch_flag(self) -> None:
         near = _louvered(sol_azi=120, sol_elev=40, roof_pitch=0)
@@ -343,25 +354,27 @@ class TestMaxSlatAngle:
     """``max_slat_angle`` overrides the mode's 90/180 as clamp + %-denominator."""
 
     def test_ceiling_above_raw_scales_percentage(self) -> None:
-        # gamma=0 (near side, no flip), elev=30 → raw ~130.5° on a flat roof.
-        base = _louvered(sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2")
+        # gamma=0 (near side, no flip), elev=65 → raw cut-off 77.8° < 90, so the
+        # max-opening angle is 180 − 77.8 = 102.2° (past vertical). This exercises
+        # the max_slat_angle scaling on a near-side angle above the horizontal.
+        base = _louvered(sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2")
         raw = base.calculate_position()
-        assert raw == pytest.approx(130.5, abs=0.2)
+        assert raw == pytest.approx(102.2, abs=0.2)
 
         denom = int(raw) + 10  # ceiling above the raw angle: position unchanged
         wide = _louvered(
-            sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2", max_slat_angle=denom
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=denom
         )
         assert wide.calculate_position() == pytest.approx(raw)
         assert wide.calculate_percentage() == round(raw / denom * 100)
 
     def test_ceiling_below_raw_clamps_and_saturates(self) -> None:
-        base = _louvered(sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2")
+        base = _louvered(sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2")
         raw = base.calculate_position()
 
         ceil = int(raw) - 20  # ceiling below the raw angle: clamp + 100%
         low = _louvered(
-            sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2", max_slat_angle=ceil
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=ceil
         )
         assert low.calculate_position() == pytest.approx(float(ceil))
         assert low.calculate_percentage() == 100
@@ -372,18 +385,60 @@ class TestMaxSlatAngle:
 
     def test_default_zero_matches_mode(self) -> None:
         m = _louvered(
-            sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2", max_slat_angle=0
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=0
         )
-        ref = _louvered(sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2")
+        ref = _louvered(sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2")
         assert m.calculate_position() == pytest.approx(ref.calculate_position())
         assert m.calculate_percentage() == ref.calculate_percentage()
 
     def test_trace_max_degrees_reflects_effective_ceiling(self) -> None:
         cover = _louvered(
-            sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2", max_slat_angle=160
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=160
         )
         cover.calculate_position()
         assert cover._last_calc_details["max_degrees"] == 160
+
+
+class TestMaxOpeningObjective:
+    """The louvered slat objective is MAX OPENING (closest to vertical/90°).
+
+    Unlike the interior venetian, the bioclimatic roof wants the slats as OPEN
+    as possible while still blocking the direct beam. The physical inclination
+    from vertical is ``i = max(0, 90 − cutoff)`` and the slat angle is ``90 + i``
+    on the facing side / ``90 − i`` on the far side — i.e. ``max(90, 180 − cutoff)``
+    facing and ``min(90, cutoff)`` far. Once the slats self-block (``cutoff ≥ 90``)
+    the angle clamps to fully open (90°), NOT the steep venetian cut-off.
+    """
+
+    def test_full_open_when_cutoff_ge_90(self) -> None:
+        # Flat roof, low near-side sun (elev=30) → raw cut-off 130.5° ≥ 90 →
+        # inclination 0 → fully OPEN (90°), not the steep 130.5° the interior
+        # venetian objective would drive to.
+        cover = _louvered(sol_azi=180, sol_elev=30, roof_pitch=0, mode="mode2")
+        beta = math.radians(90.0 - 30.0)  # flat-roof complement, gamma=0
+        raw, _, _ = slat_cutoff_angle(beta, cover.slat_distance, cover.depth)
+        assert raw > 90.0  # precondition: old objective drove past vertical
+        assert cover.calculate_position() == pytest.approx(90.0)
+
+    def test_near_side_tracks_toward_vertical(self) -> None:
+        # Flat roof, high near-side sun (elev=65) → raw cut-off 77.8° < 90 →
+        # max-opening angle is 180 − cut-off = 102.2° (just past vertical), NOT
+        # the 77.8° venetian cut-off.
+        cover = _louvered(sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2")
+        beta = math.radians(90.0 - 65.0)
+        raw, _, _ = slat_cutoff_angle(beta, cover.slat_distance, cover.depth)
+        assert raw < 90.0
+        result = cover.calculate_position()
+        assert result == pytest.approx(180.0 - raw)
+        assert result > 90.0
+
+    def test_far_side_full_open_low_sun(self) -> None:
+        # Far-side (gamma=120) low sun (elev=20) → raw cut-off ≥ 90 → inclination
+        # 0 → fully OPEN (90°) == min(90, cut-off). The OLD far-side mirror drove
+        # this to a near-closed 59.2° instead.
+        cover = _louvered(sol_azi=60, sol_elev=20, roof_pitch=0, mode="mode2")
+        assert cover._is_far_side() is True
+        assert cover.calculate_position() == pytest.approx(90.0)
 
 
 class TestFovAngle:


### PR DESCRIPTION
## Summary
Three refinements to the unreleased louvered-roof cover type, from @holzartdani's two-day hardware verification. Delivered as three commits:

- **Max-opening objective** (engine): `_resolve_slat_angle` now returns the blocking angle closest to vertical instead of the venetian steepest cut-off, so bioclimatic slats open toward vertical for airflow and clamp fully open at low sun. Gated on `roof_pitch` so the vertical-pitch venetian reduction stays bit-for-bit.
- **Slat depth cap + pergola defaults** (config): shared slat depth/spacing range raised 150mm -> 300mm; louvered geometry defaults to 170mm/150mm. Rollback-safe (range widen + form default only, no config-version bump).
- **Hide inert field** (UX): the "shaded distance" field is hidden on the louvered form via a polymorphic `CoverTypePolicy.includes_shaded_distance()` hook (no cover-type-string branch).

## Testing
- ✅ 6250 tests passing (full suite)

## Related Issues
Refs #830