### PR TITLE
feat: add temperature unit_of_measurement to diagnostics (#969)

### DIFF
--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -46,6 +46,7 @@ class SensorSource:
     entity_id: Any  # str | list | None — the raw option value
     source: str
     state: str
+    unit_of_measurement: str | None = None  # issue #969 (rule 14)
 
 
 # ---------------------------------------------------------------------------
@@ -654,6 +655,9 @@ class DiagnosticsBuilder:
                 "entity_id": ctx.temp_sensor_entity_id,
                 "source": ctx.temp_sensor_source,
                 "area_id": ctx.temp_sensor_area_id,
+                "unit_of_measurement": DiagnosticsBuilder._read_unit_of_measurement(
+                    ctx.hass, ctx.temp_sensor_entity_id
+                ),
             }
 
         result = ctx.pipeline_result
@@ -1028,6 +1032,7 @@ class DiagnosticsBuilder:
                 entity_id=entity_id,
                 source=source,
                 state=cls._classify_sensor_state(ctx.hass, entity_id),
+                unit_of_measurement=cls._read_unit_of_measurement(ctx.hass, entity_id),
             )
             bucket.append(asdict(descriptor))
 
@@ -1074,6 +1079,21 @@ class DiagnosticsBuilder:
             if state is not None and state.state not in _UNAVAILABLE_HA_STATES:
                 return _SENSOR_STATE_AVAILABLE
         return _SENSOR_STATE_UNAVAILABLE
+
+    @staticmethod
+    def _read_unit_of_measurement(hass: Any, entity_id: Any) -> str | None:
+        """Return a scalar entity's ``unit_of_measurement`` attribute, or None.
+
+        None when hass is absent, entity_id is falsy, or entity_id is a list
+        (the multi-entity gate/severe-sensor keys have no single unit to
+        report). ``getattr`` guards state stand-ins lacking ``.attributes``.
+        """
+        if hass is None or not entity_id or isinstance(entity_id, list):
+            return None
+        state = hass.states.get(entity_id)
+        if state is None:
+            return None
+        return getattr(state, "attributes", {}).get("unit_of_measurement")
 
     @staticmethod
     def _templated_thresholds(ctx: DiagnosticContext) -> dict:

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -738,7 +738,47 @@ class TestClimateDiagnostics:
             "entity_id": "sensor.bedroom_temp",
             "source": "area",
             "area_id": "area_bedroom",
+            "unit_of_measurement": None,
         }
+
+    def test_temp_sensor_includes_unit_of_measurement(
+        self, builder: DiagnosticsBuilder
+    ):
+        """temp_sensor carries the resolved entity's unit_of_measurement (#969)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+        state = SimpleNamespace(state="21.5", attributes={"unit_of_measurement": "°C"})
+        hass = SimpleNamespace(
+            states=SimpleNamespace(get=lambda entity_id: state),
+        )
+        diag, _ = builder.build(
+            _base_ctx(
+                climate_mode=True,
+                pipeline_result=pr,
+                hass=hass,
+                temp_sensor_entity_id="sensor.bedroom_temp",
+                temp_sensor_source="area",
+                temp_sensor_area_id="area_bedroom",
+            )
+        )
+        assert diag["temp_sensor"]["unit_of_measurement"] == "°C"
+
+    def test_temp_sensor_unit_of_measurement_none_without_hass(
+        self, builder: DiagnosticsBuilder
+    ):
+        """No hass on the context -> unit_of_measurement resolves to None (#969)."""
+        cd = self._make_climate_data()
+        pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+        diag, _ = builder.build(
+            _base_ctx(
+                climate_mode=True,
+                pipeline_result=pr,
+                temp_sensor_entity_id="sensor.bedroom_temp",
+                temp_sensor_source="area",
+                temp_sensor_area_id="area_bedroom",
+            )
+        )
+        assert diag["temp_sensor"]["unit_of_measurement"] is None
 
     def test_temperature_details_include_outside_temp_source(
         self, builder: DiagnosticsBuilder

--- a/tests/test_diagnostics/test_building_profile_sources.py
+++ b/tests/test_diagnostics/test_building_profile_sources.py
@@ -19,6 +19,7 @@ import pytest
 from custom_components.adaptive_cover_pro.const import (
     CONF_BUILDING_PROFILE_ID,
     CONF_CLOUD_COVERAGE_ENTITY,
+    CONF_DAYTIME_GATE_SENSORS,
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
     CONF_OUTSIDETEMP_ENTITY,
@@ -51,6 +52,10 @@ class _FakeConfigEntries:
 
 def _state(value: str) -> SimpleNamespace:
     return SimpleNamespace(state=value)
+
+
+def _state_with_unit(value: str, unit: str) -> SimpleNamespace:
+    return SimpleNamespace(state=value, attributes={"unit_of_measurement": unit})
 
 
 def _entry(entry_id: str, options: dict) -> SimpleNamespace:
@@ -140,6 +145,34 @@ def test_linked_emits_two_subsections(builder: DiagnosticsBuilder):
     # Profile-sourced keys do not also appear in the local block.
     assert CONF_LUX_ENTITY not in local
     assert CONF_OUTSIDETEMP_ENTITY not in local
+
+
+def test_sensor_source_entries_carry_unit_of_measurement(builder: DiagnosticsBuilder):
+    """Each shared-sensor entry carries the live entity's unit_of_measurement (#969).
+
+    Configured scalar entity -> the real unit. Not-configured key -> None.
+    List-valued key (gate/severe sensors) -> None, since there is no single
+    unit to report for a multi-entity key.
+    """
+    cover_options = {
+        CONF_OUTSIDETEMP_ENTITY: "sensor.outside_temp",
+        CONF_DAYTIME_GATE_SENSORS: ["binary_sensor.gate_a", "binary_sensor.gate_b"],
+    }
+    hass = _make_hass(
+        {"sensor.outside_temp": _state_with_unit("21.5", "°C")},
+        [],
+    )
+    ctx = _base_ctx(config_options=cover_options, hass=hass)
+    diag, _ = builder.build(ctx)
+
+    local = _by_key(diag["local_sensors"])
+
+    # Configured scalar entity with a real state -> unit surfaces.
+    assert local[CONF_OUTSIDETEMP_ENTITY]["unit_of_measurement"] == "°C"
+    # Not-configured key -> no unit.
+    assert local[CONF_CLOUD_COVERAGE_ENTITY]["unit_of_measurement"] is None
+    # List-valued key -> no single unit to report.
+    assert local[CONF_DAYTIME_GATE_SENSORS]["unit_of_measurement"] is None
 
 
 def test_linked_override_source(builder: DiagnosticsBuilder):


### PR DESCRIPTION
## Summary
Adds each temperature sensor's `unit_of_measurement` to the diagnostics payload so the Setup/Troubleshooting Wizard rule 14 (mixed °F/°C detection) can run. Introduces a nullable `unit_of_measurement` field on `SensorSource` plus a defensive HA-state reader (`_read_unit_of_measurement`), populated at both the `_build_sensor_sources` site and the inside-temp `temp_sensor` block in `_build_climate`. Read-only payload enrichment: no new config keys, no config-entry version bump.

Rule 17 (`debug_config.dry_run`) was already shipped back in April and needs no change here; its existing lock test (`test_debug_diagnostics.py`) was verified green. The Phase 0 issue description was stale on that point.

## Testing
- ✅ 7664 tests passing, 1 xfailed (+3 new diagnostics tests)
- New `_read_unit_of_measurement` branches 100% covered; ruff + black clean

## Related Issues
Refs #969

https://claude.ai/code/session_01CgDx1eunbyStsKKW5a2jcT