### PR TITLE
fix: force endpoint close/open for non-venetian covers (#897)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -405,9 +405,31 @@ class CoverTypePolicy(ABC):
         """
         return {}
 
+    def targets_full_mechanical_endpoint(self, result: PipelineResult) -> bool:
+        """Whether this update drives the position axis to a full mechanical stop.
+
+        Single source of truth for the ``full_endpoint_target`` flag (issue #897,
+        generalizing #755). When True and ``endpoint_use_open_close`` is on, the
+        command manager forces close_cover/open_cover instead of dropping the
+        final approach to 0/100 as ``same_position`` — so a cover that settles a
+        step short of its true stop still seats there. The base default covers
+        every single-axis position cover (blind, awning, sliding_curtain, …):
+        the target is a full endpoint iff it is 0 or 100. VenetianPolicy narrows
+        this to the paired dual-axis endpoint; TiltPolicy (no position axis)
+        widens it to never.
+        """
+        if result is None or result.position is None:
+            return False
+        return result.position in (POSITION_CLOSED, POSITION_OPEN)
+
     def position_context_overrides(self, result: PipelineResult) -> dict[str, Any]:
-        """Extra kwargs for ``PositionContext``. Default: empty."""
-        return {}
+        """Extra kwargs for ``PositionContext``.
+
+        Carries the cover-type-agnostic ``full_endpoint_target`` flag derived
+        from :meth:`targets_full_mechanical_endpoint` so the command manager can
+        force open_cover/close_cover at the mechanical stops (issue #897).
+        """
+        return {"full_endpoint_target": self.targets_full_mechanical_endpoint(result)}
 
     def secondary_axis_check(self, result: PipelineResult, cmd_svc) -> Any | None:
         """Return a manual-override secondary-axis check, or ``None``."""

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
     from ..engine.covers import AdaptiveGeneralCover
+    from ..pipeline.types import PipelineResult
     from ..services.configuration_service import ConfigurationService
 
 
@@ -230,6 +231,18 @@ class TiltPolicy(CoverTypePolicy, register=True):
         else:
             effective_angle = max_degrees - angle_deg if gamma_deg >= 0 else angle_deg
         return round((effective_angle / max_degrees) * 100)
+
+    def targets_full_mechanical_endpoint(
+        self,
+        result: PipelineResult,  # noqa: ARG002
+    ) -> bool:
+        """Tilt-only covers have no position axis, so never route open/close.
+
+        ``route_service_call`` only substitutes close_cover/open_cover on the
+        position axis; a slat-only cover has none, so it can never target a
+        full *mechanical* endpoint in the sense the manager forces (issue #897).
+        """
+        return False
 
     def build_calc_engine(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -746,22 +746,36 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         self._last_tilt = tilt
         return replace(result, position=position, tilt=tilt, decision_trace=trace)
 
+    def targets_full_mechanical_endpoint(self, result: PipelineResult) -> bool:
+        """Report a full mechanical endpoint only when BOTH axes reach it.
+
+        Narrows the base single-axis predicate (issue #897): a venetian is at a
+        true 0/0 or 100/100 stop only when carriage and slats target the same
+        endpoint. Position 0 with tilt 100 (a legitimate solar state) is NOT a
+        mechanical stop. Only the venetian policy knows the paired tilt, so this
+        dual-axis decision stays here (issue #755).
+        """
+        return (
+            result is not None
+            and result.tilt is not None
+            and result.position is not None
+            and result.position == result.tilt
+            and result.position in (POSITION_CLOSED, POSITION_OPEN)
+        )
+
     def position_context_overrides(self, result: PipelineResult) -> dict[str, Any]:
         """Thread the resolved tilt into ``PositionContext.tilt``.
 
         When BOTH axes target the same full mechanical endpoint (0/0 or
         100/100) also set the cover-type-agnostic ``full_endpoint_target`` flag
-        so the command manager forces close_cover/open_cover instead of dropping
-        the move as same_position (issue #755). Only the venetian policy knows
-        the paired tilt, so this decision lives here.
+        (via :meth:`targets_full_mechanical_endpoint`) so the command manager
+        forces close_cover/open_cover instead of dropping the move as
+        same_position (issue #755).
         """
         if result is None or result.tilt is None:
             return {}
         overrides: dict[str, Any] = {"tilt": result.tilt}
-        if result.position == result.tilt and result.position in (
-            POSITION_CLOSED,
-            POSITION_OPEN,
-        ):
+        if self.targets_full_mechanical_endpoint(result):
             overrides["full_endpoint_target"] = True
         return overrides
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1169,18 +1169,27 @@ class CoverCommandService:
 
         _current = self._get_current_position(entity_id)
 
-        # Full mechanical endpoint forcing (issue #755). When the owning
-        # cover-type policy (venetian) flagged this update as a paired full
-        # endpoint (0/0 or 100/100), the endpoint_use_open_close feature is on,
-        # and the cover is not actually parked at the mechanical stop (HA state
-        # not closed/open — NOT a position tolerance), bypass the same-position
-        # band and the delta/time gates so route_service_call can emit
-        # close_cover/open_cover (#697). This is cover-type-agnostic: the flag
-        # carries the decision, the manager never inspects cover type.
+        # Full mechanical endpoint forcing (issue #755, generalized to any
+        # position-capable cover by #897). When the owning cover-type policy
+        # flagged this update as a full endpoint (single-axis 0/100, or a
+        # venetian's paired 0/0 or 100/100), the endpoint_use_open_close feature
+        # is on, and the cover is not actually parked at the mechanical stop (HA
+        # state not closed/open — NOT a position tolerance), bypass the
+        # same-position band and the delta/time gates so route_service_call can
+        # emit close_cover/open_cover (#697). This is cover-type-agnostic: the
+        # flag carries the decision, the manager never inspects cover type.
+        #
+        # forced_endpoint is the anti-relay latch (#897/#507): a cover that
+        # settles a step short and never reports the mechanical state (state
+        # stays "open" at 2%) would otherwise re-force every cycle. We read the
+        # latch here (old value) and write it only after a successful send, so
+        # the endpoint is forced exactly once per transition. != position lets a
+        # flip to the other endpoint re-fire.
         force_endpoint = (
             context.full_endpoint_target
             and self._endpoint_use_open_close
             and not self._is_at_mechanical_stop(state_obj, position)
+            and self._get(entity_id).forced_endpoint != position
         )
 
         # Hard kill switch — blocks ALL commands, including safety overrides and
@@ -1237,12 +1246,15 @@ class CoverCommandService:
         # validity is a sentinel that we must re-confirm the cover position even
         # if it hasn't changed numerically.
         #
-        # force_endpoint is the other exception (issue #755): a venetian whose
-        # desired final state is a full mechanical endpoint (0/0 or 100/100) must
-        # NOT be swallowed by this _position_tolerance carve-out — it falls
-        # through to routing so close_cover/open_cover fires. Idempotency for
-        # that case is owned by the HA-state mechanical-stop check above, not by
-        # tolerance, so the gap can't be reintroduced here.
+        # force_endpoint is the other exception (issue #755, generalized to any
+        # position-capable cover by #897): a cover whose desired final state is a
+        # full mechanical endpoint (single-axis 0/100, or a venetian's paired
+        # 0/0 or 100/100) must NOT be swallowed by this _position_tolerance
+        # carve-out — it falls through to routing so close_cover/open_cover
+        # fires. Idempotency is owned by the HA-state mechanical-stop check plus
+        # the forced_endpoint latch above (covers that never report the
+        # mechanical state), not by tolerance, so the gap can't be reintroduced
+        # here nor can it relay-click every cycle.
         #
         # _current is None is its own exception (issue #779): Somfy RTS covers
         # (and any open/close-only cover without genuine position feedback) sit
@@ -1426,6 +1438,15 @@ class CoverCommandService:
         self._track_action(
             entity_id, service, position, supports_position, context.inverse_state
         )
+
+        # Anti-relay latch bookkeeping (#897/#507). Arm the latch to the forced
+        # endpoint so a cover that never reports the mechanical state (state
+        # stays "open" a step short of 0) isn't re-forced next cycle. Clear it on
+        # any non-endpoint move so a later endpoint command re-fires exactly once.
+        if force_endpoint:
+            self.state(entity_id).forced_endpoint = position
+        elif position not in (POSITION_CLOSED, POSITION_OPEN):
+            self.state(entity_id).forced_endpoint = None
 
         # Cover-type policy hook: dual-axis covers (venetian) run their
         # settle+tilt sequence here. Default policies are no-ops, so vertical /

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -59,6 +59,15 @@ class PerEntityState:
     # ``transit_states()`` surface is gated on ``waiting`` so it disappears
     # exactly when the transit window closes.
     transit_direction: str | None = None
+    # Anti-relay latch for full-mechanical-endpoint forcing (issue #897). Holds
+    # the endpoint (0 or 100) that ``apply_position`` last force-routed via
+    # close_cover/open_cover. Read BEFORE computing force_endpoint and written
+    # only after a successful send, so a cover that never reports the mechanical
+    # state (state stays "open" at 2%) is forced exactly once instead of
+    # relay-clicking every cycle (#507 preserved). Cleared when a non-endpoint
+    # move fires; a flip to the other endpoint re-fires because the latched
+    # value differs from the new target.
+    forced_endpoint: int | None = None
 
 
 @dataclasses.dataclass

--- a/tests/test_cover_types/test_calc_engine_dispatch.py
+++ b/tests/test_cover_types/test_calc_engine_dispatch.py
@@ -30,7 +30,8 @@ from custom_components.adaptive_cover_pro.engine.covers import (
     AdaptiveTiltCover,
     AdaptiveVerticalCover,
 )
-from custom_components.adaptive_cover_pro.const import TiltMode
+from custom_components.adaptive_cover_pro.const import ControlMethod, TiltMode
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
 
 def _common_cover_config() -> CoverConfig:
@@ -160,9 +161,82 @@ class TestDefaultHooks:
         out = policy_cls().post_pipeline_resolve(result, **calc_kwargs)
         assert out is result
 
-    @pytest.mark.parametrize("policy_cls", [BlindPolicy, AwningPolicy, TiltPolicy])
-    def test_position_context_overrides_empty(self, policy_cls):
-        assert policy_cls().position_context_overrides(MagicMock()) == {}
+    @pytest.mark.parametrize("policy_cls", [BlindPolicy, AwningPolicy])
+    @pytest.mark.parametrize(
+        ("position", "expect"),
+        [(0, True), (100, True), (50, False), (30, False)],
+    )
+    def test_single_axis_position_endpoint_sets_full_endpoint_flag(
+        self, policy_cls, position, expect
+    ):
+        """Single-axis position covers flag 0/100 as a full mechanical endpoint.
+
+        Issue #897 — the base policy generalizes the #755 venetian bypass to any
+        position-capable cover so ``endpoint_use_open_close`` routes 0→close_cover
+        and 100→open_cover instead of being swallowed as same_position.
+        """
+        result = PipelineResult(
+            position=position, control_method=ControlMethod.SOLAR, reason="t"
+        )
+        assert (
+            policy_cls()
+            .position_context_overrides(result)
+            .get("full_endpoint_target", False)
+            is expect
+        )
+
+    @pytest.mark.parametrize("position", [0, 100, 50])
+    def test_tilt_only_never_sets_full_endpoint_flag(self, position):
+        """Tilt-only covers have no position axis, so never flag a full endpoint."""
+        result = PipelineResult(
+            position=position, control_method=ControlMethod.SOLAR, reason="t"
+        )
+        assert (
+            TiltPolicy()
+            .position_context_overrides(result)
+            .get("full_endpoint_target", False)
+            is False
+        )
+
+    def test_targets_full_mechanical_endpoint_predicate(self):
+        """The predicate is True at 0/100 for position covers, always False for tilt."""
+        blind = BlindPolicy()
+        assert (
+            blind.targets_full_mechanical_endpoint(
+                PipelineResult(
+                    position=0, control_method=ControlMethod.SOLAR, reason="t"
+                )
+            )
+            is True
+        )
+        assert (
+            blind.targets_full_mechanical_endpoint(
+                PipelineResult(
+                    position=100, control_method=ControlMethod.SOLAR, reason="t"
+                )
+            )
+            is True
+        )
+        assert (
+            blind.targets_full_mechanical_endpoint(
+                PipelineResult(
+                    position=50, control_method=ControlMethod.SOLAR, reason="t"
+                )
+            )
+            is False
+        )
+        tilt = TiltPolicy()
+        for position in (0, 100, 50):
+            assert (
+                tilt.targets_full_mechanical_endpoint(
+                    PipelineResult(
+                        position=position,
+                        control_method=ControlMethod.SOLAR,
+                        reason="t",
+                    )
+                )
+                is False
+            )
 
     @pytest.mark.parametrize("policy_cls", [BlindPolicy, AwningPolicy, TiltPolicy])
     def test_secondary_axis_check_none(self, policy_cls):

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -108,6 +108,16 @@ def test_is_in_tilt_suppression_returns_bool(policy: CoverTypePolicy) -> None:
 
 
 @pytest.mark.unit
+def test_targets_full_mechanical_endpoint_returns_bool(policy: CoverTypePolicy) -> None:
+    """Every policy answers the endpoint predicate with a real bool (issue #897)."""
+    from custom_components.adaptive_cover_pro.const import ControlMethod
+    from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+    result = PipelineResult(position=0, control_method=ControlMethod.SOLAR, reason="t")
+    assert isinstance(policy.targets_full_mechanical_endpoint(result), bool)
+
+
+@pytest.mark.unit
 def test_position_for_intent_returns_open_or_closed(policy: CoverTypePolicy) -> None:
     """``position_for_intent`` returns 0 or 100, and the two intents differ."""
     pos_through = policy.position_for_intent(sun_through=True)

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1473,6 +1473,176 @@ async def test_force_endpoint_within_tolerance_skips_command_gate(
     mock_hass.services.async_call.assert_not_called()
 
 
+# --- non-venetian (single-axis) full endpoint forcing + latch (issue #897) ---
+
+
+def _endpoint_service(
+    entity_id, position, inverse_state=False, is_safety=False, use_my_position=False
+):
+    """_prepare_service_call side_effect: route 0→close, 100→open, else set_position."""
+    if position == 0:
+        return ("close_cover", {"entity_id": entity_id}, True)
+    if position == 100:
+        return ("open_cover", {"entity_id": entity_id}, True)
+    return ("set_cover_position", {"entity_id": entity_id, "position": position}, True)
+
+
+def _sent_services(mock_hass) -> list[str]:
+    """Return the cover service name from every async_call (positional arg 1)."""
+    return [call.args[1] for call in mock_hass.services.async_call.call_args_list]
+
+
+@pytest.mark.asyncio
+async def test_non_venetian_endpoint_close_fires_once_when_never_reports_closed(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #897 — single-axis blind, target 0, state never 'closed': fire once.
+
+    A ZHA rollershade that settles at current_position=2 and reports HA state
+    'open' forever must route close_cover exactly once (so it can seat at the
+    mechanical stop), then be latched so it does not relay-click every cycle
+    (#507 anti-storm preserved for the generalized path).
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=2, state="open")
+    ctx = _ctx_full_endpoint(full_endpoint_target=True, tilt=None)
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=2),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(svc, "_prepare_service_call", side_effect=_endpoint_service),
+    ):
+        outcome1 = await svc.apply_position("cover.test", 0, "custom_position", ctx)
+        outcome2 = await svc.apply_position("cover.test", 0, "custom_position", ctx)
+
+    assert outcome1 == ("sent", "close_cover")
+    assert outcome2 == ("skipped", "same_position")
+    assert mock_hass.services.async_call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_endpoint_latch_clears_on_midrange_move(mock_hass, logger, grace_mgr):
+    """Issue #897 — a mid-range move clears the endpoint latch so 0 re-fires.
+
+    Force-close to 0 arms the latch; a mid-range 50 move (no endpoint flag)
+    sends and clears it; commanding 0 again re-routes close_cover.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=2, state="open")
+
+    close_ctx = _ctx_full_endpoint(full_endpoint_target=True, tilt=None)
+    mid_ctx = _ctx_full_endpoint(full_endpoint_target=False, tilt=None)
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=2),
+        patch.object(svc, "_check_position_delta", return_value=True),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(svc, "_prepare_service_call", side_effect=_endpoint_service),
+    ):
+        await svc.apply_position("cover.test", 0, "custom_position", close_ctx)
+        await svc.apply_position("cover.test", 50, "solar", mid_ctx)
+        await svc.apply_position("cover.test", 0, "custom_position", close_ctx)
+
+    assert _sent_services(mock_hass).count("close_cover") == 2
+
+
+@pytest.mark.asyncio
+async def test_endpoint_latch_refires_on_endpoint_flip(mock_hass, logger, grace_mgr):
+    """Issue #897 — flipping to the other endpoint re-fires (latch is per-target).
+
+    Force-close to 0 arms the latch at 0; a subsequent open to 100 (cover still
+    not mechanically open) routes open_cover because the latched endpoint (0)
+    differs from the new target (100).
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=2, state="open")
+    state_obj = mock_hass.states.get.return_value
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=2),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(svc, "_prepare_service_call", side_effect=_endpoint_service),
+    ):
+        await svc.apply_position(
+            "cover.test",
+            0,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=None),
+        )
+        # Cover now reports 'closed'; commanding the opposite endpoint (100) must
+        # not be suppressed by the latch armed at 0.
+        state_obj.state = "closed"
+        await svc.apply_position(
+            "cover.test",
+            100,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=None),
+        )
+
+    services = _sent_services(mock_hass)
+    assert services == ["close_cover", "open_cover"]
+
+
+@pytest.mark.asyncio
+async def test_non_venetian_open_endpoint_within_tolerance_still_skips(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #897 / #507 lock — target 100, current 98, state 'open': SKIPPED.
+
+    On the OPEN endpoint the cover already reports state 'open' at any position
+    > 0, so the mechanical-stop check suppresses forcing and the #507 tolerance
+    band still applies — no open_cover relay click.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=98, state="open")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=98),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(svc, "_prepare_service_call", side_effect=_endpoint_service),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            100,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=None),
+        )
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_venetian_close_endpoint_within_tolerance_fires(
+    mock_hass, logger, grace_mgr
+):
+    """Issue #897 — target 0, current 1, state 'open': routes close_cover.
+
+    Unlike the open endpoint, a cover only reports 'closed' at true 0, so a
+    cover pinned at 1 with state 'open' is NOT at the mechanical stop and the
+    within-tolerance close must route close_cover at least once (#697 promise).
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=1, state="open")
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=1),
+        patch.object(svc, "_check_time_delta", return_value=True),
+        patch.object(svc, "_prepare_service_call", side_effect=_endpoint_service),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "custom_position",
+            _ctx_full_endpoint(full_endpoint_target=True, tilt=None),
+        )
+
+    assert outcome == "sent"
+    assert reason == "close_cover"
+    mock_hass.services.async_call.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_apply_position_exact_equality_still_skips(mock_hass, logger, grace_mgr):
     """The same-position SEND gate suppresses true no-ops (exact equality).


### PR DESCRIPTION
## Summary
When `endpoint_use_open_close` is on (the default), a target of 0 is meant to route to `cover.close_cover` so the cover seats at its true mechanical stop. That force-through was gated on a flag only the venetian policy set, so blinds, awnings, and plain roller shades never received it: once the cover was within `position_tolerance` (default 3%) of the endpoint, the same-position band (#507) skipped the command and `close_cover` never fired — the cover stalled a percent or two short and never fully closed.

This generalizes the venetian full-endpoint mechanism (#755) to every position-capable cover via a polymorphic `CoverTypePolicy.targets_full_mechanical_endpoint` predicate (base default for single-axis targets of 0/100; venetian keeps its paired position==tilt condition; tilt-only opts out). The manager stays cover-type-agnostic — it still reads only the `full_endpoint_target` bool.

The #507 anti-relay-click protection is preserved with a once-per-endpoint latch (`forced_endpoint` on `PerEntityState`): the endpoint command fires exactly once per transition for covers that never report `closed`/`open`, re-arming on a mid-range move or an endpoint flip. Venetian behavior is observably unchanged.

## Testing
- ✅ 6294 tests passing (full suite; baseline was 6270)
- ✅ ruff clean

## Related Issues
Refs #897