### PR TITLE
fix: refresh immediately after a user stop so the card updates (#888)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2931,6 +2931,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self._cmd_svc.begin_transit(
                 entity_id, self._cmd_svc.get_transit_direction(entity_id)
             )
+        # A user stop engages an override and (for a My cover) records the new
+        # target + assumed position + transit window. None of that reaches the
+        # sensors until a coordinator cycle rebuilds them, so without an explicit
+        # refresh the card shows nothing until the next scheduled update — long
+        # enough that the ~45s transit window opens and closes unseen. Request a
+        # refresh now (debounced, so a blanket stop coalesces to one cycle).
+        await self.async_request_refresh()
         return result
 
     def build_axis_discovery(

--- a/tests/test_services_stop.py
+++ b/tests/test_services_stop.py
@@ -96,6 +96,7 @@ async def test_async_apply_user_stop_calls_mark_user_command_and_stop() -> None:
     coord.manager = MagicMock()
     coord._cmd_svc = MagicMock()
     coord._cmd_svc.apply_user_stop = AsyncMock(return_value=("sent", "stop_cover"))
+    coord.async_request_refresh = AsyncMock()
 
     # Bind the real method
     coord.async_apply_user_stop = (
@@ -108,6 +109,34 @@ async def test_async_apply_user_stop_calls_mark_user_command_and_stop() -> None:
         "cover.test_blind", reason="stop"
     )
     coord._cmd_svc.apply_user_stop.assert_awaited_once_with("cover.test_blind")
+
+
+@pytest.mark.asyncio
+async def test_async_apply_user_stop_requests_immediate_refresh() -> None:
+    """A user stop requests a coordinator refresh so the card updates promptly.
+
+    Without it the sensors (and the ~45s transit window) only rebuild on the
+    next scheduled cycle, which can be well over a minute — long enough that the
+    transit indicator opens and closes before the card ever sees it.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock()
+    coord.manager = MagicMock()
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.apply_user_stop = AsyncMock(return_value=("sent", "stop_cover"))
+    coord._cmd_svc.is_waiting_for_target.return_value = True  # skip the My block
+    coord.async_request_refresh = AsyncMock()
+
+    coord.async_apply_user_stop = (
+        AdaptiveDataUpdateCoordinator.async_apply_user_stop.__get__(coord)
+    )
+
+    await coord.async_apply_user_stop("cover.test_blind", trigger="stop")
+
+    coord.async_request_refresh.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -241,6 +270,7 @@ def _make_coord_for_assumed(
     coord.config_entry.options = (
         {} if my_position is None else {"my_position_value": my_position}
     )
+    coord.async_request_refresh = AsyncMock()
     return coord
 
 


### PR DESCRIPTION
## Summary
Diagnosed live on a user's Somfy-RTS Deck shade: pressing the card's stop button worked at the service level (ACP dispatched `cover.stop_cover`, recorded My=50, engaged the override), but the card didn't reflect it for ~90 seconds, and the Opening/Closing indicator never appeared.

Root cause: `async_apply_user_stop` engages the override and records My + the transit window, then returns **without requesting a coordinator refresh**. Every other user-action path refreshes; this one didn't. So the sensors (and the card) only rebuild on the next scheduled cycle — long enough that the ~45 s transit window opens and closes before the display ever updates.

## Fix
Add `await self.async_request_refresh()` at the end of `async_apply_user_stop`. Debounced, so a blanket stop across many covers coalesces to one cycle, while a single card stop updates promptly. The display now reflects My immediately and the transit indicator is visible during its window.

## Testing
- ✅ 6270 tests passing (full suite)
- New `test_async_apply_user_stop_requests_immediate_refresh`; existing stop-path test fixtures stub `async_request_refresh`

## Related Issues
Refs #888