### PR TITLE
fix: translate venetian select options in the options flow

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -149,6 +149,25 @@ _EXPLICIT_USER_POSITION_METHODS = frozenset(
 )
 
 
+def _venetian_select(
+    options: tuple[str, ...], translation_key: str
+) -> selector.SelectSelector:
+    """Build a translated dropdown for one of the venetian enum fields.
+
+    Mirrors the working pattern in ``config_dynamic.py``
+    (``blind_spot_elevation_mode``) / ``config_fields._select()`` — a bare
+    ``vol.In(...)`` renders raw enum values in the frontend with no
+    translation attempted at all.
+    """
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=list(options),
+            mode=selector.SelectSelectorMode.LIST,
+            translation_key=translation_key,
+        )
+    )
+
+
 def _venetian_extras_schema() -> dict:
     """Return the venetian-only schema dict (unit-independent fields)."""
     return {
@@ -162,7 +181,7 @@ def _venetian_extras_schema() -> dict:
         ),
         vol.Optional(
             CONF_VENETIAN_TILT_SKIP_MODE, default=DEFAULT_VENETIAN_TILT_SKIP_MODE
-        ): vol.In(VENETIAN_TILT_SKIP_MODES),
+        ): _venetian_select(VENETIAN_TILT_SKIP_MODES, "venetian_tilt_skip_mode"),
         vol.Optional(
             CONF_VENETIAN_TILT_RESET_THRESHOLD,
             default=DEFAULT_VENETIAN_TILT_RESET_THRESHOLD,
@@ -176,21 +195,23 @@ def _venetian_extras_schema() -> dict:
         vol.Optional(
             CONF_VENETIAN_TILT_RESET_DIRECTION,
             default=DEFAULT_VENETIAN_TILT_RESET_DIRECTION,
-        ): vol.In(VENETIAN_TILT_RESET_DIRECTIONS),
+        ): _venetian_select(
+            VENETIAN_TILT_RESET_DIRECTIONS, "venetian_tilt_reset_direction"
+        ),
         vol.Optional(
             CONF_VENETIAN_TILT_RESET_SCOPE,
             default=DEFAULT_VENETIAN_TILT_RESET_SCOPE,
-        ): vol.In(VENETIAN_TILT_RESET_SCOPES),
-        vol.Optional(CONF_VENETIAN_MODE, default=DEFAULT_VENETIAN_MODE): vol.In(
-            VENETIAN_MODES
-        ),
+        ): _venetian_select(VENETIAN_TILT_RESET_SCOPES, "venetian_tilt_reset_scope"),
+        vol.Optional(
+            CONF_VENETIAN_MODE, default=DEFAULT_VENETIAN_MODE
+        ): _venetian_select(VENETIAN_MODES, "venetian_mode"),
         vol.Optional(
             CONF_VENETIAN_POST_SETTLE_HOLD,
             default=DEFAULT_VENETIAN_POST_SETTLE_HOLD_SECONDS,
         ): vol.All(vol.Coerce(float), vol.Range(min=0.0, max=10.0)),
         vol.Optional(
             CONF_VENETIAN_POST_SETTLE_MODE, default=DEFAULT_VENETIAN_POST_SETTLE_MODE
-        ): vol.In(VENETIAN_POST_SETTLE_MODES),
+        ): _venetian_select(VENETIAN_POST_SETTLE_MODES, "venetian_post_settle_mode"),
         vol.Optional(
             CONF_VENETIAN_BACKROTATE_PUBLISH_LAG,
             default=DEFAULT_VENETIAN_BACKROTATE_PUBLISH_LAG_SECONDS,

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1219,6 +1219,36 @@
         "intermediate": "Übergangszeit",
         "summer": "Sommer"
       }
+    },
+    "venetian_mode": {
+      "options": {
+        "position_and_tilt": "Position und Neigung",
+        "tilt_only": "Nur Neigung"
+      }
+    },
+    "venetian_tilt_reset_direction": {
+      "options": {
+        "open": "Öffnen",
+        "close": "Schließen"
+      }
+    },
+    "venetian_tilt_reset_scope": {
+      "options": {
+        "all_tilt_commands": "Alle Neigungsbefehle",
+        "sun_tracking_only": "Nur Sonnenverfolgung"
+      }
+    },
+    "venetian_tilt_skip_mode": {
+      "options": {
+        "neutral": "Neutral",
+        "suppress": "Unterdrücken"
+      }
+    },
+    "venetian_post_settle_mode": {
+      "options": {
+        "fixed_delay": "Feste Verzögerung",
+        "entity_state": "Entitätszustand"
+      }
     }
   },
   "services": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1219,6 +1219,36 @@
         "intermediate": "Intermediate",
         "summer": "Summer"
       }
+    },
+    "venetian_mode": {
+      "options": {
+        "position_and_tilt": "Position and tilt",
+        "tilt_only": "Tilt only"
+      }
+    },
+    "venetian_tilt_reset_direction": {
+      "options": {
+        "open": "Open",
+        "close": "Close"
+      }
+    },
+    "venetian_tilt_reset_scope": {
+      "options": {
+        "all_tilt_commands": "All tilt commands",
+        "sun_tracking_only": "Sun-tracking only"
+      }
+    },
+    "venetian_tilt_skip_mode": {
+      "options": {
+        "neutral": "Neutral",
+        "suppress": "Suppress"
+      }
+    },
+    "venetian_post_settle_mode": {
+      "options": {
+        "fixed_delay": "Fixed delay",
+        "entity_state": "Entity state"
+      }
     }
   },
   "services": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1219,6 +1219,36 @@
         "intermediate": "Intersaison",
         "summer": "Été"
       }
+    },
+    "venetian_mode": {
+      "options": {
+        "position_and_tilt": "Position et inclinaison",
+        "tilt_only": "Inclinaison seule"
+      }
+    },
+    "venetian_tilt_reset_direction": {
+      "options": {
+        "open": "Ouvrir",
+        "close": "Fermer"
+      }
+    },
+    "venetian_tilt_reset_scope": {
+      "options": {
+        "all_tilt_commands": "Toutes les commandes d'inclinaison",
+        "sun_tracking_only": "Suivi du soleil uniquement"
+      }
+    },
+    "venetian_tilt_skip_mode": {
+      "options": {
+        "neutral": "Neutre",
+        "suppress": "Supprimer"
+      }
+    },
+    "venetian_post_settle_mode": {
+      "options": {
+        "fixed_delay": "Délai fixe",
+        "entity_state": "État de l'entité"
+      }
     }
   },
   "services": {

--- a/tests/test_config_flow_schema_placement.py
+++ b/tests/test_config_flow_schema_placement.py
@@ -29,6 +29,10 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_SUNSET_TIME_ENTITY,
     CONF_TRANSIT_TIMEOUT,
     CONF_VENETIAN_MODE,
+    CONF_VENETIAN_POST_SETTLE_MODE,
+    CONF_VENETIAN_TILT_RESET_DIRECTION,
+    CONF_VENETIAN_TILT_RESET_SCOPE,
+    CONF_VENETIAN_TILT_SKIP_MODE,
 )
 
 
@@ -153,6 +157,37 @@ def test_venetian_mode_in_geometry_venetian_schema() -> None:
 
     keys = _schema_keys(GEOMETRY_VENETIAN_SCHEMA)
     assert CONF_VENETIAN_MODE in keys
+
+
+@pytest.mark.parametrize(
+    "conf_key, expected_translation_key",
+    [
+        (CONF_VENETIAN_MODE, "venetian_mode"),
+        (CONF_VENETIAN_TILT_RESET_DIRECTION, "venetian_tilt_reset_direction"),
+        (CONF_VENETIAN_TILT_RESET_SCOPE, "venetian_tilt_reset_scope"),
+        (CONF_VENETIAN_TILT_SKIP_MODE, "venetian_tilt_skip_mode"),
+        (CONF_VENETIAN_POST_SETTLE_MODE, "venetian_post_settle_mode"),
+    ],
+)
+def test_venetian_select_fields_use_selector_with_translation_key(
+    conf_key: str, expected_translation_key: str
+) -> None:
+    """The 5 venetian enum fields must render via SelectSelector(translation_key=...),
+    not a bare vol.In(...), or the frontend shows raw enum values instead of
+    translated labels (issue: untranslated venetian select options).
+    """
+    from homeassistant.helpers import selector as ha_selector
+
+    from custom_components.adaptive_cover_pro.cover_types.venetian import (
+        GEOMETRY_VENETIAN_SCHEMA,
+    )
+
+    marker = next(k for k in GEOMETRY_VENETIAN_SCHEMA.schema if str(k) == conf_key)
+    value_validator = GEOMETRY_VENETIAN_SCHEMA.schema[marker]
+    assert isinstance(
+        value_validator, ha_selector.SelectSelector
+    ), f"{conf_key} must use SelectSelector, not vol.In"
+    assert value_validator.config.get("translation_key") == expected_translation_key
 
 
 def test_tilt_sun_only_toggles_in_venetian_schema_default_false() -> None:

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -436,6 +436,34 @@ def test_venetian_mode_in_en_geometry_translations() -> None:
     ), "venetian_mode description missing from options.step.geometry.data_description"
 
 
+def test_venetian_select_options_translated_in_en() -> None:
+    """The 5 venetian enum fields must carry a selector.<key>.options block whose
+    keys exactly match the corresponding const tuple values, or SelectSelector's
+    translation_key lookup resolves to nothing and the frontend falls back to raw
+    enum values (issue: untranslated venetian select options).
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        VENETIAN_MODES,
+        VENETIAN_POST_SETTLE_MODES,
+        VENETIAN_TILT_RESET_DIRECTIONS,
+        VENETIAN_TILT_RESET_SCOPES,
+        VENETIAN_TILT_SKIP_MODES,
+    )
+
+    en = _load(TRANSLATIONS_DIR / "en.json")
+    sel = en["selector"]
+    expected = {
+        "venetian_mode": set(VENETIAN_MODES),
+        "venetian_tilt_reset_direction": set(VENETIAN_TILT_RESET_DIRECTIONS),
+        "venetian_tilt_reset_scope": set(VENETIAN_TILT_RESET_SCOPES),
+        "venetian_tilt_skip_mode": set(VENETIAN_TILT_SKIP_MODES),
+        "venetian_post_settle_mode": set(VENETIAN_POST_SETTLE_MODES),
+    }
+    for key, option_values in expected.items():
+        assert key in sel, f"selector.{key} missing from en.json"
+        assert set(sel[key]["options"].keys()) == option_values
+
+
 def test_priority_field_documents_all_three_gates() -> None:
     """The slot-1 priority description names all three bypassed gates (#711).
 


### PR DESCRIPTION
## Summary
The five venetian geometry selects in the options flow (Operating Mode, drift-reset direction, drift-reset scope, tilt-skip mode, post-settle mode) were defined with bare `vol.In(TUPLE)`. Home Assistant renders `vol.In` selects with no translation lookup, so their options showed as raw enum keys (`position_and_tilt`, `tilt_only`, `close`, `all_tilt_commands`, `sun_tracking_only`, …) instead of readable labels. The field labels/descriptions rendered fine because those come from a separate translation path.

Fix: route all five through a single `_venetian_select(options, translation_key)` helper using `SelectSelector` + `translation_key`, add the matching `selector.*.options` blocks to `en.json`, and sync DE/FR.

## Testing
- ✅ Affected suites pass (`test_config_flow_schema_placement`, `test_cover_types/test_venetian`, `test_translations`, `test_config_flow_summary_i18n`, `test_reason_i18n`, `test_services_options`)
- ✅ New guard tests: schema-placement asserts each field is a `SelectSelector` with the right `translation_key`; translations asserts the `en.json` option blocks exist and match the const tuples
- ✅ Translation validator green (DE/FR at full parity)

https://claude.ai/code/session_0189Ec7R3jpgqSFcpYVnc3SB