### PR TITLE
fix: localize config summary via instance-language fallback (#905)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1699,14 +1699,38 @@ async def _load_summary_labels(hass: HomeAssistant, language: str) -> dict[str, 
     The labels live in the integration's ``summary_i18n/`` bundle (a custom
     ``config_summary`` category cannot live under ``translations/`` — hassfest
     rejects it). This overlays the language bundle onto the English defaults so
-    any missing key falls back to English. ``language`` is the per-user flow
-    language (``self.context.get("language", "en")``) — never the system
-    language. File I/O is offloaded to the executor.
+    any missing key falls back to English. ``language`` is pre-resolved by the
+    caller via ``_resolve_summary_language`` (issue #905) — this helper just
+    loads whatever language string it's handed. File I/O is offloaded to the
+    executor.
 
     Both ``ConfigFlow.async_step_summary`` and ``OptionsFlow.async_step_summary``
     call this single helper (no duplication).
     """
     return await hass.async_add_executor_job(_load_summary_labels_sync, language)
+
+
+def _resolve_summary_language(hass: HomeAssistant, context: dict[str, Any]) -> str:
+    """Resolve the language for the config-summary labels (issue #905).
+
+    Prefers the per-user flow language (``context["language"]``) when HA
+    supplies one. HA does not currently populate this for config/options
+    flows — no HA-core code path sets it, so it's always absent in
+    practice — leaving the summary permanently stuck in English even though
+    the ``summary_i18n/{de,fr}.json`` bundles exist (issue #258 built the
+    bundle; #905 is that the language was never actually selected). Falls
+    back to the HA instance language (``hass.config.language``) as a
+    best-effort proxy, and finally to English.
+
+    This is intentionally scoped to the server-rendered summary block only.
+    Per-user language is not available server-side in a flow, but reading
+    the system language for the rest of the flow's UI (menu/step labels) was
+    exactly the #227 bug — see
+    ``tests/test_config_flow_integration.py::test_config_flow_does_not_use_system_language``,
+    which guards against ``hass.config.language`` appearing anywhere else in
+    this module.
+    """
+    return context.get("language") or hass.config.language or "en"
 
 
 def _build_group_summary(
@@ -4088,7 +4112,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_update()
         sun_times = await _compute_todays_sun_times(self.hass, self.config)
         labels = await _load_summary_labels(
-            self.hass, self.context.get("language", "en")
+            self.hass, _resolve_summary_language(self.hass, self.context)
         )
         summary_text = _build_config_summary(
             self.config, self.type_blind, self.hass, sun_times, labels=labels
@@ -5327,7 +5351,7 @@ class OptionsFlowHandler(OptionsFlow):
             return await self.async_step_init()
         sun_times = await _compute_todays_sun_times(self.hass, self.options)
         labels = await _load_summary_labels(
-            self.hass, self.context.get("language", "en")
+            self.hass, _resolve_summary_language(self.hass, self.context)
         )
         summary_text = _build_config_summary(
             self.options, self.sensor_type, self.hass, sun_times, labels=labels

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -1413,25 +1413,41 @@ async def test_options_menu_every_entry_has_a_label(
 
 
 def test_config_flow_does_not_use_system_language() -> None:
-    """config_flow must not read the system language (issue #227).
+    """config_flow must not read the system language outside one sanctioned spot
+    (issue #227).
 
     The #227 bug was server-side translation fetching keyed on
     ``self.hass.config.language`` (the system language) instead of the per-user
-    flow language. The config-summary i18n (issue #258) legitimately imports
-    ``async_get_translations``, but must select the language via
+    flow language. Menu/step labels must always select the language via
     ``self.context.get("language", ...)`` — never ``hass.config.language``.
 
-    Guard the source text directly so any reintroduction of the system-language
-    read fails here.
+    Issue #905: HA never actually populates ``context["language"]`` for
+    config/options flows, so the server-rendered config-summary block (issue
+    #258's ``summary_i18n/`` bundle, narrative text that cannot be
+    client-translated the way menu/step labels are) needs a best-effort
+    fallback to the HA instance language. That fallback is deliberately
+    isolated in the single ``_resolve_summary_language`` helper. Guard the
+    rest of the module's source text so any *other* reintroduction of the
+    system-language read — e.g. in menu or step label selection, the actual
+    #227 failure mode — fails here.
     """
     import inspect
 
     import custom_components.adaptive_cover_pro.config_flow as cf_module
 
     source = inspect.getsource(cf_module)
-    assert "config.language" not in source, (
-        "config_flow must not read hass.config.language (system language) — "
-        "the flow user's language comes from self.context['language'] (issue #227)"
+    sanctioned_source = inspect.getsource(cf_module._resolve_summary_language)
+    assert "config.language" in sanctioned_source, (
+        "expected the sanctioned system-language fallback to live inside "
+        "_resolve_summary_language (issue #905) — the guard below assumes it "
+        "does"
+    )
+    source_outside_helper = source.replace(sanctioned_source, "")
+    assert "config.language" not in source_outside_helper, (
+        "config_flow must not read hass.config.language (system language) "
+        "outside _resolve_summary_language — the flow user's language comes "
+        "from self.context['language'] (issue #227); the one documented "
+        "exception is the config-summary fallback (issue #905)"
     )
 
 

--- a/tests/test_config_flow_summary_i18n.py
+++ b/tests/test_config_flow_summary_i18n.py
@@ -26,6 +26,7 @@ from custom_components.adaptive_cover_pro.config_flow import (
     _build_config_summary,
     _load_summary_labels,
     _load_summary_labels_sync,
+    _resolve_summary_language,
 )
 from custom_components.adaptive_cover_pro.const import (
     CoverType,
@@ -128,6 +129,52 @@ async def test_load_summary_labels_async_uses_passed_language() -> None:
     assert hass.calls == [("fr",)]
     # The result is the French bundle overlaid on English.
     assert labels == _load_summary_labels_sync("fr")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_summary_language — issue #905: HA never populates
+# context["language"] for config/options flows, so the summary always
+# rendered in English regardless of the HA instance language. These tests
+# cover the helper's three-way fallback: context -> hass.config.language ->
+# "en".
+# ---------------------------------------------------------------------------
+
+
+class _FakeHassConfig:
+    def __init__(self, language: str | None) -> None:
+        self.language = language
+
+
+class _FakeHassWithConfig:
+    def __init__(self, language: str | None) -> None:
+        self.config = _FakeHassConfig(language)
+
+
+def test_resolve_summary_language_prefers_context_language() -> None:
+    """When ``context`` carries a language, it wins over ``hass.config.language``."""
+    hass = _FakeHassWithConfig("de")
+    assert _resolve_summary_language(hass, {"language": "fr"}) == "fr"
+
+
+def test_resolve_summary_language_falls_back_to_hass_config_language_when_context_has_none() -> (
+    None
+):
+    """An empty context (HA's actual behavior for config/options flows) falls
+    back to the HA instance language — this is the issue #905 bug-fix
+    assertion.
+    """
+    hass = _FakeHassWithConfig("fr")
+    assert _resolve_summary_language(hass, {}) == "fr"
+
+
+def test_resolve_summary_language_falls_back_to_english_when_nothing_available() -> (
+    None
+):
+    """When both context and ``hass.config.language`` are empty/falsy, the
+    English default wins.
+    """
+    hass = _FakeHassWithConfig(None)
+    assert _resolve_summary_language(hass, {}) == "en"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
HA never populates `context["language"]` for config/options flows, so the narrative config-summary block (`_build_config_summary`) always rendered in English and the `summary_i18n/{de,fr}.json` bundles added in #258 were dead code. I pulled the summary language selection into a new `_resolve_summary_language` helper that falls back to `hass.config.language` (then `"en"`) when the flow context carries no language, so a French instance now sees the French summary. Both `ConfigFlowHandler.async_step_summary` and `OptionsFlowHandler.async_step_summary` delegate to the one helper (no duplication). Narrowed the #227 guard test to sanction that single scoped `hass.config.language` read while still catching any other system-language reintroduction.

## Testing
- ✅ 78 config-flow tests passing (11 in test_config_flow_summary_i18n.py including 3 new fallback tests; 67 in test_config_flow_integration.py including the narrowed #227 guard)

## Related Issues
Refs #905
Refs #258