### PR TITLE
fix: track health-check debounce timer as an HA background task (#975)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -340,6 +340,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     # Register cleanup for cover command service reconciliation timer
     entry.async_on_unload(coordinator._cmd_svc.stop)
 
+    # Register cleanup for the health-check debounce timers (issues #786, #975).
+    # Their shutdown lives only inside coordinator.async_shutdown, which is not
+    # wired to unload, so an unhealthy condition (e.g. sun.sun missing) would
+    # otherwise leak a 900s TimeoutController task across every reload/unload.
+    entry.async_on_unload(coordinator._sensor_health.shutdown)
+    entry.async_on_unload(coordinator._repair.shutdown)
+
     # Register cleanup for the periodic position-forecast recompute timer
     # (scheduled in async_config_entry_first_refresh — see issue #437). Wrap
     # in a closure because the unsub handle isn't created until after this

--- a/custom_components/adaptive_cover_pro/managers/common/debounced_repair.py
+++ b/custom_components/adaptive_cover_pro/managers/common/debounced_repair.py
@@ -80,7 +80,9 @@ class _DebouncedRepairBase:
         timer = self._timers.get(issue_key)
         if timer is not None and timer.is_running:
             return  # debounce already in flight
-        timer = TimeoutController(self._logger, label=f"debounced repair {issue_key}")
+        timer = TimeoutController(
+            self._logger, label=f"debounced repair {issue_key}", hass=self._hass
+        )
         self._timers[issue_key] = timer
         timer.start(
             self._debounce,

--- a/custom_components/adaptive_cover_pro/managers/common/timeout_controller.py
+++ b/custom_components/adaptive_cover_pro/managers/common/timeout_controller.py
@@ -42,7 +42,7 @@ class TimeoutController:
     timeout"``) used in debug logs only — not user-facing.
     """
 
-    def __init__(self, logger, *, label: str = "timeout") -> None:
+    def __init__(self, logger, *, label: str = "timeout", hass=None) -> None:
         """Initialize with the manager's logger and a short label.
 
         Args:
@@ -51,10 +51,20 @@ class TimeoutController:
                 output stays attributable to the owning manager.
             label: Short identifier for log messages. Convention is
                 ``"<feature> timeout"`` (e.g. ``"motion timeout"``).
+            hass: Optional HomeAssistant instance. When provided, the
+                timer task is spawned via ``hass.async_create_background_task``
+                so Home Assistant tracks it and cancels it on stop — this is
+                what keeps a long debounce (e.g. the 900s health-check timer)
+                from leaking as a lingering asyncio task when the owning entry
+                is never explicitly shut down (issue #975). When ``None`` the
+                helper falls back to a bare ``asyncio.create_task`` — the
+                original behaviour, kept for the event-driven managers whose
+                own lifecycle already cancels their timers.
 
         """
         self._logger = logger
         self._label = label
+        self._hass = hass
         self._task: asyncio.Task | None = None
 
     @property
@@ -80,7 +90,13 @@ class TimeoutController:
 
         """
         self.cancel()
-        self._task = asyncio.create_task(self._run(seconds, on_expire))
+        coro = self._run(seconds, on_expire)
+        if self._hass is not None:
+            # HA-tracked: cancelled automatically on Home Assistant stop, so a
+            # pending long debounce never lingers as an orphan task.
+            self._task = self._hass.async_create_background_task(coro, name=self._label)
+        else:
+            self._task = asyncio.create_task(coro)
 
     async def _run(
         self,

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -67,6 +67,12 @@ class _Hass:
     def __init__(self, mapping: dict[str, str]) -> None:
         self.states = _States(mapping)
 
+    def async_create_background_task(self, coro, name=None, eager_start=True):
+        # Mirror HA's tracked-task helper so the debounce timer (now spawned
+        # via async_create_background_task for leak-free cleanup) runs under
+        # the test event loop and a single _drain() fires it.
+        return asyncio.create_task(coro)
+
 
 async def _drain():
     for _ in range(4):

--- a/tests/test_managers/test_debounced_repair_base.py
+++ b/tests/test_managers/test_debounced_repair_base.py
@@ -35,6 +35,20 @@ async def _drain():
         await asyncio.sleep(0)
 
 
+def _bg_hass():
+    """Mock hass whose async_create_background_task creates a real task.
+
+    The debounce timer is now spawned via HA's tracked-task helper (issue #975
+    lingering-task fix), so the double must return a real asyncio task for
+    ``_drain()`` to fire the debounce.
+    """
+    hass = MagicMock()
+    hass.async_create_background_task = (
+        lambda coro, name=None, eager_start=True: asyncio.create_task(coro)
+    )
+    return hass
+
+
 class _Probe(_DebouncedRepairBase):
     """Trivial concrete subclass — the base carries all behavior under test."""
 
@@ -44,7 +58,7 @@ class TestDebouncedRepairBase:
 
     async def test_schedule_debounces_once_and_raises(self, logger):
         """A single debounce raises exactly one informational Repair."""
-        hass = MagicMock()
+        hass = _bg_hass()
         probe = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
         with patch(f"{_MOD}.ir.async_create_issue") as create:
             probe._schedule("k1", "tk", {"name": "x"}, still_unhealthy=lambda: True)
@@ -58,7 +72,7 @@ class TestDebouncedRepairBase:
 
     async def test_cancel_before_expiry_suppresses_raise(self, logger):
         """If ``still_unhealthy`` flips False before expiry, no Repair is raised."""
-        hass = MagicMock()
+        hass = _bg_hass()
         probe = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
         unhealthy = True
         with patch(f"{_MOD}.ir.async_create_issue") as create:
@@ -69,7 +83,7 @@ class TestDebouncedRepairBase:
 
     async def test_shutdown_cancels_inflight_timers(self, logger):
         """``shutdown`` cancels a pending debounce so it never raises."""
-        hass = MagicMock()
+        hass = _bg_hass()
         probe = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=100)
         with patch(f"{_MOD}.ir.async_create_issue") as create:
             probe._schedule("k1", "tk", {}, still_unhealthy=lambda: True)
@@ -86,7 +100,7 @@ class TestDebouncedRepairBase:
         (``async_delete_issue`` is idempotent) so the stale Repair does not
         persist until an HA restart.
         """
-        hass = MagicMock()
+        hass = _bg_hass()
         # Prior lifetime raised the Repair; the registry now carries it.
         prior = _Probe(hass, logger, domain="adaptive_cover_pro", debounce_seconds=0)
         with patch(f"{_MOD}.ir.async_create_issue"):

--- a/tests/test_managers/test_repair_predicate.py
+++ b/tests/test_managers/test_repair_predicate.py
@@ -37,13 +37,27 @@ async def _drain():
         await asyncio.sleep(0)
 
 
+def _bg_hass():
+    """Mock hass whose async_create_background_task creates a real task.
+
+    The debounce timer is now spawned via HA's tracked-task helper (issue #975
+    lingering-task fix), so the double must return a real asyncio task for
+    ``_drain()`` to fire the debounce.
+    """
+    hass = MagicMock()
+    hass.async_create_background_task = (
+        lambda coro, name=None, eager_start=True: asyncio.create_task(coro)
+    )
+    return hass
+
+
 class TestRepairManager:
     """Raise-on-sustained-incoherence, clear-on-fix, debounce, shutdown."""
 
     async def test_predicate_raises_when_unhealthy_past_debounce(self, logger):
         """An incoherent config held past debounce raises the informational Repair."""
         mgr = RepairManager(
-            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+            _bg_hass(), logger, domain="adaptive_cover_pro", debounce_seconds=0
         )
         mgr.update_predicate(
             _ISSUE_KEY,
@@ -63,7 +77,7 @@ class TestRepairManager:
     async def test_predicate_cleared_when_healthy(self, logger):
         """A raised Repair is deleted once the predicate turns coherent."""
         mgr = RepairManager(
-            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+            _bg_hass(), logger, domain="adaptive_cover_pro", debounce_seconds=0
         )
         mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
         with (
@@ -79,7 +93,7 @@ class TestRepairManager:
     async def test_predicate_fixed_before_expiry_suppressed(self, logger):
         """Fixed before the debounce elapses → no Repair (debounce gate)."""
         mgr = RepairManager(
-            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=100
+            _bg_hass(), logger, domain="adaptive_cover_pro", debounce_seconds=100
         )
         mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
         with (
@@ -95,7 +109,7 @@ class TestRepairManager:
     async def test_shutdown_cancels(self, logger):
         """``shutdown`` cancels an in-flight predicate debounce."""
         mgr = RepairManager(
-            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=100
+            _bg_hass(), logger, domain="adaptive_cover_pro", debounce_seconds=100
         )
         mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
         with patch(f"{_MOD}.ir.async_create_issue") as create:
@@ -113,7 +127,7 @@ class TestRepairManager:
         restart.
         """
         mgr = RepairManager(
-            MagicMock(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+            _bg_hass(), logger, domain="adaptive_cover_pro", debounce_seconds=0
         )
         mgr.update_predicate(_ISSUE_KEY, False, translation_key=_TRANSLATION_KEY)
         with patch(f"{_MOD}.ir.async_delete_issue") as delete:

--- a/tests/test_managers/test_sensor_health_repairs.py
+++ b/tests/test_managers/test_sensor_health_repairs.py
@@ -37,6 +37,12 @@ def _make_hass(state):
     """Mock hass whose states.get returns ``state`` (a mock or None)."""
     hass = MagicMock()
     hass.states.get.return_value = state
+    # The debounce timer is now spawned via async_create_background_task so HA
+    # tracks and cancels it (issue #975 lingering-task fix); make the double
+    # create a real task so a single _drain() still fires the debounce.
+    hass.async_create_background_task = (
+        lambda coro, name=None, eager_start=True: asyncio.create_task(coro)
+    )
     return hass
 
 

--- a/tests/test_managers/test_timeout_controller.py
+++ b/tests/test_managers/test_timeout_controller.py
@@ -179,3 +179,53 @@ class TestCallbackMayRestart:
         assert second_fired.is_set()
         # Final state must be idle, not stuck with the first task's handle.
         assert ctrl.is_running is False
+
+
+class TestHassTrackedSpawn:
+    """When a hass is provided, the timer is an HA-tracked background task.
+
+    Regression guard for the #975 lingering-task failure: the health-check
+    debounce spawned a bare ``asyncio.create_task`` that Home Assistant did not
+    track, so a pending 900s timer leaked as a lingering task whenever the
+    owning entry was never explicitly shut down (surfaced under xdist). Passing
+    ``hass`` routes the task through ``hass.async_create_background_task`` so HA
+    cancels it on stop.
+    """
+
+    async def test_uses_background_task_when_hass_given(self, logger) -> None:
+        from unittest.mock import MagicMock
+
+        calls: list[str] = []
+
+        def _bg(coro, name=None, eager_start=True):
+            calls.append(name)
+            return asyncio.create_task(coro)
+
+        hass = MagicMock()
+        hass.async_create_background_task = _bg
+        ctrl = TimeoutController(logger, label="hc timer", hass=hass)
+
+        async def _noop() -> None:
+            await asyncio.sleep(0)
+
+        ctrl.start(seconds=100, on_expire=_noop)
+        # The spawn went through HA's tracked helper (not bare create_task).
+        assert calls == ["hc timer"]
+        assert ctrl.is_running is True
+        ctrl.cancel()
+
+    async def test_bare_create_task_when_no_hass(self, logger) -> None:
+        # Default (no hass) keeps the original event-driven-manager behaviour.
+        ctrl = TimeoutController(logger, label="motion timeout")
+        fired = asyncio.Event()
+
+        async def _fire() -> None:
+            fired.set()
+
+        ctrl.start(seconds=0, on_expire=_fire)
+        for _ in range(4):
+            if fired.is_set():
+                break
+            await asyncio.sleep(0)
+        assert fired.is_set()
+        assert ctrl.is_running is False


### PR DESCRIPTION
## Summary
Fixes the `Develop Build` CI failure introduced by #975 (#977): `Lingering task after test <TimeoutController._run()>` on the HA-stable and HA-dev test gates.

**Root cause:** the non-sensor health checks schedule a 900s debounce via `TimeoutController`, which used a bare `asyncio.create_task`. When `sun.sun` (C1) or a controlled cover (A1) is unavailable — common in tests — that timer is scheduled every update cycle and was only cancelled by `coordinator.async_shutdown`, which is **never wired to entry unload**. HA doesn't track a bare task, so on `hass` stop it lingered and `verify_cleanup` failed under xdist (timing-dependent: serial masked it).

**Fix:**
- `TimeoutController` gains an optional `hass`; when set it spawns via `hass.async_create_background_task`, so HA tracks and cancels the task on stop. Only the debounced-repair base passes `hass` — the event-driven managers (Motion/Weather/Grace) keep the original bare path.
- Wire the two health managers' `shutdown` via `entry.async_on_unload` so a reload cancels a pending debounce without waiting for `hass` stop (also fixes a minor real-world leak across reloads).
- Test doubles gain `async_create_background_task`; added a regression guard in `test_timeout_controller.py`.

## Testing
- ✅ 6960 tests passing under `-n auto` across 3 runs, zero lingering tasks (previously 1–5 lingering-task errors per run).

## Related Issues
Refs #975, #973
