### PR TITLE
feat: dual-panel cover type — independent sheer + blackout (#996)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -247,6 +247,31 @@ DAY_NIGHT_SPLIT_MIDPOINT = 50  # % — split-range fabric boundary (blackout bel
 # Model C middle-rail entity: which of the instance's cover entities is the
 # middle rail (the other configured cover is the bottom rail / primary).
 CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY = "day_night_middle_rail_entity"
+
+# --- Dual-panel shade (#996) ------------------------------------------------
+# Two INDEPENDENT HA shade entities over one window: a sheer FRONT that
+# sun-tracks like a plain vertical blind, and a blackout BACK that deploys only
+# when one of the configured triggers is active. ``CONF_DUAL_PANEL_FRONT_ENTITY``
+# names which of the instance's covers is the front/sheer one (the remainder is
+# the back/blackout); ``CONF_DUAL_PANEL_BLACKOUT_TRIGGERS`` is the user-selected
+# subset of the trigger set that drives the blackout. Unlike day/night Model C
+# the two panels are NOT coupled — there is no ``M >= P`` no-pass invariant.
+CONF_DUAL_PANEL_FRONT_ENTITY = "dual_panel_front_entity"
+CONF_DUAL_PANEL_BLACKOUT_TRIGGERS = "dual_panel_blackout_triggers"
+# The three conditions that can deploy the blackout back. ``heat`` fires on a
+# climate summer / extreme-heat full block; ``privacy`` fires in the sunset
+# window; ``night`` fires when the sun is below the horizon.
+DUAL_PANEL_TRIGGER_HEAT = "heat"
+DUAL_PANEL_TRIGGER_PRIVACY = "privacy"
+DUAL_PANEL_TRIGGER_NIGHT = "night"
+DUAL_PANEL_BLACKOUT_TRIGGERS = (
+    DUAL_PANEL_TRIGGER_HEAT,
+    DUAL_PANEL_TRIGGER_PRIVACY,
+    DUAL_PANEL_TRIGGER_NIGHT,
+)
+# Default: no trigger selected → the back never deploys until the user opts in.
+DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS: tuple[str, ...] = ()
+
 CONF_FOV_LEFT = "fov_left"  # left half-FOV from azimuth, degrees 0-180
 CONF_FOV_RIGHT = "fov_right"  # right half-FOV from azimuth, degrees 0-180
 DEFAULT_FOV_LEFT = 90  # degrees; matches config flow default
@@ -2076,6 +2101,7 @@ class CoverType(StrEnum):
     SLIDING_CURTAIN = "cover_sliding_curtain"
     LOUVERED_ROOF = "cover_louvered_roof"
     DAY_NIGHT_SHADE = "cover_day_night_shade"
+    DUAL_PANEL = "cover_dual_panel"
     # Virtual entry type — not a physical cover. Holds shared building-level
     # sensor entity IDs that linked covers copy into their own options. Its
     # policy registers no platforms (``controls_cover = False``).
@@ -2104,6 +2130,7 @@ class CoverType(StrEnum):
             self.SLIDING_CURTAIN: "Sliding Curtain",
             self.LOUVERED_ROOF: "Louvered Roof",
             self.DAY_NIGHT_SHADE: "Day/Night Shade",
+            self.DUAL_PANEL: "Dual Panel Shade",
             self.BUILDING_PROFILE: "Building Profile",
             self.GROUP: "Cover Group",
         }[self]

--- a/custom_components/adaptive_cover_pro/cover_types/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/__init__.py
@@ -23,6 +23,7 @@ from .tilt import TiltPolicy
 from .venetian import VenetianPolicy
 from .louvered_roof import LouveredRoofPolicy
 from .day_night_shade import DayNightShadePolicy
+from .dual_panel import DualPanelPolicy
 
 # Virtual entry types — imported LAST so they sort to the bottom of
 # registry-derived menus (``SENSOR_TYPE_MENU`` follows registration order).
@@ -62,6 +63,7 @@ __all__ = [
     "BuildingProfilePolicy",
     "CoverTypePolicy",
     "DayNightShadePolicy",
+    "DualPanelPolicy",
     "GroupPolicy",
     "LouveredRoofPolicy",
     "OscillatingAwningPolicy",

--- a/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
+++ b/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
@@ -55,6 +55,7 @@ COVER_TYPE_LABELS_EN: dict[str, str] = {
     "cover_types.sliding_curtain": "Sliding Curtain",
     "cover_types.louvered_roof": "Louvered Roof",
     "cover_types.day_night_shade": "Day/Night Shade",
+    "cover_types.dual_panel": "Dual Panel Shade",
 }
 
 # --- Geometry / physical-dimension templates (namespace config_summary.geometry.*)
@@ -121,6 +122,11 @@ GEOMETRY_LABELS_EN: dict[str, str] = {
     "geometry.day_night.model_position_tilt": "position and tilt (dual axis)",
     "geometry.day_night.model_split_range": "split range (single axis)",
     "geometry.day_night.model_dual_entity": "two rail entities (dual entity)",
+    # Dual-panel shade (#996): the front/sheer designator + the blackout
+    # trigger list rendered on the config summary.
+    "geometry.dual_panel.front_entity": "front (sheer) panel: {v}",
+    "geometry.dual_panel.triggers": "blackout deploys on: {v}",
+    "geometry.dual_panel.none": "no triggers",
     # Computed-FOV read-only line (blind + venetian Measurements mode, #565).
     "geometry.fov.computed": (
         "Computed acceptance angle ≈ {deg}°/{deg}° " "({w} m width, {d} m reveal depth)"

--- a/custom_components/adaptive_cover_pro/cover_types/dual_panel/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/dual_panel/__init__.py
@@ -1,0 +1,19 @@
+"""Dual-panel (sheer front + blackout back) cover-type package (#996).
+
+Re-exports the public surface so ``from cover_types.dual_panel import
+DualPanelPolicy`` resolves. The policy drives TWO independent HA shade entities
+over one window: a sheer FRONT that sun-tracks like a plain vertical blind, and
+a blackout BACK that deploys only on a configured trigger. It rides the shipped
+``resolve_entity_target`` / ``post_pipeline_resolve`` seam — but, unlike the
+day/night Model C shade, the two panels are NOT coupled (no ``M >= P`` no-pass
+invariant).
+"""
+
+from __future__ import annotations
+
+from .policy import GEOMETRY_DUAL_PANEL_SCHEMA, DualPanelPolicy
+
+__all__ = [
+    "GEOMETRY_DUAL_PANEL_SCHEMA",
+    "DualPanelPolicy",
+]

--- a/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
@@ -1,0 +1,396 @@
+"""Dual-panel shade cover policy (#996).
+
+Two INDEPENDENT HA shade entities over one window:
+
+* the **front** is a sheer / light-filtering shade that tracks the sun exactly
+  like a plain vertical blind — its target is the adaptive position the pipeline
+  already computed, so ``resolve_entity_target`` returns it verbatim;
+* the **back** is a blackout shade that stays retracted (open) most of the time
+  and deploys (closes) only when one of the user-configured triggers
+  ``{heat, privacy, night}`` is active.
+
+The defining difference from the day/night Model C shade (#993) is that the two
+panels are INDEPENDENT — there is no ``M >= P`` no-pass coupling between them.
+Each panel's target is decided once through the pure ``engine/covers/layered``
+helpers (``blackout_should_deploy`` / ``compute_layered``) and dispatched on the
+shipped ``resolve_entity_target`` / ``post_pipeline_resolve`` seam, which the
+coordinator already routes every per-entity command through.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+import voluptuous as vol
+from homeassistant.helpers import selector
+
+from ...const import (
+    CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    CONF_DUAL_PANEL_FRONT_ENTITY,
+    CONF_INVERSE_STATE,
+    DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    DUAL_PANEL_BLACKOUT_TRIGGERS,
+    DUAL_PANEL_TRIGGER_HEAT,
+    DUAL_PANEL_TRIGGER_NIGHT,
+    DUAL_PANEL_TRIGGER_PRIVACY,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    ControlMethod,
+)
+from ...engine.covers import AdaptiveVerticalCover
+from ...engine.covers.layered import blackout_should_deploy, compute_layered
+from ...managers.manual_override import inverse_state
+from ...pipeline.types import DecisionStep
+from .._helpers import window_dimensions_lines
+from .._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
+from ..base import (
+    CAP_HAS_SET_POSITION,
+    POSITION_AXIS,
+    CoverAxis,
+    CoverTypePolicy,
+    caps_get,
+)
+from ..blind import VERTICAL_LENGTH_KEYS, geometry_vertical_schema
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from ...engine.covers import AdaptiveGeneralCover
+    from ...pipeline.types import PipelineResult
+    from ...services.configuration_service import ConfigurationService
+
+
+# Control methods whose full-block strategy counts as the "heat" trigger — a
+# climate summer close or an extreme-heat force-hold. Kept here (not branched
+# inline) so the trigger derivation reads off one set.
+_HEAT_METHODS = frozenset({ControlMethod.SUMMER, ControlMethod.EXTREME_HEAT})
+
+
+def _front_entity_select() -> selector.EntitySelector:
+    """Return a single-cover entity picker for the front/sheer panel."""
+    return selector.EntitySelector(selector.EntitySelectorConfig(domain="cover"))
+
+
+def _blackout_triggers_select() -> selector.SelectSelector:
+    """Return the multi-select of blackout triggers ({heat, privacy, night})."""
+    return selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=list(DUAL_PANEL_BLACKOUT_TRIGGERS),
+            multiple=True,
+            mode=selector.SelectSelectorMode.LIST,
+            translation_key="dual_panel_blackout_triggers",
+        )
+    )
+
+
+def geometry_dual_panel_schema(hass: HomeAssistant | None = None) -> vol.Schema:
+    """Vertical window geometry plus the front-entity + trigger-set options."""
+    return geometry_vertical_schema(hass).extend(
+        {
+            # Which of the instance's cover entities is the front/sheer panel
+            # (the remainder is the back/blackout). Optional with no default so
+            # an un-set value is simply absent from options — and the policy
+            # then degrades gracefully to a plain vertical blind.
+            vol.Optional(CONF_DUAL_PANEL_FRONT_ENTITY): _front_entity_select(),
+            vol.Optional(
+                CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+                default=list(DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS),
+            ): _blackout_triggers_select(),
+        }
+    )
+
+
+# Module-level constant for hass=None (metric) identity, matching the other
+# policies so schema-identity tests keep passing.
+GEOMETRY_DUAL_PANEL_SCHEMA = geometry_dual_panel_schema()
+
+
+class DualPanelPolicy(CoverTypePolicy, register=True):
+    """Two independent shades (sheer front sun-tracks; blackout back on trigger)."""
+
+    cover_type = "cover_dual_panel"
+    # Single position axis — the front sheer sun-tracks exactly like a vertical
+    # blind, and the back is a pure open/closed decision on its own position
+    # axis. No tilt axis, so no dual-axis sensor / custom-position tilt sliders.
+    axes: ClassVar[tuple[CoverAxis, ...]] = (POSITION_AXIS,)
+    supports_glare_zones: ClassVar[bool] = True
+    supports_return_to_default_switch: ClassVar[bool] = True
+    supports_fov_compute: ClassVar[bool] = True
+    exposes_dual_axis_sensor: ClassVar[bool] = False
+    custom_position_includes_tilt: ClassVar[bool] = False
+
+    def __init__(self) -> None:
+        """Initialise the per-cycle dispatch cache (filled post-pipeline)."""
+        # Cached once per cycle by ``post_pipeline_resolve`` because the
+        # coordinator dispatch seam receives no ``options`` and no pipeline
+        # result. ``_front_entity`` names the sheer panel; ``_deploy_back``
+        # records the blackout decision; ``_back_inverse`` mirrors whether
+        # ``coordinator.state`` actually inverted the dispatched value this
+        # cycle; ``_back_bypass`` records a safety/bypass cycle in which every
+        # entity passes through untouched.
+        self._front_entity: str | None = None
+        self._deploy_back: bool = False
+        self._back_inverse: bool = False
+        self._back_bypass: bool = False
+
+    # ---- Identity / labels -------------------------------------------- #
+
+    def wiki_anchor(self) -> str:
+        """Dual-panel shade wiki page."""
+        return "Configuration-Dual-Panel"
+
+    def display_label(self, labels: dict[str, str] | None = None) -> str:
+        """User-facing label for dual-panel shades."""
+        L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
+        return L["cover_types.dual_panel"]
+
+    # ---- Geometry / config-flow surfaces ------------------------------ #
+
+    def disallowed_geometry_fields(
+        self,
+        *,
+        vertical_only: set[str],
+        awning_only: set[str],
+        tilt_only: set[str],
+    ) -> list[tuple[set[str], str]]:
+        """Accept vertical geometry; reject awning and slat (tilt) geometry."""
+        return [(awning_only, "awning"), (tilt_only, "tilt")]
+
+    def geometry_schema(
+        self,
+        hass: HomeAssistant | None = None,
+        options: dict | None = None,  # noqa: ARG002
+    ) -> vol.Schema:
+        """Return the vertical + dual-panel geometry schema for the given locale."""
+        if hass is None:
+            return GEOMETRY_DUAL_PANEL_SCHEMA
+        return geometry_dual_panel_schema(hass)
+
+    def geometry_length_keys(self) -> tuple[str, ...]:
+        """Dual-panel shades carry the vertical-blind window dimensions in metres."""
+        return VERTICAL_LENGTH_KEYS
+
+    def entity_selector_filter(self) -> selector.EntityFilterSelectorConfig:
+        """Plain ``cover`` domain — both panels are ordinary position covers."""
+        return selector.EntityFilterSelectorConfig(domain="cover")
+
+    def glare_zones_config(self, config_service, options: dict):
+        """Return the glare-zones config (the front sheer sun-tracks, #996)."""
+        return config_service.get_glare_zones_config(options)
+
+    def summary_geometry_lines(
+        self, config: dict[str, Any], labels: dict[str, str] | None = None
+    ) -> list[str]:
+        """Render the window block plus the front-entity + trigger-list lines."""
+        lines = window_dimensions_lines(config, labels)
+        L = {**GEOMETRY_LABELS_EN, **(labels or {})}
+        front = config.get(CONF_DUAL_PANEL_FRONT_ENTITY)
+        if front:
+            lines.append(L["geometry.dual_panel.front_entity"].format(v=front))
+        triggers = config.get(
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+            list(DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS),
+        )
+        trig_str = ", ".join(triggers) if triggers else L["geometry.dual_panel.none"]
+        lines.append(L["geometry.dual_panel.triggers"].format(v=trig_str))
+        return lines
+
+    def cover_capability_warnings(self, known: dict[str, dict]) -> list[str]:
+        """Warn about covers that don't support ``set_position``.
+
+        Both panels are driven to absolute positions, so every bound cover must
+        expose ``set_position``. Mirrors the vertical-blind requirement but
+        names each offending entity (both panels matter here).
+        """
+        missing = [
+            eid
+            for eid, caps in known.items()
+            if not caps_get(caps, CAP_HAS_SET_POSITION)
+        ]
+        if missing:
+            return [
+                "⚠️ Configured as dual-panel shade but "
+                f"{', '.join(missing)} does not support set_position — "
+                "both the front and back panel need set_position."
+            ]
+        return []
+
+    def capability_warnings_for_options(
+        self, known: dict[str, dict], options: dict
+    ) -> list[str]:
+        """Add a front-entity validity check to the per-panel capability warnings.
+
+        The front-entity designator must name one of the instance's configured
+        covers; a typo / stale pick warns just like the day/night middle rail.
+        """
+        warnings = self.cover_capability_warnings(known)
+        front = options.get(CONF_DUAL_PANEL_FRONT_ENTITY)
+        if front and front not in known:
+            warnings.append(
+                "⚠️ Configured as a dual-panel shade but the front-panel entity "
+                f"{front} is not one of this instance's covers — add it to the "
+                "cover list or pick a configured cover."
+            )
+        return warnings
+
+    def lift_travel_metres(
+        self,
+        config_service: ConfigurationService,
+        options: dict,
+    ) -> float | None:
+        """Return the configured window height the front carriage travels."""
+        return config_service.get_vertical_data(options).h_win
+
+    # ---- Calculation engine ------------------------------------------- #
+
+    def build_calc_engine(
+        self,
+        *,
+        logger,
+        sol_azi: float,
+        sol_elev: float,
+        sun_data,
+        config,
+        config_service: ConfigurationService,
+        options: dict,
+    ) -> AdaptiveGeneralCover:
+        """Build a vertical calc engine (the front sheer is a vertical blind)."""
+        from dataclasses import replace
+
+        vert_config = config_service.get_vertical_data(options)
+        glare_zones_cfg = config_service.get_glare_zones_config(options)
+        if glare_zones_cfg is not None:
+            vert_config = replace(vert_config, glare_zones=glare_zones_cfg)
+        return AdaptiveVerticalCover(
+            logger=logger,
+            sol_azi=sol_azi,
+            sol_elev=sol_elev,
+            sun_data=sun_data,
+            config=config,
+            vert_config=vert_config,
+        )
+
+    # ---- Dual-panel dispatch seam (per-cycle cache + resolve) --------- #
+
+    def _derive_active_triggers(
+        self, result: PipelineResult, sol_elev: float
+    ) -> tuple[str, ...]:
+        """Map the pipeline result onto the currently-active blackout triggers.
+
+        ``heat`` fires on a climate summer / extreme-heat full block; ``privacy``
+        fires inside the sunset window; ``night`` fires when the sun is below the
+        horizon. The configured subset (``blackout_should_deploy``) then decides
+        whether any of these actually deploys the back — this method only reports
+        what is happening, never what the user opted into.
+        """
+        active: list[str] = []
+        if result.control_method in _HEAT_METHODS:
+            active.append(DUAL_PANEL_TRIGGER_HEAT)
+        if result.is_sunset_active:
+            active.append(DUAL_PANEL_TRIGGER_PRIVACY)
+        if sol_elev < 0:
+            active.append(DUAL_PANEL_TRIGGER_NIGHT)
+        return tuple(active)
+
+    def post_pipeline_resolve(
+        self,
+        result: PipelineResult,
+        *,
+        logger,  # noqa: ARG002
+        sol_azi: float,  # noqa: ARG002
+        sol_elev: float,
+        sun_data,  # noqa: ARG002
+        config,  # noqa: ARG002
+        config_service: ConfigurationService,  # noqa: ARG002
+        options: dict,
+        cover: AdaptiveGeneralCover | None = None,  # noqa: ARG002
+    ) -> PipelineResult:
+        """Cache the per-cycle dual-panel dispatch state; leave position/tilt as-is.
+
+        The coordinator dispatch seam (``resolve_entity_target``) receives no
+        ``options`` and no pipeline result, so the front-entity designator, the
+        blackout deploy decision, the inverse-state flag, and the bypass flag are
+        stashed here once per cycle. The front panel keeps the pipeline's
+        adaptive position untouched — only the back panel's target is substituted
+        at dispatch — so this hook does not rewrite ``result.position``.
+        """
+        if result is None:
+            return result
+
+        active = self._derive_active_triggers(result, sol_elev)
+        configured = options.get(
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+            list(DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS),
+        )
+        self._front_entity = options.get(CONF_DUAL_PANEL_FRONT_ENTITY)
+        self._deploy_back = blackout_should_deploy(active, configured)
+        self._back_bypass = result.bypass_auto_control
+        self._back_inverse = self._resolve_inverse(result, options)
+
+        trace = list(result.decision_trace)
+        trace.append(
+            DecisionStep(
+                handler="dual_panel_back",
+                matched=self._deploy_back,
+                reason=(
+                    f"blackout {'deploy' if self._deploy_back else 'retract'} — "
+                    f"active triggers: {', '.join(active) if active else 'none'}; "
+                    f"configured: {', '.join(configured) if configured else 'none'}"
+                ),
+                position=result.position,
+            )
+        )
+        from dataclasses import replace
+
+        return replace(result, decision_trace=trace)
+
+    @staticmethod
+    def _resolve_inverse(result: PipelineResult, options: dict) -> bool:
+        """Mirror whether ``coordinator.state`` actually inverted this cycle.
+
+        ``state`` returns ``result.position`` RAW (no inverse) on the
+        safety/bypass path, for a floor-clamped winner, and under interpolation;
+        so the back panel must invert its open/closed target in exactly the same
+        cases the primary dispatch did — never merely when inverse-state is
+        configured. Byte-identical to the day/night Model C ``_cache_dual_entity``
+        inverse rule (#993).
+        """
+        from ...const import CONF_INTERP
+
+        inverse_cfg = bool(options.get(CONF_INVERSE_STATE, False))
+        use_interp = bool(options.get(CONF_INTERP, False))
+        return (
+            inverse_cfg
+            and not use_interp
+            and not (result.bypass_auto_control or result.floor_clamp_applied)
+        )
+
+    def resolve_entity_target(
+        self, entity_id: str, position: int, *, inverted: bool | None = None
+    ) -> int:
+        """Substitute the back panel's blackout target; the front passes through.
+
+        The front/sheer panel dispatches the pipeline's adaptive position
+        verbatim. Every other bound entity is the back/blackout panel, whose
+        target is a pure open/closed decision — INDEPENDENT of the front, with no
+        ``M >= P`` no-pass clamp (the defining difference from day/night Model C).
+        When no front is designated the cover degrades to a plain vertical blind
+        (identity for all); a safety/bypass cycle also passes every entity
+        through untouched so the safety winner is never overwritten.
+
+        ``inverted`` names the wire value's inversion space: ``None`` reuses the
+        cached per-cycle decision (the main dispatch path); the broadcast seams
+        pass an explicit ``True``/``False`` for their own divergent space.
+        """
+        if self._front_entity is None or self._back_bypass:
+            return position
+        if entity_id == self._front_entity:
+            return position
+        layered = compute_layered(
+            front=position,
+            deploy_blackout=self._deploy_back,
+            open_position=POSITION_OPEN,
+            closed_position=POSITION_CLOSED,
+        )
+        inverse = self._back_inverse if inverted is None else inverted
+        return inverse_state(layered.back) if inverse else layered.back

--- a/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
@@ -41,6 +41,7 @@ from ...engine.covers import AdaptiveVerticalCover
 from ...engine.covers.layered import blackout_should_deploy, compute_layered
 from ...managers.manual_override import inverse_state
 from ...pipeline.types import DecisionStep
+from ...position_utils import interpolate_position
 from .._helpers import window_dimensions_lines
 from .._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from ..base import (
@@ -124,14 +125,22 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         # Cached once per cycle by ``post_pipeline_resolve`` because the
         # coordinator dispatch seam receives no ``options`` and no pipeline
         # result. ``_front_entity`` names the sheer panel; ``_deploy_back``
-        # records the blackout decision; ``_back_inverse`` mirrors whether
-        # ``coordinator.state`` actually inverted the dispatched value this
-        # cycle; ``_back_bypass`` records a safety/bypass cycle in which every
-        # entity passes through untouched.
+        # records the blackout decision; ``_back_inverse`` records whether the
+        # back's absolute open/closed target must be inverted into the device's
+        # wire space (device inverse semantics only); ``_back_interp`` +
+        # ``_interp_*`` carry the interpolation calibration curve so the back's
+        # canonical endpoints go through the same mapping as the front;
+        # ``_back_bypass`` records a safety/bypass cycle in which every entity
+        # passes through untouched.
         self._front_entity: str | None = None
         self._deploy_back: bool = False
         self._back_inverse: bool = False
         self._back_bypass: bool = False
+        self._back_interp: bool = False
+        self._interp_start: Any = None
+        self._interp_end: Any = None
+        self._interp_list: Any = None
+        self._interp_list_new: Any = None
 
     # ---- Identity / labels -------------------------------------------- #
 
@@ -273,20 +282,27 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
     # ---- Dual-panel dispatch seam (per-cycle cache + resolve) --------- #
 
     def _derive_active_triggers(
-        self, result: PipelineResult, sol_elev: float
+        self, result: PipelineResult, sol_elev: float, *, sunset_valid: bool
     ) -> tuple[str, ...]:
         """Map the pipeline result onto the currently-active blackout triggers.
 
         ``heat`` fires on a climate summer / extreme-heat full block; ``privacy``
-        fires inside the sunset window; ``night`` fires when the sun is below the
-        horizon. The configured subset (``blackout_should_deploy``) then decides
-        whether any of these actually deploys the back — this method only reports
-        what is happening, never what the user opted into.
+        fires inside the astronomical sunset WINDOW; ``night`` fires when the sun
+        is below the horizon. The configured subset (``blackout_should_deploy``)
+        then decides whether any of these actually deploys the back — this method
+        only reports what is happening, never what the user opted into.
+
+        ``sunset_valid`` is the cover's own astronomical sunset/sunrise-window
+        flag (``AdaptiveGeneralCover.sunset_valid``), which is TRUE inside the
+        window regardless of whether a ``sunset_position`` is configured — unlike
+        ``result.is_sunset_active``, which is hard-False without a sunset
+        position (#996 Finding 2). Privacy therefore means "the sunset window is
+        active" as the option description promises.
         """
         active: list[str] = []
         if result.control_method in _HEAT_METHODS:
             active.append(DUAL_PANEL_TRIGGER_HEAT)
-        if result.is_sunset_active:
+        if sunset_valid:
             active.append(DUAL_PANEL_TRIGGER_PRIVACY)
         if sol_elev < 0:
             active.append(DUAL_PANEL_TRIGGER_NIGHT)
@@ -303,21 +319,28 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         config,  # noqa: ARG002
         config_service: ConfigurationService,  # noqa: ARG002
         options: dict,
-        cover: AdaptiveGeneralCover | None = None,  # noqa: ARG002
+        cover: AdaptiveGeneralCover | None = None,
     ) -> PipelineResult:
         """Cache the per-cycle dual-panel dispatch state; leave position/tilt as-is.
 
         The coordinator dispatch seam (``resolve_entity_target``) receives no
         ``options`` and no pipeline result, so the front-entity designator, the
-        blackout deploy decision, the inverse-state flag, and the bypass flag are
-        stashed here once per cycle. The front panel keeps the pipeline's
-        adaptive position untouched — only the back panel's target is substituted
-        at dispatch — so this hook does not rewrite ``result.position``.
+        blackout deploy decision, the inverse-state flag, the interpolation
+        calibration curve, and the bypass flag are stashed here once per cycle.
+        The front panel keeps the pipeline's adaptive position untouched — only
+        the back panel's target is substituted at dispatch — so this hook does
+        not rewrite ``result.position``.
         """
         if result is None:
             return result
 
-        active = self._derive_active_triggers(result, sol_elev)
+        # Privacy keys on the cover's own astronomical sunset WINDOW, not on
+        # ``result.is_sunset_active`` (which needs a sunset_position) — #996
+        # Finding 2. No cover object → no window signal.
+        sunset_valid = bool(getattr(cover, "sunset_valid", False))
+        active = self._derive_active_triggers(
+            result, sol_elev, sunset_valid=sunset_valid
+        )
         configured = options.get(
             CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
             list(DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS),
@@ -325,7 +348,16 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         self._front_entity = options.get(CONF_DUAL_PANEL_FRONT_ENTITY)
         self._deploy_back = blackout_should_deploy(active, configured)
         self._back_bypass = result.bypass_auto_control
-        self._back_inverse = self._resolve_inverse(result, options)
+        self._cache_inverse_and_interp(options)
+
+        # The back decision is only APPLIED on cycles where a front is designated
+        # AND the safety/bypass path isn't overwriting every entity. Recording a
+        # ``dual_panel_back`` step on an inapplicable cycle (no front, or a bypass
+        # winner) would show a decision in the trace that never reaches a cover —
+        # so skip it there (#996 Finding 8).
+        back_applies = bool(self._front_entity) and not self._back_bypass
+        if not back_applies:
+            return result
 
         trace = list(result.decision_trace)
         trace.append(
@@ -344,26 +376,39 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
 
         return replace(result, decision_trace=trace)
 
-    @staticmethod
-    def _resolve_inverse(result: PipelineResult, options: dict) -> bool:
-        """Mirror whether ``coordinator.state`` actually inverted this cycle.
+    def _cache_inverse_and_interp(self, options: dict) -> None:
+        """Cache the back's wire-space transform (inverse XOR interpolation).
 
-        ``state`` returns ``result.position`` RAW (no inverse) on the
-        safety/bypass path, for a floor-clamped winner, and under interpolation;
-        so the back panel must invert its open/closed target in exactly the same
-        cases the primary dispatch did — never merely when inverse-state is
-        configured. Byte-identical to the day/night Model C ``_cache_dual_entity``
-        inverse rule (#993).
+        The back target is an ABSOLUTE SUBSTITUTION (canonical open/closed), NOT
+        a transform of the front's dispatched value, so its wire space depends
+        ONLY on the device's inverse semantics and the instance's interpolation
+        calibration — NEVER on whether the front's value was bypass- or
+        floor-clamped (#996 Finding 1). This deliberately DIVERGES from the
+        day/night Model C middle-rail rule, whose target IS derived from the
+        front's dispatched value and so must mirror ``coordinator.state``'s
+        clamp/bypass short-circuits.
+
+        Interpolation and inverse-state are mutually exclusive at dispatch — the
+        coordinator ignores inverse-state under interpolation — so the back
+        interpolates its canonical 0/100 through the same curve as the front when
+        interp is on (#996 Finding 5), and inverts otherwise.
         """
-        from ...const import CONF_INTERP
-
-        inverse_cfg = bool(options.get(CONF_INVERSE_STATE, False))
-        use_interp = bool(options.get(CONF_INTERP, False))
-        return (
-            inverse_cfg
-            and not use_interp
-            and not (result.bypass_auto_control or result.floor_clamp_applied)
+        from ...const import (
+            CONF_INTERP,
+            CONF_INTERP_END,
+            CONF_INTERP_LIST,
+            CONF_INTERP_LIST_NEW,
+            CONF_INTERP_START,
         )
+
+        use_interp = bool(options.get(CONF_INTERP, False))
+        inverse_cfg = bool(options.get(CONF_INVERSE_STATE, False))
+        self._back_interp = use_interp
+        self._back_inverse = inverse_cfg and not use_interp
+        self._interp_start = options.get(CONF_INTERP_START)
+        self._interp_end = options.get(CONF_INTERP_END)
+        self._interp_list = options.get(CONF_INTERP_LIST)
+        self._interp_list_new = options.get(CONF_INTERP_LIST_NEW)
 
     def resolve_entity_target(
         self, entity_id: str, position: int, *, inverted: bool | None = None
@@ -378,11 +423,14 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         (identity for all); a safety/bypass cycle also passes every entity
         through untouched so the safety winner is never overwritten.
 
-        ``inverted`` names the wire value's inversion space: ``None`` reuses the
-        cached per-cycle decision (the main dispatch path); the broadcast seams
-        pass an explicit ``True``/``False`` for their own divergent space.
+        ``inverted`` names the wire value's inversion space: ``None`` (the main
+        dispatch path) applies the cached per-cycle transform — interpolation
+        through the calibration curve when configured, else inverse-state per the
+        device semantics. A broadcast seam passes an explicit ``True``/``False``
+        for its own inversion space; those seams dispatch their absolute default
+        un-interpolated, so the back mirrors exactly the inversion they applied.
         """
-        if self._front_entity is None or self._back_bypass:
+        if not self._front_entity or self._back_bypass:
             return position
         if entity_id == self._front_entity:
             return position
@@ -392,5 +440,22 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
             open_position=POSITION_OPEN,
             closed_position=POSITION_CLOSED,
         )
-        inverse = self._back_inverse if inverted is None else inverted
-        return inverse_state(layered.back) if inverse else layered.back
+        back = layered.back
+        if inverted is None:
+            # Main dispatch path — interpolation XOR inverse, matching how
+            # ``coordinator.state`` transforms the front's value this cycle.
+            if self._back_interp:
+                return int(
+                    round(
+                        interpolate_position(
+                            back,
+                            self._interp_start,
+                            self._interp_end,
+                            self._interp_list,
+                            self._interp_list_new,
+                        )
+                    )
+                )
+            return inverse_state(back) if self._back_inverse else back
+        # Broadcast seam — mirror the seam's own (un-interpolated) inversion.
+        return inverse_state(back) if inverted else back

--- a/custom_components/adaptive_cover_pro/engine/covers/layered.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/layered.py
@@ -1,0 +1,70 @@
+"""Layered dual-panel (sheer front + blackout back) calculation.
+
+A dual-panel cover drives two SEPARATE full-height vertical shades on one
+window, layered front-to-back:
+
+- the **front** is a sheer / light-filtering shade that tracks the sun exactly
+  like a normal vertical blind — it filters glare while admitting diffuse
+  light — so its target is simply the adaptive position the pipeline already
+  computed;
+- the **back** is a blackout shade that stays retracted (open) most of the
+  time and only deploys (closes) when conditions call for a full block — a
+  hot-/cold-day climate strategy or the astronomical sunset / privacy window.
+
+Unlike venetian (two axes on one HA entity, tightly sequenced) the two panels
+are independent entities with no coupling, so this module only *decides* each
+panel's target; the per-entity command machinery dispatches them separately.
+
+The functions here are pure and take primitives only (no HA, no const enums),
+so they unit-test in isolation. The owning ``DualPanelPolicy`` maps the
+``PipelineResult`` onto the ``active_triggers`` set and the canonical
+open/closed values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class LayeredResult:
+    """Per-panel targets for a dual-panel (front/back) cover."""
+
+    front: int  # 0–100 position for the sheer/front layer
+    back: int  # 0–100 position for the blackout/back layer
+
+
+def blackout_should_deploy(
+    active_triggers: Iterable[str],
+    configured_triggers: Iterable[str],
+) -> bool:
+    """Return whether the blackout back should deploy (close) this cycle.
+
+    Deploys when ANY configured trigger is currently active. ``active_triggers``
+    is the set of trigger keys the policy derived from the pipeline result
+    (e.g. a climate full-block strategy, or the sunset window);
+    ``configured_triggers`` is the user-selected subset that should drive the
+    blackout. An empty ``configured_triggers`` means the back never deploys.
+    """
+    active = set(active_triggers)
+    return any(trigger in active for trigger in configured_triggers)
+
+
+def compute_layered(
+    *,
+    front: int,
+    deploy_blackout: bool,
+    open_position: int,
+    closed_position: int,
+) -> LayeredResult:
+    """Compose the two panel targets.
+
+    ``front`` is the already-resolved sheer position (the adaptive sun-tracking
+    value). The back is ``closed_position`` when the blackout deploys, else
+    ``open_position``. Callers pass the open/closed values already mapped into
+    the dispatched coordinate space (inverse-state applied), so this function
+    stays free of any cover-direction semantics.
+    """
+    back = closed_position if deploy_blackout else open_position
+    return LayeredResult(front=front, back=back)

--- a/custom_components/adaptive_cover_pro/engine/covers/layered.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/layered.py
@@ -62,9 +62,12 @@ def compute_layered(
 
     ``front`` is the already-resolved sheer position (the adaptive sun-tracking
     value). The back is ``closed_position`` when the blackout deploys, else
-    ``open_position``. Callers pass the open/closed values already mapped into
-    the dispatched coordinate space (inverse-state applied), so this function
-    stays free of any cover-direction semantics.
+    ``open_position``. Callers pass the CANONICAL open/closed endpoints
+    (``POSITION_OPEN`` / ``POSITION_CLOSED``); this function only *selects*
+    between them and applies no cover-direction semantics. The owning policy
+    maps the chosen endpoint into the device's wire space afterward —
+    interpolation through the calibration curve, or inverse-state — so no
+    wire-space transform is baked in here.
     """
     back = closed_position if deploy_blackout else open_position
     return LayeredResult(front=front, back=back)

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -51,6 +51,8 @@ from ..const import (
     CONF_DEFAULT_TILT,
     CONF_DELTA_POSITION,
     CONF_DELTA_TIME,
+    CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    CONF_DUAL_PANEL_FRONT_ENTITY,
     CONF_DEVICE_ID,
     CONF_DISTANCE,
     CONF_ENABLE_BLIND_SPOT,
@@ -166,6 +168,7 @@ from ..const import (
     CONF_VENETIAN_TILT_SKIP_MODE,
     CONF_VENETIAN_TILT_TRANSFORM,
     DAY_NIGHT_CONTROL_MODELS,
+    DUAL_PANEL_BLACKOUT_TRIGGERS,
     SLIDING_SLIDE_DIRECTIONS,
     VENETIAN_MODES,
     VENETIAN_POST_SETTLE_MODES,
@@ -344,6 +347,28 @@ def _select_v(*options: str):
     return vol.Any(None, vol.In(list(options)))
 
 
+def _list_subset_v(*options: str):
+    """Validate ``None`` or a list whose members are all within *options*.
+
+    Used for multi-select literal sets (e.g. the dual-panel blackout triggers) —
+    an empty list is valid (nothing selected); any member outside the allowed
+    set raises ``vol.Invalid``.
+    """
+    allowed = set(options)
+
+    def _validate(value):
+        if value is None:
+            return None
+        if not isinstance(value, list):
+            raise vol.Invalid("expected a list")
+        bad = [item for item in value if item not in allowed]
+        if bad:
+            raise vol.Invalid(f"unknown option(s): {', '.join(map(str, bad))}")
+        return value
+
+    return _validate
+
+
 # Maps option key → validator callable. Used by validate_options_patch and set_option.
 # Numeric ranges live in ``const.OPTION_RANGES`` (single source of truth shared
 # with config_flow.py); ``_range(key)`` reads from there. Per-slot custom-position
@@ -381,6 +406,9 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD: _range(CONF_DAY_NIGHT_BLACKOUT_THRESHOLD),
     CONF_DAY_NIGHT_CONTROL_MODEL: _select_v(*DAY_NIGHT_CONTROL_MODELS),
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _entity_v(),
+    # Geometry — dual-panel shade (#996)
+    CONF_DUAL_PANEL_FRONT_ENTITY: _entity_v(),
+    CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: _list_subset_v(*DUAL_PANEL_BLACKOUT_TRIGGERS),
     # Geometry — tilt/venetian
     CONF_TILT_DEPTH: _range(CONF_TILT_DEPTH),
     CONF_TILT_DISTANCE: _range(CONF_TILT_DISTANCE),
@@ -851,6 +879,15 @@ _SECTION_GEOMETRY_DAY_NIGHT = frozenset(
         CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     }
 )
+_SECTION_GEOMETRY_DUAL_PANEL = frozenset(
+    {
+        # Both have FIELD_VALIDATORS entries, so they must be service-settable
+        # too (else the validators are dead code and the keys silently dropped) —
+        # mirrors the day/night middle-rail wiring (#996 Finding 3).
+        CONF_DUAL_PANEL_FRONT_ENTITY,
+        CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    }
+)
 _SECTION_GEOMETRY_ALL = (
     _SECTION_GEOMETRY_VERTICAL
     | _SECTION_GEOMETRY_AWNING
@@ -859,6 +896,7 @@ _SECTION_GEOMETRY_ALL = (
     | _SECTION_GEOMETRY_ROOF
     | _SECTION_GEOMETRY_SLIDING
     | _SECTION_GEOMETRY_DAY_NIGHT
+    | _SECTION_GEOMETRY_DUAL_PANEL
 )
 
 _SECTION_VENETIAN = frozenset(

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -224,7 +224,8 @@
     "roof_window": "Dachfenster",
     "sliding_curtain": "Schiebevorhang",
     "louvered_roof": "Lamellendach",
-    "day_night_shade": "Tag/Nacht-Rollo"
+    "day_night_shade": "Tag/Nacht-Rollo",
+    "dual_panel": "Doppelpaneel-Beschattung"
   },
   "geometry": {
     "window": {
@@ -288,6 +289,11 @@
       "model_position_tilt": "position und neigung (zweiachsig)",
       "model_split_range": "geteilter bereich (einachsig)",
       "model_dual_entity": "zwei Schienen-Entitäten (Doppelentität)"
+    },
+    "dual_panel": {
+      "front_entity": "transparentes Frontpaneel: {v}",
+      "triggers": "Verdunkelung schließt bei: {v}",
+      "none": "keine Auslöser"
     }
   },
   "group": {

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -224,7 +224,8 @@
     "roof_window": "Roof Window",
     "sliding_curtain": "Sliding Curtain",
     "louvered_roof": "Louvered Roof",
-    "day_night_shade": "Day/Night Shade"
+    "day_night_shade": "Day/Night Shade",
+    "dual_panel": "Dual Panel Shade"
   },
   "axes": {
     "position": "Position",
@@ -289,6 +290,11 @@
       "model_position_tilt": "position and tilt (dual axis)",
       "model_split_range": "split range (single axis)",
       "model_dual_entity": "two rail entities (dual entity)"
+    },
+    "dual_panel": {
+      "front_entity": "front (sheer) panel: {v}",
+      "triggers": "blackout deploys on: {v}",
+      "none": "no triggers"
     },
     "fov": {
       "computed": "Computed acceptance angle ≈ {deg}°/{deg}° ({w} m width, {d} m reveal depth)"

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -224,7 +224,8 @@
     "roof_window": "Fenêtre de toit",
     "sliding_curtain": "Rideau coulissant",
     "louvered_roof": "Toit à lames",
-    "day_night_shade": "Store jour/nuit"
+    "day_night_shade": "Store jour/nuit",
+    "dual_panel": "Store à double panneau"
   },
   "geometry": {
     "window": {
@@ -288,6 +289,11 @@
       "model_position_tilt": "position et inclinaison (à deux axes)",
       "model_split_range": "plage fractionnée (à un seul axe)",
       "model_dual_entity": "deux entités de rail (double entité)"
+    },
+    "dual_panel": {
+      "front_entity": "panneau avant (voile) : {v}",
+      "triggers": "l'occultant se déploie sur : {v}",
+      "none": "aucun déclencheur"
     }
   },
   "group": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -114,7 +114,9 @@
           "day_night_opacity_blackout": "Deckkraft Verdunkelungsstoff (%)",
           "day_night_blackout_threshold": "Verdunkelungs-Aktivierungsschwellenwert (%)",
           "day_night_control_model": "Kontrollmodell",
-          "day_night_middle_rail_entity": "Mittlere Schiene-Entität (Doppelentitäts-Modell)"
+          "day_night_middle_rail_entity": "Mittlere Schiene-Entität (Doppelentitäts-Modell)",
+          "dual_panel_front_entity": "Transparentes Frontpaneel",
+          "dual_panel_blackout_triggers": "Verdunkelungs-Auslöser"
         },
         "data_description": {
           "window_height": "Höhe Ihres Fensters (von unten bis oben des Glasbereichs). In der von Home Assistant konfigurierten Einheit angezeigt. Beispiele: Standard-Tür = 2,0 m / 79 in, Kleines Fenster = 1,5 m / 59 in, Vom Boden bis zur Decke = 2,5 m / 98 in. Messen Sie von dort, wo die Beschattung beginnt, bis dort, wo sie endet, wenn sie vollständig ausgefahren ist.",
@@ -167,7 +169,9 @@
           "day_night_opacity_blackout": "Wie viel Licht der undurchsichtige **Verdunkelungsstoff** blockiert (0–100 %). Wird nur zur Abschätzung der Filterung verwendet. Standard 100 (vollständig undurchsichtig).",
           "day_night_blackout_threshold": "Wenn die Sonne während des Sommers im Nachführfenster ist und die Deckkraft des Sheer-Stoffs **unter** diesem Wert liegt, eskaliert das Rollo auf den Verdunkelungsstoff, um die Wärme zu blockieren. Standard 65. Erhöhen Sie es, um früher zur Verdunkelung zu greifen; verringern Sie es, um den Sheer-Stoff länger zu behalten.",
           "day_night_control_model": "Wie das abstrakte Coverage + Stoff-Paar auf Ihre physische Beschattung abgebildet wird. **Position + Neigung** (Standard): Die Beschattung steuert set_position für die Abdeckung und set_tilt_position für die Sheer/Verdunkelung-Mischung — für Hardware, die beide Achsen freilegt. **Geteilter Bereich**: Eine einachsige Beschattung, deren Positionsbereich beide kodiert — die untere Hälfte (0–50%) wählt den Verdunkelungsstoff, die obere Hälfte (50–100%) den Sheer-Stoff — für Hardware mit nur einem Motor. **Zwei Schienen-Entitäten**: zwei separate Beschattungs-Entitäten — eine untere Schiene und eine mittlere Schiene — wobei die Stoff-Mischung in die absolute Position der mittleren Schiene eingefaltet wird.",
-          "day_night_middle_rail_entity": "Nur für das **Zwei Schienen-Entitäten**-Modell: Welche Beschattung dieser Instanz ist die mittlere Schiene. Die andere konfigurierte Beschattung ist die untere Schiene. Die mittlere Schiene wird garantiert nicht unter die untere Schiene fallen."
+          "day_night_middle_rail_entity": "Nur für das **Zwei Schienen-Entitäten**-Modell: Welche Beschattung dieser Instanz ist die mittlere Schiene. Die andere konfigurierte Beschattung ist die untere Schiene. Die mittlere Schiene wird garantiert nicht unter die untere Schiene fallen.",
+          "dual_panel_front_entity": "Welches der Covers dieser Instanz ist das **transparente Frontpaneel**. Es folgt der Sonne wie eine normale Jalousie. Alle anderen konfigurierten Covers sind das **Verdunkelungspaneel**. Lassen Sie diesen Wert leer, um als normale Jalousie zu funktionieren.",
+          "dual_panel_blackout_triggers": "Wenn das **Verdunkelungspaneel** schließt. **Wärme**: Klima-Sommer / extreme Hitze Block. **Datenschutz**: Sonnenuntergangsfenster. **Nacht**: Sonne unter dem Horizont. Wählen Sie eine beliebige Kombination – das Verdunkelungspaneel öffnet sich, wenn keiner der ausgewählten Auslöser aktiv ist. Die beiden Paneele sind unabhängig."
         }
       },
       "duplicate_select": {
@@ -388,7 +392,9 @@
           "day_night_opacity_blackout": "Deckkraft Verdunkelungsstoff (%)",
           "day_night_blackout_threshold": "Verdunkelungs-Aktivierungsschwellenwert (%)",
           "day_night_control_model": "Kontrollmodell",
-          "day_night_middle_rail_entity": "Mittlere Schiene-Entität (Doppelentitäts-Modell)"
+          "day_night_middle_rail_entity": "Mittlere Schiene-Entität (Doppelentitäts-Modell)",
+          "dual_panel_front_entity": "Transparentes Frontpaneel",
+          "dual_panel_blackout_triggers": "Verdunkelungs-Auslöser"
         },
         "data_description": {
           "window_height": "Höhe Ihres Fensters (von unten bis oben des Glasbereichs). In der von Home Assistant konfigurierten Einheit angezeigt. Beispiele: Standard-Tür = 2,0 m / 79 in, Kleines Fenster = 1,5 m / 59 in, Vom Boden bis zur Decke = 2,5 m / 98 in. Messen Sie von dort, wo die Beschattung beginnt, bis dort, wo sie endet, wenn sie vollständig ausgefahren ist.",
@@ -441,7 +447,9 @@
           "day_night_opacity_blackout": "Wie viel Licht der undurchsichtige **Verdunkelungsstoff** blockiert (0–100 %). Wird nur zur Abschätzung der Filterung verwendet. Standard 100 (vollständig undurchsichtig).",
           "day_night_blackout_threshold": "Wenn die Sonne während des Sommers im Nachführfenster ist und die Deckkraft des Sheer-Stoffs **unter** diesem Wert liegt, eskaliert das Rollo auf den Verdunkelungsstoff, um die Wärme zu blockieren. Standard 65. Erhöhen Sie es, um früher zur Verdunkelung zu greifen; verringern Sie es, um den Sheer-Stoff länger zu behalten.",
           "day_night_control_model": "Wie das abstrakte Coverage + Stoff-Paar auf Ihre physische Beschattung abgebildet wird. **Position + Neigung** (Standard): Die Beschattung steuert set_position für die Abdeckung und set_tilt_position für die Sheer/Verdunkelung-Mischung — für Hardware, die beide Achsen freilegt. **Geteilter Bereich**: Eine einachsige Beschattung, deren Positionsbereich beide kodiert — die untere Hälfte (0–50%) wählt den Verdunkelungsstoff, die obere Hälfte (50–100%) den Sheer-Stoff — für Hardware mit nur einem Motor. **Zwei Schienen-Entitäten**: zwei separate Beschattungs-Entitäten — eine untere Schiene und eine mittlere Schiene — wobei die Stoff-Mischung in die absolute Position der mittleren Schiene eingefaltet wird.",
-          "day_night_middle_rail_entity": "Nur für das **Zwei Schienen-Entitäten**-Modell: Welche Beschattung dieser Instanz ist die mittlere Schiene. Die andere konfigurierte Beschattung ist die untere Schiene. Die mittlere Schiene wird garantiert nicht unter die untere Schiene fallen."
+          "day_night_middle_rail_entity": "Nur für das **Zwei Schienen-Entitäten**-Modell: Welche Beschattung dieser Instanz ist die mittlere Schiene. Die andere konfigurierte Beschattung ist die untere Schiene. Die mittlere Schiene wird garantiert nicht unter die untere Schiene fallen.",
+          "dual_panel_front_entity": "Welches der Covers dieser Instanz ist das **transparente Frontpaneel**. Es folgt der Sonne wie eine normale Jalousie. Alle anderen konfigurierten Covers sind das **Verdunkelungspaneel**. Lassen Sie diesen Wert leer, um als normale Jalousie zu funktionieren.",
+          "dual_panel_blackout_triggers": "Wenn das **Verdunkelungspaneel** schließt. **Wärme**: Klima-Sommer / extreme Hitze Block. **Datenschutz**: Sonnenuntergangsfenster. **Nacht**: Sonne unter dem Horizont. Wählen Sie eine beliebige Kombination – das Verdunkelungspaneel öffnet sich, wenn keiner der ausgewählten Auslöser aktiv ist. Die beiden Paneele sind unabhängig."
         }
       },
       "sun_tracking": {
@@ -1200,7 +1208,8 @@
         "cover_roof_window": "Dachfenster",
         "cover_sliding_curtain": "Schiebevorhang (horizontal)",
         "cover_louvered_roof": "Lamellendach",
-        "cover_day_night_shade": "Tag/Nacht-Rollo (Doppelstoff)"
+        "cover_day_night_shade": "Tag/Nacht-Rollo (Doppelstoff)",
+        "cover_dual_panel": "Doppelpaneel (transparent + Verdunkelung)"
       }
     },
     "tilt_mode": {
@@ -1322,6 +1331,13 @@
         "position_tilt": "Position + Neigung (zweiachsig)",
         "split_range": "Geteilter Bereich (einachsig)",
         "dual_entity": "Zwei Schienen-Entitäten (Doppelentität)"
+      }
+    },
+    "dual_panel_blackout_triggers": {
+      "options": {
+        "heat": "Wärme (Klima-Sommer / extreme Hitze)",
+        "privacy": "Datenschutz (Sonnenuntergangsfenster)",
+        "night": "Nacht (Sonne unter dem Horizont)"
       }
     }
   },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -114,7 +114,9 @@
           "day_night_opacity_blackout": "Blackout Fabric Opacity (%)",
           "day_night_blackout_threshold": "Blackout Engage Threshold (%)",
           "day_night_control_model": "Control Model",
-          "day_night_middle_rail_entity": "Middle Rail Entity (dual-entity model)"
+          "day_night_middle_rail_entity": "Middle Rail Entity (dual-entity model)",
+          "dual_panel_front_entity": "Front (Sheer) Panel Entity",
+          "dual_panel_blackout_triggers": "Blackout Deploy Triggers"
         },
         "data_description": {
           "window_height": "Height of your window (from bottom to top of the glass area). Shown in the unit Home Assistant is configured for. Examples: Standard door = 2.0 m / 79 in, Small window = 1.5 m / 59 in, Floor-to-ceiling = 2.5 m / 98 in. Measure from where the cover starts to where it ends when fully extended.",
@@ -167,7 +169,9 @@
           "day_night_opacity_blackout": "How much light the opaque **blackout** fabric blocks (0–100%). Used only for the filtering estimate. Default 100 (fully opaque).",
           "day_night_blackout_threshold": "When the sun is in the tracking window during summer and the sheer fabric's opacity is **below** this value, the shade escalates to the blackout fabric to block the heat. Default 65. Raise it to reach for blackout sooner; lower it to keep the sheer fabric longer.",
           "day_night_control_model": "How the abstract coverage + fabric pair maps onto your physical cover. **Position + tilt** (default): the shade drives set_position for coverage and set_tilt_position for the sheer/blackout fabric blend — for hardware exposing both axes. **Split range**: a single-axis cover whose position range encodes both — the lower half (0–50%) selects the blackout fabric, the upper half (50–100%) the sheer fabric — for hardware with only one motor. **Two rail entities**: two separate cover entities — a bottom rail and a middle rail — where the fabric blend folds into the middle rail's absolute position.",
-          "day_night_middle_rail_entity": "For the **Two rail entities** model only: which of this instance's covers is the middle rail. The other configured cover is the bottom rail. The middle rail is guaranteed never to drop below the bottom rail."
+          "day_night_middle_rail_entity": "For the **Two rail entities** model only: which of this instance's covers is the middle rail. The other configured cover is the bottom rail. The middle rail is guaranteed never to drop below the bottom rail.",
+          "dual_panel_front_entity": "Which of this instance's covers is the **front / sheer** panel. It sun-tracks like a plain vertical blind. Every other configured cover is the **back / blackout** panel. Leave unset to run as a plain vertical blind.",
+          "dual_panel_blackout_triggers": "When the back **blackout** panel deploys (closes). **Heat**: a climate summer / extreme-heat full block. **Privacy**: the sunset window. **Night**: the sun is below the horizon. Select any combination — the back retracts (opens) whenever none of the selected triggers is active. The two panels are independent (no no-pass coupling)."
         }
       },
       "duplicate_select": {
@@ -410,7 +414,9 @@
           "day_night_opacity_blackout": "Blackout Fabric Opacity (%)",
           "day_night_blackout_threshold": "Blackout Engage Threshold (%)",
           "day_night_control_model": "Control Model",
-          "day_night_middle_rail_entity": "Middle Rail Entity (dual-entity model)"
+          "day_night_middle_rail_entity": "Middle Rail Entity (dual-entity model)",
+          "dual_panel_front_entity": "Front (Sheer) Panel Entity",
+          "dual_panel_blackout_triggers": "Blackout Deploy Triggers"
         },
         "data_description": {
           "window_height": "Height of your window (from bottom to top of the glass area). Shown in the unit Home Assistant is configured for. Examples: Standard door = 2.0 m / 79 in, Small window = 1.5 m / 59 in, Floor-to-ceiling = 2.5 m / 98 in. Measure from where the cover starts to where it ends when fully extended.",
@@ -463,7 +469,9 @@
           "day_night_opacity_blackout": "How much light the opaque **blackout** fabric blocks (0–100%). Used only for the filtering estimate. Default 100 (fully opaque).",
           "day_night_blackout_threshold": "When the sun is in the tracking window during summer and the sheer fabric's opacity is **below** this value, the shade escalates to the blackout fabric to block the heat. Default 65. Raise it to reach for blackout sooner; lower it to keep the sheer fabric longer.",
           "day_night_control_model": "How the abstract coverage + fabric pair maps onto your physical cover. **Position + tilt** (default): the shade drives set_position for coverage and set_tilt_position for the sheer/blackout fabric blend — for hardware exposing both axes. **Split range**: a single-axis cover whose position range encodes both — the lower half (0–50%) selects the blackout fabric, the upper half (50–100%) the sheer fabric — for hardware with only one motor. **Two rail entities**: two separate cover entities — a bottom rail and a middle rail — where the fabric blend folds into the middle rail's absolute position.",
-          "day_night_middle_rail_entity": "For the **Two rail entities** model only: which of this instance's covers is the middle rail. The other configured cover is the bottom rail. The middle rail is guaranteed never to drop below the bottom rail."
+          "day_night_middle_rail_entity": "For the **Two rail entities** model only: which of this instance's covers is the middle rail. The other configured cover is the bottom rail. The middle rail is guaranteed never to drop below the bottom rail.",
+          "dual_panel_front_entity": "Which of this instance's covers is the **front / sheer** panel. It sun-tracks like a plain vertical blind. Every other configured cover is the **back / blackout** panel. Leave unset to run as a plain vertical blind.",
+          "dual_panel_blackout_triggers": "When the back **blackout** panel deploys (closes). **Heat**: a climate summer / extreme-heat full block. **Privacy**: the sunset window. **Night**: the sun is below the horizon. Select any combination — the back retracts (opens) whenever none of the selected triggers is active. The two panels are independent (no no-pass coupling)."
         }
       },
       "sun_tracking": {
@@ -1200,7 +1208,15 @@
         "cover_roof_window": "Roof window",
         "cover_sliding_curtain": "Sliding curtain (horizontal)",
         "cover_louvered_roof": "Louvered roof",
-        "cover_day_night_shade": "Day/night shade (dual-fabric)"
+        "cover_day_night_shade": "Day/night shade (dual-fabric)",
+        "cover_dual_panel": "Dual panel (sheer + blackout)"
+      }
+    },
+    "dual_panel_blackout_triggers": {
+      "options": {
+        "heat": "Heat (climate summer / extreme heat)",
+        "privacy": "Privacy (sunset window)",
+        "night": "Night (sun below the horizon)"
       }
     },
     "tilt_mode": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -114,7 +114,9 @@
           "day_night_opacity_blackout": "Opacité du Tissu Occultant (%)",
           "day_night_blackout_threshold": "Seuil d'Activation du Tissu Occultant (%)",
           "day_night_control_model": "Modèle de contrôle",
-          "day_night_middle_rail_entity": "Entité du Rail Central (modèle double entité)"
+          "day_night_middle_rail_entity": "Entité du Rail Central (modèle double entité)",
+          "dual_panel_front_entity": "Entité du panneau avant (voile)",
+          "dual_panel_blackout_triggers": "Déclencheurs du déploiement de l'occultant"
         },
         "data_description": {
           "window_height": "Hauteur de votre fenêtre (de bas en haut de la zone vitrée). Affiché dans l'unité configurée dans Home Assistant. Exemples : Porte standard = 2,0 m / 79 in, Petite fenêtre = 1,5 m / 59 in, Du sol au plafond = 2,5 m / 98 in. Mesurez d'où la protection commence à d'où elle finit lorsqu'elle est complètement étendue.",
@@ -167,7 +169,9 @@
           "day_night_opacity_blackout": "Quantité de lumière bloquée par le tissu **occultant** opaque (0–100%). Utilisé uniquement pour l'estimation du filtrage. Par défaut 100 (totalement opaque).",
           "day_night_blackout_threshold": "Lorsque le soleil est dans la fenêtre de suivi pendant l'été et que l'opacité du tissu voile est **inférieure** à cette valeur, le store passe au tissu occultant pour bloquer la chaleur. Par défaut 65. Augmentez pour atteindre l'occultant plus tôt ; diminuez pour garder le voile plus longtemps.",
           "day_night_control_model": "Comment la paire abstraite couverture + tissu se mappe sur votre store physique. **Position + inclinaison** (par défaut) : la store commande set_position pour la couverture et set_tilt_position pour le mélange de tissu voile/occultant — pour le matériel exposant les deux axes. **Plage partagée** : une store monaxe dont la plage de position encode les deux — la moitié inférieure (0–50%) sélectionne le tissu occultant, la moitié supérieure (50–100%) le tissu voile — pour le matériel avec un seul moteur. **Deux entités de rail** : deux entités de store distinctes — un rail inférieur et un rail central — où le mélange de tissu se replie dans la position absolue du rail central.",
-          "day_night_middle_rail_entity": "Pour le modèle **Deux entités de rail** uniquement : laquelle des stores configurées de cette instance est le rail central. L'autre store configurée est le rail inférieur. Le rail central est garanti de ne jamais descendre en dessous du rail inférieur."
+          "day_night_middle_rail_entity": "Pour le modèle **Deux entités de rail** uniquement : laquelle des stores configurées de cette instance est le rail central. L'autre store configurée est le rail inférieur. Le rail central est garanti de ne jamais descendre en dessous du rail inférieur.",
+          "dual_panel_front_entity": "Quel store de cette instance est le panneau **avant / voile**. Il suit le soleil comme un store vertical simple. Tous les autres stores configurés sont le panneau **arrière / occultant**. Laissez non défini pour fonctionner comme un store vertical simple.",
+          "dual_panel_blackout_triggers": "Quand le panneau **occultant** arrière se déploie (se ferme). **Chaleur** : un été climatique / blocage total chaleur extrême. **Confidentialité** : la fenêtre du coucher du soleil. **Nuit** : le soleil est sous l'horizon. Sélectionnez n'importe quelle combinaison — l'arrière se rétracte (s'ouvre) chaque fois qu'aucun des déclencheurs sélectionnés n'est actif. Les deux panneaux sont indépendants (aucun couplage no-pass)."
         }
       },
       "duplicate_select": {
@@ -388,7 +392,9 @@
           "day_night_opacity_blackout": "Opacité du Tissu Occultant (%)",
           "day_night_blackout_threshold": "Seuil d'Activation du Tissu Occultant (%)",
           "day_night_control_model": "Modèle de contrôle",
-          "day_night_middle_rail_entity": "Entité du Rail Central (modèle double entité)"
+          "day_night_middle_rail_entity": "Entité du Rail Central (modèle double entité)",
+          "dual_panel_front_entity": "Entité du panneau avant (voile)",
+          "dual_panel_blackout_triggers": "Déclencheurs du déploiement de l'occultant"
         },
         "data_description": {
           "window_height": "Hauteur de votre fenêtre (de bas en haut de la zone vitrée). Affiché dans l'unité configurée dans Home Assistant. Exemples : Porte standard = 2,0 m / 79 in, Petite fenêtre = 1,5 m / 59 in, Du sol au plafond = 2,5 m / 98 in. Mesurez d'où la protection commence à d'où elle finit lorsqu'elle est complètement étendue.",
@@ -441,7 +447,9 @@
           "day_night_opacity_blackout": "Quantité de lumière bloquée par le tissu **occultant** opaque (0–100%). Utilisé uniquement pour l'estimation du filtrage. Par défaut 100 (totalement opaque).",
           "day_night_blackout_threshold": "Lorsque le soleil est dans la fenêtre de suivi pendant l'été et que l'opacité du tissu voile est **inférieure** à cette valeur, le store passe au tissu occultant pour bloquer la chaleur. Par défaut 65. Augmentez pour atteindre l'occultant plus tôt ; diminuez pour garder le voile plus longtemps.",
           "day_night_control_model": "Comment la paire abstraite couverture + tissu se mappe sur votre store physique. **Position + inclinaison** (par défaut) : la store commande set_position pour la couverture et set_tilt_position pour le mélange de tissu voile/occultant — pour le matériel exposant les deux axes. **Plage partagée** : une store monaxe dont la plage de position encode les deux — la moitié inférieure (0–50%) sélectionne le tissu occultant, la moitié supérieure (50–100%) le tissu voile — pour le matériel avec un seul moteur. **Deux entités de rail** : deux entités de store distinctes — un rail inférieur et un rail central — où le mélange de tissu se replie dans la position absolue du rail central.",
-          "day_night_middle_rail_entity": "Pour le modèle **Deux entités de rail** uniquement : laquelle des stores configurées de cette instance est le rail central. L'autre store configurée est le rail inférieur. Le rail central est garanti de ne jamais descendre en dessous du rail inférieur."
+          "day_night_middle_rail_entity": "Pour le modèle **Deux entités de rail** uniquement : laquelle des stores configurées de cette instance est le rail central. L'autre store configurée est le rail inférieur. Le rail central est garanti de ne jamais descendre en dessous du rail inférieur.",
+          "dual_panel_front_entity": "Quel store de cette instance est le panneau **avant / voile**. Il suit le soleil comme un store vertical simple. Tous les autres stores configurés sont le panneau **arrière / occultant**. Laissez non défini pour fonctionner comme un store vertical simple.",
+          "dual_panel_blackout_triggers": "Quand le panneau **occultant** arrière se déploie (se ferme). **Chaleur** : un été climatique / blocage total chaleur extrême. **Confidentialité** : la fenêtre du coucher du soleil. **Nuit** : le soleil est sous l'horizon. Sélectionnez n'importe quelle combinaison — l'arrière se rétracte (s'ouvre) chaque fois qu'aucun des déclencheurs sélectionnés n'est actif. Les deux panneaux sont indépendants (aucun couplage no-pass)."
         }
       },
       "sun_tracking": {
@@ -1200,7 +1208,8 @@
         "cover_roof_window": "Fenêtre de toit",
         "cover_sliding_curtain": "Rideau coulissant (horizontal)",
         "cover_louvered_roof": "Toit à lames",
-        "cover_day_night_shade": "Store jour/nuit (double tissu)"
+        "cover_day_night_shade": "Store jour/nuit (double tissu)",
+        "cover_dual_panel": "Double panneau (voile + occultant)"
       }
     },
     "tilt_mode": {
@@ -1322,6 +1331,13 @@
         "position_tilt": "Position + inclinaison (à deux axes)",
         "split_range": "Plage fractionnée (à un seul axe)",
         "dual_entity": "Deux entités de rail (double entité)"
+      }
+    },
+    "dual_panel_blackout_triggers": {
+      "options": {
+        "heat": "Chaleur (été climatique / chaleur extrême)",
+        "privacy": "Confidentialité (fenêtre du coucher du soleil)",
+        "night": "Nuit (soleil sous l'horizon)"
       }
     }
   },

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -31,6 +31,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_DELTA_POSITION,
     CONF_DELTA_TIME,
     CONF_DISTANCE,
+    CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    CONF_DUAL_PANEL_FRONT_ENTITY,
     CONF_ENABLE_BLIND_SPOT,
     CONF_ENABLE_GLARE_ZONES,
     CONF_ENABLE_MAX_POSITION,
@@ -544,6 +546,26 @@ def test_geometry_roof_window_ridge_height_omitted_when_zero():
     cfg = {CONF_ROOF_PITCH: 40, CONF_ROOF_HEIGHT_ABOVE: 0.0}
     summary = _build_config_summary(cfg, CoverType.ROOF_WINDOW)
     assert "roof above window" not in summary
+
+
+def test_geometry_dual_panel_shows_front_entity_and_triggers():
+    """Dual-panel summary renders the front-panel designator + trigger list (#996)."""
+    cfg = {
+        CONF_HEIGHT_WIN: 2.0,
+        CONF_DISTANCE: 0.5,
+        CONF_DUAL_PANEL_FRONT_ENTITY: "cover.sheer_front",
+        CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["heat", "night"],
+    }
+    summary = _build_config_summary(cfg, CoverType.DUAL_PANEL)
+    assert "front (sheer) panel: cover.sheer_front" in summary
+    assert "blackout deploys on: heat, night" in summary
+
+
+def test_geometry_dual_panel_shows_no_triggers_when_empty():
+    """With no triggers configured the summary says so (back never deploys)."""
+    cfg = {CONF_HEIGHT_WIN: 2.0, CONF_DISTANCE: 0.5}
+    summary = _build_config_summary(cfg, CoverType.DUAL_PANEL)
+    assert "blackout deploys on: no triggers" in summary
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_axes.py
+++ b/tests/test_cover_types/test_axes.py
@@ -50,6 +50,7 @@ ALL_COVER_TYPES = [
     "cover_sliding_curtain",
     "cover_louvered_roof",
     "cover_day_night_shade",
+    "cover_dual_panel",
 ]
 
 
@@ -164,6 +165,7 @@ class TestPolicyAxesDeclarations:
             ("cover_venetian", (AXIS_NAME_POSITION, AXIS_NAME_TILT)),
             ("cover_louvered_roof", (AXIS_NAME_TILT,)),
             ("cover_day_night_shade", (AXIS_NAME_POSITION, AXIS_NAME_TILT)),
+            ("cover_dual_panel", (AXIS_NAME_POSITION,)),
         ],
     )
     def test_axes_declaration(self, cover_type, expected_axis_names):
@@ -178,6 +180,7 @@ class TestPolicyAxesDeclarations:
             "cover_venetian",
             "cover_louvered_roof",
             "cover_day_night_shade",
+            "cover_dual_panel",
         ):
             assert get_policy(cover_type).axes[0].open_blocks_sun is False
 
@@ -196,7 +199,13 @@ class TestForecastSecondaryAxesHook:
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "cover_type",
-        ["cover_blind", "cover_awning", "cover_tilt", "cover_louvered_roof"],
+        [
+            "cover_blind",
+            "cover_awning",
+            "cover_tilt",
+            "cover_louvered_roof",
+            "cover_dual_panel",
+        ],
     )
     def test_single_axis_policy_returns_no_secondary_axes(self, cover_type):
         from unittest.mock import MagicMock
@@ -236,6 +245,7 @@ class TestForecastSecondaryAxesHook:
                 "cover_sliding_curtain": AXIS_NAME_POSITION,
                 "cover_louvered_roof": AXIS_NAME_TILT,
                 "cover_day_night_shade": AXIS_NAME_POSITION,
+                "cover_dual_panel": AXIS_NAME_POSITION,
             },
         ),
         (
@@ -252,6 +262,8 @@ class TestForecastSecondaryAxesHook:
                 "cover_louvered_roof": AXIS_NAME_TILT,
                 # day/night shade routes its primary (position) axis.
                 "cover_day_night_shade": AXIS_NAME_POSITION,
+                # dual-panel routes its primary (position) axis too.
+                "cover_dual_panel": AXIS_NAME_POSITION,
             },
         ),
         (
@@ -269,6 +281,8 @@ class TestForecastSecondaryAxesHook:
                 "cover_louvered_roof": AXIS_NAME_TILT,
                 # Tilt-only fallback routes a dual-axis type to TILT too.
                 "cover_day_night_shade": AXIS_NAME_TILT,
+                # Tilt-only fallback routes the position-axis dual-panel to TILT.
+                "cover_dual_panel": AXIS_NAME_TILT,
             },
         ),
     ],
@@ -330,6 +344,7 @@ class TestPositionForIntent:
             ("cover_venetian", POSITION_OPEN, POSITION_CLOSED),
             ("cover_louvered_roof", POSITION_OPEN, POSITION_CLOSED),
             ("cover_day_night_shade", POSITION_OPEN, POSITION_CLOSED),
+            ("cover_dual_panel", POSITION_OPEN, POSITION_CLOSED),
         ],
     )
     def test_intent_map(self, cover_type, sun_through_value, sun_blocked_value):
@@ -571,6 +586,7 @@ def test_is_in_tilt_suppression_uniform_signature(cover_type: str) -> None:
         ("cover_venetian", False),
         ("cover_louvered_roof", False),
         ("cover_day_night_shade", False),
+        ("cover_dual_panel", True),
     ],
 )
 def test_supports_return_to_default_switch(cover_type: str, expected: bool) -> None:
@@ -749,6 +765,7 @@ def test_no_tilt_mode_string_branching_outside_cover_types() -> None:
         ("cover_venetian", True),
         ("cover_louvered_roof", False),
         ("cover_day_night_shade", True),
+        ("cover_dual_panel", False),
     ],
 )
 def test_exposes_dual_axis_sensor(cover_type: str, expected: bool) -> None:
@@ -771,6 +788,7 @@ def test_exposes_dual_axis_sensor(cover_type: str, expected: bool) -> None:
         ("cover_venetian", True),
         ("cover_louvered_roof", False),
         ("cover_day_night_shade", True),
+        ("cover_dual_panel", False),
     ],
 )
 def test_custom_position_includes_tilt(cover_type: str, expected: bool) -> None:
@@ -793,6 +811,7 @@ def test_custom_position_includes_tilt(cover_type: str, expected: bool) -> None:
         ("cover_venetian", "Venetian-Blinds"),
         ("cover_louvered_roof", "Configuration-Louvered-Roof"),
         ("cover_day_night_shade", "Configuration-Day-Night-Shade"),
+        ("cover_dual_panel", "Configuration-Dual-Panel"),
     ],
 )
 def test_wiki_anchor(cover_type: str, anchor: str) -> None:
@@ -814,6 +833,7 @@ def test_wiki_anchor(cover_type: str, anchor: str) -> None:
         ("cover_venetian", True),
         ("cover_louvered_roof", False),
         ("cover_day_night_shade", False),
+        ("cover_dual_panel", False),
     ],
 )
 def test_drift_reset_option_is_venetian_only(cover_type: str, expected: bool) -> None:
@@ -882,6 +902,12 @@ class TestLiftTravelMetres:
         svc = self._fake_config_service(h_win=1.9)
         assert get_policy("cover_day_night_shade").lift_travel_metres(svc, {}) == 1.9
 
+    @pytest.mark.unit
+    def test_dual_panel_returns_window_height(self) -> None:
+        # The front sheer panel travels the configured window height.
+        svc = self._fake_config_service(h_win=2.2)
+        assert get_policy("cover_dual_panel").lift_travel_metres(svc, {}) == 2.2
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
@@ -893,6 +919,7 @@ class TestLiftTravelMetres:
         ("cover_venetian", "Venetian Blind (Dual-Axis)"),
         ("cover_louvered_roof", "Louvered Roof"),
         ("cover_day_night_shade", "Day/Night Shade"),
+        ("cover_dual_panel", "Dual Panel Shade"),
     ],
 )
 def test_display_label(cover_type: str, label: str) -> None:

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -1,0 +1,468 @@
+"""Unit tests for the dual-panel cover type (#996).
+
+A dual-panel cover drives TWO independent HA shade entities over one window:
+
+* the **front** is a sheer / light-filtering shade that tracks the sun exactly
+  like a plain vertical blind — ``resolve_entity_target`` returns its adaptive
+  position verbatim;
+* the **back** is a blackout shade that deploys (closes) only when one of the
+  configured triggers ``{heat, privacy, night}`` is active, and retracts (opens)
+  otherwise.
+
+Unlike the day/night Model C shade (#993) the two panels are INDEPENDENT — there
+is no ``M >= P`` no-pass coupling. The back's deploy/retract decision is composed
+once through the pure ``engine/covers/layered.py`` helpers and dispatched on the
+shipped ``resolve_entity_target`` / ``post_pipeline_resolve`` seam.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    CONF_DUAL_PANEL_FRONT_ENTITY,
+    DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    DUAL_PANEL_BLACKOUT_TRIGGERS,
+    DUAL_PANEL_TRIGGER_HEAT,
+    DUAL_PANEL_TRIGGER_NIGHT,
+    DUAL_PANEL_TRIGGER_PRIVACY,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    ControlMethod,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    POSITION_AXIS,
+)
+from custom_components.adaptive_cover_pro.cover_types.dual_panel import (
+    DualPanelPolicy,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+# ---------------------------------------------------------------------------
+# Step 2 — enum, display name, trigger constants
+# ---------------------------------------------------------------------------
+
+
+def test_cover_type_registered_in_enum() -> None:
+    """The new sensor_type string resolves to a CoverType with a display name."""
+    assert CoverType("cover_dual_panel") is CoverType.DUAL_PANEL
+    assert CoverType.DUAL_PANEL.display_name == "Dual Panel Shade"
+
+
+def test_trigger_constants() -> None:
+    """The three trigger literals + the canonical tuple + the empty default."""
+    assert DUAL_PANEL_TRIGGER_HEAT == "heat"
+    assert DUAL_PANEL_TRIGGER_PRIVACY == "privacy"
+    assert DUAL_PANEL_TRIGGER_NIGHT == "night"
+    assert DUAL_PANEL_BLACKOUT_TRIGGERS == (
+        DUAL_PANEL_TRIGGER_HEAT,
+        DUAL_PANEL_TRIGGER_PRIVACY,
+        DUAL_PANEL_TRIGGER_NIGHT,
+    )
+    assert DEFAULT_DUAL_PANEL_BLACKOUT_TRIGGERS == ()
+
+
+def test_conf_keys() -> None:
+    """The two config-wire keys are stable strings."""
+    assert CONF_DUAL_PANEL_FRONT_ENTITY == "dual_panel_front_entity"
+    assert CONF_DUAL_PANEL_BLACKOUT_TRIGGERS == "dual_panel_blackout_triggers"
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — policy registration + ClassVar gates + geometry surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_policy_registered_with_flags() -> None:
+    policy = get_policy("cover_dual_panel")
+    assert isinstance(policy, DualPanelPolicy)
+    # Single position axis — the front sheer sun-tracks like a vertical blind.
+    assert policy.axes == (POSITION_AXIS,)
+    assert policy.supports_glare_zones is True
+    assert policy.supports_return_to_default_switch is True
+    assert policy.supports_fov_compute is True
+    assert policy.exposes_dual_axis_sensor is False
+    assert policy.custom_position_includes_tilt is False
+    assert policy.wiki_anchor() == "Configuration-Dual-Panel"
+    assert policy.display_label() == "Dual Panel Shade"
+
+
+def test_geometry_schema_has_vertical_plus_dual_panel_keys() -> None:
+    import voluptuous as vol
+
+    from custom_components.adaptive_cover_pro.const import CONF_HEIGHT_WIN
+
+    schema = DualPanelPolicy().geometry_schema()
+    keys = {(k.schema if isinstance(k, vol.Marker) else k) for k in schema.schema}
+    # Vertical window geometry (the front sheer is a plain vertical blind).
+    assert CONF_HEIGHT_WIN in keys
+    # Plus the dual-panel designator + trigger-set option.
+    assert CONF_DUAL_PANEL_FRONT_ENTITY in keys
+    assert CONF_DUAL_PANEL_BLACKOUT_TRIGGERS in keys
+
+
+def test_geometry_length_keys_are_vertical() -> None:
+    from custom_components.adaptive_cover_pro.cover_types.blind import (
+        VERTICAL_LENGTH_KEYS,
+    )
+
+    assert DualPanelPolicy().geometry_length_keys() == VERTICAL_LENGTH_KEYS
+
+
+def test_entity_selector_filter_is_plain_cover_domain() -> None:
+    flt = DualPanelPolicy().entity_selector_filter()
+    assert flt.get("domain") == "cover"
+    # No tilt-capability requirement — both panels are plain position covers.
+    assert "supported_features" not in flt
+
+
+def test_build_calc_engine_returns_vertical_cover() -> None:
+    from tests.cover_helpers import make_cover_config, make_vertical_config
+
+    from custom_components.adaptive_cover_pro.engine.covers import (
+        AdaptiveVerticalCover,
+    )
+
+    svc = MagicMock()
+    svc.get_vertical_data.return_value = make_vertical_config()
+    svc.get_glare_zones_config.return_value = None
+    engine = DualPanelPolicy().build_calc_engine(
+        logger=MagicMock(),
+        sol_azi=180.0,
+        sol_elev=45.0,
+        sun_data=MagicMock(),
+        config=make_cover_config(),
+        config_service=svc,
+        options={},
+    )
+    assert isinstance(engine, AdaptiveVerticalCover)
+
+
+class TestCapabilityWarnings:
+    """Dual-panel needs set_position on each panel and a valid front entity."""
+
+    def test_warns_on_missing_set_position(self) -> None:
+        warn = DualPanelPolicy().cover_capability_warnings(
+            {"cover.a": {"has_set_position": False}}
+        )
+        assert any("set_position" in w for w in warn)
+
+    def test_no_warning_when_set_position_present(self) -> None:
+        warn = DualPanelPolicy().cover_capability_warnings(
+            {"cover.a": {"has_set_position": True}}
+        )
+        assert warn == []
+
+    def test_warns_when_front_entity_not_among_covers(self) -> None:
+        opts = {CONF_DUAL_PANEL_FRONT_ENTITY: "cover.not_configured"}
+        warn = DualPanelPolicy().capability_warnings_for_options(
+            {
+                "cover.front": {"has_set_position": True},
+                "cover.back": {"has_set_position": True},
+            },
+            opts,
+        )
+        assert any("cover.not_configured" in w for w in warn)
+
+    def test_no_front_warning_when_front_is_a_configured_cover(self) -> None:
+        opts = {CONF_DUAL_PANEL_FRONT_ENTITY: "cover.front"}
+        warn = DualPanelPolicy().capability_warnings_for_options(
+            {
+                "cover.front": {"has_set_position": True},
+                "cover.back": {"has_set_position": True},
+            },
+            opts,
+        )
+        assert warn == []
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — the resolve seam (front identity, independent blackout back)
+# ---------------------------------------------------------------------------
+
+_FRONT = "cover.front_sheer"
+_BACK = "cover.back_blackout"
+
+
+def _resolve_kwargs(**overrides):
+    from tests.cover_helpers import make_cover_config, make_vertical_config
+
+    svc = MagicMock()
+    svc.get_vertical_data.return_value = make_vertical_config()
+    svc.get_glare_zones_config.return_value = None
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+    kw = {
+        "logger": MagicMock(),
+        "sol_azi": 180.0,
+        "sol_elev": 45.0,
+        "sun_data": sun_data,
+        "config": make_cover_config(),
+        "config_service": svc,
+        "options": {},
+    }
+    kw.update(overrides)
+    return kw
+
+
+def _opts(*, triggers=None, front: str | None = _FRONT, inverse: bool = False) -> dict:
+    opts: dict = {}
+    if front is not None:
+        opts[CONF_DUAL_PANEL_FRONT_ENTITY] = front
+    if triggers is not None:
+        opts[CONF_DUAL_PANEL_BLACKOUT_TRIGGERS] = list(triggers)
+    if inverse:
+        from custom_components.adaptive_cover_pro.const import CONF_INVERSE_STATE
+
+        opts[CONF_INVERSE_STATE] = True
+    return opts
+
+
+def _resolve(
+    policy: DualPanelPolicy,
+    *,
+    control_method: ControlMethod = ControlMethod.SOLAR,
+    position: int = 40,
+    is_sunset_active: bool = False,
+    bypass: bool = False,
+    sol_elev: float = 45.0,
+    triggers=None,
+    front: str | None = _FRONT,
+    inverse: bool = False,
+) -> PipelineResult:
+    """Run ``post_pipeline_resolve`` so the per-cycle dispatch cache is set."""
+    kw = _resolve_kwargs(
+        options=_opts(triggers=triggers, front=front, inverse=inverse),
+        sol_elev=sol_elev,
+    )
+    result = PipelineResult(
+        position=position,
+        control_method=control_method,
+        reason="test",
+        is_sunset_active=is_sunset_active,
+        bypass_auto_control=bypass,
+    )
+    return policy.post_pipeline_resolve(result, cover=None, **kw)
+
+
+class TestResolveFrontPassThrough:
+    """The front sheer panel always dispatches its adaptive position verbatim."""
+
+    def test_front_identity_after_resolve(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, triggers=["heat"], control_method=ControlMethod.SUMMER)
+        assert policy.resolve_entity_target(_FRONT, 40) == 40
+        assert policy.resolve_entity_target(_FRONT, 73) == 73
+
+
+class TestResolveBackDeployDecision:
+    """The back blackout deploys/retracts on the configured trigger set."""
+
+    def test_back_deploys_on_heat(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["heat"])
+        # Deployed → closed (0 in open-percent, non-inverse).
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
+
+    def test_back_deploys_on_extreme_heat(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.EXTREME_HEAT, triggers=["heat"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
+
+    def test_back_retracts_with_no_active_trigger(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.SOLAR, triggers=["heat"])
+        # No heat/privacy/night active → retracted (open, 100).
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
+    def test_night_uses_sol_elev(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, sol_elev=-3.0, triggers=["night"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
+        # Daytime (elevation positive) → not deployed.
+        policy2 = DualPanelPolicy()
+        _resolve(policy2, sol_elev=10.0, triggers=["night"])
+        assert policy2.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
+    def test_privacy_uses_is_sunset_active(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, is_sunset_active=True, triggers=["privacy"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
+        policy2 = DualPanelPolicy()
+        _resolve(policy2, is_sunset_active=False, triggers=["privacy"])
+        assert policy2.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
+    def test_empty_trigger_set_never_deploys(self) -> None:
+        policy = DualPanelPolicy()
+        # Every condition active, but no trigger configured → never deploys.
+        _resolve(
+            policy,
+            control_method=ControlMethod.SUMMER,
+            is_sunset_active=True,
+            sol_elev=-5.0,
+            triggers=[],
+        )
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
+    def test_active_trigger_not_configured_does_not_deploy(self) -> None:
+        policy = DualPanelPolicy()
+        # Heat active but only "privacy" configured → no deploy.
+        _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["privacy"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
+
+class TestResolveNoFrontConfigured:
+    """With no front designated the cover degrades to a plain vertical blind."""
+
+    def test_identity_for_all_entities(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(
+            policy,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            front=None,
+        )
+        # Even a would-be back entity passes through untouched.
+        assert policy.resolve_entity_target(_BACK, 40) == 40
+        assert policy.resolve_entity_target(_FRONT, 40) == 40
+
+
+class TestResolveIndependence:
+    """The back is NOT coupled to the front — no ``M >= P`` no-pass clamp."""
+
+    def test_back_deployed_is_not_clamped_to_front(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["heat"])
+        # Front sits low (20) or high (90); the deployed back is a pure closed
+        # value regardless — it never tracks or clamps to the front position.
+        assert policy.resolve_entity_target(_BACK, 20) == POSITION_CLOSED
+        assert policy.resolve_entity_target(_BACK, 90) == POSITION_CLOSED
+
+    def test_back_retracted_is_not_clamped_to_front(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.SOLAR, triggers=["heat"])
+        # Retracted back is fully open regardless of a high front position —
+        # the day/night Model C M >= P clamp is deliberately absent here.
+        assert policy.resolve_entity_target(_BACK, 90) == POSITION_OPEN
+        assert policy.resolve_entity_target(_BACK, 5) == POSITION_OPEN
+
+
+class TestResolveInverseState:
+    """Inverse-state swaps open/closed in wire space; kwarg overrides the cache."""
+
+    def test_cached_inverse_swaps_open_closed(self) -> None:
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            inverse_state,
+        )
+
+        deployed = DualPanelPolicy()
+        _resolve(
+            deployed,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            inverse=True,
+        )
+        # Deployed closed (0) inverts to wire 100.
+        assert deployed.resolve_entity_target(_BACK, 40) == inverse_state(
+            POSITION_CLOSED
+        )
+
+        retracted = DualPanelPolicy()
+        _resolve(
+            retracted,
+            control_method=ControlMethod.SOLAR,
+            triggers=["heat"],
+            inverse=True,
+        )
+        assert retracted.resolve_entity_target(_BACK, 40) == inverse_state(
+            POSITION_OPEN
+        )
+
+    def test_explicit_inverted_kwarg_overrides_cache(self) -> None:
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            inverse_state,
+        )
+
+        policy = DualPanelPolicy()
+        # Cache says non-inverse, but the broadcast seam passes inverted=True.
+        _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["heat"])
+        assert policy.resolve_entity_target(_BACK, 40, inverted=True) == inverse_state(
+            POSITION_CLOSED
+        )
+        # And inverted=False forces non-inverse even if the cache said invert.
+        inv = DualPanelPolicy()
+        _resolve(
+            inv, control_method=ControlMethod.SUMMER, triggers=["heat"], inverse=True
+        )
+        assert inv.resolve_entity_target(_BACK, 40, inverted=False) == POSITION_CLOSED
+
+
+class TestResolveBypassCycle:
+    """A safety/bypass cycle passes every entity through untouched."""
+
+    def test_bypass_makes_back_identity(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(
+            policy,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            bypass=True,
+        )
+        # Safety wins: the back is NOT substituted, it dispatches verbatim.
+        assert policy.resolve_entity_target(_BACK, 40) == 40
+
+
+class TestResolveStaleCache:
+    """The dispatch cache is recomputed every cycle."""
+
+    def test_second_cycle_flips_decision(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["heat"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
+        # Next cycle: no trigger active → the cache flips to retract.
+        _resolve(policy, control_method=ControlMethod.SOLAR, triggers=["heat"])
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_OPEN
+
+
+class TestResolveDecisionTrace:
+    """``post_pipeline_resolve`` records the back decision in the trace."""
+
+    def test_trace_records_deploy_and_active_triggers(self) -> None:
+        policy = DualPanelPolicy()
+        out = _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["heat"])
+        steps = [s for s in out.decision_trace if s.handler == "dual_panel_back"]
+        assert steps
+        assert "heat" in steps[-1].reason
+        # Position / tilt are left unchanged by the resolve.
+        assert out.position == 40
+        assert out.tilt is None
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — config-summary geometry rendering
+# ---------------------------------------------------------------------------
+
+
+def test_summary_geometry_lines_render_front_and_triggers() -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_HEIGHT_WIN
+
+    lines = DualPanelPolicy().summary_geometry_lines(
+        {
+            CONF_HEIGHT_WIN: 2.0,
+            CONF_DUAL_PANEL_FRONT_ENTITY: "cover.sheer_front",
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["heat", "privacy"],
+        }
+    )
+    assert any("cover.sheer_front" in line for line in lines)
+    assert any("heat, privacy" in line for line in lines)
+
+
+def test_summary_geometry_lines_render_no_triggers() -> None:
+    from custom_components.adaptive_cover_pro.const import CONF_HEIGHT_WIN
+
+    lines = DualPanelPolicy().summary_geometry_lines({CONF_HEIGHT_WIN: 2.0})
+    assert any("no triggers" in line for line in lines)

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -222,31 +222,42 @@ def _opts(*, triggers=None, front: str | None = _FRONT, inverse: bool = False) -
     return opts
 
 
+def _sunset_cover(sunset_valid: bool):
+    """Minimal cover stub exposing ``sunset_valid`` (the privacy-window signal)."""
+    cover = MagicMock()
+    cover.sunset_valid = sunset_valid
+    return cover
+
+
 def _resolve(
     policy: DualPanelPolicy,
     *,
     control_method: ControlMethod = ControlMethod.SOLAR,
     position: int = 40,
-    is_sunset_active: bool = False,
+    sunset_valid: bool = False,
     bypass: bool = False,
+    floor_clamp: bool = False,
+    interp: bool = False,
     sol_elev: float = 45.0,
     triggers=None,
     front: str | None = _FRONT,
     inverse: bool = False,
 ) -> PipelineResult:
     """Run ``post_pipeline_resolve`` so the per-cycle dispatch cache is set."""
-    kw = _resolve_kwargs(
-        options=_opts(triggers=triggers, front=front, inverse=inverse),
-        sol_elev=sol_elev,
-    )
+    opts = _opts(triggers=triggers, front=front, inverse=inverse)
+    if interp:
+        from custom_components.adaptive_cover_pro.const import CONF_INTERP
+
+        opts[CONF_INTERP] = True
+    kw = _resolve_kwargs(options=opts, sol_elev=sol_elev)
     result = PipelineResult(
         position=position,
         control_method=control_method,
         reason="test",
-        is_sunset_active=is_sunset_active,
         bypass_auto_control=bypass,
+        floor_clamp_applied=floor_clamp,
     )
-    return policy.post_pipeline_resolve(result, cover=None, **kw)
+    return policy.post_pipeline_resolve(result, cover=_sunset_cover(sunset_valid), **kw)
 
 
 class TestResolveFrontPassThrough:
@@ -288,12 +299,14 @@ class TestResolveBackDeployDecision:
         _resolve(policy2, sol_elev=10.0, triggers=["night"])
         assert policy2.resolve_entity_target(_BACK, 40) == POSITION_OPEN
 
-    def test_privacy_uses_is_sunset_active(self) -> None:
+    def test_privacy_uses_sunset_window(self) -> None:
+        # Privacy fires on the astronomical sunset WINDOW (cover.sunset_valid),
+        # independent of whether a sunset_position is configured (#996 Finding 2).
         policy = DualPanelPolicy()
-        _resolve(policy, is_sunset_active=True, triggers=["privacy"])
+        _resolve(policy, sunset_valid=True, triggers=["privacy"])
         assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
         policy2 = DualPanelPolicy()
-        _resolve(policy2, is_sunset_active=False, triggers=["privacy"])
+        _resolve(policy2, sunset_valid=False, triggers=["privacy"])
         assert policy2.resolve_entity_target(_BACK, 40) == POSITION_OPEN
 
     def test_empty_trigger_set_never_deploys(self) -> None:
@@ -302,7 +315,7 @@ class TestResolveBackDeployDecision:
         _resolve(
             policy,
             control_method=ControlMethod.SUMMER,
-            is_sunset_active=True,
+            sunset_valid=True,
             sol_elev=-5.0,
             triggers=[],
         )
@@ -327,6 +340,19 @@ class TestResolveNoFrontConfigured:
             front=None,
         )
         # Even a would-be back entity passes through untouched.
+        assert policy.resolve_entity_target(_BACK, 40) == 40
+        assert policy.resolve_entity_target(_FRONT, 40) == 40
+
+    def test_empty_string_front_is_identity_for_all(self) -> None:
+        # A stored empty-string front must degrade to identity, not flip every
+        # entity to the blackout substitution (#996 Finding 6).
+        policy = DualPanelPolicy()
+        _resolve(
+            policy,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            front="",
+        )
         assert policy.resolve_entity_target(_BACK, 40) == 40
         assert policy.resolve_entity_target(_FRONT, 40) == 40
 
@@ -401,6 +427,174 @@ class TestResolveInverseState:
         assert inv.resolve_entity_target(_BACK, 40, inverted=False) == POSITION_CLOSED
 
 
+class TestResolveInverseIndependentOfClamp:
+    """The back's inverse wire-space is device semantics only (#996 Finding 1).
+
+    The back target is an ABSOLUTE SUBSTITUTION (open/closed), not a transform
+    of the front's dispatched value, so its wire space must NOT depend on whether
+    the front's value was floor-clamped. Inverse-state alone decides it.
+    """
+
+    def test_deploy_inverse_on_floor_clamp_stays_inverted(self) -> None:
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            inverse_state,
+        )
+
+        policy = DualPanelPolicy()
+        _resolve(
+            policy,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            inverse=True,
+            floor_clamp=True,
+        )
+        # Deployed → device physically CLOSED → wire inverse_state(CLOSED)=100.
+        # The floor clamp on the FRONT must not un-invert the back's blackout.
+        assert policy.resolve_entity_target(_BACK, 40) == inverse_state(POSITION_CLOSED)
+
+    def test_retract_inverse_on_floor_clamp_stays_inverted(self) -> None:
+        from custom_components.adaptive_cover_pro.managers.manual_override import (
+            inverse_state,
+        )
+
+        policy = DualPanelPolicy()
+        _resolve(
+            policy,
+            control_method=ControlMethod.SOLAR,
+            triggers=["heat"],
+            inverse=True,
+            floor_clamp=True,
+        )
+        # Retracted → device physically OPEN → wire inverse_state(OPEN)=0.
+        assert policy.resolve_entity_target(_BACK, 40) == inverse_state(POSITION_OPEN)
+
+    def test_non_clamp_matches_clamp(self) -> None:
+        """Clamp and non-clamp cycles produce the SAME back wire target."""
+        clamp = DualPanelPolicy()
+        _resolve(
+            clamp,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            inverse=True,
+            floor_clamp=True,
+        )
+        plain = DualPanelPolicy()
+        _resolve(
+            plain,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            inverse=True,
+            floor_clamp=False,
+        )
+        assert clamp.resolve_entity_target(_BACK, 40) == plain.resolve_entity_target(
+            _BACK, 40
+        )
+
+    def test_inverse_off_floor_clamp_is_canonical(self) -> None:
+        policy = DualPanelPolicy()
+        _resolve(
+            policy,
+            control_method=ControlMethod.SUMMER,
+            triggers=["heat"],
+            inverse=False,
+            floor_clamp=True,
+        )
+        assert policy.resolve_entity_target(_BACK, 40) == POSITION_CLOSED
+
+
+class TestResolveInterpolation:
+    """With interpolation on the back endpoints go through the calibration curve.
+
+    Interpolation and inverse-state are mutually exclusive at dispatch (the
+    coordinator ignores inverse under interp), so the back must interpolate its
+    canonical 0/100 rather than send raw values that could overdrive a
+    narrower-calibrated device (#996 Finding 5).
+    """
+
+    def _interp_opts(self, base: dict) -> dict:
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_INTERP_END,
+            CONF_INTERP_START,
+        )
+
+        # A device whose physical travel is calibrated to 10..90 %.
+        base[CONF_INTERP_START] = 10
+        base[CONF_INTERP_END] = 90
+        return base
+
+    def test_back_deploy_is_interpolated(self) -> None:
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_INTERP,
+            CONF_INTERP_END,
+            CONF_INTERP_START,
+        )
+        from custom_components.adaptive_cover_pro.position_utils import (
+            interpolate_position,
+        )
+
+        policy = DualPanelPolicy()
+        opts = _opts(triggers=["heat"], front=_FRONT)
+        opts[CONF_INTERP] = True
+        opts[CONF_INTERP_START] = 10
+        opts[CONF_INTERP_END] = 90
+        kw = _resolve_kwargs(options=opts)
+        result = PipelineResult(
+            position=40, control_method=ControlMethod.SUMMER, reason="t"
+        )
+        policy.post_pipeline_resolve(result, cover=_sunset_cover(False), **kw)
+        expected = int(round(interpolate_position(POSITION_CLOSED, 10, 90, None, None)))
+        assert policy.resolve_entity_target(_BACK, 40) == expected
+        # Overdrive guard: not the raw canonical 0.
+        assert policy.resolve_entity_target(_BACK, 40) != POSITION_CLOSED
+
+    def test_back_retract_is_interpolated(self) -> None:
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_INTERP,
+            CONF_INTERP_END,
+            CONF_INTERP_START,
+        )
+        from custom_components.adaptive_cover_pro.position_utils import (
+            interpolate_position,
+        )
+
+        policy = DualPanelPolicy()
+        opts = _opts(triggers=["heat"], front=_FRONT)
+        opts[CONF_INTERP] = True
+        opts[CONF_INTERP_START] = 10
+        opts[CONF_INTERP_END] = 90
+        kw = _resolve_kwargs(options=opts)
+        result = PipelineResult(
+            position=40, control_method=ControlMethod.SOLAR, reason="t"
+        )
+        policy.post_pipeline_resolve(result, cover=_sunset_cover(False), **kw)
+        expected = int(round(interpolate_position(POSITION_OPEN, 10, 90, None, None)))
+        assert policy.resolve_entity_target(_BACK, 40) == expected
+
+    def test_interp_wins_over_inverse(self) -> None:
+        """Under interp the back is interpolated, not inverted (matches state)."""
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_INTERP,
+            CONF_INTERP_END,
+            CONF_INTERP_START,
+        )
+        from custom_components.adaptive_cover_pro.position_utils import (
+            interpolate_position,
+        )
+
+        policy = DualPanelPolicy()
+        opts = _opts(triggers=["heat"], front=_FRONT, inverse=True)
+        opts[CONF_INTERP] = True
+        opts[CONF_INTERP_START] = 10
+        opts[CONF_INTERP_END] = 90
+        kw = _resolve_kwargs(options=opts)
+        result = PipelineResult(
+            position=40, control_method=ControlMethod.SUMMER, reason="t"
+        )
+        policy.post_pipeline_resolve(result, cover=_sunset_cover(False), **kw)
+        expected = int(round(interpolate_position(POSITION_CLOSED, 10, 90, None, None)))
+        assert policy.resolve_entity_target(_BACK, 40) == expected
+
+
 class TestResolveBypassCycle:
     """A safety/bypass cycle passes every entity through untouched."""
 
@@ -440,6 +634,24 @@ class TestResolveDecisionTrace:
         # Position / tilt are left unchanged by the resolve.
         assert out.position == 40
         assert out.tilt is None
+
+    def test_no_trace_step_when_no_front_configured(self) -> None:
+        # The back decision is never applied without a front, so no trace step
+        # should appear for a cycle that can't dispatch it (#996 Finding 8).
+        policy = DualPanelPolicy()
+        out = _resolve(
+            policy, control_method=ControlMethod.SUMMER, triggers=["heat"], front=None
+        )
+        assert [s for s in out.decision_trace if s.handler == "dual_panel_back"] == []
+
+    def test_no_trace_step_on_bypass_cycle(self) -> None:
+        # A safety/bypass winner overwrites every entity — the back is never
+        # substituted, so no dual_panel_back step should be recorded.
+        policy = DualPanelPolicy()
+        out = _resolve(
+            policy, control_method=ControlMethod.SUMMER, triggers=["heat"], bypass=True
+        )
+        assert [s for s in out.decision_trace if s.handler == "dual_panel_back"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dual_panel_dispatch.py
+++ b/tests/test_dual_panel_dispatch.py
@@ -1,0 +1,252 @@
+"""Coordinator-seam integration tests for the dual-panel cover type (#996).
+
+A dual-panel instance binds TWO ``cover.*`` entities — a front sheer panel that
+sun-tracks and a back blackout panel that deploys on a trigger set. One resolved
+pipeline position must fan out to DIFFERENT physical targets per entity: the
+front gets the resolved position verbatim; the back is substituted by the
+policy's ``resolve_entity_target`` hook (open/closed, in the device's wire space)
+via the coordinator's polymorphic ``_entity_target`` dispatch seam. There is NO
+cover-type branch in the coordinator — every other cover type's hook is identity.
+
+Harness mirrors ``tests/test_day_night_dual_entity.py``: a minimal mock
+coordinator is built and the *real* unbound coordinator methods
+(``_dispatch_to_cover``, ``_entity_target``, ``async_handle_state_change``) are
+bound onto it, so the seam is exercised end-to-end against a real policy.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+    CONF_DUAL_PANEL_FRONT_ENTITY,
+    CONF_INTERP,
+    CONF_INTERP_END,
+    CONF_INTERP_START,
+    CONF_INVERSE_STATE,
+    POSITION_CLOSED,
+    POSITION_OPEN,
+    ControlMethod,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types.dual_panel import (
+    DualPanelPolicy,
+)
+from custom_components.adaptive_cover_pro.managers.manual_override import inverse_state
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.position_utils import interpolate_position
+
+_FRONT = "cover.front_sheer"
+_BACK = "cover.back_blackout"
+
+
+class _FakeCmdSvc:
+    """Minimal command service that records the target sent to each entity."""
+
+    def __init__(self) -> None:
+        self._targets: dict[str, int] = {}
+        self.calls: list[tuple[str, int, str]] = []
+
+    async def apply_position(self, entity_id, position, reason, context=None):
+        self._targets[entity_id] = position
+        self.calls.append((entity_id, position, reason))
+        return ("sent", "set_cover_position")
+
+    def get_target(self, entity_id: str) -> int | None:
+        return self._targets.get(entity_id)
+
+
+def _sunset_cover(sunset_valid: bool):
+    cover = MagicMock()
+    cover.sunset_valid = sunset_valid
+    return cover
+
+
+def _primed_policy(
+    *,
+    control_method: ControlMethod = ControlMethod.SOLAR,
+    triggers=None,
+    sol_elev: float = 45.0,
+    sunset_valid: bool = False,
+    inverse: bool = False,
+    interp: bool = False,
+    floor_clamp: bool = False,
+    front: str = _FRONT,
+) -> DualPanelPolicy:
+    """Return a real dual-panel policy with the dispatch cache primed for a cycle."""
+    from tests.cover_helpers import make_cover_config, make_vertical_config
+
+    policy = DualPanelPolicy()
+    svc = MagicMock()
+    svc.get_vertical_data.return_value = make_vertical_config()
+    svc.get_glare_zones_config.return_value = None
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+
+    opts: dict = {CONF_DUAL_PANEL_FRONT_ENTITY: front}
+    if triggers is not None:
+        opts[CONF_DUAL_PANEL_BLACKOUT_TRIGGERS] = list(triggers)
+    if inverse:
+        opts[CONF_INVERSE_STATE] = True
+    if interp:
+        opts[CONF_INTERP] = True
+        opts[CONF_INTERP_START] = 10
+        opts[CONF_INTERP_END] = 90
+
+    result = PipelineResult(
+        position=40,
+        control_method=control_method,
+        reason="test",
+        floor_clamp_applied=floor_clamp,
+    )
+    policy.post_pipeline_resolve(
+        result,
+        logger=MagicMock(),
+        sol_azi=180.0,
+        sol_elev=sol_elev,
+        sun_data=sun_data,
+        config=make_cover_config(),
+        config_service=svc,
+        options=opts,
+        cover=_sunset_cover(sunset_valid),
+    )
+    return policy
+
+
+def _make_coordinator(
+    policy: DualPanelPolicy, *, state: int, clock_window_open: bool = True
+) -> MagicMock:
+    coordinator = MagicMock()
+    coordinator.entities = [_FRONT, _BACK]
+    coordinator.logger = MagicMock()
+    coordinator._policy = policy
+    coordinator._cmd_svc = _FakeCmdSvc()
+
+    coordinator._pipeline_result = PipelineResult(
+        position=state, control_method=ControlMethod.SOLAR, reason="solar"
+    )
+    coordinator._pipeline_is_safety_handler = False
+    coordinator._pipeline_bypasses_auto_control = False
+    coordinator.clock_window_open = clock_window_open
+    coordinator.state_change = True
+    coordinator._last_state_change_entity = None
+    coordinator._custom_position_template_trigger = False
+    coordinator._check_sun_validity_transition = MagicMock(return_value=False)
+    coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
+    coordinator._build_position_context = MagicMock(return_value=MagicMock())
+
+    coordinator._entity_target = types.MethodType(
+        AdaptiveDataUpdateCoordinator._entity_target, coordinator
+    )
+    coordinator._dispatch_to_cover = types.MethodType(
+        AdaptiveDataUpdateCoordinator._dispatch_to_cover, coordinator
+    )
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_deploy_dispatches_front_identity_back_closed() -> None:
+    # Night active + night configured → back closes; front keeps its position.
+    policy = _primed_policy(triggers=["night"], sol_elev=-3.0)
+    coordinator = _make_coordinator(policy, state=40)
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=40, options={}
+    )
+
+    cmd = coordinator._cmd_svc
+    assert cmd.get_target(_FRONT) == 40
+    assert cmd.get_target(_BACK) == POSITION_CLOSED
+    assert {c[0] for c in cmd.calls} == {_FRONT, _BACK}
+
+
+@pytest.mark.asyncio
+async def test_retract_dispatches_back_open() -> None:
+    # No trigger active → the back stays retracted (open).
+    policy = _primed_policy(triggers=["night"], sol_elev=30.0)
+    coordinator = _make_coordinator(policy, state=55)
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=55, options={}
+    )
+
+    cmd = coordinator._cmd_svc
+    assert cmd.get_target(_FRONT) == 55
+    assert cmd.get_target(_BACK) == POSITION_OPEN
+
+
+@pytest.mark.asyncio
+async def test_floor_clamp_inverse_back_stays_inverted_end_to_end() -> None:
+    """Finding 1 end-to-end: a floor-clamped inverse cycle still inverts the back.
+
+    A floor clamp on the FRONT must not un-invert the back's absolute blackout
+    substitution. With inverse-state ON and a deploy, the back's wire target is
+    ``inverse_state(CLOSED)`` — physically closed — through the real dispatch
+    seam. The pre-fix rule (``... and not floor_clamp``) drove it to raw CLOSED
+    (wire 0), leaving an inverted device physically OPEN (no blackout).
+    """
+    policy = _primed_policy(
+        triggers=["night"], sol_elev=-3.0, inverse=True, floor_clamp=True
+    )
+    # A floor-clamped winner short-circuits interp/inverse in coordinator.state,
+    # so the FRONT's dispatched value is the raw clamped position.
+    coordinator = _make_coordinator(policy, state=30)
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=30, options={}
+    )
+
+    cmd = coordinator._cmd_svc
+    assert cmd.get_target(_FRONT) == 30
+    assert cmd.get_target(_BACK) == inverse_state(POSITION_CLOSED)  # wire 100 = closed
+
+
+@pytest.mark.asyncio
+async def test_interpolation_back_endpoint_is_calibrated_end_to_end() -> None:
+    """Finding 5 end-to-end: the back's endpoint goes through the interp curve."""
+    policy = _primed_policy(triggers=["night"], sol_elev=-3.0, interp=True)
+    # With interp on, coordinator.state feeds the FRONT its interpolated value;
+    # the back is substituted then interpolated by the policy.
+    front_state = int(round(interpolate_position(40, 10, 90, None, None)))
+    coordinator = _make_coordinator(policy, state=front_state)
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=front_state, options={}
+    )
+
+    cmd = coordinator._cmd_svc
+    expected_back = int(
+        round(interpolate_position(POSITION_CLOSED, 10, 90, None, None))
+    )
+    assert cmd.get_target(_BACK) == expected_back
+    assert cmd.get_target(_BACK) != POSITION_CLOSED  # not overdriven to raw 0
+
+
+@pytest.mark.xfail(
+    reason="#996 Finding 4 dispatch-timing gap: with an end_time set and no "
+    "sunset_position, the night/privacy blackout is never physically dispatched "
+    "while the operating window is clock-closed (coordinator.py gate at ~2509 "
+    "skips all non-safety cycles). The back deploy is not is_safety, so it is "
+    "gated off with the front. Needs a follow-up per-entity out-of-window "
+    "dispatch path for the back panel.",
+    strict=True,
+)
+@pytest.mark.asyncio
+async def test_night_blackout_deploys_outside_operating_window() -> None:
+    # Window clock-closed (after end_time) at night; night trigger active. The
+    # back SHOULD still deploy the blackout, but the whole-cycle window gate
+    # currently skips it. This xfail documents the desired behaviour.
+    policy = _primed_policy(triggers=["night"], sol_elev=-3.0)
+    coordinator = _make_coordinator(policy, state=40, clock_window_open=False)
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=40, options={}
+    )
+
+    assert coordinator._cmd_svc.get_target(_BACK) == POSITION_CLOSED

--- a/tests/test_engine/test_layered.py
+++ b/tests/test_engine/test_layered.py
@@ -1,0 +1,95 @@
+"""Pure-engine unit tests for the layered dual-panel calculation (#996).
+
+``engine/covers/layered.py`` is a pure, HA-free module: it *decides* each of a
+dual-panel cover's two independent panel targets (a sheer front that tracks the
+sun, a blackout back that deploys on a trigger set). The owning
+``DualPanelPolicy`` maps the pipeline result onto the trigger set and the
+open/closed values; these functions only compose primitives.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from custom_components.adaptive_cover_pro.engine.covers.layered import (
+    LayeredResult,
+    blackout_should_deploy,
+    compute_layered,
+)
+
+
+class TestBlackoutShouldDeploy:
+    """``blackout_should_deploy`` — deploy iff any configured trigger is active."""
+
+    def test_deploys_when_a_configured_trigger_is_active(self) -> None:
+        assert blackout_should_deploy(["heat"], ["heat"]) is True
+
+    def test_deploys_when_any_of_several_configured_triggers_matches(self) -> None:
+        # Only "night" is active; it is one of the configured triggers → deploy.
+        assert blackout_should_deploy(["night"], ["heat", "privacy", "night"]) is True
+
+    def test_empty_configured_set_never_deploys(self) -> None:
+        # No trigger is configured to drive the blackout → never deploys, even
+        # with several active triggers.
+        assert blackout_should_deploy(["heat", "privacy", "night"], []) is False
+
+    def test_ignores_active_triggers_that_are_not_configured(self) -> None:
+        # "heat" is active but only "privacy" is configured → no deploy.
+        assert blackout_should_deploy(["heat"], ["privacy"]) is False
+
+    def test_no_active_triggers_does_not_deploy(self) -> None:
+        assert blackout_should_deploy([], ["heat", "privacy", "night"]) is False
+
+    def test_accepts_arbitrary_iterables(self) -> None:
+        # Sets and tuples work as well as lists.
+        assert blackout_should_deploy({"privacy"}, ("privacy",)) is True
+
+
+class TestComputeLayered:
+    """``compute_layered`` — front passes through, back is open/closed."""
+
+    def test_front_passes_through_verbatim(self) -> None:
+        result = compute_layered(
+            front=37, deploy_blackout=False, open_position=0, closed_position=100
+        )
+        assert result.front == 37
+
+    def test_back_closed_when_blackout_deploys(self) -> None:
+        result = compute_layered(
+            front=37, deploy_blackout=True, open_position=0, closed_position=100
+        )
+        assert result.back == 100
+
+    def test_back_open_when_blackout_retracts(self) -> None:
+        result = compute_layered(
+            front=37, deploy_blackout=False, open_position=0, closed_position=100
+        )
+        assert result.back == 0
+
+    def test_back_uses_supplied_wire_space_values(self) -> None:
+        # The caller maps open/closed into the dispatched coordinate space, so
+        # inverted wire values flow straight through (no direction semantics).
+        deployed = compute_layered(
+            front=37, deploy_blackout=True, open_position=100, closed_position=0
+        )
+        assert deployed.back == 0
+        retracted = compute_layered(
+            front=37, deploy_blackout=False, open_position=100, closed_position=0
+        )
+        assert retracted.back == 100
+
+
+class TestLayeredResultShape:
+    """``LayeredResult`` is a frozen, slotted dataclass."""
+
+    def test_is_frozen(self) -> None:
+        result = LayeredResult(front=10, back=20)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.front = 99  # type: ignore[misc]
+
+    def test_uses_slots(self) -> None:
+        result = LayeredResult(front=10, back=20)
+        with pytest.raises(AttributeError):
+            result.__dict__  # noqa: B018

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -1876,6 +1876,77 @@ class TestSetGeometry:
         )
         assert patch_out == {CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: "cover.middle_rail"}
 
+    def test_set_geometry_accepts_dual_panel_front_entity(self):
+        # The dual-panel front-entity designator has a FIELD_VALIDATORS entry, so
+        # the set_geometry section list must include it too (#996 Finding 3).
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_DUAL_PANEL_FRONT_ENTITY,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            _SECTION_GEOMETRY_ALL,
+            _build_patch,
+        )
+
+        patch_out = _build_patch(
+            {CONF_DUAL_PANEL_FRONT_ENTITY: "cover.front_sheer"},
+            _SECTION_GEOMETRY_ALL,
+        )
+        assert patch_out == {CONF_DUAL_PANEL_FRONT_ENTITY: "cover.front_sheer"}
+
+    def test_set_geometry_accepts_dual_panel_blackout_triggers(self):
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            _SECTION_GEOMETRY_ALL,
+            _build_patch,
+        )
+
+        patch_out = _build_patch(
+            {CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["heat", "night"]},
+            _SECTION_GEOMETRY_ALL,
+        )
+        assert patch_out == {CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["heat", "night"]}
+
+    def test_dual_panel_front_entity_validator_accepts_string_and_none(self):
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_DUAL_PANEL_FRONT_ENTITY,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            FIELD_VALIDATORS,
+        )
+
+        v = FIELD_VALIDATORS[CONF_DUAL_PANEL_FRONT_ENTITY]
+        assert v("cover.front") == "cover.front"
+        assert v(None) is None
+
+    def test_dual_panel_triggers_validator_accepts_subset(self):
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            FIELD_VALIDATORS,
+        )
+
+        v = FIELD_VALIDATORS[CONF_DUAL_PANEL_BLACKOUT_TRIGGERS]
+        assert v(["heat", "privacy", "night"]) == ["heat", "privacy", "night"]
+        assert v([]) == []
+        assert v(None) is None
+
+    def test_dual_panel_triggers_validator_rejects_unknown_member(self):
+        import voluptuous as vol
+
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            FIELD_VALIDATORS,
+        )
+
+        v = FIELD_VALIDATORS[CONF_DUAL_PANEL_BLACKOUT_TRIGGERS]
+        with pytest.raises(vol.Invalid):
+            v(["heat", "bogus"])
+
 
 class TestSetOption:
     """Integration tests for generic set_option service."""


### PR DESCRIPTION
## Summary
Adds a new `cover_dual_panel` cover type — two **independent** shades over one window: a sun-tracking **sheer front** and a trigger-deployed **blackout back** — built on the shipped `resolve_entity_target` / `post_pipeline_resolve` seam (the day/night Model C pattern), not PR #527's competing `resolve_axis_targets` dispatch model. Salvages the pure `engine/covers/layered.py` helper from #527. Unlike day/night, the two layers are independent — no `M>=P` no-pass coupling.

- **Front** is designated via a front-entity picker (mirrors `CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY`); every other configured cover is a back/blackout panel. Unset → runs as a plain vertical blind.
- **Back** deploys on any selected trigger from `{heat, privacy, night}` (climate summer/extreme-heat, astronomical sunset window, sun below horizon), retracts when none is active.

Includes deep-audit fixes: back-panel inverse-state no longer depends on the front's bypass/floor-clamp state (absolute substitution owns its own wire space); privacy keys on the astronomical sunset window (not the optional `sunset_position`); the two new options are service-settable; the back respects interpolation calibration; empty-string front degrades to a plain vertical blind.

## Testing
- ✅ 7661 passing, 1 xfailed (a documented dispatch-timing gap — see below)
- Two fable deep audits; the re-audit extracted the pre-fix commit and confirmed 12 new tests fail against it (the fixes are load-bearing) and no new defects
- DE/FR translations synced; parity + string-branch guard scans green

## Related Issues
Refs #996. Rebuilds the still-wanted dual-panel slice of PR #527 on the shipped seam (close/trim #527 once this ships). Lineage: Refs #351.

## Known follow-up
The night/privacy blackout is gated off outside the operating time window (regular non-safety cycles are skipped when the clock window is closed), so on a config with `end_time` set the back may not deploy at night. Captured as a strict `xfail` (`test_night_blackout_deploys_outside_operating_window`); a proper fix needs a per-entity, back-only, out-of-window dispatch path and is filed as a separate issue.

https://claude.ai/code/session_01Kk8fZPD3Bu2nxQmeyhahha