### PR TITLE
fix: false manual override after mid-flight handler reevaluation (#1006)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2752,8 +2752,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     else min(self.manual_threshold, self._position_tolerance)
                 )
 
+            # Issue #1006: pass entity_id so a multi-axis policy can anchor the
+            # secondary-axis expected value to what ACP last DISPATCHED for THIS
+            # entity, not the mutable per-cycle pipeline result a mid-transit
+            # reevaluation may have changed.
             secondary_axis_check = (
-                self._policy.secondary_axis_check(self._pipeline_result, self._cmd_svc)
+                self._policy.secondary_axis_check(
+                    self._pipeline_result, self._cmd_svc, entity_id
+                )
                 if self._pipeline_result is not None
                 else None
             )

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -431,8 +431,17 @@ class CoverTypePolicy(ABC):
         """
         return {"full_endpoint_target": self.targets_full_mechanical_endpoint(result)}
 
-    def secondary_axis_check(self, result: PipelineResult, cmd_svc) -> Any | None:
-        """Return a manual-override secondary-axis check, or ``None``."""
+    def secondary_axis_check(
+        self, result: PipelineResult, cmd_svc, entity_id: str | None = None
+    ) -> Any | None:
+        """Return a manual-override secondary-axis check, or ``None``.
+
+        ``entity_id`` (issue #1006) lets a multi-axis policy anchor the check's
+        expected value to the value ACP last DISPATCHED for that entity rather
+        than the mutable per-cycle ``result`` — see the module rule in
+        ``managers/manual_override/secondary_axis.py``. Additive with a safe
+        default so single-axis policies and legacy 2-arg callers are unaffected.
+        """
         return None
 
     def resolve_entity_target(

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -862,9 +862,14 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         )
 
     def secondary_axis_check(
-        self, result: PipelineResult, cmd_svc
+        self, result: PipelineResult, cmd_svc, entity_id: str | None = None
     ) -> SecondaryAxisCheck | None:
-        """Build the per-cycle blend-axis manual-override check."""
+        """Build the per-cycle blend-axis manual-override check.
+
+        ``entity_id`` (issue #1006) is accepted for signature parity with the
+        base hook; the day/night shade blend axis has no dispatched-value store
+        to anchor against, so it keeps sourcing ``expected`` from ``result``.
+        """
         # Single-carriage models (B, C) have no physical blend axis to check.
         if not self._drives_dual_axis():
             return None

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -56,7 +56,11 @@ from ...engine.covers.day_night_shade import (
     DAY_NIGHT_SHEER,
     FabricSelection,
 )
-from ...managers.manual_override import SecondaryAxisCheck, inverse_state
+from ...managers.manual_override import (
+    SecondaryAxisCheck,
+    inverse_state,
+    resolve_dispatched_secondary_expected,
+)
 from ...pipeline.axis_constraints import clamp_to_bounds, tilt_clamp_step
 from ...pipeline.types import DecisionStep
 from .._helpers import window_dimensions_lines
@@ -866,9 +870,14 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
     ) -> SecondaryAxisCheck | None:
         """Build the per-cycle blend-axis manual-override check.
 
-        ``entity_id`` (issue #1006) is accepted for signature parity with the
-        base hook; the day/night shade blend axis has no dispatched-value store
-        to anchor against, so it keeps sourcing ``expected`` from ``result``.
+        Issue #1006: Model A drives its blend axis through the SAME
+        ``DualAxisSequencer`` (and the same ``_tilt_targets`` store) venetian
+        uses, so ``expected`` is anchored to the value ACP last DISPATCHED via
+        the shared :func:`resolve_dispatched_secondary_expected` rule — never the
+        mutable per-cycle ``result.tilt`` a mid-transit reevaluation may have
+        changed. When no blend has been dispatched (empty anchor) the helper
+        returns ``None`` and the check yields no independent blend
+        manual-detection. ``entity_id`` carries the per-entity anchor context.
         """
         # Single-carriage models (B, C) have no physical blend axis to check.
         if not self._drives_dual_axis():
@@ -876,7 +885,9 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         if result is None or result.tilt is None:
             return None
         return SecondaryAxisCheck(
-            expected=result.tilt,
+            expected=resolve_dispatched_secondary_expected(
+                self._sequencer, entity_id, result
+            ),
             attribute="current_tilt_position",
             label="tilt",
             suppression=self.primary_axis_suppression,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -1059,13 +1059,25 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         return self._grace_mgr.is_in_command_grace_period(entity_id)
 
     def secondary_axis_check(
-        self, result: PipelineResult, cmd_svc
+        self, result: PipelineResult, cmd_svc, entity_id: str | None = None
     ) -> SecondaryAxisCheck | None:
         """Build the per-cycle tilt-axis manual-override check.
 
         Returns ``None`` when no tilt has been resolved (e.g. on a refresh
         where the engine couldn't compute one); otherwise carries the
         expected tilt and the suppression callback into manual_override.
+
+        Issue #1006: the ``expected`` tilt is anchored to the value ACP last
+        DISPATCHED for this entity (``sequencer.last_tilt_target``), not the
+        ``result.tilt`` of the current cycle. A handler reevaluation mid-transit
+        can recompute a different tilt without sending any replacement command;
+        binding ``expected`` to the reevaluated value made the actuator's
+        end-of-travel arrival at the still-commanded tilt read as a manual move.
+        Anchoring to the dispatched tilt is the same rule the position axis
+        already follows via its recorded target — see the module comment in
+        ``managers/manual_override/secondary_axis.py``. Falls back to
+        ``result.tilt`` when no dispatched tilt is stored yet (first command,
+        or a non-attached policy in tests).
 
         The suppression callback is the same predicate
         :meth:`primary_axis_suppression` exposes for the position axis
@@ -1084,8 +1096,14 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         if result is None or result.tilt is None:
             return None
 
+        expected = result.tilt
+        if self._sequencer is not None and entity_id is not None:
+            dispatched = self._sequencer.last_tilt_target(entity_id)
+            if dispatched is not None:
+                expected = dispatched
+
         return SecondaryAxisCheck(
-            expected=result.tilt,
+            expected=expected,
             attribute="current_tilt_position",
             label="tilt",
             suppression=self.primary_axis_suppression,

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -81,7 +81,10 @@ from ...const import (
     VENETIAN_TILT_TRANSFORM_CLAMP,
 )
 from ...engine.covers import AdaptiveVerticalCover, VenetianCoverCalculation
-from ...managers.manual_override import SecondaryAxisCheck
+from ...managers.manual_override import (
+    SecondaryAxisCheck,
+    resolve_dispatched_secondary_expected,
+)
 from ...pipeline.axis_constraints import clamp_to_bounds, tilt_clamp_step
 from ...pipeline.types import DecisionStep
 from ...position_utils import PositionConverter
@@ -1068,16 +1071,16 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         expected tilt and the suppression callback into manual_override.
 
         Issue #1006: the ``expected`` tilt is anchored to the value ACP last
-        DISPATCHED for this entity (``sequencer.last_tilt_target``), not the
-        ``result.tilt`` of the current cycle. A handler reevaluation mid-transit
-        can recompute a different tilt without sending any replacement command;
-        binding ``expected`` to the reevaluated value made the actuator's
-        end-of-travel arrival at the still-commanded tilt read as a manual move.
-        Anchoring to the dispatched tilt is the same rule the position axis
-        already follows via its recorded target — see the module comment in
-        ``managers/manual_override/secondary_axis.py``. Falls back to
-        ``result.tilt`` when no dispatched tilt is stored yet (first command,
-        or a non-attached policy in tests).
+        DISPATCHED for this entity via the shared
+        :func:`resolve_dispatched_secondary_expected` rule (day/night-shade's
+        blend axis delegates to the same helper). A handler reevaluation
+        mid-transit can recompute a different tilt without sending any
+        replacement command; binding ``expected`` to the reevaluated value made
+        the actuator's end-of-travel arrival at the still-commanded tilt read as
+        a manual move. When ACP has no dispatched tilt stored (suppress mode, HA
+        restart, drift-verify pop, Auto-Control off→on) the helper returns
+        ``None`` and the check yields no independent tilt manual-detection — the
+        value-based ``excursion_match`` below (issue #927) still runs.
 
         The suppression callback is the same predicate
         :meth:`primary_axis_suppression` exposes for the position axis
@@ -1096,14 +1099,10 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         if result is None or result.tilt is None:
             return None
 
-        expected = result.tilt
-        if self._sequencer is not None and entity_id is not None:
-            dispatched = self._sequencer.last_tilt_target(entity_id)
-            if dispatched is not None:
-                expected = dispatched
-
         return SecondaryAxisCheck(
-            expected=expected,
+            expected=resolve_dispatched_secondary_expected(
+                self._sequencer, entity_id, result
+            ),
             attribute="current_tilt_position",
             label="tilt",
             suppression=self.primary_axis_suppression,

--- a/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
@@ -24,6 +24,7 @@ from .secondary_axis import (
     SecondaryAxisCheck,
     SecondaryAxisResult,
     effective_manual_threshold,
+    resolve_dispatched_secondary_expected,
 )
 from .time_window import TimeWindowDetector
 
@@ -46,4 +47,5 @@ __all__ = [
     "effective_manual_threshold",
     "get_detector",
     "inverse_state",
+    "resolve_dispatched_secondary_expected",
 ]

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -16,13 +16,19 @@ mid-transit handler reevaluation may have changed after the command was sent:
   (``CoverCommandService.get_target``), written only by the dispatch chokepoint
   ``_prepare_service_call``. A reevaluation that sends no replacement command
   leaves it intact.
-* Secondary (tilt) axis — ``SecondaryAxisCheck.expected`` is anchored by the
-  owning policy to its last dispatched value (venetian:
-  ``sequencer.last_tilt_target``) rather than the reevaluated ``result.tilt``.
+* Secondary (tilt/blend) axis — ``SecondaryAxisCheck.expected`` is anchored to
+  the last dispatched value via the single shared rule
+  :func:`resolve_dispatched_secondary_expected`. Every multi-axis policy
+  (venetian tilt, day/night-shade blend — both driving the same
+  ``DualAxisSequencer`` and its ``last_tilt_target`` store) delegates to that
+  one helper rather than mirroring the rule. When no value has been dispatched
+  the helper returns ``None`` and the check yields NO delta-based manual
+  detection on this axis — ACP has no commanded reference to police, so a
+  reevaluated ``result.tilt`` must not stand in for one.
 
-Both read sites express the same concept; keep them in sync so an in-flight
-movement whose expected target/tilt was recomputed mid-transit is not orphaned
-and misclassified as a manual move.
+Both read sites express the same concept; the shared helper keeps them in sync
+so an in-flight movement whose expected target/tilt was recomputed mid-transit
+is not orphaned and misclassified as a manual move.
 """
 
 from __future__ import annotations
@@ -32,6 +38,41 @@ from collections.abc import Callable
 from typing import Any
 
 from ...const import POSITION_TOLERANCE_PERCENT
+
+
+def resolve_dispatched_secondary_expected(
+    sequencer: Any, entity_id: str | None, result: Any
+) -> int | None:
+    """Resolve a secondary-axis ``expected`` anchored to ACP's last DISPATCHED value.
+
+    Single source of the issue #1006 anchoring rule, shared by every multi-axis
+    policy's ``secondary_axis_check`` (venetian tilt, day/night-shade blend) so
+    the rule lives in exactly one place. Returns:
+
+    * the value ACP last DISPATCHED for this entity
+      (``sequencer.last_tilt_target(entity_id)``) — the value the actuator is
+      actually travelling toward — when ACP has a per-entity command context and
+      has dispatched an independent secondary-axis command;
+    * ``None`` when ACP has a per-entity context but NO dispatched value is
+      stored (suppress mode never sent an independent tilt, an HA restart, a
+      drift-verify pop, or an Auto-Control off→on ``clear_tilt_targets``). ACP
+      has no commanded reference to police, so the caller must build a check that
+      yields NO independent manual-detection on this axis rather than falling
+      back to the mutable per-cycle ``result.tilt`` — a mid-transit handler
+      reevaluation can change ``result.tilt`` without sending a replacement
+      command, and comparing the actuator's end-of-travel arrival against that
+      recomputed value is exactly the #1006 miscorrelation;
+    * ``result.tilt`` only when there is no per-entity context at all
+      (``entity_id`` or ``sequencer`` is ``None`` — the direct-delta unit paths
+      that predate the anchor and hand-feed the expected value).
+
+    This mirrors the position axis, whose ``our_state`` derives from the recorded
+    command target written only by the dispatch chokepoint — never re-anchored by
+    a reevaluation that sends nothing.
+    """
+    if entity_id is not None and sequencer is not None:
+        return sequencer.last_tilt_target(entity_id)
+    return result.tilt
 
 
 def effective_manual_threshold(user_threshold: int | None) -> int:
@@ -88,7 +129,11 @@ class SecondaryAxisCheck:
     a target-return publish consumes it (#930).
     """
 
-    expected: int
+    # ``None`` (issue #1006) means ACP has no DISPATCHED value to police on this
+    # axis (empty anchor): the value-based ``excursion_match`` still runs, but no
+    # delta-based manual detection may fire — a mid-transit reevaluation must not
+    # be able to assert an expectation ACP never commanded.
+    expected: int | None
     attribute: str  # e.g. "current_tilt_position"
     label: str  # e.g. "tilt" — flavours the rejection-reason text
     suppression: Callable[[str, float], bool] | None = None
@@ -159,6 +204,15 @@ class SecondaryAxisCheck:
                     ),
                 },
             )
+
+        # Issue #1006: with no DISPATCHED anchor there is no commanded value to
+        # police on this axis. The value-based excursion check above has already
+        # run (so #927 suppression is unaffected); skip all delta-based detection
+        # so an in-flight movement whose expected value was recomputed mid-transit
+        # (and never re-dispatched) cannot be misread as a manual move. The
+        # position axis, which carries its own recorded target, still runs.
+        if self.expected is None:
+            return SecondaryAxisResult()
 
         delta = abs(self.expected - new_value)
 

--- a/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/secondary_axis.py
@@ -4,6 +4,25 @@ Co-located so the single-source-of-truth threshold helper sits next to both
 of its consumers — the position-delta detector
 (:mod:`.position_delta`) and the secondary-axis check below — without
 creating an import cycle through the manager.
+
+Dispatched-value anchoring rule (issue #1006)
+---------------------------------------------
+The manual-override gate correlates an incoming cover state change with "this
+is ACP's own movement" by comparing the actuator feedback against the value ACP
+last DISPATCHED for that axis — never a mutable per-cycle value that a
+mid-transit handler reevaluation may have changed after the command was sent:
+
+* Position axis — ``our_state`` derives from the recorded command target
+  (``CoverCommandService.get_target``), written only by the dispatch chokepoint
+  ``_prepare_service_call``. A reevaluation that sends no replacement command
+  leaves it intact.
+* Secondary (tilt) axis — ``SecondaryAxisCheck.expected`` is anchored by the
+  owning policy to its last dispatched value (venetian:
+  ``sequencer.last_tilt_target``) rather than the reevaluated ``result.tilt``.
+
+Both read sites express the same concept; keep them in sync so an in-flight
+movement whose expected target/tilt was recomputed mid-transit is not orphaned
+and misclassified as a manual move.
 """
 
 from __future__ import annotations

--- a/tests/test_issue_1006_reevaluation_false_override.py
+++ b/tests/test_issue_1006_reevaluation_false_override.py
@@ -2,40 +2,54 @@
 
 Scenario (venetian ``position_and_tilt``, WAREMA/KNX):
 
-ACP dispatches ``open_cover`` (+ tilt=70) to a cover. A few tens of
+A solar cycle dispatches position=60 + tilt=45 to a cover (a producible tuple —
+60 is below ``tilt_skip_above=95`` so the tilt is genuinely sent). A few tens of
 milliseconds later a transiently-unavailable input recovers and ACP
 **reevaluates its handler state** — a different handler now wins with a
-different position/tilt target — **while the open movement is still
-travelling**, and dispatches NO replacement command. Seconds later the KNX
-actuator reaches the commanded open end-position (position≈100, tilt≈70).
+different position/tilt target — **while the movement is still travelling**, and
+dispatches NO replacement command. Seconds later the actuator settles at the
+commanded values (position=60, tilt=45).
 
-The manual-override gate must recognise that end-of-travel feedback as ACP's
-OWN movement. The defect: the tilt-axis ``SecondaryAxisCheck.expected`` was
-sourced from the freshly-reevaluated ``PipelineResult`` (tilt=30) rather than
-the tilt ACP actually DISPATCHED (70), so the end-of-travel tilt=70 read a
-delta of 40% and tripped a false ``manual_override_set``.
+The manual-override gate must recognise that settle feedback as ACP's OWN
+movement. The defect: the tilt-axis ``SecondaryAxisCheck.expected`` was sourced
+from the freshly-reevaluated ``PipelineResult`` (tilt=20) rather than the tilt
+ACP actually DISPATCHED (45), so the settle tilt=45 read a large delta and
+tripped a false ``manual_override_set``.
 
-The fix anchors the correlation to the value ACP last DISPATCHED per axis:
-the tilt axis reads ``sequencer.last_tilt_target(entity_id)`` (the stored
-commanded tilt) instead of the mutable per-cycle pipeline value. The position
-axis was already robust — a reevaluation that dispatches nothing never
-re-anchors the recorded target (``_prepare_service_call`` is the sole writer,
-and it only runs on an actual send) and the venetian post-tilt rebase
-early-returns at the endpoint (drift≈0). Test C pins that robustness.
+The fix anchors the correlation to the value ACP last DISPATCHED per axis, in
+one shared rule (:func:`resolve_dispatched_secondary_expected`) that both the
+venetian tilt axis and the day/night-shade blend axis delegate to: the check's
+expected reads ``sequencer.last_tilt_target(entity_id)`` (the stored commanded
+value) instead of the mutable per-cycle pipeline value. When ACP dispatched no
+independent tilt (empty anchor — suppress mode, HA restart, drift-verify pop,
+Auto-Control off→on), the rule returns ``None`` and the check yields NO
+independent tilt manual-detection rather than falling back to the reevaluated
+``result.tilt``.
 
-Tests A/B/D drive the post-fix 3-arg ``policy.secondary_axis_check(result,
-cmd_svc, entity_id)`` accessor exactly as the coordinator does, so the tilt
-expected value is derived, not hand-fed.
+The position axis was already robust — a reevaluation that dispatches nothing
+never re-anchors the recorded target (``_prepare_service_call`` is the sole
+writer, and it only runs on an actual send), and the venetian post-tilt rebase
+refuses to re-anchor while the carriage is mid-transit (drift beyond
+``VENETIAN_REBASE_MAX_DRIFT_PERCENT``). Test C pins that refusal guard.
+
+Tests A/B/D drive the tilt anchor through the real ``update_tilt_only`` dispatch
+path and the post-fix 3-arg ``policy.secondary_axis_check(result, cmd_svc,
+entity_id)`` accessor exactly as the coordinator does, so the tilt expected
+value is derived, not hand-fed. The DNS and empty-anchor tests cover Findings 1
+and 2.
 """
 
 from __future__ import annotations
 
 import datetime as dt
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.cover_types.day_night_shade.policy import (
+    DayNightShadePolicy,
+)
 from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
     VenetianPolicy,
 )
@@ -136,28 +150,31 @@ def _reevaluated_result(*, position: int, tilt: int) -> PipelineResult:
 # ---------------------------------------------------------------------------
 
 
-def test_tilt_expected_is_dispatched_target_not_reevaluated() -> None:
-    """``SecondaryAxisCheck.expected`` binds to the DISPATCHED tilt (70), not 30.
+async def test_tilt_expected_is_dispatched_target_not_reevaluated() -> None:
+    """``SecondaryAxisCheck.expected`` binds to the DISPATCHED tilt (45), not 20.
 
-    ACP dispatched tilt=70 (stored in ``_tilt_targets``). A reevaluation then
-    recomputed tilt=30 with no replacement send. The check the coordinator
-    builds from the reevaluated result must still expect 70 — the tilt ACP is
-    actually driving toward — so the end-of-travel tilt=70 is not misread.
+    A solar-tracking cycle dispatches tilt=45 at position=60 through the real
+    sequencer path (a producible tuple — 60 is below ``tilt_skip_above=95`` so
+    the tilt is not skipped). A reevaluation then recomputes tilt=20 with no
+    replacement send. The check the coordinator builds from the reevaluated
+    result must still expect 45 — the tilt ACP is actually driving toward — so
+    the end-of-travel tilt=45 is not misread.
     """
     entity_id = "cover.raffstore_wc"
-    policy = _make_attached_policy(entity_id)
-    # ACP dispatched tilt=70 — the value the actuator is travelling toward.
-    policy.sequencer._tilt_targets[entity_id] = 70
+    policy = _make_dispatch_venetian_policy()
+    # Real solar-cycle dispatch → _tilt_targets populated by production code.
+    await _dispatch_tilt(policy, entity_id, tilt=45, position=60)
+    assert policy.sequencer.last_tilt_target(entity_id) == 45
 
     cmd_svc = _make_cmd_svc()
-    result = _reevaluated_result(position=30, tilt=30)
+    result = _reevaluated_result(position=30, tilt=20)
 
     check = policy.secondary_axis_check(result, cmd_svc, entity_id)
 
     assert check is not None
-    assert check.expected == 70, (
-        "tilt expected must be the dispatched target (70), not the mid-transit "
-        f"reevaluated pipeline value (30); got {check.expected}"
+    assert check.expected == 45, (
+        "tilt expected must be the dispatched target (45), not the mid-transit "
+        f"reevaluated pipeline value (20); got {check.expected}"
     )
 
 
@@ -166,30 +183,31 @@ def test_tilt_expected_is_dispatched_target_not_reevaluated() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_endpoint_tilt_arrival_after_reevaluation_is_not_manual() -> None:
-    """Actuator settles at the commanded tilt (70) after a reevaluation to 30.
+async def test_endpoint_tilt_arrival_after_reevaluation_is_not_manual() -> None:
+    """Actuator settles at the commanded tilt (45) after a reevaluation to 20.
 
-    The position axis reached its recorded target (100). The end-of-travel
-    feedback (position=100, tilt=70) must NOT engage manual override — it is
-    ACP's own commanded movement completing.
+    A solar cycle dispatched position=60 + tilt=45 (a producible tuple). The
+    position axis reached its recorded target (60). The settle feedback
+    (position=60, tilt=45) must NOT engage manual override — it is ACP's own
+    commanded movement completing.
     """
     entity_id = "cover.raffstore_wc"
-    policy = _make_attached_policy(entity_id)
-    policy.sequencer._tilt_targets[entity_id] = 70
+    policy = _make_dispatch_venetian_policy()
+    await _dispatch_tilt(policy, entity_id, tilt=45, position=60)
 
     cmd_svc = _make_cmd_svc()
-    cmd_svc.set_target(entity_id, 100)  # dispatched open → recorded target 100
+    cmd_svc.set_target(entity_id, 60)  # solar cycle commanded position 60
 
-    result = _reevaluated_result(position=30, tilt=30)
+    result = _reevaluated_result(position=30, tilt=20)
 
     # Coordinator derivation (post-fix form): tilt expected from dispatched.
     check = policy.secondary_axis_check(result, cmd_svc, entity_id)
     recorded_target = cmd_svc.get_target(entity_id)
-    expected_position = recorded_target  # 100
+    expected_position = recorded_target  # 60
 
     mgr = _make_manager(entity_id)
     mgr.handle_state_change(
-        states_data=_make_event(entity_id, position=100, tilt=70),
+        states_data=_make_event(entity_id, position=60, tilt=45),
         our_state=expected_position,
         policy=policy,
         allow_reset=True,
@@ -202,25 +220,39 @@ def test_endpoint_tilt_arrival_after_reevaluation_is_not_manual() -> None:
     )
 
     assert not mgr.is_cover_manual(entity_id), (
-        "end-of-travel arrival at the commanded tilt after a reevaluation must "
-        "NOT trip manual override"
+        "settle at the commanded tilt after a reevaluation must NOT trip manual "
+        "override"
     )
 
 
 # ---------------------------------------------------------------------------
-# Test C — position axis is robust to a no-dispatch reevaluation
+# Test C — position axis: a MID-TRANSIT venetian rebase must NOT orphan the
+# dispatched endpoint. Exercises the real ``VENETIAN_REBASE_MAX_DRIFT_PERCENT``
+# refusal branch (not a drift-0 early-return): the one production path that
+# could re-anchor the recorded position target without a fresh dispatch.
 # ---------------------------------------------------------------------------
 
 
-def test_position_anchor_survives_reevaluation_without_dispatch() -> None:
-    """A reevaluation that dispatches nothing must not orphan the position anchor.
+def test_mid_transit_rebase_does_not_orphan_dispatched_position_endpoint() -> None:
+    """A large-drift post-tilt rebase mid-transit must leave the target intact.
 
-    The recorded target is written only by the dispatch chokepoint, so a
-    no-dispatch reevaluation leaves it intact (100). The venetian post-tilt
-    rebase early-returns at the endpoint (actual≈target → drift≈0), so it does
-    not re-anchor either. The endpoint arrival (position=100) is therefore
-    correctly recognised as target-reached and stays automatic.
+    ACP dispatched ``open_cover`` → recorded target 100. The venetian post-tilt
+    rebase (``_rebase_commanded_position``, the sole non-dispatch path that can
+    rewrite the recorded position target) fires WHILE the carriage is still far
+    from the endpoint (actual=40, drift=60% ≫ ``VENETIAN_REBASE_MAX_DRIFT_PERCENT
+    =15``). Its refusal guard must decline to rebase, so the recorded target
+    stays 100. When the carriage later reaches the physical endpoint (100), the
+    arrival is recognised as target-reached and stays automatic.
+
+    Counterfactual that makes this a real guard: if the refusal branch were
+    removed, the target would rebase to 40, and the endpoint arrival at 100
+    (delta 60) would be misclassified as a manual move — exactly the #1006
+    orphaned-anchor failure, on the position axis.
     """
+    from custom_components.adaptive_cover_pro.const import (
+        VENETIAN_REBASE_MAX_DRIFT_PERCENT,
+    )
+
     entity_id = "cover.raffstore_wc"
     policy = _make_attached_policy(entity_id)
 
@@ -228,20 +260,21 @@ def test_position_anchor_survives_reevaluation_without_dispatch() -> None:
     cmd_svc.set_target(entity_id, 100)  # dispatched open
     cmd_svc.set_waiting(entity_id, True)
 
-    # Reevaluation recomputes a different target but dispatches nothing — the
-    # recorded target must be untouched (no _prepare_service_call ran).
-    assert cmd_svc.get_target(entity_id) == 100
+    # Mid-transit: the carriage is at 40, still travelling toward 100.
+    mid_transit_actual = 40
+    drift = abs(mid_transit_actual - 100)
+    assert drift > VENETIAN_REBASE_MAX_DRIFT_PERCENT  # refusal branch is exercised
 
-    # The real post-tilt rebase at the endpoint: actual == target → early
-    # return, target stays 100 (does not re-anchor to a mid value).
-    policy.sequencer._get_current_position = lambda _eid: 100
+    policy.sequencer._get_current_position = lambda _eid: mid_transit_actual
     policy.sequencer._set_commanded_position = lambda eid, pos: cmd_svc.set_target(
         eid, pos
     )
     policy.sequencer._rebase_commanded_position(entity_id, 100)
+
+    # Guard held: the recorded target was NOT re-anchored to the mid value.
     assert cmd_svc.get_target(entity_id) == 100
 
-    # Endpoint arrival: the recorded target is reached.
+    # Later endpoint arrival: the intact recorded target is reached.
     assert cmd_svc.check_target_reached(entity_id, 100) is True
 
     recorded_target = cmd_svc.get_target(entity_id)
@@ -266,31 +299,35 @@ def test_position_anchor_survives_reevaluation_without_dispatch() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_combined_position_and_tilt_endpoint_after_reevaluation_is_not_manual() -> None:
-    """The full #1006 incident: dispatch open+tilt=70, reevaluate to 30/30, no send.
+async def test_combined_position_and_tilt_endpoint_after_reevaluation_is_not_manual() -> (
+    None
+):
+    """The full #1006 incident: dispatch position=60+tilt=45, reevaluate to 30/20.
 
-    Both axes reach their commanded endpoints (position=100, tilt=70). Neither
-    axis may misclassify the arrival: the tilt axis compares against the
-    dispatched 70 (not the reevaluated 30) and the position axis against the
-    intact recorded target (100).
+    A solar cycle dispatched a producible tuple (position=60, tilt=45). A
+    mid-transit reevaluation recomputes position=30 + tilt=20 and sends nothing.
+    Both axes reach their commanded values (position=60, tilt=45). Neither axis
+    may misclassify the arrival: the tilt axis compares against the dispatched 45
+    (not the reevaluated 20) and the position axis against the intact recorded
+    target (60).
     """
     entity_id = "cover.raffstore_wc"
-    policy = _make_attached_policy(entity_id)
-    policy.sequencer._tilt_targets[entity_id] = 70  # dispatched tilt
+    policy = _make_dispatch_venetian_policy()
+    await _dispatch_tilt(policy, entity_id, tilt=45, position=60)  # dispatched tilt
 
     cmd_svc = _make_cmd_svc()
-    cmd_svc.set_target(entity_id, 100)  # dispatched open
+    cmd_svc.set_target(entity_id, 60)  # solar cycle commanded position
 
     # Mid-transit reevaluation wants a different position AND tilt; sends nothing.
-    result = _reevaluated_result(position=30, tilt=30)
+    result = _reevaluated_result(position=30, tilt=20)
 
     check = policy.secondary_axis_check(result, cmd_svc, entity_id)
     recorded_target = cmd_svc.get_target(entity_id)
-    expected_position = recorded_target  # 100
+    expected_position = recorded_target  # 60
 
     mgr = _make_manager(entity_id)
     mgr.handle_state_change(
-        states_data=_make_event(entity_id, position=100, tilt=70),
+        states_data=_make_event(entity_id, position=60, tilt=45),
         our_state=expected_position,
         policy=policy,
         allow_reset=True,
@@ -304,4 +341,200 @@ def test_combined_position_and_tilt_endpoint_after_reevaluation_is_not_manual() 
 
     assert not mgr.is_cover_manual(
         entity_id
-    ), "the incident's combined endpoint arrival must NOT trip manual override"
+    ), "the incident's combined settle arrival must NOT trip manual override"
+
+
+# ---------------------------------------------------------------------------
+# Real-dispatch helpers (Finding 4): drive the tilt anchor through the public
+# sequencer path so the stored ``_tilt_targets`` value is one the real dispatch
+# path actually produces, not a hand-poked number.
+# ---------------------------------------------------------------------------
+
+
+def _make_dispatch_hass() -> MagicMock:
+    """Return a hass whose ``services.async_call`` is awaitable so a send runs."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    return hass
+
+
+def _make_quiet_grace_mgr() -> MagicMock:
+    """Return a grace manager that never spawns a timeout task nor reports grace.
+
+    A real ``GracePeriodManager.start_command_grace_period`` (fired by the
+    sequencer on every send) spawns an asyncio timer that outlives the test.
+    Mocking it keeps the driven dispatch timer-free, and forcing
+    ``is_in_command_grace_period`` to ``False`` stops the suppression callback
+    from swallowing the check — so these tests exercise the anchor, not grace.
+    """
+    grace_mgr = MagicMock()
+    grace_mgr.is_in_command_grace_period = lambda _eid: False
+    return grace_mgr
+
+
+def _make_dispatch_venetian_policy() -> VenetianPolicy:
+    """Return a VenetianPolicy whose sequencer can actually dispatch a tilt send.
+
+    Uses an awaitable ``async_call`` and a timer-free grace mock so a real
+    ``update_tilt_only`` runs, populating ``_tilt_targets`` through the same code
+    a solar-tracking cycle uses (Finding 4: producible anchor values, not
+    hand-poked numbers).
+    """
+    policy = VenetianPolicy()
+    policy.attach(
+        hass=_make_dispatch_hass(),
+        logger=MagicMock(),
+        grace_mgr=_make_quiet_grace_mgr(),
+        get_current_position=lambda _eid: None,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_state=lambda _eid: "open",
+        venetian_mode="position_and_tilt",
+    )
+    return policy
+
+
+def _make_attached_dns_policy(entity_id: str) -> DayNightShadePolicy:
+    """Return a Day/Night Shade Model A policy with a real DualAxisSequencer.
+
+    Model A (``position_tilt``, the default control model) drives the blend
+    (tilt) axis through the SAME ``DualAxisSequencer`` venetian uses — so
+    ``sequencer.last_tilt_target`` is populated by ``update_tilt_only`` exactly
+    as it is for venetian. This is the store Finding 1 says the DNS
+    ``secondary_axis_check`` must anchor against.
+    """
+    policy = DayNightShadePolicy()
+    policy.attach(
+        hass=_make_dispatch_hass(),
+        logger=MagicMock(),
+        grace_mgr=_make_quiet_grace_mgr(),
+        get_current_position=lambda _eid: None,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_state=lambda _eid: "open",
+    )
+    return policy
+
+
+async def _dispatch_tilt(policy, entity_id: str, *, tilt: int, position: int) -> None:
+    """Drive a real tilt send through the public sequencer path.
+
+    Populates ``_tilt_targets[entity_id]`` via the same code a solar-tracking
+    cycle uses — the anchor the manual-override check must read.
+    """
+    await policy.sequencer.update_tilt_only(
+        entity_id, tilt_target=tilt, current_position=position, reason="solar"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — Day/Night Shade Model A: blend-axis expected must be DISPATCHED
+# ---------------------------------------------------------------------------
+
+
+async def test_dns_model_a_tilt_expected_is_dispatched_not_reevaluated() -> None:
+    """DNS Model A blend axis anchors ``expected`` to the DISPATCHED tilt.
+
+    The reporter's incident on the venetian path applies identically to the
+    Day/Night Shade Model A blend axis: it reuses the venetian
+    ``DualAxisSequencer`` by composition and dispatches its blend through the
+    same ``_tilt_targets`` store. ACP dispatches blend=45 (a producible
+    mid-range solar value), a mid-transit reevaluation recomputes blend=20 and
+    sends nothing, and the actuator settles at the commanded 45. The check the
+    coordinator builds from the reevaluated result must expect the dispatched
+    45, not the reevaluated 20 — otherwise the settle reads as a manual move.
+    """
+    entity_id = "cover.day_night_shade_a"
+    policy = _make_attached_dns_policy(entity_id)
+    assert policy._drives_dual_axis(), "default DNS control model must be Model A"
+
+    # Real dispatch of the blend axis → populates the shared _tilt_targets store.
+    await _dispatch_tilt(policy, entity_id, tilt=45, position=60)
+    assert policy.sequencer.last_tilt_target(entity_id) == 45
+
+    cmd_svc = _make_cmd_svc()
+    cmd_svc.set_target(entity_id, 60)  # dispatched mid position
+    result = _reevaluated_result(position=20, tilt=20)  # reevaluated, no send
+
+    check = policy.secondary_axis_check(result, cmd_svc, entity_id)
+    assert check is not None
+    assert check.expected == 45, (
+        "DNS Model A blend expected must be the dispatched value (45), not the "
+        f"mid-transit reevaluated pipeline value (20); got {check.expected}"
+    )
+
+    # End-to-end: settle at the commanded blend (45) must NOT trip override.
+    recorded_target = cmd_svc.get_target(entity_id)
+    mgr = _make_manager(entity_id)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=60, tilt=45),
+        our_state=recorded_target,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        has_recorded_target=recorded_target is not None,
+        secondary_axis_check=check,
+        is_in_command_grace=lambda _eid: False,
+        is_in_transit=lambda _eid: False,
+    )
+    assert not mgr.is_cover_manual(entity_id), (
+        "DNS Model A settle at the dispatched blend after a reevaluation must "
+        "NOT trip manual override"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — empty anchor (suppress mode / restart / Auto-Control off→on):
+# no dispatched tilt → NO independent tilt manual-detection (not result.tilt)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_tilt_anchor_yields_no_tilt_manual_detection() -> None:
+    """No dispatched tilt anchor → the tilt axis must NOT assert an expectation.
+
+    The reporter's WAREMA exterior raffstore runs ``venetian_tilt_skip_mode =
+    suppress``: opening above ``tilt_skip_above`` dispatches NO independent tilt,
+    so ``last_tilt_target`` is empty (the same state after an HA restart, a
+    drift-verify pop, or an Auto-Control off→on ``clear_tilt_targets``). ACP has
+    no commanded tilt reference to police here.
+
+    A mid-transit reevaluation computes some ``result.tilt`` (20). The actuator
+    then settles at the coupled open endpoint, publishing tilt≈100. Falling back
+    to the reevaluated ``result.tilt`` (the pre-fix behaviour) makes |20−100|=80
+    read as a manual move. With no dispatched anchor, the secondary-axis check
+    must yield NO independent tilt manual-detection instead.
+    """
+    entity_id = "cover.raffstore_wc_suppress"
+    policy = _make_attached_policy(entity_id)
+    # No tilt dispatched — anchor is empty.
+    assert policy.sequencer.last_tilt_target(entity_id) is None
+
+    cmd_svc = _make_cmd_svc()
+    cmd_svc.set_target(entity_id, 100)  # dispatched open (position axis only)
+    result = _reevaluated_result(position=20, tilt=20)
+
+    check = policy.secondary_axis_check(result, cmd_svc, entity_id)
+    recorded_target = cmd_svc.get_target(entity_id)
+
+    mgr = _make_manager(entity_id)
+    mgr.handle_state_change(
+        # Coupled open endpoint: position reached (100), tilt follows to ≈100.
+        states_data=_make_event(entity_id, position=100, tilt=100),
+        our_state=recorded_target,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        has_recorded_target=recorded_target is not None,
+        secondary_axis_check=check,
+        is_in_command_grace=lambda _eid: False,
+        is_in_transit=lambda _eid: False,
+    )
+
+    assert not mgr.is_cover_manual(entity_id), (
+        "with no dispatched tilt anchor, the coupled end-of-travel tilt must NOT "
+        "be misclassified as a manual move via the reevaluated result.tilt"
+    )

--- a/tests/test_issue_1006_reevaluation_false_override.py
+++ b/tests/test_issue_1006_reevaluation_false_override.py
@@ -1,0 +1,307 @@
+"""Issue #1006: false manual override after a handler reevaluation mid-transit.
+
+Scenario (venetian ``position_and_tilt``, WAREMA/KNX):
+
+ACP dispatches ``open_cover`` (+ tilt=70) to a cover. A few tens of
+milliseconds later a transiently-unavailable input recovers and ACP
+**reevaluates its handler state** — a different handler now wins with a
+different position/tilt target — **while the open movement is still
+travelling**, and dispatches NO replacement command. Seconds later the KNX
+actuator reaches the commanded open end-position (position≈100, tilt≈70).
+
+The manual-override gate must recognise that end-of-travel feedback as ACP's
+OWN movement. The defect: the tilt-axis ``SecondaryAxisCheck.expected`` was
+sourced from the freshly-reevaluated ``PipelineResult`` (tilt=30) rather than
+the tilt ACP actually DISPATCHED (70), so the end-of-travel tilt=70 read a
+delta of 40% and tripped a false ``manual_override_set``.
+
+The fix anchors the correlation to the value ACP last DISPATCHED per axis:
+the tilt axis reads ``sequencer.last_tilt_target(entity_id)`` (the stored
+commanded tilt) instead of the mutable per-cycle pipeline value. The position
+axis was already robust — a reevaluation that dispatches nothing never
+re-anchors the recorded target (``_prepare_service_call`` is the sole writer,
+and it only runs on an actual send) and the venetian post-tilt rebase
+early-returns at the endpoint (drift≈0). Test C pins that robustness.
+
+Tests A/B/D drive the post-fix 3-arg ``policy.secondary_axis_check(result,
+cmd_svc, entity_id)`` accessor exactly as the coordinator does, so the tilt
+expected value is derived, not hand-fed.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.cover_types.venetian.policy import (
+    VenetianPolicy,
+)
+from custom_components.adaptive_cover_pro.managers.grace_period import (
+    GracePeriodManager,
+)
+from custom_components.adaptive_cover_pro.managers.manual_override import (
+    AdaptiveCoverManager,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+# The venetian sequencer otherwise waits on real-motor post-tilt delays.
+pytestmark = pytest.mark.usefixtures("neutralize_venetian_delays")
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _make_event(entity_id: str, *, position: int | None, tilt: int | None):
+    """Build a fake StateChangedData reporting both axes."""
+    attrs: dict = {}
+    if position is not None:
+        attrs["current_position"] = position
+    if tilt is not None:
+        attrs["current_tilt_position"] = tilt
+    event = MagicMock()
+    event.entity_id = entity_id
+    event.new_state = MagicMock()
+    event.new_state.state = "open"
+    event.new_state.attributes = attrs
+    event.new_state.last_updated = dt.datetime.now(dt.UTC)
+    event.old_state = None
+    return event
+
+
+def _make_manager(entity_id: str) -> AdaptiveCoverManager:
+    mgr = AdaptiveCoverManager(
+        hass=MagicMock(),
+        reset_duration={"hours": 2},
+        logger=MagicMock(),
+    )
+    mgr.hass.states.get = MagicMock(return_value=None)
+    mgr.add_covers([entity_id])
+    return mgr
+
+
+def _make_attached_policy(entity_id: str) -> VenetianPolicy:
+    """Build a VenetianPolicy with a real DualAxisSequencer attached.
+
+    Grace is NOT stamped — the tilt correlation under test is the stored
+    dispatched-tilt anchor, not any time-based grace window.
+    """
+    policy = VenetianPolicy()
+    policy.attach(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        grace_mgr=GracePeriodManager(logger=MagicMock()),
+        get_current_position=lambda _eid: None,
+        set_commanded_position=lambda *_: None,
+        position_tolerance=5,
+        is_dry_run=lambda: False,
+        get_state=lambda _eid: "open",
+        venetian_mode="position_and_tilt",
+    )
+    return policy
+
+
+def _make_cmd_svc():
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+    )
+
+    grace_mgr = GracePeriodManager(logger=MagicMock(), command_grace_seconds=5.0)
+    return CoverCommandService(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        cover_type="cover_venetian",
+        grace_mgr=grace_mgr,
+        position_tolerance=5,
+        transit_timeout_seconds=45,
+    )
+
+
+def _reevaluated_result(*, position: int, tilt: int) -> PipelineResult:
+    """Return the different position/tilt a mid-transit reevaluation computed."""
+    return PipelineResult(
+        position=position,
+        control_method=ControlMethod.SOLAR,
+        reason="solar",
+        tilt=tilt,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test A — tilt unit: expected must be the DISPATCHED tilt, not the reeval value
+# ---------------------------------------------------------------------------
+
+
+def test_tilt_expected_is_dispatched_target_not_reevaluated() -> None:
+    """``SecondaryAxisCheck.expected`` binds to the DISPATCHED tilt (70), not 30.
+
+    ACP dispatched tilt=70 (stored in ``_tilt_targets``). A reevaluation then
+    recomputed tilt=30 with no replacement send. The check the coordinator
+    builds from the reevaluated result must still expect 70 — the tilt ACP is
+    actually driving toward — so the end-of-travel tilt=70 is not misread.
+    """
+    entity_id = "cover.raffstore_wc"
+    policy = _make_attached_policy(entity_id)
+    # ACP dispatched tilt=70 — the value the actuator is travelling toward.
+    policy.sequencer._tilt_targets[entity_id] = 70
+
+    cmd_svc = _make_cmd_svc()
+    result = _reevaluated_result(position=30, tilt=30)
+
+    check = policy.secondary_axis_check(result, cmd_svc, entity_id)
+
+    assert check is not None
+    assert check.expected == 70, (
+        "tilt expected must be the dispatched target (70), not the mid-transit "
+        f"reevaluated pipeline value (30); got {check.expected}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test B — end-to-end tilt: settle at commanded tilt after reevaluation
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_tilt_arrival_after_reevaluation_is_not_manual() -> None:
+    """Actuator settles at the commanded tilt (70) after a reevaluation to 30.
+
+    The position axis reached its recorded target (100). The end-of-travel
+    feedback (position=100, tilt=70) must NOT engage manual override — it is
+    ACP's own commanded movement completing.
+    """
+    entity_id = "cover.raffstore_wc"
+    policy = _make_attached_policy(entity_id)
+    policy.sequencer._tilt_targets[entity_id] = 70
+
+    cmd_svc = _make_cmd_svc()
+    cmd_svc.set_target(entity_id, 100)  # dispatched open → recorded target 100
+
+    result = _reevaluated_result(position=30, tilt=30)
+
+    # Coordinator derivation (post-fix form): tilt expected from dispatched.
+    check = policy.secondary_axis_check(result, cmd_svc, entity_id)
+    recorded_target = cmd_svc.get_target(entity_id)
+    expected_position = recorded_target  # 100
+
+    mgr = _make_manager(entity_id)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=100, tilt=70),
+        our_state=expected_position,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        has_recorded_target=recorded_target is not None,
+        secondary_axis_check=check,
+        is_in_command_grace=lambda _eid: False,
+        is_in_transit=lambda _eid: False,
+    )
+
+    assert not mgr.is_cover_manual(entity_id), (
+        "end-of-travel arrival at the commanded tilt after a reevaluation must "
+        "NOT trip manual override"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test C — position axis is robust to a no-dispatch reevaluation
+# ---------------------------------------------------------------------------
+
+
+def test_position_anchor_survives_reevaluation_without_dispatch() -> None:
+    """A reevaluation that dispatches nothing must not orphan the position anchor.
+
+    The recorded target is written only by the dispatch chokepoint, so a
+    no-dispatch reevaluation leaves it intact (100). The venetian post-tilt
+    rebase early-returns at the endpoint (actual≈target → drift≈0), so it does
+    not re-anchor either. The endpoint arrival (position=100) is therefore
+    correctly recognised as target-reached and stays automatic.
+    """
+    entity_id = "cover.raffstore_wc"
+    policy = _make_attached_policy(entity_id)
+
+    cmd_svc = _make_cmd_svc()
+    cmd_svc.set_target(entity_id, 100)  # dispatched open
+    cmd_svc.set_waiting(entity_id, True)
+
+    # Reevaluation recomputes a different target but dispatches nothing — the
+    # recorded target must be untouched (no _prepare_service_call ran).
+    assert cmd_svc.get_target(entity_id) == 100
+
+    # The real post-tilt rebase at the endpoint: actual == target → early
+    # return, target stays 100 (does not re-anchor to a mid value).
+    policy.sequencer._get_current_position = lambda _eid: 100
+    policy.sequencer._set_commanded_position = lambda eid, pos: cmd_svc.set_target(
+        eid, pos
+    )
+    policy.sequencer._rebase_commanded_position(entity_id, 100)
+    assert cmd_svc.get_target(entity_id) == 100
+
+    # Endpoint arrival: the recorded target is reached.
+    assert cmd_svc.check_target_reached(entity_id, 100) is True
+
+    recorded_target = cmd_svc.get_target(entity_id)
+    mgr = _make_manager(entity_id)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=100, tilt=None),
+        our_state=recorded_target,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        has_recorded_target=recorded_target is not None,
+        secondary_axis_check=None,
+        is_in_command_grace=lambda _eid: False,
+        is_in_transit=lambda _eid: False,
+    )
+    assert not mgr.is_cover_manual(entity_id)
+
+
+# ---------------------------------------------------------------------------
+# Test D — the literal incident: combined position_and_tilt endpoint arrival
+# ---------------------------------------------------------------------------
+
+
+def test_combined_position_and_tilt_endpoint_after_reevaluation_is_not_manual() -> None:
+    """The full #1006 incident: dispatch open+tilt=70, reevaluate to 30/30, no send.
+
+    Both axes reach their commanded endpoints (position=100, tilt=70). Neither
+    axis may misclassify the arrival: the tilt axis compares against the
+    dispatched 70 (not the reevaluated 30) and the position axis against the
+    intact recorded target (100).
+    """
+    entity_id = "cover.raffstore_wc"
+    policy = _make_attached_policy(entity_id)
+    policy.sequencer._tilt_targets[entity_id] = 70  # dispatched tilt
+
+    cmd_svc = _make_cmd_svc()
+    cmd_svc.set_target(entity_id, 100)  # dispatched open
+
+    # Mid-transit reevaluation wants a different position AND tilt; sends nothing.
+    result = _reevaluated_result(position=30, tilt=30)
+
+    check = policy.secondary_axis_check(result, cmd_svc, entity_id)
+    recorded_target = cmd_svc.get_target(entity_id)
+    expected_position = recorded_target  # 100
+
+    mgr = _make_manager(entity_id)
+    mgr.handle_state_change(
+        states_data=_make_event(entity_id, position=100, tilt=70),
+        our_state=expected_position,
+        policy=policy,
+        allow_reset=True,
+        is_waiting=lambda _eid: False,
+        manual_threshold=5,
+        has_recorded_target=recorded_target is not None,
+        secondary_axis_check=check,
+        is_in_command_grace=lambda _eid: False,
+        is_in_transit=lambda _eid: False,
+    )
+
+    assert not mgr.is_cover_manual(
+        entity_id
+    ), "the incident's combined endpoint arrival must NOT trip manual override"


### PR DESCRIPTION
## Summary
A handler reevaluation that dispatched no replacement movement re-anchored the manual-override tilt expectation from the freshly recomputed pipeline result while ACP's own `open_cover` was still traveling. When the actuator settled at the commanded tilt it no longer matched the reevaluated expectation, so the end-of-travel feedback was misclassified as a manual override (six covers in the reporter's incident on #1006).

The manual-override gate now sources the secondary-axis (tilt) expectation from the tilt ACP last dispatched (`sequencer.last_tilt_target`), extracted into a single shared helper (`resolve_dispatched_secondary_expected`) that both `VenetianPolicy` and `DayNightShadePolicy` delegate to. When ACP dispatched no independent tilt (tilt-skip suppress, HA restart, drift-verify pop, Auto-Control re-enable) the check now asserts no tilt expectation rather than falling back to the reevaluated pipeline tilt, which closes the same gap for mechanically-coupled exterior venetians. The position axis is unaffected: its recorded target is only written at the dispatch chokepoint, so a no-dispatch reevaluation can't re-anchor it.

## Testing
- ✅ 7702 tests passing (1 pre-existing xfail)
- New `tests/test_issue_1006_reevaluation_false_override.py` — venetian, Day/Night Shade, and empty-anchor coverage; each fails against pre-fix code
- Regression guards green: #518, #271, #172, #875, #927, Day/Night Shade, cover-type axes
- Deep audit (fable) run twice; the first pass's findings (DNS gap, no-duplication, empty-anchor fallback) were fixed, no confirmed defects remain

## Related Issues
Refs #1006

https://claude.ai/code/session_01C4tHJgfUNxNScVqWR2WwZF
