### PR TITLE
feat: healthcheck for covers not reaching commanded position (#990)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -738,6 +738,9 @@ ISSUE_COVER_UNAVAILABLE = "cover_unavailable"  # a controlled cover is unavailab
 ISSUE_SUN_UNAVAILABLE = "sun_unavailable"  # sun.sun is unavailable/missing
 ISSUE_CONFIG_POSITION_ENVELOPE = "config_position_envelope"  # min>max or slot outside
 ISSUE_CONFIG_TIME_WINDOW = "config_time_window"  # start >= end
+ISSUE_COVER_NOT_MOVING = (
+    "cover_not_moving"  # commanded but not reaching target (issue #990)
+)
 # Generous debounce so integration restarts / device re-adds don't nag before
 # a genuinely dead sensor is flagged.
 DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS = 900.0

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -1577,13 +1577,27 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # moving (waiting) or under manual override, so a slow cover / a
             # user move never trips. Clear any stale key for a cover dropped
             # since last cycle (symmetric unwatch).
+            # Per-entity guard (issue #990 audit): the A2 block runs BEFORE
+            # ``evaluate()``, so a predicate that raises every cycle would abort
+            # the whole try and silently starve A1/B1/B2/C1 (they'd be watched
+            # but never evaluated/cleared). Wrap each ``is_target_unreached``
+            # call so one entity's exception only skips that entity — the loop
+            # and the downstream ``evaluate()``/orphan-sweep still complete. The
+            # outer fail-open guard stays as belt-and-suspenders.
             a2_desired: set[str] = set()
             for eid in self.entities:
+                try:
+                    unreached = self._cmd_svc.is_target_unreached(eid)
+                except Exception:  # noqa: BLE001 — one entity must not starve the rest
+                    self.logger.debug(
+                        "A2 predicate failed for %s; skipping", eid, exc_info=True
+                    )
+                    continue
                 key = f"{ISSUE_COVER_NOT_MOVING}_{self.config_entry.entry_id}_{eid}"
                 a2_desired.add(key)
                 self._repair.update_predicate(
                     key,
-                    self._cmd_svc.is_target_unreached(eid),
+                    unreached,
                     translation_key=ISSUE_COVER_NOT_MOVING,
                     placeholders={"entity_id": eid, "name": name},
                 )

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -99,6 +99,7 @@ from .const import (
     DOMAIN,
     ISSUE_CONFIG_POSITION_ENVELOPE,
     ISSUE_CONFIG_TIME_WINDOW,
+    ISSUE_COVER_NOT_MOVING,
     ISSUE_COVER_UNAVAILABLE,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
@@ -384,6 +385,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Namespaced cover-availability watch keys currently registered, so a
         # cover dropped from config gets unwatched (its Repair cleared) next cycle.
         self._cover_issue_keys: set[str] = set()
+        # A2 (issue #990): per-entity "commanded but not reaching target" Repair
+        # keys currently tracked, so a cover dropped from config gets its
+        # predicate cleared next cycle (symmetric with _cover_issue_keys).
+        self._a2_issue_keys: set[str] = set()
         # One-shot: the first health-check cycle of this lifetime sweeps the issue
         # registry for A1 Repairs orphaned by a prior lifetime (removing a cover
         # reloads the entry, so a cross-lifetime orphan is in neither the fresh
@@ -1566,31 +1571,54 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 },
             )
 
+            # A2 — commanded-but-unreached (issue #990). Per-entity like A1;
+            # predicate-shaped like B1/B2, so it rides the same RepairManager.
+            # is_target_unreached is read-only and False while a cover is still
+            # moving (waiting) or under manual override, so a slow cover / a
+            # user move never trips. Clear any stale key for a cover dropped
+            # since last cycle (symmetric unwatch).
+            a2_desired: set[str] = set()
+            for eid in self.entities:
+                key = f"{ISSUE_COVER_NOT_MOVING}_{self.config_entry.entry_id}_{eid}"
+                a2_desired.add(key)
+                self._repair.update_predicate(
+                    key,
+                    self._cmd_svc.is_target_unreached(eid),
+                    translation_key=ISSUE_COVER_NOT_MOVING,
+                    placeholders={"entity_id": eid, "name": name},
+                )
+            for stale in self._a2_issue_keys - a2_desired:
+                self._repair.clear_predicate(stale)
+            self._a2_issue_keys = a2_desired
+
             self._sensor_health.evaluate()
             self._repair.evaluate()
 
-            # A1 cross-lifetime orphan sweep (issue #975 audit). The primary fix
-            # for a cover_unavailable Repair is REMOVING the cover, which reloads
-            # the config entry → a fresh coordinator with an empty
-            # ``_cover_issue_keys``. The removed cover's key is in neither
-            # ``desired`` (recomputed above) nor the in-lifetime unwatch loop, so
-            # its Repair would orphan until an HA restart. Once per lifetime,
-            # enumerate this integration's issues and delete any A1 Repair for
-            # this entry that is no longer desired. Runs last (inside the single
-            # fail-open guard) so a registry hiccup can never skip A1/B1/B2. The
-            # ``desired``-membership filter is critical: a still-configured but
-            # unavailable cover IS in ``desired`` (it is watched), so its valid
-            # warning is preserved rather than flapped on every restart.
+            # Per-cover cross-lifetime orphan sweep (issue #975 audit, extended
+            # for A2 in #990). The primary fix for a per-cover Repair is REMOVING
+            # the cover, which reloads the config entry → a fresh coordinator with
+            # empty ``_cover_issue_keys`` / ``_a2_issue_keys``. The removed cover's
+            # key is in neither the recomputed ``desired`` sets nor the in-lifetime
+            # unwatch loops, so its Repair would orphan until an HA restart. Once
+            # per lifetime, enumerate this integration's issues and delete any A1
+            # (cover_unavailable) or A2 (cover_not_moving) Repair for this entry
+            # that is no longer desired. Runs last (inside the single fail-open
+            # guard) so a registry hiccup can never skip A1/B1/B2/A2. The
+            # membership filter is critical: a still-configured cover IS in its
+            # desired set, so its valid warning is preserved rather than flapped.
             if not self._a1_orphans_swept:
-                a1_prefix = f"{ISSUE_COVER_UNAVAILABLE}_{self.config_entry.entry_id}_"
+                entry_id = self.config_entry.entry_id
+                sweeps = (
+                    (f"{ISSUE_COVER_UNAVAILABLE}_{entry_id}_", self._cover_issue_keys),
+                    (f"{ISSUE_COVER_NOT_MOVING}_{entry_id}_", self._a2_issue_keys),
+                )
                 registry = ir.async_get(self.hass)
                 for reg_domain, issue_id in list(registry.issues):
-                    if (
-                        reg_domain == DOMAIN
-                        and issue_id.startswith(a1_prefix)
-                        and issue_id not in self._cover_issue_keys
-                    ):
-                        ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+                    if reg_domain != DOMAIN:
+                        continue
+                    for prefix, desired_keys in sweeps:
+                        if issue_id.startswith(prefix) and issue_id not in desired_keys:
+                            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
                 self._a1_orphans_swept = True
         except Exception:  # noqa: BLE001 — health check must never break the cycle
             self.logger.debug("Health-check evaluation failed", exc_info=True)

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1660,12 +1660,16 @@ class CoverCommandService:
         * Dry-run: ``_prepare_service_call`` sets ``target``/``waiting`` BEFORE
           the dry-run gate returns, so the flags reflect a simulated command,
           not a real one. Never nag about a cover ACP never actually commanded.
-        * Open/close-only surface: such a cover can only ever report an endpoint
-          (0/100), so a non-endpoint ("My" preset) target can never register as
-          reached. We cannot verify "unreached" there, so stay quiet — reusing
-          the exact capability signal the position read uses
-          (:meth:`CoverTypePolicy.position_axis_supported`), never a cover-type
-          branch.
+        * Unverifiable surface: a cover that cannot report the granular axis it
+          was commanded on can only ever report an endpoint (0/100), so a
+          non-endpoint ("My" preset) target can never register as reached. We
+          cannot verify "unreached" there, so stay quiet. Gates on the *default
+          axis* the position read and command routing resolve via
+          :meth:`CoverTypePolicy.select_default_axis` (honouring the tilt
+          fallback) — NOT the primary position axis — so a blind/venetian
+          driven through ``set_cover_tilt_position`` (``has_set_position=False,
+          has_set_tilt_position=True``) reads a granular ``current_tilt_position``
+          and stays verifiable. Never a cover-type branch.
         """
         if self._dry_run:
             return False
@@ -1678,7 +1682,13 @@ class CoverCommandService:
         if actual is None:  # unreadable → A1 owns availability; A2 stays quiet
             return False
         caps = self.get_cover_capabilities(entity_id)
-        if not self._policy.position_axis_supported(caps) and s.target not in (
+        # Gate on the SAME capability signal the position read/command routing
+        # uses — the default axis's capability key (which honours the tilt
+        # fallback) — so "can this cover verify a granular target?" is answered
+        # consistently with how it is read and commanded. A cover that cannot
+        # report the axis it was commanded on can only surface an endpoint.
+        axis = self._policy.select_default_axis(caps)
+        if not caps_get(caps, axis.capability_key, default=True) and s.target not in (
             POSITION_CLOSED,
             POSITION_OPEN,
         ):

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1641,6 +1641,30 @@ class CoverCommandService:
 
         return False
 
+    def is_target_unreached(self, entity_id: str) -> bool:
+        """Read-only A2 predicate: True iff a commanded cover has settled off-target.
+
+        True when a target is set, the cover is no longer ``waiting`` (its
+        transit / grace window elapsed — a still-moving cover returns False),
+        the entity is not under manual override, its position reads, and it is
+        outside tolerance of the target. Reuses :meth:`_at_target` (the exact
+        seam :meth:`check_target_reached` uses — no re-derived tolerance).
+
+        NO side effects — never clears ``waiting`` or resets ``retry_count``,
+        and uses :meth:`_get` (the non-inserting accessor) so polling an
+        unknown entity does not pollute ``_state``. Called every cycle from the
+        coordinator health path (issue #990).
+        """
+        s = self._get(entity_id)
+        if s.target is None or s.waiting:
+            return False
+        if entity_id in self._manual_override_entities:
+            return False
+        actual = self._get_current_position(entity_id)
+        if actual is None:  # unreadable → A1 owns availability; A2 stays quiet
+            return False
+        return not self._at_target(actual, s.target)
+
     # ------------------------------------------------------------------ #
     # Reconciliation timer
     # ------------------------------------------------------------------ #

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1654,7 +1654,21 @@ class CoverCommandService:
         and uses :meth:`_get` (the non-inserting accessor) so polling an
         unknown entity does not pollute ``_state``. Called every cycle from the
         coordinator health path (issue #990).
+
+        Two quiet-cases (issue #990 audit):
+
+        * Dry-run: ``_prepare_service_call`` sets ``target``/``waiting`` BEFORE
+          the dry-run gate returns, so the flags reflect a simulated command,
+          not a real one. Never nag about a cover ACP never actually commanded.
+        * Open/close-only surface: such a cover can only ever report an endpoint
+          (0/100), so a non-endpoint ("My" preset) target can never register as
+          reached. We cannot verify "unreached" there, so stay quiet — reusing
+          the exact capability signal the position read uses
+          (:meth:`CoverTypePolicy.position_axis_supported`), never a cover-type
+          branch.
         """
+        if self._dry_run:
+            return False
         s = self._get(entity_id)
         if s.target is None or s.waiting:
             return False
@@ -1662,6 +1676,12 @@ class CoverCommandService:
             return False
         actual = self._get_current_position(entity_id)
         if actual is None:  # unreadable → A1 owns availability; A2 stays quiet
+            return False
+        caps = self.get_cover_capabilities(entity_id)
+        if not self._policy.position_axis_supported(caps) and s.target not in (
+            POSITION_CLOSED,
+            POSITION_OPEN,
+        ):
             return False
         return not self._at_target(actual, s.target)
 

--- a/custom_components/adaptive_cover_pro/managers/repair.py
+++ b/custom_components/adaptive_cover_pro/managers/repair.py
@@ -62,6 +62,18 @@ class RepairManager(_DebouncedRepairBase):
             placeholders=placeholders,
         )
 
+    def clear_predicate(self, issue_key: str) -> None:
+        """Drop a per-entity predicate and clear its timer + Repair.
+
+        Symmetric unwatch for per-entity keys (issue #990 A2): when a cover is
+        removed from config its stored predicate must be popped so a later
+        ``evaluate`` cannot re-raise it, and any active Repair cleared. Reuses
+        the base ``_recover`` (cancel timer + delete issue) — no duplicated
+        clear logic.
+        """
+        self._predicates.pop(issue_key, None)
+        self._recover(issue_key)
+
     # -- per-cycle evaluation ----------------------------------------------
 
     def evaluate(self) -> None:

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -20,6 +20,10 @@
     "config_time_window": {
       "title": "Betriebszeitfenster ist invertiert",
       "description": "Das Betriebszeitfenster auf **{name}** beginnt um {start}, was nach seinem Ende um {end} liegt. Das Fenster öffnet sich nie, daher wird die automatische Sonnenverfolgung nicht ausgeführt. Überprüfen Sie die Start- und Endzeiten in den Optionen der Beschattung."
+    },
+    "cover_not_moving": {
+      "title": "Gesteuerte Beschattung erreicht Position nicht",
+      "description": "Adaptive Cover Pro hat eine Position an die Beschattung `{entity_id}` gesteuert von **{name}** gesendet, doch diese hat die Position seit längerer Zeit nicht erreicht. Der Motor könnte festsitzen, das Gerät könnte offline sein, oder die Beschattung könnte sich nicht physisch bewegen. Überprüfen Sie, dass das Gerät der Beschattung online ist und auf manuelle Befehle reagiert."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -20,6 +20,10 @@
     "config_time_window": {
       "title": "Operational time window is inverted",
       "description": "The operational time window on **{name}** starts at {start}, which is after its end at {end}. The window never opens, so automatic sun tracking will not run. Review the start and end times in the cover's options."
+    },
+    "cover_not_moving": {
+      "title": "Cover not reaching commanded position",
+      "description": "Adaptive Cover Pro sent a position to the cover `{entity_id}` controlled by **{name}**, but it has not reached that position for a while. The motor may be stuck, the device may be offline, or the cover may not physically move. Check that the cover's device is online and that it responds when you command it manually."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -20,6 +20,10 @@
     "config_time_window": {
       "title": "La fenêtre temporelle opérationnelle est inversée",
       "description": "La fenêtre temporelle opérationnelle sur **{name}** commence à {start}, ce qui est après sa fin à {end}. La fenêtre ne s'ouvre jamais, donc le suivi automatique du soleil ne s'exécutera pas. Vérifiez les heures de début et de fin dans les options du store."
+    },
+    "cover_not_moving": {
+      "title": "Store ne parvient pas à atteindre la position commandée",
+      "description": "Adaptive Cover Pro a envoyé une position au store `{entity_id}` contrôlé par **{name}**, mais il n'a pas atteint cette position depuis un certain temps. Le moteur peut être bloqué, l'appareil peut être hors ligne, ou le store peut ne pas se déplacer physiquement. Vérifiez que l'appareil du store est en ligne et qu'il répond quand vous le commandez manuellement."
     }
   },
   "config": {

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -31,6 +31,7 @@ from custom_components.adaptive_cover_pro.const import (
     DOMAIN,
     ISSUE_CONFIG_POSITION_ENVELOPE,
     ISSUE_CONFIG_TIME_WINDOW,
+    ISSUE_COVER_NOT_MOVING,
     ISSUE_COVER_UNAVAILABLE,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
@@ -111,6 +112,12 @@ def _make_coord(
     coord._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}"
     coord._cover_issue_keys = set()
     coord._a1_orphans_swept = False
+    # A2 (issue #990): the command service supplies the per-entity
+    # "commanded but not reached" predicate. Default False so A1/B1/B2/C1
+    # tests see no spurious A2 Repairs; A2 tests override the return value.
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.is_target_unreached.return_value = False
+    coord._a2_issue_keys = set()
     coord._resolved_options = options or {}
     return coord
 
@@ -503,3 +510,128 @@ async def test_shutdown_cancels_both_managers():
         await coord.async_shutdown()
         await _drain()
     create.assert_not_called()
+
+
+# --- A2: commanded-but-unreached (issue #990) ------------------------------
+
+
+async def test_a2_raises_when_cover_stuck_past_debounce():
+    """A settled off-target cover raises cover_not_moving after the debounce."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )
+    coord._cmd_svc.is_target_unreached.side_effect = lambda eid: eid == "cover.a"
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.a" in _raised_keys(create)
+
+
+async def test_a2_does_not_raise_before_debounce():
+    """A single stuck cycle under a long debounce does not raise (debounce gate)."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        debounce=100,
+    )
+    coord._cmd_svc.is_target_unreached.return_value = True
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.a" not in _raised_keys(create)
+    coord._repair.shutdown()  # cancel the in-flight (long) debounce timer
+
+
+async def test_a2_clears_on_recovery():
+    """Once the cover reaches target, the A2 Repair is deleted."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )
+    key = f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.a"
+    coord._cmd_svc.is_target_unreached.return_value = True
+    await _run(coord, {})  # cycle 1: raise
+    coord._cmd_svc.is_target_unreached.return_value = False
+    _create, delete = await _run(coord, {})  # cycle 2: recovered
+    assert key in {call.args[2] for call in delete.call_args_list}
+
+
+async def test_a2_no_false_positive_on_slow_cover():
+    """A cover whose predicate stays False (still moving) never raises."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )
+    coord._cmd_svc.is_target_unreached.return_value = False
+    create, _delete = await _run(coord, {})
+    await _run(coord, {})
+    assert f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.a" not in _raised_keys(create)
+
+
+async def test_a2_fail_open_on_predicate_exception():
+    """A raising A2 predicate is swallowed by the single fail-open guard.
+
+    The A2 block sits inside the same ``try/except`` as A1/B1/B2/C1, so a
+    predicate that explodes must never propagate out of
+    ``_evaluate_health_checks`` and break the update cycle.
+    """
+    coord = _make_coord(
+        states={"sun.sun": "unavailable", "cover.a": "open"},
+        entities=["cover.a"],
+    )
+    coord.logger = MagicMock()
+    coord._cmd_svc.is_target_unreached.side_effect = RuntimeError("boom")
+    # Patch the orphan-sweep registry read too, so the ONLY exception source is
+    # the A2 predicate — otherwise the sweep's async_get would trip the guard on
+    # the mock hass and mask whether A2 is actually inside it.
+    with (
+        patch(f"{_BASE}.ir.async_create_issue"),
+        patch(f"{_BASE}.ir.async_delete_issue"),
+        patch(f"{_COORD}.ir.async_get", return_value=SimpleNamespace(issues={})),
+        patch(f"{_COORD}.ir.async_delete_issue"),
+    ):
+        # Must not raise — the fail-open guard catches it and logs.
+        coord._evaluate_health_checks({})
+        await _drain()
+    coord.logger.debug.assert_called_once()
+    assert "Health-check evaluation failed" in coord.logger.debug.call_args.args[0]
+
+
+async def test_a2_stale_key_cleared_when_cover_removed():
+    """A cover dropped from config has its A2 predicate cleared (in-lifetime)."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )
+    key = f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.a"
+    coord._cmd_svc.is_target_unreached.return_value = True
+    await _run(coord, {})  # cycle 1: cover.a tracked
+    assert key in coord._a2_issue_keys
+    coord.entities = []
+    _create, delete = await _run(coord, {})  # cycle 2: cover removed
+    assert key in {call.args[2] for call in delete.call_args_list}
+    assert coord._a2_issue_keys == set()
+
+
+async def test_a2_orphan_cleared_on_reload_after_cover_removed():
+    """An A2 Repair for a cover no longer configured is swept once per lifetime."""
+    orphan = f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.old"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.current": "open"},
+        entities=["cover.current"],
+    )
+    registry = SimpleNamespace(issues={(DOMAIN, orphan): object()})
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    assert orphan in _swept_keys(coord_delete)
+
+
+async def test_a2_configured_stuck_cover_not_swept():
+    """A still-configured stuck cover keeps its A2 Repair (in ``a2_desired``)."""
+    key = f"{ISSUE_COVER_NOT_MOVING}_{_ENTRY}_cover.a"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )
+    coord._cmd_svc.is_target_unreached.return_value = True
+    registry = SimpleNamespace(issues={(DOMAIN, key): object()})
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    assert key not in _swept_keys(coord_delete)

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -566,11 +566,15 @@ async def test_a2_no_false_positive_on_slow_cover():
 
 
 async def test_a2_fail_open_on_predicate_exception():
-    """A raising A2 predicate is swallowed by the single fail-open guard.
+    """A raising A2 predicate must not starve A1/B1/B2/C1 (issue #990 audit).
 
-    The A2 block sits inside the same ``try/except`` as A1/B1/B2/C1, so a
-    predicate that explodes must never propagate out of
-    ``_evaluate_health_checks`` and break the update cycle.
+    The per-entity ``is_target_unreached`` call has its own narrow guard, so an
+    entity whose predicate explodes is skipped — the A2 loop still finishes,
+    ``evaluate()`` runs, and a concurrently-unhealthy C1 (``sun.sun``
+    unavailable) Repair STILL raises. Without the per-entity guard the exception
+    would abort the try before ``evaluate()`` and silently block every other
+    check. The outer fail-open guard stays as belt-and-suspenders, but this
+    per-entity guard is what preserves the original design guarantee.
     """
     coord = _make_coord(
         states={"sun.sun": "unavailable", "cover.a": "open"},
@@ -582,16 +586,21 @@ async def test_a2_fail_open_on_predicate_exception():
     # the A2 predicate — otherwise the sweep's async_get would trip the guard on
     # the mock hass and mask whether A2 is actually inside it.
     with (
-        patch(f"{_BASE}.ir.async_create_issue"),
+        patch(f"{_BASE}.ir.async_create_issue") as create,
         patch(f"{_BASE}.ir.async_delete_issue"),
         patch(f"{_COORD}.ir.async_get", return_value=SimpleNamespace(issues={})),
         patch(f"{_COORD}.ir.async_delete_issue"),
     ):
-        # Must not raise — the fail-open guard catches it and logs.
+        # Must not raise — the per-entity guard swallows the predicate exception.
         coord._evaluate_health_checks({})
         await _drain()
+    # C1 still evaluated despite the A2 predicate blowing up: the sun_unavailable
+    # Repair still raises. This is the original design guarantee.
+    assert f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}" in _raised_keys(create)
+    # The per-entity guard logged the skip exactly once (debug logged once).
     coord.logger.debug.assert_called_once()
-    assert "Health-check evaluation failed" in coord.logger.debug.call_args.args[0]
+    assert "A2 predicate failed" in coord.logger.debug.call_args.args[0]
+    assert coord.logger.debug.call_args.args[1] == "cover.a"
 
 
 async def test_a2_stale_key_cleared_when_cover_removed():

--- a/tests/test_health_issue_translations.py
+++ b/tests/test_health_issue_translations.py
@@ -30,6 +30,7 @@ _HEALTH_ISSUES = {
     "sun_unavailable": {"{name}"},
     "config_position_envelope": {"{name}", "{min}", "{max}"},
     "config_time_window": {"{name}", "{start}", "{end}"},
+    "cover_not_moving": {"{name}", "{entity_id}"},
 }
 
 

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -2295,3 +2295,27 @@ def test_is_target_unreached_false_for_my_preset_on_open_close_only_cover(cmd_sv
         patch.object(cmd_svc, "_get_current_position", return_value=100),
     ):
         assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_true_for_tilt_fallback_cover_off_target(cmd_svc):
+    """A tilt-fallback cover off its granular target is verifiable — A2 must fire (#990 re-audit).
+
+    A blind/venetian configured ``has_set_position=False, has_set_tilt_position=True``
+    routes commands to ``set_cover_tilt_position`` with a granular target (1–99) and
+    reads a granular ``current_tilt_position`` — so an intermediate ("My") target IS
+    verifiable, unlike a genuinely open/close-only cover. The guard must gate on the
+    default axis actually read/commanded (tilt here), not the primary position axis,
+    or it wrongly silences A2 for this healthy-but-stuck cover.
+    """
+    s = cmd_svc.state("cover.x")
+    s.target = 50  # granular My preset — verifiable on the tilt axis
+    s.waiting = False
+    tilt_fallback = {
+        "has_set_position": False,
+        "has_set_tilt_position": True,
+    }
+    with (
+        patch.object(cmd_svc, "get_cover_capabilities", return_value=tilt_fallback),
+        patch.object(cmd_svc, "_get_current_position", return_value=0),
+    ):
+        assert cmd_svc.is_target_unreached("cover.x") is True

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -2173,3 +2173,85 @@ async def test_apply_position_repeated_my_preset_suppressed_when_current_unknown
 
     assert (outcome2, reason2) == ("skipped", "same_position")
     mock_hass.services.async_call.assert_not_called()
+
+
+# --- is_target_unreached: A2 read-only "commanded but not reached" predicate ---
+# Issue #990. Read-only predicate the coordinator polls each cycle to raise the
+# cover_not_moving Repair. True iff a target is set, the cover has settled
+# (not waiting), it is not under manual override, its position reads, and it is
+# outside tolerance of the target. Reuses _at_target; must have NO side effects.
+
+
+def test_is_target_unreached_true_when_settled_offtarget(cmd_svc):
+    """A settled cover far from its commanded target is unreached."""
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = False
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        assert cmd_svc.is_target_unreached("cover.x") is True
+
+
+def test_is_target_unreached_false_while_waiting(cmd_svc):
+    """A cover still in transit (waiting) is not flagged — slow-cover guard."""
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = True
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_false_under_manual_override(cmd_svc):
+    """A cover the user moved (manual override) is not flagged."""
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = False
+    cmd_svc.manual_override_entities = {"cover.x"}
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_false_when_position_unreadable(cmd_svc):
+    """An unreadable position defers to A1 (cover_unavailable) — no double-nag."""
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = False
+    with patch.object(cmd_svc, "_get_current_position", return_value=None):
+        assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_false_when_at_target(cmd_svc):
+    """A cover within tolerance of its target is reached (clear-on-recovery)."""
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = False
+    # Default tolerance is 3% — 51 is within tolerance of 50.
+    with patch.object(cmd_svc, "_get_current_position", return_value=51):
+        assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_false_when_no_target(cmd_svc):
+    """No commanded target → nothing to be unreached."""
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_has_no_side_effects(cmd_svc):
+    """The predicate never mutates waiting/retry_count/target and never inserts.
+
+    Locks the StateClassifier / reconciliation invariants (#147/#172/#186/
+    #271/#285/#518): a read-only health poll must not clear waiting, reset
+    retry_count, or pollute _state with an empty record for an unknown entity.
+    """
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = False
+    s.retry_count = 2
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        cmd_svc.is_target_unreached("cover.x")
+    assert s.waiting is False
+    assert s.retry_count == 2
+    assert s.target == 50
+    # An unknown entity must not insert a new state record (uses _get, not state).
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        cmd_svc.is_target_unreached("cover.unknown")
+    assert "cover.unknown" not in cmd_svc._state

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -2255,3 +2255,43 @@ def test_is_target_unreached_has_no_side_effects(cmd_svc):
     with patch.object(cmd_svc, "_get_current_position", return_value=0):
         cmd_svc.is_target_unreached("cover.unknown")
     assert "cover.unknown" not in cmd_svc._state
+
+
+def test_is_target_unreached_false_in_dry_run(cmd_svc):
+    """Dry-run never sends commands, so a simulated target must never nag (#990 audit).
+
+    ``_prepare_service_call`` sets ``target``/``waiting``/``sent_at`` BEFORE the
+    dry-run gate returns, so in dry-run the predicate would otherwise go True for
+    a cover ACP never actually commanded. The early dry-run guard prevents that.
+    """
+    cmd_svc.dry_run = True
+    s = cmd_svc.state("cover.x")
+    s.target = 50
+    s.waiting = False
+    with patch.object(cmd_svc, "_get_current_position", return_value=0):
+        assert cmd_svc.is_target_unreached("cover.x") is False
+
+
+def test_is_target_unreached_false_for_my_preset_on_open_close_only_cover(cmd_svc):
+    """An intermediate ("My") target on an open/close-only cover is unverifiable (#990 audit).
+
+    An open/close-only cover (no granular position axis) can only ever report an
+    endpoint (0/100), so a My-preset target (1–99) can never register as
+    reached — the predicate would go permanently True against a healthy cover.
+    The guard returns False for a non-endpoint target on that surface. Reuses the
+    exact capability signal the position read uses (``position_axis_supported``).
+    """
+    s = cmd_svc.state("cover.x")
+    s.target = 50  # My preset — not an endpoint
+    s.waiting = False
+    open_close_only = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    with (
+        patch.object(cmd_svc, "get_cover_capabilities", return_value=open_close_only),
+        patch.object(cmd_svc, "_get_current_position", return_value=100),
+    ):
+        assert cmd_svc.is_target_unreached("cover.x") is False

--- a/tests/test_managers/test_repair_predicate.py
+++ b/tests/test_managers/test_repair_predicate.py
@@ -131,15 +131,18 @@ class TestRepairManager:
         )
         mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
         with (
-            patch(f"{_MOD}.ir.async_create_issue"),
+            patch(f"{_MOD}.ir.async_create_issue") as create,
             patch(f"{_MOD}.ir.async_delete_issue") as delete,
         ):
             mgr.evaluate()  # raise
             await _drain()
+            create.reset_mock()  # ignore the first-raise call; watch for a RE-raise
             mgr.clear_predicate(_ISSUE_KEY)
             # A later evaluate must not re-raise — the predicate was popped.
             mgr.evaluate()
             await _drain()
+            # Explicit: the dropped predicate produces no new Repair.
+            create.assert_not_called()
         assert _ISSUE_KEY in {call.args[2] for call in delete.call_args_list}
         assert _ISSUE_KEY not in mgr._predicates
 

--- a/tests/test_managers/test_repair_predicate.py
+++ b/tests/test_managers/test_repair_predicate.py
@@ -118,6 +118,31 @@ class TestRepairManager:
             await _drain()
         create.assert_not_called()
 
+    async def test_clear_predicate_drops_and_recovers(self, logger):
+        """``clear_predicate`` deletes an active Repair and pops the predicate.
+
+        Per-entity A2 keys (issue #990) need a symmetric unwatch: when a cover
+        is removed the coordinator calls ``clear_predicate`` so the stored
+        predicate is dropped (a later ``evaluate`` cannot re-raise it) and any
+        active Repair is deleted.
+        """
+        mgr = RepairManager(
+            _bg_hass(), logger, domain="adaptive_cover_pro", debounce_seconds=0
+        )
+        mgr.update_predicate(_ISSUE_KEY, True, translation_key=_TRANSLATION_KEY)
+        with (
+            patch(f"{_MOD}.ir.async_create_issue"),
+            patch(f"{_MOD}.ir.async_delete_issue") as delete,
+        ):
+            mgr.evaluate()  # raise
+            await _drain()
+            mgr.clear_predicate(_ISSUE_KEY)
+            # A later evaluate must not re-raise — the predicate was popped.
+            mgr.evaluate()
+            await _drain()
+        assert _ISSUE_KEY in {call.args[2] for call in delete.call_args_list}
+        assert _ISSUE_KEY not in mgr._predicates
+
     async def test_orphan_cleared_on_fresh_instance(self, logger):
         """A predicate healthy on a fresh manager clears a Repair from a prior lifetime.
 


### PR DESCRIPTION
## Summary
Adds healthcheck A2 (part of #973): Adaptive Cover Pro now raises an informational HA Repair when it commands a cover to a position the cover never reaches (a stuck motor, a dead Zigbee device, or a cover that reports state but never actuates), and clears it automatically on recovery.

It builds on the phase-1 healthcheck infrastructure from #977: it reuses the `RepairManager` predicate sibling and its existing 900s debounce (no bespoke counter), keyed per entity like the A1 cover-unavailable check. A new read-only `is_target_unreached` predicate on `CoverCommandService` rides the `_at_target` tolerance seam with zero side effects.

Guards baked in (each with a regression test) after a deep pre-merge audit:
- Skips dry-run mode (no command is ever sent).
- Skips a "My" preset target on a cover that cannot verify it, gating on the same default-axis capability the read and command paths use, so tilt-fallback covers are still checked.
- Per-entity fail-open: one entity's predicate raising cannot starve the A1/B1/B2/C1 checks for the cycle.

No new user config; the debounce is the shared 900s constant. `en`/`de`/`fr` translations added for the new `cover_not_moving` issue.

## Testing
- ✅ 7040 tests passing
- Deep audit (fable) run pre-merge across three rounds; surfaced and fixed the dry-run, My-preset, tilt-fallback, and starvation edge cases above.

## Related Issues
Refs #990, #973
