### PR TITLE
fix: dual-panel back wire space comes from options (#1035)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -537,6 +537,20 @@ class CoverTypePolicy(ABC):
         logical→wire transforms the caller already applied — so a remapping
         policy can reproduce or undo it.
 
+        **Transform vs. substitute — the rule that decides whether to consult
+        them at all.** A policy that *transforms* the supplied ``position``
+        into its entity's target (the Model C day/night middle rail, derived
+        from the bottom rail's dispatched value) MUST consult the frame, or it
+        will undo a transform that was never applied. A policy that *replaces*
+        it with an absolute target (the dual panel's blackout, a pure
+        open/closed decision independent of the front) MUST ignore the frame
+        and derive its own wire space from ``options`` — the caller's frame
+        describes a value that policy never consumes, and honouring it
+        dispatches into the wrong space whenever the two diverge (#1035).
+        ``options`` does not reach this hook: a substituting policy caches its
+        wire space in ``post_pipeline_resolve``, which is where ``options``
+        arrives, and reads that cache here (see ``DualPanelPolicy``).
+
         * ``inverted=None`` (the default, and the only value the identity
           implementation ever needs) means "use the policy's own cached
           per-cycle decision": the main pipeline dispatch path, whose frame the
@@ -549,7 +563,9 @@ class CoverTypePolicy(ABC):
           they leave ``interpolated`` at its default. A user command
           (``async_apply_user_position``) rides the SAME transform as the main
           pipeline but off-cycle, so it names both dimensions rather than
-          trusting a cache built for a different value (#993 / #1027).
+          trusting a cache built for a different value (#993 / #1027). What a
+          *substituting* policy does with that frame is governed by the rule
+          above: nothing.
 
         ``interpolated`` exists because ``inverted`` alone cannot describe an
         interpolating install: "interpolated, not inverted" and "neither" both

--- a/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
@@ -428,8 +428,8 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         entity_id: str,
         position: int,
         *,
-        inverted: bool | None = None,
-        interpolated: bool = False,
+        inverted: bool | None = None,  # noqa: ARG002
+        interpolated: bool = False,  # noqa: ARG002
     ) -> int:
         """Substitute the back panel's blackout target; the front passes through.
 
@@ -441,14 +441,20 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         (identity for all); a safety/bypass cycle also passes every entity
         through untouched so the safety winner is never overwritten.
 
-        ``inverted`` / ``interpolated`` name the dispatch frame. ``None``
-        (the main dispatch path) applies the cached per-cycle transform;
-        anything else names the caller's own frame outright. Both routes then
-        run the SAME application step, so the back can never be calibrated on
-        one path and left raw on the other — which is exactly what happened
-        while the seam could only say "inverted or not": a user command on an
-        interpolating install named ``inverted=False`` and drove the blackout
-        panel to raw 0, outside its calibrated band (#1027).
+        ``inverted`` / ``interpolated`` are accepted for seam parity and
+        DELIBERATELY NOT CONSULTED. They name the frame of the incoming
+        ``position``, and this policy substitutes an absolute target rather
+        than transforming that value — ``compute_layered`` never reads
+        ``front`` when computing ``back`` — so the only wire space that
+        applies is the device's own, cached by ``_cache_inverse_and_interp``
+        from ``options`` alone (#996 Finding 1, #1035).
+
+        History: the interpolation behaviour #1027 added is preserved, just
+        sourced from the cache instead of the kwarg. Before #1027 the seam
+        could only say "inverted or not", so an interpolating install's user
+        command named ``inverted=False`` and drove the blackout to raw 0,
+        outside its calibrated band. Reading the cache unconditionally is a
+        strictly stronger answer: no caller can produce that value at all.
         """
         if not self._front_entity or self._back_bypass:
             return position
@@ -461,10 +467,14 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
             closed_position=POSITION_CLOSED,
         )
         back = layered.back
-        # Interpolation XOR inverse — the same mutual exclusion
-        # ``coordinator._to_cover_frame`` applies to the front's value.
-        use_interp = self._back_interp if inverted is None else interpolated
-        use_inverse = self._back_inverse if inverted is None else inverted
-        if use_interp:
+        # The back's target is an ABSOLUTE SUBSTITUTION — ``compute_layered``
+        # discards ``front`` — so the caller's frame describes a value this
+        # panel never consumes. Its wire space is device semantics only
+        # (#996 Finding 1), which ``_cache_inverse_and_interp`` derives from
+        # ``options`` alone: interpolation XOR inverse, the same mutual
+        # exclusion ``coordinator._to_cover_frame`` applies to the front's
+        # value. A floor raise is a statement about the FRONT's target, not
+        # about how the back is wired (#1035).
+        if self._back_interp:
             return self._calibrated_back(back)
-        return inverse_state(back) if use_inverse else back
+        return inverse_state(back) if self._back_inverse else back

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -378,7 +378,12 @@ class TestResolveIndependence:
 
 
 class TestResolveInverseState:
-    """Inverse-state swaps open/closed in wire space; kwarg overrides the cache."""
+    """Inverse-state swaps open/closed in the back's OWN device wire space.
+
+    The cache is the only source of that space; no caller can override it
+    (#1035). Contrast ``DayNightShadePolicy``, whose middle rail IS derived
+    from the front's dispatched value and therefore must consult the frame.
+    """
 
     def test_cached_inverse_swaps_open_closed(self) -> None:
         from custom_components.adaptive_cover_pro.managers.manual_override import (
@@ -408,23 +413,67 @@ class TestResolveInverseState:
             POSITION_OPEN
         )
 
-    def test_explicit_inverted_kwarg_overrides_cache(self) -> None:
+    def test_back_wire_space_ignores_caller_frame(self) -> None:
+        """No caller can push the back into a wire space its device is not in.
+
+        #1035: ``compute_layered`` discards ``front`` when computing ``back``,
+        so the frame naming the incoming ``position`` (#993/#1027) says nothing
+        about how this panel is wired. Its wire space is device semantics only
+        (#996 Finding 1) — the same invariant ``TestResolveInverseIndependent
+        OfClamp`` states for the clamp axis, now closed against the caller axis
+        too. This replaces ``test_explicit_inverted_kwarg_overrides_cache``,
+        whose ``inverted=False`` assertion was the #1035 defect written as an
+        expectation and contradicted that sibling class outright.
+        """
+        from custom_components.adaptive_cover_pro.const import (
+            CONF_INTERP,
+            CONF_INTERP_END,
+            CONF_INTERP_START,
+        )
         from custom_components.adaptive_cover_pro.managers.manual_override import (
             inverse_state,
         )
-
-        policy = DualPanelPolicy()
-        # Cache says non-inverse, but the broadcast seam passes inverted=True.
-        _resolve(policy, control_method=ControlMethod.SUMMER, triggers=["heat"])
-        assert policy.resolve_entity_target(_BACK, 40, inverted=True) == inverse_state(
-            POSITION_CLOSED
+        from custom_components.adaptive_cover_pro.position_utils import (
+            interpolate_position,
         )
-        # And inverted=False forces non-inverse even if the cache said invert.
+
+        # 1. Cache non-inverse — a caller asking for inversion cannot impose it.
+        plain = DualPanelPolicy()
+        _resolve(plain, control_method=ControlMethod.SUMMER, triggers=["heat"])
+        assert plain.resolve_entity_target(_BACK, 40, inverted=True) == POSITION_CLOSED
+
+        # 2. Cache inverse — the floor-raise seam's ``inverted=False`` cannot
+        #    un-invert it. THIS assertion is issue #1035.
         inv = DualPanelPolicy()
         _resolve(
             inv, control_method=ControlMethod.SUMMER, triggers=["heat"], inverse=True
         )
-        assert inv.resolve_entity_target(_BACK, 40, inverted=False) == POSITION_CLOSED
+        assert inv.resolve_entity_target(_BACK, 40, inverted=False) == inverse_state(
+            POSITION_CLOSED
+        )
+
+        # 3. Cache interpolating — a broadcast seam's implicit
+        #    ``interpolated=False`` cannot defeat the calibration curve
+        #    (#996 Finding 5; seams 4/5).
+        interp = DualPanelPolicy()
+        opts = _opts(triggers=["heat"], front=_FRONT)
+        opts[CONF_INTERP] = True
+        opts[CONF_INTERP_START] = 10
+        opts[CONF_INTERP_END] = 90
+        interp.post_pipeline_resolve(
+            PipelineResult(
+                position=40, control_method=ControlMethod.SUMMER, reason="t"
+            ),
+            cover=_sunset_cover(False),
+            **_resolve_kwargs(options=opts),
+        )
+        expected = int(round(interpolate_position(POSITION_CLOSED, 10, 90, None, None)))
+        assert interp.resolve_entity_target(_BACK, 40, inverted=False) == expected
+
+        # 4. Cache non-interpolating — a caller cannot impose a curve either.
+        assert (
+            plain.resolve_entity_target(_BACK, 40, interpolated=True) == POSITION_CLOSED
+        )
 
 
 class TestResolveInverseIndependentOfClamp:

--- a/tests/test_dual_panel_dispatch.py
+++ b/tests/test_dual_panel_dispatch.py
@@ -16,18 +16,21 @@ bound onto it, so the seam is exercised end-to-end against a real policy.
 
 from __future__ import annotations
 
+import datetime as dt
 import types
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
     CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
     CONF_DUAL_PANEL_FRONT_ENTITY,
     CONF_INTERP,
     CONF_INTERP_END,
     CONF_INTERP_START,
     CONF_INVERSE_STATE,
+    CONF_SUNSET_POS,
     POSITION_CLOSED,
     POSITION_OPEN,
     ControlMethod,
@@ -250,3 +253,169 @@ async def test_night_blackout_deploys_outside_operating_window() -> None:
     )
 
     assert coordinator._cmd_svc.get_target(_BACK) == POSITION_CLOSED
+
+
+# ---------------------------------------------------------------------------
+# Broadcast seams (#1035). Each of these dispatches OFF the main pipeline cycle
+# and names a frame that is a true statement about the FRONT's value — and a
+# false one about the back's absolute substitution. Direct counterparts of the
+# day/night seam trio at tests/test_day_night_dual_entity.py:361/423/474, which
+# pins the OPPOSITE contract for a policy that genuinely derives from the front.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auto_control_off_seam_keeps_the_back_inverted() -> None:
+    """#1035 seam 6: the return-to-default broadcast must not un-invert the back.
+
+    ``switch.py:388`` names ``inverted=False`` because THAT loop never inverts
+    the raw default — a true statement about the FRONT's value (#993). The
+    back's absolute substitution never consumed it, so on an inverse install
+    the blackout's wire target is still ``inverse_state(CLOSED)`` = 100. Raw 0
+    leaves an inverted device physically OPEN. Previously unreported; cured by
+    the same policy change.
+    """
+    from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
+
+    policy = _primed_policy(triggers=["night"], sol_elev=-3.0, inverse=True)
+
+    coord = MagicMock()
+    coord.logger = MagicMock()
+    coord.entities = [_FRONT, _BACK]
+    coord._policy = policy
+    coord.return_to_default_toggle = True
+    coord.automatic_control = False
+    coord.manager.manual_controlled = []
+    coord.config_entry.options = {CONF_DEFAULT_HEIGHT: 60}
+    coord.async_refresh = AsyncMock()
+    coord._cmd_svc = _FakeCmdSvc()
+    coord._build_position_context = MagicMock(return_value=MagicMock())
+    coord._entity_target = types.MethodType(
+        AdaptiveDataUpdateCoordinator._entity_target, coord
+    )
+
+    switch = object.__new__(AdaptiveCoverSwitch)
+    switch.coordinator = coord
+    switch._key = "automatic_control"
+    switch._name = "test_switch"
+    switch._attr_is_on = True
+    switch.schedule_update_ha_state = MagicMock()
+
+    await switch.async_turn_off()
+
+    assert coord._cmd_svc.get_target(_FRONT) == 60  # front: the raw default
+    assert coord._cmd_svc.get_target(_BACK) == inverse_state(POSITION_CLOSED)
+    assert coord._cmd_svc.get_target(_BACK) != POSITION_CLOSED
+
+
+@pytest.mark.asyncio
+async def test_end_time_default_seam_calibrates_the_back_under_interpolation() -> None:
+    """#1035 seam 4: the end-of-window broadcast must not skip the back's curve.
+
+    The seam names ``inverted=self._inverse_state`` and never interpolates —
+    deliberate and #993-mandated for the FRONT's value. The back's absolute
+    substitution is not that value, so it still belongs on the motor curve
+    (#996 Finding 5): canonical CLOSED (0) on a 10..90 device is wire 10, not
+    raw 0, which is outside the calibrated band.
+    """
+    policy = _primed_policy(triggers=["night"], sol_elev=-3.0, interp=True)
+
+    coord = MagicMock()
+    coord._policy = policy
+    coord._inverse_state = False
+    coord.entities = [_FRONT, _BACK]
+    coord._track_end_time = True
+    coord.automatic_control = True
+    coord._pipeline_has_active_override = MagicMock(return_value=False)
+    coord.async_refresh = AsyncMock()
+    coord.config_entry.options = {}
+    coord._compute_current_effective_default = MagicMock(return_value=(60, False))
+    coord._check_sunset_window_transition = AsyncMock()
+
+    targets: dict[str, int] = {}
+
+    async def _apply(entity, position, reason, context=None):
+        targets[entity] = position
+
+    coord._cmd_svc.apply_position = _apply
+    coord._cmd_svc.clear_non_safety_targets = MagicMock()
+    coord._build_position_context = MagicMock(return_value=MagicMock())
+    coord._entity_target = types.MethodType(
+        AdaptiveDataUpdateCoordinator._entity_target, coord
+    )
+
+    async def _fire_closed(*, track_end_time, refresh_callback, on_window_open):
+        await refresh_callback()
+
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.check_transition = _fire_closed
+
+    await AdaptiveDataUpdateCoordinator._check_time_window_transition(
+        coord, dt.datetime.now(dt.UTC)
+    )
+
+    expected_back = int(
+        round(interpolate_position(POSITION_CLOSED, 10, 90, None, None))
+    )
+    # Assert ONLY the back. This seam deliberately does not interpolate the
+    # FRONT (#993, coordinator.py:3927-3930) — that divergence is out of scope
+    # and must not be "helpfully" fixed.
+    assert targets[_BACK] == expected_back
+    assert targets[_BACK] != POSITION_CLOSED
+
+
+@pytest.mark.asyncio
+async def test_sunset_seam_calibrates_the_back_under_interpolation() -> None:
+    """#1035 seam 5: the sunset broadcast must not skip the back's curve.
+
+    Same shape as seam 4 — ``coordinator.py:4117`` binds
+    ``inverted=self._inverse_state`` and leaves ``interpolated`` at its
+    default, which is right for the sunset position it sends and wrong for the
+    back's substitution.
+    """
+    from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
+        WindowTransitionTracker,
+    )
+
+    policy = _primed_policy(triggers=["night"], sol_elev=-3.0, interp=True)
+
+    coord = MagicMock()
+    coord._policy = policy
+    coord._inverse_state = False
+    coord.entities = [_FRONT, _BACK]
+    coord._track_end_time = True
+    coord.automatic_control = True
+    coord.manager.is_cover_manual = lambda _e: False
+    coord._pipeline_has_active_override = MagicMock(return_value=False)
+    coord.async_refresh = AsyncMock()
+    coord.config_entry.options = {CONF_SUNSET_POS: 0}
+
+    is_sunset = {"v": False}
+    coord._window_tracker = WindowTransitionTracker(
+        MagicMock(),
+        MagicMock(),
+        event_buffer=MagicMock(),
+        effective_default_fn=lambda _o: (0, is_sunset["v"]),
+    )
+
+    targets: dict[str, int] = {}
+
+    async def _apply(entity, position, reason, context=None):
+        targets[entity] = position
+
+    coord._cmd_svc.apply_position = _apply
+    coord._build_position_context = MagicMock(return_value=MagicMock())
+    coord._entity_target = types.MethodType(
+        AdaptiveDataUpdateCoordinator._entity_target, coord
+    )
+
+    # Seed prior state (no dispatch), then open the sunset window.
+    await AdaptiveDataUpdateCoordinator._check_sunset_window_transition(coord)
+    is_sunset["v"] = True
+    await AdaptiveDataUpdateCoordinator._check_sunset_window_transition(coord)
+
+    expected_back = int(
+        round(interpolate_position(POSITION_CLOSED, 10, 90, None, None))
+    )
+    assert targets[_BACK] == expected_back
+    assert targets[_BACK] != POSITION_CLOSED

--- a/tests/test_user_auto_dispatch_parity.py
+++ b/tests/test_user_auto_dispatch_parity.py
@@ -34,6 +34,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_INTERP_START,
     CONF_INVERSE_STATE,
     DAY_NIGHT_MODEL_DUAL_ENTITY,
+    POSITION_CLOSED,
     ControlMethod,
     CoverType,
 )
@@ -44,7 +45,9 @@ from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
     DayNightShadePolicy,
 )
 from custom_components.adaptive_cover_pro.cover_types.dual_panel import DualPanelPolicy
+from custom_components.adaptive_cover_pro.managers.manual_override import inverse_state
 from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
     DecisionStep,
     PipelineResult,
 )
@@ -70,6 +73,24 @@ _FRAMES: dict[str, dict] = {
     "interpolated": dict(_INTERP_OPTIONS),
     "inverse+interpolated": {CONF_INVERSE_STATE: True, **_INTERP_OPTIONS},
 }
+
+# A min-mode floor whose priority strictly exceeds ManualOverrideHandler's (80).
+# At or below 80, ``floor_applies`` is False at coordinator.py:3180 and the
+# floor never clamps a user move at all (#472) — the sweep would silently
+# degrade to the no-floor case.
+_FLOOR_POS = 40
+
+
+def _floor_slot(pos: int, priority: int = 82) -> CustomPositionSensorState:
+    """Build an active min-mode floor slot that outranks manual override."""
+    return CustomPositionSensorState(
+        entity_ids=(f"binary_sensor.floor_{pos}",),
+        is_on=True,
+        position=pos,
+        priority=priority,
+        min_mode=True,
+        use_my=False,
+    )
 
 
 def _sunset_cover(sunset_valid: bool) -> MagicMock:
@@ -102,7 +123,7 @@ def _prime(policy, result: PipelineResult, options: dict, cover) -> None:
     )
 
 
-def _dual_panel_case(frame_options: dict, logical: int):
+def _dual_panel_case(frame_options: dict, logical: int, *, floor: int | None = None):
     """Real dual-panel policy + options + the entities to compare."""
     options = {
         CONF_DUAL_PANEL_FRONT_ENTITY: _FRONT,
@@ -113,7 +134,10 @@ def _dual_panel_case(frame_options: dict, logical: int):
     _prime(
         policy,
         PipelineResult(
-            position=logical, control_method=ControlMethod.SOLAR, reason="solar"
+            position=logical,
+            control_method=ControlMethod.SOLAR,
+            reason="solar",
+            floor_clamp_applied=floor is not None,
         ),
         options,
         _sunset_cover(False),
@@ -121,7 +145,7 @@ def _dual_panel_case(frame_options: dict, logical: int):
     return policy, options, (_FRONT, _BACK), CoverType.DUAL_PANEL
 
 
-def _day_night_case(frame_options: dict, logical: int):
+def _day_night_case(frame_options: dict, logical: int, *, floor: int | None = None):
     """Real Model C day/night policy + options + the entities to compare."""
     options = {
         CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
@@ -136,6 +160,7 @@ def _day_night_case(frame_options: dict, logical: int):
             control_method=ControlMethod.CUSTOM_POSITION,
             reason="custom",
             tilt=50,
+            floor_clamp_applied=floor is not None,
         ),
         options,
         None,
@@ -149,7 +174,9 @@ _CASES = {
 }
 
 
-def _make_coord(policy, options: dict, cover_type: str, logical: int):
+def _make_coord(
+    policy, options: dict, cover_type: str, logical: int, *, floor: int | None = None
+):
     """Coordinator-shaped mock carrying a real policy and real frame inputs."""
     from tests.test_pipeline.conftest import make_snapshot
 
@@ -166,7 +193,11 @@ def _make_coord(policy, options: dict, cover_type: str, logical: int):
     coord._resolved_options = options
 
     coord._snapshot_builder = MagicMock()
-    coord._snapshot_builder.build = MagicMock(return_value=make_snapshot())
+    coord._snapshot_builder.build = MagicMock(
+        return_value=make_snapshot(
+            custom_position_sensors=[_floor_slot(floor)] if floor is not None else []
+        )
+    )
     coord._cover_data = MagicMock(name="cover_data")
     coord._cover_type = cover_type
     coord._weather_readings = None
@@ -183,6 +214,7 @@ def _make_coord(policy, options: dict, cover_type: str, logical: int):
         position=logical,
         control_method=ControlMethod.SOLAR,
         reason="solar",
+        floor_clamp_applied=floor is not None,
         decision_trace=[
             DecisionStep(
                 handler="solar", matched=True, reason="solar", position=logical
@@ -223,27 +255,43 @@ def _auto_target(coord, entity_id: str) -> int:
 @pytest.mark.parametrize("case_name", sorted(_CASES))
 @pytest.mark.parametrize("frame_name", sorted(_FRAMES))
 @pytest.mark.parametrize("logical", [0, 30, 50, 100])
+@pytest.mark.parametrize("floor", [None, _FLOOR_POS])
 async def test_user_and_auto_paths_resolve_identical_entity_targets(
-    case_name: str, frame_name: str, logical: int
+    case_name: str, frame_name: str, logical: int, floor: int | None
 ) -> None:
-    """Same logical value, same wire target — on every entity, in every frame.
+    """Same logical value, same wire target — every entity, every frame, floor or not.
 
     The ``inverted: bool`` seam could name the inversion space but not the
     interpolation space, so an interpolating dual-panel user command routed
     into the broadcast-seam branch and skipped the back panel's calibration
     entirely (auto 20, user 0 for a deployed blackout). Parity is the property
     that was actually broken; assert the property.
+
+    The floor axis closes #1035. When a min-mode floor above the request is
+    active, BOTH paths carve out the transforms — the registry already raised
+    the winner into cover space (#469) and the user path's ``skip_transforms``
+    mirrors it (#472/#469) — so the number they must agree on is the floor
+    itself. A policy whose target is an absolute substitution rather than a
+    transform of that number must still land in its own device wire space; the
+    dual-panel back did not, and dispatched raw canonical 0 while the automatic
+    side sent wire 100 (inverse) or calibrated 20 (interpolated).
     """
+    # With the floor active the registry has ALREADY raised the pipeline winner
+    # to the floor, so the agreed number IS the floor; the user asks for
+    # something strictly below it and the #472 clamp raises it there.
+    agreed = logical if floor is None else floor
+    requested = logical if floor is None else min(logical, floor - 1)
+
     policy, options, entities, cover_type = _CASES[case_name](
-        _FRAMES[frame_name], logical
+        _FRAMES[frame_name], agreed, floor=floor
     )
-    coord = _make_coord(policy, options, cover_type, logical)
+    coord = _make_coord(policy, options, cover_type, agreed, floor=floor)
 
     for entity_id in entities:
         auto = _auto_target(coord, entity_id)
-        user = await _user_target(coord, entity_id, logical)
+        user = await _user_target(coord, entity_id, requested)
         assert user == auto, (
-            f"{case_name} / {frame_name} / logical {logical}: "
+            f"{case_name} / {frame_name} / logical {logical} / floor {floor}: "
             f"{entity_id} auto target {auto} != user target {user}"
         )
 
@@ -263,3 +311,29 @@ async def test_interpolating_dual_panel_user_command_calibrates_the_back_panel()
     coord = _make_coord(policy, options, cover_type, 30)
 
     assert await _user_target(coord, _BACK, 30) == 20
+
+
+@pytest.mark.asyncio
+async def test_floor_raised_user_command_keeps_the_back_panel_inverted() -> None:
+    """#1035: a floor clamp on the FRONT must not un-invert the back's blackout.
+
+    Pinned separately from the parity sweep so the failure names the physical
+    consequence. The floor raises a user request into cover space, so the seam
+    correctly names ``(inverted=False, interpolated=False)`` — a true statement
+    about the FRONT's value (#993/#1027). The back's target is an absolute
+    substitution that never consumed that value, so its wire space is device
+    semantics only (#996 Finding 1): a deployed blackout on an inverse install
+    is wire 100 = physically CLOSED. Raw 0 leaves the device physically OPEN
+    and the blackout silently never deploys on a night/privacy/heat trigger.
+    """
+    policy, options, _entities, cover_type = _dual_panel_case(
+        {CONF_INVERSE_STATE: True}, _FLOOR_POS, floor=_FLOOR_POS
+    )
+    coord = _make_coord(policy, options, cover_type, _FLOOR_POS, floor=_FLOOR_POS)
+
+    target = await _user_target(coord, _BACK, 10)
+
+    assert target == inverse_state(POSITION_CLOSED)  # wire 100 = physically closed
+    # Legibility guard, mirroring the overdrive assertion at
+    # tests/test_dual_panel_dispatch.py:228 — name the physical failure.
+    assert target != POSITION_CLOSED


### PR DESCRIPTION
## Summary

On a dual-panel instance a floor-raised user command dispatched the back panel raw while the automatic path on a floor-clamped cycle calibrated it — same logical intent, two different physical back-panel positions. On an inverse install the blackout went to wire 0 (physically OPEN) instead of 100, so it silently never deployed; under interpolation it went to raw 0 instead of the calibrated 20, outside the device's band.

The root condition is that one seam vocabulary was answering two different questions. Day/night's middle rail needs *"what frame is the incoming value in"*, because it derives from that value. The dual-panel back needs *"what frame should my absolute substitution be in"* — and `compute_layered` never reads `front` when computing `back`.

So I made the rule explicit: **a policy that discards the incoming position must also discard the incoming frame.** `DualPanelPolicy.resolve_entity_target` now always uses its own option-derived `_back_inverse`/`_back_interp` and ignores the caller's kwargs entirely, so no caller can defeat it. The kwargs stay for Liskov (`# noqa: ARG002`). No coordinator change, no seam-signature change.

This also cures a previously unreported instance of the same bug at the auto-control-off return seam (`switch.py:387`).

The `⚠️ Inverse State — DO NOT CHANGE` ordering is preserved exactly (calculate → invert → send). Only *which boolean* selects the invert step changed, never where the inversion sits relative to dispatch.

### Rejected alternatives

- **Pass the device frame unconditionally from the coordinator** — built and measured; it breaks day/night's middle rail on an inverse floor-clamped command (70 vs 20), the exact #993 regression.
- **A second frame pair / `DispatchFrame` dataclass** — solves by addition what is better solved by subtraction; touches six call sites plus the base hook.
- **A new sentinel for "value was untransformed"** — overloads a bool into a four-state enum, the same ambiguity that produced #1027 and this issue.

## Testing

- ✅ 8391 tests passing (8392 collected, 1 xfailed)
- Widened `tests/test_user_auto_dispatch_parity.py` with a floor axis, 32 → 64 cases, per the issue's scope note rather than adding a parallel file
- Added `test_floor_raised_user_command_keeps_the_back_panel_inverted` — names the physical consequence
- Added three broadcast-seam guards in `tests/test_dual_panel_dispatch.py` for the previously-unpinned auto-control-off, end-of-window and sunset paths
- Rewrote `test_explicit_inverted_kwarg_overrides_cache` → `test_back_wire_space_ignores_caller_frame`. Its `inverted=False` assertion **was this defect written as an expectation**, contradicting its own sibling class `TestResolveInverseIndependentOfClamp` (#996 Finding 1), and its stated premise is unreachable in production. Replaced, not deleted — the new test pins 4 caller-frame scenarios where the old pinned 2.

Every #996 and #993 guard stays green untouched, including `test_user_position_entity_target_frame_is_untransformed_when_floor_skips` — the coordinator does not change.

A pre-merge audit verified the new tests fail against pre-fix code (17 failures, exactly as predicted) by running them against a restored pre-fix method body, and confirmed a second plausible-but-wrong design (folding `floor_clamp_applied` into the cache day/night-style) is caught by 5 tests. The invariant is guarded from both directions.

## Related Issues

Refs #1035
Refs #996
Refs #1027

https://claude.ai/code/session_01PGkno6i4EknWK2RzJpnQoD