### PR TITLE
fix: derive proxy tilt read inversion from the owning axis (#1034)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -9,7 +9,7 @@ import json
 import pathlib
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .forecast import Forecast
@@ -3611,28 +3611,55 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """
         return axis_inverted(self._policy.axes[0], self.config_entry.options)
 
-    @property
-    def tilt_read_inverted(self) -> bool:
+    def tilt_read_inverted(self, caps: Any) -> bool:
         """Whether the source's TILT attribute holds a re-framed value.
 
-        True only for the cover types whose primary axis IS the tilt axis
-        (``cover_tilt``, ``cover_louvered_roof``). Their single axis writes the
-        tilt attribute, and their user commands fall through
-        ``async_apply_user_tilt`` onto ``async_apply_user_position``, so the
-        number that reaches the device went through :meth:`_to_cover_frame`
-        (#1027). A reader that mirrors the attribute verbatim would therefore
-        publish 70 for a slider the user dragged to 30.
+        Two different write-side transforms can land on
+        ``current_tilt_position``, and the proxy read owes the inverse of
+        whichever one actually produced the number (#1034). This reconciles
+        them:
 
-        A venetian / day-night shade's tilt is its SECOND axis: it is keyed on
-        ``inverse_tilt``, converted by the venetian sequencer's ``_to_wire``,
-        and untouched by the position dispatch path — so it is excluded here
-        rather than swept in. Derived from the axis descriptor, not from a
-        cover-type string, so a future tilt-primary type is covered for free.
+        * **The policy declares a tilt axis.** The axis descriptor already
+          knows which transform ran and on which option. A venetian /
+          day-night shade's SECOND axis is ``TILT_AXIS`` — keyed on
+          ``inverse_tilt``, converted by the dual-axis sequencer's ``_to_wire``
+          and never interpolation-gated. A tilt-PRIMARY type's only axis is
+          ``TILT_AXIS_PRIMARY`` — keyed on ``inverse_state``, converted by
+          :meth:`_to_cover_frame` because ``async_apply_user_tilt`` falls
+          through to ``async_apply_user_position`` (#1027). ``axis_inverted``
+          carries that whole asymmetry, so the descriptor answers for both and
+          no formula is rewritten here.
+        * **The policy declares no tilt axis, but the dispatch went there
+          anyway.** ``should_use_tilt`` routes ANY policy onto
+          ``set_cover_tilt_position`` when the bound entity advertises
+          ``set_tilt_position`` but not ``set_position``. The value such an
+          install writes was re-framed by :meth:`_to_cover_frame` on
+          ``inverse_state``, so the frame is the POSITION axis's and the answer
+          is :attr:`position_axis_inverted`. Deliberately not
+          ``axis_inverted(select_default_axis(caps), …)``: that call hands back
+          the shared ``TILT_AXIS``, which keys on ``inverse_tilt`` — an option
+          this install was never offered and never set.
+
+        A declared axis wins over the caps fallback. A venetian bound to
+        tilt-only hardware still has its slats written through the sequencer,
+        so the descriptor names the transform that really ran.
+
+        Derived from axis descriptors and ``caps``, never from a cover-type
+        string, so a future tilt-carrying type is covered for free. ``caps`` is
+        a required argument rather than a defaulted one so a later caller
+        cannot silently drop back to the axis-only answer; ``None`` is accepted
+        and normalised by ``select_default_axis``.
         """
-        primary = self._policy.axes[0]
-        if primary.state_attr != STATE_ATTR_TILT_POSITION:
-            return False
-        return self.position_axis_inverted
+        axis = next(
+            (a for a in self._policy.axes if a.state_attr == STATE_ATTR_TILT_POSITION),
+            None,
+        )
+        if axis is not None:
+            return axis_inverted(axis, self.config_entry.options)
+        dispatch_axis = self._policy.select_default_axis(caps)
+        if dispatch_axis.state_attr == STATE_ATTR_TILT_POSITION:
+            return self.position_axis_inverted
+        return False
 
     def _to_cover_frame(self, value: float, *, skip_transforms: bool = False) -> int:
         """Map a logical (HA-convention) position into this cover's dispatch frame.

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -216,17 +216,20 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
 
     @property
     def current_cover_tilt_position(self) -> int | None:
-        """Source ``current_tilt_position``, re-framed only for a tilt-primary cover.
+        """Source ``current_tilt_position`` expressed in the logical frame.
 
-        A tilt-PRIMARY cover (``cover_tilt``, ``cover_louvered_roof``) has no
-        separate position axis: ``async_apply_user_tilt`` falls back to
-        ``async_apply_user_position``, so the value on the wire went through
-        ``_to_cover_frame`` and the read owes the slider the inverse (#1027).
-        A venetian's second tilt axis is converted by its own sequencer and is
-        left verbatim — ``tilt_read_inverted`` draws that line.
+        Every write that reaches the tilt attribute was re-framed by exactly
+        one transform, and this read owes that transform its inverse — a
+        venetian / day-night shade's slats via the dual-axis sequencer's
+        ``_to_wire`` on ``inverse_tilt``, a tilt-PRIMARY cover or a
+        position-only cover bound to tilt-only hardware via ``_to_cover_frame``
+        on ``inverse_state`` (#1027 / #1034). ``tilt_read_inverted`` resolves
+        which one ran; the source's capabilities are passed because the last
+        case is a routing decision, not a config one.
         """
         return self._logical_axis_value(
-            STATE_ATTR_TILT_POSITION, inverted=self.coordinator.tilt_read_inverted
+            STATE_ATTR_TILT_POSITION,
+            inverted=self.coordinator.tilt_read_inverted(self._source_caps()),
         )
 
     @property

--- a/tests/cover/test_proxy_cover_commands.py
+++ b/tests/cover/test_proxy_cover_commands.py
@@ -6,16 +6,20 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from homeassistant.components.cover import CoverEntityFeature
 from homeassistant.const import ATTR_ENTITY_ID
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_ENABLE_PROXY_COVER,
     CONF_ENTITIES,
     CONF_INTERP,
     CONF_INTERP_LIST,
     CONF_INTERP_LIST_NEW,
     CONF_INVERSE_STATE,
+    CONF_INVERSE_TILT,
     CONF_SENSOR_TYPE,
+    DAY_NIGHT_MODEL_POSITION_TILT,
     DOMAIN,
     CoverType,
 )
@@ -448,7 +452,24 @@ async def test_proxy_slider_round_trip_inverse_state(hass) -> None:
 # tilt read has to be re-framed with it.
 # ---------------------------------------------------------------------------
 
-_TILT_ONLY_FEATURES = 128 | 15
+# Everything: OPEN | CLOSE | SET_POSITION | STOP | SET_TILT_POSITION. Despite
+# the name it carried until #1034, ``128 | 15`` includes SET_POSITION (bit 4),
+# so it describes a FULLY capable cover, not a tilt-only one.
+_POSITION_AND_TILT_FEATURES = 128 | 15
+
+# A genuinely tilt-only cover. The load-bearing part is the bit that is NOT
+# here: SET_POSITION. Without it ``should_use_tilt`` reroutes any policy's
+# dispatch onto ``set_cover_tilt_position``. Spelled from the enum so the
+# omission is visible rather than hidden inside a magic number.
+_TILT_ONLY_FEATURES = int(
+    CoverEntityFeature.OPEN
+    | CoverEntityFeature.CLOSE
+    | CoverEntityFeature.STOP
+    | CoverEntityFeature.OPEN_TILT
+    | CoverEntityFeature.CLOSE_TILT
+    | CoverEntityFeature.STOP_TILT
+    | CoverEntityFeature.SET_TILT_POSITION
+)
 
 
 async def test_proxy_tilt_round_trip_inverse_state_on_tilt_only_cover(hass) -> None:
@@ -470,7 +491,7 @@ async def test_proxy_tilt_round_trip_inverse_state_on_tilt_only_cover(hass) -> N
         options=options,
         attrs={
             "current_tilt_position": 50,
-            "supported_features": _TILT_ONLY_FEATURES,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
         },
     )
     calls = _capture_cover_calls(hass, "cover.living_room")
@@ -494,7 +515,7 @@ async def test_proxy_tilt_round_trip_inverse_state_on_tilt_only_cover(hass) -> N
         "open",
         {
             "current_tilt_position": commanded,
-            "supported_features": _TILT_ONLY_FEATURES,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
         },
     )
     await hass.async_block_till_done()
@@ -503,12 +524,19 @@ async def test_proxy_tilt_round_trip_inverse_state_on_tilt_only_cover(hass) -> N
 
 
 async def test_proxy_tilt_read_stays_verbatim_for_second_axis_tilt(hass) -> None:
-    """A venetian's SECOND tilt axis is deliberately left alone.
+    """``inverse_state`` does not reach a venetian's SECOND tilt axis.
 
-    Its wire conversion lives in the venetian sequencer's ``_to_wire`` and is
-    keyed on ``inverse_tilt``, not ``inverse_state``; nothing on the #1027
-    dispatch path touches it. Pinning the boundary keeps a future "just invert
-    every tilt read" edit from silently double-flipping the venetian.
+    One specific negative, and only that one. The slats' wire conversion lives
+    in the venetian sequencer's ``_to_wire``, which is keyed on ``inverse_tilt``
+    — a separately-configured option — so nothing the ``inverse_state``
+    dispatch path (#1027) does can land on this attribute, and mirroring it
+    verbatim is correct.
+
+    This does NOT say the venetian tilt read is never re-framed: under
+    ``inverse_tilt`` it is, which is the positive half that
+    ``test_proxy_tilt_round_trip_inverse_tilt_on_venetian`` pins (#1034). The
+    two together are the whole boundary — the read follows ``inverse_tilt``
+    here and ``inverse_state`` never.
     """
     options = dict(TILT_OPTIONS)
     options[CONF_INVERSE_STATE] = True
@@ -520,8 +548,176 @@ async def test_proxy_tilt_read_stays_verbatim_for_second_axis_tilt(hass) -> None
         attrs={
             "current_position": 60,
             "current_tilt_position": 30,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
+        },
+    )
+
+    assert hass.states.get(proxy_eid).attributes.get("current_tilt_position") == 30
+
+
+# ---------------------------------------------------------------------------
+# Issue #1034: every write-side tilt transform owes the read side its inverse
+# ---------------------------------------------------------------------------
+
+
+async def test_proxy_tilt_round_trip_inverse_tilt_on_venetian(hass) -> None:
+    """Drag a venetian proxy's tilt to 30 under ``inverse_tilt`` and read 30 back.
+
+    A venetian's slat dispatch runs through the dual-axis sequencer's
+    ``_to_wire``, which flips on ``inverse_tilt`` and is never
+    interpolation-gated. Before #1034 the read side asked a predicate keyed on
+    the PRIMARY axis, which is the position axis here, so it answered "not
+    inverted" and mirrored the wire value verbatim: the user dragged the slider
+    to 30, the source was commanded 70, and the slider settled back on 70.
+    """
+    options = dict(TILT_OPTIONS)
+    options[CONF_INVERSE_TILT] = True
+    _entry, _coord, proxy_eid = await _setup_proxy(
+        hass,
+        cover_type=CoverType.VENETIAN,
+        entry_id="proxy_cmd_venetian_inv_tilt",
+        options=options,
+        attrs={
+            "current_position": 60,
+            "current_tilt_position": 50,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
+        },
+    )
+    calls = _capture_cover_calls(hass, "cover.living_room")
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_tilt_position",
+        {"entity_id": proxy_eid, "tilt_position": 30},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    sent = calls.get("set_cover_tilt_position", [])
+    assert sent, f"no tilt command reached the source: {calls}"
+    # A static mock source never publishes the new tilt, so the verify path may
+    # fire a bounded drift retry of the SAME value (#500) — assert the value,
+    # not the call count.
+    assert all(c["tilt_position"] == 70 for c in sent), sent
+
+    # The source now reports what it was actually driven to.
+    hass.states.async_set(
+        "cover.living_room",
+        "open",
+        {
+            "current_position": 60,
+            "current_tilt_position": 70,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(proxy_eid).attributes.get("current_tilt_position") == 30
+
+
+async def test_proxy_tilt_round_trip_inverse_tilt_on_day_night_shade(hass) -> None:
+    """The day/night blend axis rides the same sequencer, so it owes the same inverse.
+
+    ``cover_day_night_shade`` Model A declares ``(position, tilt)`` and forwards
+    ``invert_tilt`` into the shared ``DualAxisSequencer``, and
+    ``coordinator._inverse_tilt`` reads ``inverse_tilt`` for EVERY cover type —
+    so the write side flips here exactly as it does for a venetian.
+
+    ``inverse_tilt`` is not offered by the day/night geometry schema and
+    ``adaptive_cover_pro.set_options`` rejects it, but
+    ``adaptive_cover_pro.import_config`` merges every non-``_``-prefixed key
+    wholesale (``services/import_service.py:117-144``) and validates only keys
+    present in ``OPTION_RANGES``. A hand-edited export therefore reaches this
+    config: not config-flow-offered, but not unreachable either.
+    """
+    options = dict(VERTICAL_OPTIONS)
+    options[CONF_INVERSE_TILT] = True
+    # Pinned explicitly rather than relying on the default staying Model A.
+    options[CONF_DAY_NIGHT_CONTROL_MODEL] = DAY_NIGHT_MODEL_POSITION_TILT
+    _entry, _coord, proxy_eid = await _setup_proxy(
+        hass,
+        cover_type=CoverType.DAY_NIGHT_SHADE,
+        entry_id="proxy_cmd_day_night_inv_tilt",
+        options=options,
+        attrs={
+            "current_position": 60,
+            "current_tilt_position": 50,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
+        },
+    )
+    calls = _capture_cover_calls(hass, "cover.living_room")
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_tilt_position",
+        {"entity_id": proxy_eid, "tilt_position": 30},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    sent = calls.get("set_cover_tilt_position", [])
+    assert sent, f"no tilt command reached the source: {calls}"
+    assert all(c["tilt_position"] == 70 for c in sent), sent
+
+    hass.states.async_set(
+        "cover.living_room",
+        "open",
+        {
+            "current_position": 60,
+            "current_tilt_position": 70,
+            "supported_features": _POSITION_AND_TILT_FEATURES,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(proxy_eid).attributes.get("current_tilt_position") == 30
+
+
+async def test_proxy_tilt_round_trip_inverse_state_on_tilt_only_hardware(hass) -> None:
+    """A position-only cover type on tilt-only hardware re-frames on ``inverse_state``.
+
+    ``should_use_tilt`` flips ANY policy's dispatch onto
+    ``set_cover_tilt_position`` when the bound entity advertises
+    ``set_tilt_position`` but not ``set_position``. A ``cover_blind`` on such an
+    entity has no tilt hook, so ``async_apply_user_tilt`` falls back to
+    ``async_apply_user_position``: the value is re-framed by ``_to_cover_frame``
+    on ``inverse_state`` and then routed onto the tilt service by
+    ``select_default_axis``. The read side has to follow it there.
+    """
+    options = dict(VERTICAL_OPTIONS)
+    options[CONF_INVERSE_STATE] = True
+    _entry, _coord, proxy_eid = await _setup_proxy(
+        hass,
+        cover_type=CoverType.BLIND,
+        entry_id="proxy_cmd_blind_tilt_only_hw",
+        options=options,
+        attrs={
+            "current_tilt_position": 50,
             "supported_features": _TILT_ONLY_FEATURES,
         },
     )
+    calls = _capture_cover_calls(hass, "cover.living_room")
+
+    await hass.services.async_call(
+        "cover",
+        "set_cover_tilt_position",
+        {"entity_id": proxy_eid, "tilt_position": 30},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    sent = calls.get("set_cover_tilt_position", [])
+    assert sent, f"no tilt command reached the source: {calls}"
+    assert all(c["tilt_position"] == 70 for c in sent), sent
+
+    hass.states.async_set(
+        "cover.living_room",
+        "open",
+        {
+            "current_tilt_position": 70,
+            "supported_features": _TILT_ONLY_FEATURES,
+        },
+    )
+    await hass.async_block_till_done()
 
     assert hass.states.get(proxy_eid).attributes.get("current_tilt_position") == 30

--- a/tests/test_coordinator_tilt_read_inverted.py
+++ b/tests/test_coordinator_tilt_read_inverted.py
@@ -1,0 +1,342 @@
+"""The full truth table for ``coordinator.tilt_read_inverted`` (issue #1034).
+
+``grep -rn "tilt_read_inverted" tests/`` returned zero hits before this module:
+the predicate #1033 added was only ever exercised indirectly, through two proxy
+round-trip tests, which is how #1034's three broken cases stayed invisible.
+
+Written AFTER the fix by design. The three integration reproductions in
+``tests/cover/test_proxy_cover_commands.py`` are what proved the behaviour
+change (they failed on the published value and now pass); this module is the
+regression net around it, pinning ~180 (cover type × options × capability)
+combinations that no single reproduction can express.
+
+Parametrisation is derived from ``POLICY_REGISTRY`` rather than hand-listed —
+the same technique as ``tests/test_cover_types/test_axis_inverted.py`` — so a
+tenth cover type cannot slip past.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_INTERP,
+    CONF_INVERSE_STATE,
+    CONF_INVERSE_TILT,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types import POLICY_REGISTRY, get_policy
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    AXIS_NAME_TILT,
+    CAP_HAS_SET_POSITION,
+    CAP_HAS_SET_TILT_POSITION,
+    STATE_ATTR_TILT_POSITION,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Registry-derived cover-type groups
+# ---------------------------------------------------------------------------
+
+# Venetian / day-night shade: a SECOND axis owns the tilt attribute. It is
+# ``TILT_AXIS`` — keyed on ``inverse_tilt``, written through the dual-axis
+# sequencer's ``_to_wire``, never interpolation-gated.
+_DUAL_AXIS_COVER_TYPES = sorted(
+    cover_type for cover_type, cls in POLICY_REGISTRY.items() if len(cls.axes) > 1
+)
+
+# ``cover_tilt`` / ``cover_louvered_roof``: the tilt attribute is owned by the
+# PRIMARY (and only) axis, ``TILT_AXIS_PRIMARY`` — keyed on ``inverse_state``,
+# written through ``_to_cover_frame``, and interpolation-suppressed with it.
+_TILT_PRIMARY_COVER_TYPES = sorted(
+    cover_type
+    for cover_type, cls in POLICY_REGISTRY.items()
+    if len(cls.axes) == 1 and cls.axes[0].name == AXIS_NAME_TILT
+)
+
+# Everything that declares axes but none that owns the tilt attribute. These
+# only ever write it when ``should_use_tilt`` reroutes them there.
+_POSITION_ONLY_COVER_TYPES = sorted(
+    cover_type
+    for cover_type, cls in POLICY_REGISTRY.items()
+    if cls.axes
+    and not any(axis.state_attr == STATE_ATTR_TILT_POSITION for axis in cls.axes)
+)
+
+
+# ---------------------------------------------------------------------------
+# Capability sets — what the BOUND entity advertises, not what is configured
+# ---------------------------------------------------------------------------
+
+_CAPS_POSITION_AND_TILT = {
+    CAP_HAS_SET_POSITION: True,
+    CAP_HAS_SET_TILT_POSITION: True,
+}
+_CAPS_POSITION_ONLY = {
+    CAP_HAS_SET_POSITION: True,
+    CAP_HAS_SET_TILT_POSITION: False,
+}
+_CAPS_TILT_ONLY = {
+    CAP_HAS_SET_POSITION: False,
+    CAP_HAS_SET_TILT_POSITION: True,
+}
+
+# ``caps=None`` is what ``check_cover_features`` hands back when it cannot read
+# the entity (HA hasn't initialised it, or it is unavailable).
+_ALL_CAPS = [
+    pytest.param(_CAPS_POSITION_AND_TILT, id="caps_position_and_tilt"),
+    pytest.param(_CAPS_POSITION_ONLY, id="caps_position_only"),
+    pytest.param(_CAPS_TILT_ONLY, id="caps_tilt_only"),
+    pytest.param(None, id="caps_unknown"),
+]
+
+_ALL_OPTIONS = [
+    pytest.param({}, id="opts_none"),
+    pytest.param({CONF_INVERSE_STATE: True}, id="opts_inverse_state"),
+    pytest.param({CONF_INVERSE_TILT: True}, id="opts_inverse_tilt"),
+    pytest.param(
+        {CONF_INVERSE_STATE: True, CONF_INVERSE_TILT: True}, id="opts_both_inversions"
+    ),
+    pytest.param(
+        {CONF_INVERSE_STATE: True, CONF_INTERP: True}, id="opts_inverse_state_interp"
+    ),
+    pytest.param(
+        {CONF_INVERSE_TILT: True, CONF_INTERP: True}, id="opts_inverse_tilt_interp"
+    ),
+]
+
+_INVERSE_TILT_OPTIONS = [
+    pytest.param({CONF_INVERSE_TILT: True}, id="opts_inverse_tilt"),
+    pytest.param(
+        {CONF_INVERSE_STATE: True, CONF_INVERSE_TILT: True}, id="opts_both_inversions"
+    ),
+    pytest.param(
+        {CONF_INVERSE_TILT: True, CONF_INTERP: True}, id="opts_inverse_tilt_interp"
+    ),
+]
+
+_POSITION_CAPABLE_CAPS = [
+    pytest.param(_CAPS_POSITION_AND_TILT, id="caps_position_and_tilt"),
+    pytest.param(_CAPS_POSITION_ONLY, id="caps_position_only"),
+]
+
+
+def _coordinator(cover_type: str, options: dict) -> MagicMock:
+    """Build a coordinator stub carrying only the seam ``tilt_read_inverted`` reads.
+
+    Same pattern as ``tests/test_day_night_dual_entity.py`` — a ``MagicMock``
+    for the surrounding object, with the REAL unbound members bound onto it, so
+    the production code under test is the shipped code and not a paraphrase.
+    """
+    coord = MagicMock()
+    coord._policy = get_policy(cover_type)
+    coord.config_entry.options = options
+    coord.position_axis_inverted = (
+        AdaptiveDataUpdateCoordinator.position_axis_inverted.fget(coord)
+    )
+    coord.tilt_read_inverted = types.MethodType(
+        AdaptiveDataUpdateCoordinator.tilt_read_inverted, coord
+    )
+    return coord
+
+
+def test_registry_derived_parametrisation_is_populated() -> None:
+    """Guard the derivations above against silently collapsing to empty lists."""
+    assert _DUAL_AXIS_COVER_TYPES
+    assert _TILT_PRIMARY_COVER_TYPES
+    assert _POSITION_ONLY_COVER_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Dual-axis (venetian, day/night shade): the SECOND axis owns the attribute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cover_type", _DUAL_AXIS_COVER_TYPES)
+@pytest.mark.parametrize("options", _INVERSE_TILT_OPTIONS)
+@pytest.mark.parametrize("caps", _ALL_CAPS)
+def test_dual_axis_tilt_read_inverts_on_inverse_tilt(
+    cover_type: str, options: dict, caps: dict | None
+) -> None:
+    """The core of #1034 — the slat read owes ``_to_wire`` its inverse.
+
+    Every venetian / day-night tilt dispatch goes through the sequencer's
+    ``_to_wire``, which flips on ``inverse_tilt``. The read side answered
+    ``False`` here until #1034 because it asked about the PRIMARY axis, which
+    on these types is the position axis.
+
+    Independent of ``caps``: this is a configured transform, not a routing one.
+    """
+    coord = _coordinator(cover_type, options)
+    assert coord.tilt_read_inverted(caps) is True
+
+
+@pytest.mark.parametrize("cover_type", _DUAL_AXIS_COVER_TYPES)
+@pytest.mark.parametrize("caps", _ALL_CAPS)
+def test_dual_axis_tilt_read_ignores_inverse_state(
+    cover_type: str, caps: dict | None
+) -> None:
+    """``inverse_state`` does not reach a dual-axis cover's tilt attribute.
+
+    It keys the POSITION axis; the slats are keyed on ``inverse_tilt`` alone.
+    The negative half of the same boundary
+    ``test_proxy_tilt_read_stays_verbatim_for_second_axis_tilt`` pins
+    end-to-end.
+    """
+    coord = _coordinator(cover_type, {CONF_INVERSE_STATE: True})
+    assert coord.tilt_read_inverted(caps) is False
+
+
+@pytest.mark.parametrize("cover_type", _DUAL_AXIS_COVER_TYPES)
+@pytest.mark.parametrize("caps", _ALL_CAPS)
+def test_dual_axis_tilt_read_not_suppressed_by_interpolation(
+    cover_type: str, caps: dict | None
+) -> None:
+    """Interpolation must never suppress tilt inversion on a dual-axis cover.
+
+    ``TILT_AXIS.interpolatable`` is ``False`` deliberately (#925): ``_to_wire``
+    reads ``inverse_tilt`` raw and never consults the calibration curve, so a
+    read that gated on interpolation would stop un-inverting a value the write
+    side still inverted.
+    """
+    coord = _coordinator(cover_type, {CONF_INVERSE_TILT: True, CONF_INTERP: True})
+    assert coord.tilt_read_inverted(caps) is True
+
+
+@pytest.mark.parametrize("cover_type", _DUAL_AXIS_COVER_TYPES)
+def test_declared_tilt_axis_wins_over_caps_routing(cover_type: str) -> None:
+    """A declared tilt axis beats the caps fallback — branch ORDER is load-bearing.
+
+    On tilt-only hardware a dual-axis cover is pathological (carriage and slats
+    both land on ``current_tilt_position``; ``tilt_capability_contradiction``
+    warns about it), but the slats are still written by the sequencer on
+    ``inverse_tilt``. Consulting ``select_default_axis`` first would answer
+    ``position_axis_inverted`` and report ``True`` for an install configured
+    only with ``inverse_state`` — the exact inversion a well-meaning refactor
+    would introduce.
+    """
+    coord = _coordinator(cover_type, {CONF_INVERSE_STATE: True})
+    assert coord.tilt_read_inverted(_CAPS_TILT_ONLY) is False
+
+
+# ---------------------------------------------------------------------------
+# Tilt-primary (cover_tilt, cover_louvered_roof): #1033's behaviour, pinned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cover_type", _TILT_PRIMARY_COVER_TYPES)
+@pytest.mark.parametrize("caps", _ALL_CAPS)
+def test_tilt_primary_tilt_read_inverts_on_inverse_state(
+    cover_type: str, caps: dict | None
+) -> None:
+    """#1033, unchanged: a tilt-only type's single axis is keyed on ``inverse_state``.
+
+    ``async_apply_user_tilt`` falls through to ``async_apply_user_position``,
+    so the wire value came out of ``_to_cover_frame``.
+    """
+    coord = _coordinator(cover_type, {CONF_INVERSE_STATE: True})
+    assert coord.tilt_read_inverted(caps) is True
+
+
+@pytest.mark.parametrize("cover_type", _TILT_PRIMARY_COVER_TYPES)
+@pytest.mark.parametrize("caps", _ALL_CAPS)
+def test_tilt_primary_tilt_read_ignores_inverse_tilt(
+    cover_type: str, caps: dict | None
+) -> None:
+    """#1033, unchanged: ``inverse_tilt`` is offered by the venetian schema alone.
+
+    A tilt-only instance can never set it, so an axis keyed off it would read
+    an option that is never written.
+    """
+    coord = _coordinator(cover_type, {CONF_INVERSE_TILT: True})
+    assert coord.tilt_read_inverted(caps) is False
+
+
+@pytest.mark.parametrize("cover_type", _TILT_PRIMARY_COVER_TYPES)
+@pytest.mark.parametrize("caps", _ALL_CAPS)
+def test_tilt_primary_tilt_read_suppressed_by_interpolation(
+    cover_type: str, caps: dict | None
+) -> None:
+    """#1033, unchanged: interpolation and inverse-state are mutually exclusive.
+
+    ``TILT_AXIS_PRIMARY.interpolatable`` is ``True`` — a single-axis cover runs
+    its one axis through the calibration curve like any other, and
+    ``_to_cover_frame`` logs the combination as unsupported and skips the flip.
+    The read has to skip it too.
+    """
+    coord = _coordinator(cover_type, {CONF_INVERSE_STATE: True, CONF_INTERP: True})
+    assert coord.tilt_read_inverted(caps) is False
+
+
+# ---------------------------------------------------------------------------
+# Position-only types: the tilt attribute is reached only by caps routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cover_type", _POSITION_ONLY_COVER_TYPES)
+@pytest.mark.parametrize("options", _ALL_OPTIONS)
+@pytest.mark.parametrize("caps", _POSITION_CAPABLE_CAPS)
+def test_position_only_tilt_read_false_with_position_capable_caps(
+    cover_type: str, options: dict, caps: dict
+) -> None:
+    """An entity that can take ``set_position`` never has its tilt attribute driven.
+
+    ``should_use_tilt`` only reroutes when position is absent, so nothing ACP
+    writes lands on ``current_tilt_position`` here — whatever the source
+    reports is somebody else's number and must be mirrored verbatim.
+    """
+    coord = _coordinator(cover_type, options)
+    assert coord.tilt_read_inverted(caps) is False
+
+
+@pytest.mark.parametrize("cover_type", _POSITION_ONLY_COVER_TYPES)
+@pytest.mark.parametrize(
+    ("options", "expected"),
+    [
+        pytest.param({}, False, id="opts_none"),
+        pytest.param({CONF_INVERSE_STATE: True}, True, id="opts_inverse_state"),
+        pytest.param({CONF_INVERSE_TILT: True}, False, id="opts_inverse_tilt"),
+        pytest.param(
+            {CONF_INVERSE_STATE: True, CONF_INTERP: True},
+            False,
+            id="opts_inverse_state_interp",
+        ),
+    ],
+)
+def test_position_only_tilt_read_follows_inverse_state_on_tilt_only_caps(
+    cover_type: str, options: dict, expected: bool
+) -> None:
+    """Tilt-only hardware reroutes the dispatch, so the read follows it there.
+
+    ``should_use_tilt`` sends any policy onto ``set_cover_tilt_position`` when
+    the entity advertises ``set_tilt_position`` but not ``set_position``. The
+    value written is ``_to_cover_frame``'s, so the frame is the POSITION axis's
+    — ``inverse_state``, suppressed by interpolation, and deaf to
+    ``inverse_tilt`` (which ``select_default_axis``'s returned ``TILT_AXIS``
+    would have wrongly consulted).
+    """
+    coord = _coordinator(cover_type, options)
+    assert coord.tilt_read_inverted(_CAPS_TILT_ONLY) is expected
+
+
+@pytest.mark.parametrize("cover_type", _POSITION_ONLY_COVER_TYPES)
+@pytest.mark.parametrize("options", _ALL_OPTIONS)
+def test_position_only_tilt_read_false_when_caps_unknown(
+    cover_type: str, options: dict
+) -> None:
+    """Unknown caps must not be guessed into a re-framed read.
+
+    ``select_default_axis`` normalises ``None`` to ``{}``, where
+    ``has_set_position`` defaults to ``True`` — the same assumption every other
+    dispatch-side caller makes, so the read cannot disagree with the write
+    about a cover HA has not described yet.
+    """
+    coord = _coordinator(cover_type, options)
+    assert coord.tilt_read_inverted(None) is False


### PR DESCRIPTION
## Summary

The proxy cover's tilt read was mirrored verbatim while the write side inverted, so a slider round trip did not close under Inverse Tilt. Drag the proxy tilt to 30, the source got commanded 70, and the proxy published 70 back.

`tilt_read_inverted` short-circuited on `policy.axes[0]`, which is the tilt axis only for `cover_tilt` and `cover_louvered_roof`. A venetian carries tilt as its *second* axis, so the dual-axis sequencer's `_to_wire` inversion was never undone on the way out.

I replaced the positional index with an attribute-owner lookup: find the declared axis whose `state_attr` is the tilt attribute and hand that to `axis_inverted`. The descriptor already encodes the whole asymmetry (`TILT_AXIS` keys on `inverse_tilt` and is not interpolation-gated, `TILT_AXIS_PRIMARY` keys on `inverse_state`), so no formula is rewritten and the tilt-primary answer from #1033 is byte-identical to before. It also drops the `axes[0]` coupling that #964's tilt unification would otherwise have had to unwind.

That left one reachable case still broken, so I closed it in the same pass. `should_use_tilt` routes *any* policy onto `set_cover_tilt_position` when the bound entity supports `set_tilt_position` but not `set_position`, so a blind or awning on tilt-only hardware with Inverse State had the identical read/write split. The predicate now takes `caps` and falls back to `position_axis_inverted` for that routing, deliberately not `axis_inverted(select_default_axis(caps), ...)`, which would key on `inverse_tilt`, an option those installs were never offered. The declared-axis branch wins over the caps branch, so a venetian bound to tilt-only hardware still answers from the axis whose transform actually ran.

Day/night shade is fixed for free. `inverse_tilt` is not in its config-flow schema, but `import_config` merges unvalidated keys wholesale, so a hand-edited export reaches it.

`tilt_read_inverted` had zero test coverage before this. The new module pins the full registry-derived table, including the #1033 tilt-primary behaviour and the branch ordering.

## Verified behaviour delta

Exactly 30 of 180 combinations change, all intended:

- `cover_venetian` and `cover_day_night_shade` with `inverse_tilt`, under every caps set: `False -> True`
- The six position-only types with `inverse_state` **and** tilt-only caps: `False -> True`

Unchanged: `cover_tilt` and `cover_louvered_roof` across all 18 combinations each (#1033 preserved), venetian with `inverse_state` only, and position-only types with position-capable caps or `caps=None`.

## Release note

Two lines, two populations:

- **Proxy tilt now reports the logical frame (#1034):** on venetian and day/night shade instances with **Inverse Tilt** set, the proxy cover's `current_tilt_position` was mirroring the inverted wire value. Drag the slider to 30 and it settled on 70. It now reports 30. If you compensated with `100 - value` in a template or automation, remove the compensation.
- The same correction applies to any single-axis instance (blind, awning, roof window, sliding curtain, dual panel) bound to a cover that supports tilt but **not** `set_position`, with **Inverse State** set. Those were routed onto the tilt service by the capability fallback and had the identical broken round trip.

## Testing

- ✅ 8557 tests passing (1 xfailed, the pre-existing unrelated one). Baseline was 8355 + 1, so +202: 3 integration reproductions plus 199 predicate-table cases.
- New `tests/test_coordinator_tilt_read_inverted.py` closes the zero-coverage gap on `tilt_read_inverted`.
- Regression guards re-run as a set: 463 passed. `_to_wire`, `position_axis_inverted`, and `coordinator._inverse_tilt` are untouched.
- Diff coverage 100% on the production change.

## Related Issues

Refs #1034