### PR TITLE
feat: healthcheck A3 — Repair for tilt cover type without tilt support (#991)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -807,6 +807,9 @@ ISSUE_CONFIG_TIME_WINDOW = "config_time_window"  # start >= end
 ISSUE_COVER_NOT_MOVING = (
     "cover_not_moving"  # commanded but not reaching target (issue #990)
 )
+ISSUE_COVER_TILT_UNSUPPORTED = (
+    "cover_tilt_unsupported"  # tilt cover type bound to a non-tilt device (issue #991)
+)
 # Generous debounce so integration restarts / device re-adds don't nag before
 # a genuinely dead sensor is flagged.
 DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS = 900.0

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -38,6 +38,7 @@ from homeassistant.util import dt as dt_util
 
 from .config_types import CoverConfig, RuntimeConfig
 from .helpers import (
+    check_cover_features,
     compute_effective_default,
     custom_position_slot_delivers_fixed_position,
     custom_position_slot_sensors,
@@ -100,6 +101,7 @@ from .const import (
     ISSUE_CONFIG_POSITION_ENVELOPE,
     ISSUE_CONFIG_TIME_WINDOW,
     ISSUE_COVER_NOT_MOVING,
+    ISSUE_COVER_TILT_UNSUPPORTED,
     ISSUE_COVER_UNAVAILABLE,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
@@ -389,6 +391,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # keys currently tracked, so a cover dropped from config gets its
         # predicate cleared next cycle (symmetric with _cover_issue_keys).
         self._a2_issue_keys: set[str] = set()
+        # A3 (issue #991): per-entity "tilt cover type on a non-tilt device"
+        # Repair keys currently tracked, cleared symmetrically when a cover is
+        # dropped from config (same shape as _a2_issue_keys).
+        self._a3_issue_keys: set[str] = set()
         # One-shot: the first health-check cycle of this lifetime sweeps the issue
         # registry for A1 Repairs orphaned by a prior lifetime (removing a cover
         # reloads the entry, so a cross-lifetime orphan is in neither the fresh
@@ -1605,26 +1611,69 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self._repair.clear_predicate(stale)
             self._a2_issue_keys = a2_desired
 
+            # A3 — tilt cover type on a non-tilt-capable device (issue #991).
+            # Per-entity like A1/A2; predicate-shaped like B1/B2. The "is this a
+            # tilt contradiction?" decision lives on the policy
+            # (``tilt_capability_contradiction``) so the coordinator never
+            # branches on cover type or a hardcoded capability literal. Read RAW
+            # ``check_cover_features`` (None-preserving) rather than the masked
+            # ``read_single_capabilities`` — a still-loading cover reads None,
+            # and skipping it avoids a false contradiction (mirrors B2's "only
+            # fire when the reading is real"). Same per-entity guard as A2 so one
+            # entity's read/predicate blow-up can't starve the rest before
+            # ``evaluate()``.
+            a3_desired: set[str] = set()
+            for eid in self.entities:
+                try:
+                    caps = check_cover_features(self.hass, eid)
+                    if caps is None:
+                        continue  # unreadable → don't claim a contradiction
+                    contradiction = self._policy.tilt_capability_contradiction(caps)
+                except Exception:  # noqa: BLE001 — one entity must not starve the rest
+                    self.logger.debug(
+                        "A3 predicate failed for %s; skipping", eid, exc_info=True
+                    )
+                    continue
+                key = (
+                    f"{ISSUE_COVER_TILT_UNSUPPORTED}_{self.config_entry.entry_id}_{eid}"
+                )
+                a3_desired.add(key)
+                self._repair.update_predicate(
+                    key,
+                    contradiction,
+                    translation_key=ISSUE_COVER_TILT_UNSUPPORTED,
+                    placeholders={"entity_id": eid, "name": name},
+                )
+            for stale in self._a3_issue_keys - a3_desired:
+                self._repair.clear_predicate(stale)
+            self._a3_issue_keys = a3_desired
+
             self._sensor_health.evaluate()
             self._repair.evaluate()
 
             # Per-cover cross-lifetime orphan sweep (issue #975 audit, extended
-            # for A2 in #990). The primary fix for a per-cover Repair is REMOVING
-            # the cover, which reloads the config entry → a fresh coordinator with
-            # empty ``_cover_issue_keys`` / ``_a2_issue_keys``. The removed cover's
-            # key is in neither the recomputed ``desired`` sets nor the in-lifetime
-            # unwatch loops, so its Repair would orphan until an HA restart. Once
-            # per lifetime, enumerate this integration's issues and delete any A1
-            # (cover_unavailable) or A2 (cover_not_moving) Repair for this entry
-            # that is no longer desired. Runs last (inside the single fail-open
-            # guard) so a registry hiccup can never skip A1/B1/B2/A2. The
-            # membership filter is critical: a still-configured cover IS in its
-            # desired set, so its valid warning is preserved rather than flapped.
+            # for A2 in #990, A3 in #991). The primary fix for a per-cover Repair
+            # is REMOVING the cover, which reloads the config entry → a fresh
+            # coordinator with empty ``_cover_issue_keys`` / ``_a2_issue_keys`` /
+            # ``_a3_issue_keys``. The removed cover's key is in neither the
+            # recomputed ``desired`` sets nor the in-lifetime unwatch loops, so
+            # its Repair would orphan until an HA restart. Once per lifetime,
+            # enumerate this integration's issues and delete any A1
+            # (cover_unavailable), A2 (cover_not_moving), or A3
+            # (cover_tilt_unsupported) Repair for this entry that is no longer
+            # desired. Runs last (inside the single fail-open guard) so a registry
+            # hiccup can never skip A1/A2/A3/B1/B2. The membership filter is
+            # critical: a still-configured cover IS in its desired set, so its
+            # valid warning is preserved rather than flapped.
             if not self._a1_orphans_swept:
                 entry_id = self.config_entry.entry_id
                 sweeps = (
                     (f"{ISSUE_COVER_UNAVAILABLE}_{entry_id}_", self._cover_issue_keys),
                     (f"{ISSUE_COVER_NOT_MOVING}_{entry_id}_", self._a2_issue_keys),
+                    (
+                        f"{ISSUE_COVER_TILT_UNSUPPORTED}_{entry_id}_",
+                        self._a3_issue_keys,
+                    ),
                 )
                 registry = ir.async_get(self.hass)
                 for reg_domain, issue_id in list(registry.issues):

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -627,6 +627,26 @@ class CoverTypePolicy(ABC):
             return TILT_AXIS
         return primary
 
+    def tilt_capability_contradiction(self, caps: Any) -> bool:
+        """Whether this cover type drives a tilt axis the device can't (#991, A3).
+
+        True when the policy declares a tilt axis (``capability_key ==
+        CAP_HAS_SET_TILT_POSITION``) that ``caps`` cannot drive. The tilt axis
+        has no ``drive_fallbacks``, so ``is_drivable`` reduces to "native tilt
+        present" — a tilt-declaring type (tilt / louvered_roof / venetian) bound
+        to a cover lacking ``set_tilt_position`` returns ``True``; a
+        position-only cover reached via ``open_cover`` / ``close_cover`` never
+        declares a tilt axis, so it stays ``False`` (issue #991's out-of-scope
+        carve-out). Single source of truth behind the cover-type boundary for
+        the runtime A3 Repair, so the coordinator never branches on cover type
+        or a hardcoded capability literal. Liskov-safe base default — no
+        subclass override needed.
+        """
+        return any(
+            a.capability_key == CAP_HAS_SET_TILT_POSITION and not a.is_drivable(caps)
+            for a in self.axes
+        )
+
     def supported_axes(self, caps: Any) -> tuple[CoverAxis, ...]:
         """Return the declared axes this entity's capabilities actually expose.
 

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -452,6 +452,24 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """
         return self._control_model == DAY_NIGHT_MODEL_POSITION_TILT
 
+    def tilt_capability_contradiction(self, caps: Any) -> bool:
+        """Report an A3 tilt contradiction only when the model needs a tilt axis.
+
+        The static ``axes`` declaration always lists ``TILT_AXIS``, but only
+        Model A (``position_tilt``) drives a *physical* tilt axis. The
+        single-carriage models — ``split_range`` and ``dual_entity`` — need only
+        ``set_position``, so a position-only cover is their intended, supported
+        hardware: reporting a contradiction there would raise a
+        ``cover_tilt_unsupported`` Repair that never clears (#991). Gated on the
+        same ``_drives_dual_axis`` model predicate as every other blend-axis
+        hook, so runtime A3 and the config-time ``require_tilt`` warning agree on
+        one source of truth. Kept behind the cover-type boundary — the
+        coordinator never branches on model here.
+        """
+        if not self._drives_dual_axis():
+            return False
+        return super().tilt_capability_contradiction(caps)
+
     # ---- Split-range wire mapping (Model B) --------------------------- #
 
     def _split_range_wire(self, position: int, blend: int) -> int:

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -24,6 +24,10 @@
     "cover_not_moving": {
       "title": "Gesteuerte Beschattung erreicht Position nicht",
       "description": "Adaptive Cover Pro hat eine Position an die Beschattung `{entity_id}` gesteuert von **{name}** gesendet, doch diese hat die Position seit längerer Zeit nicht erreicht. Der Motor könnte festsitzen, das Gerät könnte offline sein, oder die Beschattung könnte sich nicht physisch bewegen. Überprüfen Sie, dass das Gerät der Beschattung online ist und auf manuelle Befehle reagiert."
+    },
+    "cover_tilt_unsupported": {
+      "title": "Neigung wird nicht unterstützt",
+      "description": "**{name}** ist als neigungsfähiger Beschattungstyp konfiguriert, aber die Beschattung `{entity_id}` bietet keine Neigungssteuerung an (set_tilt_position). Neigungspositionen können nicht angewendet werden. Wählen Sie eine Beschattungsentität, die Neigung unterstützt, oder ändern Sie den Beschattungstyp in einen ohne Neigung."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -24,6 +24,10 @@
     "cover_not_moving": {
       "title": "Cover not reaching commanded position",
       "description": "Adaptive Cover Pro sent a position to the cover `{entity_id}` controlled by **{name}**, but it has not reached that position for a while. The motor may be stuck, the device may be offline, or the cover may not physically move. Check that the cover's device is online and that it responds when you command it manually."
+    },
+    "cover_tilt_unsupported": {
+      "title": "Cover cannot tilt",
+      "description": "**{name}** is configured as a tilt-capable cover type, but the cover `{entity_id}` does not advertise tilt control (set_tilt_position). Tilt positions cannot be applied to it. Pick a cover entity that supports tilt, or change the cover type to one that does not use tilt."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -24,6 +24,10 @@
     "cover_not_moving": {
       "title": "Store ne parvient pas à atteindre la position commandée",
       "description": "Adaptive Cover Pro a envoyé une position au store `{entity_id}` contrôlé par **{name}**, mais il n'a pas atteint cette position depuis un certain temps. Le moteur peut être bloqué, l'appareil peut être hors ligne, ou le store peut ne pas se déplacer physiquement. Vérifiez que l'appareil du store est en ligne et qu'il répond quand vous le commandez manuellement."
+    },
+    "cover_tilt_unsupported": {
+      "title": "La protection ne peut pas s'incliner",
+      "description": "**{name}** est configuré en tant que type de protection capable d'inclinaison, mais la protection `{entity_id}` n'annonce pas le contrôle d'inclinaison (set_tilt_position). Les positions d'inclinaison ne peuvent pas lui être appliquées. Sélectionnez une entité de protection qui prend en charge l'inclinaison, ou changez le type de protection pour un qui n'utilise pas l'inclinaison."
     }
   },
   "config": {

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -32,6 +32,7 @@ from custom_components.adaptive_cover_pro.const import (
     ISSUE_CONFIG_POSITION_ENVELOPE,
     ISSUE_CONFIG_TIME_WINDOW,
     ISSUE_COVER_NOT_MOVING,
+    ISSUE_COVER_TILT_UNSUPPORTED,
     ISSUE_COVER_UNAVAILABLE,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
@@ -39,6 +40,7 @@ from custom_components.adaptive_cover_pro.const import (
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.managers.repair import RepairManager
 from custom_components.adaptive_cover_pro.managers.sensor_health import (
     SensorHealthManager,
@@ -52,8 +54,14 @@ _ENTRY = "entry1"
 
 
 class _State:
-    def __init__(self, state: str) -> None:
+    def __init__(self, state: str, attributes: dict | None = None) -> None:
         self.state = state
+        # A3 (issue #991) reads capabilities via ``check_cover_features``, which
+        # touches ``state.attributes``. Default to an empty dict so the real
+        # helper returns optimistic (position-only, no-tilt) defaults for a
+        # readable cover rather than raising — A3 tests patch the helper directly
+        # when they need specific capabilities.
+        self.attributes = attributes if attributes is not None else {}
 
 
 class _States:
@@ -89,6 +97,7 @@ def _make_coord(
     start: dt.datetime | None = None,
     end: dt.datetime | None = None,
     debounce: float = 0,
+    policy=None,
 ):
     """Build a minimal coordinator stub wired for _evaluate_health_checks."""
     hass = _Hass(states if states is not None else {"sun.sun": "above_horizon"})
@@ -118,6 +127,12 @@ def _make_coord(
     coord._cmd_svc = MagicMock()
     coord._cmd_svc.is_target_unreached.return_value = False
     coord._a2_issue_keys = set()
+    # A3 (issue #991): the active cover-type policy answers the tilt-capability
+    # contradiction predicate. Default to a NON-tilt policy (blind) so the
+    # A1/A2/B/C tests never see a spurious A3 Repair; A3 tests pass a
+    # tilt-declaring policy explicitly.
+    coord._policy = policy if policy is not None else get_policy("cover_blind")
+    coord._a3_issue_keys = set()
     coord._resolved_options = options or {}
     return coord
 
@@ -644,3 +659,190 @@ async def test_a2_configured_stuck_cover_not_swept():
     _reg_get, coord_delete = _sweep_run(coord, {}, registry)
     await _drain()
     assert key not in _swept_keys(coord_delete)
+
+
+# --- A3: tilt cover type bound to a non-tilt-capable device (issue #991) -----
+#
+# A3 is a config-vs-hardware coherence check: a tilt-declaring cover type
+# (venetian / tilt / louvered_roof) bound to a cover whose supported_features
+# lacks set_tilt_position can never honour its tilt behaviour. Predicate-shaped
+# like B1/B2 and per-entity like A1/A2, so it rides the same RepairManager. The
+# contradiction test lives on the policy (``tilt_capability_contradiction``);
+# the coordinator reads RAW capabilities via ``check_cover_features`` (None when
+# a cover is still loading) so an unreadable cover never false-fires. Open/close
+# only covers are OUT of scope and must never raise.
+
+# Capability dicts as ``check_cover_features`` returns them (helper shape).
+_NO_TILT = {"has_set_position": True, "has_set_tilt_position": False}
+_WITH_TILT = {"has_set_position": True, "has_set_tilt_position": True}
+_OPEN_CLOSE_ONLY = {"has_open": True, "has_close": True}
+
+
+async def test_a3_raises_for_tilt_type_without_set_tilt_position():
+    """A tilt-declaring type on a device lacking set_tilt_position raises."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        create, _delete = await _run(coord, {})
+    assert f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" in _raised_keys(create)
+
+
+async def test_a3_no_raise_for_open_close_only_cover():
+    """A blind/awning (no declared tilt axis) never raises A3, even open/close only."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )  # default policy = blind (no tilt axis)
+    with patch(f"{_COORD}.check_cover_features", return_value=_OPEN_CLOSE_ONLY):
+        create, _delete = await _run(coord, {})
+    assert (
+        f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" not in _raised_keys(create)
+    )
+
+
+async def test_a3_no_raise_for_tilt_type_with_set_tilt_position():
+    """A tilt-declaring type on a tilt-capable device is coherent — no raise."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    with patch(f"{_COORD}.check_cover_features", return_value=_WITH_TILT):
+        create, _delete = await _run(coord, {})
+    assert (
+        f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" not in _raised_keys(create)
+    )
+
+
+async def test_a3_no_false_fire_on_unknown_caps():
+    """An unreadable cover (``check_cover_features`` → None) never raises A3.
+
+    ``check_cover_features`` returns None while a cover is still loading /
+    unavailable. Reading the masked ``read_single_capabilities`` would surface
+    has_set_tilt_position=False and false-fire; reading the raw helper and
+    skipping None does not. The skipped cover is also NOT tracked, so the stale
+    loop can't act on a key it never added.
+    """
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    key = f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a"
+    with patch(f"{_COORD}.check_cover_features", return_value=None):
+        create, _delete = await _run(coord, {})
+    assert key not in _raised_keys(create)
+    assert key not in coord._a3_issue_keys
+
+
+async def test_a3_does_not_raise_before_debounce():
+    """A single contradictory cycle under a long debounce does not raise."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+        debounce=100,
+    )
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        create, _delete = await _run(coord, {})
+    assert (
+        f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" not in _raised_keys(create)
+    )
+    coord._repair.shutdown()  # cancel the in-flight (long) debounce timer
+
+
+async def test_a3_clears_on_recovery():
+    """Once the device gains tilt support, the A3 Repair is deleted."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    key = f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a"
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        await _run(coord, {})  # cycle 1: raise
+    with patch(f"{_COORD}.check_cover_features", return_value=_WITH_TILT):
+        _create, delete = await _run(coord, {})  # cycle 2: recovered
+    assert key in {call.args[2] for call in delete.call_args_list}
+
+
+async def test_a3_stale_key_cleared_when_cover_removed():
+    """A cover dropped from config has its A3 predicate cleared (in-lifetime)."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    key = f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a"
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        await _run(coord, {})  # cycle 1: cover.a tracked
+    assert key in coord._a3_issue_keys
+    coord.entities = []
+    _create, delete = await _run(coord, {})  # cycle 2: cover removed
+    assert key in {call.args[2] for call in delete.call_args_list}
+    assert coord._a3_issue_keys == set()
+
+
+async def test_a3_orphan_cleared_on_reload_after_cover_removed():
+    """An A3 Repair for a cover no longer configured is swept once per lifetime."""
+    orphan = f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.old"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.current": "open"},
+        entities=["cover.current"],
+        policy=get_policy("cover_venetian"),
+    )
+    registry = SimpleNamespace(issues={(DOMAIN, orphan): object()})
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    assert orphan in _swept_keys(coord_delete)
+
+
+async def test_a3_configured_contradiction_not_swept():
+    """A still-configured contradictory cover keeps its A3 Repair (in ``a3_desired``)."""
+    key = f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a"
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    registry = SimpleNamespace(issues={(DOMAIN, key): object()})
+    _reg_get, coord_delete = _sweep_run(coord, {}, registry)
+    await _drain()
+    assert key not in _swept_keys(coord_delete)
+
+
+async def test_a3_fail_open_on_predicate_exception():
+    """A raising A3 predicate must not starve A1/A2/B/C1 (mirrors the A2 audit).
+
+    The per-entity capability-read + predicate call has its own narrow guard, so
+    an entity whose read explodes is skipped — the A3 loop still finishes,
+    ``evaluate()`` runs, and a concurrently-unhealthy C1 (``sun.sun``
+    unavailable) Repair STILL raises. The outer fail-open guard stays as
+    belt-and-suspenders, but this per-entity guard preserves the design
+    guarantee.
+    """
+    coord = _make_coord(
+        states={"sun.sun": "unavailable", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=get_policy("cover_venetian"),
+    )
+    coord.logger = MagicMock()
+    with (
+        patch(f"{_BASE}.ir.async_create_issue") as create,
+        patch(f"{_BASE}.ir.async_delete_issue"),
+        patch(f"{_COORD}.ir.async_get", return_value=SimpleNamespace(issues={})),
+        patch(f"{_COORD}.ir.async_delete_issue"),
+        patch(f"{_COORD}.check_cover_features", side_effect=RuntimeError("boom")),
+    ):
+        # Must not raise — the per-entity guard swallows the read/predicate error.
+        coord._evaluate_health_checks({})
+        await _drain()
+    # C1 still evaluated despite the A3 read blowing up: sun_unavailable raises.
+    assert f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}" in _raised_keys(create)
+    # The per-entity guard logged the skip exactly once.
+    coord.logger.debug.assert_called_once()
+    assert "A3 predicate failed" in coord.logger.debug.call_args.args[0]
+    assert coord.logger.debug.call_args.args[1] == "cover.a"

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -28,6 +28,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MIN_POSITION,
     CUSTOM_POSITION_SAFETY_PRIORITY,
     CUSTOM_POSITION_SLOTS,
+    DAY_NIGHT_MODEL_DUAL_ENTITY,
+    DAY_NIGHT_MODEL_SPLIT_RANGE,
     DOMAIN,
     ISSUE_CONFIG_POSITION_ENVELOPE,
     ISSUE_CONFIG_TIME_WINDOW,
@@ -715,6 +717,67 @@ async def test_a3_no_raise_for_tilt_type_with_set_tilt_position():
     assert (
         f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" not in _raised_keys(create)
     )
+
+
+async def test_a3_no_raise_for_day_night_split_range_on_position_only_cover():
+    """A Model B (split_range) day/night shade needs only set_position (#991).
+
+    The day/night policy statically declares a tilt axis, but the single-carriage
+    split-range model drives only the carriage. A position-only cover is its
+    intended, supported hardware, so A3 must NOT raise a cover_tilt_unsupported
+    Repair that could never clear.
+    """
+    policy = get_policy("cover_day_night_shade")
+    policy._control_model = DAY_NIGHT_MODEL_SPLIT_RANGE
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=policy,
+    )
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        create, _delete = await _run(coord, {})
+    assert (
+        f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" not in _raised_keys(create)
+    )
+
+
+async def test_a3_no_raise_for_day_night_dual_entity_on_position_only_cover():
+    """A Model C (dual_entity) day/night shade needs only set_position (#991).
+
+    Same single-carriage relaxation as split-range: the blend folds into a
+    second entity's position axis, never a physical tilt axis, so a position-only
+    cover is coherent and must not raise A3.
+    """
+    policy = get_policy("cover_day_night_shade")
+    policy._control_model = DAY_NIGHT_MODEL_DUAL_ENTITY
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=policy,
+    )
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        create, _delete = await _run(coord, {})
+    assert (
+        f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" not in _raised_keys(create)
+    )
+
+
+async def test_a3_raises_for_day_night_model_a_on_position_only_cover():
+    """A Model A (position_tilt) day/night shade DOES need a physical tilt axis.
+
+    The dual-axis model drives the fabric blend on a real tilt axis, so binding
+    it to a position-only cover is a genuine contradiction that must raise A3 —
+    the model-aware override relaxes B/C without masking A.
+    """
+    policy = get_policy("cover_day_night_shade")  # default model = position_tilt (A)
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+        policy=policy,
+    )
+    with patch(f"{_COORD}.check_cover_features", return_value=_NO_TILT):
+        create, _delete = await _run(coord, {})
+    assert f"{ISSUE_COVER_TILT_UNSUPPORTED}_{_ENTRY}_cover.a" in _raised_keys(create)
 
 
 async def test_a3_no_false_fire_on_unknown_caps():

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -38,6 +38,8 @@ from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.cover_types.base import (
     AXIS_NAME_POSITION,
     AXIS_NAME_TILT,
+    CAP_HAS_SET_POSITION,
+    CAP_HAS_SET_TILT_POSITION,
     POSITION_AXIS,
     TILT_AXIS,
 )
@@ -830,6 +832,54 @@ class TestSplitRangeResolve:
         assert policy._control_model == DAY_NIGHT_MODEL_POSITION_TILT
         # Dual-axis dispatch still threads the blend.
         assert policy.position_context_overrides(out)["tilt"] == DAY_NIGHT_SHEER
+
+
+# ---------------------------------------------------------------------------
+# Step 17 — model-aware A3 tilt-capability contradiction (#991)
+# ---------------------------------------------------------------------------
+
+
+class TestTiltCapabilityContradiction:
+    """A3 (#991): only Model A physically drives a tilt (blend) axis.
+
+    The static ``axes = (POSITION_AXIS, TILT_AXIS)`` declaration is shared by all
+    three control models, but only Model A (``position_tilt``) actually drives a
+    physical tilt axis. Models B (``split_range``) and C (``dual_entity``) are
+    single-carriage, position-only models — a position-only cover is their
+    intended, supported hardware — so binding one to such a cover must NOT report
+    a contradiction (which would raise a ``cover_tilt_unsupported`` Repair that
+    never clears). Mirrors the config-time ``require_tilt`` gate.
+    """
+
+    _NO_TILT = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: False}
+    _WITH_TILT = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: True}
+
+    def test_model_a_position_only_caps_is_contradiction(self) -> None:
+        policy = DayNightShadePolicy()
+        policy._control_model = DAY_NIGHT_MODEL_POSITION_TILT
+        assert policy.tilt_capability_contradiction(self._NO_TILT) is True
+
+    def test_model_a_tilt_capable_caps_no_contradiction(self) -> None:
+        policy = DayNightShadePolicy()
+        policy._control_model = DAY_NIGHT_MODEL_POSITION_TILT
+        assert policy.tilt_capability_contradiction(self._WITH_TILT) is False
+
+    def test_model_b_split_range_position_only_no_contradiction(self) -> None:
+        policy = DayNightShadePolicy()
+        policy._control_model = DAY_NIGHT_MODEL_SPLIT_RANGE
+        assert policy.tilt_capability_contradiction(self._NO_TILT) is False
+
+    def test_model_c_dual_entity_position_only_no_contradiction(self) -> None:
+        policy = DayNightShadePolicy()
+        policy._control_model = DAY_NIGHT_MODEL_DUAL_ENTITY
+        assert policy.tilt_capability_contradiction(self._NO_TILT) is False
+
+    def test_default_model_is_a_and_contradicts_position_only(self) -> None:
+        # A freshly-constructed policy defaults to the dual-axis Model A, so a
+        # position-only cover is a genuine contradiction until options relax it.
+        policy = DayNightShadePolicy()
+        assert policy._control_model == DAY_NIGHT_MODEL_POSITION_TILT
+        assert policy.tilt_capability_contradiction(self._NO_TILT) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -172,6 +172,48 @@ def test_axes_tuple_non_empty(policy: CoverTypePolicy) -> None:
     assert len(policy.axes) >= 1
 
 
+@pytest.mark.unit
+def test_tilt_capability_contradiction_contract(policy: CoverTypePolicy) -> None:
+    """A3 (#991): the predicate fires iff a declared tilt axis can't be driven.
+
+    ``tilt_capability_contradiction`` is the single source of truth the A3
+    runtime Repair consults — True means "this cover type drives a tilt axis the
+    bound device can't honour". The Liskov-safe base default derives the answer
+    from ``self.axes`` alone, so every registered policy and stub satisfies it
+    without an override:
+
+    * a tilt-declaring type (tilt / louvered_roof / venetian) on a device that
+      lacks ``set_tilt_position`` → contradiction;
+    * any type on a fully-capable device → never a contradiction;
+    * a position-only cover reached via open/close (no ``set_tilt_position``) is
+      explicitly OUT of scope — it only trips for a *declared* tilt axis, so a
+      blind/awning never fires.
+    """
+    from custom_components.adaptive_cover_pro.cover_types.base import (
+        CAP_HAS_CLOSE,
+        CAP_HAS_OPEN,
+    )
+
+    has_tilt_axis = any(
+        a.capability_key == CAP_HAS_SET_TILT_POSITION for a in policy.axes
+    )
+
+    # Device advertises position but NOT tilt → contradiction iff a tilt axis
+    # is declared by this cover type.
+    no_tilt = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: False}
+    assert policy.tilt_capability_contradiction(no_tilt) is has_tilt_axis
+
+    # Fully-capable device → never a contradiction, for any cover type.
+    full = {CAP_HAS_SET_POSITION: True, CAP_HAS_SET_TILT_POSITION: True}
+    assert policy.tilt_capability_contradiction(full) is False
+
+    # Open/close-only position cover (no set_position, no set_tilt_position):
+    # the position axis is drivable via the open/close fallback, so only a
+    # declared tilt axis can contradict — proving the out-of-scope carve-out.
+    open_close = {CAP_HAS_OPEN: True, CAP_HAS_CLOSE: True}
+    assert policy.tilt_capability_contradiction(open_close) is has_tilt_axis
+
+
 # ---- Discovery descriptors (issue #725) ---------------------------------- #
 
 

--- a/tests/test_health_issue_translations.py
+++ b/tests/test_health_issue_translations.py
@@ -31,6 +31,7 @@ _HEALTH_ISSUES = {
     "config_position_envelope": {"{name}", "{min}", "{max}"},
     "config_time_window": {"{name}", "{start}", "{end}"},
     "cover_not_moving": {"{name}", "{entity_id}"},
+    "cover_tilt_unsupported": {"{name}", "{entity_id}"},
 }
 
 


### PR DESCRIPTION
## Summary
Adds healthcheck **A3** (item of #973): raise an informational, auto-clearing HA Repair when a tilt-declaring cover type is bound to a cover whose `supported_features` lacks `set_tilt_position`, so a config-vs-hardware contradiction surfaces in Settings > Repairs.

- Reuses the shipped `RepairManager` predicate infra (informational only, `is_fixable=False`, `WARNING`, 900 s debounce, auto-clears on recovery).
- The tilt-vs-hardware test lives on `CoverTypePolicy` (`tilt_capability_contradiction`) — no cover-type-string branch — so open/close-only covers stay out of scope automatically.
- Day/night shade is model-aware: Models B (split range) and C (dual entity) are position-only and never raise; only Model A (position+tilt) does, reusing the existing `_drives_dual_axis()` model predicate.
- English/German/French strings included.

## Testing
- ✅ 7693 tests passing (full suite; 1 pre-existing xfail unrelated)

## Related Issues
Refs #991