### PR TITLE
fix: use ceil() in fov_from_reveal for conservative FOV rounding

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -5,7 +5,7 @@ Extracted from AdaptiveGeneralCover to enable standalone testing and reuse.
 
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from math import atan, degrees, radians, tan
+from math import atan, ceil, degrees, radians, tan
 
 import pandas as pd
 
@@ -77,12 +77,17 @@ def fov_from_reveal(width_m: float, depth_m: float) -> int:
     blocks nothing, so the FOV is the full hemisphere (the default half-angle).
     The result is clamped to the configured FOV range and rounded to an integer
     because ``fov_left``/``fov_right`` are stored as integer degrees.
+
+    Ceiling (not nearest-integer) rounding is intentional: rounding down would
+    shorten the active tracking window, causing the cover to open while the sun
+    is still geometrically entering the reveal.  A 1° over-estimate keeps the
+    cover active marginally longer — the conservative side of the error.
     """
     if depth_m <= 0 or width_m <= 0:
         return DEFAULT_FOV_LEFT
     deg = degrees(atan(width_m / depth_m))
     lo, hi = OPTION_RANGES[CONF_FOV_LEFT]
-    return int(round(min(max(deg, lo), hi)))
+    return int(ceil(min(max(deg, lo), hi)))
 
 
 def computed_fov_line(

--- a/tests/test_engine/test_sun_geometry_fov.py
+++ b/tests/test_engine/test_sun_geometry_fov.py
@@ -16,13 +16,13 @@ from custom_components.adaptive_cover_pro.const import (
 from custom_components.adaptive_cover_pro.engine.sun_geometry import fov_from_reveal
 
 
-def test_width_2_depth_1_is_63_degrees():
-    # atan(2/1) = atan(2) ≈ 63.43° → rounds to 63
-    assert fov_from_reveal(2.0, 1.0) == 63
+def test_width_2_depth_1_is_64_degrees():
+    # atan(2/1) = atan(2) ≈ 63.43° → ceil → 64 (conservative: never round down)
+    assert fov_from_reveal(2.0, 1.0) == 64
 
 
 def test_width_2_depth_half_is_76_degrees():
-    # atan(2/0.5) = atan(4) ≈ 75.96° → rounds to 76
+    # atan(2/0.5) = atan(4) ≈ 75.96° → ceil → 76
     assert fov_from_reveal(2.0, 0.5) == 76
 
 
@@ -54,20 +54,20 @@ def test_returns_int():
 @pytest.mark.parametrize(
     ("width", "depth", "expected"),
     [
-        (1.0, 1.0, 45),  # atan(1.0) = 45.00° → 45
-        (3.0, 1.0, 72),  # atan(3.0) ≈ 71.57° → 72
-        (1.2, 0.5, 67),  # atan(2.4) ≈ 67.38° → 67 (the summary example)
+        (1.0, 1.0, 45),  # atan(1.0) = 45.00° → ceil → 45 (exact integer, unchanged)
+        (3.0, 1.0, 72),  # atan(3.0) ≈ 71.57° → ceil → 72
+        (1.2, 0.5, 68),  # atan(2.4) ≈ 67.38° → ceil → 68 (the summary example)
     ],
 )
 def test_known_angles(width, depth, expected):
     assert fov_from_reveal(width, depth) == expected
 
 
-def test_real_world_reveal_0_84_x_0_25_is_73_degrees():
+def test_real_world_reveal_0_84_x_0_25_is_74_degrees():
     """Reporter's window: 0.84 m wide, 0.25 m deep reveal.
 
     Ground truth: sun first reaches cover at ~228° for a 300° normal → 72° off-normal.
-    arctan(0.84 / 0.25) = arctan(3.36) ≈ 73.43° → rounds to 73.
+    arctan(0.84 / 0.25) = arctan(3.36) ≈ 73.43° → ceil → 74 (conservative).
     Regression guard for issue #565 (buggy /2 formula returned 59).
     """
-    assert fov_from_reveal(0.84, 0.25) == 73
+    assert fov_from_reveal(0.84, 0.25) == 74


### PR DESCRIPTION
Closes #980.

## What

Replace `int(round(...))` with `int(ceil(...))` in `fov_from_reveal()` (`engine/sun_geometry.py`).

## Why

`fov_from_reveal` derives the active FOV half-angle as `arctan(width / depth)`. This is the **exact** azimuth at which a sun ray just grazes the outer edge of the reveal. Rounding **down** (nearest-integer) shortens the tracking window: the cover opens while the sun is still geometrically entering through the window.

Ceiling rounding ensures the cover stays active for at least as long as the reveal geometry requires. The worst case is 1° of over-estimate — the conservative, correct side of the error.

See #980 for the full analysis and the table of affected cases.

## Related

Issue #978 tracks the same class of bug in the position percentage formula.

## Changes

- `engine/sun_geometry.py`: import `ceil`; replace `round()` with `ceil()` in `fov_from_reveal`; add docstring note explaining the intentional choice.
- `tests/test_engine/test_sun_geometry_fov.py`: update 3 expected values where `ceil ≠ round` (63→64, 67→68, 73→74); update function names and comments to reflect ceiling semantics.

## Test plan

- [ ] `pytest tests/test_engine/test_sun_geometry_fov.py` — all cases pass
- [ ] `pytest tests/test_config_flow_fov_compute.py` — no regressions (the `fov_from_reveal(2.0, 0.5) == 76` case is unaffected since `ceil(75.96°) == round(75.96°) == 76`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)