### PR TITLE
fix: profile/group edit steps return to menu on submit (#1003)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -5026,8 +5026,9 @@ class OptionsFlowHandler(OptionsFlow):
         """Edit the cover-group membership rosters (issue #790).
 
         Same one page as the create flow: ACP members first, generic covers
-        below. Saves on submit, mirroring ``profile_sensors``. Sanitization
-        drops duplicates, the group itself, and generic entities owned by a
+        below. Submitting returns to the group menu (issue #1003) — only
+        ``async_step_done`` saves and closes the dialog. Sanitization drops
+        duplicates, the group itself, and generic entities owned by a
         selected ACP member.
         """
         if user_input is not None:
@@ -5051,7 +5052,7 @@ class OptionsFlowHandler(OptionsFlow):
                     for member, scenes in opt_out.items()
                     if member in roster
                 }
-            return self.async_create_entry(title="", data=self.options)
+            return await self.async_step_init()
 
         schema = vol.Schema(
             _group_membership_schema_dict(
@@ -5092,7 +5093,7 @@ class OptionsFlowHandler(OptionsFlow):
                 if member_id in member_ids:
                     opt_out.setdefault(member_id, []).append(scene_value)
             self.options[CONF_GROUP_MEMBER_OPT_OUT] = opt_out
-            return self.async_create_entry(title="", data=self.options)
+            return await self.async_step_init()
 
         stagger_spec = config_fields.FIELD_SPECS[CONF_GROUP_STAGGER_DELAY]
         stagger_marker, stagger_selector = stagger_spec.to_marker(
@@ -5142,7 +5143,7 @@ class OptionsFlowHandler(OptionsFlow):
         """
         if user_input is not None:
             self.options.update(user_input)
-            return self.async_create_entry(title="", data=self.options)
+            return await self.async_step_init()
 
         schema = vol.Schema(
             {
@@ -5177,12 +5178,14 @@ class OptionsFlowHandler(OptionsFlow):
         """Edit the shared building-level sensor IDs on a Building Profile entry.
 
         This is the only options step for a profile: it exposes exactly the
-        ``BUILDING_PROFILE_SENSOR_KEYS`` pickers and saves on submit.  Mirrors
-        the create-flow's ``async_step_create_building_profile`` sensor section.
+        ``BUILDING_PROFILE_SENSOR_KEYS`` pickers.  Mirrors the create-flow's
+        ``async_step_create_building_profile`` sensor section.  Submitting
+        returns to the profile menu (issue #1003) — only ``async_step_done``
+        actually saves and closes the dialog.
         """
         if user_input is not None:
             self.options.update(user_input)
-            return self.async_create_entry(title="", data=self.options)
+            return await self.async_step_init()
 
         schema = building_profile_sensors_schema()
         return self.async_show_form(

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -347,7 +347,7 @@ async def test_cover_save_records_profile_override(hass: HomeAssistant) -> None:
 async def test_building_profile_options_flow_saves_sensors(
     hass: HomeAssistant,
 ) -> None:
-    """Submitting the profile_sensors step saves options and closes the flow."""
+    """Submitting profile_sensors returns to the menu; Done persists it (#1003)."""
     profile = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
@@ -360,10 +360,19 @@ async def test_building_profile_options_flow_saves_sensors(
     flow = OptionsFlowHandler(profile)
     flow.hass = hass
 
-    # Submitting sensor data must produce create_entry (save).
+    # Submitting sensor data returns to the profile menu, not create_entry —
+    # the dialog must stay open so the user can navigate or pick "done".
     result = await flow.async_step_profile_sensors({CONF_LUX_ENTITY: "sensor.new_lux"})
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_LUX_ENTITY] == "sensor.new_lux"
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    # The edit is held in-memory but not yet written to the config entry.
+    assert flow.options[CONF_LUX_ENTITY] == "sensor.new_lux"
+    assert CONF_LUX_ENTITY not in profile.options
+
+    # Only explicitly picking "done" persists the change.
+    result2 = await flow.async_step_done()
+    assert result2["type"] == "create_entry"
+    assert result2["data"][CONF_LUX_ENTITY] == "sensor.new_lux"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_group_config_flow.py
+++ b/tests/test_group_config_flow.py
@@ -215,9 +215,10 @@ async def test_group_membership_step_saves_sanitized(hass: HomeAssistant) -> Non
         }
     )
 
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_MEMBER_ENTRIES] == ["cover_a"]
-    assert result["data"][CONF_MEMBER_COVERS] == ["cover.generic"]
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    assert flow.options[CONF_MEMBER_ENTRIES] == ["cover_a"]
+    assert flow.options[CONF_MEMBER_COVERS] == ["cover.generic"]
 
 
 async def test_cover_entries_excludes_groups(hass: HomeAssistant) -> None:
@@ -275,10 +276,11 @@ async def test_group_arbitration_step_saves_stagger_and_opt_out(
             "scene_opt_outs": [f"cover_a|{GroupScene.PRIVACY}"],
         }
     )
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_GROUP_STAGGER_DELAY] == 2.5
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    assert flow.options[CONF_GROUP_STAGGER_DELAY] == 2.5
     # Only members with opt-outs are stored.
-    assert result["data"][CONF_GROUP_MEMBER_OPT_OUT] == {
+    assert flow.options[CONF_GROUP_MEMBER_OPT_OUT] == {
         "cover_a": [str(GroupScene.PRIVACY)]
     }
 
@@ -313,8 +315,9 @@ async def test_membership_save_prunes_opt_out_of_removed_members(
         {CONF_MEMBER_ENTRIES: ["cover_a"], CONF_MEMBER_COVERS: []}
     )
 
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_GROUP_MEMBER_OPT_OUT] == {
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    assert flow.options[CONF_GROUP_MEMBER_OPT_OUT] == {
         "cover_a": [str(GroupScene.PRIVACY)]
     }
 
@@ -367,9 +370,10 @@ async def test_group_entities_step_saves_toggles(hass: HomeAssistant) -> None:
             CONF_GROUP_ENABLE_WHO_WON_SENSOR: False,
         }
     )
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_GROUP_ENABLE_COVER_ENTITY] is True
-    assert result["data"][CONF_GROUP_ENABLE_STATE_SENSOR] is False
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    assert flow.options[CONF_GROUP_ENABLE_COVER_ENTITY] is True
+    assert flow.options[CONF_GROUP_ENABLE_STATE_SENSOR] is False
 
 
 # ---------------------------------------------------------------------------
@@ -409,7 +413,8 @@ async def test_membership_step_updates_and_clears_area(hass: HomeAssistant) -> N
     result = await flow.async_step_group_membership(
         {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: [], CONF_GROUP_AREA: "new_area"}
     )
-    assert result["data"][CONF_GROUP_AREA] == "new_area"
+    assert result["type"] == "menu"
+    assert flow.options[CONF_GROUP_AREA] == "new_area"
 
     # Clearing the picker removes the area source entirely.
     flow2 = OptionsFlowHandler(hass.config_entries.async_get_entry("group_1"))
@@ -417,4 +422,4 @@ async def test_membership_step_updates_and_clears_area(hass: HomeAssistant) -> N
     result = await flow2.async_step_group_membership(
         {CONF_MEMBER_ENTRIES: [], CONF_MEMBER_COVERS: []}
     )
-    assert CONF_GROUP_AREA not in result["data"]
+    assert CONF_GROUP_AREA not in flow2.options


### PR DESCRIPTION
## Summary
The Building Profile "Shared sensors" options step and the three Cover Group edit steps (membership, arbitration, entities) called `self.async_create_entry(...)` on submit. That is Home Assistant's flow-terminal call, so submitting closed the whole options dialog instead of returning to the entry's menu where "Done" (save & close) lives. Every other options sub-step (cover edit, geometry, etc.) instead does `return await self.async_step_init()`, which is why editing a cover never had this problem.

This conforms all four steps to `return await self.async_step_init()`. Edits are now held in memory until the user picks "Done", matching every other sub-step. The two docstrings that falsely claimed "saves on submit" were corrected.

## Testing
- ✅ 34 config-flow tests passing (building profile + cover group); regression guards green

## Related Issues
Refs #1003