### PR TITLE
fix: skip redundant endpoint resend on sun-appeared reconfirm (hotfix) (#985)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1093,8 +1093,21 @@ class CoverCommandService:
         # covers are all handled by the one routing source of truth. Delta/time
         # gates and reconciliation deliberately keep reading the real (unknown)
         # _current — this fallback is scoped to the same-position gate only.
+        # sun_just_appeared re-confirms position even at the same numeric target
+        # (feedback-poor covers, mid-range tracking) — but NOT when the target is
+        # a hard mechanical endpoint the cover already physically occupies.
+        # Re-sending close_cover/open_cover there is a true no-op on single-axis
+        # covers and actively disturbs a coupled venetian's slats (issue #985).
+        # The force_endpoint channel above already excludes the at-mechanical-stop
+        # case via _is_at_mechanical_stop; mirror it here. No-feedback covers
+        # (HA state unknown) are NOT at a mechanical stop, so their re-confirm is
+        # preserved (issue #779).
+        sun_reconfirm = context.sun_just_appeared and not (
+            position in (POSITION_CLOSED, POSITION_OPEN)
+            and self._is_at_mechanical_stop(state_obj, position)
+        )
         if (
-            not context.sun_just_appeared
+            not sun_reconfirm
             and not force_endpoint
             and (
                 (

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -1405,6 +1405,46 @@ async def test_sun_just_appeared_false_enforces_delta(svc, mock_hass):
     assert reason == "delta_too_small"
 
 
+@pytest.mark.asyncio
+async def test_sun_just_appeared_no_resend_at_mechanical_stop(svc, mock_hass):
+    """Issue #985: sun_just_appeared must NOT re-fire an endpoint command the
+    cover already occupies (state=closed, target=0). Re-sending close_cover there
+    is a no-op on single-axis covers and disturbs a venetian's slats. The tilt
+    axis is still serviced via the same-position skip branch.
+    """
+    _patch_position(svc, 0)  # carriage already at 0
+    state = MagicMock()
+    state.state = "closed"  # STATE_CLOSED -> _is_at_mechanical_stop True
+    mock_hass.states.get.return_value = state
+    # Spy: the same-position skip branch must still service the tilt axis so a
+    # forced handler transition still delivers the tilt (#770).
+    policy = MagicMock()
+    policy.maybe_update_tilt_only = AsyncMock()
+    with (
+        _patch_caps(),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+            return_value=None,
+        ),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.test",
+            0,
+            "solar",
+            context=_ctx(
+                min_change=1,
+                special_positions=[0, 100, 50],
+                sun_just_appeared=True,
+                policy=policy,
+                tilt=50,
+            ),
+        )
+    assert outcome == "skipped"
+    assert reason == "same_position"
+    mock_hass.services.async_call.assert_not_called()
+    policy.maybe_update_tilt_only.assert_awaited_once()
+
+
 # ------------------------------------------------------------------ #
 # Force override release — end-to-end gate behavior (#177)
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
## Summary
Hotfix backport of #986 (on `develop`) to `main` so it can ship as an in-month patch.

In venetian `tilt_only` + `endpoint_use_open_close`, the `sun_just_appeared` sentinel set on the default to solar FOV-entry transition bypassed the same-position gate in `apply_position()` and re-fired `close_cover` for a carriage already parked at 0%. On Somfy blinds `close_cover` also closes the slats, so the unchanged 0/50 target caused a 50 to 0 tilt disturbance that ACP then restored.

The fix scopes the `sun_just_appeared` re-confirm so it no longer applies when the target is a hard mechanical endpoint the cover already occupies, reusing `_is_at_mechanical_stop` (the same idempotency the `force_endpoint` channel already respects). The same-position skip branch still services the tilt axis via `maybe_update_tilt_only`, so #770 forced-tilt and #779 no-feedback re-confirm are preserved. Cover-type-agnostic.

Reconciled for `main` (which lacks develop's #900/#954): the source change is applied on main's gate structure and the regression test asserts on main's `maybe_update_tilt_only` tilt-servicing call.

## Testing
- ✅ 5643 tests passing on main (full suite)

## Related Issues
Refs #985

Cherry-picked from #986 for a hotfix release.