### PR TITLE
feat: show custom slot names in config-flow priority preview

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -220,6 +220,7 @@ from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
 from .helpers import (
     custom_position_slot_configured,
+    custom_position_slot_name,
     custom_position_slot_sensors,
     mirror_legacy_slot_sensor_keys,
 )
@@ -1841,6 +1842,9 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     #    has_trigger)
     _custom_slots: list[tuple[int, str, int, int, bool, int | None, bool, bool]] = []
     _and_no_sensor_slots: list[int] = []
+    # slot -> configured custom_position_name_N (issue #910); feeds the
+    # Decision Priority chain's per-slot label below.
+    _custom_slot_names: dict[int, str] = {}
     for _i, _slot_keys in CUSTOM_POSITION_SLOTS.items():
         if not custom_position_slot_configured(config, _slot_keys):
             continue
@@ -1881,6 +1885,9 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                 _has_trigger,
             )
         )
+        _name = custom_position_slot_name(config, _slot_keys)
+        if _name:
+            _custom_slot_names[_i] = _name
     has_custom_position = bool(_custom_slots)
     my_pos = config.get(CONF_MY_POSITION_VALUE)  # None = not configured
     has_cloud = bool(config.get(CONF_CLOUD_SUPPRESSION))
@@ -2743,6 +2750,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
         supports_glare=summary_policy.supports_glare_zones,
         custom_slots=_custom_slots,
         priorities=_handler_priority_overrides(config),
+        slot_names=_custom_slot_names,
     )
     chain = [_ch(e.active, e.label) for e in _chain_entries]
 
@@ -2764,6 +2772,7 @@ def _render_priority_scale(config: dict, policy) -> str:
     ladder reflects the *last submitted* priorities and refreshes on re-render.
     """
     custom_slots: list[tuple] = []
+    slot_names: dict[int, str] = {}
     for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
         if not custom_position_slot_configured(config, slot_keys):
             continue
@@ -2772,6 +2781,9 @@ def _render_priority_scale(config: dict, policy) -> str:
         )
         # build_priority_chain reads index 0 (slot) and 3 (priority).
         custom_slots.append((slot, None, 0, priority, False, None, False))
+        name = custom_position_slot_name(config, slot_keys)
+        if name:
+            slot_names[slot] = name
 
     entries = build_priority_chain(
         has_weather=True,
@@ -2783,6 +2795,7 @@ def _render_priority_scale(config: dict, policy) -> str:
         supports_glare=policy.supports_glare_zones,
         custom_slots=custom_slots,
         priorities=_handler_priority_overrides(config),
+        slot_names=slot_names,
     )
 
     lines = ["```"]

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -131,6 +131,18 @@ def custom_position_slot_configured(
     return has_trigger and options.get(slot_keys["position"]) is not None
 
 
+def custom_position_slot_name(
+    options: Mapping, slot_keys: Mapping[str, str]
+) -> str | None:
+    """Return a custom-position slot's user-configured label, or None.
+
+    Single source of truth for reading ``custom_position_name_N`` (issue
+    #867): an empty string (a cleared text box) and an absent key both
+    normalize to ``None`` so every consumer treats "unset" the same way.
+    """
+    return options.get(slot_keys["name"]) or None
+
+
 def get_safe_state(hass: HomeAssistant, entity_id: str):
     """Get a safe state value if not available."""
     state = hass.states.get(entity_id)

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -100,6 +100,7 @@ from ..const import (
 from ..helpers import (
     compute_effective_default,
     custom_position_slot_configured,
+    custom_position_slot_name,
     custom_position_slot_sensors,
 )
 from ..templates import combine_with_mode, is_template_string, render_condition
@@ -286,7 +287,7 @@ class PipelineSnapshotBuilder:
             )
             # Optional user-configured label (issue #867); empty string (a
             # cleared text box) normalizes to None, same as an absent key.
-            custom_name = options.get(slot_keys["name"]) or None
+            custom_name = custom_position_slot_name(options, slot_keys)
 
             priority = int(
                 options.get(slot_keys["priority"]) or DEFAULT_CUSTOM_POSITION_PRIORITY

--- a/custom_components/adaptive_cover_pro/priority_chain.py
+++ b/custom_components/adaptive_cover_pro/priority_chain.py
@@ -62,6 +62,7 @@ def build_priority_chain(
     supports_glare: bool,
     custom_slots: Iterable[Sequence] = (),
     priorities: Mapping[str, int] | None = None,
+    slot_names: Mapping[int, str] | None = None,
 ) -> list[PriorityChainEntry]:
     """Return the decision chain ordered highest-priority-first.
 
@@ -71,7 +72,10 @@ def build_priority_chain(
     slot tuples ``(slot, trigger, position, priority, use_my, tilt, tilt_only)``;
     each is interleaved at its configured priority. The sort is stable, so a
     custom slot sharing a fixed handler's priority renders after that handler
-    (fixed anchors are inserted first).
+    (fixed anchors are inserted first). ``slot_names`` is an optional
+    ``slot -> custom_position_name_N`` map (issue #910); when a slot has a
+    non-empty name, its label is ``f"{name}({priority})"`` instead of the
+    default ``f"Custom#{slot}({priority})"``.
     """
     overrides = priorities or {}
 
@@ -92,9 +96,9 @@ def build_priority_chain(
     for slot_tuple in custom_slots:
         slot = slot_tuple[0]
         priority = slot_tuple[3]
-        entries.append(
-            PriorityChainEntry(priority, f"Custom#{slot}({priority})", True, slot=slot)
-        )
+        name = (slot_names or {}).get(slot)
+        label = f"{name}({priority})" if name else f"Custom#{slot}({priority})"
+        entries.append(PriorityChainEntry(priority, label, True, slot=slot))
     # Stable sort highest-priority-first; ties keep insertion order (fixed
     # anchors before custom slots).
     entries.sort(key=lambda e: e.priority, reverse=True)

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -54,6 +54,7 @@ from .managers.manual_override.expiry import (
 )
 from .helpers import (
     custom_position_slot_configured,
+    custom_position_slot_name,
     custom_position_slot_sensors,
     motion_entities,
 )
@@ -983,7 +984,7 @@ def _build_custom_position_slots_snapshot(
                 "sensor_name": sensor_name,
                 # User-configured slot label (issue #867); overrides sensor_name
                 # in the reason/decision_trace/card when set. None = unset.
-                "custom_name": options.get(slot_keys["name"]) or None,
+                "custom_name": custom_position_slot_name(options, slot_keys),
                 "position": int(position) if configured else None,
                 "priority": (
                     int(

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -1657,6 +1657,19 @@ def test_priority_safety_slot_in_chain():
     assert "✅Custom#5(100)" in summary
 
 
+def test_priority_custom_slot_named_shown_in_decision_priority():
+    """A named custom slot renders its name, not Custom#N (issue #910)."""
+    cfg = {
+        "custom_position_sensors_2": ["binary_sensor.protection_solaire_canicule"],
+        "custom_position_2": 10,
+        "custom_position_priority_2": 75,
+        "custom_position_name_2": "Canicule",
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "✅Canicule(75)" in summary
+    assert "Custom#2" not in summary
+
+
 def test_priority_no_force_entry_remains():
     """The standalone Force chain entry is gone (merged into custom slots, #563)."""
     summary = _build_config_summary({}, CoverType.BLIND)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -15,6 +15,7 @@ from custom_components.adaptive_cover_pro.helpers import (
     check_cover_features,
     check_time_passed,
     custom_position_slot_configured,
+    custom_position_slot_name,
     custom_position_slot_sensors,
     dt_check_time_passed,
     get_datetime_from_str,
@@ -93,6 +94,20 @@ def test_slot_configured_requires_trigger_and_position():
     assert not custom_position_slot_configured(
         {_SLOT1["template"]: "not a template", _SLOT1["position"]: 50}, _SLOT1
     )
+
+
+@pytest.mark.unit
+def test_custom_position_slot_name_reads_option_key():
+    """Returns the configured custom_position_name_N value (issue #867/#910)."""
+    options = {_SLOT1["name"]: "Canicule"}
+    assert custom_position_slot_name(options, _SLOT1) == "Canicule"
+
+
+@pytest.mark.unit
+def test_custom_position_slot_name_empty_string_normalizes_to_none():
+    """An empty string (cleared text box) and an absent key both mean unset."""
+    assert custom_position_slot_name({_SLOT1["name"]: ""}, _SLOT1) is None
+    assert custom_position_slot_name({}, _SLOT1) is None
 
 
 @pytest.mark.unit

--- a/tests/test_priority_chain_helper.py
+++ b/tests/test_priority_chain_helper.py
@@ -105,6 +105,32 @@ def test_custom_slot_ties_break_after_fixed_handler():
     assert motion_idx < custom_idx
 
 
+def test_custom_slot_uses_configured_name_when_provided():
+    """A named slot's label is the configured name, not Custom#N (issue #910)."""
+    slots = [(2, "sensor.x", 0, 75, False, None, False)]
+    chain = build_priority_chain(
+        **_kwargs(custom_slots=slots, slot_names={2: "Canicule"})
+    )
+    custom = next(e for e in chain if e.slot == 2)
+    assert custom.label == "Canicule(75)"
+
+
+def test_custom_slot_falls_back_to_default_label_when_name_absent():
+    """A slot missing from slot_names still renders Custom#N (fallback)."""
+    slots = [(2, "sensor.x", 0, 75, False, None, False)]
+    chain = build_priority_chain(**_kwargs(custom_slots=slots, slot_names={}))
+    custom = next(e for e in chain if e.slot == 2)
+    assert custom.label == "Custom#2(75)"
+
+
+def test_custom_slot_empty_or_missing_slot_names_mapping_falls_back():
+    """slot_names=None (the default) must not change today's label behavior."""
+    slots = [(2, "sensor.x", 0, 75, False, None, False)]
+    chain = build_priority_chain(**_kwargs(custom_slots=slots))
+    custom = next(e for e in chain if e.slot == 2)
+    assert custom.label == "Custom#2(75)"
+
+
 def test_entry_is_priority_chain_entry():
     chain = build_priority_chain(**_kwargs())
     assert all(isinstance(e, PriorityChainEntry) for e in chain)
@@ -163,3 +189,20 @@ def test_priority_scale_unconfigured_slots_absent():
 
     scale = _render_priority_scale({}, _blind_policy())
     assert "◀" not in scale  # no custom slot configured → no marker
+
+
+def test_priority_scale_shows_custom_name_when_configured():
+    """A named slot's ladder entry shows its name, not Custom#N (issue #910)."""
+    from custom_components.adaptive_cover_pro.config_flow import _render_priority_scale
+    from custom_components.adaptive_cover_pro.const import CUSTOM_POSITION_SLOTS
+
+    slot1 = CUSTOM_POSITION_SLOTS[1]
+    config = {
+        slot1["sensors"]: ["binary_sensor.x"],
+        slot1["position"]: 40,
+        slot1["priority"]: 85,
+        slot1["name"]: "Canicule",
+    }
+    scale = _render_priority_scale(config, _blind_policy())
+    assert "Canicule(85)" in scale
+    assert "Custom#1" not in scale


### PR DESCRIPTION
## Summary
The config-flow "Decision priority" preview — both the Configuration Summary's compact chain and the priority ladder — hardcoded custom-position labels as `Custom#N(priority)`, ignoring the already-stored `custom_position_name_N` option. Both surfaces now render the user's configured name (e.g. `Canicule(75)`) when set, falling back to `Custom#N(priority)` when unset, via a new optional `slot_names` mapping on the shared `build_priority_chain()` choke point. Extracted a `custom_position_slot_name()` helper and refactored the two pre-existing duplicate inline reads (`sensor.py`, `pipeline/snapshot_builder.py`) to it. No translation changes — the label content is raw Python interpolation.

## Testing
- ✅ 6441 tests passing

## Related Issues
Refs #910

https://claude.ai/code/session_016fRLaVoNedJUhk4RmiWCSv