### PR TITLE
fix: building profile edit step returns to menu on submit (#1003) (hotfix)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4421,12 +4421,14 @@ class OptionsFlowHandler(OptionsFlow):
         """Edit the shared building-level sensor IDs on a Building Profile entry.
 
         This is the only options step for a profile: it exposes exactly the
-        ``BUILDING_PROFILE_SENSOR_KEYS`` pickers and saves on submit.  Mirrors
-        the create-flow's ``async_step_create_building_profile`` sensor section.
+        ``BUILDING_PROFILE_SENSOR_KEYS`` pickers.  Mirrors the create-flow's
+        ``async_step_create_building_profile`` sensor section.  Submitting
+        returns to the profile menu (issue #1003) — only ``async_step_done``
+        actually saves and closes the dialog.
         """
         if user_input is not None:
             self.options.update(user_input)
-            return self.async_create_entry(title="", data=self.options)
+            return await self.async_step_init()
 
         schema = building_profile_sensors_schema()
         return self.async_show_form(

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -351,7 +351,7 @@ async def test_cover_save_records_profile_override(hass: HomeAssistant) -> None:
 async def test_building_profile_options_flow_saves_sensors(
     hass: HomeAssistant,
 ) -> None:
-    """Submitting the profile_sensors step saves options and closes the flow."""
+    """Submitting profile_sensors returns to the menu; Done persists it (#1003)."""
     profile = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
@@ -364,10 +364,19 @@ async def test_building_profile_options_flow_saves_sensors(
     flow = OptionsFlowHandler(profile)
     flow.hass = hass
 
-    # Submitting sensor data must produce create_entry (save).
+    # Submitting sensor data returns to the profile menu, not create_entry —
+    # the dialog must stay open so the user can navigate or pick "done".
     result = await flow.async_step_profile_sensors({CONF_LUX_ENTITY: "sensor.new_lux"})
-    assert result["type"] == "create_entry"
-    assert result["data"][CONF_LUX_ENTITY] == "sensor.new_lux"
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    # The edit is held in-memory but not yet written to the config entry.
+    assert flow.options[CONF_LUX_ENTITY] == "sensor.new_lux"
+    assert CONF_LUX_ENTITY not in profile.options
+
+    # Only explicitly picking "done" persists the change.
+    result2 = await flow.async_step_done()
+    assert result2["type"] == "create_entry"
+    assert result2["data"][CONF_LUX_ENTITY] == "sensor.new_lux"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The Building Profile "Shared sensors" options step called `self.async_create_entry(...)` on submit. That is Home Assistant's flow-terminal call, so submitting closed the whole options dialog instead of returning to the profile menu where "Done" (save & close) lives. Every other options sub-step returns to the menu via `return await self.async_step_init()`, which is why editing a cover never had the problem. This conforms the profile step to that convention: edits are held in memory until the user picks "Done".

This is the building-profile-only slice of the develop fix (#1008). The three Cover Group edit steps that shared the same pattern on `develop` do not exist on the stable branch, so only `async_step_profile_sensors` applies here.

## Testing
- ✅ 81 tests passing on main (building profile config flow, link, propagation, init, config-flow integration); ruff clean

## Related Issues
Refs #1003

Cherry-picked (building-profile portion) from #1008 for a hotfix release.