### PR TITLE
fix: record My on user stop even mid-move for RTS covers (#888)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2912,25 +2912,35 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         was_waiting = self._cmd_svc.is_waiting_for_target(entity_id)
         self.manager.mark_user_command(entity_id, reason=trigger)
         result = await self._cmd_svc.apply_user_stop(entity_id)
-        # set_target so reconciliation/hold compares against My; the assumed
-        # write is caps-confined to open/close-only covers by the shared helper.
         my_position_value = self.config_entry.options.get(CONF_MY_POSITION_VALUE)
-        if my_position_value is not None and not was_waiting:
-            # Capture the raw prior position BEFORE set_target overwrites it so
-            # the synthetic direction reflects the move toward My.
-            prior_position = self._cmd_svc.get_current_position(entity_id)
-            self._cmd_svc.set_target(entity_id, int(my_position_value))
+        if my_position_value is not None:
+            # The override engaged unconditionally (mark_user_command above), so
+            # the display-only assumed My must be recorded unconditionally too — a
+            # no-feedback open/close-only cover (Somfy RTS) physically lands on My
+            # when stopped, even mid its-own-move. Caps-confined to open/close-only
+            # covers by the shared helper (it clears any stale assumed value on
+            # position-capable covers), so this is safe for every cover type.
+            # Without it, a stop while ACP is mid-move (was_waiting) leaves the stale
+            # close/open endpoint assumed value and every reported surface shows it (#888).
             self._cmd_svc._record_assumed_if_blind(entity_id, int(my_position_value))
-            # Give the My move a ~45s transit window (open/close-only covers) so
-            # the card renders "Opening…/Closing…". The direction is caps-gated
-            # by the shared helper; begin_transit stamps waiting + sent_at so the
-            # reconciliation timer clears it when the window closes.
-            self._cmd_svc._set_transit_direction_if_blind(
-                entity_id, int(my_position_value), prior_position
-            )
-            self._cmd_svc.begin_transit(
-                entity_id, self._cmd_svc.get_transit_direction(entity_id)
-            )
+            if not was_waiting:
+                # Fresh target + transit window only when ACP was NOT already
+                # mid-move: a mid-halt cover is already inside its transit window,
+                # and set_target(My) on a position-capable halt would be wrong.
+                # Capture the raw prior position BEFORE set_target overwrites it so
+                # the synthetic direction reflects the move toward My.
+                prior_position = self._cmd_svc.get_current_position(entity_id)
+                self._cmd_svc.set_target(entity_id, int(my_position_value))
+                # Give the My move a ~45s transit window (open/close-only covers) so
+                # the card renders "Opening…/Closing…". The direction is caps-gated
+                # by the shared helper; begin_transit stamps waiting + sent_at so the
+                # reconciliation timer clears it when the window closes.
+                self._cmd_svc._set_transit_direction_if_blind(
+                    entity_id, int(my_position_value), prior_position
+                )
+                self._cmd_svc.begin_transit(
+                    entity_id, self._cmd_svc.get_transit_direction(entity_id)
+                )
         # A user stop engages an override and (for a My cover) records the new
         # target + assumed position + transit window. None of that reaches the
         # sensors until a coordinator cycle rebuilds them, so without an explicit

--- a/tests/test_assumed_position_surface.py
+++ b/tests/test_assumed_position_surface.py
@@ -121,6 +121,50 @@ async def test_actual_positions_shows_my_after_user_stop(
     assert coordinator._snapshot.cover_positions["cover.test_blind"] == 50
 
 
+@pytest.mark.asyncio
+async def test_actual_positions_shows_my_after_user_stop_while_waiting(
+    hass: HomeAssistant,
+) -> None:
+    """Issue #888 follow-up: a user stop mid ACP-move must still surface My.
+
+    Live Deck scenario: ACP was solar-tracking and had just sent ``close_cover``,
+    leaving ``waiting=True`` with the stale endpoint (0) stashed as the assumed
+    value. Pressing the card's stop button engages the override unconditionally,
+    but the My assumed record used to be gated behind ``not was_waiting`` — so
+    every reported surface kept showing the stale 0 instead of My. A Somfy-RTS
+    stop physically lands on My even mid-move, so the display must show My.
+    """
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+
+    # The cover reports "closed" with assumed_state=True (last close command).
+    hass.states.async_set(
+        "cover.test_blind",
+        "closed",
+        {"supported_features": _OPEN_CLOSE_STOP, "assumed_state": True},
+    )
+
+    # Simulate ACP mid its-own close move: waiting + the stale close endpoint (0)
+    # already recorded as the assumed value, exactly as a routine close_cover left it.
+    coordinator._cmd_svc.set_waiting("cover.test_blind", True)
+    coordinator._cmd_svc.record_assumed_position("cover.test_blind", 0)
+
+    # The card stop button routes here while ACP is still mid-move.
+    coordinator._cmd_svc._dry_run = True
+    await coordinator.async_apply_user_stop("cover.test_blind", trigger="stop")
+    coordinator._cmd_svc._dry_run = False
+
+    # The assumed store must now hold My, not the stale 0.
+    assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") == 50
+
+    # Diagnostics surface (build_diagnostic_data → read_positions).
+    diag = coordinator.build_diagnostic_data()
+    assert diag["covers"]["cover.test_blind"]["current_position"] == 50
+
+    # Sensor surface: snapshot.cover_positions, rebuilt on the next update cycle.
+    await coordinator.async_refresh()
+    assert coordinator._snapshot.cover_positions["cover.test_blind"] == 50
+
+
 # ---------------------------------------------------------------------------
 # Step 7 — invalidation
 # ---------------------------------------------------------------------------

--- a/tests/test_services_stop.py
+++ b/tests/test_services_stop.py
@@ -421,8 +421,15 @@ async def test_user_stop_records_my_when_idle() -> None:
 
 
 @pytest.mark.asyncio
-async def test_user_stop_no_my_when_waiting() -> None:
-    """A stop mid ACP-move (waiting) is a halt, not a My landing — no assumed."""
+async def test_user_stop_records_my_when_waiting() -> None:
+    """A stop mid ACP-move still records assumed=My on an open/close-only cover.
+
+    #888 follow-up: a no-feedback cover (Somfy RTS) physically lands on My when
+    stopped even mid its-own-move, so the display-only assumed value must reflect
+    My regardless of ``was_waiting``. The fresh target / transit window stays
+    gated on ``not was_waiting`` — a mid-halt cover is already in a transit
+    window — so ``target`` is left untouched here.
+    """
     from unittest.mock import patch
 
     coord = _bind_user_stop(_make_coord_for_assumed(my_position=50))
@@ -435,7 +442,10 @@ async def test_user_stop_no_my_when_waiting() -> None:
     ):
         await coord.async_apply_user_stop(entity_id, trigger="stop")
 
-    assert coord._cmd_svc.get_assumed_position(entity_id) is None
+    # Display-only assumed My is recorded unconditionally (caps-confined).
+    assert coord._cmd_svc.get_assumed_position(entity_id) == 50
+    # But the target/transit block stays gated: no fresh My target while waiting.
+    assert coord._cmd_svc.get_target(entity_id) != 50
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Follow-up defect in the just-merged #888 feature, reproduced on a live open/close/stop-only assumed-state cover (`cover.deck_front_shade`, `my_position_value=50`): I pressed the card's stop button while ACP was mid solar-track, the shade landed on its hardware My preset — but ACP held and reported **0%** on every surface (`held_position=0`, `actual_positions={cover:0}`) instead of My.

**Root cause** (`coordinator.py` `async_apply_user_stop`): `mark_user_command` engages the manual override unconditionally, but the `_record_assumed_if_blind(My)` write was gated behind `not was_waiting`. A routine `close_cover` leaves `waiting=True` and stashes the endpoint `0` as the assumed value, so a stop mid-move skipped the My record and every reported surface kept showing the stale `0`.

**Fix:** hoist the caps-confined `_record_assumed_if_blind(My)` call out of the `was_waiting` gate — a no-feedback Somfy-RTS cover physically lands on My when stopped, even mid-move, so the display-only assumed value must reflect My regardless of `was_waiting`. The fresh target/transit block stays gated (a mid-halt cover is already in a transit window; `set_target(My)` on a position-capable halt would be wrong). The helper already clears the assumed value on position-capable covers, so this is safe for every cover type — no cover-type string branch, no duplicated call.

## Testing
- ✅ New regression test `test_actual_positions_shows_my_after_user_stop_while_waiting` — reproduces the mid-move stop (`waiting=True` + stale assumed `0`); asserts assumed/diagnostics/snapshot all surface My=50. Fails before the fix (`assert 0 == 50`), passes after.
- ✅ Updated `test_user_stop_no_my_when_waiting` → `test_user_stop_records_my_when_waiting` to the new contract (assumed=My recorded; target left untouched while waiting).
- ✅ Full suite: 6271 passed. Ruff + black clean.

## Related Issues
Refs #888

https://claude.ai/code/session_01UZyhEmPvSpPtnQaa55eHeu