### PR TITLE
fix: service venetian tilt when position delta is too small (#954)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1433,9 +1433,10 @@ class CoverCommandService:
                 # itself enforces for the carriage. The user gets the cover,
                 # both axes, until the override clears — UNLESS a forced
                 # cycle (safety / custom-position slot, floor clamp) reaches
-                # the tilt axis via the same_position or delta branches above,
-                # which is intentional: see _service_secondary_axis's
-                # docstring.
+                # the tilt axis via the same_position branch above, which is
+                # intentional: see _service_secondary_axis's docstring. The
+                # delta branches are not force-reachable; a forced cycle
+                # falls through to the send path instead.
                 return self._skip(
                     entity_id,
                     "manual_override",

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1120,18 +1120,27 @@ class CoverCommandService:
 
         Called from every gate where the carriage declines to move for a
         *hysteresis* reason (``same_position``, ``delta_too_small``,
-        ``time_delta_too_small``) — never from ``manual_override``, which is
-        genuine hands-off intent rather than hysteresis. Position and tilt
-        are independent axes with independent gates; a carriage delta under
-        ``CONF_DELTA_POSITION`` must gate only the carriage, not silently
-        drop the secondary-axis target too (issue #954).
+        ``time_delta_too_small``). Position and tilt are independent axes
+        with independent gates; a carriage delta under ``CONF_DELTA_POSITION``
+        must gate only the carriage, not silently drop the secondary-axis
+        target too (issue #954).
+
+        Never services the axis while ``context.manual_override`` is set —
+        that is genuine hands-off intent, not hysteresis, and the guard below
+        enforces the exclusion directly so it holds regardless of branch
+        order (moving tilt under an active override would regress the
+        false-manual-override family, #927/#930).
 
         No-op on single-axis cover types via the base ``CoverTypePolicy``'s
         no-op ``maybe_update_tilt_only`` default — this method never branches
         on cover type itself, it only decides *that* the policy gets a
         chance, never *what* it does with it.
         """
-        if context.policy is not None and context.tilt is not None:
+        if (
+            context.policy is not None
+            and context.tilt is not None
+            and not context.manual_override
+        ):
             await context.policy.maybe_update_tilt_only(
                 entity_id,
                 current_position=current_position,
@@ -1410,13 +1419,17 @@ class CoverCommandService:
                 )
 
             if context.manual_override:
-                # Deliberately NOT serviced (issue #954 scope decision): manual
-                # override is genuine hands-off intent, not a hysteresis gate.
-                # Moving the tilt axis while ACP has stepped back for a user
-                # touch would regress the false-manual-override family
-                # (#927/#930) that the drift-reset suppression machinery
-                # guards against — the user gets the cover, both axes, until
-                # the override clears.
+                # Manual override is genuine hands-off intent, not a hysteresis
+                # gate (issue #954 scope decision). The secondary axis is
+                # already excluded here — this branch is reached only after
+                # delta_too_small/time_delta_too_small pass, and
+                # _service_secondary_axis's own guard checks
+                # context.manual_override directly, so the exclusion holds no
+                # matter which gate this cover trips first. Moving the tilt
+                # axis while ACP has stepped back for a user touch would
+                # regress the false-manual-override family (#927/#930) that
+                # the drift-reset suppression machinery guards against — the
+                # user gets the cover, both axes, until the override clears.
                 return self._skip(
                     entity_id,
                     "manual_override",

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1125,11 +1125,16 @@ class CoverCommandService:
         must gate only the carriage, not silently drop the secondary-axis
         target too (issue #954).
 
-        Never services the axis while ``context.manual_override`` is set —
-        that is genuine hands-off intent, not hysteresis, and the guard below
-        enforces the exclusion directly so it holds regardless of branch
-        order (moving tilt under an active override would regress the
-        false-manual-override family, #927/#930).
+        Excludes ``context.manual_override`` the same place production gates
+        it: only when ``context.force`` is not set. ``PositionContext.force``
+        is documented as "skip delta/time/manual_override gates", and the
+        ``same_position`` branch above is deliberately reached even while
+        forced (it has no ``not context.force`` guard) — a safety /
+        custom-position slot or a floor clamp must still be able to land the
+        tilt on the very cycle it forces the carriage. An unforced cycle
+        keeps the exclusion: manual override is genuine hands-off intent,
+        not hysteresis, and moving tilt under an active override would
+        regress the false-manual-override family (#927/#930).
 
         No-op on single-axis cover types via the base ``CoverTypePolicy``'s
         no-op ``maybe_update_tilt_only`` default — this method never branches
@@ -1139,7 +1144,7 @@ class CoverCommandService:
         if (
             context.policy is not None
             and context.tilt is not None
-            and not context.manual_override
+            and not (context.manual_override and not context.force)
         ):
             await context.policy.maybe_update_tilt_only(
                 entity_id,
@@ -1420,16 +1425,17 @@ class CoverCommandService:
 
             if context.manual_override:
                 # Manual override is genuine hands-off intent, not a hysteresis
-                # gate (issue #954 scope decision). The secondary axis is
-                # already excluded here — this branch is reached only after
-                # delta_too_small/time_delta_too_small pass, and
-                # _service_secondary_axis's own guard checks
-                # context.manual_override directly, so the exclusion holds no
-                # matter which gate this cover trips first. Moving the tilt
-                # axis while ACP has stepped back for a user touch would
-                # regress the false-manual-override family (#927/#930) that
-                # the drift-reset suppression machinery guards against — the
-                # user gets the cover, both axes, until the override clears.
+                # gate (issue #954 scope decision). This branch only runs
+                # inside `if not context.force`, so `context.force` is False
+                # by construction here — _service_secondary_axis's guard
+                # (`not (manual_override and not force)`) therefore still
+                # excludes the tilt axis, matching the exclusion this branch
+                # itself enforces for the carriage. The user gets the cover,
+                # both axes, until the override clears — UNLESS a forced
+                # cycle (safety / custom-position slot, floor clamp) reaches
+                # the tilt axis via the same_position or delta branches above,
+                # which is intentional: see _service_secondary_axis's
+                # docstring.
                 return self._skip(
                     entity_id,
                     "manual_override",

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1108,6 +1108,37 @@ class CoverCommandService:
         )
         return last_target == plan.routed_target
 
+    async def _service_secondary_axis(
+        self,
+        entity_id: str,
+        *,
+        current_position: int | None,
+        context: PositionContext,
+        trigger: str,
+    ) -> None:
+        """Give the cover-type policy a chance to move its secondary axis.
+
+        Called from every gate where the carriage declines to move for a
+        *hysteresis* reason (``same_position``, ``delta_too_small``,
+        ``time_delta_too_small``) — never from ``manual_override``, which is
+        genuine hands-off intent rather than hysteresis. Position and tilt
+        are independent axes with independent gates; a carriage delta under
+        ``CONF_DELTA_POSITION`` must gate only the carriage, not silently
+        drop the secondary-axis target too (issue #954).
+
+        No-op on single-axis cover types via the base ``CoverTypePolicy``'s
+        no-op ``maybe_update_tilt_only`` default — this method never branches
+        on cover type itself, it only decides *that* the policy gets a
+        chance, never *what* it does with it.
+        """
+        if context.policy is not None and context.tilt is not None:
+            await context.policy.maybe_update_tilt_only(
+                entity_id,
+                current_position=current_position,
+                context=context,
+                reason=trigger,
+            )
+
     # ------------------------------------------------------------------ #
     # Primary entry point
     # ------------------------------------------------------------------ #
@@ -1275,6 +1306,14 @@ class CoverCommandService:
         # recurring resends (custom_position, override-clear) also set and which
         # MUST stay deduped here to avoid relay clicks (issue #290/#779). So the
         # bypass keys on user_command, not force (issue #900).
+        #
+        # This same_position branch is ONE of three hysteresis gates that now
+        # service the secondary axis via _service_secondary_axis (issue #954):
+        # delta_too_small and time_delta_too_small below do too. A carriage
+        # delta under CONF_DELTA_POSITION (or a too-recent command) is a
+        # reason to hold the carriage still — it is not a reason to also
+        # starve the tilt axis, which owns its own independent min-delta and
+        # suppression gates downstream (VenetianPolicy/DualAxisSequencer).
         if (
             not context.sun_just_appeared
             and not force_endpoint
@@ -1297,13 +1336,12 @@ class CoverCommandService:
                 )
             )
         ):
-            if context.policy is not None and context.tilt is not None:
-                await context.policy.maybe_update_tilt_only(
-                    entity_id,
-                    current_position=_current,
-                    context=context,
-                    reason=_trigger,
-                )
+            await self._service_secondary_axis(
+                entity_id,
+                current_position=_current,
+                context=context,
+                trigger=_trigger,
+            )
             return self._skip(
                 entity_id,
                 "same_position",
@@ -1322,6 +1360,19 @@ class CoverCommandService:
                 sun_just_appeared=context.sun_just_appeared,
             ):
                 _delta = abs(_current - position) if _current is not None else None
+                # Issue #954: the carriage delta gates only the carriage. The
+                # tilt axis is independent and owns its own gates downstream
+                # (VenetianPolicy.maybe_update_tilt_only ->
+                # DualAxisSequencer.update_tilt_only's target-unchanged dedup
+                # and min-delta check) — give it the same chance the
+                # same_position branch above already gives it, before this
+                # skip drops the carriage command.
+                await self._service_secondary_axis(
+                    entity_id,
+                    current_position=_current,
+                    context=context,
+                    trigger=_trigger,
+                )
                 return self._skip(
                     entity_id,
                     "delta_too_small",
@@ -1337,6 +1388,14 @@ class CoverCommandService:
 
             if not self._check_time_delta(entity_id, context.time_threshold):
                 _elapsed = self._elapsed_minutes(entity_id)
+                # Issue #954: delta_time is a carriage rate-limiter, not a
+                # tilt gate — same reasoning as delta_too_small above.
+                await self._service_secondary_axis(
+                    entity_id,
+                    current_position=_current,
+                    context=context,
+                    trigger=_trigger,
+                )
                 return self._skip(
                     entity_id,
                     "time_delta_too_small",
@@ -1351,6 +1410,13 @@ class CoverCommandService:
                 )
 
             if context.manual_override:
+                # Deliberately NOT serviced (issue #954 scope decision): manual
+                # override is genuine hands-off intent, not a hysteresis gate.
+                # Moving the tilt axis while ACP has stepped back for a user
+                # touch would regress the false-manual-override family
+                # (#927/#930) that the drift-reset suppression machinery
+                # guards against — the user gets the cover, both axes, until
+                # the override clears.
                 return self._skip(
                     entity_id,
                     "manual_override",

--- a/tests/test_issue_954_tilt_independent_of_position_delta.py
+++ b/tests/test_issue_954_tilt_independent_of_position_delta.py
@@ -288,6 +288,66 @@ async def test_tilt_not_sent_under_manual_override_when_time_delta_too_small(svc
 
 
 @pytest.mark.asyncio
+async def test_forced_cycle_services_tilt_despite_manual_override(svc):
+    """Re-audit regression pin: a forced cycle must still service the tilt
+    axis even while ``manual_override`` is latched.
+
+    The ``same_position`` branch has no ``not context.force`` guard — only
+    ``sun_just_appeared``/``force_endpoint``/``user_command`` bypass it — so a
+    safety slot or any custom-position slot outranking
+    ``ManualOverrideHandler`` (priority 80) reaches it with ``force=True``
+    while override is still latched. If the carriage already sits at the
+    slot's position, this is the exact scenario: current == target == 50,
+    tilt=47, force=True, manual_override=True. The tilt must still go out —
+    ``_service_secondary_axis``'s guard only excludes manual_override when
+    NOT forced, mirroring where the production gates actually live
+    (``PositionContext.force``: "skip delta/time/manual_override gates").
+    """
+    entity_id = "cover.og_studio_tur"
+    _patch_position(svc, 50)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy, manual_override=True, force=True)
+
+    outcome, reason = await svc.apply_position(entity_id, 50, "custom_position", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    policy.maybe_update_tilt_only.assert_awaited_once_with(
+        entity_id,
+        current_position=50,
+        context=ctx,
+        reason="custom_position",
+    )
+
+
+@pytest.mark.asyncio
+async def test_unforced_same_position_does_not_service_tilt_under_manual_override(svc):
+    """The other direction of the force interaction: without ``force``, the
+    manual-override exclusion still applies on the ``same_position`` branch.
+
+    Same current/target/tilt as the forced test above, but ``force=False`` —
+    pins that the fix doesn't accidentally drop the exclusion for the
+    ordinary (non-safety, non-custom-position-slot) case.
+    """
+    entity_id = "cover.og_studio_tur"
+    _patch_position(svc, 50)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy, manual_override=True, force=False)
+
+    outcome, reason = await svc.apply_position(entity_id, 50, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    policy.maybe_update_tilt_only.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_same_position_branch_still_updates_tilt(svc):
     """The pre-existing same_position -> tilt wiring must survive the extraction."""
     entity_id = "cover.og_kuche"

--- a/tests/test_issue_954_tilt_independent_of_position_delta.py
+++ b/tests/test_issue_954_tilt_independent_of_position_delta.py
@@ -1,0 +1,320 @@
+"""Issue #954 — venetian tilt axis silently coupled to the carriage delta gate.
+
+Three venetian covers (``venetian_mode: position_and_tilt``) stopped emitting
+tilt commands entirely while the solar handler kept winning and the engine
+kept calculating changing tilt targets. Root cause:
+``VenetianPolicy.maybe_update_tilt_only`` — the only mechanism that services
+the tilt axis on a cycle where the carriage doesn't move — had exactly ONE
+call site: the ``same_position`` branch of
+``CoverCommandService.apply_position``. Every other early-return
+(``delta_too_small``, ``time_delta_too_small``, ``manual_override``) returned
+without giving the policy a chance at the secondary axis, so a below-threshold
+*carriage* delta silently dropped the tilt target for hours (reporter's exact
+numbers: calculated 1%, current 2%, min delta 5%).
+
+The fix extracts a private ``_service_secondary_axis`` helper and calls it
+from the ``same_position``, ``delta_too_small``, and ``time_delta_too_small``
+branches — but deliberately NOT from ``manual_override`` (genuine hands-off
+intent, not hysteresis; see #927/#930).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.cover_types import VenetianPolicy, get_policy
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
+)
+
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services.async_call = AsyncMock()
+    return h
+
+
+@pytest.fixture
+def svc(hass):
+    """Return a venetian CoverCommandService — matches the reporter's cover type.
+
+    ``_get_current_position`` is monkeypatched per-test (see ``_patch_position``)
+    so tests don't need to construct realistic ``hass.states.get(...)`` mocks;
+    only ``hass.services.async_call`` needs to be real for tests that assert
+    on dispatched service calls.
+    """
+    s = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_venetian",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+    )
+    s._enabled = True
+    return s
+
+
+def _patch_position(svc, value):
+    svc._get_current_position = MagicMock(return_value=value)
+
+
+def _ctx(**overrides) -> PositionContext:
+    """PositionContext with all gates passing by default (force=False)."""
+    defaults = {
+        "auto_control": True,
+        "manual_override": False,
+        "sun_just_appeared": False,
+        "min_change": 5,
+        "time_threshold": 10,
+        "special_positions": [0, 100],
+        "inverse_state": False,
+        "force": False,
+    }
+    defaults.update(overrides)
+    return PositionContext(**defaults)
+
+
+def _attach_venetian_policy(hass, *, current_position: int, event_buffer=None):
+    """Real VenetianPolicy + DualAxisSequencer, mocked hass (issue #954 repro)."""
+    policy = VenetianPolicy()
+    policy.attach(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=lambda _eid: current_position,
+        set_commanded_position=MagicMock(),
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        event_buffer=event_buffer,
+    )
+    return policy
+
+
+# ---------------------------------------------------------------------------
+# RED — new behaviour: the delta/time gates must still service the tilt axis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tilt_still_sent_when_position_delta_too_small(svc):
+    """Reporter's exact scenario: calc=1, current=2, min_change=5 → delta_too_small
+    on the carriage, but ``context.tilt`` (47%, the engine's live calculation)
+    must still reach ``maybe_update_tilt_only`` — the tilt axis owns its own
+    independent gates downstream and must not be starved by the carriage gate.
+    """
+    entity_id = "cover.og_studio_tur"
+    _patch_position(svc, 2)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy)
+
+    outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "delta_too_small"
+    policy.maybe_update_tilt_only.assert_awaited_once_with(
+        entity_id,
+        current_position=2,
+        context=ctx,
+        reason="solar",
+    )
+
+    skip = svc.last_skipped_action
+    assert skip["reason"] == "delta_too_small"
+    assert skip["position_delta"] == 1
+    assert skip["min_delta_required"] == 5
+
+
+@pytest.mark.asyncio
+async def test_tilt_sequencer_emits_command_when_position_delta_too_small(svc, hass):
+    """End-to-end reproduction of the diagnostics: 83 minutes of delta_too_small
+    skips with zero tilt events (d2 skip-histogram: ``delta_too_small: 124``,
+    nothing else). Position delta is below min_change (2 -> 1, delta=1 < 5) so
+    the carriage is correctly gated, but the real ``DualAxisSequencer`` must
+    still dispatch ``set_cover_tilt_position`` and record ``tilt_command_sent``.
+    """
+    from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
+        EventBuffer,
+    )
+
+    buf = EventBuffer(maxlen=20)
+    entity_id = "cover.og_studio_tur"
+    _patch_position(svc, 2)
+
+    policy = _attach_venetian_policy(hass, current_position=2, event_buffer=buf)
+    policy._last_tilt = 47  # engine's calculated tilt this cycle (d2/d3 diagnostics)
+
+    ctx = _ctx(tilt=47, policy=policy)
+
+    outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "delta_too_small"
+
+    tilt_calls = [
+        c
+        for c in hass.services.async_call.call_args_list
+        if c.args[1] == "set_cover_tilt_position"
+    ]
+    assert len(tilt_calls) == 1
+    assert tilt_calls[0].args[2]["tilt_position"] == 47
+
+    sent_events = [e for e in buf.snapshot() if e.get("event") == "tilt_command_sent"]
+    assert len(sent_events) == 1
+    assert sent_events[0]["tilt_position"] == 47
+
+
+@pytest.mark.asyncio
+async def test_tilt_still_sent_when_time_delta_too_small(svc):
+    """Same shape as the delta gate, but tripping the time gate instead.
+
+    ``delta_time`` is a carriage rate-limiter, not a tilt gate (approved
+    in-scope decision) — a carriage move suppressed for being too recent must
+    not also block the independently-gated tilt axis.
+    """
+    entity_id = "cover.og_studio_fenster"
+    _patch_position(svc, 90)  # large position delta so only the time gate fires
+    recent = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=10)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+        return_value=recent,
+    ):
+        outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "time_delta_too_small"
+    policy.maybe_update_tilt_only.assert_awaited_once_with(
+        entity_id,
+        current_position=90,
+        context=ctx,
+        reason="solar",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pins — existing behaviour that must NOT change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tilt_not_sent_under_manual_override(svc):
+    """Manual override is genuine hands-off intent, not hysteresis (#927/#930).
+
+    The hook must NOT be called and the skip reason must stay
+    ``manual_override`` — pins the fix against over-reaching into the
+    false-manual-override family the drift-reset suppression machinery
+    guards against.
+    """
+    entity_id = "cover.og_kuche"
+    _patch_position(svc, 90)  # position + time gates both pass
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy, manual_override=True, time_threshold=0)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+        return_value=None,
+    ):
+        outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "manual_override"
+    policy.maybe_update_tilt_only.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_same_position_branch_still_updates_tilt(svc):
+    """The pre-existing same_position -> tilt wiring must survive the extraction."""
+    entity_id = "cover.og_kuche"
+    _patch_position(svc, 2)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=62, policy=policy)
+
+    outcome, reason = await svc.apply_position(entity_id, 2, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    policy.maybe_update_tilt_only.assert_awaited_once_with(
+        entity_id,
+        current_position=2,
+        context=ctx,
+        reason="solar",
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_axis_cover_delta_branch_does_not_call_tilt_hook(svc):
+    """Single-axis cover types (no tilt) never trip the new call site.
+
+    ``context.tilt=None`` short-circuits the guard in the shared helper
+    regardless of which ``CoverTypePolicy`` is in play — the base's no-op
+    ``maybe_update_tilt_only`` is what makes every non-venetian cover type
+    correct, but the guard itself must not even reach the policy call.
+    """
+    entity_id = "cover.living_room_blind"
+    _patch_position(svc, 2)
+
+    policy = get_policy("cover_blind")
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=None, policy=policy)
+
+    outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "delta_too_small"
+    policy.maybe_update_tilt_only.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delta_branch_tilt_respects_drift_reset_eligibility(hass, svc):
+    """Guard against #930/#927: the delta-branch tilt send must thread the exact
+    same ``drift_reset_eligible`` value through to the sequencer that the
+    ``same_position`` branch already produces for an identical context.
+
+    Reporter's setting: ``venetian_tilt_reset_scope=all_tilt_commands``
+    (the module default) — the most exposed configuration, since every tilt
+    send is drift-reset eligible under that scope.
+    """
+    entity_id = "cover.og_kuche"
+    policy = _attach_venetian_policy(hass, current_position=2)
+    policy._last_tilt = 62  # d1's calculated tilt
+
+    spy = AsyncMock()
+    policy._sequencer.update_tilt_only = spy
+
+    ctx = _ctx(tilt=62, policy=policy)
+
+    # Drive through the same_position branch (current == target == 2).
+    _patch_position(svc, 2)
+    await svc.apply_position(entity_id, 2, "solar", ctx)
+    assert spy.await_count == 1
+    same_position_eligible = spy.await_args.kwargs["drift_reset_eligible"]
+
+    # Drive through the delta_too_small branch (current=2, target=1, delta=1<5)
+    # with an otherwise identical context.
+    await svc.apply_position(entity_id, 1, "solar", ctx)
+    assert spy.await_count == 2
+    delta_branch_eligible = spy.await_args.kwargs["drift_reset_eligible"]
+
+    assert delta_branch_eligible == same_position_eligible

--- a/tests/test_issue_954_tilt_independent_of_position_delta.py
+++ b/tests/test_issue_954_tilt_independent_of_position_delta.py
@@ -240,6 +240,54 @@ async def test_tilt_not_sent_under_manual_override(svc):
 
 
 @pytest.mark.asyncio
+async def test_tilt_not_sent_under_manual_override_when_position_delta_too_small(svc):
+    """Manual override combined with a tripped hysteresis gate (audit finding).
+
+    ``delta_too_small`` and ``time_delta_too_small`` are evaluated BEFORE the
+    ``manual_override`` branch, so the branch-ordering alone cannot be relied
+    on to keep tilt off the wire under override — the guard inside
+    ``_service_secondary_axis`` itself must check ``context.manual_override``.
+    Reporter's exact numbers: current=2, target=1, min_change=5 -> delta=1<5.
+    """
+    entity_id = "cover.og_studio_tur"
+    _patch_position(svc, 2)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy, manual_override=True)
+
+    outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "delta_too_small"
+    policy.maybe_update_tilt_only.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tilt_not_sent_under_manual_override_when_time_delta_too_small(svc):
+    """Same as above but tripping the time gate instead of the delta gate."""
+    entity_id = "cover.og_studio_fenster"
+    _patch_position(svc, 90)  # large position delta so only the time gate fires
+    recent = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=10)
+
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+
+    ctx = _ctx(tilt=47, policy=policy, manual_override=True)
+
+    with patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+        return_value=recent,
+    ):
+        outcome, reason = await svc.apply_position(entity_id, 1, "solar", ctx)
+
+    assert outcome == "skipped"
+    assert reason == "time_delta_too_small"
+    policy.maybe_update_tilt_only.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_same_position_branch_still_updates_tilt(svc):
     """The pre-existing same_position -> tilt wiring must survive the extraction."""
     entity_id = "cover.og_kuche"


### PR DESCRIPTION
## Summary

`VenetianPolicy.maybe_update_tilt_only()` is the only thing that services the tilt axis on a cycle where the carriage doesn't move, and it had exactly one call site: the `same_position` branch of `apply_position`. The `delta_too_small` branch returned via `_skip()` without ever offering the policy the secondary axis, so `context.tilt` was silently discarded every cycle.

With the reporter's numbers (calculated 1%, current 2%, `delta_position` 5%), the same-position gate misses, the delta gate fires, and the tilt target is dropped for hours. Their diagnostics show it precisely: tilt tracked fine while the skip reason was `same_position` (calculated 0%), then died the moment solar stepped it to 1% and the reason became `delta_too_small`. That also explains why it hit three covers at once, since they crossed that boundary at the same geometry.

This extracts `_service_secondary_axis()` and calls it from `same_position` (behaviour-preserving delegation), `delta_too_small`, and `time_delta_too_small`. `delta_time` is a carriage rate-limiter, not a tilt gate, so omitting it would just resurface the bug on a 10-minute cadence. The tilt axis carries its own dedup and min-delta gates downstream, so reaching the call is the whole fix.

The `manual_override` branch deliberately still does not service tilt: that's genuine hands-off intent, not hysteresis. A **forced** cycle (safety slot, custom position above priority 80, floor clamp) does service it, matching `PositionContext.force`'s documented contract to skip the delta/time/override gates. Both directions are pinned by tests.

The same-position gate is untouched. Widening it to a tolerance band is the change #567 reverted, and CODING_GUIDELINES forbids it.

## Testing

- ✅ 6677 tests passing
- 11 new tests in `tests/test_issue_954_tilt_independent_of_position_delta.py`, covering the reporter's exact scenario end-to-end through a real `VenetianPolicy` + `DualAxisSequencer`, the full `manual_override` x `force` truth table, drift-reset eligibility parity (#930/#927), and the single-axis no-op guard
- Regression guards green: #770, #930/#927, #756, #853, skip-reason contract, cover-type axes

## Related Issues

Refs #954

https://claude.ai/code/session_01JFcXGsYqbUTsHLxJ1jh5BD