### PR TITLE
fix: use learn_more placeholder for create-summary link (hassfest) (#945)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3980,7 +3980,12 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="summary",
             data_schema=vol.Schema({}),
-            description_placeholders={"summary": summary_text},
+            description_placeholders={
+                "summary": summary_text,
+                # The wiki link is supplied as a placeholder, not baked into the
+                # translation string — hassfest forbids literal URLs in strings.
+                "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/First-Time-Setup",
+            },
         )
 
     async def async_step_update(self, user_input: dict[str, Any] | None = None):

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -150,7 +150,7 @@
       },
       "summary": {
         "title": "Konfigurationszusammenfassung",
-        "description": "{summary}\n\n**Weiter:** Sonnenverfolgung, Position, Übersteuerungen, benutzerdefinierte Positionen, Blendungszonen, Klima, Bewegung, Wetter und Automatisierung werden nach dem Abschluss alle unter **Konfigurieren** eingerichtet. Siehe die [Einrichtungsanleitung](https://github.com/jrhubott/adaptive-cover-pro/wiki/First-Time-Setup)."
+        "description": "{summary}\n\n**Weiter:** Sonnenverfolgung, Position, Übersteuerungen, benutzerdefinierte Positionen, Blendungszonen, Klima, Bewegung, Wetter und Automatisierung werden nach dem Abschluss alle unter **Konfigurieren** eingerichtet. Siehe die [Einrichtungsanleitung]({learn_more})."
       },
       "create_building_profile": {
         "title": "Gebäudeprofil erstellen",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -150,7 +150,7 @@
       },
       "summary": {
         "title": "Configuration Summary",
-        "description": "{summary}\n\n**Next:** sun tracking, position, overrides, custom positions, blind spots, glare zones, climate, motion, weather, and automation are all configured under **Configure** after you finish. See the [setup guide](https://github.com/jrhubott/adaptive-cover-pro/wiki/First-Time-Setup)."
+        "description": "{summary}\n\n**Next:** sun tracking, position, overrides, custom positions, blind spots, glare zones, climate, motion, weather, and automation are all configured under **Configure** after you finish. See the [setup guide]({learn_more})."
       },
       "create_building_profile": {
         "title": "Create Building Profile",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -150,7 +150,7 @@
       },
       "summary": {
         "title": "Résumé de la configuration",
-        "description": "{summary}\n\n**Ensuite :** le suivi solaire, la position, les dérogations, les positions personnalisées, les zones d'éblouissement, le climat, le mouvement, la météo et l'automatisation se configurent tous sous **Configurer** une fois terminé. Consultez le [guide de configuration](https://github.com/jrhubott/adaptive-cover-pro/wiki/First-Time-Setup)."
+        "description": "{summary}\n\n**Ensuite :** le suivi solaire, la position, les dérogations, les positions personnalisées, les zones d'éblouissement, le climat, le mouvement, la météo et l'automatisation se configurent tous sous **Configurer** une fois terminé. Consultez le [guide de configuration]({learn_more})."
       },
       "create_building_profile": {
         "title": "Créer un profil de bâtiment",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -201,6 +201,39 @@ def test_no_invisible_unicode_chars(lang_file: Path) -> None:
             )
 
 
+@pytest.mark.parametrize("lang_file", TRANSLATION_FILES, ids=LANGUAGE_CODES)
+def test_no_literal_urls_in_config_and_options_step_strings(lang_file: Path) -> None:
+    """config/options step strings must not embed literal URLs — pass them as
+    description placeholders instead.
+
+    HA's hassfest rejects a literal ``http(s)://`` URL inside any ``config`` /
+    ``options`` step title/description/data string with "the string should not
+    contain URLs, please use description placeholders instead". That rule is not
+    covered by ``validate_translations.py`` or structural-parity tests, so a
+    literal wiki link slips past local CI and only fails in the Hassfest GitHub
+    job (this bit issue #945 Part 2's summary pointer). This guard reproduces
+    the rule locally: every wiki link must be authored as ``[text]({learn_more})``
+    (or similar) with the URL supplied at runtime via ``description_placeholders``.
+    """
+    data = _load(lang_file)
+    offenders: list[str] = []
+    for section in ("config", "options"):
+        steps = data.get(section, {}).get("step", {})
+        for step_id, step in steps.items():
+            # _flatten returns leaf dotpaths; re-walk each to read its value.
+            for dotpath in _flatten(step):
+                node = step
+                for part in dotpath.split("."):
+                    node = node[part]
+                if isinstance(node, str) and ("http://" in node or "https://" in node):
+                    offenders.append(f"{section}.step.{step_id}.{dotpath}")
+    assert not offenders, (
+        f"{lang_file.name}: literal URL(s) in config/options step strings — "
+        f"hassfest forbids this. Use a {{learn_more}} placeholder instead:\n"
+        + "\n".join(f"  - {o}" for o in offenders)
+    )
+
+
 # ---------------------------------------------------------------------------
 # Issue #211 Option 2 — blind_spot labels are acceptance-edge-relative, not
 # azimuth-relative. Issue #604 renamed the "FOV" frame to "acceptance edge".


### PR DESCRIPTION
## Summary
Follow-up to #948. The minimal create wizard's summary pointer embedded a literal wiki URL in `config.step.summary.description`, which **hassfest rejects** ("the string should not contain URLs, please use description placeholders instead") — failing the Hassfest CI job on `develop`.

- Author the link as `[setup guide]({learn_more})` in en/de/fr; supply the URL at runtime via `description_placeholders` in `async_step_summary` (the same pattern every other step uses).
- Add a regression guard `test_no_literal_urls_in_config_and_options_step_strings` that reproduces the hassfest rule locally, so this class of bug fails in the test suite instead of only in the Hassfest GitHub job.

## Testing
- ✅ `validate_translations.py --ci` clean; `test_translations.py` green (incl. the new guard, verified it catches a planted URL)
- ✅ create-summary flow + minimal-wizard tests pass

## Related Issues
Refs #945