### PR TITLE
fix: defer sunset/end-time dispatch to active custom position (#895)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -3280,6 +3280,35 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """
         return bool(self._pipeline_result and self._pipeline_result.is_safety)
 
+    def _pipeline_has_active_override(self) -> bool:
+        """Return True when a non-DEFAULT handler currently owns the pipeline result.
+
+        Consulted by both fast-dispatch paths that bypass the pipeline
+        registry entirely — ``_on_window_closed`` (end-of-window default) and
+        ``WindowTransitionTracker.check_sunset_window`` (astronomical-sunset
+        transition) — so neither force-sends the raw sunset/default position
+        over a higher-priority handler's already-winning result (e.g. a
+        CUSTOM_POSITION slot holding a user's sleep-mode floor). Without this
+        guard the sunset transition overwrites the custom position and only
+        the next refresh cycle corrects it back — a spurious double-move
+        (issue #895).
+
+        MANUAL is intentionally NOT special-cased here: it is already handled
+        per-cover-entity via ``is_cover_manual`` in the sunset dispatch loop,
+        whereas ``control_method`` is a single coordinator-wide decision — the
+        two checks are complementary, not redundant.
+
+        Uses ``getattr`` because some minimal test doubles construct the
+        coordinator via ``object.__new__`` without running ``__init__`` (which
+        is where ``_pipeline_result`` is first set to ``None``); treating a
+        missing attribute the same as ``None`` mirrors real startup, where the
+        pipeline hasn't evaluated yet.
+        """
+        result = getattr(self, "_pipeline_result", None)
+        if result is None:
+            return False
+        return result.control_method is not ControlMethod.DEFAULT
+
     def _is_custom_position_sensor_trigger(self) -> bool:
         """Return True when this refresh was edge-triggered by a custom-position slot's own trigger.
 
@@ -3374,6 +3403,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             (issue #215/#216).  The necessary guards (return_sunset toggle,
             automatic_control) are already applied above; there is no reason
             to bypass the command-service delta/manual-override gates here.
+
+            Also skips when a higher-priority handler (e.g. CUSTOM_POSITION)
+            is currently the pipeline's winner — see
+            ``_pipeline_has_active_override`` (issue #895).
             """
             # Always clear stale daytime targets when the window closes so
             # reconciliation cannot resend them overnight.
@@ -3384,6 +3417,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self.logger.debug(
                     "End time reached but automatic control is OFF — "
                     "skipping return-to-default reposition"
+                )
+                return
+            if self._pipeline_has_active_override():
+                self.logger.debug(
+                    "End time reached but a higher-priority handler (%s) is "
+                    "active — skipping return-to-default reposition (issue #895)",
+                    self._pipeline_result.control_method,
                 )
                 return
             options = self.config_entry.options
@@ -3544,7 +3584,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Delegate astronomical-sunset-window transition handling to the tracker.
 
         See :meth:`WindowTransitionTracker.check_sunset_window` for the
-        full contract (issue #266).
+        full contract (issue #266) including the override-precedence guard
+        (issue #895).
         """
         options = self.config_entry.options
         await self._window_tracker.check_sunset_window(
@@ -3555,6 +3596,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             inverse_state_enabled=self._inverse_state,
             entities=self.entities,
             is_cover_manual=self.manager.is_cover_manual,
+            has_active_override=self._pipeline_has_active_override(),
             build_position_context=lambda c, o: self._build_position_context(
                 c, o, force=False
             ),

--- a/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
+++ b/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
@@ -132,6 +132,7 @@ class WindowTransitionTracker:
         inverse_state_enabled: bool,
         entities: list[str],
         is_cover_manual: IsCoverManualFn,
+        has_active_override: bool = False,
         build_position_context: BuildContextFn,
         apply_position: ApplyPositionFn,
         refresh: RefreshFn,
@@ -142,7 +143,13 @@ class WindowTransitionTracker:
         the cover uses inverse state) to every non-manual cover.  No-ops
         when the user has not opted in to ``return_sunset`` tracking, when
         automatic control is disabled, when no sunset position is
-        configured, or on the seeding call.
+        configured, on the seeding call, or when ``has_active_override`` is
+        True — a higher-priority pipeline handler (e.g. a CUSTOM_POSITION
+        slot) is currently winning and must not be overwritten by the raw
+        sunset position (issue #895). In that last case the internal
+        False→True edge is deliberately left unresolved so the dispatch fires
+        on the first subsequent call where the override is no longer active,
+        rather than being lost.
         """
         if not track_end_time:
             return
@@ -152,6 +159,12 @@ class WindowTransitionTracker:
             )
             return
         if sunset_pos_cfg is None:
+            return
+        if has_active_override:
+            self._logger.debug(
+                "Sunset window transition detected but a higher-priority "
+                "handler is currently active — skipping reposition (issue #895)"
+            )
             return
 
         _effective_pos, is_sunset = self._effective_default_fn(options)

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -558,6 +558,93 @@ async def test_window_close_sends_reposition_when_auto_control_on():
     assert cmd_svc.apply_position.call_args[0][2] == "end_time_default"
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_window_close_skips_reposition_when_custom_position_active():
+    """_on_window_closed must not send positions when a higher-priority handler wins.
+
+    Regression for issue #895: mirrors
+    test_window_close_sends_reposition_when_auto_control_on, but with the
+    pipeline's current control_method set to CUSTOM_POSITION (a user's
+    sleep-mode floor, priority 77). The raw end-of-window default must not
+    force-overwrite that higher-priority slot's position.
+    """
+    import datetime as dt
+    from types import SimpleNamespace
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DEFAULT_HEIGHT,
+        ControlMethod,
+    )
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.logger = MagicMock()
+    coord._toggles = ToggleManager()
+    coord._event_buffer = EventBuffer(maxlen=50)
+    coord.automatic_control = True
+    coord._track_end_time = True
+    coord._inverse_state = False
+    coord.entities = [MagicMock()]
+    coord.hass = MagicMock()
+    coord._pipeline_result = SimpleNamespace(
+        control_method=ControlMethod.CUSTOM_POSITION
+    )
+
+    cmd_svc = MagicMock()
+    cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
+    cmd_svc.clear_non_safety_targets = MagicMock()
+    coord._cmd_svc = cmd_svc
+    coord.async_refresh = AsyncMock()
+
+    options = {CONF_DEFAULT_HEIGHT: 0}
+    config_entry = MagicMock()
+    config_entry.options = options
+    coord.config_entry = config_entry
+
+    cover_data = MagicMock()
+    cover_data.sun_data = MagicMock()
+    coord.get_blind_data = MagicMock(return_value=cover_data)
+    coord._build_position_context = MagicMock(return_value=MagicMock(force=True))
+    coord.manager = MagicMock()
+
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    tracker = WindowTransitionTracker(
+        hass=MagicMock(),
+        logger=coord.logger,
+        event_buffer=coord._event_buffer,
+        effective_default_fn=lambda _opts: (0, False),
+    )
+    tracker._prev_sunset_active = True
+    coord._window_tracker = tracker
+
+    with patch(
+        "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+        return_value=(0, False),
+    ):
+        time_mgr = MagicMock()
+
+        async def _invoke(track_end_time, refresh_callback, on_window_open=None):
+            await refresh_callback()
+
+        time_mgr.check_transition = _invoke
+        coord._time_mgr = time_mgr
+
+        await coord._check_time_window_transition(dt.datetime.now(dt.UTC))
+
+    # Stale-target cleanup must still run regardless of override state
+    cmd_svc.clear_non_safety_targets.assert_called_once()
+    cmd_svc.apply_position.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _build_pipeline: tilt threaded from options to CustomPositionHandler
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_266_sunset_transition.py
+++ b/tests/test_issue_266_sunset_transition.py
@@ -8,11 +8,12 @@ the transition and dispatch the sunset position.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.adaptive_cover_pro.const import CONF_SUNSET_POS
+from custom_components.adaptive_cover_pro.const import CONF_SUNSET_POS, ControlMethod
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
@@ -31,14 +32,24 @@ def _make_coord(
     sunset_pos: int | None = 0,
     inverse_state: bool = False,
     n_entities: int = 1,
+    pipeline_control_method: ControlMethod | None = None,
 ) -> AdaptiveDataUpdateCoordinator:
-    """Minimal coordinator fixture for _check_sunset_window_transition tests."""
+    """Minimal coordinator fixture for _check_sunset_window_transition tests.
+
+    ``pipeline_control_method``, when given, seeds ``coord._pipeline_result``
+    with that control method (issue #895 — a higher-priority handler, e.g.
+    CUSTOM_POSITION, currently winning the pipeline must suppress the sunset
+    dispatch). Left unset by default so existing callers keep exercising the
+    startup/no-pipeline-result-yet case exactly as before.
+    """
     coord = object.__new__(AdaptiveDataUpdateCoordinator)
     coord.logger = MagicMock()
     coord._toggles = ToggleManager()
     coord.automatic_control = automatic_control
     coord._track_end_time = track_end_time
     coord._inverse_state = inverse_state
+    if pipeline_control_method is not None:
+        coord._pipeline_result = SimpleNamespace(control_method=pipeline_control_method)
 
     entities = [MagicMock() for _ in range(n_entities)]
     coord.entities = entities
@@ -269,3 +280,48 @@ async def test_end_time_after_sunset_does_not_double_dispatch():
     await coord._check_sunset_window_transition()
 
     coord._cmd_svc.apply_position.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Issue #895: priority inversion — sunset dispatch must not override a
+# currently-active higher-priority pipeline handler (e.g. CUSTOM_POSITION).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_skips_dispatch_when_custom_position_currently_active():
+    """No dispatch when a higher-priority handler currently owns the pipeline.
+
+    Regression for issue #895: the astronomical-sunset dispatch bypassed the
+    pipeline entirely and force-sent the raw sunset position even when a
+    higher-priority CustomPositionHandler slot (e.g. a user's sleep-mode
+    floor) was the pipeline's current winner. That overwrote the custom
+    position until the next refresh cycle silently corrected it back — a
+    spurious double-move.
+    """
+    coord = _make_coord(
+        sunset_pos=0, pipeline_control_method=ControlMethod.CUSTOM_POSITION
+    )
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_dispatch_still_occurs_when_pipeline_control_method_is_default():
+    """Happy path: an explicit DEFAULT control_method does not suppress dispatch.
+
+    Locks in that the issue #895 override guard only blocks *non-DEFAULT*
+    control methods — when the pipeline's own winner is the DEFAULT handler
+    (which sunset itself is a variant of), the sunset dispatch still fires.
+    """
+    coord = _make_coord(sunset_pos=0, pipeline_control_method=ControlMethod.DEFAULT)
+    _seed_sunset_state(coord, prev=False, current_is_sunset=True)
+
+    await coord._check_sunset_window_transition()
+
+    coord._cmd_svc.apply_position.assert_called_once()


### PR DESCRIPTION
## Summary
The astronomical-sunset transition and the end-of-window default dispatch both bypassed the pipeline registry and force-sent the raw sunset/default position, ignoring a higher-priority handler that already owned the pipeline result. When a CUSTOM_POSITION slot held a user's sleep-mode floor, the sunset transition overwrote it with the default, then the next refresh corrected it back — a spurious double-move that stranded a hardware-limited blind at ~75%.

The fix adds a single `_pipeline_has_active_override()` predicate and consults it from both fast-dispatch paths, so custom position keeps winning through the sunset transition per the documented priority chain (CUSTOM_POSITION > … > DEFAULT). MANUAL stays handled per-cover via the existing `is_cover_manual` check.

## Testing
- ✅ 6301 tests passing (full suite, 0 failed)
- Added `test_skips_dispatch_when_custom_position_currently_active` + a happy-path companion (sunset transition), and `test_window_close_skips_reposition_when_custom_position_active` (end-of-window)

## Related Issues
Refs #895