### PR TITLE
fix: suppress false override from drift-reset intermediate tilt publishes (hotfix) (#930)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -944,10 +944,10 @@ class VenetianPolicy(CoverTypePolicy, register=True):
 
         ``excursion_match`` wires the drift-reset endpoint guard (issue #927)
         onto the TILT axis only. It is value-based (matches the raw published
-        wire tilt against the recorded endpoint) and consumed before the grace
-        check, so a stale endpoint publish landing after the command grace
-        closes is recognised as ACP's own move — without the position axis ever
-        consulting it.
+        wire tilt against the recorded endpoint) and consulted before the grace
+        check; it tracks the full out-and-back trajectory (#930), so a stale
+        endpoint publish landing after the command grace closes is recognised as
+        ACP's own move — without the position axis ever consulting it.
         """
         if result is None or result.tilt is None:
             return None

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -103,11 +103,23 @@ class _ResetExcursion:
     (``POSITION_OPEN``/``POSITION_CLOSED``) — matched against the published wire
     value via :meth:`DualAxisSequencer._to_wire`; ``at`` is the UTC instant the
     endpoint command was sent, bounding the publish-lag window in
-    :meth:`DualAxisSequencer.is_reset_excursion_publish`.
+    :meth:`DualAxisSequencer.is_reset_excursion_publish`. ``target`` is the
+    LOGICAL tilt target the reset returns to; together the ``(endpoint,
+    target)`` pair defines the physical traversal band (slats travel
+    target->endpoint->target), so an intermediate publish landing inside that
+    band is recognised as ACP's own move rather than a manual override (#930).
+
+    ``endpoint_seen`` flips True once the endpoint's publish has been observed;
+    the record then survives the return leg and is consumed when a publish lands
+    back within tolerance of ``target`` (or on window expiry). This keeps the
+    whole out-and-back trajectory (target->endpoint->target) protected instead
+    of burning the record on the endpoint publish alone (#930).
     """
 
     endpoint: int
     at: dt.datetime
+    target: int
+    endpoint_seen: bool = False
 
 
 class DualAxisSequencer:
@@ -217,11 +229,13 @@ class DualAxisSequencer:
         # Per-entity list of drift-reset endpoint excursions awaiting their
         # late state publish (issue #927). A reset drives the slats to a
         # mechanical endpoint and back; on slow actuators the endpoint's stale
-        # ``current_tilt_position`` publishes after the command grace closes.
-        # ``is_reset_excursion_publish`` consumes one one-shot record per
-        # matching publish (value-matched, time-boxed) so it isn't misread as a
-        # manual move. A list (not a single slot) so two resets firing inside
-        # the same window each keep their own record instead of clobbering.
+        # ``current_tilt_position`` — and the intermediate values on both legs —
+        # publish after the command grace closes. ``is_reset_excursion_publish``
+        # tracks the full out-and-back trajectory (value-matched, time-boxed):
+        # the endpoint publish marks the record, and it is consumed only when a
+        # publish lands back on the target (or on expiry) so it isn't misread as
+        # a manual move (#930). A list (not a single slot) so two resets firing
+        # inside the same window each keep their own record instead of clobbering.
         self._reset_excursion: dict[str, list[_ResetExcursion]] = {}
 
     # -- tilt inversion ---------------------------------------------------- #
@@ -237,6 +251,19 @@ class DualAxisSequencer:
         if self._invert_tilt is not None and self._invert_tilt():
             return inverse_state(tilt)
         return tilt
+
+    def _publish_matches(self, new_value: float, logical_tilt: int) -> bool:
+        """Whether a published wire value matches a LOGICAL tilt within tolerance."""
+        return abs(new_value - self._to_wire(logical_tilt)) <= (
+            VENETIAN_TILT_VERIFY_TOLERANCE
+        )
+
+    def _store_excursions(self, entity_id: str, records: list[_ResetExcursion]) -> None:
+        """Write back the excursion list, popping the key when it empties."""
+        if records:
+            self._reset_excursion[entity_id] = records
+        else:
+            self._reset_excursion.pop(entity_id, None)
 
     def _resolve_tilt_anchor(self, entity_id: str) -> tuple[int | None, str]:
         """Return ``(anchor, source)`` for the tilt min-delta gate.
@@ -429,34 +456,49 @@ class DualAxisSequencer:
         return delta <= VENETIAN_BACKROTATE_MAX_DELTA_PERCENT
 
     def is_reset_excursion_publish(self, entity_id: str, new_value: float) -> bool:
-        """Suppress the late state publish of a drift-reset endpoint excursion (#927).
+        """Suppress the late state publishes of a drift-reset excursion trajectory (#927/#930).
 
         A drift reset (``_maybe_drift_reset``) drives the slats to a mechanical
         endpoint (``tilt→0`` for ``direction=close``) and restores the target
         ~1.5 s later. On a slow Somfy IO/Overkiz actuator the endpoint's
-        ``current_tilt_position`` publishes ~6-7 s after it was sent — after
-        the 5 s command grace has closed — and the tilt-only path never opened
-        the back-rotate suppression window, so nothing else guards it.
-        ``SecondaryAxisCheck.evaluate`` then reads it as a large-delta manual
-        move and fires a false ``manual_override_set``.
+        ``current_tilt_position`` — plus every intermediate value the slats pass
+        through on the way out and back — publishes seconds after it was sent,
+        after the 5 s command grace has closed, and the tilt-only path never
+        opened the back-rotate suppression window, so nothing else guards them.
+        ``SecondaryAxisCheck.evaluate`` would otherwise read a large-delta
+        publish as a manual move and fire a false ``manual_override_set``.
 
-        Matches on the PUBLISHED WIRE VALUE, not on a reconstructed delta: the
-        stale publish's ``new_value`` is the wire endpoint reading, and a match
-        holds when it lands within ``VENETIAN_TILT_VERIFY_TOLERANCE`` of the
-        recorded LOGICAL endpoint mapped through :meth:`_to_wire` (so inversion
-        is handled once). Value-matching — rather than the old
-        ``abs(delta - expected_delta)`` reconstruction — means a genuine user
-        tilt move to the *mirror* value ``2·target − endpoint`` (which produces
-        the same delta) is NOT swallowed, and it never reads ``_tilt_targets``,
-        so a diverged stored target (e.g. tilt-skip-above open mode) can't make
-        the guard silently inert.
+        The record tracks the FULL out-and-back trajectory
+        (target->endpoint->target) via three rules, all matched on the PUBLISHED
+        WIRE VALUE (never a reconstructed delta, never reading ``_tilt_targets``)
+        with logical endpoints/targets mapped through :meth:`_to_wire` so
+        inversion is handled once:
 
-        One record per matching publish is consumed (first match popped, order
-        preserved); non-matching intermediate events leave every record intact
-        so the real endpoint publish still matches. Expired records (older than
-        the configured ``backrotate_publish_lag_seconds`` window, default 45 s)
-        are dropped first, so a genuine user move to the same value seconds
-        later — once the window has lapsed — still trips.
+        1. **Endpoint publish** — a value within ``VENETIAN_TILT_VERIFY_TOLERANCE``
+           of the recorded endpoint: mark the first unmarked matching record's
+           ``endpoint_seen`` flag, suppress, and RETAIN the record so the return
+           leg stays protected.
+        2. **Target publish** — a value within tolerance of the target: fall
+           through (return False) so a simultaneous genuine POSITION move stays
+           observable, and consume the first matching record that has already
+           seen its endpoint (excursion complete). This is also why a value
+           within tolerance of the target is deliberately NOT treated as an
+           in-band intermediate — it must stay observable (finding #2).
+        3. **In-band intermediate** — a value inside the closed traversal band
+           ``[min(endpoint, target), max(endpoint, target)]`` (±tolerance, both
+           mapped through :meth:`_to_wire`): suppress and RETAIN. This covers
+           both the outbound and the return legs (finding #1).
+
+        The mirror value ``2·target − endpoint`` lies on the far side of the
+        target, outside the band, so a genuine user move to it still trips.
+        A diverged stored target (e.g. tilt-skip-above open mode) can't make the
+        guard inert because matching never reads ``_tilt_targets``. In the
+        degenerate case ``|target − endpoint| <= 2·tolerance`` the endpoint and
+        target windows overlap; the overlap favours the bounded false-negative
+        (suppress) rather than a false override. Expired records (older than the
+        configured ``backrotate_publish_lag_seconds`` window, default 45 s) are
+        dropped first, so a genuine user move — once the window has lapsed —
+        still trips.
         """
         records = self._reset_excursion.get(entity_id)
         if not records:
@@ -468,21 +510,57 @@ class DualAxisSequencer:
             for record in records
             if self._seconds_since(record.at) < self._backrotate_publish_lag_seconds
         ]
-        matched = False
-        remaining: list[_ResetExcursion] = []
-        for record in live:
-            if not matched and (
-                abs(new_value - self._to_wire(record.endpoint))
-                <= VENETIAN_TILT_VERIFY_TOLERANCE
-            ):
-                matched = True  # one-shot: consume only the first matching record
-                continue
-            remaining.append(record)
-        if remaining:
-            self._reset_excursion[entity_id] = remaining
-        else:
+        if not live:
             self._reset_excursion.pop(entity_id, None)
-        return matched
+            return False
+
+        # (1) Endpoint publish: suppress + RETAIN; mark the first unmarked
+        # matching record so the return leg stays protected.
+        endpoint_matched = False
+        marked = False
+        updated: list[_ResetExcursion] = []
+        for record in live:
+            if self._publish_matches(new_value, record.endpoint):
+                endpoint_matched = True
+                if not marked and not record.endpoint_seen:
+                    marked = True
+                    record = dataclasses.replace(record, endpoint_seen=True)
+            updated.append(record)
+        self._store_excursions(entity_id, updated)
+        if endpoint_matched:
+            return True
+        live = updated
+
+        # (2) Target publish: fall through so a simultaneous genuine POSITION
+        # move stays observable (finding #2); consume the first completed
+        # (endpoint_seen) matching record — the excursion is done.
+        target_matched = False
+        for index, record in enumerate(live):
+            if self._publish_matches(new_value, record.target):
+                target_matched = True
+                if record.endpoint_seen:
+                    self._store_excursions(entity_id, live[:index] + live[index + 1 :])
+                    break
+        if target_matched:
+            return False
+
+        # (3) In-band intermediate publish: the slats physically travel
+        # target->endpoint->target, so a publish whose wire value lands in the
+        # closed traversal band (±tolerance) is ACP's own mid-excursion move on
+        # either leg. Suppress + RETAIN. Checked over LIVE records only, so it
+        # stays time-boxed; the mirror value 2*target-endpoint lies outside the
+        # band, so a genuine mirror move still trips.
+        for record in live:
+            lo, hi = sorted(
+                (self._to_wire(record.endpoint), self._to_wire(record.target))
+            )
+            if (
+                lo - VENETIAN_TILT_VERIFY_TOLERANCE
+                <= new_value
+                <= hi + VENETIAN_TILT_VERIFY_TOLERANCE
+            ):
+                return True
+        return False
 
     # -- tilt sequence ----------------------------------------------------- #
 
@@ -823,10 +901,12 @@ class DualAxisSequencer:
         :meth:`_send_tilt_command` (reusing inverse / grace / dedup gates per
         the no-duplication rule):
 
-        1. Record a per-entity endpoint-excursion stamp (issue #927) so a stale
-           endpoint state publish arriving after the command grace closes is
-           later recognised by :meth:`is_reset_excursion_publish` as ACP's own
-           move rather than a manual override, then drive the slats to the
+        1. Record a per-entity excursion stamp (issue #927) so the stale state
+           publishes arriving after the command grace closes are later
+           recognised by :meth:`is_reset_excursion_publish` as ACP's own
+           excursion trajectory rather than a manual override; the record is
+           consumed when the target-return publish lands (or on expiry), not on
+           the endpoint publish alone (#930), then drive the slats to the
            mechanical endpoint chosen by ``get_tilt_reset_direction`` (issue
            #686) — logical ``POSITION_OPEN`` (default) or ``POSITION_CLOSED``
            (``force=True``, ``verify=False``). The literal logical value is
@@ -886,10 +966,12 @@ class DualAxisSequencer:
                 force=True,
                 verify=False,
             )
-            # Record the endpoint excursion so a stale endpoint state publish
-            # that lands after the command grace closes is recognised as ACP's
-            # own move, not a manual override (issue #927). The LOGICAL endpoint
-            # is stored; is_reset_excursion_publish applies _to_wire on match.
+            # Record the excursion so the stale state publishes that land after
+            # the command grace closes are recognised as ACP's own excursion
+            # trajectory, not a manual override (issue #927). The record is
+            # consumed when the target-return publish lands (or on expiry), not
+            # on the endpoint publish alone (#930). The LOGICAL endpoint is
+            # stored; is_reset_excursion_publish applies _to_wire on match.
             # Only stamp when the endpoint command ACTUALLY dispatched: in
             # dry-run the send is skipped, and a HomeAssistantError leaves the
             # slats put — either way a stamp would linger with no matching
@@ -897,7 +979,11 @@ class DualAxisSequencer:
             # reset inside the window keeps its own record.
             if sent:
                 self._reset_excursion.setdefault(entity_id, []).append(
-                    _ResetExcursion(endpoint=reset_endpoint, at=dt.datetime.now(dt.UTC))
+                    _ResetExcursion(
+                        endpoint=reset_endpoint,
+                        at=dt.datetime.now(dt.UTC),
+                        target=original_target,
+                    )
                 )
             await asyncio.sleep(VENETIAN_POST_TILT_REBASE_DELAY_SECONDS)
             self._record_event(

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -239,6 +239,38 @@ class AdaptiveCoverManager:
             reason=reason,
         )
 
+    def _reject_gated_update(
+        self,
+        entity_id: str,
+        *,
+        event_name: str,
+        reason: str,
+        our_state,
+        secondary_axis_check,
+        new_state,
+    ) -> None:
+        """Reject an update at an early gate, advancing any excursion trajectory.
+
+        The wait_for_target and command-grace gates both short-circuit
+        ``handle_state_change`` before ``secondary_axis_check.evaluate`` runs.
+        On a slow actuator the drift-reset publishes land inside one of these
+        gates — the excursion trajectory must keep advancing here (mark endpoint
+        / consume on target return), otherwise the record lingers the full
+        publish-lag window and later swallows a genuine move to the same value
+        (issue #927; PR #928 fixed the command-grace gate, and the
+        wait_for_target analog is issue #930). The generic ``consume_excursion``
+        call keeps the manager cover-type-agnostic.
+        """
+        if secondary_axis_check is not None:
+            secondary_axis_check.consume_excursion(entity_id, new_state)
+        self._record_event(
+            entity_id,
+            event_name,
+            our_state=our_state,
+            new_position=None,
+            reason=reason,
+        )
+
     def get_event_buffer(self) -> list[dict]:
         """Return a snapshot of the ring buffer (backward-compat wrapper)."""
         return self._event_buffer.snapshot()
@@ -364,29 +396,23 @@ class AdaptiveCoverManager:
         if entity_id not in self.covers:
             return
         if is_waiting(entity_id):
-            self._record_event(
+            self._reject_gated_update(
                 entity_id,
-                "manual_override_rejected_wait_for_target",
-                our_state=our_state,
-                new_position=None,
+                event_name="manual_override_rejected_wait_for_target",
                 reason="wait_for_target active",
+                our_state=our_state,
+                secondary_axis_check=secondary_axis_check,
+                new_state=event.new_state,
             )
             return
         if is_in_command_grace is not None and is_in_command_grace(entity_id):
-            # Consume any matching one-shot excursion stamp BEFORE returning
-            # (#927). The grace gate short-circuits the secondary-axis check, but
-            # on fast actuators the drift-reset endpoint publish lands inside the
-            # command-grace window — if the stamp isn't consumed here it lingers
-            # the full publish-lag window and later swallows a genuine move to
-            # the same value. Generic call keeps the manager cover-type-agnostic.
-            if secondary_axis_check is not None:
-                secondary_axis_check.consume_excursion(entity_id, event.new_state)
-            self._record_event(
+            self._reject_gated_update(
                 entity_id,
-                "manual_override_rejected_command_grace",
-                our_state=our_state,
-                new_position=None,
+                event_name="manual_override_rejected_command_grace",
                 reason="command grace period active",
+                our_state=our_state,
+                secondary_axis_check=secondary_axis_check,
+                new_state=event.new_state,
             )
             return
 

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -63,8 +63,10 @@ class SecondaryAxisCheck:
     receives the raw PUBLISHED value (not a delta) and reports whether it
     matches an integration-issued excursion the axis owner recorded (e.g.
     venetian's drift-reset endpoint publish). It is consulted BEFORE
-    ``suppression`` so a matching publish is recognised and consumed whether or
-    not a time-based grace window happens to be open at the same instant.
+    ``suppression`` so a matching publish is recognised whether or not a
+    time-based grace window happens to be open at the same instant. The record
+    is trajectory-tracked, not one-shot-popped: an endpoint publish marks it and
+    a target-return publish consumes it (#930).
     """
 
     expected: int
@@ -72,23 +74,32 @@ class SecondaryAxisCheck:
     label: str  # e.g. "tilt" — flavours the rejection-reason text
     suppression: Callable[[str, float], bool] | None = None
     # Value-based (not delta-based) predicate over the raw published value;
-    # matches an integration-issued excursion so its stale late publish isn't
-    # misread as a manual move (issue #927).
+    # matches an integration-issued excursion so its stale late publishes aren't
+    # misread as a manual move. Trajectory advanced (trajectory-tracked, not
+    # one-shot-popped): endpoint publish marks, target-return consumes
+    # (issue #927/#930).
     excursion_match: Callable[[str, float], bool] | None = None
 
     def consume_excursion(self, entity_id: str, new_state) -> None:
-        """Consume a matching one-shot excursion stamp under another gate.
+        """Advance the excursion trajectory state under another gate.
 
-        When another gate (e.g. command grace) already suppressed this update,
-        pop any matching one-shot excursion stamp anyway so it does not linger
-        and later swallow a genuine move to the same value (issue #927).
+        When another gate (e.g. command grace or wait_for_target) already
+        suppressed this update, feed the published value to ``excursion_match``
+        anyway for its side effects so the excursion trajectory keeps advancing
+        while ``evaluate`` is short-circuited: an endpoint publish marks the
+        record, a target-return publish consumes it (issue #927/#930).
+        Intermediate and endpoint publishes do NOT pop the record — only a
+        target-return (or window expiry) does — so it can't linger and later
+        swallow a genuine move to the same value.
         """
         if self.excursion_match is None:
             return
         new_value = new_state.attributes.get(self.attribute)
         if new_value is None:
             return
-        self.excursion_match(entity_id, new_value)  # one-shot pop on match
+        # Side-effect call: advances trajectory state (mark endpoint / consume
+        # on target-return); the boolean return is intentionally discarded.
+        self.excursion_match(entity_id, new_value)
 
     def evaluate(
         self,
@@ -104,13 +115,14 @@ class SecondaryAxisCheck:
         effective_threshold = effective_manual_threshold(manual_threshold)
 
         # Issue #927: consult the value-based excursion predicate FIRST, before
-        # the delta-based suppression grace check. A drift-reset endpoint
-        # publish must be recognised and consume its one-shot record even when
-        # the command-grace window is simultaneously open — otherwise the grace
-        # term short-circuits, the record lingers the full publish-lag window,
-        # and a genuine later move to the endpoint value gets swallowed. This
-        # matches on the raw published value, so a user move to the mirror value
-        # (same delta, different value) is not swallowed.
+        # the delta-based suppression grace check. A drift-reset publish must be
+        # recognised and its trajectory state advanced (endpoint marked /
+        # target-return consumed) even when the command-grace window is
+        # simultaneously open — otherwise the grace term short-circuits, the
+        # record lingers the full publish-lag window, and a genuine later move to
+        # the endpoint value gets swallowed. This matches on the raw published
+        # value, so a user move to the mirror value (same delta, different value)
+        # is not swallowed.
         if self.excursion_match is not None and self.excursion_match(
             entity_id, new_value
         ):
@@ -122,8 +134,8 @@ class SecondaryAxisCheck:
                     "new_position": new_value,
                     "effective_threshold": effective_threshold,
                     "reason": (
-                        f"{self.label} value {new_value:.0f}% matches an ACP "
-                        "drift-reset endpoint excursion; suppressing both tilt "
+                        f"{self.label} value {new_value:.0f}% lies on an ACP "
+                        "drift-reset excursion trajectory; suppressing both tilt "
                         "and position checks"
                     ),
                 },

--- a/tests/test_cover_types/test_venetian_drift_reset.py
+++ b/tests/test_cover_types/test_venetian_drift_reset.py
@@ -952,18 +952,31 @@ class TestResetExcursionPublishSuppression:
         seq = await self._run_reset(target=79, anchor=0)
         assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
 
-    async def test_match_is_one_shot(self):
+    async def test_endpoint_retained_until_target_return_consumes(self):
+        """#930: the endpoint publish MARKS+RETAINS; only target return consumes.
+
+        A close reset to target 79 stamps endpoint 0. The endpoint publish
+        (value 0) marks the record and suppresses, and a republished endpoint
+        still suppresses — the record survives the whole out-and-back. Only a
+        publish landing back on the target (79) consumes it; afterwards the
+        protection is over.
+        """
         seq = await self._run_reset(target=79, anchor=0)
         assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
-        # Consumed — a second identical query no longer suppresses.
+        # Republished endpoint still suppressed — record retained, not burned.
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        # Target-return publish consumes the completed excursion.
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+        assert "cover.x" not in seq._reset_excursion
+        # Protection over: a later endpoint value now falls through.
         assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
 
-    async def test_non_matching_value_not_suppressed_and_record_retained(self):
-        seq = await self._run_reset(target=79, anchor=0)
-        # An intermediate non-endpoint publish (value 40, endpoint 0).
-        assert seq.is_reset_excursion_publish("cover.x", 40.0) is False
-        # The real endpoint publish still matches — record was NOT burned.
-        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+    # NOTE (#930): the former ``test_non_matching_value_not_suppressed_and_record_
+    # retained`` asserted an IN-BAND intermediate (value 40, target 79/endpoint 0)
+    # was NOT suppressed. Issue #930 deliberately reverses that: an intermediate
+    # inside the traversal band IS now suppressed. Its surviving guarantee — a
+    # genuine OUT-OF-band move is not suppressed and the record is retained — is
+    # covered by ``test_out_of_band_value_not_suppressed_and_record_retained``.
 
     async def test_user_move_to_mirror_value_not_suppressed(self):
         """Finding #1: the old delta-based match swallowed a user move to the
@@ -1008,16 +1021,136 @@ class TestResetExcursionPublishSuppression:
         """Finding #4: two resets inside the window keep two records.
 
         A single-slot store would let the second reset clobber the first, so
-        only one endpoint publish would suppress. With a list, both do — in
-        either order — and a third query then falls through.
+        only one excursion would survive. With a list, both do: each endpoint
+        publish marks its own record (#930), and each is consumed only when a
+        publish lands back on that record's target.
         """
         seq = await self._run_reset(target=79, anchor=0)  # record 1, endpoint 0
         # Second reset on the SAME sequencer; anchor now the restored target 79.
         await self._run_reset(target=20, anchor=79, seq=seq)  # record 2, endpoint 0
         assert len(seq._reset_excursion["cover.x"]) == 2
+        # Endpoint publishes mark each record in turn; both stay retained.
         assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
         assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        assert all(r.endpoint_seen for r in seq._reset_excursion["cover.x"])
+        # A further endpoint publish is still suppressed (records survive).
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        # Target returns consume each completed record in turn.
+        assert seq.is_reset_excursion_publish("cover.x", 79.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 20.0) is False
+        assert "cover.x" not in seq._reset_excursion
         assert seq.is_reset_excursion_publish("cover.x", 0.0) is False
+
+    async def test_intermediate_in_band_publish_suppressed_without_burning_record(self):
+        """Issue #930: in-band intermediates suppress; only target return consumes.
+
+        Close reset from anchor 0 to target 41 stamps endpoint 0. The slats
+        travel 41→0→41, so a mid-excursion publish anywhere in the band
+        ``[-5, 46]`` (endpoint 0 .. target 41, ±tolerance) is ACP's own move —
+        suppressed WITHOUT consuming the record. The endpoint publish marks the
+        record (still suppressed, still retained); only a publish landing back
+        on the target consumes it, ending protection.
+        """
+        seq = await self._run_reset(target=41, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 9.0) is True
+        # Non-consuming: a second in-band intermediate still suppresses.
+        assert seq.is_reset_excursion_publish("cover.x", 28.0) is True
+        # The endpoint publish marks the record; still suppressed, still retained.
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        # Return-leg endpoint republish still suppressed (record survives).
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        # Target-return publish consumes the completed excursion.
+        assert seq.is_reset_excursion_publish("cover.x", 41.0) is False
+        assert "cover.x" not in seq._reset_excursion
+        assert seq.is_reset_excursion_publish("cover.x", 9.0) is False
+
+    async def test_intermediate_at_seven_percent_delta_suppressed(self):
+        """Issue #930: the reporter's ``28 @ delta 7%`` intermediate suppresses.
+
+        Close reset to target 35 (band ``[-5, 40]``); a tilt-28 publish (delta 7
+        from target) is in-band and suppressed, then the endpoint publish marks
+        the record (consumption happens on the later target-return, not here).
+        """
+        seq = await self._run_reset(target=35, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 28.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+
+    async def test_out_of_band_value_not_suppressed_and_record_retained(self):
+        """A genuine move OUTSIDE the traversal band is not suppressed; record kept.
+
+        Close reset to target 79 (band ``[-5, 84]``). A publish of 90 lies beyond
+        the target side of the band — a genuine move — so it is NOT suppressed,
+        and the endpoint publish still matches (record was not burned). This is
+        the surviving half of the deleted ``test_non_matching_value_not_...``.
+        """
+        seq = await self._run_reset(target=79, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 90.0) is False
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+
+    async def test_return_leg_intermediate_after_endpoint_still_suppressed(self):
+        """#930 finding 1: an intermediate on the RETURN leg stays suppressed.
+
+        Close reset to target 35 stamps endpoint 0. Once the endpoint publish
+        has marked the record, the slats travel 0→35 (the return leg); an
+        intermediate publish (28, in-band) on that leg must still be suppressed
+        because the record survives until the target-return consumes it.
+        """
+        seq = await self._run_reset(target=35, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+        assert seq._reset_excursion["cover.x"][0].endpoint_seen is True
+        # Return-leg intermediate — still protected (pre-#930 this tripped).
+        assert seq.is_reset_excursion_publish("cover.x", 28.0) is True
+        # Target return consumes and falls through.
+        assert seq.is_reset_excursion_publish("cover.x", 35.0) is False
+        assert "cover.x" not in seq._reset_excursion
+        assert seq.is_reset_excursion_publish("cover.x", 28.0) is False
+
+    async def test_near_target_value_falls_through_without_consuming(self):
+        """#930 finding 2: a near-target value falls through (position stays observable).
+
+        Close reset to target 35. A publish of 34 is within tolerance of the
+        target, so it is treated as the settled resting position and falls
+        through (returns False) rather than being swallowed as an in-band
+        intermediate — leaving a simultaneous genuine POSITION move detectable.
+        The record is not consumed (no endpoint seen yet), so the endpoint
+        publish still protects the excursion.
+        """
+        seq = await self._run_reset(target=35, anchor=0)
+        assert seq.is_reset_excursion_publish("cover.x", 34.0) is False
+        records = seq._reset_excursion["cover.x"]
+        assert len(records) == 1
+        assert records[0].endpoint_seen is False
+        assert seq.is_reset_excursion_publish("cover.x", 0.0) is True
+
+    async def test_in_band_value_after_window_expiry_not_suppressed(self):
+        """After the publish-lag window lapses, an in-band value no longer suppresses.
+
+        The band check runs only over LIVE records; once the excursion stamp is
+        older than ``backrotate_publish_lag_seconds`` it is dropped on the expiry
+        sweep, so a genuine same-region move seconds later trips.
+        """
+        seq = await self._run_reset(target=41, anchor=0)
+        records = seq._reset_excursion["cover.x"]
+        seq._reset_excursion["cover.x"] = [
+            dataclasses.replace(
+                r,
+                at=r.at
+                - dt.timedelta(seconds=seq._backrotate_publish_lag_seconds + 1.0),
+            )
+            for r in records
+        ]
+        assert seq.is_reset_excursion_publish("cover.x", 9.0) is False
+
+    async def test_band_respects_tilt_inversion(self):
+        """The traversal band is computed on WIRE values, honouring tilt inversion.
+
+        With inversion, close reset to target 79: logical endpoint 0 → wire 100,
+        target 79 → wire 21, so the wire band is ``[16, 105]``. A wire-60 publish
+        is in-band (suppressed); a wire-5 publish is below the band (trips).
+        """
+        seq = await self._run_reset(target=79, anchor=0, invert_tilt=lambda: True)
+        assert seq.is_reset_excursion_publish("cover.x", 60.0) is True
+        assert seq.is_reset_excursion_publish("cover.x", 5.0) is False
 
     async def test_dry_run_does_not_stamp(self):
         """Finding #5: no stamp when the endpoint send is dry-run skipped.

--- a/tests/test_manual_override_venetian.py
+++ b/tests/test_manual_override_venetian.py
@@ -1219,19 +1219,21 @@ async def test_position_axis_move_during_window_trips_override() -> None:
     )
 
 
-async def test_endpoint_publish_inside_grace_consumes_record() -> None:
-    """Finding #3: a matching endpoint publish inside grace consumes the record.
+async def test_endpoint_publish_inside_grace_marks_record_then_target_return_consumes() -> (
+    None
+):
+    """#930 finding 3: an endpoint publish inside grace MARKS; target return consumes.
 
     Mirrors production: the coordinator wires ``is_in_command_grace`` to the
     SAME ``GracePeriodManager`` the policy's excursion window uses. On a fast
     actuator the endpoint publish lands WHILE that command-grace window is still
     open, so ``handle_state_change`` returns early in the grace-reject branch
-    BEFORE ``secondary_axis_check.evaluate`` ever runs. Without a fix the
-    one-shot excursion record is never consumed and lingers the full window,
-    later swallowing a genuine user tilt-to-endpoint move (bounded false
-    negative). The fix consumes the matching excursion stamp in the grace-reject
-    branch via the generic ``SecondaryAxisCheck.consume_excursion`` so the record
-    does not linger; a later genuine move to the endpoint value then trips.
+    BEFORE ``secondary_axis_check.evaluate`` ever runs. The grace-reject branch
+    still advances the excursion trajectory via the generic
+    ``SecondaryAxisCheck.consume_excursion``: the endpoint publish marks the
+    record (it survives the return leg), and a later publish back on the target
+    consumes it. A genuine user move to the endpoint after the whole trajectory
+    then trips.
     """
     entity_id = "cover.og_studio_tur_grace"
     seq, policy = await _drive_drift_reset(entity_id, target=79, grace_active=True)
@@ -1240,7 +1242,8 @@ async def test_endpoint_publish_inside_grace_consumes_record() -> None:
     mgr = _make_manager(entity_id)
     mgr.hass.states.get = MagicMock(return_value=None)
     # In-grace endpoint publish: command grace is active (as production wires it
-    # off the same GracePeriodManager), so the grace-reject branch fires first.
+    # off the same GracePeriodManager), so the grace-reject branch fires first
+    # and marks (not consumes) the excursion record.
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=50, tilt=0),
         our_state=50,
@@ -1251,16 +1254,28 @@ async def test_endpoint_publish_inside_grace_consumes_record() -> None:
         secondary_axis_check=_secondary_check(policy, 79),
         is_in_command_grace=lambda _eid: True,
     )
+    assert not mgr.is_cover_manual(entity_id)
+    assert entity_id in seq._reset_excursion
+    assert seq._reset_excursion[entity_id][0].endpoint_seen is True
 
-    # Grace rejects the update, so no override — but the one-shot record MUST be
-    # consumed so it can't linger and swallow a genuine later move (finding #3).
+    # In-grace target-return publish (tilt back to 79) consumes the record.
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=79),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 79),
+        is_in_command_grace=lambda _eid: True,
+    )
     assert not mgr.is_cover_manual(entity_id)
     assert entity_id not in seq._reset_excursion
 
     # After grace expires, a genuine user tilt-to-endpoint move (no stamp left)
-    # must still trip override — proving the consume did not disable detection.
-    # Flip the policy's command grace off too (the suppression callback consults
-    # it), mirroring the window having closed.
+    # must still trip override — proving the trajectory tracking did not disable
+    # detection. Flip the policy's command grace off too (the suppression
+    # callback consults it), mirroring the window having closed.
     policy._grace_mgr.is_in_command_grace_period = lambda _eid: False
     mgr.handle_state_change(
         states_data=_make_event(entity_id, position=50, tilt=0),
@@ -1275,6 +1290,69 @@ async def test_endpoint_publish_inside_grace_consumes_record() -> None:
     assert mgr.is_cover_manual(
         entity_id
     ), "a genuine user move to the endpoint after grace must still trip override"
+
+
+async def test_endpoint_publish_during_wait_for_target_marks_record_then_target_return_consumes() -> (
+    None
+):
+    """Case 2 (#930): an endpoint publish inside wait_for_target marks; target return consumes.
+
+    The ``is_waiting`` gate returns early — like the command-grace gate — BEFORE
+    ``secondary_axis_check.evaluate`` runs. When a position command is still
+    awaiting its target as the drift-reset endpoint publish lands, the
+    grace-reject branch advances the excursion trajectory: the endpoint publish
+    marks the record (retained through the return leg), and a later publish back
+    on the target consumes it. Symmetric with
+    ``test_endpoint_publish_inside_grace_marks_record_then_target_return_consumes``.
+    """
+    entity_id = "cover.og_studio_tur_wait"
+    seq, policy = await _drive_drift_reset(entity_id, target=79)
+    assert entity_id in seq._reset_excursion
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    # In-flight position command: wait_for_target active — the is_waiting branch
+    # fires first and marks (not consumes) the excursion record.
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: True,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 79),
+    )
+    assert not mgr.is_cover_manual(entity_id)
+    assert entity_id in seq._reset_excursion
+    assert seq._reset_excursion[entity_id][0].endpoint_seen is True
+
+    # Target-return publish while still waiting consumes the record.
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=79),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: True,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 79),
+    )
+    assert not mgr.is_cover_manual(entity_id)
+    assert entity_id not in seq._reset_excursion
+
+    # Once the command settles (is_waiting False, no stamp left), a genuine user
+    # tilt-to-endpoint move must still trip override.
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 79),
+    )
+    assert mgr.is_cover_manual(
+        entity_id
+    ), "a genuine user move to the endpoint after wait_for_target must still trip"
 
 
 async def test_endpoint_publish_after_excursion_window_trips_override() -> None:
@@ -1311,3 +1389,138 @@ async def test_endpoint_publish_after_excursion_window_trips_override() -> None:
     assert mgr.is_cover_manual(
         entity_id
     ), "endpoint publish after the excursion window must trip manual override"
+
+
+async def test_drift_reset_intermediate_publish_does_not_trip_override() -> None:
+    """Case 1 (#930): a mid-excursion INTERMEDIATE tilt publish must NOT trip.
+
+    A close reset to target 41 drives the slats 41→0→41. On a slow actuator an
+    intermediate ``current_tilt_position=9`` publishes mid-travel — delta 32
+    from the 41 target, well over the threshold. The traversal-band suppression
+    recognises it as ACP's own excursion. The endpoint publish then marks the
+    record (still retained, not burned); only a publish landing back on the
+    target (41) consumes it.
+    """
+    entity_id = "cover.og_studio_tur_intermediate"
+    seq, policy = await _drive_drift_reset(entity_id, target=41)
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=9),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 41),
+    )
+    assert not mgr.is_cover_manual(
+        entity_id
+    ), "an intermediate mid-excursion tilt publish must NOT trip manual override"
+
+    # The endpoint publish marks the record; it is RETAINED, not consumed, so it
+    # still protects the return leg (#930).
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=0),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 41),
+    )
+    assert not mgr.is_cover_manual(entity_id)
+    assert entity_id in seq._reset_excursion
+
+    # The target-return publish (tilt back to 41) consumes the record.
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=50, tilt=41),
+        our_state=50,
+        policy=get_policy("cover_venetian"),
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 41),
+    )
+    assert not mgr.is_cover_manual(entity_id)
+    assert entity_id not in seq._reset_excursion
+
+
+async def test_return_leg_intermediate_after_endpoint_publish_does_not_trip_override() -> (
+    None
+):
+    """#930 finding 1: an intermediate on the RETURN leg must NOT trip override.
+
+    A close reset to target 35 drives the slats 35→0→35. The endpoint publish
+    (tilt 0) marks the record; then on the return leg an intermediate tilt-28
+    publish lands (delta 7 from the 35 target, over the threshold). Because the
+    record survives until the target-return consumes it, the return-leg
+    intermediate is recognised as ACP's own move. Pre-#930 the endpoint publish
+    burned the one-shot, so this return-leg intermediate tripped a false
+    override.
+    """
+    entity_id = "cover.og_studio_tur_return"
+    seq, policy = await _drive_drift_reset(entity_id, target=35)
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+
+    def _drive(tilt: int) -> None:
+        mgr.handle_state_change(
+            states_data=_make_event(entity_id, position=50, tilt=tilt),
+            our_state=50,
+            policy=get_policy("cover_venetian"),
+            allow_reset=True,
+            is_waiting=lambda _eid: False,
+            manual_threshold=2,
+            secondary_axis_check=_secondary_check(policy, 35),
+        )
+
+    # Endpoint publish marks the record.
+    _drive(0)
+    assert not mgr.is_cover_manual(entity_id)
+    # Return-leg intermediate — must NOT trip (pre-#930 it did).
+    _drive(28)
+    assert not mgr.is_cover_manual(entity_id)
+    # Target return consumes the record.
+    _drive(35)
+    assert not mgr.is_cover_manual(entity_id)
+    assert entity_id not in seq._reset_excursion
+
+    # A genuine user move to the endpoint after the trajectory completes trips.
+    _drive(0)
+    assert mgr.is_cover_manual(entity_id)
+
+
+async def test_near_target_tilt_publish_position_axis_still_evaluated() -> None:
+    """#930 finding 2: a near-target tilt publish keeps the position axis observable.
+
+    After a close reset to target 35, a tilt publish of 34 is within tolerance
+    of the target, so the excursion predicate falls through (rather than
+    swallowing both axes as an in-band intermediate). With the tilt delta below
+    threshold, a simultaneous genuine POSITION move (our_state 50 →
+    current_position 15) must still trip manual override. Pre-#930 the near-
+    target value was swallowed by the band rule and the position move was lost.
+    """
+    entity_id = "cover.og_studio_tur_near_target"
+    seq, policy = await _drive_drift_reset(entity_id, target=35)
+
+    mgr = _make_manager(entity_id)
+    mgr.hass.states.get = MagicMock(return_value=None)
+    # Pass the WIRED policy so the position axis consults the sequencer-backed
+    # ``primary_axis_suppression`` (which must NOT swallow this move).
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=15, tilt=34),
+        our_state=50,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=2,
+        secondary_axis_check=_secondary_check(policy, 35),
+    )
+
+    assert mgr.is_cover_manual(entity_id), (
+        "a near-target tilt publish must fall through so a genuine position "
+        "move still trips (finding #2)"
+    )


### PR DESCRIPTION
## Summary
Cherry-picked from #934 for a hotfix release. Follow-up to #927 / PR #928, closing the two residual false-override cases on Venetian drift resets that value-based endpoint matching left open.

The excursion record now tracks the full out-and-back trajectory. The endpoint publish marks the record and retains it; in-band intermediates (either leg) are suppressed without consuming; the record is consumed when a publish returns within tolerance of the target (or on expiry). This fixes mid-excursion intermediate publishes (the issue's `28 @ 7%` return-leg reading) being scored as manual moves, and keeps a near-target tilt publish falling through so a simultaneous genuine position move stays detectable. The mirror value `2*target-endpoint` lies outside the band and still trips.

No new config option, migration, or version bump; additive only.

## Testing
- ✅ 5642 tests passing on main

## Related Issues
Refs #930

Cherry-picked from #934 for a hotfix release.

https://claude.ai/code/session_01Vf4y3BJne5ZTywCVwnr78i