### PR TITLE
feat: localize pipeline decision-trace reason strings (#882)

### DIFF
--- a/.claude/skills/acp-translate/SKILL.md
+++ b/.claude/skills/acp-translate/SKILL.md
@@ -5,12 +5,13 @@ description: Sync DE/FR translations with en.json, add a new language, drop a la
 
 # ACP Translate
 
-Maintains **two parallel translation bundles**, each with `en.json` as the single source of truth and every other language matching its structure exactly:
+Maintains **three parallel translation bundles**, each with `en.json` as the single source of truth and every other language matching its structure exactly:
 
 1. **`custom_components/adaptive_cover_pro/translations/`** — the standard HA translation files (`title`, `config`, `options`, `entity`, `selector`, `services`). Validated by hassfest against HA's strict schema.
 2. **`custom_components/adaptive_cover_pro/summary_i18n/`** — the config-summary label bundle (`en.json` / `de.json` / `fr.json`), a nested tree of dotted-key → template strings consumed by `_build_config_summary` in `config_flow.py`. This lives **outside** `translations/` on purpose: it is a custom `config_summary` category that hassfest's schema forbids as a top-level key in `translations/en.json`, so it is loaded directly by `_load_summary_labels` instead of via `async_get_translations`.
+3. **`custom_components/adaptive_cover_pro/reason_i18n/`** — the pipeline-reason label bundle (`en.json` / `de.json` / `fr.json`), a nested tree of dotted reason-code → Python `str.format` template strings consumed by the pure `reason_i18n.py` resolver to localize pipeline decision-trace reasons, position explanations, and control-state reasons on `sensor.*` attributes and for the companion Lovelace card. This also lives **outside** `translations/` on purpose: it is not an HA translation category, so it is loaded directly by `reason_i18n.py`'s resolver instead of via `async_get_translations`.
 
-⚠️ **Every operation below applies to BOTH directories.** When syncing, adding, or dropping a language, process `translations/<lang>.json` *and* `summary_i18n/<lang>.json`. The `summary_i18n/en.json` source of truth must stay byte-identical (flattened) to the code-owned `_SUMMARY_LABELS_EN` (config_flow.py) + `COVER_TYPE_LABELS_EN` / `GEOMETRY_LABELS_EN` (cover_types/_summary_labels.py) dicts — a drift guard in `tests/test_config_flow_summary_i18n.py` / `tests/test_policy_summary_i18n.py` enforces this. If you change those code dicts, regenerate `summary_i18n/en.json` first, then sync de/fr.
+⚠️ **Every operation below applies to ALL THREE directories.** When syncing, adding, or dropping a language, process `translations/<lang>.json`, `summary_i18n/<lang>.json`, _and_ `reason_i18n/<lang>.json`. The `summary_i18n/en.json` source of truth must stay byte-identical (flattened) to the code-owned `_SUMMARY_LABELS_EN` (config_flow.py) + `COVER_TYPE_LABELS_EN` / `GEOMETRY_LABELS_EN` (cover_types/\_summary_labels.py) dicts — a drift guard in `tests/test_config_flow_summary_i18n.py` / `tests/test_policy_summary_i18n.py` enforces this. Likewise, the `reason_i18n/en.json` source of truth must stay byte-identical (flattened) to the code-owned `_REASON_TEMPLATES_EN` dict (`reason_i18n.py`) — a drift guard in `tests/test_reason_i18n.py` enforces this. If you change those code dicts, regenerate `summary_i18n/en.json` and/or `reason_i18n/en.json` first, then sync de/fr.
 
 Officially shipped languages: **en, de, fr**. Any new language is added only on explicit maintainer request via this skill.
 
@@ -56,9 +57,9 @@ Use when `translations/en.json` has changed and DE/FR need to catch up.
 
 ### Steps
 
-> **Both bundles.** Run the diff + dispatch for `translations/` **and** `summary_i18n/`. A given language's two files can have independent deltas — compute and propagate each separately. The `summary_i18n` files are small nested trees (flatten the same way); their dotpaths look like `rules.force`, `cover_types.blind`, `geometry.slat.depth`.
+> **All three bundles.** Run the diff + dispatch for `translations/`, `summary_i18n/`, **and** `reason_i18n/`. A given language's three files can have independent deltas — compute and propagate each separately. The `summary_i18n` files are small nested trees (flatten the same way); their dotpaths look like `rules.force`, `cover_types.blind`, `geometry.slat.depth`. The `reason_i18n` files are likewise small nested trees; their dotpaths look like `solar.tracking`, `manual.holding_label`, `fragment.season_summer`, `engine.direct_sun`.
 
-1. **Diff.** Load all translation files (both directories) via Bash+Python (see **Reading Translation Files** — do NOT use the Read tool). Flatten each to dot-path keys. For each non-en file compute:
+1. **Diff.** Load all translation files (all three directories) via Bash+Python (see **Reading Translation Files** — do NOT use the Read tool). Flatten each to dot-path keys. For each non-en file compute:
 
    - `added`: keys in en but not in target
    - `removed`: keys in target but not in en
@@ -66,9 +67,9 @@ Use when `translations/en.json` has changed and DE/FR need to catch up.
 
 2. **If nothing to do**, report "DE/FR already in sync with en.json" and exit.
 
-3. **Dispatch one subagent per language in parallel** (single message, two `Agent` tool calls). Each subagent handles BOTH that language's files (`translations/<lang>.json` and `summary_i18n/<lang>.json`) and receives:
+3. **Dispatch one subagent per language in parallel** (single message, two `Agent` tool calls). Each subagent handles all THREE of that language's files (`translations/<lang>.json`, `summary_i18n/<lang>.json`, and `reason_i18n/<lang>.json`) and receives:
 
-   - Absolute paths to `translations/en.json` + `summary_i18n/en.json` and to its own two target files
+   - Absolute paths to `translations/en.json` + `summary_i18n/en.json` + `reason_i18n/en.json` and to its own three target files
    - The list of `added` + `changed` dotpaths to translate, per file
    - The list of `removed` dotpaths to strip from each target
    - The language name and ISO code
@@ -80,7 +81,7 @@ Use when `translations/en.json` has changed and DE/FR need to catch up.
    - Load the target file, merge in the new values, delete `removed` keys, and write it back via Bash+Python.
    - Return a one-paragraph summary: counts added/changed/removed, any placeholder-preservation warnings, cost estimate.
 
-4. **Verify.** Run `./scripts/validate_translations.py --ci` and `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py -q`. If either fails, report the failure verbatim and stop. Do not attempt a second auto-sync round.
+4. **Verify.** Run `./scripts/validate_translations.py --ci` (covers `translations/` only — it does not validate `summary_i18n/` or `reason_i18n/`) and `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py tests/test_reason_i18n.py -q`. If either fails, report the failure verbatim and stop. Do not attempt a second auto-sync round.
 
 5. **Report.** Use the Output Format below.
 
@@ -96,19 +97,19 @@ Use to rebuild DE/FR from scratch **or** to add a brand-new language.
 
 2. **Delete the existing file** if rebuilding, so the subagent produces a clean file.
 
-3. **Dispatch one subagent per requested language in parallel.** If the user says "add DE and FR", send a single message with two `Agent` tool calls. Each subagent builds BOTH files for its language and receives:
+3. **Dispatch one subagent per requested language in parallel.** If the user says "add DE and FR", send a single message with two `Agent` tool calls. Each subagent builds all THREE files for its language and receives:
 
-   - Absolute paths to `translations/en.json` AND `summary_i18n/en.json`
-   - Absolute paths to the two target files it must write (`translations/<lang>.json`, `summary_i18n/<lang>.json`)
+   - Absolute paths to `translations/en.json`, `summary_i18n/en.json`, AND `reason_i18n/en.json`
+   - Absolute paths to the three target files it must write (`translations/<lang>.json`, `summary_i18n/<lang>.json`, `reason_i18n/<lang>.json`)
    - Language name + ISO code
    - The domain-term glossary (see below) — customized per language
 
    The subagent's job:
 
-   - Load the full `translations/en.json` and `summary_i18n/en.json` trees via Bash+Python (see **Reading Translation Files**).
-   - **Pass 1 — Haiku bulk:** Run the Haiku translation prompt on all keys from both files. Capture output as a JSON object.
-   - **Pass 2 — Sonnet review (data_descriptions only):** Filter the Haiku output to include ONLY keys containing `.data_description.` (these exist only in `translations/`, not `summary_i18n/`) — do not send any other keys to Sonnet. Run the Sonnet review prompt on this filtered subset. Merge corrected values back into the Haiku output.
-   - Write `translations/<lang>.json` AND `summary_i18n/<lang>.json` via Bash+Python: each with the same nested structure as its en.json source, 2-space indent, `ensure_ascii=False`, trailing newline.
+   - Load the full `translations/en.json`, `summary_i18n/en.json`, and `reason_i18n/en.json` trees via Bash+Python (see **Reading Translation Files**).
+   - **Pass 1 — Haiku bulk:** Run the Haiku translation prompt on all keys from all three files. Capture output as a JSON object.
+   - **Pass 2 — Sonnet review (data_descriptions only):** Filter the Haiku output to include ONLY keys containing `.data_description.` (these exist only in `translations/`, not `summary_i18n/` or `reason_i18n/`) — do not send any other keys to Sonnet. `reason_i18n` has no `data_description` keys at all, so it never enters the Sonnet pass — it stays Haiku-only, same as summary_i18n's non-data_description keys. Run the Sonnet review prompt on this filtered subset. Merge corrected values back into the Haiku output.
+   - Write `translations/<lang>.json`, `summary_i18n/<lang>.json`, AND `reason_i18n/<lang>.json` via Bash+Python: each with the same nested structure as its en.json source, 2-space indent, `ensure_ascii=False`, trailing newline.
    - Return a summary: key counts written per file, how many data_description keys were reviewed by Sonnet, placeholder warnings, cost estimate.
 
 4. **Update tooling.** After subagents return:
@@ -116,7 +117,7 @@ Use to rebuild DE/FR from scratch **or** to add a brand-new language.
    - Add the language code to the `LANGUAGES` constant in `scripts/validate_translations.py` (unless already present).
    - Update any per-language lists in `tests/test_translations.py`.
 
-5. **Verify.** Run `./scripts/validate_translations.py --ci` and `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py -q`. Do not proceed to commit if either fails.
+5. **Verify.** Run `./scripts/validate_translations.py --ci` (covers `translations/` only — it does not validate `summary_i18n/` or `reason_i18n/`) and `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py tests/test_reason_i18n.py -q`. Do not proceed to commit if either fails.
 
 6. **Report.** If the language is new (not in the previously-shipped set), remind the user to update README's supported-languages list and add a release-notes line.
 
@@ -125,25 +126,25 @@ Use to rebuild DE/FR from scratch **or** to add a brand-new language.
 ## Operation 3 — Drop Language
 
 1. Confirm the language is not `en`, `de`, or `fr`. If the user asks to drop one of the core three, explicitly confirm with them before proceeding (this changes the officially supported set).
-2. Delete BOTH `translations/<lang>.json` and `summary_i18n/<lang>.json`.
+2. Delete ALL THREE of `translations/<lang>.json`, `summary_i18n/<lang>.json`, and `reason_i18n/<lang>.json`.
 3. Remove the code from `scripts/validate_translations.py` `LANGUAGES` list.
 4. Remove any language-specific expectations from `tests/test_translations.py`.
-5. Run `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py -q` to confirm.
+5. Run `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py tests/test_reason_i18n.py -q` to confirm.
 6. Report what was removed.
 
 ---
 
 ## Operation 4 — Status
 
-1. Run `./scripts/validate_translations.py` (no flags) and show its dashboard output.
-2. Run `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py -q` and show pass/fail counts (covers both `translations/` and `summary_i18n/` parity + the en-source drift guards).
+1. Run `./scripts/validate_translations.py` (no flags) and show its dashboard output. This covers `translations/` only — it does not validate `summary_i18n/` or `reason_i18n/`.
+2. Run `venv/bin/python -m pytest tests/test_translations.py tests/test_config_flow_summary_i18n.py tests/test_policy_summary_i18n.py tests/test_reason_i18n.py -q` and show pass/fail counts (covers `translations/`, `summary_i18n/`, and `reason_i18n/` parity + the en-source drift guards).
 3. No subagents, no writes.
 
 ---
 
 ## Reading Translation Files
 
-⚠️ **The `translations/` JSON files exceed the Read tool's 25,000-token limit. Never use the Read tool directly on `translations/en.json`, `de.json`, or `fr.json`.** Use Bash+Python instead. The `summary_i18n/` files are smaller (~10 KB) and Read-safe, but use the same Bash+Python flatten/merge flow for consistency and to keep the write format identical (2-space indent, `ensure_ascii=False`, trailing newline).
+⚠️ **The `translations/` JSON files exceed the Read tool's 25,000-token limit. Never use the Read tool directly on `translations/en.json`, `de.json`, or `fr.json`.** Use Bash+Python instead. The `summary_i18n/` and `reason_i18n/` files are smaller (~10 KB) and Read-safe, but use the same Bash+Python flatten/merge flow for consistency and to keep the write format identical (2-space indent, `ensure_ascii=False`, trailing newline).
 
 **Extract specific dotpath values from en.json (Sync):**
 
@@ -295,6 +296,9 @@ Input:
 - motion sensor → Bewegungssensor
 - presence → Anwesenheit
 - field of view / FOV → Sichtfeld / FOV
+- occupancy → Anwesenheit / Belegung
+- acceptance angle → Akzeptanzwinkel
+- sunset → Sonnenuntergang
 
 **French (fr):**
 
@@ -314,6 +318,9 @@ Input:
 - motion sensor → détecteur de mouvement
 - presence → présence
 - field of view / FOV → champ de vision / FOV
+- occupancy → présence / occupation
+- acceptance angle → angle d'acceptation
+- sunset → coucher du soleil
 
 For other languages, tell the subagent to "use the HA community standard translation of these terms for <language>; when in doubt prefer the shortest unambiguous term."
 
@@ -321,21 +328,21 @@ For other languages, tell the subagent to "use the HA community standard transla
 
 ## File Format
 
-Non-EN files (in BOTH `translations/` and `summary_i18n/`) must:
+Non-EN files (in ALL THREE of `translations/`, `summary_i18n/`, and `reason_i18n/`) must:
 
 - Be valid JSON, 2-space indent.
 - Use `ensure_ascii=False` (keep accented characters as-is, not `\uXXXX`).
 - End with exactly one trailing newline.
-- Preserve the matching en.json's nested structure exactly — for `translations/` every top-level section including `services`; for `summary_i18n/` the full nested label tree (`rules`, `weather`, `cover_types`, `geometry`, …).
+- Preserve the matching en.json's nested structure exactly — for `translations/` every top-level section including `services`; for `summary_i18n/` the full nested label tree (`rules`, `weather`, `cover_types`, `geometry`, …); for `reason_i18n/` the full nested reason-code tree (`solar`, `manual`, `fragment`, `engine`, …).
 - Contain no `mdi:` icon references, no zero-width characters, no empty string values.
 
-⚠️ **Placeholder parity is critical for `summary_i18n/`.** Each label is a Python `str.format` template; the translated value must carry the IDENTICAL set of `{field}` placeholders (and escaped literal `{{`/`}}`) as the English source, or `_build_config_summary` raises at render time. `tests/test_config_flow_summary_i18n.py` enforces this per key.
+⚠️ **Placeholder parity is critical for `summary_i18n/` and `reason_i18n/`.** Each label is a Python `str.format` template; the translated value must carry the IDENTICAL set of `{field}` placeholders — including any format specs, e.g. `{distance:.2f}` — and escaped literal `{{`/`}}` as the English source, or the consuming code raises at render time (`_build_config_summary` for `summary_i18n/`; the `reason_i18n.py` resolver for `reason_i18n/`). `tests/test_config_flow_summary_i18n.py` enforces this per key for `summary_i18n/`; `tests/test_reason_i18n.py` (`test_reason_placeholder_parity_de_fr`) enforces it for `reason_i18n/`.
 
 ---
 
 ## Safety Rules
 
-- **Never delete `en.json`** (in either `translations/` or `summary_i18n/`).
+- **Never delete `en.json`** (in any of `translations/`, `summary_i18n/`, or `reason_i18n/`).
 - **Never write a translation file without running the validator and tests afterwards.**
 - **Never silently drop keys from a target file.** If a key was removed from en.json, the Sync operation must list it under "removed" in the report.
 - **If Haiku output fails JSON parse**, retry once; if still failing, dispatch Sonnet for that batch as a fallback. Do not return partial results.
@@ -354,6 +361,9 @@ translations/  en: <N> keys (unchanged)
   de.json: +<A> added, ~<C> changed, -<R> removed → <T> keys
   fr.json: +<A> added, ~<C> changed, -<R> removed → <T> keys
 summary_i18n/  en: <N> keys (unchanged)
+  de.json: +<A> added, ~<C> changed, -<R> removed → <T> keys
+  fr.json: +<A> added, ~<C> changed, -<R> removed → <T> keys
+reason_i18n/  en: <N> keys (unchanged)
   de.json: +<A> added, ~<C> changed, -<R> removed → <T> keys
   fr.json: +<A> added, ~<C> changed, -<R> removed → <T> keys
 

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -343,6 +343,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
 
     entry.async_on_unload(_cancel_forecast_timer)
 
+    # Prime the instance-language reason-template overlay once (issue #882),
+    # mirroring the summary_i18n priming: resolve the language the same way
+    # (the HA instance language, #905 semantics) and offload the bundle file
+    # read to the executor so no JSON I/O runs on the event loop. The resolved
+    # mapping is cached on the coordinator, threaded into the DiagnosticContext,
+    # and read by sensor.py to localize decision-trace reason strings.
+    from .reason_i18n import async_prime as _async_prime_reason_labels
+
+    coordinator._reason_labels = await _async_prime_reason_labels(
+        hass, hass.config.language or "en"
+    )
+
     # Store coordinator before platform setup so sensor async_added_to_hass can
     # access it during RestoreEntity rehydration (must run before first_refresh).
     entry.runtime_data = coordinator

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from functools import cache
 from pathlib import Path
@@ -218,6 +217,7 @@ from .const import (
     TemplateCombineMode,
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
+from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
 from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_sensors,
@@ -1654,16 +1654,13 @@ _SUMMARY_I18N_DIR = Path(__file__).parent / "summary_i18n"
 
 
 def _flatten_summary_labels(node: object, prefix: str = "") -> dict[str, str]:
-    """Flatten a nested label tree to dotted keys (``rules.force`` → template)."""
-    out: dict[str, str] = {}
-    if isinstance(node, dict):
-        for key, value in node.items():
-            out.update(
-                _flatten_summary_labels(value, f"{prefix}.{key}" if prefix else key)
-            )
-    elif isinstance(node, str):
-        out[prefix] = node
-    return out
+    """Flatten a nested label tree to dotted keys (``rules.force`` → template).
+
+    Thin delegate to the shared :func:`i18n_bundle.flatten_bundle` (issue #882
+    extracted the flatten/overlay/merge logic so summary_i18n and reason_i18n
+    share one implementation — no duplication).
+    """
+    return flatten_bundle(node, prefix)
 
 
 @cache
@@ -1673,15 +1670,9 @@ def _summary_label_overlay(language: str) -> tuple[tuple[str, str], ...]:
     Cached (the bundles are shipped, read-only) and returned as a tuple of items
     so the cached value cannot be mutated by callers. ``en`` and any missing or
     malformed file yield an empty overlay — the English defaults then apply.
+    Delegates the read/flatten to the shared :func:`i18n_bundle.load_bundle_overlay`.
     """
-    if not language or language == "en":
-        return ()
-    path = _SUMMARY_I18N_DIR / f"{language}.json"
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return ()
-    return tuple(_flatten_summary_labels(data).items())
+    return tuple(load_bundle_overlay(_SUMMARY_I18N_DIR, language).items())
 
 
 def _load_summary_labels_sync(language: str) -> dict[str, str]:
@@ -1690,7 +1681,7 @@ def _load_summary_labels_sync(language: str) -> dict[str, str]:
     English defaults overlaid with the translated bundle. Pure/synchronous —
     safe to unit-test directly.
     """
-    return {**_SUMMARY_LABELS_EN, **dict(_summary_label_overlay(language))}
+    return merge_labels(_SUMMARY_LABELS_EN, dict(_summary_label_overlay(language)))
 
 
 async def _load_summary_labels(hass: HomeAssistant, language: str) -> dict[str, str]:

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1377,7 +1377,7 @@ class ReasonCode(StrEnum):
     CUSTOM_HEAD_NAMED = "custom.head_named"
     CUSTOM_HEAD_SLOT = "custom.head_slot"
     CUSTOM_USE_MY = "custom.use_my"
-    CUSTOM_POSITION_ = "custom.position"
+    CUSTOM_POSITION = "custom.position"
 
     # -- default handler
     DEFAULT_SUNSET_USE_MY = "default.sunset_use_my"

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1312,6 +1312,130 @@ class ClimateInactiveReason:
     READINGS_UNAVAILABLE = "readings_unavailable"  # sensors misconfigured/unavailable
 
 
+class ReasonCode(StrEnum):
+    """Stable identifiers for every human-readable reason/explanation string.
+
+    Each value is the join key into the ``reason_i18n/`` template bundle
+    (mirrors the ``summary_i18n/`` mechanism): the integration renders the
+    English template on the ``sensor.*`` reason attributes and the Lovelace
+    card localizes the same codes+params into the user's language.
+
+    These are FROZEN identifiers exposed in diagnostics and consumed by the
+    card; do not rename without updating both ``reason_i18n/*.json`` and the
+    downstream card templates. Dotted values group by emitter
+    (``solar.*``, ``manual.*``, ``registry.*``, ``builder.*``, ``engine.*``,
+    ``skip.*``, ``fragment.*``).
+    """
+
+    # -- fragments: composed sub-phrases rendered inline into a parent template
+    FRAGMENT_SUNSET_POSITION = "fragment.sunset_position"
+    FRAGMENT_DEFAULT_POSITION = "fragment.default_position"
+    FRAGMENT_CLOUDY_POSITION = "fragment.cloudy_position"
+    FRAGMENT_COVERAGE_STEP = "fragment.coverage_step"
+    FRAGMENT_Z_ADJUSTED = "fragment.z_adjusted"
+    FRAGMENT_BYPASS_NOTE = "fragment.bypass_note"
+    FRAGMENT_SEASON_EXTREME_HEAT = "fragment.season_extreme_heat"
+    FRAGMENT_SEASON_TRACKING_OFF = "fragment.season_tracking_off"
+    FRAGMENT_SEASON_SUMMER = "fragment.season_summer"
+    FRAGMENT_SEASON_WINTER = "fragment.season_winter"
+    FRAGMENT_SEASON_GLARE_LOW_LIGHT = "fragment.season_glare_low_light"
+    FRAGMENT_SEASON_GLARE = "fragment.season_glare"
+    FRAGMENT_TRIGGER_NOT_SUNNY = "fragment.trigger_not_sunny"
+    FRAGMENT_TRIGGER_LUX_BELOW = "fragment.trigger_lux_below"
+    FRAGMENT_TRIGGER_IRRADIANCE_BELOW = "fragment.trigger_irradiance_below"
+    FRAGMENT_TRIGGER_CLOUD_ABOVE = "fragment.trigger_cloud_above"
+    FRAGMENT_TRIGGER_SMOOTHING_HOLD = "fragment.trigger_smoothing_hold"
+    FRAGMENT_TRIGGER_TEMPLATE = "fragment.trigger_template"
+    FRAGMENT_TRIGGER_FALLBACK = "fragment.trigger_fallback"
+
+    # -- solar handler
+    SOLAR_TRACKING = "solar.tracking"
+
+    # -- manual override handler
+    MANUAL_HOLDING_SOLAR = "manual.holding_solar"
+    MANUAL_SOLAR_ONLY = "manual.solar_only"
+    MANUAL_HOLDING_LABEL = "manual.holding_label"
+    MANUAL_LABEL_ONLY = "manual.label_only"
+
+    # -- motion/occupancy timeout handler (#881 wording)
+    OCCUPANCY_HOLDING = "occupancy.holding"
+    OCCUPANCY_LABEL = "occupancy.label"
+
+    # -- climate handler
+    CLIMATE_ACTIVE = "climate.active"
+
+    # -- glare zone handler
+    GLARE_PROTECTION = "glare.protection"
+
+    # -- cloud suppression handler
+    CLOUD_SUPPRESSION = "cloud.suppression"
+
+    # -- weather override handler
+    WEATHER_ACTIVE = "weather.active"
+
+    # -- custom position handler
+    CUSTOM_HEAD_NAMED = "custom.head_named"
+    CUSTOM_HEAD_SLOT = "custom.head_slot"
+    CUSTOM_USE_MY = "custom.use_my"
+    CUSTOM_POSITION_ = "custom.position"
+
+    # -- default handler
+    DEFAULT_SUNSET_USE_MY = "default.sunset_use_my"
+    DEFAULT_NO_CONDITION = "default.no_condition"
+
+    # -- group handlers
+    GROUP_LOCK = "group.lock"
+    GROUP_SCENE = "group.scene"
+
+    # -- registry composition (outprioritized / floor / tilt-axis passes)
+    REGISTRY_OUTPRIORITIZED = "registry.outprioritized"
+    REGISTRY_FLOOR_RAISED = "registry.floor_raised"
+    REGISTRY_FLOOR_INACTIVE = "registry.floor_inactive"
+    REGISTRY_TILT_APPLIED = "registry.tilt_applied"
+    REGISTRY_TILT_DEFERRED = "registry.tilt_deferred"
+
+    # -- diagnostics builder (control-state reason + position explanation)
+    BUILDER_UNKNOWN = "builder.unknown"
+    BUILDER_CONTROL_OCCUPANCY_TIMEOUT = "builder.control_occupancy_timeout"
+    BUILDER_CONTROL_MANUAL_OVERRIDE = "builder.control_manual_override"
+    BUILDER_CONTROL_TRACKING_OFF_SEASON = "builder.control_tracking_off_season"
+    BUILDER_CONTROL_TILT_FIXED = "builder.control_tilt_fixed"
+    BUILDER_OUTSIDE_WINDOW = "builder.outside_window"
+    BUILDER_MANUAL_DIVERGENCE = "builder.manual_divergence"
+    BUILDER_TILT_FIXED = "builder.tilt_fixed"
+    BUILDER_INTERPOLATED = "builder.interpolated"
+    BUILDER_INVERSED = "builder.inversed"
+
+    # -- engine control_state_reason (pure calc layer — codes resolved at boundary)
+    ENGINE_DIRECT_SUN = "engine.direct_sun"
+    ENGINE_DEFAULT_SUNSET_OFFSET = "engine.default_sunset_offset"
+    ENGINE_DEFAULT_ELEVATION_LIMIT = "engine.default_elevation_limit"
+    ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT = "engine.default_acceptance_angle_exit"
+    ENGINE_DEFAULT_BLIND_SPOT = "engine.default_blind_spot"
+    ENGINE_DEFAULT = "engine.default"
+
+    # -- describe_skip / inactive-reason prose
+    SKIP_OUTSIDE_WINDOW = "skip.outside_window"
+    SKIP_SUN_OUTSIDE = "skip.sun_outside"
+    SKIP_MANUAL_NOT_ACTIVE = "skip.manual_not_active"
+    SKIP_OCCUPANCY_DISABLED = "skip.occupancy_disabled"
+    SKIP_OCCUPANCY_NOT_ACTIVE = "skip.occupancy_not_active"
+    SKIP_CLIMATE_MODE_OFF = "skip.climate_mode_off"
+    SKIP_CLIMATE_READINGS_UNAVAILABLE = "skip.climate_readings_unavailable"
+    SKIP_CLIMATE_DEFERRED = "skip.climate_deferred"
+    SKIP_NO_GLARE_ZONES = "skip.no_glare_zones"
+    SKIP_CLOUD_SKIPPED = "skip.cloud_skipped"
+    SKIP_CLOUD_INACTIVE = "skip.cloud_inactive"
+    SKIP_WEATHER_NOT_ACTIVE = "skip.weather_not_active"
+    SKIP_CUSTOM_NOT_ACTIVE = "skip.custom_not_active"
+    SKIP_ALWAYS_MATCHES = "skip.always_matches"
+    SKIP_GROUP_SCENE_NOT_LOCK = "skip.group_scene_not_lock"
+    SKIP_NO_GROUP_LOCK = "skip.no_group_lock"
+    SKIP_GROUP_LOCK_NOT_SCENE = "skip.group_lock_not_scene"
+    SKIP_NO_GROUP_SCENE = "skip.no_group_scene"
+    SKIP_NOT_ACTIVE = "skip.not_active"
+
+
 # =============================================================================
 # 24. Geometric Accuracy (calc engine)
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -433,6 +433,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Diagnostics builder (extracted from coordinator)
         self._diagnostics_builder = DiagnosticsBuilder()
 
+        # Instance-language reason-template overlay (issue #882). Primed once in
+        # async_setup_entry via reason_i18n.async_prime(hass.config.language) and
+        # threaded into the DiagnosticContext + read by sensor.py so decision-trace
+        # reason strings render in the user's language. ``None`` → English defaults.
+        self._reason_labels: dict[str, str] | None = None
+
         # Track position explanation for change detection logging
         self._last_position_explanation: str = ""
 
@@ -3153,6 +3159,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self.config_entry.options.get(CONF_END_OF_WINDOW_POS) is not None
                 and not self.before_end_time
             ),
+            # issue #882: instance-language reason templates, primed once at setup.
+            reason_labels=self._reason_labels,
         )
 
         diagnostics, explanation = self._diagnostics_builder.build(ctx)

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -21,7 +21,7 @@ from ..const import (
     ReasonCode,
     SunState,
 )
-from ..reason_i18n import _REASON_TEMPLATES_EN, Reason, render
+from ..reason_i18n import Reason, render
 
 # Sensor state classifications (issue #693, Q3).
 _SENSOR_STATE_NOT_CONFIGURED = "not_configured"
@@ -284,7 +284,7 @@ class DiagnosticsBuilder:
         the cover's English ``control_state_reason`` prose when no code is
         exposed (e.g. legacy test doubles).
         """
-        labels = ctx.reason_labels or _REASON_TEMPLATES_EN
+        labels = ctx.reason_labels
         result = ctx.pipeline_result
         if result is not None and result.control_method == ControlMethod.MOTION:
             reason = render(
@@ -331,10 +331,10 @@ class DiagnosticsBuilder:
         When manual override is active and the cover's physical position diverges
         from the solar calculation, the divergence is surfaced explicitly.
         """
-        labels = ctx.reason_labels or _REASON_TEMPLATES_EN
+        labels = ctx.reason_labels
         result = ctx.pipeline_result
         if result is None:
-            return "Unknown"
+            return render(Reason(ReasonCode.BUILDER_UNKNOWN), labels)
 
         # Outside time window — pipeline ran but commands are gated
         if not ctx.check_adaptive_time:

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -9,11 +9,19 @@ never accesses the coordinator directly.
 from __future__ import annotations
 
 import datetime as dt
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from ..const import ControlStatus
-from ..const import ClimateStrategy, ControlMethod, FORECAST_STEP_MINUTES, SunState
+from ..const import (
+    ClimateStrategy,
+    ControlMethod,
+    FORECAST_STEP_MINUTES,
+    ReasonCode,
+    SunState,
+)
+from ..reason_i18n import _REASON_TEMPLATES_EN, Reason, render
 
 # Sensor state classifications (issue #693, Q3).
 _SENSOR_STATE_NOT_CONFIGURED = "not_configured"
@@ -164,6 +172,12 @@ class DiagnosticContext:
     # live reading.
     outside_temp_source: str = "live"
 
+    # issue #882: the instance-language reason-template overlay, primed once at
+    # setup by the coordinator (``coordinator._reason_labels``). ``None`` → the
+    # English defaults, so ``render(...)`` output is byte-identical on an EN
+    # install. Kept HA-free (a plain mapping) so the builder stays unit-testable.
+    reason_labels: Mapping[str, str] | None = None
+
 
 # ---------------------------------------------------------------------------
 # Strategy label map (moved from coordinator class attribute)
@@ -260,26 +274,51 @@ class DiagnosticsBuilder:
 
     @staticmethod
     def _get_control_state_reason(ctx: DiagnosticContext) -> str:
-        """Get the current control state reason from pipeline result or cover geometry."""
+        """Get the current control state reason from pipeline result or cover geometry.
+
+        Renders through the instance-language ``ctx.reason_labels`` overlay
+        (issue #882); ``None`` → English defaults, byte-identical to the legacy
+        prose. The builder-owned control-state labels emit ``Reason(builder.*)``
+        codes; the cover-geometry branch prefers the engine's stable
+        ``control_state_reason_code`` (rendered with labels) and falls back to
+        the cover's English ``control_state_reason`` prose when no code is
+        exposed (e.g. legacy test doubles).
+        """
+        labels = ctx.reason_labels or _REASON_TEMPLATES_EN
         result = ctx.pipeline_result
         if result is not None and result.control_method == ControlMethod.MOTION:
-            reason = "Occupancy Timeout"
+            reason = render(
+                Reason(ReasonCode.BUILDER_CONTROL_OCCUPANCY_TIMEOUT), labels
+            )
         elif result is not None and result.control_method == ControlMethod.MANUAL:
-            reason = "Manual Override"
+            reason = render(Reason(ReasonCode.BUILDER_CONTROL_MANUAL_OVERRIDE), labels)
         elif (
             result is not None
             and result.climate_strategy == ClimateStrategy.TRACKING_SEASON_GATE
         ):
-            reason = "Default: Tracking Off This Season"
+            reason = render(
+                Reason(ReasonCode.BUILDER_CONTROL_TRACKING_OFF_SEASON), labels
+            )
         elif ctx.cover:
-            reason = ctx.cover.control_state_reason
+            code = getattr(ctx.cover, "control_state_reason_code", None)
+            reason = (
+                render(Reason(code), labels)
+                if code is not None
+                else ctx.cover.control_state_reason
+            )
         else:
-            reason = "Unknown"
+            reason = render(Reason(ReasonCode.BUILDER_UNKNOWN), labels)
 
         # An applied tilt-only custom slot is otherwise invisible on the tracker
         # entity because the position winner owns the status (#667).
         if result is not None and result.tilt_only_slot is not None:
-            reason = f"{reason} — tilt fixed by Custom #{result.tilt_only_slot}"
+            reason = render(
+                Reason(
+                    ReasonCode.BUILDER_CONTROL_TILT_FIXED,
+                    {"reason": reason, "slot": result.tilt_only_slot},
+                ),
+                labels,
+            )
         return reason
 
     @staticmethod
@@ -292,6 +331,7 @@ class DiagnosticsBuilder:
         When manual override is active and the cover's physical position diverges
         from the solar calculation, the divergence is surfaced explicitly.
         """
+        labels = ctx.reason_labels or _REASON_TEMPLATES_EN
         result = ctx.pipeline_result
         if result is None:
             return "Unknown"
@@ -299,13 +339,28 @@ class DiagnosticsBuilder:
         # Outside time window — pipeline ran but commands are gated
         if not ctx.check_adaptive_time:
             pos = result.default_position
-            pos_label = (
-                "sunset position" if result.is_sunset_active else "default position"
+            pos_label = Reason(
+                ReasonCode.FRAGMENT_SUNSET_POSITION
+                if result.is_sunset_active
+                else ReasonCode.FRAGMENT_DEFAULT_POSITION
             )
-            return f"Outside time window → {pos_label} {pos}% (commands paused)"
+            return render(
+                Reason(
+                    ReasonCode.BUILDER_OUTSIDE_WINDOW,
+                    {"pos_label": pos_label, "pos": pos},
+                ),
+                labels,
+            )
 
-        # Base explanation is the pipeline reason (already human-readable)
-        parts: list[str] = [result.reason]
+        # Base explanation is the pipeline reason (already human-readable). Prefer
+        # the structured payload so the base localizes; fall back to the legacy
+        # English ``reason`` string when a result carries no payload.
+        base = (
+            render(result.reason_payload, labels)
+            if result.reason_payload is not None
+            else result.reason
+        )
+        parts: list[str] = [base]
 
         # Surface the divergence between the physical held position and the solar calc
         # only when they differ — avoids noise when the cover happens to be at the
@@ -316,23 +371,43 @@ class DiagnosticsBuilder:
             and result.held_position != result.raw_calculated_position
         ):
             parts.append(
-                f"manual override active — holding cover at {result.held_position}%"
-                f" (solar would be {result.raw_calculated_position}%)"
+                render(
+                    Reason(
+                        ReasonCode.BUILDER_MANUAL_DIVERGENCE,
+                        {
+                            "held": result.held_position,
+                            "raw": result.raw_calculated_position,
+                        },
+                    ),
+                    labels,
+                )
             )
 
         # Surface an applied tilt-only custom slot alongside the position winner
         # so it is visible in the Control Status string (#667).
         if result.tilt_only_slot is not None:
             parts.append(
-                f"tilt fixed at {result.tilt}% by Custom #{result.tilt_only_slot}"
+                render(
+                    Reason(
+                        ReasonCode.BUILDER_TILT_FIXED,
+                        {"tilt": result.tilt, "slot": result.tilt_only_slot},
+                    ),
+                    labels,
+                )
             )
 
         # Append post-processing transforms if they changed the value
         final = ctx.final_state
         if ctx.use_interpolation:
-            parts.append(f"interpolated → {final}%")
+            parts.append(
+                render(
+                    Reason(ReasonCode.BUILDER_INTERPOLATED, {"final": final}), labels
+                )
+            )
         elif ctx.inverse_state and final != result.position:
-            parts.append(f"inversed → {final}%")
+            parts.append(
+                render(Reason(ReasonCode.BUILDER_INVERSED, {"final": final}), labels)
+            )
 
         return " → ".join(parts)
 

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -8,6 +8,8 @@ from datetime import datetime
 
 from ...config_context_adapter import ConfigContextAdapter
 from ...config_types import CoverConfig
+from ...const import ReasonCode
+from ...reason_i18n import Reason, render_en
 from ...sun import SunData
 from ..sun_geometry import SunGeometry, azimuth_within_fov
 
@@ -230,19 +232,32 @@ class AdaptiveGeneralCover(ABC):
         return result
 
     @property
-    def control_state_reason(self) -> str:
-        """Determine why the cover is tracking the sun or using the default position."""
+    def control_state_reason_code(self) -> ReasonCode:
+        """Return the stable :class:`ReasonCode` for the current control state.
+
+        The pure engine emits a frozen code (no HA, no translation); the prose
+        is resolved at the diagnostics/sensor boundary. Branches mirror
+        :attr:`control_state_reason` exactly.
+        """
         if self.direct_sun_valid:
-            return "Direct Sun"
+            return ReasonCode.ENGINE_DIRECT_SUN
         if self.sunset_valid:
-            return "Default: Sunset Offset"
+            return ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET
         if not self.valid:
             if not self.valid_elevation:
-                return "Default: Elevation Limit"
-            return "Default: Acceptance Angle Exit"
+                return ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT
+            return ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT
         if self.is_sun_in_blind_spot:
-            return "Default: Blind Spot"
-        return "Default"
+            return ReasonCode.ENGINE_DEFAULT_BLIND_SPOT
+        return ReasonCode.ENGINE_DEFAULT
+
+    @property
+    def control_state_reason(self) -> str:
+        """Determine why the cover is tracking the sun or using the default position.
+
+        Byte-identical English shim over :attr:`control_state_reason_code`.
+        """
+        return render_en(Reason(self.control_state_reason_code))
 
     @abstractmethod
     def calculate_position(self) -> float:

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -17,7 +17,9 @@ from ..const import (
     DEGREES_IN_CIRCLE,
     OPTION_RANGES,
     BlindSpot,
+    ReasonCode,
 )
+from ..reason_i18n import Reason, render_en
 from ..sun import SunData
 
 
@@ -328,25 +330,43 @@ class SunGeometry:
         return result
 
     @property
+    def control_state_reason_code(self) -> ReasonCode:
+        """Return the stable :class:`ReasonCode` for the current control state.
+
+        The pure engine emits a frozen code (no HA, no translation); the prose
+        is resolved at the diagnostics/sensor boundary. Branches mirror
+        :attr:`control_state_reason` exactly.
+
+        Returns:
+            One of ``ReasonCode.ENGINE_*``: DIRECT_SUN, DEFAULT_SUNSET_OFFSET,
+            DEFAULT_ELEVATION_LIMIT, DEFAULT_ACCEPTANCE_ANGLE_EXIT,
+            DEFAULT_BLIND_SPOT, or DEFAULT.
+
+        """
+        if self.direct_sun_valid:
+            return ReasonCode.ENGINE_DIRECT_SUN
+        if self.sunset_valid:
+            return ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET
+        if not self.valid:
+            if not self.valid_elevation:
+                return ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT
+            return ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT
+        if self.is_sun_in_blind_spot:
+            return ReasonCode.ENGINE_DEFAULT_BLIND_SPOT
+        return ReasonCode.ENGINE_DEFAULT
+
+    @property
     def control_state_reason(self) -> str:
         """Determine why the cover is tracking the sun or using the default position.
+
+        Byte-identical English shim over :attr:`control_state_reason_code`.
 
         Returns:
             Reason string: "Direct Sun", "Default: Acceptance Angle Exit", "Default: Elevation Limit",
             "Default: Sunset Offset", or "Default: Blind Spot".
 
         """
-        if self.direct_sun_valid:
-            return "Direct Sun"
-        if self.sunset_valid:
-            return "Default: Sunset Offset"
-        if not self.valid:
-            if not self.valid_elevation:
-                return "Default: Elevation Limit"
-            return "Default: Acceptance Angle Exit"
-        if self.is_sun_in_blind_spot:
-            return "Default: Blind Spot"
-        return "Default"
+        return render_en(Reason(self.control_state_reason_code))
 
     # ------------------------------------------------------------------
     # FOV helpers

--- a/custom_components/adaptive_cover_pro/i18n_bundle.py
+++ b/custom_components/adaptive_cover_pro/i18n_bundle.py
@@ -1,0 +1,50 @@
+"""Shared i18n-bundle helpers (pure, stdlib only).
+
+Both the config/options ``summary_i18n/`` bundle (issue #258) and the runtime
+``reason_i18n/`` bundle (issue #882) ship translated templates as nested JSON
+trees and resolve them by overlaying a language bundle onto the code-owned
+English defaults. This module holds the flatten / load-overlay / merge logic
+so it lives in exactly one place (CODING_GUIDELINES § No Duplication) — both
+``config_flow._load_summary_labels_sync`` and ``reason_i18n.load_reason_labels``
+delegate here.
+
+No Home Assistant imports: the helpers take a directory + language and return
+plain dicts, safe to import from any layer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def flatten_bundle(node: object, prefix: str = "") -> dict[str, str]:
+    """Flatten a nested label tree to dotted keys (``{"a": {"b": "x"}}`` → ``{"a.b": "x"}``)."""
+    out: dict[str, str] = {}
+    if isinstance(node, dict):
+        for key, value in node.items():
+            out.update(flatten_bundle(value, f"{prefix}.{key}" if prefix else key))
+    elif isinstance(node, str):
+        out[prefix] = node
+    return out
+
+
+def load_bundle_overlay(directory: Path | str, language: str) -> dict[str, str]:
+    """Return the flattened ``<directory>/<language>.json`` overlay.
+
+    ``en`` (the code-owned source of truth) and any missing or malformed file
+    yield an empty overlay — the English defaults then apply unchanged.
+    """
+    if not language or language == "en":
+        return {}
+    path = Path(directory) / f"{language}.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return flatten_bundle(data)
+
+
+def merge_labels(defaults: dict[str, str], overlay: dict[str, str]) -> dict[str, str]:
+    """Overlay the translated bundle onto the English defaults, per key."""
+    return {**defaults, **overlay}

--- a/custom_components/adaptive_cover_pro/pipeline/handler.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handler.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from ..const import ReasonCode
+from ..reason_i18n import Reason
 from .types import PipelineResult, PipelineSnapshot
 
 
@@ -36,6 +38,12 @@ class OverrideHandler(ABC):
         """
         return {}
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
-        """Reason string when this handler does not match."""
-        return "not active"
+    def describe_skip(self, snapshot: PipelineSnapshot) -> str | Reason:  # noqa: ARG002
+        """Reason when this handler does not match.
+
+        May return either a legacy English ``str`` (subclass overrides not yet
+        migrated) or a stable :class:`Reason` payload. The registry normalizes
+        both — see ``PipelineRegistry.evaluate`` — so handlers migrate to codes
+        one batch at a time (issue #882).
+        """
+        return Reason(ReasonCode.SKIP_NOT_ACTIVE)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -20,14 +20,16 @@ from ...const import (
     ClimateInactiveReason,
     ClimateStrategy,
     ControlMethod,
+    ReasonCode,
 )
+from ...reason_i18n import Reason, _REASON_TEMPLATES_EN
 from ..handler import OverrideHandler
 from ..helpers import (
     apply_snapshot_limits,
     compute_raw_calculated_position,
     compute_solar_position,
 )
-from ..types import PipelineResult, PipelineSnapshot
+from ..types import DecisionStep, PipelineResult, PipelineSnapshot
 from .climate_modes import (
     NORMAL_WITH_PRESENCE,
     NORMAL_WITHOUT_PRESENCE,
@@ -277,23 +279,63 @@ class ClimateCoverState:
 
 
 # ---------------------------------------------------------------------------
-# Inactive-reason slug derivation — shared by ClimateHandler and sensor.py
+# Inactive-reason ↔ reason-code mapping — shared by ClimateHandler and sensor.py
 # ---------------------------------------------------------------------------
 
-# Maps each ClimateInactiveReason slug to a human-readable prose string.
-# This is the single source of truth so that describe_skip and the slug helper
-# stay in sync without duplicating branch logic.
-_SLUG_TO_PROSE: dict[str, str] = {
-    ClimateInactiveReason.MODE_OFF: "climate mode not enabled",
-    ClimateInactiveReason.OUTSIDE_TIME_WINDOW: "outside time window",
-    ClimateInactiveReason.READINGS_UNAVAILABLE: "climate readings or options unavailable",
-    ClimateInactiveReason.THRESHOLDS_NOT_MET: "deferred glare-control to solar/glare handlers",
-    # ACTIVE and OTHER_MODE_ACTIVE have no describe_skip prose (handler wins / outprioritized)
+# Each ClimateInactiveReason slug that has describe_skip prose maps to a frozen
+# ReasonCode (issue #882). The CODE — never the localized prose — is the join
+# key, so describe_skip and the reverse derivation below both stay
+# language-independent. ACTIVE and OTHER_MODE_ACTIVE have no describe_skip code
+# (the handler wins / is outprioritized before describe_skip runs).
+_INACTIVE_REASON_TO_CODE: dict[str, str] = {
+    ClimateInactiveReason.MODE_OFF: ReasonCode.SKIP_CLIMATE_MODE_OFF,
+    ClimateInactiveReason.OUTSIDE_TIME_WINDOW: ReasonCode.SKIP_OUTSIDE_WINDOW,
+    ClimateInactiveReason.READINGS_UNAVAILABLE: (
+        ReasonCode.SKIP_CLIMATE_READINGS_UNAVAILABLE
+    ),
+    ClimateInactiveReason.THRESHOLDS_NOT_MET: ReasonCode.SKIP_CLIMATE_DEFERRED,
 }
 
-# Reverse map for deriving a slug from a describe_skip prose string (sensor.py use).
-# Built once at module load from _SLUG_TO_PROSE — stays in sync automatically.
-_PROSE_TO_SLUG: dict[str, str] = {v: k for k, v in _SLUG_TO_PROSE.items()}
+# Reverse map: derive the inactive-reason slug from a decision step's frozen
+# reason CODE. Built once from the forward map so the two stay in sync.
+_CODE_TO_INACTIVE_REASON: dict[str, str] = {
+    code: slug for slug, code in _INACTIVE_REASON_TO_CODE.items()
+}
+
+# Defensive fallback for legacy, payload-less decision steps (pre-#882 steps
+# carrying only English prose). Built from the English templates so no prose
+# literal is duplicated here. Production steps always carry reason_payload, so
+# this only fires for hand-constructed or historical steps.
+_LEGACY_PROSE_TO_INACTIVE_REASON: dict[str, str] = {
+    _REASON_TEMPLATES_EN[code]: slug
+    for code, slug in _CODE_TO_INACTIVE_REASON.items()
+    if code in _REASON_TEMPLATES_EN
+}
+
+
+def _climate_step_inactive_reason(step: DecisionStep) -> str:
+    """Derive a ClimateInactiveReason from a non-winning climate decision step.
+
+    Keys on the frozen ``reason_payload.code`` (language-independent) — the
+    "outprioritized" case is detected by code equality with
+    ``ReasonCode.REGISTRY_OUTPRIORITIZED``, not by matching prose. Falls back to
+    English-prose matching only for legacy payload-less steps (defensive).
+    """
+    if step.matched:
+        return ClimateInactiveReason.ACTIVE
+    payload = step.reason_payload
+    if payload is not None:
+        if payload.code == ReasonCode.REGISTRY_OUTPRIORITIZED:
+            return ClimateInactiveReason.OTHER_MODE_ACTIVE
+        return _CODE_TO_INACTIVE_REASON.get(
+            payload.code, ClimateInactiveReason.THRESHOLDS_NOT_MET
+        )
+    # Legacy payload-less step: match the English prose (defensive only).
+    if step.reason.startswith("outprioritized by"):
+        return ClimateInactiveReason.OTHER_MODE_ACTIVE
+    return _LEGACY_PROSE_TO_INACTIVE_REASON.get(
+        step.reason, ClimateInactiveReason.THRESHOLDS_NOT_MET
+    )
 
 
 def inactive_reason(
@@ -323,16 +365,13 @@ def inactive_reason(
     if snapshot.climate_readings is None or snapshot.climate_options is None:
         return ClimateInactiveReason.READINGS_UNAVAILABLE
 
-    # Inspect the decision trace for the climate step.
+    # Inspect the decision trace for the climate step. The distinction between
+    # ACTIVE / OTHER_MODE_ACTIVE / THRESHOLDS_NOT_MET is derived from the step's
+    # frozen reason CODE (see _climate_step_inactive_reason), not its prose.
     if pipeline_result is not None:
         for step in pipeline_result.decision_trace:
             if step.handler == "climate":
-                if step.matched:
-                    return ClimateInactiveReason.ACTIVE
-                if step.reason.startswith("outprioritized by"):
-                    return ClimateInactiveReason.OTHER_MODE_ACTIVE
-                # Present but not matched and not outprioritized → deferred
-                return ClimateInactiveReason.THRESHOLDS_NOT_MET
+                return _climate_step_inactive_reason(step)
 
     # No climate step in trace (e.g. climate deferred without a trace entry)
     return ClimateInactiveReason.THRESHOLDS_NOT_MET
@@ -343,9 +382,10 @@ def inactive_reason_from_result(
 ) -> str:
     """Derive a ClimateInactiveReason slug from a PipelineResult alone.
 
-    Used by sensor.py where no PipelineSnapshot is in scope.  Inspects the
-    decision_trace climate step and maps via _PROSE_TO_SLUG (the reverse of
-    the _SLUG_TO_PROSE map that describe_skip uses) — single source of truth.
+    Used by sensor.py where no PipelineSnapshot is in scope. Inspects the
+    decision_trace climate step and maps its frozen ``reason_payload.code`` back
+    to a slug via _CODE_TO_INACTIVE_REASON. Keying on the CODE — not the
+    (now localizable) prose — keeps this join language-independent (issue #882).
 
     Falls back to MODE_OFF when the result is None or has no climate step.
     """
@@ -354,14 +394,7 @@ def inactive_reason_from_result(
 
     for step in pipeline_result.decision_trace:
         if step.handler == "climate":
-            if step.matched:
-                return ClimateInactiveReason.ACTIVE
-            if step.reason.startswith("outprioritized by"):
-                return ClimateInactiveReason.OTHER_MODE_ACTIVE
-            # Map the prose reason back to a slug via the reverse map.
-            return _PROSE_TO_SLUG.get(
-                step.reason, ClimateInactiveReason.THRESHOLDS_NOT_MET
-            )
+            return _climate_step_inactive_reason(step)
 
     # No climate step in trace → climate was never considered → mode off or not applicable.
     return ClimateInactiveReason.MODE_OFF
@@ -445,7 +478,7 @@ class ClimateHandler(OverrideHandler):
             # get_state()/apply_snapshot_limits above — this branch only sets the
             # label + control method, never a short-circuit before get_state().
             method = ControlMethod.EXTREME_HEAT
-            season = "extreme heat"
+            season_code = ReasonCode.FRAGMENT_SEASON_EXTREME_HEAT
         elif (
             climate_cover_state.climate_strategy == ClimateStrategy.TRACKING_SEASON_GATE
         ):
@@ -454,28 +487,31 @@ class ClimateHandler(OverrideHandler):
             # before is_summer/is_winter because the gate can fire in any season
             # the user deselected, and DEFAULT is the honest control method.
             method = ControlMethod.DEFAULT
-            season = "default: tracking off this season"
+            season_code = ReasonCode.FRAGMENT_SEASON_TRACKING_OFF
         elif climate_data.is_summer:
             method = ControlMethod.SUMMER
-            season = "summer"
+            season_code = ReasonCode.FRAGMENT_SEASON_SUMMER
         elif climate_data.is_winter:
             method = ControlMethod.WINTER
-            season = "winter"
+            season_code = ReasonCode.FRAGMENT_SEASON_WINTER
         elif climate_cover_state.climate_strategy == ClimateStrategy.LOW_LIGHT:
             # Low-light / no-sun branch — the cover returns to its default
             # position rather than tracking the sun.  Emitting SOLAR here
             # would cause VenetianPolicy to synthesise a tilt from the
             # still-drifting azimuth even when the sun has set (issue #33).
             method = ControlMethod.DEFAULT
-            season = "glare control (low light)"
+            season_code = ReasonCode.FRAGMENT_SEASON_GLARE_LOW_LIGHT
         else:
             method = ControlMethod.SOLAR
-            season = "glare control"
+            season_code = ReasonCode.FRAGMENT_SEASON_GLARE
 
         return PipelineResult(
             position=position,
             control_method=method,
-            reason=f"climate mode active ({season}) — position {position}%",
+            reason_payload=Reason(
+                ReasonCode.CLIMATE_ACTIVE,
+                {"season": Reason(season_code), "position": position},
+            ),
             climate_state=position,
             climate_strategy=climate_cover_state.climate_strategy,
             climate_data=climate_data,
@@ -494,13 +530,15 @@ class ClimateHandler(OverrideHandler):
             return {}
         return {"climate_data": climate_data}
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when climate handler does not match.
 
         Delegates to the inactive_reason slug helper (single source of truth)
-        and maps each slug to its prose via _SLUG_TO_PROSE.  The other_mode_active
-        and active slugs never reach describe_skip (those paths win the handler),
-        so their prose entries are omitted from the map.
+        and maps each slug to its frozen ReasonCode via _INACTIVE_REASON_TO_CODE
+        so the registry can localize it (issue #882). The other_mode_active and
+        active slugs never reach describe_skip (those paths win the handler), so
+        their codes are omitted from the map.
         """
         slug = inactive_reason(snapshot, pipeline_result=None)
-        return _SLUG_TO_PROSE.get(slug, slug)
+        code = _INACTIVE_REASON_TO_CODE.get(slug, ReasonCode.SKIP_NOT_ACTIVE)
+        return Reason(code)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/cloud_suppression.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import (
     apply_snapshot_limits,
@@ -50,43 +51,49 @@ class CloudSuppressionHandler(OverrideHandler):
             return None
 
         r = snapshot.climate_readings
-        triggers = []
+        triggers: list[Reason] = []
         if not r.is_sunny:
-            triggers.append("weather not sunny")
+            triggers.append(Reason(ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY))
         if r.lux_below_threshold:
-            triggers.append("lux below threshold")
+            triggers.append(Reason(ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW))
         if r.irradiance_below_threshold:
-            triggers.append("irradiance below threshold")
+            triggers.append(Reason(ReasonCode.FRAGMENT_TRIGGER_IRRADIANCE_BELOW))
         if r.cloud_coverage_above_threshold:
-            triggers.append("cloud coverage above threshold")
+            triggers.append(Reason(ReasonCode.FRAGMENT_TRIGGER_CLOUD_ABOVE))
         # The latch may be held by hysteresis / hold-time with no raw trigger
         # momentarily met — label that as a smoothing hold (issue #864).
         if not triggers:
-            triggers.append("smoothing hold")
+            triggers.append(Reason(ReasonCode.FRAGMENT_TRIGGER_SMOOTHING_HOLD))
 
         cloudy = snapshot.climate_options.cloudy_position
         if snapshot.is_sunset_active:
             position = compute_default_position(snapshot)
-            pos_label = "sunset position"
+            pos_label = Reason(ReasonCode.FRAGMENT_SUNSET_POSITION)
         elif cloudy is not None:
             position = apply_snapshot_limits(snapshot, cloudy, sun_valid=False)
-            pos_label = "cloudy position"
+            pos_label = Reason(ReasonCode.FRAGMENT_CLOUDY_POSITION)
         else:
             position = compute_default_position(snapshot)
-            pos_label = "default position"
+            pos_label = Reason(ReasonCode.FRAGMENT_DEFAULT_POSITION)
 
-        trigger_detail = ", ".join(triggers)
         return PipelineResult(
             position=position,
             control_method=ControlMethod.CLOUD,
-            reason=f"cloud/low-light suppression — {trigger_detail} → {pos_label} {position}%",
+            reason_payload=Reason(
+                ReasonCode.CLOUD_SUPPRESSION,
+                {
+                    "triggers": tuple(triggers),
+                    "pos_label": pos_label,
+                    "position": position,
+                },
+            ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when cloud suppression is not active."""
         if not snapshot.in_time_window:
-            return "outside time window"
+            return Reason(ReasonCode.SKIP_OUTSIDE_WINDOW)
         if not snapshot.cover.direct_sun_valid:
-            return "cloud suppression skipped (sun outside acceptance angle)"
-        return "cloud suppression inactive (direct sun present or feature disabled)"
+            return Reason(ReasonCode.SKIP_CLOUD_SKIPPED)
+        return Reason(ReasonCode.SKIP_CLOUD_INACTIVE)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from ...const import (
     CUSTOM_POSITION_SAFETY_PRIORITY,
     ControlMethod,
+    ReasonCode,
     custom_position_handler_name,
 )
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
 from ..types import CustomPositionSensorState, PipelineResult, PipelineSnapshot
@@ -72,27 +74,36 @@ class CustomPositionHandler(OverrideHandler):
         return self.priority >= CUSTOM_POSITION_SAFETY_PRIORITY
 
     @staticmethod
-    def _trigger_label(state: CustomPositionSensorState) -> str:
-        """Describe what activated the slot, for reason strings.
+    def _trigger_param(state: CustomPositionSensorState) -> object:
+        """Describe what activated the slot, as a reason-template param.
 
-        Active sensors are joined like the old force-override reason; a
-        template-only activation reads ``template``.
+        Active sensor entity ids stay scalar strings (never translated); a
+        template activation contributes a ``trigger_template`` fragment. When
+        both are present the value is a tuple rendered joined by ``", "`` (the
+        old force-override reason format). A slot with neither falls back to the
+        ``trigger_fallback`` fragment.
         """
-        parts = list(state.active_entity_ids)
+        parts: list[object] = list(state.active_entity_ids)
         if state.template_active:
-            parts.append("template")
-        return ", ".join(parts) if parts else "trigger"
+            parts.append(Reason(ReasonCode.FRAGMENT_TRIGGER_TEMPLATE))
+        if parts:
+            return tuple(parts)
+        return Reason(ReasonCode.FRAGMENT_TRIGGER_FALLBACK)
 
-    def _reason_head(self, state: CustomPositionSensorState) -> str:
-        """Return the leading clause of the reason string (issue #867).
+    def _reason_head(self, state: CustomPositionSensorState) -> Reason:
+        """Return the leading-clause fragment of the reason (issue #867).
 
-        A configured slot name reads ``"<name> active"``; otherwise falls
-        back to today's exact ``"custom position #N active (trigger)"`` form.
-        Single source of truth for both PipelineResult reason branches below.
+        A configured slot name renders ``"<name> active"`` (the name is a raw
+        scalar, never translated); otherwise falls back to today's exact
+        ``"custom position #N active (trigger)"`` form. Single source of truth
+        for both PipelineResult reason branches below.
         """
         if state.custom_name:
-            return f"{state.custom_name} active"
-        return f"custom position #{self._slot} active ({self._trigger_label(state)})"
+            return Reason(ReasonCode.CUSTOM_HEAD_NAMED, {"name": state.custom_name})
+        return Reason(
+            ReasonCode.CUSTOM_HEAD_SLOT,
+            {"slot": self._slot, "trigger": self._trigger_param(state)},
+        )
 
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
         """Return the configured position when this slot's trigger is active.
@@ -120,8 +131,10 @@ class CustomPositionHandler(OverrideHandler):
                     # Issue #767: only the priority-100 safety slot bypasses the
                     # Automatic-Control-OFF gate. Ordinary slots respect the switch.
                     bypass_auto_control = self._is_safety
-                    bypass_note = (
-                        " [bypasses automatic control]" if bypass_auto_control else ""
+                    bypass_note: Reason | str = (
+                        Reason(ReasonCode.FRAGMENT_BYPASS_NOTE)
+                        if bypass_auto_control
+                        else ""
                     )
                     # "Use My" path: route through the cover's hardware-stored My preset.
                     # my_position_value acts as both the target and the reason annotation.
@@ -135,8 +148,13 @@ class CustomPositionHandler(OverrideHandler):
                             bypass_auto_control=bypass_auto_control,
                             is_safety=self._is_safety,
                             control_method=ControlMethod.CUSTOM_POSITION,
-                            reason=(
-                                f"{reason_head} — use My position ({pos}%){bypass_note}"
+                            reason_payload=Reason(
+                                ReasonCode.CUSTOM_USE_MY,
+                                {
+                                    "head": reason_head,
+                                    "position": pos,
+                                    "bypass_note": bypass_note,
+                                },
                             ),
                             raw_calculated_position=raw,
                             custom_position_active_slot=self._slot,
@@ -152,7 +170,14 @@ class CustomPositionHandler(OverrideHandler):
                         bypass_auto_control=bypass_auto_control,
                         is_safety=self._is_safety,
                         control_method=ControlMethod.CUSTOM_POSITION,
-                        reason=f"{reason_head} — position {pos}%{bypass_note}",
+                        reason_payload=Reason(
+                            ReasonCode.CUSTOM_POSITION_,
+                            {
+                                "head": reason_head,
+                                "position": pos,
+                                "bypass_note": bypass_note,
+                            },
+                        ),
                         raw_calculated_position=raw,
                         custom_position_active_slot=self._slot,
                         custom_position_minimum_mode=None,
@@ -164,6 +189,6 @@ class CustomPositionHandler(OverrideHandler):
         # Slot not found in snapshot — configuration mismatch or not yet loaded
         return None
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:  # noqa: ARG002
         """Reason when this slot's trigger is not active."""
-        return f"custom position #{self._slot} not active"
+        return Reason(ReasonCode.SKIP_CUSTOM_NOT_ACTIVE, {"slot": self._slot})

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -171,7 +171,7 @@ class CustomPositionHandler(OverrideHandler):
                         is_safety=self._is_safety,
                         control_method=ControlMethod.CUSTOM_POSITION,
                         reason_payload=Reason(
-                            ReasonCode.CUSTOM_POSITION_,
+                            ReasonCode.CUSTOM_POSITION,
                             {
                                 "head": reason_head,
                                 "position": pos,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/default.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/default.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
 from ...position_utils import PositionConverter
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_default_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -63,20 +64,27 @@ class DefaultHandler(OverrideHandler):
                 tilt=tilt,
                 use_my_position=True,
                 control_method=ControlMethod.DEFAULT,
-                reason=f"sunset position — use My position ({pos}%)",
+                reason_payload=Reason(
+                    ReasonCode.DEFAULT_SUNSET_USE_MY, {"position": pos}
+                ),
                 raw_calculated_position=position,
             )
-        pos_label = (
-            "sunset position" if snapshot.is_sunset_active else "default position"
+        pos_label = Reason(
+            ReasonCode.FRAGMENT_SUNSET_POSITION
+            if snapshot.is_sunset_active
+            else ReasonCode.FRAGMENT_DEFAULT_POSITION
         )
         return PipelineResult(
             position=position,
             tilt=tilt,
             control_method=ControlMethod.DEFAULT,
-            reason=f"no active condition — {pos_label} {position}%",
+            reason_payload=Reason(
+                ReasonCode.DEFAULT_NO_CONDITION,
+                {"pos_label": pos_label, "position": position},
+            ),
             raw_calculated_position=position,
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:  # noqa: ARG002
         """DefaultHandler always matches — this should never be called."""
-        return "always matches"
+        return Reason(ReasonCode.SKIP_ALWAYS_MATCHES)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/glare_zone.py
@@ -15,7 +15,8 @@ from ...engine.covers.vertical import (
     AdaptiveVerticalCover,
     glare_zone_effective_distance,
 )
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import (
     apply_snapshot_limits,
@@ -131,19 +132,26 @@ class GlareZoneHandler(OverrideHandler):
 
         zone_names = ", ".join(contributing_zones)
         z_adjusted = any(zones_by_name[name].z > 0 for name in contributing_zones)
-        z_suffix = " (Z-adjusted)" if z_adjusted else ""
+        z_suffix: Reason | str = (
+            Reason(ReasonCode.FRAGMENT_Z_ADJUSTED) if z_adjusted else ""
+        )
         return PipelineResult(
             position=position,
             control_method=ControlMethod.GLARE_ZONE,
-            reason=(
-                f"glare zone protection ({zone_names}) — "
-                f"effective distance {min_distance:.2f}m{z_suffix} → position {position}%"
+            reason_payload=Reason(
+                ReasonCode.GLARE_PROTECTION,
+                {
+                    "zones": zone_names,
+                    "distance": min_distance,
+                    "z_suffix": z_suffix,
+                    "position": position,
+                },
             ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when glare zone handler does not match."""
         if not snapshot.in_time_window:
-            return "outside time window"
-        return "no active glare zones or sun outside acceptance angle"
+            return Reason(ReasonCode.SKIP_OUTSIDE_WINDOW)
+        return Reason(ReasonCode.SKIP_NO_GLARE_ZONES)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
@@ -10,7 +10,13 @@ physical safety local to the cover trumps a zone lock.
 
 from __future__ import annotations
 
-from ...const import CUSTOM_POSITION_SAFETY_PRIORITY, ControlMethod, GroupIntentKind
+from ...const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    ControlMethod,
+    GroupIntentKind,
+    ReasonCode,
+)
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -39,15 +45,18 @@ class GroupLockHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.GROUP_LOCK,
-            reason=(f"group lock from group {intent.group_id} — holding {position}%"),
+            reason_payload=Reason(
+                ReasonCode.GROUP_LOCK,
+                {"group_id": intent.group_id, "position": position},
+            ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
             held_position=held,
             skip_command=True,
             bypass_auto_control=True,
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when no lock intent is live."""
         if snapshot.group_intent is not None:
-            return "group intent is a scene, not a lock"
-        return "no group lock intent"
+            return Reason(ReasonCode.SKIP_GROUP_SCENE_NOT_LOCK)
+        return Reason(ReasonCode.SKIP_NO_GROUP_LOCK)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_scene.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_scene.py
@@ -8,8 +8,14 @@ still overrides a group scene. Not user-overridable.
 
 from __future__ import annotations
 
-from ...const import GROUP_SCENE_PRIORITY, ControlMethod, GroupIntentKind
+from ...const import (
+    GROUP_SCENE_PRIORITY,
+    ControlMethod,
+    GroupIntentKind,
+    ReasonCode,
+)
 from ...cover_types import get_policy
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -37,9 +43,13 @@ class GroupSceneHandler(OverrideHandler):
         return PipelineResult(
             position=position,
             control_method=ControlMethod.GROUP_SCENE,
-            reason=(
-                f"group scene '{intent.scene}' from group {intent.group_id}"
-                f" → {position}%"
+            reason_payload=Reason(
+                ReasonCode.GROUP_SCENE,
+                {
+                    "scene": intent.scene,
+                    "group_id": intent.group_id,
+                    "position": position,
+                },
             ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
             # Explicit user intent: runs even with automatic control off —
@@ -47,8 +57,8 @@ class GroupSceneHandler(OverrideHandler):
             bypass_auto_control=True,
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when no scene intent is live."""
         if snapshot.group_intent is not None:
-            return "group intent is a lock, not a scene"
-        return "no group scene intent"
+            return Reason(ReasonCode.SKIP_GROUP_LOCK_NOT_SCENE)
+        return Reason(ReasonCode.SKIP_NO_GROUP_SCENE)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/manual_override.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import (
     compute_default_position,
@@ -38,29 +39,40 @@ class ManualOverrideHandler(OverrideHandler):
         if snapshot.cover.direct_sun_valid:
             position = compute_solar_position(snapshot)
             if held_position is not None:
-                reason = (
-                    f"manual override active — holding {held_position}%"
-                    f" (solar would-be {position}%)"
+                reason_payload = Reason(
+                    ReasonCode.MANUAL_HOLDING_SOLAR,
+                    {"held": held_position, "position": position},
                 )
             else:
-                reason = f"manual override active — solar would-be {position}%"
+                reason_payload = Reason(
+                    ReasonCode.MANUAL_SOLAR_ONLY, {"position": position}
+                )
         else:
             position = compute_default_position(snapshot)
-            pos_label = (
-                "sunset position" if snapshot.is_sunset_active else "default position"
+            pos_label = Reason(
+                ReasonCode.FRAGMENT_SUNSET_POSITION
+                if snapshot.is_sunset_active
+                else ReasonCode.FRAGMENT_DEFAULT_POSITION
             )
             if held_position is not None:
-                reason = (
-                    f"manual override active — holding {held_position}%"
-                    f" ({pos_label} would be {position}%)"
+                reason_payload = Reason(
+                    ReasonCode.MANUAL_HOLDING_LABEL,
+                    {
+                        "held": held_position,
+                        "pos_label": pos_label,
+                        "position": position,
+                    },
                 )
             else:
-                reason = f"manual override active — {pos_label} {position}%"
+                reason_payload = Reason(
+                    ReasonCode.MANUAL_LABEL_ONLY,
+                    {"pos_label": pos_label, "position": position},
+                )
 
         return PipelineResult(
             position=position,
             control_method=ControlMethod.MANUAL,
-            reason=reason,
+            reason_payload=reason_payload,
             raw_calculated_position=compute_raw_calculated_position(snapshot),
             held_position=held_position,
             # When the cover's physical position is known, genuinely hold there:
@@ -72,6 +84,6 @@ class ManualOverrideHandler(OverrideHandler):
             skip_command=held_position is not None,
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:  # noqa: ARG002
         """Reason when manual override is not active."""
-        return "manual override not active"
+        return Reason(ReasonCode.SKIP_MANUAL_NOT_ACTIVE)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_default_position, compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -40,24 +41,29 @@ class MotionTimeoutHandler(OverrideHandler):
             return PipelineResult(
                 position=held,
                 control_method=ControlMethod.MOTION,
-                reason=f"occupancy timeout — holding position {held}% (sun within acceptance angle)",
+                reason_payload=Reason(ReasonCode.OCCUPANCY_HOLDING, {"held": held}),
                 skip_command=True,
                 raw_calculated_position=compute_raw_calculated_position(snapshot),
             )
 
         position = compute_default_position(snapshot)
-        pos_label = (
-            "sunset position" if snapshot.is_sunset_active else "default position"
+        pos_label = Reason(
+            ReasonCode.FRAGMENT_SUNSET_POSITION
+            if snapshot.is_sunset_active
+            else ReasonCode.FRAGMENT_DEFAULT_POSITION
         )
         return PipelineResult(
             position=position,
             control_method=ControlMethod.MOTION,
-            reason=f"occupancy timeout active — {pos_label} {position}%",
+            reason_payload=Reason(
+                ReasonCode.OCCUPANCY_LABEL,
+                {"pos_label": pos_label, "position": position},
+            ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when occupancy timeout is not active."""
         if not snapshot.motion_control_enabled:
-            return "occupancy detection disabled"
-        return "occupancy timeout not active"
+            return Reason(ReasonCode.SKIP_OCCUPANCY_DISABLED)
+        return Reason(ReasonCode.SKIP_OCCUPANCY_NOT_ACTIVE)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/solar.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/solar.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import anticipated_solar_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -28,19 +29,21 @@ class SolarHandler(OverrideHandler):
             return None
 
         position = anticipated_solar_position(snapshot)
-        reason = f"sun within acceptance angle — position {position}%"
+        suffix: Reason | str = ""
         if getattr(snapshot, "minimize_movements", False):
             steps = getattr(snapshot, "max_coverage_steps", 1)
-            reason += f" (coverage step, max {steps})"
+            suffix = Reason(ReasonCode.FRAGMENT_COVERAGE_STEP, {"steps": steps})
         return PipelineResult(
             position=position,
             control_method=ControlMethod.SOLAR,
-            reason=reason,
+            reason_payload=Reason(
+                ReasonCode.SOLAR_TRACKING, {"position": position, "suffix": suffix}
+            ),
             raw_calculated_position=position,
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:
         """Reason when solar handler does not match."""
         if not snapshot.in_time_window:
-            return "outside time window"
-        return "sun outside acceptance angle or elevation limits"
+            return Reason(ReasonCode.SKIP_OUTSIDE_WINDOW)
+        return Reason(ReasonCode.SKIP_SUN_OUTSIDE)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/weather.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/weather.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from ...const import ControlMethod
+from ...const import ControlMethod, ReasonCode
+from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
 from ..types import PipelineResult, PipelineSnapshot
@@ -42,18 +43,21 @@ class WeatherOverrideHandler(OverrideHandler):
         pos = snapshot.weather_override_position
         bypass = snapshot.weather_bypass_auto_control
         raw = compute_raw_calculated_position(snapshot)
-        reason = f"weather override active — position {pos}%"
+        bypass_note: Reason | str = ""
         if bypass:
-            reason += " [bypasses automatic control]"
+            bypass_note = Reason(ReasonCode.FRAGMENT_BYPASS_NOTE)
         return PipelineResult(
             position=pos,
             control_method=ControlMethod.WEATHER,
-            reason=reason,
+            reason_payload=Reason(
+                ReasonCode.WEATHER_ACTIVE,
+                {"position": pos, "bypass_note": bypass_note},
+            ),
             bypass_auto_control=bypass,
             is_safety=True,
             raw_calculated_position=raw,
         )
 
-    def describe_skip(self, snapshot: PipelineSnapshot) -> str:  # noqa: ARG002
+    def describe_skip(self, snapshot: PipelineSnapshot) -> Reason:  # noqa: ARG002
         """Reason when weather override is not active."""
-        return "weather override not active"
+        return Reason(ReasonCode.SKIP_WEATHER_NOT_ACTIVE)

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -5,11 +5,27 @@ from __future__ import annotations
 import dataclasses
 import datetime as dt
 
+from ..const import ReasonCode
 from ..diagnostics.event_buffer import EventBuffer
+from ..reason_i18n import Reason, render_en
 from .floors import effective_floor, gather_active_floors
 from .handler import OverrideHandler
 from .tilt_axis import resolve_tilt_axis
 from .types import DecisionStep, PipelineResult, PipelineSnapshot
+
+
+def _normalize_reason(value: str | Reason) -> tuple[str, Reason | None]:
+    """Split a str-or-:class:`Reason` into (english text, payload-or-None).
+
+    Handlers migrate their ``describe_skip`` / ``reason`` emitters to stable
+    :class:`Reason` codes one batch at a time (issue #882). Until every emitter
+    is migrated the registry must accept both: a ``Reason`` yields its
+    English rendering plus the payload (for the card); a legacy ``str`` passes
+    through unchanged with no payload.
+    """
+    if isinstance(value, Reason):
+        return render_en(value), value
+    return value, None
 
 
 def _drop_trace_steps(
@@ -82,6 +98,7 @@ class PipelineRegistry:
                             handler=handler.name,
                             matched=True,
                             reason=result.reason,
+                            reason_payload=result.reason_payload,
                             position=result.position,
                             held_position=result.held_position,
                             priority=handler.priority,
@@ -92,17 +109,24 @@ class PipelineRegistry:
                         DecisionStep(
                             handler=handler.name,
                             matched=False,
-                            reason=f"outprioritized by {winning_handler.name}",
+                            reason_payload=Reason(
+                                ReasonCode.REGISTRY_OUTPRIORITIZED,
+                                {"handler": winning_handler.name},
+                            ),
                             position=result.position,
                             priority=handler.priority,
                         )
                     )
             else:
+                skip_text, skip_payload = _normalize_reason(
+                    handler.describe_skip(snapshot)
+                )
                 trace.append(
                     DecisionStep(
                         handler=handler.name,
                         matched=False,
-                        reason=handler.describe_skip(snapshot),
+                        reason=skip_text,
+                        reason_payload=skip_payload,
                         position=None,
                         priority=handler.priority,
                     )
@@ -166,9 +190,13 @@ class PipelineRegistry:
                 DecisionStep(
                     handler="floor_clamp",
                     matched=True,
-                    reason=(
-                        f"floor raised winner from {effective_winner_pos}% to "
-                        f"{floor_pos}% by {floor_info.label}"
+                    reason_payload=Reason(
+                        ReasonCode.REGISTRY_FLOOR_RAISED,
+                        {
+                            "from_pos": effective_winner_pos,
+                            "to_pos": floor_pos,
+                            "label": floor_info.label,
+                        },
                     ),
                     position=floor_pos,
                 )
@@ -186,9 +214,12 @@ class PipelineRegistry:
                 DecisionStep(
                     handler=info.source,
                     matched=False,
-                    reason=(
-                        f"floor {info.position}% inactive "
-                        f"(winner {effective_winner_pos}% above floor)"
+                    reason_payload=Reason(
+                        ReasonCode.REGISTRY_FLOOR_INACTIVE,
+                        {
+                            "floor_pos": info.position,
+                            "winner_pos": effective_winner_pos,
+                        },
                     ),
                     position=info.position,
                 )
@@ -221,10 +252,13 @@ class PipelineRegistry:
                     DecisionStep(
                         handler=tilt_contribution.source,
                         matched=True,
-                        reason=(
-                            f"tilt-only: slat angle fixed at "
-                            f"{tilt_contribution.tilt}% by {tilt_contribution.label}"
-                            f"; position driven by {winning_handler.name}"
+                        reason_payload=Reason(
+                            ReasonCode.REGISTRY_TILT_APPLIED,
+                            {
+                                "tilt": tilt_contribution.tilt,
+                                "label": tilt_contribution.label,
+                                "handler": winning_handler.name,
+                            },
                         ),
                         position=None,
                         tilt=tilt_contribution.tilt,
@@ -235,10 +269,13 @@ class PipelineRegistry:
                     DecisionStep(
                         handler=tilt_contribution.source,
                         matched=False,
-                        reason=(
-                            f"tilt-only {tilt_contribution.tilt}% deferred — "
-                            f"{winning_handler.name} already set tilt "
-                            f"{winner.tilt}%"
+                        reason_payload=Reason(
+                            ReasonCode.REGISTRY_TILT_DEFERRED,
+                            {
+                                "tilt": tilt_contribution.tilt,
+                                "handler": winning_handler.name,
+                                "winner_tilt": winner.tilt,
+                            },
                         ),
                         position=None,
                         tilt=tilt_contribution.tilt,

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -12,6 +12,7 @@ from ..const import (
     GroupIntentKind,
     GroupScene,
 )
+from ..reason_i18n import Reason, render_en
 
 if TYPE_CHECKING:
     from ..config_types import CoverConfig, GlareZonesConfig
@@ -324,8 +325,12 @@ class DecisionStep:
 
     handler: str
     matched: bool
-    reason: str
-    position: int | None
+    # Canonical English reason string. When ``reason_payload`` is provided and
+    # ``reason`` is left empty, ``__post_init__`` derives ``reason`` from it via
+    # ``render_en`` so the byte-identical EN prose is always available; passing
+    # an explicit ``reason`` (the legacy path) keeps it verbatim.
+    reason: str = ""
+    position: int | None = None
     tilt: int | None = None
     # Evaluation priority of the handler that produced this step (higher wins).
     # Surfaced in diagnostics so a re-ordered chain is visible for debugging.
@@ -337,6 +342,15 @@ class DecisionStep:
     # handlers and all other steps. Consumers must use explicit is-not-None
     # checks because 0% (fully closed) is a valid held position.
     held_position: int | None = None
+    # Stable reason code + params (issue #882). Localized by the Lovelace card
+    # and used to render the ``reason`` string above in the user's language.
+    # None on legacy steps that still carry only an English ``reason`` string.
+    reason_payload: Reason | None = None
+
+    def __post_init__(self) -> None:
+        """Derive the English ``reason`` from ``reason_payload`` when unset."""
+        if self.reason_payload is not None and not self.reason:
+            object.__setattr__(self, "reason", render_en(self.reason_payload))
 
 
 @dataclass(frozen=True)
@@ -345,7 +359,10 @@ class PipelineResult:
 
     position: int
     control_method: ControlMethod
-    reason: str
+    # Canonical English reason string. When ``reason_payload`` is provided and
+    # ``reason`` is left empty, ``__post_init__`` derives ``reason`` from it via
+    # ``render_en``; an explicit ``reason`` (the legacy path) is kept verbatim.
+    reason: str = ""
     decision_trace: list[DecisionStep] = field(default_factory=list)
     tilt: int | None = None
 
@@ -438,3 +455,14 @@ class PipelineResult:
     # None when the sensor isn't loaded, has no friendly_name, or when any
     # non-custom handler wins.
     custom_position_active_slot_name: str | None = None
+
+    # Stable reason code + params (issue #882). The winning handler's structured
+    # reason; the registry propagates it onto the winner's DecisionStep so the
+    # Lovelace card can localize it. None on legacy results that still carry only
+    # an English ``reason`` string (handlers migrate in later dispatches).
+    reason_payload: Reason | None = None
+
+    def __post_init__(self) -> None:
+        """Derive the English ``reason`` from ``reason_payload`` when unset."""
+        if self.reason_payload is not None and not self.reason:
+            object.__setattr__(self, "reason", render_en(self.reason_payload))

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -22,6 +22,7 @@ passed-in hass executor; it imports nothing from Home Assistant.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cache
@@ -29,6 +30,8 @@ from pathlib import Path
 
 from .const import ReasonCode
 from .i18n_bundle import load_bundle_overlay, merge_labels
+
+_LOGGER = logging.getLogger(__name__)
 
 _REASON_I18N_DIR = Path(__file__).parent / "reason_i18n"
 
@@ -116,7 +119,7 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
     ReasonCode.CUSTOM_HEAD_NAMED: "{name} active",
     ReasonCode.CUSTOM_HEAD_SLOT: "custom position #{slot} active ({trigger})",
     ReasonCode.CUSTOM_USE_MY: "{head} — use My position ({position}%){bypass_note}",
-    ReasonCode.CUSTOM_POSITION_: "{head} — position {position}%{bypass_note}",
+    ReasonCode.CUSTOM_POSITION: "{head} — position {position}%{bypass_note}",
     # -- default handler
     ReasonCode.DEFAULT_SUNSET_USE_MY: "sunset position — use My position ({position}%)",
     ReasonCode.DEFAULT_NO_CONDITION: "no active condition — {pos_label} {position}%",
@@ -189,13 +192,14 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
-def _render_value(value: object, labels: Mapping[str, str]) -> object:
+def _render_value(value: object, labels: Mapping[str, str] | None = None) -> object:
     """Render a single param value, recursing into fragments.
 
     A :class:`Reason` renders to its (localized) prose; a non-str sequence of
     values renders each element and joins with ``", "``; every other value
     passes through unchanged so the parent template's format spec (e.g.
-    ``{distance:.2f}``) still applies.
+    ``{distance:.2f}``) still applies. ``labels`` of ``None`` renders in
+    English (mirrors :func:`render`).
     """
     if isinstance(value, Reason):
         return render(value, labels)
@@ -204,26 +208,28 @@ def _render_value(value: object, labels: Mapping[str, str]) -> object:
     return value
 
 
-def render(reason: Reason, labels: Mapping[str, str]) -> str:
+def render(reason: Reason, labels: Mapping[str, str] | None = None) -> str:
     """Render ``reason`` using ``labels``, falling back to English per key.
 
     ``labels`` is an overlay (a translated bundle): a key it lacks falls back
-    to :data:`_REASON_TEMPLATES_EN`. An unknown code degrades gracefully to the
-    code string itself.
+    to :data:`_REASON_TEMPLATES_EN`. ``None`` renders entirely in English. An
+    unknown code degrades gracefully to the code string itself.
     """
-    template = labels.get(reason.code) or _REASON_TEMPLATES_EN.get(reason.code)
+    active = labels if labels is not None else _REASON_TEMPLATES_EN
+    template = active.get(reason.code) or _REASON_TEMPLATES_EN.get(reason.code)
     if template is None:
         return str(reason.code)
     rendered = {key: _render_value(val, labels) for key, val in reason.params.items()}
     try:
         return template.format(**rendered)
-    except (KeyError, IndexError, ValueError):
+    except (KeyError, IndexError, ValueError) as exc:
+        _LOGGER.debug("reason render fallback for %s: %r", reason.code, exc)
         return template
 
 
 def render_en(reason: Reason) -> str:
     """Render ``reason`` with the English templates."""
-    return render(reason, _REASON_TEMPLATES_EN)
+    return render(reason)
 
 
 def reason_to_dict(reason: Reason) -> dict[str, object]:

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -1,0 +1,269 @@
+"""Reason-string i18n foundation (issue #882).
+
+Pipeline handlers, the diagnostics builder, and the engine emit a stable
+:class:`Reason` payload (``code`` + ``params``) instead of a hardcoded English
+f-string. This module owns:
+
+* ``_REASON_TEMPLATES_EN`` — the English ``str.format`` template for every
+  :class:`~..const.ReasonCode`, byte-identical to the legacy f-string output.
+* :func:`render` / :func:`render_en` — resolve a ``Reason`` (recursively
+  rendering nested-fragment params and joining fragment sequences with
+  ``", "``) into localized prose.
+* :func:`reason_to_dict` — a JSON-safe nested ``{"code", "params"}`` payload
+  the Lovelace card consumes to localize with its own templates.
+* :func:`load_reason_labels` / :func:`async_prime` — overlay the shipped
+  ``reason_i18n/<lang>.json`` bundle onto the English defaults (via the shared
+  :mod:`.i18n_bundle` loader), cached for the coordinator to prime once.
+
+Pure module: stdlib only, no ``homeassistant`` import (mirrors the engine's
+0-HA-imports constraint). ``async_prime`` merely offloads the sync loader to a
+passed-in hass executor; it imports nothing from Home Assistant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from functools import cache
+from pathlib import Path
+
+from .const import ReasonCode
+from .i18n_bundle import load_bundle_overlay, merge_labels
+
+_REASON_I18N_DIR = Path(__file__).parent / "reason_i18n"
+
+
+# ---------------------------------------------------------------------------
+# Reason payload
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Reason:
+    """A stable reason code plus its interpolation parameters.
+
+    ``params`` values may be plain scalars (``int``/``float``/``str``), a
+    nested :class:`Reason` fragment (rendered inline), or a sequence of
+    fragments (rendered and joined with ``", "``). Frozen + slotted; the
+    ``params`` default normalizes to an empty mapping in ``__post_init__``
+    (a frozen dataclass cannot use ``default_factory`` with ``slots``).
+    """
+
+    code: str
+    params: Mapping[str, object] = field(default=None)  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        """Normalize a ``None`` params default to an empty mapping."""
+        if self.params is None:
+            object.__setattr__(self, "params", {})
+
+
+# ---------------------------------------------------------------------------
+# English templates — byte-identical to the legacy f-string output
+# ---------------------------------------------------------------------------
+
+_REASON_TEMPLATES_EN: dict[str, str] = {
+    # -- fragments
+    ReasonCode.FRAGMENT_SUNSET_POSITION: "sunset position",
+    ReasonCode.FRAGMENT_DEFAULT_POSITION: "default position",
+    ReasonCode.FRAGMENT_CLOUDY_POSITION: "cloudy position",
+    ReasonCode.FRAGMENT_COVERAGE_STEP: " (coverage step, max {steps})",
+    ReasonCode.FRAGMENT_Z_ADJUSTED: " (Z-adjusted)",
+    ReasonCode.FRAGMENT_BYPASS_NOTE: " [bypasses automatic control]",
+    ReasonCode.FRAGMENT_SEASON_EXTREME_HEAT: "extreme heat",
+    ReasonCode.FRAGMENT_SEASON_TRACKING_OFF: "default: tracking off this season",
+    ReasonCode.FRAGMENT_SEASON_SUMMER: "summer",
+    ReasonCode.FRAGMENT_SEASON_WINTER: "winter",
+    ReasonCode.FRAGMENT_SEASON_GLARE_LOW_LIGHT: "glare control (low light)",
+    ReasonCode.FRAGMENT_SEASON_GLARE: "glare control",
+    ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY: "weather not sunny",
+    ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW: "lux below threshold",
+    ReasonCode.FRAGMENT_TRIGGER_IRRADIANCE_BELOW: "irradiance below threshold",
+    ReasonCode.FRAGMENT_TRIGGER_CLOUD_ABOVE: "cloud coverage above threshold",
+    ReasonCode.FRAGMENT_TRIGGER_SMOOTHING_HOLD: "smoothing hold",
+    ReasonCode.FRAGMENT_TRIGGER_TEMPLATE: "template",
+    ReasonCode.FRAGMENT_TRIGGER_FALLBACK: "trigger",
+    # -- solar
+    ReasonCode.SOLAR_TRACKING: "sun within acceptance angle — position {position}%{suffix}",
+    # -- manual override
+    ReasonCode.MANUAL_HOLDING_SOLAR: (
+        "manual override active — holding {held}% (solar would-be {position}%)"
+    ),
+    ReasonCode.MANUAL_SOLAR_ONLY: "manual override active — solar would-be {position}%",
+    ReasonCode.MANUAL_HOLDING_LABEL: (
+        "manual override active — holding {held}% ({pos_label} would be {position}%)"
+    ),
+    ReasonCode.MANUAL_LABEL_ONLY: "manual override active — {pos_label} {position}%",
+    # -- occupancy / motion timeout
+    ReasonCode.OCCUPANCY_HOLDING: (
+        "occupancy timeout — holding position {held}% (sun within acceptance angle)"
+    ),
+    ReasonCode.OCCUPANCY_LABEL: "occupancy timeout active — {pos_label} {position}%",
+    # -- climate
+    ReasonCode.CLIMATE_ACTIVE: "climate mode active ({season}) — position {position}%",
+    # -- glare zone
+    ReasonCode.GLARE_PROTECTION: (
+        "glare zone protection ({zones}) — "
+        "effective distance {distance:.2f}m{z_suffix} → position {position}%"
+    ),
+    # -- cloud suppression
+    ReasonCode.CLOUD_SUPPRESSION: (
+        "cloud/low-light suppression — {triggers} → {pos_label} {position}%"
+    ),
+    # -- weather override
+    ReasonCode.WEATHER_ACTIVE: "weather override active — position {position}%{bypass_note}",
+    # -- custom position
+    ReasonCode.CUSTOM_HEAD_NAMED: "{name} active",
+    ReasonCode.CUSTOM_HEAD_SLOT: "custom position #{slot} active ({trigger})",
+    ReasonCode.CUSTOM_USE_MY: "{head} — use My position ({position}%){bypass_note}",
+    ReasonCode.CUSTOM_POSITION_: "{head} — position {position}%{bypass_note}",
+    # -- default handler
+    ReasonCode.DEFAULT_SUNSET_USE_MY: "sunset position — use My position ({position}%)",
+    ReasonCode.DEFAULT_NO_CONDITION: "no active condition — {pos_label} {position}%",
+    # -- group handlers
+    ReasonCode.GROUP_LOCK: "group lock from group {group_id} — holding {position}%",
+    ReasonCode.GROUP_SCENE: "group scene '{scene}' from group {group_id} → {position}%",
+    # -- registry composition
+    ReasonCode.REGISTRY_OUTPRIORITIZED: "outprioritized by {handler}",
+    ReasonCode.REGISTRY_FLOOR_RAISED: (
+        "floor raised winner from {from_pos}% to {to_pos}% by {label}"
+    ),
+    ReasonCode.REGISTRY_FLOOR_INACTIVE: (
+        "floor {floor_pos}% inactive (winner {winner_pos}% above floor)"
+    ),
+    ReasonCode.REGISTRY_TILT_APPLIED: (
+        "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}"
+    ),
+    ReasonCode.REGISTRY_TILT_DEFERRED: (
+        "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+    ),
+    # -- diagnostics builder
+    ReasonCode.BUILDER_UNKNOWN: "Unknown",
+    ReasonCode.BUILDER_CONTROL_OCCUPANCY_TIMEOUT: "Occupancy Timeout",
+    ReasonCode.BUILDER_CONTROL_MANUAL_OVERRIDE: "Manual Override",
+    ReasonCode.BUILDER_CONTROL_TRACKING_OFF_SEASON: "Default: Tracking Off This Season",
+    ReasonCode.BUILDER_CONTROL_TILT_FIXED: "{reason} — tilt fixed by Custom #{slot}",
+    ReasonCode.BUILDER_OUTSIDE_WINDOW: (
+        "Outside time window → {pos_label} {pos}% (commands paused)"
+    ),
+    ReasonCode.BUILDER_MANUAL_DIVERGENCE: (
+        "manual override active — holding cover at {held}% (solar would be {raw}%)"
+    ),
+    ReasonCode.BUILDER_TILT_FIXED: "tilt fixed at {tilt}% by Custom #{slot}",
+    ReasonCode.BUILDER_INTERPOLATED: "interpolated → {final}%",
+    ReasonCode.BUILDER_INVERSED: "inversed → {final}%",
+    # -- engine control_state_reason
+    ReasonCode.ENGINE_DIRECT_SUN: "Direct Sun",
+    ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET: "Default: Sunset Offset",
+    ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT: "Default: Elevation Limit",
+    ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT: "Default: Acceptance Angle Exit",
+    ReasonCode.ENGINE_DEFAULT_BLIND_SPOT: "Default: Blind Spot",
+    ReasonCode.ENGINE_DEFAULT: "Default",
+    # -- describe_skip / inactive-reason prose
+    ReasonCode.SKIP_OUTSIDE_WINDOW: "outside time window",
+    ReasonCode.SKIP_SUN_OUTSIDE: "sun outside acceptance angle or elevation limits",
+    ReasonCode.SKIP_MANUAL_NOT_ACTIVE: "manual override not active",
+    ReasonCode.SKIP_OCCUPANCY_DISABLED: "occupancy detection disabled",
+    ReasonCode.SKIP_OCCUPANCY_NOT_ACTIVE: "occupancy timeout not active",
+    ReasonCode.SKIP_CLIMATE_MODE_OFF: "climate mode not enabled",
+    ReasonCode.SKIP_CLIMATE_READINGS_UNAVAILABLE: "climate readings or options unavailable",
+    ReasonCode.SKIP_CLIMATE_DEFERRED: "deferred glare-control to solar/glare handlers",
+    ReasonCode.SKIP_NO_GLARE_ZONES: "no active glare zones or sun outside acceptance angle",
+    ReasonCode.SKIP_CLOUD_SKIPPED: "cloud suppression skipped (sun outside acceptance angle)",
+    ReasonCode.SKIP_CLOUD_INACTIVE: (
+        "cloud suppression inactive (direct sun present or feature disabled)"
+    ),
+    ReasonCode.SKIP_WEATHER_NOT_ACTIVE: "weather override not active",
+    ReasonCode.SKIP_CUSTOM_NOT_ACTIVE: "custom position #{slot} not active",
+    ReasonCode.SKIP_ALWAYS_MATCHES: "always matches",
+    ReasonCode.SKIP_GROUP_SCENE_NOT_LOCK: "group intent is a scene, not a lock",
+    ReasonCode.SKIP_NO_GROUP_LOCK: "no group lock intent",
+    ReasonCode.SKIP_GROUP_LOCK_NOT_SCENE: "group intent is a lock, not a scene",
+    ReasonCode.SKIP_NO_GROUP_SCENE: "no group scene intent",
+    ReasonCode.SKIP_NOT_ACTIVE: "not active",
+}
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+def _render_value(value: object, labels: Mapping[str, str]) -> object:
+    """Render a single param value, recursing into fragments.
+
+    A :class:`Reason` renders to its (localized) prose; a non-str sequence of
+    values renders each element and joins with ``", "``; every other value
+    passes through unchanged so the parent template's format spec (e.g.
+    ``{distance:.2f}``) still applies.
+    """
+    if isinstance(value, Reason):
+        return render(value, labels)
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return ", ".join(str(_render_value(item, labels)) for item in value)
+    return value
+
+
+def render(reason: Reason, labels: Mapping[str, str]) -> str:
+    """Render ``reason`` using ``labels``, falling back to English per key.
+
+    ``labels`` is an overlay (a translated bundle): a key it lacks falls back
+    to :data:`_REASON_TEMPLATES_EN`. An unknown code degrades gracefully to the
+    code string itself.
+    """
+    template = labels.get(reason.code) or _REASON_TEMPLATES_EN.get(reason.code)
+    if template is None:
+        return str(reason.code)
+    rendered = {key: _render_value(val, labels) for key, val in reason.params.items()}
+    try:
+        return template.format(**rendered)
+    except (KeyError, IndexError, ValueError):
+        return template
+
+
+def render_en(reason: Reason) -> str:
+    """Render ``reason`` with the English templates."""
+    return render(reason, _REASON_TEMPLATES_EN)
+
+
+def reason_to_dict(reason: Reason) -> dict[str, object]:
+    """Return a JSON-safe nested ``{"code", "params"}`` payload for the card."""
+    return {
+        "code": reason.code,
+        "params": {key: _param_to_json(val) for key, val in reason.params.items()},
+    }
+
+
+def _param_to_json(value: object) -> object:
+    if isinstance(value, Reason):
+        return reason_to_dict(value)
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes):
+        return [_param_to_json(item) for item in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Bundle loading (delegates to the shared i18n_bundle loader)
+# ---------------------------------------------------------------------------
+
+
+@cache
+def _reason_overlay(language: str) -> tuple[tuple[str, str], ...]:
+    """Flattened ``reason_i18n/<language>.json`` overlay (cached, immutable)."""
+    return tuple(load_bundle_overlay(_REASON_I18N_DIR, language).items())
+
+
+def load_reason_labels(language: str) -> dict[str, str]:
+    """Build the reason templates for ``language`` (English overlaid with the bundle)."""
+    return merge_labels(_REASON_TEMPLATES_EN, dict(_reason_overlay(language)))
+
+
+async def async_prime(hass: object, language: str) -> dict[str, str]:
+    """Load + cache the reason templates for ``language`` off the event loop.
+
+    The coordinator can call this once at setup to warm :func:`load_reason_labels`
+    without a first-render file read on the loop. File I/O is offloaded to the
+    executor; nothing from Home Assistant is imported here — only the passed-in
+    ``hass`` executor hook is used.
+    """
+    return await hass.async_add_executor_job(load_reason_labels, language)

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -1,0 +1,110 @@
+{
+  "fragment": {
+    "sunset_position": "sunset position",
+    "default_position": "default position",
+    "cloudy_position": "cloudy position",
+    "coverage_step": " (coverage step, max {steps})",
+    "z_adjusted": " (Z-adjusted)",
+    "bypass_note": " [bypasses automatic control]",
+    "season_extreme_heat": "extreme heat",
+    "season_tracking_off": "default: tracking off this season",
+    "season_summer": "summer",
+    "season_winter": "winter",
+    "season_glare_low_light": "glare control (low light)",
+    "season_glare": "glare control",
+    "trigger_not_sunny": "weather not sunny",
+    "trigger_lux_below": "lux below threshold",
+    "trigger_irradiance_below": "irradiance below threshold",
+    "trigger_cloud_above": "cloud coverage above threshold",
+    "trigger_smoothing_hold": "smoothing hold",
+    "trigger_template": "template",
+    "trigger_fallback": "trigger"
+  },
+  "solar": {
+    "tracking": "sun within acceptance angle — position {position}%{suffix}"
+  },
+  "manual": {
+    "holding_solar": "manual override active — holding {held}% (solar would-be {position}%)",
+    "solar_only": "manual override active — solar would-be {position}%",
+    "holding_label": "manual override active — holding {held}% ({pos_label} would be {position}%)",
+    "label_only": "manual override active — {pos_label} {position}%"
+  },
+  "occupancy": {
+    "holding": "occupancy timeout — holding position {held}% (sun within acceptance angle)",
+    "label": "occupancy timeout active — {pos_label} {position}%"
+  },
+  "climate": {
+    "active": "climate mode active ({season}) — position {position}%"
+  },
+  "glare": {
+    "protection": "glare zone protection ({zones}) — effective distance {distance:.2f}m{z_suffix} → position {position}%"
+  },
+  "cloud": {
+    "suppression": "cloud/low-light suppression — {triggers} → {pos_label} {position}%"
+  },
+  "weather": {
+    "active": "weather override active — position {position}%{bypass_note}"
+  },
+  "custom": {
+    "head_named": "{name} active",
+    "head_slot": "custom position #{slot} active ({trigger})",
+    "use_my": "{head} — use My position ({position}%){bypass_note}",
+    "position": "{head} — position {position}%{bypass_note}"
+  },
+  "default": {
+    "sunset_use_my": "sunset position — use My position ({position}%)",
+    "no_condition": "no active condition — {pos_label} {position}%"
+  },
+  "group": {
+    "lock": "group lock from group {group_id} — holding {position}%",
+    "scene": "group scene '{scene}' from group {group_id} → {position}%"
+  },
+  "registry": {
+    "outprioritized": "outprioritized by {handler}",
+    "floor_raised": "floor raised winner from {from_pos}% to {to_pos}% by {label}",
+    "floor_inactive": "floor {floor_pos}% inactive (winner {winner_pos}% above floor)",
+    "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
+    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+  },
+  "builder": {
+    "unknown": "Unknown",
+    "control_occupancy_timeout": "Occupancy Timeout",
+    "control_manual_override": "Manual Override",
+    "control_tracking_off_season": "Default: Tracking Off This Season",
+    "control_tilt_fixed": "{reason} — tilt fixed by Custom #{slot}",
+    "outside_window": "Outside time window → {pos_label} {pos}% (commands paused)",
+    "manual_divergence": "manual override active — holding cover at {held}% (solar would be {raw}%)",
+    "tilt_fixed": "tilt fixed at {tilt}% by Custom #{slot}",
+    "interpolated": "interpolated → {final}%",
+    "inversed": "inversed → {final}%"
+  },
+  "engine": {
+    "direct_sun": "Direct Sun",
+    "default_sunset_offset": "Default: Sunset Offset",
+    "default_elevation_limit": "Default: Elevation Limit",
+    "default_acceptance_angle_exit": "Default: Acceptance Angle Exit",
+    "default_blind_spot": "Default: Blind Spot",
+    "default": "Default"
+  },
+  "skip": {
+    "outside_window": "outside time window",
+    "sun_outside": "sun outside acceptance angle or elevation limits",
+    "manual_not_active": "manual override not active",
+    "occupancy_disabled": "occupancy detection disabled",
+    "occupancy_not_active": "occupancy timeout not active",
+    "climate_mode_off": "climate mode not enabled",
+    "climate_readings_unavailable": "climate readings or options unavailable",
+    "climate_deferred": "deferred glare-control to solar/glare handlers",
+    "no_glare_zones": "no active glare zones or sun outside acceptance angle",
+    "cloud_skipped": "cloud suppression skipped (sun outside acceptance angle)",
+    "cloud_inactive": "cloud suppression inactive (direct sun present or feature disabled)",
+    "weather_not_active": "weather override not active",
+    "custom_not_active": "custom position #{slot} not active",
+    "always_matches": "always matches",
+    "group_scene_not_lock": "group intent is a scene, not a lock",
+    "no_group_lock": "no group lock intent",
+    "group_lock_not_scene": "group intent is a lock, not a scene",
+    "no_group_scene": "no group scene intent",
+    "not_active": "not active"
+  }
+}

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -1,110 +1,110 @@
 {
   "fragment": {
-    "sunset_position": "sunset position",
-    "default_position": "default position",
-    "cloudy_position": "cloudy position",
-    "coverage_step": " (coverage step, max {steps})",
-    "z_adjusted": " (Z-adjusted)",
-    "bypass_note": " [bypasses automatic control]",
-    "season_extreme_heat": "extreme heat",
-    "season_tracking_off": "default: tracking off this season",
-    "season_summer": "summer",
-    "season_winter": "winter",
-    "season_glare_low_light": "glare control (low light)",
-    "season_glare": "glare control",
-    "trigger_not_sunny": "weather not sunny",
-    "trigger_lux_below": "lux below threshold",
-    "trigger_irradiance_below": "irradiance below threshold",
-    "trigger_cloud_above": "cloud coverage above threshold",
-    "trigger_smoothing_hold": "smoothing hold",
-    "trigger_template": "template",
-    "trigger_fallback": "trigger"
+    "sunset_position": "Sonnenuntergang-Position",
+    "default_position": "Standardposition",
+    "cloudy_position": "bewölkte Position",
+    "coverage_step": " (Abdeckungsschritt, max {steps})",
+    "z_adjusted": " (Z-angepasst)",
+    "bypass_note": " [umgeht automatische Steuerung]",
+    "season_extreme_heat": "extreme Hitze",
+    "season_tracking_off": "Standard: Verfolgung diese Saison aus",
+    "season_summer": "Sommer",
+    "season_winter": "Winter",
+    "season_glare_low_light": "Blendungsschutz (schwaches Licht)",
+    "season_glare": "Blendungsschutz",
+    "trigger_not_sunny": "Wetter nicht sonnig",
+    "trigger_lux_below": "Lux unter Schwelle",
+    "trigger_irradiance_below": "Bestrahlungsstärke unter Schwelle",
+    "trigger_cloud_above": "Wolkenbedeckung über Schwelle",
+    "trigger_smoothing_hold": "Glättungshalt",
+    "trigger_template": "Vorlage",
+    "trigger_fallback": "Auslöser"
   },
   "solar": {
-    "tracking": "sun within acceptance angle — position {position}%{suffix}"
+    "tracking": "Sonne im Akzeptanzwinkel — Position {position}%{suffix}"
   },
   "manual": {
-    "holding_solar": "manual override active — holding {held}% (solar would-be {position}%)",
-    "solar_only": "manual override active — solar would-be {position}%",
-    "holding_label": "manual override active — holding {held}% ({pos_label} would be {position}%)",
-    "label_only": "manual override active — {pos_label} {position}%"
+    "holding_solar": "manuelle Übersteuerung aktiv — halten {held}% (Sonne würde {position}% sein)",
+    "solar_only": "manuelle Übersteuerung aktiv — Sonne würde {position}% sein",
+    "holding_label": "manuelle Übersteuerung aktiv — halten {held}% ({pos_label} würde {position}% sein)",
+    "label_only": "manuelle Übersteuerung aktiv — {pos_label} {position}%"
   },
   "occupancy": {
-    "holding": "occupancy timeout — holding position {held}% (sun within acceptance angle)",
-    "label": "occupancy timeout active — {pos_label} {position}%"
+    "holding": "Anwesenheits-Timeout — Position halten {held}% (Sonne im Akzeptanzwinkel)",
+    "label": "Anwesenheits-Timeout aktiv — {pos_label} {position}%"
   },
   "climate": {
-    "active": "climate mode active ({season}) — position {position}%"
+    "active": "Klimamodus aktiv ({season}) — Position {position}%"
   },
   "glare": {
-    "protection": "glare zone protection ({zones}) — effective distance {distance:.2f}m{z_suffix} → position {position}%"
+    "protection": "Blendungszone-Schutz ({zones}) — effektive Entfernung {distance:.2f}m{z_suffix} → Position {position}%"
   },
   "cloud": {
-    "suppression": "cloud/low-light suppression — {triggers} → {pos_label} {position}%"
+    "suppression": "Wolken-/Schwachlicht-Unterdrückung — {triggers} → {pos_label} {position}%"
   },
   "weather": {
-    "active": "weather override active — position {position}%{bypass_note}"
+    "active": "Wetter-Außerkraftsetzung aktiv — Position {position}%{bypass_note}"
   },
   "custom": {
-    "head_named": "{name} active",
-    "head_slot": "custom position #{slot} active ({trigger})",
-    "use_my": "{head} — use My position ({position}%){bypass_note}",
-    "position": "{head} — position {position}%{bypass_note}"
+    "head_named": "{name} aktiv",
+    "head_slot": "benutzerdefinierte Position #{slot} aktiv ({trigger})",
+    "use_my": "{head} — Meine Position verwenden ({position}%){bypass_note}",
+    "position": "{head} — Position {position}%{bypass_note}"
   },
   "default": {
-    "sunset_use_my": "sunset position — use My position ({position}%)",
-    "no_condition": "no active condition — {pos_label} {position}%"
+    "sunset_use_my": "Sonnenuntergang-Position — Meine Position verwenden ({position}%)",
+    "no_condition": "keine aktive Bedingung — {pos_label} {position}%"
   },
   "group": {
-    "lock": "group lock from group {group_id} — holding {position}%",
-    "scene": "group scene '{scene}' from group {group_id} → {position}%"
+    "lock": "Gruppensperrung von Gruppe {group_id} — Position halten {position}%",
+    "scene": "Gruppenszenario '{scene}' von Gruppe {group_id} → {position}%"
   },
   "registry": {
-    "outprioritized": "outprioritized by {handler}",
-    "floor_raised": "floor raised winner from {from_pos}% to {to_pos}% by {label}",
-    "floor_inactive": "floor {floor_pos}% inactive (winner {winner_pos}% above floor)",
-    "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
-    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+    "outprioritized": "von {handler} übergeordnet",
+    "floor_raised": "Untergrenze angehobener Gewinner von {from_pos}% zu {to_pos}% durch {label}",
+    "floor_inactive": "Untergrenze {floor_pos}% inaktiv (Gewinner {winner_pos}% über Untergrenze)",
+    "tilt_applied": "nur Neigung: Lamellen-Winkel fest bei {tilt}% durch {label}; Position gesteuert durch {handler}",
+    "tilt_deferred": "nur Neigung {tilt}% verschoben — {handler} hat bereits Neigung {winner_tilt}% gesetzt"
   },
   "builder": {
-    "unknown": "Unknown",
-    "control_occupancy_timeout": "Occupancy Timeout",
-    "control_manual_override": "Manual Override",
-    "control_tracking_off_season": "Default: Tracking Off This Season",
-    "control_tilt_fixed": "{reason} — tilt fixed by Custom #{slot}",
-    "outside_window": "Outside time window → {pos_label} {pos}% (commands paused)",
-    "manual_divergence": "manual override active — holding cover at {held}% (solar would be {raw}%)",
-    "tilt_fixed": "tilt fixed at {tilt}% by Custom #{slot}",
-    "interpolated": "interpolated → {final}%",
-    "inversed": "inversed → {final}%"
+    "unknown": "Unbekannt",
+    "control_occupancy_timeout": "Anwesenheits-Timeout",
+    "control_manual_override": "Manuelle Übersteuerung",
+    "control_tracking_off_season": "Standard: Verfolgung diese Saison aus",
+    "control_tilt_fixed": "{reason} — Neigung fixiert durch Benutzer #{slot}",
+    "outside_window": "Außerhalb des Zeitfensters → {pos_label} {pos}% (Befehle pausiert)",
+    "manual_divergence": "manuelle Übersteuerung aktiv — Beschattung halten bei {held}% (Sonne würde {raw}% sein)",
+    "tilt_fixed": "Neigung fixiert bei {tilt}% durch Benutzer #{slot}",
+    "interpolated": "interpoliert → {final}%",
+    "inversed": "invertiert → {final}%"
   },
   "engine": {
-    "direct_sun": "Direct Sun",
-    "default_sunset_offset": "Default: Sunset Offset",
-    "default_elevation_limit": "Default: Elevation Limit",
-    "default_acceptance_angle_exit": "Default: Acceptance Angle Exit",
-    "default_blind_spot": "Default: Blind Spot",
-    "default": "Default"
+    "direct_sun": "Direkte Sonne",
+    "default_sunset_offset": "Standard: Sonnenuntergang-Versatz",
+    "default_elevation_limit": "Standard: Höhenlimit",
+    "default_acceptance_angle_exit": "Standard: Akzeptanzwinkel-Ausgang",
+    "default_blind_spot": "Standard: Blinder Fleck",
+    "default": "Standard"
   },
   "skip": {
-    "outside_window": "outside time window",
-    "sun_outside": "sun outside acceptance angle or elevation limits",
-    "manual_not_active": "manual override not active",
-    "occupancy_disabled": "occupancy detection disabled",
-    "occupancy_not_active": "occupancy timeout not active",
-    "climate_mode_off": "climate mode not enabled",
-    "climate_readings_unavailable": "climate readings or options unavailable",
-    "climate_deferred": "deferred glare-control to solar/glare handlers",
-    "no_glare_zones": "no active glare zones or sun outside acceptance angle",
-    "cloud_skipped": "cloud suppression skipped (sun outside acceptance angle)",
-    "cloud_inactive": "cloud suppression inactive (direct sun present or feature disabled)",
-    "weather_not_active": "weather override not active",
-    "custom_not_active": "custom position #{slot} not active",
-    "always_matches": "always matches",
-    "group_scene_not_lock": "group intent is a scene, not a lock",
-    "no_group_lock": "no group lock intent",
-    "group_lock_not_scene": "group intent is a lock, not a scene",
-    "no_group_scene": "no group scene intent",
-    "not_active": "not active"
+    "outside_window": "außerhalb des Zeitfensters",
+    "sun_outside": "Sonne außerhalb des Akzeptanzwinkels oder Höhenlimits",
+    "manual_not_active": "manuelle Übersteuerung nicht aktiv",
+    "occupancy_disabled": "Anwesenheitserkennung deaktiviert",
+    "occupancy_not_active": "Anwesenheits-Timeout nicht aktiv",
+    "climate_mode_off": "Klimamodus nicht aktiviert",
+    "climate_readings_unavailable": "Klimamesswerte oder Optionen nicht verfügbar",
+    "climate_deferred": "Blendungsschutz zu Solar-/Blendungszone-Handlern verschoben",
+    "no_glare_zones": "keine aktiven Blendungszonen oder Sonne außerhalb des Akzeptanzwinkels",
+    "cloud_skipped": "Wolkenunterdrückung übersprungen (Sonne außerhalb des Akzeptanzwinkels)",
+    "cloud_inactive": "Wolkenunterdrückung inaktiv (direkte Sonne vorhanden oder Funktion deaktiviert)",
+    "weather_not_active": "Wetter-Außerkraftsetzung nicht aktiv",
+    "custom_not_active": "benutzerdefinierte Position #{slot} nicht aktiv",
+    "always_matches": "entspricht immer",
+    "group_scene_not_lock": "Gruppenszenario ist keine Sperre",
+    "no_group_lock": "keine Gruppensperrung",
+    "group_lock_not_scene": "Gruppensperrung ist kein Szenario",
+    "no_group_scene": "kein Gruppenszenario",
+    "not_active": "nicht aktiv"
   }
 }

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -1,0 +1,110 @@
+{
+  "fragment": {
+    "sunset_position": "sunset position",
+    "default_position": "default position",
+    "cloudy_position": "cloudy position",
+    "coverage_step": " (coverage step, max {steps})",
+    "z_adjusted": " (Z-adjusted)",
+    "bypass_note": " [bypasses automatic control]",
+    "season_extreme_heat": "extreme heat",
+    "season_tracking_off": "default: tracking off this season",
+    "season_summer": "summer",
+    "season_winter": "winter",
+    "season_glare_low_light": "glare control (low light)",
+    "season_glare": "glare control",
+    "trigger_not_sunny": "weather not sunny",
+    "trigger_lux_below": "lux below threshold",
+    "trigger_irradiance_below": "irradiance below threshold",
+    "trigger_cloud_above": "cloud coverage above threshold",
+    "trigger_smoothing_hold": "smoothing hold",
+    "trigger_template": "template",
+    "trigger_fallback": "trigger"
+  },
+  "solar": {
+    "tracking": "sun within acceptance angle — position {position}%{suffix}"
+  },
+  "manual": {
+    "holding_solar": "manual override active — holding {held}% (solar would-be {position}%)",
+    "solar_only": "manual override active — solar would-be {position}%",
+    "holding_label": "manual override active — holding {held}% ({pos_label} would be {position}%)",
+    "label_only": "manual override active — {pos_label} {position}%"
+  },
+  "occupancy": {
+    "holding": "occupancy timeout — holding position {held}% (sun within acceptance angle)",
+    "label": "occupancy timeout active — {pos_label} {position}%"
+  },
+  "climate": {
+    "active": "climate mode active ({season}) — position {position}%"
+  },
+  "glare": {
+    "protection": "glare zone protection ({zones}) — effective distance {distance:.2f}m{z_suffix} → position {position}%"
+  },
+  "cloud": {
+    "suppression": "cloud/low-light suppression — {triggers} → {pos_label} {position}%"
+  },
+  "weather": {
+    "active": "weather override active — position {position}%{bypass_note}"
+  },
+  "custom": {
+    "head_named": "{name} active",
+    "head_slot": "custom position #{slot} active ({trigger})",
+    "use_my": "{head} — use My position ({position}%){bypass_note}",
+    "position": "{head} — position {position}%{bypass_note}"
+  },
+  "default": {
+    "sunset_use_my": "sunset position — use My position ({position}%)",
+    "no_condition": "no active condition — {pos_label} {position}%"
+  },
+  "group": {
+    "lock": "group lock from group {group_id} — holding {position}%",
+    "scene": "group scene '{scene}' from group {group_id} → {position}%"
+  },
+  "registry": {
+    "outprioritized": "outprioritized by {handler}",
+    "floor_raised": "floor raised winner from {from_pos}% to {to_pos}% by {label}",
+    "floor_inactive": "floor {floor_pos}% inactive (winner {winner_pos}% above floor)",
+    "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
+    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+  },
+  "builder": {
+    "unknown": "Unknown",
+    "control_occupancy_timeout": "Occupancy Timeout",
+    "control_manual_override": "Manual Override",
+    "control_tracking_off_season": "Default: Tracking Off This Season",
+    "control_tilt_fixed": "{reason} — tilt fixed by Custom #{slot}",
+    "outside_window": "Outside time window → {pos_label} {pos}% (commands paused)",
+    "manual_divergence": "manual override active — holding cover at {held}% (solar would be {raw}%)",
+    "tilt_fixed": "tilt fixed at {tilt}% by Custom #{slot}",
+    "interpolated": "interpolated → {final}%",
+    "inversed": "inversed → {final}%"
+  },
+  "engine": {
+    "direct_sun": "Direct Sun",
+    "default_sunset_offset": "Default: Sunset Offset",
+    "default_elevation_limit": "Default: Elevation Limit",
+    "default_acceptance_angle_exit": "Default: Acceptance Angle Exit",
+    "default_blind_spot": "Default: Blind Spot",
+    "default": "Default"
+  },
+  "skip": {
+    "outside_window": "outside time window",
+    "sun_outside": "sun outside acceptance angle or elevation limits",
+    "manual_not_active": "manual override not active",
+    "occupancy_disabled": "occupancy detection disabled",
+    "occupancy_not_active": "occupancy timeout not active",
+    "climate_mode_off": "climate mode not enabled",
+    "climate_readings_unavailable": "climate readings or options unavailable",
+    "climate_deferred": "deferred glare-control to solar/glare handlers",
+    "no_glare_zones": "no active glare zones or sun outside acceptance angle",
+    "cloud_skipped": "cloud suppression skipped (sun outside acceptance angle)",
+    "cloud_inactive": "cloud suppression inactive (direct sun present or feature disabled)",
+    "weather_not_active": "weather override not active",
+    "custom_not_active": "custom position #{slot} not active",
+    "always_matches": "always matches",
+    "group_scene_not_lock": "group intent is a scene, not a lock",
+    "no_group_lock": "no group lock intent",
+    "group_lock_not_scene": "group intent is a lock, not a scene",
+    "no_group_scene": "no group scene intent",
+    "not_active": "not active"
+  }
+}

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -1,0 +1,110 @@
+{
+  "fragment": {
+    "sunset_position": "sunset position",
+    "default_position": "default position",
+    "cloudy_position": "cloudy position",
+    "coverage_step": " (coverage step, max {steps})",
+    "z_adjusted": " (Z-adjusted)",
+    "bypass_note": " [bypasses automatic control]",
+    "season_extreme_heat": "extreme heat",
+    "season_tracking_off": "default: tracking off this season",
+    "season_summer": "summer",
+    "season_winter": "winter",
+    "season_glare_low_light": "glare control (low light)",
+    "season_glare": "glare control",
+    "trigger_not_sunny": "weather not sunny",
+    "trigger_lux_below": "lux below threshold",
+    "trigger_irradiance_below": "irradiance below threshold",
+    "trigger_cloud_above": "cloud coverage above threshold",
+    "trigger_smoothing_hold": "smoothing hold",
+    "trigger_template": "template",
+    "trigger_fallback": "trigger"
+  },
+  "solar": {
+    "tracking": "sun within acceptance angle — position {position}%{suffix}"
+  },
+  "manual": {
+    "holding_solar": "manual override active — holding {held}% (solar would-be {position}%)",
+    "solar_only": "manual override active — solar would-be {position}%",
+    "holding_label": "manual override active — holding {held}% ({pos_label} would be {position}%)",
+    "label_only": "manual override active — {pos_label} {position}%"
+  },
+  "occupancy": {
+    "holding": "occupancy timeout — holding position {held}% (sun within acceptance angle)",
+    "label": "occupancy timeout active — {pos_label} {position}%"
+  },
+  "climate": {
+    "active": "climate mode active ({season}) — position {position}%"
+  },
+  "glare": {
+    "protection": "glare zone protection ({zones}) — effective distance {distance:.2f}m{z_suffix} → position {position}%"
+  },
+  "cloud": {
+    "suppression": "cloud/low-light suppression — {triggers} → {pos_label} {position}%"
+  },
+  "weather": {
+    "active": "weather override active — position {position}%{bypass_note}"
+  },
+  "custom": {
+    "head_named": "{name} active",
+    "head_slot": "custom position #{slot} active ({trigger})",
+    "use_my": "{head} — use My position ({position}%){bypass_note}",
+    "position": "{head} — position {position}%{bypass_note}"
+  },
+  "default": {
+    "sunset_use_my": "sunset position — use My position ({position}%)",
+    "no_condition": "no active condition — {pos_label} {position}%"
+  },
+  "group": {
+    "lock": "group lock from group {group_id} — holding {position}%",
+    "scene": "group scene '{scene}' from group {group_id} → {position}%"
+  },
+  "registry": {
+    "outprioritized": "outprioritized by {handler}",
+    "floor_raised": "floor raised winner from {from_pos}% to {to_pos}% by {label}",
+    "floor_inactive": "floor {floor_pos}% inactive (winner {winner_pos}% above floor)",
+    "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
+    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+  },
+  "builder": {
+    "unknown": "Unknown",
+    "control_occupancy_timeout": "Occupancy Timeout",
+    "control_manual_override": "Manual Override",
+    "control_tracking_off_season": "Default: Tracking Off This Season",
+    "control_tilt_fixed": "{reason} — tilt fixed by Custom #{slot}",
+    "outside_window": "Outside time window → {pos_label} {pos}% (commands paused)",
+    "manual_divergence": "manual override active — holding cover at {held}% (solar would be {raw}%)",
+    "tilt_fixed": "tilt fixed at {tilt}% by Custom #{slot}",
+    "interpolated": "interpolated → {final}%",
+    "inversed": "inversed → {final}%"
+  },
+  "engine": {
+    "direct_sun": "Direct Sun",
+    "default_sunset_offset": "Default: Sunset Offset",
+    "default_elevation_limit": "Default: Elevation Limit",
+    "default_acceptance_angle_exit": "Default: Acceptance Angle Exit",
+    "default_blind_spot": "Default: Blind Spot",
+    "default": "Default"
+  },
+  "skip": {
+    "outside_window": "outside time window",
+    "sun_outside": "sun outside acceptance angle or elevation limits",
+    "manual_not_active": "manual override not active",
+    "occupancy_disabled": "occupancy detection disabled",
+    "occupancy_not_active": "occupancy timeout not active",
+    "climate_mode_off": "climate mode not enabled",
+    "climate_readings_unavailable": "climate readings or options unavailable",
+    "climate_deferred": "deferred glare-control to solar/glare handlers",
+    "no_glare_zones": "no active glare zones or sun outside acceptance angle",
+    "cloud_skipped": "cloud suppression skipped (sun outside acceptance angle)",
+    "cloud_inactive": "cloud suppression inactive (direct sun present or feature disabled)",
+    "weather_not_active": "weather override not active",
+    "custom_not_active": "custom position #{slot} not active",
+    "always_matches": "always matches",
+    "group_scene_not_lock": "group intent is a scene, not a lock",
+    "no_group_lock": "no group lock intent",
+    "group_lock_not_scene": "group intent is a lock, not a scene",
+    "no_group_scene": "no group scene intent",
+    "not_active": "not active"
+  }
+}

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -1,110 +1,110 @@
 {
   "fragment": {
-    "sunset_position": "sunset position",
-    "default_position": "default position",
-    "cloudy_position": "cloudy position",
-    "coverage_step": " (coverage step, max {steps})",
-    "z_adjusted": " (Z-adjusted)",
-    "bypass_note": " [bypasses automatic control]",
-    "season_extreme_heat": "extreme heat",
-    "season_tracking_off": "default: tracking off this season",
-    "season_summer": "summer",
-    "season_winter": "winter",
-    "season_glare_low_light": "glare control (low light)",
-    "season_glare": "glare control",
-    "trigger_not_sunny": "weather not sunny",
-    "trigger_lux_below": "lux below threshold",
-    "trigger_irradiance_below": "irradiance below threshold",
-    "trigger_cloud_above": "cloud coverage above threshold",
-    "trigger_smoothing_hold": "smoothing hold",
-    "trigger_template": "template",
-    "trigger_fallback": "trigger"
+    "sunset_position": "position coucher du soleil",
+    "default_position": "position par défaut",
+    "cloudy_position": "position nuageux",
+    "coverage_step": " (étape de couverture, max {steps})",
+    "z_adjusted": " (Z-ajusté)",
+    "bypass_note": " [contourne le contrôle automatique]",
+    "season_extreme_heat": "chaleur extrême",
+    "season_tracking_off": "défaut : suivi désactivé cette saison",
+    "season_summer": "été",
+    "season_winter": "hiver",
+    "season_glare_low_light": "contrôle d'éblouissement (faible luminosité)",
+    "season_glare": "contrôle d'éblouissement",
+    "trigger_not_sunny": "météo non ensoleillée",
+    "trigger_lux_below": "lux sous le seuil",
+    "trigger_irradiance_below": "irradiance sous le seuil",
+    "trigger_cloud_above": "couverture nuageuse au-dessus du seuil",
+    "trigger_smoothing_hold": "maintien de lissage",
+    "trigger_template": "modèle",
+    "trigger_fallback": "déclencheur"
   },
   "solar": {
-    "tracking": "sun within acceptance angle — position {position}%{suffix}"
+    "tracking": "soleil dans l'angle d'acceptation — position {position}%{suffix}"
   },
   "manual": {
-    "holding_solar": "manual override active — holding {held}% (solar would-be {position}%)",
-    "solar_only": "manual override active — solar would-be {position}%",
-    "holding_label": "manual override active — holding {held}% ({pos_label} would be {position}%)",
-    "label_only": "manual override active — {pos_label} {position}%"
+    "holding_solar": "dérogation manuelle active — maintien {held}% (soleil serait {position}%)",
+    "solar_only": "dérogation manuelle active — soleil serait {position}%",
+    "holding_label": "dérogation manuelle active — maintien {held}% ({pos_label} serait {position}%)",
+    "label_only": "dérogation manuelle active — {pos_label} {position}%"
   },
   "occupancy": {
-    "holding": "occupancy timeout — holding position {held}% (sun within acceptance angle)",
-    "label": "occupancy timeout active — {pos_label} {position}%"
+    "holding": "délai d'absence — maintien position {held}% (soleil dans l'angle d'acceptation)",
+    "label": "délai d'absence actif — {pos_label} {position}%"
   },
   "climate": {
-    "active": "climate mode active ({season}) — position {position}%"
+    "active": "mode climatique actif ({season}) — position {position}%"
   },
   "glare": {
-    "protection": "glare zone protection ({zones}) — effective distance {distance:.2f}m{z_suffix} → position {position}%"
+    "protection": "protection zone d'éblouissement ({zones}) — distance effective {distance:.2f}m{z_suffix} → position {position}%"
   },
   "cloud": {
-    "suppression": "cloud/low-light suppression — {triggers} → {pos_label} {position}%"
+    "suppression": "suppression nuages/faible luminosité — {triggers} → {pos_label} {position}%"
   },
   "weather": {
-    "active": "weather override active — position {position}%{bypass_note}"
+    "active": "dérogation météo active — position {position}%{bypass_note}"
   },
   "custom": {
-    "head_named": "{name} active",
-    "head_slot": "custom position #{slot} active ({trigger})",
-    "use_my": "{head} — use My position ({position}%){bypass_note}",
+    "head_named": "{name} actif",
+    "head_slot": "position personnalisée #{slot} active ({trigger})",
+    "use_my": "{head} — utiliser ma position ({position}%){bypass_note}",
     "position": "{head} — position {position}%{bypass_note}"
   },
   "default": {
-    "sunset_use_my": "sunset position — use My position ({position}%)",
-    "no_condition": "no active condition — {pos_label} {position}%"
+    "sunset_use_my": "position coucher du soleil — utiliser ma position ({position}%)",
+    "no_condition": "aucune condition active — {pos_label} {position}%"
   },
   "group": {
-    "lock": "group lock from group {group_id} — holding {position}%",
-    "scene": "group scene '{scene}' from group {group_id} → {position}%"
+    "lock": "verrouillage groupe depuis groupe {group_id} — maintien {position}%",
+    "scene": "scène groupe '{scene}' depuis groupe {group_id} → {position}%"
   },
   "registry": {
-    "outprioritized": "outprioritized by {handler}",
-    "floor_raised": "floor raised winner from {from_pos}% to {to_pos}% by {label}",
-    "floor_inactive": "floor {floor_pos}% inactive (winner {winner_pos}% above floor)",
-    "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
-    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+    "outprioritized": "déprioritisé par {handler}",
+    "floor_raised": "minimum augmenté gagnant de {from_pos}% à {to_pos}% par {label}",
+    "floor_inactive": "minimum {floor_pos}% inactif (gagnant {winner_pos}% au-dessus du minimum)",
+    "tilt_applied": "inclinaison seule : angle lame fixé à {tilt}% par {label} ; position pilotée par {handler}",
+    "tilt_deferred": "inclinaison seule {tilt}% différée — {handler} a déjà défini inclinaison {winner_tilt}%"
   },
   "builder": {
-    "unknown": "Unknown",
-    "control_occupancy_timeout": "Occupancy Timeout",
-    "control_manual_override": "Manual Override",
-    "control_tracking_off_season": "Default: Tracking Off This Season",
-    "control_tilt_fixed": "{reason} — tilt fixed by Custom #{slot}",
-    "outside_window": "Outside time window → {pos_label} {pos}% (commands paused)",
-    "manual_divergence": "manual override active — holding cover at {held}% (solar would be {raw}%)",
-    "tilt_fixed": "tilt fixed at {tilt}% by Custom #{slot}",
-    "interpolated": "interpolated → {final}%",
-    "inversed": "inversed → {final}%"
+    "unknown": "Inconnu",
+    "control_occupancy_timeout": "Délai d'Absence",
+    "control_manual_override": "Dérogation Manuelle",
+    "control_tracking_off_season": "Défaut : Suivi Désactivé Cette Saison",
+    "control_tilt_fixed": "{reason} — inclinaison fixée par Position Personnalisée #{slot}",
+    "outside_window": "En dehors de la plage horaire → {pos_label} {pos}% (commandes en pause)",
+    "manual_divergence": "dérogation manuelle active — maintien protection à {held}% (soleil serait {raw}%)",
+    "tilt_fixed": "inclinaison fixée à {tilt}% par Position Personnalisée #{slot}",
+    "interpolated": "interpolé → {final}%",
+    "inversed": "inversé → {final}%"
   },
   "engine": {
-    "direct_sun": "Direct Sun",
-    "default_sunset_offset": "Default: Sunset Offset",
-    "default_elevation_limit": "Default: Elevation Limit",
-    "default_acceptance_angle_exit": "Default: Acceptance Angle Exit",
-    "default_blind_spot": "Default: Blind Spot",
-    "default": "Default"
+    "direct_sun": "Soleil Direct",
+    "default_sunset_offset": "Défaut : Décalage Coucher du Soleil",
+    "default_elevation_limit": "Défaut : Limite d'Élévation",
+    "default_acceptance_angle_exit": "Défaut : Sortie Angle d'Acceptation",
+    "default_blind_spot": "Défaut : Angle Mort",
+    "default": "Défaut"
   },
   "skip": {
-    "outside_window": "outside time window",
-    "sun_outside": "sun outside acceptance angle or elevation limits",
-    "manual_not_active": "manual override not active",
-    "occupancy_disabled": "occupancy detection disabled",
-    "occupancy_not_active": "occupancy timeout not active",
-    "climate_mode_off": "climate mode not enabled",
-    "climate_readings_unavailable": "climate readings or options unavailable",
-    "climate_deferred": "deferred glare-control to solar/glare handlers",
-    "no_glare_zones": "no active glare zones or sun outside acceptance angle",
-    "cloud_skipped": "cloud suppression skipped (sun outside acceptance angle)",
-    "cloud_inactive": "cloud suppression inactive (direct sun present or feature disabled)",
-    "weather_not_active": "weather override not active",
-    "custom_not_active": "custom position #{slot} not active",
-    "always_matches": "always matches",
-    "group_scene_not_lock": "group intent is a scene, not a lock",
-    "no_group_lock": "no group lock intent",
-    "group_lock_not_scene": "group intent is a lock, not a scene",
-    "no_group_scene": "no group scene intent",
-    "not_active": "not active"
+    "outside_window": "en dehors de la plage horaire",
+    "sun_outside": "soleil en dehors de l'angle d'acceptation ou des limites d'élévation",
+    "manual_not_active": "dérogation manuelle non active",
+    "occupancy_disabled": "détection de présence désactivée",
+    "occupancy_not_active": "délai d'absence non actif",
+    "climate_mode_off": "mode climatique non activé",
+    "climate_readings_unavailable": "lectures climatiques ou options indisponibles",
+    "climate_deferred": "contrôle d'éblouissement différé aux gestionnaires soleil/éblouissement",
+    "no_glare_zones": "aucune zone d'éblouissement active ou soleil en dehors de l'angle d'acceptation",
+    "cloud_skipped": "suppression nuages ignorée (soleil en dehors de l'angle d'acceptation)",
+    "cloud_inactive": "suppression nuages inactive (soleil direct présent ou fonction désactivée)",
+    "weather_not_active": "dérogation météo non active",
+    "custom_not_active": "position personnalisée #{slot} non active",
+    "always_matches": "toujours valide",
+    "group_scene_not_lock": "l'intention groupe est une scène, pas un verrouillage",
+    "no_group_lock": "aucune intention de verrouillage groupe",
+    "group_lock_not_scene": "l'intention groupe est un verrouillage, pas une scène",
+    "no_group_scene": "aucune intention de scène groupe",
+    "not_active": "non actif"
   }
 }

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -57,8 +57,42 @@ from .helpers import (
     custom_position_slot_sensors,
     motion_entities,
 )
+from .reason_i18n import _REASON_TEMPLATES_EN, Reason, render, reason_to_dict
 from .templates import is_template_string
 from .unit_system import length_display_unit, to_display_length
+
+
+def _localized_reason(
+    coordinator: AdaptiveDataUpdateCoordinator,
+    payload: Reason | None,
+    fallback: str,
+) -> str:
+    """Render a reason payload in the instance language (issue #882).
+
+    Uses the coordinator's primed ``_reason_labels`` overlay (``None`` → English
+    defaults, byte-identical). Legacy payload-less reasons keep their English
+    ``fallback`` string. Shared by the cover-position and decision-trace sensors
+    so the render path lives in exactly one place.
+    """
+    if payload is None:
+        return fallback
+    labels = coordinator._reason_labels or _REASON_TEMPLATES_EN  # noqa: SLF001
+    return render(payload, labels)
+
+
+def _reason_to_dict_attrs(payload: Reason) -> dict[str, Any]:
+    """Map a reason payload to the additive ``reason_code`` + ``reason_params`` attrs.
+
+    ``reason_to_dict`` yields a JSON-safe ``{"code", "params"}`` payload (nested
+    fragments preserved); this flattens it into the two attribute names the
+    companion card reads to localize with its own templates (issue #882).
+    """
+    payload_dict = reason_to_dict(payload)
+    return {
+        "reason_code": payload_dict["code"],
+        "reason_params": payload_dict["params"],
+    }
+
 
 # ---------------------------------------------------------------------------
 # Description dataclass
@@ -326,7 +360,9 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
     attrs["control_method"] = s.data.states.get("control")
     pipeline_result = s.coordinator._pipeline_result  # noqa: SLF001
     if pipeline_result is not None:
-        attrs["reason"] = pipeline_result.reason
+        attrs["reason"] = _localized_reason(
+            s.coordinator, pipeline_result.reason_payload, pipeline_result.reason
+        )
     diagnostics = s.coordinator.data.diagnostics if s.coordinator.data else None
     if diagnostics:
         position_explanation = diagnostics.get("position_explanation")
@@ -976,7 +1012,11 @@ def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
             {
                 "handler": step.handler,
                 "matched": step.matched,
-                "reason": step.reason,
+                # Localized to the instance language (issue #882); falls back to
+                # the step's English ``reason`` for legacy payload-less steps.
+                "reason": _localized_reason(
+                    s.coordinator, step.reason_payload, step.reason
+                ),
                 "position": step.position,
                 **({"tilt": step.tilt} if step.tilt is not None else {}),
                 **(
@@ -984,10 +1024,22 @@ def _decision_trace_attrs(s: _ACPDiagnosticSensor) -> Mapping[str, Any] | None:
                     if step.held_position is not None
                     else {}
                 ),
+                # Additive card payload (issue #882): the stable code + params so
+                # the companion card can localize with its own templates. Omitted
+                # on legacy steps that carry only an English ``reason`` string.
+                **(
+                    _reason_to_dict_attrs(step.reason_payload)
+                    if step.reason_payload is not None
+                    else {}
+                ),
             }
             for step in result.decision_trace
         ]
-        attrs["reason"] = result.reason
+        attrs["reason"] = _localized_reason(
+            s.coordinator, result.reason_payload, result.reason
+        )
+        if result.reason_payload is not None:
+            attrs.update(_reason_to_dict_attrs(result.reason_payload))
         attrs["bypass_auto_control"] = result.bypass_auto_control
         attrs["default_position"] = result.default_position
         attrs["is_sunset_active"] = result.is_sunset_active

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -57,7 +57,7 @@ from .helpers import (
     custom_position_slot_sensors,
     motion_entities,
 )
-from .reason_i18n import _REASON_TEMPLATES_EN, Reason, render, reason_to_dict
+from .reason_i18n import Reason, render, reason_to_dict
 from .templates import is_template_string
 from .unit_system import length_display_unit, to_display_length
 
@@ -76,8 +76,7 @@ def _localized_reason(
     """
     if payload is None:
         return fallback
-    labels = coordinator._reason_labels or _REASON_TEMPLATES_EN  # noqa: SLF001
-    return render(payload, labels)
+    return render(payload, coordinator._reason_labels)  # noqa: SLF001
 
 
 def _reason_to_dict_attrs(payload: Reason) -> dict[str, Any]:

--- a/tests/test_diagnostics/test_reason_localization.py
+++ b/tests/test_diagnostics/test_reason_localization.py
@@ -1,0 +1,283 @@
+"""Localization of the diagnostics builder's reason strings (issue #882, step 9b).
+
+The builder renders ``position_explanation`` and ``control_state_reason`` through
+the injected ``DiagnosticContext.reason_labels`` overlay (falling back to English
+per key). With ``reason_labels=None`` the output stays byte-identical to the
+legacy English literals; with a translated overlay it renders in that language.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.adaptive_cover_pro.const import (
+    ClimateStrategy,
+    ControlMethod,
+    ReasonCode,
+)
+from custom_components.adaptive_cover_pro.diagnostics.builder import (
+    DiagnosticContext,
+    DiagnosticsBuilder,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cover(*, control_state_reason: str = "Sun in FOV", **code):
+    """Minimal cover mock; optionally carries a ``control_state_reason_code``."""
+    ns = SimpleNamespace(control_state_reason=control_state_reason)
+    if "control_state_reason_code" in code:
+        ns.control_state_reason_code = code["control_state_reason_code"]
+    return ns
+
+
+def _ctx(**overrides) -> DiagnosticContext:
+    defaults = {  # noqa: C408
+        "pos_sun": [180.0, 45.0],
+        "cover": _make_cover(),
+        "pipeline_result": None,
+        "climate_mode": False,
+        "check_adaptive_time": True,
+        "after_start_time": True,
+        "before_end_time": True,
+        "start_time": None,
+        "end_time": None,
+        "automatic_control": True,
+        "last_cover_action": {},
+        "last_skipped_action": {},
+        "min_change": 1,
+        "time_threshold": 2,
+        "switch_mode": False,
+        "inverse_state": False,
+        "use_interpolation": False,
+        "final_state": 50,
+        "config_options": {},
+        "motion_detected": True,
+        "motion_timeout_active": False,
+    }
+    defaults.update(overrides)
+    return DiagnosticContext(**defaults)
+
+
+# A small hand-written German overlay (only the keys these tests exercise).
+_FAKE_DE = {
+    ReasonCode.SOLAR_TRACKING: "Sonne im Sichtfeld — Position {position}%{suffix}",
+    ReasonCode.BUILDER_INTERPOLATED: "interpoliert → {final}%",
+    ReasonCode.BUILDER_INVERSED: "invertiert → {final}%",
+    ReasonCode.BUILDER_OUTSIDE_WINDOW: (
+        "Außerhalb des Zeitfensters → {pos_label} {pos}% (Befehle pausiert)"
+    ),
+    ReasonCode.FRAGMENT_SUNSET_POSITION: "Sonnenuntergangsposition",
+    ReasonCode.FRAGMENT_DEFAULT_POSITION: "Standardposition",
+    ReasonCode.BUILDER_CONTROL_MANUAL_OVERRIDE: "Manuelle Übersteuerung",
+    ReasonCode.BUILDER_CONTROL_OCCUPANCY_TIMEOUT: "Anwesenheits-Timeout",
+    ReasonCode.BUILDER_CONTROL_TRACKING_OFF_SEASON: (
+        "Standard: Nachführung in dieser Jahreszeit aus"
+    ),
+    ReasonCode.BUILDER_UNKNOWN: "Unbekannt",
+    ReasonCode.BUILDER_CONTROL_TILT_FIXED: "{reason} — Neigung fest durch Custom #{slot}",
+    ReasonCode.BUILDER_MANUAL_DIVERGENCE: (
+        "manuelle Übersteuerung aktiv — halte {held}% (Solar wäre {raw}%)"
+    ),
+    ReasonCode.BUILDER_TILT_FIXED: "Neigung fest bei {tilt}% durch Custom #{slot}",
+    ReasonCode.ENGINE_DIRECT_SUN: "Direkte Sonne",
+}
+
+
+# ---------------------------------------------------------------------------
+# position_explanation — DE
+# ---------------------------------------------------------------------------
+
+
+def test_position_explanation_base_renders_from_payload_in_de() -> None:
+    pr = PipelineResult(
+        position=72,
+        control_method=ControlMethod.SOLAR,
+        reason_payload=Reason(
+            ReasonCode.SOLAR_TRACKING, {"position": 72, "suffix": ""}
+        ),
+        raw_calculated_position=72,
+    )
+    ctx = _ctx(
+        pipeline_result=pr,
+        reason_labels=_FAKE_DE,
+        use_interpolation=True,
+        final_state=65,
+    )
+    result = DiagnosticsBuilder._build_position_explanation(ctx)
+    assert result == "Sonne im Sichtfeld — Position 72% → interpoliert → 65%"
+
+
+def test_position_explanation_outside_window_renders_de_with_fragment() -> None:
+    pr = PipelineResult(
+        position=30,
+        control_method=ControlMethod.DEFAULT,
+        default_position=30,
+        is_sunset_active=True,
+    )
+    ctx = _ctx(pipeline_result=pr, check_adaptive_time=False, reason_labels=_FAKE_DE)
+    result = DiagnosticsBuilder._build_position_explanation(ctx)
+    assert result == (
+        "Außerhalb des Zeitfensters → Sonnenuntergangsposition 30% (Befehle pausiert)"
+    )
+
+
+def test_position_explanation_manual_divergence_and_inverse_de() -> None:
+    pr = PipelineResult(
+        position=72,
+        control_method=ControlMethod.MANUAL,
+        reason_payload=Reason(
+            ReasonCode.SOLAR_TRACKING, {"position": 72, "suffix": ""}
+        ),
+        raw_calculated_position=72,
+        held_position=40,
+    )
+    ctx = _ctx(
+        pipeline_result=pr,
+        reason_labels=_FAKE_DE,
+        inverse_state=True,
+        final_state=28,
+    )
+    result = DiagnosticsBuilder._build_position_explanation(ctx)
+    assert result == (
+        "Sonne im Sichtfeld — Position 72% → "
+        "manuelle Übersteuerung aktiv — halte 40% (Solar wäre 72%) → "
+        "invertiert → 28%"
+    )
+
+
+# ---------------------------------------------------------------------------
+# control_state_reason — DE
+# ---------------------------------------------------------------------------
+
+
+def test_control_state_reason_manual_override_de() -> None:
+    pr = PipelineResult(position=50, control_method=ControlMethod.MANUAL)
+    ctx = _ctx(pipeline_result=pr, reason_labels=_FAKE_DE)
+    assert DiagnosticsBuilder._get_control_state_reason(ctx) == "Manuelle Übersteuerung"
+
+
+def test_control_state_reason_tracking_off_season_de() -> None:
+    pr = PipelineResult(
+        position=50,
+        control_method=ControlMethod.DEFAULT,
+        climate_strategy=ClimateStrategy.TRACKING_SEASON_GATE,
+    )
+    ctx = _ctx(pipeline_result=pr, reason_labels=_FAKE_DE)
+    assert DiagnosticsBuilder._get_control_state_reason(ctx) == (
+        "Standard: Nachführung in dieser Jahreszeit aus"
+    )
+
+
+def test_control_state_reason_engine_code_de() -> None:
+    """When the cover exposes a code, the engine control state localizes too."""
+    pr = PipelineResult(position=50, control_method=ControlMethod.SOLAR)
+    cover = _make_cover(control_state_reason_code=ReasonCode.ENGINE_DIRECT_SUN)
+    ctx = _ctx(pipeline_result=pr, cover=cover, reason_labels=_FAKE_DE)
+    assert DiagnosticsBuilder._get_control_state_reason(ctx) == "Direkte Sonne"
+
+
+def test_control_state_reason_tilt_suffix_de() -> None:
+    pr = PipelineResult(
+        position=50, control_method=ControlMethod.MANUAL, tilt_only_slot=2
+    )
+    ctx = _ctx(pipeline_result=pr, reason_labels=_FAKE_DE)
+    assert DiagnosticsBuilder._get_control_state_reason(ctx) == (
+        "Manuelle Übersteuerung — Neigung fest durch Custom #2"
+    )
+
+
+def test_control_state_reason_unknown_de() -> None:
+    ctx = _ctx(pipeline_result=None, cover=None, reason_labels=_FAKE_DE)
+    assert DiagnosticsBuilder._get_control_state_reason(ctx) == "Unbekannt"
+
+
+# ---------------------------------------------------------------------------
+# EN byte-identical (reason_labels=None → English)
+# ---------------------------------------------------------------------------
+
+
+def test_control_state_reason_manual_override_en_byte_identical() -> None:
+    pr = PipelineResult(position=50, control_method=ControlMethod.MANUAL)
+    assert DiagnosticsBuilder._get_control_state_reason(_ctx(pipeline_result=pr)) == (
+        "Manual Override"
+    )
+
+
+def test_control_state_reason_occupancy_en_byte_identical() -> None:
+    pr = PipelineResult(position=50, control_method=ControlMethod.MOTION)
+    assert DiagnosticsBuilder._get_control_state_reason(_ctx(pipeline_result=pr)) == (
+        "Occupancy Timeout"
+    )
+
+
+def test_control_state_reason_unknown_en_byte_identical() -> None:
+    assert (
+        DiagnosticsBuilder._get_control_state_reason(
+            _ctx(pipeline_result=None, cover=None)
+        )
+        == "Unknown"
+    )
+
+
+def test_control_state_reason_cover_prose_passthrough_en() -> None:
+    """A cover without a code attr falls back to its prose (legacy mocks)."""
+    pr = PipelineResult(position=50, control_method=ControlMethod.SOLAR)
+    ctx = _ctx(pipeline_result=pr, cover=_make_cover(control_state_reason="Sun in FOV"))
+    assert DiagnosticsBuilder._get_control_state_reason(ctx) == "Sun in FOV"
+
+
+def test_control_state_reason_tilt_suffix_en_byte_identical() -> None:
+    pr = PipelineResult(
+        position=50, control_method=ControlMethod.MANUAL, tilt_only_slot=2
+    )
+    assert DiagnosticsBuilder._get_control_state_reason(_ctx(pipeline_result=pr)) == (
+        "Manual Override — tilt fixed by Custom #2"
+    )
+
+
+def test_position_explanation_outside_window_en_byte_identical() -> None:
+    pr = PipelineResult(
+        position=30,
+        control_method=ControlMethod.DEFAULT,
+        default_position=30,
+        is_sunset_active=True,
+    )
+    ctx = _ctx(pipeline_result=pr, check_adaptive_time=False)
+    assert DiagnosticsBuilder._build_position_explanation(ctx) == (
+        "Outside time window → sunset position 30% (commands paused)"
+    )
+
+
+def test_position_explanation_base_payload_en_byte_identical() -> None:
+    pr = PipelineResult(
+        position=72,
+        control_method=ControlMethod.SOLAR,
+        reason_payload=Reason(
+            ReasonCode.SOLAR_TRACKING, {"position": 72, "suffix": ""}
+        ),
+        raw_calculated_position=72,
+    )
+    ctx = _ctx(pipeline_result=pr, use_interpolation=True, final_state=65)
+    assert DiagnosticsBuilder._build_position_explanation(ctx) == (
+        "sun within acceptance angle — position 72% → interpolated → 65%"
+    )
+
+
+def test_position_explanation_legacy_reason_without_payload_en() -> None:
+    """A result carrying only a legacy ``reason`` string still renders it verbatim."""
+    pr = PipelineResult(
+        position=65,
+        control_method=ControlMethod.SOLAR,
+        reason="sun in FOV — position 65%",
+        raw_calculated_position=65,
+    )
+    ctx = _ctx(pipeline_result=pr)
+    assert (
+        DiagnosticsBuilder._build_position_explanation(ctx)
+        == "sun in FOV — position 65%"
+    )

--- a/tests/test_diagnostics/test_reason_localization.py
+++ b/tests/test_diagnostics/test_reason_localization.py
@@ -126,6 +126,12 @@ def test_position_explanation_outside_window_renders_de_with_fragment() -> None:
     )
 
 
+def test_position_explanation_unknown_de() -> None:
+    """A None pipeline result localizes the ``Unknown`` fallback (issue #882)."""
+    ctx = _ctx(pipeline_result=None, reason_labels=_FAKE_DE)
+    assert DiagnosticsBuilder._build_position_explanation(ctx) == "Unbekannt"
+
+
 def test_position_explanation_manual_divergence_and_inverse_de() -> None:
     pr = PipelineResult(
         position=72,
@@ -251,6 +257,12 @@ def test_position_explanation_outside_window_en_byte_identical() -> None:
     assert DiagnosticsBuilder._build_position_explanation(ctx) == (
         "Outside time window → sunset position 30% (commands paused)"
     )
+
+
+def test_position_explanation_unknown_en_byte_identical() -> None:
+    """The None-result fallback stays exactly ``Unknown`` with EN labels."""
+    ctx = _ctx(pipeline_result=None)
+    assert DiagnosticsBuilder._build_position_explanation(ctx) == "Unknown"
 
 
 def test_position_explanation_base_payload_en_byte_identical() -> None:

--- a/tests/test_engine/test_control_state_reason_code.py
+++ b/tests/test_engine/test_control_state_reason_code.py
@@ -1,0 +1,273 @@
+"""Tests for the engine ``control_state_reason_code`` property (issue #882).
+
+The engine emits a stable :class:`ReasonCode` for its control-state branches; the
+legacy ``control_state_reason`` prose property is a one-line ``render_en`` shim over
+that code. These tests lock:
+
+* each geometry branch → the correct frozen ``ReasonCode``,
+* ``render_en(Reason(code))`` is byte-identical to the legacy English literal,
+* the prose property equals the rendered code (shim consistency),
+
+on both ``SunGeometry`` (the pure geometry object) and ``AdaptiveGeneralCover``
+(via ``AdaptiveVerticalCover``), the two engine sites that own the property.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
+
+from custom_components.adaptive_cover_pro.calculation import AdaptiveVerticalCover
+from custom_components.adaptive_cover_pro.config_types import CoverConfig
+from custom_components.adaptive_cover_pro.const import ReasonCode
+from custom_components.adaptive_cover_pro.engine.sun_geometry import SunGeometry
+from custom_components.adaptive_cover_pro.reason_i18n import Reason, render_en
+from tests.cover_helpers import build_vertical_cover
+
+# Frozen code → legacy English literal that the engine emitted before #882.
+ENGINE_CODE_LITERALS = {
+    ReasonCode.ENGINE_DIRECT_SUN: "Direct Sun",
+    ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET: "Default: Sunset Offset",
+    ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT: "Default: Elevation Limit",
+    ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT: "Default: Acceptance Angle Exit",
+    ReasonCode.ENGINE_DEFAULT_BLIND_SPOT: "Default: Blind Spot",
+    ReasonCode.ENGINE_DEFAULT: "Default",
+}
+
+
+class TestEngineReasonCodeRendersLegacyLiteral:
+    """render_en(Reason(code)) must equal the exact pre-#882 prose."""
+
+    def test_each_engine_code_renders_legacy_literal(self):
+        for code, literal in ENGINE_CODE_LITERALS.items():
+            assert render_en(Reason(code)) == literal
+
+
+# ------------------------------------------------------------------
+# SunGeometry.control_state_reason_code
+# ------------------------------------------------------------------
+
+
+def _make_config(**overrides) -> CoverConfig:
+    defaults = {
+        "win_azi": 180,
+        "fov_left": 45,
+        "fov_right": 45,
+        "h_def": 50,
+        "sunset_pos": 0,
+        "sunset_off": 0,
+        "sunrise_off": 0,
+        "max_pos": 100,
+        "min_pos": 0,
+        "max_pos_sun_only": False,
+        "min_pos_sun_only": False,
+        "blind_spot_left": None,
+        "blind_spot_right": None,
+        "blind_spot_elevation": None,
+        "blind_spot_on": False,
+        "min_elevation": None,
+        "max_elevation": None,
+    }
+    defaults.update(overrides)
+    return CoverConfig(**defaults)
+
+
+def _make_logger():
+    logger = MagicMock()
+    logger.debug = Mock()
+    return logger
+
+
+def _make_sun_data():
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+    return sun_data
+
+
+def _sun_data_daytime():
+    sun_data = _make_sun_data()
+    sun_data.sunset.return_value = datetime(2024, 1, 1, 18, 0, 0)
+    sun_data.sunrise.return_value = datetime(2024, 1, 1, 6, 0, 0)
+    return sun_data
+
+
+class TestSunGeometryReasonCode:
+    """SunGeometry.control_state_reason_code returns the frozen code per branch."""
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_direct_sun(self, mock_dt):
+        mock_dt.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        sg = SunGeometry(
+            180.0, 45.0, _sun_data_daytime(), _make_config(), _make_logger()
+        )
+        assert sg.control_state_reason_code == ReasonCode.ENGINE_DIRECT_SUN
+        assert sg.control_state_reason == render_en(
+            Reason(sg.control_state_reason_code)
+        )
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_fov_exit(self, mock_dt):
+        mock_dt.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        sg = SunGeometry(
+            10.0, 45.0, _sun_data_daytime(), _make_config(), _make_logger()
+        )
+        assert (
+            sg.control_state_reason_code
+            == ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT
+        )
+        assert sg.control_state_reason == render_en(
+            Reason(sg.control_state_reason_code)
+        )
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_sunset_offset(self, mock_dt):
+        mock_dt.now.return_value = datetime(2024, 1, 1, 19, 0, 0)
+        sg = SunGeometry(
+            180.0, 45.0, _sun_data_daytime(), _make_config(), _make_logger()
+        )
+        assert sg.control_state_reason_code == ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET
+        assert sg.control_state_reason == render_en(
+            Reason(sg.control_state_reason_code)
+        )
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_elevation_limit(self, mock_dt):
+        mock_dt.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        config = _make_config(min_elevation=20)
+        sg = SunGeometry(180.0, 5.0, _sun_data_daytime(), config, _make_logger())
+        assert sg.control_state_reason_code == ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT
+        assert sg.control_state_reason == render_en(
+            Reason(sg.control_state_reason_code)
+        )
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_blind_spot(self, mock_dt):
+        mock_dt.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        config = _make_config(
+            blind_spot_left=10, blind_spot_right=30, blind_spot_on=True
+        )
+        sg = SunGeometry(160.0, 45.0, _sun_data_daytime(), config, _make_logger())
+        assert sg.control_state_reason_code == ReasonCode.ENGINE_DEFAULT_BLIND_SPOT
+        assert sg.control_state_reason == render_en(
+            Reason(sg.control_state_reason_code)
+        )
+
+
+# ------------------------------------------------------------------
+# AdaptiveGeneralCover.control_state_reason_code (via AdaptiveVerticalCover)
+# ------------------------------------------------------------------
+
+
+def _make_cover(mock_sun_data, mock_logger, **overrides) -> AdaptiveVerticalCover:
+    defaults = {
+        "logger": mock_logger,
+        "sol_azi": 180.0,
+        "sol_elev": 45.0,
+        "sunset_pos": 0,
+        "sunset_off": 0,
+        "sunrise_off": 0,
+        "sun_data": mock_sun_data,
+        "fov_left": 45,
+        "fov_right": 45,
+        "win_azi": 180,
+        "h_def": 50,
+        "max_pos": 100,
+        "min_pos": 0,
+        "max_pos_bool": False,
+        "min_pos_bool": False,
+        "blind_spot_left": None,
+        "blind_spot_right": None,
+        "blind_spot_elevation": None,
+        "blind_spot_on": False,
+        "min_elevation": None,
+        "max_elevation": None,
+        "distance": 0.5,
+        "h_win": 2.0,
+    }
+    defaults.update(overrides)
+    return build_vertical_cover(**defaults)
+
+
+class TestCoverReasonCode:
+    """AdaptiveGeneralCover.control_state_reason_code mirrors each branch."""
+
+    def test_direct_sun(self, mock_sun_data, mock_logger):
+        cover = _make_cover(mock_sun_data, mock_logger, sol_azi=180.0, sol_elev=45.0)
+        with patch.object(
+            type(cover), "sunset_valid", new_callable=PropertyMock, return_value=False
+        ):
+            assert cover.control_state_reason_code == ReasonCode.ENGINE_DIRECT_SUN
+            assert cover.control_state_reason == render_en(
+                Reason(cover.control_state_reason_code)
+            )
+
+    def test_fov_exit(self, mock_sun_data, mock_logger):
+        cover = _make_cover(mock_sun_data, mock_logger, sol_azi=0.0, sol_elev=45.0)
+        with patch.object(
+            type(cover), "sunset_valid", new_callable=PropertyMock, return_value=False
+        ):
+            assert (
+                cover.control_state_reason_code
+                == ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT
+            )
+            assert cover.control_state_reason == render_en(
+                Reason(cover.control_state_reason_code)
+            )
+
+    def test_sunset_offset(self, mock_sun_data, mock_logger):
+        cover = _make_cover(mock_sun_data, mock_logger, sol_azi=180.0, sol_elev=45.0)
+        with patch.object(
+            type(cover), "sunset_valid", new_callable=PropertyMock, return_value=True
+        ):
+            assert (
+                cover.control_state_reason_code
+                == ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET
+            )
+            assert cover.control_state_reason == render_en(
+                Reason(cover.control_state_reason_code)
+            )
+
+    def test_elevation_limit(self, mock_sun_data, mock_logger):
+        cover = _make_cover(
+            mock_sun_data, mock_logger, sol_azi=180.0, sol_elev=5.0, min_elevation=10
+        )
+        with patch.object(
+            type(cover), "sunset_valid", new_callable=PropertyMock, return_value=False
+        ):
+            assert (
+                cover.control_state_reason_code
+                == ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT
+            )
+            assert cover.control_state_reason == render_en(
+                Reason(cover.control_state_reason_code)
+            )
+
+    def test_blind_spot(self, mock_sun_data, mock_logger):
+        cover = _make_cover(
+            mock_sun_data,
+            mock_logger,
+            sol_azi=180.0,
+            sol_elev=45.0,
+            blind_spot_left=10,
+            blind_spot_right=30,
+            blind_spot_on=True,
+            fov_left=45,
+        )
+        with (
+            patch.object(
+                type(cover),
+                "sunset_valid",
+                new_callable=PropertyMock,
+                return_value=False,
+            ),
+            patch.object(
+                type(cover),
+                "is_sun_in_blind_spot",
+                new_callable=PropertyMock,
+                return_value=True,
+            ),
+        ):
+            assert (
+                cover.control_state_reason_code == ReasonCode.ENGINE_DEFAULT_BLIND_SPOT
+            )
+            assert cover.control_state_reason == render_en(
+                Reason(cover.control_state_reason_code)
+            )

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -334,7 +334,9 @@ class TestClimateHandlerGlareControl:
             climate_readings=_make_readings(inside_temperature=22.0, is_presence=True),
             climate_options=_make_options(temp_low=18.0, temp_high=26.0),
         )
-        assert "deferred" in self.handler.describe_skip(snap).lower()
+        from custom_components.adaptive_cover_pro.reason_i18n import render_en
+
+        assert "deferred" in render_en(self.handler.describe_skip(snap)).lower()
 
 
 class TestClimateHandlerMetadata:
@@ -354,6 +356,53 @@ class TestClimateHandlerMetadata:
         result = self.handler.evaluate(snap)
         assert result is not None
         assert result.climate_strategy is not None
+
+    def test_winning_reason_payload_carries_season_fragment(self) -> None:
+        """The winning result's reason_payload is CLIMATE_ACTIVE with a nested season fragment."""
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+        from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(inside_temperature=15.0),
+            climate_options=_make_options(temp_low=18.0),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        payload = result.reason_payload
+        assert payload is not None
+        assert payload.code == ReasonCode.CLIMATE_ACTIVE
+        assert payload.params["position"] == result.position
+        season = payload.params["season"]
+        assert isinstance(season, Reason)
+        # Cold inside (15 < temp_low 18) → winter season fragment.
+        assert season.code == ReasonCode.FRAGMENT_SEASON_WINTER
+
+    def test_winning_reason_payload_summer_fragment(self) -> None:
+        """Hot inside above temp_high labels the season fragment as summer."""
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+        from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+        cover = _make_blind_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            climate_mode_enabled=True,
+            climate_readings=_make_readings(inside_temperature=30.0),
+            climate_options=_make_options(
+                temp_low=18.0, temp_high=26.0, transparent_blind=True
+            ),
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.control_method == ControlMethod.SUMMER
+        payload = result.reason_payload
+        assert payload is not None
+        assert payload.code == ReasonCode.CLIMATE_ACTIVE
+        season = payload.params["season"]
+        assert isinstance(season, Reason)
+        assert season.code == ReasonCode.FRAGMENT_SEASON_SUMMER
 
     def test_priority_is_50(self) -> None:
         """ClimateHandler has priority 50."""
@@ -611,8 +660,10 @@ class TestClimateHandlerTimeWindow:
 
     def test_describe_skip_outside_window(self) -> None:
         """describe_skip() should mention 'time window' when outside window."""
+        from custom_components.adaptive_cover_pro.reason_i18n import render_en
+
         snap = self._active_snap(in_time_window=False)
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert (
             "time window" in reason.lower()
         ), f"Expected 'time window' in describe_skip reason but got: {reason!r}"

--- a/tests/test_pipeline/test_climate_inactive_reason.py
+++ b/tests/test_pipeline/test_climate_inactive_reason.py
@@ -258,15 +258,21 @@ class TestClimateInactiveReasonSlugsDescribeSkipConsistency:
 
         self.handler = ClimateHandler()
 
+    def _describe_skip_en(self, snap) -> str:
+        """Render describe_skip's Reason payload to English prose (issue #882)."""
+        from custom_components.adaptive_cover_pro.reason_i18n import render_en
+
+        return render_en(self.handler.describe_skip(snap)).lower()
+
     def test_describe_skip_outside_time_window_still_works(self) -> None:
         """Refactored describe_skip must still mention 'time window' for outside-window case."""
         snap = make_snapshot(climate_mode_enabled=True, in_time_window=False)
-        assert "time window" in self.handler.describe_skip(snap).lower()
+        assert "time window" in self._describe_skip_en(snap)
 
     def test_describe_skip_mode_off_still_works(self) -> None:
         """Refactored describe_skip must still mention 'not enabled' for mode-off case."""
         snap = make_snapshot(climate_mode_enabled=False)
-        assert "not enabled" in self.handler.describe_skip(snap).lower()
+        assert "not enabled" in self._describe_skip_en(snap)
 
     def test_describe_skip_unavailable_still_works(self) -> None:
         """Refactored describe_skip must still mention 'unavailable' for readings-missing case."""
@@ -276,7 +282,7 @@ class TestClimateInactiveReasonSlugsDescribeSkipConsistency:
             climate_readings=None,
             climate_options=None,
         )
-        assert "unavailable" in self.handler.describe_skip(snap).lower()
+        assert "unavailable" in self._describe_skip_en(snap)
 
     def test_describe_skip_deferred_still_works(self) -> None:
         """Refactored describe_skip must still mention 'deferred' for threshold-not-met case."""
@@ -309,4 +315,104 @@ class TestClimateInactiveReasonSlugsDescribeSkipConsistency:
             climate_readings=readings,
             climate_options=opts,
         )
-        assert "deferred" in self.handler.describe_skip(snap).lower()
+        assert "deferred" in self._describe_skip_en(snap)
+
+
+class TestInactiveReasonFromResultLanguageIndependence:
+    """inactive_reason_from_result must key on the frozen reason CODE, not prose.
+
+    Once decision-trace reason strings are localized (issue #882) the climate
+    step's ``reason`` prose can be German/French. The reverse-map that derives a
+    ClimateInactiveReason must resolve from ``reason_payload.code`` so the join
+    key is language-independent. Each fixture carries deliberately non-English
+    prose while its payload code names the real climate skip/outprioritized code.
+    """
+
+    def _climate_step_with(self, code: str, params, prose: str) -> DecisionStep:
+        from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+        return DecisionStep(
+            handler="climate",
+            matched=False,
+            reason=prose,  # non-English junk — must be ignored by the reverse map
+            reason_payload=Reason(code, params),
+            position=None,
+        )
+
+    def _result_with(self, climate_step: DecisionStep) -> PipelineResult:
+        from custom_components.adaptive_cover_pro.const import ControlMethod
+
+        return PipelineResult(
+            position=50,
+            control_method=ControlMethod.DEFAULT,
+            reason="irgendein deutscher text",
+            decision_trace=[climate_step],
+        )
+
+    def test_outprioritized_from_code_not_german_prose(self) -> None:
+        """registry.outprioritized code + German prose → OTHER_MODE_ACTIVE."""
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+        from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+            inactive_reason_from_result,
+        )
+
+        step = self._climate_step_with(
+            ReasonCode.REGISTRY_OUTPRIORITIZED,
+            {"handler": "manual_override"},
+            prose="von Übersteuerung überstimmt",  # NOT "outprioritized by ..."
+        )
+        assert (
+            inactive_reason_from_result(self._result_with(step))
+            == ClimateInactiveReason.OTHER_MODE_ACTIVE
+        )
+
+    def test_mode_off_from_code_not_french_prose(self) -> None:
+        """skip.climate_mode_off code + French prose → MODE_OFF."""
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+        from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+            inactive_reason_from_result,
+        )
+
+        step = self._climate_step_with(
+            ReasonCode.SKIP_CLIMATE_MODE_OFF,
+            {},
+            prose="mode climatique désactivé",
+        )
+        assert (
+            inactive_reason_from_result(self._result_with(step))
+            == ClimateInactiveReason.MODE_OFF
+        )
+
+    def test_readings_unavailable_from_code_not_german_prose(self) -> None:
+        """skip.climate_readings_unavailable code + German prose → READINGS_UNAVAILABLE."""
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+        from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+            inactive_reason_from_result,
+        )
+
+        step = self._climate_step_with(
+            ReasonCode.SKIP_CLIMATE_READINGS_UNAVAILABLE,
+            {},
+            prose="Klimawerte nicht verfügbar",
+        )
+        assert (
+            inactive_reason_from_result(self._result_with(step))
+            == ClimateInactiveReason.READINGS_UNAVAILABLE
+        )
+
+    def test_deferred_from_code_not_french_prose(self) -> None:
+        """skip.climate_deferred code + French prose → THRESHOLDS_NOT_MET."""
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+        from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+            inactive_reason_from_result,
+        )
+
+        step = self._climate_step_with(
+            ReasonCode.SKIP_CLIMATE_DEFERRED,
+            {},
+            prose="contrôle de l'éblouissement différé",
+        )
+        assert (
+            inactive_reason_from_result(self._result_with(step))
+            == ClimateInactiveReason.THRESHOLDS_NOT_MET
+        )

--- a/tests/test_pipeline/test_cloud_handler.py
+++ b/tests/test_pipeline/test_cloud_handler.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
 from custom_components.adaptive_cover_pro.pipeline.handlers.cloud_suppression import (
     CloudSuppressionHandler,
 )
 from custom_components.adaptive_cover_pro.pipeline.types import ClimateOptions
+from custom_components.adaptive_cover_pro.reason_i18n import render_en
 from custom_components.adaptive_cover_pro.state.climate_provider import ClimateReadings
 from tests.test_pipeline.conftest import make_snapshot
 
@@ -227,7 +228,7 @@ class TestCloudHandlerTimeWindow:
             climate_options=_make_options(enabled=True),
             in_time_window=False,
         )
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert (
             "time window" in reason.lower()
         ), f"Expected 'time window' in describe_skip reason but got: {reason!r}"
@@ -318,6 +319,74 @@ class TestCloudHandlerReasonString:
         assert "lux below threshold" in result.reason
         assert "cloud coverage above threshold" in result.reason
 
+    def test_reason_payload_code_triggers_and_pos_label(self) -> None:
+        """The payload carries a tuple of trigger fragments + a pos_label fragment."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(
+                is_sunny=False,
+                lux_below_threshold=True,
+                cloud_coverage_above_threshold=True,
+            ),
+            climate_options=_make_options(enabled=True),
+            default_position=25,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.CLOUD_SUPPRESSION
+        assert result.reason_payload.params["position"] == 25
+        trigger_codes = [t.code for t in result.reason_payload.params["triggers"]]
+        assert trigger_codes == [
+            ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY,
+            ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW,
+            ReasonCode.FRAGMENT_TRIGGER_CLOUD_ABOVE,
+        ]
+        assert (
+            result.reason_payload.params["pos_label"].code
+            == ReasonCode.FRAGMENT_DEFAULT_POSITION
+        )
+
+    def test_reason_payload_cloudy_position_fragment(self) -> None:
+        """A configured cloudy_position uses the cloudy pos_label fragment."""
+        options = ClimateOptions(
+            temp_low=None,
+            temp_high=None,
+            temp_switch=False,
+            transparent_blind=False,
+            temp_summer_outside=None,
+            cloud_suppression_enabled=True,
+            winter_close_insulation=False,
+            cloudy_position=15,
+        )
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=options,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert (
+            result.reason_payload.params["pos_label"].code
+            == ReasonCode.FRAGMENT_CLOUDY_POSITION
+        )
+
+    def test_reason_payload_smoothing_hold_fragment(self) -> None:
+        """A latch-only fire (no raw trigger) emits the smoothing-hold fragment."""
+        snap = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=True),
+            climate_options=_make_options(enabled=True),
+            cloud_suppression_active=True,
+            default_position=40,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        trigger_codes = [t.code for t in result.reason_payload.params["triggers"]]
+        assert trigger_codes == [ReasonCode.FRAGMENT_TRIGGER_SMOOTHING_HOLD]
+
     def test_reason_does_not_say_no_direct_sun_detected(self) -> None:
         """Old generic phrase 'no direct sun detected' must not appear (Issue #222, sun in FOV)."""
         snap = make_snapshot(
@@ -394,10 +463,37 @@ class TestCloudHandlerFOVGate:
             climate_options=_make_options(enabled=True),
             in_time_window=True,
         )
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert (
             "acceptance angle" in reason.lower()
         ), f"Expected 'acceptance angle' in describe_skip reason but got: {reason!r}"
+
+    def test_describe_skip_payloads(self) -> None:
+        """describe_skip returns the correct stable code for each non-fire path."""
+        outside = make_snapshot(
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            in_time_window=False,
+        )
+        assert (
+            self.handler.describe_skip(outside).code == ReasonCode.SKIP_OUTSIDE_WINDOW
+        )
+        sun_out = make_snapshot(
+            direct_sun_valid=False,
+            climate_readings=_make_readings(is_sunny=False),
+            climate_options=_make_options(enabled=True),
+            in_time_window=True,
+        )
+        assert self.handler.describe_skip(sun_out).code == ReasonCode.SKIP_CLOUD_SKIPPED
+        inactive = make_snapshot(
+            direct_sun_valid=True,
+            climate_readings=_make_readings(is_sunny=True),
+            climate_options=_make_options(enabled=True),
+            in_time_window=True,
+        )
+        assert (
+            self.handler.describe_skip(inactive).code == ReasonCode.SKIP_CLOUD_INACTIVE
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -7,6 +7,7 @@ import pytest
 from custom_components.adaptive_cover_pro.const import (
     CUSTOM_POSITION_SAFETY_PRIORITY,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
+    ReasonCode,
 )
 from custom_components.adaptive_cover_pro.const import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
@@ -15,6 +16,7 @@ from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position impo
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
 )
+from custom_components.adaptive_cover_pro.reason_i18n import render_en
 
 from .conftest import make_snapshot
 
@@ -139,9 +141,15 @@ class TestEvaluateNoMatchingSlot:
 
     def test_describe_skip_mentions_slot(self) -> None:
         snapshot = make_snapshot(custom_position_sensors=[])
-        skip = _handler(slot=2).describe_skip(snapshot)
+        skip = render_en(_handler(slot=2).describe_skip(snapshot))
         assert "#2" in skip
         assert "not active" in skip
+
+    def test_describe_skip_payload_names_slot(self) -> None:
+        snapshot = make_snapshot(custom_position_sensors=[])
+        payload = _handler(slot=2).describe_skip(snapshot)
+        assert payload.code == ReasonCode.SKIP_CUSTOM_NOT_ACTIVE
+        assert payload.params["slot"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +281,118 @@ class TestTriggerReason:
         result = _handler(position=40).evaluate(snapshot)
         assert result is not None
         assert "binary_sensor.wind, template" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# reason_payload — stable code + params (issue #882)
+# ---------------------------------------------------------------------------
+
+
+class TestReasonPayload:
+    """The migrated handler emits a stable Reason payload on every path."""
+
+    def test_slot_head_position_payload(self) -> None:
+        """An unnamed slot on the exact-position path nests a head_slot fragment."""
+        snapshot = _snapshot_with(
+            "binary_sensor.morning", is_on=True, position=70, slot=2
+        )
+        result = _handler(slot=2, position=70).evaluate(snapshot)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.CUSTOM_POSITION_
+        assert result.reason_payload.params["position"] == 70
+        assert result.reason_payload.params["bypass_note"] == ""
+        head = result.reason_payload.params["head"]
+        assert head.code == ReasonCode.CUSTOM_HEAD_SLOT
+        assert head.params["slot"] == 2
+        # The trigger is a tuple of the active entity ids (scalars).
+        assert list(head.params["trigger"]) == ["binary_sensor.morning"]
+
+    def test_named_head_payload(self) -> None:
+        """A named slot nests a head_named fragment carrying the raw name."""
+        state = _make_state(
+            "binary_sensor.movie",
+            True,
+            40,
+            _DEFAULT_PRIORITY,
+            False,
+            False,
+            slot=3,
+            custom_name="Movie night",
+        )
+        snapshot = make_snapshot(custom_position_sensors=[state])
+        result = _handler(slot=3, position=40).evaluate(snapshot)
+        assert result is not None
+        assert result.reason_payload is not None
+        head = result.reason_payload.params["head"]
+        assert head.code == ReasonCode.CUSTOM_HEAD_NAMED
+        assert head.params["name"] == "Movie night"
+
+    def test_use_my_path_payload(self) -> None:
+        """The use-My path emits a custom.use_my payload."""
+        state = _make_state(_ENTITY, True, 50, _DEFAULT_PRIORITY, False, True)
+        snapshot = make_snapshot(custom_position_sensors=[state], my_position_value=30)
+        result = _handler(position=50).evaluate(snapshot)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.CUSTOM_USE_MY
+        assert result.reason_payload.params["position"] == 30
+
+    def test_bypass_note_fragment_on_safety_slot(self) -> None:
+        """A safety-priority slot sets bypass_note to a bypass fragment."""
+        state = _make_state(
+            _ENTITY, True, 50, CUSTOM_POSITION_SAFETY_PRIORITY, False, False
+        )
+        snapshot = make_snapshot(custom_position_sensors=[state])
+        result = _handler(
+            position=50, priority=CUSTOM_POSITION_SAFETY_PRIORITY
+        ).evaluate(snapshot)
+        assert result is not None
+        assert result.reason_payload is not None
+        bypass = result.reason_payload.params["bypass_note"]
+        assert bypass.code == ReasonCode.FRAGMENT_BYPASS_NOTE
+
+    def test_trigger_tuple_includes_template_fragment(self) -> None:
+        """A sensor + template trigger nests the entity id and a template fragment."""
+        state = CustomPositionSensorState(
+            entity_ids=("binary_sensor.wind",),
+            is_on=True,
+            position=40,
+            priority=_DEFAULT_PRIORITY,
+            min_mode=False,
+            use_my=False,
+            slot=1,
+            active_entity_ids=("binary_sensor.wind",),
+            template_active=True,
+        )
+        snapshot = make_snapshot(custom_position_sensors=[state])
+        result = _handler(position=40).evaluate(snapshot)
+        assert result is not None
+        head = result.reason_payload.params["head"]
+        assert head.code == ReasonCode.CUSTOM_HEAD_SLOT
+        trigger = list(head.params["trigger"])
+        assert trigger[0] == "binary_sensor.wind"
+        assert trigger[1].code == ReasonCode.FRAGMENT_TRIGGER_TEMPLATE
+
+    def test_trigger_fallback_fragment_when_empty(self) -> None:
+        """A slot with no active sensors and no template uses the fallback fragment."""
+        state = CustomPositionSensorState(
+            entity_ids=(),
+            is_on=True,
+            position=40,
+            priority=_DEFAULT_PRIORITY,
+            min_mode=False,
+            use_my=False,
+            slot=1,
+            active_entity_ids=(),
+            template_active=False,
+        )
+        snapshot = make_snapshot(custom_position_sensors=[state])
+        result = _handler(position=40).evaluate(snapshot)
+        assert result is not None
+        head = result.reason_payload.params["head"]
+        trigger = head.params["trigger"]
+        assert trigger.code == ReasonCode.FRAGMENT_TRIGGER_FALLBACK
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -299,7 +299,7 @@ class TestReasonPayload:
         result = _handler(slot=2, position=70).evaluate(snapshot)
         assert result is not None
         assert result.reason_payload is not None
-        assert result.reason_payload.code == ReasonCode.CUSTOM_POSITION_
+        assert result.reason_payload.code == ReasonCode.CUSTOM_POSITION
         assert result.reason_payload.params["position"] == 70
         assert result.reason_payload.params["bypass_note"] == ""
         head = result.reason_payload.params["head"]

--- a/tests/test_pipeline/test_default_handler.py
+++ b/tests/test_pipeline/test_default_handler.py
@@ -1,0 +1,62 @@
+"""Tests for DefaultHandler — reason payloads (issue #882) + byte-identical prose."""
+
+from __future__ import annotations
+
+from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
+from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
+    DefaultHandler,
+)
+from tests.test_pipeline.conftest import make_snapshot
+
+
+class TestDefaultHandlerReasonPayload:
+    """DefaultHandler emits stable Reason payloads for every reason it renders."""
+
+    handler = DefaultHandler()
+
+    def test_no_condition_default_position(self) -> None:
+        """Non-sunset fallback carries a default.no_condition payload (default label)."""
+        snap = make_snapshot(default_position=100, is_sunset_active=False)
+        result = self.handler.evaluate(snap)
+        assert result.control_method == ControlMethod.DEFAULT
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.DEFAULT_NO_CONDITION
+        pos_label = result.reason_payload.params["pos_label"]
+        assert pos_label.code == ReasonCode.FRAGMENT_DEFAULT_POSITION
+        assert result.reason_payload.params["position"] == result.position
+        assert (
+            result.reason
+            == f"no active condition — default position {result.position}%"
+        )
+
+    def test_no_condition_sunset_position(self) -> None:
+        """Sunset fallback carries a default.no_condition payload (sunset label)."""
+        snap = make_snapshot(default_position=20, is_sunset_active=True)
+        result = self.handler.evaluate(snap)
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.DEFAULT_NO_CONDITION
+        pos_label = result.reason_payload.params["pos_label"]
+        assert pos_label.code == ReasonCode.FRAGMENT_SUNSET_POSITION
+        assert (
+            result.reason == f"no active condition — sunset position {result.position}%"
+        )
+
+    def test_sunset_use_my(self) -> None:
+        """The sunset use-My path carries a default.sunset_use_my payload."""
+        snap = make_snapshot(
+            default_position=20,
+            is_sunset_active=True,
+            sunset_use_my=True,
+            my_position_value=55,
+        )
+        result = self.handler.evaluate(snap)
+        assert result.use_my_position is True
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.DEFAULT_SUNSET_USE_MY
+        assert result.reason_payload.params["position"] == 55
+        assert result.reason == "sunset position — use My position (55%)"
+
+    def test_describe_skip_payload(self) -> None:
+        """describe_skip returns a skip.always_matches payload."""
+        payload = self.handler.describe_skip(make_snapshot())
+        assert payload.code == ReasonCode.SKIP_ALWAYS_MATCHES

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -216,6 +216,86 @@ def test_custom_position_floor_above_climate_is_inert() -> None:
     assert cp_step.matched is False
 
 
+def test_floor_raised_step_carries_reason_payload_code() -> None:
+    """The floor_clamp step carries a registry.floor_raised code + params,
+    while its English reason stays byte-identical to the legacy f-string.
+    """
+    from custom_components.adaptive_cover_pro.const import ReasonCode
+
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=_summer_readings(),
+        climate_options=_summer_options(),
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    registry = _registry_with_custom([_cp_handler(1, 60)])
+    result = registry.evaluate(snap)
+    clamp = next(
+        s for s in result.decision_trace if s.handler == "floor_clamp" and s.matched
+    )
+    from_pos = clamp.reason_payload.params["from_pos"]
+    assert clamp.reason_payload is not None
+    assert clamp.reason_payload.code == ReasonCode.REGISTRY_FLOOR_RAISED
+    assert clamp.reason_payload.params == {
+        "from_pos": from_pos,
+        "to_pos": 60,
+        "label": "Table",
+    }
+    assert clamp.reason == f"floor raised winner from {from_pos}% to 60% by Table"
+
+
+def test_floor_inactive_step_carries_reason_payload_code() -> None:
+    """The inactive-floor step carries a registry.floor_inactive code + params,
+    while its English reason stays byte-identical to the legacy f-string.
+    """
+    from custom_components.adaptive_cover_pro.const import ReasonCode
+
+    cover = _climate_cover(direct_sun_valid=False)
+    snap = make_snapshot(
+        cover=cover,
+        climate_mode_enabled=True,
+        climate_readings=ClimateReadings(
+            outside_temperature=None,
+            inside_temperature=22.0,
+            is_presence=False,
+            is_sunny=False,
+            lux_below_threshold=False,
+            irradiance_below_threshold=False,
+            cloud_coverage_above_threshold=False,
+        ),
+        climate_options=_summer_options(),
+        default_position=80,
+        direct_sun_valid=False,
+        custom_position_sensors=[
+            _cp_state(
+                "binary_sensor.cp1",
+                is_on=True,
+                position=60,
+                min_mode=True,
+                sensor_name="Table",
+            )
+        ],
+    )
+    registry = _registry_with_custom([_cp_handler(1, 60)])
+    result = registry.evaluate(snap)
+    cp_step = next(s for s in result.decision_trace if s.handler == "custom_position_1")
+    assert cp_step.reason_payload is not None
+    assert cp_step.reason_payload.code == ReasonCode.REGISTRY_FLOOR_INACTIVE
+    assert cp_step.reason_payload.params == {"floor_pos": 60, "winner_pos": 80}
+    assert cp_step.reason == "floor 60% inactive (winner 80% above floor)"
+
+
 def test_two_custom_floors_pick_highest() -> None:
     """Two active floors at 40 and 60 — winner clamped to max (60)."""
     cover = _climate_cover(direct_sun_valid=False)

--- a/tests/test_pipeline/test_glare_zone_handler.py
+++ b/tests/test_pipeline/test_glare_zone_handler.py
@@ -16,10 +16,11 @@ from custom_components.adaptive_cover_pro.config_types import (
 from custom_components.adaptive_cover_pro.engine.covers.vertical import (
     AdaptiveVerticalCover,
 )
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
 from custom_components.adaptive_cover_pro.pipeline.handlers.glare_zone import (
     GlareZoneHandler,
 )
+from custom_components.adaptive_cover_pro.reason_i18n import render_en
 from tests.test_pipeline.conftest import make_snapshot
 
 
@@ -90,7 +91,19 @@ class TestGlareZoneHandlerGating:
             active_zone_names={"desk"},
             in_time_window=False,
         )
-        assert self.handler.describe_skip(snap) == "outside time window"
+        assert render_en(self.handler.describe_skip(snap)) == "outside time window"
+
+    def test_describe_skip_payload_outside_time_window(self) -> None:
+        """describe_skip returns a skip.outside_window payload outside the window."""
+        cover = _make_vertical_cover(direct_sun_valid=True)
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=_make_glare_config(),
+            active_zone_names={"desk"},
+            in_time_window=False,
+        )
+        assert self.handler.describe_skip(snap).code == ReasonCode.SKIP_OUTSIDE_WINDOW
 
     def test_matches_inside_time_window(self) -> None:
         """Returns result when in_time_window is True and all conditions met."""
@@ -737,9 +750,10 @@ class TestGlareZoneDescribeSkip:
             in_time_window=True,
         )
         assert (
-            self.handler.describe_skip(snap)
+            render_en(self.handler.describe_skip(snap))
             == "no active glare zones or sun outside acceptance angle"
         )
+        assert self.handler.describe_skip(snap).code == ReasonCode.SKIP_NO_GLARE_ZONES
 
     def test_describe_skip_sun_not_valid(self) -> None:
         """Sun not in FOV → same 'no active glare zones' message."""
@@ -755,9 +769,10 @@ class TestGlareZoneDescribeSkip:
             in_time_window=True,
         )
         assert (
-            self.handler.describe_skip(snap)
+            render_en(self.handler.describe_skip(snap))
             == "no active glare zones or sun outside acceptance angle"
         )
+        assert self.handler.describe_skip(snap).code == ReasonCode.SKIP_NO_GLARE_ZONES
 
 
 class TestGlareZoneReasonString:
@@ -832,6 +847,57 @@ class TestGlareZoneReasonString:
         assert result is not None
         assert "position" in result.reason
         assert "%" in result.reason
+
+    def test_reason_payload_code_and_params(self) -> None:
+        """The payload carries glare.protection with zone names, distance, position."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=30.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="my_monitor", x=0.0, y=1.0, radius=0.0)],
+            window_width=2.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"my_monitor"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.GLARE_PROTECTION
+        assert result.reason_payload.params["zones"] == "my_monitor"
+        assert result.reason_payload.params["distance"] == pytest.approx(1.0, abs=0.01)
+        assert result.reason_payload.params["z_suffix"] == ""
+
+    def test_reason_payload_z_suffix_fragment_when_zone_has_z(self) -> None:
+        """The z_suffix param is a z_adjusted fragment when a contributing zone has Z>0."""
+        cover = _make_vertical_cover(
+            distance=5.0,
+            gamma=0.0,
+            sol_elev=45.0,
+            direct_sun_valid=True,
+            calculate_percentage_return=30.0,
+        )
+        glare_cfg = GlareZonesConfig(
+            zones=[GlareZone(name="eye", x=0.0, y=1.0, radius=0.0, z=1.1)],
+            window_width=2.0,
+        )
+        snap = make_snapshot(
+            cover=cover,
+            cover_type="cover_blind",
+            glare_zones=glare_cfg,
+            active_zone_names={"eye"},
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        z_suffix = result.reason_payload.params["z_suffix"]
+        assert z_suffix.code == ReasonCode.FRAGMENT_Z_ADJUSTED
 
     def test_reason_includes_z_adjusted_suffix_when_contributing_zone_has_z(
         self,

--- a/tests/test_pipeline/test_group_handlers.py
+++ b/tests/test_pipeline/test_group_handlers.py
@@ -19,6 +19,7 @@ from custom_components.adaptive_cover_pro.const import (
     ControlMethod,
     GroupIntentKind,
     GroupScene,
+    ReasonCode,
 )
 from custom_components.adaptive_cover_pro.pipeline.handlers import build_handlers
 from custom_components.adaptive_cover_pro.pipeline.handlers.group_lock import (
@@ -109,6 +110,31 @@ def test_scene_handler_reason_names_scene() -> None:
     assert str(GroupScene.ALL_OPEN) in result.reason
 
 
+def test_scene_handler_reason_payload_code_and_params() -> None:
+    """The scene winner carries a group.scene payload; prose byte-identical."""
+    handler = GroupSceneHandler()
+    snapshot = make_snapshot(cover_type="cover_blind", group_intent=_scene_intent())
+    result = handler.evaluate(snapshot)
+    assert result is not None
+    assert result.reason_payload is not None
+    assert result.reason_payload.code == ReasonCode.GROUP_SCENE
+    assert result.reason_payload.params["scene"] == GroupScene.PRIVACY
+    assert result.reason_payload.params["group_id"] == GROUP_ID
+    assert result.reason_payload.params["position"] == POSITION_CLOSED
+    assert result.reason == (
+        f"group scene '{GroupScene.PRIVACY}' from group {GROUP_ID}"
+        f" → {POSITION_CLOSED}%"
+    )
+
+
+def test_scene_handler_describe_skip_payloads() -> None:
+    handler = GroupSceneHandler()
+    no_intent = handler.describe_skip(make_snapshot())
+    assert no_intent.code == ReasonCode.SKIP_NO_GROUP_SCENE
+    on_lock = handler.describe_skip(make_snapshot(group_intent=_lock_intent()))
+    assert on_lock.code == ReasonCode.SKIP_GROUP_LOCK_NOT_SCENE
+
+
 # ---------------------------------------------------------------------------
 # GroupLockHandler
 # ---------------------------------------------------------------------------
@@ -152,6 +178,27 @@ def test_lock_handler_without_readable_position_uses_default() -> None:
     assert result is not None
     assert result.skip_command is True
     assert result.position == 60
+
+
+def test_lock_handler_reason_payload_code_and_params() -> None:
+    """The lock winner carries a group.lock payload; prose byte-identical."""
+    handler = GroupLockHandler()
+    snapshot = make_snapshot(group_intent=_lock_intent(), current_cover_position=37)
+    result = handler.evaluate(snapshot)
+    assert result is not None
+    assert result.reason_payload is not None
+    assert result.reason_payload.code == ReasonCode.GROUP_LOCK
+    assert result.reason_payload.params["group_id"] == GROUP_ID
+    assert result.reason_payload.params["position"] == 37
+    assert result.reason == f"group lock from group {GROUP_ID} — holding 37%"
+
+
+def test_lock_handler_describe_skip_payloads() -> None:
+    handler = GroupLockHandler()
+    no_intent = handler.describe_skip(make_snapshot())
+    assert no_intent.code == ReasonCode.SKIP_NO_GROUP_LOCK
+    on_scene = handler.describe_skip(make_snapshot(group_intent=_scene_intent()))
+    assert on_scene.code == ReasonCode.SKIP_GROUP_SCENE_NOT_LOCK
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from custom_components.adaptive_cover_pro.const import (
     CUSTOM_POSITION_SAFETY_PRIORITY,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
+    ReasonCode,
 )
 from custom_components.adaptive_cover_pro.const import ControlMethod
 from custom_components.adaptive_cover_pro.pipeline.handlers import (
@@ -192,9 +193,16 @@ class TestSafetyCustomPositionHandler:
     def test_describe_skip_mentions_slot(self) -> None:
         """describe_skip names the slot when skipped."""
         snap = make_snapshot(custom_position_sensors=[])
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert "#5" in reason
         assert "not active" in reason
+
+    def test_describe_skip_payload_names_slot(self) -> None:
+        """describe_skip returns a skip.custom_not_active payload naming the slot."""
+        snap = make_snapshot(custom_position_sensors=[])
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_CUSTOM_NOT_ACTIVE
+        assert payload.params["slot"] == 5
 
     def test_priority_is_100(self) -> None:
         """Safety slot has priority 100 (highest)."""
@@ -419,16 +427,42 @@ class TestMotionTimeoutHandler:
     def test_describe_skip_motion_control_disabled(self) -> None:
         """describe_skip returns 'occupancy detection disabled' when switch is off."""
         snap = make_snapshot(motion_timeout_active=True, motion_control_enabled=False)
-        assert self.handler.describe_skip(snap) == "occupancy detection disabled"
+        assert (
+            render_en(self.handler.describe_skip(snap))
+            == "occupancy detection disabled"
+        )
 
     def test_describe_skip_timeout_not_active(self) -> None:
         """describe_skip returns timeout-not-active message when enabled but no timeout."""
         snap = make_snapshot(motion_timeout_active=False, motion_control_enabled=True)
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         # issue #723: user-facing reason uses occupancy wording, not "motion".
         assert "occupancy" in reason.lower()
         assert "motion" not in reason.lower()
         assert "disabled" not in reason.lower()
+
+    def test_describe_skip_payload_occupancy_disabled(self) -> None:
+        """describe_skip returns skip.occupancy_disabled when the switch is off."""
+        snap = make_snapshot(motion_timeout_active=True, motion_control_enabled=False)
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_OCCUPANCY_DISABLED
+
+    def test_describe_skip_payload_occupancy_not_active(self) -> None:
+        """describe_skip returns skip.occupancy_not_active when enabled but no timeout."""
+        snap = make_snapshot(motion_timeout_active=False, motion_control_enabled=True)
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_OCCUPANCY_NOT_ACTIVE
+
+    def test_reason_payload_occupancy_label(self) -> None:
+        """The return-to-default branch emits an occupancy.label payload."""
+        snap = make_snapshot(motion_timeout_active=True, default_position=int(20.0))
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.OCCUPANCY_LABEL
+        assert result.reason_payload.params["position"] == 20
+        pos_label = result.reason_payload.params["pos_label"]
+        assert pos_label.code == ReasonCode.FRAGMENT_DEFAULT_POSITION
 
     def test_priority_is_75(self) -> None:
         """MotionTimeoutHandler has priority 75."""
@@ -525,6 +559,80 @@ class TestMotionTimeoutHandlerHoldMode:
         assert result.position == 20
         assert result.control_method == ControlMethod.MOTION
 
+    def test_reason_payload_occupancy_holding(self) -> None:
+        """Hold-mode branch emits an occupancy.holding payload with the held position."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=True,
+            direct_sun_valid=True,
+            current_cover_position=42,
+            default_position=10,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.OCCUPANCY_HOLDING
+        assert result.reason_payload.params["held"] == 42
+
+
+class TestOccupancyWordingLock:
+    """Issue #881 lock: the occupancy reason strings render byte-identically.
+
+    These EN strings are the exact wording #881 introduced. The i18n migration
+    (#882) must reproduce them character-for-character or #881 silently
+    regresses.
+    """
+
+    def test_occupancy_label_render_matches_881_wording(self) -> None:
+        from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+        reason = Reason(
+            ReasonCode.OCCUPANCY_LABEL,
+            {"pos_label": Reason(ReasonCode.FRAGMENT_DEFAULT_POSITION), "position": 20},
+        )
+        assert render_en(reason) == "occupancy timeout active — default position 20%"
+
+    def test_occupancy_label_sunset_render_matches_881_wording(self) -> None:
+        from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+        reason = Reason(
+            ReasonCode.OCCUPANCY_LABEL,
+            {"pos_label": Reason(ReasonCode.FRAGMENT_SUNSET_POSITION), "position": 33},
+        )
+        assert render_en(reason) == "occupancy timeout active — sunset position 33%"
+
+    def test_occupancy_holding_render_matches_881_wording(self) -> None:
+        from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+        reason = Reason(ReasonCode.OCCUPANCY_HOLDING, {"held": 42})
+        assert render_en(reason) == (
+            "occupancy timeout — holding position 42% (sun within acceptance angle)"
+        )
+
+    def test_handler_return_to_default_reason_byte_identical(self) -> None:
+        """End-to-end: the handler's auto-derived reason equals the #881 string."""
+        snap = make_snapshot(motion_timeout_active=True, default_position=int(20.0))
+        result = MotionTimeoutHandler().evaluate(snap)
+        assert result is not None
+        assert result.reason == "occupancy timeout active — default position 20%"
+
+    def test_handler_hold_mode_reason_byte_identical(self) -> None:
+        """End-to-end: the hold-mode auto-derived reason equals the #881 string."""
+        snap = make_snapshot(
+            motion_timeout_active=True,
+            motion_timeout_mode="hold_position",
+            in_time_window=True,
+            direct_sun_valid=True,
+            current_cover_position=42,
+            default_position=10,
+        )
+        result = MotionTimeoutHandler().evaluate(snap)
+        assert result is not None
+        assert result.reason == (
+            "occupancy timeout — holding position 42% (sun within acceptance angle)"
+        )
+
 
 # ---------------------------------------------------------------------------
 # ManualOverrideHandler
@@ -567,8 +675,91 @@ class TestManualOverrideHandler:
     def test_describe_skip_meaningful(self) -> None:
         """describe_skip mentions 'manual' when skipped."""
         snap = make_snapshot(manual_override_active=False)
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert "manual" in reason.lower()
+
+    def test_describe_skip_payload_manual_not_active(self) -> None:
+        """describe_skip returns a skip.manual_not_active payload."""
+        snap = make_snapshot(manual_override_active=False)
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_MANUAL_NOT_ACTIVE
+
+    def test_reason_payload_holding_solar(self) -> None:
+        """Sun valid + held known → manual.holding_solar payload."""
+        snap = make_snapshot(
+            manual_override_active=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=60.0,
+            current_cover_position=44,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.MANUAL_HOLDING_SOLAR
+        assert result.reason_payload.params["held"] == 44
+        assert result.reason_payload.params["position"] == 60
+
+    def test_reason_payload_solar_only(self) -> None:
+        """Sun valid + held unknown → manual.solar_only payload."""
+        snap = make_snapshot(
+            manual_override_active=True,
+            direct_sun_valid=True,
+            calculate_percentage_return=60.0,
+            current_cover_position=None,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.MANUAL_SOLAR_ONLY
+        assert result.reason_payload.params["position"] == 60
+
+    def test_reason_payload_holding_label(self) -> None:
+        """Sun invalid + held known → manual.holding_label payload with a pos_label fragment."""
+        snap = make_snapshot(
+            manual_override_active=True,
+            direct_sun_valid=False,
+            default_position=25,
+            current_cover_position=30,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.MANUAL_HOLDING_LABEL
+        assert result.reason_payload.params["held"] == 30
+        assert result.reason_payload.params["position"] == 25
+        pos_label = result.reason_payload.params["pos_label"]
+        assert pos_label.code == ReasonCode.FRAGMENT_DEFAULT_POSITION
+
+    def test_reason_payload_label_only(self) -> None:
+        """Sun invalid + held unknown → manual.label_only payload with a pos_label fragment."""
+        snap = make_snapshot(
+            manual_override_active=True,
+            direct_sun_valid=False,
+            default_position=25,
+            current_cover_position=None,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.MANUAL_LABEL_ONLY
+        assert result.reason_payload.params["position"] == 25
+        pos_label = result.reason_payload.params["pos_label"]
+        assert pos_label.code == ReasonCode.FRAGMENT_DEFAULT_POSITION
+
+    def test_reason_payload_label_only_sunset(self) -> None:
+        """Sunset-active label uses the sunset fragment, not default."""
+        snap = make_snapshot(
+            manual_override_active=True,
+            direct_sun_valid=False,
+            is_sunset_active=True,
+            default_position=25,
+            current_cover_position=None,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        pos_label = result.reason_payload.params["pos_label"]
+        assert pos_label.code == ReasonCode.FRAGMENT_SUNSET_POSITION
 
     def test_priority_is_80(self) -> None:
         """ManualOverrideHandler has priority 80."""

--- a/tests/test_pipeline/test_handlers.py
+++ b/tests/test_pipeline/test_handlers.py
@@ -24,6 +24,7 @@ from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
     PipelineResult,
 )
+from custom_components.adaptive_cover_pro.reason_i18n import render_en
 
 from tests.test_pipeline.conftest import make_snapshot
 
@@ -678,9 +679,9 @@ class TestDefaultHandler:
         assert DefaultHandler.name == "default"
 
     def test_describe_skip_returns_string(self) -> None:
-        """describe_skip returns meaningful string."""
+        """describe_skip renders a meaningful English string."""
         snap = make_snapshot()
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert isinstance(reason, str)
         assert len(reason) > 0
 

--- a/tests/test_pipeline/test_registry.py
+++ b/tests/test_pipeline/test_registry.py
@@ -457,3 +457,29 @@ def test_outprioritized_handler_trace_has_descriptive_reason() -> None:
     default_step = next(s for s in result.decision_trace if s.handler == "default")
     assert default_step.matched is False
     assert "outprioritized" in default_step.reason
+
+
+def test_outprioritized_step_carries_reason_payload_code() -> None:
+    """The outprioritized step carries a registry.outprioritized code + params,
+    while its English reason stays byte-identical to the legacy f-string.
+    """
+    from custom_components.adaptive_cover_pro.const import ReasonCode
+
+    handlers = [
+        _make_custom_position_handler(),
+        SolarHandler(),
+        DefaultHandler(),
+    ]
+    registry = PipelineRegistry(handlers)
+    snap = make_snapshot(
+        direct_sun_valid=True,
+        calculate_percentage_return=70.0,
+        custom_position_sensors=[_custom_state()],
+    )
+    result = registry.evaluate(snap)
+    winner = result.decision_trace[0]
+    solar_step = next(s for s in result.decision_trace if s.handler == "solar")
+    assert solar_step.reason_payload is not None
+    assert solar_step.reason_payload.code == ReasonCode.REGISTRY_OUTPRIORITIZED
+    assert solar_step.reason_payload.params == {"handler": winner.handler}
+    assert solar_step.reason == f"outprioritized by {winner.handler}"

--- a/tests/test_pipeline/test_solar_handler.py
+++ b/tests/test_pipeline/test_solar_handler.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import dataclasses
 from unittest.mock import MagicMock
 
 
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
 from custom_components.adaptive_cover_pro.pipeline.handlers.solar import SolarHandler
+from custom_components.adaptive_cover_pro.reason_i18n import render_en
 from tests.test_pipeline.conftest import make_snapshot
 
 
@@ -80,13 +82,51 @@ class TestSolarHandler:
     def test_describe_skip_outside_time_window(self) -> None:
         """describe_skip returns 'outside time window' when in_time_window is False."""
         snap = make_snapshot(direct_sun_valid=True, in_time_window=False)
-        assert self.handler.describe_skip(snap) == "outside time window"
+        assert render_en(self.handler.describe_skip(snap)) == "outside time window"
 
     def test_describe_skip_mentions_sun(self) -> None:
         """describe_skip mentions sun or FOV when skipped inside the window."""
         snap = make_snapshot(direct_sun_valid=False, in_time_window=True)
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert any(word in reason.lower() for word in ("sun", "fov", "elevation"))
+
+    def test_reason_payload_code_and_params(self) -> None:
+        """Winning result carries a solar.tracking payload with byte-identical prose."""
+        snap = make_snapshot(direct_sun_valid=True, calculate_percentage_return=42.0)
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.SOLAR_TRACKING
+        assert result.reason_payload.params["position"] == 42
+        assert result.reason_payload.params["suffix"] == ""
+        assert result.reason == "sun within acceptance angle — position 42%"
+
+    def test_reason_payload_coverage_step_suffix(self) -> None:
+        """minimize_movements folds a coverage-step fragment into the suffix param."""
+        base = make_snapshot(direct_sun_valid=True, calculate_percentage_return=42.0)
+        snap = dataclasses.replace(base, minimize_movements=True, max_coverage_steps=3)
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.SOLAR_TRACKING
+        suffix = result.reason_payload.params["suffix"]
+        assert suffix.code == ReasonCode.FRAGMENT_COVERAGE_STEP
+        assert suffix.params == {"steps": 3}
+        assert result.reason == (
+            "sun within acceptance angle — position 42% (coverage step, max 3)"
+        )
+
+    def test_describe_skip_payload_outside_window(self) -> None:
+        """describe_skip returns a skip.outside_window payload outside the window."""
+        snap = make_snapshot(direct_sun_valid=True, in_time_window=False)
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_OUTSIDE_WINDOW
+
+    def test_describe_skip_payload_sun_outside(self) -> None:
+        """describe_skip returns a skip.sun_outside payload inside the window."""
+        snap = make_snapshot(direct_sun_valid=False, in_time_window=True)
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_SUN_OUTSIDE
 
     def test_priority_is_40(self) -> None:
         """SolarHandler has priority 40."""

--- a/tests/test_pipeline/test_tilt_only_contribution.py
+++ b/tests/test_pipeline/test_tilt_only_contribution.py
@@ -448,6 +448,43 @@ class TestRegistryOverlaysTilt:
         assert step.tilt == 25
         assert "not active" not in step.reason
 
+    def test_applied_tilt_step_carries_reason_payload_code(self) -> None:
+        """The applied tilt-only step carries a registry.tilt_applied code +
+        params, while its English reason stays byte-identical.
+        """
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+
+        cover = _solar_cover(calculate_percentage_return=60.0)
+        snap = make_snapshot(
+            cover=cover,
+            custom_position_sensors=[
+                _cp_state(
+                    "binary_sensor.t",
+                    is_on=True,
+                    position=80,
+                    tilt=25,
+                    tilt_only=True,
+                    slot=1,
+                    sensor_name="Slot one",
+                )
+            ],
+        )
+        handler = _cp_handler(1, 80, tilt=25)
+        result = _registry([handler]).evaluate(snap)
+        step = next(
+            s for s in result.decision_trace if s.handler == "custom_position_1"
+        )
+        assert step.reason_payload is not None
+        assert step.reason_payload.code == ReasonCode.REGISTRY_TILT_APPLIED
+        assert step.reason_payload.params == {
+            "tilt": 25,
+            "label": "Slot one",
+            "handler": "solar",
+        }
+        assert step.reason == (
+            "tilt-only: slat angle fixed at 25% by Slot one; position driven by solar"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Step 5 — fill-when-unset: winner with explicit tilt is not overwritten
@@ -511,6 +548,58 @@ class TestFillWhenUnset:
         assert deferred[0].matched is False
         # Deferred (not applied) → no slot recorded for the Control Status surface (#667).
         assert result.tilt_only_slot is None
+
+    def test_deferred_tilt_step_carries_reason_payload_code(self) -> None:
+        """The deferred tilt-only step carries a registry.tilt_deferred code +
+        params, while its English reason stays byte-identical.
+        """
+        from custom_components.adaptive_cover_pro.const import ReasonCode
+
+        cover = _solar_cover(calculate_percentage_return=60.0)
+        snap = make_snapshot(
+            cover=cover,
+            custom_position_sensors=[
+                _cp_state(
+                    "binary_sensor.winner",
+                    is_on=True,
+                    position=40,
+                    tilt=70,
+                    tilt_only=False,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY + 10,
+                    slot=1,
+                ),
+                _cp_state(
+                    "binary_sensor.tiltonly",
+                    is_on=True,
+                    position=80,
+                    tilt=25,
+                    tilt_only=True,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+                    slot=2,
+                    sensor_name="Tilt-only slot",
+                ),
+            ],
+        )
+        winner_handler = _cp_handler(
+            1, 40, tilt=70, priority=DEFAULT_CUSTOM_POSITION_PRIORITY + 10
+        )
+        tiltonly_handler = _cp_handler(
+            2, 80, tilt=25, priority=DEFAULT_CUSTOM_POSITION_PRIORITY
+        )
+        result = _registry([winner_handler, tiltonly_handler]).evaluate(snap)
+        step = next(
+            s for s in result.decision_trace if s.handler == "custom_position_2"
+        )
+        assert step.reason_payload is not None
+        assert step.reason_payload.code == ReasonCode.REGISTRY_TILT_DEFERRED
+        assert step.reason_payload.params == {
+            "tilt": 25,
+            "handler": "custom_position_1",
+            "winner_tilt": 70,
+        }
+        assert step.reason == (
+            "tilt-only 25% deferred — custom_position_1 already set tilt 70%"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_weather_handler.py
+++ b/tests/test_pipeline/test_weather_handler.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import ControlMethod, ReasonCode
 from custom_components.adaptive_cover_pro.pipeline.handlers.weather import (
     WeatherOverrideHandler,
 )
+from custom_components.adaptive_cover_pro.reason_i18n import Reason, render_en
 from tests.test_pipeline.conftest import make_snapshot
 
 
@@ -64,11 +65,49 @@ class TestWeatherOverrideHandler:
         assert WeatherOverrideHandler.name == "weather"
 
     def test_describe_skip_meaningful(self) -> None:
-        """describe_skip returns a non-empty string."""
+        """describe_skip renders a non-empty English string."""
         snap = make_snapshot()
-        reason = self.handler.describe_skip(snap)
+        reason = render_en(self.handler.describe_skip(snap))
         assert isinstance(reason, str)
         assert len(reason) > 0
+
+    def test_reason_payload_code_and_params(self) -> None:
+        """Winning result carries a weather.active payload; prose byte-identical."""
+        snap = make_snapshot(
+            weather_override_active=True,
+            weather_override_position=10,
+            weather_bypass_auto_control=False,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        assert result.reason_payload.code == ReasonCode.WEATHER_ACTIVE
+        assert result.reason_payload.params["position"] == 10
+        assert result.reason_payload.params["bypass_note"] == ""
+        assert result.reason == "weather override active — position 10%"
+
+    def test_reason_payload_bypass_note(self) -> None:
+        """bypass_auto_control folds a bypass-note fragment into the payload."""
+        snap = make_snapshot(
+            weather_override_active=True,
+            weather_override_position=10,
+            weather_bypass_auto_control=True,
+        )
+        result = self.handler.evaluate(snap)
+        assert result is not None
+        assert result.reason_payload is not None
+        bypass_note = result.reason_payload.params["bypass_note"]
+        assert isinstance(bypass_note, Reason)
+        assert bypass_note.code == ReasonCode.FRAGMENT_BYPASS_NOTE
+        assert result.reason == (
+            "weather override active — position 10% [bypasses automatic control]"
+        )
+
+    def test_describe_skip_payload_code(self) -> None:
+        """describe_skip returns a skip.weather_not_active payload."""
+        snap = make_snapshot()
+        payload = self.handler.describe_skip(snap)
+        assert payload.code == ReasonCode.SKIP_WEATHER_NOT_ACTIVE
 
     @pytest.mark.parametrize("position", [0, 10, 50, 75, 100])
     def test_various_positions(self, position: int) -> None:

--- a/tests/test_position_explanation.py
+++ b/tests/test_position_explanation.py
@@ -816,6 +816,7 @@ class TestPositionExplanationChangeDetection:
         coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
         coord._diagnostics_builder = DiagnosticsBuilder()
         coord._last_position_explanation = ""
+        coord._reason_labels = None
         coord.logger = MagicMock()
 
         # Minimal stubs for DiagnosticContext construction

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -1,0 +1,617 @@
+"""Tests for the reason-string i18n foundation (issue #882).
+
+The pipeline decision-trace reason strings, diagnostics explanations, and
+engine control-state reasons are localized via a ``reason_i18n/`` bundle that
+mirrors the ``summary_i18n/`` mechanism. English output must stay
+byte-identical to the pre-i18n f-strings so the ~40 reason-asserting test
+files stay green.
+
+This file covers the foundation only (plan steps 1 & 2): the ``ReasonCode``
+vocabulary, the ``_REASON_TEMPLATES_EN`` map, the ``Reason`` payload + render
+helpers, the shipped ``reason_i18n/{en,de,fr}.json`` bundles + parity locks,
+and the shared ``i18n_bundle`` loader. No handler/builder/engine emitter is
+migrated yet.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import string
+from pathlib import Path
+
+import pytest
+
+from custom_components.adaptive_cover_pro import i18n_bundle, reason_i18n
+from custom_components.adaptive_cover_pro.const import ReasonCode
+from custom_components.adaptive_cover_pro.reason_i18n import (
+    _REASON_TEMPLATES_EN,
+    Reason,
+    async_prime,
+    load_reason_labels,
+    reason_to_dict,
+    render,
+    render_en,
+)
+
+pytestmark = pytest.mark.unit
+
+REASON_I18N_DIR = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "reason_i18n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Legacy-string render table — one row per ReasonCode with representative
+# params, asserting render_en() reproduces the exact legacy f-string output.
+# ``params`` values may be nested ``Reason`` fragments (composed sub-phrases)
+# or plain values.
+# ---------------------------------------------------------------------------
+
+_SUNSET = Reason(ReasonCode.FRAGMENT_SUNSET_POSITION)
+_DEFAULT = Reason(ReasonCode.FRAGMENT_DEFAULT_POSITION)
+
+# (code, params, expected legacy string)
+LEGACY_CASES: list[tuple[str, dict, str]] = [
+    # --- fragments (rendered standalone) ---
+    (ReasonCode.FRAGMENT_SUNSET_POSITION, {}, "sunset position"),
+    (ReasonCode.FRAGMENT_DEFAULT_POSITION, {}, "default position"),
+    (ReasonCode.FRAGMENT_CLOUDY_POSITION, {}, "cloudy position"),
+    (ReasonCode.FRAGMENT_COVERAGE_STEP, {"steps": 3}, " (coverage step, max 3)"),
+    (ReasonCode.FRAGMENT_Z_ADJUSTED, {}, " (Z-adjusted)"),
+    (
+        ReasonCode.FRAGMENT_BYPASS_NOTE,
+        {},
+        " [bypasses automatic control]",
+    ),
+    (ReasonCode.FRAGMENT_SEASON_EXTREME_HEAT, {}, "extreme heat"),
+    (
+        ReasonCode.FRAGMENT_SEASON_TRACKING_OFF,
+        {},
+        "default: tracking off this season",
+    ),
+    (ReasonCode.FRAGMENT_SEASON_SUMMER, {}, "summer"),
+    (ReasonCode.FRAGMENT_SEASON_WINTER, {}, "winter"),
+    (
+        ReasonCode.FRAGMENT_SEASON_GLARE_LOW_LIGHT,
+        {},
+        "glare control (low light)",
+    ),
+    (ReasonCode.FRAGMENT_SEASON_GLARE, {}, "glare control"),
+    (ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY, {}, "weather not sunny"),
+    (ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW, {}, "lux below threshold"),
+    (
+        ReasonCode.FRAGMENT_TRIGGER_IRRADIANCE_BELOW,
+        {},
+        "irradiance below threshold",
+    ),
+    (
+        ReasonCode.FRAGMENT_TRIGGER_CLOUD_ABOVE,
+        {},
+        "cloud coverage above threshold",
+    ),
+    (ReasonCode.FRAGMENT_TRIGGER_SMOOTHING_HOLD, {}, "smoothing hold"),
+    (ReasonCode.FRAGMENT_TRIGGER_TEMPLATE, {}, "template"),
+    (ReasonCode.FRAGMENT_TRIGGER_FALLBACK, {}, "trigger"),
+    # --- solar ---
+    (
+        ReasonCode.SOLAR_TRACKING,
+        {"position": 50, "suffix": ""},
+        "sun within acceptance angle — position 50%",
+    ),
+    (
+        ReasonCode.SOLAR_TRACKING,
+        {
+            "position": 50,
+            "suffix": Reason(ReasonCode.FRAGMENT_COVERAGE_STEP, {"steps": 4}),
+        },
+        "sun within acceptance angle — position 50% (coverage step, max 4)",
+    ),
+    # --- manual override ---
+    (
+        ReasonCode.MANUAL_HOLDING_SOLAR,
+        {"held": 30, "position": 60},
+        "manual override active — holding 30% (solar would-be 60%)",
+    ),
+    (
+        ReasonCode.MANUAL_SOLAR_ONLY,
+        {"position": 60},
+        "manual override active — solar would-be 60%",
+    ),
+    (
+        ReasonCode.MANUAL_HOLDING_LABEL,
+        {"held": 30, "pos_label": _SUNSET, "position": 60},
+        "manual override active — holding 30% (sunset position would be 60%)",
+    ),
+    (
+        ReasonCode.MANUAL_LABEL_ONLY,
+        {"pos_label": _DEFAULT, "position": 60},
+        "manual override active — default position 60%",
+    ),
+    # --- occupancy / motion timeout (#881 wording) ---
+    (
+        ReasonCode.OCCUPANCY_HOLDING,
+        {"held": 42},
+        "occupancy timeout — holding position 42% (sun within acceptance angle)",
+    ),
+    (
+        ReasonCode.OCCUPANCY_LABEL,
+        {"pos_label": _DEFAULT, "position": 20},
+        "occupancy timeout active — default position 20%",
+    ),
+    # --- climate ---
+    (
+        ReasonCode.CLIMATE_ACTIVE,
+        {"season": Reason(ReasonCode.FRAGMENT_SEASON_SUMMER), "position": 10},
+        "climate mode active (summer) — position 10%",
+    ),
+    # --- glare zone ---
+    (
+        ReasonCode.GLARE_PROTECTION,
+        {"zones": "Desk, Sofa", "distance": 1.5, "z_suffix": "", "position": 35},
+        "glare zone protection (Desk, Sofa) — effective distance 1.50m → position 35%",
+    ),
+    (
+        ReasonCode.GLARE_PROTECTION,
+        {
+            "zones": "Desk",
+            "distance": 2.0,
+            "z_suffix": Reason(ReasonCode.FRAGMENT_Z_ADJUSTED),
+            "position": 35,
+        },
+        "glare zone protection (Desk) — effective distance 2.00m (Z-adjusted) → position 35%",
+    ),
+    # --- cloud suppression ---
+    (
+        ReasonCode.CLOUD_SUPPRESSION,
+        {
+            "triggers": [
+                Reason(ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY),
+                Reason(ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW),
+            ],
+            "pos_label": _DEFAULT,
+            "position": 25,
+        },
+        "cloud/low-light suppression — weather not sunny, lux below threshold → default position 25%",
+    ),
+    # --- weather ---
+    (
+        ReasonCode.WEATHER_ACTIVE,
+        {"position": 0, "bypass_note": ""},
+        "weather override active — position 0%",
+    ),
+    (
+        ReasonCode.WEATHER_ACTIVE,
+        {"position": 0, "bypass_note": Reason(ReasonCode.FRAGMENT_BYPASS_NOTE)},
+        "weather override active — position 0% [bypasses automatic control]",
+    ),
+    # --- custom position ---
+    (
+        ReasonCode.CUSTOM_HEAD_NAMED,
+        {"name": "Privacy"},
+        "Privacy active",
+    ),
+    (
+        ReasonCode.CUSTOM_HEAD_SLOT,
+        {"slot": 3, "trigger": "binary_sensor.a"},
+        "custom position #3 active (binary_sensor.a)",
+    ),
+    (
+        ReasonCode.CUSTOM_USE_MY,
+        {
+            "head": Reason(ReasonCode.CUSTOM_HEAD_NAMED, {"name": "Privacy"}),
+            "position": 70,
+            "bypass_note": "",
+        },
+        "Privacy active — use My position (70%)",
+    ),
+    (
+        ReasonCode.CUSTOM_POSITION_,
+        {
+            "head": Reason(
+                ReasonCode.CUSTOM_HEAD_SLOT, {"slot": 3, "trigger": "template"}
+            ),
+            "position": 70,
+            "bypass_note": Reason(ReasonCode.FRAGMENT_BYPASS_NOTE),
+        },
+        "custom position #3 active (template) — position 70% [bypasses automatic control]",
+    ),
+    # --- default handler ---
+    (
+        ReasonCode.DEFAULT_SUNSET_USE_MY,
+        {"position": 55},
+        "sunset position — use My position (55%)",
+    ),
+    (
+        ReasonCode.DEFAULT_NO_CONDITION,
+        {"pos_label": _SUNSET, "position": 55},
+        "no active condition — sunset position 55%",
+    ),
+    # --- group ---
+    (
+        ReasonCode.GROUP_LOCK,
+        {"group_id": "living", "position": 40},
+        "group lock from group living — holding 40%",
+    ),
+    (
+        ReasonCode.GROUP_SCENE,
+        {"scene": "Privacy", "group_id": "living", "position": 40},
+        "group scene 'Privacy' from group living → 40%",
+    ),
+    # --- registry ---
+    (
+        ReasonCode.REGISTRY_OUTPRIORITIZED,
+        {"handler": "weather"},
+        "outprioritized by weather",
+    ),
+    (
+        ReasonCode.REGISTRY_FLOOR_RAISED,
+        {"from_pos": 10, "to_pos": 60, "label": "Desk sensor"},
+        "floor raised winner from 10% to 60% by Desk sensor",
+    ),
+    (
+        ReasonCode.REGISTRY_FLOOR_INACTIVE,
+        {"floor_pos": 60, "winner_pos": 80},
+        "floor 60% inactive (winner 80% above floor)",
+    ),
+    (
+        ReasonCode.REGISTRY_TILT_APPLIED,
+        {"tilt": 30, "label": "Slat sensor", "handler": "solar"},
+        "tilt-only: slat angle fixed at 30% by Slat sensor; position driven by solar",
+    ),
+    (
+        ReasonCode.REGISTRY_TILT_DEFERRED,
+        {"tilt": 30, "handler": "solar", "winner_tilt": 45},
+        "tilt-only 30% deferred — solar already set tilt 45%",
+    ),
+    # --- builder ---
+    (ReasonCode.BUILDER_UNKNOWN, {}, "Unknown"),
+    (ReasonCode.BUILDER_CONTROL_OCCUPANCY_TIMEOUT, {}, "Occupancy Timeout"),
+    (ReasonCode.BUILDER_CONTROL_MANUAL_OVERRIDE, {}, "Manual Override"),
+    (
+        ReasonCode.BUILDER_CONTROL_TRACKING_OFF_SEASON,
+        {},
+        "Default: Tracking Off This Season",
+    ),
+    (
+        ReasonCode.BUILDER_CONTROL_TILT_FIXED,
+        {"reason": "Manual Override", "slot": 5},
+        "Manual Override — tilt fixed by Custom #5",
+    ),
+    (
+        ReasonCode.BUILDER_OUTSIDE_WINDOW,
+        {"pos_label": _DEFAULT, "pos": 50},
+        "Outside time window → default position 50% (commands paused)",
+    ),
+    (
+        ReasonCode.BUILDER_MANUAL_DIVERGENCE,
+        {"held": 30, "raw": 60},
+        "manual override active — holding cover at 30% (solar would be 60%)",
+    ),
+    (
+        ReasonCode.BUILDER_TILT_FIXED,
+        {"tilt": 30, "slot": 5},
+        "tilt fixed at 30% by Custom #5",
+    ),
+    (ReasonCode.BUILDER_INTERPOLATED, {"final": 48}, "interpolated → 48%"),
+    (ReasonCode.BUILDER_INVERSED, {"final": 52}, "inversed → 52%"),
+    # --- engine control_state_reason ---
+    (ReasonCode.ENGINE_DIRECT_SUN, {}, "Direct Sun"),
+    (ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET, {}, "Default: Sunset Offset"),
+    (ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT, {}, "Default: Elevation Limit"),
+    (
+        ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT,
+        {},
+        "Default: Acceptance Angle Exit",
+    ),
+    (ReasonCode.ENGINE_DEFAULT_BLIND_SPOT, {}, "Default: Blind Spot"),
+    (ReasonCode.ENGINE_DEFAULT, {}, "Default"),
+    # --- skip / describe_skip ---
+    (ReasonCode.SKIP_OUTSIDE_WINDOW, {}, "outside time window"),
+    (
+        ReasonCode.SKIP_SUN_OUTSIDE,
+        {},
+        "sun outside acceptance angle or elevation limits",
+    ),
+    (ReasonCode.SKIP_MANUAL_NOT_ACTIVE, {}, "manual override not active"),
+    (ReasonCode.SKIP_OCCUPANCY_DISABLED, {}, "occupancy detection disabled"),
+    (ReasonCode.SKIP_OCCUPANCY_NOT_ACTIVE, {}, "occupancy timeout not active"),
+    (ReasonCode.SKIP_CLIMATE_MODE_OFF, {}, "climate mode not enabled"),
+    (
+        ReasonCode.SKIP_CLIMATE_READINGS_UNAVAILABLE,
+        {},
+        "climate readings or options unavailable",
+    ),
+    (
+        ReasonCode.SKIP_CLIMATE_DEFERRED,
+        {},
+        "deferred glare-control to solar/glare handlers",
+    ),
+    (
+        ReasonCode.SKIP_NO_GLARE_ZONES,
+        {},
+        "no active glare zones or sun outside acceptance angle",
+    ),
+    (
+        ReasonCode.SKIP_CLOUD_SKIPPED,
+        {},
+        "cloud suppression skipped (sun outside acceptance angle)",
+    ),
+    (
+        ReasonCode.SKIP_CLOUD_INACTIVE,
+        {},
+        "cloud suppression inactive (direct sun present or feature disabled)",
+    ),
+    (ReasonCode.SKIP_WEATHER_NOT_ACTIVE, {}, "weather override not active"),
+    (
+        ReasonCode.SKIP_CUSTOM_NOT_ACTIVE,
+        {"slot": 2},
+        "custom position #2 not active",
+    ),
+    (ReasonCode.SKIP_ALWAYS_MATCHES, {}, "always matches"),
+    (
+        ReasonCode.SKIP_GROUP_SCENE_NOT_LOCK,
+        {},
+        "group intent is a scene, not a lock",
+    ),
+    (ReasonCode.SKIP_NO_GROUP_LOCK, {}, "no group lock intent"),
+    (
+        ReasonCode.SKIP_GROUP_LOCK_NOT_SCENE,
+        {},
+        "group intent is a lock, not a scene",
+    ),
+    (ReasonCode.SKIP_NO_GROUP_SCENE, {}, "no group scene intent"),
+    (ReasonCode.SKIP_NOT_ACTIVE, {}, "not active"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Step 1: contract — every code has a template and vice-versa
+# ---------------------------------------------------------------------------
+
+
+def test_every_reason_code_has_template() -> None:
+    codes = {c.value for c in ReasonCode}
+    templates = set(_REASON_TEMPLATES_EN)
+    assert codes == templates, (
+        f"codes-without-template: {sorted(codes - templates)}\n"
+        f"templates-without-code: {sorted(templates - codes)}"
+    )
+
+
+def test_en_render_matches_legacy_strings() -> None:
+    """render_en() reproduces the exact legacy f-string output for every code."""
+    for code, params, expected in LEGACY_CASES:
+        got = render_en(Reason(code, params))
+        assert got == expected, f"{code}: {got!r} != {expected!r}"
+
+
+def test_legacy_cases_cover_every_code() -> None:
+    """The legacy-render table must exercise every ReasonCode at least once."""
+    covered = {code for code, _, _ in LEGACY_CASES}
+    all_codes = {c.value for c in ReasonCode}
+    assert covered == all_codes, (
+        f"uncovered codes: {sorted(all_codes - covered)}\n"
+        f"unknown codes in table: {sorted(covered - all_codes)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fragment recursion + fallback
+# ---------------------------------------------------------------------------
+
+
+def test_nested_reason_fragment_renders_inline() -> None:
+    reason = Reason(
+        ReasonCode.MANUAL_LABEL_ONLY,
+        {"pos_label": Reason(ReasonCode.FRAGMENT_SUNSET_POSITION), "position": 60},
+    )
+    assert render_en(reason) == "manual override active — sunset position 60%"
+
+
+def test_fragment_sequence_joins_with_comma_space() -> None:
+    reason = Reason(
+        ReasonCode.CLOUD_SUPPRESSION,
+        {
+            "triggers": (
+                Reason(ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY),
+                Reason(ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW),
+                Reason(ReasonCode.FRAGMENT_TRIGGER_SMOOTHING_HOLD),
+            ),
+            "pos_label": Reason(ReasonCode.FRAGMENT_CLOUDY_POSITION),
+            "position": 25,
+        },
+    )
+    assert render_en(reason) == (
+        "cloud/low-light suppression — weather not sunny, lux below threshold, "
+        "smoothing hold → cloudy position 25%"
+    )
+
+
+def test_unknown_code_falls_back_to_code_string() -> None:
+    """An unknown/missing code degrades to the code string itself."""
+    assert render_en(Reason("does.not.exist")) == "does.not.exist"
+    assert render(Reason("also.missing", {"x": 1}), {}) == "also.missing"
+
+
+def test_reason_to_dict_is_json_safe_and_nested() -> None:
+    reason = Reason(
+        ReasonCode.CLOUD_SUPPRESSION,
+        {
+            "triggers": [Reason(ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY)],
+            "pos_label": Reason(ReasonCode.FRAGMENT_DEFAULT_POSITION),
+            "position": 25,
+        },
+    )
+    d = reason_to_dict(reason)
+    # Round-trips through JSON unchanged (proves it is JSON-safe).
+    assert json.loads(json.dumps(d)) == d
+    assert d["code"] == ReasonCode.CLOUD_SUPPRESSION
+    assert d["params"]["position"] == 25
+    assert d["params"]["triggers"][0]["code"] == ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY
+    assert d["params"]["pos_label"]["code"] == ReasonCode.FRAGMENT_DEFAULT_POSITION
+
+
+def test_reason_params_default_is_empty_mapping() -> None:
+    reason = Reason(ReasonCode.ENGINE_DIRECT_SUN)
+    assert dict(reason.params) == {}
+    assert render_en(reason) == "Direct Sun"
+
+
+# ---------------------------------------------------------------------------
+# Bundle parity locks (mirror summary_i18n)
+# ---------------------------------------------------------------------------
+
+
+def _flat(data: dict) -> dict[str, str]:
+    out: dict[str, str] = {}
+
+    def _walk(node: object, prefix: str) -> None:
+        if isinstance(node, dict):
+            for k, v in node.items():
+                _walk(v, f"{prefix}.{k}" if prefix else k)
+        elif isinstance(node, str):
+            out[prefix] = node
+
+    _walk(data, "")
+    return out
+
+
+def _load_json(name: str) -> dict:
+    with (REASON_I18N_DIR / name).open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _placeholders(template: str) -> set[tuple[str, str | None, str | None]]:
+    """Return the (field, format_spec, conversion) placeholder tuples.
+
+    Includes the format spec (e.g. ``.2f``) so a DE/FR template that drops a
+    numeric format is caught, not just a renamed field.
+    """
+    stripped = template.replace("{{", "").replace("}}", "")
+    return {
+        (field, spec, conv)
+        for _, field, spec, conv in string.Formatter().parse(stripped)
+        if field
+    }
+
+
+def test_reason_i18n_en_matches_code_defaults() -> None:
+    """Flattened ``reason_i18n/en.json`` == ``_REASON_TEMPLATES_EN`` byte-for-byte."""
+    assert _flat(_load_json("en.json")) == _REASON_TEMPLATES_EN
+
+
+def test_reason_i18n_key_parity_de_fr() -> None:
+    en = _flat(_load_json("en.json"))
+    assert en, "en.json must not be empty"
+    for lang in ("de", "fr"):
+        target = _flat(_load_json(f"{lang}.json"))
+        assert set(target) == set(en), (
+            f"{lang}.json key-set differs from en.json:\n"
+            f"  missing: {sorted(set(en) - set(target))[:10]}\n"
+            f"  extra:   {sorted(set(target) - set(en))[:10]}"
+        )
+
+
+def test_reason_placeholder_parity_de_fr() -> None:
+    en = _flat(_load_json("en.json"))
+    for lang in ("de", "fr"):
+        target = _flat(_load_json(f"{lang}.json"))
+        for key, en_value in en.items():
+            assert key in target, f"{lang}.json missing key {key!r}"
+            assert _placeholders(en_value) == _placeholders(target[key]), (
+                f"{lang}.json[{key}] placeholders {_placeholders(target[key])} "
+                f"!= en {_placeholders(en_value)}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Step 2: shared i18n_bundle loader
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_bundle_nested_to_dotted() -> None:
+    nested = {"solar": {"tracking": "T"}, "skip": {"not_active": "N"}}
+    assert i18n_bundle.flatten_bundle(nested) == {
+        "solar.tracking": "T",
+        "skip.not_active": "N",
+    }
+
+
+def test_load_bundle_overlay_partial_overrides_only_its_keys(tmp_path: Path) -> None:
+    """A partial overlay overrides only its keys; the rest fall back to defaults."""
+    (tmp_path / "xx.json").write_text(
+        json.dumps({"solar": {"tracking": "XX-TRACK"}}), encoding="utf-8"
+    )
+    defaults = {"solar.tracking": "EN-TRACK", "skip.not_active": "EN-NA"}
+    overlay = i18n_bundle.load_bundle_overlay(tmp_path, "xx")
+    merged = i18n_bundle.merge_labels(defaults, overlay)
+    assert merged == {"solar.tracking": "XX-TRACK", "skip.not_active": "EN-NA"}
+
+
+def test_load_bundle_overlay_missing_language_is_empty(tmp_path: Path) -> None:
+    assert i18n_bundle.load_bundle_overlay(tmp_path, "zz") == {}
+
+
+def test_load_bundle_overlay_en_is_empty(tmp_path: Path) -> None:
+    (tmp_path / "en.json").write_text('{"a": "b"}', encoding="utf-8")
+    assert i18n_bundle.load_bundle_overlay(tmp_path, "en") == {}
+
+
+def test_load_bundle_overlay_malformed_is_empty(tmp_path: Path) -> None:
+    (tmp_path / "bad.json").write_text("{not json", encoding="utf-8")
+    assert i18n_bundle.load_bundle_overlay(tmp_path, "bad") == {}
+
+
+def test_load_reason_labels_en_returns_code_defaults() -> None:
+    assert load_reason_labels("en") == _REASON_TEMPLATES_EN
+
+
+def test_load_reason_labels_missing_language_falls_back_to_english() -> None:
+    assert load_reason_labels("zz") == _REASON_TEMPLATES_EN
+
+
+def test_load_reason_labels_seeded_de_fr_equal_english() -> None:
+    """DE/FR are seeded = EN for now, so they overlay to the same result."""
+    for lang in ("de", "fr"):
+        assert load_reason_labels(lang) == _REASON_TEMPLATES_EN
+
+
+def test_load_reason_labels_is_cached() -> None:
+    assert load_reason_labels("fr") is not None
+    assert load_reason_labels("fr") == load_reason_labels("fr")
+
+
+async def test_async_prime_offloads_language_to_executor() -> None:
+    class _FakeHass:
+        def __init__(self) -> None:
+            self.calls: list[tuple] = []
+
+        async def async_add_executor_job(self, func, *args):
+            self.calls.append(args)
+            return func(*args)
+
+    hass = _FakeHass()
+    labels = await async_prime(hass, "fr")
+    assert hass.calls == [("fr",)]
+    assert labels == load_reason_labels("fr")
+
+
+def test_reason_i18n_module_has_no_homeassistant_import() -> None:
+    """The reason_i18n module must stay pure stdlib (engine-like constraint)."""
+    src = inspect.getsource(reason_i18n)
+    assert "import homeassistant" not in src
+    assert "from homeassistant" not in src
+
+
+def test_render_en_renders_via_overlay_fallback() -> None:
+    """render(reason, labels) uses the overlay, falling back to EN per key."""
+    reason = Reason(ReasonCode.ENGINE_DIRECT_SUN)
+    assert render(reason, {ReasonCode.ENGINE_DIRECT_SUN: "Direkte Sonne"}) == (
+        "Direkte Sonne"
+    )
+    # A key absent from the overlay falls back to English.
+    assert render(reason, {"other.key": "x"}) == "Direct Sun"

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -209,7 +209,7 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
         "Privacy active — use My position (70%)",
     ),
     (
-        ReasonCode.CUSTOM_POSITION_,
+        ReasonCode.CUSTOM_POSITION,
         {
             "head": Reason(
                 ReasonCode.CUSTOM_HEAD_SLOT, {"slot": 3, "trigger": "template"}
@@ -607,6 +607,48 @@ def test_reason_i18n_module_has_no_homeassistant_import() -> None:
     src = inspect.getsource(reason_i18n)
     assert "import homeassistant" not in src
     assert "from homeassistant" not in src
+
+
+def test_render_without_labels_equals_render_en() -> None:
+    """``render(reason)`` with no labels arg == ``render_en(reason)`` for every code.
+
+    Covers plain scalars, nested-fragment params, and fragment sequences.
+    """
+    for code, params, expected in LEGACY_CASES:
+        reason = Reason(code, params)
+        assert render(reason) == render_en(reason) == expected
+
+
+def test_render_none_labels_matches_english() -> None:
+    """Passing ``labels=None`` explicitly is identical to the English default."""
+    reason = Reason(
+        ReasonCode.CLOUD_SUPPRESSION,
+        {
+            "triggers": [
+                Reason(ReasonCode.FRAGMENT_TRIGGER_NOT_SUNNY),
+                Reason(ReasonCode.FRAGMENT_TRIGGER_LUX_BELOW),
+            ],
+            "pos_label": Reason(ReasonCode.FRAGMENT_DEFAULT_POSITION),
+            "position": 25,
+        },
+    )
+    assert render(reason, None) == render(reason) == render_en(reason)
+
+
+def test_render_logs_debug_on_bad_params(caplog: pytest.LogCaptureFixture) -> None:
+    """A template whose params can't format logs a debug line and returns the template."""
+    import logging
+
+    reason = Reason(ReasonCode.SOLAR_TRACKING, {})  # missing position/suffix
+    with caplog.at_level(
+        logging.DEBUG, logger="custom_components.adaptive_cover_pro.reason_i18n"
+    ):
+        result = render(reason, {})
+    # Fallback behavior is unchanged: the raw template is returned.
+    assert result == _REASON_TEMPLATES_EN[ReasonCode.SOLAR_TRACKING]
+    assert any(
+        ReasonCode.SOLAR_TRACKING in record.getMessage() for record in caplog.records
+    )
 
 
 def test_render_en_renders_via_overlay_fallback() -> None:

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -615,3 +615,94 @@ def test_render_en_renders_via_overlay_fallback() -> None:
     )
     # A key absent from the overlay falls back to English.
     assert render(reason, {"other.key": "x"}) == "Direct Sun"
+
+
+# ---------------------------------------------------------------------------
+# Step 3: reason_payload wire format on pipeline types + base handler
+# ---------------------------------------------------------------------------
+#
+# ``PipelineResult`` / ``DecisionStep`` gain a ``reason_payload`` field so
+# handlers can emit a stable ``Reason`` code+params. The canonical EN
+# ``reason`` string is auto-derived from the payload when no explicit reason is
+# passed, and the legacy explicit-string path is preserved unchanged.
+
+
+from custom_components.adaptive_cover_pro.const import ControlMethod  # noqa: E402
+from custom_components.adaptive_cover_pro.pipeline.handler import (  # noqa: E402
+    OverrideHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import (  # noqa: E402
+    DecisionStep,
+    PipelineResult,
+)
+
+
+def test_pipeline_result_payload_autoderives_reason() -> None:
+    """A payload with no explicit reason auto-derives reason == render_en(payload)."""
+    payload = Reason(ReasonCode.SOLAR_TRACKING, {"position": 50, "suffix": ""})
+    result = PipelineResult(
+        position=50,
+        control_method=ControlMethod.SOLAR,
+        reason_payload=payload,
+    )
+    assert result.reason == "sun within acceptance angle — position 50%"
+    assert result.reason == render_en(payload)
+    assert result.reason_payload is payload
+
+
+def test_pipeline_result_explicit_reason_preserved_without_payload() -> None:
+    """The legacy explicit-string path is unchanged (payload stays None)."""
+    result = PipelineResult(
+        position=50,
+        control_method=ControlMethod.SOLAR,
+        reason="legacy free text",
+    )
+    assert result.reason == "legacy free text"
+    assert result.reason_payload is None
+
+
+def test_pipeline_result_explicit_reason_wins_over_payload() -> None:
+    """An explicit reason is kept even when a payload is also supplied."""
+    payload = Reason(ReasonCode.SOLAR_TRACKING, {"position": 50, "suffix": ""})
+    result = PipelineResult(
+        position=50,
+        control_method=ControlMethod.SOLAR,
+        reason="explicit",
+        reason_payload=payload,
+    )
+    assert result.reason == "explicit"
+    assert result.reason_payload is payload
+
+
+def test_decision_step_payload_autoderives_reason() -> None:
+    payload = Reason(ReasonCode.REGISTRY_OUTPRIORITIZED, {"handler": "weather"})
+    step = DecisionStep(
+        handler="solar",
+        matched=False,
+        reason_payload=payload,
+        position=50,
+    )
+    assert step.reason == "outprioritized by weather"
+    assert step.reason_payload is payload
+
+
+def test_decision_step_explicit_reason_preserved_without_payload() -> None:
+    step = DecisionStep(handler="solar", matched=True, reason="won", position=50)
+    assert step.reason == "won"
+    assert step.reason_payload is None
+
+
+def test_base_describe_skip_returns_not_active_reason() -> None:
+    """The base handler's describe_skip returns Reason(SKIP_NOT_ACTIVE)."""
+
+    class _Bare(OverrideHandler):
+        name = "bare"
+        priority = 5
+
+        def evaluate(self, snapshot):  # noqa: ARG002
+            return None
+
+    skip = _Bare().describe_skip(object())  # type: ignore[arg-type]
+    assert isinstance(skip, Reason)
+    assert skip.code == ReasonCode.SKIP_NOT_ACTIVE
+    assert render_en(skip) == "not active"

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -574,10 +574,12 @@ def test_load_reason_labels_missing_language_falls_back_to_english() -> None:
     assert load_reason_labels("zz") == _REASON_TEMPLATES_EN
 
 
-def test_load_reason_labels_seeded_de_fr_equal_english() -> None:
-    """DE/FR are seeded = EN for now, so they overlay to the same result."""
+def test_load_reason_labels_de_fr_are_translated() -> None:
+    """DE/FR ship real translations: they cover every code but diverge from EN."""
     for lang in ("de", "fr"):
-        assert load_reason_labels(lang) == _REASON_TEMPLATES_EN
+        labels = load_reason_labels(lang)
+        assert set(labels) == set(_REASON_TEMPLATES_EN)
+        assert labels != _REASON_TEMPLATES_EN
 
 
 def test_load_reason_labels_is_cached() -> None:

--- a/tests/test_reason_labels_priming.py
+++ b/tests/test_reason_labels_priming.py
@@ -1,0 +1,73 @@
+"""Coordinator priming + threading of the reason-label overlay (issue #882, 9a).
+
+``async_setup_entry`` primes ``coordinator._reason_labels`` for the HA instance
+language (mirroring the summary_i18n priming), and the coordinator threads that
+overlay into the ``DiagnosticContext`` so ``position_explanation`` renders in the
+instance language.
+"""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    CoverType,
+    DOMAIN,
+    ReasonCode,
+)
+from custom_components.adaptive_cover_pro.reason_i18n import load_reason_labels
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+
+async def _setup(hass: HomeAssistant):
+    hass.states.async_set("cover.test_blind", "open", {"current_position": 50})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Prime", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="reason_prime_01",
+        title="Prime",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry.runtime_data
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_setup_primes_reason_labels_for_instance_language(
+    hass: HomeAssistant,
+) -> None:
+    hass.config.language = "de"
+    coordinator = await _setup(hass)
+    assert coordinator._reason_labels == load_reason_labels("de")
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_reason_labels_thread_into_position_explanation(
+    hass: HomeAssistant,
+) -> None:
+    coordinator = await _setup(hass)
+    # Inject a fake DE overlay onto the live coordinator; the next diagnostics
+    # build must render the explanation base through it.
+    coordinator._reason_labels = {
+        ReasonCode.SOLAR_TRACKING: "Sonne — Position {position}%{suffix}",
+        ReasonCode.CLIMATE_ACTIVE: "Klimamodus ({season}) — Position {position}%",
+        ReasonCode.DEFAULT_NO_CONDITION: "keine Bedingung — {pos_label} {position}%",
+        ReasonCode.FRAGMENT_DEFAULT_POSITION: "Standardposition",
+        ReasonCode.FRAGMENT_SUNSET_POSITION: "Sonnenuntergangsposition",
+    }
+    diag = coordinator.build_diagnostic_data()
+    explanation = diag["position_explanation"]
+    # Whatever handler won, the base is one of the injected DE templates — assert
+    # no English base leaked through (the German umlaut / word is present, or the
+    # outside-window German phrase). The explanation must not contain the English
+    # "no active condition" / "sun within acceptance angle" prose.
+    assert "no active condition" not in explanation
+    assert "sun within acceptance angle" not in explanation

--- a/tests/test_sensor_reason_localization.py
+++ b/tests/test_sensor_reason_localization.py
@@ -1,0 +1,145 @@
+"""Sensor-side reason localization + card code/params attrs (issue #882, step 9c).
+
+The decision_trace sensor renders the winner ``reason`` and each trace step's
+``reason`` through the coordinator's primed instance-language labels
+(``coordinator._reason_labels``). It additionally exposes, on the winner and on
+every trace step, JSON-serializable ``reason_code`` + ``reason_params``
+attributes so the companion card can localize with its own templates. On an EN
+install (``_reason_labels`` None or English) the ``reason`` strings stay
+byte-identical.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    ControlMethod,
+    CoverType,
+    ReasonCode,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    DecisionStep,
+    PipelineResult,
+)
+from custom_components.adaptive_cover_pro.reason_i18n import Reason
+from custom_components.adaptive_cover_pro.sensor import AdaptiveCoverDecisionTraceSensor
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config.units.temperature_unit = "°C"
+    return hass
+
+
+def _make_config_entry(options: dict | None = None):
+    entry = MagicMock()
+    entry.entry_id = "reason_loc_entry"
+    entry.data = {"name": "Test", CONF_SENSOR_TYPE: CoverType.BLIND}
+    entry.options = options or {}
+    return entry
+
+
+def _make_coordinator(result, reason_labels):
+    coord = MagicMock()
+    coord._pipeline_result = result
+    coord._reason_labels = reason_labels
+    coord.logger = MagicMock()
+    coord.hass = _make_hass()
+    coord.check_adaptive_time = True
+    coord.data = None
+    coord._cover_data = None
+    return coord
+
+
+def _make_sensor(result, reason_labels):
+    return AdaptiveCoverDecisionTraceSensor(
+        "reason_loc_entry",
+        _make_hass(),
+        _make_config_entry(),
+        "Test",
+        _make_coordinator(result, reason_labels),
+    )
+
+
+def _solar_result():
+    payload = Reason(ReasonCode.SOLAR_TRACKING, {"position": 72, "suffix": ""})
+    return PipelineResult(
+        position=72,
+        control_method=ControlMethod.SOLAR,
+        reason_payload=payload,
+        raw_calculated_position=72,
+        decision_trace=[
+            DecisionStep(
+                handler="solar",
+                matched=True,
+                reason_payload=payload,
+                position=72,
+            )
+        ],
+    )
+
+
+_FAKE_DE = {ReasonCode.SOLAR_TRACKING: "Sonne — Position {position}%{suffix}"}
+
+
+# ---------------------------------------------------------------------------
+# DE localization
+# ---------------------------------------------------------------------------
+
+
+def test_decision_trace_reason_localizes_de() -> None:
+    sensor = _make_sensor(_solar_result(), _FAKE_DE)
+    attrs = sensor.extra_state_attributes or {}
+    assert attrs["reason"] == "Sonne — Position 72%"
+    assert attrs["trace"][0]["reason"] == "Sonne — Position 72%"
+
+
+def test_decision_trace_exposes_reason_code_and_params() -> None:
+    sensor = _make_sensor(_solar_result(), _FAKE_DE)
+    attrs = sensor.extra_state_attributes or {}
+    step = attrs["trace"][0]
+    assert step["reason_code"] == "solar.tracking"
+    assert step["reason_params"] == {"position": 72, "suffix": ""}
+    # Winner also carries code + params.
+    assert attrs["reason_code"] == "solar.tracking"
+    assert attrs["reason_params"] == {"position": 72, "suffix": ""}
+    # Everything must be JSON serializable for the card.
+    json.dumps({"trace": attrs["trace"], "reason_params": attrs["reason_params"]})
+
+
+# ---------------------------------------------------------------------------
+# EN byte-identical
+# ---------------------------------------------------------------------------
+
+
+def test_decision_trace_reason_en_byte_identical() -> None:
+    sensor = _make_sensor(_solar_result(), None)
+    attrs = sensor.extra_state_attributes or {}
+    assert attrs["reason"] == "sun within acceptance angle — position 72%"
+    assert attrs["trace"][0]["reason"] == "sun within acceptance angle — position 72%"
+    # Card attrs are still present on an EN install (additive).
+    assert attrs["trace"][0]["reason_code"] == "solar.tracking"
+
+
+def test_decision_trace_legacy_step_without_payload_en() -> None:
+    """A legacy step carrying only a ``reason`` string keeps it and omits code."""
+    result = PipelineResult(
+        position=50,
+        control_method=ControlMethod.SOLAR,
+        reason="sun in FOV — position 50%",
+        decision_trace=[
+            DecisionStep(
+                handler="solar",
+                matched=True,
+                reason="sun in FOV — position 50%",
+                position=50,
+            )
+        ],
+    )
+    sensor = _make_sensor(result, None)
+    attrs = sensor.extra_state_attributes or {}
+    assert attrs["trace"][0]["reason"] == "sun in FOV — position 50%"
+    assert "reason_code" not in attrs["trace"][0]


### PR DESCRIPTION
## Summary

Localizes every human-readable reason string the integration surfaces — pipeline decision-trace reasons, `describe_skip` entries, the position explanation, and control-state reasons — which were previously hardcoded English f-strings. DE/FR users now see localized decision traces on `sensor.*` attributes.

**Approach — hybrid (Option 3 from the issue):**
- Handlers/registry/engine emit a stable frozen `ReasonCode` + a `params` dict (`Reason` frozen dataclass) as the wire format. Codes live in `const.py` beside `ControlStatus`/`ClimateInactiveReason` with the same "card localizes the slugs; never rename" contract.
- New pure `reason_i18n.py` resolver + `reason_i18n/{en,de,fr}.json` bundle, mirroring the existing `summary_i18n` mechanism. A shared `i18n_bundle.py` loader is extracted so `config_flow`'s summary plumbing and the new bundle share one flatten/overlay/merge path (no duplication).
- The bundle is primed for the instance language (`hass.config.language`) at setup; the diagnostics builder and sensor render via the payloads. **EN output is byte-identical** to today (the EN bundle is the source of truth + fallback), pinned by a lock test — so the ~40 prose-asserting test files stay green.
- The engine (`control_state_reason`) stays 0-HA-imports: it emits frozen codes and its prose property is a `render_en` shim; localization happens only at the diagnostics/sensor boundary.
- The climate reverse-map (`inactive_reason_from_result`) now keys on the frozen `ReasonCode` instead of English prose, so climate control-state resolves correctly under localization (verified language-independent by a dedicated test).
- Real DE/FR translations shipped; `acp-translate` skill extended to treat `reason_i18n` as a third bundle.

**For the companion card:** each decision-trace step and the winner now additionally expose `reason_code` + `reason_params` attributes (JSON-safe, fragments nested) so the card can do its own display-language templating. The existing `reason` attribute is unchanged in name (its value is now localized).

⚠️ **Coordination note (card repo):** if [`adaptive-cover-pro-card`](https://github.com/jrhubott/adaptive-cover-pro-card) currently pattern-matches the English `reason` prose, a DE/FR install would change that text. The card follow-up is to switch to `reason_code`/`reason_params`. Recommend verifying the card's prose-matching before broadly promoting DE/FR reason localization.

No config-entry migration (display-only; rollback-safe).

## Testing
- ✅ 6429 tests passing (full suite, `pytest -n auto`)
- EN byte-identical guarantee locked by `test_reason_i18n_en_matches_code_defaults` + the legacy-string render table; #881 occupancy wording pinned byte-for-byte
- DE/FR key + placeholder parity locked by `test_reason_i18n_key_parity_de_fr` / `test_reason_placeholder_parity_de_fr`
- `summary_i18n` parity stays green through the shared-loader extraction; engine stays 0-HA-imports

## Related Issues
Refs #882

**Note (runtime language):** the reason bundle is primed once at `async_setup_entry`, so a change to `hass.config.language` takes effect after the config entry reloads or HA restarts. This matches how HA treats language changes for entity attributes.