### PR TITLE
fix: unbreak CI (PHCC http patch shim + time-dependent window test)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,19 @@
 # load our custom integration from the local ``custom_components/`` directory.
 pytest_plugins = ["pytest_homeassistant_custom_component"]
 
+# --- HA / pytest-homeassistant-custom-component compatibility shim ---
+# PHCC's ``disable_http_server`` fixture runs
+# ``patch("homeassistant.components.http.start_http_server_and_save_config")``
+# with no ``create=True``. That symbol only exists in a narrow band of HA
+# releases, so on the HA versions our CI matrix installs (min / stable / dev)
+# the patch raises AttributeError and every test using the ``hass`` fixture
+# errors at setup. Pre-create a harmless stub when HA lacks the symbol so the
+# patch target exists; when HA already defines it we leave the real one alone.
+import homeassistant.components.http as _ha_http
+
+if not hasattr(_ha_http, "start_http_server_and_save_config"):
+    _ha_http.start_http_server_and_save_config = lambda *args, **kwargs: None
+
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 

--- a/tests/test_managers/test_time_window_resolved_start.py
+++ b/tests/test_managers/test_time_window_resolved_start.py
@@ -14,6 +14,7 @@ import datetime as dt
 import logging
 
 import pytest
+from freezegun import freeze_time
 
 from custom_components.adaptive_cover_pro.const import BLANK_TIME
 from custom_components.adaptive_cover_pro.managers.time_window import TimeWindowManager
@@ -83,6 +84,12 @@ def test_unset_start_resolves_to_none(mgr):
     assert mgr.resolved_start_time is None
 
 
+# Freeze to inside the 08:00-18:00 window: ``is_active`` is
+# ``before_end_time and after_start_time and ...``, which short-circuits before
+# ``after_start_time`` (the property that populates ``_cached_start_time``) when
+# the wall clock is past the end time. Without a fixed clock this test passes
+# only when it happens to run mid-window and fails on any evening CI run.
+@freeze_time("2026-07-19 10:00:00")
 def test_resolved_start_matches_value_is_active_uses(mgr):
     """``resolved_start_time`` equals the cached start ``is_active`` compares."""
     mgr.update_config(


### PR DESCRIPTION
## Summary
The Develop Build has been red independently of any feature work (it failed on the commit before the last merge too). Two pre-existing causes:

1. **PHCC vs HA symbol drift (mass `ERROR at setup`).** `pytest-homeassistant-custom-component`'s `disable_http_server` fixture does `patch("homeassistant.components.http.start_http_server_and_save_config")` with no `create=True`. That symbol is absent in the HA versions the CI matrix installs (`2026.3.1` min, `2026.6.4` stable, `2026.8.0.dev0` dev), so every test using the `hass` fixture errored at setup. Local passed only because local HA (`2026.6.3`) still exposes it. Fixed with a small compatibility shim in `tests/conftest.py`: pre-create a harmless stub when HA lacks the symbol, leave the real one alone when present. Channel-agnostic, no dependency-pin changes.

2. **A masked time-dependent test.** `test_resolved_start_matches_value_is_active_uses` relied on the wall clock sitting inside the 08:00-18:00 window; `is_active` short-circuits before the property that caches the start time once the clock is past the end. CI at 20:49 UTC hit the failing branch. Fixed with `@freeze_time` to a mid-window time.

## Testing
- ✅ Reproduced the CI `AttributeError` locally by deleting the symbol.
- ✅ Full suite with the symbol simulated absent (true CI condition): 6987 passing.
- ✅ Full suite normal env: 6987 passing.