### PR TITLE
fix: make scripts/lint work from a linked worktree

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -4,10 +4,24 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-# Activate virtual environment
+# Activate the virtual environment. A linked worktree has no venv/ of its own,
+# so fall back to the main checkout's — git-common-dir points at the shared
+# .git directory, whose parent is the main working tree.
 if [[ -d "venv" ]]; then
     source venv/bin/activate
+else
+    main_checkout="$(dirname "$(git rev-parse --git-common-dir)")"
+    if [[ -d "$main_checkout/venv" ]]; then
+        source "$main_checkout/venv/bin/activate"
+    fi
 fi
+
+for tool in ruff black; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "$tool not found. Run ./scripts/setup, or activate a venv that has it." >&2
+        exit 1
+    fi
+done
 
 ruff check . --fix
 black .


### PR DESCRIPTION
## Summary

`scripts/lint` activates `venv/` relative to the repo root. A linked worktree has no `venv/` of its own, so that block was a no-op there and `ruff` was never on PATH.

The script did fail loudly (`set -e` gave exit 127), but `ruff: command not found` is a poor signal for "you are in a worktree", and there was no way to lint from one without hand-rolling the interpreter path.

I fall back to the main checkout's venv when the local one is absent, resolved from `git rev-parse --git-common-dir`'s parent rather than a hardcoded path, so it works for any worktree layout. Both tools are then checked up front, so a half-configured environment names the missing one instead of dying mid-run after `ruff --fix` has already rewritten files.

## Testing

- ✅ Runs clean from a linked worktree: `All checks passed!` / `483 files left unchanged`, exit 0.
- ✅ With the fallback path pointed at a nonexistent directory and a stripped PATH, exits 1 with `ruff not found. Run ./scripts/setup, or activate a venv that has it.`
- Behaviour in the main checkout is unchanged: local `venv/` still wins the first branch.

No production code touched.