### PR TITLE
fix: hold last valid Is Sunny opinion on transient invalid read (#1014)

### DIFF
--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -16,7 +16,7 @@ from ..engine.climate_crossings import (
     winter_crossing,
 )
 from ..helpers import get_domain, get_safe_state, is_entity_active, state_attr
-from ..templates import fold_condition_template
+from ..templates import fold_condition_template, is_template_string
 from .area_resolver import AreaSensorResolver
 
 if TYPE_CHECKING:
@@ -85,6 +85,10 @@ class ClimateProvider:
         self._hass = hass
         self._logger = logger
         self._area_resolver = AreaSensorResolver(hass)
+        # Last authoritative is_sunny opinion, held across a transient invalid
+        # sensor/template read so a blip cannot substitute a lower-authority
+        # weather fallback (issue #1014; mirrors #1010's custom-position hold).
+        self._last_valid_is_sunny: bool | None = None
 
     def read(
         self,
@@ -356,9 +360,15 @@ class ClimateProvider:
         sensor's on/off state and the rendered template combine via
         ``is_sunny_template_mode`` (issue #639). A sensor that is
         unavailable/unknown and a template that is empty or fails to render are
-        each treated as "no opinion": when NEITHER source is authoritative the
-        code falls through to the weather-entity logic so a stale source cannot
-        strand the integration in a fixed state.
+        each treated as "no opinion" this cycle. When a source is configured
+        and a PRIOR cycle produced an authoritative opinion, that opinion is
+        HELD across the transient invalid read instead of falling through to
+        weather (issue #1014 — mirrors #1010's custom-position hold: a
+        transient invalid read must not be read as a lower-authority signal).
+        Only when a configured source has never yet produced an opinion, or no
+        source is configured at all, does the code fall through to the
+        weather-entity logic — preserving the original "stale source cannot
+        strand the integration" intent for that first-ever-invalid case.
         """
         sensor_state = (
             get_safe_state(self._hass, is_sunny_sensor) if is_sunny_sensor else None
@@ -378,7 +388,17 @@ class ClimateProvider:
                 is_sunny_template,
                 combined,
             )
+            self._last_valid_is_sunny = combined
             return combined
+        configured = bool(is_sunny_sensor) or is_template_string(is_sunny_template)
+        if configured and self._last_valid_is_sunny is not None:
+            self._logger.debug(
+                "is_sunny(): sensor=%r template=%r invalid — holding last-valid %s",
+                is_sunny_sensor,
+                is_sunny_template,
+                self._last_valid_is_sunny,
+            )
+            return self._last_valid_is_sunny
         if is_sunny_sensor:
             self._logger.debug(
                 "is_sunny(): sensor %s unavailable (%r) — falling through to weather",

--- a/tests/test_state/test_climate_provider.py
+++ b/tests/test_state/test_climate_provider.py
@@ -544,6 +544,114 @@ class TestSunnySensor:
 
 
 # ---------------------------------------------------------------------------
+# is_sunny transient-invalid HOLD (issue #1014) — mirrors #1010's pattern: a
+# transient unavailable/unknown/missing read on a configured, previously-valid
+# source must hold the last opinion instead of falling through to weather.
+# ---------------------------------------------------------------------------
+
+
+class TestSunnyTransientHold:
+    """A configured sensor that was valid must HOLD across a transient blip."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("invalid_value", ["unavailable", "unknown", None])
+    def test_transient_unavailable_sensor_holds_last_valid_off(
+        self, provider, mock_hass, invalid_value
+    ):
+        """Sensor off → valid False; sensor blips invalid → HELD False, not weather True."""
+        states = {
+            "binary_sensor.sunny": _mock_state("binary_sensor.sunny", "off"),
+            "weather.home": _mock_state("weather.home", "sunny"),
+        }
+        mock_hass.states.get.side_effect = lambda eid: states.get(eid)
+
+        # Cycle 1: sensor off → valid, authoritative.
+        readings1 = provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+        assert readings1.is_sunny is False
+
+        # Cycle 2: sensor transiently invalid → HELD to the last-valid False,
+        # NOT the weather fall-through (which would report sunny → True).
+        if invalid_value is None:
+            states.pop("binary_sensor.sunny", None)
+        else:
+            states["binary_sensor.sunny"] = _mock_state(
+                "binary_sensor.sunny", invalid_value
+            )
+        readings2 = provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+        assert readings2.is_sunny is False  # fails today: weather fallback → True
+
+    @pytest.mark.unit
+    def test_valid_off_after_transient_hold_still_releases(self, provider, mock_hass):
+        """A genuine off read after a held transient still reports off."""
+        states = {
+            "binary_sensor.sunny": _mock_state("binary_sensor.sunny", "off"),
+            "weather.home": _mock_state("weather.home", "sunny"),
+        }
+        mock_hass.states.get.side_effect = lambda eid: states.get(eid)
+
+        provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+        states["binary_sensor.sunny"] = _mock_state(
+            "binary_sensor.sunny", "unavailable"
+        )
+        provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+
+        states["binary_sensor.sunny"] = _mock_state("binary_sensor.sunny", "off")
+        readings3 = provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+        assert readings3.is_sunny is False
+
+    @pytest.mark.unit
+    def test_off_to_on_still_releases(self, provider, mock_hass):
+        """After holding off across a blip, a genuine on read must flip True."""
+        states = {
+            "binary_sensor.sunny": _mock_state("binary_sensor.sunny", "off"),
+            "weather.home": _mock_state("weather.home", "rainy"),
+        }
+        mock_hass.states.get.side_effect = lambda eid: states.get(eid)
+
+        provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+        states["binary_sensor.sunny"] = _mock_state(
+            "binary_sensor.sunny", "unavailable"
+        )
+        provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+
+        states["binary_sensor.sunny"] = _mock_state("binary_sensor.sunny", "on")
+        readings3 = provider.read(
+            weather_entity="weather.home",
+            weather_condition=["sunny"],
+            is_sunny_sensor="binary_sensor.sunny",
+        )
+        assert readings3.is_sunny is True
+
+
+# ---------------------------------------------------------------------------
 # is_sunny condition template (issue #639) — needs a real hass to render Jinja
 # ---------------------------------------------------------------------------
 
@@ -644,6 +752,60 @@ class TestSunnyTemplate:
             is_sunny_template="just text",
         )
         assert readings.is_sunny is False
+
+
+class TestSunnyTemplateTransientHold:
+    """A template-only source that was valid must HOLD across a render failure."""
+
+    async def test_transient_template_failure_holds_last_valid(self, hass):
+        """Template renders True, then fails, then renders True again.
+
+        Weather is configured to a NON-sunny condition so the pre-fix
+        fall-through and the fixed hold produce visibly different results:
+        the buggy fall-through would report False (weather rainy) on the
+        middle cycle, while the fix must hold the last-valid True.
+        """
+        hass.states.async_set("weather.home", "rainy")
+        await hass.async_block_till_done()
+        p = _real_provider(hass)
+
+        sunny_template = "{{ states('sensor.elev') | float > 10 }}"
+        render_results = iter([True, None, True])
+
+        def fake_render(_hass, template_str):
+            # Only intercept the is_sunny template read; a bare call also
+            # runs for the (unused) presence template each cycle and must
+            # keep returning None like the real function does for "no
+            # template configured", not consume our side-effect sequence.
+            if template_str == sunny_template:
+                return next(render_results)
+            return None
+
+        with patch(
+            "custom_components.adaptive_cover_pro.templates.render_condition_or_none",
+            side_effect=fake_render,
+        ):
+            readings1 = p.read(
+                weather_entity="weather.home",
+                weather_condition=["sunny"],
+                is_sunny_template=sunny_template,
+            )
+            readings2 = p.read(
+                weather_entity="weather.home",
+                weather_condition=["sunny"],
+                is_sunny_template=sunny_template,
+            )
+            readings3 = p.read(
+                weather_entity="weather.home",
+                weather_condition=["sunny"],
+                is_sunny_template=sunny_template,
+            )
+
+        assert readings1.is_sunny is True
+        assert (
+            readings2.is_sunny is True
+        )  # fails today: falls through to weather → False
+        assert readings3.is_sunny is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A transient `unavailable`/`unknown` read on a configured Is Sunny sensor or template (for example during an HA `template.reload`) was falling through `ClimateProvider._read_sunny()` to the weather entity instead of holding the last valid opinion. That briefly released cloud suppression and let the solar handler dispatch a real cover move to covers in the sun, with recovery then blocked by the command delta-time gate until periodic reconciliation.

`_read_sunny()` now records the last authoritative sensor/template opinion and holds it across any subsequent invalid read from a configured source, mirroring the #1010 custom-position-slot hold pattern. A genuine `off`/`on` transition still flows through immediately, and the first-ever-invalid and weather-only fall-through paths (#639) are preserved.

## Testing
- 7867 tests passing (full suite; new hold + release tests in `tests/test_state/test_climate_provider.py`, regression guards `test_issue_1005_transient_unavailable_hold.py` / `test_issue_1006_reevaluation_false_override.py` green)

## Related Issues
Refs #1014