### PR TITLE
fix: hold custom-position slot on transient unavailable sensor (#1005)

### DIFF
--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from collections.abc import Callable
 
-from homeassistant.const import ATTR_FRIENDLY_NAME
+from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_ON
 
 from ..const import (
     CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
@@ -106,8 +106,9 @@ from ..helpers import (
     custom_position_slot_configured,
     custom_position_slot_name,
     custom_position_slot_sensors,
+    get_safe_state,
 )
-from ..templates import combine_with_mode, is_template_string, render_condition
+from ..templates import combine_with_mode, is_template_string, render_condition_or_none
 from .types import (
     ClimateOptions,
     ClimateTempFlags,
@@ -174,6 +175,14 @@ class PipelineSnapshotBuilder:
         self._toggles = toggles
         self._policy = policy
         self._config_service = config_service
+        # Last VALID per-slot read, keyed by slot number (issue #1005). Written
+        # only on a valid read; on an invalid read (transient unavailable /
+        # unknown / missing sensor) the slot's activation is held to this so a
+        # blip does not fire a false release edge. Per-instance state living on
+        # the one builder the coordinator owns, so both per-cycle callers
+        # (build() and the coordinator release-edge stamp) share it and agree.
+        # A config-entry reload constructs a fresh builder, clearing it.
+        self._last_valid_custom_position: dict[int, CustomPositionSensorState] = {}
 
     # ---- HA reads ---------------------------------------------------------
 
@@ -285,18 +294,30 @@ class PipelineSnapshotBuilder:
             if not (custom_position_slot_configured(options, slot_keys) and enabled):
                 continue
             sensors = custom_position_slot_sensors(options, slot_keys)
+            # Raw state objects are kept only for friendly-name labelling.
+            # Activation and validity read through get_safe_state so a
+            # transient unavailable/unknown/missing sensor is distinguished
+            # from a valid ``off`` (issue #1005) — get_safe_state returns None
+            # for any state in helpers._INVALID_STATES or a missing entity.
             states = {s: self._hass.states.get(s) for s in sensors}
-            states_on = {
-                s: bool(state and state.state == "on") for s, state in states.items()
-            }
+            safe_states = {s: get_safe_state(self._hass, s) for s in sensors}
+            states_on = {s: v == STATE_ON for s, v in safe_states.items()}
             active = tuple(s for s, on in states_on.items() if on)
             sensors_on = bool(active)
+            # The slot has a usable sensor input this cycle when at least one
+            # bound sensor reported a non-invalid value.
+            sensors_valid = any(v is not None for v in safe_states.values())
 
             template = options.get(slot_keys["template"])
             has_template = is_template_string(template)
-            template_active = (
-                render_condition(self._hass, template) if has_template else None
+            # Tri-state render: None = no template OR the template failed to
+            # render (no opinion). A rendered opinion is both the activation
+            # signal and a valid input for the slot.
+            template_opinion = (
+                render_condition_or_none(self._hass, template) if has_template else None
             )
+            template_active = bool(template_opinion) if has_template else None
+            template_valid = template_opinion is not None
             mode = (
                 options.get(slot_keys["template_mode"]) or DEFAULT_TEMPLATE_COMBINE_MODE
             )
@@ -307,6 +328,18 @@ class PipelineSnapshotBuilder:
                 has_template=has_template,
                 has_others=bool(sensors),
             )
+
+            # A read is valid when any usable input (sensor or template) spoke
+            # this cycle. On an invalid read, hold the last valid activation so
+            # a transient blip neither deactivates the pipeline handler nor
+            # fires a false release edge in the coordinator (issue #1005). A
+            # first-ever invalid read has no prior state → is_on stays False.
+            is_valid = sensors_valid or template_valid
+            if not is_valid:
+                held = self._last_valid_custom_position.get(slot)
+                if held is not None:
+                    is_on = held.is_on
+                    active = held.active_entity_ids
 
             # Friendly name of the first active sensor (else the first sensor)
             # so diagnostics label the slot by what actually triggered it.
@@ -361,26 +394,31 @@ class PipelineSnapshotBuilder:
             elif use_my:
                 position_max = None
 
-            result.append(
-                CustomPositionSensorState(
-                    entity_ids=tuple(sensors),
-                    is_on=is_on,
-                    position=position,
-                    priority=priority,
-                    min_mode=min_mode,
-                    use_my=use_my,
-                    tilt=tilt,
-                    tilt_only=tilt_only,
-                    sensor_name=sensor_name,
-                    slot=slot,
-                    active_entity_ids=active,
-                    template_active=template_active,
-                    custom_name=custom_name,
-                    position_max=position_max,
-                    tilt_min=tilt_min,
-                    tilt_max=tilt_max,
-                )
+            state = CustomPositionSensorState(
+                entity_ids=tuple(sensors),
+                is_on=is_on,
+                position=position,
+                priority=priority,
+                min_mode=min_mode,
+                use_my=use_my,
+                tilt=tilt,
+                tilt_only=tilt_only,
+                sensor_name=sensor_name,
+                slot=slot,
+                active_entity_ids=active,
+                template_active=template_active,
+                custom_name=custom_name,
+                position_max=position_max,
+                tilt_min=tilt_min,
+                tilt_max=tilt_max,
+                is_valid=is_valid,
             )
+            # Remember the last valid read so the next invalid read can hold it.
+            # Written only on a valid read → idempotent across the two same-cycle
+            # callers (same value both times).
+            if is_valid:
+                self._last_valid_custom_position[slot] = state
+            result.append(state)
         return result
 
     # ---- Pure assembly ----------------------------------------------------

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -137,6 +137,8 @@ class CustomPositionSensorState:
     entity_ids: tuple[str, ...]
     # Slot activation: OR across the sensors, folded with the optional
     # condition template via templates.combine_with_mode() at snapshot time.
+    # On an *invalid* read (``is_valid`` False) this carries the last-valid
+    # activation held across the transient (issue #1005), not the current read.
     is_on: bool
     # The slot's position claim, in pre-inversion canonical space. ``None`` =
     # the slot makes no position claim — a constraint-only slot (e.g. trigger →
@@ -186,6 +188,14 @@ class CustomPositionSensorState:
     position_max: int | None = None
     tilt_min: int | None = None
     tilt_max: int | None = None
+
+    # Whether this cycle's read was usable (issue #1005). True when at least one
+    # bound sensor reported a non-invalid state (not unavailable/unknown/missing)
+    # OR a condition template rendered an opinion. False = no usable input this
+    # cycle, in which case ``is_on`` / ``active_entity_ids`` are HELD to the last
+    # valid read so a transient sensor blip does not fire a false release edge.
+    # Default True so every pre-#1005 construction path stays a valid read.
+    is_valid: bool = True
 
     @property
     def position_mode(self) -> AxisConstraintMode:

--- a/tests/test_issue_1005_transient_unavailable_hold.py
+++ b/tests/test_issue_1005_transient_unavailable_hold.py
@@ -1,0 +1,261 @@
+"""Transient-unavailable custom-position sensor must HOLD activation (#1005).
+
+A custom-position slot sensor that flips ``on → unavailable → on`` for a few
+milliseconds (a template reload, a Zigbee round-trip) must NOT be read as a
+release. The old code coerced ``unavailable``/``unknown``/missing to the same
+``False`` as a valid ``off`` (``state.state == "on"``), so a transient invalid
+read flipped the slot ``is_on True → False``. That (a) deactivated the pipeline
+handler → the default position resolved, and (b) fired a false active→inactive
+release edge → ``use_force=True`` → every cover failed open.
+
+The fix keys on VALIDITY, not on ``is_on``: a literal ``off`` stays a valid
+release; only an *invalid* (unavailable / unknown / missing) read is HELD to
+its last-valid activation. The hold lives on ``PipelineSnapshotBuilder`` (one
+per coordinator) so both per-cycle consumers — the pipeline snapshot and the
+coordinator release-edge stamp — see the same held ``is_on`` with zero
+coordinator edits.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_END_TIME,
+    CONF_SENSOR_TYPE,
+    CONF_START_TIME,
+    CoverType,
+    DOMAIN,
+)
+from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
+    PipelineSnapshotBuilder,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+# Slot mirrors the incident: single sensor, position 0%, priority 78 (NOT a
+# safety slot — the ordinary custom_position_released force-path).
+_OPTIONS = {
+    "custom_position_sensors_1": ["binary_sensor.mode"],
+    "custom_position_1": 0,
+    "custom_position_priority_1": 78,
+}
+
+
+def _make_builder(mock_hass) -> PipelineSnapshotBuilder:
+    """Snapshot builder bound to the mock hass — the real sensor-read surface."""
+    return PipelineSnapshotBuilder(
+        hass=mock_hass,
+        logger=MagicMock(),
+        climate_provider=MagicMock(),
+        toggles=MagicMock(),
+        policy=MagicMock(),
+        config_service=MagicMock(),
+    )
+
+
+def _set_sensor_states(mock_hass, states: dict[str, str | None]) -> None:
+    """Wire mock_hass.states.get to return the given per-entity states."""
+
+    def get_state(entity_id):
+        value = states.get(entity_id)
+        if value is None:
+            return None
+        state_obj = MagicMock()
+        state_obj.state = value
+        state_obj.attributes = {}
+        return state_obj
+
+    mock_hass.states.get.side_effect = get_state
+
+
+# ---------------------------------------------------------------------------
+# Builder-level unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid_value", ["unavailable", "unknown", None])
+def test_transient_invalid_read_holds_activation(mock_hass, invalid_value):
+    """A transient invalid read holds the last-valid activation (is_on stays True)."""
+    builder = _make_builder(mock_hass)
+
+    # Cycle 1: sensor on → valid activation.
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": "on"})
+    (c1,) = builder.read_custom_position_sensors(_OPTIONS)
+    assert c1.is_on is True
+    assert c1.is_valid is True
+
+    # Cycle 2: sensor invalid (transient) → HELD to the last valid activation.
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": invalid_value})
+    (c2,) = builder.read_custom_position_sensors(_OPTIONS)
+    assert c2.is_on is True  # fails today: coerced to False
+    assert c2.is_valid is False
+    assert c2.active_entity_ids == ("binary_sensor.mode",)
+
+    # Cycle 3: sensor recovers to on → valid again.
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": "on"})
+    (c3,) = builder.read_custom_position_sensors(_OPTIONS)
+    assert c3.is_on is True
+    assert c3.is_valid is True
+
+
+@pytest.mark.unit
+def test_valid_off_after_hold_still_releases(mock_hass):
+    """A literal off is a VALID release, even right after a held invalid read."""
+    builder = _make_builder(mock_hass)
+
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": "on"})
+    (c1,) = builder.read_custom_position_sensors(_OPTIONS)
+    assert c1.is_on is True
+
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": "unavailable"})
+    (c2,) = builder.read_custom_position_sensors(_OPTIONS)
+    assert c2.is_on is True  # held
+
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": "off"})
+    (c3,) = builder.read_custom_position_sensors(_OPTIONS)
+    assert c3.is_on is False  # genuine release
+    assert c3.is_valid is True
+
+
+@pytest.mark.unit
+def test_one_valid_sensor_keeps_slot_valid(mock_hass):
+    """One usable sensor makes the slot validly-off — NOT held."""
+    builder = _make_builder(mock_hass)
+    options = {
+        "custom_position_sensors_1": ["binary_sensor.rain", "binary_sensor.wind"],
+        "custom_position_1": 0,
+        "custom_position_priority_1": 78,
+    }
+
+    _set_sensor_states(
+        mock_hass, {"binary_sensor.rain": "on", "binary_sensor.wind": "off"}
+    )
+    (c1,) = builder.read_custom_position_sensors(options)
+    assert c1.is_on is True
+
+    # rain unavailable, wind off → the slot has a usable input (wind=off), so it
+    # is validly off; the hold must NOT kick in.
+    _set_sensor_states(
+        mock_hass, {"binary_sensor.rain": "unavailable", "binary_sensor.wind": "off"}
+    )
+    (c2,) = builder.read_custom_position_sensors(options)
+    assert c2.is_valid is True
+    assert c2.is_on is False
+
+
+@pytest.mark.unit
+def test_first_ever_invalid_read_defaults_off(mock_hass):
+    """A fresh builder whose very first read is invalid defaults to off (no hold)."""
+    builder = _make_builder(mock_hass)
+    _set_sensor_states(mock_hass, {"binary_sensor.mode": "unavailable"})
+
+    (state,) = builder.read_custom_position_sensors(_OPTIONS)
+
+    assert state.is_on is False
+    assert state.is_valid is False
+
+
+@pytest.mark.unit
+def test_template_render_failure_holds_last_valid(mock_hass):
+    """A template-only slot holds its last-valid activation on a render failure."""
+    builder = _make_builder(mock_hass)
+    _set_sensor_states(mock_hass, {})  # template-only: no sensors
+    options = {
+        "custom_position_template_1": "{{ is_state('binary_sensor.mode', 'on') }}",
+        "custom_position_1": 0,
+        "custom_position_priority_1": 78,
+    }
+
+    # render_condition_or_none returns None when a template fails to render.
+    with patch(
+        "custom_components.adaptive_cover_pro.pipeline.snapshot_builder."
+        "render_condition_or_none",
+        side_effect=[True, None, True],
+    ):
+        (c1,) = builder.read_custom_position_sensors(options)
+        (c2,) = builder.read_custom_position_sensors(options)
+        (c3,) = builder.read_custom_position_sensors(options)
+
+    assert (c1.is_on, c1.is_valid) == (True, True)
+    assert (c2.is_on, c2.is_valid) == (True, False)  # held across render failure
+    assert (c3.is_on, c3.is_valid) == (True, True)
+
+
+# ---------------------------------------------------------------------------
+# Coordinator integration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_transient_unavailable_does_not_release_or_dispatch(
+    hass: HomeAssistant,
+) -> None:
+    """A transient unavailable read must not release the slot nor move covers."""
+    from pytest_homeassistant_custom_component.common import async_mock_service
+
+    calls = async_mock_service(hass, "cover", "set_cover_position")
+
+    # Sun away from the window (azimuth 0 vs window 180) → no direct sun, so the
+    # would-be default is deterministic when the slot is (wrongly) deactivated.
+    hass.states.async_set(
+        "sun.sun",
+        "above_horizon",
+        {"azimuth": 0.0, "elevation": 45.0, "rising": True},
+    )
+    # Cover already sits at the slot's commanded 0% so an active slot never
+    # dispatches; only a false release to the default (50%) would.
+    hass.states.async_set(
+        "cover.test_blind",
+        "closed",
+        {"current_position": 0, "supported_features": 143},
+    )
+    hass.states.async_set("binary_sensor.mode", "on")
+
+    options = {
+        **dict(VERTICAL_OPTIONS),
+        **_OPTIONS,
+        CONF_START_TIME: "00:00:00",
+        CONF_END_TIME: "23:59:59",
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Hold", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=options,
+        entry_id="issue_1005_01",
+        title="Hold",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    coordinator = entry.runtime_data
+
+    # Cycle 1: sensor on → slot active, stamped.
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert coordinator._prev_custom_position_states[1].is_on is True
+    baseline = len(calls)
+
+    # Cycle 2: sensor transiently unavailable → held, no release, no dispatch.
+    hass.states.async_set("binary_sensor.mode", "unavailable")
+    await hass.async_block_till_done()
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert coordinator._prev_custom_position_states[1].is_on is True  # fails today
+    assert coordinator._prev_custom_position_states[1].is_valid is False
+    assert len(calls) == baseline  # fails today: false release fans out to covers
+
+    # Cycle 3: sensor recovers → slot still active, still no spurious dispatch.
+    hass.states.async_set("binary_sensor.mode", "on")
+    await hass.async_block_till_done()
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert coordinator._prev_custom_position_states[1].is_on is True
+    assert coordinator._prev_custom_position_states[1].is_valid is True
+    assert len(calls) == baseline

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -182,9 +182,9 @@ def test_read_custom_position_sensors_template_only_slot():
         first_slot_keys["template"]: "{{ is_state('sun.sun', 'above_horizon') }}",
         first_slot_keys["position"]: 42,
     }
-    # render_condition needs a working hass; mock it at the builder's import site.
+    # render_condition_or_none needs a working hass; mock at the builder's import site.
     with patch(
-        "custom_components.adaptive_cover_pro.pipeline.snapshot_builder.render_condition",
+        "custom_components.adaptive_cover_pro.pipeline.snapshot_builder.render_condition_or_none",
         return_value=True,
     ):
         out = builder.read_custom_position_sensors(opts)
@@ -208,7 +208,7 @@ def test_read_custom_position_sensors_template_false_keeps_slot_off():
         first_slot_keys["position"]: 42,
     }
     with patch(
-        "custom_components.adaptive_cover_pro.pipeline.snapshot_builder.render_condition",
+        "custom_components.adaptive_cover_pro.pipeline.snapshot_builder.render_condition_or_none",
         return_value=False,
     ):
         out = builder.read_custom_position_sensors(opts)


### PR DESCRIPTION
## Summary

A transiently `unavailable`/`unknown` custom-position sensor was coerced to the same `False` as a valid `off`. During a brief sensor dropout (for example HA's `template.reload`, about 65 ms in the report), the slot's `is_on` flipped `True -> False`, which did two things at once: it deactivated the pipeline handler so the default position resolved, and it fired a false active-to-inactive release edge in the coordinator that set `use_force=True`, bypassing the time-window and delta gates. Every controlled cover then fail-opened to the default position.

The fix distinguishes a valid `off` from a no-usable-value read. `read_custom_position_sensors()` now reads activation through `get_safe_state` (a `STATE_ON` compare) plus a tri-state template render, derives a per-slot `is_valid`, and on an invalid read holds the slot's last-valid `is_on`/`active_entity_ids` from a per-instance cache in `PipelineSnapshotBuilder`. A literal `off` stays a valid release; only `unavailable`/`unknown`/missing is held, so both the activation path and the release-edge path are fixed with no coordinator change.

## Testing

- ✅ 7704 passing, 1 xfailed (full suite, `-n auto`)
- New `tests/test_issue_1005_transient_unavailable_hold.py`: the cross-cycle transition (on -> unavailable -> on) holds activation, fires no release edge, and dispatches nothing; a valid `off` after a hold still releases; one valid sensor keeps the slot valid; a first-ever invalid read defaults off; a template render failure holds last-valid; and a full-HA coordinator integration test asserts zero `set_cover_position` calls during the transient.

## Related Issues

Refs #1005

Reported and precisely diagnosed by @Rondal, whose root-cause hypothesis (the `state.state == "on"` coercion plus the coordinator release edge) matched the code exactly. Companion report #1006 (false manual override from the same movement) is tracked separately.

https://claude.ai/code/session_01EDa43s1X3WRM3N8J8R3LAr
