### PR TITLE
fix: stop inferring position frame from provenance flags (#1036)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -3246,21 +3246,21 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # must stay deduped by the same-position gate (issue #290).
             user_command=True,
         )
-        # The floor raised the request, so ``clamped`` is a user-typed value
-        # that already lives in cover space — the same carve-out ``state``
-        # applies to a floor-clamped pipeline winner (#469).
-        skip_transforms = clamped != requested
+        # ``clamped`` is logical whether or not the floor raised it: the request
+        # is a logical user value and so is the configured floor, so the max()
+        # above never leaves that frame (#1036 — this used to skip the mapping
+        # on a raise, which dispatched the floor's raw number).
         target = self._entity_target(
             entity_id,
-            self._to_cover_frame(clamped, skip_transforms=skip_transforms),
+            self._to_cover_frame(clamped),
             # A user command runs the same transform as the main pipeline but
             # off-cycle, so the policy's cached per-cycle decision may describe
             # a different value's frame (#993). Name BOTH halves of the frame
             # this dispatch actually used: ``inverted`` alone cannot say
             # "interpolated, not inverted", and a remapping policy handed that
             # ambiguity drops the calibration curve entirely (#1027).
-            inverted=not skip_transforms and self.position_axis_inverted,
-            interpolated=not skip_transforms and self._use_interpolation,
+            inverted=self.position_axis_inverted,
+            interpolated=self._use_interpolation,
         )
         return await self._cmd_svc.apply_position(entity_id, target, trigger, ctx)
 
@@ -3634,7 +3634,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return False
         return self.position_axis_inverted
 
-    def _to_cover_frame(self, value: float, *, skip_transforms: bool = False) -> int:
+    def _to_cover_frame(self, value: float) -> int:
         """Map a logical (HA-convention) position into this cover's dispatch frame.
 
         The one place the position axis crosses from the frame every user-facing
@@ -3647,18 +3647,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         Interpolation and inverse-state are mutually exclusive by design — the
         combination is unsupported and logged — so a single ordered pass covers
-        both. ``skip_transforms`` reproduces the caller's own carve-out for a
-        value that is *already* in cover space (a safety-override or
-        floor-clamped pipeline winner, or a user request the floor raised);
-        see :attr:`state` and issue #469.
+        both. There is no escape hatch: every value that reaches here is
+        logical, so a caller cannot opt out of the mapping on the grounds that
+        some flag rode along with it (issue #1036 removed the ``skip_transforms``
+        carve-out both callers used to pass).
 
         Deliberately NOT shared with the end-of-window sender: that seam inverts
-        unconditionally of bypass/floor-clamp/interpolation and never
-        interpolates, which is a genuinely different transform (#993).
+        unconditionally of interpolation and never interpolates, which is a
+        genuinely different transform (#993).
         """
-        if skip_transforms:
-            return int(round(value))
-
         if self._use_interpolation:
             value = interpolate_position(
                 value,
@@ -3682,27 +3679,28 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     def state(self) -> int:
         """Final cover position after pipeline, interpolation, and inverse_state transforms.
 
-        The pipeline always runs so _pipeline_result is always set.  Safety
-        override handlers (ForceOverride, WeatherOverride) set
-        bypass_auto_control=True on their result, which causes their position
-        to be returned directly — bypassing interpolation and inverse_state —
-        even when automatic_control is OFF or outside the time window.
+        The pipeline always runs, so ``_pipeline_result`` is always set, and
+        :attr:`PipelineResult.position` is contractually a LOGICAL
+        (pre-inversion canonical) value for every winner — a handler holding a
+        raw cover read converts it before assigning the field
+        (``pipeline/types.py``; ``motion_timeout`` and ``group_lock`` both do).
+        So this boundary answers "what frame is this in?" from the type
+        contract, never from provenance, and maps every winner unconditionally.
 
-        Floor-clamped winners (issue #469): when the registry raises a
-        non-bypass winner's position to a user-configured floor, the
-        resulting value is already in cover-position space.  Interpolation
-        and inverse_state would re-map a user-typed floor through the
-        calibration curve and silently dispatch a different position, so
-        the same short-circuit applies.
+        Neither flag on the result says anything about the frame (issue #1036):
+
+        - ``bypass_auto_control`` governs GATE PRECEDENCE — the position is
+          applied even when Automatic Control is OFF and outside the start/end
+          window (issue #767). A safety close of logical 0 must still reach an
+          inverse cover as wire 100, or the safety override opens the cover.
+        - ``floor_clamp_applied`` records that a user-configured bound clamped
+          this winner, which drives reason labelling and forces the dispatch
+          through a hold (issues #534 / #809). A configured floor is a logical
+          value like any other, so it is calibrated and inverted like any other
+          — issue #469 skipped both transforms for it, which made a "minimum
+          25% open" floor drive an inverse cover to 75% open and made dispatch
+          non-monotonic in the logical request.
         """
-        # Safety overrides and floor-clamped winners both produce positions
-        # already in cover-position space — skip post-processing transforms.
-        if (
-            self._pipeline_bypasses_auto_control
-            or self._pipeline_result.floor_clamp_applied
-        ):
-            return self._pipeline_result.position
-
         return self._to_cover_frame(self._pipeline_result.position)
 
     # --- Toggle property delegates (switch entities use setattr) ---

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2193,9 +2193,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # ``held_position``. A motion hold describes the same physical
             # place in ``position``, converted to the logical frame so
             # ``coordinator.state`` can invert it back out — so flip it here
-            # rather than pushing the raw value onto ``held_position``, which
-            # is also the value the registry clamps a floor against and must
-            # stay comparable to the user's logical floor (#534 / #809).
+            # rather than pushing the raw value onto ``held_position``. That
+            # keeps every hold type's ``held_position`` in one frame, the
+            # cover's own (#534 / #809). The registry converts it to logical
+            # itself, at the one site that compares it against a floor (#1036).
             held = result.held_position
             if held is None:
                 held = (

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -596,19 +596,22 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
 
         The cached ``_dual_entity_inverse`` flag records whether inversion was
         ACTUALLY applied to the dispatched value this cycle — mirroring
-        ``coordinator.state`` exactly — not merely whether inverse-state is
-        configured. ``state`` returns ``result.position`` RAW (no inverse) on
-        the safety/bypass path, for a floor-clamped winner, and under
-        interpolation; if the middle-rail remap un-inverted a value that was
-        never inverted, it would drive the rail to the wrong physical position
-        (bottom raw 30 → middle physical 0 instead of fully open). Keeping the
-        flag in the dispatched value's OWN space is what preserves the physical
-        no-pass invariant regardless of inverse / bypass / clamp (#993).
+        ``coordinator.state`` exactly. If the middle-rail remap un-inverted a
+        value that was never inverted, it would drive the rail to the wrong
+        physical position (bottom raw 30 → middle physical 0 instead of fully
+        open). Keeping the flag in the dispatched value's OWN space is what
+        preserves the physical no-pass invariant (#993).
+
+        ``state`` now maps EVERY winner through ``_to_cover_frame``, so mirroring
+        it is exactly ``axis_inverted`` — the same predicate the coordinator's
+        own ``position_axis_inverted`` reads, which already folds in
+        interpolation's suppression of inverse-state. The bypass / floor-clamp
+        exclusion this used to carry described a dispatch carve-out that no
+        longer exists (#1036); the broadcast seams still dispatch in a divergent
+        space and still say so explicitly — see ``resolve_entity_target``.
         """
         self._dual_entity_blend = resolved.tilt
-        self._dual_entity_inverse = axis_inverted(self.axes[0], options) and not (
-            resolved.bypass_auto_control or resolved.floor_clamp_applied
-        )
+        self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
 
     def resolve_entity_target(
@@ -637,8 +640,8 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         ``_dual_entity_inverse`` (mirroring ``coordinator.state``) and passes
         ``None`` here to reuse it. The broadcast seams dispatch in a divergent
         space — the sunset/end-time loops invert iff inverse-state is CONFIGURED
-        (unconditional of bypass/floor-clamp/interp), the auto-off return loop
-        never inverts — so each passes its own explicit ``True``/``False``.
+        (unconditional of interpolation), the auto-off return loop never
+        inverts — so each passes its own explicit ``True``/``False``.
         Reusing the cached flag there would un-invert with the wrong assumption
         and cross the bottom rail physically (#993).
 

--- a/custom_components/adaptive_cover_pro/diagnostics/builder.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/builder.py
@@ -21,7 +21,6 @@ from ..const import (
     ReasonCode,
     SunState,
 )
-from ..managers.manual_override import inverse_state
 from ..reason_i18n import Reason, render
 
 # Sensor state classifications (issue #693, Q3).
@@ -452,17 +451,20 @@ class DiagnosticsBuilder:
     def _logical_position(ctx: DiagnosticContext) -> int:
         """Return the winner's position in the logical frame (issue #1028).
 
-        Mirrors ``coordinator.state``'s short-circuit: a bypass or floor-clamped
-        winner is returned to the cover verbatim, so on an inverted install its
-        position is a cover-frame value and must be flipped to become logical.
-        Every other winner's position is already logical.
+        ``PipelineResult.position`` is contractually logical for every winner —
+        ``coordinator.state`` maps all of them through ``_to_cover_frame`` on
+        the way to the wire — so this is the identity.
+
+        Kept as a named method rather than inlined: it is the single place that
+        states which frame ``linear_position`` publishes, and the guarantee it
+        carries (#1028) is unchanged. Until #1036 the guarantee was delivered by
+        un-flipping bypass / floor-clamped winners, because ``state`` handed
+        those to the cover verbatim; that un-flip was compensating for the
+        carve-out, not for a real frame difference, and went away with it.
         """
         result = ctx.pipeline_result
         if result is None:
             return 0
-        cover_frame = result.bypass_auto_control or result.floor_clamp_applied
-        if cover_frame and ctx.position_axis_inverted:
-            return inverse_state(result.position)
         return result.position
 
     @classmethod
@@ -477,12 +479,9 @@ class DiagnosticsBuilder:
         # interpolation maps it onto the motor curve.
         #
         # It equals the motor value ``coordinator.state`` publishes only when
-        # neither interpolation nor inverse-state is in play. Bypass and
-        # floor-clamped winners short-circuit ``coordinator.state``, so their
-        # position is already in the cover's frame — flip those back so the
-        # field's frame does not depend on which handler won. Under
-        # interpolation such a value passes through in the motor frame; mapping
-        # a motor value back onto the linear scale is #925's scope.
+        # neither interpolation nor inverse-state is in play. Every winner's
+        # position is logical regardless of which handler won (#1036), so the
+        # field's frame never depends on provenance.
         diagnostics["linear_position"] = cls._logical_position(ctx)
 
         if result is not None and result.climate_state is not None:

--- a/custom_components/adaptive_cover_pro/managers/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/__init__.py
@@ -2,7 +2,7 @@
 
 from .cover_command import CoverCommandService, PositionContext
 from .grace_period import GracePeriodManager
-from .manual_override import AdaptiveCoverManager, inverse_state
+from .manual_override import AdaptiveCoverManager, inverse_state, to_logical
 from .motion import MotionManager
 from .time_window import TimeWindowManager
 from .toggles import ToggleManager
@@ -16,4 +16,5 @@ __all__ = [
     "TimeWindowManager",
     "ToggleManager",
     "inverse_state",
+    "to_logical",
 ]

--- a/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
@@ -17,7 +17,7 @@ from .detector import (
     default_stop_to_my_decision,
     default_user_context_decision,
 )
-from .manager import AdaptiveCoverManager, inverse_state
+from .manager import AdaptiveCoverManager, inverse_state, to_logical
 from .position_delta import PositionDeltaDetector
 from .registry import DEFAULT_DETECTOR, DETECTOR_REGISTRY, get_detector
 from .secondary_axis import (
@@ -48,4 +48,5 @@ __all__ = [
     "get_detector",
     "inverse_state",
     "resolve_dispatched_secondary_expected",
+    "to_logical",
 ]

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -922,3 +922,21 @@ class AdaptiveCoverManager:
 def inverse_state(state: int) -> int:
     """Inverse state."""
     return 100 - state
+
+
+def to_logical(value: int, *, inverted: bool) -> int:
+    """Map a RAW cover-frame reading into the logical (pre-inversion) frame.
+
+    Single source of truth for the ``inverse_state(v) if inverted else v``
+    conditional (issue #1036). Every producer that reads a physical position off
+    an entity and then hands it to a logical-frame field needs exactly this:
+    ``PipelineResult.position`` is logical for every winner, so a handler
+    holding a raw read (``MotionTimeoutHandler``'s hold, ``GroupLockHandler``'s
+    freeze) must convert first, and the registry must convert before comparing a
+    held position against a user-configured bound.
+
+    Lives beside :func:`inverse_state` so the involution is written once — the
+    caller supplies the "is this axis inverted right now?" answer, which is
+    itself sourced from ``cover_types.base.axis_inverted``.
+    """
+    return inverse_state(value) if inverted else value

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
@@ -16,6 +16,7 @@ from ...const import (
     GroupIntentKind,
     ReasonCode,
 )
+from ...managers.manual_override import to_logical
 from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
@@ -41,13 +42,32 @@ class GroupLockHandler(OverrideHandler):
         if intent is None or intent.kind is not GroupIntentKind.LOCK:
             return None
         held = snapshot.current_cover_position
-        position = held if held is not None else snapshot.default_position
+        # ``held`` is a RAW cover-frame read, but ``PipelineResult.position`` is
+        # a logical-frame field: ``coordinator.state`` maps every winner through
+        # ``_to_cover_frame`` on the way out, so handing the raw value over
+        # would invert it a second time and publish a target that contradicts
+        # where the cover actually is (issue #1028 / #1036).
+        #
+        # ``bypass_auto_control=True`` below used to dodge that conversion by
+        # accident. That flag means "apply even when automatic control is OFF"
+        # — a statement about gate precedence, not about the number's frame —
+        # and it is set here because a group lock outranks the switch, exactly
+        # as ``motion_timeout`` explains for its own hold. Convert the frame
+        # instead and leave the flag alone. ``default_position`` is already
+        # logical, so only the entity read needs it.
+        if held is not None:
+            position = to_logical(held, inverted=snapshot.position_axis_inverted)
+            # The raw read stays in the reason payload / diagnostics, beside
+            # ``held_position`` — both describe where the cover physically is.
+            reported = held
+        else:
+            position = reported = snapshot.default_position
         return PipelineResult(
             position=position,
             control_method=ControlMethod.GROUP_LOCK,
             reason_payload=Reason(
                 ReasonCode.GROUP_LOCK,
-                {"group_id": intent.group_id, "position": position},
+                {"group_id": intent.group_id, "position": reported},
             ),
             raw_calculated_position=compute_raw_calculated_position(snapshot),
             held_position=held,

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ...const import ControlMethod, ReasonCode
-from ...managers.manual_override import inverse_state
+from ...managers.manual_override import to_logical
 from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_default_position, compute_raw_calculated_position
@@ -40,9 +40,9 @@ class MotionTimeoutHandler(OverrideHandler):
         ):
             held = snapshot.current_cover_position
             # ``held`` is a RAW cover-frame read, but ``PipelineResult.position``
-            # is a logical-frame field: ``coordinator.state`` inverts every
-            # non-bypass winner on the way out, so handing the raw value over
-            # would invert it a second time and publish a target that
+            # is a logical-frame field: ``coordinator.state`` maps every winner
+            # through ``_to_cover_frame`` on the way out, so handing the raw
+            # value over would invert it a second time and publish a target that
             # contradicts where the cover actually is (issue #1028).
             #
             # Setting ``bypass_auto_control=True`` would also dodge that
@@ -54,9 +54,7 @@ class MotionTimeoutHandler(OverrideHandler):
             # interpolation ``coordinator.state`` re-interpolates the held motor
             # read, so the published target still drifts. Pre-existing.
             return PipelineResult(
-                position=(
-                    inverse_state(held) if snapshot.position_axis_inverted else held
-                ),
+                position=to_logical(held, inverted=snapshot.position_axis_inverted),
                 control_method=ControlMethod.MOTION,
                 # The raw read stays in the reason payload / diagnostics.
                 reason_payload=Reason(ReasonCode.OCCUPANCY_HOLDING, {"held": held}),

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -8,6 +8,7 @@ import datetime as dt
 from ..const import AxisConstraintMode, ReasonCode
 from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
 from ..diagnostics.event_buffer import EventBuffer
+from ..managers.manual_override import to_logical
 from ..reason_i18n import Reason, render_en
 from .axis_constraints import (
     bound_label,
@@ -336,8 +337,18 @@ class PipelineRegistry:
         # so a bound must clamp against held_position when present (#534).
         # Every other handler leaves held_position=None, so this preserves the
         # existing behaviour exactly.
+        #
+        # ``held_position`` is a RAW cover-frame read, deliberately so — the
+        # coordinator publishes it as a cover-frame diagnostic extra, "one
+        # frame for every hold type" (#1028). The bounds it is compared against
+        # are logical (pre-inversion canonical) user values, so convert HERE,
+        # at the one site that does the comparing, rather than re-framing the
+        # field itself. Without this the registry asks "is 25%-open above
+        # 75%-open?" on an inverse install and answers wrong in both
+        # directions: a compliant cover held at logical 80 gets *lowered* to a
+        # logical-25 floor (#1036). A no-op on non-inverse installs.
         effective_winner_pos = (
-            winner.held_position
+            to_logical(winner.held_position, inverted=snapshot.position_axis_inverted)
             if winner.held_position is not None
             else winner.position
         )
@@ -386,6 +397,9 @@ class PipelineRegistry:
                 if position_binding is not None
                 else constraint_label(constraints, AXIS_NAME_POSITION)
             )
+            # Both endpoints are logical now that ``effective_winner_pos`` is
+            # converted above, so "floor raised from X% to Y%" no longer mixes a
+            # motor reading with a user-typed bound (#1036).
             params = {
                 "from_pos": effective_winner_pos,
                 "to_pos": final_pos,
@@ -586,9 +600,11 @@ class PipelineRegistry:
             # A position clamp must reach the cover even when the winner is a
             # hold (manual-override / motion): clear skip_command so the composed
             # result is dispatched, not suppressed (issue #809 / #534).
-            # floor_clamp_applied marks the position as already in cover space
-            # so the coordinator skips interpolation (#469) — true of a ceiling
-            # lower for the same reason it is true of a floor raise.
+            # floor_clamp_applied records only that a user-configured bound
+            # clamped this winner — a floor raise (#463) or a ceiling lower
+            # (#943) — which is what drives that forced dispatch and the reason
+            # labelling. It makes NO claim about the value's frame: the composed
+            # position is logical, exactly like the winner's own was (#1036).
             winner = dataclasses.replace(
                 winner,
                 position=clamped_position,

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -388,8 +388,9 @@ class PipelineSnapshot:
     # (inverse-state configured and not suppressed by interpolation, per
     # ``cover_types.base.axis_inverted``). A handler that puts a raw cover read
     # such as ``current_cover_position`` into ``PipelineResult.position`` must
-    # convert it to the logical frame first, because ``coordinator.state``
-    # inverts every non-bypass winner on the way out (issue #1028).
+    # convert it to the logical frame first (``managers.manual_override
+    # .to_logical``), because ``coordinator.state`` maps every winner through
+    # ``_to_cover_frame`` on the way out — no flag exempts one (#1028 / #1036).
     position_axis_inverted: bool = False
 
     # The CoverTypePolicy chosen at coordinator startup. Handlers should consult
@@ -540,10 +541,16 @@ class PipelineResult:
 
     # When True, the registry's axis-constraint composition pass clamped this
     # winner's position to a user-configured bound — a floor raise (issue #463)
-    # or, since issue #943, a ceiling lower. The coordinator's `state` property
-    # treats the position as already in cover-position space and skips
-    # interpolation / inverse-state remapping (issue #469); that holds for
-    # either bound, since both are values the user typed in cover space.
+    # or, since issue #943, a ceiling lower. Drives the reason/trace labelling
+    # and clears `skip_command` so the clamp still reaches a cover the winner
+    # was merely holding (issues #534 / #809).
+    #
+    # It makes NO claim about the value's frame: `position` stays logical, and
+    # `coordinator.state` interpolates/inverts a clamped winner exactly like any
+    # other (issue #1036 removed the #469 carve-out that skipped both). The name
+    # predates that and is due a rename to `position_constraint_applied` in a
+    # follow-up — it is a rename only, deliberately kept out of a
+    # behaviour-changing PR.
     floor_clamp_applied: bool = False
 
     # Composed tilt bounds that could not be applied during evaluation because

--- a/tests/test_coordinator_apply_user_position.py
+++ b/tests/test_coordinator_apply_user_position.py
@@ -777,13 +777,15 @@ async def test_user_position_inverse_with_interpolation_interpolates_only() -> N
 
 
 @pytest.mark.asyncio
-async def test_user_position_floor_clamped_dispatches_verbatim() -> None:
-    """A floor that actually raised the request dispatches verbatim (#469).
+async def test_user_position_floor_clamped_runs_the_frame_transform() -> None:
+    """A floor that raised the request still runs the frame transform (#1036).
 
-    ``coordinator.state`` short-circuits post-processing for a floor-clamped
-    winner because a user-typed floor is already a cover-frame number. The user
-    path must apply the identical carve-out, or the same configured floor would
-    dispatch differently on the two paths — #1027's own defect, in a corner.
+    The requirement is the one #469/#1027 actually needed: the same configured
+    floor must dispatch identically on the user and automatic paths. That now
+    holds because BOTH transform, not because both skip. A user-typed floor is a
+    logical value (0 = closed, 100 = open), so on an inverse install the raised
+    request of 25 reaches the cover as wire 75 — under the old carve-out it
+    dispatched 25, driving a "minimum 25% open" floor to 75% open.
     """
     coord, ctx = _make_coord(
         [_slot(25, is_on=True, min_mode=True, priority=82)],
@@ -793,7 +795,7 @@ async def test_user_position_floor_clamped_dispatches_verbatim() -> None:
     await coord.async_apply_user_position("cover.test", 10, trigger="set_position")
 
     coord._cmd_svc.apply_position.assert_awaited_once_with(
-        "cover.test", 25, "set_position", ctx
+        "cover.test", 75, "set_position", ctx
     )
 
 
@@ -851,20 +853,28 @@ async def test_user_position_routes_through_entity_target_with_explicit_frame(
 
 
 @pytest.mark.asyncio
-async def test_user_position_entity_target_frame_is_untransformed_when_floor_skips() -> (
+async def test_user_position_entity_target_frame_names_both_halves_after_a_floor_raise() -> (
     None
 ):
-    """A floor-skipped dispatch names the untransformed frame, never ``None``."""
+    """A floor-raised dispatch names both halves of its frame, never ``None``.
+
+    The requirement (#1027) is unchanged: the seam must state the frame the
+    value is actually in, and ``inverted`` alone cannot express "interpolated,
+    not inverted". What changed is the frame itself — a floor raise no longer
+    skips the transform (#1036), so with inverse + interpolation configured
+    (interpolation suppresses inversion) the raised 25 is calibrated to 45 and
+    the seam is told ``inverted=False, interpolated=True``.
+    """
     coord, _ctx = _make_coord(
         [_slot(25, is_on=True, min_mode=True, priority=82)],
         default_options={CONF_INVERSE_STATE: True, **_INTERP_OPTIONS},
     )
     policy = MagicMock()
-    policy.resolve_entity_target = MagicMock(return_value=25)
+    policy.resolve_entity_target = MagicMock(return_value=45)
     coord._policy = policy
 
     await coord.async_apply_user_position("cover.test", 10, trigger="set_position")
 
     policy.resolve_entity_target.assert_called_once_with(
-        "cover.test", 25, inverted=False, interpolated=False
+        "cover.test", 45, inverted=False, interpolated=True
     )

--- a/tests/test_day_night_deep_audit_fixes.py
+++ b/tests/test_day_night_deep_audit_fixes.py
@@ -276,28 +276,40 @@ def _cache_dual(
 
 
 class TestDualEntityInverseConsistency:
-    """The middle-rail remap tracks the ACTUAL dispatched space, not config."""
+    """The middle-rail remap tracks the ACTUAL dispatched space (#993).
+
+    Still the requirement; the derivation moved. ``coordinator.state`` maps
+    every winner through ``_to_cover_frame``, so the dispatched space is
+    "inverse configured AND interpolation off" for all of them — a bypass or
+    floor-clamp flag riding the result no longer changes it (#1036).
+    """
 
     def test_floor_clamp_summer_blackout_middle_opens_not_closes(self) -> None:
         # The audit's exact failure: inverse_state=True + a min-position floor
-        # clamp + summer solar (blend 0). coordinator.state returns the raw
-        # floor-clamped 30 (NO inverse applied). The middle rail must open fully
+        # clamp + summer solar (blend 0). The middle rail must open fully
         # (physical 100), NOT be slammed to physical 0.
+        #
+        # Re-derived for #1036: a floor-clamped winner's position is LOGICAL
+        # like every other winner, so coordinator.state dispatches
+        # inverse_state(30) rather than a raw 30. Feed the remap what state
+        # actually sends and assert the invariant in physical terms.
         policy = DayNightShadePolicy()
         # Reproduce the summer-solar blend-0 outcome deterministically via a
         # handler blend of 0 with the floor-clamp flag set + inverse configured.
         _cache_dual(policy, position=30, blend=0, inverse=True, floor_clamp=True)
-        middle = policy.resolve_entity_target(_MIDDLE, 30)
-        assert middle == 100
-        assert middle != 0
+        middle_wire = policy.resolve_entity_target(_MIDDLE, inverse_state(30))
+        assert inverse_state(middle_wire) == 100
+        assert inverse_state(middle_wire) != 0
 
     def test_bypass_slot_carrying_blend_uses_dispatched_space(self) -> None:
-        # A safety/bypass slot returns result.position RAW (no inverse). With
-        # inverse configured but bypassed, the remap must treat 40 as open-space.
+        # A safety/bypass slot's position is logical too (#1036), so the value
+        # that reaches the wire is inverse_state(40) = 60. The remap must
+        # un-invert it, compose in open-space, and re-invert.
         policy = DayNightShadePolicy()
         _cache_dual(policy, position=40, blend=50, inverse=True, bypass=True)
         # open-space: M = 100 - 50*(100-40)/100 = 70.
-        assert policy.resolve_entity_target(_MIDDLE, 40) == 70
+        middle_wire = policy.resolve_entity_target(_MIDDLE, inverse_state(40))
+        assert inverse_state(middle_wire) == 70
 
     @pytest.mark.parametrize("floor_clamp", [False, True])
     @pytest.mark.parametrize("bypass", [False, True])
@@ -315,9 +327,10 @@ class TestDualEntityInverseConsistency:
         blend: int,
     ) -> None:
         # Whatever the dispatched space, the middle rail must never physically
-        # pass below the bottom rail. Inversion is ACTUALLY applied only when
-        # inverse is on AND interpolation is off AND neither bypass nor floor
-        # clamp short-circuited coordinator.state.
+        # pass below the bottom rail. Inversion is ACTUALLY applied when inverse
+        # is on AND interpolation is off — the flags ride the result but no
+        # longer buy an exemption from the frame transform (#1036), so they must
+        # not appear in the derivation of "what space is the wire value in".
         policy = DayNightShadePolicy()
         _cache_dual(
             policy,
@@ -328,7 +341,7 @@ class TestDualEntityInverseConsistency:
             floor_clamp=floor_clamp,
             bypass=bypass,
         )
-        actually_inverted = inverse and not interp and not (floor_clamp or bypass)
+        actually_inverted = inverse and not interp
 
         def phys(v: int) -> int:
             return inverse_state(v) if actually_inverted else v
@@ -348,13 +361,18 @@ class TestBroadcastSeamInverseSpace:
     """
 
     def test_explicit_inverted_overrides_diverging_cached_flag(self) -> None:
-        # Cache the main-pipeline flag as False (floor-clamped inverse cycle),
-        # then dispatch a value the sunset/end-time seam produced in INVERTED
-        # space (wire 100 for logical 0). The seam passes inverted=True; the
-        # middle rail must un-invert 100 → open 0 → wire 0 (physically OPEN),
-        # NOT reuse the cached False.
+        # Cache the main-pipeline flag as False (a non-inverse cycle), then
+        # dispatch a value the sunset/end-time seam produced in INVERTED space
+        # (wire 100 for logical 0). The seam passes inverted=True; the middle
+        # rail must un-invert 100 → open 0 → wire 0 (physically OPEN), NOT
+        # reuse the cached False.
+        #
+        # The divergence used to be produced with a floor-clamped inverse cycle;
+        # #1036 removed that lever (the clamp no longer un-sets the cached
+        # flag), so it is produced from the config instead. The requirement is
+        # unchanged: an explicit seam-supplied ``inverted`` beats the cache.
         policy = DayNightShadePolicy()
-        _cache_dual(policy, position=30, blend=0, inverse=True, floor_clamp=True)
+        _cache_dual(policy, position=30, blend=0, inverse=False)
         assert policy._dual_entity_inverse is False  # cached main-path space
         wire = policy.resolve_entity_target(_MIDDLE, 100, inverted=True)
         assert inverse_state(wire) == 100  # open-space fully open

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -1863,12 +1863,15 @@ class TestLinearPosition:
     def test_bypass_winner_normalized_to_logical_under_inverse(
         self, builder: DiagnosticsBuilder
     ):
-        """A bypass winner carries a cover-frame value — publish it as logical.
+        """A bypass winner's position is already logical — publish it unchanged.
 
-        ``coordinator.state`` returns a bypass winner's position verbatim, so
-        on an inverted install that number is already in the cover's frame.
-        ``linear_position`` claims the logical frame, so it must be flipped
-        back (issue #1028).
+        The requirement is unchanged (#1028): ``linear_position`` publishes the
+        LOGICAL frame regardless of which handler won. What changed is what
+        delivers it. ``coordinator.state`` used to return a bypass winner's
+        position verbatim, so the builder had to flip it back; now ``state``
+        maps every winner through ``_to_cover_frame``, which means the winner's
+        position was logical all along and the un-flip was compensating for the
+        carve-out rather than for a real frame difference (#1036).
         """
         diag, _ = builder.build(
             _base_ctx(
@@ -1876,19 +1879,25 @@ class TestLinearPosition:
                 position_axis_inverted=True,
             )
         )
-        assert diag["linear_position"] == 90
+        assert diag["linear_position"] == 10
 
     def test_floor_clamp_winner_normalized_to_logical_under_inverse(
         self, builder: DiagnosticsBuilder
     ):
-        """Floor-clamped winners take the same short-circuit as bypass (#469)."""
+        """A floor-clamped winner is logical too — same guarantee, same identity.
+
+        A configured floor is a pre-inversion canonical value (0 = closed,
+        100 = open), so composing it onto ``PipelineResult.position`` keeps the
+        field logical. ``linear_position`` must publish the number the user
+        typed, not its cover-frame mirror (#1028 / #1036).
+        """
         diag, _ = builder.build(
             _base_ctx(
                 pipeline_result=_make_pr(position=25, floor_clamp_applied=True),
                 position_axis_inverted=True,
             )
         )
-        assert diag["linear_position"] == 75
+        assert diag["linear_position"] == 25
 
     def test_solar_winner_unchanged_under_inverse(self, builder: DiagnosticsBuilder):
         """An ordinary winner's position is already logical — never touch it."""

--- a/tests/test_display_rounding.py
+++ b/tests/test_display_rounding.py
@@ -105,8 +105,16 @@ class TestCoordinatorStateIntCoercion:
         )
 
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        pr = SimpleNamespace(position=0, bypass_auto_control=True)
+        pr = SimpleNamespace(
+            position=0, bypass_auto_control=True, floor_clamp_applied=False
+        )
         coord._pipeline_result = pr
+        # A safety winner runs the same frame transform as any other (#1036),
+        # so the fixture needs the same frame inputs as its sibling above.
+        coord._use_interpolation = False
+        coord._inverse_state = False
+        coord._policy = get_policy("cover_blind")
+        coord.config_entry = SimpleNamespace(options={})
 
         result = AdaptiveDataUpdateCoordinator.state.fget(coord)
         assert isinstance(result, int)

--- a/tests/test_inverse_state_integration.py
+++ b/tests/test_inverse_state_integration.py
@@ -5,7 +5,8 @@ Tests the full chain: pipeline position → coordinator.state property
 
 Covers:
 - Step 15: Solar position inverted (30% → 70%) when inverse_state=True
-- Step 16: Force override bypasses inverse state (safety handlers are exempt)
+- Step 16: Safety/bypass positions are logical too, so they invert like the rest
+  (``bypass_auto_control`` is a gate-precedence flag, not a frame claim — #1036)
 - Step 17: Open/close-only cover: threshold checked after inversion
 - Step 18: Interpolation + inverse_state → inverse NOT applied (conflict guard)
 """
@@ -158,18 +159,27 @@ class TestSolarPositionInverted:
 
 
 # ---------------------------------------------------------------------------
-# Step 16: Force override bypasses inverse state
+# Step 16: Safety/bypass positions are logical too (issue #1036)
 # ---------------------------------------------------------------------------
 
 
-class TestForceOverrideBypassesInverseState:
-    """Safety handlers (force/weather) bypass inverse state via bypass_auto_control."""
+class TestSafetyOverridePositionsAreLogical:
+    """``bypass_auto_control`` governs gate precedence, never the value's frame.
 
-    def test_force_override_position_not_inverted(self):
-        """ForceOverrideHandler result is returned as-is even with inverse_state=True.
+    Safety handlers (force/weather/priority-100 custom slots) set
+    ``bypass_auto_control=True`` so their position reaches the cover even when
+    Automatic Control is OFF and outside the time window (#767). That is the
+    requirement these tests still enforce. What they no longer claim — and what
+    issue #1036 removed — is that the flag also means "this number is already in
+    the cover's frame": ``PipelineResult.position`` is a logical, pre-inversion
+    value for every handler, so ``coordinator.state`` inverts it like any other.
+    """
 
-        Safety handlers set bypass_auto_control=True, causing coordinator.state
-        to return the pipeline position directly without post-processing transforms.
+    def test_force_override_position_is_inverted(self):
+        """A safety slot's logical 75 reaches an inverse cover as wire 25.
+
+        Before #1036 this dispatched 75, driving the cover to 25% open — the
+        opposite of what the user configured.
         """
         result = _make_pipeline_result(
             position=75,
@@ -180,11 +190,16 @@ class TestForceOverrideBypassesInverseState:
 
         state = AdaptiveDataUpdateCoordinator.state.fget(coord)
 
-        # 75% NOT inverted to 25% — safety bypasses all transforms
-        assert state == 75
+        assert state == 25
 
-    def test_weather_override_position_not_inverted(self):
-        """WeatherOverrideHandler result is also returned as-is."""
+    def test_weather_override_position_is_inverted(self):
+        """The headline case: a weather safety CLOSE must physically close the cover.
+
+        ``weather_override_position`` is a logical value (0 = closed). On an
+        inverse-state install the wire number for "closed" is 100. Before #1036
+        the bypass carve-out dispatched 0 — fully OPEN — during exactly the
+        conditions the safety override exists to protect against.
+        """
         result = _make_pipeline_result(
             position=0,
             control_method=ControlMethod.WEATHER,
@@ -194,11 +209,10 @@ class TestForceOverrideBypassesInverseState:
 
         state = AdaptiveDataUpdateCoordinator.state.fget(coord)
 
-        # 0% NOT inverted to 100% — safety bypasses transforms
-        assert state == 0
+        assert state == 100
 
-    def test_force_zero_percent_stays_zero(self):
-        """Force override to 0% stays 0% (not inverted to 100%)."""
+    def test_force_zero_percent_is_inverted_to_one_hundred(self):
+        """Force override to logical 0% dispatches wire 100% on an inverse cover."""
         result = _make_pipeline_result(
             position=0,
             control_method=ControlMethod.FORCE,
@@ -208,7 +222,7 @@ class TestForceOverrideBypassesInverseState:
 
         state = AdaptiveDataUpdateCoordinator.state.fget(coord)
 
-        assert state == 0
+        assert state == 100
 
     def test_non_safety_manual_position_IS_inverted(self):
         """ManualOverrideHandler does NOT set bypass_auto_control, so it IS inverted."""

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -645,6 +645,12 @@ def test_state_property_safety_custom_position_precedence():
     coordinator._use_interpolation = False
     coordinator._inverse_state = False
     coordinator.position_axis_inverted = False
+    # A safety winner runs the same frame transform as any other (#1036), so
+    # bind the real logical → cover-frame helper instead of letting the bare
+    # MagicMock intercept it.
+    coordinator._to_cover_frame = AdaptiveDataUpdateCoordinator._to_cover_frame.__get__(
+        coordinator
+    )
 
     type(coordinator).is_motion_timeout_active = property(lambda self: True)
 

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -998,3 +998,76 @@ def test_effective_floor_returns_winning_floor_priority() -> None:
     assert pos == 65
     assert info is not None
     assert info.priority == 82
+
+
+# ---------------------------------------------------------------------------
+# The frame a floor is compared IN (issue #1036)
+# ---------------------------------------------------------------------------
+
+
+class TestFloorComparesInLogicalFrame:
+    """A logical floor must be compared against a logical held position.
+
+    ``held_position`` is a RAW cover-frame read (``snapshot.current_cover_position``
+    straight off the entity), while a configured floor is a logical
+    pre-inversion value (``CustomPositionSensorState.position``). Comparing them
+    directly means that on an ``inverse_state`` install the registry asks
+    "is 25%-open above 75%-open?" — and answers wrong in both directions.
+
+    Both assertions are on the registry's own composed LOGICAL ``position``, with
+    no transform written into the assertion, so they cannot be satisfied by
+    restating the conversion.
+    """
+
+    @staticmethod
+    def _registry() -> PipelineRegistry:
+        return PipelineRegistry(
+            [
+                ManualOverrideHandler(),
+                _cp_handler(1, 25),
+                ClimateHandler(),
+                SolarHandler(),
+                DefaultHandler(),
+            ]
+        )
+
+    @staticmethod
+    def _snapshot(*, current_cover_position: int):
+        return make_snapshot(
+            manual_override_active=True,
+            current_cover_position=current_cover_position,
+            position_axis_inverted=True,
+            default_position=80,
+            custom_position_sensors=[
+                _cp_state(
+                    "binary_sensor.floor",
+                    is_on=True,
+                    position=25,
+                    min_mode=True,
+                    slot=1,
+                )
+            ],
+        )
+
+    def test_compliant_hold_is_not_lowered_by_the_floor(self) -> None:
+        """Raw 20 on an inverse cover IS logical 80 — already above a logical-25 floor.
+
+        Nothing should bind. Before #1036 the registry compared the logical floor
+        (25) against the raw read (20), called it a raise, and drove an
+        already-compliant cover from logical 80 down to logical 25.
+        """
+        result = self._registry().evaluate(self._snapshot(current_cover_position=20))
+
+        assert result.position == 80
+        assert result.floor_clamp_applied is False
+
+    def test_non_compliant_hold_is_still_raised_by_the_floor(self) -> None:
+        """Mirror case, so the fix cannot be "never clamp a held cover".
+
+        Raw 90 on an inverse cover is logical 10 — genuinely below the logical-25
+        floor — so the floor must bind and lift it to 25.
+        """
+        result = self._registry().evaluate(self._snapshot(current_cover_position=90))
+
+        assert result.position == 25
+        assert result.floor_clamp_applied is True

--- a/tests/test_pipeline/test_floor_dispatch_integration.py
+++ b/tests/test_pipeline/test_floor_dispatch_integration.py
@@ -1,19 +1,28 @@
-"""Integration tests for floor-clamp short-circuit in coordinator dispatch.
+"""The dispatch boundary reads the frame from the contract, not from provenance.
 
-Regression coverage for issue #469: when the pipeline registry's floor-clamp
-composition raises a non-bypass winner's position to a user-configured floor,
-the coordinator's ``state`` property must treat the resulting position as
-already in cover-position space and skip interpolation / inverse-state.
+Issue #1036 re-derives issue #469's guards. ``PipelineResult.position`` is
+contractually a LOGICAL (pre-inversion canonical) value for *every* winner —
+``pipeline/types.py`` says so at the field's definition site and requires any
+handler holding a raw cover read to convert it first. So
+``coordinator.state`` must never decide "which frame is this number in?" from
+provenance flags (``bypass_auto_control`` / ``floor_clamp_applied``): it maps
+every winner through :meth:`_to_cover_frame`, unconditionally.
 
-Pre-#469 behaviour applied interpolation and inverse_state to the
-floor-clamped position, so the dispatched cover command diverged from the
-``pipeline_evaluated`` event's reported position.
+#469's genuine requirement survives, asserted harder than before: **the
+dispatched value must be explicable from the reported one**. Equality was one
+way to get that; frame invariance — ``state == _to_cover_frame(position)`` for
+every winner shape in every frame — is strictly stronger, because it also rules
+out the non-monotonic dispatch curve the carve-out produced. Under #469's
+behaviour a "minimum 25% open" floor drove an inverse-state cover to 75% open,
+and a user asking for logical 10 landed further open than one asking for 30.
 """
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
@@ -24,7 +33,19 @@ from custom_components.adaptive_cover_pro.const import (
     ControlMethod,
 )
 from custom_components.adaptive_cover_pro.cover_types import get_policy
-from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
+    CustomPositionHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.default import (
+    DefaultHandler,
+)
+from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
+from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
+    PipelineResult,
+)
+
+from tests.test_pipeline.conftest import make_snapshot
 
 
 def _make_pipeline_result(
@@ -33,6 +54,7 @@ def _make_pipeline_result(
     control_method: ControlMethod = ControlMethod.DEFAULT,
     bypass_auto_control: bool = False,
     floor_clamp_applied: bool = False,
+    is_safety: bool = False,
 ) -> PipelineResult:
     return PipelineResult(
         position=position,
@@ -40,6 +62,7 @@ def _make_pipeline_result(
         reason="test",
         bypass_auto_control=bypass_auto_control,
         floor_clamp_applied=floor_clamp_applied,
+        is_safety=is_safety,
     )
 
 
@@ -85,35 +108,73 @@ def _make_coordinator(
     return coordinator
 
 
-# ---------------------------------------------------------------------------
-# Floor-clamp short-circuit (issue #469)
-# ---------------------------------------------------------------------------
+# A calibration curve with a visibly non-linear middle so an interpolated value
+# cannot coincide with its input by luck.
+_CURVE = {
+    "use_interpolation": True,
+    "normal_list": [0, 25, 58, 100],
+    "new_list": [0, 45, 58, 100],
+    "start_value": 0,
+    "end_value": 100,
+}
 
 
-def test_floor_clamped_non_bypass_winner_skips_interpolation():
-    """Floor-clamped position must not be remapped through interpolation."""
-    result = _make_pipeline_result(
-        position=25,
-        control_method=ControlMethod.DEFAULT,
-        bypass_auto_control=False,
-        floor_clamp_applied=True,
-    )
-    coord = _make_coordinator(
-        pipeline_result=result,
-        use_interpolation=True,
-        normal_list=[0, 25, 58, 100],
-        new_list=[0, 45, 58, 100],
-        start_value=0,
-        end_value=100,
-    )
+# ---------------------------------------------------------------------------
+# Frame invariance — the replacement for #469's carve-out guards
+# ---------------------------------------------------------------------------
+
+# Every shape a winner can reach the dispatch boundary in. The two flags each
+# still do real work (reason labelling, skip_command=False / forced dispatch,
+# the auto-control gate) — none of them says anything about the value's frame.
+_WINNER_SHAPES: dict[str, dict] = {
+    "plain": {},
+    "floor_clamped": {"floor_clamp_applied": True},
+    "bypass": {"bypass_auto_control": True},
+    "bypass+safety": {"bypass_auto_control": True, "is_safety": True},
+    "bypass+floor_clamped": {
+        "bypass_auto_control": True,
+        "floor_clamp_applied": True,
+    },
+}
+
+_FRAMES: dict[str, dict] = {
+    "plain": {},
+    "inverse": {"inverse_state_enabled": True},
+    "interpolated": dict(_CURVE),
+    "inverse+interpolated": {"inverse_state_enabled": True, **_CURVE},
+}
+
+
+@pytest.mark.parametrize("shape_name", sorted(_WINNER_SHAPES))
+@pytest.mark.parametrize("frame_name", sorted(_FRAMES))
+@pytest.mark.parametrize("position", [0, 25, 42, 58, 100])
+def test_state_equals_to_cover_frame_for_every_winner(
+    shape_name: str, frame_name: str, position: int
+) -> None:
+    """``state`` is ``_to_cover_frame(position)`` for every winner, in every frame.
+
+    The property #469 actually needed: the dispatched value must be explicable
+    from the reported one. Provenance flags cannot buy an exemption, because
+    ``PipelineResult.position`` is logical no matter which handler produced it
+    (#1036).
+    """
+    result = _make_pipeline_result(position=position, **_WINNER_SHAPES[shape_name])
+    coord = _make_coordinator(pipeline_result=result, **_FRAMES[frame_name])
 
     state = AdaptiveDataUpdateCoordinator.state.fget(coord)
 
-    assert state == 25
+    assert state == coord._to_cover_frame(result.position), (
+        f"{shape_name} / {frame_name} / logical {position}: "
+        f"state {state} is not the frame transform of the reported position"
+    )
 
 
-def test_floor_clamped_non_bypass_winner_skips_inverse_state():
-    """Floor-clamped position must not be inverted (100 - 25 = 75)."""
+def test_floor_clamped_winner_is_inverted_like_any_other() -> None:
+    """Concrete pin: a logical-25 floor on an inverse cover dispatches 75.
+
+    Under #469 this dispatched 25 — a "minimum 25% open" floor driving the
+    cover to 75% open.
+    """
     result = _make_pipeline_result(
         position=25,
         control_method=ControlMethod.DEFAULT,
@@ -128,7 +189,52 @@ def test_floor_clamped_non_bypass_winner_skips_inverse_state():
 
     state = AdaptiveDataUpdateCoordinator.state.fget(coord)
 
-    assert state == 25
+    assert state == 75
+
+
+def test_floor_clamped_winner_is_interpolated_like_any_other() -> None:
+    """Concrete pin: a floor is a *calculated* position, so it is calibrated.
+
+    ``interp_list`` is documented as "the theoretical positions the integration
+    calculates" and ``interp_list_new`` as "what actually gets sent" — a floor
+    composed onto ``PipelineResult.position`` is the former. Under #469 it
+    escaped the curve entirely.
+    """
+    result = _make_pipeline_result(
+        position=25,
+        control_method=ControlMethod.DEFAULT,
+        bypass_auto_control=False,
+        floor_clamp_applied=True,
+    )
+    coord = _make_coordinator(pipeline_result=result, **_CURVE)
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 45
+
+
+def test_bypass_winner_is_transformed_like_any_other() -> None:
+    """Concrete pin: a bypass winner is calibrated too (42 → 52 on this curve).
+
+    ``bypass_auto_control`` means "apply even when automatic control is OFF and
+    outside the time window" — a statement about gate precedence (#767), never
+    about the number's frame.
+    """
+    result = _make_pipeline_result(
+        position=42,
+        control_method=ControlMethod.FORCE,
+        bypass_auto_control=True,
+        floor_clamp_applied=False,
+    )
+    coord = _make_coordinator(
+        pipeline_result=result,
+        inverse_state_enabled=True,
+        **_CURVE,
+    )
+
+    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
+
+    assert state == 52
 
 
 def test_non_floor_winner_still_runs_interpolation():
@@ -172,24 +278,53 @@ def test_non_floor_winner_still_runs_inverse_state():
     assert state == 75
 
 
-def test_bypass_auto_control_still_short_circuits_independently_of_floor_flag():
-    """bypass_auto_control short-circuit works regardless of floor flag value."""
-    result = _make_pipeline_result(
-        position=42,
-        control_method=ControlMethod.FORCE,
-        bypass_auto_control=True,
-        floor_clamp_applied=False,
-    )
-    coord = _make_coordinator(
-        pipeline_result=result,
-        use_interpolation=True,
-        inverse_state_enabled=True,
-        normal_list=[0, 25, 58, 100],
-        new_list=[0, 45, 58, 100],
-        start_value=0,
-        end_value=100,
+# ---------------------------------------------------------------------------
+# Monotonicity — the property that generalises past specific numbers
+# ---------------------------------------------------------------------------
+
+_FLOOR = 25
+
+
+def _min_mode_slot(position: int) -> CustomPositionSensorState:
+    return CustomPositionSensorState(
+        entity_ids=("binary_sensor.floor",),
+        is_on=True,
+        position=position,
+        priority=90,
+        min_mode=True,
+        use_my=False,
+        slot=1,
+        active_entity_ids=("binary_sensor.floor",),
     )
 
-    state = AdaptiveDataUpdateCoordinator.state.fget(coord)
 
-    assert state == 42
+@pytest.mark.parametrize("frame_name", sorted(_FRAMES))
+def test_dispatch_is_monotone_in_the_logical_request(frame_name: str) -> None:
+    """Sweeping the logical request with an active floor yields a monotone curve.
+
+    Built through the REAL ``PipelineRegistry`` so composition and dispatch are
+    both exercised — a hand-set ``floor_clamp_applied`` would only test half of
+    it. Under #469 the inverse-state curve was
+    ``[25, 25, 25, 75, 74, 70, ..., 0]``: asking for logical 10 opened the cover
+    further than asking for logical 30. No restatement of any transform can
+    satisfy monotonicity; only a single consistent frame can.
+    """
+    registry = PipelineRegistry(
+        [
+            CustomPositionHandler(slot=1, position=_FLOOR, priority=90),
+            DefaultHandler(),
+        ]
+    )
+    curve: list[int] = []
+    for logical in range(0, 101, 5):
+        snapshot = make_snapshot(
+            default_position=logical,
+            custom_position_sensors=[_min_mode_slot(_FLOOR)],
+        )
+        result = registry.evaluate(snapshot)
+        coord = _make_coordinator(pipeline_result=result, **_FRAMES[frame_name])
+        curve.append(AdaptiveDataUpdateCoordinator.state.fget(coord))
+
+    assert curve == sorted(curve) or curve == sorted(
+        curve, reverse=True
+    ), f"{frame_name}: non-monotonic dispatch curve {curve}"

--- a/tests/test_pipeline/test_group_handlers.py
+++ b/tests/test_pipeline/test_group_handlers.py
@@ -165,6 +165,38 @@ def test_lock_handler_freezes_in_place() -> None:
     assert GROUP_ID in result.reason
 
 
+def test_lock_handler_publishes_a_logical_position_on_an_inverse_install() -> None:
+    """The raw hold read is converted before it lands in ``position`` (#1036).
+
+    ``current_cover_position`` is a RAW cover-frame read but
+    ``PipelineResult.position`` is a logical-frame field — ``coordinator.state``
+    maps every winner through ``_to_cover_frame`` on the way out, so handing the
+    raw value over would invert it a second time and publish a target that
+    contradicts where the cover actually is (``pipeline/types.py``, and the
+    ``motion_timeout`` handler's identical conversion).
+
+    Setting ``bypass_auto_control=True`` used to dodge that inversion by
+    accident; that flag means "apply even when automatic control is OFF", not
+    "this number is already in the cover's frame". The raw read stays available
+    in ``held_position`` and in the reason payload.
+    """
+    handler = GroupLockHandler()
+    snapshot = make_snapshot(
+        group_intent=_lock_intent(),
+        current_cover_position=20,
+        position_axis_inverted=True,
+    )
+
+    result = handler.evaluate(snapshot)
+
+    assert result is not None
+    assert result.position == 80
+    # The cover-frame read is preserved where a cover-frame read belongs.
+    assert result.held_position == 20
+    assert result.reason_payload is not None
+    assert result.reason_payload.params["position"] == 20
+
+
 def test_lock_handler_without_readable_position_uses_default() -> None:
     handler = GroupLockHandler()
     snapshot = make_snapshot(

--- a/tests/test_user_auto_dispatch_parity.py
+++ b/tests/test_user_auto_dispatch_parity.py
@@ -45,6 +45,7 @@ from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
 )
 from custom_components.adaptive_cover_pro.cover_types.dual_panel import DualPanelPolicy
 from custom_components.adaptive_cover_pro.pipeline.types import (
+    CustomPositionSensorState,
     DecisionStep,
     PipelineResult,
 )
@@ -70,6 +71,40 @@ _FRAMES: dict[str, dict] = {
     "interpolated": dict(_INTERP_OPTIONS),
     "inverse+interpolated": {CONF_INVERSE_STATE: True, **_INTERP_OPTIONS},
 }
+
+
+# A min-mode floor high enough to bind on part of the logical sweep and not on
+# the rest, so the parametrisation exercises both the clamped and the inert
+# branch. Priority 90 is load-bearing: ``async_apply_user_position`` only lets a
+# floor clamp a user move when it strictly outranks manual override (#472).
+_FLOOR = 60
+_FLOOR_PRIORITY = 90
+
+
+def _floor_slot() -> CustomPositionSensorState:
+    return CustomPositionSensorState(
+        entity_ids=("binary_sensor.floor",),
+        is_on=True,
+        position=_FLOOR,
+        priority=_FLOOR_PRIORITY,
+        min_mode=True,
+        use_my=False,
+        slot=1,
+        active_entity_ids=("binary_sensor.floor",),
+    )
+
+
+def _composed(logical: int, floor_clamped: bool) -> tuple[int, bool]:
+    """Compose what the registry's axis-constraint pass puts on the winner.
+
+    Returns ``(position, floor_clamp_applied)``. The flag is DERIVED — it is
+    only True when the floor actually binds — because forcing it on for the
+    whole sweep would exercise a shape the registry never produces.
+    """
+    if not floor_clamped:
+        return logical, False
+    raised = max(logical, _FLOOR)
+    return raised, raised != logical
 
 
 def _sunset_cover(sunset_valid: bool) -> MagicMock:
@@ -102,18 +137,22 @@ def _prime(policy, result: PipelineResult, options: dict, cover) -> None:
     )
 
 
-def _dual_panel_case(frame_options: dict, logical: int):
+def _dual_panel_case(frame_options: dict, logical: int, floor_clamped: bool):
     """Real dual-panel policy + options + the entities to compare."""
     options = {
         CONF_DUAL_PANEL_FRONT_ENTITY: _FRONT,
         CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["night"],
         **frame_options,
     }
+    position, clamped = _composed(logical, floor_clamped)
     policy = DualPanelPolicy()
     _prime(
         policy,
         PipelineResult(
-            position=logical, control_method=ControlMethod.SOLAR, reason="solar"
+            position=position,
+            control_method=ControlMethod.SOLAR,
+            reason="solar",
+            floor_clamp_applied=clamped,
         ),
         options,
         _sunset_cover(False),
@@ -121,21 +160,23 @@ def _dual_panel_case(frame_options: dict, logical: int):
     return policy, options, (_FRONT, _BACK), CoverType.DUAL_PANEL
 
 
-def _day_night_case(frame_options: dict, logical: int):
+def _day_night_case(frame_options: dict, logical: int, floor_clamped: bool):
     """Real Model C day/night policy + options + the entities to compare."""
     options = {
         CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
         CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _MIDDLE,
         **frame_options,
     }
+    position, clamped = _composed(logical, floor_clamped)
     policy = DayNightShadePolicy()
     _prime(
         policy,
         PipelineResult(
-            position=logical,
+            position=position,
             control_method=ControlMethod.CUSTOM_POSITION,
             reason="custom",
             tilt=50,
+            floor_clamp_applied=clamped,
         ),
         options,
         None,
@@ -149,7 +190,9 @@ _CASES = {
 }
 
 
-def _make_coord(policy, options: dict, cover_type: str, logical: int):
+def _make_coord(
+    policy, options: dict, cover_type: str, logical: int, floor_clamped: bool = False
+):
     """Coordinator-shaped mock carrying a real policy and real frame inputs."""
     from tests.test_pipeline.conftest import make_snapshot
 
@@ -166,7 +209,11 @@ def _make_coord(policy, options: dict, cover_type: str, logical: int):
     coord._resolved_options = options
 
     coord._snapshot_builder = MagicMock()
-    coord._snapshot_builder.build = MagicMock(return_value=make_snapshot())
+    coord._snapshot_builder.build = MagicMock(
+        return_value=make_snapshot(
+            custom_position_sensors=[_floor_slot()] if floor_clamped else []
+        )
+    )
     coord._cover_data = MagicMock(name="cover_data")
     coord._cover_type = cover_type
     coord._weather_readings = None
@@ -178,14 +225,18 @@ def _make_coord(policy, options: dict, cover_type: str, logical: int):
     coord._cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))
 
     # Solar winner at priority 40 — below manual override, so a user command
-    # reaches dispatch instead of being preempted.
+    # reaches dispatch instead of being preempted. When the sweep asks for a
+    # floor-clamped axis the winner carries what the registry's constraint pass
+    # would have composed onto it (#1036).
+    position, clamped = _composed(logical, floor_clamped)
     winner = PipelineResult(
-        position=logical,
+        position=position,
         control_method=ControlMethod.SOLAR,
         reason="solar",
+        floor_clamp_applied=clamped,
         decision_trace=[
             DecisionStep(
-                handler="solar", matched=True, reason="solar", position=logical
+                handler="solar", matched=True, reason="solar", position=position
             )
         ],
     )
@@ -223,8 +274,9 @@ def _auto_target(coord, entity_id: str) -> int:
 @pytest.mark.parametrize("case_name", sorted(_CASES))
 @pytest.mark.parametrize("frame_name", sorted(_FRAMES))
 @pytest.mark.parametrize("logical", [0, 30, 50, 100])
+@pytest.mark.parametrize("floor_clamped", [False, True])
 async def test_user_and_auto_paths_resolve_identical_entity_targets(
-    case_name: str, frame_name: str, logical: int
+    case_name: str, frame_name: str, logical: int, floor_clamped: bool
 ) -> None:
     """Same logical value, same wire target — on every entity, in every frame.
 
@@ -233,17 +285,24 @@ async def test_user_and_auto_paths_resolve_identical_entity_targets(
     into the broadcast-seam branch and skipped the back panel's calibration
     entirely (auto 20, user 0 for a deployed blackout). Parity is the property
     that was actually broken; assert the property.
+
+    The ``floor_clamped`` axis (#1035's Scope note, #1036) widens the sweep onto
+    a winner an active min-mode floor raised. Both paths used to *skip* the
+    frame transform in that case, and skipped it differently — the automatic
+    seam reused a per-cycle cached flag that ignores the clamp, the user seam
+    hard-named ``inverted=False, interpolated=False``.
     """
     policy, options, entities, cover_type = _CASES[case_name](
-        _FRAMES[frame_name], logical
+        _FRAMES[frame_name], logical, floor_clamped
     )
-    coord = _make_coord(policy, options, cover_type, logical)
+    coord = _make_coord(policy, options, cover_type, logical, floor_clamped)
 
     for entity_id in entities:
         auto = _auto_target(coord, entity_id)
         user = await _user_target(coord, entity_id, logical)
         assert user == auto, (
-            f"{case_name} / {frame_name} / logical {logical}: "
+            f"{case_name} / {frame_name} / logical {logical} / "
+            f"floor_clamped={floor_clamped}: "
             f"{entity_id} auto target {auto} != user target {user}"
         )
 
@@ -259,7 +318,9 @@ async def test_interpolating_dual_panel_user_command_calibrates_the_back_panel()
     hardware, and driving the blackout panel to 0 puts it outside its
     calibrated band (#996 Finding 5).
     """
-    policy, options, _entities, cover_type = _dual_panel_case(dict(_INTERP_OPTIONS), 30)
+    policy, options, _entities, cover_type = _dual_panel_case(
+        dict(_INTERP_OPTIONS), 30, False
+    )
     coord = _make_coord(policy, options, cover_type, 30)
 
     assert await _user_target(coord, _BACK, 30) == 20


### PR DESCRIPTION
## Summary

`coordinator.state` decided "is this value already in the cover's frame?" from provenance flags (`bypass_auto_control`, `floor_clamp_applied`) rather than from any statement about the value's frame. But `PipelineResult.position` is contractually logical for every winner (`pipeline/types.py:383-393`), so both branches of that carve-out were wrong.

On an inverse-state or calibrated install that meant:

- a configured "minimum 25% open" floor dispatched its raw number and opened the cover to **75%**
- a weather safety **close** of logical 0 dispatched wire 0, i.e. fully **open**
- dispatch was non-monotonic in the logical request: asking for logical 10 opened the cover further than asking for 30

```
logical  0  10  24 | 25  26  30  50 100
dispatch 25  25  25 | 75  74  70  50   0   <- before
```

This deletes the frame carve-out at the dispatch boundary (both halves), removes `_to_cover_frame`'s `skip_transforms` escape hatch and the user-path mirror #1033 shipped, fixes `pipeline/registry.py` comparing a logical floor against a raw cover-frame `held_position`, fixes `GroupLockHandler` publishing a raw read into a logical field, and collapses the remaining mirrors in `diagnostics/builder._logical_position` and `day_night_shade._dual_entity_inverse`.

Both flags survive with their real jobs: reason labelling, `skip_command=False` forced dispatch (#534/#809), and the auto-control gate (#767). Only their frame use is gone.

### Which frame do configured floors live in?

Logical (pre-inversion canonical). Four independent in-tree declarations already said so: the type comment on `CustomPositionSensorState.position`, the `PipelineResult.position` contract, `axis_constraints.py` / `floors.py`, and the config-flow help text in `en.json`, which is byte-identical to the `default_percentage` / `sunset_position` carry.

### This reverses shipped behaviour from #469, deliberately

#469's carve-out was compensating for an observability gap, not a positioning bug. Its reporter ran interpolation with no `inverse_state`, and the reported divergence was two events naming two frames without saying which. #1028 already fixed that class. #469's genuine requirement, that the dispatched value be explicable from the reported value, survives as a strictly stronger frame-invariance property (`state == _to_cover_frame(position)`).

## ⚠️ User-visible behaviour change

Covers on inverse-state or calibrated installs will move to **different physical places** than they do today, because today's places are wrong. Anyone who compensated by typing a pre-inverted floor, or a pre-inverted `weather_override_position`, will see it flip. Priority-100 `use_my` slots on inverse installs now invert `my_position_value` through `state`, consistent with #1027. Same compatibility class #1027 already accepted; needs a release-note callout.

**No config migration.** Stored floor values already meant what the config flow says; only the dispatch code disagreed. `VERSION` stays 3, `MINOR_VERSION` stays 11, `async_migrate_entry` untouched. Rollback-safe.

## Scope notes

**`group_lock` is in scope on purpose.** `GroupLockHandler` was putting a raw cover read straight into `PipelineResult.position`; the bypass carve-out made that accidentally correct. Shipping the carve-out removal without this would introduce a diagnostics regression on inverse installs with group locks. Harm was bounded (`skip_command=True`, so no cover command was emitted) but it reached `would_be_position`, `final_state`, the resolved-target signature and the decision-trace sensor.

**This does not close #1035.** It subsumes #1035's floor-raise half (its stated cause at `coordinator.py:3262-3263` is deleted here), but the residual stays open: the end-of-window and sunset broadcast seams name their frame explicitly while the main cycle uses the cached decision, pinned by the #996 guards.

**Deliberately deferred**, filed as follow-ups: #1041 (the day/night seam sweep lost its diverging-cache lever and is now degenerate in two tests, requirement still guarded elsewhere) and #1042 (give the frame converters a pure home, and rename `floor_clamp_applied` to `position_constraint_applied` now that the name implies a frame claim it no longer makes).

## Testing

- ✅ 8494 tests passing (1 pre-existing xfail, `test_night_blackout_deploys_outside_operating_window`, #996 Finding 4)

Baseline before this branch was 8355 passing. The +139 are the new guards:

- **frame invariance** across every winner shape x frame, replacing #469's three carve-out guards
- **monotonicity sweep** over logical 0..100 on all four frames, built through the real `PipelineRegistry`
- **floor-vs-held comparison** asserted in logical units, both directions
- **weather safety close** of logical 0 dispatching wire 100 on an inverse cover
- **`group_lock` frame** coverage, which did not exist at all
- a **floor-clamped axis** widening the #1027 parity sweep, as #1035's scope note asked

Twelve guards were rewritten rather than deleted; each still enforces its original requirement. Reviewed pre-merge by a deep audit that independently re-ran the new guards against pre-fix source to confirm they catch the defect.

## Related Issues

Refs #1036