### PR TITLE
fix: set device manufacturer to Jason Rhubottom

### DIFF
--- a/custom_components/adaptive_cover_pro/entity_base.py
+++ b/custom_components/adaptive_cover_pro/entity_base.py
@@ -69,7 +69,7 @@ class AdaptiveCoverBaseEntity(CoordinatorEntity["AdaptiveDataUpdateCoordinator"]
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._device_id)},
             name=self._name,
-            manufacturer="BasHeijermans",
+            manufacturer="Jason Rhubottom",
             model=f"Adaptive {type_display} Cover",
             configuration_url="https://github.com/jrhubott/adaptive-cover-pro",
         )

--- a/tests/test_device_association.py
+++ b/tests/test_device_association.py
@@ -192,7 +192,7 @@ def test_device_info_standalone_when_no_device_id(mock_hass):
 
     info = entity.device_info
     assert (DOMAIN, "test-entry-id") in info["identifiers"]
-    assert info.get("manufacturer") == "BasHeijermans"
+    assert info.get("manufacturer") == "Jason Rhubottom"
 
 
 @pytest.mark.unit
@@ -253,7 +253,7 @@ def test_device_info_fallback_when_device_not_found(mock_hass):
 
     # Should fall back to standalone virtual device
     assert (DOMAIN, "test-entry-id") in info["identifiers"]
-    assert info.get("manufacturer") == "BasHeijermans"
+    assert info.get("manufacturer") == "Jason Rhubottom"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
HA rendered "by BasHeijermans" under every Adaptive Cover Pro device because the `DeviceInfo.manufacturer` was still hardcoded to the upstream author's name from the integration this project forked from. Updated it to "Jason Rhubottom" to reflect the fork's ownership.

This only affects standalone (virtual) devices; when a cover is linked to a physical device via `CONF_DEVICE_ID`, the device inherits the linked device's identity and this field isn't used.

## Testing
- ✅ 11 tests passing (`tests/test_device_association.py`)

https://claude.ai/code/session_017RYaF7NN5qdHqiZtHaWQyR