### PR TITLE
fix: skip redundant endpoint resend on sun-appeared reconfirm (#985)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1328,8 +1328,21 @@ class CoverCommandService:
         # reason to hold the carriage still — it is not a reason to also
         # starve the tilt axis, which owns its own independent min-delta and
         # suppression gates downstream (VenetianPolicy/DualAxisSequencer).
+        # sun_just_appeared re-confirms position even at the same numeric target
+        # (feedback-poor covers, mid-range tracking) — but NOT when the target is
+        # a hard mechanical endpoint the cover already physically occupies.
+        # Re-sending close_cover/open_cover there is a true no-op on single-axis
+        # covers and actively disturbs a coupled venetian's slats (issue #985).
+        # The force_endpoint channel above already excludes the at-mechanical-stop
+        # case via _is_at_mechanical_stop; mirror it here. No-feedback covers
+        # (HA state unknown) are NOT at a mechanical stop, so their re-confirm is
+        # preserved (issue #779).
+        sun_reconfirm = context.sun_just_appeared and not (
+            position in (POSITION_CLOSED, POSITION_OPEN)
+            and self._is_at_mechanical_stop(state_obj, position)
+        )
         if (
-            not context.sun_just_appeared
+            not sun_reconfirm
             and not force_endpoint
             and not context.user_command
             and (

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -1405,6 +1405,41 @@ async def test_sun_just_appeared_false_enforces_delta(svc, mock_hass):
     assert reason == "delta_too_small"
 
 
+@pytest.mark.asyncio
+async def test_sun_just_appeared_no_resend_at_mechanical_stop(svc, mock_hass):
+    """Issue #985: sun_just_appeared must NOT re-fire an endpoint command the
+    cover already occupies (state=closed, target=0). Re-sending close_cover there
+    is a no-op on single-axis covers and disturbs a venetian's slats. The tilt
+    axis is still serviced via the same-position skip branch.
+    """
+    _patch_position(svc, 0)  # carriage already at 0
+    state = MagicMock()
+    state.state = "closed"  # STATE_CLOSED -> _is_at_mechanical_stop True
+    mock_hass.states.get.return_value = state
+    svc._service_secondary_axis = AsyncMock()  # spy: tilt must still get a turn
+    with (
+        _patch_caps(),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+            return_value=None,
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "solar",
+            context=_ctx(
+                min_change=1,
+                special_positions=[0, 100, 50],
+                sun_just_appeared=True,
+            ),
+        )
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+    svc._service_secondary_axis.assert_awaited_once()
+
+
 # ------------------------------------------------------------------ #
 # Force override release — end-to-end gate behavior (#177)
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
In venetian `tilt_only` + `endpoint_use_open_close`, the `sun_just_appeared` sentinel set on the default to solar FOV-entry transition bypassed the same-position gate in `apply_position()` and re-fired `close_cover` for a carriage already parked at 0%. On Somfy blinds `close_cover` also closes the slats, so the unchanged 0/50 target caused a 50 to 0 tilt disturbance that ACP then restored.

The fix scopes the `sun_just_appeared` re-confirm so it no longer applies when the target is a hard mechanical endpoint the cover already occupies, reusing `_is_at_mechanical_stop` (the same idempotency the `force_endpoint` channel already respects). The cycle falls into the existing same-position skip branch, which still services the tilt axis, so the #770/#775 forced-tilt behavior and #779 no-feedback re-confirm are preserved. Cover-type-agnostic (no venetian branch in the manager).

## Testing
- ✅ 154 tests passing

## Related Issues
Refs #985