### PR TITLE
fix: suppress false override from late drift-reset tilt publish (#927)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -861,12 +861,21 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         Per CODING_GUIDELINES.md § "No Code Duplication" the shared
         callback inside :meth:`secondary_axis_check` now delegates here
         instead of inlining its own OR-composition.
+
+        Issue #927 adds a third term: a drift-reset endpoint excursion
+        (``DualAxisSequencer.is_reset_excursion_publish``). The tilt-only reset
+        path never opens the back-rotate window and the endpoint's stale
+        ``current_tilt_position`` publish can arrive after the command grace
+        closes; the value-matched, time-boxed, one-shot excursion predicate
+        catches exactly that late publish without widening the general cap.
         """
         if self._sequencer is None:
             return False
-        return self._sequencer.is_in_suppression_with_cap(
-            entity_id, delta
-        ) or self._is_in_tilt_command_grace(entity_id, delta)
+        return (
+            self._sequencer.is_in_suppression_with_cap(entity_id, delta)
+            or self._is_in_tilt_command_grace(entity_id, delta)
+            or self._sequencer.is_reset_excursion_publish(entity_id, delta)
+        )
 
     def _clear_last_tilt(self) -> None:
         """Forget the last resolved tilt so tilt-only cycles don't replay it.
@@ -1035,9 +1044,10 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         The suppression callback is the same predicate
         :meth:`primary_axis_suppression` exposes for the position axis
         (issue #33 Phase 5 cross-axis): the motor back-rotate window
-        OR'd with the command-grace period. Sharing one callback across
-        both axes keeps the publish-lag and grace logic from drifting per
-        CODING_GUIDELINES.md § "No Code Duplication".
+        OR'd with the command-grace period OR'd with the drift-reset
+        endpoint excursion (issue #927). Sharing one callback across
+        both axes keeps the publish-lag, grace, and excursion logic from
+        drifting per CODING_GUIDELINES.md § "No Code Duplication".
         """
         if result is None or result.tilt is None:
             return None

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -862,20 +862,18 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         callback inside :meth:`secondary_axis_check` now delegates here
         instead of inlining its own OR-composition.
 
-        Issue #927 adds a third term: a drift-reset endpoint excursion
-        (``DualAxisSequencer.is_reset_excursion_publish``). The tilt-only reset
-        path never opens the back-rotate window and the endpoint's stale
-        ``current_tilt_position`` publish can arrive after the command grace
-        closes; the value-matched, time-boxed, one-shot excursion predicate
-        catches exactly that late publish without widening the general cap.
+        The drift-reset endpoint excursion guard (issue #927) is deliberately
+        NOT folded in here: it is a value-based, tilt-axis-only predicate wired
+        as ``SecondaryAxisCheck.excursion_match`` on the tilt axis. The position
+        axis must not consult it, or a position move whose delta coincidentally
+        matched a stale tilt excursion would be suppressed and the excursion's
+        one-shot record burned before the real tilt publish arrives.
         """
         if self._sequencer is None:
             return False
-        return (
-            self._sequencer.is_in_suppression_with_cap(entity_id, delta)
-            or self._is_in_tilt_command_grace(entity_id, delta)
-            or self._sequencer.is_reset_excursion_publish(entity_id, delta)
-        )
+        return self._sequencer.is_in_suppression_with_cap(
+            entity_id, delta
+        ) or self._is_in_tilt_command_grace(entity_id, delta)
 
     def _clear_last_tilt(self) -> None:
         """Forget the last resolved tilt so tilt-only cycles don't replay it.
@@ -1044,10 +1042,16 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         The suppression callback is the same predicate
         :meth:`primary_axis_suppression` exposes for the position axis
         (issue #33 Phase 5 cross-axis): the motor back-rotate window
-        OR'd with the command-grace period OR'd with the drift-reset
-        endpoint excursion (issue #927). Sharing one callback across
-        both axes keeps the publish-lag, grace, and excursion logic from
-        drifting per CODING_GUIDELINES.md § "No Code Duplication".
+        OR'd with the command-grace period. Sharing one callback across
+        both axes keeps the publish-lag and grace logic from drifting per
+        CODING_GUIDELINES.md § "No Code Duplication".
+
+        ``excursion_match`` wires the drift-reset endpoint guard (issue #927)
+        onto the TILT axis only. It is value-based (matches the raw published
+        wire tilt against the recorded endpoint) and consumed before the grace
+        check, so a stale endpoint publish landing after the command grace
+        closes is recognised as ACP's own move — without the position axis ever
+        consulting it.
         """
         if result is None or result.tilt is None:
             return None
@@ -1057,6 +1061,11 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             attribute="current_tilt_position",
             label="tilt",
             suppression=self.primary_axis_suppression,
+            excursion_match=(
+                self._sequencer.is_reset_excursion_publish
+                if self._sequencer is not None
+                else None
+            ),
         )
 
     def _drift_reset_eligible(self, context: Any) -> bool:

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -581,8 +581,15 @@ class DualAxisSequencer:
         verify: bool = True,
         drift_reset_eligible: bool = True,
         _retry_depth: int = 0,
-    ) -> None:
+    ) -> bool:
         """Emit ``set_cover_tilt_position`` and rebase the commanded position.
+
+        Returns ``True`` only when the ``set_cover_tilt_position`` service call
+        actually dispatched. Every early-out — target-unchanged dedup,
+        min-delta gate, dry-run, and a ``HomeAssistantError`` from the service
+        call — returns ``False``. The drift-reset endpoint stamp (issue #927)
+        relies on this so it records only after the endpoint move really went
+        out; a failed send leaves no stale record to swallow a later user move.
 
         Shared by ``run_sequence`` (post-settle chase) and ``update_tilt_only``
         (tilt-only update when position hasn't changed).
@@ -635,7 +642,7 @@ class DualAxisSequencer:
                 await self._verify_and_record_tilt(
                     entity_id, tilt_target, _retry_depth=_retry_depth
                 )
-            return
+            return False
 
         if not force and self._get_min_change is not None:
             anchor, anchor_source = self._resolve_tilt_anchor(entity_id)
@@ -669,7 +676,7 @@ class DualAxisSequencer:
                     anchor_source=anchor_source,
                     min_delta_required=self._get_min_change(),
                 )
-                return
+                return False
 
         if self._is_dry_run():
             self._logger.info(
@@ -685,7 +692,7 @@ class DualAxisSequencer:
                 position_target=position_target,
                 trigger=reason,
             )
-            return
+            return False
 
         # Capture the pre-send anchor BEFORE overwriting _tilt_targets so the
         # drift accumulator (issue #663) measures real commanded travel. Uses
@@ -746,7 +753,7 @@ class DualAxisSequencer:
                 position_target=position_target,
                 trigger=reason,
             )
-            return
+            return False
 
         self._record_event(
             "tilt_command_sent",
@@ -771,7 +778,7 @@ class DualAxisSequencer:
             )
 
         if not verify:
-            return
+            return True
 
         # Wait for the motor's mechanical back-drive on the vertical axis to
         # settle before reading current_position for the rebase. Without this
@@ -797,6 +804,7 @@ class DualAxisSequencer:
                 position_target=position_target,
                 trigger=reason,
             )
+        return True
 
     async def _maybe_drift_reset(
         self,
@@ -870,19 +878,7 @@ class DualAxisSequencer:
                 entity_id=entity_id,
                 tilt_position=reset_endpoint,
             )
-            # Record the endpoint excursion so a stale endpoint state publish
-            # that lands after the command grace closes is recognised as ACP's
-            # own move, not a manual override (issue #927). The LOGICAL endpoint
-            # is stored; is_reset_excursion_publish applies _to_wire on match.
-            # Only stamp when the endpoint command will actually be sent: in
-            # dry-run the send below is skipped, so a stamp would linger with no
-            # matching publish and could later swallow a genuine move. Append —
-            # a second reset inside the window keeps its own record.
-            if not self._is_dry_run():
-                self._reset_excursion.setdefault(entity_id, []).append(
-                    _ResetExcursion(endpoint=reset_endpoint, at=dt.datetime.now(dt.UTC))
-                )
-            await self._send_tilt_command(
+            sent = await self._send_tilt_command(
                 entity_id,
                 tilt_target=reset_endpoint,
                 position_target=position_target,
@@ -890,6 +886,19 @@ class DualAxisSequencer:
                 force=True,
                 verify=False,
             )
+            # Record the endpoint excursion so a stale endpoint state publish
+            # that lands after the command grace closes is recognised as ACP's
+            # own move, not a manual override (issue #927). The LOGICAL endpoint
+            # is stored; is_reset_excursion_publish applies _to_wire on match.
+            # Only stamp when the endpoint command ACTUALLY dispatched: in
+            # dry-run the send is skipped, and a HomeAssistantError leaves the
+            # slats put — either way a stamp would linger with no matching
+            # publish and could later swallow a genuine move. Append — a second
+            # reset inside the window keeps its own record.
+            if sent:
+                self._reset_excursion.setdefault(entity_id, []).append(
+                    _ResetExcursion(endpoint=reset_endpoint, at=dt.datetime.now(dt.UTC))
+                )
             await asyncio.sleep(VENETIAN_POST_TILT_REBASE_DELAY_SECONDS)
             self._record_event(
                 "tilt_reset_return",

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -100,8 +100,9 @@ class _ResetExcursion:
     back, a slow actuator (Somfy IO/Overkiz) may publish the endpoint's
     ``current_tilt_position`` several seconds later — after the command grace
     window has closed. ``endpoint`` is the LOGICAL endpoint the reset drove to
-    (``POSITION_OPEN``/``POSITION_CLOSED``); ``at`` is the UTC instant the
-    endpoint command was sent, anchoring the value-matching window in
+    (``POSITION_OPEN``/``POSITION_CLOSED``) — matched against the published wire
+    value via :meth:`DualAxisSequencer._to_wire`; ``at`` is the UTC instant the
+    endpoint command was sent, bounding the publish-lag window in
     :meth:`DualAxisSequencer.is_reset_excursion_publish`.
     """
 
@@ -213,14 +214,15 @@ class DualAxisSequencer:
         # tilt actually sends via ``update_tilt_only``. Drives
         # ``has_pending_tilt`` so the coordinator keeps re-attempting dispatch.
         self._pending_tilt: dict[str, dict] = {}
-        # Per-entity drift-reset endpoint excursion awaiting its late state
-        # publish (issue #927). A reset drives the slats to a mechanical
-        # endpoint and back; on slow actuators the endpoint's stale
+        # Per-entity list of drift-reset endpoint excursions awaiting their
+        # late state publish (issue #927). A reset drives the slats to a
+        # mechanical endpoint and back; on slow actuators the endpoint's stale
         # ``current_tilt_position`` publishes after the command grace closes.
-        # ``is_reset_excursion_publish`` consumes this one-shot to suppress
-        # that late publish (value-matched, time-boxed) so it isn't misread as
-        # a manual move.
-        self._reset_excursion: dict[str, _ResetExcursion] = {}
+        # ``is_reset_excursion_publish`` consumes one one-shot record per
+        # matching publish (value-matched, time-boxed) so it isn't misread as a
+        # manual move. A list (not a single slot) so two resets firing inside
+        # the same window each keep their own record instead of clobbering.
+        self._reset_excursion: dict[str, list[_ResetExcursion]] = {}
 
     # -- tilt inversion ---------------------------------------------------- #
 
@@ -426,7 +428,7 @@ class DualAxisSequencer:
             return True
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
 
-    def is_reset_excursion_publish(self, entity_id: str, delta: float) -> bool:
+    def is_reset_excursion_publish(self, entity_id: str, new_value: float) -> bool:
         """Suppress the late state publish of a drift-reset endpoint excursion (#927).
 
         A drift reset (``_maybe_drift_reset``) drives the slats to a mechanical
@@ -438,35 +440,49 @@ class DualAxisSequencer:
         ``SecondaryAxisCheck.evaluate`` then reads it as a large-delta manual
         move and fires a false ``manual_override_set``.
 
-        Delta reconstruction: ``SecondaryAxisCheck.expected`` is the stored
-        logical tilt target (``result.tilt``) and the late publish's
-        ``new_value`` is the wire endpoint value, so ``evaluate`` computes
-        ``delta = abs(stored_target - wire_endpoint)``. This predicate rebuilds
-        that same quantity from the recorded LOGICAL endpoint via
-        :meth:`_to_wire` (so inversion is handled once) and matches within
-        ``VENETIAN_TILT_VERIFY_TOLERANCE``. On a match the record is consumed
-        (one-shot) and True is returned; a non-matching intermediate event
-        leaves the record intact so the real endpoint publish still matches.
+        Matches on the PUBLISHED WIRE VALUE, not on a reconstructed delta: the
+        stale publish's ``new_value`` is the wire endpoint reading, and a match
+        holds when it lands within ``VENETIAN_TILT_VERIFY_TOLERANCE`` of the
+        recorded LOGICAL endpoint mapped through :meth:`_to_wire` (so inversion
+        is handled once). Value-matching — rather than the old
+        ``abs(delta - expected_delta)`` reconstruction — means a genuine user
+        tilt move to the *mirror* value ``2·target − endpoint`` (which produces
+        the same delta) is NOT swallowed, and it never reads ``_tilt_targets``,
+        so a diverged stored target (e.g. tilt-skip-above open mode) can't make
+        the guard silently inert.
 
-        The window reuses the configured publish-lag setting
-        (``backrotate_publish_lag_seconds``, default 45 s) — the same clock
-        that already absorbs slow-bus republish on this class of actuator — so
-        a genuine user move to the same value seconds later still trips.
+        One record per matching publish is consumed (first match popped, order
+        preserved); non-matching intermediate events leave every record intact
+        so the real endpoint publish still matches. Expired records (older than
+        the configured ``backrotate_publish_lag_seconds`` window, default 45 s)
+        are dropped first, so a genuine user move to the same value seconds
+        later — once the window has lapsed — still trips.
         """
-        record = self._reset_excursion.get(entity_id)
-        if record is None:
+        records = self._reset_excursion.get(entity_id)
+        if not records:
             return False
-        if self._seconds_since(record.at) >= self._backrotate_publish_lag_seconds:
+        # Drop expired records before matching so a stale record can't outlive
+        # its publish-lag window and swallow a genuine later move.
+        live = [
+            record
+            for record in records
+            if self._seconds_since(record.at) < self._backrotate_publish_lag_seconds
+        ]
+        matched = False
+        remaining: list[_ResetExcursion] = []
+        for record in live:
+            if not matched and (
+                abs(new_value - self._to_wire(record.endpoint))
+                <= VENETIAN_TILT_VERIFY_TOLERANCE
+            ):
+                matched = True  # one-shot: consume only the first matching record
+                continue
+            remaining.append(record)
+        if remaining:
+            self._reset_excursion[entity_id] = remaining
+        else:
             self._reset_excursion.pop(entity_id, None)
-            return False
-        stored = self._tilt_targets.get(entity_id)
-        if stored is None:
-            return False
-        expected_delta = abs(stored - self._to_wire(record.endpoint))
-        if abs(delta - expected_delta) <= VENETIAN_TILT_VERIFY_TOLERANCE:
-            self._reset_excursion.pop(entity_id, None)  # one-shot consume
-            return True
-        return False
+        return matched
 
     # -- tilt sequence ----------------------------------------------------- #
 
@@ -858,9 +874,14 @@ class DualAxisSequencer:
             # that lands after the command grace closes is recognised as ACP's
             # own move, not a manual override (issue #927). The LOGICAL endpoint
             # is stored; is_reset_excursion_publish applies _to_wire on match.
-            self._reset_excursion[entity_id] = _ResetExcursion(
-                endpoint=reset_endpoint, at=dt.datetime.now(dt.UTC)
-            )
+            # Only stamp when the endpoint command will actually be sent: in
+            # dry-run the send below is skipped, so a stamp would linger with no
+            # matching publish and could later swallow a genuine move. Append —
+            # a second reset inside the window keeps its own record.
+            if not self._is_dry_run():
+                self._reset_excursion.setdefault(entity_id, []).append(
+                    _ResetExcursion(endpoint=reset_endpoint, at=dt.datetime.now(dt.UTC))
+                )
             await self._send_tilt_command(
                 entity_id,
                 tilt_target=reset_endpoint,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -22,6 +22,7 @@ machinery belongs next to its policy, not in the cover-type-agnostic
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import datetime as dt
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -89,6 +90,23 @@ _ANCHOR_SOURCE_TARGET_FALLBACK = "target_fallback"
 # intent and must never be silently swallowed by drift suppression. This
 # mirrors the position-axis behaviour in ``managers/cover_command/routing.py``.
 _TILT_SPECIAL_POSITIONS: list[int] = [POSITION_CLOSED, POSITION_OPEN]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _ResetExcursion:
+    """A drift-reset endpoint excursion awaiting its late state publish (#927).
+
+    When ``_maybe_drift_reset`` drives the slats to a mechanical endpoint and
+    back, a slow actuator (Somfy IO/Overkiz) may publish the endpoint's
+    ``current_tilt_position`` several seconds later — after the command grace
+    window has closed. ``endpoint`` is the LOGICAL endpoint the reset drove to
+    (``POSITION_OPEN``/``POSITION_CLOSED``); ``at`` is the UTC instant the
+    endpoint command was sent, anchoring the value-matching window in
+    :meth:`DualAxisSequencer.is_reset_excursion_publish`.
+    """
+
+    endpoint: int
+    at: dt.datetime
 
 
 class DualAxisSequencer:
@@ -195,6 +213,14 @@ class DualAxisSequencer:
         # tilt actually sends via ``update_tilt_only``. Drives
         # ``has_pending_tilt`` so the coordinator keeps re-attempting dispatch.
         self._pending_tilt: dict[str, dict] = {}
+        # Per-entity drift-reset endpoint excursion awaiting its late state
+        # publish (issue #927). A reset drives the slats to a mechanical
+        # endpoint and back; on slow actuators the endpoint's stale
+        # ``current_tilt_position`` publishes after the command grace closes.
+        # ``is_reset_excursion_publish`` consumes this one-shot to suppress
+        # that late publish (value-matched, time-boxed) so it isn't misread as
+        # a manual move.
+        self._reset_excursion: dict[str, _ResetExcursion] = {}
 
     # -- tilt inversion ---------------------------------------------------- #
 
@@ -399,6 +425,48 @@ class DualAxisSequencer:
         ):
             return True
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
+
+    def is_reset_excursion_publish(self, entity_id: str, delta: float) -> bool:
+        """Suppress the late state publish of a drift-reset endpoint excursion (#927).
+
+        A drift reset (``_maybe_drift_reset``) drives the slats to a mechanical
+        endpoint (``tilt→0`` for ``direction=close``) and restores the target
+        ~1.5 s later. On a slow Somfy IO/Overkiz actuator the endpoint's
+        ``current_tilt_position`` publishes ~6-7 s after it was sent — after
+        the 5 s command grace has closed — and the tilt-only path never opened
+        the back-rotate suppression window, so nothing else guards it.
+        ``SecondaryAxisCheck.evaluate`` then reads it as a large-delta manual
+        move and fires a false ``manual_override_set``.
+
+        Delta reconstruction: ``SecondaryAxisCheck.expected`` is the stored
+        logical tilt target (``result.tilt``) and the late publish's
+        ``new_value`` is the wire endpoint value, so ``evaluate`` computes
+        ``delta = abs(stored_target - wire_endpoint)``. This predicate rebuilds
+        that same quantity from the recorded LOGICAL endpoint via
+        :meth:`_to_wire` (so inversion is handled once) and matches within
+        ``VENETIAN_TILT_VERIFY_TOLERANCE``. On a match the record is consumed
+        (one-shot) and True is returned; a non-matching intermediate event
+        leaves the record intact so the real endpoint publish still matches.
+
+        The window reuses the configured publish-lag setting
+        (``backrotate_publish_lag_seconds``, default 45 s) — the same clock
+        that already absorbs slow-bus republish on this class of actuator — so
+        a genuine user move to the same value seconds later still trips.
+        """
+        record = self._reset_excursion.get(entity_id)
+        if record is None:
+            return False
+        if self._seconds_since(record.at) >= self._backrotate_publish_lag_seconds:
+            self._reset_excursion.pop(entity_id, None)
+            return False
+        stored = self._tilt_targets.get(entity_id)
+        if stored is None:
+            return False
+        expected_delta = abs(stored - self._to_wire(record.endpoint))
+        if abs(delta - expected_delta) <= VENETIAN_TILT_VERIFY_TOLERANCE:
+            self._reset_excursion.pop(entity_id, None)  # one-shot consume
+            return True
+        return False
 
     # -- tilt sequence ----------------------------------------------------- #
 
@@ -731,12 +799,16 @@ class DualAxisSequencer:
         :meth:`_send_tilt_command` (reusing inverse / grace / dedup gates per
         the no-duplication rule):
 
-        1. Drive the slats to the mechanical endpoint chosen by
-           ``get_tilt_reset_direction`` (issue #686) — logical ``POSITION_OPEN``
-           (default) or ``POSITION_CLOSED`` (``force=True``, ``verify=False``).
-           The literal logical value is passed so ``_to_wire`` applies inversion
-           exactly once; it is NOT clamped to ``CONF_MAX_TILT`` — the hardware
-           endpoint is the correct re-zero anchor.
+        1. Record a per-entity endpoint-excursion stamp (issue #927) so a stale
+           endpoint state publish arriving after the command grace closes is
+           later recognised by :meth:`is_reset_excursion_publish` as ACP's own
+           move rather than a manual override, then drive the slats to the
+           mechanical endpoint chosen by ``get_tilt_reset_direction`` (issue
+           #686) — logical ``POSITION_OPEN`` (default) or ``POSITION_CLOSED``
+           (``force=True``, ``verify=False``). The literal logical value is
+           passed so ``_to_wire`` applies inversion exactly once; it is NOT
+           clamped to ``CONF_MAX_TILT`` — the hardware endpoint is the correct
+           re-zero anchor.
         2. Settle (``VENETIAN_POST_TILT_REBASE_DELAY_SECONDS``).
         3. Re-send the original target (``force=True``, ``verify=True``) so the
            dedup gate doesn't swallow the unchanged value.
@@ -781,6 +853,13 @@ class DualAxisSequencer:
                 "tilt_reset_open",
                 entity_id=entity_id,
                 tilt_position=reset_endpoint,
+            )
+            # Record the endpoint excursion so a stale endpoint state publish
+            # that lands after the command grace closes is recognised as ACP's
+            # own move, not a manual override (issue #927). The LOGICAL endpoint
+            # is stored; is_reset_excursion_publish applies _to_wire on match.
+            self._reset_excursion[entity_id] = _ResetExcursion(
+                endpoint=reset_endpoint, at=dt.datetime.now(dt.UTC)
             )
             await self._send_tilt_command(
                 entity_id,

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -382,6 +382,14 @@ class AdaptiveCoverManager:
             )
             return
         if is_in_command_grace is not None and is_in_command_grace(entity_id):
+            # Consume any matching one-shot excursion stamp BEFORE returning
+            # (#927). The grace gate short-circuits the secondary-axis check, but
+            # on fast actuators the drift-reset endpoint publish lands inside the
+            # command-grace window — if the stamp isn't consumed here it lingers
+            # the full publish-lag window and later swallows a genuine move to
+            # the same value. Generic call keeps the manager cover-type-agnostic.
+            if secondary_axis_check is not None:
+                secondary_axis_check.consume_excursion(entity_id, event.new_state)
             self._record_event(
                 entity_id,
                 "manual_override_rejected_command_grace",

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -58,12 +58,23 @@ class SecondaryAxisCheck:
     diagnostic event names. The engine calls ``evaluate`` once and dispatches
     on the returned ``SecondaryAxisResult`` — it stays ignorant of which axis
     is being checked.
+
+    ``excursion_match`` (issue #927) is an optional axis-agnostic callback that
+    receives the raw PUBLISHED value (not a delta) and reports whether it
+    matches an integration-issued excursion the axis owner recorded (e.g.
+    venetian's drift-reset endpoint publish). It is consulted BEFORE
+    ``suppression`` so a matching publish is recognised and consumed whether or
+    not a time-based grace window happens to be open at the same instant.
     """
 
     expected: int
     attribute: str  # e.g. "current_tilt_position"
     label: str  # e.g. "tilt" — flavours the rejection-reason text
     suppression: Callable[[str, float], bool] | None = None
+    # Value-based (not delta-based) predicate over the raw published value;
+    # matches an integration-issued excursion so its stale late publish isn't
+    # misread as a manual move (issue #927).
+    excursion_match: Callable[[str, float], bool] | None = None
 
     def evaluate(
         self,
@@ -77,6 +88,33 @@ class SecondaryAxisCheck:
             return SecondaryAxisResult()
 
         effective_threshold = effective_manual_threshold(manual_threshold)
+
+        # Issue #927: consult the value-based excursion predicate FIRST, before
+        # the delta-based suppression grace check. A drift-reset endpoint
+        # publish must be recognised and consume its one-shot record even when
+        # the command-grace window is simultaneously open — otherwise the grace
+        # term short-circuits, the record lingers the full publish-lag window,
+        # and a genuine later move to the endpoint value gets swallowed. This
+        # matches on the raw published value, so a user move to the mirror value
+        # (same delta, different value) is not swallowed.
+        if self.excursion_match is not None and self.excursion_match(
+            entity_id, new_value
+        ):
+            return SecondaryAxisResult(
+                consumed=True,
+                event_name="manual_override_rejected_tilt_suppression",
+                event_kwargs={
+                    "our_state": self.expected,
+                    "new_position": new_value,
+                    "effective_threshold": effective_threshold,
+                    "reason": (
+                        f"{self.label} value {new_value:.0f}% matches an ACP "
+                        "drift-reset endpoint excursion; suppressing both tilt "
+                        "and position checks"
+                    ),
+                },
+            )
+
         delta = abs(self.expected - new_value)
 
         # Check suppression BEFORE the on-target short-circuit. When the motor

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -76,6 +76,20 @@ class SecondaryAxisCheck:
     # misread as a manual move (issue #927).
     excursion_match: Callable[[str, float], bool] | None = None
 
+    def consume_excursion(self, entity_id: str, new_state) -> None:
+        """Consume a matching one-shot excursion stamp under another gate.
+
+        When another gate (e.g. command grace) already suppressed this update,
+        pop any matching one-shot excursion stamp anyway so it does not linger
+        and later swallow a genuine move to the same value (issue #927).
+        """
+        if self.excursion_match is None:
+            return
+        new_value = new_state.attributes.get(self.attribute)
+        if new_value is None:
+            return
+        self.excursion_match(entity_id, new_value)  # one-shot pop on match
+
     def evaluate(
         self,
         entity_id: str,

--- a/tests/test_cover_types/test_venetian_drift_reset.py
+++ b/tests/test_cover_types/test_venetian_drift_reset.py
@@ -14,6 +14,8 @@ top exercise the config/runtime wiring.
 
 from __future__ import annotations
 
+import dataclasses
+import datetime as dt
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -893,3 +895,128 @@ class TestRuntimeConfigScopePlumbing:
         assert policy._get_tilt_reset_scope() == VENETIAN_TILT_RESET_SCOPE_ALL
         box["value"] = VENETIAN_TILT_RESET_SCOPE_SOLAR
         assert policy._get_tilt_reset_scope() == VENETIAN_TILT_RESET_SCOPE_SOLAR
+
+
+# ---------------------------------------------------------------------------
+# Issue #927 — the drift-reset endpoint excursion records a one-shot,
+# value-matched, time-boxed suppression so a stale endpoint state publish
+# arriving after the command grace closes is not misread as a manual move.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestResetExcursionPublishSuppression:
+    """``is_reset_excursion_publish`` recognises ACP's own endpoint excursion."""
+
+    async def _run_reset(
+        self,
+        *,
+        target,
+        anchor,
+        direction=VENETIAN_TILT_RESET_CLOSE,
+        invert_tilt=None,
+        threshold=1,
+    ):
+        """Drive one close/open drift reset through the public path.
+
+        Seeds the tilt anchor so the accumulator crosses ``threshold`` and the
+        two-step endpoint excursion runs. ``get_current_tilt_position`` is left
+        unwired so the verify step is a no-op and ``_tilt_targets`` ends at the
+        restored ``target``.
+        """
+        _, seq = _build_sequencer(
+            get_tilt_reset_threshold=lambda: threshold,
+            get_tilt_reset_direction=lambda: direction,
+            invert_tilt=invert_tilt,
+        )
+        seq._tilt_targets["cover.x"] = anchor
+        await seq.update_tilt_only(
+            "cover.x", tilt_target=target, current_position=40, reason="solar"
+        )
+        return seq
+
+    async def test_reset_stamps_excursion_record(self):
+        seq = await self._run_reset(target=79, anchor=0)
+        record = seq._reset_excursion["cover.x"]
+        assert record.endpoint == POSITION_CLOSED
+
+    async def test_matching_delta_within_window_suppresses(self):
+        seq = await self._run_reset(target=79, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+
+    async def test_match_is_one_shot(self):
+        seq = await self._run_reset(target=79, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+        # Consumed — a second identical query no longer suppresses.
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+
+    async def test_mismatch_not_suppressed_and_record_retained(self):
+        seq = await self._run_reset(target=79, anchor=0)
+        # An intermediate non-endpoint publish (delta 50 vs expected 79).
+        assert seq.is_reset_excursion_publish("cover.x", 50.0) is False
+        # The real endpoint publish still matches — record was NOT burned.
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+
+    async def test_window_expiry_not_suppressed(self):
+        seq = await self._run_reset(target=79, anchor=0)
+        record = seq._reset_excursion["cover.x"]
+        seq._reset_excursion["cover.x"] = dataclasses.replace(
+            record,
+            at=record.at
+            - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
+        )
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+        # The stale record is popped on the expiry check.
+        assert "cover.x" not in seq._reset_excursion
+
+    async def test_open_direction_endpoint_match(self):
+        seq = await self._run_reset(
+            target=21, anchor=100, direction=VENETIAN_TILT_RESET_OPEN
+        )
+        assert seq._reset_excursion["cover.x"].endpoint == POSITION_OPEN
+        # |21 - 100| = 79.
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+
+    async def test_inverted_tilt_endpoint_match(self):
+        seq = await self._run_reset(target=60, anchor=0, invert_tilt=lambda: True)
+        # Logical endpoint POSITION_CLOSED (0) → wire inverse_state(0) = 100.
+        # Expected delta = |stored 60 - wire 100| = 40.
+        # The naive |target - 0| = 60 must NOT match (proves _to_wire is used).
+        assert seq.is_reset_excursion_publish("cover.x", 60.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 40.0) is True
+
+    async def test_no_reset_no_suppression(self):
+        _, seq = _build_sequencer(get_tilt_reset_threshold=lambda: 0)
+        seq._tilt_targets["cover.x"] = 0
+        await seq.update_tilt_only(
+            "cover.x", tilt_target=60, current_position=40, reason="solar"
+        )
+        assert "cover.x" not in seq._reset_excursion
+        assert seq.is_reset_excursion_publish("cover.x", 60.0) is False
+
+    async def test_record_present_but_no_stored_target_not_suppressed(self):
+        # A drift pop (verify failure) can clear _tilt_targets while the
+        # excursion record is still open; with no stored target to reconstruct
+        # against, the predicate cannot match and must not suppress.
+        seq = await self._run_reset(target=79, anchor=0)
+        seq._tilt_targets.pop("cover.x", None)
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+
+    async def test_reset_two_step_send_sequence_unchanged(self):
+        buf = EventBuffer(maxlen=100)
+        hass, seq = _build_sequencer(
+            get_tilt_reset_threshold=lambda: 50,
+            get_tilt_reset_direction=lambda: VENETIAN_TILT_RESET_CLOSE,
+            event_buffer=buf,
+        )
+        seq._tilt_targets["cover.x"] = 0  # anchor 0 → delta 60 ≥ 50
+        await seq.update_tilt_only(
+            "cover.x", tilt_target=60, current_position=40, reason="solar"
+        )
+        tilt_values = [
+            c.args[2]["tilt_position"] for c in hass.services.async_call.call_args_list
+        ]
+        assert tilt_values == [60, POSITION_CLOSED, 60]
+        events = [e["event"] for e in buf.snapshot()]
+        assert "tilt_reset_open" in events
+        assert "tilt_reset_return" in events

--- a/tests/test_cover_types/test_venetian_drift_reset.py
+++ b/tests/test_cover_types/test_venetian_drift_reset.py
@@ -20,6 +20,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.adaptive_cover_pro.config_types import RuntimeConfig
 from custom_components.adaptive_cover_pro.const import (
@@ -1029,6 +1030,27 @@ class TestResetExcursionPublishSuppression:
             dry_run=True,
             get_tilt_reset_threshold=lambda: 1,
             get_tilt_reset_direction=lambda: VENETIAN_TILT_RESET_CLOSE,
+        )
+        await seq._maybe_drift_reset(
+            "cover.x", original_target=79, position_target=50, pre_send_anchor=0
+        )
+        assert "cover.x" not in seq._reset_excursion
+
+    async def test_stamp_not_recorded_when_endpoint_send_fails(self):
+        """No stamp when the endpoint ``set_cover_tilt_position`` raises.
+
+        If the endpoint send fails the slats never leave their angle, so no
+        stale endpoint publish is coming. Recording the excursion stamp anyway
+        would leave a one-shot that later swallows a genuine user move to that
+        value. The stamp is recorded only after the endpoint send dispatches
+        successfully.
+        """
+        hass, seq = _build_sequencer(
+            get_tilt_reset_threshold=lambda: 1,
+            get_tilt_reset_direction=lambda: VENETIAN_TILT_RESET_CLOSE,
+        )
+        hass.services.async_call = AsyncMock(
+            side_effect=HomeAssistantError("service unavailable")
         )
         await seq._maybe_drift_reset(
             "cover.x", original_target=79, position_target=50, pre_send_anchor=0

--- a/tests/test_cover_types/test_venetian_drift_reset.py
+++ b/tests/test_cover_types/test_venetian_drift_reset.py
@@ -899,8 +899,10 @@ class TestRuntimeConfigScopePlumbing:
 
 # ---------------------------------------------------------------------------
 # Issue #927 — the drift-reset endpoint excursion records a one-shot,
-# value-matched, time-boxed suppression so a stale endpoint state publish
+# VALUE-matched, time-boxed suppression so a stale endpoint state publish
 # arriving after the command grace closes is not misread as a manual move.
+# Matching is on the published WIRE tilt value (the endpoint the reset drove
+# to), never on a reconstructed delta and never reading ``_tilt_targets``.
 # ---------------------------------------------------------------------------
 
 
@@ -916,19 +918,22 @@ class TestResetExcursionPublishSuppression:
         direction=VENETIAN_TILT_RESET_CLOSE,
         invert_tilt=None,
         threshold=1,
+        seq=None,
     ):
         """Drive one close/open drift reset through the public path.
 
         Seeds the tilt anchor so the accumulator crosses ``threshold`` and the
         two-step endpoint excursion runs. ``get_current_tilt_position`` is left
         unwired so the verify step is a no-op and ``_tilt_targets`` ends at the
-        restored ``target``.
+        restored ``target``. Pass ``seq`` to run a second reset on the SAME
+        sequencer (multi-slot coverage).
         """
-        _, seq = _build_sequencer(
-            get_tilt_reset_threshold=lambda: threshold,
-            get_tilt_reset_direction=lambda: direction,
-            invert_tilt=invert_tilt,
-        )
+        if seq is None:
+            _, seq = _build_sequencer(
+                get_tilt_reset_threshold=lambda: threshold,
+                get_tilt_reset_direction=lambda: direction,
+                invert_tilt=invert_tilt,
+            )
         seq._tilt_targets["cover.x"] = anchor
         await seq.update_tilt_only(
             "cover.x", tilt_target=target, current_position=40, reason="solar"
@@ -937,53 +942,114 @@ class TestResetExcursionPublishSuppression:
 
     async def test_reset_stamps_excursion_record(self):
         seq = await self._run_reset(target=79, anchor=0)
-        record = seq._reset_excursion["cover.x"]
-        assert record.endpoint == POSITION_CLOSED
+        records = seq._reset_excursion["cover.x"]
+        assert [r.endpoint for r in records] == [POSITION_CLOSED]
 
-    async def test_matching_delta_within_window_suppresses(self):
+    async def test_matching_value_within_window_suppresses(self):
+        # Close reset drove tilt to the wire endpoint 0; the stale publish is
+        # current_tilt_position=0 — that VALUE (not the delta 79) is what matches.
         seq = await self._run_reset(target=79, anchor=0)
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
 
     async def test_match_is_one_shot(self):
         seq = await self._run_reset(target=79, anchor=0)
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
         # Consumed — a second identical query no longer suppresses.
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
 
-    async def test_mismatch_not_suppressed_and_record_retained(self):
+    async def test_non_matching_value_not_suppressed_and_record_retained(self):
         seq = await self._run_reset(target=79, anchor=0)
-        # An intermediate non-endpoint publish (delta 50 vs expected 79).
-        assert seq.is_reset_excursion_publish("cover.x", 50.0) is False
+        # An intermediate non-endpoint publish (value 40, endpoint 0).
+        assert seq.is_reset_excursion_publish("cover.x", 40.0) is False
         # The real endpoint publish still matches — record was NOT burned.
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+
+    async def test_user_move_to_mirror_value_not_suppressed(self):
+        """Finding #1: the old delta-based match swallowed a user move to the
+        mirror value ``2·target − endpoint`` (same delta, different value).
+
+        target=35, wire endpoint 0 → mirror = 70. The value-based predicate
+        matches on 0, not on the 35-delta, so a genuine move to tilt 70 is NOT
+        suppressed and the record survives for the real endpoint publish.
+        """
+        seq = await self._run_reset(target=35, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 70.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+
+    async def test_diverged_stored_target_still_suppressed_by_value(self):
+        """Finding #6: matching must not read ``_tilt_targets``.
+
+        A diverged stored target (e.g. tilt-skip-above open mode stored 100
+        while the restored target differs) must not make the guard inert. With
+        the value-based predicate the endpoint publish (value 0) still matches
+        regardless of what ``_tilt_targets`` holds.
+        """
+        seq = await self._run_reset(target=79, anchor=0)
+        seq._tilt_targets["cover.x"] = 100  # diverged from the endpoint
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
 
     async def test_window_expiry_not_suppressed(self):
         seq = await self._run_reset(target=79, anchor=0)
-        record = seq._reset_excursion["cover.x"]
-        seq._reset_excursion["cover.x"] = dataclasses.replace(
-            record,
-            at=record.at
-            - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
+        records = seq._reset_excursion["cover.x"]
+        seq._reset_excursion["cover.x"] = [
+            dataclasses.replace(
+                r,
+                at=r.at
+                - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
+            )
+            for r in records
+        ]
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
+        # The stale record is dropped on the expiry sweep.
+        assert "cover.x" not in seq._reset_excursion
+
+    async def test_multi_slot_two_resets_both_endpoint_publishes_suppressed(self):
+        """Finding #4: two resets inside the window keep two records.
+
+        A single-slot store would let the second reset clobber the first, so
+        only one endpoint publish would suppress. With a list, both do — in
+        either order — and a third query then falls through.
+        """
+        seq = await self._run_reset(target=79, anchor=0)  # record 1, endpoint 0
+        # Second reset on the SAME sequencer; anchor now the restored target 79.
+        await self._run_reset(target=20, anchor=79, seq=seq)  # record 2, endpoint 0
+        assert len(seq._reset_excursion["cover.x"]) == 2
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
+
+    async def test_dry_run_does_not_stamp(self):
+        """Finding #5: no stamp when the endpoint send is dry-run skipped.
+
+        ``_maybe_drift_reset`` is invoked directly with dry-run active so the
+        endpoint ``_send_tilt_command`` is skipped; stamping anyway would leave
+        a record with no possible matching publish.
+        """
+        _, seq = _build_sequencer(
+            dry_run=True,
+            get_tilt_reset_threshold=lambda: 1,
+            get_tilt_reset_direction=lambda: VENETIAN_TILT_RESET_CLOSE,
         )
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
-        # The stale record is popped on the expiry check.
+        await seq._maybe_drift_reset(
+            "cover.x", original_target=79, position_target=50, pre_send_anchor=0
+        )
         assert "cover.x" not in seq._reset_excursion
 
     async def test_open_direction_endpoint_match(self):
         seq = await self._run_reset(
             target=21, anchor=100, direction=VENETIAN_TILT_RESET_OPEN
         )
-        assert seq._reset_excursion["cover.x"].endpoint == POSITION_OPEN
-        # |21 - 100| = 79.
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is True
+        assert [r.endpoint for r in seq._reset_excursion["cover.x"]] == [POSITION_OPEN]
+        # Open reset drove tilt to wire endpoint 100; the publish value is 100.
+        assert seq.is_reset_excursion_publish("cover.x", 100.0) is True
 
     async def test_inverted_tilt_endpoint_match(self):
         seq = await self._run_reset(target=60, anchor=0, invert_tilt=lambda: True)
         # Logical endpoint POSITION_CLOSED (0) → wire inverse_state(0) = 100.
-        # Expected delta = |stored 60 - wire 100| = 40.
-        # The naive |target - 0| = 60 must NOT match (proves _to_wire is used).
-        assert seq.is_reset_excursion_publish("cover.x", 60.0) is False
-        assert seq.is_reset_excursion_publish("cover.x", 40.0) is True
+        # The published wire value is 100; the naive logical 0 must NOT match
+        # (proves _to_wire is applied to the recorded endpoint).
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 100.0) is True
 
     async def test_no_reset_no_suppression(self):
         _, seq = _build_sequencer(get_tilt_reset_threshold=lambda: 0)
@@ -992,15 +1058,7 @@ class TestResetExcursionPublishSuppression:
             "cover.x", tilt_target=60, current_position=40, reason="solar"
         )
         assert "cover.x" not in seq._reset_excursion
-        assert seq.is_reset_excursion_publish("cover.x", 60.0) is False
-
-    async def test_record_present_but_no_stored_target_not_suppressed(self):
-        # A drift pop (verify failure) can clear _tilt_targets while the
-        # excursion record is still open; with no stored target to reconstruct
-        # against, the predicate cannot match and must not suppress.
-        seq = await self._run_reset(target=79, anchor=0)
-        seq._tilt_targets.pop("cover.x", None)
-        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
 
     async def test_reset_two_step_send_sequence_unchanged(self):
         buf = EventBuffer(maxlen=100)

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import dataclasses
 import datetime as dt
 from collections.abc import Callable
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1027,9 +1028,10 @@ def test_warn_log_fires_on_first_suppression_per_entity(caplog) -> None:
 # grace expires must not be misread as a manual override. The reset drives the
 # slats to a mechanical endpoint (tilt→0 for direction=close) and back; on slow
 # Somfy IO/Overkiz actuators the endpoint's ``current_tilt_position=0`` publishes
-# ~6-7 s later — past the command grace. The shared primary_axis_suppression
-# predicate must recognise that stale endpoint publish as ACP's own excursion
-# (value-matched, time-boxed, one-shot), while a genuine user move still trips.
+# ~6-7 s later — past the command grace. A VALUE-based, tilt-axis-only
+# ``excursion_match`` predicate (wired on the tilt ``SecondaryAxisCheck``, NOT
+# folded into the shared position-axis suppression) recognises that stale
+# endpoint publish as ACP's own excursion, while a genuine user move still trips.
 # ---------------------------------------------------------------------------
 
 
@@ -1039,6 +1041,7 @@ async def _drive_drift_reset(
     target: int,
     anchor: int = 0,
     reset_threshold: int = 1,
+    grace_active: bool = False,
 ) -> tuple[DualAxisSequencer, VenetianPolicy]:
     """Run a real close-direction drift reset and return ``(seq, policy)``.
 
@@ -1047,8 +1050,10 @@ async def _drive_drift_reset(
     the accumulator crosses the threshold, then drives one tilt-only update so
     the two-step endpoint excursion (tilt→0 then back to ``target``) runs
     through the public path. Wraps the sequencer in a ``VenetianPolicy`` whose
-    command grace is already expired — the #927 timeline where the endpoint
-    publish lands ~0.6 s after grace closes.
+    command grace is expired by default (``grace_active=False``) — the #927
+    timeline where the endpoint publish lands ~0.6 s after grace closes. Set
+    ``grace_active=True`` to model the endpoint publish landing WHILE the policy
+    command-grace window is still open (finding #3).
 
     ``get_current_tilt_position`` is left unwired so the verify step is a no-op
     (no phantom drift pop of ``_tilt_targets``) and the drift accumulator
@@ -1074,11 +1079,21 @@ async def _drive_drift_reset(
     )
 
     grace_mgr = MagicMock()
-    grace_mgr.is_in_command_grace_period = lambda _eid: False
+    grace_mgr.is_in_command_grace_period = lambda _eid: grace_active
     policy = VenetianPolicy()
     policy._sequencer = seq
     policy._grace_mgr = grace_mgr
     return seq, policy
+
+
+def _secondary_check(policy: VenetianPolicy, expected: int) -> SecondaryAxisCheck:
+    """Build the tilt ``SecondaryAxisCheck`` via the production policy path.
+
+    Going through ``policy.secondary_axis_check`` (rather than constructing the
+    check by hand) exercises the real wiring — ``suppression`` AND the #927
+    ``excursion_match`` — so these tests break if either is mis-wired.
+    """
+    return policy.secondary_axis_check(SimpleNamespace(tilt=expected), None)
 
 
 async def test_drift_reset_endpoint_publish_after_grace_is_suppressed() -> None:
@@ -1086,10 +1101,10 @@ async def test_drift_reset_endpoint_publish_after_grace_is_suppressed() -> None:
 
     A close-direction reset drives the slats to tilt 0 and restores 79; the
     endpoint's ``current_tilt_position=0`` publishes ~7 s later, past the 5 s
-    command grace. Pre-fix, ``SecondaryAxisCheck.evaluate`` sees delta=79% and
-    fires ``manual_override_set``. Post-fix, ``is_reset_excursion_publish``
-    recognises the value-matched endpoint publish inside the excursion window
-    and suppresses it.
+    command grace. Pre-fix (no excursion mechanism) ``evaluate`` sees delta=79%
+    and fires ``manual_override_set``. Post-fix ``excursion_match`` recognises
+    the value-matched endpoint publish inside the excursion window and
+    suppresses it.
     """
     entity_id = "cover.og_studio_tur"
     seq, policy = await _drive_drift_reset(entity_id, target=79)
@@ -1103,12 +1118,7 @@ async def test_drift_reset_endpoint_publish_after_grace_is_suppressed() -> None:
         allow_reset=True,
         is_waiting=lambda _eid: False,
         manual_threshold=2,
-        secondary_axis_check=SecondaryAxisCheck(
-            expected=79,
-            attribute="current_tilt_position",
-            label="tilt",
-            suppression=policy.primary_axis_suppression,
-        ),
+        secondary_axis_check=_secondary_check(policy, 79),
     )
 
     assert not mgr.is_cover_manual(
@@ -1137,17 +1147,108 @@ async def test_user_tilt_move_to_endpoint_without_reset_trips_override() -> None
         allow_reset=True,
         is_waiting=lambda _eid: False,
         manual_threshold=2,
-        secondary_axis_check=SecondaryAxisCheck(
-            expected=79,
-            attribute="current_tilt_position",
-            label="tilt",
-            suppression=policy.primary_axis_suppression,
-        ),
+        secondary_axis_check=_secondary_check(policy, 79),
     )
 
     assert mgr.is_cover_manual(
         entity_id
     ), "a real user move to the endpoint with no reset must trip manual override"
+
+
+async def test_user_tilt_move_to_mirror_value_during_window_trips_override() -> None:
+    """Finding #1: a user move to the MIRROR value during the window must trip.
+
+    Close reset from anchor 0 to target 35 stamps an endpoint-0 excursion. The
+    old delta-based predicate matched any publish whose ``|expected − value|``
+    equalled the excursion delta (35), so a genuine user move to the mirror
+    value ``2·35 − 0 = 70`` (delta 35) was wrongly swallowed and burned the
+    one-shot. The value-based predicate matches only value≈0, so the move to
+    tilt 70 trips override.
+    """
+    entity_id = "cover.og_studio_tur_mirror"
+    seq, policy = await _drive_drift_reset(entity_id, target=35)
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=70),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 35),
+    )
+
+    assert mgr.is_cover_manual(
+        entity_id
+    ), "a user tilt move to the mirror value must trip, not be swallowed (finding #1)"
+
+
+async def test_position_axis_move_during_window_trips_override() -> None:
+    """Finding #2: the POSITION axis must not consult the tilt excursion.
+
+    After a close reset (endpoint-0 excursion, delta 35), the tilt reports
+    on-target (35) so the secondary axis falls through, and a genuine POSITION
+    move (our_state 50 → current_position 15, delta 35) must trip. The old
+    design OR'd the excursion into the shared ``primary_axis_suppression`` that
+    the position axis probes, so this position move — coincidentally matching
+    the excursion delta — was suppressed and the tilt one-shot burned.
+    """
+    entity_id = "cover.og_studio_tur_pos"
+    seq, policy = await _drive_drift_reset(entity_id, target=35)
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    # Pass the WIRED policy so the position axis consults the same
+    # ``primary_axis_suppression`` the sequencer backs — this is the path
+    # finding #2 lives on (the old design folded the excursion into it).
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=15, tilt=35),
+        our_state=50,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 35),
+    )
+
+    assert mgr.is_cover_manual(entity_id), (
+        "a genuine position-axis move must trip; the position axis must not "
+        "consult the tilt excursion (finding #2)"
+    )
+
+
+async def test_endpoint_publish_inside_grace_consumes_record() -> None:
+    """Finding #3: a matching endpoint publish inside grace consumes the record.
+
+    With the policy command-grace window still open, the grace term short-
+    circuited the old OR-composition so the excursion term was never evaluated
+    and the record lingered the full window — later swallowing a genuine move.
+    Now ``excursion_match`` is consulted BEFORE the grace check, so the matching
+    endpoint publish is recognised and its one-shot record is consumed even
+    while grace is active. A later genuine move to the endpoint value then trips.
+    """
+    entity_id = "cover.og_studio_tur_grace"
+    seq, policy = await _drive_drift_reset(entity_id, target=79, grace_active=True)
+    assert entity_id in seq._reset_excursion
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 79),
+    )
+
+    assert not mgr.is_cover_manual(entity_id)
+    # The one-shot record is consumed by the in-grace publish (finding #3):
+    # the grace term no longer short-circuits it into lingering.
+    assert entity_id not in seq._reset_excursion
 
 
 async def test_endpoint_publish_after_excursion_window_trips_override() -> None:
@@ -1161,11 +1262,13 @@ async def test_endpoint_publish_after_excursion_window_trips_override() -> None:
     entity_id = "cover.og_studio_tur_late"
     seq, policy = await _drive_drift_reset(entity_id, target=79)
     # Backdate the excursion stamp past the publish-lag-sized window.
-    record = seq._reset_excursion[entity_id]
-    seq._reset_excursion[entity_id] = dataclasses.replace(
-        record,
-        at=record.at - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
-    )
+    seq._reset_excursion[entity_id] = [
+        dataclasses.replace(
+            r,
+            at=r.at - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
+        )
+        for r in seq._reset_excursion[entity_id]
+    ]
 
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
@@ -1176,12 +1279,7 @@ async def test_endpoint_publish_after_excursion_window_trips_override() -> None:
         allow_reset=True,
         is_waiting=lambda _eid: False,
         manual_threshold=2,
-        secondary_axis_check=SecondaryAxisCheck(
-            expected=79,
-            attribute="current_tilt_position",
-            label="tilt",
-            suppression=policy.primary_axis_suppression,
-        ),
+        secondary_axis_check=_secondary_check(policy, 79),
     )
 
     assert mgr.is_cover_manual(

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -1222,12 +1222,16 @@ async def test_position_axis_move_during_window_trips_override() -> None:
 async def test_endpoint_publish_inside_grace_consumes_record() -> None:
     """Finding #3: a matching endpoint publish inside grace consumes the record.
 
-    With the policy command-grace window still open, the grace term short-
-    circuited the old OR-composition so the excursion term was never evaluated
-    and the record lingered the full window — later swallowing a genuine move.
-    Now ``excursion_match`` is consulted BEFORE the grace check, so the matching
-    endpoint publish is recognised and its one-shot record is consumed even
-    while grace is active. A later genuine move to the endpoint value then trips.
+    Mirrors production: the coordinator wires ``is_in_command_grace`` to the
+    SAME ``GracePeriodManager`` the policy's excursion window uses. On a fast
+    actuator the endpoint publish lands WHILE that command-grace window is still
+    open, so ``handle_state_change`` returns early in the grace-reject branch
+    BEFORE ``secondary_axis_check.evaluate`` ever runs. Without a fix the
+    one-shot excursion record is never consumed and lingers the full window,
+    later swallowing a genuine user tilt-to-endpoint move (bounded false
+    negative). The fix consumes the matching excursion stamp in the grace-reject
+    branch via the generic ``SecondaryAxisCheck.consume_excursion`` so the record
+    does not linger; a later genuine move to the endpoint value then trips.
     """
     entity_id = "cover.og_studio_tur_grace"
     seq, policy = await _drive_drift_reset(entity_id, target=79, grace_active=True)
@@ -1235,6 +1239,8 @@ async def test_endpoint_publish_inside_grace_consumes_record() -> None:
 
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
+    # In-grace endpoint publish: command grace is active (as production wires it
+    # off the same GracePeriodManager), so the grace-reject branch fires first.
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=50, tilt=0),
         our_state=50,
@@ -1243,12 +1249,32 @@ async def test_endpoint_publish_inside_grace_consumes_record() -> None:
         is_waiting=lambda _eid: False,
         manual_threshold=2,
         secondary_axis_check=_secondary_check(policy, 79),
+        is_in_command_grace=lambda _eid: True,
     )
 
+    # Grace rejects the update, so no override — but the one-shot record MUST be
+    # consumed so it can't linger and swallow a genuine later move (finding #3).
     assert not mgr.is_cover_manual(entity_id)
-    # The one-shot record is consumed by the in-grace publish (finding #3):
-    # the grace term no longer short-circuits it into lingering.
     assert entity_id not in seq._reset_excursion
+
+    # After grace expires, a genuine user tilt-to-endpoint move (no stamp left)
+    # must still trip override — proving the consume did not disable detection.
+    # Flip the policy's command grace off too (the suppression callback consults
+    # it), mirroring the window having closed.
+    policy._grace_mgr.is_in_command_grace_period = lambda _eid: False
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 79),
+        is_in_command_grace=lambda _eid: False,
+    )
+    assert mgr.is_cover_manual(
+        entity_id
+    ), "a genuine user move to the endpoint after grace must still trip override"
 
 
 async def test_endpoint_publish_after_excursion_window_trips_override() -> None:

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -12,9 +12,10 @@ Wired through ``SecondaryAxisCheck`` — a per-cover-type plug supplied by
 
 from __future__ import annotations
 
+import dataclasses
 import datetime as dt
 from collections.abc import Callable
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -25,7 +26,10 @@ from custom_components.adaptive_cover_pro.cover_types.venetian import (
 from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
     VenetianPolicy,
 )
-from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.const import (
+    VENETIAN_TILT_RESET_CLOSE,
+    ControlMethod,
+)
 from custom_components.adaptive_cover_pro.managers.grace_period import (
     GracePeriodManager,
 )
@@ -1016,3 +1020,170 @@ def test_warn_log_fires_on_first_suppression_per_entity(caplog) -> None:
     assert (
         len(suppression_warns_after_throttle) == 1
     ), "expected the per-hour throttle to release a second WARN line"
+
+
+# ---------------------------------------------------------------------------
+# Issue #927: a drift-reset endpoint publish that arrives AFTER the 5 s command
+# grace expires must not be misread as a manual override. The reset drives the
+# slats to a mechanical endpoint (tilt→0 for direction=close) and back; on slow
+# Somfy IO/Overkiz actuators the endpoint's ``current_tilt_position=0`` publishes
+# ~6-7 s later — past the command grace. The shared primary_axis_suppression
+# predicate must recognise that stale endpoint publish as ACP's own excursion
+# (value-matched, time-boxed, one-shot), while a genuine user move still trips.
+# ---------------------------------------------------------------------------
+
+
+async def _drive_drift_reset(
+    entity_id: str,
+    *,
+    target: int,
+    anchor: int = 0,
+    reset_threshold: int = 1,
+) -> tuple[DualAxisSequencer, VenetianPolicy]:
+    """Run a real close-direction drift reset and return ``(seq, policy)``.
+
+    Builds a real ``DualAxisSequencer`` wired for a close-direction reset that
+    fires on essentially every send (``threshold=1``), seeds the tilt anchor so
+    the accumulator crosses the threshold, then drives one tilt-only update so
+    the two-step endpoint excursion (tilt→0 then back to ``target``) runs
+    through the public path. Wraps the sequencer in a ``VenetianPolicy`` whose
+    command grace is already expired — the #927 timeline where the endpoint
+    publish lands ~0.6 s after grace closes.
+
+    ``get_current_tilt_position`` is left unwired so the verify step is a no-op
+    (no phantom drift pop of ``_tilt_targets``) and the drift accumulator
+    anchors on the seeded stored target — the same pattern
+    ``test_venetian_drift_reset.py`` uses.
+    """
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    seq = DualAxisSequencer(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=lambda _eid: None,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_tilt_reset_threshold=lambda: reset_threshold,
+        get_tilt_reset_direction=lambda: VENETIAN_TILT_RESET_CLOSE,
+    )
+    seq._tilt_targets[entity_id] = anchor  # seed accumulator anchor
+    await seq.update_tilt_only(
+        entity_id, tilt_target=target, current_position=50, reason="solar"
+    )
+
+    grace_mgr = MagicMock()
+    grace_mgr.is_in_command_grace_period = lambda _eid: False
+    policy = VenetianPolicy()
+    policy._sequencer = seq
+    policy._grace_mgr = grace_mgr
+    return seq, policy
+
+
+async def test_drift_reset_endpoint_publish_after_grace_is_suppressed() -> None:
+    """The reporter's #927 timeline: stale tilt→0 endpoint publish must NOT trip.
+
+    A close-direction reset drives the slats to tilt 0 and restores 79; the
+    endpoint's ``current_tilt_position=0`` publishes ~7 s later, past the 5 s
+    command grace. Pre-fix, ``SecondaryAxisCheck.evaluate`` sees delta=79% and
+    fires ``manual_override_set``. Post-fix, ``is_reset_excursion_publish``
+    recognises the value-matched endpoint publish inside the excursion window
+    and suppresses it.
+    """
+    entity_id = "cover.og_studio_tur"
+    seq, policy = await _drive_drift_reset(entity_id, target=79)
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=79,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=policy.primary_axis_suppression,
+        ),
+    )
+
+    assert not mgr.is_cover_manual(
+        entity_id
+    ), "stale drift-reset endpoint publish after grace must NOT trip manual override"
+
+
+async def test_user_tilt_move_to_endpoint_without_reset_trips_override() -> None:
+    """A genuine user move to tilt 0 with NO drift reset must still trip override.
+
+    Same wiring as the repro but ``threshold=0`` so no reset fires and no
+    excursion is stamped. The tilt=0 publish is then a real user grab and must
+    set manual override — proving the suppression is scoped to ACP's own
+    excursion, not a blanket widening.
+    """
+    entity_id = "cover.og_studio_tur_user"
+    seq, policy = await _drive_drift_reset(entity_id, target=79, reset_threshold=0)
+    assert entity_id not in seq._reset_excursion
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=79,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=policy.primary_axis_suppression,
+        ),
+    )
+
+    assert mgr.is_cover_manual(
+        entity_id
+    ), "a real user move to the endpoint with no reset must trip manual override"
+
+
+async def test_endpoint_publish_after_excursion_window_trips_override() -> None:
+    """A matching endpoint publish arriving AFTER the excursion window trips.
+
+    The reset stamps the excursion, but the late publish only lands after the
+    publish-lag-sized window elapses. Backdating the excursion stamp past the
+    window closes the one-shot suppression, so the tilt=0 event is treated as a
+    user move.
+    """
+    entity_id = "cover.og_studio_tur_late"
+    seq, policy = await _drive_drift_reset(entity_id, target=79)
+    # Backdate the excursion stamp past the publish-lag-sized window.
+    record = seq._reset_excursion[entity_id]
+    seq._reset_excursion[entity_id] = dataclasses.replace(
+        record,
+        at=record.at - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
+    )
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=SecondaryAxisCheck(
+            expected=79,
+            attribute="current_tilt_position",
+            label="tilt",
+            suppression=policy.primary_axis_suppression,
+        ),
+    )
+
+    assert mgr.is_cover_manual(
+        entity_id
+    ), "endpoint publish after the excursion window must trip manual override"


### PR DESCRIPTION
## Summary
Venetian Tilt Drift Reset drives the slats to a mechanical endpoint and back. On slow Somfy IO/Overkiz actuators the endpoint's `current_tilt_position` publish lands ~6-7s later — after the 5s command grace expires — and the tilt-only path never opens the back-rotate suppression window, so `SecondaryAxisCheck` misreads the stale endpoint as a large-delta manual move and fires a false manual override (~0.6s after grace expiry).

The fix records a per-entity, value-matched, time-boxed (reusing the configured back-rotate publish-lag window), one-shot excursion stamp when `_maybe_drift_reset` sends the endpoint command, and OR's a new `is_reset_excursion_publish` predicate into the shared `primary_axis_suppression` predicate both axes already consult. A genuine user move (no recorded excursion, expired window, or non-endpoint value) still trips. All fix code stays inside `cover_types/venetian/`; no new option, no config migration, no VERSION/MINOR_VERSION change.

## Testing
- ✅ 6643 tests passing (13 new; targeted venetian/manual-override suites 206 → 219). Repro test confirmed failing before the fix and passing after.

## Related Issues
Refs #927