### PR TITLE
fix: gate sun-behind-plane and unify cos-gamma foreshortening (#1030)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1769,6 +1769,7 @@ class ReasonCode(StrEnum):
     ENGINE_DEFAULT_SUNSET_OFFSET = "engine.default_sunset_offset"
     ENGINE_DEFAULT_ELEVATION_LIMIT = "engine.default_elevation_limit"
     ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT = "engine.default_acceptance_angle_exit"
+    ENGINE_DEFAULT_SUN_BEHIND_PLANE = "engine.default_sun_behind_plane"
     ENGINE_DEFAULT_BLIND_SPOT = "engine.default_blind_spot"
     ENGINE_DEFAULT = "engine.default"
 
@@ -1924,6 +1925,15 @@ DEFAULT_WINDOW_AZIMUTH = 180  # degrees — config-flow default (south-facing)
 MAX_WINDOW_DEPTH = 5.0  # metres — UI cap for window depth
 MAX_AWNING_ANGLE = 45  # degrees — UI cap for awning tilt
 DEGREES_IN_CIRCLE = 360  # used for azimuth/wind-direction wrap-around math
+
+# Minimum cos(gamma) before the foreshortening division ``tan(elev)/cos γ``
+# (gamma ≈ 89.43°). ``d/cos γ → ∞`` as ``γ → 90⁻`` is real geometry — a ray
+# parallel to the wall never reaches depth ``d`` — so the magnitude gets a floor
+# rather than a reformulation. The floor is ONE-SIDED: the illumination gate on
+# ``AdaptiveGeneralCover`` (``cos(AOI) > 0``) makes ``|γ| > 90`` unreachable, so
+# a negative cosine never arrives here (#1030). Cross-file: consumed by the
+# shared helpers in ``engine/sun_geometry.py``.
+MIN_COS_GAMMA_CLAMP = 0.01
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
+from math import cos, radians
 
 from ...config_context_adapter import ConfigContextAdapter
 from ...config_types import CoverConfig
@@ -148,9 +149,39 @@ class AdaptiveGeneralCover(ABC):
         return self.solar.gamma
 
     @property
+    def cos_aoi(self) -> float:
+        """Cosine of the angle of incidence on this cover's own plane (``s·n``).
+
+        Polymorphic hook, same shape as :attr:`fov_angle`. The default is the
+        vertical facade, ``cos(elev)·cos(gamma)``; cover types whose working
+        plane is not vertical (roof window, louvered roof) override it with the
+        pitched-plane form. Positive means the sun strikes the outer face.
+        """
+        return cos(radians(self.sol_elev)) * cos(radians(self.gamma))
+
+    @property
+    def sun_behind_plane(self) -> bool:
+        """Whether the sun is on the far side of this cover's plane (#1030).
+
+        The single predicate both the illumination gate and the reason branch
+        read. ``cos(AOI) <= 0`` means the face receives no direct sun at all, so
+        the shading projection has no answer — asking it anyway is what made
+        ``tan(elev)/cos(gamma)`` flip sign past ``|gamma| = 90`` and slam
+        vertical / tilt / venetian covers to an endpoint (and drive a drop-arm
+        awning to full extension). Cover types whose shade target is not the
+        glass — an area-mode patio awning — override this.
+        """
+        return self.cos_aoi <= 0.0
+
+    @property
     def valid_elevation(self) -> bool:
-        """Delegate to SunGeometry.valid_elevation."""
-        return self.solar.valid_elevation
+        """Configured elevation bounds AND the sun striking the outer face.
+
+        The bounds come from ``SunGeometry``; the illumination clause is added
+        here because "is this plane lit?" is a per-geometry question that
+        ``SunGeometry`` (cover-type agnostic) deliberately does not answer.
+        """
+        return bool(self.solar.valid_elevation and not self.sun_behind_plane)
 
     @property
     def sunset_valid(self) -> bool:
@@ -252,6 +283,12 @@ class AdaptiveGeneralCover(ABC):
         if self.sunset_valid:
             return ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET
         if not self.valid:
+            # An unlit face outranks the elevation clause: reporting "Elevation
+            # Limit" for a sun behind the plane sends the user to a bound that
+            # is satisfied (#1030 — also the roof window's pre-existing
+            # mis-attribution).
+            if self.sun_behind_plane:
+                return ReasonCode.ENGINE_DEFAULT_SUN_BEHIND_PLANE
             if not self.valid_elevation:
                 return ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT
             return ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT

--- a/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/horizontal.py
@@ -46,6 +46,28 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
         """Get awning angle from horiz_config."""
         return self.horiz_config.awn_angle
 
+    @property
+    def sun_behind_plane(self) -> bool:
+        """Area mode opts out of the illumination gate (#1025 / #1030).
+
+        A patio awning in **area** mode shades the patio, not the glass, so the
+        window plane's ``cos(AOI)`` says nothing about whether it should be
+        extended — it must stay out across the whole (possibly >90°) field of
+        view. **Window** mode projects an overhang onto the glass, so it keeps
+        the gate and falls through to the default position past ``|gamma| = 90``.
+
+        ``horiz_config`` is ``None`` for :class:`AdaptiveOscillatingCover`
+        (production builds a drop-arm awning with ``vert_config`` + ``osc_config``
+        only), which must land on the gated default — that awning's fail-open
+        branch is the worst outcome of the #1030 sign flip.
+        """
+        if (
+            self.horiz_config is not None
+            and self.horiz_config.shade_mode == AWNING_SHADE_MODE_AREA
+        ):
+            return False
+        return super().sun_behind_plane
+
     def _build_horizontal_trace(
         self,
         *,

--- a/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
@@ -74,12 +74,17 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
         """Roof-plane pitch from horizontal in degrees (0=flat, 90=vertical)."""
         return self.roof_config.roof_pitch
 
-    def _cos_aoi(self) -> float:
+    @property
+    def cos_aoi(self) -> float:
         """Cosine of the angle of incidence on the roof plane (``s·n``).
 
         Positive → the sun strikes the working (outer) face of the slats. At
         ``roof_pitch = 0`` this is ``sin(elev)`` (azimuth-independent); at
         ``roof_pitch = 90`` it is ``cos(elev)·cos(gamma)`` (the vertical case).
+
+        Overriding the :class:`AdaptiveGeneralCover` hook is the whole gate: the
+        base ``valid_elevation`` composes ``cos(AOI) > 0`` for every cover type
+        (#1030), so this class no longer carries its own copy.
         """
         return float(roof_cos_aoi(self.gamma, self.sol_elev, self.roof_pitch))
 
@@ -167,16 +172,6 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
         return int(m) if m else self._max_degrees()
 
     @property
-    def valid_elevation(self) -> bool:
-        """Keep the elevation bounds and additionally require sun on the face.
-
-        Composes the inherited min/max-elevation gate with the tilted-plane AOI
-        illumination test (``cos(AOI) > 0``), mirroring
-        :class:`AdaptiveRoofWindowCover`.
-        """
-        return bool(super().valid_elevation and self._cos_aoi() > 0)
-
-    @property
     def fov_angle(self) -> float:
         """FOV azimuth measured in the tilted roof plane (#830, mirrors #212).
 
@@ -195,7 +190,7 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
         self._last_calc_details = {
             **self._last_calc_details,
             TRACE_KEY_ROOF_PITCH_DEG: float(self.roof_pitch),
-            TRACE_KEY_COS_AOI: self._cos_aoi(),
+            TRACE_KEY_COS_AOI: self.cos_aoi,
             TRACE_KEY_SLOPE_RATIO: float(
                 roof_slope_ratio(self.gamma, self.sol_elev, self.roof_pitch)
             ),

--- a/custom_components/adaptive_cover_pro/engine/covers/oscillating.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/oscillating.py
@@ -45,7 +45,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
-from numpy import cos, sin, tan
+from numpy import cos, sin
 from numpy import radians as rad
 
 from ...config_types import OscillatingConfig
@@ -53,30 +53,15 @@ from ...const import (
     OSCILLATING_ARC_SCAN_SAMPLES,
     OSCILLATING_PROTECTED_BOUNDARY_DEFAULT,
 )
+from ..sun_geometry import foreshortened_slope
 from .horizontal import AdaptiveHorizontalCover
-from .vertical import MIN_COS_GAMMA_CLAMP, AdaptiveVerticalCover
+from .vertical import AdaptiveVerticalCover
 
 # Tolerance (metres) for treating two coverage-floor heights as equal when the
 # fail-open branch selects the deepest-coverage angle. Once the running floor
 # plateaus, any angle within this band shades equally, so the awning is driven
 # to the largest (most-extended) such angle.
 _COVERAGE_PLATEAU_EPS = 1e-6
-
-
-def _foreshortened_drop_per_reach(sol_elev: float, gamma: float) -> float:
-    """Vertical drop of a sun ray per metre of horizontal lip reach.
-
-    A ray grazing the lip descends toward the wall at ``tan(elev)`` per metre of
-    in-room depth; the surface-azimuth foreshortening divides by ``cos(gamma)``.
-    Shares the ``MIN_COS_GAMMA_CLAMP`` guard with the vertical engine so a
-    near-90° gamma cannot divide by zero (single source of truth for the
-    foreshortening factor used on the window face).
-    """
-    cos_gamma = float(cos(rad(gamma)))
-    cos_gamma_clamped = max(abs(cos_gamma), MIN_COS_GAMMA_CLAMP) * (
-        1 if cos_gamma >= 0 else -1
-    )
-    return float(tan(rad(sol_elev))) / cos_gamma_clamped
 
 
 def _lip_shadow_top(
@@ -95,11 +80,16 @@ def _lip_shadow_top(
     lip's projected reach so the shadow drops lower on the pane (``0.0`` =
     flush, a no-op). Lower return values mean the lip shades further down the
     face (more coverage).
+
+    The lip's drop per metre of reach is the same Vertical Shadow Angle tangent
+    the window face uses everywhere else, taken from the shared
+    ``foreshortened_slope`` helper (#1030) rather than a local copy of the
+    ``cos(gamma)`` guard.
     """
     theta = rad(theta_deg)
     reach = pivot_offset + arm_length * float(sin(theta))
     lip_y = pivot_y + arm_length * float(cos(theta))
-    return lip_y - reach * _foreshortened_drop_per_reach(sol_elev, gamma)
+    return lip_y - reach * foreshortened_slope(sol_elev, gamma)
 
 
 def _monotone_coverage_floor(shadow_tops: np.ndarray) -> np.ndarray:

--- a/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/roof_window.py
@@ -40,7 +40,8 @@ from math import atan, cos, degrees, radians, sin, tan
 import numpy as np
 
 from ...config_types import RoofWindowConfig
-from .vertical import MIN_COS_GAMMA_CLAMP, AdaptiveVerticalCover
+from ..sun_geometry import foreshortened_slope
+from .vertical import AdaptiveVerticalCover
 
 # --- Numeric guards (file-local) ---
 # Pitch (from horizontal) at which the glass is vertical and the geometry
@@ -98,32 +99,34 @@ def roof_slope_ratio(gamma: float, elev: float, pitch: float) -> float:
 
     Single source of truth for the slope-projection math shared by the
     roof-window drop projection (``_project_drop``) and the louvered-roof
-    profile angle (``beta = arctan|slope_ratio|``).
+    profile angle (``beta = arctan|slope_ratio|``). Evaluated straight from the
+    dot products::
 
-    Factoring the numerator and denominator by ``cos(elev)·cos Δazi`` expresses
-    the ratio through the vertical foreshortening ``f = tan(elev)/cos(gamma)``::
+        s·t = −cosβ·cos(elev)·cos γ + sinβ·sin(elev)
+        s·n =  sinβ·cos(elev)·cos γ + cosβ·sin(elev)
 
-        (s·t)/(s·n) = (−cosβ + sinβ·f) / (sinβ + cosβ·f)
+    with **no ``cos γ`` in either denominator**, so the ``γ → 90°`` singularity
+    simply does not exist here. The earlier form factored both sides by
+    ``cos(elev)·cos γ`` to reuse the vertical foreshortening ``f =
+    tan(elev)/cos γ``; that introduced an artificial divisor whose clamp froze
+    the ratio across ``|γ| ∈ (89.43°, 90.57°)`` and misreported it by up to
+    3.96 % at pitch 30 — unboundedly at pitch 0, where the true ratio crosses
+    zero and the clamped one jumped ±0.01732 (#1030).
 
-    which collapses to ``f`` at ``β = 90°`` (vertical plane — the roof-window
-    bit-for-bit regression anchor) and to ``−1/f = −cot(elev)`` at ``β = 0°``,
-    ``gamma = 0`` (flat plane, aligned sun). ``cos(gamma)`` is clamped exactly as
-    the vertical engine clamps it (``MIN_COS_GAMMA_CLAMP``) so the roof-window
-    projection stays byte-for-byte; the tiny ``β`` denominator is clamped by
-    ``MIN_SLOPE_DENOMINATOR`` at the grazing limit.
+    ``β = 90°`` (vertical glass) keeps the factored fast path: the ratio is then
+    exactly ``f``, and routing it through ``foreshortened_slope`` preserves the
+    bit-for-bit vertical-engine regression anchor. The surviving denominator is
+    ``cos(AOI)`` itself, which the illumination gate keeps positive; the residual
+    ``MIN_SLOPE_DENOMINATOR`` guard covers only the true grazing limit.
     """
-    cos_gamma = float(cos(radians(gamma)))
-    cos_gamma_clamped = max(abs(cos_gamma), MIN_COS_GAMMA_CLAMP) * (
-        1 if cos_gamma >= 0 else -1
-    )
-    f = float(tan(radians(elev))) / cos_gamma_clamped
     if pitch == VERTICAL_GLASS_PITCH_DEG:
-        return f
+        return foreshortened_slope(elev, gamma)
     beta = radians(pitch)
-    sin_b = sin(beta)
-    cos_b = cos(beta)
-    numerator = -cos_b + sin_b * f
-    denominator = sin_b + cos_b * f
+    sin_b, cos_b = sin(beta), cos(beta)
+    horizontal = cos(radians(elev)) * cos(radians(gamma))
+    vertical = sin(radians(elev))
+    numerator = -cos_b * horizontal + sin_b * vertical
+    denominator = sin_b * horizontal + cos_b * vertical
     if abs(denominator) < MIN_SLOPE_DENOMINATOR:
         denominator = (
             MIN_SLOPE_DENOMINATOR if denominator >= 0 else -MIN_SLOPE_DENOMINATOR
@@ -151,13 +154,20 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
     # Sun-on-glass geometry
     # ------------------------------------------------------------------
 
-    def _cos_aoi(self) -> float:
+    @property
+    def cos_aoi(self) -> float:
         """Cosine of the angle of incidence on the tilted glass plane (``s·n``).
 
         ``cos(AOI) = sinβ·cos(elev)·cos Δazi + cosβ·sin(elev)`` with
         ``cos Δazi = cos(gamma)``. Positive → the sun strikes the outer face.
-        At β=90° this is ``cos(elev)·cos(gamma)`` (the vertical case); at β=0°
-        it is ``sin(elev)`` (a flat skylight, azimuth-independent).
+        At β=90° this is ``cos(elev)·cos(gamma)`` — exactly the vertical-facade
+        default on :class:`AdaptiveGeneralCover`, of which this is the pitched
+        generalisation; at β=0° it is ``sin(elev)`` (a flat skylight,
+        azimuth-independent).
+
+        Overriding the base hook is all the illumination gate needs: the base
+        ``valid_elevation`` composes ``cos(AOI) > 0`` for every cover type
+        (#1030), so this class no longer carries its own copy of that gate.
         """
         return float(roof_cos_aoi(self.gamma, self.sol_elev, self.roof_pitch))
 
@@ -231,16 +241,6 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
     # ------------------------------------------------------------------
 
     @property
-    def valid_elevation(self) -> bool:
-        """Replace the bare above-horizon test with the tilted-plane AOI gate.
-
-        Keeps the inherited min/max-elevation bounds (``super().valid_elevation``)
-        and additionally requires the sun to strike the outer glass face
-        (``cos(AOI) > 0``). The azimuth FOV gate still applies in ``valid``.
-        """
-        return bool(super().valid_elevation and self._cos_aoi() > 0)
-
-    @property
     def direct_sun_valid(self) -> bool:
         """Direct sun also requires the roof above the window not to occlude it.
 
@@ -299,7 +299,7 @@ class AdaptiveRoofWindowCover(AdaptiveVerticalCover):
         self._last_calc_details = {
             **self._last_calc_details,
             TRACE_KEY_ROOF_PITCH_DEG: float(self.roof_pitch),
-            TRACE_KEY_COS_AOI: float(self._cos_aoi()),
+            TRACE_KEY_COS_AOI: float(self.cos_aoi),
             TRACE_KEY_SLOPE_RATIO: float(getattr(self, "_roof_slope_ratio", 0.0)),
             TRACE_KEY_RIDGE_GATE_ENABLED: bool(self.roof_height_above > 0),
             TRACE_KEY_RIDGE_GATE_OCCLUDED: bool(self._is_sun_behind_ridge()),

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
-from numpy import cos, tan
-from numpy import radians as rad
+from numpy import tan
 
 from ...config_types import TiltConfig
 from ...const import (
@@ -18,6 +17,7 @@ from ...const import (
 )
 from ...geometry import SafetyMarginCalculator
 from ...position_utils import PositionConverter
+from ..sun_geometry import foreshortened_slope
 from .base import AdaptiveGeneralCover
 
 
@@ -85,12 +85,16 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         perspective, accounting for both sun elevation and horizontal angle (gamma).
         Used in slat tilt calculation to block direct sun while maximizing view/light.
 
+        The argument is the shared ``foreshortened_slope`` VSA tangent. This copy
+        had drifted — it divided by a raw ``cos(gamma)`` with no guard at all, so
+        past ``|gamma| = 90`` it returned ``≈ −π/2`` instead of ``+π/2`` and the
+        cut-off solve collapsed the slat angle 180° → 0° (#1030).
+
         Returns:
             Beta angle in radians.
 
         """
-        beta = np.arctan(tan(rad(self.sol_elev)) / cos(rad(self.gamma)))
-        return beta
+        return float(np.arctan(foreshortened_slope(self.sol_elev, self.gamma)))
 
     def _max_degrees(self) -> float:
         """Resolve max slat degrees for the configured mode (string or enum)."""

--- a/custom_components/adaptive_cover_pro/engine/covers/vertical.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/vertical.py
@@ -17,7 +17,7 @@ from ...const import (
 )
 from ...geometry import EdgeCaseHandler, SafetyMarginCalculator
 from ...position_utils import PositionConverter
-from ..sun_geometry import ray_x_at_window_plane
+from ..sun_geometry import clamped_cos_gamma, ray_x_at_window_plane
 from .base import AdaptiveGeneralCover
 
 # --- Numeric guards (file-local) ---
@@ -25,10 +25,6 @@ from .base import AdaptiveGeneralCover
 # elevation ≈ 2.9°, below which the projected shadow is geometrically
 # unbounded. Capping the divisor keeps sill_offset finite at low sun.
 MIN_TAN_ELEVATION_CLAMP = 0.05
-# Minimum |cos(gamma)| before path-length division — corresponds to gamma
-# ≈ 89.4°. Bridges the gap between the edge-case threshold (85°) and the
-# 90° singularity where cos(gamma) → 0.
-MIN_COS_GAMMA_CLAMP = 0.01
 
 
 def _elevation_offset(height_m: float, sol_elev: float) -> float:
@@ -214,11 +210,12 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         onto a tilted plane without duplicating the surrounding edge-case /
         window-depth / sill / safety-margin pipeline (CODING_GUIDELINES.md
         "Code duplication is not okay").
+
+        The divisor comes from the shared one-sided ``clamped_cos_gamma`` guard
+        (#1030); the raw ``cos_gamma`` is still returned for the #682 trace.
         """
         cos_gamma = float(cos(rad(self.gamma)))
-        cos_gamma_clamped = max(abs(cos_gamma), MIN_COS_GAMMA_CLAMP) * (
-            1 if cos_gamma >= 0 else -1
-        )
+        cos_gamma_clamped = clamped_cos_gamma(self.gamma)
         path_length = effective_distance / cos_gamma_clamped
         base_height = path_length * float(tan(rad(self.sol_elev)))
         return base_height, cos_gamma, cos_gamma_clamped, path_length

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -86,9 +86,18 @@ def ray_x_at_window_plane(x_floor: float, y_floor: float, gamma_deg: float) -> f
     ``tan γ`` is expanded to ``sin γ / clamped_cos_gamma(γ)`` — the fifth copy of
     the ``cos γ`` divisor, folded into the one shared guard (#1030). Identical to
     ``tan γ`` for ``|γ| ≤ 89.43°``; past that it stays bounded instead of
-    reaching 3.27e16 at exactly 90. Both consumers run behind
-    ``direct_sun_valid``, which the illumination gate now keeps inside
-    ``|γ| < 90``, so the clamp band is unreachable in production either way.
+    reaching 3.27e16 at exactly 90.
+
+    Both consumers run behind ``direct_sun_valid`` — but that alone does not
+    bound ``γ``. The bound comes from the illumination gate collapsing to
+    ``|γ| < 90`` only on engines that keep the DEFAULT vertical-plane
+    ``cos_aoi = cos(elev)·cos γ``, and both consumers do: the sliding curtain
+    inherits it, and the glare-zone projection is reachable only via
+    ``supports_glare_zones``, True for the blind and dual-panel policies alone.
+    So the clamp band is unreachable in production today. Revisit if glare zones
+    ever extend to awnings — ``AdaptiveHorizontalCover`` overrides
+    ``sun_behind_plane`` to opt area mode out of the gate, which puts ``|γ| > 90``
+    back in reach here.
     """
     # Parenthesised so the ratio is formed BEFORE the multiply — that keeps the
     # result bit-identical to the previous ``y_floor * tan(gamma)``.

--- a/custom_components/adaptive_cover_pro/engine/sun_geometry.py
+++ b/custom_components/adaptive_cover_pro/engine/sun_geometry.py
@@ -5,7 +5,7 @@ Extracted from AdaptiveGeneralCover to enable standalone testing and reuse.
 
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
-from math import atan, ceil, degrees, radians, tan
+from math import atan, ceil, cos, degrees, radians, sin, tan
 
 import pandas as pd
 
@@ -15,6 +15,7 @@ from ..const import (
     CONF_FOV_LEFT,
     DEFAULT_FOV_LEFT,
     DEGREES_IN_CIRCLE,
+    MIN_COS_GAMMA_CLAMP,
     OPTION_RANGES,
     BlindSpot,
     ReasonCode,
@@ -40,6 +41,35 @@ def azimuth_within_fov(angle: float, fov_left: float, fov_right: float) -> bool:
     return bool(_in_fov_cone(angle, fov_left, fov_right))
 
 
+def clamped_cos_gamma(gamma_deg: float) -> float:
+    """``cos γ`` with a one-sided magnitude floor of ``MIN_COS_GAMMA_CLAMP``.
+
+    The ONE guard for every ``… / cos γ`` division on a lit face (#1030). It is
+    one-sided — ``max(cos γ, ε)``, not ``sign(cos γ)·max(|cos γ|, ε)`` — because
+    the illumination gate on :class:`~engine.covers.base.AdaptiveGeneralCover`
+    (``cos(AOI) > 0``) makes ``|γ| > 90`` unreachable, so a negative cosine
+    never arrives. The two-sided form each caller used to carry faithfully
+    reproduced "sun behind the wall" as a NEGATIVE projected drop, which the
+    surrounding clamps then read as an endpoint command.
+    """
+    return max(cos(radians(gamma_deg)), MIN_COS_GAMMA_CLAMP)
+
+
+def foreshortened_slope(sol_elev: float, gamma_deg: float) -> float:
+    """Vertical Shadow Angle tangent ``f = tan(elev) / cos γ`` on a lit facade.
+
+    The vertical drop a sun ray covers per metre of in-room depth, foreshortened
+    by the surface-solar azimuth (NRC CBD-59; reviewed in #206). The formula is
+    defined only for ``|γ| < 90`` — the domain restriction #1030 supplies via the
+    illumination gate — so ``clamped_cos_gamma`` needs no sign branch.
+
+    Shared by the vertical blind's drop projection, the drop-arm awning's
+    lip-shadow slope, the tilt/venetian profile angle, and the roof window's
+    vertical-glass reduction.
+    """
+    return tan(radians(sol_elev)) / clamped_cos_gamma(gamma_deg)
+
+
 def ray_x_at_window_plane(x_floor: float, y_floor: float, gamma_deg: float) -> float:
     """Along-wall coordinate where a sun ray crossed the window plane.
 
@@ -52,8 +82,17 @@ def ray_x_at_window_plane(x_floor: float, y_floor: float, gamma_deg: float) -> f
     glare-zone projection and the sliding-curtain shade-area projection share one
     formula (#829). Positive ``gamma`` shifts the entry point toward +x; ``gamma =
     0`` (perpendicular sun) crosses at the floor point's own ``x``.
+
+    ``tan γ`` is expanded to ``sin γ / clamped_cos_gamma(γ)`` — the fifth copy of
+    the ``cos γ`` divisor, folded into the one shared guard (#1030). Identical to
+    ``tan γ`` for ``|γ| ≤ 89.43°``; past that it stays bounded instead of
+    reaching 3.27e16 at exactly 90. Both consumers run behind
+    ``direct_sun_valid``, which the illumination gate now keeps inside
+    ``|γ| < 90``, so the clamp band is unreachable in production either way.
     """
-    return x_floor + y_floor * tan(radians(gamma_deg))
+    # Parenthesised so the ratio is formed BEFORE the multiply — that keeps the
+    # result bit-identical to the previous ``y_floor * tan(gamma)``.
+    return x_floor + y_floor * (sin(radians(gamma_deg)) / clamped_cos_gamma(gamma_deg))
 
 
 def fov_from_reveal(width_m: float, depth_m: float) -> int:
@@ -216,6 +255,12 @@ class SunGeometry:
     @property
     def valid_elevation(self) -> bool:
         """Check if sun elevation is within configured limits.
+
+        This is the elevation bound ONLY. Whether the sun actually strikes the
+        cover's plane is per-geometry, so the illumination clause lives one layer
+        up on :class:`~engine.covers.base.AdaptiveGeneralCover`, which composes
+        ``cos(AOI) > 0`` on top of this (#1030). ``SunGeometry`` stays
+        cover-type agnostic.
 
         Returns:
             True if sun elevation within configured min/max range (or no limits set).
@@ -381,6 +426,11 @@ class SunGeometry:
         The pure engine emits a frozen code (no HA, no translation); the prose
         is resolved at the diagnostics/sensor boundary. Branches mirror
         :attr:`control_state_reason` exactly.
+
+        Cover-agnostic by design: there is deliberately no
+        ``DEFAULT_SUN_BEHIND_PLANE`` branch here, because this class does not
+        know the cover's plane. ``AdaptiveGeneralCover`` adds that branch on top
+        (#1030), so this keeps its original two-way azimuth/elevation split.
 
         Returns:
             One of ``ReasonCode.ENGINE_*``: DIRECT_SUN, DEFAULT_SUNSET_OFFSET,

--- a/custom_components/adaptive_cover_pro/geometry.py
+++ b/custom_components/adaptive_cover_pro/geometry.py
@@ -66,14 +66,20 @@ def _edge_case(
     Only the very-low-elevation guard remains (issue #600). The former
     extreme-gamma and very-high-elevation branches were removed: the
     projection in ``AdaptiveVerticalCover.calculate_position`` now carries its
-    own numerical guards — ``MIN_COS_GAMMA_CLAMP`` on the ``cos(gamma)``
-    divisor, ``MIN_TAN_ELEVATION_CLAMP`` on the sill division, and the
+    own numerical guards — the shared one-sided ``clamped_cos_gamma`` floor on
+    the ``cos(gamma)`` divisor (``engine/sun_geometry.py``, #1030),
+    ``MIN_TAN_ELEVATION_CLAMP`` on the sill division, and the
     ``effective_distance < 0 → 0`` clamp (#358/#559) — so those two branches
     either duplicated the normal path (very high elevation) or contradicted it
     (extreme gamma forced fully-closed where the grazing geometry is open,
     the root cause of #598). The low-elevation floor is retained as a
     deliberate policy: a sun on the horizon should drive full coverage, and
     the normal path does not enforce that for a zero-sill window.
+
+    ⚠️ Do not reintroduce an extreme-gamma branch here. A sun past the plane is
+    handled upstream as an *illumination gate* — ``direct_sun_valid`` goes
+    False and the DefaultHandler takes over — never as a position value of 0,
+    which is the exact inversion #598 reported.
 
     ``gamma``, ``distance`` and ``h_win`` are unused now but kept on the
     signature so the cached call site and ``EdgeCaseHandler.check_and_handle``

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate.py
@@ -244,8 +244,11 @@ class ClimateCoverState:
 
         ``gamma_deg``/``beta_deg`` are computed once here for tilt covers — the
         same ``float(tilt_cover.gamma)`` / ``np.rad2deg(tilt_cover.beta)`` the
-        original routers used, evaluated regardless of validity to match the
-        prior behavior.
+        original routers used, still evaluated unconditionally. Past the #1030
+        illumination gate ``beta_deg`` is no longer meaningful (the clamped
+        cosine changes it, e.g. −49° → +89° at ``γ = 120``), but its only
+        consumer — ``_tilt_winter_mode2`` — sits behind ``cover_valid``, so the
+        value is discarded there rather than acted on.
         """
         gamma_deg = 0.0
         beta_deg = 0.0

--- a/custom_components/adaptive_cover_pro/reason_i18n.py
+++ b/custom_components/adaptive_cover_pro/reason_i18n.py
@@ -184,6 +184,7 @@ _REASON_TEMPLATES_EN: dict[str, str] = {
     ReasonCode.ENGINE_DEFAULT_SUNSET_OFFSET: "Default: Sunset Offset",
     ReasonCode.ENGINE_DEFAULT_ELEVATION_LIMIT: "Default: Elevation Limit",
     ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT: "Default: Acceptance Angle Exit",
+    ReasonCode.ENGINE_DEFAULT_SUN_BEHIND_PLANE: "Default: Sun Behind Plane",
     ReasonCode.ENGINE_DEFAULT_BLIND_SPOT: "Default: Blind Spot",
     ReasonCode.ENGINE_DEFAULT: "Default",
     # -- describe_skip / inactive-reason prose

--- a/custom_components/adaptive_cover_pro/reason_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/de.json
@@ -90,6 +90,7 @@
     "default_sunset_offset": "Standard: Sonnenuntergang-Versatz",
     "default_elevation_limit": "Standard: Höhenlimit",
     "default_acceptance_angle_exit": "Standard: Akzeptanzwinkel-Ausgang",
+    "default_sun_behind_plane": "Standard: Sonne hinter der Ebene",
     "default_blind_spot": "Standard: Blinder Fleck",
     "default": "Standard"
   },

--- a/custom_components/adaptive_cover_pro/reason_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/en.json
@@ -90,6 +90,7 @@
     "default_sunset_offset": "Default: Sunset Offset",
     "default_elevation_limit": "Default: Elevation Limit",
     "default_acceptance_angle_exit": "Default: Acceptance Angle Exit",
+    "default_sun_behind_plane": "Default: Sun Behind Plane",
     "default_blind_spot": "Default: Blind Spot",
     "default": "Default"
   },

--- a/custom_components/adaptive_cover_pro/reason_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/reason_i18n/fr.json
@@ -90,6 +90,7 @@
     "default_sunset_offset": "Défaut : Décalage Coucher du Soleil",
     "default_elevation_limit": "Défaut : Limite d'Élévation",
     "default_acceptance_angle_exit": "Défaut : Sortie Angle d'Acceptation",
+    "default_sun_behind_plane": "Défaut : Soleil Derrière le Plan",
     "default_blind_spot": "Défaut : Angle Mort",
     "default": "Défaut"
   },

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -16,7 +16,7 @@ from custom_components.adaptive_cover_pro.config_types import (
 )
 
 
-def make_daytime_sun_data(**overrides) -> MagicMock:
+def make_daytime_sun_data() -> MagicMock:
     """Return a SunData mock whose sunrise/sunset bracket *now*.
 
     ``SunGeometry.sunset_valid`` compares wall-clock now against the sunrise /
@@ -30,8 +30,6 @@ def make_daytime_sun_data(**overrides) -> MagicMock:
     sun_data.timezone = "UTC"
     sun_data.sunrise.return_value = now - timedelta(hours=6)
     sun_data.sunset.return_value = now + timedelta(hours=6)
-    for key, value in overrides.items():
-        setattr(sun_data, key, value)
     return sun_data
 
 

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -5,12 +5,34 @@ which accept flat kwargs (old-style API) and route them to the correct typed
 config dataclasses (CoverConfig, VerticalConfig, etc.).
 """
 
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
 from custom_components.adaptive_cover_pro.config_types import (
     CoverConfig,
     HorizontalConfig,
     TiltConfig,
     VerticalConfig,
 )
+
+
+def make_daytime_sun_data(**overrides) -> MagicMock:
+    """Return a SunData mock whose sunrise/sunset bracket *now*.
+
+    ``SunGeometry.sunset_valid`` compares wall-clock now against the sunrise /
+    sunset offsets, so a bare ``MagicMock`` makes it unevaluatable. Bracketing
+    now with real datetimes makes ``sunset_valid`` cleanly ``False``, which is
+    what a test asserting on ``direct_sun_valid`` needs without patching the
+    property away.
+    """
+    now = datetime.now(UTC)
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+    sun_data.sunrise.return_value = now - timedelta(hours=6)
+    sun_data.sunset.return_value = now + timedelta(hours=6)
+    for key, value in overrides.items():
+        setattr(sun_data, key, value)
+    return sun_data
 
 
 def make_cover_config(**overrides) -> CoverConfig:

--- a/tests/test_adaptive_horizontal_cover.py
+++ b/tests/test_adaptive_horizontal_cover.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.cover_helpers import build_horizontal_cover
+from tests.cover_helpers import build_horizontal_cover, make_daytime_sun_data
 
 # ---------------------------------------------------------------------------
 # Issue #1025 — corrected overhang projection + area/window shade modes.
@@ -144,6 +144,41 @@ class TestAreaShadeMode1025:
         # And a window-mode awning does NOT sit at full extension at moderate sun.
         cover = _awning_1025(sol_elev=25.0, gamma=45.0)
         assert cover.calculate_position() < _AWN_LENGTH_1025
+
+
+class TestAreaShadeModeGate:
+    """#1025 area mode at the GATE, not just at ``calculate_position`` (#1030).
+
+    ``TestAreaShadeMode1025`` calls ``calculate_position()`` directly, so it
+    never touches ``direct_sun_valid`` — the illumination gate #1030 adds could
+    silently retract an area-mode patio awning past ``|gamma| = 90`` while that
+    class stayed green. These assert the routing decision itself.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("gamma", [95.0, 130.0])
+    def test_area_mode_direct_sun_valid_past_90(self, gamma):
+        """A patio awning shades the PATIO, not the glass — it opts out of the gate."""
+        cover = _awning_1025(
+            sol_elev=30.0,
+            gamma=gamma,
+            shade_mode="area",
+            fov_left=137,
+            sun_data=make_daytime_sun_data(),
+        )
+        assert cover.direct_sun_valid is True
+        assert cover.calculate_position() == pytest.approx(_AWN_LENGTH_1025)
+
+    @pytest.mark.unit
+    def test_window_mode_direct_sun_valid_gated_past_90(self):
+        """Window mode shades the glass, so past 90 it falls through to default."""
+        cover = _awning_1025(
+            sol_elev=30.0,
+            gamma=91.0,
+            fov_left=137,
+            sun_data=make_daytime_sun_data(),
+        )
+        assert cover.direct_sun_valid is False
 
 
 class TestAdaptiveHorizontalCover:

--- a/tests/test_control_state_reason.py
+++ b/tests/test_control_state_reason.py
@@ -75,8 +75,13 @@ class TestControlStateReasonDirectSun:
 class TestControlStateReasonFOVExit:
     """Tests for 'Default: Acceptance Angle Exit' reason."""
 
-    def test_fov_exit_sun_behind_window(self, mock_sun_data, mock_logger):
-        """Sun behind the window (180° away) → Default: Acceptance Angle Exit."""
+    def test_sun_behind_window_reports_behind_plane(self, mock_sun_data, mock_logger):
+        """Sun behind the window (180° away) → Default: Sun Behind Plane (#1030).
+
+        A face 180° from the sun is not lit at all, which is a stronger and more
+        actionable statement than "outside the acceptance angle" — the latter
+        implies a config the user could widen.
+        """
         cover = make_cover(
             mock_sun_data,
             mock_logger,
@@ -87,7 +92,7 @@ class TestControlStateReasonFOVExit:
             type(cover), "sunset_valid", new_callable=PropertyMock, return_value=False
         ):
             reason = cover.control_state_reason
-            assert reason == "Default: Acceptance Angle Exit"
+            assert reason == "Default: Sun Behind Plane"
 
     def test_fov_exit_sun_outside_fov_left(self, mock_sun_data, mock_logger):
         """Sun outside left FOV boundary → Default: Acceptance Angle Exit."""
@@ -294,8 +299,13 @@ class TestControlStateReasonPriority:
             reason = cover.control_state_reason
             assert reason == "Default: Elevation Limit"
 
-    def test_fov_exit_when_only_azimuth_invalid(self, mock_sun_data, mock_logger):
-        """Invalid azimuth with valid elevation → FOV Exit (not elevation limit)."""
+    def test_behind_plane_when_only_azimuth_invalid(self, mock_sun_data, mock_logger):
+        """Invalid azimuth with valid elevation → Sun Behind Plane, not elevation limit.
+
+        γ = −180 here, so the face is unlit; the #1030 branch outranks the
+        elevation clause while still never reporting an elevation limit that is
+        satisfied.
+        """
         cover = make_cover(
             mock_sun_data,
             mock_logger,
@@ -308,4 +318,4 @@ class TestControlStateReasonPriority:
             type(cover), "sunset_valid", new_callable=PropertyMock, return_value=False
         ):
             reason = cover.control_state_reason
-            assert reason == "Default: Acceptance Angle Exit"
+            assert reason == "Default: Sun Behind Plane"

--- a/tests/test_cover_types/test_roof_window.py
+++ b/tests/test_cover_types/test_roof_window.py
@@ -15,7 +15,7 @@ azimuth, so each case can drive a real engine while pinning gamma precisely.
 
 from __future__ import annotations
 
-from datetime import UTC, date, datetime, timedelta
+from datetime import date
 from math import atan, atan2, cos, degrees, radians, sin, tan
 from unittest.mock import MagicMock
 
@@ -35,20 +35,15 @@ from custom_components.adaptive_cover_pro.engine.covers.roof_window import (
     TRACE_KEY_RIDGE_GATE_OCCLUDED,
     TRACE_KEY_ROOF_PITCH_DEG,
     TRACE_KEY_SLOPE_RATIO,
+    roof_slope_ratio,
 )
-from tests.cover_helpers import make_cover_config, make_vertical_config
+from tests.cover_helpers import (
+    make_cover_config,
+    make_daytime_sun_data,
+    make_vertical_config,
+)
 
 _WIN_AZI = 180.0
-
-
-def _safe_sun_data() -> MagicMock:
-    """Build a sun_data mock with far-off sunset/sunrise (sunset_valid=False)."""
-    sun_data = MagicMock()
-    sun_data.timezone = "UTC"
-    now = datetime.now(UTC)
-    sun_data.sunset.return_value = now + timedelta(hours=6)
-    sun_data.sunrise.return_value = now - timedelta(hours=6)
-    return sun_data
 
 
 def _roof(
@@ -68,7 +63,7 @@ def _roof(
         logger=MagicMock(),
         sol_azi=_WIN_AZI - gamma,
         sol_elev=sol_elev,
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=make_cover_config(
             win_azi=_WIN_AZI, fov_left=fov_left, fov_right=fov_right
         ),
@@ -99,7 +94,7 @@ def _vertical(
         logger=MagicMock(),
         sol_azi=_WIN_AZI - gamma,
         sol_elev=sol_elev,
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=make_cover_config(
             win_azi=_WIN_AZI, fov_left=fov_left, fov_right=fov_right
         ),
@@ -481,6 +476,28 @@ def test_projection_denominator_guard_stays_finite():
     assert 0.0 <= pos <= 2.0
 
 
+@pytest.mark.parametrize("pitch", [0.0, 30.0, 45.0])
+@pytest.mark.parametrize("gamma", [45.0, 89.0, 89.5, 90.0, 90.1, 91.0, 120.0])
+def test_slope_ratio_equals_exact_dot_products(pitch, gamma):
+    """``roof_slope_ratio`` IS ``(s·t)/(s·n)`` — including inside the clamp band (#1030).
+
+    The shipped form factored numerator and denominator by ``cos(elev)·cos γ``,
+    which introduced a ``cos γ`` divisor the exact geometry does not have. The
+    ``MIN_COS_GAMMA_CLAMP`` floor on that divisor then froze the ratio across
+    ``|γ| ∈ (89.43°, 90.57°)`` and the outer expression *compressed* the plateau
+    into a wrong finite value — 3.96 % off at pitch 30, unbounded at pitch 0,
+    where the true ratio crosses zero. Computing the dot products directly
+    removes the singularity instead of guarding it.
+    """
+    elev = 30.0
+    beta, e, g = radians(pitch), radians(elev), radians(gamma)
+    s_dot_t = -cos(beta) * cos(e) * cos(g) + sin(beta) * sin(e)
+    s_dot_n = sin(beta) * cos(e) * cos(g) + cos(beta) * sin(e)
+    assert roof_slope_ratio(gamma, elev, pitch) == pytest.approx(
+        s_dot_t / s_dot_n, abs=1e-9
+    )
+
+
 # ---------------------------------------------------------------------------
 # Policy hooks
 # ---------------------------------------------------------------------------
@@ -536,7 +553,7 @@ def test_policy_build_calc_engine_returns_roof_engine():
         logger=MagicMock(),
         sol_azi=170.0,
         sol_elev=40.0,
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=make_cover_config(),
         config_service=svc,
         options=options,
@@ -587,7 +604,7 @@ def _effective_gamma(pitch: float, elev: float, gamma: float) -> float:
 def test_reporter_geometry_stays_valid_beyond_fov(gamma):
     """β=45°, FOV 85°, elev 60°: lit glass stays valid even past raw |gamma|=fov."""
     roof = _roof(roof_pitch=45, sol_elev=60.0, gamma=gamma, fov_left=85, fov_right=85)
-    assert roof._cos_aoi() > 0
+    assert roof.cos_aoi > 0
     assert roof.valid is True
     assert roof.direct_sun_valid is True
     assert roof.control_state_reason == "Direct Sun"
@@ -604,7 +621,7 @@ def test_in_fov_tracks_illumination_for_tilted_pitch(gamma):
 def test_pitch_30_stays_valid_beyond_fov(gamma):
     """A shallower pitch (β=30°) widens acceptance even further."""
     roof = _roof(roof_pitch=30, sol_elev=45.0, gamma=gamma, fov_left=85, fov_right=85)
-    assert roof._cos_aoi() > 0
+    assert roof.cos_aoi > 0
     assert roof.valid is True
 
 
@@ -629,7 +646,7 @@ def test_narrow_fov_still_rejects_far_sideways_sun():
     roof = _roof(
         roof_pitch=pitch, sol_elev=elev, gamma=gamma, fov_left=fov, fov_right=fov
     )
-    assert roof._cos_aoi() > 0
+    assert roof.cos_aoi > 0
     assert roof.valid is False
 
 
@@ -690,7 +707,7 @@ def _roof_with_blind_spot(
         logger=MagicMock(),
         sol_azi=_WIN_AZI - gamma,
         sol_elev=sol_elev,
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=make_cover_config(
             win_azi=_WIN_AZI,
             fov_left=fov_left,
@@ -762,7 +779,7 @@ def test_blind_spot_bit_identical_at_vertical_pitch():
         logger=MagicMock(),
         sol_azi=_WIN_AZI - kwargs["gamma"],
         sol_elev=kwargs["sol_elev"],
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=make_cover_config(
             win_azi=_WIN_AZI,
             fov_left=90,
@@ -804,12 +821,12 @@ def test_vertical_cover_blind_spot_equals_raw_sun_geometry():
         logger=MagicMock(),
         sol_azi=_WIN_AZI - gamma,
         sol_elev=sol_elev,
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=cover_config,
         vert_config=make_vertical_config(distance=1.0, h_win=2.0),
     )
     sg = SunGeometry(
-        _WIN_AZI - gamma, sol_elev, _safe_sun_data(), cover_config, MagicMock()
+        _WIN_AZI - gamma, sol_elev, make_daytime_sun_data(), cover_config, MagicMock()
     )
     assert vert.fov_angle == pytest.approx(sg.gamma)
     assert vert.is_sun_in_blind_spot is True  # a real wedge hit, not a shared miss

--- a/tests/test_cover_types/test_sliding_curtain_engine.py
+++ b/tests/test_cover_types/test_sliding_curtain_engine.py
@@ -23,19 +23,9 @@ from custom_components.adaptive_cover_pro.const import POSITION_CLOSED, POSITION
 from custom_components.adaptive_cover_pro.engine.covers import (
     AdaptiveSlidingCurtainCover,
 )
-from tests.cover_helpers import make_cover_config
+from tests.cover_helpers import make_cover_config, make_daytime_sun_data
 
 _WIN_AZI = 180.0
-
-
-def _safe_sun_data() -> MagicMock:
-    """Sun data with far-off sunset/sunrise → ``sunset_valid`` is False."""
-    sun_data = MagicMock()
-    sun_data.timezone = "UTC"
-    now = datetime.now(UTC)
-    sun_data.sunset.return_value = now + timedelta(hours=6)
-    sun_data.sunrise.return_value = now - timedelta(hours=6)
-    return sun_data
 
 
 def _past_sunset_sun_data() -> MagicMock:
@@ -60,7 +50,7 @@ def _curtain(
         logger=MagicMock(),
         sol_azi=_WIN_AZI - gamma,
         sol_elev=sol_elev,
-        sun_data=sun_data if sun_data is not None else _safe_sun_data(),
+        sun_data=sun_data if sun_data is not None else make_daytime_sun_data(),
         config=make_cover_config(
             win_azi=_WIN_AZI, fov_left=fov_left, fov_right=fov_right
         ),

--- a/tests/test_engine/test_control_state_reason_code.py
+++ b/tests/test_engine/test_control_state_reason_code.py
@@ -200,14 +200,15 @@ class TestCoverReasonCode:
                 Reason(cover.control_state_reason_code)
             )
 
-    def test_fov_exit(self, mock_sun_data, mock_logger):
+    def test_sun_behind_plane(self, mock_sun_data, mock_logger):
+        """γ = −180 → the cover layer reports the unlit face, not an azimuth exit (#1030)."""
         cover = _make_cover(mock_sun_data, mock_logger, sol_azi=0.0, sol_elev=45.0)
         with patch.object(
             type(cover), "sunset_valid", new_callable=PropertyMock, return_value=False
         ):
             assert (
                 cover.control_state_reason_code
-                == ReasonCode.ENGINE_DEFAULT_ACCEPTANCE_ANGLE_EXIT
+                == ReasonCode.ENGINE_DEFAULT_SUN_BEHIND_PLANE
             )
             assert cover.control_state_reason == render_en(
                 Reason(cover.control_state_reason_code)

--- a/tests/test_engine/test_louvered_roof.py
+++ b/tests/test_engine/test_louvered_roof.py
@@ -227,12 +227,12 @@ class TestAoiGate:
         # Steep pitch facing south (win_azi=180); sun low in the north
         # (azimuth 0) → sun strikes the BACK of the plane → cos_aoi <= 0.
         cover = _louvered(sol_azi=0, sol_elev=10, roof_pitch=80, win_azi=180)
-        assert cover._cos_aoi() <= 0
+        assert cover.cos_aoi <= 0
         assert cover.valid_elevation is False
 
     def test_pitched_roof_true_when_sun_on_face(self) -> None:
         cover = _louvered(sol_azi=180, sol_elev=40, roof_pitch=40, win_azi=180)
-        assert cover._cos_aoi() > 0
+        assert cover.cos_aoi > 0
         assert cover.valid_elevation is True
 
 

--- a/tests/test_engine/test_ray_x_at_window_plane.py
+++ b/tests/test_engine/test_ray_x_at_window_plane.py
@@ -62,3 +62,21 @@ def test_matches_vertical_glare_zone_projection() -> None:
     nearest_x, nearest_y, gamma = 0.42, 3.6, 28.0
     expected = nearest_x + nearest_y * math.tan(math.radians(gamma))
     assert ray_x_at_window_plane(nearest_x, nearest_y, gamma) == expected
+
+
+# ---------------------------------------------------------------------------
+# The tan(gamma) pole. Raw ``tan`` reaches 3.27e16 at exactly 90° and flips sign
+# one step past it; routing through the shared ``clamped_cos_gamma`` guard keeps
+# the projection bounded (#1030). Both consumers already bail on
+# ``|x| > half_width``, so a bounded-but-large value produces the same decision
+# as an astronomically large one — the point is that no caller can inherit an
+# unguarded infinity.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("gamma", [89.9, 90.0, 90.1, -89.9, -90.0, -90.1])
+def test_pole_region_stays_finite_and_bounded(gamma):
+    x = ray_x_at_window_plane(0.0, 2.0, gamma)
+    assert math.isfinite(x)
+    # 2 m of depth over the 0.01 cosine floor caps the shift at 200 m.
+    assert abs(x) <= 2.0 / 0.01

--- a/tests/test_engine/test_sliding_curtain_area.py
+++ b/tests/test_engine/test_sliding_curtain_area.py
@@ -12,7 +12,6 @@ azimuth.
 from __future__ import annotations
 
 import math
-from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -21,18 +20,9 @@ from custom_components.adaptive_cover_pro.config_types import SlidingCurtainConf
 from custom_components.adaptive_cover_pro.engine.covers import (
     AdaptiveSlidingCurtainCover,
 )
-from tests.cover_helpers import make_cover_config
+from tests.cover_helpers import make_cover_config, make_daytime_sun_data
 
 _WIN_AZI = 180.0
-
-
-def _safe_sun_data() -> MagicMock:
-    sun_data = MagicMock()
-    sun_data.timezone = "UTC"
-    now = datetime.now(UTC)
-    sun_data.sunset.return_value = now + timedelta(hours=6)
-    sun_data.sunrise.return_value = now - timedelta(hours=6)
-    return sun_data
 
 
 def _curtain(
@@ -47,7 +37,7 @@ def _curtain(
         logger=MagicMock(),
         sol_azi=_WIN_AZI - gamma,
         sol_elev=sol_elev,
-        sun_data=_safe_sun_data(),
+        sun_data=make_daytime_sun_data(),
         config=make_cover_config(
             win_azi=_WIN_AZI, fov_left=fov_left, fov_right=fov_right
         ),

--- a/tests/test_engine/test_sun_behind_plane.py
+++ b/tests/test_engine/test_sun_behind_plane.py
@@ -1,0 +1,252 @@
+"""Illumination gate — the sun behind the cover plane (issue #1030).
+
+``f = tan(elev)/cos(gamma)`` is the textbook Vertical Shadow Angle tangent, and
+VSA is only defined for ``|gamma| < 90``. Past that the sun is BEHIND the glass
+and the face is not lit at all, so the projection is not a hard number to
+compute — it is a question with no answer. Before #1030 every vertical-family
+engine answered it anyway (with a sign-flipped ``cos gamma``), slamming the
+cover to an endpoint one hundredth of a degree past 90.
+
+The fix promotes the illumination test the roof window already shipped
+(``cos(AOI) > 0``) to :class:`AdaptiveGeneralCover`, so an unlit face never
+reaches the projection and the pipeline routes to the DefaultHandler instead.
+These tests pin the gate itself (not a position value), the pitched cover types
+that legitimately track past ``gamma = 90``, and the continuity of every engine
+across the former discontinuity.
+"""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.config_types import (
+    LouveredRoofConfig,
+    OscillatingConfig,
+    RoofWindowConfig,
+)
+from custom_components.adaptive_cover_pro.const import ReasonCode
+from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
+    AdaptiveLouveredRoofCover,
+)
+from custom_components.adaptive_cover_pro.engine.covers.oscillating import (
+    AdaptiveOscillatingCover,
+)
+from custom_components.adaptive_cover_pro.engine.covers.roof_window import (
+    AdaptiveRoofWindowCover,
+)
+from custom_components.adaptive_cover_pro.engine.covers.tilt import AdaptiveTiltCover
+from custom_components.adaptive_cover_pro.engine.covers.venetian import (
+    VenetianCoverCalculation,
+)
+from custom_components.adaptive_cover_pro.engine.covers.vertical import (
+    AdaptiveVerticalCover,
+)
+
+from tests.cover_helpers import (
+    make_cover_config,
+    make_daytime_sun_data,
+    make_tilt_config,
+    make_vertical_config,
+)
+
+pytestmark = pytest.mark.unit
+
+# The real field config from #1025's reporter: a 137° acceptance angle admits
+# |gamma| > 90, which is exactly how the sign flip reaches production.
+_FOV = 137
+_WIN_AZI = 180
+_SOL_ELEV = 30.0
+
+# gamma = (win_azi − sol_azi + 180) % 360 − 180, so sol_azi = win_azi − gamma
+# realises an exact surface-solar azimuth.
+
+
+def _cover_config(**overrides):
+    return make_cover_config(
+        win_azi=_WIN_AZI, fov_left=_FOV, fov_right=_FOV, **overrides
+    )
+
+
+def _vertical(gamma: float, sol_elev: float = _SOL_ELEV) -> AdaptiveVerticalCover:
+    return AdaptiveVerticalCover(
+        logger=MagicMock(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=sol_elev,
+        sun_data=make_daytime_sun_data(),
+        config=_cover_config(),
+        vert_config=make_vertical_config(distance=0.5, h_win=2.0),
+    )
+
+
+def _tilt(
+    gamma: float, sol_elev: float = _SOL_ELEV, mode: str = "mode1"
+) -> AdaptiveTiltCover:
+    return AdaptiveTiltCover(
+        logger=MagicMock(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=sol_elev,
+        sun_data=make_daytime_sun_data(),
+        config=_cover_config(),
+        tilt_config=make_tilt_config(mode=mode),
+    )
+
+
+def _venetian(gamma: float, sol_elev: float = _SOL_ELEV) -> VenetianCoverCalculation:
+    return VenetianCoverCalculation(
+        config=_cover_config(),
+        vert_config=make_vertical_config(distance=0.5, h_win=2.0),
+        tilt_config=make_tilt_config(),
+        sun_data=make_daytime_sun_data(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=sol_elev,
+        logger=MagicMock(),
+    )
+
+
+def _oscillating(gamma: float, sol_elev: float = _SOL_ELEV) -> AdaptiveOscillatingCover:
+    """Build the drop-arm awning EXACTLY as production builds it.
+
+    ``OscillatingAwningCoverType.build_calc_engine`` passes ``vert_config`` +
+    ``osc_config`` only — ``horiz_config`` stays ``None``. The horizontal
+    area-mode opt-out is inherited by this subclass, so it must be None-safe and
+    must fall through to the gate; otherwise the fail-open bug survives here.
+    """
+    return AdaptiveOscillatingCover(
+        logger=MagicMock(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=sol_elev,
+        sun_data=make_daytime_sun_data(),
+        config=_cover_config(),
+        vert_config=make_vertical_config(distance=0.5, h_win=2.0),
+        osc_config=OscillatingConfig(arm_length=0.85, housing_offset=0.15),
+    )
+
+
+def _roof_window(gamma: float, pitch: float) -> AdaptiveRoofWindowCover:
+    return AdaptiveRoofWindowCover(
+        logger=MagicMock(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=_SOL_ELEV,
+        sun_data=make_daytime_sun_data(),
+        config=_cover_config(),
+        vert_config=make_vertical_config(distance=0.5, h_win=2.0),
+        roof_config=RoofWindowConfig(roof_pitch=pitch),
+    )
+
+
+def _louvered(gamma: float, pitch: float = 0.0) -> AdaptiveLouveredRoofCover:
+    return AdaptiveLouveredRoofCover(
+        logger=MagicMock(),
+        sol_azi=_WIN_AZI - gamma,
+        sol_elev=_SOL_ELEV,
+        sun_data=make_daytime_sun_data(),
+        config=_cover_config(),
+        tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+        roof_config=LouveredRoofConfig(roof_pitch=pitch),
+    )
+
+
+class TestIlluminationGate:
+    """``direct_sun_valid`` must go False once the sun is behind the plane."""
+
+    def test_vertical_direct_sun_valid_flips_at_90(self):
+        assert _vertical(89.0).direct_sun_valid is True
+        assert _vertical(91.0).direct_sun_valid is False
+        assert _vertical(120.0).direct_sun_valid is False
+
+    def test_tilt_direct_sun_valid_flips_at_90(self):
+        assert _tilt(89.0).direct_sun_valid is True
+        assert _tilt(91.0).direct_sun_valid is False
+        assert _tilt(120.0).direct_sun_valid is False
+
+    def test_venetian_direct_sun_valid_flips_at_90(self):
+        assert _venetian(89.0).direct_sun_valid is True
+        assert _venetian(91.0).direct_sun_valid is False
+
+    def test_oscillating_direct_sun_valid_flips_at_90(self):
+        """Anti-leak lock: the horizontal area-mode opt-out must not reach here."""
+        assert _oscillating(89.0).direct_sun_valid is True
+        assert _oscillating(91.0).direct_sun_valid is False
+        assert _oscillating(120.0).direct_sun_valid is False
+
+    def test_boundary_gamma_90_still_lit(self):
+        """``cos(radians(90)) = +6.12e-17 > 0`` — the gate is strict, so 90 is lit.
+
+        Pins the boundary so ``test_fov_exit_sun_outside_fov_left`` (gamma = 90
+        exactly, expecting the acceptance-angle reason) can never move.
+        """
+        assert _vertical(90.0).direct_sun_valid is True
+        assert _tilt(90.0).direct_sun_valid is True
+
+    def test_pitched_planes_keep_tracking_past_90(self):
+        """The gate is ``cos(AOI) > 0``, NOT ``cos(gamma) > 0`` — pitch-aware.
+
+        A 30°-pitch roof window and a flat louvered roof are both genuinely lit
+        at gamma = 120 (``cos(AOI) = 0.2165`` and ``0.5``), so promoting the gate
+        to the base must leave them tracking.
+        """
+        roof = _roof_window(120.0, pitch=30.0)
+        assert roof.valid_elevation is True
+        assert roof.direct_sun_valid is True
+
+        louvered = _louvered(120.0, pitch=0.0)
+        assert louvered.valid_elevation is True
+        assert louvered.direct_sun_valid is True
+
+    def test_reason_code_sun_behind_plane(self):
+        """In-FOV but unlit reports its own reason, not an azimuth/elevation exit."""
+        cover = _vertical(120.0)
+        assert cover.in_fov is True
+        assert (
+            cover.control_state_reason_code
+            == ReasonCode.ENGINE_DEFAULT_SUN_BEHIND_PLANE
+        )
+        assert cover.control_state_reason == "Default: Sun Behind Plane"
+
+
+# ---------------------------------------------------------------------------
+# Continuity across the former discontinuity
+# ---------------------------------------------------------------------------
+
+_SWEEP = [85.0 + 0.05 * i for i in range(int((95.0 - 85.0) / 0.05) + 1)]
+# One 0.01° step of azimuth used to flip a blind from 100 % to 0 %. Anything
+# above a couple of percent per 0.05° step is a slam, not a projection.
+_MAX_STEP_PCT = 2.0
+
+
+def _assert_continuous(values: list[float]) -> None:
+    """Every sample finite, in [0, 100], and no jump between adjacent samples."""
+    for gamma, value in zip(_SWEEP, values, strict=True):
+        assert math.isfinite(value), f"non-finite at gamma={gamma}: {value}"
+        assert 0.0 <= value <= 100.0, f"out of range at gamma={gamma}: {value}"
+    for gamma, prev, cur in zip(_SWEEP[1:], values[:-1], values[1:], strict=True):
+        assert (
+            abs(cur - prev) <= _MAX_STEP_PCT
+        ), f"discontinuity at gamma={gamma}: {prev} → {cur}"
+
+
+class TestGammaContinuityAcrossNinety:
+    """Sweep gamma 85→95 calling the raw engine, bypassing the routing gate.
+
+    ``test_pole_regions_finite_and_bounded`` only asserts "finite and in
+    [0, 100]" — a 100 → 0 slam passes that. These sweeps pin the engine's own
+    continuity independent of whether the pipeline would have routed there.
+    """
+
+    def test_vertical_percentage_is_continuous(self):
+        _assert_continuous([_vertical(g).calculate_percentage() for g in _SWEEP])
+
+    def test_oscillating_percentage_is_continuous(self):
+        _assert_continuous([_oscillating(g).calculate_percentage() for g in _SWEEP])
+
+    @pytest.mark.parametrize("mode", ["mode1", "mode2"])
+    def test_tilt_percentage_is_continuous(self, mode):
+        _assert_continuous([_tilt(g, mode=mode).calculate_percentage() for g in _SWEEP])
+
+    def test_venetian_both_axes_are_continuous(self):
+        duals = [_venetian(g).calculate_dual() for g in _SWEEP]
+        _assert_continuous([float(d.position) for d in duals])
+        _assert_continuous([float(d.tilt) for d in duals])

--- a/tests/test_reason_i18n.py
+++ b/tests/test_reason_i18n.py
@@ -342,6 +342,7 @@ LEGACY_CASES: list[tuple[str, dict, str]] = [
         {},
         "Default: Acceptance Angle Exit",
     ),
+    (ReasonCode.ENGINE_DEFAULT_SUN_BEHIND_PLANE, {}, "Default: Sun Behind Plane"),
     (ReasonCode.ENGINE_DEFAULT_BLIND_SPOT, {}, "Default: Blind Spot"),
     (ReasonCode.ENGINE_DEFAULT, {}, "Default"),
     # --- skip / describe_skip ---


### PR DESCRIPTION
## Summary

The signed clamp `max(|cos γ|, 0.01)·sign(cos γ)` flipped sign at |γ|=90, so past 90° off the window normal `path_length` and `base_height` went negative and clipped to 0. A vertical blind slammed from 100% to 0% on a 0.01° step of sun azimuth. Tilt and venetian inherited it; drop-arm awnings failed the other way, to full extension. It's live for anyone with an acceptance angle above 90° — the sliders allow up to 180, and #1025's reporter runs 137°.

I promoted the illumination test to `AdaptiveGeneralCover` as a polymorphic `cos_aoi` property folded into `valid_elevation`, so past-90 routes to the default position instead of a hard projection. The gate is `cos AOI > 0`, **not** `cos γ > 0` — that's what keeps pitched roof windows and flat louvered roofs tracking where they legitimately need γ > 90; both delete their duplicate `valid_elevation` overrides. Horizontal awnings opt out in area mode so #1025's patio shading stays extended.

With the negative branch unreachable, the four bespoke clamps collapse into one shared one-sided `foreshortened_slope()` in `sun_geometry.py`, and `roof_slope_ratio` is un-factored to exact dot products — no `cos γ` divisor at all, which also removes a 3.96% accuracy error at 30° pitch (unbounded at flat pitch).

New reason code `ENGINE_DEFAULT_SUN_BEHIND_PLANE` (EN/DE/FR) replaces the misleading "Acceptance Angle Exit" and fixes the roof window's existing mis-attribution to "Elevation Limit".

The issue body named four copies of the clamp math. Only three carry a live sign-flip; `roof_slope_ratio` absorbs the sign in `abs()` and carried an accuracy bug instead. There was also an unlisted fifth copy, `ray_x_at_window_plane`, folded into the consolidation.

## User-visible behaviour changes

- Wide-acceptance-angle vertical/tilt/venetian covers fall through to their **default position** past |γ|=90 instead of slamming fully closed.
- Drop-arm awnings no longer fail open to full extension with the sun behind the wall.
- Fixed awnings in **window** mode fall through to default past 90°; **area** mode is unchanged and stays extended across the whole field of view.
- A below-horizon sun in the behind-plane hemisphere now reports "Sun Behind Plane" rather than "Elevation Limit".

## Testing

- ✅ 8175 tests passing (baseline 8133 — +42 new, no losses)
- New `tests/test_engine/test_sun_behind_plane.py`: gate assertions per engine, a γ=90.0 boundary pin, a pitched-plane lock proving the gate is `cos AOI > 0`, and continuity sweeps across γ=90 in 0.05° steps asserting max adjacent |Δpct| ≤ 2.0 — the assertion the old `test_pole_regions_finite_and_bounded` lacked, since a 100→0 slam passes "finite and bounded".
- New `TestAreaShadeModeGate` closes the #1025 coverage hole: the existing area-mode test calls `calculate_position()` directly and cannot see gate-level regressions. The pre-merge audit mutation-tested this — neutralizing the opt-out turns both cases red.
- New `test_slope_ratio_equals_exact_dot_products` pins the roof ratio against literal dot products across pitch × γ.

## Related Issues

Refs #1030
Refs #1025