### PR TITLE
feat: non-sensor healthchecks for cover, config coherence, sun.sun (#975)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -730,6 +730,14 @@ DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA = True
 # Repair issue id (issue_registry) raised when the effective indoor temperature
 # sensor stays unavailable/missing beyond the debounce window (issue #786).
 ISSUE_TEMP_SENSOR_UNAVAILABLE = "temp_sensor_unavailable"
+# Non-sensor health-check Repair ids (issue #975), all informational
+# (is_fixable=False, WARNING, auto-clear on recovery) and debounced on the same
+# DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS window. Per-config-entry namespaced at
+# raise time (`{id}_{entry_id}` — A1 also appends the cover entity_id).
+ISSUE_COVER_UNAVAILABLE = "cover_unavailable"  # a controlled cover is unavailable
+ISSUE_SUN_UNAVAILABLE = "sun_unavailable"  # sun.sun is unavailable/missing
+ISSUE_CONFIG_POSITION_ENVELOPE = "config_position_envelope"  # min>max or slot outside
+ISSUE_CONFIG_TIME_WINDOW = "config_time_window"  # start >= end
 # Generous debounce so integration restarts / device re-adds don't nag before
 # a genuinely dead sensor is flagged.
 DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS = 900.0

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -35,9 +35,10 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .config_types import RuntimeConfig
+from .config_types import CoverConfig, RuntimeConfig
 from .helpers import (
     compute_effective_default,
+    custom_position_slot_delivers_fixed_position,
     custom_position_slot_sensors,
     get_datetime_from_str,
     get_safe_state,
@@ -77,8 +78,6 @@ from .const import (
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MANUAL_OVERRIDE_STRATEGY,
     CONF_MANUAL_THRESHOLD,
-    CONF_MAX_POSITION,
-    CONF_MIN_POSITION,
     CONF_MY_POSITION_VALUE,
     CONF_OPEN_CLOSE_THRESHOLD,
     CONF_RETURN_SUNSET,
@@ -1493,9 +1492,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
             self._cover_issue_keys = desired
 
-            # B1 — position-envelope coherence.
-            min_pos = self._min_position(options)
-            max_pos = self._max_position(options)
+            # B1 — position-envelope coherence. Consume the canonical min/max
+            # resolution from CoverConfig (single source of truth) instead of
+            # re-deriving the defaults here, and render the placeholders as plain
+            # ints so a HA NumberSelector float doesn't surface as "80.0".
+            cover_cfg = CoverConfig.from_options(options)
+            min_pos = int(cover_cfg.min_pos)
+            max_pos = int(cover_cfg.max_pos)
             self._repair.update_predicate(
                 self._envelope_issue_key,
                 self._position_envelope_incoherent(options, min_pos, max_pos),
@@ -1524,28 +1527,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.logger.debug("Health-check evaluation failed", exc_info=True)
 
     @staticmethod
-    def _min_position(options: dict) -> int:
-        """Effective minimum position (0 when unset) — mirrors RuntimeConfig."""
-        return options.get(CONF_MIN_POSITION) or 0
-
-    @staticmethod
-    def _max_position(options: dict) -> int:
-        """Effective maximum position (100 when unset) — mirrors RuntimeConfig.
-
-        No ``or`` fallback: an explicit 0 ("always closed", #806) must survive.
-        """
-        value = options.get(CONF_MAX_POSITION)
-        return 100 if value is None else int(value)
-
-    @staticmethod
     def _position_envelope_incoherent(
         options: dict, min_pos: int, max_pos: int
     ) -> bool:
         """Whether the position envelope is self-contradictory (issue #975, B1).
 
-        True when ``min > max`` or any enabled, non-safety custom-position slot is
-        pinned outside ``[min, max]``. Cover-type-agnostic: loops the slots
-        generically, no branching on cover type or capabilities.
+        True when ``min > max`` or an enabled, non-safety slot that would deliver
+        an exact (FIXED) cover position pins it outside ``[min, max]``. Slots that
+        never deliver a fixed position claim — ``use_my``, tilt-only, or a
+        non-FIXED constraint mode (floor / ceiling / range) — are exempt: they
+        compose as constraints the envelope clamps and cannot conflict with it.
+        Cover-type-agnostic: loops the slots generically and delegates the
+        fixed-position determination to the shared helper (same seam the pipeline
+        handler uses), with no branching on cover type or capabilities.
         """
         if min_pos > max_pos:
             return True
@@ -1557,9 +1551,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             if priority == CUSTOM_POSITION_SAFETY_PRIORITY:
                 continue  # safety slots command outside the envelope by design
+            if not custom_position_slot_delivers_fixed_position(options, slot_keys):
+                continue  # only exact-position slots can contradict the envelope
             position = options.get(slot_keys["position"])
-            if position is None:
-                continue  # slot has no pinned position to check
             if position < min_pos or position > max_pos:
                 return True
         return False

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -77,6 +77,8 @@ from .const import (
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MANUAL_OVERRIDE_STRATEGY,
     CONF_MANUAL_THRESHOLD,
+    CONF_MAX_POSITION,
+    CONF_MIN_POSITION,
     CONF_MY_POSITION_VALUE,
     CONF_OPEN_CLOSE_THRESHOLD,
     CONF_RETURN_SUNSET,
@@ -88,11 +90,17 @@ from .const import (
     CONF_TRANSIT_TIMEOUT,
     CUSTOM_POSITION_SAFETY_PRIORITY,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_ENABLED,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
     DEFAULT_MANUAL_OVERRIDE_STRATEGY,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     DIAG_CACHE_KEY,
     DOMAIN,
+    ISSUE_CONFIG_POSITION_ENVELOPE,
+    ISSUE_CONFIG_TIME_WINDOW,
+    ISSUE_COVER_UNAVAILABLE,
+    ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
     LOGGER,
     POSITION_TOLERANCE_PERCENT,
@@ -115,6 +123,7 @@ from .managers.manual_override import (
 from .managers.climate_smoothing import ClimateSmoothingManager
 from .managers.cloud_suppression import CloudSuppressionManager
 from .managers.motion import MotionManager
+from .managers.repair import RepairManager
 from .managers.sensor_health import SensorHealthManager
 from .managers.weather import WeatherManager
 from .managers.time_window import TimeWindowManager
@@ -357,6 +366,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._temp_issue_key = (
             f"{ISSUE_TEMP_SENSOR_UNAVAILABLE}_{self.config_entry.entry_id}"
         )
+        # Non-sensor health checks (issue #975): controlled-cover + sun.sun
+        # availability (entity-shaped, on SensorHealthManager) and config-coherence
+        # predicates (envelope, time window) on the RepairManager sibling. Same
+        # informational contract and debounce as the temp watch. Issue keys are
+        # per-config-entry namespaced so each cover instance owns its Repairs.
+        self._repair = RepairManager(self.hass, self.logger, domain=DOMAIN)
+        entry_id = self.config_entry.entry_id
+        self._sun_issue_key = f"{ISSUE_SUN_UNAVAILABLE}_{entry_id}"
+        self._envelope_issue_key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{entry_id}"
+        self._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{entry_id}"
+        # Namespaced cover-availability watch keys currently registered, so a
+        # cover dropped from config gets unwatched (its Repair cleared) next cycle.
+        self._cover_issue_keys: set[str] = set()
         # Override pipeline — custom position handlers are created per-slot so
         # each can carry an independent priority configured by the user.
         self._pipeline = self._build_pipeline()
@@ -1412,6 +1434,136 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             self._start_weather_timeout()
 
+    def _evaluate_health_checks(self, options: dict) -> None:
+        """Raise/clear informational Repairs for sensor + config health.
+
+        One fail-open guard covers all checks (issue #786, #975) so none can
+        break the update cycle. Entity-availability checks (temp sensor, each
+        controlled cover, ``sun.sun``) ride the ``SensorHealthManager``; config
+        coherence (position envelope, time window) rides the ``RepairManager``
+        predicate sibling. Everything is per-config-entry namespaced and cleared
+        automatically on recovery.
+        """
+        try:
+            name = self.config_entry.data.get("name", "") or ""
+
+            # Temp sensor (issue #786): watch the effective indoor temp entity
+            # only when climate mode is on — an unavailable sensor is not worth
+            # nagging about when climate is off. Watching the resolved effective
+            # entity covers both explicit and area-resolved cases.
+            climate_on = bool(options.get(CONF_CLIMATE_MODE, False))
+            effective_temp = (
+                self._weather_readings.inside_temperature_entity_id
+                if climate_on
+                else None
+            )
+            self._sensor_health.update_watch(
+                self._temp_issue_key,
+                effective_temp,
+                translation_key=ISSUE_TEMP_SENSOR_UNAVAILABLE,
+                placeholders={"entity_id": effective_temp or "", "name": name},
+            )
+
+            # C1 — sun.sun availability. Always watched; the whole integration
+            # depends on it, so an unavailable sun entity is always worth flagging.
+            self._sensor_health.update_watch(
+                self._sun_issue_key,
+                "sun.sun",
+                translation_key=ISSUE_SUN_UNAVAILABLE,
+                placeholders={"name": name},
+            )
+
+            # A1 — each controlled cover's availability. Watch every entity under
+            # its own namespaced key; unwatch (and clear) any cover dropped from
+            # config since last cycle. A cover removed from the registry has no
+            # state → already treated unhealthy.
+            desired: set[str] = set()
+            for eid in self.entities:
+                key = f"{ISSUE_COVER_UNAVAILABLE}_{self.config_entry.entry_id}_{eid}"
+                desired.add(key)
+                self._sensor_health.update_watch(
+                    key,
+                    eid,
+                    translation_key=ISSUE_COVER_UNAVAILABLE,
+                    placeholders={"entity_id": eid, "name": name},
+                )
+            for stale in self._cover_issue_keys - desired:
+                self._sensor_health.update_watch(
+                    stale, None, translation_key=ISSUE_COVER_UNAVAILABLE
+                )
+            self._cover_issue_keys = desired
+
+            # B1 — position-envelope coherence.
+            min_pos = self._min_position(options)
+            max_pos = self._max_position(options)
+            self._repair.update_predicate(
+                self._envelope_issue_key,
+                self._position_envelope_incoherent(options, min_pos, max_pos),
+                translation_key=ISSUE_CONFIG_POSITION_ENVELOPE,
+                placeholders={"name": name, "min": str(min_pos), "max": str(max_pos)},
+            )
+
+            # B2 — time-window coherence. Only fire when BOTH sides resolve, so an
+            # entity-provided-but-unavailable start/end never false-fires.
+            start = self._time_mgr.resolved_start_time
+            end = self._time_mgr.end_time
+            self._repair.update_predicate(
+                self._time_window_issue_key,
+                start is not None and end is not None and start >= end,
+                translation_key=ISSUE_CONFIG_TIME_WINDOW,
+                placeholders={
+                    "name": name,
+                    "start": start.strftime("%H:%M") if start is not None else "",
+                    "end": end.strftime("%H:%M") if end is not None else "",
+                },
+            )
+
+            self._sensor_health.evaluate()
+            self._repair.evaluate()
+        except Exception:  # noqa: BLE001 — health check must never break the cycle
+            self.logger.debug("Health-check evaluation failed", exc_info=True)
+
+    @staticmethod
+    def _min_position(options: dict) -> int:
+        """Effective minimum position (0 when unset) — mirrors RuntimeConfig."""
+        return options.get(CONF_MIN_POSITION) or 0
+
+    @staticmethod
+    def _max_position(options: dict) -> int:
+        """Effective maximum position (100 when unset) — mirrors RuntimeConfig.
+
+        No ``or`` fallback: an explicit 0 ("always closed", #806) must survive.
+        """
+        value = options.get(CONF_MAX_POSITION)
+        return 100 if value is None else int(value)
+
+    @staticmethod
+    def _position_envelope_incoherent(
+        options: dict, min_pos: int, max_pos: int
+    ) -> bool:
+        """Whether the position envelope is self-contradictory (issue #975, B1).
+
+        True when ``min > max`` or any enabled, non-safety custom-position slot is
+        pinned outside ``[min, max]``. Cover-type-agnostic: loops the slots
+        generically, no branching on cover type or capabilities.
+        """
+        if min_pos > max_pos:
+            return True
+        for slot_keys in CUSTOM_POSITION_SLOTS.values():
+            if not options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED):
+                continue
+            priority = options.get(
+                slot_keys["priority"], DEFAULT_CUSTOM_POSITION_PRIORITY
+            )
+            if priority == CUSTOM_POSITION_SAFETY_PRIORITY:
+                continue  # safety slots command outside the envelope by design
+            position = options.get(slot_keys["position"])
+            if position is None:
+                continue  # slot has no pinned position to check
+            if position < min_pos or position > max_pos:
+                return True
+        return False
+
     def _calculate_cover_state(self, cover_data, options) -> int:
         """Calculate cover state via pipeline and return final position.
 
@@ -1440,30 +1592,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # snapshot sees this cycle's resolved flags.
         self._reconcile_climate_smoothing(self._weather_readings)
 
-        # Sensor-health Repair (issue #786): watch the effective indoor temp
-        # entity only when climate mode is on (the sensor is otherwise unused,
-        # so an unavailable one is not worth nagging about). Watching the
-        # resolved effective entity covers both explicit and area-resolved
-        # cases. Fail-open: never let this raise into the update cycle.
-        try:
-            climate_on = bool(options.get(CONF_CLIMATE_MODE, False))
-            effective_temp = (
-                self._weather_readings.inside_temperature_entity_id
-                if climate_on
-                else None
-            )
-            self._sensor_health.update_watch(
-                self._temp_issue_key,
-                effective_temp,
-                translation_key=ISSUE_TEMP_SENSOR_UNAVAILABLE,
-                placeholders={
-                    "entity_id": effective_temp or "",
-                    "name": self.config_entry.data.get("name", "") or "",
-                },
-            )
-            self._sensor_health.evaluate()
-        except Exception:  # noqa: BLE001 — health check must never break the cycle
-            self.logger.debug("Sensor-health evaluation failed", exc_info=True)
+        # Health-check Repairs (issue #786, #975): sensor availability + config
+        # coherence, all informational and debounced. Runs inside one fail-open
+        # guard so no check can break the update cycle.
+        self._evaluate_health_checks(options)
 
         # Compute the effective default position from astronomical sunset/sunrise.
         # This is the single source of truth — all pipeline handlers use it via
@@ -3688,8 +3820,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Cancel weather clear-delay timeout task
         self._cancel_weather_timeout()
 
-        # Cancel any in-flight sensor-health debounce timers (issue #786).
+        # Cancel any in-flight health-check debounce timers (issue #786, #975).
         self._sensor_health.shutdown()
+        self._repair.shutdown()
 
         # Stop cover command service reconciliation timer
         self._cmd_svc.stop()

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     # Fallback for older Home Assistant versions
     EventStateChangedData = dict  # type: ignore[misc,assignment]
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
@@ -378,6 +379,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Namespaced cover-availability watch keys currently registered, so a
         # cover dropped from config gets unwatched (its Repair cleared) next cycle.
         self._cover_issue_keys: set[str] = set()
+        # One-shot: the first health-check cycle of this lifetime sweeps the issue
+        # registry for A1 Repairs orphaned by a prior lifetime (removing a cover
+        # reloads the entry, so a cross-lifetime orphan is in neither the fresh
+        # ``desired`` set nor the in-lifetime unwatch loop). Mirrors the base's
+        # ``_reconciled`` first-pass philosophy — see _evaluate_health_checks.
+        self._a1_orphans_swept = False
         # Override pipeline — custom position handlers are created per-slot so
         # each can carry an independent priority configured by the user.
         self._pipeline = self._build_pipeline()
@@ -1523,6 +1530,30 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
             self._sensor_health.evaluate()
             self._repair.evaluate()
+
+            # A1 cross-lifetime orphan sweep (issue #975 audit). The primary fix
+            # for a cover_unavailable Repair is REMOVING the cover, which reloads
+            # the config entry → a fresh coordinator with an empty
+            # ``_cover_issue_keys``. The removed cover's key is in neither
+            # ``desired`` (recomputed above) nor the in-lifetime unwatch loop, so
+            # its Repair would orphan until an HA restart. Once per lifetime,
+            # enumerate this integration's issues and delete any A1 Repair for
+            # this entry that is no longer desired. Runs last (inside the single
+            # fail-open guard) so a registry hiccup can never skip A1/B1/B2. The
+            # ``desired``-membership filter is critical: a still-configured but
+            # unavailable cover IS in ``desired`` (it is watched), so its valid
+            # warning is preserved rather than flapped on every restart.
+            if not self._a1_orphans_swept:
+                a1_prefix = f"{ISSUE_COVER_UNAVAILABLE}_{self.config_entry.entry_id}_"
+                registry = ir.async_get(self.hass)
+                for reg_domain, issue_id in list(registry.issues):
+                    if (
+                        reg_domain == DOMAIN
+                        and issue_id.startswith(a1_prefix)
+                        and issue_id not in self._cover_issue_keys
+                    ):
+                        ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+                self._a1_orphans_swept = True
         except Exception:  # noqa: BLE001 — health check must never break the cycle
             self.logger.debug("Health-check evaluation failed", exc_info=True)
 

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
     CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_TILT_ONLY,
 )
 from .templates import is_template_string
 
@@ -146,6 +147,46 @@ def custom_position_slot_configured(
         options.get(slot_keys[sub]) is not None for sub in CUSTOM_POSITION_CLAIM_KEYS
     )
     return has_trigger and has_claim
+
+
+def custom_position_slot_delivers_fixed_position(
+    options: Mapping, slot_keys: Mapping[str, str]
+) -> bool:
+    """Return True when a slot would deliver an exact (FIXED) cover-position claim.
+
+    Single source of truth for "does this custom-position slot pin the position
+    axis to a stored value?", shared by the pipeline handler's position-axis
+    determination and the B1 position-envelope health check (issue #975). A slot
+    pins an exact position only when it is neither ``use_my`` (routes to the
+    hardware My preset, ignoring the stored position) nor ``tilt_only`` (fixes the
+    slat angle and lets solar drive the carriage) and its position mode resolves
+    to ``FIXED``. Every other mode — a floor (``min_mode``), a ceiling/range, or
+    no position claim — composes as a constraint that the min/max envelope clamps,
+    so it can never contradict the envelope with an out-of-range exact value.
+
+    Reuses :attr:`CustomPositionSensorState.position_mode` — the same derivation
+    the handler and axis-constraint composer use — so B1 and the pipeline agree.
+    """
+    from .const import AxisConstraintMode
+    from .pipeline.types import CustomPositionSensorState
+
+    if bool(options.get(slot_keys["use_my"], False)):
+        return False
+    raw_pos = options.get(slot_keys["position"])
+    raw_pos_max = options.get(slot_keys["position_max"])
+    state = CustomPositionSensorState(
+        entity_ids=(),
+        is_on=False,
+        position=int(raw_pos) if raw_pos is not None else None,
+        priority=0,
+        min_mode=bool(options.get(slot_keys["min_mode"], False)),
+        use_my=False,
+        tilt_only=bool(
+            options.get(slot_keys["tilt_only"], DEFAULT_CUSTOM_POSITION_TILT_ONLY)
+        ),
+        position_max=int(raw_pos_max) if raw_pos_max is not None else None,
+    )
+    return state.position_mode is AxisConstraintMode.FIXED
 
 
 def custom_position_slot_name(

--- a/custom_components/adaptive_cover_pro/managers/common/debounced_repair.py
+++ b/custom_components/adaptive_cover_pro/managers/common/debounced_repair.py
@@ -52,6 +52,13 @@ class _DebouncedRepairBase:
         self._debounce = debounce_seconds
         self._timers: dict[str, TimeoutController] = {}
         self._active: set[str] = set()
+        # Keys whose registry state this manager lifetime has already reconciled.
+        # The primary fix path (options flow) reloads the config entry, so a
+        # Repair raised in a prior lifetime is invisible to this instance's
+        # ``_active`` set. The first healthy clear for a key therefore attempts a
+        # delete unconditionally (idempotent) to sweep any orphan, then records
+        # the key here so subsequent healthy cycles skip the redundant no-op.
+        self._reconciled: set[str] = set()
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -102,6 +109,7 @@ class _DebouncedRepairBase:
             translation_placeholders=placeholders,
         )
         self._active.add(issue_key)
+        self._reconciled.add(issue_key)
 
     def _recover(self, issue_key: str) -> None:
         """Cancel any pending debounce and clear an active Repair."""
@@ -114,9 +122,14 @@ class _DebouncedRepairBase:
             timer.cancel()
 
     def _delete_issue(self, issue_key: str) -> None:
-        if issue_key in self._active:
+        # Clear when we know it is active, OR on the first healthy pass of this
+        # lifetime to sweep a stale orphan left by a prior lifetime (config-entry
+        # reload dropped the ``_active`` set). ``async_delete_issue`` is a no-op
+        # when the issue is absent, so the extra first-pass call is harmless.
+        if issue_key in self._active or issue_key not in self._reconciled:
             ir.async_delete_issue(self._hass, self._domain, issue_key)
             self._active.discard(issue_key)
+            self._reconciled.add(issue_key)
 
     def shutdown(self) -> None:
         """Cancel all in-flight debounce timers (on reload / unload)."""

--- a/custom_components/adaptive_cover_pro/managers/common/debounced_repair.py
+++ b/custom_components/adaptive_cover_pro/managers/common/debounced_repair.py
@@ -1,0 +1,124 @@
+"""Shared debounce/raise/clear lifecycle for informational Repairs.
+
+Both ``SensorHealthManager`` (entity-availability watches) and
+``RepairManager`` (config-coherence predicates) need the same machinery: a
+per-key debounce timer so transient conditions don't nag, a re-check at expiry
+so a condition that recovered mid-debounce never raises, and raise/clear of an
+informational Home Assistant Repair via the issue registry.
+
+This base owns that machinery in one place (no-duplication rule). The one
+entity-specific line in the original ``SensorHealthManager._raise`` — the
+"still unhealthy at expiry?" re-check — is parameterized as a per-key
+``still_unhealthy`` callable the subclass supplies at ``_schedule`` time, so
+the availability watcher can poll a live entity while the predicate manager can
+read a stored boolean.
+
+Side-effect ownership: this is manager infrastructure — it holds per-instance
+timer/active state and orchestrates the Repair lifecycle. Subclasses decide
+*what* is unhealthy; the base decides *how* the Repair is debounced and raised.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import issue_registry as ir
+
+from ...const import DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS
+from .timeout_controller import TimeoutController
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from homeassistant.core import HomeAssistant
+
+
+class _DebouncedRepairBase:
+    """Debounce, re-check, and raise/clear informational Repairs per issue key."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: Logger,
+        *,
+        domain: str,
+        debounce_seconds: float = DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS,
+    ) -> None:
+        """Bind the manager to hass, the integration domain, and a debounce."""
+        self._hass = hass
+        self._logger = logger
+        self._domain = domain
+        self._debounce = debounce_seconds
+        self._timers: dict[str, TimeoutController] = {}
+        self._active: set[str] = set()
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def _schedule(
+        self,
+        issue_key: str,
+        translation_key: str,
+        placeholders: dict[str, str],
+        *,
+        still_unhealthy: Callable[[], bool],
+    ) -> None:
+        """Start (once) the debounce timer that will raise the Repair.
+
+        ``still_unhealthy`` is re-evaluated at expiry so a condition that
+        recovered during the debounce window never raises.
+        """
+        if issue_key in self._active:
+            return  # already raised — nothing to debounce
+        timer = self._timers.get(issue_key)
+        if timer is not None and timer.is_running:
+            return  # debounce already in flight
+        timer = TimeoutController(self._logger, label=f"debounced repair {issue_key}")
+        self._timers[issue_key] = timer
+        timer.start(
+            self._debounce,
+            lambda: self._raise(
+                issue_key, translation_key, placeholders, still_unhealthy
+            ),
+        )
+
+    async def _raise(
+        self,
+        issue_key: str,
+        translation_key: str,
+        placeholders: dict[str, str],
+        still_unhealthy: Callable[[], bool],
+    ) -> None:
+        """Raise the Repair — but only if still unhealthy at expiry."""
+        if not still_unhealthy():
+            return
+        ir.async_create_issue(
+            self._hass,
+            self._domain,
+            issue_key,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=translation_key,
+            translation_placeholders=placeholders,
+        )
+        self._active.add(issue_key)
+
+    def _recover(self, issue_key: str) -> None:
+        """Cancel any pending debounce and clear an active Repair."""
+        self._cancel_timer(issue_key)
+        self._delete_issue(issue_key)
+
+    def _cancel_timer(self, issue_key: str) -> None:
+        timer = self._timers.pop(issue_key, None)
+        if timer is not None:
+            timer.cancel()
+
+    def _delete_issue(self, issue_key: str) -> None:
+        if issue_key in self._active:
+            ir.async_delete_issue(self._hass, self._domain, issue_key)
+            self._active.discard(issue_key)
+
+    def shutdown(self) -> None:
+        """Cancel all in-flight debounce timers (on reload / unload)."""
+        for issue_key in list(self._timers):
+            self._cancel_timer(issue_key)

--- a/custom_components/adaptive_cover_pro/managers/repair.py
+++ b/custom_components/adaptive_cover_pro/managers/repair.py
@@ -1,0 +1,78 @@
+"""Config-coherence Repair manager (issue #975).
+
+Sibling to :class:`~.sensor_health.SensorHealthManager`: same debounced
+raise/clear lifecycle (shared via
+:class:`~.common.debounced_repair._DebouncedRepairBase`), but driven by a
+caller-computed boolean rather than a live entity poll. Config predicates —
+"is the min/max position envelope inverted?", "is the start time after the end
+time?" — have no entity to watch, so the coordinator evaluates the predicate
+each cycle and pushes the verdict via :meth:`update_predicate`.
+
+The manager stores the latest verdict per issue key and re-reads it at debounce
+expiry, so a multi-step options edit that transiently looks incoherent settles
+before nagging, and a genuine fix mid-debounce suppresses the Repair entirely.
+
+Side-effect ownership: a manager (per-instance predicate/timer state, Repair
+lifecycle). It computes nothing itself — the coordinator owns the predicate
+logic and reads config generically (no cover-type branching).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .common.debounced_repair import _DebouncedRepairBase
+
+
+@dataclass(slots=True, frozen=True)
+class _Predicate:
+    """One config predicate's latest verdict and the Repair metadata to raise."""
+
+    unhealthy: bool
+    translation_key: str
+    placeholders: dict[str, str] | None
+
+
+class RepairManager(_DebouncedRepairBase):
+    """Raise/clear informational Repairs from caller-computed config predicates."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Bind the shared lifecycle and initialise the predicate registry."""
+        super().__init__(*args, **kwargs)
+        self._predicates: dict[str, _Predicate] = {}
+
+    # -- registration -------------------------------------------------------
+
+    def update_predicate(
+        self,
+        issue_key: str,
+        unhealthy: bool,
+        *,
+        translation_key: str,
+        placeholders: dict[str, str] | None = None,
+    ) -> None:
+        """Store this cycle's verdict for ``issue_key``.
+
+        ``unhealthy`` True means the config is incoherent — raise (after
+        debounce); False means coherent — clear any pending timer or Repair.
+        """
+        self._predicates[issue_key] = _Predicate(
+            unhealthy=unhealthy,
+            translation_key=translation_key,
+            placeholders=placeholders,
+        )
+
+    # -- per-cycle evaluation ----------------------------------------------
+
+    def evaluate(self) -> None:
+        """Re-drive the lifecycle for every stored predicate once per cycle."""
+        for issue_key, predicate in list(self._predicates.items()):
+            if not predicate.unhealthy:
+                self._recover(issue_key)
+            else:
+                self._schedule(
+                    issue_key,
+                    predicate.translation_key,
+                    predicate.placeholders or {},
+                    still_unhealthy=lambda k=issue_key: self._predicates[k].unhealthy,
+                )

--- a/custom_components/adaptive_cover_pro/managers/sensor_health.py
+++ b/custom_components/adaptive_cover_pro/managers/sensor_health.py
@@ -8,9 +8,13 @@ do not nag the user before a genuinely dead sensor is flagged.
 
 The manager is deliberately entity-agnostic: wiring a new sensor is a single
 ``update_watch`` call with its own ``issue_key`` and ``translation_key`` — no
-per-sensor branching here (no-duplication rule). This PR wires only the
-effective indoor temperature entity, but motion/wind/humidity could register
-the same way later.
+per-sensor branching here (no-duplication rule). It now wires the effective
+indoor temperature entity, the controlled covers, and ``sun.sun``.
+
+The debounce/raise/clear/shutdown machinery lives on the shared
+:class:`~.common.debounced_repair._DebouncedRepairBase` so the config-predicate
+sibling (:class:`~.repair.RepairManager`) reuses the exact same lifecycle
+rather than copying it.
 
 Side-effect ownership: this is a manager (it holds per-instance state and
 orchestrates the Repair lifecycle). The resolution *read* stays in the
@@ -23,10 +27,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from homeassistant.helpers import issue_registry as ir
-
 from ..const import DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS
-from .common import TimeoutController
+from .common.debounced_repair import _DebouncedRepairBase
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -46,7 +48,7 @@ class _Watch:
     placeholders: dict[str, str] = field(default_factory=dict)
 
 
-class SensorHealthManager:
+class SensorHealthManager(_DebouncedRepairBase):
     """Raise/clear informational Repairs for unhealthy watched sensors."""
 
     def __init__(
@@ -58,13 +60,8 @@ class SensorHealthManager:
         debounce_seconds: float = DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS,
     ) -> None:
         """Bind the manager to hass and the integration domain."""
-        self._hass = hass
-        self._logger = logger
-        self._domain = domain
-        self._debounce = debounce_seconds
+        super().__init__(hass, logger, domain=domain, debounce_seconds=debounce_seconds)
         self._watched: dict[str, _Watch] = {}
-        self._timers: dict[str, TimeoutController] = {}
-        self._active: set[str] = set()
 
     # -- registration -------------------------------------------------------
 
@@ -98,7 +95,12 @@ class SensorHealthManager:
             if self._is_healthy(watch.entity_id):
                 self._recover(issue_key)
             else:
-                self._schedule(issue_key, watch)
+                self._schedule(
+                    issue_key,
+                    watch.translation_key,
+                    watch.placeholders,
+                    still_unhealthy=lambda w=watch: not self._is_healthy(w.entity_id),
+                )
 
     def _is_healthy(self, entity_id: str) -> bool:
         """Return True iff the watched entity has a real (non-null) state."""
@@ -107,56 +109,8 @@ class SensorHealthManager:
             return False
         return state.state not in _UNHEALTHY_STATES
 
-    # -- lifecycle ----------------------------------------------------------
-
-    def _schedule(self, issue_key: str, watch: _Watch) -> None:
-        """Start (once) the debounce timer that will raise the Repair."""
-        if issue_key in self._active:
-            return  # already raised — nothing to debounce
-        timer = self._timers.get(issue_key)
-        if timer is not None and timer.is_running:
-            return  # debounce already in flight
-        timer = TimeoutController(self._logger, label=f"sensor health {issue_key}")
-        self._timers[issue_key] = timer
-        timer.start(self._debounce, lambda: self._raise(issue_key, watch))
-
-    async def _raise(self, issue_key: str, watch: _Watch) -> None:
-        """Raise the Repair — but only if still unhealthy at expiry."""
-        if self._is_healthy(watch.entity_id):
-            return
-        ir.async_create_issue(
-            self._hass,
-            self._domain,
-            issue_key,
-            is_fixable=False,
-            severity=ir.IssueSeverity.WARNING,
-            translation_key=watch.translation_key,
-            translation_placeholders=watch.placeholders,
-        )
-        self._active.add(issue_key)
-
-    def _recover(self, issue_key: str) -> None:
-        """Cancel any pending debounce and clear an active Repair."""
-        self._cancel_timer(issue_key)
-        self._delete_issue(issue_key)
-
     def _unwatch(self, issue_key: str) -> None:
         """Stop watching a key and clear its timer + Repair."""
         self._watched.pop(issue_key, None)
         self._cancel_timer(issue_key)
         self._delete_issue(issue_key)
-
-    def _cancel_timer(self, issue_key: str) -> None:
-        timer = self._timers.pop(issue_key, None)
-        if timer is not None:
-            timer.cancel()
-
-    def _delete_issue(self, issue_key: str) -> None:
-        if issue_key in self._active:
-            ir.async_delete_issue(self._hass, self._domain, issue_key)
-            self._active.discard(issue_key)
-
-    def shutdown(self) -> None:
-        """Cancel all in-flight debounce timers (on reload / unload)."""
-        for issue_key in list(self._timers):
-            self._cancel_timer(issue_key)

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -275,6 +275,49 @@ class TimeWindowManager:
             return time.replace(year=today.year, month=today.month, day=today.day)
         return time
 
+    def _resolve_start_datetime(self) -> dt.datetime | None:
+        """Resolve the configured start time to a datetime, clock-independent.
+
+        The pure start-resolution ``_start_has_passed`` performs, without the
+        "has it passed now?" comparison: entity → parse + normalize-to-today,
+        static non-blank config → parse. Returns ``None`` when there is no real
+        start time (no entity and the static value is unset or the blank
+        sentinel ``BLANK_TIME``) or the entity/config value could not be parsed.
+
+        """
+        if self._start_time_entity is not None:
+            time = get_datetime_from_str(
+                get_safe_state(self._hass, self._start_time_entity)
+            )
+            if time is None:
+                self.logger.debug(
+                    "Start time entity %s returned None, treating as no start set",
+                    self._start_time_entity,
+                )
+                return None
+            return self._normalize_to_today(time)
+        if self._start_time is not None and self._start_time != BLANK_TIME:
+            time = get_datetime_from_str(self._start_time)
+            if time is None:
+                self.logger.debug(
+                    "Start time config value could not be parsed, treating as no start set"
+                )
+                return None
+            return time
+        return None
+
+    @property
+    def resolved_start_time(self) -> dt.datetime | None:
+        """Resolved operational-window start datetime, or ``None`` when unset.
+
+        Clock-independent view of the start time (issue #975) — the config
+        time-window health check compares this against :pyattr:`end_time` to flag
+        a start-after-end misconfiguration without keying on the wall clock.
+        ``None`` means "no explicit start" (no entity, blank/unset static value,
+        or an unparseable value) — distinct from an explicit 00:00 start.
+        """
+        return self._resolve_start_datetime()
+
     def _start_has_passed(self) -> bool | None:
         """Evaluate the configured start time against now.
 
@@ -287,36 +330,15 @@ class TimeWindowManager:
             operational-window start" — distinct from an explicit 00:00 start.
 
         """
+        resolved = self._resolve_start_datetime()
+        if resolved is None:
+            return None
         now = dt.datetime.now()
-        if self._start_time_entity is not None:
-            time = get_datetime_from_str(
-                get_safe_state(self._hass, self._start_time_entity)
-            )
-            if time is None:
-                self.logger.debug(
-                    "Start time entity %s returned None, treating as no start set",
-                    self._start_time_entity,
-                )
-                return None
-            time = self._normalize_to_today(time)
-            self.logger.debug(
-                "Start time: %s, now: %s, now >= time: %s ", time, now, now >= time
-            )
-            self._cached_start_time = time
-            return now >= time
-        if self._start_time is not None and self._start_time != BLANK_TIME:
-            time = get_datetime_from_str(self._start_time)
-            if time is None:
-                self.logger.debug(
-                    "Start time config value could not be parsed, treating as no start set"
-                )
-                return None
-            self.logger.debug(
-                "Start time: %s, now: %s, now >= time: %s", time, now, now >= time
-            )
-            self._cached_start_time = time
-            return now >= time
-        return None
+        self.logger.debug(
+            "Start time: %s, now: %s, now >= time: %s", resolved, now, now >= resolved
+        )
+        self._cached_start_time = resolved
+        return now >= resolved
 
     @property
     def after_start_time(self) -> bool:

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -15,7 +15,7 @@
     },
     "config_position_envelope": {
       "title": "Positionierungsgrenzen sind widersprüchlich",
-      "description": "Die auf **{name}** konfigurierten Positionierungsgrenzen sind inkonsistent: Das Minimum ({min}) liegt über dem Maximum ({max}), oder eine benutzerdefinierte Position befindet sich außerhalb dieses Bereichs. Beschattungen können auf eine unerwartete Position begrenzt werden. Überprüfen Sie die Einstellungen für Mindest- und Höchstposition sowie benutzerdefinierte Positionen in den Optionen der Beschattung."
+      "description": "Die auf **{name}** konfigurierten Positionierungsgrenzen sind inkonsistent: Das Minimum ({min}) liegt über dem Maximum ({max}), oder eine benutzerdefinierte Position ist außerhalb dieses Bereichs festgelegt und würde diese Grenzen außer Kraft setzen. Überprüfen Sie die Einstellungen für Mindest- und Höchstposition sowie benutzerdefinierte Positionen in den Optionen der Beschattung."
     },
     "config_time_window": {
       "title": "Betriebszeitfenster ist invertiert",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -4,6 +4,22 @@
     "temp_sensor_unavailable": {
       "title": "Innentemperatursensor nicht verfügbar",
       "description": "Der vom Klimamodus auf **{name}** verwendete Innentemperatursensor `{entity_id}` ist seit einiger Zeit nicht verfügbar. Klimaentscheidungen laufen möglicherweise ohne aktuellen Innenmesswert. Prüfe, ob das Gerät des Sensors online ist, oder wähle einen anderen Sensor (oder deaktiviere die automatische Ermittlung aus dem Bereich) in den Temperatur- & Klimaoptionen der Abdeckung."
+    },
+    "cover_unavailable": {
+      "title": "Gesteuerte Beschattung nicht verfügbar",
+      "description": "Die Beschattung `{entity_id}` gesteuert von **{name}** ist seit längerer Zeit nicht verfügbar. Adaptive Cover Pro kann ihre Position nicht auslesen oder Befehle senden. Überprüfen Sie, dass das Gerät der Beschattung online ist, oder entfernen Sie sie aus der Geräteliste, falls sie nicht mehr in Verwendung ist."
+    },
+    "sun_unavailable": {
+      "title": "Sonnen-Integration nicht verfügbar",
+      "description": "Die `sun.sun`-Entity verwendet von **{name}** ist seit längerer Zeit nicht verfügbar. Die Sonnenverfolgung kann ohne die Sonnenposition nicht ausgeführt werden, daher fallen Beschattungen auf ihre Standardposition zurück. Überprüfen Sie, dass Home Assistants Sonnen-Integration konfiguriert ist und Ihr Standort festgelegt wurde."
+    },
+    "config_position_envelope": {
+      "title": "Positionierungsgrenzen sind widersprüchlich",
+      "description": "Die auf **{name}** konfigurierten Positionierungsgrenzen sind inkonsistent: Das Minimum ({min}) liegt über dem Maximum ({max}), oder eine benutzerdefinierte Position befindet sich außerhalb dieses Bereichs. Beschattungen können auf eine unerwartete Position begrenzt werden. Überprüfen Sie die Einstellungen für Mindest- und Höchstposition sowie benutzerdefinierte Positionen in den Optionen der Beschattung."
+    },
+    "config_time_window": {
+      "title": "Betriebszeitfenster ist invertiert",
+      "description": "Das Betriebszeitfenster auf **{name}** beginnt um {start}, was nach seinem Ende um {end} liegt. Das Fenster öffnet sich nie, daher wird die automatische Sonnenverfolgung nicht ausgeführt. Überprüfen Sie die Start- und Endzeiten in den Optionen der Beschattung."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -4,6 +4,22 @@
     "temp_sensor_unavailable": {
       "title": "Indoor temperature sensor unavailable",
       "description": "The indoor temperature sensor `{entity_id}` used by climate mode on **{name}** has been unavailable for a while. Climate decisions may be running without a current indoor reading. Check that the sensor's device is online, or set a different sensor (or turn off area auto-resolution) in the cover's Temperature & Climate options."
+    },
+    "cover_unavailable": {
+      "title": "Controlled cover unavailable",
+      "description": "The cover `{entity_id}` controlled by **{name}** has been unavailable for a while. Adaptive Cover Pro cannot read its position or send it commands. Check that the cover's device is online, or remove it from the cover's entity list if it is no longer in use."
+    },
+    "sun_unavailable": {
+      "title": "Sun integration unavailable",
+      "description": "The `sun.sun` entity used by **{name}** has been unavailable for a while. Sun tracking cannot run without the sun's position, so covers are falling back to their default position. Check that Home Assistant's Sun integration is set up and your location is configured."
+    },
+    "config_position_envelope": {
+      "title": "Position limits are contradictory",
+      "description": "The position limits configured on **{name}** are inconsistent: the minimum ({min}) is above the maximum ({max}), or a custom position is pinned outside that range. Covers may be clamped to an unexpected position. Review the minimum/maximum position and custom-position settings in the cover's options."
+    },
+    "config_time_window": {
+      "title": "Operational time window is inverted",
+      "description": "The operational time window on **{name}** starts at {start}, which is after its end at {end}. The window never opens, so automatic sun tracking will not run. Review the start and end times in the cover's options."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -15,7 +15,7 @@
     },
     "config_position_envelope": {
       "title": "Position limits are contradictory",
-      "description": "The position limits configured on **{name}** are inconsistent: the minimum ({min}) is above the maximum ({max}), or a custom position is pinned outside that range. Covers may be clamped to an unexpected position. Review the minimum/maximum position and custom-position settings in the cover's options."
+      "description": "The position limits configured on **{name}** are inconsistent: the minimum ({min}) is above the maximum ({max}), or a custom position is pinned outside that range and would override those limits. Review the minimum/maximum position and custom-position settings in the cover's options."
     },
     "config_time_window": {
       "title": "Operational time window is inverted",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -4,6 +4,22 @@
     "temp_sensor_unavailable": {
       "title": "Capteur de température intérieure indisponible",
       "description": "Le capteur de température intérieure `{entity_id}` utilisé par le mode climatique sur **{name}** est indisponible depuis un moment. Les décisions climatiques s'exécutent peut-être sans relevé intérieur à jour. Vérifiez que l'appareil du capteur est en ligne, ou choisissez un autre capteur (ou désactivez la résolution automatique depuis la zone) dans les options Température et Climat de la couverture."
+    },
+    "cover_unavailable": {
+      "title": "Store contrôlé indisponible",
+      "description": "Le store `{entity_id}` contrôlé par **{name}** est indisponible depuis un certain temps. Adaptive Cover Pro ne peut pas lire sa position ou lui envoyer des commandes. Vérifiez que l'appareil du store est en ligne, ou supprimez-le de la liste des entités du store s'il n'est plus utilisé."
+    },
+    "sun_unavailable": {
+      "title": "Intégration Soleil indisponible",
+      "description": "L'entité `sun.sun` utilisée par **{name}** est indisponible depuis un certain temps. Le suivi du soleil ne peut pas fonctionner sans la position du soleil, donc les stores reviennent à leur position par défaut. Vérifiez que l'intégration Soleil de Home Assistant est configurée et que votre localisation est définie."
+    },
+    "config_position_envelope": {
+      "title": "Les limites de position sont contradictoires",
+      "description": "Les limites de position configurées sur **{name}** sont incohérentes : le minimum ({min}) est supérieur au maximum ({max}), ou une position personnalisée est fixée en dehors de cette plage. Les stores peuvent être limités à une position inattendue. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
+    },
+    "config_time_window": {
+      "title": "La fenêtre temporelle opérationnelle est inversée",
+      "description": "La fenêtre temporelle opérationnelle sur **{name}** commence à {start}, ce qui est après sa fin à {end}. La fenêtre ne s'ouvre jamais, donc le suivi automatique du soleil ne s'exécutera pas. Vérifiez les heures de début et de fin dans les options de la store."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -15,11 +15,11 @@
     },
     "config_position_envelope": {
       "title": "Les limites de position sont contradictoires",
-      "description": "Les limites de position configurées sur **{name}** sont incohérentes : le minimum ({min}) est supérieur au maximum ({max}), ou une position personnalisée est fixée en dehors de cette plage. Les stores peuvent être limités à une position inattendue. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
+      "description": "Les limites de position configurées sur **{name}** sont incohérentes : le minimum ({min}) est supérieur au maximum ({max}), ou une position personnalisée est fixée en dehors de cette plage et remplacerait ces limites. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
     },
     "config_time_window": {
       "title": "La fenêtre temporelle opérationnelle est inversée",
-      "description": "La fenêtre temporelle opérationnelle sur **{name}** commence à {start}, ce qui est après sa fin à {end}. La fenêtre ne s'ouvre jamais, donc le suivi automatique du soleil ne s'exécutera pas. Vérifiez les heures de début et de fin dans les options de la store."
+      "description": "La fenêtre temporelle opérationnelle sur **{name}** commence à {start}, ce qui est après sa fin à {end}. La fenêtre ne s'ouvre jamais, donc le suivi automatique du soleil ne s'exécutera pas. Vérifiez les heures de début et de fin dans les options du store."
     }
   },
   "config": {

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -1,0 +1,318 @@
+"""Coordinator wiring for the non-sensor health checks (issue #975).
+
+Covers A1 (controlled-cover availability, per entity + stale-cover unwatch),
+C1 (``sun.sun`` availability), B1 (position-envelope coherence), and B2
+(time-window coherence). All four are informational Repairs raised/cleared
+through the shared debounced lifecycle. The wiring lives in one fail-open guard
+so no health check can break the update cycle, and every issue key is
+per-config-entry namespaced.
+
+The tests drive ``_evaluate_health_checks`` directly against a minimal
+coordinator stub (built without ``__init__``) wired with real
+``SensorHealthManager`` / ``RepairManager`` instances (debounce 0 so a raise
+lands after one event-loop drain), patching the issue registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_MAX_POSITION,
+    CONF_MIN_POSITION,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    CUSTOM_POSITION_SLOTS,
+    DOMAIN,
+    ISSUE_CONFIG_POSITION_ENVELOPE,
+    ISSUE_CONFIG_TIME_WINDOW,
+    ISSUE_COVER_UNAVAILABLE,
+    ISSUE_SUN_UNAVAILABLE,
+    ISSUE_TEMP_SENSOR_UNAVAILABLE,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.managers.repair import RepairManager
+from custom_components.adaptive_cover_pro.managers.sensor_health import (
+    SensorHealthManager,
+)
+
+pytestmark = pytest.mark.unit
+
+_BASE = "custom_components.adaptive_cover_pro.managers.common.debounced_repair"
+_ENTRY = "entry1"
+
+
+class _State:
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+
+class _States:
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self._d = {k: _State(v) for k, v in mapping.items()}
+
+    def get(self, entity_id: str):
+        return self._d.get(entity_id)
+
+
+class _Hass:
+    def __init__(self, mapping: dict[str, str]) -> None:
+        self.states = _States(mapping)
+
+
+async def _drain():
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+
+def _make_coord(
+    *,
+    states: dict[str, str] | None = None,
+    entities: list[str] | None = None,
+    options: dict | None = None,
+    inside_temp: str | None = None,
+    start: dt.datetime | None = None,
+    end: dt.datetime | None = None,
+    debounce: float = 0,
+):
+    """Build a minimal coordinator stub wired for _evaluate_health_checks."""
+    hass = _Hass(states if states is not None else {"sun.sun": "above_horizon"})
+    logger = logging.getLogger("test.coord_health")
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord.hass = hass
+    coord.logger = logger
+    coord.config_entry = SimpleNamespace(entry_id=_ENTRY, data={"name": "Bedroom"})
+    coord.entities = entities if entities is not None else []
+    coord._weather_readings = SimpleNamespace(inside_temperature_entity_id=inside_temp)
+    coord._time_mgr = SimpleNamespace(resolved_start_time=start, end_time=end)
+    coord._sensor_health = SensorHealthManager(
+        hass, logger, domain=DOMAIN, debounce_seconds=debounce
+    )
+    coord._repair = RepairManager(
+        hass, logger, domain=DOMAIN, debounce_seconds=debounce
+    )
+    coord._temp_issue_key = f"{ISSUE_TEMP_SENSOR_UNAVAILABLE}_{_ENTRY}"
+    coord._sun_issue_key = f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}"
+    coord._envelope_issue_key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}"
+    coord._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}"
+    coord._cover_issue_keys = set()
+    coord._resolved_options = options or {}
+    return coord
+
+
+def _raised_keys(create_mock) -> set[str]:
+    """Issue keys passed to ir.async_create_issue (3rd positional arg)."""
+    return {call.args[2] for call in create_mock.call_args_list}
+
+
+async def _run(coord, options):
+    with (
+        patch(f"{_BASE}.ir.async_create_issue") as create,
+        patch(f"{_BASE}.ir.async_delete_issue") as delete,
+    ):
+        coord._evaluate_health_checks(options)
+        await _drain()
+        return create, delete
+
+
+# --- A1: controlled-cover availability -------------------------------------
+
+
+async def test_a1_raises_per_unavailable_cover_only():
+    coord = _make_coord(
+        states={
+            "sun.sun": "above_horizon",
+            "cover.a": "unavailable",
+            "cover.b": "open",
+        },
+        entities=["cover.a", "cover.b"],
+    )
+    create, _delete = await _run(coord, {})
+    raised = _raised_keys(create)
+    assert f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.a" in raised
+    assert f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.b" not in raised
+
+
+async def test_a1_missing_cover_is_unhealthy():
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon"},  # cover.gone has no state
+        entities=["cover.gone"],
+    )
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.gone" in _raised_keys(create)
+
+
+async def test_a1_stale_cover_is_unwatched_and_cleared():
+    """A cover dropped from config has its active Repair cleared."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "unavailable"},
+        entities=["cover.a"],
+    )
+    # Cycle 1: cover.a unavailable → raise + tracked in _cover_issue_keys.
+    await _run(coord, {})
+    assert f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.a" in coord._cover_issue_keys
+    # Cycle 2: cover.a removed from config → its issue is deleted (unwatch).
+    coord.entities = []
+    _create, delete = await _run(coord, {})
+    assert f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.a" in {
+        call.args[2] for call in delete.call_args_list
+    }
+    assert coord._cover_issue_keys == set()
+
+
+# --- C1: sun.sun availability ----------------------------------------------
+
+
+async def test_c1_raises_when_sun_unavailable():
+    coord = _make_coord(states={"sun.sun": "unavailable"}, entities=[])
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_c1_no_raise_when_sun_healthy():
+    coord = _make_coord(states={"sun.sun": "above_horizon"}, entities=[])
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}" not in _raised_keys(create)
+
+
+# --- B1: position envelope --------------------------------------------------
+
+
+async def test_b1_inverted_envelope_raises():
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, {CONF_MIN_POSITION: 80, CONF_MAX_POSITION: 20})
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_b1_pinned_slot_outside_envelope_raises():
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,  # above max
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_b1_safety_slot_ignored():
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,
+        slot["priority"]: CUSTOM_POSITION_SAFETY_PRIORITY,  # safety → exempt
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b1_disabled_slot_ignored():
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: False,
+        slot["position"]: 80,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b1_coherent_envelope_no_raise():
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 100,
+        slot["enabled"]: True,
+        slot["position"]: 50,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+
+
+# --- B2: time window --------------------------------------------------------
+
+
+async def test_b2_inverted_window_raises():
+    start = dt.datetime(2026, 7, 19, 18, 0)
+    end = dt.datetime(2026, 7, 19, 8, 0)
+    coord = _make_coord(entities=[], start=start, end=end)
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_b2_coherent_window_no_raise():
+    start = dt.datetime(2026, 7, 19, 8, 0)
+    end = dt.datetime(2026, 7, 19, 18, 0)
+    coord = _make_coord(entities=[], start=start, end=end)
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b2_one_side_none_no_raise():
+    # Entity-provided start unavailable (None) → do not false-fire.
+    coord = _make_coord(entities=[], start=None, end=dt.datetime(2026, 7, 19, 8, 0))
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}" not in _raised_keys(create)
+
+
+# --- fail-open + shutdown ---------------------------------------------------
+
+
+async def test_health_checks_fail_open():
+    """A predicate that raises must not break the cycle."""
+    coord = _make_coord(entities=[])
+    # Force an error inside the guard: weather readings access explodes.
+    coord._weather_readings = None
+    with (
+        patch(f"{_BASE}.ir.async_create_issue"),
+        patch(f"{_BASE}.ir.async_delete_issue"),
+    ):
+        # Must not raise.
+        coord._evaluate_health_checks({})
+        await _drain()
+
+
+async def test_shutdown_cancels_both_managers():
+    """async_shutdown cancels in-flight timers on both health managers."""
+    coord = _make_coord(
+        states={"sun.sun": "unavailable", "cover.a": "unavailable"},
+        entities=["cover.a"],
+        start=dt.datetime(2026, 7, 19, 18, 0),
+        end=dt.datetime(2026, 7, 19, 8, 0),
+        debounce=100,
+    )
+    # Stub out the rest of async_shutdown's cleanup collaborators.
+    coord._grace_mgr = MagicMock()
+    coord._cancel_motion_timeout = MagicMock()
+    coord._cancel_weather_timeout = MagicMock()
+    coord._cmd_svc = MagicMock()
+    coord._forecast_unsub = None
+    coord._forecast_max_unsub = None
+    coord._gate_fallback_unsub = None
+    coord._refresh_after_unsub = None
+    with (
+        patch(f"{_BASE}.ir.async_create_issue") as create,
+        patch(f"{_BASE}.ir.async_delete_issue"),
+    ):
+        coord._evaluate_health_checks({CONF_MIN_POSITION: 80, CONF_MAX_POSITION: 20})
+        # Both managers now have in-flight (long) debounce timers.
+        assert coord._sensor_health._timers
+        assert coord._repair._timers
+        await coord.async_shutdown()
+        await _drain()
+    create.assert_not_called()

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -191,6 +191,29 @@ async def test_b1_inverted_envelope_raises():
     assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
 
 
+def _envelope_call(create_mock):
+    """Return the ir.async_create_issue call that raised the envelope Repair."""
+    key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}"
+    for call in create_mock.call_args_list:
+        if call.args[2] == key:
+            return call
+    return None
+
+
+async def test_b1_placeholders_render_as_int():
+    """min/max placeholders render as plain ints even when HA stores floats."""
+    coord = _make_coord(entities=[])
+    # NumberSelector hands back floats — the Repair text must not read "80.0".
+    create, _delete = await _run(
+        coord, {CONF_MIN_POSITION: 80.0, CONF_MAX_POSITION: 20.0}
+    )
+    call = _envelope_call(create)
+    assert call is not None
+    placeholders = call.kwargs["translation_placeholders"]
+    assert placeholders["min"] == "80"
+    assert placeholders["max"] == "20"
+
+
 async def test_b1_pinned_slot_outside_envelope_raises():
     slot = CUSTOM_POSITION_SLOTS[1]
     options = {
@@ -202,6 +225,57 @@ async def test_b1_pinned_slot_outside_envelope_raises():
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
     assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_b1_use_my_slot_outside_envelope_no_raise():
+    """A ``use_my`` slot routes to the hardware My preset — its stored position
+    is ignored, so it cannot conflict with the envelope.
+    """
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,  # outside, but not the delivered position
+        slot["use_my"]: True,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b1_tilt_only_slot_outside_envelope_no_raise():
+    """A ``tilt_only`` slot fixes only the slat angle; solar drives position, so
+    the stored position value is not a fixed-position claim.
+    """
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,
+        slot["tilt_only"]: True,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b1_nonfixed_mode_slot_outside_envelope_no_raise():
+    """A non-FIXED constraint-mode slot (here a ``min_mode`` floor) composes as a
+    constraint and never overrides the envelope with an exact position.
+    """
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,  # a FLOOR (min_mode), not an exact position
+        slot["min_mode"]: True,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
 
 
 async def test_b1_safety_slot_ignored():

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -46,6 +46,7 @@ from custom_components.adaptive_cover_pro.managers.sensor_health import (
 pytestmark = pytest.mark.unit
 
 _BASE = "custom_components.adaptive_cover_pro.managers.common.debounced_repair"
+_COORD = "custom_components.adaptive_cover_pro.coordinator"
 _ENTRY = "entry1"
 
 
@@ -103,6 +104,7 @@ def _make_coord(
     coord._envelope_issue_key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}"
     coord._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}"
     coord._cover_issue_keys = set()
+    coord._a1_orphans_swept = False
     coord._resolved_options = options or {}
     return coord
 
@@ -165,6 +167,111 @@ async def test_a1_stale_cover_is_unwatched_and_cleared():
         call.args[2] for call in delete.call_args_list
     }
     assert coord._cover_issue_keys == set()
+
+
+# --- A1: cross-lifetime orphan sweep (issue #975 audit) --------------------
+
+
+def _sweep_run(coord, options, registry):
+    """Run one health-check cycle with the coordinator issue registry patched.
+
+    Patches ``ir`` in both the debounced-repair module (raise/clear of live
+    Repairs) and the coordinator module (the one-time orphan sweep, which calls
+    ``ir.async_get`` + ``ir.async_delete_issue`` directly).
+    """
+    with (
+        patch(f"{_BASE}.ir.async_create_issue"),
+        patch(f"{_BASE}.ir.async_delete_issue"),
+        patch(f"{_COORD}.ir.async_get", return_value=registry) as reg_get,
+        patch(f"{_COORD}.ir.async_delete_issue") as coord_delete,
+    ):
+        coord._evaluate_health_checks(options)
+        return reg_get, coord_delete
+
+
+def _swept_keys(coord_delete) -> set[str]:
+    """Issue ids the coordinator sweep deleted (3rd positional arg)."""
+    return {call.args[2] for call in coord_delete.call_args_list}
+
+
+async def test_a1_orphan_cleared_on_reload_after_cover_removed():
+    """A Repair for a cover no longer configured is swept once per lifetime.
+
+    Removing a cover (the fix path for a cover_unavailable Repair) reloads the
+    config entry → fresh coordinator with an empty ``_cover_issue_keys``. The
+    removed cover's key is in neither ``desired`` nor the in-lifetime unwatch
+    loop, so only the registry sweep can clear it.
+    """
+    orphan = f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.old"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.current": "open"},
+        entities=["cover.current"],  # cover.old was removed from config
+    )
+    registry = SimpleNamespace(issues={(DOMAIN, orphan): object()})
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    assert orphan in _swept_keys(coord_delete)
+
+
+async def test_a1_configured_unavailable_cover_not_swept():
+    """A still-configured but unavailable cover keeps its Repair (in ``desired``).
+
+    Sweeping its key would clear a valid warning and force a debounce re-raise
+    flap on every restart.
+    """
+    key = f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.a"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "unavailable"},
+        entities=["cover.a"],  # still configured, just unavailable
+    )
+    registry = SimpleNamespace(issues={(DOMAIN, key): object()})
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    assert key not in _swept_keys(coord_delete)
+
+
+async def test_a1_orphan_sweep_runs_once_per_lifetime():
+    """The registry enumeration fires a single time per coordinator lifetime."""
+    orphan = f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.old"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.current": "open"},
+        entities=["cover.current"],
+    )
+    registry = SimpleNamespace(issues={(DOMAIN, orphan): object()})
+    reg_get, _coord_delete = _sweep_run(coord, {}, registry)
+    _sweep_run(coord, {}, registry)  # second cycle: sweep already done
+    await _drain()
+    assert reg_get.call_count == 1
+
+
+async def test_a1_sweep_ignores_other_entry_and_domain():
+    """The sweep only touches this entry's A1 prefix under this integration.
+
+    ``other_entry`` (a different config entry) and ``other_domain`` (a different
+    integration) share the A1 shape but must survive. Both issue ids are never
+    watched, so their absence from the delete calls is attributable to the
+    sweep's prefix/domain filter alone (nothing else would delete them).
+    """
+    orphan = f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.old"
+    other_entry = f"{ISSUE_COVER_UNAVAILABLE}_entryOTHER_cover.old"
+    other_domain_id = f"{ISSUE_COVER_UNAVAILABLE}_{_ENTRY}_cover.zzz"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.current": "open"},
+        entities=["cover.current"],
+    )
+    registry = SimpleNamespace(
+        issues={
+            (DOMAIN, orphan): object(),
+            (DOMAIN, other_entry): object(),
+            ("other_domain", other_domain_id): object(),
+        }
+    )
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    swept = _swept_keys(coord_delete)
+    assert orphan in swept
+    assert other_entry not in swept
+    assert other_domain_id not in swept
 
 
 # --- C1: sun.sun availability ----------------------------------------------

--- a/tests/test_health_issue_translations.py
+++ b/tests/test_health_issue_translations.py
@@ -1,0 +1,54 @@
+"""en.json coverage for the non-sensor health-check Repairs (issue #975).
+
+Each Repair id maps to an ``issues.<id>`` entry with a title and a description,
+and the description must carry every placeholder token the coordinator passes so
+HA renders them (a description whose placeholder set differs from the code's is
+dropped by HA). en.json is the source of truth; DE/FR parity is enforced
+separately by ``tests/test_translations.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_EN = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "translations"
+    / "en.json"
+)
+
+# {translation_key: required placeholder tokens in the description}
+_HEALTH_ISSUES = {
+    "cover_unavailable": {"{name}", "{entity_id}"},
+    "sun_unavailable": {"{name}"},
+    "config_position_envelope": {"{name}", "{min}", "{max}"},
+    "config_time_window": {"{name}", "{start}", "{end}"},
+}
+
+
+@pytest.fixture(scope="module")
+def issues() -> dict:
+    with _EN.open(encoding="utf-8") as fh:
+        return json.load(fh)["issues"]
+
+
+@pytest.mark.parametrize("key", sorted(_HEALTH_ISSUES))
+def test_health_issue_has_title_and_description(issues, key):
+    assert key in issues, f"en.json issues.* missing '{key}'"
+    entry = issues[key]
+    assert entry.get("title"), f"issues.{key}.title is empty"
+    assert entry.get("description"), f"issues.{key}.description is empty"
+
+
+@pytest.mark.parametrize("key", sorted(_HEALTH_ISSUES))
+def test_health_issue_description_has_placeholders(issues, key):
+    description = issues[key]["description"]
+    for token in _HEALTH_ISSUES[key]:
+        assert token in description, f"issues.{key}.description missing {token}"

--- a/tests/test_issue_632_daytime_gate.py
+++ b/tests/test_issue_632_daytime_gate.py
@@ -374,6 +374,7 @@ async def test_async_shutdown_cancels_gate_fallback_handle():
     coord._cancel_motion_timeout = MagicMock()
     coord._cancel_weather_timeout = MagicMock()
     coord._sensor_health = MagicMock()
+    coord._repair = MagicMock()
     coord._cmd_svc = MagicMock()
     coord._forecast_unsub = None
     coord._forecast_max_unsub = None

--- a/tests/test_managers/test_debounced_repair_base.py
+++ b/tests/test_managers/test_debounced_repair_base.py
@@ -1,0 +1,78 @@
+"""Tests for _DebouncedRepairBase — the shared debounce/raise/clear lifecycle.
+
+The base owns the machinery both ``SensorHealthManager`` (entity-availability
+watches) and ``RepairManager`` (config predicates) reuse: a per-key debounce
+timer, a re-check at expiry via an injected ``still_unhealthy`` callable, and
+raise/clear of an informational Home Assistant Repair. Extracted so the two
+managers share one lifecycle rather than copy it (no-duplication rule).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.managers.common.debounced_repair import (
+    _DebouncedRepairBase,
+)
+
+pytestmark = pytest.mark.unit
+
+_MOD = "custom_components.adaptive_cover_pro.managers.common.debounced_repair"
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test.debounced_repair")
+
+
+async def _drain():
+    """Let the debounce task run (seconds=0)."""
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+
+class _Probe(_DebouncedRepairBase):
+    """Trivial concrete subclass — the base carries all behavior under test."""
+
+
+class TestDebouncedRepairBase:
+    """Debounce-once, still-unhealthy re-check at expiry, shutdown cancel."""
+
+    async def test_schedule_debounces_once_and_raises(self, logger):
+        """A single debounce raises exactly one informational Repair."""
+        hass = MagicMock()
+        probe = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            probe._schedule("k1", "tk", {"name": "x"}, still_unhealthy=lambda: True)
+            # Second schedule while the timer is in flight is a no-op (debounce).
+            probe._schedule("k1", "tk", {"name": "x"}, still_unhealthy=lambda: True)
+            await _drain()
+        create.assert_called_once()
+        _args, kwargs = create.call_args
+        assert kwargs.get("is_fixable") is False
+        assert kwargs.get("translation_key") == "tk"
+
+    async def test_cancel_before_expiry_suppresses_raise(self, logger):
+        """If ``still_unhealthy`` flips False before expiry, no Repair is raised."""
+        hass = MagicMock()
+        probe = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
+        unhealthy = True
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            probe._schedule("k1", "tk", {}, still_unhealthy=lambda: unhealthy)
+            unhealthy = False  # recovered before the expiry re-check
+            await _drain()
+        create.assert_not_called()
+
+    async def test_shutdown_cancels_inflight_timers(self, logger):
+        """``shutdown`` cancels a pending debounce so it never raises."""
+        hass = MagicMock()
+        probe = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=100)
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            probe._schedule("k1", "tk", {}, still_unhealthy=lambda: True)
+            probe.shutdown()
+            await _drain()
+        create.assert_not_called()

--- a/tests/test_managers/test_debounced_repair_base.py
+++ b/tests/test_managers/test_debounced_repair_base.py
@@ -76,3 +76,29 @@ class TestDebouncedRepairBase:
             probe.shutdown()
             await _drain()
         create.assert_not_called()
+
+    async def test_orphaned_issue_cleared_after_reload(self, logger):
+        """A Repair raised in a prior lifetime clears when a fresh instance is healthy.
+
+        The main fix path (options flow) reloads the config entry → a brand-new
+        manager whose in-memory ``_active`` set is empty. A healthy ``_recover``
+        in that fresh lifetime must still reconcile the issue registry once
+        (``async_delete_issue`` is idempotent) so the stale Repair does not
+        persist until an HA restart.
+        """
+        hass = MagicMock()
+        # Prior lifetime raised the Repair; the registry now carries it.
+        prior = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
+        with patch(f"{_MOD}.ir.async_create_issue"):
+            prior._schedule("k1", "tk", {}, still_unhealthy=lambda: True)
+            await _drain()
+        # New lifetime: empty state, the condition is already healthy.
+        fresh = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
+        with patch(f"{_MOD}.ir.async_delete_issue") as delete:
+            fresh._recover("k1")
+        delete.assert_called_once()
+        assert delete.call_args.args[2] == "k1"
+        # Reconciled once per lifetime: a second healthy pass is a no-op.
+        with patch(f"{_MOD}.ir.async_delete_issue") as delete2:
+            fresh._recover("k1")
+        delete2.assert_not_called()

--- a/tests/test_managers/test_repair_predicate.py
+++ b/tests/test_managers/test_repair_predicate.py
@@ -103,3 +103,20 @@ class TestRepairManager:
             mgr.shutdown()
             await _drain()
         create.assert_not_called()
+
+    async def test_orphan_cleared_on_fresh_instance(self, logger):
+        """A predicate healthy on a fresh manager clears a Repair from a prior lifetime.
+
+        The options-flow fix reloads the entry → a new RepairManager with an
+        empty ``_active`` set. Evaluating the (now coherent) predicate must still
+        reconcile the registry once so the stale Repair clears without an HA
+        restart.
+        """
+        mgr = RepairManager(
+            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_predicate(_ISSUE_KEY, False, translation_key=_TRANSLATION_KEY)
+        with patch(f"{_MOD}.ir.async_delete_issue") as delete:
+            mgr.evaluate()  # healthy on a brand-new instance (empty _active)
+        delete.assert_called_once()
+        assert delete.call_args.args[2] == _ISSUE_KEY

--- a/tests/test_managers/test_repair_predicate.py
+++ b/tests/test_managers/test_repair_predicate.py
@@ -1,0 +1,105 @@
+"""Tests for RepairManager — informational Repairs from config-coherence predicates.
+
+The predicate manager has no entity to poll: the coordinator computes a boolean
+each cycle and pushes it via ``update_predicate``. The manager stores it and
+drives the shared debounce/raise/clear lifecycle, re-reading the stored boolean
+at expiry so a config edit that fixes the incoherence mid-debounce suppresses
+the Repair.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.adaptive_cover_pro.managers.repair import RepairManager
+
+pytestmark = pytest.mark.unit
+
+# ``ir.*`` is resolved in the shared base module where ``_raise`` is defined.
+_MOD = "custom_components.adaptive_cover_pro.managers.common.debounced_repair"
+_ISSUE_KEY = "config_position_envelope_entry1"
+_TRANSLATION_KEY = "config_position_envelope"
+
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test.repair")
+
+
+async def _drain():
+    """Let the debounce task run (seconds=0)."""
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+
+class TestRepairManager:
+    """Raise-on-sustained-incoherence, clear-on-fix, debounce, shutdown."""
+
+    async def test_predicate_raises_when_unhealthy_past_debounce(self, logger):
+        """An incoherent config held past debounce raises the informational Repair."""
+        mgr = RepairManager(
+            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_predicate(
+            _ISSUE_KEY,
+            True,
+            translation_key=_TRANSLATION_KEY,
+            placeholders={"name": "Bedroom"},
+        )
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            mgr.evaluate()
+            await _drain()
+        create.assert_called_once()
+        _args, kwargs = create.call_args
+        assert kwargs.get("is_fixable") is False
+        assert kwargs.get("severity") == ir.IssueSeverity.WARNING
+        assert kwargs.get("translation_key") == _TRANSLATION_KEY
+
+    async def test_predicate_cleared_when_healthy(self, logger):
+        """A raised Repair is deleted once the predicate turns coherent."""
+        mgr = RepairManager(
+            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
+        with (
+            patch(f"{_MOD}.ir.async_create_issue"),
+            patch(f"{_MOD}.ir.async_delete_issue") as delete,
+        ):
+            mgr.evaluate()
+            await _drain()
+            mgr.update_predicate(_ISSUE_KEY, False, translation_key=_TRANSLATION_KEY)
+            mgr.evaluate()
+        delete.assert_called_once()
+
+    async def test_predicate_fixed_before_expiry_suppressed(self, logger):
+        """Fixed before the debounce elapses → no Repair (debounce gate)."""
+        mgr = RepairManager(
+            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=100
+        )
+        mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
+        with (
+            patch(f"{_MOD}.ir.async_create_issue") as create,
+            patch(f"{_MOD}.ir.async_delete_issue"),
+        ):
+            mgr.evaluate()  # starts the (long) debounce timer
+            mgr.update_predicate(_ISSUE_KEY, False, translation_key=_TRANSLATION_KEY)
+            mgr.evaluate()  # cancels the pending timer
+            await _drain()
+        create.assert_not_called()
+
+    async def test_shutdown_cancels(self, logger):
+        """``shutdown`` cancels an in-flight predicate debounce."""
+        mgr = RepairManager(
+            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=100
+        )
+        mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
+        with patch(f"{_MOD}.ir.async_create_issue") as create:
+            mgr.evaluate()
+            mgr.shutdown()
+            await _drain()
+        create.assert_not_called()

--- a/tests/test_managers/test_sensor_health_repairs.py
+++ b/tests/test_managers/test_sensor_health_repairs.py
@@ -19,7 +19,11 @@ from custom_components.adaptive_cover_pro.managers.sensor_health import (
 
 pytestmark = pytest.mark.unit
 
-_MOD = "custom_components.adaptive_cover_pro.managers.sensor_health"
+# ``ir.async_create_issue`` / ``ir.async_delete_issue`` are resolved in the
+# module where ``_raise`` / ``_delete_issue`` are DEFINED — the shared
+# ``debounced_repair`` base, not ``sensor_health`` — so the patch anchor lives
+# there after the lifecycle extraction.
+_MOD = "custom_components.adaptive_cover_pro.managers.common.debounced_repair"
 _ISSUE_KEY = "temp_sensor_unavailable_entry1"
 _TRANSLATION_KEY = "temp_sensor_unavailable"
 

--- a/tests/test_managers/test_time_window_resolved_start.py
+++ b/tests/test_managers/test_time_window_resolved_start.py
@@ -1,0 +1,96 @@
+"""Tests for TimeWindowManager.resolved_start_time (issue #975, B2 predicate).
+
+The config-time-window health check compares the resolved start against the end
+time. ``resolved_start_time`` exposes the same start-resolution ``_start_has_passed``
+already performs — static/entity parse, blank-sentinel → None — without the
+"has it passed now?" comparison, so the predicate can be evaluated regardless of
+the wall clock. This is a behavior-preserving extraction: ``is_active`` /
+``after_start_time`` must be unchanged.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import BLANK_TIME
+from custom_components.adaptive_cover_pro.managers.time_window import TimeWindowManager
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeState:
+    def __init__(self, state: str) -> None:
+        self.state = state
+        self.attributes: dict = {}
+
+
+class _FakeStates:
+    def __init__(self) -> None:
+        self._d: dict[str, _FakeState] = {}
+
+    def set(self, entity_id: str, state: str) -> None:
+        self._d[entity_id] = _FakeState(state)
+
+    def get(self, entity_id: str):
+        return self._d.get(entity_id)
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.states = _FakeStates()
+
+
+@pytest.fixture
+def mgr():
+    return TimeWindowManager(_FakeHass(), logging.getLogger("test_resolved_start"))
+
+
+def test_static_start_resolves_to_datetime(mgr):
+    """A static start time resolves to a datetime at that time-of-day."""
+    mgr.update_config(
+        start_time="08:00:00",
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity=None,
+    )
+    resolved = mgr.resolved_start_time
+    assert isinstance(resolved, dt.datetime)
+    assert resolved.time() == dt.time(8, 0)
+
+
+def test_blank_start_resolves_to_none(mgr):
+    """The blank sentinel means 'no explicit start' → None."""
+    mgr.update_config(
+        start_time=BLANK_TIME,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity=None,
+    )
+    assert mgr.resolved_start_time is None
+
+
+def test_unset_start_resolves_to_none(mgr):
+    """No entity and no static value → None."""
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity=None,
+    )
+    assert mgr.resolved_start_time is None
+
+
+def test_resolved_start_matches_value_is_active_uses(mgr):
+    """``resolved_start_time`` equals the cached start ``is_active`` compares."""
+    mgr.update_config(
+        start_time="08:00:00",
+        start_time_entity=None,
+        end_time="18:00:00",
+        end_time_entity=None,
+    )
+    # Drive is_active so _cached_start_time (the value is_active compares) is set.
+    _ = mgr.is_active
+    assert mgr.resolved_start_time == mgr.start_time_value


### PR DESCRIPTION
## Summary
Implements the first phase of #973 — the cheap, high-signal non-sensor healthchecks — as informational HA Repairs built on the #840 debounced raise/clear pattern:

- **A1** — controlled cover `unavailable`/`unknown`/removed from the registry past a debounce (per-cover card)
- **B1** — inverted/empty position envelope (`min > max`, or a fixed-position custom slot pinned outside the effective range)
- **B2** — inverted time window (`start >= end`, so the tracking window never opens)
- **C1** — `sun.sun` unavailable/missing past a debounce

All are informational only (`is_fixable=False`, `WARNING`, auto-clear on recovery), fail-open (evaluation can never break the update cycle), and namespaced per config entry.

### Design
- Extracted the shared debounce/raise/clear/shutdown lifecycle into `_DebouncedRepairBase`. A1/C1 reuse `SensorHealthManager` (entity-availability shaped); B1/B2 use a new predicate-shaped `RepairManager` sibling — no duplicated lifecycle.
- B1 only flags custom-position slots that actually deliver a **fixed** position claim (skips `use_my`, tilt-only, and non-`FIXED` constraint modes) via a shared helper, so working configs aren't nagged.
- Repairs reconcile across config-entry reloads: a stale card is swept once on the first healthy pass of a new coordinator lifetime, including the entity-keyed A1 card for a cover that was removed from the instance.
- en/de/fr translations for all four `issues.*` entries.

### Out of scope (remain open on #973)
A2 (commands not taking effect), A3 (capability contradiction), B3 (climate mode with no resolvable temp source).

## Testing
- ✅ 6958 tests passing
- Ran a deep (fable) pre-merge audit across three rounds; every finding (a reload-clear gap, a B1 false-positive, a no-duplication nit, translation polish, and an A1 removed-cover reload gap) was fixed and re-verified. One accepted low-severity false-negative (a `use_my` slot with an unset `my_position` still delivering a fixed position) is noted on #973 as a follow-up.

## Related Issues
Refs #975, #973, #840
