### PR TITLE
fix: template-mode keys mis-cataloged as unavailable sensors (#1017)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -2340,6 +2340,17 @@ BUILDING_PROFILE_SENSOR_KEYS = (
     )
 )
 
+# Entity-valued subset of the shared keys — the sensor-source diagnostics
+# blocks catalogue only these. Template bodies (``*_template``) and combine
+# modes (``*_template_mode``, a TemplateCombineMode scalar like "or"/"and")
+# are config, not entities; cataloguing their values as entity_ids made the
+# Troubleshoot step flag them as unavailable sensors (issue #1017).
+BUILDING_PROFILE_ENTITY_KEYS = frozenset(
+    k
+    for k in BUILDING_PROFILE_SENSOR_KEYS
+    if not (k.endswith("_template") or k.endswith("_template_mode"))
+)
+
 
 class TiltMode(StrEnum):
     """Tilt mode for venetian blinds (slat travel range)."""

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -997,7 +997,7 @@ class DiagnosticsBuilder:
     def _build_sensor_sources(cls, ctx: DiagnosticContext) -> dict:
         """Build the two shared-sensor source/state subsections (issue #693, Q3).
 
-        Every key in ``BUILDING_PROFILE_SENSOR_KEYS`` is classified per cover via
+        Every key in ``BUILDING_PROFILE_ENTITY_KEYS`` is classified per cover via
         the three-way ``classify_profile_sensor_source``: ``"profile"`` (inherited
         from the profile), ``"override"`` (profile defines it but the cover
         overrides it locally), or ``"local"`` (profile leaves it blank, cover keeps
@@ -1012,7 +1012,7 @@ class DiagnosticsBuilder:
         flat ``configuration`` dict is untouched so current consumers keep
         working.
         """
-        from ..const import BUILDING_PROFILE_SENSOR_KEYS, CONF_BUILDING_PROFILE_ID
+        from ..const import BUILDING_PROFILE_ENTITY_KEYS, CONF_BUILDING_PROFILE_ID
         from ..profile_link import classify_profile_sensor_source
 
         options = ctx.config_options or {}
@@ -1022,7 +1022,7 @@ class DiagnosticsBuilder:
 
         profile_block: list[dict] = []
         local_block: list[dict] = []
-        for key in sorted(BUILDING_PROFILE_SENSOR_KEYS):
+        for key in sorted(BUILDING_PROFILE_ENTITY_KEYS):
             source, entity_id = classify_profile_sensor_source(
                 key, options, profile_options
             )

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -282,6 +282,18 @@ def _is_template(value: object) -> bool:
     return isinstance(value, str) and ("{{" in value or "{%" in value)
 
 
+def _is_entity_id(value: object) -> bool:
+    """Return True when ``value`` looks like an HA entity_id (``domain.object_id``).
+
+    A non-entity scalar — e.g. a ``TemplateCombineMode`` value like ``"or"``
+    mistakenly surfacing as a sensor-source ``entity_id`` — must never be
+    reported as an unavailable entity (issue #1017 defense-in-depth). Shared by
+    both the sensors and covers paths of rule 8b and by rule 8a's capabilities
+    path, so the "looks like an entity id" test lives in exactly one place.
+    """
+    return isinstance(value, str) and "." in value
+
+
 def _slot_sensors(options: Mapping, keys: Mapping[str, str]) -> list[str]:
     """Return a custom-position slot's trigger sensors (mirrors helpers.py)."""
     sensors = options.get(keys["sensors"])
@@ -521,7 +533,7 @@ def _check_cover_not_ready(data: Mapping) -> Iterable[Mapping]:
     if not isinstance(capabilities, Mapping):
         return
     for eid, caps in capabilities.items():
-        if caps is None:
+        if caps is None and _is_entity_id(eid):
             yield {"eid": eid}
 
 
@@ -534,13 +546,17 @@ def _check_entity_unavailable(data: Mapping) -> Iterable[Mapping]:
                 if (
                     isinstance(descriptor, Mapping)
                     and descriptor.get("state") == "unavailable"
-                    and descriptor.get("entity_id")
+                    and _is_entity_id(descriptor.get("entity_id"))
                 ):
                     yield {"eid": descriptor["entity_id"]}
     covers = _get(data, "covers")
     if isinstance(covers, Mapping):
         for eid, cover in covers.items():
-            if isinstance(cover, Mapping) and cover.get("available") is False:
+            if (
+                isinstance(cover, Mapping)
+                and cover.get("available") is False
+                and _is_entity_id(eid)
+            ):
                 yield {"eid": eid}
 
 

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -538,17 +538,32 @@ def _check_cover_not_ready(data: Mapping) -> Iterable[Mapping]:
 
 
 def _check_entity_unavailable(data: Mapping) -> Iterable[Mapping]:
-    """Rule 8b — a configured sensor or cover entity is currently unavailable."""
+    """Rule 8b — a configured sensor or cover entity is currently unavailable.
+
+    A sensor-source descriptor's ``entity_id`` is either a scalar (single
+    entity) or a LIST (``weather_severe_sensors``/``daytime_gate_sensors`` —
+    multiple sensors combined into one logical source). The builder only marks
+    such a descriptor ``"unavailable"`` when EVERY member is down, so once that
+    state is reached every list member is genuinely unavailable and gets its
+    own finding — one per entity, same as the scalar case.
+    """
     for section in ("local_sensors", "building_profile_sensors"):
         sensors = _get(data, section)
-        if isinstance(sensors, list):
-            for descriptor in sensors:
-                if (
-                    isinstance(descriptor, Mapping)
-                    and descriptor.get("state") == "unavailable"
-                    and _is_entity_id(descriptor.get("entity_id"))
-                ):
-                    yield {"eid": descriptor["entity_id"]}
+        if not isinstance(sensors, list):
+            continue
+        for descriptor in sensors:
+            if (
+                not isinstance(descriptor, Mapping)
+                or descriptor.get("state") != "unavailable"
+            ):
+                continue
+            eid = descriptor.get("entity_id")
+            if isinstance(eid, list):
+                for member in eid:
+                    if _is_entity_id(member):
+                        yield {"eid": member}
+            elif _is_entity_id(eid):
+                yield {"eid": eid}
     covers = _get(data, "covers")
     if isinstance(covers, Mapping):
         for eid, cover in covers.items():

--- a/tests/test_diagnostics/test_building_profile_sources.py
+++ b/tests/test_diagnostics/test_building_profile_sources.py
@@ -23,6 +23,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
     CONF_OUTSIDETEMP_ENTITY,
+    CONF_WEATHER_IS_RAINING_TEMPLATE_MODE,
+    CONF_WEATHER_IS_WINDY_SENSOR,
 )
 from custom_components.adaptive_cover_pro.diagnostics.builder import DiagnosticsBuilder
 
@@ -198,3 +200,35 @@ def test_linked_override_source(builder: DiagnosticsBuilder):
     assert local[CONF_LUX_ENTITY]["source"] == "override"
     assert local[CONF_LUX_ENTITY]["entity_id"] == "sensor.cover_lux"
     assert CONF_LUX_ENTITY not in _by_key(diag["building_profile_sensors"])
+
+
+def test_template_mode_scalar_not_catalogued_as_entity(builder: DiagnosticsBuilder):
+    """A ``*_template_mode`` combine-mode scalar is config, not an entity (#1017).
+
+    ``weather_is_raining_template_mode`` stores a ``TemplateCombineMode`` value
+    like ``"or"``/``"and"`` — not an entity_id. Cataloguing it as a sensor source
+    made the Troubleshoot step misread it as an unavailable entity named "or".
+    No descriptor for the key should be emitted at all; an ordinary entity-valued
+    key on the same options dict must still be catalogued normally.
+    """
+    cover_options = {
+        CONF_WEATHER_IS_RAINING_TEMPLATE_MODE: "or",
+        CONF_WEATHER_IS_WINDY_SENSOR: "binary_sensor.windy",
+    }
+    hass = _make_hass({"binary_sensor.windy": _state("off")}, [])
+    ctx = _base_ctx(config_options=cover_options, hass=hass)
+    diag, _ = builder.build(ctx)
+
+    local = _by_key(diag["local_sensors"])
+
+    # No descriptor at all for the template-mode key.
+    assert CONF_WEATHER_IS_RAINING_TEMPLATE_MODE not in local
+    # In particular, nothing carries the bogus "or" entity_id/unavailable state.
+    assert not any(
+        row.get("entity_id") == "or" or row.get("state") == "unavailable"
+        for row in diag["local_sensors"]
+    )
+    # An ordinary entity-valued key is still catalogued.
+    assert local[CONF_WEATHER_IS_WINDY_SENSOR]["source"] == "local"
+    assert local[CONF_WEATHER_IS_WINDY_SENSOR]["entity_id"] == "binary_sensor.windy"
+    assert local[CONF_WEATHER_IS_WINDY_SENSOR]["state"] == "available"

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -438,6 +438,44 @@ def test_rule8b_ignores_non_entity_cover_key() -> None:
     assert _params(_fire(TriageCode.ENTITY_UNAVAILABLE, view)) == [{"eid": "cover.a"}]
 
 
+def test_rule8b_list_valued_entity_id_yields_one_finding_per_member() -> None:
+    """A list-valued ``entity_id`` (e.g. ``weather_severe_sensors`` /
+    ``daytime_gate_sensors``) with ``state: "unavailable"`` yields one finding
+    per member entity id, not zero.
+
+    ``_classify_sensor_state`` only reports ``"unavailable"`` for a list
+    descriptor when EVERY member is down, so each member genuinely is
+    unavailable and deserves its own finding — closing the audit gap where
+    ``_is_entity_id`` (scalar-only) rejected the list outright and silently
+    dropped multi-sensor descriptors after the #1017 fix.
+    """
+    view = {
+        "local_sensors": [
+            {
+                "entity_id": ["sensor.severe_a", "sensor.severe_b"],
+                "state": "unavailable",
+            },
+        ],
+    }
+    assert _params(_fire(TriageCode.ENTITY_UNAVAILABLE, view)) == [
+        {"eid": "sensor.severe_a"},
+        {"eid": "sensor.severe_b"},
+    ]
+
+
+def test_rule8b_list_valued_entity_id_skips_non_entity_members() -> None:
+    """Within a list-valued descriptor, only entity-id-shaped members fire."""
+    view = {
+        "local_sensors": [
+            {
+                "entity_id": ["sensor.ok", "or"],
+                "state": "unavailable",
+            },
+        ],
+    }
+    assert _params(_fire(TriageCode.ENTITY_UNAVAILABLE, view)) == [{"eid": "sensor.ok"}]
+
+
 # ---------------------------------------------------------------------------
 # Rule 9 — MIN_FLOOR_BYPASSED
 # ---------------------------------------------------------------------------

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -365,6 +365,14 @@ def test_rule8a_near_miss_all_ready() -> None:
     assert _fire(TriageCode.COVER_NOT_READY, view) == []
 
 
+def test_rule8a_ignores_non_entity_capability_key() -> None:
+    """A bogus non-entity capabilities key (e.g. a stray combine-mode scalar)
+    must not be reported as an unready cover (#1017 defense-in-depth).
+    """
+    view = {"capabilities": {"or": None, "cover.a": None}}
+    assert _params(_fire(TriageCode.COVER_NOT_READY, view)) == [{"eid": "cover.a"}]
+
+
 # ---------------------------------------------------------------------------
 # Rule 8b — ENTITY_UNAVAILABLE (per-entity)
 # ---------------------------------------------------------------------------
@@ -401,6 +409,33 @@ def test_rule8b_near_miss_all_available() -> None:
         "covers": {"cover.b": {"available": True}},
     }
     assert _fire(TriageCode.ENTITY_UNAVAILABLE, view) == []
+
+
+def test_rule8b_ignores_non_entity_sensor_descriptor() -> None:
+    """A ``*_template_mode`` scalar (e.g. "or") is not an entity_id (#1017).
+
+    Defense-in-depth: even if a non-entity value slips into a sensor-source
+    descriptor, rule 8b must not treat it as an unavailable entity — but a
+    genuine unavailable entity on the same view still fires.
+    """
+    view = {
+        "local_sensors": [
+            {"entity_id": "or", "state": "unavailable"},
+            {"entity_id": "sensor.x", "state": "unavailable"},
+        ],
+    }
+    assert _params(_fire(TriageCode.ENTITY_UNAVAILABLE, view)) == [{"eid": "sensor.x"}]
+
+
+def test_rule8b_ignores_non_entity_cover_key() -> None:
+    """The covers-path key must also look like an entity_id before firing."""
+    view = {
+        "covers": {
+            "or": {"available": False},
+            "cover.a": {"available": False},
+        },
+    }
+    assert _params(_fire(TriageCode.ENTITY_UNAVAILABLE, view)) == [{"eid": "cover.a"}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The read-only Troubleshoot step rendered garbled findings — `⚠️ or is unavailable — the integration cannot read its state.` — with the entity name showing as the literal `or`.

Root cause: the sensor-source diagnostics blocks (`local_sensors` / `building_profile_sensors`) iterated `BUILDING_PROFILE_SENSOR_KEYS`, which mixes entity keys with non-entity scalar keys — template bodies (`*_template`) and combine modes (`*_template_mode`, a `TemplateCombineMode` of `"or"`/`"and"`). Their raw values were catalogued as `entity_id`s and stamped `unavailable`, and seed rule 8b `ENTITY_UNAVAILABLE` then flagged them. Confirmed live on the Patio Stairs Shade cover (two findings).

Fix, two layers:
- **Builder** iterates a new entity-only `BUILDING_PROFILE_ENTITY_KEYS` (excludes `*_template`/`*_template_mode`); the full `BUILDING_PROFILE_SENSOR_KEYS` stays for profile override-tracking.
- **Triage** rule 8 ignores any descriptor whose id isn't a valid entity id, and a fully-unavailable list-valued multi-sensor set (severe-weather / daytime-gate) now flags each member instead of nothing.

## Testing
- ✅ 8084 tests passing (1 xfailed)
- Regression guards green: `test_config_flow_summary.py` (295), `test_cover_types/test_axes.py` (173)
- Passed opus pre-merge audit

## Related Issues
Refs #1017

https://claude.ai/code/session_01Cz4e1DqUPGqgDsNXebbDgz