### PR TITLE
feat: expose linear_position attr for pre-interpolation display (#911)

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -448,6 +448,10 @@ class DiagnosticsBuilder:
         result = ctx.pipeline_result
         raw_pos = result.raw_calculated_position if result is not None else 0
         diagnostics["calculated_position"] = raw_pos
+        # Pre-interpolation logical target (issue #911): the position the pipeline
+        # decided, before interpolation maps it onto the motor curve. Equals the
+        # interpolated motor value when interpolation is off.
+        diagnostics["linear_position"] = result.position if result is not None else 0
 
         if result is not None and result.climate_state is not None:
             diagnostics["calculated_position_climate"] = result.climate_state

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -368,6 +368,9 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         if position_explanation is not None:
             attrs["position_explanation"] = position_explanation
         attrs["raw_calculated_position"] = diagnostics.get("calculated_position")
+        # Pre-interpolation logical target (issue #911); the companion card shows
+        # this as the primary position, demoting the interpolated `state`.
+        attrs["linear_position"] = diagnostics.get("linear_position")
         calc_details = diagnostics.get("calculation_details")
         if calc_details:
             attrs["edge_case_detected"] = calc_details.get("edge_case_detected")

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -1760,3 +1760,67 @@ class TestCalculationDetailsAllCoverTypes:
         assert "beta_rad" in details["tilt"]
         # Top-level position axis present.
         assert "position_pct" in details
+
+
+# ---------------------------------------------------------------------------
+# linear_position — pre-interpolation logical target (issue #911)
+# ---------------------------------------------------------------------------
+
+
+class TestLinearPosition:
+    """`linear_position` exposes the pipeline's logical target, pre-interpolation."""
+
+    def test_equals_pipeline_position_when_interpolating(
+        self, builder: DiagnosticsBuilder
+    ):
+        """When interpolation maps 10 -> 31, linear_position stays the logical 10."""
+        diag, _ = builder.build(
+            _base_ctx(
+                pipeline_result=_make_pr(position=10),
+                use_interpolation=True,
+                final_state=31,
+            )
+        )
+        assert diag["linear_position"] == 10
+        # Decoupled from the interpolated motor value.
+        assert diag["linear_position"] != 31
+
+    def test_equals_final_state_when_not_interpolating(
+        self, builder: DiagnosticsBuilder
+    ):
+        """With interpolation off, linear_position matches the motor value."""
+        diag, _ = builder.build(
+            _base_ctx(
+                pipeline_result=_make_pr(position=40),
+                use_interpolation=False,
+                final_state=40,
+            )
+        )
+        assert diag["linear_position"] == 40
+
+    def test_is_plain_int(self, builder: DiagnosticsBuilder):
+        """linear_position is a plain int, never a numpy scalar."""
+        diag, _ = builder.build(_base_ctx(pipeline_result=_make_pr(position=10)))
+        # isinstance still rejects numpy scalars (np.int64 is not an int subclass).
+        assert isinstance(diag["linear_position"], int)
+
+    def test_present_for_safety_winner(self, builder: DiagnosticsBuilder):
+        """Safety winners (interpolation bypassed) still carry linear_position."""
+        diag, _ = builder.build(
+            _base_ctx(pipeline_result=_make_pr(position=10, is_safety=True))
+        )
+        assert diag["linear_position"] == 10
+
+    def test_present_for_bypass_winner(self, builder: DiagnosticsBuilder):
+        """Bypass winners still carry linear_position."""
+        diag, _ = builder.build(
+            _base_ctx(pipeline_result=_make_pr(position=10, bypass_auto_control=True))
+        )
+        assert diag["linear_position"] == 10
+
+    def test_defaults_to_zero_without_pipeline_result(
+        self, builder: DiagnosticsBuilder
+    ):
+        """No pipeline result -> linear_position defaults to 0, like calculated_position."""
+        diag, _ = builder.build(_base_ctx(pipeline_result=None))
+        assert diag["linear_position"] == 0

--- a/tests/test_linear_position.py
+++ b/tests/test_linear_position.py
@@ -1,0 +1,46 @@
+"""Cover_Position sensor surfaces `linear_position` (issue #911).
+
+`linear_position` mirrors the diagnostics field of the same name onto the
+Cover_Position sensor so the companion card can show the pre-interpolation
+logical target instead of the interpolated motor value.
+"""
+
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.sensor import _cover_position_attrs
+
+
+def _make_sensor(diagnostics: dict) -> MagicMock:
+    """Minimal MagicMock sensor exercising only the diagnostics branch."""
+    s = MagicMock()
+    s.data.attributes = {}
+    s.data.states = {"control": "solar", "state": 31, "held_position": None}
+    s.coordinator._pipeline_result = None
+    s.coordinator.data.diagnostics = diagnostics
+    s.coordinator._cmd_svc.transit_states.return_value = {}
+    s.coordinator._snapshot = None
+    # lift_travel_metres None -> _compute_distance_attrs returns None (skip).
+    s.coordinator._policy.lift_travel_metres.return_value = None
+    return s
+
+
+def test_linear_position_mirrored_from_diagnostics():
+    """The sensor copies diagnostics['linear_position'] onto its attributes."""
+    s = _make_sensor({"linear_position": 10, "calculated_position": 40})
+    attrs = _cover_position_attrs(s)
+    assert attrs["linear_position"] == 10
+
+
+def test_linear_position_distinct_from_state():
+    """linear_position (10) is exposed alongside the interpolated state (31)."""
+    s = _make_sensor({"linear_position": 10, "calculated_position": 40})
+    attrs = _cover_position_attrs(s)
+    assert attrs["linear_position"] == 10
+    assert s.data.states["state"] == 31
+
+
+def test_linear_position_none_when_absent():
+    """Missing diagnostics key -> attribute present as None (backwards safe)."""
+    s = _make_sensor({"calculated_position": 40})
+    attrs = _cover_position_attrs(s)
+    assert attrs["linear_position"] is None


### PR DESCRIPTION
## Summary
Adds a purely additive `linear_position` attribute on the Cover_Position sensor carrying the pipeline's **pre-interpolation logical target** (`PipelineResult.position` — e.g. 10%), so the companion card can show the value the user configured instead of the interpolated motor command (e.g. 31%).

- Plumbed single-source through diagnostics (`_build_position_base`), mirroring how `raw_calculated_position` is already exposed, then surfaced on the sensor in `_cover_position_attrs`.
- **`state` is unchanged** — it still publishes the interpolated motor value (31), which the motor genuinely receives and the physical cover reports. `linear_position` equals `state` when interpolation is off.
- No engine/pipeline/motor-command changes; zero risk to delta gating, `all_at_target`, or distance calcs.

The visible card behavior (badge showing 10%, motor value demoted to secondary) lands in the companion card repo — see the backwards-compatible companion issue below.

## Testing
- ✅ 168 targeted tests passing (`test_diagnostics/test_builder.py`, `test_linear_position.py`, `test_position_explanation.py`, `test_sensor_unrecorded_attributes.py`)
- New `TestLinearPosition` covers: decoupling from the interpolated value, equality when interpolation off, plain-int type, and safety/bypass/no-result cases.

## Related Issues
Refs #911
Companion (card, backwards-compatible): jrhubott/adaptive-cover-pro-card#219

https://claude.ai/code/session_01AnekFeqTJ5dY24fGVvXLo5
