### PR TITLE
feat: add group Stop button/service and Climate-mode switch (#922)

### DIFF
--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -470,6 +470,12 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             coordinator.automatic_control = enabled
             await coordinator.async_refresh()
 
+    async def async_set_climate_mode(self, enabled: bool) -> None:
+        """Bulk-enable/disable climate mode on every ACP member."""
+        for _entry, coordinator in self.resolved_members():
+            coordinator.switch_mode = enabled
+            await coordinator.async_refresh()
+
     async def async_clear_overrides(self) -> None:
         """Clear manual overrides on every ACP member via its shared reset path."""
         for _entry, coordinator in self.resolved_members():

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -152,6 +152,42 @@ class GroupLockSwitch(_GroupEntityBase, SwitchEntity):
         self.async_write_ha_state()
 
 
+class GroupClimateSwitch(_GroupEntityBase, SwitchEntity):
+    """Bulk-enable/disable climate mode across all ACP members.
+
+    Unlike ``GroupAutomationSwitch`` (which mirrors its last command), this
+    reflects live reality: ``is_on`` is true when any member currently
+    reports an active climate mode. ``member_climate_modes`` returns non-None
+    only when a member's climate handler is actually active, so the switch
+    honestly tracks member state with no drift and no RestoreEntity.
+    """
+
+    _attr_translation_key = "group_climate_mode"
+    _attr_icon = "mdi:sun-thermometer-outline"
+
+    def __init__(self, *args) -> None:
+        """Initialize the group climate switch."""
+        super().__init__(*args, "group_climate_mode")
+
+    @property
+    def is_on(self) -> bool:
+        """True when any member currently reports an active climate mode."""
+        return any(
+            mode is not None
+            for mode in self.coordinator.member_climate_modes().values()
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
+        """Bulk-enable climate mode on all members."""
+        await self.coordinator.async_set_climate_mode(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
+        """Bulk-disable climate mode on all members."""
+        await self.coordinator.async_set_climate_mode(False)
+        self.async_write_ha_state()
+
+
 class GroupWhoWonSensor(_GroupEntityBase, SensorEntity):
     """How many members this group currently drives, with per-member detail.
 
@@ -317,6 +353,21 @@ class GroupClearOverridesButton(_GroupEntityBase, ButtonEntity):
         await self.coordinator.async_clear_overrides()
 
 
+class GroupStopButton(_GroupEntityBase, ButtonEntity):
+    """Stop every member cover mid-travel across the group."""
+
+    _attr_translation_key = "group_stop"
+    _attr_icon = "mdi:stop"
+
+    def __init__(self, *args) -> None:
+        """Initialize the stop button."""
+        super().__init__(*args, "group_stop")
+
+    async def async_press(self) -> None:
+        """Stop every member cover immediately."""
+        await self.coordinator.async_stop()
+
+
 class GroupSceneSelect(_GroupEntityBase, SelectEntity):
     """Scene picker: selecting an option activates the scene group-wide."""
 
@@ -383,6 +434,7 @@ def build_group_switches(
     return [
         GroupAutomationSwitch(entry_id, hass, config_entry, coordinator),
         GroupLockSwitch(entry_id, hass, config_entry, coordinator),
+        GroupClimateSwitch(entry_id, hass, config_entry, coordinator),
     ]
 
 
@@ -397,6 +449,7 @@ def build_group_buttons(
     return [
         *(GroupSceneButton(*args, scene) for scene in GroupScene),
         GroupClearOverridesButton(*args),
+        GroupStopButton(*args),
     ]
 
 

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -155,36 +155,30 @@ class GroupLockSwitch(_GroupEntityBase, SwitchEntity):
 class GroupClimateSwitch(_GroupEntityBase, SwitchEntity):
     """Bulk-enable/disable climate mode across all ACP members.
 
-    Unlike ``GroupAutomationSwitch`` (which mirrors its last command), this
-    reflects live reality: ``is_on`` is true when any member currently
-    reports an active climate mode. ``member_climate_modes`` returns non-None
-    only when a member's climate handler is actually active, so the switch
-    honestly tracks member state with no drift and no RestoreEntity.
+    Reflects the last bulk command sent through this group (defaults to off),
+    not a consensus of live member states — members remain individually
+    togglable. For the "what's actually acting" view, the read-only
+    ``sensor.<group>_climate_mode`` rolls up live member climate modes.
     """
 
     _attr_translation_key = "group_climate_mode"
     _attr_icon = "mdi:sun-thermometer-outline"
 
     def __init__(self, *args) -> None:
-        """Initialize the group climate switch."""
+        """Initialize with climate mode considered off."""
         super().__init__(*args, "group_climate_mode")
-
-    @property
-    def is_on(self) -> bool:
-        """True when any member currently reports an active climate mode."""
-        return any(
-            mode is not None
-            for mode in self.coordinator.member_climate_modes().values()
-        )
+        self._attr_is_on = False
 
     async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
         """Bulk-enable climate mode on all members."""
         await self.coordinator.async_set_climate_mode(True)
+        self._attr_is_on = True
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
         """Bulk-disable climate mode on all members."""
         await self.coordinator.async_set_climate_mode(False)
+        self._attr_is_on = False
         self.async_write_ha_state()
 
 

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1429,6 +1429,15 @@ group_clear_overrides:
     entity:
       integration: adaptive_cover_pro
 
+group_stop:
+  name: "Group: stop"
+  description: >-
+    Stops every member cover of the targeted cover groups mid-travel. With no
+    target, acts on all cover groups.
+  target:
+    entity:
+      integration: adaptive_cover_pro
+
 group_set_automation:
   name: "Group: set automation"
   description: >-

--- a/custom_components/adaptive_cover_pro/services/group_service.py
+++ b/custom_components/adaptive_cover_pro/services/group_service.py
@@ -35,6 +35,7 @@ GROUP_SERVICE_NAMES: tuple[str, ...] = (
     "group_unlock",
     "group_clear_overrides",
     "group_set_automation",
+    "group_stop",
 )
 
 _SCENE_CHOICES: tuple[str, ...] = (
@@ -182,6 +183,12 @@ async def async_handle_group_set_automation(call: ServiceCall) -> None:
         await group.async_set_automation(enabled)
 
 
+async def async_handle_group_stop(call: ServiceCall) -> None:
+    """Stop every member cover of the targeted groups mid-travel."""
+    for group in resolve_group_targets(call.hass, call):
+        await group.async_stop()
+
+
 def register_group_services(hass: HomeAssistant) -> None:
     """Register the six group services (called from async_setup_services)."""
     hass.services.async_register(
@@ -213,4 +220,7 @@ def register_group_services(hass: HomeAssistant) -> None:
         "group_set_automation",
         async_handle_group_set_automation,
         schema=GROUP_SET_AUTOMATION_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN, "group_stop", async_handle_group_stop, schema=GROUP_NO_FIELDS_SCHEMA
     )

--- a/custom_components/adaptive_cover_pro/services/group_service.py
+++ b/custom_components/adaptive_cover_pro/services/group_service.py
@@ -190,7 +190,7 @@ async def async_handle_group_stop(call: ServiceCall) -> None:
 
 
 def register_group_services(hass: HomeAssistant) -> None:
-    """Register the six group services (called from async_setup_services)."""
+    """Register the seven group services (called from async_setup_services)."""
     hass.services.async_register(
         DOMAIN,
         "group_activate_scene",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1891,6 +1891,9 @@
       },
       "group_lock": {
         "name": "Gruppensperre"
+      },
+      "group_climate_mode": {
+        "name": "Gruppen-Klimamodus"
       }
     },
     "button": {
@@ -1908,6 +1911,9 @@
       },
       "group_clear_overrides": {
         "name": "Mitglied-Übersteuerungen löschen"
+      },
+      "group_stop": {
+        "name": "Beschattungen stoppen"
       }
     },
     "number": {
@@ -2740,6 +2746,10 @@
           "description": "Sekunden zum Warten, nachdem die Belegung endet, bevor die Belegungs-Timeout-Position angewendet wird (30–3600)."
         }
       }
+    },
+    "group_stop": {
+      "name": "Gruppe: Stoppen",
+      "description": "Stoppt alle Mitglied-Beschattungen der angestrebten Beschattungsgruppen während der Fahrt. Ohne Ziel wirkt es auf alle Beschattungsgruppen."
     }
   }
 }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1891,6 +1891,9 @@
       },
       "group_lock": {
         "name": "Group Lock"
+      },
+      "group_climate_mode": {
+        "name": "Group Climate Mode"
       }
     },
     "button": {
@@ -1908,6 +1911,9 @@
       },
       "group_clear_overrides": {
         "name": "Clear Member Overrides"
+      },
+      "group_stop": {
+        "name": "Stop Covers"
       }
     },
     "number": {
@@ -2730,6 +2736,10 @@
     "group_clear_overrides": {
       "name": "Group: clear member overrides",
       "description": "Clears manual overrides on every ACP member of the targeted cover groups and resends each member's pipeline position."
+    },
+    "group_stop": {
+      "name": "Group: stop",
+      "description": "Stops every member cover of the targeted cover groups mid-travel. With no target, acts on all cover groups."
     },
     "group_set_automation": {
       "name": "Group: set automation",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1891,6 +1891,9 @@
       },
       "group_lock": {
         "name": "Verrouillage de groupe"
+      },
+      "group_climate_mode": {
+        "name": "Mode climatique du groupe"
       }
     },
     "button": {
@@ -1908,6 +1911,9 @@
       },
       "group_clear_overrides": {
         "name": "Supprimer les dérogations des membres"
+      },
+      "group_stop": {
+        "name": "Arrêter les stores"
       }
     },
     "number": {
@@ -2740,6 +2746,10 @@
           "description": "Secondes à attendre après que l'occupation disparaisse avant d'appliquer la position du délai d'occupation (30–3600)."
         }
       }
+    },
+    "group_stop": {
+      "name": "Groupe : arrêter",
+      "description": "Arrête chaque membre des groupes de stores ciblés en cours de déplacement. Sans cible, s'applique à tous les groupes de stores."
     }
   }
 }

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -181,6 +181,21 @@ async def test_set_automation_flips_member_toggles(group_setup) -> None:
     assert blind_coord.automatic_control is True
 
 
+async def test_set_climate_mode_flips_member_switch_mode(group_setup) -> None:
+    """Bulk climate on sets each member's switch_mode and refreshes."""
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_set_climate_mode(True)
+
+    for member in (blind_coord, awning_coord):
+        assert member.switch_mode is True
+        member.async_refresh.assert_awaited_once()
+
+    await coordinator.async_set_climate_mode(False)
+    assert blind_coord.switch_mode is False
+    assert awning_coord.switch_mode is False
+
+
 async def test_clear_overrides_delegates_to_members(group_setup) -> None:
     """Bulk clear rides each member's shared reset path."""
     coordinator, blind_coord, awning_coord = group_setup

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -220,10 +220,10 @@ async def test_group_lock_switch_drives_lock_intent(hass, group_entry) -> None:
     assert lock.is_on is False
 
 
-async def test_group_climate_switch_drives_and_reflects_members(
+async def test_group_climate_switch_drives_and_mirrors_command(
     hass, group_entry
 ) -> None:
-    """Turn on/off delegate to the coordinator; is_on derives from member modes."""
+    """Turn on/off delegate to the coordinator; is_on mirrors the last command."""
     coordinator = group_entry.runtime_data
     coordinator.async_set_climate_mode = AsyncMock()
     entities = {
@@ -232,17 +232,15 @@ async def test_group_climate_switch_drives_and_reflects_members(
     climate = entities["group_01_group_climate_mode"]
     climate.async_write_ha_state = MagicMock()
 
-    coordinator.member_climate_modes = MagicMock(return_value={"cover.a": None})
-    assert climate.is_on is False
-    coordinator.member_climate_modes = MagicMock(
-        return_value={"cover.a": "summer_mode"}
-    )
-    assert climate.is_on is True
+    assert climate.is_on is False  # climate off by default
 
     await climate.async_turn_on()
     coordinator.async_set_climate_mode.assert_awaited_once_with(True)
+    assert climate.is_on is True
+
     await climate.async_turn_off()
     coordinator.async_set_climate_mode.assert_awaited_with(False)
+    assert climate.is_on is False
 
 
 async def test_select_auto_clears_scene(hass, group_entry) -> None:

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -123,6 +123,7 @@ async def test_switch_platform_builds_group_automation_switch(
     assert [e.unique_id for e in entities] == [
         "group_01_group_automation",
         "group_01_group_lock",
+        "group_01_group_climate_mode",
     ]
 
     coordinator = group_entry.runtime_data
@@ -146,11 +147,13 @@ async def test_button_platform_builds_scene_and_clear_buttons(
     assert unique_ids == {
         *(f"group_01_group_scene_{scene}" for scene in GroupScene),
         "group_01_group_clear_overrides",
+        "group_01_group_stop",
     }
 
     coordinator = group_entry.runtime_data
     coordinator.async_activate_scene = AsyncMock()
     coordinator.async_clear_overrides = AsyncMock()
+    coordinator.async_stop = AsyncMock()
     by_id = {e.unique_id: e for e in entities}
 
     await by_id[f"group_01_group_scene_{GroupScene.ALL_OPEN}"].async_press()
@@ -158,6 +161,9 @@ async def test_button_platform_builds_scene_and_clear_buttons(
 
     await by_id["group_01_group_clear_overrides"].async_press()
     coordinator.async_clear_overrides.assert_awaited_once()
+
+    await by_id["group_01_group_stop"].async_press()
+    coordinator.async_stop.assert_awaited_once()
 
 
 async def test_select_platform_builds_scene_picker(hass, group_entry) -> None:
@@ -212,6 +218,31 @@ async def test_group_lock_switch_drives_lock_intent(hass, group_entry) -> None:
     await lock.async_turn_off()
     coordinator.async_set_lock.assert_awaited_with(False)
     assert lock.is_on is False
+
+
+async def test_group_climate_switch_drives_and_reflects_members(
+    hass, group_entry
+) -> None:
+    """Turn on/off delegate to the coordinator; is_on derives from member modes."""
+    coordinator = group_entry.runtime_data
+    coordinator.async_set_climate_mode = AsyncMock()
+    entities = {
+        e.unique_id: e for e in await _added_entities(switch, hass, group_entry)
+    }
+    climate = entities["group_01_group_climate_mode"]
+    climate.async_write_ha_state = MagicMock()
+
+    coordinator.member_climate_modes = MagicMock(return_value={"cover.a": None})
+    assert climate.is_on is False
+    coordinator.member_climate_modes = MagicMock(
+        return_value={"cover.a": "summer_mode"}
+    )
+    assert climate.is_on is True
+
+    await climate.async_turn_on()
+    coordinator.async_set_climate_mode.assert_awaited_once_with(True)
+    await climate.async_turn_off()
+    coordinator.async_set_climate_mode.assert_awaited_with(False)
 
 
 async def test_select_auto_clears_scene(hass, group_entry) -> None:

--- a/tests/test_group_services.py
+++ b/tests/test_group_services.py
@@ -64,6 +64,7 @@ def _mock_group_coordinator() -> MagicMock:
         "async_set_lock",
         "async_clear_overrides",
         "async_set_automation",
+        "async_stop",
     ):
         setattr(coord, name, AsyncMock())
     return coord
@@ -177,6 +178,9 @@ async def test_group_services_drive_coordinator_methods(hass, loaded_pair) -> No
         DOMAIN, "group_set_automation", {"enabled": False}, blocking=True
     )
     group_coord.async_set_automation.assert_awaited_once_with(False)
+
+    await hass.services.async_call(DOMAIN, "group_stop", {}, blocking=True)
+    group_coord.async_stop.assert_awaited_once()
 
 
 async def test_group_set_position_without_tilt_skips_tilt(hass, loaded_pair) -> None:

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -81,11 +81,13 @@ from custom_components.adaptive_cover_pro.group_entities import (
     GroupAutomationSwitch,
     GroupClearOverridesButton,
     GroupClimateSensor,
+    GroupClimateSwitch,
     GroupLockSwitch,
     GroupPositionSensor,
     GroupSceneButton,
     GroupSceneSelect,
     GroupStateSensor,
+    GroupStopButton,
     GroupWhoWonSensor,
 )
 
@@ -327,6 +329,18 @@ ENTITY_FACTORIES: dict[type, object] = {
         _make_config_entry(),
         _make_coordinator(),
         "group_climate_mode",
+    ),
+    GroupClimateSwitch: lambda: GroupClimateSwitch(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
+    ),
+    GroupStopButton: lambda: GroupStopButton(
+        "test_avail_entry",
+        _make_hass(),
+        _make_config_entry(),
+        _make_coordinator(),
     ),
     AdaptiveGroupCover: lambda: AdaptiveGroupCover(
         "test_avail_entry",

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -25,6 +25,7 @@ from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
     GroupClimateSensor,
+    GroupClimateSwitch,
     GroupLockSwitch,
     GroupPositionSensor,
     GroupStateSensor,
@@ -88,7 +89,8 @@ _GROUP_SENSOR_TRANSLATION_KEYS: frozenset[str] = frozenset(
     )
 )
 _GROUP_SWITCH_TRANSLATION_KEYS: frozenset[str] = frozenset(
-    _class_translation_key(cls) for cls in (GroupAutomationSwitch, GroupLockSwitch)
+    _class_translation_key(cls)
+    for cls in (GroupAutomationSwitch, GroupLockSwitch, GroupClimateSwitch)
 )
 
 


### PR DESCRIPTION
## Summary
Adds two group-level controls so the companion card's group tile can bind mass Stop and Climate on/off (card #37/#225):

- `button.<group>_stop` and a parity `adaptive_cover_pro.group_stop` service, both delegating to the existing `GroupCoordinator.async_stop()` fan-out (matches the `group_clear_overrides` button/service pattern).
- `switch.<group>_climate_mode`, backed by a new `GroupCoordinator.async_set_climate_mode()` that fans climate on/off across ACP members. The switch mirrors its last bulk command like the group automation/lock switches; the read-only `sensor.<group>_climate_mode` still shows live member climate.

English, German, and French strings included. No persisted config option, so no config-flow or migration changes.

## Testing
- ✅ 6664 tests passing

## Related Issues
Refs #922