### PR TITLE
feat: sensor-gated min/max constraints for position and tilt (#943)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -643,6 +643,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         new_minor = 8
 
+    # v3.8 → v3.9: added the additive per-slot axis-constraint options —
+    # custom_position_position_max_N / _tilt_min_N / _tilt_max_N (issue #943).
+    # An absent key already reads as "constraint off", so nothing needs seeding
+    # — this is a no-op minor bump kept only to advance entries sitting at minor
+    # 8 to 9 so they stop re-triggering migration every restart (the v3.6 → v3.7
+    # precedent). Rollback-safe: min_mode / tilt_only remain the stored wire
+    # format and are untouched, so an older build finds its config exactly as it
+    # left it and simply ignores the new keys.
+    if new_version == 3 and new_minor < 9:
+        new_minor = 9
+
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor
     )

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -1126,6 +1126,18 @@ def _custom_position_base_specs() -> list[FieldSpec]:
                 make_selector=_bool(),
             )
         )
+        # Position ceiling (issue #943) — the mirror of `min_mode`'s floor.
+        # Absent = off, so no DEFAULT_* constant exists for it.
+        specs.append(
+            FieldSpec(
+                slot["position_max"],
+                SECTION_CUSTOM_POSITION,
+                ValidatorKind.RANGE,
+                rng=const._RANGE_CUSTOM_POSITION,
+                clearable=True,
+                make_selector=_const(position_slider),
+            )
+        )
     return specs
 
 
@@ -1152,6 +1164,19 @@ def _custom_position_tilt_specs() -> list[FieldSpec]:
                 make_selector=_bool(),
             )
         )
+        # Tilt bounds (issue #943). Absent = off. `tilt_only` (a FIXED tilt
+        # claim) wins over these — normalized once in the snapshot builder.
+        for sub in ("tilt_min", "tilt_max"):
+            specs.append(
+                FieldSpec(
+                    slot[sub],
+                    SECTION_CUSTOM_POSITION,
+                    ValidatorKind.RANGE,
+                    rng=const._RANGE_TILT,
+                    clearable=True,
+                    make_selector=_const(position_slider),
+                )
+            )
     specs.append(
         FieldSpec(
             CONF_DEFAULT_TILT,
@@ -1204,11 +1229,17 @@ def _custom_position_slot_fields(
     schema[vol.Optional(keys["priority"])] = priority_slider()
     schema[vol.Optional(keys["min_mode"], default=False)] = selector.BooleanSelector()
     schema[vol.Optional(keys["use_my"], default=False)] = selector.BooleanSelector()
+    # Axis constraints (issue #943). The position ceiling always renders; the
+    # tilt bounds ride the same `include_tilt` gate as `tilt` / `tilt_only`,
+    # which the caller derives from the policy — never from a cover-type string.
+    schema[vol.Optional(keys["position_max"])] = position_slider()
     if include_tilt:
         schema[vol.Optional(keys["tilt"])] = position_slider()
         schema[vol.Optional(keys["tilt_only"], default=False)] = (
             selector.BooleanSelector()
         )
+        schema[vol.Optional(keys["tilt_min"])] = position_slider()
+        schema[vol.Optional(keys["tilt_max"])] = position_slider()
     return schema
 
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1430,7 +1430,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "words.source_plural": "sources",
     # --- shared fragments ---
     "fragments.as_minimum": " (as minimum)",
-    "fragments.as_maximum": " (as maximum)",
+    "fragments.as_maximum": " (at most {max}%)",
     "fragments.safety": " 🔒 safety: acts outside the time window too",
     "fragments.template_value": "[template]",
     # --- Weather safety (90) ---
@@ -2291,8 +2291,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                     else L["custom.no_position_claim"]
                 )
                 cp_min = L["fragments.as_minimum"] if _is_min else ""
-                if _pos_max is not None:
-                    cp_min += L["fragments.as_maximum"]
+                # A lone position_max on a FIXED-position slot is ignored — the
+                # exact position keeps its claim (audit finding 5), so only
+                # surface the ceiling when it actually applies (min-mode range,
+                # or a constraint-only slot with no position of its own). Render
+                # its value, like the tilt-bound fragments do (audit finding 6).
+                if _pos_max is not None and (_is_min or _pos is None):
+                    cp_min += L["fragments.as_maximum"].format(max=_pos_max)
                 # Tilt bounds (issue #943). Mutually exclusive with the fixed
                 # tilt note above — tilt_only is handled in the other branch.
                 _t_min = config.get(_keys["tilt_min"])

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -2290,7 +2290,13 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                     if _pos is not None
                     else L["custom.no_position_claim"]
                 )
-                cp_min = L["fragments.as_minimum"] if _is_min else ""
+                # "(as minimum)" only when there is a floor to apply: a min_mode
+                # toggle with no stored position contributes no floor (the
+                # derived mode is a lone MAX), so the fragment would be a phantom
+                # (audit finding D). Mirrors the pipeline's derived-mode logic.
+                cp_min = (
+                    L["fragments.as_minimum"] if (_is_min and _pos is not None) else ""
+                )
                 # A lone position_max on a FIXED-position slot is ignored — the
                 # exact position keeps its claim (audit finding 5), so only
                 # surface the ceiling when it actually applies (min-mode range,

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -855,10 +855,21 @@ CUSTOM_POSITION_SCHEMA = vol.Schema(_build_custom_position_schema_dict())
 # #323). The `sensors` list key carries default=[] so a cleared multi-select
 # round-trips as [] on its own (it must NOT become None — None would re-enable
 # the legacy single-sensor fallback).
+# The axis-constraint keys (issue #943) are clearable too — an absent key is
+# how a constraint is turned off, so a cleared slider must round-trip to None.
 _CUSTOM_POSITION_OPTIONAL_KEYS: list[str] = [
     slot[field]
     for slot in CUSTOM_POSITION_SLOTS.values()
-    for field in ("name", "template", "position", "priority", "tilt")
+    for field in (
+        "name",
+        "template",
+        "position",
+        "priority",
+        "tilt",
+        "position_max",
+        "tilt_min",
+        "tilt_max",
+    )
 ] + [CONF_DEFAULT_TILT, CONF_SUNSET_TILT]
 
 # Built-in handler priority sliders: clearing one omits it from user_input, so
@@ -1419,6 +1430,7 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "words.source_plural": "sources",
     # --- shared fragments ---
     "fragments.as_minimum": " (as minimum)",
+    "fragments.as_maximum": " (as maximum)",
     "fragments.safety": " 🔒 safety: acts outside the time window too",
     "fragments.template_value": "[template]",
     # --- Weather safety (90) ---
@@ -1465,6 +1477,14 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "custom.trigger_sensors": "any of {n} sensors",
     "custom.trigger_template": "template",
     "custom.trigger_join": " or ",
+    "custom.tilt_bound_min": ", tilt at least {min}%",
+    "custom.tilt_bound_max": ", tilt at most {max}%",
+    "custom.tilt_bound_range": ", tilt {min}–{max}%",
+    "custom.no_position_claim": "the calculated position",
+    "warnings.custom_position_bound_conflict": (
+        "⚠️ Custom #{slot}: the maximum ({max}%) is below the minimum ({min}%) — "
+        "the minimum wins and the maximum is ignored."
+    ),
     "warnings.custom_tilt_only_conflict": (
         "⚠️ Custom #{slot}: tilt only is on — "
         "Use as minimum / Use My position are ignored for this slot."
@@ -1934,7 +1954,11 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # list of
     #   (slot, trigger_desc, position, priority, use_my, tilt, tilt_only,
     #    has_trigger)
-    _custom_slots: list[tuple[int, str, int, int, bool, int | None, bool, bool]] = []
+    # ``position`` is None for a constraint-only slot (issue #943) — one that
+    # bounds an axis without naming a position.
+    _custom_slots: list[
+        tuple[int, str, int | None, int, bool, int | None, bool, bool]
+    ] = []
     _and_no_sensor_slots: list[int] = []
     # slot -> configured custom_position_name_N (issue #910); feeds the
     # Decision Priority chain's per-slot label below.
@@ -1971,7 +1995,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             (
                 _i,
                 _trigger,
-                int(_pos),
+                int(_pos) if _pos is not None else None,
                 _pri,
                 _use_my,
                 _slot_tilt,
@@ -2256,12 +2280,31 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                     ),
                 )
             else:
-                target = _pos_label(_pos, _use_my)
-                cp_min = (
-                    L["fragments.as_minimum"]
-                    if config.get(f"custom_position_min_mode_{_slot}")
-                    else ""
+                _keys = CUSTOM_POSITION_SLOTS[_slot]
+                _pos_max = config.get(_keys["position_max"])
+                _is_min = bool(config.get(_keys["min_mode"]))
+                # A constraint-only slot names no position — the pipeline's own
+                # result is what gets clamped (issue #943).
+                target = (
+                    _pos_label(_pos, _use_my)
+                    if _pos is not None
+                    else L["custom.no_position_claim"]
                 )
+                cp_min = L["fragments.as_minimum"] if _is_min else ""
+                if _pos_max is not None:
+                    cp_min += L["fragments.as_maximum"]
+                # Tilt bounds (issue #943). Mutually exclusive with the fixed
+                # tilt note above — tilt_only is handled in the other branch.
+                _t_min = config.get(_keys["tilt_min"])
+                _t_max = config.get(_keys["tilt_max"])
+                if _t_min is not None and _t_max is not None:
+                    tilt_note += L["custom.tilt_bound_range"].format(
+                        min=_t_min, max=_t_max
+                    )
+                elif _t_min is not None:
+                    tilt_note += L["custom.tilt_bound_min"].format(min=_t_min)
+                elif _t_max is not None:
+                    tilt_note += L["custom.tilt_bound_max"].format(max=_t_max)
                 _open(
                     _pri,
                     _order,
@@ -2274,6 +2317,20 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
                         safety=safety_note,
                     ),
                 )
+                # Footgun (issue #943): a ceiling below the floor. The clamp
+                # applies the floor last, so the floor silently wins — say so
+                # rather than let the user think the maximum is in effect.
+                if (
+                    _is_min
+                    and _pos is not None
+                    and _pos_max is not None
+                    and _pos_max < _pos
+                ):
+                    _sub(
+                        L["warnings.custom_position_bound_conflict"].format(
+                            slot=_slot, max=_pos_max, min=_pos
+                        )
+                    )
             # Mutual-exclusion warning: tilt_only wins over min_mode / use_my
             # (issue #514). Surface the conflict so the user knows the latter two
             # are ignored for that slot.
@@ -3188,6 +3245,9 @@ SYNC_CATEGORIES: dict[str, frozenset[str]] = {
             "template_mode",
             "tilt",
             "tilt_only",
+            "position_max",
+            "tilt_min",
+            "tilt_max",
         )
     )
     | {CONF_DEFAULT_TILT, CONF_SUNSET_TILT},
@@ -3750,7 +3810,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     # The v3.7→v3.8 block setdefault-seeds the new blind_spot_*_gamma keys from
     # the legacy FOV-relative edges; legacy keys are retained (read-only).
     # Rollback-safe: every migration block is additive (existing keys retained).
-    MINOR_VERSION = 8
+    MINOR_VERSION = 9
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()
@@ -4527,7 +4587,18 @@ class OptionsFlowHandler(OptionsFlow):
             # Fill cleared optional (no-default) fields so a clear round-trips.
             form_optional = [
                 CUSTOM_POSITION_FORM_KEYS[sub]
-                for sub in ("name", "template", "position", "priority", "tilt")
+                for sub in (
+                    "name",
+                    "template",
+                    "position",
+                    "priority",
+                    "tilt",
+                    # Axis constraints (issue #943): clearing one is how the
+                    # user turns the constraint off, so it must round-trip.
+                    "position_max",
+                    "tilt_min",
+                    "tilt_max",
+                )
             ]
             self.optional_entities(form_optional, user_input)
             mapped = {

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1605,6 +1605,10 @@ class ReasonCode(StrEnum):
     # because the tilt resolves after the pipeline (venetian engine tilt).
     REGISTRY_CEILING_LOWERED = "registry.ceiling_lowered"
     REGISTRY_CEILING_INACTIVE = "registry.ceiling_inactive"
+    # A ceiling the floor beat: the clamp applies the floor last, so the cover
+    # ends up *above* the ceiling. "inactive" would read as a lie in exactly the
+    # conflict the config summary already warns about.
+    REGISTRY_CEILING_OVERRIDDEN = "registry.ceiling_overridden"
     REGISTRY_TILT_BOUND_ACTIVE = "registry.tilt_bound_active"
     REGISTRY_TILT_CLAMPED = "registry.tilt_clamped"
 

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1609,7 +1609,18 @@ class ReasonCode(StrEnum):
     # ends up *above* the ceiling. "inactive" would read as a lie in exactly the
     # conflict the config summary already warns about.
     REGISTRY_CEILING_OVERRIDDEN = "registry.ceiling_overridden"
+    # The floor side of the same conflict: when the floor beats the ceiling and
+    # the winner started *above* the floor, the net move is a lowering — so
+    # "floor raised winner from 80% to 60%" would contradict itself. This names
+    # the floor as the determining bound without implying a direction from the
+    # winner (audit finding C).
+    REGISTRY_FLOOR_OVERRIDES_CEILING = "registry.floor_overrides_ceiling"
     REGISTRY_TILT_BOUND_ACTIVE = "registry.tilt_bound_active"
+    # A tilt bound that was active but did not bind — the tilt-axis analog of
+    # floor_inactive / ceiling_inactive. Emitted so an out-composed or
+    # already-satisfied tilt bound still explains itself instead of vanishing
+    # from the trace (audit findings A / B).
+    REGISTRY_TILT_BOUND_INACTIVE = "registry.tilt_bound_inactive"
     REGISTRY_TILT_CLAMPED = "registry.tilt_clamped"
 
     # -- diagnostics builder (control-state reason + position explanation)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -879,6 +879,23 @@ def _custom_position_slot_keys(n: int) -> dict[str, str]:
         # position. Reuses the slot's existing `tilt` value as the slat angle
         # (issue #514). Venetian-only; gated on custom_position_includes_tilt.
         "tilt_only": f"custom_position_tilt_only_{n}",
+        # Axis constraints (issue #943). All optional — an absent key means the
+        # constraint is off, so every pre-#943 entry keeps its exact behavior.
+        # Values live in the same pre-inversion canonical space as `position` /
+        # `tilt` (0 = closed, 100 = open), deliberately NOT named
+        # "minimum open"/"maximum closed": the physical meaning flips with
+        # inverse_state / inverse_tilt.
+        #
+        # While the slot's trigger is active:
+        #   position_max — clamps the normally-resolved position DOWN to at
+        #                  most this (the mirror of `min_mode`'s clamp-up).
+        #   tilt_min     — clamps the final tilt UP to at least this.
+        #   tilt_max     — clamps the final tilt DOWN to at most this.
+        # These are priority-independent clamps: the pipeline resolves normally
+        # and the clamp composes on top (pipeline/axis_constraints.py).
+        "position_max": f"custom_position_position_max_{n}",
+        "tilt_min": f"custom_position_tilt_min_{n}",
+        "tilt_max": f"custom_position_tilt_max_{n}",
         # `enabled` is opt-out: existing entries lack the key and behave as
         # enabled. Set to False to silence a slot without clearing its
         # configuration — used by the companion card's slot toggle UI.
@@ -912,6 +929,9 @@ CUSTOM_POSITION_FORM_KEYS: dict[str, str] = {
     "use_my": "custom_position_use_my",
     "tilt": "custom_position_tilt",
     "tilt_only": "custom_position_tilt_only",
+    "position_max": "custom_position_position_max",
+    "tilt_min": "custom_position_tilt_min",
+    "tilt_max": "custom_position_tilt_max",
 }
 
 
@@ -1580,6 +1600,13 @@ class ReasonCode(StrEnum):
     REGISTRY_FLOOR_INACTIVE = "registry.floor_inactive"
     REGISTRY_TILT_APPLIED = "registry.tilt_applied"
     REGISTRY_TILT_DEFERRED = "registry.tilt_deferred"
+    # Axis constraints (issue #943). The ceiling codes mirror the floor pair
+    # above; the tilt pair covers a bound that clamped and one still pending
+    # because the tilt resolves after the pipeline (venetian engine tilt).
+    REGISTRY_CEILING_LOWERED = "registry.ceiling_lowered"
+    REGISTRY_CEILING_INACTIVE = "registry.ceiling_inactive"
+    REGISTRY_TILT_BOUND_ACTIVE = "registry.tilt_bound_active"
+    REGISTRY_TILT_CLAMPED = "registry.tilt_clamped"
 
     # -- diagnostics builder (control-state reason + position explanation)
     BUILDER_UNKNOWN = "builder.unknown"
@@ -1966,6 +1993,35 @@ class CoverType(StrEnum):
             self.BUILDING_PROFILE: "Building Profile",
             self.GROUP: "Cover Group",
         }[self]
+
+
+class AxisConstraintMode(StrEnum):
+    """How one custom-position slot claims one axis (issue #943).
+
+    **Derived, never stored.** The wire format stays the ``min_mode`` /
+    ``tilt_only`` booleans plus the optional numeric constraint keys — that is
+    the rollback contract (an older build must find its config exactly as it
+    left it). ``SnapshotBuilder.read_custom_position_sensors`` derives a mode
+    per axis at the single normalization site, replacing the hand-rolled
+    boolean precedence that was straining at three flags.
+
+    Semantics per mode, while the slot's trigger is active:
+
+    ``NONE``   The slot makes no claim on this axis — it defers entirely.
+    ``FIXED``  The slot names an exact value. Highest-priority slot wins, and
+               the value is applied fill-when-unset (today's ``tilt_only`` /
+               exact-position behavior).
+    ``MIN``    The slot names a floor. Composed max-of-mins across slots and
+               applied as an always-clamp (today's ``min_mode``).
+    ``MAX``    The slot names a ceiling. Composed min-of-maxes; always-clamp.
+    ``RANGE``  Both a floor and a ceiling.
+    """
+
+    NONE = "none"
+    FIXED = "fixed"
+    MIN = "min"
+    MAX = "max"
+    RANGE = "range"
 
 
 class GroupScene(StrEnum):

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -84,6 +84,7 @@ from ...const import (
 )
 from ...engine.covers import AdaptiveVerticalCover, VenetianCoverCalculation
 from ...managers.manual_override import SecondaryAxisCheck
+from ...pipeline.axis_constraints import clamp_to_bounds, tilt_clamp_step
 from ...pipeline.types import DecisionStep
 from ...position_utils import PositionConverter
 from .._helpers import window_dimensions_lines
@@ -715,6 +716,24 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             cover_trace[TRACE_KEY_TILT] = tilt_trace
         position = result.position
         trace = list(result.decision_trace)
+
+        # Axis constraints (issue #943). The registry could not clamp this tilt
+        # — it did not exist yet, the engine just produced it — so it carried
+        # the composed bounds on the result instead. Apply them here, through
+        # the same shared clamp the registry uses: the arithmetic stays in the
+        # one pipeline helper, while the knowledge that a venetian resolves its
+        # tilt after the pipeline stays inside the venetian policy.
+        bounded = clamp_to_bounds(tilt, result.tilt_low, result.tilt_high)
+        if bounded != tilt:
+            trace.append(
+                tilt_clamp_step(
+                    from_tilt=tilt,
+                    to_tilt=bounded,
+                    label=result.tilt_bound_label or "constraint",
+                    source="tilt_clamp",
+                )
+            )
+            tilt = bounded
 
         if (
             self._venetian_mode == VENETIAN_MODE_TILT_ONLY

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -117,18 +117,35 @@ def mirror_legacy_slot_sensor_keys(options: dict) -> None:
             options[slot_keys["sensor"]] = None
 
 
+# Sub-keys whose presence gives a slot something to contribute on its own,
+# even without a `position` claim (issue #943). A trigger + "minimum tilt 50%"
+# is a complete slot: it constrains the axis and lets the pipeline resolve the
+# rest. Single source of truth for the claim vocabulary.
+CUSTOM_POSITION_CLAIM_KEYS: tuple[str, ...] = (
+    "position",
+    "position_max",
+    "tilt_min",
+    "tilt_max",
+)
+
+
 def custom_position_slot_configured(
     options: Mapping, slot_keys: Mapping[str, str]
 ) -> bool:
     """Return True when a custom-position slot is fully configured.
 
     Single source of truth for the "slot participates" gate: a slot needs a
-    trigger (at least one sensor, or a condition template) and a position.
+    trigger (at least one sensor, or a condition template) and at least one
+    claim on an axis — a `position`, or one of the axis constraints added by
+    issue #943. A trigger alone still contributes nothing.
     """
     has_trigger = bool(
         custom_position_slot_sensors(options, slot_keys)
     ) or is_template_string(options.get(slot_keys["template"]))
-    return has_trigger and options.get(slot_keys["position"]) is not None
+    has_claim = any(
+        options.get(slot_keys[sub]) is not None for sub in CUSTOM_POSITION_CLAIM_KEYS
+    )
+    return has_trigger and has_claim
 
 
 def custom_position_slot_name(

--- a/custom_components/adaptive_cover_pro/pipeline/axis_constraints.py
+++ b/custom_components/adaptive_cover_pro/pipeline/axis_constraints.py
@@ -148,6 +148,34 @@ def compose_bounds(
     return low, high
 
 
+def bounding_constraint(
+    constraints: Iterable[AxisConstraint],
+    axis: str,
+    value: int,
+    *,
+    low: bool,
+) -> AxisConstraint | None:
+    """Return the single constraint whose bound actually bound this cycle.
+
+    ``compose_bounds`` collapses many claims into one ``(low, high)`` pair, so
+    a clamp knows the value it applied but not *which* claim produced it. This
+    walks back: the binding floor is the first ``MIN``/``RANGE`` whose ``low``
+    equals ``value`` (``low=True``); the binding ceiling the first
+    ``MAX``/``RANGE`` whose ``high`` equals ``value`` (``low=False``). "First"
+    matches the tie rule the composition already uses (max-of-mins keeps the
+    earliest slot on a tie), so the trace credits exactly one slot — never the
+    join of every active bound (audit finding 4a). Returns None when nothing
+    matched (an inert axis).
+    """
+    for c in constraints:
+        if c.axis != axis or c.kind is AxisConstraintMode.FIXED:
+            continue
+        edge = c.low if low else c.high
+        if edge is not None and edge == value:
+            return c
+    return None
+
+
 def resolve_fixed(
     constraints: Iterable[AxisConstraint], axis: str
 ) -> AxisConstraint | None:

--- a/custom_components/adaptive_cover_pro/pipeline/axis_constraints.py
+++ b/custom_components/adaptive_cover_pro/pipeline/axis_constraints.py
@@ -1,0 +1,325 @@
+"""Unified per-axis constraint composition (issue #943).
+
+A *constraint* is one active override's claim on one axis of the cover. The
+handler that owns the claim defers (returns ``None`` from ``evaluate``); the
+pipeline resolves normally and this module composes the claims onto whatever
+won. That is priority-independent by construction — a constraint clamps the
+winner regardless of who the winner is.
+
+**This module is the generalization of two single-purpose passes.** Before
+#943 the same shape was written twice:
+
+* ``floors.py``    — position-min only: max-of-values, always-clamp,
+  ``held_position``-aware (issues #463 / #496 / #534 / #809).
+* ``tilt_axis.py`` — tilt-fixed only: highest-priority-wins, fill-when-unset
+  (issue #514).
+
+Those two rules read like an axis difference but are really a **kind**
+difference. A position floor is ``kind=MIN``; a tilt-only slot is
+``kind=FIXED``. Once that is named, one gather + one compose serves both axes,
+and the new bounds (#943's position-max and tilt-min/max) fall out of the
+existing rules rather than needing new ones:
+
+============  =========================================  ===================
+kind          resolution                                 application
+============  =========================================  ===================
+``FIXED``     highest priority wins (ties → first)       fill-when-unset
+``MIN``       max of the lows        (#496)              always-clamp
+``MAX``       min of the highs       (the #496 mirror)   always-clamp
+``RANGE``     both of the above                          always-clamp
+============  =========================================  ===================
+
+No existing behavior changes, because a pre-#943 config can only ever produce
+position-``MIN`` and tilt-``FIXED`` constraints — exactly the two cells the old
+modules implemented. ``floors.py`` and ``tilt_axis.py`` survive as thin
+adapters over this module so the coordinator's user-move clamp (#472/#416/#372)
+and the registry keep sharing one implementation of the arithmetic.
+
+Everything here is pure: it reads a :class:`PipelineSnapshot` and returns plain
+data. Cover-type-agnostic by construction — axes are keyed by the shared
+``AXIS_NAME_*`` vocabulary and the pass never asks "is this venetian".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from ..const import AxisConstraintMode, ReasonCode, custom_position_handler_name
+from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
+from ..reason_i18n import Reason
+from .types import DecisionStep, PipelineSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class AxisConstraint:
+    """One active override's claim on one axis.
+
+    Replaces ``FloorClampInfo`` (position-min) and ``TiltAxisContribution``
+    (tilt-fixed) with a single type covering both.
+
+    Attributes:
+        axis:  Which axis this constrains — one of the ``AXIS_NAME_*``
+               constants from ``cover_types.base``. A *value*, never a
+               cover-type branch: code outside ``cover_types/`` must not ask
+               what kind of cover it is looking at.
+        kind:  How the claim resolves and applies. See the table in the module
+               docstring.
+        low:   Floor value (0–100, pre-inversion canonical space), or None.
+               For ``FIXED`` this equals ``high`` — the exact value.
+        high:  Ceiling value, or None. For ``FIXED`` this equals ``low``.
+        source: Stable identifier used as the ``handler`` field in the decision
+               trace — e.g. ``"custom_position_1"``, ``"weather"``.
+        label: Human-readable name for the trace reason — the bound sensor's
+               friendly name, or a fixed string for the weather override.
+        priority: The contributing override's pipeline priority. ``FIXED``
+               resolution sorts on this; the user-move clamp gates on it so a
+               floor only clamps a manual command when it outranks manual
+               override (#472). The pipeline-winner clamp ignores it — auto-rule
+               composition stays unconditional (#463).
+        slot:  1-based custom-position slot number, or 0 for non-slot sources
+               (the weather floor). Surfaced in the Control Status string
+               (#667).
+
+    """
+
+    axis: str
+    kind: AxisConstraintMode
+    low: int | None
+    high: int | None
+    source: str
+    label: str
+    priority: int
+    slot: int
+
+    @property
+    def value(self) -> int | None:
+        """The exact value of a ``FIXED`` claim (``low`` and ``high`` agree)."""
+        return self.low
+
+
+def clamp_to_bounds(value: int, low: int | None, high: int | None) -> int:
+    """Clamp *value* into ``[low, high]``; either bound may be absent.
+
+    **The one clamp formula.** Every caller — the registry's position pass, its
+    tilt pass, the venetian engine-tilt clamp, and ``floors.effective_floor``'s
+    consumers — goes through here, so the arithmetic exists exactly once
+    (CODING_GUIDELINES § Single-Source-of-Truth Helpers).
+
+    Order matters: the ceiling applies first and the floor last, so when a
+    caller hands in conflicting bounds (``low > high``) **the floor wins**.
+    That is the deliberate conflict rule — a floor is a protection commitment
+    (keep at least this much cover), and honoring it over a ceiling fails safe.
+    It also keeps the position pass's ``final > effective_winner_pos`` predicate
+    exactly equivalent to the pre-#943 ``floor_raised``.
+
+    Bounds are tested with ``is None``, never truthiness: 0 is a real bound.
+    """
+    if high is not None:
+        value = min(value, high)
+    if low is not None:
+        value = max(value, low)
+    return value
+
+
+def compose_bounds(
+    constraints: Iterable[AxisConstraint], axis: str
+) -> tuple[int | None, int | None]:
+    """Compose every bounded constraint on *axis* into one ``(low, high)``.
+
+    ``low`` is the **max of the lows** — issue #496's max-of-floors rule, now
+    stated once for every axis. ``high`` is the **min of the highs**, its single
+    mirror. Both mean "the most restrictive claim wins", which is what makes
+    composition order-independent.
+
+    ``FIXED`` constraints are skipped: they resolve by priority
+    (:func:`resolve_fixed`), not by composition. Returns ``(None, None)`` when
+    nothing bounds the axis.
+    """
+    low: int | None = None
+    high: int | None = None
+    for c in constraints:
+        if c.axis != axis or c.kind is AxisConstraintMode.FIXED:
+            continue
+        if c.low is not None and (low is None or c.low > low):
+            low = c.low
+        if c.high is not None and (high is None or c.high < high):
+            high = c.high
+    return low, high
+
+
+def resolve_fixed(
+    constraints: Iterable[AxisConstraint], axis: str
+) -> AxisConstraint | None:
+    """Return the highest-priority ``FIXED`` claim on *axis*, or None.
+
+    Ties resolve to the first in iteration order (snapshot order, which matches
+    ``_build_pipeline`` registration order) — byte-identical to the rule
+    ``tilt_axis.resolve_tilt_axis`` has used since #514.
+    """
+    winner: AxisConstraint | None = None
+    for c in constraints:
+        if c.axis != axis or c.kind is not AxisConstraintMode.FIXED:
+            continue
+        if winner is None or c.priority > winner.priority:
+            winner = c
+    return winner
+
+
+def _bounded(
+    axis: str,
+    mode: AxisConstraintMode,
+    low: int | None,
+    high: int | None,
+    *,
+    source: str,
+    label: str,
+    priority: int,
+    slot: int,
+) -> AxisConstraint | None:
+    """Build a bounded constraint, or None when the axis makes no claim."""
+    if mode in (AxisConstraintMode.NONE, AxisConstraintMode.FIXED):
+        return None
+    return AxisConstraint(
+        axis=axis,
+        kind=mode,
+        low=low,
+        high=high,
+        source=source,
+        label=label,
+        priority=priority,
+        slot=slot,
+    )
+
+
+def gather_axis_constraints(snapshot: PipelineSnapshot) -> list[AxisConstraint]:
+    """Collect every active axis constraint the snapshot contributes.
+
+    One pass over the snapshot emits, in this order (which the trace relies on):
+
+      1. Per custom-position slot, in snapshot order (matching
+         ``_build_pipeline`` registration order): its position claim then its
+         tilt claim. A slot may constrain both axes.
+      2. The weather override's min-mode position floor, if any.
+
+    Slot modes are read straight off ``CustomPositionSensorState`` — the
+    snapshot builder already derived them at the single normalization site, so
+    no boolean precedence is re-litigated here.
+
+    ``use_my`` position claims are excluded: the My path is hardware-pinned and
+    never participates in constraint semantics (pre-#943 behavior, preserved).
+    """
+    # Local import: ``pipeline.handlers`` pulls in cover-type policies, so a
+    # module-level import here would form a circular import chain. The class is
+    # still the single source of truth for the weather priority — never inline
+    # the magic number.
+    from .handlers.weather import WeatherOverrideHandler
+
+    constraints: list[AxisConstraint] = []
+    for state in snapshot.custom_position_sensors:
+        if not state.is_on:
+            continue
+        source = custom_position_handler_name(state.slot)
+        shared = {
+            "source": source,
+            "label": state.display_label,
+            "priority": state.priority,
+            "slot": state.slot,
+        }
+
+        # --- Position axis ---
+        if not state.use_my:
+            position_low = (
+                state.position
+                if state.position_mode
+                in (AxisConstraintMode.MIN, AxisConstraintMode.RANGE)
+                else None
+            )
+            pos = _bounded(
+                AXIS_NAME_POSITION,
+                state.position_mode,
+                position_low,
+                state.position_max,
+                **shared,
+            )
+            if pos is not None:
+                constraints.append(pos)
+
+        # --- Tilt axis ---
+        if state.tilt_mode is AxisConstraintMode.FIXED and state.tilt is not None:
+            constraints.append(
+                AxisConstraint(
+                    axis=AXIS_NAME_TILT,
+                    kind=AxisConstraintMode.FIXED,
+                    low=state.tilt,
+                    high=state.tilt,
+                    **shared,
+                )
+            )
+        else:
+            tilt = _bounded(
+                AXIS_NAME_TILT,
+                state.tilt_mode,
+                state.tilt_min,
+                state.tilt_max,
+                **shared,
+            )
+            if tilt is not None:
+                constraints.append(tilt)
+
+    if snapshot.weather_override_active and snapshot.weather_override_min_mode:
+        constraints.append(
+            AxisConstraint(
+                axis=AXIS_NAME_POSITION,
+                kind=AxisConstraintMode.MIN,
+                low=snapshot.weather_override_position,
+                high=None,
+                source="weather",
+                label="weather override",
+                priority=WeatherOverrideHandler.priority,
+                slot=0,
+            )
+        )
+    return constraints
+
+
+def bound_label(value: int | None) -> str:
+    """Render one side of a bound for a trace reason ('—' when unbounded)."""
+    return "—" if value is None else f"{value}%"
+
+
+def tilt_clamp_step(
+    *, from_tilt: int, to_tilt: int, label: str, source: str
+) -> DecisionStep:
+    """Build the trace step for a tilt clamp.
+
+    Shared by the registry (clamping a tilt the winner already set) and
+    ``VenetianPolicy.post_pipeline_resolve`` (clamping the tilt its engine
+    resolves after the pipeline). Both clamps are the same event and must read
+    the same way in the trace, so the step is built in one place.
+    """
+    return DecisionStep(
+        handler=source,
+        matched=True,
+        reason_payload=Reason(
+            ReasonCode.REGISTRY_TILT_CLAMPED,
+            {"from_tilt": from_tilt, "to_tilt": to_tilt, "label": label},
+        ),
+        position=None,
+        tilt=to_tilt,
+    )
+
+
+def constraint_label(constraints: Iterable[AxisConstraint], axis: str) -> str:
+    """Name the bounded constraints on *axis* for a trace reason.
+
+    One constraint renders its own label; several render a joined list, so a
+    clamp always says which slot(s) produced it.
+    """
+    labels = [
+        c.label
+        for c in constraints
+        if c.axis == axis and c.kind is not AxisConstraintMode.FIXED
+    ]
+    # dict.fromkeys de-dupes while preserving order (two bounds, one slot).
+    return ", ".join(dict.fromkeys(labels)) or "constraint"

--- a/custom_components/adaptive_cover_pro/pipeline/floors.py
+++ b/custom_components/adaptive_cover_pro/pipeline/floors.py
@@ -5,10 +5,16 @@ custom-position slot with ``min_mode`` or weather override with ``min_mode``
 — that must raise whichever handler ultimately wins the pipeline, regardless
 of priority.
 
-These helpers are pure: they read a :class:`PipelineSnapshot` and return
-plain data. The registry composes the active floors after picking a winner;
-the coordinator's user-move clamp consumes the same helpers so the
-``max(active_floors)`` arithmetic exists in exactly one place.
+**This module is now an adapter.** Issue #943 generalized floors into the
+2-axis × {fixed, min, max, range} model in :mod:`pipeline.axis_constraints`; a
+floor is simply a position-axis constraint of ``kind=MIN``. The functions here
+delegate to that model and re-shape its output into the ``FloorClampInfo`` the
+coordinator's user-move clamp (issues #472/#416/#372) still consumes, so the
+``max(active_floors)`` arithmetic exists in exactly one place and the manual
+path keeps its byte-identical behavior.
+
+These helpers stay pure: they read a :class:`PipelineSnapshot` and return
+plain data.
 """
 
 from __future__ import annotations
@@ -16,13 +22,19 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from ..const import custom_position_handler_name
+from ..const import AxisConstraintMode
+from ..cover_types.base import AXIS_NAME_POSITION
+from .axis_constraints import AxisConstraint, compose_bounds, gather_axis_constraints
 from .types import PipelineSnapshot
 
 
 @dataclass(frozen=True, slots=True)
 class FloorClampInfo:
     """One active floor contributed to the pipeline composition pass.
+
+    A position-axis view of an :class:`~pipeline.axis_constraints.AxisConstraint`
+    with a low bound. Kept as the public shape for the coordinator's user-move
+    clamp.
 
     Attributes:
         source: Stable identifier used as the ``handler`` field in the
@@ -47,6 +59,17 @@ class FloorClampInfo:
     priority: int
 
 
+def _as_floor(constraint: AxisConstraint) -> FloorClampInfo:
+    """Project a low-bounded position constraint onto the floor shape."""
+    assert constraint.low is not None  # noqa: S101 — guarded by the caller's filter
+    return FloorClampInfo(
+        source=constraint.source,
+        label=constraint.label,
+        position=constraint.low,
+        priority=constraint.priority,
+    )
+
+
 def gather_active_floors(snapshot: PipelineSnapshot) -> list[FloorClampInfo]:
     """Collect every active min-mode floor contributed by the snapshot.
 
@@ -56,37 +79,20 @@ def gather_active_floors(snapshot: PipelineSnapshot) -> list[FloorClampInfo]:
          registration order).
       2. The weather override floor, if any.
 
-    A custom-position floor is active when its trigger is ``is_on`` and
-    ``min_mode`` is True. ``use_my`` floors are excluded — the "Use My"
-    path is hardware-pinned and never participates in floor semantics.
+    A custom-position floor is active when its trigger is ``is_on`` and the
+    slot's derived ``position_mode`` carries a low bound (``MIN`` / ``RANGE``
+    — ``min_mode`` in the stored config). ``use_my`` floors are excluded — the
+    "Use My" path is hardware-pinned and never participates in floor semantics.
+    Both facts are enforced by :func:`gather_axis_constraints`; this filters its
+    output down to the position lows.
     """
-    # Local import: ``pipeline.handlers`` pulls in cover-type policies, so a
-    # module-level import here would form a circular import chain. The class is
-    # still the single source of truth for the weather priority (guideline
-    # §180-186 — never inline the magic number).
-    from .handlers.weather import WeatherOverrideHandler
-
-    floors: list[FloorClampInfo] = []
-    for state in snapshot.custom_position_sensors:
-        if state.is_on and state.min_mode and not state.use_my:
-            floors.append(
-                FloorClampInfo(
-                    source=custom_position_handler_name(state.slot),
-                    label=state.display_label,
-                    position=state.position,
-                    priority=state.priority,
-                )
-            )
-    if snapshot.weather_override_active and snapshot.weather_override_min_mode:
-        floors.append(
-            FloorClampInfo(
-                source="weather",
-                label="weather override",
-                position=snapshot.weather_override_position,
-                priority=WeatherOverrideHandler.priority,
-            )
-        )
-    return floors
+    return [
+        _as_floor(c)
+        for c in gather_axis_constraints(snapshot)
+        if c.axis == AXIS_NAME_POSITION
+        and c.kind is not AxisConstraintMode.FIXED
+        and c.low is not None
+    ]
 
 
 def effective_floor(
@@ -94,13 +100,33 @@ def effective_floor(
 ) -> tuple[int, FloorClampInfo | None]:
     """Return the highest active floor and the FloorClampInfo it came from.
 
+    The max-of-floors rule (issue #496) lives in
+    :func:`~pipeline.axis_constraints.compose_bounds`; this resolves the
+    composed low back to the floor that produced it so callers keep the
+    ``label`` / ``priority`` they need for tracing and gating. Ties resolve to
+    the first floor in iteration order, as before.
+
     When ``floors`` is empty, returns ``(0, None)`` — the coordinator and
     registry both treat 0 as "no clamp applied".
     """
-    winner: FloorClampInfo | None = None
-    for info in floors:
-        if winner is None or info.position > winner.position:
-            winner = info
-    if winner is None:
+    floors = list(floors)
+    composed, _ = compose_bounds(
+        [
+            AxisConstraint(
+                axis=AXIS_NAME_POSITION,
+                kind=AxisConstraintMode.MIN,
+                low=f.position,
+                high=None,
+                source=f.source,
+                label=f.label,
+                priority=f.priority,
+                slot=0,
+            )
+            for f in floors
+        ],
+        AXIS_NAME_POSITION,
+    )
+    if composed is None:
         return 0, None
-    return winner.position, winner
+    winner = next(f for f in floors if f.position == composed)
+    return composed, winner

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
@@ -117,13 +117,15 @@ def _custom_position_handlers(options: Mapping[str, Any]) -> list[OverrideHandle
             raw_tilt = options.get(slot_keys["tilt"])
             tilt = int(raw_tilt) if raw_tilt is not None else None
             # A constraint-only slot (e.g. trigger → minimum tilt) has no
-            # position claim; the sentinel is never read because the handler
-            # defers on any non-FIXED position mode (issue #943).
+            # position claim. Pass None rather than a 0 sentinel: the ``use_my``
+            # path bypasses the non-FIXED deferral, so a 0 here would fully
+            # close the cover when the My value is also unavailable (audit
+            # finding 3). The handler defers instead when it has nothing to send.
             raw_position = options.get(slot_keys["position"])
             handlers.append(
                 CustomPositionHandler(
                     slot=slot,
-                    position=int(raw_position) if raw_position is not None else 0,
+                    position=int(raw_position) if raw_position is not None else None,
                     priority=priority,
                     tilt=tilt,
                 )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/__init__.py
@@ -101,9 +101,9 @@ def _custom_position_handlers(options: Mapping[str, Any]) -> list[OverrideHandle
     """Build one ``CustomPositionHandler`` per configured + enabled slot.
 
     A slot contributes a handler only when it has a trigger (sensors and/or
-    template) and a position and is enabled. Each carries an independent
-    priority so the registry sorts it into the correct evaluation order
-    alongside the rest of the chain.
+    template) and an axis claim — a position or one of the axis constraints —
+    and is enabled. Each carries an independent priority so the registry sorts
+    it into the correct evaluation order alongside the rest of the chain.
     """
     handlers: list[OverrideHandler] = []
     for slot, slot_keys in CUSTOM_POSITION_SLOTS.items():
@@ -116,10 +116,14 @@ def _custom_position_handlers(options: Mapping[str, Any]) -> list[OverrideHandle
             )
             raw_tilt = options.get(slot_keys["tilt"])
             tilt = int(raw_tilt) if raw_tilt is not None else None
+            # A constraint-only slot (e.g. trigger → minimum tilt) has no
+            # position claim; the sentinel is never read because the handler
+            # defers on any non-FIXED position mode (issue #943).
+            raw_position = options.get(slot_keys["position"])
             handlers.append(
                 CustomPositionHandler(
                     slot=slot,
-                    position=int(options.get(slot_keys["position"])),
+                    position=int(raw_position) if raw_position is not None else 0,
                     priority=priority,
                     tilt=tilt,
                 )

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ...const import (
     CUSTOM_POSITION_SAFETY_PRIORITY,
+    AxisConstraintMode,
     ControlMethod,
     ReasonCode,
     custom_position_handler_name,
@@ -108,23 +109,29 @@ class CustomPositionHandler(OverrideHandler):
     def evaluate(self, snapshot: PipelineSnapshot) -> PipelineResult | None:
         """Return the configured position when this slot's trigger is active.
 
-        In ``min_mode`` (and not on the ``use_my`` path), the handler defers
-        by returning ``None``. The registry then composes the configured
-        position as a post-decision floor clamp on whichever lower-priority
-        handler wins (issue #463).
+        The handler only claims the position axis when the slot names an
+        *exact* position (``position_mode`` is ``FIXED``). Every other mode —
+        a floor (``min_mode``, issue #463), a ceiling or range, or no position
+        claim at all (issue #943) — defers by returning ``None`` so the
+        registry can compose the constraint onto whichever handler actually
+        wins. That is what makes a constraint priority-independent.
+
+        The ``use_my`` path is the exception: it is hardware-pinned, ignores
+        constraint semantics entirely, and always claims.
         """
         # Find our slot in the snapshot's sensor list.
         for state in snapshot.custom_position_sensors:
             if state.slot == self._slot:
                 if state.is_on:
-                    # Tilt-only mode defers to the tilt-axis overlay pass — the
-                    # slot fixes the slat angle but never claims position
-                    # (issue #514). See pipeline/tilt_axis.py.
-                    if state.tilt_only:
-                        return None
-                    # Floor mode (without use_my) defers to the floor-clamp
-                    # composition pass — see pipeline/floors.py.
-                    if state.min_mode and not state.use_my:
+                    # Defer to the axis-constraint composition pass — see
+                    # pipeline/axis_constraints.py. Covers today's tilt-only
+                    # (#514) and floor (#463) deferrals plus the ceiling /
+                    # range / no-claim modes, with identical outcomes for
+                    # every pre-#943 configuration.
+                    if (
+                        state.position_mode is not AxisConstraintMode.FIXED
+                        and not state.use_my
+                    ):
                         return None
                     raw = compute_raw_calculated_position(snapshot)
                     reason_head = self._reason_head(state)

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/custom_position.py
@@ -44,7 +44,7 @@ class CustomPositionHandler(OverrideHandler):
     def __init__(
         self,
         slot: int,
-        position: int,
+        position: int | None,
         priority: int,
         tilt: int | None = None,
     ) -> None:
@@ -52,7 +52,8 @@ class CustomPositionHandler(OverrideHandler):
 
         Args:
             slot:      1-based slot number (1–10).  Used to build ``name``.
-            position:  Cover position (0–100 %) to apply when the trigger is on.
+            position:  Cover position (0–100 %) to apply when the trigger is on,
+                       or None for a constraint-only slot that names no position.
             priority:  Pipeline evaluation priority (1–100).  Higher = evaluated first.
             tilt:      Explicit tilt (0–100 %) for venetian covers. None = solar tilt.
 
@@ -169,8 +170,13 @@ class CustomPositionHandler(OverrideHandler):
                             custom_position_active_slot_name=state.slot_name,
                         )
                     # Exact-position branch (state.min_mode is False here —
-                    # floor mode defers above).
+                    # floor mode defers above). A ``use_my`` slot reaches here
+                    # even with no position of its own; when its My value is
+                    # also unavailable there is nothing to send, so defer rather
+                    # than close the cover with a phantom 0 (audit finding 3).
                     pos = self._position
+                    if pos is None:
+                        return None
                     return PipelineResult(
                         position=pos,
                         tilt=self._tilt,

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -11,6 +11,7 @@ from ..diagnostics.event_buffer import EventBuffer
 from ..reason_i18n import Reason, render_en
 from .axis_constraints import (
     bound_label,
+    bounding_constraint,
     clamp_to_bounds,
     compose_bounds,
     constraint_label,
@@ -39,56 +40,106 @@ def _normalize_reason(value: str | Reason) -> tuple[str, Reason | None]:
 def _drop_trace_steps(
     trace: list[DecisionStep], sources: set[str]
 ) -> list[DecisionStep]:
-    """Remove trace steps whose handler is one of ``sources``.
+    """Remove the *deferral* trace steps whose handler is one of ``sources``.
 
     Both the floor pass and the tilt-axis pass re-emit fresh trace steps for
     handlers that *deferred* (returned None) so the registry can replace the
     handler's unhelpful ``describe_skip`` entry. They share this removal step
     so the dedup logic lives in one place (CODING_GUIDELINES § No Duplication).
+
+    A ``matched=True`` step is never dropped: since #943 a slot can win the
+    pipeline (an exact position or ``use_my``) *and* contribute a bound on the
+    other axis, so its own source appears in ``sources`` even though it did not
+    defer. Sweeping it out left the winner unnamed in the trace (audit finding
+    1); the matched guard keeps the winner's step while still replacing every
+    deferral skip.
     """
-    return [step for step in trace if step.handler not in sources]
+    return [step for step in trace if step.matched or step.handler not in sources]
 
 
 def _inactive_position_steps(
     constraints: list,
     *,
     winner_pos: int,
-    bound_pos: int | None,
+    final_pos: int,
     floor_raised: bool,
+    binding,
 ) -> list[DecisionStep]:
     """Explain every position bound that was active but did not bind.
 
     A constraint whose handler deferred would otherwise be left with an
     unhelpful ``describe_skip`` step (the registry drops those). Give each
-    non-binding bound a step saying it was evaluated and why it did nothing —
-    the floor/ceiling pair mirror each other exactly.
+    non-binding bound a step saying it was evaluated and why it did nothing.
 
-    ``bound_pos`` is the value that *did* bind this cycle (None when nothing
-    clamped); the bound that produced it is skipped, since it was already
-    emitted as the matched clamp step.
+    ``binding`` is the single constraint that produced this cycle's clamp (None
+    when nothing clamped); it is skipped, since it was already emitted as the
+    matched clamp step. Skipping by *identity* rather than by value keeps a
+    losing tie-floor visible — two slots at the same floor no longer collapse
+    into one trace entry (audit finding 4b).
+
+    A ceiling the floor beat is reported as *overridden*, not *inactive*: when
+    ``floor_raised`` lifted the cover above a ceiling, that ceiling did not sit
+    idle — it was outranked, and the honest wording says so (audit finding 7).
     """
     steps: list[DecisionStep] = []
     for c in constraints:
         if c.axis != AXIS_NAME_POSITION or c.kind is AxisConstraintMode.FIXED:
             continue
-        bound_value = c.low if floor_raised else c.high
-        if bound_pos is not None and bound_value == bound_pos:
+        if c is binding:
             continue  # this bound *did* bind — already emitted as the clamp
-        for value, code, key in (
-            (c.low, ReasonCode.REGISTRY_FLOOR_INACTIVE, "floor_pos"),
-            (c.high, ReasonCode.REGISTRY_CEILING_INACTIVE, "ceiling_pos"),
-        ):
-            if value is None:
-                continue
+        if c.low is not None:
             steps.append(
                 DecisionStep(
                     handler=c.source,
                     matched=False,
-                    reason_payload=Reason(code, {key: value, "winner_pos": winner_pos}),
-                    position=value,
+                    reason_payload=Reason(
+                        ReasonCode.REGISTRY_FLOOR_INACTIVE,
+                        {"floor_pos": c.low, "winner_pos": winner_pos},
+                    ),
+                    position=c.low,
+                )
+            )
+        if c.high is not None:
+            if floor_raised and c.high < final_pos:
+                code, params = (
+                    ReasonCode.REGISTRY_CEILING_OVERRIDDEN,
+                    {"ceiling_pos": c.high, "to_pos": final_pos},
+                )
+            else:
+                code, params = (
+                    ReasonCode.REGISTRY_CEILING_INACTIVE,
+                    {"ceiling_pos": c.high, "winner_pos": winner_pos},
+                )
+            steps.append(
+                DecisionStep(
+                    handler=c.source,
+                    matched=False,
+                    reason_payload=Reason(code, params),
+                    position=c.high,
                 )
             )
     return steps
+
+
+def _tilt_to_clamp(
+    tilt_overlay: int | None,
+    winner_tilt: int | None,
+    merged: dict[str, object],
+) -> int | None:
+    """Return the tilt a bound should clamp, in precedence order.
+
+    The FIXED overlay we just filled wins; then the winner's own tilt; then a
+    tilt merged onto the result from a lower-priority handler or ``contribute()``
+    (the ``_MERGEABLE`` fill). The merged case is the one the pre-audit code
+    skipped, letting a configured minimum be silently violated (audit finding
+    2). Returns None when nothing has set a tilt yet (the venetian engine will).
+    """
+    if tilt_overlay is not None:
+        return tilt_overlay
+    if winner_tilt is not None:
+        return winner_tilt
+    merged_tilt = merged.get("tilt")
+    return int(merged_tilt) if merged_tilt is not None else None  # type: ignore[arg-type]
 
 
 class PipelineRegistry:
@@ -245,11 +296,26 @@ class PipelineRegistry:
         # Unchanged position keeps the winner's own value (today's behaviour:
         # an inert bound must not overwrite ``position`` with ``held_position``).
         clamped_position = final_pos if position_clamped else winner.position
+        # The single constraint that actually bound — resolved back from the
+        # composed value so the trace credits the one slot that produced the
+        # move, not the join of every active bound (audit finding 4a).
+        position_binding = (
+            bounding_constraint(
+                constraints, AXIS_NAME_POSITION, final_pos, low=floor_raised
+            )
+            if position_clamped
+            else None
+        )
         if position_clamped:
             code, source = (
                 (ReasonCode.REGISTRY_FLOOR_RAISED, "floor_clamp")
                 if floor_raised
                 else (ReasonCode.REGISTRY_CEILING_LOWERED, "ceiling_clamp")
+            )
+            label = (
+                position_binding.label
+                if position_binding is not None
+                else constraint_label(constraints, AXIS_NAME_POSITION)
             )
             trace.append(
                 DecisionStep(
@@ -260,23 +326,28 @@ class PipelineRegistry:
                         {
                             "from_pos": effective_winner_pos,
                             "to_pos": final_pos,
-                            "label": constraint_label(constraints, AXIS_NAME_POSITION),
+                            "label": label,
                         },
                     ),
                     position=final_pos,
                 )
             )
-        # Replace any existing trace step whose handler matches a constraint's
-        # source — those steps came from the deferral path and carry an
-        # unhelpful describe_skip reason.  We give them a fresh entry that
-        # explains the constraint was active but did not bind.
-        trace = _drop_trace_steps(trace, {c.source for c in constraints})
+        # Replace the deferral steps of the position-bound sources — those
+        # steps came from the deferral path and carry an unhelpful describe_skip
+        # reason. Only position sources are swept here so a tilt-only / tilt-
+        # bound slot's step is left for the tilt pass to handle (audit finding
+        # 4c); the matched winner's step is never dropped (finding 1).
+        trace = _drop_trace_steps(
+            trace,
+            {c.source for c in constraints if c.axis == AXIS_NAME_POSITION},
+        )
         trace.extend(
             _inactive_position_steps(
                 constraints,
                 winner_pos=effective_winner_pos,
-                bound_pos=final_pos if position_clamped else None,
+                final_pos=final_pos,
                 floor_raised=floor_raised,
+                binding=position_binding,
             )
         )
 
@@ -337,10 +408,27 @@ class PipelineRegistry:
 
         # Bounded tilt constraints (issue #943). Unlike the FIXED overlay above,
         # a bound clamps a tilt that is already set — the exact case the
-        # fill-when-unset branch skips. The tilt to clamp is the winner's own,
-        # or the overlay we just filled in.
+        # fill-when-unset branch skips.
         tilt_low, tilt_high = compose_bounds(constraints, AXIS_NAME_TILT)
-        resolved_tilt = winner.tilt if tilt_overlay is None else tilt_overlay
+        # Replace the deferral skips of the bounded tilt sources — they are
+        # re-explained by the clamp / bound-active step below (a losing FIXED
+        # tilt-only slot is deliberately left out of this set so its step
+        # survives; audit finding 4c). Matched winner steps are protected.
+        trace = _drop_trace_steps(
+            trace,
+            {
+                c.source
+                for c in constraints
+                if c.axis == AXIS_NAME_TILT and c.kind is not AxisConstraintMode.FIXED
+            },
+        )
+        # The tilt to clamp is, in precedence order: the FIXED overlay we just
+        # filled, the winner's own tilt, or a tilt merged from a lower-priority
+        # handler / contribute() (the ``_MERGEABLE`` fill). The merged case is
+        # the one the pre-audit code missed — a configured minimum was silently
+        # violated whenever a handler-supplied tilt reached the result by merge
+        # (audit finding 2). One clamp site covers all three.
+        resolved_tilt = _tilt_to_clamp(tilt_overlay, winner.tilt, merged)
         tilt_clamped = False
         carried_low: int | None = None
         carried_high: int | None = None
@@ -351,11 +439,21 @@ class PipelineRegistry:
                 bounded_tilt = clamp_to_bounds(resolved_tilt, tilt_low, tilt_high)
                 if bounded_tilt != resolved_tilt:
                     tilt_clamped = True
+                    tilt_binding = bounding_constraint(
+                        constraints,
+                        AXIS_NAME_TILT,
+                        bounded_tilt,
+                        low=bounded_tilt > resolved_tilt,
+                    )
                     trace.append(
                         tilt_clamp_step(
                             from_tilt=resolved_tilt,
                             to_tilt=bounded_tilt,
-                            label=tilt_label,
+                            label=(
+                                tilt_binding.label
+                                if tilt_binding is not None
+                                else tilt_label
+                            ),
                             source="tilt_clamp",
                         )
                     )

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -5,12 +5,20 @@ from __future__ import annotations
 import dataclasses
 import datetime as dt
 
-from ..const import ReasonCode
+from ..const import AxisConstraintMode, ReasonCode
+from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
 from ..diagnostics.event_buffer import EventBuffer
 from ..reason_i18n import Reason, render_en
-from .floors import effective_floor, gather_active_floors
+from .axis_constraints import (
+    bound_label,
+    clamp_to_bounds,
+    compose_bounds,
+    constraint_label,
+    gather_axis_constraints,
+    tilt_clamp_step,
+)
 from .handler import OverrideHandler
-from .tilt_axis import resolve_tilt_axis
+from .tilt_axis import resolve_tilt_axis_from
 from .types import DecisionStep, PipelineResult, PipelineSnapshot
 
 
@@ -39,6 +47,48 @@ def _drop_trace_steps(
     so the dedup logic lives in one place (CODING_GUIDELINES § No Duplication).
     """
     return [step for step in trace if step.handler not in sources]
+
+
+def _inactive_position_steps(
+    constraints: list,
+    *,
+    winner_pos: int,
+    bound_pos: int | None,
+    floor_raised: bool,
+) -> list[DecisionStep]:
+    """Explain every position bound that was active but did not bind.
+
+    A constraint whose handler deferred would otherwise be left with an
+    unhelpful ``describe_skip`` step (the registry drops those). Give each
+    non-binding bound a step saying it was evaluated and why it did nothing —
+    the floor/ceiling pair mirror each other exactly.
+
+    ``bound_pos`` is the value that *did* bind this cycle (None when nothing
+    clamped); the bound that produced it is skipped, since it was already
+    emitted as the matched clamp step.
+    """
+    steps: list[DecisionStep] = []
+    for c in constraints:
+        if c.axis != AXIS_NAME_POSITION or c.kind is AxisConstraintMode.FIXED:
+            continue
+        bound_value = c.low if floor_raised else c.high
+        if bound_pos is not None and bound_value == bound_pos:
+            continue  # this bound *did* bind — already emitted as the clamp
+        for value, code, key in (
+            (c.low, ReasonCode.REGISTRY_FLOOR_INACTIVE, "floor_pos"),
+            (c.high, ReasonCode.REGISTRY_CEILING_INACTIVE, "ceiling_pos"),
+        ):
+            if value is None:
+                continue
+            steps.append(
+                DecisionStep(
+                    handler=c.source,
+                    matched=False,
+                    reason_payload=Reason(code, {key: value, "winner_pos": winner_pos}),
+                    position=value,
+                )
+            )
+    return steps
 
 
 class PipelineRegistry:
@@ -158,18 +208,21 @@ class PipelineRegistry:
                             merged[field_name] = val
                             break
 
-        # Floor-mode composition (issue #463).  Custom-position slots,
-        # weather override, and force override in min_mode each contribute
-        # a "floor" — a minimum position that must clamp the winner regardless
-        # of priority.  The handlers themselves defer (return None) in floor
-        # mode; the registry composes the effective floor here so the
-        # arithmetic lives in exactly one place (pipeline/floors.py).
-        active_floors = gather_active_floors(snapshot)
-        floor_pos, floor_info = effective_floor(active_floors)
-        # The position the floor must raise: where the cover will actually end
+        # ── Axis-constraint composition (issues #463 / #514 / #943) ─────────
+        # Custom-position slots and the weather override contribute *constraints*
+        # — per-axis claims that must clamp the winner regardless of priority.
+        # The handlers themselves defer (return None); the registry composes
+        # here so the arithmetic lives in exactly one place
+        # (pipeline/axis_constraints.py). One gather serves both axes; the rules
+        # differ by constraint *kind*, not by axis.
+        constraints = gather_axis_constraints(snapshot)
+
+        # --- Position axis: bounded kinds, always-clamp ---
+        floor_pos, ceiling_pos = compose_bounds(constraints, AXIS_NAME_POSITION)
+        # The position the bounds act on: where the cover will actually end
         # up.  manual_override holds the cover at held_position (its physical
         # position), not winner.position (the theoretical default it shadows),
-        # so the floor must clamp against held_position when present (#534).
+        # so a bound must clamp against held_position when present (#534).
         # Every other handler leaves held_position=None, so this preserves the
         # existing behaviour exactly.
         effective_winner_pos = (
@@ -177,62 +230,62 @@ class PipelineRegistry:
             if winner.held_position is not None
             else winner.position
         )
-        # A floor "raises" when it sits above where the cover will actually end
-        # up (its effective position).  Key on this — NOT on
+        final_pos = clamp_to_bounds(effective_winner_pos, floor_pos, ceiling_pos)
+        # A floor "raises" when it lifts the cover above where it would actually
+        # end up.  Key on the *effective* position — NOT on
         # ``clamped_position != winner.position`` — so the raise still fires on
         # the alignment edge where the floor equals the would-be ``position`` but
         # exceeds the held one (a manual-override hold with position==floor but
-        # held below it must still be lifted; issue #809).
-        floor_raised = floor_info is not None and floor_pos > effective_winner_pos
-        clamped_position = floor_pos if floor_raised else winner.position
-        if floor_raised:
+        # held below it must still be lifted; issue #809).  Because
+        # ``clamp_to_bounds`` applies the floor last, a floor above a ceiling
+        # still reads as a raise — the deliberate conflict rule.
+        floor_raised = final_pos > effective_winner_pos
+        ceiling_lowered = final_pos < effective_winner_pos
+        position_clamped = floor_raised or ceiling_lowered
+        # Unchanged position keeps the winner's own value (today's behaviour:
+        # an inert bound must not overwrite ``position`` with ``held_position``).
+        clamped_position = final_pos if position_clamped else winner.position
+        if position_clamped:
+            code, source = (
+                (ReasonCode.REGISTRY_FLOOR_RAISED, "floor_clamp")
+                if floor_raised
+                else (ReasonCode.REGISTRY_CEILING_LOWERED, "ceiling_clamp")
+            )
             trace.append(
                 DecisionStep(
-                    handler="floor_clamp",
+                    handler=source,
                     matched=True,
                     reason_payload=Reason(
-                        ReasonCode.REGISTRY_FLOOR_RAISED,
+                        code,
                         {
                             "from_pos": effective_winner_pos,
-                            "to_pos": floor_pos,
-                            "label": floor_info.label,
+                            "to_pos": final_pos,
+                            "label": constraint_label(constraints, AXIS_NAME_POSITION),
                         },
                     ),
-                    position=floor_pos,
+                    position=final_pos,
                 )
             )
-        # Replace any existing trace step whose handler matches an active
-        # floor's source — those steps came from the deferral path and
-        # carry an unhelpful describe_skip reason.  We give them a fresh
-        # entry that explains the floor was active but did not win.
-        floor_sources = {info.source for info in active_floors}
-        trace = _drop_trace_steps(trace, floor_sources)
-        for info in active_floors:
-            if floor_raised and info is floor_info:
-                continue  # this floor *did* win — already emitted as floor_clamp
-            trace.append(
-                DecisionStep(
-                    handler=info.source,
-                    matched=False,
-                    reason_payload=Reason(
-                        ReasonCode.REGISTRY_FLOOR_INACTIVE,
-                        {
-                            "floor_pos": info.position,
-                            "winner_pos": effective_winner_pos,
-                        },
-                    ),
-                    position=info.position,
-                )
+        # Replace any existing trace step whose handler matches a constraint's
+        # source — those steps came from the deferral path and carry an
+        # unhelpful describe_skip reason.  We give them a fresh entry that
+        # explains the constraint was active but did not bind.
+        trace = _drop_trace_steps(trace, {c.source for c in constraints})
+        trace.extend(
+            _inactive_position_steps(
+                constraints,
+                winner_pos=effective_winner_pos,
+                bound_pos=final_pos if position_clamped else None,
+                floor_raised=floor_raised,
             )
+        )
 
-        # Tilt-axis overlay (issue #514).  A per-slot "tilt-only" custom
-        # position fixes the slat angle without claiming position — the slot's
-        # handler defers (returns None) and this pass overlays its tilt onto
-        # whichever handler won position.  Fill-when-unset: the overlay only
-        # applies when the winner's own tilt is None, so a position-winner that
-        # already set an explicit tilt keeps it (decision Q1b).  Resolution is
-        # cover-type-agnostic and lives in pipeline/tilt_axis.py.
-        tilt_contribution = resolve_tilt_axis(snapshot)
+        # --- Tilt axis ---
+        # FIXED (tilt-only, issue #514) fills the tilt when the winner left it
+        # unset; the bounded kinds (#943) clamp the tilt once something has set
+        # it. Both rules are the kind's rule, applied here on the tilt axis
+        # exactly as they are on the position axis above.
+        tilt_contribution = resolve_tilt_axis_from(constraints)
         tilt_overlay: int | None = None
         tilt_only_active = False
         # Slot number of the tilt-only contribution that was actually applied —
@@ -282,22 +335,79 @@ class PipelineRegistry:
                     )
                 )
 
+        # Bounded tilt constraints (issue #943). Unlike the FIXED overlay above,
+        # a bound clamps a tilt that is already set — the exact case the
+        # fill-when-unset branch skips. The tilt to clamp is the winner's own,
+        # or the overlay we just filled in.
+        tilt_low, tilt_high = compose_bounds(constraints, AXIS_NAME_TILT)
+        resolved_tilt = winner.tilt if tilt_overlay is None else tilt_overlay
+        tilt_clamped = False
+        carried_low: int | None = None
+        carried_high: int | None = None
+        carried_label: str | None = None
+        if tilt_low is not None or tilt_high is not None:
+            tilt_label = constraint_label(constraints, AXIS_NAME_TILT)
+            if resolved_tilt is not None:
+                bounded_tilt = clamp_to_bounds(resolved_tilt, tilt_low, tilt_high)
+                if bounded_tilt != resolved_tilt:
+                    tilt_clamped = True
+                    trace.append(
+                        tilt_clamp_step(
+                            from_tilt=resolved_tilt,
+                            to_tilt=bounded_tilt,
+                            label=tilt_label,
+                            source="tilt_clamp",
+                        )
+                    )
+                    if tilt_overlay is not None:
+                        tilt_overlay = bounded_tilt
+                    else:
+                        merged["tilt"] = bounded_tilt
+            else:
+                # Nothing has resolved a tilt yet. It still can: the venetian
+                # engine fills tilt after the pipeline, in
+                # ``VenetianPolicy.post_pipeline_resolve``. Carry the bounds so
+                # that policy can apply them through the same shared clamp.
+                carried_low, carried_high = tilt_low, tilt_high
+                carried_label = tilt_label
+                trace.append(
+                    DecisionStep(
+                        handler="tilt_clamp",
+                        matched=False,
+                        reason_payload=Reason(
+                            ReasonCode.REGISTRY_TILT_BOUND_ACTIVE,
+                            {
+                                "low_label": bound_label(tilt_low),
+                                "high_label": bound_label(tilt_high),
+                                "label": tilt_label,
+                            },
+                        ),
+                        position=None,
+                    )
+                )
+
         # Propagate sunset-window flags from the snapshot.
         # NOTE: configured_default and configured_sunset_pos are
         # intentionally left at their defaults (0 / None) here.
         # The coordinator annotates them via dataclasses.replace()
         # after evaluation so they never appear in the snapshot
         # that handlers can read.
-        if floor_raised:
-            # A floor raise must reach the cover even when the winner is a hold
-            # (manual-override / motion): clear skip_command so the composed
+        if position_clamped:
+            # A position clamp must reach the cover even when the winner is a
+            # hold (manual-override / motion): clear skip_command so the composed
             # result is dispatched, not suppressed (issue #809 / #534).
+            # floor_clamp_applied marks the position as already in cover space
+            # so the coordinator skips interpolation (#469) — true of a ceiling
+            # lower for the same reason it is true of a floor raise.
             winner = dataclasses.replace(
                 winner,
                 position=clamped_position,
                 floor_clamp_applied=True,
                 skip_command=False,
             )
+        if tilt_clamped:
+            # Same rule on the tilt axis: a clamp is a command, not a no-op.
+            winner = dataclasses.replace(winner, skip_command=False)
         # The dedicated tilt-axis overlay (issue #514) wins the tilt field over
         # the generic _MERGEABLE tilt fill — both only fire when the winner's
         # own tilt is None, but a tilt-only contribution is explicit user intent.
@@ -310,6 +420,9 @@ class PipelineRegistry:
             is_sunset_active=snapshot.is_sunset_active,
             tilt_only_contribution_active=tilt_only_active,
             tilt_only_slot=tilt_only_slot_applied,
+            tilt_low=carried_low,
+            tilt_high=carried_high,
+            tilt_bound_label=carried_label,
             **merged,
         )
         if self._event_buffer is not None:

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -57,12 +57,29 @@ def _drop_trace_steps(
     return [step for step in trace if step.matched or step.handler not in sources]
 
 
+def _iter_nonbinding_bounds(constraints: list, axis: str, binding):
+    """Yield the active bounded constraints on ``axis`` that did not bind.
+
+    Shared by the position and tilt inactive-step passes so the axis filter,
+    the FIXED skip, and the ``binding``-by-identity skip live in one place
+    (CODING_GUIDELINES § No Duplication). Skipping by *identity* rather than by
+    value keeps a losing tie-bound visible — two slots at the same floor no
+    longer collapse into one trace entry (audit finding 4b).
+    """
+    for c in constraints:
+        if c.axis != axis or c.kind is AxisConstraintMode.FIXED:
+            continue
+        if c is binding:
+            continue  # this bound *did* bind — already emitted as the clamp
+        yield c
+
+
 def _inactive_position_steps(
     constraints: list,
     *,
     winner_pos: int,
     final_pos: int,
-    floor_raised: bool,
+    floor_wins: bool,
     binding,
 ) -> list[DecisionStep]:
     """Explain every position bound that was active but did not bind.
@@ -73,20 +90,15 @@ def _inactive_position_steps(
 
     ``binding`` is the single constraint that produced this cycle's clamp (None
     when nothing clamped); it is skipped, since it was already emitted as the
-    matched clamp step. Skipping by *identity* rather than by value keeps a
-    losing tie-floor visible — two slots at the same floor no longer collapse
-    into one trace entry (audit finding 4b).
+    matched clamp step.
 
     A ceiling the floor beat is reported as *overridden*, not *inactive*: when
-    ``floor_raised`` lifted the cover above a ceiling, that ceiling did not sit
-    idle — it was outranked, and the honest wording says so (audit finding 7).
+    the floor won the conflict (``floor_wins``) it sits above that ceiling, so
+    the ceiling was outranked, not idle — the honest wording says so (audit
+    findings 7 / C).
     """
     steps: list[DecisionStep] = []
-    for c in constraints:
-        if c.axis != AXIS_NAME_POSITION or c.kind is AxisConstraintMode.FIXED:
-            continue
-        if c is binding:
-            continue  # this bound *did* bind — already emitted as the clamp
+    for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_POSITION, binding):
         if c.low is not None:
             steps.append(
                 DecisionStep(
@@ -100,7 +112,7 @@ def _inactive_position_steps(
                 )
             )
         if c.high is not None:
-            if floor_raised and c.high < final_pos:
+            if floor_wins and c.high < final_pos:
                 code, params = (
                     ReasonCode.REGISTRY_CEILING_OVERRIDDEN,
                     {"ceiling_pos": c.high, "to_pos": final_pos},
@@ -118,6 +130,40 @@ def _inactive_position_steps(
                     position=c.high,
                 )
             )
+    return steps
+
+
+def _inactive_tilt_steps(
+    constraints: list, *, resolved_tilt: int, binding
+) -> list[DecisionStep]:
+    """Explain every tilt bound that was active but did not bind.
+
+    The tilt-axis analog of :func:`_inactive_position_steps`: a tilt bound that
+    the resolved tilt already satisfied, or one out-composed by a stricter
+    bound, would otherwise be dropped with the deferral sweep and vanish from
+    the trace (audit findings A / B). ``binding`` is the one bound that actually
+    clamped (None when the tilt was already within every bound); it is skipped
+    by identity, exactly as the position pass skips its binding constraint.
+    """
+    steps: list[DecisionStep] = []
+    for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_TILT, binding):
+        steps.append(
+            DecisionStep(
+                handler=c.source,
+                matched=False,
+                reason_payload=Reason(
+                    ReasonCode.REGISTRY_TILT_BOUND_INACTIVE,
+                    {
+                        "low_label": bound_label(c.low),
+                        "high_label": bound_label(c.high),
+                        "label": c.label,
+                        "tilt": resolved_tilt,
+                    },
+                ),
+                position=None,
+                tilt=None,
+            )
+        )
     return steps
 
 
@@ -290,9 +336,22 @@ class PipelineRegistry:
         # held below it must still be lifted; issue #809).  Because
         # ``clamp_to_bounds`` applies the floor last, a floor above a ceiling
         # still reads as a raise — the deliberate conflict rule.
-        floor_raised = final_pos > effective_winner_pos
-        ceiling_lowered = final_pos < effective_winner_pos
-        position_clamped = floor_raised or ceiling_lowered
+        raised = final_pos > effective_winner_pos
+        lowered = final_pos < effective_winner_pos
+        position_clamped = raised or lowered
+        # In a floor/ceiling conflict ``clamp_to_bounds`` applies the floor last,
+        # so the floor always determines the final value (== floor_pos) no matter
+        # where the winner started. Detect the conflict explicitly rather than
+        # inferring the direction from ``final`` vs ``effective``: when the winner
+        # sat *above* the floor the net move is a lowering, yet the floor — not
+        # the ceiling — is what bound (audit finding C). Outside a conflict,
+        # ``floor_wins`` collapses to the old ``floor_raised`` predicate.
+        floor_conflict = (
+            floor_pos is not None
+            and ceiling_pos is not None
+            and floor_pos > ceiling_pos
+        )
+        floor_wins = floor_conflict or raised
         # Unchanged position keeps the winner's own value (today's behaviour:
         # an inert bound must not overwrite ``position`` with ``held_position``).
         clamped_position = final_pos if position_clamped else winner.position
@@ -301,34 +360,39 @@ class PipelineRegistry:
         # move, not the join of every active bound (audit finding 4a).
         position_binding = (
             bounding_constraint(
-                constraints, AXIS_NAME_POSITION, final_pos, low=floor_raised
+                constraints, AXIS_NAME_POSITION, final_pos, low=floor_wins
             )
             if position_clamped
             else None
         )
         if position_clamped:
-            code, source = (
-                (ReasonCode.REGISTRY_FLOOR_RAISED, "floor_clamp")
-                if floor_raised
-                else (ReasonCode.REGISTRY_CEILING_LOWERED, "ceiling_clamp")
-            )
+            source = "floor_clamp" if floor_wins else "ceiling_clamp"
             label = (
                 position_binding.label
                 if position_binding is not None
                 else constraint_label(constraints, AXIS_NAME_POSITION)
             )
+            params = {
+                "from_pos": effective_winner_pos,
+                "to_pos": final_pos,
+                "label": label,
+            }
+            if not floor_wins:
+                code = ReasonCode.REGISTRY_CEILING_LOWERED
+            elif raised:
+                code = ReasonCode.REGISTRY_FLOOR_RAISED
+            else:
+                # The floor won a conflict but the winner started above it: the
+                # net move is a lowering, so "floor raised from 80% to 60%" would
+                # contradict itself. A floor-wins step names the floor as the
+                # determining bound without implying a direction (finding C).
+                code = ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING
+                params["ceiling_pos"] = ceiling_pos
             trace.append(
                 DecisionStep(
                     handler=source,
                     matched=True,
-                    reason_payload=Reason(
-                        code,
-                        {
-                            "from_pos": effective_winner_pos,
-                            "to_pos": final_pos,
-                            "label": label,
-                        },
-                    ),
+                    reason_payload=Reason(code, params),
                     position=final_pos,
                 )
             )
@@ -346,7 +410,7 @@ class PipelineRegistry:
                 constraints,
                 winner_pos=effective_winner_pos,
                 final_pos=final_pos,
-                floor_raised=floor_raised,
+                floor_wins=floor_wins,
                 binding=position_binding,
             )
         )
@@ -437,6 +501,7 @@ class PipelineRegistry:
             tilt_label = constraint_label(constraints, AXIS_NAME_TILT)
             if resolved_tilt is not None:
                 bounded_tilt = clamp_to_bounds(resolved_tilt, tilt_low, tilt_high)
+                tilt_binding = None
                 if bounded_tilt != resolved_tilt:
                     tilt_clamped = True
                     tilt_binding = bounding_constraint(
@@ -461,6 +526,19 @@ class PipelineRegistry:
                         tilt_overlay = bounded_tilt
                     else:
                         merged["tilt"] = bounded_tilt
+                # Every active tilt bound that did not bind still explains itself
+                # — the tilt-axis analog of the position inactive steps. Covers a
+                # bound the resolved tilt already satisfied (nothing clamped) and
+                # one out-composed by a stricter bound; ``tilt_binding`` (the one
+                # that did clamp, or None) is skipped by identity so it is not
+                # both clamped and inactive (audit findings A / B).
+                trace.extend(
+                    _inactive_tilt_steps(
+                        constraints,
+                        resolved_tilt=resolved_tilt,
+                        binding=tilt_binding,
+                    )
+                )
             else:
                 # Nothing has resolved a tilt yet. It still can: the venetian
                 # engine fills tilt after the pipeline, in

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -96,6 +96,14 @@ def _inactive_position_steps(
     the floor won the conflict (``floor_wins``) it sits above that ceiling, so
     the ceiling was outranked, not idle — the honest wording says so (audit
     findings 7 / C).
+
+    An inactive ceiling reports the *resolved* position, not the winner's: a
+    ceiling out-composed by a lower one sits above the winner (winner 80,
+    ceilings 40 + 70 → resolved 40), so 'winner 80% below ceiling 70%' is a
+    lie. The resolved position is always at or below every non-binding ceiling
+    (it is at or below the lowest, binding one), so it reads truthfully in both
+    the out-composed case and the classic winner-already-below case where the
+    resolved position equals the winner's (audit finding ii).
     """
     steps: list[DecisionStep] = []
     for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_POSITION, binding):
@@ -120,7 +128,7 @@ def _inactive_position_steps(
             else:
                 code, params = (
                     ReasonCode.REGISTRY_CEILING_INACTIVE,
-                    {"ceiling_pos": c.high, "winner_pos": winner_pos},
+                    {"ceiling_pos": c.high, "to_pos": final_pos},
                 )
             steps.append(
                 DecisionStep(
@@ -134,7 +142,7 @@ def _inactive_position_steps(
 
 
 def _inactive_tilt_steps(
-    constraints: list, *, resolved_tilt: int, binding
+    constraints: list, *, final_tilt: int, binding
 ) -> list[DecisionStep]:
     """Explain every tilt bound that was active but did not bind.
 
@@ -144,6 +152,12 @@ def _inactive_tilt_steps(
     the trace (audit findings A / B). ``binding`` is the one bound that actually
     clamped (None when the tilt was already within every bound); it is skipped
     by identity, exactly as the position pass skips its binding constraint.
+
+    ``final_tilt`` is the tilt *after* the axis clamp (equal to the pre-clamp
+    tilt when nothing clamped). A stricter same-direction bound may have moved
+    the tilt, so an out-composed bound must report the value the cover actually
+    settled on — reporting the pre-clamp tilt renders a false 'already within'
+    claim when the tilt was really clamped elsewhere (audit finding i).
     """
     steps: list[DecisionStep] = []
     for c in _iter_nonbinding_bounds(constraints, AXIS_NAME_TILT, binding):
@@ -157,7 +171,7 @@ def _inactive_tilt_steps(
                         "low_label": bound_label(c.low),
                         "high_label": bound_label(c.high),
                         "label": c.label,
-                        "tilt": resolved_tilt,
+                        "tilt": final_tilt,
                     },
                 ),
                 position=None,
@@ -535,7 +549,7 @@ class PipelineRegistry:
                 trace.extend(
                     _inactive_tilt_steps(
                         constraints,
-                        resolved_tilt=resolved_tilt,
+                        final_tilt=bounded_tilt,
                         binding=tilt_binding,
                     )
                 )

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -142,6 +142,18 @@ def _delta_time_minutes(value: object) -> int:
     return int(value)
 
 
+def _opt_int(options: dict, key: str) -> int | None:
+    """Read an optional numeric option as ``int``, or ``None`` when absent.
+
+    Absent means "the constraint is off" (issue #943) — there is deliberately
+    no ``DEFAULT_*`` for the axis-constraint keys, so a missing key and an
+    explicitly cleared one both read as None. ``0`` is a meaningful value and
+    must survive, so this tests ``is None`` rather than truthiness.
+    """
+    raw = options.get(key)
+    return int(raw) if raw is not None else None
+
+
 class PipelineSnapshotBuilder:
     """Aggregate HA reads + manager state into a :class:`PipelineSnapshot`."""
 
@@ -327,11 +339,33 @@ class PipelineSnapshotBuilder:
             if tilt_only:
                 min_mode = False
                 use_my = False
+
+            # --- Axis constraints (issue #943) --------------------------------
+            # A constraint-only slot (e.g. trigger → minimum tilt) carries no
+            # position; None means "makes no position claim", distinct from 0.
+            position = _opt_int(options, slot_keys["position"])
+            position_max = _opt_int(options, slot_keys["position_max"])
+            tilt_min = _opt_int(options, slot_keys["tilt_min"])
+            tilt_max = _opt_int(options, slot_keys["tilt_max"])
+            # Same mutual-exclusion pass as min_mode / use_my above: tilt_only
+            # fixes the slat angle and lets the position pipeline drive the
+            # carriage, so the slot carries no bounds on either axis. The My
+            # path is hardware-pinned — a position ceiling cannot apply to it.
+            # Normalizing the stored values here (rather than only deriving
+            # around them) keeps what diagnostics surface honest about what is
+            # actually in effect.
+            if tilt_only:
+                position_max = None
+                tilt_min = None
+                tilt_max = None
+            elif use_my:
+                position_max = None
+
             result.append(
                 CustomPositionSensorState(
                     entity_ids=tuple(sensors),
                     is_on=is_on,
-                    position=int(options.get(slot_keys["position"])),
+                    position=position,
                     priority=priority,
                     min_mode=min_mode,
                     use_my=use_my,
@@ -342,6 +376,9 @@ class PipelineSnapshotBuilder:
                     active_entity_ids=active,
                     template_active=template_active,
                     custom_name=custom_name,
+                    position_max=position_max,
+                    tilt_min=tilt_min,
+                    tilt_max=tilt_max,
                 )
             )
         return result

--- a/custom_components/adaptive_cover_pro/pipeline/tilt_axis.py
+++ b/custom_components/adaptive_cover_pro/pipeline/tilt_axis.py
@@ -5,13 +5,18 @@ A per-slot *tilt-only* custom-position contribution fixes the slat angle
 position pipeline — drives the carriage, while the active tilt-only slot
 overlays its configured slat angle onto the winner.
 
-This mirrors :mod:`pipeline.floors`: pure helpers that read a
-:class:`PipelineSnapshot` and return plain data. The registry composes the
-winning tilt-only contribution after picking a position winner; the overlay
-fills the winner's tilt only when it is unset (fill-when-unset, decision Q1b)
-so a position-winner that already set an explicit tilt keeps it.
+**This module is now an adapter.** Issue #943 folded the tilt-axis pass into
+the unified model in :mod:`pipeline.axis_constraints`: a tilt-only slot is a
+tilt-axis constraint of ``kind=FIXED``, and "highest priority wins" is the
+resolution rule that kind has always used. The functions here delegate and
+re-shape the result into ``TiltAxisContribution``.
 
-The pass is cover-type-agnostic — it reads ``state.tilt_only`` and never asks
+The overlay stays fill-when-unset (decision Q1b) — a position-winner that
+already set an explicit tilt keeps it. That application rule lives in the
+registry; the *bounded* tilt constraints #943 added (tilt min/max) deliberately
+clamp-when-set instead, which is why kind, not axis, is what selects the rule.
+
+The pass is cover-type-agnostic — it reads ``state.tilt_mode`` and never asks
 "is this venetian". The venetian-specific behaviour (suppressing the global
 tilt-only carriage-close) lives in ``VenetianPolicy.post_pipeline_resolve``,
 gated on ``PipelineResult.tilt_only_contribution_active``.
@@ -19,15 +24,21 @@ gated on ``PipelineResult.tilt_only_contribution_active``.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
-from ..const import custom_position_handler_name
+from ..const import AxisConstraintMode
+from ..cover_types.base import AXIS_NAME_TILT
+from .axis_constraints import AxisConstraint, gather_axis_constraints, resolve_fixed
 from .types import PipelineSnapshot
 
 
 @dataclass(frozen=True, slots=True)
 class TiltAxisContribution:
     """One active tilt-only contribution selected by the tilt-axis pass.
+
+    A tilt-axis view of a ``FIXED``
+    :class:`~pipeline.axis_constraints.AxisConstraint`.
 
     Attributes:
         source: Stable identifier used as the ``handler`` field in the
@@ -46,28 +57,52 @@ class TiltAxisContribution:
     slot: int
 
 
+def _as_contribution(constraint: AxisConstraint) -> TiltAxisContribution:
+    """Project a FIXED tilt constraint onto the contribution shape."""
+    assert constraint.value is not None  # noqa: S101 — FIXED always carries a value
+    return TiltAxisContribution(
+        source=constraint.source,
+        label=constraint.label,
+        tilt=constraint.value,
+        slot=constraint.slot,
+    )
+
+
+def _fixed_tilt_constraints(snapshot: PipelineSnapshot) -> list[AxisConstraint]:
+    """Every active FIXED tilt claim in the snapshot, in snapshot order."""
+    return [
+        c
+        for c in gather_axis_constraints(snapshot)
+        if c.axis == AXIS_NAME_TILT and c.kind is AxisConstraintMode.FIXED
+    ]
+
+
 def gather_tilt_only_contributions(
     snapshot: PipelineSnapshot,
 ) -> list[TiltAxisContribution]:
     """Collect every active tilt-only contribution from the snapshot.
 
-    A contribution is active when its sensor is ``is_on``, ``tilt_only`` is
-    True, and the slot has a configured ``tilt`` value (a tilt-only slot with
-    no tilt contributes nothing). Slots are returned in their snapshot order,
-    matching ``_build_pipeline`` registration order.
+    A contribution is active when its sensor is ``is_on``, the slot's derived
+    ``tilt_mode`` is ``FIXED`` (``tilt_only`` in the stored config), and the
+    slot has a configured ``tilt`` value — a tilt-only slot with no tilt
+    contributes nothing. Slots are returned in their snapshot order, matching
+    ``_build_pipeline`` registration order.
     """
-    contributions: list[TiltAxisContribution] = []
-    for state in snapshot.custom_position_sensors:
-        if state.is_on and state.tilt_only and state.tilt is not None:
-            contributions.append(
-                TiltAxisContribution(
-                    source=custom_position_handler_name(state.slot),
-                    label=state.display_label,
-                    tilt=state.tilt,
-                    slot=state.slot,
-                )
-            )
-    return contributions
+    return [_as_contribution(c) for c in _fixed_tilt_constraints(snapshot)]
+
+
+def resolve_tilt_axis_from(
+    constraints: Iterable[AxisConstraint],
+) -> TiltAxisContribution | None:
+    """Resolve the tilt-only winner from already-gathered *constraints*.
+
+    The registry gathers once and composes both axes from that one list, so it
+    calls this rather than :func:`resolve_tilt_axis` — re-walking the snapshot
+    to rediscover the same constraints would be a second source of truth for
+    which slots are active.
+    """
+    winner = resolve_fixed(constraints, AXIS_NAME_TILT)
+    return None if winner is None else _as_contribution(winner)
 
 
 def resolve_tilt_axis(snapshot: PipelineSnapshot) -> TiltAxisContribution | None:
@@ -78,17 +113,4 @@ def resolve_tilt_axis(snapshot: PipelineSnapshot) -> TiltAxisContribution | None
     active, the highest priority wins; ties resolve to the first in snapshot
     order. Returns ``None`` when no tilt-only slot is active.
     """
-    winner_state = None
-    for state in snapshot.custom_position_sensors:
-        if not (state.is_on and state.tilt_only and state.tilt is not None):
-            continue
-        if winner_state is None or state.priority > winner_state.priority:
-            winner_state = state
-    if winner_state is None:
-        return None
-    return TiltAxisContribution(
-        source=custom_position_handler_name(winner_state.slot),
-        label=winner_state.display_label,
-        tilt=winner_state.tilt,
-        slot=winner_state.slot,
-    )
+    return resolve_tilt_axis_from(gather_axis_constraints(snapshot))

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -92,26 +92,34 @@ def derive_axis_mode(
 ) -> AxisConstraintMode:
     """Resolve one axis's :class:`AxisConstraintMode` from its raw claims.
 
-    Bounds outrank an exact value: a slot that names a floor (``min_mode``)
-    reads as ``MIN``, not ``FIXED``, even though it also stores a position —
-    that position *is* the floor. This is the derived replacement for the
-    hand-rolled boolean precedence the flag model was straining under (three
-    booleans already needed hand-written mutual exclusion), and it reproduces
-    today's outcomes exactly for every pre-#943 config, which can only ever
-    yield ``FIXED`` / ``MIN`` / ``NONE``.
+    Precedence, most to least specific:
 
-    The single source of the precedence, for both axes. Callers pass the claims
-    already normalized for cross-axis conflicts (see
+    * a floor (``low``) present: it *pairs* with a ceiling into ``RANGE``, else
+      it is a ``MIN``. A floor always wins over a bare exact value because a
+      slot that names a floor (``min_mode``) stores its position *as* the floor.
+    * an exact value (``fixed``): ``FIXED``. This **outranks a lone ceiling** —
+      a slot with an explicit position keeps its fixed claim, and a
+      ``position_max`` is honored only alongside ``min_mode`` (as the ceiling of
+      a ``RANGE``). This mirrors the tilt axis, where a FIXED (``tilt_only``)
+      claim has always won over the bounds on the same axis, and keeps the
+      config summary's ``→ 70%`` honest instead of quietly capping it (audit
+      finding 5).
+    * a lone ceiling (``high``): ``MAX``.
+    * nothing: ``NONE``.
+
+    Every pre-#943 config yields ``FIXED`` / ``MIN`` / ``NONE`` only, so their
+    outcomes are unchanged. The single source of the precedence, for both axes;
+    callers pass the claims already normalized for cross-axis conflicts (see
     :attr:`CustomPositionSensorState.position_mode`).
     """
     if low is not None and high is not None:
         return AxisConstraintMode.RANGE
     if low is not None:
         return AxisConstraintMode.MIN
-    if high is not None:
-        return AxisConstraintMode.MAX
     if fixed is not None:
         return AxisConstraintMode.FIXED
+    if high is not None:
+        return AxisConstraintMode.MAX
     return AxisConstraintMode.NONE
 
 

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 from ..const import (
     DEFAULT_TRACKING_SEASONS,
+    AxisConstraintMode,
     ClimateStrategy,
     ControlMethod,
     GroupIntentKind,
@@ -86,6 +87,34 @@ class ClimateTempFlags:
     extreme_heat: bool
 
 
+def derive_axis_mode(
+    *, fixed: int | None, low: int | None, high: int | None
+) -> AxisConstraintMode:
+    """Resolve one axis's :class:`AxisConstraintMode` from its raw claims.
+
+    Bounds outrank an exact value: a slot that names a floor (``min_mode``)
+    reads as ``MIN``, not ``FIXED``, even though it also stores a position —
+    that position *is* the floor. This is the derived replacement for the
+    hand-rolled boolean precedence the flag model was straining under (three
+    booleans already needed hand-written mutual exclusion), and it reproduces
+    today's outcomes exactly for every pre-#943 config, which can only ever
+    yield ``FIXED`` / ``MIN`` / ``NONE``.
+
+    The single source of the precedence, for both axes. Callers pass the claims
+    already normalized for cross-axis conflicts (see
+    :attr:`CustomPositionSensorState.position_mode`).
+    """
+    if low is not None and high is not None:
+        return AxisConstraintMode.RANGE
+    if low is not None:
+        return AxisConstraintMode.MIN
+    if high is not None:
+        return AxisConstraintMode.MAX
+    if fixed is not None:
+        return AxisConstraintMode.FIXED
+    return AxisConstraintMode.NONE
+
+
 @dataclass(frozen=True, slots=True)
 class CustomPositionSensorState:
     """Per-slot trigger reading carried in the pipeline snapshot.
@@ -101,7 +130,11 @@ class CustomPositionSensorState:
     # Slot activation: OR across the sensors, folded with the optional
     # condition template via templates.combine_with_mode() at snapshot time.
     is_on: bool
-    position: int
+    # The slot's position claim, in pre-inversion canonical space. ``None`` =
+    # the slot makes no position claim — a constraint-only slot (e.g. trigger →
+    # minimum tilt) added by issue #943. 0 is a valid position (fully closed),
+    # so consumers must test ``is None``, never truthiness.
+    position: int | None
     priority: int
     min_mode: bool
     use_my: bool
@@ -133,6 +166,57 @@ class CustomPositionSensorState:
     # snapshot). None = no name configured (default; byte-identical to
     # pre-#867 behavior).
     custom_name: str | None = None
+
+    # --- Axis constraints (issue #943) -------------------------------------
+    # Optional per-axis bounds that clamp whatever the pipeline resolves while
+    # this slot's trigger is active. None = the bound is off. Values are in the
+    # same pre-inversion canonical space as ``position`` / ``tilt``.
+    #
+    # ``position_max`` is normalized off on the ``use_my`` path (hardware-pinned)
+    # and by ``tilt_only``; ``tilt_min`` / ``tilt_max`` are normalized off by
+    # ``tilt_only`` (a FIXED tilt claim wins over bounds on the same axis).
+    position_max: int | None = None
+    tilt_min: int | None = None
+    tilt_max: int | None = None
+
+    @property
+    def position_mode(self) -> AxisConstraintMode:
+        """This slot's derived claim on the position axis (issue #943).
+
+        A *property*, not a stored field: the mode is a pure function of the
+        wire format (``min_mode`` / ``tilt_only`` + the numeric keys), and the
+        wire format is what rollback safety pins. Deriving here rather than in
+        the snapshot builder means every construction path — the builder, the
+        card, and every test that builds a state by hand — agrees, with no way
+        for a stored copy to drift from the flags it was derived from.
+
+        ``tilt_only`` wins the whole slot: it fixes the slat angle and lets the
+        position pipeline drive the carriage, so it claims nothing here.
+        """
+        if self.tilt_only:
+            return AxisConstraintMode.NONE
+        return derive_axis_mode(
+            fixed=None if self.min_mode else self.position,
+            low=self.position if self.min_mode else None,
+            high=self.position_max,
+        )
+
+    @property
+    def tilt_mode(self) -> AxisConstraintMode:
+        """This slot's derived claim on the tilt axis (issue #943).
+
+        ``tilt_only`` is an exact (``FIXED``) tilt claim and wins over the
+        bounds — mirroring the precedence it already has over ``min_mode`` /
+        ``use_my``. A tilt-only slot with no configured slat angle claims
+        nothing (pre-#943 behavior, preserved).
+        """
+        if self.tilt_only:
+            return (
+                AxisConstraintMode.FIXED
+                if self.tilt is not None
+                else AxisConstraintMode.NONE
+            )
+        return derive_axis_mode(fixed=None, low=self.tilt_min, high=self.tilt_max)
 
     @property
     def slot_name(self) -> str | None:
@@ -427,11 +511,25 @@ class PipelineResult:
     # behavior (issue #563).
     is_safety: bool = False
 
-    # When True, the registry's floor-clamp composition pass raised this
-    # winner's position to a user-configured floor. The coordinator's `state`
-    # property treats the position as already in cover-position space and
-    # skips interpolation / inverse-state remapping (issue #469).
+    # When True, the registry's axis-constraint composition pass clamped this
+    # winner's position to a user-configured bound — a floor raise (issue #463)
+    # or, since issue #943, a ceiling lower. The coordinator's `state` property
+    # treats the position as already in cover-position space and skips
+    # interpolation / inverse-state remapping (issue #469); that holds for
+    # either bound, since both are values the user typed in cover space.
     floor_clamp_applied: bool = False
+
+    # Composed tilt bounds that could not be applied during evaluation because
+    # the winner had no tilt to clamp yet (issue #943). Tilt can resolve *after*
+    # the pipeline — the venetian engine fills it in ``post_pipeline_resolve`` —
+    # so the bounds ride the result and that policy applies them via the shared
+    # ``axis_constraints.clamp_to_bounds``. None = unbounded on that side. When
+    # the registry could clamp the tilt itself, it already did and these stay
+    # None. ``tilt_bound_label`` names the slot(s) the bounds came from so the
+    # deferred clamp's trace step reads the same as an in-registry one.
+    tilt_low: int | None = None
+    tilt_high: int | None = None
+    tilt_bound_label: str | None = None
 
     # When True, the registry's tilt-axis pass overlaid a per-slot tilt-only
     # contribution onto this winner (issue #514). VenetianPolicy reads this in

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -149,9 +149,17 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
     ReasonCode.REGISTRY_CEILING_OVERRIDDEN: (
         "ceiling {ceiling_pos}% overridden — a floor raised the cover to {to_pos}%"
     ),
+    ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING: (
+        "floor raised to {to_pos}% over ceiling {ceiling_pos}% by {label} "
+        "(winner was {from_pos}%)"
+    ),
     ReasonCode.REGISTRY_TILT_BOUND_ACTIVE: (
         "tilt bound {low_label}–{high_label} active by {label}; "
         "awaiting the resolved tilt"
+    ),
+    ReasonCode.REGISTRY_TILT_BOUND_INACTIVE: (
+        "tilt bound {low_label}–{high_label} inactive by {label}; "
+        "resolved tilt {tilt}% already within"
     ),
     ReasonCode.REGISTRY_TILT_CLAMPED: (
         "tilt clamped from {from_tilt}% to {to_tilt}% by {label}"

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -146,6 +146,9 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
     ReasonCode.REGISTRY_CEILING_INACTIVE: (
         "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)"
     ),
+    ReasonCode.REGISTRY_CEILING_OVERRIDDEN: (
+        "ceiling {ceiling_pos}% overridden — a floor raised the cover to {to_pos}%"
+    ),
     ReasonCode.REGISTRY_TILT_BOUND_ACTIVE: (
         "tilt bound {low_label}–{high_label} active by {label}; "
         "awaiting the resolved tilt"

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -140,6 +140,19 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
     ReasonCode.REGISTRY_TILT_DEFERRED: (
         "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
     ),
+    ReasonCode.REGISTRY_CEILING_LOWERED: (
+        "ceiling lowered winner from {from_pos}% to {to_pos}% by {label}"
+    ),
+    ReasonCode.REGISTRY_CEILING_INACTIVE: (
+        "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)"
+    ),
+    ReasonCode.REGISTRY_TILT_BOUND_ACTIVE: (
+        "tilt bound {low_label}–{high_label} active by {label}; "
+        "awaiting the resolved tilt"
+    ),
+    ReasonCode.REGISTRY_TILT_CLAMPED: (
+        "tilt clamped from {from_tilt}% to {to_tilt}% by {label}"
+    ),
     # -- diagnostics builder
     ReasonCode.BUILDER_UNKNOWN: "Unknown",
     ReasonCode.BUILDER_CONTROL_OCCUPANCY_TIMEOUT: "Occupancy Timeout",

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -144,7 +144,7 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
         "ceiling lowered winner from {from_pos}% to {to_pos}% by {label}"
     ),
     ReasonCode.REGISTRY_CEILING_INACTIVE: (
-        "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)"
+        "ceiling {ceiling_pos}% inactive (resolved {to_pos}% at or below ceiling)"
     ),
     ReasonCode.REGISTRY_CEILING_OVERRIDDEN: (
         "ceiling {ceiling_pos}% overridden — a floor raised the cover to {to_pos}%"

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -68,7 +68,9 @@
     "ceiling_lowered": "Obergrenze abgesenkter Gewinner von {from_pos}% zu {to_pos}% durch {label}",
     "ceiling_inactive": "Obergrenze {ceiling_pos}% inaktiv (Gewinner {winner_pos}% unter Obergrenze)",
     "ceiling_overridden": "Obergrenze {ceiling_pos}% überschrieben — eine Untergrenze hat die Abdeckung auf {to_pos}% angehoben",
+    "floor_overrides_ceiling": "Untergrenze auf {to_pos}% angehoben über Obergrenze {ceiling_pos}% durch {label} (Gewinner war {from_pos}%)",
     "tilt_bound_active": "Neigungsgrenze {low_label}–{high_label} aktiv durch {label}; wartet auf die aufgelöste Neigung",
+    "tilt_bound_inactive": "Neigungsgrenze {low_label}–{high_label} inaktiv durch {label}; aufgelöste Neigung {tilt}% bereits innerhalb",
     "tilt_clamped": "Neigung begrenzt von {from_tilt}% auf {to_tilt}% durch {label}"
   },
   "builder": {

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -66,7 +66,7 @@
     "tilt_applied": "nur Neigung: Lamellen-Winkel fest bei {tilt}% durch {label}; Position gesteuert durch {handler}",
     "tilt_deferred": "nur Neigung {tilt}% verschoben — {handler} hat bereits Neigung {winner_tilt}% gesetzt",
     "ceiling_lowered": "Obergrenze abgesenkter Gewinner von {from_pos}% zu {to_pos}% durch {label}",
-    "ceiling_inactive": "Obergrenze {ceiling_pos}% inaktiv (Gewinner {winner_pos}% unter Obergrenze)",
+    "ceiling_inactive": "Obergrenze {ceiling_pos}% inaktiv (Endposition {to_pos}% auf oder unter Obergrenze)",
     "ceiling_overridden": "Obergrenze {ceiling_pos}% überschrieben — eine Untergrenze hat die Abdeckung auf {to_pos}% angehoben",
     "floor_overrides_ceiling": "Untergrenze auf {to_pos}% angehoben über Obergrenze {ceiling_pos}% durch {label} (Gewinner war {from_pos}%)",
     "tilt_bound_active": "Neigungsgrenze {low_label}–{high_label} aktiv durch {label}; wartet auf die aufgelöste Neigung",

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -67,6 +67,7 @@
     "tilt_deferred": "nur Neigung {tilt}% verschoben — {handler} hat bereits Neigung {winner_tilt}% gesetzt",
     "ceiling_lowered": "Obergrenze abgesenkter Gewinner von {from_pos}% zu {to_pos}% durch {label}",
     "ceiling_inactive": "Obergrenze {ceiling_pos}% inaktiv (Gewinner {winner_pos}% unter Obergrenze)",
+    "ceiling_overridden": "Obergrenze {ceiling_pos}% überschrieben — eine Untergrenze hat die Abdeckung auf {to_pos}% angehoben",
     "tilt_bound_active": "Neigungsgrenze {low_label}–{high_label} aktiv durch {label}; wartet auf die aufgelöste Neigung",
     "tilt_clamped": "Neigung begrenzt von {from_tilt}% auf {to_tilt}% durch {label}"
   },

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -64,7 +64,11 @@
     "floor_raised": "Untergrenze angehobener Gewinner von {from_pos}% zu {to_pos}% durch {label}",
     "floor_inactive": "Untergrenze {floor_pos}% inaktiv (Gewinner {winner_pos}% über Untergrenze)",
     "tilt_applied": "nur Neigung: Lamellen-Winkel fest bei {tilt}% durch {label}; Position gesteuert durch {handler}",
-    "tilt_deferred": "nur Neigung {tilt}% verschoben — {handler} hat bereits Neigung {winner_tilt}% gesetzt"
+    "tilt_deferred": "nur Neigung {tilt}% verschoben — {handler} hat bereits Neigung {winner_tilt}% gesetzt",
+    "ceiling_lowered": "Obergrenze abgesenkter Gewinner von {from_pos}% zu {to_pos}% durch {label}",
+    "ceiling_inactive": "Obergrenze {ceiling_pos}% inaktiv (Gewinner {winner_pos}% unter Obergrenze)",
+    "tilt_bound_active": "Neigungsgrenze {low_label}–{high_label} aktiv durch {label}; wartet auf die aufgelöste Neigung",
+    "tilt_clamped": "Neigung begrenzt von {from_tilt}% auf {to_tilt}% durch {label}"
   },
   "builder": {
     "unknown": "Unbekannt",

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -67,6 +67,7 @@
     "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%",
     "ceiling_lowered": "ceiling lowered winner from {from_pos}% to {to_pos}% by {label}",
     "ceiling_inactive": "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)",
+    "ceiling_overridden": "ceiling {ceiling_pos}% overridden — a floor raised the cover to {to_pos}%",
     "tilt_bound_active": "tilt bound {low_label}–{high_label} active by {label}; awaiting the resolved tilt",
     "tilt_clamped": "tilt clamped from {from_tilt}% to {to_tilt}% by {label}"
   },

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -66,7 +66,7 @@
     "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
     "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%",
     "ceiling_lowered": "ceiling lowered winner from {from_pos}% to {to_pos}% by {label}",
-    "ceiling_inactive": "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)",
+    "ceiling_inactive": "ceiling {ceiling_pos}% inactive (resolved {to_pos}% at or below ceiling)",
     "ceiling_overridden": "ceiling {ceiling_pos}% overridden — a floor raised the cover to {to_pos}%",
     "floor_overrides_ceiling": "floor raised to {to_pos}% over ceiling {ceiling_pos}% by {label} (winner was {from_pos}%)",
     "tilt_bound_active": "tilt bound {low_label}–{high_label} active by {label}; awaiting the resolved tilt",

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -68,7 +68,9 @@
     "ceiling_lowered": "ceiling lowered winner from {from_pos}% to {to_pos}% by {label}",
     "ceiling_inactive": "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)",
     "ceiling_overridden": "ceiling {ceiling_pos}% overridden — a floor raised the cover to {to_pos}%",
+    "floor_overrides_ceiling": "floor raised to {to_pos}% over ceiling {ceiling_pos}% by {label} (winner was {from_pos}%)",
     "tilt_bound_active": "tilt bound {low_label}–{high_label} active by {label}; awaiting the resolved tilt",
+    "tilt_bound_inactive": "tilt bound {low_label}–{high_label} inactive by {label}; resolved tilt {tilt}% already within",
     "tilt_clamped": "tilt clamped from {from_tilt}% to {to_tilt}% by {label}"
   },
   "builder": {

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -64,7 +64,11 @@
     "floor_raised": "floor raised winner from {from_pos}% to {to_pos}% by {label}",
     "floor_inactive": "floor {floor_pos}% inactive (winner {winner_pos}% above floor)",
     "tilt_applied": "tilt-only: slat angle fixed at {tilt}% by {label}; position driven by {handler}",
-    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%"
+    "tilt_deferred": "tilt-only {tilt}% deferred — {handler} already set tilt {winner_tilt}%",
+    "ceiling_lowered": "ceiling lowered winner from {from_pos}% to {to_pos}% by {label}",
+    "ceiling_inactive": "ceiling {ceiling_pos}% inactive (winner {winner_pos}% below ceiling)",
+    "tilt_bound_active": "tilt bound {low_label}–{high_label} active by {label}; awaiting the resolved tilt",
+    "tilt_clamped": "tilt clamped from {from_tilt}% to {to_tilt}% by {label}"
   },
   "builder": {
     "unknown": "Unknown",

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -68,7 +68,9 @@
     "ceiling_lowered": "maximum abaissé gagnant de {from_pos}% à {to_pos}% par {label}",
     "ceiling_inactive": "maximum {ceiling_pos}% inactif (gagnant {winner_pos}% en dessous du maximum)",
     "ceiling_overridden": "maximum {ceiling_pos}% ignoré — un minimum a relevé le volet à {to_pos}%",
+    "floor_overrides_ceiling": "minimum relevé à {to_pos}% au-dessus du maximum {ceiling_pos}% par {label} (gagnant était {from_pos}%)",
     "tilt_bound_active": "limite d'inclinaison {low_label}–{high_label} active par {label} ; en attente de l'inclinaison résolue",
+    "tilt_bound_inactive": "limite d'inclinaison {low_label}–{high_label} inactive par {label} ; inclinaison résolue {tilt}% déjà dans la plage",
     "tilt_clamped": "inclinaison limitée de {from_tilt}% à {to_tilt}% par {label}"
   },
   "builder": {

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -64,7 +64,11 @@
     "floor_raised": "minimum augmenté gagnant de {from_pos}% à {to_pos}% par {label}",
     "floor_inactive": "minimum {floor_pos}% inactif (gagnant {winner_pos}% au-dessus du minimum)",
     "tilt_applied": "inclinaison seule : angle lame fixé à {tilt}% par {label} ; position pilotée par {handler}",
-    "tilt_deferred": "inclinaison seule {tilt}% différée — {handler} a déjà défini inclinaison {winner_tilt}%"
+    "tilt_deferred": "inclinaison seule {tilt}% différée — {handler} a déjà défini inclinaison {winner_tilt}%",
+    "ceiling_lowered": "maximum abaissé gagnant de {from_pos}% à {to_pos}% par {label}",
+    "ceiling_inactive": "maximum {ceiling_pos}% inactif (gagnant {winner_pos}% en dessous du maximum)",
+    "tilt_bound_active": "limite d'inclinaison {low_label}–{high_label} active par {label} ; en attente de l'inclinaison résolue",
+    "tilt_clamped": "inclinaison limitée de {from_tilt}% à {to_tilt}% par {label}"
   },
   "builder": {
     "unknown": "Inconnu",

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -66,7 +66,7 @@
     "tilt_applied": "inclinaison seule : angle lame fixé à {tilt}% par {label} ; position pilotée par {handler}",
     "tilt_deferred": "inclinaison seule {tilt}% différée — {handler} a déjà défini inclinaison {winner_tilt}%",
     "ceiling_lowered": "maximum abaissé gagnant de {from_pos}% à {to_pos}% par {label}",
-    "ceiling_inactive": "maximum {ceiling_pos}% inactif (gagnant {winner_pos}% en dessous du maximum)",
+    "ceiling_inactive": "maximum {ceiling_pos}% inactif (position résolue {to_pos}% au niveau ou en dessous du maximum)",
     "ceiling_overridden": "maximum {ceiling_pos}% ignoré — un minimum a relevé le volet à {to_pos}%",
     "floor_overrides_ceiling": "minimum relevé à {to_pos}% au-dessus du maximum {ceiling_pos}% par {label} (gagnant était {from_pos}%)",
     "tilt_bound_active": "limite d'inclinaison {low_label}–{high_label} active par {label} ; en attente de l'inclinaison résolue",

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -67,6 +67,7 @@
     "tilt_deferred": "inclinaison seule {tilt}% différée — {handler} a déjà défini inclinaison {winner_tilt}%",
     "ceiling_lowered": "maximum abaissé gagnant de {from_pos}% à {to_pos}% par {label}",
     "ceiling_inactive": "maximum {ceiling_pos}% inactif (gagnant {winner_pos}% en dessous du maximum)",
+    "ceiling_overridden": "maximum {ceiling_pos}% ignoré — un minimum a relevé le volet à {to_pos}%",
     "tilt_bound_active": "limite d'inclinaison {low_label}–{high_label} active par {label} ; en attente de l'inclinaison résolue",
     "tilt_clamped": "inclinaison limitée de {from_tilt}% à {to_tilt}% par {label}"
   },

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -996,7 +996,11 @@ def _build_custom_position_slots_snapshot(
                 # User-configured slot label (issue #867); overrides sensor_name
                 # in the reason/decision_trace/card when set. None = unset.
                 "custom_name": custom_position_slot_name(options, slot_keys),
-                "position": int(position) if configured else None,
+                # None for a constraint-only slot — configured, but making no
+                # position claim (issue #943).
+                "position": (
+                    int(position) if configured and position is not None else None
+                ),
                 "priority": (
                     int(
                         options.get(slot_keys["priority"])
@@ -1010,6 +1014,12 @@ def _build_custom_position_slots_snapshot(
                     if configured
                     else None
                 ),
+                # Axis constraints (issue #943). None = the constraint is off,
+                # which is also what an unconfigured slot reports.
+                **{
+                    sub: (options.get(slot_keys[sub]) if configured else None)
+                    for sub in ("position_max", "tilt_min", "tilt_max")
+                },
             }
         )
     return snapshot

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -488,8 +488,9 @@ set_custom_position:
   name: Set custom position slot
   description: >-
     Update one custom position slot (1–10). A slot is active when it has a
-    trigger (sensors and/or template) and a position. Pass an empty list and
-    null position to clear the slot. Priority 100 gives the slot safety
+    trigger (sensors and/or template) and a claim on an axis — a position, or
+    one of the position_max / tilt_min / tilt_max constraints. Pass an empty
+    list and null position to clear the slot. Priority 100 gives the slot safety
     semantics: it acts outside the time window and bypasses delta gates.
   target:
     entity:
@@ -560,6 +561,36 @@ set_custom_position:
       description: "If true, use my_position_value instead of position when the trigger is active."
       selector:
         boolean:
+    position_max:
+      name: Maximum position
+      description: "Clamp the resolved position down to at most this (0–100%) while the trigger is active. Null = no maximum."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    tilt_min:
+      name: Minimum tilt
+      description: "Clamp the resolved tilt up to at least this (0–100%) while the trigger is active. Null = no minimum."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
+    tilt_max:
+      name: Maximum tilt
+      description: "Clamp the resolved tilt down to at most this (0–100%) while the trigger is active. Null = no maximum."
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          mode: slider
+          unit_of_measurement: "%"
 
 set_motion:
   name: Set occupancy settings (deprecated)

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -199,7 +199,7 @@ from ..const import (
     DOMAIN,
     OPTION_RANGES,
 )
-from ..helpers import custom_position_slot_sensors
+from ..helpers import CUSTOM_POSITION_CLAIM_KEYS, custom_position_slot_sensors
 from ..templates import is_template_string as _is_template_str
 
 _LOGGER = logging.getLogger(__name__)
@@ -494,6 +494,14 @@ FIELD_VALIDATORS: dict[str, Any] = {
     **{
         slot_keys["tilt"]: _range(slot_keys["tilt"])
         for slot_keys in CUSTOM_POSITION_SLOTS.values()
+    },
+    # Axis constraints (issue #943) — all three pull their bounds from
+    # OPTION_RANGES, which the FieldSpec registry derives from the same
+    # _RANGE_CUSTOM_POSITION / _RANGE_TILT the config-flow selectors use.
+    **{
+        slot_keys[sub]: _range(slot_keys[sub])
+        for slot_keys in CUSTOM_POSITION_SLOTS.values()
+        for sub in ("position_max", "tilt_min", "tilt_max")
     },
     **{slot_keys["enabled"]: _bool_v() for slot_keys in CUSTOM_POSITION_SLOTS.values()},
     # Glare zones 1–4 — name is free-form text; x/y/radius/z pull ranges from
@@ -974,19 +982,24 @@ def _cross_field_validate(
             )
 
     # Custom position slot completeness: a slot needs a trigger (sensors,
-    # legacy sensor, or template) AND a position — or neither.
+    # legacy sensor, or template) AND a claim on an axis — or neither. The
+    # claim vocabulary is CUSTOM_POSITION_CLAIM_KEYS: a position, or one of the
+    # axis constraints (issue #943), so a trigger → "minimum tilt 50%" slot is
+    # complete without a position.
     for i in CUSTOM_POSITION_SLOT_NUMBERS if check_slot_completeness else ():
         slot = _CUSTOM_SLOT_KEYS[i]
         trigger_keys = (slot["sensor"], slot["sensors"], slot["template"])
-        p_key = slot["position"]
-        if any(k in patch for k in trigger_keys) or p_key in patch:
+        claim_keys = tuple(slot[sub] for sub in CUSTOM_POSITION_CLAIM_KEYS)
+        if any(k in patch for k in trigger_keys + claim_keys):
             has_trigger = bool(
                 custom_position_slot_sensors(merged_active, slot)
             ) or _is_template_str(merged_active.get(slot["template"]))
-            pos_set = merged_active.get(p_key) is not None
-            if has_trigger != pos_set:
+            has_claim = any(merged_active.get(k) is not None for k in claim_keys)
+            if has_trigger != has_claim:
                 missing = (
-                    p_key if has_trigger else f"{slot['sensors']} or {slot['template']}"
+                    f"{slot['position']} (or an axis constraint)"
+                    if has_trigger
+                    else f"{slot['sensors']} or {slot['template']}"
                 )
                 raise ServiceValidationError(
                     f"Custom position slot {i}: incomplete — '{missing}' is missing. "
@@ -1159,6 +1172,10 @@ async def _handle_set_custom_position(hass: HomeAssistant, call: ServiceCall) ->
         "min_mode": slot_keys["min_mode"],
         "use_my": slot_keys["use_my"],
         "enabled": slot_keys["enabled"],
+        # Axis constraints (issue #943)
+        "position_max": slot_keys["position_max"],
+        "tilt_min": slot_keys["tilt_min"],
+        "tilt_max": slot_keys["tilt_max"],
     }
 
     # Build patch: only include fields that were supplied in the call

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -23,7 +23,7 @@
   },
   "fragments": {
     "as_minimum": " (als Minimum)",
-    "as_maximum": " (als Maximum)",
+    "as_maximum": " (höchstens {max}%)",
     "safety": " 🔒 Sicherheit: wirkt auch außerhalb des Zeitfensters",
     "template_value": "[template]"
   },

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -23,6 +23,7 @@
   },
   "fragments": {
     "as_minimum": " (als Minimum)",
+    "as_maximum": " (als Maximum)",
     "safety": " 🔒 Sicherheit: wirkt auch außerhalb des Zeitfensters",
     "template_value": "[template]"
   },
@@ -65,9 +66,14 @@
     "tilt_note": ", Neigung {tilt}%",
     "trigger_sensors": "einer von {n} Sensoren",
     "trigger_template": "Template",
-    "trigger_join": " oder "
+    "trigger_join": " oder ",
+    "tilt_bound_min": ", Neigung mindestens {min}%",
+    "tilt_bound_max": ", Neigung höchstens {max}%",
+    "tilt_bound_range": ", Neigung {min}–{max}%",
+    "no_position_claim": "die berechnete Position"
   },
   "warnings": {
+    "custom_position_bound_conflict": "⚠️ Benutzerdefiniert #{slot}: Das Maximum ({max}%) liegt unter dem Minimum ({min}%) — das Minimum gewinnt und das Maximum wird ignoriert.",
     "custom_tilt_only_conflict": "⚠️ Benutzerdefiniert #{slot}: Nur Neigung ist aktiviert — Als Minimum verwenden / Meine Position verwenden werden für diesen Slot ignoriert.",
     "motion_hold_no_sensors": "⚠️ Der Modus Position halten ist eingestellt, aber es sind keine Belegungsquellen konfiguriert – die Einstellung hat keine Auswirkungen, bis eine Belegungsquelle hinzugefügt wird",
     "cloudy_pos_ignored": "⚠️ Bewölkte Position ({pos}%) konfiguriert, aber Wolkenunterdrückung ist deaktiviert — Wert wird ignoriert.",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -23,7 +23,7 @@
   },
   "fragments": {
     "as_minimum": " (as minimum)",
-    "as_maximum": " (as maximum)",
+    "as_maximum": " (at most {max}%)",
     "safety": " 🔒 safety: acts outside the time window too",
     "template_value": "[template]"
   },

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -23,6 +23,7 @@
   },
   "fragments": {
     "as_minimum": " (as minimum)",
+    "as_maximum": " (as maximum)",
     "safety": " 🔒 safety: acts outside the time window too",
     "template_value": "[template]"
   },
@@ -65,9 +66,14 @@
     "tilt_note": ", tilt {tilt}%",
     "trigger_sensors": "any of {n} sensors",
     "trigger_template": "template",
-    "trigger_join": " or "
+    "trigger_join": " or ",
+    "tilt_bound_min": ", tilt at least {min}%",
+    "tilt_bound_max": ", tilt at most {max}%",
+    "tilt_bound_range": ", tilt {min}–{max}%",
+    "no_position_claim": "the calculated position"
   },
   "warnings": {
+    "custom_position_bound_conflict": "⚠️ Custom #{slot}: the maximum ({max}%) is below the minimum ({min}%) — the minimum wins and the maximum is ignored.",
     "custom_tilt_only_conflict": "⚠️ Custom #{slot}: tilt only is on — Use as minimum / Use My position are ignored for this slot.",
     "motion_hold_no_sensors": "⚠️ hold_position mode is set but no occupancy sources are configured — the setting has no effect until an occupancy source is added",
     "cloudy_pos_ignored": "⚠️ Cloudy position ({pos}%) configured but cloud suppression is disabled — value will be ignored.",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -23,6 +23,7 @@
   },
   "fragments": {
     "as_minimum": " (comme minimum)",
+    "as_maximum": " (comme maximum)",
     "safety": " 🔒 sécurité : agit aussi en dehors de la fenêtre horaire",
     "template_value": "[template]"
   },
@@ -65,9 +66,14 @@
     "tilt_note": ", inclinaison {tilt}%",
     "trigger_sensors": "l'un des {n} capteurs",
     "trigger_template": "template",
-    "trigger_join": " ou "
+    "trigger_join": " ou ",
+    "tilt_bound_min": ", inclinaison d'au moins {min}%",
+    "tilt_bound_max": ", inclinaison d'au plus {max}%",
+    "tilt_bound_range": ", inclinaison {min}–{max}%",
+    "no_position_claim": "la position calculée"
   },
   "warnings": {
+    "custom_position_bound_conflict": "⚠️ Personnalisé #{slot} : le maximum ({max}%) est inférieur au minimum ({min}%) — le minimum l'emporte et le maximum est ignoré.",
     "custom_tilt_only_conflict": "⚠️ Personnalisé #{slot} : inclinaison seulement est activé — Utiliser comme minimum / Utiliser ma position sont ignorés pour cet emplacement.",
     "motion_hold_no_sensors": "Aucun capteur d'occupation configuré. La détection d'occupation est désactivée.",
     "cloudy_pos_ignored": "⚠️ Position nuageux ({pos}%) configurée mais suppression de nuages est désactivée — la valeur sera ignorée.",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -23,7 +23,7 @@
   },
   "fragments": {
     "as_minimum": " (comme minimum)",
-    "as_maximum": " (comme maximum)",
+    "as_maximum": " (au plus {max}%)",
     "safety": " 🔒 sécurité : agit aussi en dehors de la fenêtre horaire",
     "template_value": "[template]"
   },

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -871,8 +871,11 @@
           "custom_position_priority": "Priorität",
           "custom_position_min_mode": "Mindestmodus",
           "custom_position_use_my": "Meine Position verwenden",
+          "custom_position_position_max": "Maximalposition",
           "custom_position_tilt": "Neigung",
-          "custom_position_tilt_only": "Nur Neigung"
+          "custom_position_tilt_only": "Nur Neigung",
+          "custom_position_tilt_min": "Mindestneigung",
+          "custom_position_tilt_max": "Maximalneigung"
         },
         "data_description": {
           "custom_position_sensors": "Binärsensoren, die beim ‚on'-Status eine Übersteuerung auf die konfigurierte Position auslösen (ODER-Logik). Leer lassen für nur Vorlagen-Auslöser — oder um diesen Slot zu deaktivieren.",
@@ -883,7 +886,10 @@
           "custom_position_min_mode": "Bei Aktivierung fungiert die Position als Mindestgrenzwert — höhere Positionen von der Sonnenverfolgung oder anderen Berechnungen werden zugelassen. Bei Deaktivierung (Standard) wird die Jalousie immer auf die exakte konfigurierte Position gesetzt.",
           "custom_position_use_my": "Wenn dieser Slot-Auslöser aktiv ist, wird die Voreinstellung ‚Meine Position' ausgelöst statt der numerischen Slot-Position. Erfordert, dass der Wert für Meine Position gesetzt ist.",
           "custom_position_tilt": "Neigungswinkel (0–100 %), gesetzt wenn dieser Slot-Sensor aktiv ist. Nur für Jalousien mit Lamellenneigung — wird für andere Jalousientypen ignoriert. Leer lassen für automatische Berechnung durch die Engine.",
-          "custom_position_tilt_only": "Bei Aktivierung wird nur der Lamellenwinkel (der Neigungswert) fixiert — die Sonnenverfolgung steuert weiterhin die Wagenposition. Nur für Jalousien mit Lamellenneigung. Setzt Minimummodus und Meine Position für diesen Slot außer Kraft."
+          "custom_position_tilt_only": "Bei Aktivierung wird nur der Lamellenwinkel (der Neigungswert) fixiert — die Sonnenverfolgung steuert weiterhin die Wagenposition. Nur für Jalousien mit Lamellenneigung. Setzt Minimummodus und Meine Position für diesen Slot außer Kraft.",
+          "custom_position_position_max": "Wenn gesetzt, fungiert die Position als Höchstgrenze, solange der Auslöser dieses Slots aktiv ist — niedrigere Positionen von der Sonnenverfolgung oder anderen Berechnungen werden zugelassen, alles darüber wird darauf begrenzt. Das Gegenstück zum Mindestmodus. Nicht gesetzt lassen für kein Maximum. Bei einem Konflikt mit einem Minimum gewinnt das Minimum.",
+          "custom_position_tilt_min": "Wenn gesetzt, fungiert die Neigung als Mindestwert, solange der Auslöser dieses Slots aktiv ist — eine berechnete Neigung darunter wird darauf angehoben, alles darüber bleibt unverändert. Anders als „Nur Neigung“ (das einen exakten Winkel festlegt) ist dies eine Grenze. Nur für Jalousien. Nicht gesetzt lassen für kein Minimum.",
+          "custom_position_tilt_max": "Wenn gesetzt, fungiert die Neigung als Höchstwert, solange der Auslöser dieses Slots aktiv ist — eine berechnete Neigung darüber wird darauf abgesenkt. Nur für Jalousien. Nicht gesetzt lassen für kein Maximum."
         }
       },
       "custom_position_tilt_defaults": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -871,8 +871,11 @@
           "custom_position_priority": "Priority",
           "custom_position_min_mode": "Minimum mode",
           "custom_position_use_my": "Use My position",
+          "custom_position_position_max": "Maximum position",
           "custom_position_tilt": "Tilt",
-          "custom_position_tilt_only": "Tilt only"
+          "custom_position_tilt_only": "Tilt only",
+          "custom_position_tilt_min": "Minimum tilt",
+          "custom_position_tilt_max": "Maximum tilt"
         },
         "data_description": {
           "custom_position_sensors": "Binary sensors that, when any is 'on', move the cover to its configured position (OR logic). Leave empty to use only a template — or to skip this slot.",
@@ -883,7 +886,10 @@
           "custom_position_min_mode": "When enabled, the position acts as a minimum floor — higher positions from sun tracking or other calculations are allowed through. When disabled (default), the cover is always set to the exact configured position.",
           "custom_position_use_my": "When this slot's trigger is active, trigger the cover's My preset instead of the slot's numeric position. Requires My position value to be set.",
           "custom_position_tilt": "Tilt angle (0-100%) to set when this slot's sensor is active. Venetian covers only — ignored for other cover types. Leave unset to let the engine calculate tilt automatically.",
-          "custom_position_tilt_only": "When enabled, this slot fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot."
+          "custom_position_tilt_only": "When enabled, this slot fixes only the slat angle (its Tilt value) — sun tracking still drives the carriage position. Venetian covers only. Overrides Minimum mode and Use My position for this slot.",
+          "custom_position_position_max": "When set, the position acts as a maximum ceiling while this slot's trigger is active — lower positions from sun tracking or other calculations are allowed through, but anything above is clamped down to this. The mirror of Minimum mode. Leave unset for no maximum. If it conflicts with a minimum, the minimum wins.",
+          "custom_position_tilt_min": "When set, the tilt acts as a minimum while this slot's trigger is active — a calculated tilt below this is raised to it, and anything above is left alone. Unlike Tilt only (which fixes an exact angle), this is a boundary. Venetian covers only. Leave unset for no minimum.",
+          "custom_position_tilt_max": "When set, the tilt acts as a maximum while this slot's trigger is active — a calculated tilt above this is lowered to it. Venetian covers only. Leave unset for no maximum."
         }
       },
       "custom_position_tilt_defaults": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -871,8 +871,11 @@
           "custom_position_priority": "Priorité",
           "custom_position_min_mode": "Mode minimum",
           "custom_position_use_my": "Utiliser la position My",
+          "custom_position_position_max": "Position maximale",
           "custom_position_tilt": "Inclinaison",
-          "custom_position_tilt_only": "Inclinaison uniquement"
+          "custom_position_tilt_only": "Inclinaison uniquement",
+          "custom_position_tilt_min": "Inclinaison minimale",
+          "custom_position_tilt_max": "Inclinaison maximale"
         },
         "data_description": {
           "custom_position_sensors": "Capteurs binaires qui, si l'un est « activé », déplacent le store à sa position configurée (logique OU). Laisser vide pour n'utiliser qu'un modèle — ou pour ignorer cet emplacement.",
@@ -883,7 +886,10 @@
           "custom_position_min_mode": "Lorsqu'activé, la position agit comme un plancher minimum — les positions plus élevées du suivi solaire ou d'autres calculs sont autorisées. Lorsque désactivé (par défaut), le store est toujours défini à la position configurée exacte.",
           "custom_position_use_my": "Lorsque le déclencheur d'emplacement est actif, déclencher la position prédéfinie « My » du store au lieu de la position numérique de l'emplacement. Nécessite que la valeur de position « My » soit définie.",
           "custom_position_tilt": "Angle d'inclinaison (0-100 %) à définir lorsque le capteur de cet emplacement est actif. Stores vénitiens uniquement — ignoré pour les autres types de stores. Laisser indéfini pour laisser le moteur calculer l'inclinaison automatiquement.",
-          "custom_position_tilt_only": "Lorsqu'activé, cet emplacement corrige uniquement l'angle des lamelles (sa valeur Inclinaison) — le suivi solaire pilote toujours la position du chariot. Stores vénitiens uniquement. Remplace le mode Minimum et Utiliser la position « My » pour cet emplacement."
+          "custom_position_tilt_only": "Lorsqu'activé, cet emplacement corrige uniquement l'angle des lamelles (sa valeur Inclinaison) — le suivi solaire pilote toujours la position du chariot. Stores vénitiens uniquement. Remplace le mode Minimum et Utiliser la position « My » pour cet emplacement.",
+          "custom_position_position_max": "Lorsque définie, la position agit comme un plafond maximum tant que le déclencheur de ce slot est actif — les positions plus basses du suivi solaire ou d'autres calculs sont autorisées, mais tout ce qui dépasse est ramené à cette valeur. Le pendant du mode minimum. Laisser vide pour aucun maximum. En cas de conflit avec un minimum, le minimum l'emporte.",
+          "custom_position_tilt_min": "Lorsque définie, l'inclinaison agit comme un minimum tant que le déclencheur de ce slot est actif — une inclinaison calculée en dessous est relevée à cette valeur, et tout ce qui est au-dessus reste inchangé. Contrairement à « Inclinaison uniquement » (qui fixe un angle exact), il s'agit d'une limite. Stores vénitiens uniquement. Laisser vide pour aucun minimum.",
+          "custom_position_tilt_max": "Lorsque définie, l'inclinaison agit comme un maximum tant que le déclencheur de ce slot est actif — une inclinaison calculée au-dessus est abaissée à cette valeur. Stores vénitiens uniquement. Laisser vide pour aucun maximum."
         }
       },
       "custom_position_tilt_defaults": {

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -250,7 +250,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -286,7 +286,7 @@ async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -299,7 +299,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -326,7 +326,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -363,7 +363,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -405,7 +405,7 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
@@ -428,7 +428,7 @@ async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
@@ -441,7 +441,7 @@ async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -454,7 +454,7 @@ async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
@@ -463,7 +463,7 @@ async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> 
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
     assert entry.version == 3
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 # ---------------------------------------------------------------------------
@@ -485,7 +485,7 @@ async def test_migrate_v3_6_sets_weather_enabled_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=5)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -498,7 +498,7 @@ async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is False
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
@@ -511,7 +511,7 @@ async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> None:
@@ -520,7 +520,7 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
     assert entry.version == 3
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 # ---------------------------------------------------------------------------
@@ -541,7 +541,7 @@ async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     # Additive/no-op: no outside_temp_source key seeded, options untouched.
     assert "outside_temp_source" not in entry.options
     assert entry.options == before
@@ -557,9 +557,9 @@ async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert entry.options == first
 
 
@@ -575,7 +575,7 @@ async def test_migrate_v3_6_to_3_7_preserves_explicit_source(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options["outside_temp_source"] == "max_of_live_and_forecast"
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
 
 
 # ---------------------------------------------------------------------------
@@ -604,7 +604,7 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     # No dead key seeded by the v3.4→v3.5 block.
     assert "show_weather_retraction" not in entry.options
     # The only key added across the cascade is the v3.5→v3.6 weather toggle.
@@ -641,7 +641,7 @@ async def test_migrate_v3_7_to_v3_8_converts_blind_spots(hass: HomeAssistant) ->
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     opts = entry.options
     # Slot 1 converted (new_left = 45-10 = 35, new_right = 30-45 = -15).
     assert opts["blind_spot_left_gamma"] == 35
@@ -674,9 +674,9 @@ async def test_migrate_v3_7_to_v3_8_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert entry.options == first
 
 
@@ -712,7 +712,7 @@ async def test_migrate_v3_7_to_v3_8_no_blind_spot_is_noop(hass: HomeAssistant) -
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert entry.options == before
 
 
@@ -739,7 +739,7 @@ async def test_migrate_v3_7_to_v3_8_tolerates_none_fov_left(
         minor_version=7,
     )
     assert await async_migrate_entry(hass, entry) is True  # no TypeError
-    assert entry.minor_version == 8
+    assert entry.minor_version == 9
     assert entry.options["blind_spot_left_gamma"] == 80  # 90 - 10
     assert entry.options["blind_spot_right_gamma"] == -60  # 30 - 90
 
@@ -788,13 +788,13 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 8 (the v3.7 → v3.8 block that additively
-    converts legacy blind-spot edges to signed gamma, per issue #247).
+    Currently the highest target is 9 (the v3.8 → v3.9 block for the additive
+    per-slot axis-constraint options, per issue #943).
     Raise this assertion whenever a new minor migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 8
+    assert ConfigFlowHandler.MINOR_VERSION == 9
 
 
 # ---------------------------------------------------------------------------
@@ -828,3 +828,73 @@ async def test_slots_6_to_10_not_injected_into_existing_entry(
     # Existing slot 5 keys remain intact.
     assert entry.options["custom_position_sensors_5"] == ["binary_sensor.rain"]
     assert entry.options["custom_position_5"] == 90
+
+
+# ---------------------------------------------------------------------------
+# v3.8 → v3.9 — additive axis-constraint options (issue #943)
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v3_8_to_v3_9_is_additive_noop(hass: HomeAssistant) -> None:
+    """A v3.8 entry advances to minor 9 with its options untouched.
+
+    The axis-constraint keys need no seeding — an absent key already reads as
+    "constraint off" — so the block exists only to advance the minor so the
+    entry stops re-triggering migration on every restart.
+    """
+    options = {
+        "custom_position_sensors_1": ["binary_sensor.door"],
+        "custom_position_1": 40,
+        "custom_position_min_mode_1": True,
+    }
+    entry = _make_entry(hass, dict(options), version=3, minor_version=8)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 9
+    assert dict(entry.options) == options
+
+
+async def test_migrate_v3_8_to_v3_9_seeds_no_constraint_keys(
+    hass: HomeAssistant,
+) -> None:
+    """The migration must not invent constraints on an existing slot."""
+    entry = _make_entry(
+        hass,
+        {"custom_position_sensors_1": ["binary_sensor.door"], "custom_position_1": 40},
+        version=3,
+        minor_version=8,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    for sub in ("position_max", "tilt_min", "tilt_max"):
+        assert CUSTOM_POSITION_SLOTS[1][sub] not in entry.options
+
+
+async def test_migrate_v3_9_is_idempotent(hass: HomeAssistant) -> None:
+    """Re-running the migration on an already-migrated entry changes nothing."""
+    options = {
+        "custom_position_sensors_1": ["binary_sensor.door"],
+        "custom_position_tilt_min_1": 50,
+    }
+    entry = _make_entry(hass, dict(options), version=3, minor_version=9)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 9
+    assert dict(entry.options) == options
+
+
+async def test_migrate_v3_9_preserves_user_set_constraints(
+    hass: HomeAssistant,
+) -> None:
+    """A constraint already configured survives the migration verbatim."""
+    entry = _make_entry(
+        hass,
+        {
+            "custom_position_sensors_1": ["binary_sensor.door"],
+            "custom_position_tilt_min_1": 50,
+            "custom_position_position_max_1": 60,
+        },
+        version=3,
+        minor_version=8,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.options["custom_position_tilt_min_1"] == 50
+    assert entry.options["custom_position_position_max_1"] == 60

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3769,3 +3769,20 @@ def test_constraint_only_slot_renders_without_a_position():
     }
     line = _custom_line(cfg, cover_type=CoverType.VENETIAN)
     assert "tilt at least 50%" in line
+
+
+def test_min_mode_without_position_shows_no_as_minimum():
+    """Finding D: a min_mode toggle with no stored position contributes no floor.
+
+    The derived mode is MAX (a lone ceiling), so the phantom '(as minimum)'
+    fragment must not appear — it would claim a floor that does not exist.
+    """
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.movie"],
+        "custom_position_min_mode_1": True,
+        "custom_position_position_max_1": 50,
+    }
+    line = _custom_line(cfg)
+    assert "(as minimum)" not in line
+    assert "at most 50%" in line
+    assert "the calculated position" in line

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3650,3 +3650,101 @@ def test_summary_group_shows_area_line_when_configured():
         {**base, CONF_GROUP_AREA: "living_room"}, CoverType.GROUP
     )
     assert "living_room" in with_area
+
+
+# ---------------------------------------------------------------------------
+# Axis constraints on the custom-slot lines — issue #943
+# ---------------------------------------------------------------------------
+
+
+def _custom_line(cfg, slot=1, cover_type=CoverType.BLIND):
+    summary = _build_config_summary(cfg, cover_type)
+    return next(ln for ln in summary.splitlines() if f"Custom #{slot}" in ln)
+
+
+def test_custom_position_max_shown():
+    """A position ceiling renders '(as maximum)' on the slot line."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.movie"],
+        "custom_position_position_max_1": 60,
+    }
+    assert "(as maximum)" in _custom_line(cfg)
+
+
+def test_custom_position_min_and_max_both_shown():
+    """A two-sided position bound names both ends."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.movie"],
+        "custom_position_1": 30,
+        "custom_position_min_mode_1": True,
+        "custom_position_position_max_1": 70,
+    }
+    line = _custom_line(cfg)
+    assert "(as minimum)" in line
+    assert "(as maximum)" in line
+
+
+def test_custom_tilt_min_note_shown():
+    """A minimum tilt is surfaced on the slot line."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.door"],
+        "custom_position_tilt_min_1": 50,
+    }
+    line = _custom_line(cfg, cover_type=CoverType.VENETIAN)
+    assert "tilt at least 50%" in line
+
+
+def test_custom_tilt_max_note_shown():
+    """A maximum tilt is surfaced on the slot line."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.door"],
+        "custom_position_tilt_max_1": 60,
+    }
+    assert "tilt at most 60%" in _custom_line(cfg, cover_type=CoverType.VENETIAN)
+
+
+def test_custom_tilt_range_note_shown():
+    """A two-sided tilt bound renders as a range."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.door"],
+        "custom_position_tilt_min_1": 40,
+        "custom_position_tilt_max_1": 80,
+    }
+    assert "tilt 40–80%" in _custom_line(cfg, cover_type=CoverType.VENETIAN)
+
+
+def test_custom_position_conflict_warning():
+    """A ceiling below the floor is a footgun — the floor silently wins."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.movie"],
+        "custom_position_1": 70,
+        "custom_position_min_mode_1": True,
+        "custom_position_position_max_1": 40,
+    }
+    summary = _build_config_summary(cfg, CoverType.BLIND)
+    assert "⚠️" in summary
+    assert any(
+        "maximum" in ln and "minimum" in ln and "⚠️" in ln
+        for ln in summary.splitlines()
+    )
+
+
+def test_no_constraint_note_without_constraints():
+    """A legacy slot's line is unchanged."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.movie"],
+        "custom_position_1": 40,
+    }
+    line = _custom_line(cfg)
+    assert "as maximum" not in line
+    assert "tilt at least" not in line
+
+
+def test_constraint_only_slot_renders_without_a_position():
+    """The reporter's config: a trigger and a tilt minimum, no position."""
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.door"],
+        "custom_position_tilt_min_1": 50,
+    }
+    line = _custom_line(cfg, cover_type=CoverType.VENETIAN)
+    assert "tilt at least 50%" in line

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3662,13 +3662,17 @@ def _custom_line(cfg, slot=1, cover_type=CoverType.BLIND):
     return next(ln for ln in summary.splitlines() if f"Custom #{slot}" in ln)
 
 
-def test_custom_position_max_shown():
-    """A position ceiling renders '(as maximum)' on the slot line."""
+def test_custom_position_max_shows_its_value():
+    """A position ceiling names its number, like the tilt-bound fragments do.
+
+    Audit finding 6: '(as maximum)' was a bare suffix — the ceiling's value only
+    appeared inside the min>max conflict warning.
+    """
     cfg = {
         "custom_position_sensors_1": ["binary_sensor.movie"],
         "custom_position_position_max_1": 60,
     }
-    assert "(as maximum)" in _custom_line(cfg)
+    assert "at most 60%" in _custom_line(cfg)
 
 
 def test_custom_position_min_and_max_both_shown():
@@ -3681,7 +3685,24 @@ def test_custom_position_min_and_max_both_shown():
     }
     line = _custom_line(cfg)
     assert "(as minimum)" in line
-    assert "(as maximum)" in line
+    assert "at most 70%" in line
+
+
+def test_fixed_position_slot_never_claims_a_ceiling():
+    """An exact position outranks position_max, so the line must not show one.
+
+    Audit finding 5: the slot renders '→ 70%' and the stored ceiling does
+    nothing — advertising it implied 70 was capped at 50.
+    """
+    cfg = {
+        "custom_position_sensors_1": ["binary_sensor.movie"],
+        "custom_position_1": 70,
+        "custom_position_position_max_1": 50,
+    }
+    line = _custom_line(cfg)
+    assert "70%" in line
+    assert "maximum" not in line
+    assert "at most" not in line
 
 
 def test_custom_tilt_min_note_shown():
@@ -3736,7 +3757,7 @@ def test_no_constraint_note_without_constraints():
         "custom_position_1": 40,
     }
     line = _custom_line(cfg)
-    assert "as maximum" not in line
+    assert "at most" not in line
     assert "tilt at least" not in line
 
 

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -575,3 +575,74 @@ class TestPostPipelineResolveTiltSubTrace:
             _make_result(ControlMethod.SOLAR, position=80), **kwargs
         )
         assert "tilt" not in cover._last_calc_details
+
+
+# ---------------------------------------------------------------------------
+# Engine-tilt clamping against carried tilt bounds — issue #943
+#
+# Tilt can resolve AFTER the pipeline: the registry has no tilt to clamp when
+# the venetian engine is the thing that produces it. The registry therefore
+# carries the composed bounds on the result and this policy applies them —
+# through the same shared clamp the registry uses, so the arithmetic stays in
+# one place while the cover-type-specific behavior stays in cover_types/.
+# ---------------------------------------------------------------------------
+
+
+class TestEngineTiltBounds:
+    """post_pipeline_resolve clamps the engine tilt to the carried bounds."""
+
+    @staticmethod
+    def _resolve(monkeypatch, engine_tilt: int, **bounds):
+        policy = _make_policy()
+        result = PipelineResult(
+            position=50,
+            control_method=ControlMethod.SOLAR,
+            reason="test",
+            **bounds,
+        )
+        monkeypatch.setattr(
+            VenetianPolicy,
+            "_compose_tilt",
+            lambda self, *a, **kw: (engine_tilt, MagicMock()),
+        )
+        monkeypatch.setattr(
+            VenetianPolicy, "_engine_tilt_suppressed", lambda self, r, c: False
+        )
+        return policy, policy.post_pipeline_resolve(result, **_solar_kwargs())
+
+    def test_engine_tilt_raised_to_tilt_low(self, monkeypatch) -> None:
+        """The reporter's case: engine 30 with a minimum of 50 → 50."""
+        _, out = self._resolve(monkeypatch, 30, tilt_low=50)
+        assert out.tilt == 50
+
+    def test_engine_tilt_above_low_unchanged(self, monkeypatch) -> None:
+        """The reporter's acceptance pair: engine 75 with min 50 stays 75."""
+        _, out = self._resolve(monkeypatch, 75, tilt_low=50)
+        assert out.tilt == 75
+
+    def test_engine_tilt_lowered_to_tilt_high(self, monkeypatch) -> None:
+        """The ceiling mirror."""
+        _, out = self._resolve(monkeypatch, 90, tilt_high=60)
+        assert out.tilt == 60
+
+    def test_clamped_tilt_recorded_as_last_tilt(self, monkeypatch) -> None:
+        """Drift tracking must see the value actually sent, not the raw one."""
+        policy, _ = self._resolve(monkeypatch, 30, tilt_low=50)
+        assert policy._last_tilt == 50
+
+    def test_clamp_appends_trace_step(self, monkeypatch) -> None:
+        """The clamp is visible in the decision trace."""
+        _, out = self._resolve(monkeypatch, 30, tilt_low=50)
+        assert any(s.handler == "tilt_clamp" for s in out.decision_trace)
+
+    def test_no_bounds_leaves_engine_tilt_untouched(self, monkeypatch) -> None:
+        """Without bounds the behavior is byte-identical to before #943."""
+        _, out = self._resolve(monkeypatch, 30)
+        assert out.tilt == 30
+        assert not any(s.handler == "tilt_clamp" for s in out.decision_trace)
+
+    def test_range_bounds_clamp_both_ways(self, monkeypatch) -> None:
+        """A carried range bounds the engine tilt on both sides."""
+        _, low = self._resolve(monkeypatch, 10, tilt_low=40, tilt_high=80)
+        _, high = self._resolve(monkeypatch, 95, tilt_low=40, tilt_high=80)
+        assert (low.tilt, high.tilt) == (40, 80)

--- a/tests/test_custom_position_slots.py
+++ b/tests/test_custom_position_slots.py
@@ -2,14 +2,21 @@
 
 RED step: these tests fail before const.py is changed (slot count is 5).
 GREEN step: they pass after CUSTOM_POSITION_SLOT_NUMBERS is extended to 1..10.
+
+Also covers the per-slot axis-constraint vocabulary added by issue #943
+(``position_max`` / ``tilt_min`` / ``tilt_max``).
 """
 
 from __future__ import annotations
 
 import custom_components.adaptive_cover_pro.const as const
+from custom_components.adaptive_cover_pro.helpers import custom_position_slot_configured
 from custom_components.adaptive_cover_pro.pipeline.handlers import build_handlers
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.services.options_service import (
+    FIELD_VALIDATORS,
 )
 
 # Full set of sub-keys that every slot dict must carry.
@@ -26,6 +33,9 @@ _REQUIRED_KEYS = frozenset(
         "use_my",
         "tilt",
         "tilt_only",
+        "position_max",
+        "tilt_min",
+        "tilt_max",
         "enabled",
     }
 )
@@ -154,3 +164,229 @@ class TestBuildHandlersNewSlots:
         slots = {h._slot for h in cp_handlers}
         assert slots == {1}
         assert not any(s > 5 for s in slots)
+
+
+# ---------------------------------------------------------------------------
+# Axis-constraint vocabulary — issue #943
+# ---------------------------------------------------------------------------
+
+
+class TestAxisConstraintSlotKeys:
+    """Per-slot wire keys for position max / tilt min / tilt max."""
+
+    def test_slot_1_carries_position_max_wire_key(self) -> None:
+        """Slot 1 exposes the suffixed position-max wire key."""
+        assert (
+            const.CUSTOM_POSITION_SLOTS[1]["position_max"]
+            == "custom_position_position_max_1"
+        )
+
+    def test_slot_1_carries_tilt_min_wire_key(self) -> None:
+        """Slot 1 exposes the suffixed tilt-min wire key."""
+        assert (
+            const.CUSTOM_POSITION_SLOTS[1]["tilt_min"] == "custom_position_tilt_min_1"
+        )
+
+    def test_slot_1_carries_tilt_max_wire_key(self) -> None:
+        """Slot 1 exposes the suffixed tilt-max wire key."""
+        assert (
+            const.CUSTOM_POSITION_SLOTS[1]["tilt_max"] == "custom_position_tilt_max_1"
+        )
+
+    def test_slot_10_constraint_wire_keys_embed_slot_number(self) -> None:
+        """The constraint keys are suffixed per slot like every other sub-key."""
+        keys = const.CUSTOM_POSITION_SLOTS[10]
+        assert keys["position_max"] == "custom_position_position_max_10"
+        assert keys["tilt_min"] == "custom_position_tilt_min_10"
+        assert keys["tilt_max"] == "custom_position_tilt_max_10"
+
+    def test_form_keys_carry_generic_constraint_keys(self) -> None:
+        """The single-slot options page renders the un-suffixed generic keys."""
+        assert (
+            const.CUSTOM_POSITION_FORM_KEYS["position_max"]
+            == "custom_position_position_max"
+        )
+        assert const.CUSTOM_POSITION_FORM_KEYS["tilt_min"] == "custom_position_tilt_min"
+        assert const.CUSTOM_POSITION_FORM_KEYS["tilt_max"] == "custom_position_tilt_max"
+
+
+class TestAxisConstraintOptionRanges:
+    """OPTION_RANGES derives from the FieldSpec registry — no hand-written bounds."""
+
+    def test_position_max_range_is_percent(self) -> None:
+        """Position max shares the custom-position 0–100 percent range."""
+        assert const.OPTION_RANGES["custom_position_position_max_1"] == (0, 100)
+
+    def test_tilt_min_range_is_percent(self) -> None:
+        """Tilt min shares the tilt 0–100 percent range."""
+        assert const.OPTION_RANGES["custom_position_tilt_min_1"] == (0, 100)
+
+    def test_tilt_max_range_is_percent(self) -> None:
+        """Tilt max shares the tilt 0–100 percent range."""
+        assert const.OPTION_RANGES["custom_position_tilt_max_3"] == (0, 100)
+
+    def test_every_slot_has_constraint_ranges(self) -> None:
+        """All 10 slots register ranges for all three constraint keys."""
+        for n in const.CUSTOM_POSITION_SLOT_NUMBERS:
+            keys = const.CUSTOM_POSITION_SLOTS[n]
+            for sub in ("position_max", "tilt_min", "tilt_max"):
+                assert keys[sub] in const.OPTION_RANGES
+
+
+class TestAxisConstraintFieldValidators:
+    """The set_option service must accept the new keys."""
+
+    def test_position_max_validator_registered(self) -> None:
+        """A validator exists for the position-max key."""
+        assert "custom_position_position_max_1" in FIELD_VALIDATORS
+
+    def test_tilt_min_validator_registered(self) -> None:
+        """A validator exists for the tilt-min key."""
+        assert "custom_position_tilt_min_1" in FIELD_VALIDATORS
+
+    def test_tilt_max_validator_registered(self) -> None:
+        """A validator exists for the tilt-max key."""
+        assert "custom_position_tilt_max_1" in FIELD_VALIDATORS
+
+    def test_position_max_validator_accepts_in_range(self) -> None:
+        """A 0–100 value validates."""
+        assert FIELD_VALIDATORS["custom_position_position_max_1"](60) == 60
+
+    def test_tilt_min_validator_rejects_out_of_range(self) -> None:
+        """A value above 100 is rejected."""
+        import voluptuous as vol
+        import pytest
+
+        with pytest.raises(vol.Invalid):
+            FIELD_VALIDATORS["custom_position_tilt_min_1"](150)
+
+
+# ---------------------------------------------------------------------------
+# Slot participation — a constraint-only slot is configured (issue #943)
+# ---------------------------------------------------------------------------
+
+
+class TestSlotConfiguredWithConstraintsOnly:
+    """A slot with a trigger and only a constraint (no position) participates."""
+
+    def test_trigger_plus_tilt_min_is_configured(self) -> None:
+        """The reporter's flagship config: contact sensor → minimum tilt only."""
+        keys = const.CUSTOM_POSITION_SLOTS[1]
+        options = {
+            keys["sensors"]: ["binary_sensor.door"],
+            keys["tilt_min"]: 50,
+        }
+        assert custom_position_slot_configured(options, keys) is True
+
+    def test_trigger_plus_tilt_max_is_configured(self) -> None:
+        """A tilt-max-only slot participates."""
+        keys = const.CUSTOM_POSITION_SLOTS[2]
+        options = {
+            keys["sensors"]: ["binary_sensor.door"],
+            keys["tilt_max"]: 40,
+        }
+        assert custom_position_slot_configured(options, keys) is True
+
+    def test_trigger_plus_position_max_is_configured(self) -> None:
+        """A position-max-only slot participates."""
+        keys = const.CUSTOM_POSITION_SLOTS[3]
+        options = {
+            keys["sensors"]: ["binary_sensor.door"],
+            keys["position_max"]: 60,
+        }
+        assert custom_position_slot_configured(options, keys) is True
+
+    def test_trigger_without_position_or_constraints_is_not_configured(self) -> None:
+        """A bare trigger still contributes nothing — unchanged behavior."""
+        keys = const.CUSTOM_POSITION_SLOTS[4]
+        options = {keys["sensors"]: ["binary_sensor.door"]}
+        assert custom_position_slot_configured(options, keys) is False
+
+    def test_constraint_without_trigger_is_not_configured(self) -> None:
+        """A constraint with no trigger cannot activate — unchanged gate."""
+        keys = const.CUSTOM_POSITION_SLOTS[5]
+        options = {keys["tilt_min"]: 50}
+        assert custom_position_slot_configured(options, keys) is False
+
+    def test_trigger_plus_position_still_configured(self) -> None:
+        """Legacy exact-position slots are unaffected."""
+        keys = const.CUSTOM_POSITION_SLOTS[6]
+        options = {
+            keys["sensors"]: ["binary_sensor.door"],
+            keys["position"]: 30,
+        }
+        assert custom_position_slot_configured(options, keys) is True
+
+
+class TestBuildHandlersConstraintOnlySlot:
+    """build_handlers must tolerate a slot with no position claim."""
+
+    def test_constraint_only_slot_builds_handler(self) -> None:
+        """A tilt-min-only slot still needs its handler (it emits the trace step)."""
+        options = {
+            "custom_position_sensors_7": ["binary_sensor.door"],
+            "custom_position_tilt_min_7": 50,
+        }
+        handlers = build_handlers(options)
+        assert "custom_position_7" in [h.name for h in handlers]
+
+
+# ---------------------------------------------------------------------------
+# Card / sensor slot snapshot — issue #943
+# ---------------------------------------------------------------------------
+
+
+class TestSlotSnapshotSurfacesConstraints:
+    """The companion card's slot rows carry the axis constraints."""
+
+    @staticmethod
+    def _row(options, slot=1):
+        from unittest.mock import MagicMock
+
+        from custom_components.adaptive_cover_pro.sensor import (
+            _build_custom_position_slots_snapshot,
+        )
+
+        hass = MagicMock()
+        hass.states.get.return_value = None
+        rows = _build_custom_position_slots_snapshot(options, hass)
+        return next(r for r in rows if r["slot"] == slot)
+
+    def test_constraints_surfaced(self) -> None:
+        """A configured slot reports its three constraint values."""
+        row = self._row(
+            {
+                "custom_position_sensors_1": ["binary_sensor.door"],
+                "custom_position_1": 30,
+                "custom_position_position_max_1": 60,
+                "custom_position_tilt_min_1": 50,
+                "custom_position_tilt_max_1": 90,
+            }
+        )
+        assert row["position_max"] == 60
+        assert row["tilt_min"] == 50
+        assert row["tilt_max"] == 90
+
+    def test_absent_constraints_are_none(self) -> None:
+        """A legacy slot reports None for each constraint."""
+        row = self._row(
+            {
+                "custom_position_sensors_1": ["binary_sensor.door"],
+                "custom_position_1": 30,
+            }
+        )
+        assert row["position_max"] is None
+        assert row["tilt_min"] is None
+        assert row["tilt_max"] is None
+
+    def test_constraint_only_slot_reports_null_position(self) -> None:
+        """A slot with no position claim must not crash the snapshot."""
+        row = self._row(
+            {
+                "custom_position_sensors_1": ["binary_sensor.door"],
+                "custom_position_tilt_min_1": 50,
+            }
+        )
+        assert row["position"] is None
+        assert row["tilt_min"] == 50
+        assert row["enabled"] is True

--- a/tests/test_custom_position_slots.py
+++ b/tests/test_custom_position_slots.py
@@ -330,6 +330,21 @@ class TestBuildHandlersConstraintOnlySlot:
         handlers = build_handlers(options)
         assert "custom_position_7" in [h.name for h in handlers]
 
+    def test_constraint_only_slot_carries_no_position_sentinel(self) -> None:
+        """No stored position must stay None, not become a phantom 0.
+
+        Audit finding 3: the 0 sentinel *is* readable — the ``use_my`` path
+        bypasses the deferral — and a phantom 0 fully closes the cover.
+        """
+        options = {
+            "custom_position_sensors_7": ["binary_sensor.door"],
+            "custom_position_tilt_min_7": 50,
+        }
+        handler = next(
+            h for h in build_handlers(options) if h.name == "custom_position_7"
+        )
+        assert handler._position is None  # noqa: SLF001
+
 
 # ---------------------------------------------------------------------------
 # Card / sensor slot snapshot — issue #943

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -11,8 +11,6 @@ way they compose with the floors that were already there.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 from custom_components.adaptive_cover_pro.const import (
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     ControlMethod,
@@ -99,10 +97,40 @@ def _slot(
     )
 
 
-def _evaluate(sensors, *, winner: _StubWinner | None = None):
+class _StubTiltContributor(OverrideHandler):
+    """A lower-priority handler that matches and supplies only a tilt.
+
+    Reproduces the ``_MERGEABLE`` fill path: the winner leaves ``tilt`` unset
+    and this handler's tilt is merged onto the result.
+    """
+
+    name = "stub_tilt"
+
+    def __init__(self, tilt: int, *, priority: int = 50) -> None:
+        self._tilt = tilt
+        self.priority = priority
+
+    def evaluate(self, snapshot) -> PipelineResult:  # noqa: ARG002
+        return PipelineResult(
+            position=99,
+            tilt=self._tilt,
+            control_method=ControlMethod.SOLAR,
+            reason="stub tilt",
+        )
+
+    def describe_skip(self, snapshot):  # noqa: ARG002
+        return "stub tilt skip"
+
+
+def _evaluate(
+    sensors,
+    *,
+    winner: _StubWinner | None = None,
+    extra: list[OverrideHandler] | None = None,
+):
     """Run a registry with a stub winner plus one handler per slot."""
     win = winner or _StubWinner()
-    handlers: list[OverrideHandler] = [win, DefaultHandler()]
+    handlers: list[OverrideHandler] = [win, DefaultHandler(), *(extra or [])]
     for s in sensors:
         handlers.append(
             CustomPositionHandler(
@@ -112,9 +140,7 @@ def _evaluate(sensors, *, winner: _StubWinner | None = None):
                 tilt=s.tilt,
             )
         )
-    snap = make_snapshot(
-        cover=MagicMock(), custom_position_sensors=sensors, default_position=0
-    )
+    snap = make_snapshot(custom_position_sensors=sensors, default_position=0)
     return PipelineRegistry(handlers).evaluate(snap)
 
 
@@ -356,3 +382,208 @@ class TestTiltBoundsCarriedWhenTiltUnresolved:
         assert (res.tilt_low, res.tilt_high) is not None or True
         assert res.tilt_low is None
         assert res.tilt_high is None
+
+
+# ---------------------------------------------------------------------------
+# Pre-merge audit regressions (issue #943)
+# ---------------------------------------------------------------------------
+
+
+class TestWinnerTraceStepSurvivesItsOwnConstraint:
+    """A slot can win the pipeline *and* carry a tilt bound (audit finding 1).
+
+    Sweeping every constraint source out of the trace left the winner unnamed:
+    the card showed a move with no matched step explaining it.
+    """
+
+    def _res(self):
+        return _evaluate(
+            [_slot(1, position=40, tilt_min=50)],
+            winner=_StubWinner(80, priority=10),
+        )
+
+    def test_slot_still_wins_the_position(self) -> None:
+        """The fixed claim is unaffected — this is a trace bug, not a value bug."""
+        assert self._res().position == 40
+
+    def test_winner_keeps_its_matched_trace_step(self) -> None:
+        """The handler that won must be named in the trace."""
+        matched = [
+            s.handler for s in self._res().decision_trace if s.matched and s.position
+        ]
+        assert "custom_position_1" in matched
+
+    def test_trace_has_exactly_one_matched_position_step(self) -> None:
+        """No clamp fires here, so the winner is the only matched position step."""
+        res = self._res()
+        matched = [
+            s for s in res.decision_trace if s.matched and s.handler != "tilt_clamp"
+        ]
+        assert [s.handler for s in matched] == ["custom_position_1"]
+
+
+class TestMergedTiltIsClamped:
+    """A tilt reaching the result via the _MERGEABLE fill must be clamped.
+
+    Audit finding 2 — the headline feature failing at its own job: the registry
+    clamped only ``winner.tilt`` / the FIXED overlay, so a tilt merged from a
+    lower-priority handler (or a ``contribute()``) sailed past the bound.
+    """
+
+    def _res(self, tilt_min=50):
+        return _evaluate(
+            [_slot(3, tilt_min=tilt_min)],
+            winner=_StubWinner(70, priority=80),
+            extra=[_StubTiltContributor(30, priority=50)],
+        )
+
+    def test_merged_tilt_is_raised_to_the_bound(self) -> None:
+        """Merged tilt 30 under a minimum of 50 → 50."""
+        assert self._res().tilt == 50
+
+    def test_bounds_are_not_also_carried(self) -> None:
+        """Once a tilt is clamped there is exactly one clamp site — not two.
+
+        Carrying the bounds as well would let the venetian policy clamp the
+        already-clamped tilt a second time.
+        """
+        res = self._res()
+        assert (res.tilt_low, res.tilt_high) == (None, None)
+
+    def test_merged_tilt_within_bounds_survives(self) -> None:
+        """A merged tilt already inside the bound is untouched."""
+        assert self._res(tilt_min=20).tilt == 30
+
+    def test_clamped_merge_emits_the_trace_step(self) -> None:
+        """The clamp is visible rather than a silent value change."""
+        assert ReasonCode.REGISTRY_TILT_CLAMPED in _codes(self._res())
+
+
+class TestBindingBoundIsNamed:
+    """Trace steps name the bound that actually bound (audit finding 4a)."""
+
+    def test_floor_raised_names_only_the_binding_floor(self) -> None:
+        """Two floors, one binds — the raise must not credit the other."""
+        res = _evaluate(
+            [
+                _slot(1, position=40, min_mode=True, sensor_name="Sensor 1"),
+                _slot(2, position=60, min_mode=True, sensor_name="Sensor 2"),
+            ],
+            winner=_StubWinner(10),
+        )
+        params = _step(res, ReasonCode.REGISTRY_FLOOR_RAISED).reason_payload.params
+        assert params["label"] == "Sensor 2"
+
+    def test_ceiling_lowered_names_only_the_binding_ceiling(self) -> None:
+        """The mirror: the lowest ceiling binds and is the one credited."""
+        res = _evaluate(
+            [
+                _slot(1, position_max=60, sensor_name="Sensor 1"),
+                _slot(2, position_max=30, sensor_name="Sensor 2"),
+            ],
+            winner=_StubWinner(90),
+        )
+        params = _step(res, ReasonCode.REGISTRY_CEILING_LOWERED).reason_payload.params
+        assert params["label"] == "Sensor 2"
+
+    def test_tilt_clamp_names_only_the_binding_tilt_bound(self) -> None:
+        """Same rule on the tilt axis."""
+        res = _evaluate(
+            [
+                _slot(1, tilt_min=30, sensor_name="Sensor 1"),
+                _slot(2, tilt_min=50, sensor_name="Sensor 2"),
+            ],
+            winner=_StubWinner(50, tilt=10),
+        )
+        params = _step(res, ReasonCode.REGISTRY_TILT_CLAMPED).reason_payload.params
+        assert params["label"] == "Sensor 2"
+
+
+class TestTiedFloorsBothTraced:
+    """Tie floors: the losing slot keeps an inactive step (audit finding 4b)."""
+
+    def test_losing_tied_floor_emits_an_inactive_step(self) -> None:
+        """Equal floors resolve to the first — the second must still explain itself."""
+        res = _evaluate(
+            [
+                _slot(1, position=60, min_mode=True),
+                _slot(2, position=60, min_mode=True),
+            ],
+            winner=_StubWinner(10),
+        )
+        inactive = [
+            s.handler
+            for s in res.decision_trace
+            if s.reason_payload is not None
+            and s.reason_payload.code is ReasonCode.REGISTRY_FLOOR_INACTIVE
+        ]
+        assert inactive == ["custom_position_2"]
+
+
+class TestLosingTiltOnlySlotKeepsAStep:
+    """A deferred tilt-only loser is not swept out of the trace (finding 4c)."""
+
+    def test_losing_tilt_only_slot_is_still_named(self) -> None:
+        """Slot 2 loses the FIXED tilt resolution but must stay visible."""
+        res = _evaluate(
+            [
+                _slot(1, tilt=20, tilt_only=True, priority=90),
+                _slot(2, tilt=70, tilt_only=True, priority=50),
+            ],
+            winner=_StubWinner(50),
+        )
+        assert "custom_position_2" in [s.handler for s in res.decision_trace]
+
+
+class TestCeilingOverriddenByFloor:
+    """The floor-beats-ceiling conflict reads honestly (audit finding 7)."""
+
+    def _res(self):
+        return _evaluate(
+            [
+                _slot(1, position=60, min_mode=True, sensor_name="Floor"),
+                _slot(2, position_max=40, sensor_name="Ceiling"),
+            ],
+            winner=_StubWinner(50),
+        )
+
+    def test_overridden_ceiling_is_not_reported_as_inactive(self) -> None:
+        """The cover ended up *above* the ceiling — 'inactive' is a lie."""
+        assert ReasonCode.REGISTRY_CEILING_INACTIVE not in _codes(self._res())
+
+    def test_overridden_ceiling_emits_the_overridden_step(self) -> None:
+        """Say the floor overrode it, which is what actually happened."""
+        assert ReasonCode.REGISTRY_CEILING_OVERRIDDEN in _codes(self._res())
+
+    def test_overridden_step_names_the_final_position(self) -> None:
+        """The payload carries the ceiling and where the cover really went."""
+        params = _step(
+            self._res(), ReasonCode.REGISTRY_CEILING_OVERRIDDEN
+        ).reason_payload.params
+        assert params["ceiling_pos"] == 40
+        assert params["to_pos"] == 60
+
+    def test_inert_ceiling_still_reads_as_inactive(self) -> None:
+        """Without a conflict the ceiling keeps today's inactive wording."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(40))
+        assert ReasonCode.REGISTRY_CEILING_INACTIVE in _codes(res)
+
+
+class TestFixedPositionOutranksCeiling:
+    """An explicit position keeps its claim; position_max needs min_mode (#5)."""
+
+    def test_fixed_position_wins_over_a_stored_position_max(self) -> None:
+        """Slot names 70 with a stale ceiling of 50 → the slot claims 70."""
+        res = _evaluate(
+            [_slot(1, position=70, position_max=50)],
+            winner=_StubWinner(20, priority=10),
+        )
+        assert res.position == 70
+
+    def test_min_mode_still_pairs_with_position_max_as_a_range(self) -> None:
+        """The RANGE cell is unaffected — the ceiling applies alongside a floor."""
+        res = _evaluate(
+            [_slot(1, position=30, min_mode=True, position_max=50)],
+            winner=_StubWinner(90),
+        )
+        assert res.position == 50

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -1,0 +1,358 @@
+"""Registry composition of the new axis constraints (issue #943).
+
+The *existing* composition contract — position floors (#463/#496) and their
+interaction with ``held_position`` (#534/#809), plus the tilt-only overlay
+(#514) — is pinned by ``test_floor_composition.py`` and
+``test_tilt_only_contribution.py``, which this change must leave untouched.
+
+This file pins what #943 adds on top: position ceilings, tilt bounds, and the
+way they compose with the floors that were already there.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.adaptive_cover_pro.const import (
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+    ControlMethod,
+    ReasonCode,
+)
+from custom_components.adaptive_cover_pro.pipeline.handler import OverrideHandler
+from custom_components.adaptive_cover_pro.pipeline.handlers import DefaultHandler
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+    PipelineResult,
+)
+
+from tests.test_pipeline.conftest import make_snapshot
+
+
+class _StubWinner(OverrideHandler):
+    """A handler that always wins with a fixed position/tilt."""
+
+    name = "stub_winner"
+
+    def __init__(
+        self,
+        position: int = 50,
+        *,
+        tilt: int | None = None,
+        priority: int = 40,
+        held_position: int | None = None,
+        skip_command: bool = False,
+    ) -> None:
+        self._position = position
+        self._tilt = tilt
+        self.priority = priority
+        self._held = held_position
+        self._skip = skip_command
+
+    def evaluate(self, snapshot) -> PipelineResult:  # noqa: ARG002
+        return PipelineResult(
+            position=self._position,
+            tilt=self._tilt,
+            control_method=ControlMethod.SOLAR,
+            reason="stub",
+            held_position=self._held,
+            skip_command=self._skip,
+        )
+
+    def describe_skip(self, snapshot):  # noqa: ARG002
+        return "stub skip"
+
+
+def _slot(
+    slot: int,
+    *,
+    is_on: bool = True,
+    position: int | None = None,
+    priority: int = DEFAULT_CUSTOM_POSITION_PRIORITY,
+    min_mode: bool = False,
+    tilt: int | None = None,
+    tilt_only: bool = False,
+    position_max: int | None = None,
+    tilt_min: int | None = None,
+    tilt_max: int | None = None,
+    sensor_name: str | None = None,
+) -> CustomPositionSensorState:
+    eid = f"binary_sensor.slot{slot}"
+    return CustomPositionSensorState(
+        entity_ids=(eid,),
+        is_on=is_on,
+        position=position,
+        priority=priority,
+        min_mode=min_mode,
+        use_my=False,
+        tilt=tilt,
+        tilt_only=tilt_only,
+        sensor_name=sensor_name,
+        slot=slot,
+        active_entity_ids=(eid,) if is_on else (),
+        position_max=position_max,
+        tilt_min=tilt_min,
+        tilt_max=tilt_max,
+    )
+
+
+def _evaluate(sensors, *, winner: _StubWinner | None = None):
+    """Run a registry with a stub winner plus one handler per slot."""
+    win = winner or _StubWinner()
+    handlers: list[OverrideHandler] = [win, DefaultHandler()]
+    for s in sensors:
+        handlers.append(
+            CustomPositionHandler(
+                slot=s.slot,
+                position=s.position if s.position is not None else 0,
+                priority=s.priority,
+                tilt=s.tilt,
+            )
+        )
+    snap = make_snapshot(
+        cover=MagicMock(), custom_position_sensors=sensors, default_position=0
+    )
+    return PipelineRegistry(handlers).evaluate(snap)
+
+
+def _codes(result) -> list:
+    return [
+        s.reason_payload.code
+        for s in result.decision_trace
+        if s.reason_payload is not None
+    ]
+
+
+def _step(result, code):
+    return next(
+        s
+        for s in result.decision_trace
+        if s.reason_payload is not None and s.reason_payload.code is code
+    )
+
+
+# ---------------------------------------------------------------------------
+# Position ceiling
+# ---------------------------------------------------------------------------
+
+
+class TestPositionCeiling:
+    """A position_max slot clamps the pipeline winner down."""
+
+    def test_ceiling_lowers_winner(self) -> None:
+        """Winner at 80 with a ceiling of 60 lands on 60."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(80))
+        assert res.position == 60
+
+    def test_ceiling_sets_floor_clamp_applied(self) -> None:
+        """A ceiling clamp is a user-configured cover-space value (#469)."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(80))
+        assert res.floor_clamp_applied is True
+
+    def test_ceiling_clears_skip_command(self) -> None:
+        """A clamp must reach the cover even when the winner was a hold."""
+        res = _evaluate(
+            [_slot(1, position_max=60)],
+            winner=_StubWinner(80, skip_command=True),
+        )
+        assert res.skip_command is False
+
+    def test_ceiling_emits_lowered_trace_step(self) -> None:
+        """The clamp is visible in the decision trace."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(80))
+        assert ReasonCode.REGISTRY_CEILING_LOWERED in _codes(res)
+
+    def test_lowered_step_carries_payload_params(self) -> None:
+        """The trace step names where it came from and where it went."""
+        res = _evaluate(
+            [_slot(1, position_max=60, sensor_name="Awning")],
+            winner=_StubWinner(80),
+        )
+        params = _step(res, ReasonCode.REGISTRY_CEILING_LOWERED).reason_payload.params
+        assert params["from_pos"] == 80
+        assert params["to_pos"] == 60
+        assert params["label"] == "Awning"
+
+    def test_winner_below_ceiling_is_untouched(self) -> None:
+        """An inert ceiling leaves the winner's own position exactly as-is."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(40))
+        assert res.position == 40
+        assert res.floor_clamp_applied is False
+
+    def test_inert_ceiling_emits_inactive_step(self) -> None:
+        """An inert ceiling still explains itself rather than a stale skip."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(40))
+        assert ReasonCode.REGISTRY_CEILING_INACTIVE in _codes(res)
+
+    def test_two_ceilings_pick_the_lowest(self) -> None:
+        """min-of-maxes — the mirror of #496's max-of-floors."""
+        res = _evaluate(
+            [_slot(1, position_max=60), _slot(2, position_max=30)],
+            winner=_StubWinner(80),
+        )
+        assert res.position == 30
+
+    def test_inactive_slot_ceiling_ignored(self) -> None:
+        """An off trigger constrains nothing."""
+        res = _evaluate(
+            [_slot(1, position_max=60, is_on=False)], winner=_StubWinner(80)
+        )
+        assert res.position == 80
+
+    def test_ceiling_replaces_the_slot_skip_step(self) -> None:
+        """The slot's deferral skip step is replaced, not left stale."""
+        res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(80))
+        assert ReasonCode.SKIP_CUSTOM_NOT_ACTIVE not in _codes(res)
+
+
+class TestCeilingVersusHeldPosition:
+    """A ceiling composes against where the cover actually ends up (#534)."""
+
+    def test_ceiling_lowers_held_position(self) -> None:
+        """Held at 80 with a ceiling of 60 → lowered to 60."""
+        res = _evaluate(
+            [_slot(1, position_max=60)],
+            winner=_StubWinner(80, held_position=80, skip_command=True),
+        )
+        assert res.position == 60
+        assert res.skip_command is False
+
+    def test_ceiling_above_held_is_inert(self) -> None:
+        """Held at 50 under a ceiling of 60 → nothing to do."""
+        res = _evaluate(
+            [_slot(1, position_max=60)],
+            winner=_StubWinner(50, held_position=50, skip_command=True),
+        )
+        assert res.floor_clamp_applied is False
+        assert ReasonCode.REGISTRY_CEILING_INACTIVE in _codes(res)
+
+
+class TestFloorBeatsCeiling:
+    """Conflicting bounds resolve deterministically — the floor wins."""
+
+    def test_floor_60_beats_ceiling_40(self) -> None:
+        """A floor above a ceiling wins: protection is not silently reduced."""
+        res = _evaluate(
+            [_slot(1, position=60, min_mode=True), _slot(2, position_max=40)],
+            winner=_StubWinner(50),
+        )
+        assert res.position == 60
+
+    def test_conflict_reports_a_floor_raise_not_a_ceiling_lower(self) -> None:
+        """The trace attributes the move to the floor that produced it."""
+        res = _evaluate(
+            [_slot(1, position=60, min_mode=True), _slot(2, position_max=40)],
+            winner=_StubWinner(50),
+        )
+        codes = _codes(res)
+        assert ReasonCode.REGISTRY_FLOOR_RAISED in codes
+        assert ReasonCode.REGISTRY_CEILING_LOWERED not in codes
+
+
+# ---------------------------------------------------------------------------
+# Tilt bounds
+# ---------------------------------------------------------------------------
+
+
+class TestTiltBounds:
+    """Tilt MIN/MAX clamp a tilt the winner already set — #514's inverse."""
+
+    def test_tilt_min_raises_winner_tilt(self) -> None:
+        """The reporter's case: calculated 20 with tilt_min 50 → 50."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=20))
+        assert res.tilt == 50
+
+    def test_tilt_above_min_is_untouched(self) -> None:
+        """The reporter's acceptance pair: calculated 75 stays 75."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=75))
+        assert res.tilt == 75
+
+    def test_tilt_max_lowers_winner_tilt(self) -> None:
+        """A tilt ceiling clamps down."""
+        res = _evaluate([_slot(1, tilt_max=60)], winner=_StubWinner(50, tilt=80))
+        assert res.tilt == 60
+
+    def test_tilt_clamp_emits_trace_step(self) -> None:
+        """The tilt clamp is visible in the trace."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=20))
+        assert ReasonCode.REGISTRY_TILT_CLAMPED in _codes(res)
+
+    def test_tilt_clamp_clears_skip_command(self) -> None:
+        """A tilt clamp must reach the cover."""
+        res = _evaluate(
+            [_slot(1, tilt_min=50)],
+            winner=_StubWinner(50, tilt=20, skip_command=True),
+        )
+        assert res.skip_command is False
+
+    def test_two_tilt_mins_pick_the_max(self) -> None:
+        """max-of-mins applies on the tilt axis too — the rule is per-kind."""
+        res = _evaluate(
+            [_slot(1, tilt_min=30), _slot(2, tilt_min=50)],
+            winner=_StubWinner(50, tilt=10),
+        )
+        assert res.tilt == 50
+
+    def test_tilt_range_clamps_both_ways(self) -> None:
+        """A tilt RANGE slot bounds the winner on both sides."""
+        low = _evaluate(
+            [_slot(1, tilt_min=40, tilt_max=80)], winner=_StubWinner(50, tilt=10)
+        )
+        high = _evaluate(
+            [_slot(1, tilt_min=40, tilt_max=80)], winner=_StubWinner(50, tilt=95)
+        )
+        assert (low.tilt, high.tilt) == (40, 80)
+
+    def test_tilt_bound_slot_does_not_claim_position(self) -> None:
+        """A tilt-bound-only slot leaves the position pipeline alone."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(80, tilt=20))
+        assert res.position == 80
+
+
+class TestTiltOnlyOverlayThenClamp:
+    """FIXED fills when unset; bounds then clamp the filled value."""
+
+    def test_overlay_is_clamped_by_a_tilt_min_from_another_slot(self) -> None:
+        """Overlay 20 with a separate slot's tilt_min 50 → 50."""
+        res = _evaluate(
+            [_slot(1, position=0, tilt=20, tilt_only=True), _slot(2, tilt_min=50)],
+            winner=_StubWinner(50),
+        )
+        assert res.tilt == 50
+
+    def test_overlay_within_bounds_survives(self) -> None:
+        """An overlay already inside the bounds is untouched."""
+        res = _evaluate(
+            [_slot(1, position=0, tilt=70, tilt_only=True), _slot(2, tilt_min=50)],
+            winner=_StubWinner(50),
+        )
+        assert res.tilt == 70
+
+
+class TestTiltBoundsCarriedWhenTiltUnresolved:
+    """Tilt can resolve after the pipeline (venetian) — carry the bounds."""
+
+    def test_bounds_carried_on_result(self) -> None:
+        """With no tilt to clamp yet, the composed bounds ride the result."""
+        res = _evaluate([_slot(1, tilt_min=50, tilt_max=80)], winner=_StubWinner(50))
+        assert (res.tilt_low, res.tilt_high) == (50, 80)
+
+    def test_tilt_stays_none(self) -> None:
+        """The registry must not invent a tilt out of a bound."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50))
+        assert res.tilt is None
+
+    def test_bound_active_step_emitted(self) -> None:
+        """A pending bound is traced so it isn't invisible."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50))
+        assert ReasonCode.REGISTRY_TILT_BOUND_ACTIVE in _codes(res)
+
+    def test_no_bounds_leaves_fields_none(self) -> None:
+        """Without tilt constraints the new fields stay None."""
+        res = _evaluate([], winner=_StubWinner(50))
+        assert (res.tilt_low, res.tilt_high) is not None or True
+        assert res.tilt_low is None
+        assert res.tilt_high is None

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -569,6 +569,150 @@ class TestCeilingOverriddenByFloor:
         assert ReasonCode.REGISTRY_CEILING_INACTIVE in _codes(res)
 
 
+# ---------------------------------------------------------------------------
+# Second-round pre-merge audit regressions (issue #943)
+# ---------------------------------------------------------------------------
+
+
+class TestLosingPositionSlotWithTiltBoundStaysVisible:
+    """Finding A: a slot that loses the position axis but carries a tilt bound.
+
+    Slot 2 names an exact position that loses on priority (a matched=False
+    ``OUTPRIORITIZED`` step) while also contributing a tilt minimum. The tilt
+    pass's ``_drop_trace_steps`` swept the slot's step away with nothing
+    re-emitted, so an active, constraining slot vanished from the trace.
+    """
+
+    def _res(self):
+        return _evaluate(
+            [_slot(2, position=25, tilt_min=10, priority=50)],
+            winner=_StubWinner(80, tilt=60, priority=80),
+        )
+
+    def test_no_value_changes(self) -> None:
+        """This is a trace bug: winner keeps position 80 and tilt 60."""
+        res = self._res()
+        assert res.position == 80
+        assert res.tilt == 60
+
+    def test_losing_slot_is_named_in_the_trace(self) -> None:
+        """custom_position_2 was active and constrained — it must appear."""
+        assert "custom_position_2" in [s.handler for s in self._res().decision_trace]
+
+    def test_losing_slot_gets_a_tilt_bound_inactive_step(self) -> None:
+        """Its non-binding tilt bound explains itself with the inactive step."""
+        assert ReasonCode.REGISTRY_TILT_BOUND_INACTIVE in _codes(self._res())
+
+
+class TestTiltBoundInactiveStep:
+    """Finding B: the tilt axis gains the position axis's inactive analog."""
+
+    def test_within_bound_emits_inactive_step(self) -> None:
+        """Winner tilt 75 already satisfies tilt_min 50 — the bound stays visible."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=75))
+        assert res.tilt == 75  # value unchanged
+        assert ReasonCode.REGISTRY_TILT_BOUND_INACTIVE in _codes(res)
+
+    def test_inactive_step_carries_payload_params(self) -> None:
+        """The step names the bound and the tilt that was already within it."""
+        res = _evaluate(
+            [_slot(1, tilt_min=50, sensor_name="Door")],
+            winner=_StubWinner(50, tilt=75),
+        )
+        params = _step(
+            res, ReasonCode.REGISTRY_TILT_BOUND_INACTIVE
+        ).reason_payload.params
+        assert params["low_label"] == "50%"
+        assert params["high_label"] == "—"
+        assert params["label"] == "Door"
+        assert params["tilt"] == 75
+
+    def test_out_composed_bound_emits_inactive_step(self) -> None:
+        """A tilt_min out-composed by a stricter one still explains itself."""
+        res = _evaluate(
+            [
+                _slot(1, tilt_min=30, sensor_name="Sensor 1"),
+                _slot(2, tilt_min=50, sensor_name="Sensor 2"),
+            ],
+            winner=_StubWinner(50, tilt=10),
+        )
+        assert res.tilt == 50  # value unchanged (max-of-mins)
+        inactive = [
+            s.handler
+            for s in res.decision_trace
+            if s.reason_payload is not None
+            and s.reason_payload.code is ReasonCode.REGISTRY_TILT_BOUND_INACTIVE
+        ]
+        assert inactive == ["custom_position_1"]
+
+    def test_binding_bound_is_not_also_inactive(self) -> None:
+        """The bound that actually clamped gets the clamp step, not an inactive one."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=10))
+        assert ReasonCode.REGISTRY_TILT_CLAMPED in _codes(res)
+        assert ReasonCode.REGISTRY_TILT_BOUND_INACTIVE not in _codes(res)
+
+    def test_carried_bound_is_not_reported_inactive(self) -> None:
+        """A pending bound (no tilt resolved yet) stays 'active', never 'inactive'."""
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50))
+        assert ReasonCode.REGISTRY_TILT_BOUND_ACTIVE in _codes(res)
+        assert ReasonCode.REGISTRY_TILT_BOUND_INACTIVE not in _codes(res)
+
+
+class TestFloorBeatsCeilingWinnerAboveFloor:
+    """Finding C: floor-beats-ceiling with the winner above the floor.
+
+    Floor 60, ceiling 40, winner 80 → position 60 (floor wins). The winner
+    started above the floor, so the net move is a lowering — but the floor,
+    not the ceiling, determined the final value. The trace must say so.
+    """
+
+    def _res(self):
+        return _evaluate(
+            [
+                _slot(1, position=60, min_mode=True, sensor_name="Floor"),
+                _slot(2, position_max=40, sensor_name="Ceiling"),
+            ],
+            winner=_StubWinner(80),
+        )
+
+    def test_position_is_the_floor(self) -> None:
+        """Value unchanged from the floor-wins rule."""
+        assert self._res().position == 60
+
+    def test_move_is_attributed_to_the_floor(self) -> None:
+        """A floor-wins step names the floor; it is not a ceiling lower."""
+        codes = _codes(self._res())
+        assert ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING in codes
+        assert ReasonCode.REGISTRY_CEILING_LOWERED not in codes
+
+    def test_floor_step_names_only_the_floor_not_a_joined_label(self) -> None:
+        """The joined-label bug must not resurface — the label is just the floor."""
+        params = _step(
+            self._res(), ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING
+        ).reason_payload.params
+        assert params["label"] == "Floor"
+        assert params["to_pos"] == 60
+        assert params["ceiling_pos"] == 40
+        assert params["from_pos"] == 80
+
+    def test_floor_is_not_reported_inactive(self) -> None:
+        """The floor produced the value — it cannot also be 'inactive'."""
+        assert ReasonCode.REGISTRY_FLOOR_INACTIVE not in _codes(self._res())
+
+    def test_beaten_ceiling_reads_overridden_not_inactive(self) -> None:
+        """The cover ended up above the ceiling — 'below ceiling' would be a lie."""
+        codes = _codes(self._res())
+        assert ReasonCode.REGISTRY_CEILING_OVERRIDDEN in codes
+        assert ReasonCode.REGISTRY_CEILING_INACTIVE not in codes
+
+    def test_overridden_ceiling_names_the_final_position(self) -> None:
+        params = _step(
+            self._res(), ReasonCode.REGISTRY_CEILING_OVERRIDDEN
+        ).reason_payload.params
+        assert params["ceiling_pos"] == 40
+        assert params["to_pos"] == 60
+
+
 class TestFixedPositionOutranksCeiling:
     """An explicit position keeps its claim; position_max needs min_mode (#5)."""
 

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -731,3 +731,91 @@ class TestFixedPositionOutranksCeiling:
             winner=_StubWinner(90),
         )
         assert res.position == 50
+
+
+# ---------------------------------------------------------------------------
+# Third-round audit: inactive-step payloads must reflect the FINAL value
+# ---------------------------------------------------------------------------
+
+
+class TestOutComposedTiltBoundInactivePayload:
+    """Finding i: an out-composed tilt bound's inactive step must report the
+    FINAL (post-clamp) tilt, not the pre-clamp winner tilt.
+
+    Slot 1 tilt_min 30, slot 2 tilt_min 50, winner tilt 10 → final tilt 50
+    (max-of-mins; slot 2 binds). Slot 1's non-binding inactive step must say the
+    resolved tilt is 50 — which genuinely *is* within [30, —]. The pre-clamp 10
+    is a false 'already within' claim: 10 is below 30 and is not the final tilt.
+    """
+
+    def _res(self):
+        return _evaluate(
+            [
+                _slot(1, tilt_min=30, sensor_name="Sensor 1"),
+                _slot(2, tilt_min=50, sensor_name="Sensor 2"),
+            ],
+            winner=_StubWinner(50, tilt=10),
+        )
+
+    def test_value_unchanged(self) -> None:
+        """This is a trace bug: the final tilt is still 50."""
+        assert self._res().tilt == 50
+
+    def test_inactive_step_reports_the_final_tilt(self) -> None:
+        """The non-binding bound's payload carries the resolved tilt, not 10."""
+        step = _step(self._res(), ReasonCode.REGISTRY_TILT_BOUND_INACTIVE)
+        assert step.reason_payload.params["label"] == "Sensor 1"
+        assert step.reason_payload.params["tilt"] == 50
+
+    def test_stale_number_variant_reports_the_clamped_tilt(self) -> None:
+        """A tilt_max clamps 75→40; the inactive tilt_min must report 40, not 75."""
+        res = _evaluate(
+            [
+                _slot(1, tilt_min=20, sensor_name="Min"),
+                _slot(2, tilt_max=40, sensor_name="Max"),
+            ],
+            winner=_StubWinner(50, tilt=75),
+        )
+        assert res.tilt == 40  # value unchanged
+        step = _step(res, ReasonCode.REGISTRY_TILT_BOUND_INACTIVE)
+        assert step.reason_payload.params["label"] == "Min"
+        assert step.reason_payload.params["tilt"] == 40
+
+
+class TestOutComposedCeilingInactivePayload:
+    """Finding ii: a ceiling ABOVE the winner, out-composed by a lower ceiling,
+    must not claim the winner is 'below' it.
+
+    Ceilings 40 and 70, winner 80 → final 40 (min-of-maxes; C40 binds). C70's
+    inactive step must read truthfully relative to the resolved position (40 is
+    at or below 70) — not 'winner 80% below ceiling 70%', which is a lie: the
+    winner (80) sits *above* the 70 ceiling, and 80 is not the resolved value.
+    """
+
+    def _res(self):
+        return _evaluate(
+            [
+                _slot(1, position_max=40, sensor_name="Ceiling 40"),
+                _slot(2, position_max=70, sensor_name="Ceiling 70"),
+            ],
+            winner=_StubWinner(80),
+        )
+
+    def test_value_unchanged(self) -> None:
+        """This is a trace bug: the cover still resolves to 40."""
+        assert self._res().position == 40
+
+    def test_inactive_ceiling_reports_the_resolved_position(self) -> None:
+        """The payload carries the resolved position (40), not the winner (80)."""
+        params = _step(
+            self._res(), ReasonCode.REGISTRY_CEILING_INACTIVE
+        ).reason_payload.params
+        assert params["ceiling_pos"] == 70
+        assert params["to_pos"] == 40
+        assert "winner_pos" not in params
+
+    def test_inactive_ceiling_text_is_truthful(self) -> None:
+        """The rendered text never claims the above-ceiling winner is below it."""
+        text = _step(self._res(), ReasonCode.REGISTRY_CEILING_INACTIVE).reason
+        assert "80" not in text
+        assert "40" in text

--- a/tests/test_pipeline/test_axis_constraints.py
+++ b/tests/test_pipeline/test_axis_constraints.py
@@ -1,0 +1,459 @@
+"""Unit tests for the unified axis-constraint model (issue #943).
+
+``pipeline/axis_constraints.py`` is the generalization of two single-purpose
+composition passes: ``floors.py`` (position-min) and ``tilt_axis.py``
+(tilt-fixed). These tests pin the model itself — gather parity with what those
+two modules produce today, plus the new bounds they never supported.
+
+The behavioral contract for the *registry composition* built on top of this
+lives in ``test_floor_composition.py`` (untouched) and
+``test_axis_constraint_composition.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import AxisConstraintMode
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    AXIS_NAME_POSITION,
+    AXIS_NAME_TILT,
+)
+from custom_components.adaptive_cover_pro.pipeline.axis_constraints import (
+    AxisConstraint,
+    clamp_to_bounds,
+    compose_bounds,
+    gather_axis_constraints,
+    resolve_fixed,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+)
+
+from tests.test_pipeline.conftest import make_snapshot
+
+
+def _snapshot(*, sensors: list[CustomPositionSensorState], **kwargs):
+    """Snapshot carrying only what the gather pass reads."""
+    return make_snapshot(custom_position_sensors=sensors, **kwargs)
+
+
+def _slot(
+    slot: int,
+    *,
+    is_on: bool = True,
+    position: int | None = None,
+    priority: int = 77,
+    min_mode: bool = False,
+    use_my: bool = False,
+    tilt: int | None = None,
+    tilt_only: bool = False,
+    position_max: int | None = None,
+    tilt_min: int | None = None,
+    tilt_max: int | None = None,
+    sensor_name: str | None = None,
+) -> CustomPositionSensorState:
+    """Build a slot state. The per-axis modes derive themselves."""
+    return CustomPositionSensorState(
+        entity_ids=(f"binary_sensor.slot{slot}",),
+        is_on=is_on,
+        position=position,
+        priority=priority,
+        min_mode=min_mode,
+        use_my=use_my,
+        tilt=tilt,
+        tilt_only=tilt_only,
+        sensor_name=sensor_name,
+        slot=slot,
+        position_max=position_max,
+        tilt_min=tilt_min,
+        tilt_max=tilt_max,
+    )
+
+
+def _on(constraints, axis, kind=None):
+    """Filter constraints by axis (and optionally kind)."""
+    return [
+        c for c in constraints if c.axis == axis and (kind is None or c.kind is kind)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# clamp_to_bounds — the one clamp formula
+# ---------------------------------------------------------------------------
+
+
+class TestClampToBounds:
+    """``max(min(value, high), low)`` — the single clamp used everywhere."""
+
+    def test_value_inside_bounds_unchanged(self) -> None:
+        """A value already within the bounds passes through."""
+        assert clamp_to_bounds(50, 20, 80) == 50
+
+    def test_value_below_low_raised(self) -> None:
+        """Below the floor → raised to the floor."""
+        assert clamp_to_bounds(10, 20, 80) == 20
+
+    def test_value_above_high_lowered(self) -> None:
+        """Above the ceiling → lowered to the ceiling."""
+        assert clamp_to_bounds(90, 20, 80) == 80
+
+    def test_no_bounds_is_identity(self) -> None:
+        """Both bounds absent → the value is untouched."""
+        assert clamp_to_bounds(50, None, None) == 50
+
+    def test_only_low(self) -> None:
+        """A lone floor still raises."""
+        assert clamp_to_bounds(10, 40, None) == 40
+
+    def test_only_high(self) -> None:
+        """A lone ceiling still lowers."""
+        assert clamp_to_bounds(90, None, 60) == 60
+
+    def test_floor_wins_when_low_above_high(self) -> None:
+        """Conflicting bounds resolve deterministically: the floor wins.
+
+        ``max(min(v, high), low)`` applies the ceiling first and the floor
+        last, so a floor above the ceiling is the value that survives.
+        """
+        assert clamp_to_bounds(50, 60, 40) == 60
+
+    def test_zero_low_is_honored(self) -> None:
+        """0 is a real bound, not "unset" — must not be truthiness-tested."""
+        assert clamp_to_bounds(-5, 0, 100) == 0
+
+    def test_zero_high_is_honored(self) -> None:
+        """A ceiling of 0 (fully closed) clamps everything down to 0."""
+        assert clamp_to_bounds(80, None, 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# compose_bounds — max-of-mins / min-of-maxes, one formula per axis
+# ---------------------------------------------------------------------------
+
+
+class TestComposeBounds:
+    """Composition of many constraints into one (low, high) pair."""
+
+    def test_empty_is_unbounded(self) -> None:
+        """No constraints → no bounds."""
+        assert compose_bounds([], AXIS_NAME_POSITION) == (None, None)
+
+    def test_single_min(self) -> None:
+        """One floor composes to itself."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MIN, 40, None, "s", "l", 77, 1
+            )
+        ]
+        assert compose_bounds(cs, AXIS_NAME_POSITION) == (40, None)
+
+    def test_two_mins_pick_max(self) -> None:
+        """Issue #496's max-of-floors — now the generic rule."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MIN, 40, None, "a", "a", 77, 1
+            ),
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MIN, 70, None, "b", "b", 10, 2
+            ),
+        ]
+        assert compose_bounds(cs, AXIS_NAME_POSITION) == (70, None)
+
+    def test_two_maxes_pick_min(self) -> None:
+        """The single mirror of max-of-mins: the most restrictive ceiling."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MAX, None, 60, "a", "a", 77, 1
+            ),
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MAX, None, 30, "b", "b", 99, 2
+            ),
+        ]
+        assert compose_bounds(cs, AXIS_NAME_POSITION) == (None, 30)
+
+    def test_range_contributes_both_bounds(self) -> None:
+        """A RANGE constraint carries a low and a high at once."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.RANGE, 30, 70, "a", "a", 77, 1
+            )
+        ]
+        assert compose_bounds(cs, AXIS_NAME_POSITION) == (30, 70)
+
+    def test_min_and_max_from_different_slots_compose(self) -> None:
+        """Two slots, one bound each, compose into a range."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MIN, 30, None, "a", "a", 77, 1
+            ),
+            AxisConstraint(
+                AXIS_NAME_POSITION, AxisConstraintMode.MAX, None, 70, "b", "b", 77, 2
+            ),
+        ]
+        assert compose_bounds(cs, AXIS_NAME_POSITION) == (30, 70)
+
+    def test_other_axis_ignored(self) -> None:
+        """Composition is per-axis — a tilt bound never leaks into position."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_TILT, AxisConstraintMode.MIN, 50, None, "a", "a", 77, 1
+            )
+        ]
+        assert compose_bounds(cs, AXIS_NAME_POSITION) == (None, None)
+        assert compose_bounds(cs, AXIS_NAME_TILT) == (50, None)
+
+    def test_fixed_contributes_no_bounds(self) -> None:
+        """FIXED is resolved by priority, not composed into bounds."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_TILT, AxisConstraintMode.FIXED, 50, 50, "a", "a", 77, 1
+            )
+        ]
+        assert compose_bounds(cs, AXIS_NAME_TILT) == (None, None)
+
+    def test_tilt_axis_uses_the_same_formula(self) -> None:
+        """The rule is per-kind, not per-axis: tilt mins also take the max."""
+        cs = [
+            AxisConstraint(
+                AXIS_NAME_TILT, AxisConstraintMode.MIN, 30, None, "a", "a", 77, 1
+            ),
+            AxisConstraint(
+                AXIS_NAME_TILT, AxisConstraintMode.MIN, 50, None, "b", "b", 77, 2
+            ),
+        ]
+        assert compose_bounds(cs, AXIS_NAME_TILT) == (50, None)
+
+
+# ---------------------------------------------------------------------------
+# resolve_fixed — highest-priority wins (today's resolve_tilt_axis rule)
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFixed:
+    """FIXED resolution stays highest-priority-wins, first-in-order on a tie."""
+
+    def test_none_when_no_fixed(self) -> None:
+        """No FIXED constraint → None."""
+        assert resolve_fixed([], AXIS_NAME_TILT) is None
+
+    def test_single_fixed(self) -> None:
+        """One FIXED constraint wins by default."""
+        c = AxisConstraint(
+            AXIS_NAME_TILT, AxisConstraintMode.FIXED, 50, 50, "a", "a", 77, 1
+        )
+        assert resolve_fixed([c], AXIS_NAME_TILT) is c
+
+    def test_highest_priority_wins(self) -> None:
+        """Priority 90 beats priority 77 — parity with resolve_tilt_axis."""
+        low = AxisConstraint(
+            AXIS_NAME_TILT, AxisConstraintMode.FIXED, 20, 20, "a", "a", 77, 1
+        )
+        high = AxisConstraint(
+            AXIS_NAME_TILT, AxisConstraintMode.FIXED, 80, 80, "b", "b", 90, 2
+        )
+        assert resolve_fixed([low, high], AXIS_NAME_TILT) is high
+
+    def test_tie_resolves_to_first_in_order(self) -> None:
+        """Equal priority → the first in snapshot order, as today."""
+        first = AxisConstraint(
+            AXIS_NAME_TILT, AxisConstraintMode.FIXED, 20, 20, "a", "a", 77, 1
+        )
+        second = AxisConstraint(
+            AXIS_NAME_TILT, AxisConstraintMode.FIXED, 80, 80, "b", "b", 77, 2
+        )
+        assert resolve_fixed([first, second], AXIS_NAME_TILT) is first
+
+    def test_min_constraints_are_not_fixed_winners(self) -> None:
+        """Only FIXED participates in fixed resolution."""
+        c = AxisConstraint(
+            AXIS_NAME_TILT, AxisConstraintMode.MIN, 50, None, "a", "a", 99, 1
+        )
+        assert resolve_fixed([c], AXIS_NAME_TILT) is None
+
+
+# ---------------------------------------------------------------------------
+# gather_axis_constraints — parity with floors.py / tilt_axis.py + new bounds
+# ---------------------------------------------------------------------------
+
+
+class TestGatherPositionMinParity:
+    """Position MIN constraints must reproduce gather_active_floors exactly."""
+
+    def test_min_mode_slot_emits_position_min(self) -> None:
+        """A min_mode slot contributes a position floor."""
+        snap = _snapshot(sensors=[_slot(1, position=60, min_mode=True)])
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_POSITION)
+        assert len(cs) == 1
+        assert cs[0].kind is AxisConstraintMode.MIN
+        assert cs[0].low == 60
+
+    def test_min_mode_slot_carries_source_label_priority_slot(self) -> None:
+        """Trace-facing metadata matches what FloorClampInfo carries today."""
+        snap = _snapshot(
+            sensors=[
+                _slot(3, position=60, min_mode=True, priority=42, sensor_name="Desk")
+            ]
+        )
+        c = _on(gather_axis_constraints(snap), AXIS_NAME_POSITION)[0]
+        assert c.source == "custom_position_3"
+        assert c.label == "Desk"
+        assert c.priority == 42
+        assert c.slot == 3
+
+    def test_inactive_slot_contributes_nothing(self) -> None:
+        """An off trigger emits no constraint."""
+        snap = _snapshot(sensors=[_slot(1, position=60, min_mode=True, is_on=False)])
+        assert gather_axis_constraints(snap) == []
+
+    def test_use_my_floor_excluded(self) -> None:
+        """The My path is hardware-pinned — it never contributes a floor."""
+        snap = _snapshot(sensors=[_slot(1, position=60, min_mode=True, use_my=True)])
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
+
+    def test_exact_position_slot_contributes_no_constraint(self) -> None:
+        """A FIXED-position slot claims via its handler, not via composition."""
+        snap = _snapshot(sensors=[_slot(1, position=60)])
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
+
+    def test_weather_min_mode_emits_position_min(self) -> None:
+        """The weather override floor rides the same model."""
+        snap = _snapshot(
+            sensors=[],
+            weather_override_active=True,
+            weather_override_min_mode=True,
+            weather_override_position=70,
+        )
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_POSITION)
+        assert len(cs) == 1
+        assert cs[0].source == "weather"
+        assert cs[0].label == "weather override"
+        assert cs[0].low == 70
+
+    def test_weather_without_min_mode_emits_nothing(self) -> None:
+        """An exact weather override claims via its handler."""
+        snap = _snapshot(
+            sensors=[],
+            weather_override_active=True,
+            weather_override_min_mode=False,
+            weather_override_position=70,
+        )
+        assert gather_axis_constraints(snap) == []
+
+    def test_custom_slots_precede_weather(self) -> None:
+        """Order is custom slots (snapshot order) then weather — as today."""
+        snap = _snapshot(
+            sensors=[_slot(1, position=60, min_mode=True)],
+            weather_override_active=True,
+            weather_override_min_mode=True,
+            weather_override_position=70,
+        )
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_POSITION)
+        assert [c.source for c in cs] == ["custom_position_1", "weather"]
+
+
+class TestGatherTiltFixedParity:
+    """Tilt FIXED constraints must reproduce gather_tilt_only_contributions."""
+
+    def test_tilt_only_slot_emits_tilt_fixed(self) -> None:
+        """A tilt-only slot contributes a FIXED tilt claim."""
+        snap = _snapshot(sensors=[_slot(1, tilt=50, tilt_only=True)])
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)
+        assert len(cs) == 1
+        assert cs[0].kind is AxisConstraintMode.FIXED
+        assert cs[0].low == 50
+        assert cs[0].high == 50
+
+    def test_tilt_only_without_tilt_emits_nothing(self) -> None:
+        """A tilt-only slot with no slat angle contributes nothing — parity."""
+        snap = _snapshot(sensors=[_slot(1, position=30, tilt_only=True)])
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_TILT) == []
+
+    def test_tilt_only_slot_makes_no_position_claim(self) -> None:
+        """tilt_only defers the position axis entirely."""
+        snap = _snapshot(sensors=[_slot(1, position=30, tilt=50, tilt_only=True)])
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
+
+    def test_tilt_fixed_carries_slot_metadata(self) -> None:
+        """Source/label/slot mirror TiltAxisContribution."""
+        snap = _snapshot(
+            sensors=[_slot(2, tilt=50, tilt_only=True, sensor_name="Blind")]
+        )
+        c = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)[0]
+        assert c.source == "custom_position_2"
+        assert c.label == "Blind"
+        assert c.slot == 2
+
+
+class TestGatherNewConstraints:
+    """The constraints #943 adds — none of which existed before."""
+
+    def test_position_max_emits_position_max(self) -> None:
+        """A position ceiling."""
+        snap = _snapshot(sensors=[_slot(1, position_max=60)])
+        c = _on(gather_axis_constraints(snap), AXIS_NAME_POSITION)[0]
+        assert c.kind is AxisConstraintMode.MAX
+        assert c.low is None
+        assert c.high == 60
+
+    def test_position_range_is_one_constraint_with_both_bounds(self) -> None:
+        """min_mode + position_max is a single RANGE constraint."""
+        snap = _snapshot(
+            sensors=[_slot(1, position=30, min_mode=True, position_max=70)]
+        )
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_POSITION)
+        assert len(cs) == 1
+        assert cs[0].kind is AxisConstraintMode.RANGE
+        assert (cs[0].low, cs[0].high) == (30, 70)
+
+    def test_tilt_min_emits_tilt_min(self) -> None:
+        """The reporter's ask: a tilt floor."""
+        snap = _snapshot(sensors=[_slot(1, position=30, tilt_min=50)])
+        c = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)[0]
+        assert c.kind is AxisConstraintMode.MIN
+        assert c.low == 50
+        assert c.high is None
+
+    def test_tilt_max_emits_tilt_max(self) -> None:
+        """A tilt ceiling."""
+        snap = _snapshot(sensors=[_slot(1, position=30, tilt_max=60)])
+        c = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)[0]
+        assert c.kind is AxisConstraintMode.MAX
+        assert c.high == 60
+
+    def test_tilt_range_is_one_constraint_with_both_bounds(self) -> None:
+        """Both tilt bounds compose into a single RANGE constraint."""
+        snap = _snapshot(sensors=[_slot(1, position=30, tilt_min=40, tilt_max=80)])
+        cs = _on(gather_axis_constraints(snap), AXIS_NAME_TILT)
+        assert len(cs) == 1
+        assert cs[0].kind is AxisConstraintMode.RANGE
+        assert (cs[0].low, cs[0].high) == (40, 80)
+
+    def test_one_slot_can_constrain_both_axes(self) -> None:
+        """A slot with a position floor and a tilt floor emits two constraints."""
+        snap = _snapshot(sensors=[_slot(1, position=30, min_mode=True, tilt_min=50)])
+        cs = gather_axis_constraints(snap)
+        assert len(cs) == 2
+        assert {c.axis for c in cs} == {AXIS_NAME_POSITION, AXIS_NAME_TILT}
+
+    def test_tilt_bound_slot_is_not_a_position_claim(self) -> None:
+        """A trigger + tilt_min slot must not force a position."""
+        snap = _snapshot(sensors=[_slot(1, tilt_min=50)])
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
+
+    def test_constraints_use_the_shared_axis_vocabulary(self) -> None:
+        """Axis keys come from cover_types.base — no per-type strings."""
+        snap = _snapshot(sensors=[_slot(1, position=30, min_mode=True, tilt_min=50)])
+        for c in gather_axis_constraints(snap):
+            assert c.axis in (AXIS_NAME_POSITION, AXIS_NAME_TILT)
+
+
+class TestGatherIsPure:
+    """The gather pass is a pure read of the snapshot."""
+
+    def test_returns_frozen_constraints(self) -> None:
+        """AxisConstraint is immutable."""
+        snap = _snapshot(sensors=[_slot(1, position=60, min_mode=True)])
+        c = gather_axis_constraints(snap)[0]
+        with pytest.raises(AttributeError):
+            c.low = 99  # type: ignore[misc]

--- a/tests/test_pipeline/test_axis_constraints.py
+++ b/tests/test_pipeline/test_axis_constraints.py
@@ -28,6 +28,7 @@ from custom_components.adaptive_cover_pro.pipeline.axis_constraints import (
 )
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
+    derive_axis_mode,
 )
 
 from tests.test_pipeline.conftest import make_snapshot
@@ -446,6 +447,79 @@ class TestGatherNewConstraints:
         snap = _snapshot(sensors=[_slot(1, position=30, min_mode=True, tilt_min=50)])
         for c in gather_axis_constraints(snap):
             assert c.axis in (AXIS_NAME_POSITION, AXIS_NAME_TILT)
+
+
+class TestDeriveAxisMode:
+    """Precedence between an exact value and the bounds on one axis.
+
+    FIXED outranks MAX (audit finding 5): a slot that names a position keeps
+    its claim, and a lone ``position_max`` is ignored unless the slot is also
+    in minimum mode. This mirrors the tilt axis, where a FIXED (``tilt_only``)
+    claim has always won over the bounds on the same axis.
+    """
+
+    def test_low_and_high_is_range(self) -> None:
+        """Both bounds → RANGE."""
+        assert derive_axis_mode(fixed=None, low=30, high=70) is AxisConstraintMode.RANGE
+
+    def test_low_only_is_min(self) -> None:
+        """A lone floor → MIN."""
+        assert derive_axis_mode(fixed=None, low=30, high=None) is AxisConstraintMode.MIN
+
+    def test_high_only_is_max(self) -> None:
+        """A lone ceiling with no exact value → MAX."""
+        assert derive_axis_mode(fixed=None, low=None, high=70) is AxisConstraintMode.MAX
+
+    def test_fixed_only_is_fixed(self) -> None:
+        """An exact value with no bounds → FIXED."""
+        assert derive_axis_mode(fixed=50, low=None, high=None) is (
+            AxisConstraintMode.FIXED
+        )
+
+    def test_fixed_outranks_high(self) -> None:
+        """An exact value beats a ceiling — the stored value is the target."""
+        assert derive_axis_mode(fixed=70, low=None, high=50) is (
+            AxisConstraintMode.FIXED
+        )
+
+    def test_low_outranks_fixed(self) -> None:
+        """A floor still wins: the stored position *is* the floor (min_mode)."""
+        assert derive_axis_mode(fixed=50, low=30, high=None) is AxisConstraintMode.MIN
+
+    def test_nothing_is_none(self) -> None:
+        """No claim at all → NONE."""
+        assert derive_axis_mode(fixed=None, low=None, high=None) is (
+            AxisConstraintMode.NONE
+        )
+
+    def test_zero_fixed_is_a_claim(self) -> None:
+        """0 is a real value, not "unset"."""
+        assert derive_axis_mode(fixed=0, low=None, high=None) is (
+            AxisConstraintMode.FIXED
+        )
+
+
+class TestPositionModeFixedNormalizesTheCeiling:
+    """A FIXED position slot contributes no ceiling (audit finding 5)."""
+
+    def test_position_with_a_ceiling_derives_fixed(self) -> None:
+        """Position 70 + position_max 50, no min_mode → FIXED."""
+        state = _slot(1, position=70, position_max=50)
+        assert state.position_mode is AxisConstraintMode.FIXED
+
+    def test_fixed_position_slot_emits_no_position_constraint(self) -> None:
+        """The ceiling is normalized off — nothing composes it onto the winner."""
+        snap = _snapshot(sensors=[_slot(1, position=70, position_max=50)])
+        assert _on(gather_axis_constraints(snap), AXIS_NAME_POSITION) == []
+
+    def test_min_mode_with_a_ceiling_still_derives_range(self) -> None:
+        """The RANGE cell is untouched — a ceiling needs a floor to apply."""
+        state = _slot(1, position=30, min_mode=True, position_max=70)
+        assert state.position_mode is AxisConstraintMode.RANGE
+
+    def test_ceiling_without_a_position_still_derives_max(self) -> None:
+        """A constraint-only ceiling slot is unaffected."""
+        assert _slot(1, position_max=60).position_mode is AxisConstraintMode.MAX
 
 
 class TestGatherIsPure:

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -1091,3 +1091,102 @@ class TestCustomPositionCustomName:
         assert result.use_my_position is True
         assert result.reason.startswith("Nap time active")
         assert result.custom_position_active_slot_name == "Nap time"
+
+
+# ---------------------------------------------------------------------------
+# Axis-constraint deferral — issue #943
+#
+# The deferral generalizes from "min_mode and not use_my" to "position_mode is
+# not FIXED and not use_my". Every pre-#943 config keeps its exact outcome; the
+# new constraint modes defer for the same reason min_mode always has — the
+# registry composes them onto whichever handler actually wins.
+# ---------------------------------------------------------------------------
+
+
+def _constraint_state(
+    *,
+    position: int | None = None,
+    min_mode: bool = False,
+    use_my: bool = False,
+    position_max: int | None = None,
+    tilt_min: int | None = None,
+    tilt_max: int | None = None,
+    tilt: int | None = None,
+    tilt_only: bool = False,
+) -> CustomPositionSensorState:
+    return CustomPositionSensorState(
+        entity_ids=(_ENTITY,),
+        is_on=True,
+        position=position,
+        priority=_DEFAULT_PRIORITY,
+        min_mode=min_mode,
+        use_my=use_my,
+        tilt=tilt,
+        tilt_only=tilt_only,
+        slot=1,
+        active_entity_ids=(_ENTITY,),
+        position_max=position_max,
+        tilt_min=tilt_min,
+        tilt_max=tilt_max,
+    )
+
+
+class TestConstraintModeDeferral:
+    """Non-FIXED position modes defer so the registry can compose them."""
+
+    def test_max_mode_slot_defers(self) -> None:
+        """A position-ceiling slot must not claim an exact position."""
+        snap = make_snapshot(
+            custom_position_sensors=[_constraint_state(position_max=60)]
+        )
+        assert _handler().evaluate(snap) is None
+
+    def test_range_mode_slot_defers(self) -> None:
+        """A floor+ceiling slot defers, exactly as a floor-only slot does."""
+        snap = make_snapshot(
+            custom_position_sensors=[
+                _constraint_state(position=30, min_mode=True, position_max=70)
+            ]
+        )
+        assert _handler().evaluate(snap) is None
+
+    def test_none_mode_slot_defers(self) -> None:
+        """A tilt-bound-only slot makes no position claim at all."""
+        snap = make_snapshot(custom_position_sensors=[_constraint_state(tilt_min=50)])
+        assert _handler().evaluate(snap) is None
+
+    def test_fixed_mode_slot_still_claims(self) -> None:
+        """The exact-position path is unchanged."""
+        snap = make_snapshot(custom_position_sensors=[_constraint_state(position=50)])
+        result = _handler(position=50).evaluate(snap)
+        assert result is not None
+        assert result.position == 50
+
+    def test_min_mode_slot_still_defers(self) -> None:
+        """Parity: today's floor-mode deferral is unchanged."""
+        snap = make_snapshot(
+            custom_position_sensors=[_constraint_state(position=60, min_mode=True)]
+        )
+        assert _handler().evaluate(snap) is None
+
+    def test_use_my_with_min_mode_still_claims(self) -> None:
+        """Parity: the My path ignores floor semantics and claims (unchanged)."""
+        snap = make_snapshot(
+            custom_position_sensors=[
+                _constraint_state(position=60, min_mode=True, use_my=True)
+            ],
+            my_position_value=42,
+        )
+        result = _handler().evaluate(snap)
+        assert result is not None
+        assert result.use_my_position is True
+        assert result.position == 42
+
+    def test_tilt_bounds_do_not_stop_a_fixed_position_claim(self) -> None:
+        """A slot may fix a position and bound the tilt at the same time."""
+        snap = make_snapshot(
+            custom_position_sensors=[_constraint_state(position=50, tilt_min=50)]
+        )
+        result = _handler(position=50).evaluate(snap)
+        assert result is not None
+        assert result.position == 50

--- a/tests/test_pipeline/test_custom_position_handler.py
+++ b/tests/test_pipeline/test_custom_position_handler.py
@@ -1190,3 +1190,37 @@ class TestConstraintModeDeferral:
         result = _handler(position=50).evaluate(snap)
         assert result is not None
         assert result.position == 50
+
+
+class TestUseMyWithoutAPosition:
+    """``use_my`` bypasses the deferral — it must not claim a phantom 0.
+
+    Audit finding 3: a slot with a trigger, ``use_my`` on, no stored position
+    and a cover with no My value fell through to the handler's position
+    sentinel and silently closed the cover.
+    """
+
+    def _snap(self, *, my_position_value=None, position=None):
+        return make_snapshot(
+            custom_position_sensors=[
+                _constraint_state(position=position, use_my=True, tilt_min=50)
+            ],
+            my_position_value=my_position_value,
+        )
+
+    def test_no_my_value_and_no_position_defers(self) -> None:
+        """Nothing to claim → defer, rather than close the cover."""
+        assert _handler(position=None).evaluate(self._snap()) is None
+
+    def test_no_my_value_falls_back_to_a_stored_position(self) -> None:
+        """Parity: with a position configured the fallback is unchanged."""
+        result = _handler(position=45).evaluate(self._snap(position=45))
+        assert result is not None
+        assert result.position == 45
+
+    def test_my_value_still_claims_without_a_stored_position(self) -> None:
+        """The My path itself is unaffected by the missing position."""
+        result = _handler(position=None).evaluate(self._snap(my_position_value=42))
+        assert result is not None
+        assert result.position == 42
+        assert result.use_my_position is True

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -32,6 +32,7 @@ from custom_components.adaptive_cover_pro.const import (
     CUSTOM_POSITION_SLOTS,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_TRACKING_SEASONS,
+    AxisConstraintMode,
     TrackingSeason,
 )
 from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
@@ -803,3 +804,209 @@ def test_read_climate_use_lux_inferred_from_cloud_suppression():
     builder.read_climate(opts)
     _, kwargs = climate_provider.read.call_args
     assert kwargs["use_lux"] is True
+
+
+# ---------------------------------------------------------------------------
+# Axis-constraint derivation — issue #943
+#
+# The stored wire format stays the min_mode / tilt_only booleans plus the
+# optional numeric constraint keys; the per-axis mode is DERIVED here, at the
+# one normalization site, and never persisted.
+# ---------------------------------------------------------------------------
+
+
+def _constraint_builder(slot_keys: dict, opts: dict):
+    """Read one slot whose trigger sensor is on, and return its state."""
+    on_state = MagicMock()
+    on_state.state = "on"
+    builder, _, _ = _make_builder(states={"binary_sensor.trigger": on_state})
+    merged = {slot_keys["sensors"]: ["binary_sensor.trigger"], **opts}
+    out = builder.read_custom_position_sensors(merged)
+    assert len(out) == 1
+    return out[0]
+
+
+@pytest.mark.unit
+def test_constraint_keys_land_on_state():
+    """position_max / tilt_min / tilt_max are carried onto the slot state."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {
+            keys["position"]: 30,
+            keys["position_max"]: 70,
+            keys["tilt_min"]: 40,
+            keys["tilt_max"]: 80,
+        },
+    )
+    assert state.position_max == 70
+    assert state.tilt_min == 40
+    assert state.tilt_max == 80
+
+
+@pytest.mark.unit
+def test_constraint_keys_default_to_none():
+    """A legacy slot carries no constraints — every new field reads None."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30})
+    assert state.position_max is None
+    assert state.tilt_min is None
+    assert state.tilt_max is None
+
+
+# --- Position axis ---------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_position_mode_fixed_for_legacy_exact_slot():
+    """A plain position slot claims the position axis exactly — parity."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30})
+    assert state.position_mode is AxisConstraintMode.FIXED
+
+
+@pytest.mark.unit
+def test_position_mode_min_for_legacy_min_mode_slot():
+    """min_mode reads as a position floor — parity with today's floor pass."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30, keys["min_mode"]: True})
+    assert state.position_mode is AxisConstraintMode.MIN
+
+
+@pytest.mark.unit
+def test_position_mode_range_for_min_mode_plus_position_max():
+    """min_mode + position_max is a two-sided position bound."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {keys["position"]: 30, keys["min_mode"]: True, keys["position_max"]: 70},
+    )
+    assert state.position_mode is AxisConstraintMode.RANGE
+
+
+@pytest.mark.unit
+def test_position_mode_max_for_position_max_only():
+    """position_max alone defers the position and clamps it down."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position_max"]: 70})
+    assert state.position_mode is AxisConstraintMode.MAX
+
+
+@pytest.mark.unit
+def test_position_mode_none_for_tilt_only_slot():
+    """tilt_only makes no position claim — parity with today's deferral."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {keys["position"]: 30, keys["tilt"]: 50, keys["tilt_only"]: True},
+    )
+    assert state.position_mode is AxisConstraintMode.NONE
+
+
+@pytest.mark.unit
+def test_position_mode_none_when_no_position_claim():
+    """Trigger + tilt_min only: the slot is present but claims no position."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["tilt_min"]: 50})
+    assert state.position_mode is AxisConstraintMode.NONE
+    assert state.tilt_mode is AxisConstraintMode.MIN
+
+
+@pytest.mark.unit
+def test_use_my_keeps_my_path_and_drops_position_max():
+    """The My path is hardware-pinned — orthogonal to the constraint model."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {keys["position"]: 30, keys["use_my"]: True, keys["position_max"]: 70},
+    )
+    assert state.use_my is True
+    assert state.position_max is None
+
+
+@pytest.mark.unit
+def test_tilt_only_normalizes_position_max_off():
+    """tilt_only wins: the slot's position-axis constraints are dropped."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {keys["tilt"]: 50, keys["tilt_only"]: True, keys["position_max"]: 70},
+    )
+    assert state.position_max is None
+
+
+# --- Tilt axis -------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_tilt_mode_none_for_legacy_slot():
+    """A slot with no tilt configuration claims nothing on the tilt axis."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30})
+    assert state.tilt_mode is AxisConstraintMode.NONE
+
+
+@pytest.mark.unit
+def test_tilt_mode_fixed_for_tilt_only_slot():
+    """tilt_only + a tilt value is an exact tilt claim — parity with #514.
+
+    A tilt-only slot still stores a position (the pre-#943 gate requires one);
+    tilt_only is what makes the slot ignore it on the position axis.
+    """
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys, {keys["position"]: 30, keys["tilt"]: 50, keys["tilt_only"]: True}
+    )
+    assert state.tilt_mode is AxisConstraintMode.FIXED
+
+
+@pytest.mark.unit
+def test_tilt_mode_none_for_tilt_only_without_tilt_value():
+    """A tilt-only slot with no slat angle contributes nothing — parity."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30, keys["tilt_only"]: True})
+    assert state.tilt_mode is AxisConstraintMode.NONE
+
+
+@pytest.mark.unit
+def test_tilt_mode_min_for_tilt_min_only():
+    """The reporter's ask: a minimum tilt boundary."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30, keys["tilt_min"]: 50})
+    assert state.tilt_mode is AxisConstraintMode.MIN
+
+
+@pytest.mark.unit
+def test_tilt_mode_max_for_tilt_max_only():
+    """A maximum tilt boundary."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(keys, {keys["position"]: 30, keys["tilt_max"]: 60})
+    assert state.tilt_mode is AxisConstraintMode.MAX
+
+
+@pytest.mark.unit
+def test_tilt_mode_range_for_both_tilt_bounds():
+    """Both bounds set is a two-sided tilt range."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys, {keys["position"]: 30, keys["tilt_min"]: 40, keys["tilt_max"]: 80}
+    )
+    assert state.tilt_mode is AxisConstraintMode.RANGE
+
+
+@pytest.mark.unit
+def test_tilt_only_wins_over_tilt_bounds():
+    """FIXED beats MIN/MAX on the tilt axis, mirroring tilt_only's precedence."""
+    keys = CUSTOM_POSITION_SLOTS[1]
+    state = _constraint_builder(
+        keys,
+        {
+            keys["tilt"]: 50,
+            keys["tilt_only"]: True,
+            keys["tilt_min"]: 20,
+            keys["tilt_max"]: 80,
+        },
+    )
+    assert state.tilt_mode is AxisConstraintMode.FIXED
+    assert state.tilt_min is None
+    assert state.tilt_max is None

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -267,6 +267,26 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
         {"tilt": 30, "handler": "solar", "winner_tilt": 45},
         "tilt-only 30% deferred — solar already set tilt 45%",
     ),
+    (
+        ReasonCode.REGISTRY_CEILING_LOWERED,
+        {"from_pos": 80, "to_pos": 60, "label": "Awning sensor"},
+        "ceiling lowered winner from 80% to 60% by Awning sensor",
+    ),
+    (
+        ReasonCode.REGISTRY_CEILING_INACTIVE,
+        {"ceiling_pos": 60, "winner_pos": 40},
+        "ceiling 60% inactive (winner 40% below ceiling)",
+    ),
+    (
+        ReasonCode.REGISTRY_TILT_BOUND_ACTIVE,
+        {"low_label": "50%", "high_label": "—", "label": "Door sensor"},
+        "tilt bound 50%–— active by Door sensor; awaiting the resolved tilt",
+    ),
+    (
+        ReasonCode.REGISTRY_TILT_CLAMPED,
+        {"from_tilt": 30, "to_tilt": 50, "label": "Door sensor"},
+        "tilt clamped from 30% to 50% by Door sensor",
+    ),
     # --- builder ---
     (ReasonCode.BUILDER_UNKNOWN, {}, "Unknown"),
     (ReasonCode.BUILDER_CONTROL_OCCUPANCY_TIMEOUT, {}, "Occupancy Timeout"),

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -283,9 +283,19 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
         "ceiling 40% overridden — a floor raised the cover to 60%",
     ),
     (
+        ReasonCode.REGISTRY_FLOOR_OVERRIDES_CEILING,
+        {"to_pos": 60, "ceiling_pos": 40, "label": "Floor sensor", "from_pos": 80},
+        "floor raised to 60% over ceiling 40% by Floor sensor (winner was 80%)",
+    ),
+    (
         ReasonCode.REGISTRY_TILT_BOUND_ACTIVE,
         {"low_label": "50%", "high_label": "—", "label": "Door sensor"},
         "tilt bound 50%–— active by Door sensor; awaiting the resolved tilt",
+    ),
+    (
+        ReasonCode.REGISTRY_TILT_BOUND_INACTIVE,
+        {"low_label": "50%", "high_label": "—", "label": "Door sensor", "tilt": 75},
+        "tilt bound 50%–— inactive by Door sensor; resolved tilt 75% already within",
     ),
     (
         ReasonCode.REGISTRY_TILT_CLAMPED,

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -278,6 +278,11 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
         "ceiling 60% inactive (winner 40% below ceiling)",
     ),
     (
+        ReasonCode.REGISTRY_CEILING_OVERRIDDEN,
+        {"ceiling_pos": 40, "to_pos": 60},
+        "ceiling 40% overridden — a floor raised the cover to 60%",
+    ),
+    (
         ReasonCode.REGISTRY_TILT_BOUND_ACTIVE,
         {"low_label": "50%", "high_label": "—", "label": "Door sensor"},
         "tilt bound 50%–— active by Door sensor; awaiting the resolved tilt",

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -274,8 +274,8 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
     ),
     (
         ReasonCode.REGISTRY_CEILING_INACTIVE,
-        {"ceiling_pos": 60, "winner_pos": 40},
-        "ceiling 60% inactive (winner 40% below ceiling)",
+        {"ceiling_pos": 60, "to_pos": 40},
+        "ceiling 60% inactive (resolved 40% at or below ceiling)",
     ),
     (
         ReasonCode.REGISTRY_CEILING_OVERRIDDEN,

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -1092,6 +1092,57 @@ class TestSetCustomPosition:
         assert new_opts["custom_position_sensor_1"] == "binary_sensor.high_sun"
         assert new_opts["custom_position_1"] == 80
 
+    async def test_axis_constraints_routing(self, hass: HomeAssistant):
+        """position_max / tilt_min / tilt_max route to the slot's wire keys."""
+        await _setup(hass, entry_id="cp_axis")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_custom_position",
+                {
+                    "slot": 1,
+                    "sensor": "binary_sensor.door",
+                    "position": 80,
+                    "position_max": 60,
+                    "tilt_min": 50,
+                    "tilt_max": 90,
+                },
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_position_max_1"] == 60
+        assert new_opts["custom_position_tilt_min_1"] == 50
+        assert new_opts["custom_position_tilt_max_1"] == 90
+
+    async def test_constraint_only_slot_is_complete(self, hass: HomeAssistant):
+        """A trigger + tilt_min slot needs no position (issue #943)."""
+        await _setup(hass, entry_id="cp_conly")
+        with (
+            patch.object(hass.config_entries, "async_update_entry") as mock_update,
+            patch.object(hass.config_entries, "async_reload", new_callable=AsyncMock),
+        ):
+            await _call(
+                hass,
+                "set_custom_position",
+                {"slot": 3, "sensor": "binary_sensor.door", "tilt_min": 50},
+            )
+
+        new_opts = mock_update.call_args[1]["options"]
+        assert new_opts["custom_position_tilt_min_3"] == 50
+
+    async def test_trigger_without_any_claim_still_rejected(self, hass: HomeAssistant):
+        """A bare trigger claims nothing — the completeness gate still fires."""
+        await _setup(hass, entry_id="cp_bare")
+        with pytest.raises(Exception, match="incomplete"):
+            await _call(
+                hass,
+                "set_custom_position",
+                {"slot": 4, "sensor": "binary_sensor.door"},
+            )
+
     async def test_slot_2_routing(self, hass: HomeAssistant):
         await _setup(hass, entry_id="cp_02")
         with (


### PR DESCRIPTION
## Summary
Extends Custom Position slots with three optional numeric limits per slot (maximum position, minimum tilt, maximum tilt) that clamp the normally resolved value instead of replacing it. A value inside the limits passes through unchanged; outside, it is clamped. The clamps are priority-independent, so solar/storm/weather handlers keep their precedence and priority 100 is not needed.

Under the hood this unifies the two near-parallel composition passes (position floors in `floors.py`, tilt-fixed in `tilt_axis.py`) behind a single `AxisConstraint` model in `pipeline/axis_constraints.py`, keyed on constraint kind rather than axis. Existing configs only produce position-MIN and tilt-FIXED constraints, so observable cover behavior is unchanged; `floors.py`/`tilt_axis.py` stay as thin adapters and the coordinator manual-move clamp is untouched. Stored format keeps `min_mode`/`tilt_only`; the per-axis mode is derived, not persisted. `MINOR_VERSION` 8 to 9 additive; `VERSION` stays 3 (rollback-safe). The optional "Active period" night-mode ask is deferred to a follow-up.

Hardened across three deep-audit rounds before this PR: value-correctness first (a minimum tilt could be silently violated on the merge-fill path; a use_my slot with no position could close the cover), then decision-trace completeness.

## Testing
- ✅ 6875 tests passing

## Related Issues
Refs #943