### PR TITLE
fix: let user card commands bypass same_position gate (#900)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1756,6 +1756,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         bypass_auto_control: bool = False,
         sun_just_appeared: bool = False,
         use_my_position: bool = False,
+        user_command: bool = False,
     ) -> PositionContext:
         """Build a PositionContext for the given cover entity.
 
@@ -1789,6 +1790,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 non-position-capable covers through ``stop_cover`` instead of
                 open/close.  Caller-supplied value is ORed with the pipeline
                 result's ``use_my_position`` so either source can enable it.
+            user_command: If True, this is an explicit user-initiated command
+                (card Open/Close/Set, set_position / set_axes service, My
+                button) and must dispatch even when ACP's raw view already
+                matches the target — the same-position gate is bypassed
+                (issue #900). Distinct from ``force``: recurring resends set
+                ``force`` too but stay deduped to avoid relay clicks (#290).
 
         """
         return PositionContext(
@@ -1802,6 +1809,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             force=force,
             is_safety=is_safety,
             bypass_auto_control=bypass_auto_control,
+            user_command=user_command,
             use_my_position=(
                 use_my_position
                 or (
@@ -2817,6 +2825,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             force=True,
             bypass_auto_control=True,
             use_my_position=use_my_position,
+            # Explicit user action — must dispatch even when ACP's raw view of a
+            # no-feedback cover already matches the target (issue #900). Distinct
+            # from force=True alone, which recurring resends also set and which
+            # must stay deduped by the same-position gate (issue #290).
+            user_command=True,
         )
         return await self._cmd_svc.apply_position(entity_id, clamped, trigger, ctx)
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1267,9 +1267,18 @@ class CoverCommandService:
         # covers are all handled by the one routing source of truth. Delta/time
         # gates and reconciliation deliberately keep reading the real (unknown)
         # _current — this fallback is scoped to the same-position gate only.
+        # An explicit user command (context.user_command) must ALWAYS dispatch —
+        # a user pressing Open/Close/Set from the card is never "already there"
+        # as far as ACP is entitled to decide, especially on a no-feedback cover
+        # whose raw HA state (open->100) diverges from the assumed display value
+        # (My=50). This is distinct from the generic force=True flag, which the
+        # recurring resends (custom_position, override-clear) also set and which
+        # MUST stay deduped here to avoid relay clicks (issue #290/#779). So the
+        # bypass keys on user_command, not force (issue #900).
         if (
             not context.sun_just_appeared
             and not force_endpoint
+            and not context.user_command
             and (
                 (
                     _current is not None

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -95,6 +95,16 @@ class PositionContext:
     bypass_auto_control: bool = (
         False  # Sanctioned one-shot bypass of auto_control gate (e.g. switch return-to-default)
     )
+    user_command: bool = (
+        # An explicit user-initiated command (card Open/Close/Set, set_position /
+        # set_axes service, My button). Unlike the generic ``force`` flag — which
+        # recurring resends (custom_position, override-clear) also set and which
+        # MUST stay deduped by the same-position gate to avoid relay clicks
+        # (issue #290) — a user command must ALWAYS dispatch, even when ACP's raw
+        # view already matches the target. On a no-feedback cover ACP cannot know
+        # the true position, so it must trust the user (issue #900).
+        False
+    )
     use_my_position: bool = (
         False  # Route through send_my_position() on non-position-capable covers
     )

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -127,6 +127,7 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
         bypass_auto_control=False,
         sun_just_appeared=False,
         use_my_position=False,
+        user_command=False,
     ):
         return PositionContext(
             auto_control=False,  # reflects automatic_control=False
@@ -139,6 +140,7 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
             is_safety=is_safety,
             bypass_auto_control=bypass_auto_control,
             use_my_position=use_my_position,
+            user_command=user_command,
         )
 
     coord._build_position_context = _fake_build_ctx

--- a/tests/test_cover_command_force_gate.py
+++ b/tests/test_cover_command_force_gate.py
@@ -42,7 +42,7 @@ def svc(hass):
     return s
 
 
-def _ctx(*, force=False, is_safety=False, auto_control=True):
+def _ctx(*, force=False, is_safety=False, auto_control=True, user_command=False):
     return PositionContext(
         auto_control=auto_control,
         manual_override=False,
@@ -52,6 +52,7 @@ def _ctx(*, force=False, is_safety=False, auto_control=True):
         special_positions=[0, 100],
         force=force,
         is_safety=is_safety,
+        user_command=user_command,
     )
 
 
@@ -167,6 +168,79 @@ class TestSamePositionBypassesForceGate:
                 60,
                 "custom_position",
                 _ctx(force=True, is_safety=False, auto_control=True),
+            )
+
+        assert outcome == "skipped"
+        assert detail == "same_position"
+        hass.services.async_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #900: an explicit USER command must bypass the same-position gate
+# ---------------------------------------------------------------------------
+
+
+class TestUserCommandBypassesSamePosition:
+    """A user pressing Open/Close/Set from the card must always dispatch (#900).
+
+    On a no-feedback (assumed_state) cover the display shows the assumed My value
+    (e.g. 50) while the gate reads the raw HA open/closed state (``open`` -> 100).
+    Pressing Open (target 100) was dropped as ``same_position`` because the gate
+    ignored ``context.user_command``. A user command sets force=True too, but it
+    must NOT be deduped like the recurring force=True resends of issue #290 — so
+    the split is on ``user_command``, not ``force``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_command_same_position_is_sent(self, svc, hass):
+        """user_command=True + cover already at target must SEND, not skip."""
+        with (
+            _patch_caps(),
+            patch.object(svc, "_get_current_position", return_value=100),
+        ):
+            outcome, _detail = await svc.apply_position(
+                "cover.test",
+                100,
+                "set_axes",
+                _ctx(force=True, user_command=True, auto_control=True),
+            )
+
+        assert outcome == "sent"
+        hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_user_command_no_feedback_same_target_is_sent(self, svc, hass):
+        """No-feedback cover (_current is None, target-fallback matches) still sends for a user command."""
+        with (
+            _patch_caps(has_set_position=False),
+            patch.object(svc, "_get_current_position", return_value=None),
+            patch.object(svc, "_same_position_via_target_fallback", return_value=True),
+        ):
+            outcome, _detail = await svc.apply_position(
+                "cover.test",
+                100,
+                "set_axes",
+                _ctx(force=True, user_command=True, auto_control=True),
+            )
+
+        assert outcome == "sent"
+        hass.services.async_call.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_user_force_still_deduped_on_no_feedback(self, svc, hass):
+        """Regression guard for #779/#290: a recurring force resend (not a user command)
+        on a no-feedback cover still skips as same_position so it can't relay-click.
+        """
+        with (
+            _patch_caps(has_set_position=False),
+            patch.object(svc, "_get_current_position", return_value=None),
+            patch.object(svc, "_same_position_via_target_fallback", return_value=True),
+        ):
+            outcome, detail = await svc.apply_position(
+                "cover.test",
+                100,
+                "reconciliation",
+                _ctx(force=True, user_command=False, auto_control=True),
             )
 
         assert outcome == "skipped"


### PR DESCRIPTION
## Summary
On a no-feedback / `assumed_state` cover (e.g. a Bond or Somfy-RTS-style shade with open/close/stop and no set_position), an explicit **user** command from the card — Open, Close, or Set Position — was silently dropped with skip reason `same_position` whenever ACP's *raw* view already matched the target. Most visible at **My**: the card shows 50% but pressing **Open** does nothing.

Root cause: the `same_position` gate (`managers/cover_command/__init__.py`) is evaluated independently of user intent. A user command sets `force=True`, which bypasses the delta/time gates but not `same_position`. For a no-feedback cover the gate reads the *raw* HA state (`open`→100) while the card shows the *assumed* My value (50), so Open (target 100) matched raw 100 → dropped.

The fix cannot simply make `same_position` honor `force`: recurring `force=True` resends (custom_position, override-clear) must stay deduped to avoid relay clicks (#290/#779). So I added a dedicated `user_command` flag to `PositionContext`, set only on the user-position entry point (`async_apply_user_position`), and bypass the `same_position` gate when it is set. Explicit user commands always dispatch; automatic resends still dedup.

## Testing
- ✅ Full suite: 6298 passing
- ✅ New tests in `test_cover_command_force_gate.py`: user command at same position sends (position-capable + no-feedback fallback); non-user force resend still deduped (guards #290/#779)
- ✅ Targeted regression suites (reconciliation, optimistic replay, assumed-position, auto-control matrix, venetian) green

Diagnosed live against a Bond `assumed_state` Deck Front Shade: `last_skipped_action = same_position, current_position=100, trigger=set_axes` while the cover displayed 50% (My).

## Related Issues
Refs #900

https://claude.ai/code/session_01BVfJVSHkm525VRtBPHBKcS