### PR TITLE
feat: rules engine + read-only Troubleshoot step (#970)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -244,6 +244,7 @@ from .const import (
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
+from .troubleshoot_i18n import _TRIAGE_TEMPLATES_EN
 from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_name,
@@ -1204,16 +1205,36 @@ def _check_cover_capabilities(
 
     from .helpers import check_cover_features
 
-    cap_map: dict[str, dict[str, bool] | None] = {}
     warnings: list[str] = []
 
     from .cover_types.base import CAP_HAS_SET_POSITION, caps_get
 
+    # The "not ready (unavailable)" line (rule 8a) is rendered from the shared
+    # triage engine so the summary and troubleshoot surfaces share one rule and
+    # one string (issue #970). Build the capability map up front, then index the
+    # COVER_NOT_READY findings by entity so the per-entity warning loop below
+    # keeps its exact ordering (and its interleaving with the open/close-only and
+    # assumed_state lines). Rendered in English to match the legacy raw f-string,
+    # which was hardcoded English regardless of the summary language.
+    from .const import TriageCode
+    from .diagnostics.triage import RuleInput, run_triage
+    from .reason_i18n import render
+    from .troubleshoot_i18n import load_troubleshoot_labels
+
+    cap_map: dict[str, dict[str, bool] | None] = {
+        eid: check_cover_features(hass, eid) for eid in entities
+    }
+    _not_ready = {
+        f.reason.params["eid"]: f
+        for f in run_triage({"capabilities": cap_map}, only=RuleInput.CONFIG)
+        if f.reason.code == TriageCode.COVER_NOT_READY
+    }
+    _triage_labels = load_troubleshoot_labels("en")
+
     for eid in entities:
-        caps = check_cover_features(hass, eid)
-        cap_map[eid] = caps
+        caps = cap_map[eid]
         if caps is None:
-            warnings.append(f"⚠️ {eid}: not ready (unavailable)")
+            warnings.append(render(_not_ready[eid].reason, _triage_labels))
         else:
             if not caps_get(caps, CAP_HAS_SET_POSITION):
                 warnings.append(
@@ -1506,13 +1527,9 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
         "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are "
         "configured — the template alone activates the slot."
     ),
-    "warnings.custom_safety_bypass": (
-        "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the "
-        "automatic-control toggle, manual override, and the start/end time "
-        "window, so it can move the cover even when automatic control is OFF "
-        "and outside your schedule. Lower its priority below {safety} to make "
-        "it respect those gates."
-    ),
+    # NOTE: the safety-priority bypass warning moved to the shared triage engine
+    # (``troubleshoot_i18n`` bundle, ``TriageCode.CUSTOM_SAFETY_BYPASS``) so the
+    # summary and troubleshoot surfaces share one rule + one string (issue #970).
     # --- Motion (75) ---
     "rules.motion": (
         "🚶 Occupancy: if no occupancy for {motion_timeout}s ({sources}) → {action}"
@@ -1904,6 +1921,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     hass: HomeAssistant | None = None,
     sun_times: dict | None = None,
     labels: dict[str, str] | None = None,
+    troubleshoot_labels: dict[str, str] | None = None,
 ) -> str:
     """Build a narrative summary of the current configuration.
 
@@ -1918,8 +1936,14 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     ``labels`` maps the summary's dotted keys to translated templates. When
     ``None`` (unit tests, no hass) the English defaults in ``_SUMMARY_LABELS_EN``
     are used, so the output is byte-identical to the pre-i18n strings.
+
+    ``troubleshoot_labels`` maps the shared triage-engine ``TriageCode`` keys to
+    translated templates for the findings the summary renders through the engine
+    (issue #970 — the custom-position safety-bypass warning). ``None`` uses the
+    English defaults, keeping the English summary byte-identical.
     """
     L = labels or _SUMMARY_LABELS_EN
+    TL = troubleshoot_labels or _TRIAGE_TEMPLATES_EN
 
     # Cover groups render their own compact summary — a group has no cover
     # chain, geometry, or handler ladder (issue #790).
@@ -2266,6 +2290,21 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # its own sortable block; its warnings are folded in (issue #923) so they
     # travel with the slot's line through the priority sort instead of clumping
     # after every slot in separate passes.
+    #
+    # The safety-priority bypass warning (issue #711/#716) is rendered from the
+    # shared triage engine so the summary and troubleshoot surfaces share one
+    # CONFIG rule + one string (issue #970). Run the CONFIG rules once and index
+    # the CUSTOM_SAFETY_BYPASS findings by slot; the per-slot loop below renders
+    # the matching finding in place, byte-identically to the legacy string.
+    from .const import TriageCode
+    from .diagnostics.triage import RuleInput, run_triage
+    from .reason_i18n import render
+
+    _safety_findings = {
+        f.reason.params["slot"]: f
+        for f in run_triage({"options": config}, only=RuleInput.CONFIG)
+        if f.reason.code == TriageCode.CUSTOM_SAFETY_BYPASS
+    }
     if has_custom_position:
         for (
             _slot,
@@ -2372,12 +2411,12 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             # Footgun (issue #711): a safety-priority slot with a live trigger
             # bypasses the auto-control toggle, manual override, and the time
             # window — it can move the cover at any hour with automation off.
+            # Rendered from the shared triage engine (issue #970); the finding is
+            # present for exactly the slots this guard fires on (a configured
+            # slot at or above safety priority — the loop only visits configured
+            # slots, so ``_has_trigger`` is always True here).
             if _pri >= CUSTOM_POSITION_SAFETY_PRIORITY and _has_trigger:
-                _sub(
-                    L["warnings.custom_safety_bypass"].format(
-                        slot=_slot, safety=CUSTOM_POSITION_SAFETY_PRIORITY
-                    )
-                )
+                _sub(render(_safety_findings[_slot].reason, TL))
             # Footgun warning: AND combine mode with no sensors — the template
             # gates nothing and the slot degenerates to template-only OR.
             if _slot in _and_no_sensor_slots:
@@ -4078,12 +4117,21 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Show a read-only summary of all collected configuration before creating the entry."""
         if user_input is not None:
             return await self.async_step_update()
+        from .troubleshoot_i18n import load_troubleshoot_labels
+
         sun_times = await _compute_todays_sun_times(self.hass, self.config)
-        labels = await _load_summary_labels(
-            self.hass, _resolve_summary_language(self.hass, self.context)
+        _language = _resolve_summary_language(self.hass, self.context)
+        labels = await _load_summary_labels(self.hass, _language)
+        troubleshoot_labels = await self.hass.async_add_executor_job(
+            load_troubleshoot_labels, _language
         )
         summary_text = _build_config_summary(
-            self.config, self.type_blind, self.hass, sun_times, labels=labels
+            self.config,
+            self.type_blind,
+            self.hass,
+            sun_times,
+            labels=labels,
+            troubleshoot_labels=troubleshoot_labels,
         )
         return self.async_show_form(
             step_id="summary",
@@ -5633,12 +5681,21 @@ class OptionsFlowHandler(OptionsFlow):
         """Show a read-only summary of the current configuration."""
         if user_input is not None:
             return await self.async_step_init()
+        from .troubleshoot_i18n import load_troubleshoot_labels
+
         sun_times = await _compute_todays_sun_times(self.hass, self.options)
-        labels = await _load_summary_labels(
-            self.hass, _resolve_summary_language(self.hass, self.context)
+        _language = _resolve_summary_language(self.hass, self.context)
+        labels = await _load_summary_labels(self.hass, _language)
+        troubleshoot_labels = await self.hass.async_add_executor_job(
+            load_troubleshoot_labels, _language
         )
         summary_text = _build_config_summary(
-            self.options, self.sensor_type, self.hass, sun_times, labels=labels
+            self.options,
+            self.sensor_type,
+            self.hass,
+            sun_times,
+            labels=labels,
+            troubleshoot_labels=troubleshoot_labels,
         )
         return self.async_show_form(
             step_id="summary",

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -244,7 +244,7 @@ from .const import (
 )
 from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
-from .troubleshoot_i18n import _TRIAGE_TEMPLATES_EN
+from .troubleshoot_i18n import load_troubleshoot_labels
 from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_name,
@@ -1943,7 +1943,10 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     English defaults, keeping the English summary byte-identical.
     """
     L = labels or _SUMMARY_LABELS_EN
-    TL = troubleshoot_labels or _TRIAGE_TEMPLATES_EN
+    # English triage templates via the public loader (I/O-free for "en" —
+    # ``load_bundle_overlay`` short-circuits, so this is the same dict of English
+    # defaults, no file read). Avoids importing the private ``_TRIAGE_TEMPLATES_EN``.
+    TL = troubleshoot_labels or load_troubleshoot_labels("en")
 
     # Cover groups render their own compact summary — a group has no cover
     # chain, geometry, or handler ladder (issue #790).
@@ -2416,7 +2419,15 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
             # slot at or above safety priority — the loop only visits configured
             # slots, so ``_has_trigger`` is always True here).
             if _pri >= CUSTOM_POSITION_SAFETY_PRIORITY and _has_trigger:
-                _sub(render(_safety_findings[_slot].reason, TL))
+                # Defensive .get: the finding is present for exactly the slots
+                # this guard fires on today, so this renders byte-identically —
+                # but should the triage slot-gate ever drift from the summary's
+                # (both are hand-copies of the helpers), a missing finding is
+                # skipped rather than raising KeyError in the summary. Drift is
+                # locked out by tests/test_triage_rules.py's parity tests.
+                _safety_finding = _safety_findings.get(_slot)
+                if _safety_finding is not None:
+                    _sub(render(_safety_finding.reason, TL))
             # Footgun warning: AND combine mode with no sensors — the template
             # gates nothing and the slot degenerates to template-only OR.
             if _slot in _and_no_sensor_slots:
@@ -4540,7 +4551,7 @@ class OptionsFlowHandler(OptionsFlow):
         (``init``) entry — a list so HA translates labels client-side (#227).
         """
         from .diagnostics import resolve
-        from .diagnostics.triage import render_report, run_triage
+        from .diagnostics.triage import RuleInput, render_report, run_triage
         from .troubleshoot_i18n import load_troubleshoot_labels
 
         read = resolve.read_diagnostics(self.hass, self._config_entry.entry_id)
@@ -4552,15 +4563,25 @@ class OptionsFlowHandler(OptionsFlow):
             "capabilities": cap_map,
             **(read.payload or {}),
         }
-        findings = run_triage(view)
+        # When diagnostics are unavailable there is no runtime payload, so only
+        # the CONFIG rules can run (they read options + capabilities alone). Run
+        # just those so every fix route in the menu corresponds to a finding the
+        # user actually sees in the report — never a route for an unshown,
+        # never-evaluated runtime finding (issue #970, MINOR 3).
+        unavailable = read.source == "unavailable"
+        findings = run_triage(view, only=RuleInput.CONFIG if unavailable else None)
 
         labels = await self.hass.async_add_executor_job(
             load_troubleshoot_labels,
             _resolve_summary_language(self.hass, self.context),
         )
 
-        if read.source == "unavailable":
+        if unavailable:
+            # Lead with the note that runtime checks need diagnostics, then list
+            # any config findings that could still be evaluated.
             report = _TROUBLESHOOT_UNAVAILABLE
+            if findings:
+                report = f"{report}\n\n{render_report(findings, labels)}"
         elif findings:
             report = render_report(findings, labels)
         else:

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4282,6 +4282,20 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return f"{name} ({suffix} {counter})"
 
 
+# Server-rendered wrapper lines for the read-only Troubleshoot step (issue
+# #970). The per-finding bullets are translated via the troubleshoot_i18n
+# bundle; these two "envelope" states are not finding codes, so they are not in
+# that bundle (its parity lock is strictly TriageCode-keyed) and stay here.
+_TROUBLESHOOT_NO_ISSUES = (
+    "✅ No configuration or runtime issues detected — everything looks correctly "
+    "set up."
+)
+_TROUBLESHOOT_UNAVAILABLE = (
+    "ℹ️ Diagnostics aren't available yet for this cover — it may not have "
+    "completed a first update cycle. Re-check once it has run at least once."
+)
+
+
 class OptionsFlowHandler(OptionsFlow):
     """Options to adjust parameters."""
 
@@ -4433,7 +4447,10 @@ class OptionsFlowHandler(OptionsFlow):
 
         # ── Admin ────────────────────────────────────────────────────
         keys.append("sync")  # Multi-cover management
-        keys.extend(["summary", "debug", "done"])
+        # "troubleshoot" is a read-only diagnostics surface (issue #970) — it
+        # sits with the other read-only/diagnostic entries (summary, debug) and
+        # is offered on the cover menu ONLY (never the profile or group menus).
+        keys.extend(["summary", "troubleshoot", "debug", "done"])
 
         # Use a list so HA translates labels client-side using the user's language preference.
         # Icons are embedded directly in each translation string (e.g. "🪟 Covers & Device").
@@ -4458,6 +4475,58 @@ class OptionsFlowHandler(OptionsFlow):
                 "coffee_url": "https://www.buymeacoffee.com/jrhubott",
                 "profile_line": _profile_line,
             },
+        )
+
+    async def async_step_troubleshoot(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Read-only diagnostics triage for this cover (issue #970, Phase 1).
+
+        Resolves diagnostics WITHOUT running an update cycle — it never calls
+        ``async_refresh`` (which runs the full pipeline and can move a cover).
+        Options, per-entity capabilities, and the resolved payload are folded
+        into one view, the triage engine runs, and the findings render as a
+        bullet report into ``description_placeholders``. The menu routes each
+        finding's ``fix_step`` to the options step that fixes it (deduped,
+        first-seen order), then a re-check (``troubleshoot``) and a back
+        (``init``) entry — a list so HA translates labels client-side (#227).
+        """
+        from .diagnostics import resolve
+        from .diagnostics.triage import render_report, run_triage
+        from .troubleshoot_i18n import load_troubleshoot_labels
+
+        read = resolve.read_diagnostics(self.hass, self._config_entry.entry_id)
+        cap_map, _ = _check_cover_capabilities(
+            self.options, self.sensor_type, self.hass
+        )
+        view: dict[str, Any] = {
+            "options": dict(self.options),
+            "capabilities": cap_map,
+            **(read.payload or {}),
+        }
+        findings = run_triage(view)
+
+        labels = await self.hass.async_add_executor_job(
+            load_troubleshoot_labels,
+            _resolve_summary_language(self.hass, self.context),
+        )
+
+        if read.source == "unavailable":
+            report = _TROUBLESHOOT_UNAVAILABLE
+        elif findings:
+            report = render_report(findings, labels)
+        else:
+            report = _TROUBLESHOOT_NO_ISSUES
+
+        menu_options = [
+            *dict.fromkeys(f.fix_step for f in findings if f.fix_step),
+            "troubleshoot",
+            "init",
+        ]
+        return self.async_show_menu(  # type: ignore[return-value]
+            step_id="troubleshoot",
+            menu_options=menu_options,
+            description_placeholders={"report": report},
         )
 
     async def async_step_cover_entities(self, user_input: dict[str, Any] | None = None):

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1785,6 +1785,43 @@ class ReasonCode(StrEnum):
     SKIP_NOT_ACTIVE = "skip.not_active"
 
 
+class TriageCode(StrEnum):
+    """Stable identifiers for every diagnostics-triage finding (issue #970).
+
+    Each value is the join key into the ``troubleshoot_i18n/`` template bundle
+    (mirrors :class:`ReasonCode` + the ``reason_i18n/`` mechanism): a triage
+    rule emits a ``Reason(code, params)`` and both the integration's troubleshoot
+    step and the config summary render the English template — or the Lovelace
+    card localizes the same code+params into the user's language.
+
+    These are FROZEN identifiers; do not rename without updating both
+    ``troubleshoot_i18n/*.json`` and ``troubleshoot_i18n._TRIAGE_TEMPLATES_EN``.
+    """
+
+    # -- rule 1: a safety-priority custom position bypasses every gate (#711/#716)
+    CUSTOM_SAFETY_BYPASS = "triage.custom_safety_bypass"
+    # -- rule 2: a higher-priority handler out-ran the solar handler
+    HIGHER_PRIORITY_WON = "triage.higher_priority_won"
+    # -- rule 3: the active-window schedule looks misconfigured
+    TIME_WINDOW_SUSPECT = "triage.time_window_suspect"
+    # -- rule 4: climate mode on but the inside temperature is unavailable
+    CLIMATE_TEMP_NONE = "triage.climate_temp_none"
+    # -- rule 5: summer + presence but the blind never closes
+    SUMMER_WONT_CLOSE = "triage.summer_wont_close"
+    # -- rule 6: climate mode on with presence defaulting to always-present
+    PRESENCE_DEFAULTS_TRUE = "triage.presence_defaults_true"
+    # -- rule 7: more than one cloud/low-light input — OR semantics may surprise
+    CLOUD_OR_SEMANTICS = "triage.cloud_or_semantics"
+    # -- rule 8a: a configured cover is not ready (unavailable) — CONFIG side
+    COVER_NOT_READY = "triage.cover_not_ready"
+    # -- rule 8b: a configured sensor/cover entity is unavailable — RUNTIME side
+    ENTITY_UNAVAILABLE = "triage.entity_unavailable"
+    # -- rule 9: a min-position floor is bypassed by a lower fixed position
+    MIN_FLOOR_BYPASSED = "triage.min_floor_bypassed"
+    # -- rule 10: enable_min_position reads backwards (False = always enforce)
+    ENABLE_MIN_BACKWARDS = "triage.enable_min_backwards"
+
+
 # =============================================================================
 # 24. Geometric Accuracy (calc engine)
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/diagnostics/resolve.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/resolve.py
@@ -1,0 +1,77 @@
+"""Read-only diagnostics access (issue #970, Phase 1).
+
+Unifies the two divergent diagnostics reads (``diagnostics/__init__.py`` and
+``services/diagnostics_service.py``) onto a single resolver that NEVER triggers a
+coordinator update cycle. It deliberately does not call ``async_refresh`` — that
+runs the full pipeline and can move a blind. The resolution order is:
+
+1. the last completed cycle's payload (``coordinator.data.diagnostics``),
+2. a read-only rebuild (``coordinator.build_diagnostic_data()``), and
+3. the stale ``DIAG_CACHE_KEY`` snapshot cached in ``hass.data``.
+
+Every read yields a :class:`DiagnosticsRead` (``payload`` + ``source`` +
+``error``) so callers see which surface answered without re-deriving it. Unlike
+the pure ``triage.py`` engine, this module sits at the HA boundary and may import
+Home Assistant collaborators.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ..const import DIAG_CACHE_KEY
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticsRead:
+    """The outcome of a read-only diagnostics resolution.
+
+    ``source`` is one of ``"coordinator"`` (live ``coordinator.data``),
+    ``"built"`` (a read-only rebuild), ``"cache"`` (the stale snapshot), or
+    ``"unavailable"`` (nothing answered / a rebuild raised). ``error`` carries a
+    formatted message only when a rebuild raised.
+    """
+
+    payload: dict | None
+    source: str
+    error: str | None = None
+
+
+def read_from_coordinator(coord) -> DiagnosticsRead:
+    """Read a coordinator's diagnostics without ever running an update cycle.
+
+    Prefers the last completed cycle's ``coord.data.diagnostics``; when
+    ``coord.data`` is ``None`` (no completed cycle yet) falls back to a read-only
+    ``build_diagnostic_data()``. A rebuild that raises is wrapped into a
+    :class:`DiagnosticsRead` with a populated ``error`` (never propagates).
+    """
+    if coord.data is not None:
+        return DiagnosticsRead(coord.data.diagnostics, "coordinator")
+    try:
+        return DiagnosticsRead(coord.build_diagnostic_data(), "built")
+    except Exception as exc:  # noqa: BLE001 - a bad build must not break the read
+        return DiagnosticsRead(None, "unavailable", f"diagnostics_unavailable: {exc!r}")
+
+
+def read_diagnostics(hass: HomeAssistant, entry_id: str) -> DiagnosticsRead:
+    """Resolve read-only diagnostics for ``entry_id``.
+
+    Resolves the cover coordinator via :func:`..services.cover_coordinators`
+    (groups/profiles are filtered out there) and delegates to
+    :func:`read_from_coordinator`. With no live coordinator, falls back to the
+    stale ``DIAG_CACHE_KEY`` snapshot (source ``"cache"``); when even that is
+    absent the source is ``"unavailable"``.
+    """
+    from ..services import cover_coordinators  # noqa: PLC0415 - avoid import cycle
+
+    coord = cover_coordinators(hass).get(entry_id)
+    if coord is not None:
+        return read_from_coordinator(coord)
+    cached = hass.data.get(DIAG_CACHE_KEY, {}).get(entry_id, {}).get("diagnostics")
+    if cached is not None:
+        return DiagnosticsRead(cached, "cache")
+    return DiagnosticsRead(None, "unavailable")

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 from enum import Enum, Flag, auto
 
 from ..const import (
+    BLANK_TIME,
     CONF_CLIMATE_MODE,
     CONF_ENABLE_MIN_POSITION,
     CONF_END_TIME,
@@ -48,6 +49,7 @@ from ..const import (
     TriageCode,
 )
 from ..reason_i18n import Reason, render
+from ..troubleshoot_i18n import load_troubleshoot_labels
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -183,13 +185,18 @@ def render_report(
     """Render ``findings`` as a bullet list, one line per finding.
 
     Each bullet is a plain ``- `` marker plus the reason rendered through
-    :func:`..reason_i18n.render` against ``labels`` (the troubleshoot bundle,
-    or English when ``None``). No severity icon is prepended — every triage
-    template already leads with its own severity emoji, so prepending one here
-    would double it. Deliberately minimal — the troubleshoot step owns richer
-    presentation; this exists so both surfaces share one renderer.
+    :func:`..reason_i18n.render` against ``labels`` (a translated troubleshoot
+    bundle). When ``labels`` is ``None`` the English troubleshoot templates
+    (:func:`..troubleshoot_i18n.load_troubleshoot_labels` for ``"en"`` — I/O-free)
+    are used, so a triage finding renders its English prose rather than the raw
+    ``triage.*`` code string (``reason_i18n``'s own English table has no triage
+    codes). No severity icon is prepended — every triage template already leads
+    with its own severity emoji, so prepending one here would double it.
+    Deliberately minimal — the troubleshoot step owns richer presentation; this
+    exists so both surfaces share one renderer.
     """
-    return "\n".join(f"- {render(finding.reason, labels)}" for finding in findings)
+    active = labels if labels is not None else load_troubleshoot_labels("en")
+    return "\n".join(f"- {render(finding.reason, active)}" for finding in findings)
 
 
 # ---------------------------------------------------------------------------
@@ -313,24 +320,37 @@ def _check_higher_priority_won(data: Mapping) -> Iterable[Mapping]:
 
 
 def _check_time_window_suspect(data: Mapping) -> Iterable[Mapping]:
-    """Rule 3 — the active-window schedule looks misconfigured."""
+    """Rule 3 — the active-window schedule looks misconfigured.
+
+    Two genuinely-suspect signals: a start bound driven by a sun sensor
+    (``sensor.sun_next_*``), or an inverted window (start after end) with *real*
+    clock times. ``BLANK_TIME`` (``"00:00:00"``) is the UNSET / all-day sentinel
+    — a legacy entry carrying it tracks all day legitimately, so it is never
+    flagged on its own nor treated as a real bound in the start>end comparison
+    (issue #970, MINOR 6).
+    """
     options = _get(data, "options")
     if not isinstance(options, Mapping):
         return
     start_entity = options.get(CONF_START_ENTITY)
     start_time = options.get(CONF_START_TIME)
     end_time = options.get(CONF_END_TIME)
-    suspect = (
-        (isinstance(start_entity, str) and start_entity.startswith("sensor.sun_next_"))
-        or start_time == "00:00:00"
-        or (
-            isinstance(start_time, str)
-            and isinstance(end_time, str)
-            and start_time > end_time
-        )
+
+    sun_sensor_start = isinstance(start_entity, str) and start_entity.startswith(
+        "sensor.sun_next_"
     )
-    if suspect:
-        yield {"start": start_entity or start_time, "end": end_time}
+    real_start = isinstance(start_time, str) and start_time != BLANK_TIME
+    real_end = isinstance(end_time, str) and end_time != BLANK_TIME
+    inverted = real_start and real_end and start_time > end_time
+
+    if not (sun_sensor_start or inverted):
+        return
+
+    # MINOR 8: never render "end None" — fall back to the all-day sentinel when
+    # the end bound is unset/missing so the message stays sensible.
+    start_display = start_entity if sun_sensor_start else start_time
+    end_display = end_time if real_end else BLANK_TIME
+    yield {"start": start_display, "end": end_display}
 
 
 def _check_climate_temp_none(data: Mapping) -> Iterable[Mapping]:
@@ -561,8 +581,13 @@ TRIAGE_RULES: tuple[TriageRule, ...] = (
     TriageRule(
         code=TriageCode.ENTITY_UNAVAILABLE,
         severity=Severity.WARNING,
+        # No fix_step: an unavailable entity is an HA-side condition (the entity
+        # itself is down) and 8b fires for heterogeneous entities — local
+        # sensors AND cover entities — so no single ACP options step fixes it.
+        # The finding names the entity; the troubleshoot step drops a None
+        # fix_step from its menu, so nothing broken is routed.
         inputs=RuleInput.RUNTIME,
-        fix_step="profile_sensors",
+        fix_step=None,
         wiki="Troubleshooting#unavailable-entities",
         issues=(549, 953),
         check=_check_entity_unavailable,

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -1,0 +1,596 @@
+"""Declarative diagnostics-triage engine (issue #970, Phase 1).
+
+A cover's diagnostics payload plus its raw config options and per-entity
+capabilities are folded into a single *view* mapping; :func:`run_triage` walks a
+declarative :data:`TRIAGE_RULES` table and turns matches into :class:`Finding`
+objects. Each finding carries a :class:`~..reason_i18n.Reason` (``code`` +
+``params``) rendered through the shared :func:`..reason_i18n.render` against the
+``troubleshoot_i18n`` bundle — one renderer, never a second formatter — plus a
+severity and the options-flow step that fixes it.
+
+The ``inputs`` flag on each rule (CONFIG / RUNTIME) is the Phase-2 seam: the
+config summary and setup wizard pass ``only=RuleInput.CONFIG`` (config-only,
+coordinator-free, deterministic); the troubleshooter passes ``None`` (everything).
+
+Pure module: stdlib + project constants only, no ``homeassistant`` import and no
+``config_flow`` import (mirrors the engine's 0-HA-imports constraint and
+``reason_i18n`` — the epic's explicit anti-dependency-inversion rule so the
+English templates are never pulled from ``config_flow``). It does NOT branch on
+the cover-type string (CODING_GUIDELINES § cover-type boundary).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from enum import Enum, Flag, auto
+
+from ..const import (
+    CONF_CLIMATE_MODE,
+    CONF_ENABLE_MIN_POSITION,
+    CONF_END_TIME,
+    CONF_IRRADIANCE_ENTITY,
+    CONF_IS_SUNNY_SENSOR,
+    CONF_IS_SUNNY_TEMPLATE,
+    CONF_LUX_ENTITY,
+    CONF_MIN_POSITION,
+    CONF_PRESENCE_ENTITY,
+    CONF_PRESENCE_TEMPLATE,
+    CONF_START_ENTITY,
+    CONF_START_TIME,
+    CONF_SUNSET_POS,
+    CONF_TRANSPARENT_BLIND,
+    CONF_WEATHER_ENTITY,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    CUSTOM_POSITION_SLOTS,
+    DEFAULT_CUSTOM_POSITION_PRIORITY,
+    TriageCode,
+)
+from ..reason_i18n import Reason, render
+
+_LOGGER = logging.getLogger(__name__)
+
+# Pipeline handler name strings surfaced in the diagnostics ``decision_trace`` /
+# ``handler_priorities`` sections (``OverrideHandler.name``). Named here rather
+# than imported because ``pipeline.handlers`` pulls Home Assistant — this module
+# stays HA-free. These are handler identifiers, NOT cover-type strings.
+_SOLAR_HANDLER = "solar"
+_CLIMATE_HANDLER = "climate"
+
+# Sub-keys of a custom-position slot that count as an axis claim (mirrors
+# ``helpers.CUSTOM_POSITION_CLAIM_KEYS`` — duplicated because that module imports
+# Home Assistant and this one may not; see module docstring).
+_CLAIM_KEYS: tuple[str, ...] = ("position", "position_max", "tilt_min", "tilt_max")
+
+
+# ---------------------------------------------------------------------------
+# Engine shapes
+# ---------------------------------------------------------------------------
+
+
+class Severity(Enum):
+    """Ordered severity of a triage finding."""
+
+    CRITICAL = "critical"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class RuleInput(Flag):
+    """Which data surface a rule reads — the config/runtime Phase-2 seam."""
+
+    CONFIG = auto()
+    RUNTIME = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One rendered triage result: a reason payload + severity + fix target."""
+
+    reason: Reason
+    severity: Severity
+    fix_step: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TriageRule:
+    """A declarative rule: metadata plus a ``check`` yielding param dicts.
+
+    ``check`` receives the view mapping and yields zero or more param dicts —
+    one :class:`Finding` per yielded dict (per-entity rules emit N, single-shot
+    rules emit 0 or 1). Every read inside a check goes through :func:`_get` so an
+    absent input yields nothing instead of raising.
+    """
+
+    code: str
+    severity: Severity
+    inputs: RuleInput
+    fix_step: str | None
+    wiki: str
+    issues: tuple[int, ...]
+    check: Callable[[Mapping], Iterable[Mapping]]
+
+
+# ---------------------------------------------------------------------------
+# Dotted accessor
+# ---------------------------------------------------------------------------
+
+
+def _get(data: Mapping, path: str) -> object:
+    """Return ``data`` walked by dotted ``path``, or ``None`` on any miss.
+
+    A missing key or a non-mapping segment yields ``None`` (never raises) so a
+    check reading an absent diagnostics section simply produces no finding.
+    Falsy leaf values (``0``/``False``/``""``) pass through unchanged.
+    """
+    node: object = data
+    for segment in path.split("."):
+        if not isinstance(node, Mapping):
+            return None
+        node = node.get(segment)
+        if node is None:
+            return None
+    return node
+
+
+# ---------------------------------------------------------------------------
+# run_triage
+# ---------------------------------------------------------------------------
+
+
+def run_triage(
+    data: Mapping,
+    *,
+    only: RuleInput | None = None,
+    rules: Iterable[TriageRule] | None = None,
+) -> list[Finding]:
+    """Evaluate ``rules`` (default :data:`TRIAGE_RULES`) against ``data``.
+
+    With ``only`` set, a rule is kept iff every one of its input flags is in
+    ``only`` (subset semantics): ``only=RuleInput.CONFIG`` drops both RUNTIME and
+    mixed ``CONFIG|RUNTIME`` rows. A check that raises is logged and skipped —
+    the contract is that ``run_triage`` never propagates and ``run_triage({})``
+    returns ``[]``.
+    """
+    active = TRIAGE_RULES if rules is None else rules
+    findings: list[Finding] = []
+    for rule in active:
+        if only is not None and (rule.inputs & only) != rule.inputs:
+            continue
+        try:
+            for params in rule.check(data):
+                findings.append(
+                    Finding(
+                        Reason(rule.code, dict(params)),
+                        rule.severity,
+                        rule.fix_step,
+                    )
+                )
+        except Exception:  # noqa: BLE001 - a bad rule must never break triage
+            _LOGGER.exception("triage rule %s check failed", rule.code)
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Renderer (minimal; reuses reason_i18n.render, never a second formatter)
+# ---------------------------------------------------------------------------
+
+_SEVERITY_ICON: dict[Severity, str] = {
+    Severity.CRITICAL: "🛑",
+    Severity.WARNING: "⚠️",
+    Severity.INFO: "ℹ️",
+}
+
+
+def render_report(
+    findings: Iterable[Finding], labels: Mapping[str, str] | None = None
+) -> str:
+    """Render ``findings`` as a bullet list, one line per finding.
+
+    Each bullet is a severity icon + the reason rendered through
+    :func:`..reason_i18n.render` against ``labels`` (the troubleshoot bundle,
+    or English when ``None``). Deliberately minimal — the troubleshoot step
+    owns richer presentation; this exists so both surfaces share one renderer.
+    """
+    lines = []
+    for finding in findings:
+        icon = _SEVERITY_ICON.get(finding.severity, "")
+        lines.append(f"{icon} {render(finding.reason, labels)}".strip())
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Shared rule helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_template(value: object) -> bool:
+    """Return True when ``value`` carries Jinja2 markup (mirrors templates.py)."""
+    return isinstance(value, str) and ("{{" in value or "{%" in value)
+
+
+def _slot_sensors(options: Mapping, keys: Mapping[str, str]) -> list[str]:
+    """Return a custom-position slot's trigger sensors (mirrors helpers.py)."""
+    sensors = options.get(keys["sensors"])
+    if sensors is not None:
+        return [s for s in sensors if s]
+    legacy = options.get(keys["sensor"])
+    return [legacy] if legacy else []
+
+
+def _slot_has_trigger(options: Mapping, keys: Mapping[str, str]) -> bool:
+    """Return True when a slot has at least one sensor or a template trigger."""
+    return bool(_slot_sensors(options, keys)) or _is_template(
+        options.get(keys["template"])
+    )
+
+
+def _slot_configured(options: Mapping, keys: Mapping[str, str]) -> bool:
+    """Return True when a slot has a trigger AND an axis claim (mirrors helpers.py)."""
+    if not _slot_has_trigger(options, keys):
+        return False
+    return any(options.get(keys[sub]) is not None for sub in _CLAIM_KEYS)
+
+
+def _iter_custom_slots(
+    options: Mapping,
+) -> Iterable[tuple[int, Mapping[str, str]]]:
+    """Yield ``(slot_number, slot_keys)`` for every configured custom slot.
+
+    Shared by rules 1 and 9 — the single place that walks slots 1–10 and gates
+    on ``_slot_configured`` so both agree on which slots participate.
+    """
+    for num, keys in CUSTOM_POSITION_SLOTS.items():
+        if _slot_configured(options, keys):
+            yield num, keys
+
+
+def _trace_step(data: Mapping, handler: str) -> Mapping | None:
+    """Return the first ``decision_trace`` step for ``handler``, or ``None``."""
+    trace = _get(data, "decision_trace")
+    if not isinstance(trace, list):
+        return None
+    for step in trace:
+        if isinstance(step, Mapping) and step.get("handler") == handler:
+            return step
+    return None
+
+
+def _handler_priority(data: Mapping, handler: str) -> int | None:
+    """Return the effective priority of ``handler`` from ``handler_priorities``."""
+    value = _get(data, f"handler_priorities.{handler}.priority")
+    return value if isinstance(value, int) else None
+
+
+# ---------------------------------------------------------------------------
+# Seed rule checks (rows 1,2,3,4,5,6,7,8a,8b,9,10)
+# ---------------------------------------------------------------------------
+
+
+def _check_custom_safety_bypass(data: Mapping) -> Iterable[Mapping]:
+    """Rule 1 — a configured custom slot at safety priority bypasses every gate."""
+    options = _get(data, "options")
+    if not isinstance(options, Mapping):
+        return
+    for num, keys in _iter_custom_slots(options):
+        priority = int(
+            options.get(keys["priority"]) or DEFAULT_CUSTOM_POSITION_PRIORITY
+        )
+        if priority >= CUSTOM_POSITION_SAFETY_PRIORITY:
+            yield {"slot": num, "safety": CUSTOM_POSITION_SAFETY_PRIORITY}
+
+
+def _check_higher_priority_won(data: Mapping) -> Iterable[Mapping]:
+    """Rule 2 — a handler above solar won the cycle; solar never had a say."""
+    trace = _get(data, "decision_trace")
+    if not isinstance(trace, list):
+        return
+    winner = next(
+        (
+            step
+            for step in trace
+            if isinstance(step, Mapping) and step.get("matched") is True
+        ),
+        None,
+    )
+    if winner is None:
+        return
+    winner_name = winner.get("handler")
+    if winner_name == _SOLAR_HANDLER:
+        return
+    solar_priority = _handler_priority(data, _SOLAR_HANDLER)
+    winner_priority = _handler_priority(data, winner_name)
+    if (
+        solar_priority is None
+        or winner_priority is None
+        or winner_priority <= solar_priority
+    ):
+        return
+    priorities = _get(data, "handler_priorities")
+    lower = []
+    if isinstance(priorities, Mapping):
+        lower = sorted(
+            name
+            for name, row in priorities.items()
+            if isinstance(row, Mapping)
+            and isinstance(row.get("priority"), int)
+            and row["priority"] < winner_priority
+        )
+    yield {"winner": winner_name, "skipped": ", ".join(lower) or "none"}
+
+
+def _check_time_window_suspect(data: Mapping) -> Iterable[Mapping]:
+    """Rule 3 — the active-window schedule looks misconfigured."""
+    options = _get(data, "options")
+    if not isinstance(options, Mapping):
+        return
+    start_entity = options.get(CONF_START_ENTITY)
+    start_time = options.get(CONF_START_TIME)
+    end_time = options.get(CONF_END_TIME)
+    suspect = (
+        (isinstance(start_entity, str) and start_entity.startswith("sensor.sun_next_"))
+        or start_time == "00:00:00"
+        or (
+            isinstance(start_time, str)
+            and isinstance(end_time, str)
+            and start_time > end_time
+        )
+    )
+    if suspect:
+        yield {"start": start_entity or start_time, "end": end_time}
+
+
+def _check_climate_temp_none(data: Mapping) -> Iterable[Mapping]:
+    """Rule 4 — climate mode on but the inside temperature is unavailable."""
+    details = _get(data, "temperature_details")
+    if isinstance(details, Mapping) and details.get("inside_temperature") is None:
+        yield {}
+
+
+def _check_summer_wont_close(data: Mapping) -> Iterable[Mapping]:
+    """Rule 5 — summer + presence, blind isn't transparent, yet climate didn't act."""
+    options = _get(data, "options")
+    conditions = _get(data, "climate_conditions")
+    if not isinstance(options, Mapping) or not isinstance(conditions, Mapping):
+        return
+    if not (conditions.get("is_summer") and conditions.get("is_presence")):
+        return
+    if options.get(CONF_TRANSPARENT_BLIND):
+        return
+    climate_step = _trace_step(data, _CLIMATE_HANDLER)
+    if climate_step is not None and climate_step.get("matched") is False:
+        yield {}
+
+
+def _check_presence_defaults_true(data: Mapping) -> Iterable[Mapping]:
+    """Rule 6 — climate mode on with no presence entity/template (defaults present)."""
+    options = _get(data, "options")
+    if not isinstance(options, Mapping):
+        return
+    if not options.get(CONF_CLIMATE_MODE):
+        return
+    if options.get(CONF_PRESENCE_ENTITY) or _is_template(
+        options.get(CONF_PRESENCE_TEMPLATE)
+    ):
+        return
+    yield {}
+
+
+def _check_cloud_or_semantics(data: Mapping) -> Iterable[Mapping]:
+    """Rule 7 — more than one cloud/low-light input; OR semantics may surprise."""
+    options = _get(data, "options")
+    if not isinstance(options, Mapping):
+        return
+    configured = [
+        label
+        for label, present in (
+            ("lux", bool(options.get(CONF_LUX_ENTITY))),
+            ("irradiance", bool(options.get(CONF_IRRADIANCE_ENTITY))),
+            (
+                "weather",
+                bool(options.get(CONF_IS_SUNNY_SENSOR))
+                or _is_template(options.get(CONF_IS_SUNNY_TEMPLATE))
+                or bool(options.get(CONF_WEATHER_ENTITY)),
+            ),
+        )
+        if present
+    ]
+    if len(configured) <= 1:
+        return
+    conditions = _get(data, "climate_conditions")
+    tripped: list[str] = []
+    if isinstance(conditions, Mapping):
+        tripped = [
+            label
+            for label, key in (
+                ("lux below threshold", "lux_below_threshold"),
+                ("irradiance below threshold", "irradiance_below_threshold"),
+                ("cloud coverage above threshold", "cloud_coverage_above_threshold"),
+                ("not sunny", "is_sunny"),
+            )
+            if (
+                conditions.get(key) is False
+                if key == "is_sunny"
+                else conditions.get(key)
+            )
+        ]
+    yield {
+        "inputs": ", ".join(configured),
+        "tripped": ", ".join(tripped) or "none",
+    }
+
+
+def _check_cover_not_ready(data: Mapping) -> Iterable[Mapping]:
+    """Rule 8a — a configured cover reported no capabilities (unavailable)."""
+    capabilities = _get(data, "capabilities")
+    if not isinstance(capabilities, Mapping):
+        return
+    for eid, caps in capabilities.items():
+        if caps is None:
+            yield {"eid": eid}
+
+
+def _check_entity_unavailable(data: Mapping) -> Iterable[Mapping]:
+    """Rule 8b — a configured sensor or cover entity is currently unavailable."""
+    for section in ("local_sensors", "building_profile_sensors"):
+        sensors = _get(data, section)
+        if isinstance(sensors, list):
+            for descriptor in sensors:
+                if (
+                    isinstance(descriptor, Mapping)
+                    and descriptor.get("state") == "unavailable"
+                    and descriptor.get("entity_id")
+                ):
+                    yield {"eid": descriptor["entity_id"]}
+    covers = _get(data, "covers")
+    if isinstance(covers, Mapping):
+        for eid, cover in covers.items():
+            if isinstance(cover, Mapping) and cover.get("available") is False:
+                yield {"eid": eid}
+
+
+def _check_min_floor_bypassed(data: Mapping) -> Iterable[Mapping]:
+    """Rule 9 — a min-position floor is undercut by a lower fixed position."""
+    options = _get(data, "options")
+    if not isinstance(options, Mapping):
+        return
+    min_position = options.get(CONF_MIN_POSITION)
+    if not isinstance(min_position, int) or min_position <= 0:
+        return
+    offenders: list[str] = []
+    sunset = options.get(CONF_SUNSET_POS)
+    if isinstance(sunset, int) and sunset < min_position:
+        offenders.append("sunset position")
+    for num, keys in _iter_custom_slots(options):
+        pos = options.get(keys["position"])
+        if (
+            isinstance(pos, int)
+            and pos < min_position
+            and not options.get(keys["use_my"])
+            and not options.get(keys["min_mode"])
+        ):
+            offenders.append(f"Custom #{num}")
+    if offenders:
+        yield {"min": min_position, "offenders": ", ".join(offenders)}
+
+
+def _check_enable_min_backwards(data: Mapping) -> Iterable[Mapping]:
+    """Rule 10 — enable_min_position False (only-while-tracking) with a floor set."""
+    options = _get(data, "options")
+    if not isinstance(options, Mapping):
+        return
+    min_position = options.get(CONF_MIN_POSITION)
+    if (
+        options.get(CONF_ENABLE_MIN_POSITION) is False
+        and isinstance(min_position, int)
+        and min_position > 0
+    ):
+        yield {"min": min_position}
+
+
+# ---------------------------------------------------------------------------
+# The rule table
+# ---------------------------------------------------------------------------
+
+TRIAGE_RULES: tuple[TriageRule, ...] = (
+    TriageRule(
+        code=TriageCode.CUSTOM_SAFETY_BYPASS,
+        severity=Severity.WARNING,
+        inputs=RuleInput.CONFIG,
+        fix_step="custom_position",
+        wiki="Configuration-Custom-Positions#safety-priority",
+        issues=(711, 716),
+        check=_check_custom_safety_bypass,
+    ),
+    TriageRule(
+        code=TriageCode.HIGHER_PRIORITY_WON,
+        severity=Severity.INFO,
+        inputs=RuleInput.RUNTIME,
+        fix_step="pipeline_priorities",
+        wiki="Pipeline-Priorities#priority-order",
+        issues=(953,),
+        check=_check_higher_priority_won,
+    ),
+    TriageRule(
+        code=TriageCode.TIME_WINDOW_SUSPECT,
+        severity=Severity.WARNING,
+        inputs=RuleInput.CONFIG,
+        fix_step="automation",
+        wiki="Configuration-Common#time-window",
+        issues=(953,),
+        check=_check_time_window_suspect,
+    ),
+    TriageRule(
+        code=TriageCode.CLIMATE_TEMP_NONE,
+        severity=Severity.WARNING,
+        inputs=RuleInput.RUNTIME,
+        fix_step="temperature_climate",
+        wiki="Configuration-Climate#temperature-sensor",
+        issues=(953,),
+        check=_check_climate_temp_none,
+    ),
+    TriageRule(
+        code=TriageCode.SUMMER_WONT_CLOSE,
+        severity=Severity.WARNING,
+        inputs=RuleInput.CONFIG | RuleInput.RUNTIME,
+        fix_step="temperature_climate",
+        wiki="Configuration-Climate#summer-close",
+        issues=(953,),
+        check=_check_summer_wont_close,
+    ),
+    TriageRule(
+        code=TriageCode.PRESENCE_DEFAULTS_TRUE,
+        severity=Severity.INFO,
+        inputs=RuleInput.CONFIG,
+        fix_step="temperature_climate",
+        wiki="Configuration-Climate#presence",
+        issues=(953,),
+        check=_check_presence_defaults_true,
+    ),
+    TriageRule(
+        code=TriageCode.CLOUD_OR_SEMANTICS,
+        severity=Severity.INFO,
+        inputs=RuleInput.CONFIG | RuleInput.RUNTIME,
+        fix_step="light_cloud",
+        wiki="Configuration-Common#cloud-suppression",
+        issues=(953,),
+        check=_check_cloud_or_semantics,
+    ),
+    TriageRule(
+        code=TriageCode.COVER_NOT_READY,
+        severity=Severity.WARNING,
+        inputs=RuleInput.CONFIG,
+        fix_step="cover_entities",
+        wiki="Troubleshooting#cover-not-ready",
+        issues=(953,),
+        check=_check_cover_not_ready,
+    ),
+    TriageRule(
+        code=TriageCode.ENTITY_UNAVAILABLE,
+        severity=Severity.WARNING,
+        inputs=RuleInput.RUNTIME,
+        fix_step="profile_sensors",
+        wiki="Troubleshooting#unavailable-entities",
+        issues=(549, 953),
+        check=_check_entity_unavailable,
+    ),
+    TriageRule(
+        code=TriageCode.MIN_FLOOR_BYPASSED,
+        severity=Severity.WARNING,
+        inputs=RuleInput.CONFIG,
+        fix_step="position",
+        wiki="Configuration-Common#min-position",
+        issues=(953,),
+        check=_check_min_floor_bypassed,
+    ),
+    TriageRule(
+        code=TriageCode.ENABLE_MIN_BACKWARDS,
+        severity=Severity.INFO,
+        inputs=RuleInput.CONFIG,
+        fix_step="position",
+        wiki="Configuration-Common#enable-min-position",
+        issues=(953,),
+        check=_check_enable_min_backwards,
+    ),
+)

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -176,28 +176,20 @@ def run_triage(
 # Renderer (minimal; reuses reason_i18n.render, never a second formatter)
 # ---------------------------------------------------------------------------
 
-_SEVERITY_ICON: dict[Severity, str] = {
-    Severity.CRITICAL: "🛑",
-    Severity.WARNING: "⚠️",
-    Severity.INFO: "ℹ️",
-}
-
 
 def render_report(
     findings: Iterable[Finding], labels: Mapping[str, str] | None = None
 ) -> str:
     """Render ``findings`` as a bullet list, one line per finding.
 
-    Each bullet is a severity icon + the reason rendered through
+    Each bullet is a plain ``- `` marker plus the reason rendered through
     :func:`..reason_i18n.render` against ``labels`` (the troubleshoot bundle,
-    or English when ``None``). Deliberately minimal — the troubleshoot step
-    owns richer presentation; this exists so both surfaces share one renderer.
+    or English when ``None``). No severity icon is prepended — every triage
+    template already leads with its own severity emoji, so prepending one here
+    would double it. Deliberately minimal — the troubleshoot step owns richer
+    presentation; this exists so both surfaces share one renderer.
     """
-    lines = []
-    for finding in findings:
-        icon = _SEVERITY_ICON.get(finding.severity, "")
-        lines.append(f"{icon} {render(finding.reason, labels)}".strip())
-    return "\n".join(lines)
+    return "\n".join(f"- {render(finding.reason, labels)}" for finding in findings)
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/adaptive_cover_pro/services/diagnostics_service.py
+++ b/custom_components/adaptive_cover_pro/services/diagnostics_service.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from ..const import DOMAIN
 from ..diagnostics import _sanitize
+from ..diagnostics.resolve import read_from_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -68,21 +69,18 @@ async def async_handle_get_diagnostics(call: ServiceCall) -> dict:
 
     entries: dict[str, dict] = {}
     for entry_id, coord in coords_by_entry.items():
-        diag: dict | None = None
-
-        if coord.data is not None:
-            diag = coord.data.diagnostics
+        # Read-only resolution (prefers coord.data, else a live build) — never an
+        # update cycle. Unified with the download path via diagnostics.resolve.
+        read = read_from_coordinator(coord)
+        if read.error is not None:
+            _LOGGER.warning(
+                "get_diagnostics: could not build diagnostics for %s: %s",
+                entry_id,
+                read.error,
+            )
+            diag: dict | None = {"error": read.error}
         else:
-            # First refresh hasn't completed yet — try a live build
-            try:
-                diag = coord.build_diagnostic_data()
-            except Exception as exc:  # noqa: BLE001
-                _LOGGER.warning(
-                    "get_diagnostics: could not build diagnostics for %s: %s",
-                    entry_id,
-                    exc,
-                )
-                diag = {"error": f"diagnostics_unavailable: {exc!r}"}
+            diag = read.payload
 
         last_success_time = coord._last_update_success_time  # noqa: SLF001
         entries[entry_id] = {

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -82,7 +82,6 @@
     "somfy_my_unset": "⚠️ Somfy My-Preset ist für ein oder mehrere Ziele aktiviert, aber My Preset Value ist nicht gesetzt — fällt auf konfiguriertes % zurück.",
     "proxy_no_min": "⚠️ Proxy-Beschattung ist aktiviert, aber kein benutzerdefinierter Positionsslot hat Als Minimum verwenden aktiviert — die verwaltete Beschattung wird nicht begrenzt.",
     "custom_and_no_sensors": "⚠️ Benutzerdefiniert #{slot}: Kombinationsmodus UND ist gesetzt, aber keine Auslösesensoren konfiguriert — das Template allein aktiviert den Slot.",
-    "custom_safety_bypass": "⚠️ Benutzerdefiniert #{slot} hat Sicherheitspriorität ({safety}) – umgeht den Schalter für die automatische Steuerung, die manuelle Übersteuerung und das Start-/Endzeitfenster, kann die Beschattung also auch dann bewegen, wenn die automatische Steuerung AUS ist und außerhalb Ihres Zeitplans. Senken Sie seine Priorität unter {safety}, um diese Gates einzuhalten.",
     "group_empty": "⚠️ Diese Gruppe hat keine Mitglieder – sie wird nichts steuern.",
     "forecast_source_no_weather_entity": "⚠️ Außentemperaturquelle basiert auf Vorhersage, aber es ist keine Wetter-Entität konfiguriert — die Vorhersage wird stillschweigend auf den Live-Messwert zurückfallen. Konfigurieren Sie eine Wetter-Entität unter Wetter, Licht & Wolken."
   },

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -82,7 +82,6 @@
     "somfy_my_unset": "⚠️ Somfy My preset is enabled for one or more targets but My Preset Value is not set — falls back to configured %.",
     "proxy_no_min": "⚠️ Proxy cover is enabled but no custom-position slot has Use as minimum on — the managed cover will not clamp.",
     "custom_and_no_sensors": "⚠️ Custom #{slot}: combine mode AND is set but no trigger sensors are configured — the template alone activates the slot.",
-    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
     "group_empty": "⚠️ This group has no members — it will not command anything.",
     "forecast_source_no_weather_entity": "⚠️ Outdoor-temperature source is forecast-based but no weather entity is configured — the forecast will silently fall back to the live reading. Configure a weather entity in Weather, Light & Cloud."
   },

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -82,7 +82,6 @@
     "somfy_my_unset": "⚠️ Préréglage Somfy My est activé pour une ou plusieurs cibles mais Valeur du préréglage My n'est pas définie — revient au % configuré.",
     "proxy_no_min": "⚠️ Store mandataire est activé mais aucun emplacement de position personnalisée n'a Utiliser comme minimum activé — le store géré ne limitera pas.",
     "custom_and_no_sensors": "⚠️ Personnalisé #{slot} : le mode de combinaison ET est défini mais aucun capteur déclencheur n'est configuré — le template seul active le slot.",
-    "custom_safety_bypass": "⚠️ L'emplacement personnalisé #{slot} est à la priorité de sécurité ({safety}) — il contourne l'interrupteur de contrôle automatique, la dérogation manuelle et la fenêtre horaire de début/fin, pour que le store puisse se déplacer même quand le contrôle automatique est DÉSACTIVÉ et en dehors de votre horaire. Réduisez sa priorité en dessous de {safety} pour qu'elle respecte ces seuils.",
     "group_empty": "⚠️ Ce groupe n'a pas de membres — il ne commandera rien.",
     "forecast_source_no_weather_entity": "⚠️ La source de température extérieure est basée sur les prévisions mais aucune entité météo n'est configurée — les prévisions vont silencieusement revenir au relevé en direct. Configurez une entité météo dans Météo, lumière & nuages."
   },

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -288,7 +288,7 @@
           "motion_override": "🚶 Belegungserkennung",
           "weather_override": "🌧️ Wetter-Übersteuerung",
           "summary": "📋 Konfigurationszusammenfassung",
-          "troubleshoot": "🩺 Troubleshoot",
+          "troubleshoot": "🩺 Fehlerbehebung",
           "sync": "🔄 In andere Beschattungen kopieren",
           "debug": "🔍 Debug und Diagnose",
           "done": "✅ Speichern und schließen",
@@ -661,19 +661,19 @@
         "description": "{summary}"
       },
       "troubleshoot": {
-        "title": "Troubleshoot",
+        "title": "Fehlerbehebung",
         "description": "{report}",
         "menu_options": {
-          "custom_position": "🎯 Custom Positions",
-          "pipeline_priorities": "🔀 Handler Priorities",
-          "automation": "⏱️ Movement & Schedule",
-          "temperature_climate": "🌡️ Temperature & Climate",
-          "light_cloud": "☁️ Weather, Light & Cloud",
-          "cover_entities": "🪟 Covers & Device",
-          "profile_sensors": "📡 Shared Sensors",
-          "position": "📊 Position Settings",
-          "troubleshoot": "🔁 Re-check",
-          "init": "⬅️ Back to menu"
+          "custom_position": "🎯 Benutzerdefinierte Positionen",
+          "pipeline_priorities": "🔀 Handler-Prioritäten",
+          "automation": "⏱️ Bewegung & Zeitplan",
+          "temperature_climate": "🌡️ Temperatur und Klima",
+          "light_cloud": "☁️ Wetter, Licht & Wolken",
+          "cover_entities": "🪟 Beschattungen & Gerät",
+          "profile_sensors": "📡 Gemeinsame Sensoren",
+          "position": "📊 Positionseinstellungen",
+          "troubleshoot": "🔁 Erneut prüfen",
+          "init": "⬅️ Zurück zum Menü"
         }
       },
       "debug": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -288,6 +288,7 @@
           "motion_override": "🚶 Belegungserkennung",
           "weather_override": "🌧️ Wetter-Übersteuerung",
           "summary": "📋 Konfigurationszusammenfassung",
+          "troubleshoot": "🩺 Troubleshoot",
           "sync": "🔄 In andere Beschattungen kopieren",
           "debug": "🔍 Debug und Diagnose",
           "done": "✅ Speichern und schließen",
@@ -658,6 +659,22 @@
       "summary": {
         "title": "Konfigurationszusammenfassung",
         "description": "{summary}"
+      },
+      "troubleshoot": {
+        "title": "Troubleshoot",
+        "description": "{report}",
+        "menu_options": {
+          "custom_position": "🎯 Custom Positions",
+          "pipeline_priorities": "🔀 Handler Priorities",
+          "automation": "⏱️ Movement & Schedule",
+          "temperature_climate": "🌡️ Temperature & Climate",
+          "light_cloud": "☁️ Weather, Light & Cloud",
+          "cover_entities": "🪟 Covers & Device",
+          "profile_sensors": "📡 Shared Sensors",
+          "position": "📊 Position Settings",
+          "troubleshoot": "🔁 Re-check",
+          "init": "⬅️ Back to menu"
+        }
       },
       "debug": {
         "title": "Debug & Diagnose",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -670,7 +670,6 @@
           "temperature_climate": "🌡️ Temperatur und Klima",
           "light_cloud": "☁️ Wetter, Licht & Wolken",
           "cover_entities": "🪟 Beschattungen & Gerät",
-          "profile_sensors": "📡 Gemeinsame Sensoren",
           "position": "📊 Positionseinstellungen",
           "troubleshoot": "🔁 Erneut prüfen",
           "init": "⬅️ Zurück zum Menü"

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -290,6 +290,7 @@
           "weather_override": "🌧️ Weather Override",
           "pipeline_priorities": "🔀 Handler Priorities",
           "summary": "📋 Configuration Summary",
+          "troubleshoot": "🩺 Troubleshoot",
           "sync": "🔄 Copy to Other Covers",
           "debug": "🔍 Debug & Diagnostics",
           "done": "✅ Save & Close",
@@ -710,6 +711,22 @@
       "summary": {
         "title": "Configuration Summary",
         "description": "{summary}"
+      },
+      "troubleshoot": {
+        "title": "Troubleshoot",
+        "description": "{report}",
+        "menu_options": {
+          "custom_position": "🎯 Custom Positions",
+          "pipeline_priorities": "🔀 Handler Priorities",
+          "automation": "⏱️ Movement & Schedule",
+          "temperature_climate": "🌡️ Temperature & Climate",
+          "light_cloud": "☁️ Weather, Light & Cloud",
+          "cover_entities": "🪟 Covers & Device",
+          "profile_sensors": "📡 Shared Sensors",
+          "position": "📊 Position Settings",
+          "troubleshoot": "🔁 Re-check",
+          "init": "⬅️ Back to menu"
+        }
       },
       "debug": {
         "title": "Debug & Diagnostics",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -722,7 +722,6 @@
           "temperature_climate": "🌡️ Temperature & Climate",
           "light_cloud": "☁️ Weather, Light & Cloud",
           "cover_entities": "🪟 Covers & Device",
-          "profile_sensors": "📡 Shared Sensors",
           "position": "📊 Position Settings",
           "troubleshoot": "🔁 Re-check",
           "init": "⬅️ Back to menu"

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -288,7 +288,7 @@
           "motion_override": "🚶 Détection d'occupation",
           "weather_override": "🌧️ Dérogation météo",
           "summary": "📋 Résumé de la configuration",
-          "troubleshoot": "🩺 Troubleshoot",
+          "troubleshoot": "🩺 Dépannage",
           "sync": "🔄 Copier vers d'autres stores",
           "debug": "🔍 Débogage et diagnostics",
           "done": "✅ Enregistrer et fermer",
@@ -661,19 +661,19 @@
         "description": "{summary}"
       },
       "troubleshoot": {
-        "title": "Troubleshoot",
+        "title": "Dépannage",
         "description": "{report}",
         "menu_options": {
-          "custom_position": "🎯 Custom Positions",
-          "pipeline_priorities": "🔀 Handler Priorities",
-          "automation": "⏱️ Movement & Schedule",
-          "temperature_climate": "🌡️ Temperature & Climate",
-          "light_cloud": "☁️ Weather, Light & Cloud",
-          "cover_entities": "🪟 Covers & Device",
-          "profile_sensors": "📡 Shared Sensors",
-          "position": "📊 Position Settings",
-          "troubleshoot": "🔁 Re-check",
-          "init": "⬅️ Back to menu"
+          "custom_position": "🎯 Positions personnalisées",
+          "pipeline_priorities": "🔀 Priorités des gestionnaires",
+          "automation": "⏱️ Mouvement & horaires",
+          "temperature_climate": "🌡️ Température et climat",
+          "light_cloud": "☁️ Météo, lumière & nuages",
+          "cover_entities": "🪟 Stores et appareil",
+          "profile_sensors": "📡 Capteurs partagés",
+          "position": "📊 Paramètres de position",
+          "troubleshoot": "🔁 Vérifier à nouveau",
+          "init": "⬅️ Retour au menu"
         }
       },
       "debug": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -670,7 +670,6 @@
           "temperature_climate": "🌡️ Température et climat",
           "light_cloud": "☁️ Météo, lumière & nuages",
           "cover_entities": "🪟 Stores et appareil",
-          "profile_sensors": "📡 Capteurs partagés",
           "position": "📊 Paramètres de position",
           "troubleshoot": "🔁 Vérifier à nouveau",
           "init": "⬅️ Retour au menu"

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -288,6 +288,7 @@
           "motion_override": "🚶 Détection d'occupation",
           "weather_override": "🌧️ Dérogation météo",
           "summary": "📋 Résumé de la configuration",
+          "troubleshoot": "🩺 Troubleshoot",
           "sync": "🔄 Copier vers d'autres stores",
           "debug": "🔍 Débogage et diagnostics",
           "done": "✅ Enregistrer et fermer",
@@ -658,6 +659,22 @@
       "summary": {
         "title": "Résumé de la configuration",
         "description": "{summary}"
+      },
+      "troubleshoot": {
+        "title": "Troubleshoot",
+        "description": "{report}",
+        "menu_options": {
+          "custom_position": "🎯 Custom Positions",
+          "pipeline_priorities": "🔀 Handler Priorities",
+          "automation": "⏱️ Movement & Schedule",
+          "temperature_climate": "🌡️ Temperature & Climate",
+          "light_cloud": "☁️ Weather, Light & Cloud",
+          "cover_entities": "🪟 Covers & Device",
+          "profile_sensors": "📡 Shared Sensors",
+          "position": "📊 Position Settings",
+          "troubleshoot": "🔁 Re-check",
+          "init": "⬅️ Back to menu"
+        }
       },
       "debug": {
         "title": "Débogage et diagnostics",

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n.py
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n.py
@@ -1,0 +1,120 @@
+"""Troubleshoot-finding i18n bundle (issue #970, Phase 1).
+
+The diagnostics-triage engine (:mod:`.diagnostics.triage`) emits a stable
+:class:`~.reason_i18n.Reason` payload (``code`` + ``params``) for every finding.
+This module owns:
+
+* ``_TRIAGE_TEMPLATES_EN`` — the English ``str.format`` template for every
+  :class:`~.const.TriageCode`. Rule 1's and rule 8a's templates are byte-identical
+  to the legacy config-summary strings they migrate off of.
+* :func:`load_troubleshoot_labels` / :func:`async_prime` — overlay the shipped
+  ``troubleshoot_i18n/<lang>.json`` bundle onto the English defaults (via the
+  shared :mod:`.i18n_bundle` loader), cached for the coordinator to prime once.
+
+A :class:`~.diagnostics.triage.Finding` renders through
+:func:`.reason_i18n.render` against these labels — one renderer, no second one.
+
+Pure module: stdlib only, no ``homeassistant`` import (mirrors ``reason_i18n``
+and the engine's 0-HA-imports constraint). ``async_prime`` merely offloads the
+sync loader to a passed-in hass executor; it imports nothing from Home Assistant.
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from pathlib import Path
+
+from .const import TriageCode
+from .i18n_bundle import load_bundle_overlay, merge_labels
+
+_TROUBLESHOOT_I18N_DIR = Path(__file__).parent / "troubleshoot_i18n"
+
+
+# ---------------------------------------------------------------------------
+# English templates (one str.format template per TriageCode)
+# ---------------------------------------------------------------------------
+
+_TRIAGE_TEMPLATES_EN: dict[str, str] = {
+    # Rule 1 — byte-identical to summary_i18n/en.json "warnings.custom_safety_bypass".
+    TriageCode.CUSTOM_SAFETY_BYPASS: (
+        "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the "
+        "automatic-control toggle, manual override, and the start/end time "
+        "window, so it can move the cover even when automatic control is OFF and "
+        "outside your schedule. Lower its priority below {safety} to make it "
+        "respect those gates."
+    ),
+    # Rule 2
+    TriageCode.HIGHER_PRIORITY_WON: (
+        "ℹ️ The {winner} handler outranks solar tracking and won this cycle, so "
+        "solar never set a position. Lower-priority handlers that did not run: "
+        "{skipped}. Adjust the handler priorities if solar should win."
+    ),
+    # Rule 3
+    TriageCode.TIME_WINDOW_SUSPECT: (
+        "⚠️ The active-window schedule looks off (start {start}, end {end}); the "
+        "cover may never track. Review the start and end times."
+    ),
+    # Rule 4
+    TriageCode.CLIMATE_TEMP_NONE: (
+        "⚠️ Climate mode is on but the inside temperature is unavailable, so "
+        "climate decisions cannot run. Check the configured temperature sensor."
+    ),
+    # Rule 5
+    TriageCode.SUMMER_WONT_CLOSE: (
+        "⚠️ It is summer with presence detected and the blind is not transparent, "
+        "yet the climate handler did not close it. Review the summer close "
+        "conditions and temperature thresholds."
+    ),
+    # Rule 6
+    TriageCode.PRESENCE_DEFAULTS_TRUE: (
+        "ℹ️ Climate mode is on but no presence entity or template is set, so "
+        "presence defaults to always-present. Add a presence sensor if occupancy "
+        "should gate climate control."
+    ),
+    # Rule 7
+    TriageCode.CLOUD_OR_SEMANTICS: (
+        "ℹ️ More than one low-light input is configured ({inputs}); they combine "
+        "with OR, so any one of them tripping suppresses tracking. Currently "
+        "tripped: {tripped}."
+    ),
+    # Rule 8a — byte-identical to config_flow.py:1216.
+    TriageCode.COVER_NOT_READY: "⚠️ {eid}: not ready (unavailable)",
+    # Rule 8b
+    TriageCode.ENTITY_UNAVAILABLE: (
+        "⚠️ {eid} is unavailable — the integration cannot read its state. Check "
+        "the device or the sensor."
+    ),
+    # Rule 9
+    TriageCode.MIN_FLOOR_BYPASSED: (
+        "⚠️ A minimum position of {min}% is set, but these fall below it: "
+        "{offenders}. They are raised to the floor (or the floor is ignored) — "
+        "reconcile the values."
+    ),
+    # Rule 10
+    TriageCode.ENABLE_MIN_BACKWARDS: (
+        "ℹ️ Minimum position {min}% is set but 'enforce minimum only while sun "
+        "tracking' is off, so the floor applies at all times (the flag reads "
+        "backwards). Confirm that is intended."
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Bundle loading (delegates to the shared i18n_bundle loader)
+# ---------------------------------------------------------------------------
+
+
+@cache
+def _troubleshoot_overlay(language: str) -> tuple[tuple[str, str], ...]:
+    """Flattened ``troubleshoot_i18n/<language>.json`` overlay (cached, immutable)."""
+    return tuple(load_bundle_overlay(_TROUBLESHOOT_I18N_DIR, language).items())
+
+
+def load_troubleshoot_labels(language: str) -> dict[str, str]:
+    """Build the triage templates for ``language`` (English overlaid with the bundle)."""
+    return merge_labels(_TRIAGE_TEMPLATES_EN, dict(_troubleshoot_overlay(language)))
+
+
+async def async_prime(hass: object, language: str) -> dict[str, str]:
+    """Load + cache the triage templates for ``language`` off the event loop."""
+    return await hass.async_add_executor_job(load_troubleshoot_labels, language)

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/de.json
@@ -1,0 +1,15 @@
+{
+  "triage": {
+    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
+    "higher_priority_won": "ℹ️ The {winner} handler outranks solar tracking and won this cycle, so solar never set a position. Lower-priority handlers that did not run: {skipped}. Adjust the handler priorities if solar should win.",
+    "time_window_suspect": "⚠️ The active-window schedule looks off (start {start}, end {end}); the cover may never track. Review the start and end times.",
+    "climate_temp_none": "⚠️ Climate mode is on but the inside temperature is unavailable, so climate decisions cannot run. Check the configured temperature sensor.",
+    "summer_wont_close": "⚠️ It is summer with presence detected and the blind is not transparent, yet the climate handler did not close it. Review the summer close conditions and temperature thresholds.",
+    "presence_defaults_true": "ℹ️ Climate mode is on but no presence entity or template is set, so presence defaults to always-present. Add a presence sensor if occupancy should gate climate control.",
+    "cloud_or_semantics": "ℹ️ More than one low-light input is configured ({inputs}); they combine with OR, so any one of them tripping suppresses tracking. Currently tripped: {tripped}.",
+    "cover_not_ready": "⚠️ {eid}: not ready (unavailable)",
+    "entity_unavailable": "⚠️ {eid} is unavailable — the integration cannot read its state. Check the device or the sensor.",
+    "min_floor_bypassed": "⚠️ A minimum position of {min}% is set, but these fall below it: {offenders}. They are raised to the floor (or the floor is ignored) — reconcile the values.",
+    "enable_min_backwards": "ℹ️ Minimum position {min}% is set but 'enforce minimum only while sun tracking' is off, so the floor applies at all times (the flag reads backwards). Confirm that is intended."
+  }
+}

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/de.json
@@ -1,15 +1,15 @@
 {
   "triage": {
-    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
-    "higher_priority_won": "ℹ️ The {winner} handler outranks solar tracking and won this cycle, so solar never set a position. Lower-priority handlers that did not run: {skipped}. Adjust the handler priorities if solar should win.",
-    "time_window_suspect": "⚠️ The active-window schedule looks off (start {start}, end {end}); the cover may never track. Review the start and end times.",
-    "climate_temp_none": "⚠️ Climate mode is on but the inside temperature is unavailable, so climate decisions cannot run. Check the configured temperature sensor.",
-    "summer_wont_close": "⚠️ It is summer with presence detected and the blind is not transparent, yet the climate handler did not close it. Review the summer close conditions and temperature thresholds.",
-    "presence_defaults_true": "ℹ️ Climate mode is on but no presence entity or template is set, so presence defaults to always-present. Add a presence sensor if occupancy should gate climate control.",
-    "cloud_or_semantics": "ℹ️ More than one low-light input is configured ({inputs}); they combine with OR, so any one of them tripping suppresses tracking. Currently tripped: {tripped}.",
-    "cover_not_ready": "⚠️ {eid}: not ready (unavailable)",
-    "entity_unavailable": "⚠️ {eid} is unavailable — the integration cannot read its state. Check the device or the sensor.",
-    "min_floor_bypassed": "⚠️ A minimum position of {min}% is set, but these fall below it: {offenders}. They are raised to the floor (or the floor is ignored) — reconcile the values.",
-    "enable_min_backwards": "ℹ️ Minimum position {min}% is set but 'enforce minimum only while sun tracking' is off, so the floor applies at all times (the flag reads backwards). Confirm that is intended."
+    "custom_safety_bypass": "⚠️ Benutzerdefiniert #{slot} hat Sicherheitspriorität ({safety}) – umgeht den Schalter für die automatische Steuerung, die manuelle Übersteuerung und das Start-/Endzeitfenster, kann die Beschattung also auch dann bewegen, wenn die automatische Steuerung AUS ist und außerhalb Ihres Zeitplans. Senken Sie seine Priorität unter {safety}, um diese Gates einzuhalten.",
+    "higher_priority_won": "ℹ️ Der Handler {winner} überschattet die Sonnenstandsverfolgung und hat diesen Zyklus gewonnen, weshalb die Sonnenstandsverfolgung keine Position gesetzt hat. Handler mit niedrigerer Priorität, die nicht ausgeführt wurden: {skipped}. Passen Sie die Handler-Prioritäten an, wenn die Sonnenstandsverfolgung gewinnen soll.",
+    "time_window_suspect": "⚠️ Der Zeitplan für das aktive Fenster sieht falsch aus (Start {start}, Ende {end}); die Beschattung verfolgt möglicherweise niemals. Überprüfen Sie die Start- und Endzeiten.",
+    "climate_temp_none": "⚠️ Der Klimamodus ist eingeschaltet, aber die Innentemperatur ist nicht verfügbar, daher können keine Klimaentscheidungen getroffen werden. Überprüfen Sie den konfigurierten Temperatursensor.",
+    "summer_wont_close": "⚠️ Es ist Sommer mit erkannter Anwesenheit und die Jalousie ist nicht transparent, aber der Klimahandler hat sie nicht geschlossen. Überprüfen Sie die Sommereinstellungen zum Schließen und Temperaturschwellwerte.",
+    "presence_defaults_true": "ℹ️ Der Klimamodus ist eingeschaltet, aber es ist keine Anwesenheitsentität oder Vorlage eingestellt, daher wird die Anwesenheit auf \"immer vorhanden\" gesetzt. Fügen Sie einen Anwesenheitssensor hinzu, wenn die Belegung die Klimakontrolle steuern soll.",
+    "cloud_or_semantics": "ℹ️ Es sind mehrere Lichtsensoren konfiguriert ({inputs}); sie werden mit ODER kombiniert, sodass jedes Auslösen eines von ihnen die Verfolgung unterdrückt. Aktuell ausgelöst: {tripped}.",
+    "cover_not_ready": "⚠️ {eid}: nicht verfügbar",
+    "entity_unavailable": "⚠️ {eid} ist nicht verfügbar – die Integration kann seinen Status nicht lesen. Überprüfen Sie das Gerät oder den Sensor.",
+    "min_floor_bypassed": "⚠️ Eine Mindestposition von {min}% ist eingestellt, aber diese fallen darunter: {offenders}. Sie werden auf den Mindeststand angehoben (oder der Mindeststand wird ignoriert) – gleichen Sie die Werte ab.",
+    "enable_min_backwards": "ℹ️ Mindestposition {min}% ist eingestellt, aber \"Mindestposition nur während Sonnenstandsverfolgung erzwingen\" ist aus, also gilt der Mindeststand zu allen Zeiten (die Flagge liest sich rückwärts). Bestätigen Sie, dass dies beabsichtigt ist."
   }
 }

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/en.json
@@ -1,0 +1,15 @@
+{
+  "triage": {
+    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
+    "higher_priority_won": "ℹ️ The {winner} handler outranks solar tracking and won this cycle, so solar never set a position. Lower-priority handlers that did not run: {skipped}. Adjust the handler priorities if solar should win.",
+    "time_window_suspect": "⚠️ The active-window schedule looks off (start {start}, end {end}); the cover may never track. Review the start and end times.",
+    "climate_temp_none": "⚠️ Climate mode is on but the inside temperature is unavailable, so climate decisions cannot run. Check the configured temperature sensor.",
+    "summer_wont_close": "⚠️ It is summer with presence detected and the blind is not transparent, yet the climate handler did not close it. Review the summer close conditions and temperature thresholds.",
+    "presence_defaults_true": "ℹ️ Climate mode is on but no presence entity or template is set, so presence defaults to always-present. Add a presence sensor if occupancy should gate climate control.",
+    "cloud_or_semantics": "ℹ️ More than one low-light input is configured ({inputs}); they combine with OR, so any one of them tripping suppresses tracking. Currently tripped: {tripped}.",
+    "cover_not_ready": "⚠️ {eid}: not ready (unavailable)",
+    "entity_unavailable": "⚠️ {eid} is unavailable — the integration cannot read its state. Check the device or the sensor.",
+    "min_floor_bypassed": "⚠️ A minimum position of {min}% is set, but these fall below it: {offenders}. They are raised to the floor (or the floor is ignored) — reconcile the values.",
+    "enable_min_backwards": "ℹ️ Minimum position {min}% is set but 'enforce minimum only while sun tracking' is off, so the floor applies at all times (the flag reads backwards). Confirm that is intended."
+  }
+}

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/fr.json
@@ -1,15 +1,15 @@
 {
   "triage": {
-    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
-    "higher_priority_won": "ℹ️ The {winner} handler outranks solar tracking and won this cycle, so solar never set a position. Lower-priority handlers that did not run: {skipped}. Adjust the handler priorities if solar should win.",
-    "time_window_suspect": "⚠️ The active-window schedule looks off (start {start}, end {end}); the cover may never track. Review the start and end times.",
-    "climate_temp_none": "⚠️ Climate mode is on but the inside temperature is unavailable, so climate decisions cannot run. Check the configured temperature sensor.",
-    "summer_wont_close": "⚠️ It is summer with presence detected and the blind is not transparent, yet the climate handler did not close it. Review the summer close conditions and temperature thresholds.",
-    "presence_defaults_true": "ℹ️ Climate mode is on but no presence entity or template is set, so presence defaults to always-present. Add a presence sensor if occupancy should gate climate control.",
-    "cloud_or_semantics": "ℹ️ More than one low-light input is configured ({inputs}); they combine with OR, so any one of them tripping suppresses tracking. Currently tripped: {tripped}.",
-    "cover_not_ready": "⚠️ {eid}: not ready (unavailable)",
-    "entity_unavailable": "⚠️ {eid} is unavailable — the integration cannot read its state. Check the device or the sensor.",
-    "min_floor_bypassed": "⚠️ A minimum position of {min}% is set, but these fall below it: {offenders}. They are raised to the floor (or the floor is ignored) — reconcile the values.",
-    "enable_min_backwards": "ℹ️ Minimum position {min}% is set but 'enforce minimum only while sun tracking' is off, so the floor applies at all times (the flag reads backwards). Confirm that is intended."
+    "custom_safety_bypass": "⚠️ L'emplacement personnalisé #{slot} est à la priorité de sécurité ({safety}) — il contourne l'interrupteur de contrôle automatique, la dérogation manuelle et la fenêtre horaire de début/fin, pour que le store puisse se déplacer même quand le contrôle automatique est DÉSACTIVÉ et en dehors de votre horaire. Réduisez sa priorité en dessous de {safety} pour qu'elle respecte ces seuils.",
+    "higher_priority_won": "ℹ️ Le gestionnaire {winner} a une priorité plus élevée que le suivi solaire et a gagné ce cycle, le solaire n'a donc pas défini de position. Gestionnaires de priorité inférieure qui n'ont pas fonctionné : {skipped}. Ajustez les priorités des gestionnaires si le suivi solaire devrait gagner.",
+    "time_window_suspect": "⚠️ L'horaire de la fenêtre active semble incorrect (début {start}, fin {end}) ; le store peut ne jamais suivre. Vérifiez les heures de début et de fin.",
+    "climate_temp_none": "⚠️ Le mode climatique est activé mais la température intérieure n'est pas disponible, les décisions climatiques ne peuvent donc pas fonctionner. Vérifiez le capteur de température configuré.",
+    "summer_wont_close": "⚠️ C'est l'été avec présence détectée et le store n'est pas transparent, mais le gestionnaire climatique ne l'a pas fermé. Vérifiez les conditions de fermeture estivale et les seuils de température.",
+    "presence_defaults_true": "ℹ️ Le mode climatique est activé mais aucune entité ou modèle de présence n'est configuré, la présence est donc définie par défaut sur toujours-présent. Ajoutez un détecteur de mouvement si l'occupation devrait contrôler le mode climatique.",
+    "cloud_or_semantics": "ℹ️ Plus d'une entrée de faible lumière est configurée ({inputs}) ; elles se combinent avec OU, donc n'importe laquelle d'entre elles déclenchée supprime le suivi. Actuellement déclenchées : {tripped}.",
+    "cover_not_ready": "⚠️ {eid} : non prêt (indisponible)",
+    "entity_unavailable": "⚠️ {eid} est indisponible — l'intégration ne peut pas lire son état. Vérifiez l'appareil ou le capteur.",
+    "min_floor_bypassed": "⚠️ Une position minimale de {min}% est définie, mais ceux-ci sont en dessous : {offenders}. Ils sont portés au plancher (ou le plancher est ignoré) — réconciliez les valeurs.",
+    "enable_min_backwards": "ℹ️ La position minimale {min}% est définie mais « imposer le minimum uniquement pendant le suivi solaire » est désactivée, le plancher s'applique donc à tout moment (l'indicateur se lit à l'envers). Confirmez que c'est intentionnel."
   }
 }

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/fr.json
@@ -1,0 +1,15 @@
+{
+  "triage": {
+    "custom_safety_bypass": "⚠️ Custom #{slot} is at safety priority ({safety}) — it bypasses the automatic-control toggle, manual override, and the start/end time window, so it can move the cover even when automatic control is OFF and outside your schedule. Lower its priority below {safety} to make it respect those gates.",
+    "higher_priority_won": "ℹ️ The {winner} handler outranks solar tracking and won this cycle, so solar never set a position. Lower-priority handlers that did not run: {skipped}. Adjust the handler priorities if solar should win.",
+    "time_window_suspect": "⚠️ The active-window schedule looks off (start {start}, end {end}); the cover may never track. Review the start and end times.",
+    "climate_temp_none": "⚠️ Climate mode is on but the inside temperature is unavailable, so climate decisions cannot run. Check the configured temperature sensor.",
+    "summer_wont_close": "⚠️ It is summer with presence detected and the blind is not transparent, yet the climate handler did not close it. Review the summer close conditions and temperature thresholds.",
+    "presence_defaults_true": "ℹ️ Climate mode is on but no presence entity or template is set, so presence defaults to always-present. Add a presence sensor if occupancy should gate climate control.",
+    "cloud_or_semantics": "ℹ️ More than one low-light input is configured ({inputs}); they combine with OR, so any one of them tripping suppresses tracking. Currently tripped: {tripped}.",
+    "cover_not_ready": "⚠️ {eid}: not ready (unavailable)",
+    "entity_unavailable": "⚠️ {eid} is unavailable — the integration cannot read its state. Check the device or the sensor.",
+    "min_floor_bypassed": "⚠️ A minimum position of {min}% is set, but these fall below it: {offenders}. They are raised to the floor (or the floor is ignored) — reconcile the values.",
+    "enable_min_backwards": "ℹ️ Minimum position {min}% is set but 'enforce minimum only while sun tracking' is off, so the floor applies at all times (the flag reads backwards). Confirm that is intended."
+  }
+}

--- a/tests/_helpers/__init__.py
+++ b/tests/_helpers/__init__.py
@@ -1,0 +1,5 @@
+"""Shared test helpers (fixtures/constants used by more than one test file).
+
+Per CODING_GUIDELINES § cross-file test helpers, anything used in more than one
+test module lives here rather than being duplicated.
+"""

--- a/tests/_helpers/i18n_parity.py
+++ b/tests/_helpers/i18n_parity.py
@@ -1,0 +1,100 @@
+"""Shared i18n-bundle parity-lock helpers (issue #970).
+
+``reason_i18n/``, ``summary_i18n/``, and ``troubleshoot_i18n/`` each ship a
+nested-JSON label tree per language and hold three near-identical parity locks:
+
+* the flattened ``en.json`` must byte-match the code-owned English defaults,
+* every non-English bundle must expose the identical key set as ``en.json``, and
+* every key's ``{field}`` placeholders (field name + format spec + conversion)
+  must match ``en.json`` — else Home Assistant silently drops the translated key.
+
+Per CODING_GUIDELINES § No Duplication + "cross-file test helpers live in
+``tests/_helpers/``", those three copies collapse to the functions below,
+parametrized over a bundle directory and the code-owned English defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import string
+from collections.abc import Mapping
+from pathlib import Path
+
+
+def flatten(data: object) -> dict[str, str]:
+    """Flatten a nested label tree to dotted keys (``{"a": {"b": "x"}}`` -> ``{"a.b": "x"}``)."""
+    out: dict[str, str] = {}
+
+    def _walk(node: object, prefix: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                _walk(value, f"{prefix}.{key}" if prefix else key)
+        elif isinstance(node, str):
+            out[prefix] = node
+
+    _walk(data, "")
+    return out
+
+
+def load_bundle(bundle_dir: Path | str, name: str) -> dict:
+    """Load one ``<bundle_dir>/<name>`` JSON file."""
+    with (Path(bundle_dir) / name).open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def placeholders(template: str) -> set[tuple[str, str | None, str | None]]:
+    """Return the ``(field, format_spec, conversion)`` placeholder tuples.
+
+    Including the format spec (e.g. ``.2f``) catches a translation that drops a
+    numeric format, not just a renamed field. Literal ``{{``/``}}`` are stripped
+    first so they don't parse as fields.
+    """
+    stripped = template.replace("{{", "").replace("}}", "")
+    return {
+        (field, spec, conv)
+        for _, field, spec, conv in string.Formatter().parse(stripped)
+        if field
+    }
+
+
+def assert_en_matches_defaults(
+    bundle_dir: Path | str, code_defaults: Mapping[str, str]
+) -> None:
+    """Assert flattened ``en.json`` is byte-identical to ``code_defaults``."""
+    en = flatten(load_bundle(bundle_dir, "en.json"))
+    assert en == dict(code_defaults), (
+        "en.json differs from the code-owned English defaults:\n"
+        f"  only in en.json: {sorted(set(en) - set(code_defaults))[:10]}\n"
+        f"  only in code:    {sorted(set(code_defaults) - set(en))[:10]}"
+    )
+
+
+def assert_key_parity(
+    bundle_dir: Path | str, langs: tuple[str, ...] = ("de", "fr")
+) -> None:
+    """Assert each ``<lang>.json`` exposes the identical key set as ``en.json``."""
+    en = flatten(load_bundle(bundle_dir, "en.json"))
+    assert en, "en.json must not be empty"
+    for lang in langs:
+        target = flatten(load_bundle(bundle_dir, f"{lang}.json"))
+        assert set(target) == set(en), (
+            f"{lang}.json key-set differs from en.json:\n"
+            f"  missing: {sorted(set(en) - set(target))[:10]}\n"
+            f"  extra:   {sorted(set(target) - set(en))[:10]}"
+        )
+
+
+def assert_placeholder_parity(
+    bundle_dir: Path | str, langs: tuple[str, ...] = ("de", "fr")
+) -> None:
+    """Assert each key's placeholder set matches ``en.json`` across ``langs``."""
+    en = flatten(load_bundle(bundle_dir, "en.json"))
+    assert en, "en.json must not be empty"
+    for lang in langs:
+        target = flatten(load_bundle(bundle_dir, f"{lang}.json"))
+        for key, en_value in en.items():
+            assert key in target, f"{lang}.json missing key {key!r}"
+            assert placeholders(en_value) == placeholders(target[key]), (
+                f"{lang}.json[{key}] placeholders {placeholders(target[key])} "
+                f"!= en {placeholders(en_value)}"
+            )

--- a/tests/test_config_flow_summary_i18n.py
+++ b/tests/test_config_flow_summary_i18n.py
@@ -15,8 +15,6 @@ category in the HA translation schema, so the data is loaded directly.
 
 from __future__ import annotations
 
-import json
-import string
 from pathlib import Path
 
 import pytest
@@ -36,6 +34,7 @@ from custom_components.adaptive_cover_pro.cover_types._summary_labels import (
     COVER_TYPE_LABELS_EN,
     GEOMETRY_LABELS_EN,
 )
+from tests._helpers import i18n_parity
 
 pytestmark = pytest.mark.unit
 
@@ -91,7 +90,9 @@ def test_load_summary_labels_overlays_translated_bundle() -> None:
     """A translated bundle (de) overrides the English defaults key-for-key, and
     keys absent from the bundle fall back to English.
     """
-    de_bundle = _config_summary_flat(_load_json("de.json"))
+    de_bundle = i18n_parity.flatten(
+        i18n_parity.load_bundle(SUMMARY_I18N_DIR, "de.json")
+    )
     labels = _load_summary_labels_sync("de")
 
     # Every translated key overrides the English default with the bundle value.
@@ -183,47 +184,19 @@ def test_resolve_summary_language_falls_back_to_english_when_nothing_available()
 # ---------------------------------------------------------------------------
 
 
-def _placeholder_fields(template: str) -> set[str]:
-    """Return the set of named ``{field}`` placeholders in a format template,
-    normalizing literal ``{{`` / ``}}`` braces away first.
-    """
-    # Remove escaped literal braces so they don't parse as fields.
-    stripped = template.replace("{{", "").replace("}}", "")
-    return {
-        field_name
-        for _, field_name, _, _ in string.Formatter().parse(stripped)
-        if field_name
-    }
-
-
-def _config_summary_flat(data: dict) -> dict[str, str]:
-    """Return a summary-label bundle flattened to dotted keys."""
-    out: dict[str, str] = {}
-
-    def _walk(node: object, prefix: str) -> None:
-        if isinstance(node, dict):
-            for k, v in node.items():
-                _walk(v, f"{prefix}.{k}" if prefix else k)
-        elif isinstance(node, str):
-            out[prefix] = node
-
-    _walk(data, "")
-    return out
+_SUMMARY_CODE_DEFAULTS = {
+    **_SUMMARY_LABELS_EN,
+    **COVER_TYPE_LABELS_EN,
+    **GEOMETRY_LABELS_EN,
+    **AXIS_LABELS_EN,
+}
 
 
 def test_summary_i18n_key_parity_de_fr() -> None:
     """de/fr bundles must expose the IDENTICAL key set as en — else a summary
     line silently falls back to English.
     """
-    en = _config_summary_flat(_load_json("en.json"))
-    assert en, "en.json bundle must not be empty"
-    for lang in ("de", "fr"):
-        target = _config_summary_flat(_load_json(f"{lang}.json"))
-        assert set(target) == set(en), (
-            f"{lang}.json key-set differs from en.json:\n"
-            f"  missing: {sorted(set(en) - set(target))[:10]}\n"
-            f"  extra:   {sorted(set(target) - set(en))[:10]}"
-        )
+    i18n_parity.assert_key_parity(SUMMARY_I18N_DIR)
 
 
 def test_summary_i18n_en_matches_code_defaults() -> None:
@@ -233,37 +206,11 @@ def test_summary_i18n_en_matches_code_defaults() -> None:
     ``GEOMETRY_LABELS_EN``. The English runtime output is driven by those code
     dicts; the bundle exists as the translation source + drift guard.
     """
-    en = _config_summary_flat(_load_json("en.json"))
-    assert en == {
-        **_SUMMARY_LABELS_EN,
-        **COVER_TYPE_LABELS_EN,
-        **GEOMETRY_LABELS_EN,
-        **AXIS_LABELS_EN,
-    }
+    i18n_parity.assert_en_matches_defaults(SUMMARY_I18N_DIR, _SUMMARY_CODE_DEFAULTS)
 
 
 def test_config_summary_placeholder_parity_de_fr() -> None:
     """For every label key, de/fr must expose the IDENTICAL set of {field}
     placeholders as en — else HA silently drops the translated key.
     """
-    en = _config_summary_flat(_load_json("en.json"))
-    assert en, "en.json bundle must not be empty"
-    for lang in ("de", "fr"):
-        target = _config_summary_flat(_load_json(f"{lang}.json"))
-        for key, en_value in en.items():
-            assert key in target, f"{lang}.json missing label key {key!r}"
-            en_fields = _placeholder_fields(en_value)
-            tgt_fields = _placeholder_fields(target[key])
-            assert (
-                en_fields == tgt_fields
-            ), f"{lang}.json[{key}] placeholder set {tgt_fields} != en {en_fields}"
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _load_json(name: str) -> dict:
-    with (SUMMARY_I18N_DIR / name).open(encoding="utf-8") as fh:
-        return json.load(fh)
+    i18n_parity.assert_placeholder_parity(SUMMARY_I18N_DIR)

--- a/tests/test_config_flow_troubleshoot.py
+++ b/tests/test_config_flow_troubleshoot.py
@@ -130,14 +130,15 @@ async def test_troubleshoot_returns_menu_with_findings_and_back_options(
     hass: HomeAssistant,
 ) -> None:
     # Options fire rules 1 (custom_position), 3 (automation), 9 (position) and
-    # 10 (position) — proving fix_step order preservation + dedup.
+    # 10 (position) — proving fix_step order preservation + dedup. Rule 3 needs a
+    # genuinely-suspect window (inverted start>end), not the BLANK_TIME sentinel.
     options = {
         CONF_ENTITIES: [],
         "custom_position_sensor_1": "binary_sensor.t",
         "custom_position_1": 5,
         "custom_position_priority_1": CUSTOM_POSITION_SAFETY_PRIORITY,
-        "start_time": "00:00:00",
-        "end_time": "20:00:00",
+        "start_time": "21:00:00",
+        "end_time": "08:00:00",
         "min_position": 40,
         "enable_min_position": False,
     }
@@ -191,6 +192,22 @@ async def test_troubleshoot_diagnostics_unavailable_is_graceful(
     report = result["description_placeholders"]["report"]
     assert report.strip()
     assert result["menu_options"] == ["troubleshoot", "init"]
+
+
+async def test_troubleshoot_unavailable_still_shows_config_findings(
+    hass: HomeAssistant,
+) -> None:
+    # Diagnostics unavailable (no coordinator) but a CONFIG issue exists: the
+    # finding is rendered in the report AND its fix route appears in the menu —
+    # never a menu route for an unshown finding (issue #970, MINOR 3).
+    options = {CONF_ENTITIES: [], "enable_min_position": False, "min_position": 40}
+    flow, entry = _cover_flow(hass, options)
+    with patch(_SERVICES_COVER_COORDINATORS, return_value={}):
+        result = await flow.async_step_troubleshoot()
+    report = result["description_placeholders"]["report"]
+    assert "Diagnostics aren't available" in report  # the runtime-needs-diag note
+    assert "Minimum position 40%" in report  # the CONFIG finding is rendered
+    assert result["menu_options"] == ["position", "troubleshoot", "init"]
 
 
 async def test_troubleshoot_never_calls_async_refresh(

--- a/tests/test_config_flow_troubleshoot.py
+++ b/tests/test_config_flow_troubleshoot.py
@@ -1,0 +1,226 @@
+"""Config-flow surfaces for the read-only Troubleshoot step (issue #970, Phase 1).
+
+Three concerns:
+- ``troubleshoot`` is offered in the cover options menu (a list, for client-side
+  label translation) and NEVER in the profile or group menus.
+- ``async_step_troubleshoot`` runs the triage engine read-only against resolved
+  diagnostics, renders the report into ``description_placeholders`` and builds a
+  menu of ``[*deduped fix steps, "troubleshoot", "init"]`` — never calling
+  ``async_refresh`` (which would run the pipeline and could move a cover).
+- Every menu option the step can emit has an ``en.json`` label.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.diagnostics.triage import TRIAGE_RULES
+
+pytestmark = pytest.mark.integration
+
+_SERVICES_COVER_COORDINATORS = (
+    "custom_components.adaptive_cover_pro.services.cover_coordinators"
+)
+
+_EN_JSON = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "translations"
+    / "en.json"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _cover_flow(
+    hass, options: dict | None = None, entry_id: str = "cover_1"
+) -> tuple[OptionsFlowHandler, MockConfigEntry]:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=options if options is not None else {CONF_ENTITIES: []},
+        entry_id=entry_id,
+        title="Kitchen Blind",
+    )
+    entry.add_to_hass(hass)
+    flow = OptionsFlowHandler(entry)
+    flow.hass = hass
+    flow.context = {}
+    # HA's OptionsFlow.config_entry property resolves via self.handler (entry_id).
+    flow.handler = entry.entry_id
+    return flow, entry
+
+
+def _virtual_flow(hass, sensor_type, entry_id: str):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: sensor_type},
+        options={},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    flow = OptionsFlowHandler(entry)
+    flow.hass = hass
+    flow.context = {}
+    flow.handler = entry.entry_id
+    return flow
+
+
+def _spy_coordinator(diagnostics: dict | None = None):
+    coord = MagicMock()
+    coord.data.diagnostics = {} if diagnostics is None else diagnostics
+    coord.async_refresh = AsyncMock()
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# Menu wiring — troubleshoot is cover-only
+# ---------------------------------------------------------------------------
+
+
+async def test_cover_init_menu_contains_troubleshoot_as_list(
+    hass: HomeAssistant,
+) -> None:
+    flow, _ = _cover_flow(hass)
+    result = await flow.async_step_init()
+    assert result["type"] == "menu"
+    assert isinstance(result["menu_options"], list)
+    assert "troubleshoot" in result["menu_options"]
+
+
+async def test_profile_init_menu_omits_troubleshoot(hass: HomeAssistant) -> None:
+    flow = _virtual_flow(hass, CoverType.BUILDING_PROFILE, "profile_1")
+    result = await flow.async_step_init()
+    assert result["type"] == "menu"
+    assert "troubleshoot" not in result["menu_options"]
+
+
+async def test_group_init_menu_omits_troubleshoot(hass: HomeAssistant) -> None:
+    flow = _virtual_flow(hass, CoverType.GROUP, "group_1")
+    result = await flow.async_step_init()
+    assert result["type"] == "menu"
+    assert "troubleshoot" not in result["menu_options"]
+
+
+# ---------------------------------------------------------------------------
+# async_step_troubleshoot — the report + menu
+# ---------------------------------------------------------------------------
+
+
+async def test_troubleshoot_returns_menu_with_findings_and_back_options(
+    hass: HomeAssistant,
+) -> None:
+    # Options fire rules 1 (custom_position), 3 (automation), 9 (position) and
+    # 10 (position) — proving fix_step order preservation + dedup.
+    options = {
+        CONF_ENTITIES: [],
+        "custom_position_sensor_1": "binary_sensor.t",
+        "custom_position_1": 5,
+        "custom_position_priority_1": CUSTOM_POSITION_SAFETY_PRIORITY,
+        "start_time": "00:00:00",
+        "end_time": "20:00:00",
+        "min_position": 40,
+        "enable_min_position": False,
+    }
+    flow, entry = _cover_flow(hass, options)
+    coord = _spy_coordinator()
+    with patch(_SERVICES_COVER_COORDINATORS, return_value={entry.entry_id: coord}):
+        result = await flow.async_step_troubleshoot()
+
+    assert result["type"] == "menu"
+    assert result["menu_options"] == [
+        "custom_position",
+        "automation",
+        "position",
+        "troubleshoot",
+        "init",
+    ]
+
+
+async def test_troubleshoot_report_contains_finding_text(
+    hass: HomeAssistant,
+) -> None:
+    options = {CONF_ENTITIES: [], "enable_min_position": False, "min_position": 40}
+    flow, entry = _cover_flow(hass, options)
+    coord = _spy_coordinator()
+    with patch(_SERVICES_COVER_COORDINATORS, return_value={entry.entry_id: coord}):
+        result = await flow.async_step_troubleshoot()
+    report = result["description_placeholders"]["report"]
+    assert "Minimum position 40%" in report
+
+
+async def test_troubleshoot_no_findings_renders_clean_line(
+    hass: HomeAssistant,
+) -> None:
+    flow, entry = _cover_flow(hass, {CONF_ENTITIES: []})
+    coord = _spy_coordinator()
+    with patch(_SERVICES_COVER_COORDINATORS, return_value={entry.entry_id: coord}):
+        result = await flow.async_step_troubleshoot()
+    report = result["description_placeholders"]["report"]
+    assert report.strip()  # a non-empty "all good" line
+    assert result["menu_options"] == ["troubleshoot", "init"]
+
+
+async def test_troubleshoot_diagnostics_unavailable_is_graceful(
+    hass: HomeAssistant,
+) -> None:
+    # No coordinator registered and no cached snapshot -> source "unavailable".
+    flow, entry = _cover_flow(hass, {CONF_ENTITIES: []})
+    with patch(_SERVICES_COVER_COORDINATORS, return_value={}):
+        result = await flow.async_step_troubleshoot()
+    assert result["type"] == "menu"
+    report = result["description_placeholders"]["report"]
+    assert report.strip()
+    assert result["menu_options"] == ["troubleshoot", "init"]
+
+
+async def test_troubleshoot_never_calls_async_refresh(
+    hass: HomeAssistant,
+) -> None:
+    flow, entry = _cover_flow(hass, {CONF_ENTITIES: []})
+    coord = _spy_coordinator()
+    with patch(_SERVICES_COVER_COORDINATORS, return_value={entry.entry_id: coord}):
+        await flow.async_step_troubleshoot()
+    coord.async_refresh.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# en.json label coverage — every emittable menu option has a label
+# ---------------------------------------------------------------------------
+
+
+def test_every_troubleshoot_menu_option_has_en_label() -> None:
+    data = json.loads(_EN_JSON.read_text(encoding="utf-8"))
+    step = data["options"]["step"]["troubleshoot"]
+    assert "title" in step
+    assert "{report}" in step["description"]
+    labels = step["menu_options"]
+
+    possible = {rule.fix_step for rule in TRIAGE_RULES if rule.fix_step}
+    possible |= {"troubleshoot", "init"}
+    missing = possible - set(labels)
+    assert not missing, f"troubleshoot menu_options missing labels: {sorted(missing)}"
+
+
+def test_init_menu_has_troubleshoot_label() -> None:
+    data = json.loads(_EN_JSON.read_text(encoding="utf-8"))
+    assert "troubleshoot" in data["options"]["step"]["init"]["menu_options"]

--- a/tests/test_diagnostics_resolve.py
+++ b/tests/test_diagnostics_resolve.py
@@ -1,0 +1,170 @@
+"""Tests for the read-only diagnostics resolver (issue #970, Phase 1).
+
+The safety invariant under test: no resolve path may ever call
+``coordinator.async_refresh`` — that runs the full update cycle and can move a
+blind. Every test that touches a coordinator asserts ``async_refresh`` was NOT
+called.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from unittest.mock import MagicMock
+
+import pytest
+
+import custom_components.adaptive_cover_pro.services as services
+from custom_components.adaptive_cover_pro.const import DIAG_CACHE_KEY
+from custom_components.adaptive_cover_pro.diagnostics.resolve import (
+    DiagnosticsRead,
+    read_diagnostics,
+    read_from_coordinator,
+)
+
+# ---------------------------------------------------------------------------
+# DiagnosticsRead shape
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_read_is_frozen():
+    """DiagnosticsRead is a frozen dataclass — assignment raises."""
+    read = DiagnosticsRead(payload=None, source="unavailable")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        read.source = "coordinator"
+
+
+def test_diagnostics_read_uses_slots():
+    """DiagnosticsRead uses __slots__ — no per-instance __dict__."""
+    read = DiagnosticsRead(payload=None, source="unavailable")
+    assert not hasattr(read, "__dict__")
+
+
+def test_diagnostics_read_error_defaults_none():
+    """Error defaults to None when omitted."""
+    read = DiagnosticsRead(payload={"a": 1}, source="coordinator")
+    assert read.error is None
+
+
+# ---------------------------------------------------------------------------
+# read_from_coordinator
+# ---------------------------------------------------------------------------
+
+
+def test_prefers_coordinator_data():
+    """When coord.data is not None, returns coord.data.diagnostics, source coordinator."""
+    coord = MagicMock()
+    coord.data.diagnostics = {"a": 1}
+    read = read_from_coordinator(coord)
+    assert read.payload == {"a": 1}
+    assert read.source == "coordinator"
+    assert read.error is None
+    coord.async_refresh.assert_not_called()
+    coord.build_diagnostic_data.assert_not_called()
+
+
+def test_builds_when_data_none():
+    """When coord.data is None, calls build_diagnostic_data, source built."""
+    coord = MagicMock()
+    coord.data = None
+    coord.build_diagnostic_data.return_value = {"b": 2}
+    read = read_from_coordinator(coord)
+    assert read.payload == {"b": 2}
+    assert read.source == "built"
+    assert read.error is None
+    coord.async_refresh.assert_not_called()
+
+
+def test_wraps_build_exception_into_error():
+    """A raising build is wrapped into a populated error (never propagates)."""
+    coord = MagicMock()
+    coord.data = None
+    coord.build_diagnostic_data.side_effect = RuntimeError("update in progress")
+    read = read_from_coordinator(coord)
+    assert read.payload is None
+    assert read.source == "unavailable"
+    assert read.error is not None
+    assert "diagnostics_unavailable" in read.error
+    assert "update in progress" in read.error
+    coord.async_refresh.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# read_diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_read_diagnostics_delegates_to_coordinator(monkeypatch):
+    """Resolves the coordinator via cover_coordinators and delegates to it."""
+    coord = MagicMock()
+    coord.data.diagnostics = {"x": 1}
+    monkeypatch.setattr(services, "cover_coordinators", lambda hass: {"e1": coord})
+    read = read_diagnostics(MagicMock(), "e1")
+    assert read.payload == {"x": 1}
+    assert read.source == "coordinator"
+    coord.async_refresh.assert_not_called()
+
+
+def test_read_diagnostics_cache_fallback(monkeypatch):
+    """No coordinator → falls back to the DIAG_CACHE_KEY snapshot, source cache."""
+    monkeypatch.setattr(services, "cover_coordinators", lambda hass: {})
+    hass = MagicMock()
+    hass.data = {DIAG_CACHE_KEY: {"e1": {"diagnostics": {"cached": True}}}}
+    read = read_diagnostics(hass, "e1")
+    assert read.payload == {"cached": True}
+    assert read.source == "cache"
+    assert read.error is None
+
+
+def test_read_diagnostics_unavailable_when_nothing(monkeypatch):
+    """No coordinator and no cache → source unavailable, payload None."""
+    monkeypatch.setattr(services, "cover_coordinators", lambda hass: {})
+    hass = MagicMock()
+    hass.data = {}
+    read = read_diagnostics(hass, "e1")
+    assert read.payload is None
+    assert read.source == "unavailable"
+
+
+def test_read_diagnostics_cache_missing_entry(monkeypatch):
+    """Cache present but no entry for this entry_id → unavailable."""
+    monkeypatch.setattr(services, "cover_coordinators", lambda hass: {})
+    hass = MagicMock()
+    hass.data = {DIAG_CACHE_KEY: {"other": {"diagnostics": {"x": 1}}}}
+    read = read_diagnostics(hass, "e1")
+    assert read.payload is None
+    assert read.source == "unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Safety invariant — async_refresh is NEVER called on ANY path
+# ---------------------------------------------------------------------------
+
+
+def test_async_refresh_never_called_on_any_path(monkeypatch):
+    """The whole point: no resolve path may trigger an update cycle."""
+    # coordinator (data present) path
+    coord_data = MagicMock()
+    coord_data.data.diagnostics = {"a": 1}
+    read_from_coordinator(coord_data)
+    coord_data.async_refresh.assert_not_called()
+
+    # built (data None) path
+    coord_built = MagicMock()
+    coord_built.data = None
+    coord_built.build_diagnostic_data.return_value = {"b": 2}
+    read_from_coordinator(coord_built)
+    coord_built.async_refresh.assert_not_called()
+
+    # built-raises path
+    coord_err = MagicMock()
+    coord_err.data = None
+    coord_err.build_diagnostic_data.side_effect = RuntimeError("boom")
+    read_from_coordinator(coord_err)
+    coord_err.async_refresh.assert_not_called()
+
+    # via read_diagnostics
+    spy = MagicMock()
+    spy.data.diagnostics = {"z": 9}
+    monkeypatch.setattr(services, "cover_coordinators", lambda hass: {"e1": spy})
+    read_diagnostics(MagicMock(), "e1")
+    spy.async_refresh.assert_not_called()

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import inspect
 import json
-import string
 from pathlib import Path
 
 import pytest
@@ -33,6 +32,7 @@ from custom_components.adaptive_cover_pro.reason_i18n import (
     render,
     render_en,
 )
+from tests._helpers import i18n_parity
 
 pytestmark = pytest.mark.unit
 
@@ -501,66 +501,17 @@ def test_reason_params_default_is_empty_mapping() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _flat(data: dict) -> dict[str, str]:
-    out: dict[str, str] = {}
-
-    def _walk(node: object, prefix: str) -> None:
-        if isinstance(node, dict):
-            for k, v in node.items():
-                _walk(v, f"{prefix}.{k}" if prefix else k)
-        elif isinstance(node, str):
-            out[prefix] = node
-
-    _walk(data, "")
-    return out
-
-
-def _load_json(name: str) -> dict:
-    with (REASON_I18N_DIR / name).open(encoding="utf-8") as fh:
-        return json.load(fh)
-
-
-def _placeholders(template: str) -> set[tuple[str, str | None, str | None]]:
-    """Return the (field, format_spec, conversion) placeholder tuples.
-
-    Includes the format spec (e.g. ``.2f``) so a DE/FR template that drops a
-    numeric format is caught, not just a renamed field.
-    """
-    stripped = template.replace("{{", "").replace("}}", "")
-    return {
-        (field, spec, conv)
-        for _, field, spec, conv in string.Formatter().parse(stripped)
-        if field
-    }
-
-
 def test_reason_i18n_en_matches_code_defaults() -> None:
     """Flattened ``reason_i18n/en.json`` == ``_REASON_TEMPLATES_EN`` byte-for-byte."""
-    assert _flat(_load_json("en.json")) == _REASON_TEMPLATES_EN
+    i18n_parity.assert_en_matches_defaults(REASON_I18N_DIR, _REASON_TEMPLATES_EN)
 
 
 def test_reason_i18n_key_parity_de_fr() -> None:
-    en = _flat(_load_json("en.json"))
-    assert en, "en.json must not be empty"
-    for lang in ("de", "fr"):
-        target = _flat(_load_json(f"{lang}.json"))
-        assert set(target) == set(en), (
-            f"{lang}.json key-set differs from en.json:\n"
-            f"  missing: {sorted(set(en) - set(target))[:10]}\n"
-            f"  extra:   {sorted(set(target) - set(en))[:10]}"
-        )
+    i18n_parity.assert_key_parity(REASON_I18N_DIR)
 
 
 def test_reason_placeholder_parity_de_fr() -> None:
-    en = _flat(_load_json("en.json"))
-    for lang in ("de", "fr"):
-        target = _flat(_load_json(f"{lang}.json"))
-        for key, en_value in en.items():
-            assert key in target, f"{lang}.json missing key {key!r}"
-            assert _placeholders(en_value) == _placeholders(target[key]), (
-                f"{lang}.json[{key}] placeholders {_placeholders(target[key])} "
-                f"!= en {_placeholders(en_value)}"
-            )
+    i18n_parity.assert_placeholder_parity(REASON_I18N_DIR)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_triage_contract.py
+++ b/tests/test_triage_contract.py
@@ -1,0 +1,137 @@
+"""Contract tests: triage rules vs. the REAL DiagnosticsBuilder output.
+
+The seed rule checks in ``diagnostics/triage.py`` were written partly from the
+epic's spec. A hand-rolled fixture would be self-referential — it would agree
+with the rule by construction and rot silently against ``builder.py``. These
+tests instead drive the *actual* ``DiagnosticsBuilder`` and assert the rules
+fire on its output, so any key-path drift between a rule's check and the real
+payload surfaces here. No stored JSON fixture.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_OUTSIDETEMP_ENTITY,
+    ControlMethod,
+    TriageCode,
+)
+from custom_components.adaptive_cover_pro.diagnostics.builder import DiagnosticsBuilder
+from custom_components.adaptive_cover_pro.diagnostics.triage import run_triage
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.pipeline.handlers.climate import (
+    ClimateCoverData,
+)
+
+# Reuse the builder test's context/pipeline factories — the same shapes the real
+# coordinator feeds the builder — rather than duplicating them.
+from tests.test_diagnostics.test_builder import _base_ctx, _make_pr
+
+
+def _codes(findings):
+    return {f.reason.code for f in findings}
+
+
+def _climate_data(*, inside_temperature, outside_temperature=None):
+    return ClimateCoverData(
+        temp_low=20.0,
+        temp_high=25.0,
+        temp_switch=False,
+        policy=get_policy("cover_blind"),
+        transparent_blind=False,
+        temp_summer_outside=22.5,
+        outside_temperature=outside_temperature,
+        inside_temperature=inside_temperature,
+        is_presence=True,
+        is_sunny=True,
+        lux_below_threshold=False,
+        irradiance_below_threshold=False,
+        winter_close_insulation=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (i) run_triage tolerates a full real payload
+# ---------------------------------------------------------------------------
+
+
+def test_run_triage_never_raises_on_full_real_payload():
+    """A complete real builder payload folded with options runs cleanly."""
+    diag, _ = DiagnosticsBuilder().build(_base_ctx())
+    findings = run_triage({"options": {}, **diag})
+    assert isinstance(findings, list)
+
+
+# ---------------------------------------------------------------------------
+# (ii) rule 4 CLIMATE_TEMP_NONE fires on real climate-mode output
+# ---------------------------------------------------------------------------
+
+
+def test_climate_temp_none_fires_on_real_builder_output():
+    """inside_temperature None under climate mode → CLIMATE_TEMP_NONE.
+
+    Proves rule 4's ``temperature_details.inside_temperature`` key path matches
+    what the builder actually emits (builder.py:681).
+    """
+    cd = _climate_data(inside_temperature=None)
+    pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+    diag, _ = DiagnosticsBuilder().build(
+        _base_ctx(climate_mode=True, pipeline_result=pr)
+    )
+
+    # Sanity: the builder really did emit the section the rule reads.
+    assert diag["temperature_details"]["inside_temperature"] is None
+
+    findings = run_triage({"options": {}, **diag})
+    assert TriageCode.CLIMATE_TEMP_NONE in _codes(findings)
+
+
+def test_climate_temp_none_does_not_fire_when_temp_present():
+    """A present inside temperature must NOT fire rule 4 (guards a false positive)."""
+    cd = _climate_data(inside_temperature="21.5")
+    pr = _make_pr(control_method=ControlMethod.WINTER, climate_data=cd)
+    diag, _ = DiagnosticsBuilder().build(
+        _base_ctx(climate_mode=True, pipeline_result=pr)
+    )
+    findings = run_triage({"options": {}, **diag})
+    assert TriageCode.CLIMATE_TEMP_NONE not in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# (iii) rule 8b ENTITY_UNAVAILABLE fires on a real unavailable sensor
+# ---------------------------------------------------------------------------
+
+
+def test_entity_unavailable_fires_on_real_builder_output():
+    """A shared sensor resolving to 'unavailable' → ENTITY_UNAVAILABLE.
+
+    Proves rule 8b's ``local_sensors[].state``/``entity_id`` key paths match the
+    builder's SensorSource descriptors (builder.py:1030-1037).
+    """
+    hass = SimpleNamespace(
+        states=SimpleNamespace(
+            get=lambda eid: SimpleNamespace(state="unavailable", attributes={})
+        ),
+    )
+    diag, _ = DiagnosticsBuilder().build(
+        _base_ctx(
+            hass=hass,
+            config_options={CONF_OUTSIDETEMP_ENTITY: "sensor.outdoor_temp"},
+        )
+    )
+
+    # Sanity: the builder emitted an unavailable descriptor with the keys the
+    # rule reads.
+    descriptors = diag["local_sensors"]
+    assert any(
+        d.get("state") == "unavailable" and d.get("entity_id") == "sensor.outdoor_temp"
+        for d in descriptors
+    )
+
+    findings = run_triage({"options": {}, **diag})
+    unavailable = [
+        f for f in findings if f.reason.code == TriageCode.ENTITY_UNAVAILABLE
+    ]
+    assert unavailable
+    assert any(f.reason.params.get("eid") == "sensor.outdoor_temp" for f in unavailable)

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -230,6 +230,18 @@ def test_render_report_one_bullet_per_finding() -> None:
     assert lines[1] == "- triage.bbb"
 
 
+def test_render_report_no_labels_renders_english_not_raw_codes() -> None:
+    # With no labels, a real triage finding must render its English troubleshoot
+    # prose — NOT the raw "triage.*" code (reason_i18n's own English table has no
+    # triage codes, so a naive None-label render would leak the code string).
+    from custom_components.adaptive_cover_pro.const import TriageCode
+
+    findings = [Finding(Reason(TriageCode.CLIMATE_TEMP_NONE), Severity.WARNING, None)]
+    report = render_report(findings)
+    assert report.startswith("- ⚠️ Climate mode is on")
+    assert TriageCode.CLIMATE_TEMP_NONE.value not in report
+
+
 def test_render_report_uses_supplied_labels() -> None:
     labels = {"triage.aaa": "hello {who}"}
     findings = [Finding(Reason("triage.aaa", {"who": "world"}), Severity.INFO, None)]

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -1,0 +1,234 @@
+"""Tests for the pure diagnostics-triage engine (issue #970, Phase 1).
+
+Covers the engine shapes (``Severity``/``RuleInput``/``Finding``/``TriageRule``),
+the ``run_triage`` degradation contract, the ``only=`` input filter, and the
+dotted ``_get`` accessor. No seed rule is exercised here — those live in
+``test_triage_rules.py``.
+"""
+
+from __future__ import annotations
+
+from enum import Flag
+
+import pytest
+
+from custom_components.adaptive_cover_pro.diagnostics.triage import (
+    Finding,
+    RuleInput,
+    Severity,
+    TriageRule,
+    _get,
+    render_report,
+    run_triage,
+)
+from custom_components.adaptive_cover_pro.reason_i18n import Reason
+
+pytestmark = pytest.mark.unit
+
+
+def _rule(code, inputs, *, severity=Severity.WARNING, fix_step="position", check):
+    return TriageRule(
+        code=code,
+        severity=severity,
+        inputs=inputs,
+        fix_step=fix_step,
+        wiki="Troubleshooting#x",
+        issues=(970,),
+        check=check,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Degradation contract
+# ---------------------------------------------------------------------------
+
+
+def test_run_triage_empty_dict_returns_empty_list() -> None:
+    assert run_triage({}) == []
+
+
+def test_run_triage_all_none_values_returns_empty_list() -> None:
+    view = {"options": None, "capabilities": None, "climate_conditions": None}
+    assert run_triage(view) == []
+
+
+def test_run_triage_never_raises_on_garbage() -> None:
+    for view in ({}, {"options": None}, {"a": {"b": {"c": None}}}):
+        assert run_triage(view) == []
+
+
+# ---------------------------------------------------------------------------
+# check yields 0 / 1 / N param dicts -> 0 / 1 / N findings
+# ---------------------------------------------------------------------------
+
+
+def test_stub_rule_yields_zero_findings() -> None:
+    rule = _rule("triage.custom_safety_bypass", RuleInput.CONFIG, check=lambda _d: [])
+    assert run_triage({}, rules=[rule]) == []
+
+
+def test_stub_rule_yields_one_finding_with_reason_severity_fix_step() -> None:
+    rule = _rule(
+        "triage.custom_safety_bypass",
+        RuleInput.CONFIG,
+        severity=Severity.INFO,
+        fix_step="custom_position",
+        check=lambda _d: [{"slot": 5, "safety": 100}],
+    )
+    findings = run_triage({}, rules=[rule])
+    assert len(findings) == 1
+    (finding,) = findings
+    assert isinstance(finding, Finding)
+    assert finding.severity is Severity.INFO
+    assert finding.fix_step == "custom_position"
+    assert isinstance(finding.reason, Reason)
+    assert finding.reason.code == "triage.custom_safety_bypass"
+    assert dict(finding.reason.params) == {"slot": 5, "safety": 100}
+
+
+def test_stub_rule_yields_n_findings_one_per_param_dict() -> None:
+    params = [{"eid": "cover.a"}, {"eid": "cover.b"}, {"eid": "cover.c"}]
+    rule = _rule(
+        "triage.cover_not_ready", RuleInput.CONFIG, check=lambda _d: iter(params)
+    )
+    findings = run_triage({}, rules=[rule])
+    assert [dict(f.reason.params) for f in findings] == params
+    assert all(f.reason.code == "triage.cover_not_ready" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# only= input filter (subset semantics)
+# ---------------------------------------------------------------------------
+
+
+def test_only_config_excludes_runtime_and_mixed_rows() -> None:
+    fire = lambda _d: [{}]  # noqa: E731
+    config_rule = _rule("triage.custom_safety_bypass", RuleInput.CONFIG, check=fire)
+    runtime_rule = _rule("triage.climate_temp_none", RuleInput.RUNTIME, check=fire)
+    mixed_rule = _rule(
+        "triage.summer_wont_close",
+        RuleInput.CONFIG | RuleInput.RUNTIME,
+        check=fire,
+    )
+    rules = [config_rule, runtime_rule, mixed_rule]
+
+    only_config = run_triage({}, only=RuleInput.CONFIG, rules=rules)
+    assert [f.reason.code for f in only_config] == ["triage.custom_safety_bypass"]
+
+    only_runtime = run_triage({}, only=RuleInput.RUNTIME, rules=rules)
+    assert [f.reason.code for f in only_runtime] == ["triage.climate_temp_none"]
+
+    both = run_triage({}, only=RuleInput.CONFIG | RuleInput.RUNTIME, rules=rules)
+    assert {f.reason.code for f in both} == {
+        "triage.custom_safety_bypass",
+        "triage.climate_temp_none",
+        "triage.summer_wont_close",
+    }
+
+    unfiltered = run_triage({}, rules=rules)
+    assert len(unfiltered) == 3
+
+
+# ---------------------------------------------------------------------------
+# a raising check is logged and skipped, never propagated
+# ---------------------------------------------------------------------------
+
+
+def test_raising_check_is_skipped_not_propagated() -> None:
+    def boom(_data):
+        raise ValueError("kaboom")
+
+    bad = _rule("triage.custom_safety_bypass", RuleInput.CONFIG, check=boom)
+    good = _rule(
+        "triage.cover_not_ready",
+        RuleInput.CONFIG,
+        check=lambda _d: [{"eid": "cover.a"}],
+    )
+    findings = run_triage({}, rules=[bad, good])
+    assert [f.reason.code for f in findings] == ["triage.cover_not_ready"]
+
+
+# ---------------------------------------------------------------------------
+# _get dotted accessor
+# ---------------------------------------------------------------------------
+
+
+def test_get_nested_hit() -> None:
+    assert _get({"a": {"b": 1}}, "a.b") == 1
+
+
+def test_get_missing_returns_none() -> None:
+    assert _get({}, "x.y") is None
+    assert _get({"a": {}}, "a.b") is None
+    assert _get({"a": {"b": 1}}, "a.c") is None
+
+
+def test_get_non_mapping_segment_returns_none() -> None:
+    assert _get({"a": 5}, "a.b") is None
+    assert _get({"a": "str"}, "a.b") is None
+
+
+def test_get_falsy_leaf_values_pass_through() -> None:
+    assert _get({"a": {"b": 0}}, "a.b") == 0
+    assert _get({"a": {"b": False}}, "a.b") is False
+    assert _get({"a": {"b": ""}}, "a.b") == ""
+
+
+def test_get_single_segment() -> None:
+    assert _get({"a": 1}, "a") == 1
+    assert _get({}, "a") is None
+
+
+# ---------------------------------------------------------------------------
+# enum / dataclass shapes
+# ---------------------------------------------------------------------------
+
+
+def test_severity_members() -> None:
+    assert {s.name for s in Severity} == {"CRITICAL", "WARNING", "INFO"}
+
+
+def test_ruleinput_is_flag() -> None:
+    assert issubclass(RuleInput, Flag)
+    assert RuleInput.CONFIG != RuleInput.RUNTIME
+    assert (RuleInput.CONFIG | RuleInput.RUNTIME) & RuleInput.CONFIG == RuleInput.CONFIG
+
+
+def test_finding_is_frozen() -> None:
+    finding = Finding(Reason("triage.x"), Severity.INFO, None)
+    with pytest.raises(Exception):  # noqa: B017, PT011 - FrozenInstanceError
+        finding.severity = Severity.WARNING  # type: ignore[misc]
+
+
+def test_triage_rule_is_frozen() -> None:
+    rule = _rule("triage.x", RuleInput.CONFIG, check=lambda _d: [])
+    with pytest.raises(Exception):  # noqa: B017, PT011 - FrozenInstanceError
+        rule.code = "y"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# render_report — reuses reason_i18n.render, one bullet per finding
+# ---------------------------------------------------------------------------
+
+
+def test_render_report_empty_is_empty_string() -> None:
+    assert render_report([]) == ""
+
+
+def test_render_report_one_line_per_finding_with_icon() -> None:
+    # An unknown code renders (via reason_i18n) to the code string itself.
+    findings = [
+        Finding(Reason("triage.aaa"), Severity.WARNING, None),
+        Finding(Reason("triage.bbb"), Severity.INFO, None),
+    ]
+    report = render_report(findings)
+    lines = report.split("\n")
+    assert len(lines) == 2
+    assert lines[0].startswith("⚠️") and lines[0].endswith("triage.aaa")
+    assert lines[1].startswith("ℹ️") and lines[1].endswith("triage.bbb")
+
+
+def test_render_report_uses_supplied_labels() -> None:
+    labels = {"triage.aaa": "hello {who}"}
+    findings = [Finding(Reason("triage.aaa", {"who": "world"}), Severity.INFO, None)]
+    assert render_report(findings, labels) == "ℹ️ hello world"

--- a/tests/test_triage_engine.py
+++ b/tests/test_triage_engine.py
@@ -215,8 +215,10 @@ def test_render_report_empty_is_empty_string() -> None:
     assert render_report([]) == ""
 
 
-def test_render_report_one_line_per_finding_with_icon() -> None:
-    # An unknown code renders (via reason_i18n) to the code string itself.
+def test_render_report_one_bullet_per_finding() -> None:
+    # An unknown code renders (via reason_i18n) to the code string itself. The
+    # report uses a plain bullet marker and never prepends a severity icon — the
+    # template text carries its own leading emoji (see the double-icon test).
     findings = [
         Finding(Reason("triage.aaa"), Severity.WARNING, None),
         Finding(Reason("triage.bbb"), Severity.INFO, None),
@@ -224,11 +226,21 @@ def test_render_report_one_line_per_finding_with_icon() -> None:
     report = render_report(findings)
     lines = report.split("\n")
     assert len(lines) == 2
-    assert lines[0].startswith("⚠️") and lines[0].endswith("triage.aaa")
-    assert lines[1].startswith("ℹ️") and lines[1].endswith("triage.bbb")
+    assert lines[0] == "- triage.aaa"
+    assert lines[1] == "- triage.bbb"
 
 
 def test_render_report_uses_supplied_labels() -> None:
     labels = {"triage.aaa": "hello {who}"}
     findings = [Finding(Reason("triage.aaa", {"who": "world"}), Severity.INFO, None)]
-    assert render_report(findings, labels) == "ℹ️ hello world"
+    assert render_report(findings, labels) == "- hello world"
+
+
+def test_render_report_does_not_double_severity_icon() -> None:
+    # A real triage template already leads with its own severity emoji;
+    # render_report must NOT prepend a second one (the Chunk 3 double-icon bug).
+    labels = {"triage.warn": "⚠️ something is wrong"}
+    findings = [Finding(Reason("triage.warn"), Severity.WARNING, None)]
+    report = render_report(findings, labels)
+    assert report == "- ⚠️ something is wrong"
+    assert "⚠️ ⚠️" not in report

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -171,17 +171,37 @@ def test_rule2_near_miss_trace_absent() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_rule3_fires_on_midnight_start() -> None:
+def test_rule3_near_miss_blank_time_sentinel_start() -> None:
+    # "00:00:00" is BLANK_TIME (UNSET / all-day), not a suspect start — a legacy
+    # entry carrying it tracks all day legitimately (issue #970, MINOR 6).
     view = {"options": {"start_time": "00:00:00", "end_time": "20:00:00"}}
+    assert _fire(TriageCode.TIME_WINDOW_SUSPECT, view) == []
+
+
+def test_rule3_near_miss_blank_time_end_not_inverted() -> None:
+    # A real start with a BLANK_TIME (unset) end must NOT read as start > end.
+    view = {"options": {"start_time": "07:00:00", "end_time": "00:00:00"}}
+    assert _fire(TriageCode.TIME_WINDOW_SUSPECT, view) == []
+
+
+def test_rule3_fires_on_sun_sensor_start_entity() -> None:
+    view = {"options": {"start_entity": "sensor.sun_next_dawn"}}
     findings = _fire(TriageCode.TIME_WINDOW_SUSPECT, view)
     assert len(findings) == 1
     assert findings[0].severity is Severity.WARNING
     assert findings[0].fix_step == "automation"
 
 
-def test_rule3_fires_on_sun_sensor_start_entity() -> None:
+def test_rule3_sun_sensor_start_with_no_end_does_not_render_none() -> None:
+    # MINOR 8: a missing end must not surface as "end None" — the sentinel is used.
     view = {"options": {"start_entity": "sensor.sun_next_dawn"}}
-    assert len(_fire(TriageCode.TIME_WINDOW_SUSPECT, view)) == 1
+    params = dict(_fire(TriageCode.TIME_WINDOW_SUSPECT, view)[0].reason.params)
+    assert params["end"] is not None
+    rendered = render(
+        _fire(TriageCode.TIME_WINDOW_SUSPECT, view)[0].reason,
+        load_troubleshoot_labels("en"),
+    )
+    assert "None" not in rendered
 
 
 def test_rule3_fires_when_start_after_end() -> None:
@@ -370,7 +390,9 @@ def test_rule8b_fires_per_unavailable_sensor_and_cover() -> None:
         {"eid": "sensor.z"},
         {"eid": "cover.a"},
     ]
-    assert all(f.fix_step == "profile_sensors" for f in findings)
+    # No fix route: an unavailable entity is an HA-side condition, not something
+    # an ACP options step fixes (rule 8b fires for heterogeneous entities).
+    assert all(f.fix_step is None for f in findings)
 
 
 def test_rule8b_near_miss_all_available() -> None:
@@ -461,6 +483,39 @@ def _real_options_steps() -> frozenset[str]:
     )
 
 
+# Steps reachable from the COVER options menu (``async_step_init`` cover branch,
+# config_flow.py ~:4454-4501 — the ``keys`` list plus its conditional appends).
+# A rule's ``fix_step`` must be one of these or ``None``: a profile-only step
+# such as ``profile_sensors`` (which calls ``async_create_entry`` and closes the
+# flow) is NOT reachable here and is not a valid fix route for a cover finding.
+_COVER_MENU_STEPS: frozenset[str] = frozenset(
+    {
+        "cover_entities",
+        "geometry",
+        "sun_tracking",
+        "building_profile",
+        "blind_spot",
+        "position",
+        "behavior",
+        "interp",
+        "weather_override",
+        "manual_override",
+        "custom_position",
+        "motion_override",
+        "light_cloud",
+        "temperature_climate",
+        "glare_zones",
+        "pipeline_priorities",
+        "automation",
+        "sync",
+        "summary",
+        "troubleshoot",
+        "debug",
+        "done",
+    }
+)
+
+
 _WIKI_RE = re.compile(r"^[A-Za-z0-9-]+#[a-z0-9-]+$")
 
 
@@ -482,9 +537,19 @@ def test_rule_template_exists_in_code_defaults_and_en_json(rule) -> None:
     assert rule.code in en_flat
 
 
+def test_cover_menu_steps_are_all_real_options_steps() -> None:
+    # Drift guard: every step in the curated cover-menu set must be a real
+    # ``async_step_*`` handler, so a renamed cover step breaks this test rather
+    # than silently letting a stale name into the reachable allowlist.
+    assert _COVER_MENU_STEPS.issubset(_real_options_steps())
+
+
 @pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
-def test_rule_fix_step_is_real(rule) -> None:
-    assert rule.fix_step is None or rule.fix_step in _real_options_steps()
+def test_rule_fix_step_is_reachable_from_cover_menu(rule) -> None:
+    # A finding's fix_step must be None or a step the user can actually reach
+    # from the cover options menu — NOT merely any ``async_step_*`` (which would
+    # wrongly accept profile-only steps like ``profile_sensors``).
+    assert rule.fix_step is None or rule.fix_step in _COVER_MENU_STEPS
 
 
 @pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
@@ -497,6 +562,60 @@ def test_rule_issues_non_empty_int_tuple(rule) -> None:
     assert isinstance(rule.issues, tuple)
     assert rule.issues
     assert all(isinstance(i, int) for i in rule.issues)
+
+
+# ---------------------------------------------------------------------------
+# Slot-gate parity lock — the triage module's slot helpers are a forced
+# hand-copy of the ``helpers`` / ``templates`` originals (those import Home
+# Assistant; triage must stay HA-free). If the copies drift, the config summary
+# can index a slot with no finding and raise KeyError. Lock the copy at test
+# time so drift fails here, not in production. (HA-dependent helpers are
+# imported inside the test to keep collection HA-free, mirroring the pattern
+# above.)
+# ---------------------------------------------------------------------------
+
+
+def test_triage_claim_keys_match_helpers_constant() -> None:
+    from custom_components.adaptive_cover_pro.diagnostics.triage import _CLAIM_KEYS
+    from custom_components.adaptive_cover_pro.helpers import (
+        CUSTOM_POSITION_CLAIM_KEYS,
+    )
+
+    assert _CLAIM_KEYS == CUSTOM_POSITION_CLAIM_KEYS
+
+
+def test_triage_is_template_agrees_with_templates() -> None:
+    from custom_components.adaptive_cover_pro.diagnostics.triage import _is_template
+    from custom_components.adaptive_cover_pro.templates import is_template_string
+
+    for value in ("{{ x }}", "{% if x %}", "plain", "1000", "", None, 5, True):
+        assert _is_template(value) == is_template_string(value), value
+
+
+def test_triage_slot_configured_agrees_with_helpers() -> None:
+    from custom_components.adaptive_cover_pro.const import CUSTOM_POSITION_SLOTS
+    from custom_components.adaptive_cover_pro.diagnostics.triage import (
+        _slot_configured,
+    )
+    from custom_components.adaptive_cover_pro.helpers import (
+        custom_position_slot_configured,
+    )
+
+    keys = CUSTOM_POSITION_SLOTS[1]
+    configs = [
+        {},  # unconfigured
+        {keys["sensor"]: "binary_sensor.t", keys["position"]: 50},  # configured
+        {keys["template"]: "{{ true }}", keys["tilt_min"]: 20},  # template + claim
+        {keys["sensor"]: "binary_sensor.t"},  # trigger only, no claim
+        {keys["position"]: 50},  # claim only, no trigger
+        {keys["sensors"]: ["binary_sensor.a"], keys["position_max"]: 80},  # list+claim
+        {keys["sensors"]: [], keys["position"]: 50},  # empty list = no trigger
+        {keys["template"]: "not-a-template", keys["position"]: 50},  # plain != tmpl
+    ]
+    for cfg in configs:
+        assert _slot_configured(cfg, keys) == custom_position_slot_configured(
+            cfg, keys
+        ), cfg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -22,8 +22,10 @@ from custom_components.adaptive_cover_pro.diagnostics.triage import (
     Severity,
     run_triage,
 )
+from custom_components.adaptive_cover_pro.reason_i18n import Reason, render
 from custom_components.adaptive_cover_pro.troubleshoot_i18n import (
     _TRIAGE_TEMPLATES_EN,
+    load_troubleshoot_labels,
 )
 from tests._helpers import i18n_parity
 
@@ -535,4 +537,34 @@ def test_config_rules_are_deterministic_without_runtime() -> None:
     # And the same via the full table (only= filters mixed/runtime rows out).
     assert run_triage(full, only=RuleInput.CONFIG) == run_triage(
         config_only, only=RuleInput.CONFIG
+    )
+
+
+# ---------------------------------------------------------------------------
+# Summary-migration byte-identity lock (issue #970, Step 8). The config summary
+# renders these two CONFIG findings via reason_i18n.render (NOT render_report),
+# so the rendered English MUST byte-match the legacy hand-written strings the
+# migration replaces — guarded end-to-end by tests/test_config_flow_summary.py.
+# ---------------------------------------------------------------------------
+
+
+def test_custom_safety_bypass_renders_byte_identical_to_legacy_summary() -> None:
+    reason = Reason(
+        TriageCode.CUSTOM_SAFETY_BYPASS,
+        {"slot": 5, "safety": CUSTOM_POSITION_SAFETY_PRIORITY},
+    )
+    assert render(reason, load_troubleshoot_labels("en")) == (
+        "⚠️ Custom #5 is at safety priority (100) — it bypasses the "
+        "automatic-control toggle, manual override, and the start/end time "
+        "window, so it can move the cover even when automatic control is OFF "
+        "and outside your schedule. Lower its priority below 100 to make it "
+        "respect those gates."
+    )
+
+
+def test_cover_not_ready_renders_byte_identical_to_legacy_summary() -> None:
+    reason = Reason(TriageCode.COVER_NOT_READY, {"eid": "cover.x"})
+    assert (
+        render(reason, load_troubleshoot_labels("en"))
+        == "⚠️ cover.x: not ready (unavailable)"
     )

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -1,0 +1,536 @@
+"""Per-rule + meta tests for the seed triage rule table (issue #970, Phase 1).
+
+Each seed rule (rows 1,2,3,4,5,6,7,8a,8b,9,10) gets a firing view, a near-miss
+view, and — for per-entity rules — an N-entity view. The meta section runs over
+``TRIAGE_RULES`` and enforces table invariants plus the CONFIG-determinism lock.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CUSTOM_POSITION_SAFETY_PRIORITY,
+    TriageCode,
+)
+from custom_components.adaptive_cover_pro.diagnostics.triage import (
+    TRIAGE_RULES,
+    RuleInput,
+    Severity,
+    run_triage,
+)
+from custom_components.adaptive_cover_pro.troubleshoot_i18n import (
+    _TRIAGE_TEMPLATES_EN,
+)
+from tests._helpers import i18n_parity
+
+pytestmark = pytest.mark.unit
+
+_RULES_BY_CODE = {rule.code: rule for rule in TRIAGE_RULES}
+
+_TROUBLESHOOT_I18N_DIR = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "troubleshoot_i18n"
+)
+
+
+def _fire(code: str, view: dict) -> list:
+    """Run only the rule identified by ``code`` against ``view``."""
+    return run_triage(view, rules=[_RULES_BY_CODE[code]])
+
+
+def _params(findings: list) -> list[dict]:
+    return [dict(f.reason.params) for f in findings]
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — CUSTOM_SAFETY_BYPASS
+# ---------------------------------------------------------------------------
+
+
+def test_rule1_fires_on_configured_safety_slot() -> None:
+    view = {
+        "options": {
+            "custom_position_sensor_1": "binary_sensor.trigger",
+            "custom_position_1": 50,
+            "custom_position_priority_1": CUSTOM_POSITION_SAFETY_PRIORITY,
+        }
+    }
+    findings = _fire(TriageCode.CUSTOM_SAFETY_BYPASS, view)
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.WARNING
+    assert findings[0].fix_step == "custom_position"
+    assert dict(findings[0].reason.params) == {
+        "slot": 1,
+        "safety": CUSTOM_POSITION_SAFETY_PRIORITY,
+    }
+
+
+def test_rule1_near_miss_priority_below_safety() -> None:
+    view = {
+        "options": {
+            "custom_position_sensor_1": "binary_sensor.trigger",
+            "custom_position_1": 50,
+            "custom_position_priority_1": 77,
+        }
+    }
+    assert _fire(TriageCode.CUSTOM_SAFETY_BYPASS, view) == []
+
+
+def test_rule1_near_miss_trigger_without_claim_is_unconfigured() -> None:
+    # A safety-priority slot with a trigger but no axis claim is not configured,
+    # so it does not participate — matches the summary's slot-skip guard.
+    view = {
+        "options": {
+            "custom_position_sensor_1": "binary_sensor.trigger",
+            "custom_position_priority_1": CUSTOM_POSITION_SAFETY_PRIORITY,
+        }
+    }
+    assert _fire(TriageCode.CUSTOM_SAFETY_BYPASS, view) == []
+
+
+def test_rule1_template_via_sensors_list_key() -> None:
+    view = {
+        "options": {
+            "custom_position_sensors_2": ["binary_sensor.a", "binary_sensor.b"],
+            "custom_position_2": 30,
+            "custom_position_priority_2": CUSTOM_POSITION_SAFETY_PRIORITY,
+        }
+    }
+    assert _params(_fire(TriageCode.CUSTOM_SAFETY_BYPASS, view)) == [
+        {"slot": 2, "safety": CUSTOM_POSITION_SAFETY_PRIORITY}
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — HIGHER_PRIORITY_WON
+# ---------------------------------------------------------------------------
+
+
+def test_rule2_fires_when_climate_outranks_solar() -> None:
+    view = {
+        "decision_trace": [
+            {"handler": "climate", "matched": True, "priority": 50},
+            {"handler": "solar", "matched": False, "priority": 40},
+        ],
+        "handler_priorities": {
+            "climate": {"priority": 50},
+            "solar": {"priority": 40},
+        },
+    }
+    findings = _fire(TriageCode.HIGHER_PRIORITY_WON, view)
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.INFO
+    params = dict(findings[0].reason.params)
+    assert params["winner"] == "climate"
+    assert params["skipped"] == "solar"
+
+
+def test_rule2_near_miss_solar_is_winner() -> None:
+    view = {
+        "decision_trace": [{"handler": "solar", "matched": True, "priority": 40}],
+        "handler_priorities": {"solar": {"priority": 40}},
+    }
+    assert _fire(TriageCode.HIGHER_PRIORITY_WON, view) == []
+
+
+def test_rule2_near_miss_no_matched_step() -> None:
+    view = {
+        "decision_trace": [{"handler": "climate", "matched": False}],
+        "handler_priorities": {"climate": {"priority": 50}, "solar": {"priority": 40}},
+    }
+    assert _fire(TriageCode.HIGHER_PRIORITY_WON, view) == []
+
+
+def test_rule2_near_miss_winner_priority_not_above_solar() -> None:
+    # A non-solar winner that does not actually outrank solar (e.g. a floor
+    # clamp) must not fire.
+    view = {
+        "decision_trace": [{"handler": "glare_zone", "matched": True}],
+        "handler_priorities": {
+            "glare_zone": {"priority": 45},
+            "solar": {"priority": 45},
+        },
+    }
+    assert _fire(TriageCode.HIGHER_PRIORITY_WON, view) == []
+
+
+def test_rule2_near_miss_trace_absent() -> None:
+    assert _fire(TriageCode.HIGHER_PRIORITY_WON, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — TIME_WINDOW_SUSPECT
+# ---------------------------------------------------------------------------
+
+
+def test_rule3_fires_on_midnight_start() -> None:
+    view = {"options": {"start_time": "00:00:00", "end_time": "20:00:00"}}
+    findings = _fire(TriageCode.TIME_WINDOW_SUSPECT, view)
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.WARNING
+    assert findings[0].fix_step == "automation"
+
+
+def test_rule3_fires_on_sun_sensor_start_entity() -> None:
+    view = {"options": {"start_entity": "sensor.sun_next_dawn"}}
+    assert len(_fire(TriageCode.TIME_WINDOW_SUSPECT, view)) == 1
+
+
+def test_rule3_fires_when_start_after_end() -> None:
+    view = {"options": {"start_time": "21:00:00", "end_time": "08:00:00"}}
+    assert len(_fire(TriageCode.TIME_WINDOW_SUSPECT, view)) == 1
+
+
+def test_rule3_near_miss_sane_window() -> None:
+    view = {"options": {"start_time": "07:00:00", "end_time": "20:00:00"}}
+    assert _fire(TriageCode.TIME_WINDOW_SUSPECT, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 4 — CLIMATE_TEMP_NONE
+# ---------------------------------------------------------------------------
+
+
+def test_rule4_fires_when_inside_temp_none() -> None:
+    view = {"temperature_details": {"inside_temperature": None}}
+    findings = _fire(TriageCode.CLIMATE_TEMP_NONE, view)
+    assert len(findings) == 1
+    assert findings[0].fix_step == "temperature_climate"
+
+
+def test_rule4_near_miss_temp_present() -> None:
+    view = {"temperature_details": {"inside_temperature": 21.0}}
+    assert _fire(TriageCode.CLIMATE_TEMP_NONE, view) == []
+
+
+def test_rule4_near_miss_section_absent() -> None:
+    assert _fire(TriageCode.CLIMATE_TEMP_NONE, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — SUMMER_WONT_CLOSE
+# ---------------------------------------------------------------------------
+
+
+def test_rule5_fires_summer_presence_climate_unmatched() -> None:
+    view = {
+        "options": {},
+        "climate_conditions": {"is_summer": True, "is_presence": True},
+        "decision_trace": [{"handler": "climate", "matched": False}],
+    }
+    findings = _fire(TriageCode.SUMMER_WONT_CLOSE, view)
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.WARNING
+
+
+def test_rule5_near_miss_transparent_blind() -> None:
+    view = {
+        "options": {"transparent_blind": True},
+        "climate_conditions": {"is_summer": True, "is_presence": True},
+        "decision_trace": [{"handler": "climate", "matched": False}],
+    }
+    assert _fire(TriageCode.SUMMER_WONT_CLOSE, view) == []
+
+
+def test_rule5_near_miss_climate_matched() -> None:
+    view = {
+        "options": {},
+        "climate_conditions": {"is_summer": True, "is_presence": True},
+        "decision_trace": [{"handler": "climate", "matched": True}],
+    }
+    assert _fire(TriageCode.SUMMER_WONT_CLOSE, view) == []
+
+
+def test_rule5_near_miss_not_summer() -> None:
+    view = {
+        "options": {},
+        "climate_conditions": {"is_summer": False, "is_presence": True},
+        "decision_trace": [{"handler": "climate", "matched": False}],
+    }
+    assert _fire(TriageCode.SUMMER_WONT_CLOSE, view) == []
+
+
+def test_rule5_near_miss_climate_step_absent() -> None:
+    view = {
+        "options": {},
+        "climate_conditions": {"is_summer": True, "is_presence": True},
+        "decision_trace": [{"handler": "solar", "matched": True}],
+    }
+    assert _fire(TriageCode.SUMMER_WONT_CLOSE, view) == []
+
+
+def test_rule5_near_miss_decision_trace_absent() -> None:
+    view = {
+        "options": {},
+        "climate_conditions": {"is_summer": True, "is_presence": True},
+    }
+    assert _fire(TriageCode.SUMMER_WONT_CLOSE, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 6 — PRESENCE_DEFAULTS_TRUE
+# ---------------------------------------------------------------------------
+
+
+def test_rule6_fires_climate_on_no_presence() -> None:
+    view = {"options": {"climate_mode": True}}
+    findings = _fire(TriageCode.PRESENCE_DEFAULTS_TRUE, view)
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.INFO
+
+
+def test_rule6_near_miss_presence_entity_set() -> None:
+    view = {"options": {"climate_mode": True, "presence_entity": "binary_sensor.p"}}
+    assert _fire(TriageCode.PRESENCE_DEFAULTS_TRUE, view) == []
+
+
+def test_rule6_near_miss_climate_off() -> None:
+    view = {"options": {"climate_mode": False}}
+    assert _fire(TriageCode.PRESENCE_DEFAULTS_TRUE, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 7 — CLOUD_OR_SEMANTICS
+# ---------------------------------------------------------------------------
+
+
+def test_rule7_fires_with_two_inputs() -> None:
+    view = {
+        "options": {
+            "lux_entity": "sensor.lux",
+            "irradiance_entity": "sensor.irr",
+        },
+        "climate_conditions": {"lux_below_threshold": True},
+    }
+    findings = _fire(TriageCode.CLOUD_OR_SEMANTICS, view)
+    assert len(findings) == 1
+    params = dict(findings[0].reason.params)
+    assert params["inputs"] == "lux, irradiance"
+    assert params["tripped"] == "lux below threshold"
+
+
+def test_rule7_near_miss_single_input() -> None:
+    view = {"options": {"lux_entity": "sensor.lux"}}
+    assert _fire(TriageCode.CLOUD_OR_SEMANTICS, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 8a — COVER_NOT_READY (per-entity)
+# ---------------------------------------------------------------------------
+
+
+def test_rule8a_fires_per_unavailable_cover() -> None:
+    view = {
+        "capabilities": {
+            "cover.a": None,
+            "cover.b": {"has_set_position": True},
+            "cover.c": None,
+        }
+    }
+    findings = _fire(TriageCode.COVER_NOT_READY, view)
+    assert _params(findings) == [{"eid": "cover.a"}, {"eid": "cover.c"}]
+    assert all(f.fix_step == "cover_entities" for f in findings)
+
+
+def test_rule8a_near_miss_all_ready() -> None:
+    view = {"capabilities": {"cover.a": {"has_set_position": True}}}
+    assert _fire(TriageCode.COVER_NOT_READY, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 8b — ENTITY_UNAVAILABLE (per-entity)
+# ---------------------------------------------------------------------------
+
+
+def test_rule8b_fires_per_unavailable_sensor_and_cover() -> None:
+    view = {
+        "local_sensors": [
+            {"entity_id": "sensor.x", "state": "unavailable"},
+            {"entity_id": "sensor.y", "state": "available"},
+        ],
+        "building_profile_sensors": [
+            {"entity_id": "sensor.z", "state": "unavailable"},
+        ],
+        "covers": {
+            "cover.a": {"available": False},
+            "cover.b": {"available": True},
+        },
+    }
+    findings = _fire(TriageCode.ENTITY_UNAVAILABLE, view)
+    assert _params(findings) == [
+        {"eid": "sensor.x"},
+        {"eid": "sensor.z"},
+        {"eid": "cover.a"},
+    ]
+    assert all(f.fix_step == "profile_sensors" for f in findings)
+
+
+def test_rule8b_near_miss_all_available() -> None:
+    view = {
+        "local_sensors": [{"entity_id": "sensor.y", "state": "available"}],
+        "covers": {"cover.b": {"available": True}},
+    }
+    assert _fire(TriageCode.ENTITY_UNAVAILABLE, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 9 — MIN_FLOOR_BYPASSED
+# ---------------------------------------------------------------------------
+
+
+def test_rule9_fires_on_sunset_below_floor() -> None:
+    view = {"options": {"min_position": 40, "sunset_position": 10}}
+    findings = _fire(TriageCode.MIN_FLOOR_BYPASSED, view)
+    assert len(findings) == 1
+    params = dict(findings[0].reason.params)
+    assert params["min"] == 40
+    assert params["offenders"] == "sunset position"
+
+
+def test_rule9_fires_on_custom_position_below_floor() -> None:
+    view = {
+        "options": {
+            "min_position": 40,
+            "custom_position_sensor_1": "binary_sensor.t",
+            "custom_position_1": 5,
+            "custom_position_priority_1": 77,
+        }
+    }
+    params = dict(_fire(TriageCode.MIN_FLOOR_BYPASSED, view)[0].reason.params)
+    assert params["offenders"] == "Custom #1"
+
+
+def test_rule9_near_miss_sunset_above_floor() -> None:
+    view = {"options": {"min_position": 40, "sunset_position": 50}}
+    assert _fire(TriageCode.MIN_FLOOR_BYPASSED, view) == []
+
+
+def test_rule9_near_miss_no_floor() -> None:
+    view = {"options": {"min_position": 0, "sunset_position": 5}}
+    assert _fire(TriageCode.MIN_FLOOR_BYPASSED, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 10 — ENABLE_MIN_BACKWARDS
+# ---------------------------------------------------------------------------
+
+
+def test_rule10_fires_when_enable_min_false_with_floor() -> None:
+    view = {"options": {"enable_min_position": False, "min_position": 40}}
+    findings = _fire(TriageCode.ENABLE_MIN_BACKWARDS, view)
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.INFO
+    assert dict(findings[0].reason.params) == {"min": 40}
+
+
+def test_rule10_near_miss_enable_min_true() -> None:
+    view = {"options": {"enable_min_position": True, "min_position": 40}}
+    assert _fire(TriageCode.ENABLE_MIN_BACKWARDS, view) == []
+
+
+def test_rule10_near_miss_no_floor() -> None:
+    view = {"options": {"enable_min_position": False, "min_position": 0}}
+    assert _fire(TriageCode.ENABLE_MIN_BACKWARDS, view) == []
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — meta-test over the whole table
+# ---------------------------------------------------------------------------
+
+# TODO chunk 4: derive from OptionsFlowHandler reflection (real options steps).
+_EXPECTED_FIX_STEPS: frozenset[str] = frozenset(
+    {
+        "custom_position",
+        "pipeline_priorities",
+        "automation",
+        "temperature_climate",
+        "light_cloud",
+        "cover_entities",
+        "profile_sensors",
+        "position",
+    }
+)
+
+_WIKI_RE = re.compile(r"^[A-Za-z0-9-]+#[a-z0-9-]+$")
+
+
+def test_rule_codes_are_unique() -> None:
+    codes = [rule.code for rule in TRIAGE_RULES]
+    assert len(codes) == len(set(codes))
+
+
+def test_seed_table_covers_the_eleven_codes() -> None:
+    assert {rule.code for rule in TRIAGE_RULES} == {c.value for c in TriageCode}
+
+
+@pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
+def test_rule_template_exists_in_code_defaults_and_en_json(rule) -> None:
+    assert rule.code in _TRIAGE_TEMPLATES_EN
+    en_flat = i18n_parity.flatten(
+        i18n_parity.load_bundle(_TROUBLESHOOT_I18N_DIR, "en.json")
+    )
+    assert rule.code in en_flat
+
+
+@pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
+def test_rule_fix_step_is_real(rule) -> None:
+    assert rule.fix_step is None or rule.fix_step in _EXPECTED_FIX_STEPS
+
+
+@pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
+def test_rule_wiki_anchor_format(rule) -> None:
+    assert _WIKI_RE.match(rule.wiki), rule.wiki
+
+
+@pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
+def test_rule_issues_non_empty_int_tuple(rule) -> None:
+    assert isinstance(rule.issues, tuple)
+    assert rule.issues
+    assert all(isinstance(i, int) for i in rule.issues)
+
+
+# ---------------------------------------------------------------------------
+# CONFIG-determinism lock — a CONFIG rule's output must not depend on runtime.
+# ---------------------------------------------------------------------------
+
+
+def _full_view() -> dict:
+    return {
+        "options": {
+            "custom_position_sensor_1": "binary_sensor.t",
+            "custom_position_1": 5,
+            "custom_position_priority_1": CUSTOM_POSITION_SAFETY_PRIORITY,
+            "climate_mode": True,
+            "start_time": "00:00:00",
+            "min_position": 40,
+            "enable_min_position": False,
+            "sunset_position": 10,
+        },
+        "capabilities": {"cover.a": None, "cover.b": {"has_set_position": True}},
+        # runtime sections that CONFIG rules must ignore
+        "decision_trace": [{"handler": "climate", "matched": True, "priority": 50}],
+        "handler_priorities": {"climate": {"priority": 50}, "solar": {"priority": 40}},
+        "climate_conditions": {"is_summer": True, "is_presence": True},
+        "temperature_details": {"inside_temperature": None},
+        "local_sensors": [{"entity_id": "sensor.x", "state": "unavailable"}],
+        "covers": {"cover.a": {"available": False}},
+    }
+
+
+def test_config_rules_are_deterministic_without_runtime() -> None:
+    full = _full_view()
+    config_only = {"options": full["options"], "capabilities": full["capabilities"]}
+    config_rules = [r for r in TRIAGE_RULES if r.inputs == RuleInput.CONFIG]
+    assert run_triage(full, only=RuleInput.CONFIG, rules=config_rules) == run_triage(
+        config_only, only=RuleInput.CONFIG, rules=config_rules
+    )
+    # And the same via the full table (only= filters mixed/runtime rows out).
+    assert run_triage(full, only=RuleInput.CONFIG) == run_triage(
+        config_only, only=RuleInput.CONFIG
+    )

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -443,19 +443,21 @@ def test_rule10_near_miss_no_floor() -> None:
 # Step 4 — meta-test over the whole table
 # ---------------------------------------------------------------------------
 
-# TODO chunk 4: derive from OptionsFlowHandler reflection (real options steps).
-_EXPECTED_FIX_STEPS: frozenset[str] = frozenset(
-    {
-        "custom_position",
-        "pipeline_priorities",
-        "automation",
-        "temperature_climate",
-        "light_cloud",
-        "cover_entities",
-        "profile_sensors",
-        "position",
-    }
-)
+
+def _real_options_steps() -> frozenset[str]:
+    """Return the real ``async_step_*`` ids on ``OptionsFlowHandler``.
+
+    Imported inside the helper so the HA-dependent ``config_flow`` module is not
+    pulled in at collection time (mirrors how other tests defer that import).
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    return frozenset(
+        name.removeprefix("async_step_")
+        for name in dir(OptionsFlowHandler)
+        if name.startswith("async_step_")
+    )
+
 
 _WIKI_RE = re.compile(r"^[A-Za-z0-9-]+#[a-z0-9-]+$")
 
@@ -480,7 +482,7 @@ def test_rule_template_exists_in_code_defaults_and_en_json(rule) -> None:
 
 @pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
 def test_rule_fix_step_is_real(rule) -> None:
-    assert rule.fix_step is None or rule.fix_step in _EXPECTED_FIX_STEPS
+    assert rule.fix_step is None or rule.fix_step in _real_options_steps()
 
 
 @pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)

--- a/tests/test_troubleshoot_i18n.py
+++ b/tests/test_troubleshoot_i18n.py
@@ -1,0 +1,119 @@
+"""Tests for the troubleshoot-finding i18n bundle (issue #970, Phase 1).
+
+Mirrors ``test_reason_i18n.py``: the ``_TRIAGE_TEMPLATES_EN`` code defaults, the
+shipped ``troubleshoot_i18n/{en,de,fr}.json`` bundle, its three parity locks
+(via the shared ``tests/_helpers/i18n_parity`` helper), the English-fallback
+loader, and a real ``Finding`` rendered through ``reason_i18n.render``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.adaptive_cover_pro import reason_i18n, troubleshoot_i18n
+from custom_components.adaptive_cover_pro.const import TriageCode
+from custom_components.adaptive_cover_pro.diagnostics.triage import (
+    Finding,
+    Severity,
+)
+from custom_components.adaptive_cover_pro.reason_i18n import Reason
+from custom_components.adaptive_cover_pro.troubleshoot_i18n import (
+    _TRIAGE_TEMPLATES_EN,
+    load_troubleshoot_labels,
+)
+from tests._helpers import i18n_parity
+
+pytestmark = pytest.mark.unit
+
+TROUBLESHOOT_I18N_DIR = (
+    Path(__file__).parent.parent
+    / "custom_components"
+    / "adaptive_cover_pro"
+    / "troubleshoot_i18n"
+)
+
+
+# ---------------------------------------------------------------------------
+# Loader behavior
+# ---------------------------------------------------------------------------
+
+
+def test_load_english_returns_code_defaults() -> None:
+    assert load_troubleshoot_labels("en") == _TRIAGE_TEMPLATES_EN
+
+
+def test_unknown_language_falls_back_to_english() -> None:
+    assert load_troubleshoot_labels("zz") == _TRIAGE_TEMPLATES_EN
+
+
+def test_malformed_language_falls_back_to_english(tmp_path) -> None:
+    # load_bundle_overlay swallows OSError/ValueError -> empty overlay -> English.
+    assert load_troubleshoot_labels("") == _TRIAGE_TEMPLATES_EN
+
+
+def test_every_triage_code_has_a_template() -> None:
+    assert set(_TRIAGE_TEMPLATES_EN) == {c.value for c in TriageCode}
+
+
+async def test_async_prime_offloads_to_executor() -> None:
+    class _FakeHass:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def async_add_executor_job(self, func, *args):
+            self.calls += 1
+            return func(*args)
+
+    hass = _FakeHass()
+    labels = await troubleshoot_i18n.async_prime(hass, "en")
+    assert hass.calls == 1
+    assert labels == _TRIAGE_TEMPLATES_EN
+
+
+# ---------------------------------------------------------------------------
+# A Finding renders through reason_i18n.render with a real template
+# ---------------------------------------------------------------------------
+
+
+def test_finding_renders_through_reason_render() -> None:
+    labels = load_troubleshoot_labels("en")
+    finding = Finding(
+        Reason(TriageCode.COVER_NOT_READY, {"eid": "cover.kitchen"}),
+        Severity.WARNING,
+        "cover_entities",
+    )
+    assert (
+        reason_i18n.render(finding.reason, labels)
+        == "⚠️ cover.kitchen: not ready (unavailable)"
+    )
+
+
+def test_finding_renders_multi_param_template() -> None:
+    labels = load_troubleshoot_labels("en")
+    finding = Finding(
+        Reason(TriageCode.CUSTOM_SAFETY_BYPASS, {"slot": 5, "safety": 100}),
+        Severity.WARNING,
+        "custom_position",
+    )
+    rendered = reason_i18n.render(finding.reason, labels)
+    assert rendered.startswith("⚠️ Custom #5 is at safety priority (100)")
+    assert "Lower its priority below 100" in rendered
+
+
+# ---------------------------------------------------------------------------
+# Bundle parity locks (shared helper)
+# ---------------------------------------------------------------------------
+
+
+def test_troubleshoot_en_matches_code_defaults() -> None:
+    i18n_parity.assert_en_matches_defaults(TROUBLESHOOT_I18N_DIR, _TRIAGE_TEMPLATES_EN)
+
+
+def test_troubleshoot_key_parity_de_fr() -> None:
+    i18n_parity.assert_key_parity(TROUBLESHOOT_I18N_DIR)
+
+
+def test_troubleshoot_placeholder_parity_de_fr() -> None:
+    i18n_parity.assert_placeholder_parity(TROUBLESHOOT_I18N_DIR)


### PR DESCRIPTION
## Summary
Phase 1 of the Setup/Troubleshooting Wizard (#953): a declarative rules engine plus its first front end.

- **`diagnostics/triage.py`** — pure, 0-HA-import engine: `Severity` / `RuleInput` / `Finding` / `TriageRule`, `run_triage` (dotted-accessor degradation, `only=CONFIG` seam for Phase 2), and 11 seed rules.
- **`troubleshoot_i18n`** bundle mirroring `reason_i18n`; `Finding` composes a `Reason` and reuses `reason_i18n.render()` — one renderer.
- **`diagnostics/resolve.py`** — read-only diagnostics access (coordinator data → `build_diagnostic_data()` → `DIAG_CACHE_KEY`), never `async_refresh()`. `diagnostics_service.py` migrated onto it.
- **`async_step_troubleshoot`** — read-only Troubleshoot step on cover entries only (not profiles/groups); a list menu routes each finding to the options step that fixes it.
- **Summary migration** — the two Cover-Warnings checks (`custom_safety_bypass`, `not ready (unavailable)`) now render from `RuleInput.CONFIG` rules, byte-identical to before.
- **`tests/_helpers/i18n_parity.py`** — collapses three near-identical parity-lock copies onto one shared helper. DE/FR translations synced.

## Testing
- ✅ 7847 tests passing (1 pre-existing xfail)
- New modules (`triage.py`, `resolve.py`, `troubleshoot_i18n.py`) at 100% coverage
- The 295-function `tests/test_config_flow_summary.py` byte-identity gate passes **unchanged**
- Deep audit (fable) run pre-merge; clean after a fix pass (slot-gate drift guard + parity locks, rule 8b fix_step, rule 3 BLANK_TIME false positive, render_report English default)

## Notes
- No config-entry version bump — read-only step, no new `CONF_*` keys, rollback-safe by construction.
- Seed set is the top ~10 rules by frequency × detectability; rules 14/17 excluded (rule 17's `dry_run` isn't in the diagnostics payload yet — backfill in a later phase per the epic).
- Deferred follow-up: the "no issues found" / "diagnostics unavailable" envelope strings are English-only (need a translation round).

## Related Issues
Refs #970 · Part of epic #953

https://claude.ai/code/session_01CgDx1eunbyStsKKW5a2jcT
