### PR TITLE
fix: restore manual override across HA reboot (#1019)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -337,6 +337,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self._make_detector_config(self.config_entry.options),
             ),
         )
+        # Populate the manager's cover set at construction so the manual-override
+        # restore callback (fires during platform setup, before first_refresh) sees
+        # the configured covers instead of an empty set (issue #1019).
+        self.manager.add_covers(self.entities)
         self.ignore_intermediate_states = self.config_entry.options.get(
             CONF_MANUAL_IGNORE_INTERMEDIATE, False
         )

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -333,6 +333,39 @@ async def test_manual_override_input_template_initialized_in_init(
     assert coordinator.manual_override_input_template is None
 
 
+async def test_manager_covers_populated_at_init_for_restore(
+    hass: HomeAssistant,
+) -> None:
+    """Regression (#1019): manager.covers is populated at __init__ so the
+    RestoreEntity manual-override restore (runs during platform setup, before
+    first_refresh) sees the configured covers instead of an empty set.
+
+    Without this, `_ManualOverrideEndSensor._restore_from_attributes` filters
+    every restored override out via its `eid not in manager.covers` guard,
+    silently discarding manual overrides across a Home Assistant restart.
+    """
+    from homeassistant import config_entries as ha_config_entries
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Restore Cover", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="restore_01",
+        title="Restore Cover",
+    )
+    entry.add_to_hass(hass)
+
+    token = ha_config_entries.current_entry.set(entry)
+    try:
+        coordinator = AdaptiveDataUpdateCoordinator(hass)
+    finally:
+        ha_config_entries.current_entry.reset(token)
+
+    # Before the fix this is empty (covers only added during first_refresh),
+    # so the restore guard drops every override.
+    assert "cover.test_blind" in coordinator.manager.covers
+
+
 # ---------------------------------------------------------------------------
 # Venetian mode wiring
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
A manual override that was active at HA restart was silently discarded on reboot. The `RestoreEntity` restore callback in `_ManualOverrideEndSensor._restore_from_attributes` fires during platform setup, but `manager.covers` was only populated later by `add_covers` during `first_refresh`, so the `eid not in manager.covers` guard dropped every restored override and the cover resumed automatic control instead of honoring the remaining override.

The fix populates `manager.covers` from the configured entities in the coordinator constructor, so the guard is valid by the time the restore callback runs. The guard, and its `test_restore_from_attributes_filters_unknown_entities` regression test, stay intact (this keeps filtering out overrides for covers removed from config).

## Testing
- ✅ 36 tests passing

## Related Issues
Refs #1019