### PR TITLE
feat: add Apply Calculated Position button (#1045)

### DIFF
--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -53,6 +53,11 @@ async def async_setup_entry(
                     config_entry.entry_id, hass, config_entry, coordinator
                 )
             )
+        buttons.append(
+            AdaptiveCoverApplyCalculatedPositionButton(
+                config_entry.entry_id, hass, config_entry, coordinator
+            )
+        )
 
     async_add_entities(buttons)
 
@@ -123,3 +128,34 @@ class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):
                 force=False,
                 use_my_position=True,
             )
+
+
+class AdaptiveCoverApplyCalculatedPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):
+    """Button that force-applies the calculated position (issue #1045).
+
+    Recomputes the pipeline position and dispatches it past the
+    ``delta_position`` / ``delta_time`` gates.  The full guard policy lives on
+    the coordinator (``async_force_apply_calculated_position``) so this stays a
+    one-liner and no cover-type knowledge leaks into the button platform.
+    """
+
+    _attr_translation_key = "apply_calculated_position"
+
+    def __init__(
+        self,
+        entry_id: str,
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        coordinator: AdaptiveDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the button."""
+        super().__init__(entry_id, hass, config_entry, coordinator)
+        self._attr_unique_id = f"{entry_id}_apply_calculated_position"
+
+    async def async_press(self) -> None:
+        """Recompute and force-send the calculated position to every cover.
+
+        No entity list is passed: the coordinator resolves ``self.entities``
+        live, so covers added after this entity was constructed are included.
+        """
+        await self.coordinator.async_force_apply_calculated_position()

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -315,6 +315,9 @@ TRIGGER_PROXY_TILT = "proxy_tilt"
 # Cover-group aggregate cover entity commands (issue #790, Phase 3).
 TRIGGER_GROUP_COVER = "group_cover"
 TRIGGER_GROUP_COVER_TILT = "group_cover_tilt"
+# Apply Calculated Position button (issue #1045): force-dispatch this cycle's
+# pipeline position past the delta_position / delta_time gates.
+TRIGGER_FORCE_APPLY_CALCULATED = "force_apply_calculated"
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -110,6 +110,7 @@ from .const import (
     LOGGER,
     POSITION_TOLERANCE_PERCENT,
     STARTUP_GRACE_PERIOD_SECONDS,
+    TRIGGER_FORCE_APPLY_CALCULATED,
 )
 from .diagnostics.builder import DiagnosticContext, DiagnosticsBuilder
 from .diagnostics.event_buffer import EventBuffer
@@ -2335,7 +2336,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Time-window and automatic-control gates live in the shared send
         # path, along with force=True so time_delta/position_delta are
         # bypassed for this intentional reset.
-        sent = await self._async_send_after_override_clear(
+        sent = await self._async_force_send_pipeline_position(
             self.state,
             self.config_entry.options,
             entities=reset_entities,
@@ -2354,21 +2355,69 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self._cmd_svc.set_waiting(entity, False)
         return reset_entities
 
-    async def _async_send_after_override_clear(
+    async def async_force_apply_calculated_position(
+        self,
+        entities: list[str] | None = None,
+        *,
+        trigger: str = TRIGGER_FORCE_APPLY_CALCULATED,
+    ) -> set[str]:
+        """Recompute and force-dispatch the calculated position (issue #1045).
+
+        Backs the Apply Calculated Position button.  An explicit user press is a
+        user command, so this bypasses the ``delta_position`` / ``delta_time``
+        gates, the Automatic Control gate (the #430 My Position precedent) and
+        the clock window.  It does NOT bypass the master kill switch, the
+        cover-unavailable boundary (#342) or the same-position / relay-click
+        short-circuit (#290/#507/#567/#779), and it leaves covers under a live
+        manual override alone — the dedicated Reset Manual Override button is
+        the surface for those.
+
+        The auto-control bypass rides ``bypass_auto_control``, never
+        ``is_safety`` — an ``is_safety`` target would be resent by
+        reconciliation outside the time window (#215/#216).
+
+        Args:
+            entities: Covers to target.  ``None`` (the button's value) resolves
+                ``self.entities`` live inside the shared helper.
+            trigger: Reason string recorded against the command.
+
+        Returns:
+            Set of entity_ids that were successfully sent to.
+
+        """
+        # Recompute first so the forced position reflects current conditions
+        # rather than a stale cached state (mirrors async_reset_manual_overrides).
+        await self.async_refresh()
+
+        return await self._async_force_send_pipeline_position(
+            self.state,
+            self.config_entry.options,
+            entities=entities,
+            trigger=trigger,
+            bypass_auto_control=True,
+            respect_manual_override=True,
+            ignore_clock_window=True,
+        )
+
+    async def _async_force_send_pipeline_position(
         self,
         state: int,
         options: dict,
         *,
         entities: list[str] | None = None,
         trigger: str = "manual_override_cleared",
+        bypass_auto_control: bool = False,
+        respect_manual_override: bool = False,
+        ignore_clock_window: bool = False,
     ) -> set[str]:
-        """Send the pipeline position after a manual override clears.
+        """Force-send this cycle's pipeline position, past the delta/time gates.
 
-        Single authoritative path for both the auto-expiry timer and the reset
-        button.  All gate checks live here so neither caller needs to duplicate
-        them.
+        Single authoritative force-dispatch path.  All gate checks live here so
+        no caller needs to duplicate them.  ``force=True`` bypasses the position
+        delta, time delta and manual-override gates; ``is_safety=False`` keeps
+        the target from persisting across window boundaries (#223).
 
-        **Time-window guard:** Outside the active-hours window the integration
+        **Clock-window guard:** Outside the active-hours window the integration
         has no business repositioning covers.  The normal update cycle sends the
         correct position when the window reopens.
 
@@ -2376,7 +2425,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         must stay wherever the user left it.
 
         Args:
-            state: Post-reset pipeline position (computed without the override).
+            state: Pipeline position to send.
             options: Config entry options dict.
             entities: Covers to target.  Defaults to ``self.entities`` (all
                 covers), but the reset button supplies only the covers it just
@@ -2385,6 +2434,26 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 in ``last_skipped_action``.  Defaults to
                 ``"manual_override_cleared"`` (auto-expiry); the reset button
                 passes ``"manual_reset"``.
+            bypass_auto_control: If True, skip the Automatic-Control guard AND
+                set ``bypass_auto_control`` on the built ``PositionContext``.
+                The two must move together — skipping only this guard would
+                leave ``apply_position`` refusing the command with
+                ``auto_control_off``.  Never reach the bypass via
+                ``is_safety=True``: that also tags the target so reconciliation
+                resends it outside the window (#215/#216).
+            respect_manual_override: If True, drop covers under a live manual
+                override from the target list *before* dispatch.  Necessary
+                because ``force=True`` disables the manual-override gate inside
+                ``apply_position`` (#1022/#654).
+            ignore_clock_window: If True, skip the clock-window guard and
+                dispatch outside the active-hours window.
+
+        Every one of the three flags above defaults to ``False``, which
+        reproduces the pre-existing behaviour of the two override-clear callers
+        (``async_reset_manual_overrides`` and the auto-expiry branch in
+        ``_dispatch_for_cycle``, which passes ``entities=None``) bit-for-bit.
+        Only ``async_force_apply_calculated_position`` — the Apply Calculated
+        Position button, issue #1045 — sets all three True.
 
         Returns:
             Set of entity_ids that were successfully sent to (``"sent"``
@@ -2394,9 +2463,25 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """
         target_covers = entities if entities is not None else list(self.entities)
 
-        if not self.clock_window_open:
+        if respect_manual_override:
+            # Pre-filter rather than lean on the manual-override gate inside
+            # apply_position — ``force=True`` disables that gate, so a cover
+            # under a live override would be commanded straight through
+            # (#1022/#654).
+            kept: list[str] = []
+            for cover in target_covers:
+                if self.manager.is_cover_manual(cover):
+                    self.logger.debug(
+                        "Force-send: skipping position command for %s (manual override active/restored)",
+                        cover,
+                    )
+                    continue
+                kept.append(cover)
+            target_covers = kept
+
+        if not ignore_clock_window and not self.clock_window_open:
             self.logger.debug(
-                "Manual override cleared for %s but outside the clock window — "
+                "Force-send requested for %s but outside the clock window — "
                 "skipping reposition (pipeline position was %s; will apply when "
                 "window opens)",
                 target_covers,
@@ -2404,9 +2489,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             )
             return set()
 
-        if not self.automatic_control:
+        if not bypass_auto_control and not self.automatic_control:
             self.logger.debug(
-                "Manual override cleared for %s but automatic control is OFF — "
+                "Force-send requested for %s but automatic control is OFF — "
                 "skipping reposition (pipeline position was %s)",
                 target_covers,
                 state,
@@ -2414,7 +2499,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return set()
 
         self.logger.debug(
-            "Sending pipeline position %s after manual override cleared for %s",
+            "Force-sending pipeline position %s to %s",
             state,
             target_covers,
         )
@@ -2422,7 +2507,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         sent: set[str] = set()
         for cover in target_covers:
             ctx = self._build_position_context(
-                cover, options, force=True, sun_just_appeared=sun_just_appeared
+                cover,
+                options,
+                force=True,
+                bypass_auto_control=bypass_auto_control,
+                sun_just_appeared=sun_just_appeared,
             )
             outcome, _ = await self._cmd_svc.apply_position(
                 cover, self._entity_target(cover, state), trigger, context=ctx
@@ -2498,7 +2587,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # One or more manual overrides just timed out.  Proactively send
             # the fresh pipeline position so covers don't linger at the
             # user-moved position until the next solar/entity-state event.
-            await self._async_send_after_override_clear(state, options)
+            await self._async_force_send_pipeline_position(state, options)
         elif target_changed:
             # No state_change edge this cycle, but the resolved target moved
             # since the last dispatch — send it through the same path.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -239,6 +239,13 @@ _HOLD_SKIP_LABEL: dict[ControlMethod, str] = {
     ControlMethod.MANUAL: "manual_override_hold",
 }
 
+# Skip-record label written when a cover is left alone because a manual
+# override is live.  Mirrors the reason code the manual-override gate inside
+# ``CoverCommandService.apply_position`` emits on the normal (non-forced) path,
+# so a cover pre-filtered out of a forced dispatch renders identically in
+# ``last_skipped_action``, diagnostics and the Lovelace card.
+_MANUAL_OVERRIDE_SKIP_LABEL = "manual_override"
+
 
 class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     """Adaptive cover data update coordinator."""
@@ -2178,7 +2185,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         didn't move; the label reflects the winning control method (motion_hold
         vs manual_override_hold — issue #809). All other callers (forced
         transitions, override clears, window events) bypass this helper and call
-        apply_position directly so they are never blocked by hold mode.
+        apply_position directly so they are never blocked by hold mode — the
+        one exception being the Apply Calculated Position button (#1045), which
+        opts back in via ``_async_force_send_pipeline_position(honor_holds=True)``.
         """
         if self._pipeline_result is not None and self._pipeline_result.skip_command:
             result = self._pipeline_result
@@ -2370,7 +2379,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         cover-unavailable boundary (#342) or the same-position / relay-click
         short-circuit (#290/#507/#567/#779), and it leaves covers under a live
         manual override alone — the dedicated Reset Manual Override button is
-        the surface for those.
+        the surface for those.  A pre-filtered cover still gets a
+        ``manual_override`` skip record so diagnostics say why it stayed put.
+
+        **Pipeline holds are honoured.**  When the winning handler emits
+        ``skip_command`` — a live group lock (which outranks every handler,
+        weather included), a motion ``hold_position``, or a manual-override
+        hold — that cover is skipped and a hold-skip record is written instead
+        of a command.  A held result's position is
+        ``snapshot.current_cover_position``, the arithmetic mean of the
+        instance's covers, so dispatching it would break the hold *and* send a
+        number that is nobody's calculated position.
 
         The auto-control bypass rides ``bypass_auto_control``, never
         ``is_safety`` — an ``is_safety`` target would be resent by
@@ -2397,6 +2416,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             bypass_auto_control=True,
             respect_manual_override=True,
             ignore_clock_window=True,
+            honor_holds=True,
         )
 
     async def _async_force_send_pipeline_position(
@@ -2409,6 +2429,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         bypass_auto_control: bool = False,
         respect_manual_override: bool = False,
         ignore_clock_window: bool = False,
+        honor_holds: bool = False,
     ) -> set[str]:
         """Force-send this cycle's pipeline position, past the delta/time gates.
 
@@ -2447,13 +2468,25 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 ``apply_position`` (#1022/#654).
             ignore_clock_window: If True, skip the clock-window guard and
                 dispatch outside the active-hours window.
+            honor_holds: If True, route each dispatch through
+                ``_dispatch_to_cover`` so a pipeline hold (``skip_command`` —
+                group lock, motion hold_position, manual-override hold) is
+                honoured: no command is sent and a hold-skip record is written
+                instead.  Necessary because a held result's ``position`` is
+                ``snapshot.current_cover_position``, i.e. the arithmetic MEAN
+                of every cover's position on a multi-cover instance — sending
+                it would both break the hold and drive each cover to a number
+                that is not its calculated position.  The default ``False``
+                reproduces the documented forced-transition behaviour: forced
+                transitions, override clears and window events call
+                ``apply_position`` directly and are never blocked by hold mode.
 
-        Every one of the three flags above defaults to ``False``, which
+        Every one of the four flags above defaults to ``False``, which
         reproduces the pre-existing behaviour of the two override-clear callers
         (``async_reset_manual_overrides`` and the auto-expiry branch in
         ``_dispatch_for_cycle``, which passes ``entities=None``) bit-for-bit.
         Only ``async_force_apply_calculated_position`` — the Apply Calculated
-        Position button, issue #1045 — sets all three True.
+        Position button, issue #1045 — sets all four True.
 
         Returns:
             Set of entity_ids that were successfully sent to (``"sent"``
@@ -2474,6 +2507,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     self.logger.debug(
                         "Force-send: skipping position command for %s (manual override active/restored)",
                         cover,
+                    )
+                    # Leave the same diagnostic trace the manual-override gate
+                    # inside apply_position writes on the normal path, so
+                    # last_skipped_action / diagnostics / the Lovelace card
+                    # explain why this cover did not move.  A silent `continue`
+                    # makes the button look broken for that cover.
+                    self._cmd_svc.record_skipped_action(
+                        cover,
+                        _MANUAL_OVERRIDE_SKIP_LABEL,
+                        state,
+                        trigger=trigger,
+                        current_position=self._cmd_svc.get_current_position(cover),
+                        inverse_state=self._inverse_state,
                     )
                     continue
                 kept.append(cover)
@@ -2513,10 +2559,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 bypass_auto_control=bypass_auto_control,
                 sun_just_appeared=sun_just_appeared,
             )
-            outcome, _ = await self._cmd_svc.apply_position(
-                cover, self._entity_target(cover, state), trigger, context=ctx
-            )
-            if outcome == "sent":
+            if honor_holds:
+                # Returns None when the cover is held — no command, hold-skip
+                # record already written.  Unpack defensively so a held cover
+                # simply never joins ``sent``.
+                result = await self._dispatch_to_cover(cover, state, trigger, ctx)
+            else:
+                result = await self._cmd_svc.apply_position(
+                    cover, self._entity_target(cover, state), trigger, context=ctx
+                )
+            if result is not None and result[0] == "sent":
                 sent.add(cover)
         return sent
 

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -246,6 +246,27 @@ _HOLD_SKIP_LABEL: dict[ControlMethod, str] = {
 # ``last_skipped_action``, diagnostics and the Lovelace card.
 _MANUAL_OVERRIDE_SKIP_LABEL = "manual_override"
 
+# Control methods whose held ``PipelineResult.position`` is the INSTANCE MEAN
+# rather than any cover's calculated target — that, and only that, is why
+# ``_async_force_send_pipeline_position(honor_holds=True)`` routes through
+# ``_dispatch_to_cover``.  Both derive their position from
+# ``snapshot.current_cover_position`` (``pipeline/handlers/group_lock.py:43``,
+# ``pipeline/handlers/motion_timeout.py:40``), which on a multi-cover instance
+# is the arithmetic mean of every bound cover.  Dispatching it would break the
+# hold AND drive each cover to a number that is nobody's position.
+#
+# ``ControlMethod.MANUAL`` is deliberately NOT a member and must not be added.
+# The manual-override handler's position is ``compute_solar_position`` /
+# ``compute_default_position`` (``pipeline/handlers/manual_override.py:39,:51``)
+# — the genuine calculated position — so the mean hazard does not exist for it.
+# Its hold is also instance-wide (it fires on ``snapshot.manual_override_active``,
+# i.e. *any* cover is manual) while the ``respect_manual_override`` pre-filter is
+# per-cover: honouring it would suppress every cover on the instance, including
+# the ones the pre-filter deliberately kept.  The pre-filter owns MANUAL.
+_INSTANCE_MEAN_POSITION_HOLDS: frozenset[ControlMethod] = frozenset(
+    {ControlMethod.GROUP_LOCK, ControlMethod.MOTION}
+)
+
 
 class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     """Adaptive cover data update coordinator."""
@@ -2187,7 +2208,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         transitions, override clears, window events) bypass this helper and call
         apply_position directly so they are never blocked by hold mode — the
         one exception being the Apply Calculated Position button (#1045), which
-        opts back in via ``_async_force_send_pipeline_position(honor_holds=True)``.
+        opts back in via ``_async_force_send_pipeline_position(honor_holds=True)``
+        and is routed here only for the ``_INSTANCE_MEAN_POSITION_HOLDS``
+        winners, never for a manual-override hold.
         """
         if self._pipeline_result is not None and self._pipeline_result.skip_command:
             result = self._pipeline_result
@@ -2379,17 +2402,25 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         cover-unavailable boundary (#342) or the same-position / relay-click
         short-circuit (#290/#507/#567/#779), and it leaves covers under a live
         manual override alone — the dedicated Reset Manual Override button is
-        the surface for those.  A pre-filtered cover still gets a
-        ``manual_override`` skip record so diagnostics say why it stayed put.
+        the surface for those.  That exclusion is strictly **per cover**: on a
+        multi-cover instance one overridden cover does not stop the press from
+        moving the rest.  A pre-filtered cover still gets a ``manual_override``
+        skip record so diagnostics say why it stayed put.
 
-        **Pipeline holds are honoured.**  When the winning handler emits
-        ``skip_command`` — a live group lock (which outranks every handler,
-        weather included), a motion ``hold_position``, or a manual-override
-        hold — that cover is skipped and a hold-skip record is written instead
-        of a command.  A held result's position is
-        ``snapshot.current_cover_position``, the arithmetic mean of the
+        **The mean-position pipeline holds are honoured.**  When a live group
+        lock (which outranks every handler, weather included) or a motion
+        ``hold_position`` wins, every remaining cover is skipped and a hold-skip
+        record is written instead of a command: those two winners' ``position``
+        is ``snapshot.current_cover_position``, the arithmetic mean of the
         instance's covers, so dispatching it would break the hold *and* send a
         number that is nobody's calculated position.
+
+        A **manual-override hold** is deliberately NOT honoured here, and that
+        is not an oversight — see ``_INSTANCE_MEAN_POSITION_HOLDS``.  Its
+        ``position`` is the genuine calculated position, and its ``skip_command``
+        is instance-wide (it fires when *any* cover is manual), so honouring it
+        would cancel the press for the covers the per-cover pre-filter above
+        deliberately kept.
 
         The auto-control bypass rides ``bypass_auto_control``, never
         ``is_safety`` — an ``is_safety`` target would be resent by
@@ -2468,18 +2499,25 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 ``apply_position`` (#1022/#654).
             ignore_clock_window: If True, skip the clock-window guard and
                 dispatch outside the active-hours window.
-            honor_holds: If True, route each dispatch through
-                ``_dispatch_to_cover`` so a pipeline hold (``skip_command`` —
-                group lock, motion hold_position, manual-override hold) is
-                honoured: no command is sent and a hold-skip record is written
-                instead.  Necessary because a held result's ``position`` is
-                ``snapshot.current_cover_position``, i.e. the arithmetic MEAN
-                of every cover's position on a multi-cover instance — sending
-                it would both break the hold and drive each cover to a number
-                that is not its calculated position.  The default ``False``
-                reproduces the documented forced-transition behaviour: forced
-                transitions, override clears and window events call
-                ``apply_position`` directly and are never blocked by hold mode.
+            honor_holds: If True, route dispatch through ``_dispatch_to_cover``
+                — but ONLY when this cycle's winning control method is one of
+                ``_INSTANCE_MEAN_POSITION_HOLDS`` (group lock, motion
+                hold_position).  Those two are exactly the winners whose
+                ``position`` is ``snapshot.current_cover_position``, i.e. the
+                arithmetic MEAN of every cover's position on a multi-cover
+                instance; sending it would both break the hold and drive each
+                cover to a number that is not its calculated position, so the
+                cover is skipped and a hold-skip record written instead.
+                Any other winner — a MANUAL hold above all, whose position is
+                the genuine calculated one and whose hold is instance-wide
+                while ``respect_manual_override`` is per-cover — takes the
+                direct ``apply_position`` path even under this flag, so a
+                partial manual override cannot neutralise the whole instance.
+                No pipeline result yet (``None``) likewise means nothing to
+                honour.  The default ``False`` reproduces the documented
+                forced-transition behaviour: forced transitions, override
+                clears and window events call ``apply_position`` directly and
+                are never blocked by hold mode.
 
         Every one of the four flags above defaults to ``False``, which
         reproduces the pre-existing behaviour of the two override-clear callers
@@ -2549,6 +2587,20 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             state,
             target_covers,
         )
+        # ``honor_holds`` applies only to the holds whose position is the
+        # instance mean — see ``_INSTANCE_MEAN_POSITION_HOLDS``.  Every other
+        # winner (notably a MANUAL hold, whose position IS the calculated one
+        # and whose hold is instance-wide while the pre-filter above is
+        # per-cover) takes the direct path, so the covers the pre-filter kept
+        # still move.  Decided once: the pipeline result is instance-wide, and
+        # ``None`` (no result computed yet) simply means no hold to honour.
+        pipeline_result = self._pipeline_result
+        route_via_hold_seam = (
+            honor_holds
+            and pipeline_result is not None
+            and pipeline_result.control_method in _INSTANCE_MEAN_POSITION_HOLDS
+        )
+
         sun_just_appeared = self._check_sun_validity_transition()
         sent: set[str] = set()
         for cover in target_covers:
@@ -2559,7 +2611,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 bypass_auto_control=bypass_auto_control,
                 sun_just_appeared=sun_just_appeared,
             )
-            if honor_holds:
+            if route_via_hold_seam:
                 # Returns None when the cover is held — no command, hold-skip
                 # record already written.  Unpack defensively so a held cover
                 # simply never joins ``sent``.

--- a/custom_components/adaptive_cover_pro/icons.json
+++ b/custom_components/adaptive_cover_pro/icons.json
@@ -29,6 +29,9 @@
     "button": {
       "reset_manual_override": {
         "default": "mdi:hand-back-left-off"
+      },
+      "apply_calculated_position": {
+        "default": "mdi:target-variant"
       }
     },
     "sensor": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1188,6 +1188,9 @@
       "my_position": {
         "name": "Verwaltete My-Position"
       },
+      "apply_calculated_position": {
+        "name": "Berechnete Position anwenden"
+      },
       "group_scene_all_open": {
         "name": "Szene: Alle offen"
       },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1188,6 +1188,9 @@
       "my_position": {
         "name": "Managed My Position"
       },
+      "apply_calculated_position": {
+        "name": "Apply Calculated Position"
+      },
       "group_scene_all_open": {
         "name": "Scene: All Open"
       },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1188,6 +1188,9 @@
       "my_position": {
         "name": "Position My gérée"
       },
+      "apply_calculated_position": {
+        "name": "Appliquer la position calculée"
+      },
       "group_scene_all_open": {
         "name": "Scène : Tous ouverts"
       },

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -111,6 +111,9 @@ def _base_coord() -> AdaptiveDataUpdateCoordinator:
     coord.automatic_control = False
     coord.entities = [MagicMock()]
     coord._group_intents = {}
+    # object.__new__ skips __init__, which seeds this to None. The hold-aware
+    # dispatch seam reads it, so a bare mock coordinator must carry it too.
+    coord._pipeline_result = None
 
     cmd_svc = MagicMock()
     cmd_svc.apply_position = AsyncMock(return_value=("sent", ""))

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -214,7 +214,26 @@ async def _trigger_manual_override_expiry(coord):
     coord._time_mgr = MagicMock()
     coord._time_mgr.is_active = True  # inside time window
     coord._check_sun_validity_transition = MagicMock(return_value=False)
-    await coord._async_send_after_override_clear(50, {})
+    await coord._async_force_send_pipeline_position(50, {})
+
+
+async def _trigger_force_apply_calculated_position(coord):
+    """Trigger: the Apply Calculated Position button is pressed (issue #1045).
+
+    An explicit press is a user command, so it bypasses the auto_control gate
+    via ``bypass_auto_control=True`` — never ``is_safety=True``, which would
+    tag the target and have reconciliation resend it outside the window
+    (#215/#216).
+    """
+    from unittest.mock import patch as _patch  # noqa: PLC0415
+
+    coord.async_refresh = AsyncMock()
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {}
+    coord._time_mgr = MagicMock()
+    coord._check_sun_validity_transition = MagicMock(return_value=False)
+    with _patch.object(AdaptiveDataUpdateCoordinator, "state", new_callable=lambda: 50):
+        await coord.async_force_apply_calculated_position()
 
 
 async def _trigger_state_change_safety_custom_position(coord):
@@ -538,6 +557,18 @@ CONTROL_GATE_MATRIX: list[MatrixCase] = [
         setup=lambda _: None,
         trigger=_trigger_async_apply_user_position,
     ),
+    MatrixCase(
+        # Issue #1045: the Apply Calculated Position button. An explicit press
+        # is a user command, so it rides bypass_auto_control=True through the
+        # auto_control gate with force=True for the delta gates — but the
+        # target is NOT safety-tagged, so reconciliation will not resend it
+        # outside the time window (#215/#216).
+        id="force_apply_calculated_position",
+        is_safety_bypass=True,
+        is_safety_target=False,
+        setup=lambda _: None,
+        trigger=_trigger_force_apply_calculated_position,
+    ),
 ]
 
 
@@ -589,7 +620,7 @@ async def test_auto_control_gate(case: MatrixCase):
         assert not forced, (
             f"[{case.id}] Non-bypass path called apply_position(context.force=True) "
             f"with automatic_control=False — add an automatic_control gate before the "
-            f"apply_position call (see _async_send_after_override_clear for the pattern). "
+            f"apply_position call (see _async_force_send_pipeline_position for the pattern). "
             f"Offending calls: {forced}"
         )
 

--- a/tests/test_force_apply_allowlist.py
+++ b/tests/test_force_apply_allowlist.py
@@ -34,7 +34,7 @@ or with auto_control=OFF".  Only genuine safety handlers (ForceOverride,
 WeatherOverride) should set this True.
 
 Transitional paths that need to bypass gates for a one-shot send (e.g.
-``_async_send_after_override_clear``) use ``force=True, is_safety=False`` (the
+``_async_force_send_pipeline_position``) use ``force=True, is_safety=False`` (the
 default) — they get through the gates but do not persist as safety targets.
 This decoupling was introduced in the fix for issue #223.
 
@@ -44,7 +44,7 @@ How to respond when this test fails
 2. Decide: does this path bypass ``automatic_control`` intentionally?
    - **Non-bypass (gated):** Add an ``automatic_control`` early-return guard
      *before* the ``_build_position_context`` call (see
-     ``_async_send_after_override_clear`` for the pattern).
+     ``_async_force_send_pipeline_position`` for the pattern).
    - **Intentional bypass:** Decide whether it is a safety target (ForceOverride,
      Weather) or a transitional one-shot (override clear, force_released).
      Transitional paths use the default ``is_safety=False``.
@@ -70,8 +70,8 @@ import pytest
 ALLOWED_LITERAL_FORCE_TRUE_SITES: frozenset[str] = frozenset(
     {
         # Manual-override expiry path. Gated by automatic_control before the call.
-        # See coordinator.py::_async_send_after_override_clear, line ~1140.
-        "_async_send_after_override_clear",
+        # See coordinator.py::_async_force_send_pipeline_position, line ~1140.
+        "_async_force_send_pipeline_position",
         # _on_window_closed removed: it now uses force=False so the end-time
         # target is not safety-tagged.  See issue #215/#216 fix.
         # User-initiated single entry point (set_position service + opt-in

--- a/tests/test_issue_1045_force_apply_button.py
+++ b/tests/test_issue_1045_force_apply_button.py
@@ -537,8 +537,20 @@ async def test_press_still_deduped_by_same_position_gate():
 # ---------------------------------------------------------------------------
 
 
-def _make_hold_coordinator(*, positions: dict[str, int], control_method, state: int):
-    """Real CoverCommandService + a hold-mode (skip_command) pipeline result."""
+def _make_hold_coordinator(
+    *,
+    positions: dict[str, int],
+    control_method,
+    state: int,
+    manual_covers=(),
+):
+    """Real CoverCommandService + a hold-mode (skip_command) pipeline result.
+
+    ``manual_covers`` puts one or more of the instance's covers under a live
+    manual override so the per-cover ``respect_manual_override`` pre-filter and
+    the instance-wide hold can be exercised together — the intersection that
+    neither the pre-filter tests nor the hold tests reached on their own.
+    """
     hass = MagicMock()
     hass.services.async_call = AsyncMock()
     state_obj = MagicMock()
@@ -559,7 +571,9 @@ def _make_hold_coordinator(*, positions: dict[str, int], control_method, state: 
     svc.apply_position = AsyncMock(wraps=svc.apply_position)
     svc.record_skipped_action = MagicMock(wraps=svc.record_skipped_action)
 
-    coordinator = _make_apply_coordinator(entities=list(positions))
+    coordinator = _make_apply_coordinator(
+        entities=list(positions), manual_covers=manual_covers
+    )
     coordinator.state = state
     coordinator._cmd_svc = svc
     coordinator.min_change = 2
@@ -576,7 +590,10 @@ def _make_hold_coordinator(*, positions: dict[str, int], control_method, state: 
 
 
 async def _press_raw(coordinator):
-    """Press the button with the real service wired, no apply_position spy."""
+    """Press the button with the real service wired, no apply_position spy.
+
+    Returns the set of entity_ids the press actually sent to.
+    """
     with (
         _patch_caps(),
         patch(
@@ -584,7 +601,7 @@ async def _press_raw(coordinator):
             return_value=dt.datetime(2020, 1, 1, tzinfo=dt.UTC),
         ),
     ):
-        await _apply(coordinator)
+        return await _apply(coordinator)
 
 
 @pytest.mark.asyncio
@@ -629,6 +646,71 @@ async def test_press_honors_motion_hold():
         "motion_hold",
         "motion_hold",
     ]
+
+
+@pytest.mark.asyncio
+async def test_press_moves_unheld_covers_under_partial_manual_override():
+    """A manual hold on ONE cover must not neutralise the press for the others.
+
+    ``ManualOverrideHandler`` fires on ``snapshot.manual_override_active``,
+    which is ``any(cover is manual)`` — so its ``skip_command`` hold is
+    instance-wide while the ``respect_manual_override`` pre-filter is per-cover.
+    Honouring that hold would suppress every cover on the instance, including
+    the ones the pre-filter deliberately kept.
+
+    The mean hazard that justifies ``honor_holds`` does not exist here: a manual
+    hold's ``position`` is ``compute_solar_position`` / ``compute_default_position``
+    (the genuine calculated position), not ``snapshot.current_cover_position``.
+    """
+    coordinator, svc, hass = _make_hold_coordinator(
+        positions={"cover.a": 20, "cover.b": 80},
+        control_method=const.ControlMethod.MANUAL,
+        state=65,
+        manual_covers=("cover.a",),
+    )
+
+    sent = await _press_raw(coordinator)
+
+    assert sent == {"cover.b"}
+    svc.apply_position.assert_called_once()
+    assert svc.apply_position.call_args.args[0] == "cover.b"
+    # The calculated position — not the 50 that averaging 20 and 80 would give.
+    assert svc.apply_position.call_args.args[1] == 65
+    hass.services.async_call.assert_awaited_once()
+    service_data = hass.services.async_call.await_args.args[2]
+    assert service_data["entity_id"] == "cover.b"
+    assert service_data["position"] == 65
+    # cover.a stays put, and says why — the pre-filter's own record, not a hold.
+    assert [
+        (call.args[0], call.args[1])
+        for call in svc.record_skipped_action.call_args_list
+    ] == [("cover.a", "manual_override")]
+
+
+@pytest.mark.asyncio
+async def test_press_still_honors_group_lock_with_a_manual_cover_present():
+    """Narrowing the hold set must not re-open the mean bug when both apply.
+
+    A group lock outranks the manual-override handler, so GROUP_LOCK is still
+    the winner even with a cover under a live override. The press must send
+    nothing: cover.a is pre-filtered, cover.b is held.
+    """
+    coordinator, svc, hass = _make_hold_coordinator(
+        positions={"cover.a": 20, "cover.b": 80},
+        control_method=const.ControlMethod.GROUP_LOCK,
+        state=50,
+        manual_covers=("cover.a",),
+    )
+
+    sent = await _press_raw(coordinator)
+
+    assert sent == set()
+    svc.apply_position.assert_not_called()
+    hass.services.async_call.assert_not_awaited()
+    assert [
+        (call.args[0], call.args[1])
+        for call in svc.record_skipped_action.call_args_list
+    ] == [("cover.a", "manual_override"), ("cover.b", "hold")]
 
 
 @pytest.mark.asyncio

--- a/tests/test_issue_1045_force_apply_button.py
+++ b/tests/test_issue_1045_force_apply_button.py
@@ -1,0 +1,609 @@
+"""Tests for issue #1045: Apply Calculated Position button.
+
+A per-config-entry button that recomputes the pipeline position and
+force-dispatches it past the ``delta_position`` / ``delta_time`` gates.
+
+What it bypasses
+----------------
+* ``delta_position`` and ``delta_time`` (via the existing ``PositionContext.force``)
+* the ``auto_control`` gate — an explicit press is a user command (#430 precedent),
+  reached via ``bypass_auto_control``, never ``is_safety`` (which would tag the
+  target and regress #215/#216)
+* the clock window — same argument as ``auto_control``
+
+What it must NOT bypass
+-----------------------
+* the ``_enabled`` master kill switch
+* the cover-unavailable boundary (#342)
+* the same-position / relay-click short-circuit (#290/#507/#567/#779)
+
+It also skips covers under a live manual override, pre-filtering them rather
+than leaning on the manual-override gate that ``force=True`` disables.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro import const
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+    PositionContext,
+)
+
+# ---------------------------------------------------------------------------
+# Harness — mirrors tests/test_reset_button_time_window.py::_make_coordinator
+# ---------------------------------------------------------------------------
+
+
+def _make_coordinator(
+    *,
+    automatic_control=True,
+    clock_window_open=True,
+    entities=None,
+    manual_covers=(),
+):
+    """Minimal coordinator mock for _async_force_send_pipeline_position tests."""
+    coordinator = MagicMock()
+    coordinator.clock_window_open = clock_window_open
+    coordinator.automatic_control = automatic_control
+    coordinator.entities = list(entities) if entities is not None else ["cover.test"]
+    coordinator.logger = MagicMock()
+    coordinator._check_sun_validity_transition.return_value = False
+    coordinator.manager.is_cover_manual.side_effect = (
+        lambda cover: cover in manual_covers
+    )
+    coordinator._build_position_context.return_value = PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=2,
+        time_threshold=2,
+        special_positions=[0, 100],
+        inverse_state=False,
+        force=True,
+    )
+    coordinator._cmd_svc.apply_position = AsyncMock(
+        return_value=("sent", "set_cover_position")
+    )
+    # The per-entity dispatch seam is identity for a blind (no rail remap).
+    coordinator._entity_target = lambda cover, state: state
+    return coordinator
+
+
+def _force_send(coordinator, state=50, options=None, **kwargs):
+    """Invoke the unbound shared force-dispatch helper."""
+    return AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
+        coordinator, state, {} if options is None else options, **kwargs
+    )
+
+
+def _context_entities(coordinator) -> list[str]:
+    """Entity ids that _build_position_context was called for."""
+    return [call.args[0] for call in coordinator._build_position_context.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — bypass_auto_control parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_send_respects_auto_control_by_default():
+    """Safe-default lock: without the kwarg, auto-control OFF still blocks."""
+    coordinator = _make_coordinator(automatic_control=False)
+
+    result = await _force_send(coordinator)
+
+    coordinator._cmd_svc.apply_position.assert_not_called()
+    assert result == set()
+
+
+@pytest.mark.asyncio
+async def test_force_send_bypasses_auto_control_when_requested():
+    """bypass_auto_control=True must dispatch even with auto-control OFF."""
+    coordinator = _make_coordinator(automatic_control=False)
+
+    result = await _force_send(coordinator, bypass_auto_control=True)
+
+    coordinator._cmd_svc.apply_position.assert_called_once()
+    assert result == {"cover.test"}
+
+
+@pytest.mark.asyncio
+async def test_force_send_threads_bypass_flag_into_position_context():
+    """The coordinator guard and the context flag must move together.
+
+    Skipping only the coordinator-level guard would leave apply_position
+    skipping the command with reason ``auto_control_off``.
+    """
+    coordinator = _make_coordinator(automatic_control=False)
+
+    await _force_send(coordinator, bypass_auto_control=True)
+
+    coordinator._build_position_context.assert_called_once()
+    assert (
+        coordinator._build_position_context.call_args.kwargs["bypass_auto_control"]
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — ignore_clock_window parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_send_respects_clock_window_by_default():
+    """Safe-default lock: without the kwarg, a closed clock window still blocks."""
+    coordinator = _make_coordinator(clock_window_open=False)
+
+    result = await _force_send(coordinator)
+
+    coordinator._cmd_svc.apply_position.assert_not_called()
+    assert result == set()
+
+
+@pytest.mark.asyncio
+async def test_force_send_ignores_clock_window_when_requested():
+    """ignore_clock_window=True must dispatch outside the active-hours window."""
+    coordinator = _make_coordinator(clock_window_open=False)
+
+    result = await _force_send(coordinator, ignore_clock_window=True)
+
+    coordinator._cmd_svc.apply_position.assert_called_once()
+    assert result == {"cover.test"}
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — respect_manual_override parameter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_send_commands_through_manual_override_by_default():
+    """Safe-default lock: the auto-expiry caller still commands every cover.
+
+    ``force=True`` disables the manual-override gate inside apply_position;
+    without the new kwarg that pre-existing behaviour must be unchanged.
+    """
+    coordinator = _make_coordinator(
+        entities=["cover.a", "cover.b"], manual_covers=("cover.a",)
+    )
+
+    result = await _force_send(coordinator)
+
+    assert coordinator._cmd_svc.apply_position.call_count == 2
+    assert result == {"cover.a", "cover.b"}
+
+
+@pytest.mark.asyncio
+async def test_force_send_skips_manually_overridden_covers_when_requested():
+    """respect_manual_override=True must leave an overridden cover alone."""
+    coordinator = _make_coordinator(
+        entities=["cover.a", "cover.b"], manual_covers=("cover.a",)
+    )
+
+    result = await _force_send(coordinator, respect_manual_override=True)
+
+    assert coordinator._cmd_svc.apply_position.call_count == 1
+    assert coordinator._cmd_svc.apply_position.call_args.args[0] == "cover.b"
+    assert result == {"cover.b"}
+
+
+@pytest.mark.asyncio
+async def test_force_send_filters_override_before_building_context():
+    """The filter must run before dispatch, not lean on the force-disabled gate."""
+    coordinator = _make_coordinator(
+        entities=["cover.a", "cover.b"], manual_covers=("cover.a",)
+    )
+
+    await _force_send(coordinator, respect_manual_override=True)
+
+    assert _context_entities(coordinator) == ["cover.b"]
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — async_force_apply_calculated_position public entry point
+# ---------------------------------------------------------------------------
+
+
+def _make_apply_coordinator(**kwargs):
+    """Coordinator mock wired for the public entry point.
+
+    The shared helper is bound for real so the delegation actually runs;
+    tests that only care about the call signature re-stub it themselves.
+    """
+    coordinator = _make_coordinator(**kwargs)
+    coordinator.state = 42
+    coordinator.config_entry.options = {}
+    coordinator.async_refresh = AsyncMock()
+    coordinator._async_force_send_pipeline_position = (
+        AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position.__get__(
+            coordinator
+        )
+    )
+    return coordinator
+
+
+def _apply(coordinator, **kwargs):
+    """Invoke the unbound public entry point."""
+    return AdaptiveDataUpdateCoordinator.async_force_apply_calculated_position(
+        coordinator, **kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_force_apply_calls_refresh_before_dispatch():
+    """Recompute first so the forced position reflects current conditions."""
+    coordinator = _make_apply_coordinator()
+    order: list[str] = []
+
+    async def _refresh():
+        order.append("refresh")
+
+    async def _apply_position(*args, **kwargs):
+        order.append("apply_position")
+        return ("sent", "set_cover_position")
+
+    coordinator.async_refresh = AsyncMock(side_effect=_refresh)
+    coordinator._cmd_svc.apply_position = AsyncMock(side_effect=_apply_position)
+
+    await _apply(coordinator)
+
+    coordinator.async_refresh.assert_awaited_once()
+    assert order == ["refresh", "apply_position"]
+
+
+@pytest.mark.asyncio
+async def test_async_force_apply_delegates_with_all_three_bypasses():
+    """All three bypasses ride the one shared helper — no second implementation."""
+    coordinator = _make_apply_coordinator()
+    coordinator._async_force_send_pipeline_position = AsyncMock(
+        return_value={"cover.test"}
+    )
+
+    result = await _apply(coordinator)
+
+    coordinator._async_force_send_pipeline_position.assert_awaited_once()
+    kwargs = coordinator._async_force_send_pipeline_position.call_args.kwargs
+    assert kwargs["bypass_auto_control"] is True
+    assert kwargs["respect_manual_override"] is True
+    assert kwargs["ignore_clock_window"] is True
+    assert kwargs["entities"] is None
+    assert result == {"cover.test"}
+
+
+@pytest.mark.asyncio
+async def test_async_force_apply_default_trigger_is_the_constant():
+    """The trigger label is a named constant, not a literal."""
+    coordinator = _make_apply_coordinator()
+    coordinator._async_force_send_pipeline_position = AsyncMock(return_value=set())
+
+    await _apply(coordinator)
+
+    forwarded = coordinator._async_force_send_pipeline_position.call_args.kwargs[
+        "trigger"
+    ]
+    assert forwarded == const.TRIGGER_FORCE_APPLY_CALCULATED
+    assert const.TRIGGER_FORCE_APPLY_CALCULATED == "force_apply_calculated"
+
+
+@pytest.mark.asyncio
+async def test_async_force_apply_never_tags_safety():
+    """is_safety=True would make reconciliation resend outside the window (#215/#216)."""
+    coordinator = _make_apply_coordinator()
+    coordinator._build_position_context = (
+        AdaptiveDataUpdateCoordinator._build_position_context.__get__(coordinator)
+    )
+    coordinator._pipeline_bypasses_auto_control = False
+    coordinator._pipeline_result = None
+    coordinator.min_change = 2
+    coordinator.time_threshold = 2
+    coordinator._inverse_state = False
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    coordinator._policy = get_policy("cover_blind")
+
+    await _apply(coordinator)
+
+    calls = coordinator._cmd_svc.apply_position.call_args_list
+    assert calls
+    for call in calls:
+        assert call.kwargs["context"].is_safety is False
+        assert call.kwargs["context"].force is True
+
+
+@pytest.mark.asyncio
+async def test_async_force_apply_does_not_set_user_command():
+    """user_command=True would bypass the same-position gate and click relays (#290)."""
+    coordinator = _make_apply_coordinator()
+    coordinator._build_position_context = (
+        AdaptiveDataUpdateCoordinator._build_position_context.__get__(coordinator)
+    )
+    coordinator._pipeline_bypasses_auto_control = False
+    coordinator._pipeline_result = None
+    coordinator.min_change = 2
+    coordinator.time_threshold = 2
+    coordinator._inverse_state = False
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    coordinator._policy = get_policy("cover_blind")
+
+    await _apply(coordinator)
+
+    calls = coordinator._cmd_svc.apply_position.call_args_list
+    assert calls
+    for call in calls:
+        assert call.kwargs["context"].user_command is False
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — guard preservation against the REAL CoverCommandService
+# ---------------------------------------------------------------------------
+
+
+def _patch_caps():
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+        return_value={
+            "has_set_position": True,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+        },
+    )
+
+
+def _make_real_service_coordinator(
+    *,
+    target=50,
+    current=50,
+    min_change=2,
+    time_threshold=2,
+    cover_state="open",
+):
+    """Coordinator wired to a real CoverCommandService, like a live press."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    state_obj = MagicMock()
+    state_obj.state = cover_state
+    hass.states.get = MagicMock(return_value=state_obj)
+
+    svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        check_interval_minutes=1,
+        position_tolerance=3,
+        max_retries=3,
+    )
+    svc._get_current_position = MagicMock(return_value=current)
+
+    coordinator = _make_apply_coordinator()
+    coordinator.state = target
+    coordinator._cmd_svc = svc
+    coordinator.min_change = min_change
+    coordinator.time_threshold = time_threshold
+    coordinator._inverse_state = False
+    coordinator._pipeline_bypasses_auto_control = False
+    coordinator._pipeline_result = None
+    coordinator._build_position_context = (
+        AdaptiveDataUpdateCoordinator._build_position_context.__get__(coordinator)
+    )
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    coordinator._policy = get_policy("cover_blind")
+    return coordinator, svc, hass
+
+
+async def _press(coordinator, *, last_updated=None):
+    """Run the button's coordinator call, recording the apply_position outcome."""
+    outcomes: list[tuple[str, str]] = []
+    original = coordinator._cmd_svc.apply_position
+
+    async def _record(*args, **kwargs):
+        result = await original(*args, **kwargs)
+        outcomes.append(result)
+        return result
+
+    coordinator._cmd_svc.apply_position = _record
+    stamp = (
+        last_updated
+        if last_updated is not None
+        else dt.datetime(2020, 1, 1, tzinfo=dt.UTC)
+    )
+    with (
+        _patch_caps(),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+            return_value=stamp,
+        ),
+    ):
+        await _apply(coordinator)
+    return outcomes
+
+
+@pytest.mark.asyncio
+async def test_press_bypasses_position_delta_gate():
+    """Headline feature: a 1% move lands even with delta_position=10."""
+    coordinator, _svc, hass = _make_real_service_coordinator(
+        target=51, current=50, min_change=10
+    )
+
+    outcomes = await _press(coordinator)
+
+    assert outcomes == [("sent", "set_cover_position")]
+    hass.services.async_call.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_press_bypasses_time_delta_gate():
+    """A command 10s after the last one lands even with delta_time=30."""
+    coordinator, _svc, hass = _make_real_service_coordinator(
+        target=80, current=20, time_threshold=30
+    )
+    recent = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=10)
+
+    outcomes = await _press(coordinator, last_updated=recent)
+
+    assert outcomes == [("sent", "set_cover_position")]
+    hass.services.async_call.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_press_still_blocked_by_kill_switch():
+    """The master kill switch is not bypassed — not even by is_safety."""
+    coordinator, svc, hass = _make_real_service_coordinator(target=80, current=20)
+    svc._enabled = False
+
+    outcomes = await _press(coordinator)
+
+    assert outcomes == [("skipped", "integration_disabled")]
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_press_still_blocked_when_cover_unavailable():
+    """Cover-unavailable boundary survives the press (#342)."""
+    coordinator, _svc, hass = _make_real_service_coordinator(
+        target=80, current=20, cover_state="unavailable"
+    )
+
+    outcomes = await _press(coordinator)
+
+    assert outcomes == [("skipped", "cover_unavailable")]
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_press_still_deduped_by_same_position_gate():
+    """No relay click when the cover already sits at the calculated position."""
+    coordinator, _svc, hass = _make_real_service_coordinator(target=50, current=50)
+
+    outcomes = await _press(coordinator)
+
+    assert outcomes == [("skipped", "same_position")]
+    hass.services.async_call.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — the button entity
+# ---------------------------------------------------------------------------
+
+
+async def _setup_buttons(*, options, sensor_type="cover_blind"):
+    """Run the button platform's async_setup_entry and collect the entities."""
+    from custom_components.adaptive_cover_pro.button import async_setup_entry
+
+    hass = MagicMock()
+    config_entry = MagicMock()
+    config_entry.entry_id = "test_entry"
+    config_entry.options = options
+    config_entry.data = {"name": "Test Cover", "sensor_type": sensor_type}
+    config_entry.runtime_data = MagicMock()
+
+    added: list = []
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **kw: added.extend(entities)
+    )
+    return added
+
+
+@pytest.mark.asyncio
+async def test_apply_calculated_button_created_when_entities_configured():
+    """async_setup_entry must yield exactly one Apply Calculated Position button."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverApplyCalculatedPositionButton,
+    )
+
+    added = await _setup_buttons(options={const.CONF_ENTITIES: ["cover.test1"]})
+
+    matches = [
+        e for e in added if isinstance(e, AdaptiveCoverApplyCalculatedPositionButton)
+    ]
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_calculated_button_not_created_without_entities():
+    """No configured covers → no buttons at all."""
+    added = await _setup_buttons(options={const.CONF_ENTITIES: []})
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_apply_calculated_button_not_created_for_cover_group():
+    """Cover-group orchestrator entries expose only the group buttons."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverApplyCalculatedPositionButton,
+    )
+
+    added = await _setup_buttons(
+        options={const.CONF_ENTITIES: ["cover.test1"]}, sensor_type="cover_group"
+    )
+
+    assert not any(
+        isinstance(e, AdaptiveCoverApplyCalculatedPositionButton) for e in added
+    )
+
+
+def _make_apply_button(entry_id="test_entry"):
+    """Instantiate the button without HA infrastructure."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverApplyCalculatedPositionButton,
+    )
+
+    button = AdaptiveCoverApplyCalculatedPositionButton.__new__(
+        AdaptiveCoverApplyCalculatedPositionButton
+    )
+    button.coordinator = MagicMock()
+    button.coordinator.async_force_apply_calculated_position = AsyncMock(
+        return_value=set()
+    )
+    button._attr_unique_id = f"{entry_id}_apply_calculated_position"
+    return button
+
+
+@pytest.mark.asyncio
+async def test_apply_calculated_button_press_delegates_to_coordinator():
+    """The button is a one-liner over the coordinator entry point."""
+    button = _make_apply_button()
+
+    await button.async_press()
+
+    button.coordinator.async_force_apply_calculated_position.assert_awaited_once_with()
+
+
+def test_apply_calculated_button_identity():
+    """Translation key, unique_id, and no name override (HA resolves the name)."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverApplyCalculatedPositionButton,
+    )
+
+    assert (
+        "name" not in AdaptiveCoverApplyCalculatedPositionButton.__dict__
+    ), "must not override name — HA resolves the translated name"
+
+    entry_id = "abc123"
+    config_entry = MagicMock()
+    config_entry.entry_id = entry_id
+    config_entry.options = {const.CONF_ENTITIES: ["cover.test1"]}
+    config_entry.data = {"name": "Test Cover", "sensor_type": "cover_blind"}
+    button = AdaptiveCoverApplyCalculatedPositionButton(
+        entry_id, MagicMock(), config_entry, MagicMock()
+    )
+    # HA's CachedProperties metaclass rewrites the class-level _attr_ into a
+    # descriptor, so the value is only readable off an instance.
+    assert button._attr_translation_key == "apply_calculated_position"
+    assert button.translation_key == "apply_calculated_position"
+    assert button.unique_id == f"{entry_id}_apply_calculated_position"

--- a/tests/test_issue_1045_force_apply_button.py
+++ b/tests/test_issue_1045_force_apply_button.py
@@ -36,6 +36,7 @@ from custom_components.adaptive_cover_pro.managers.cover_command import (
     CoverCommandService,
     PositionContext,
 )
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
 # ---------------------------------------------------------------------------
 # Harness — mirrors tests/test_reset_button_time_window.py::_make_coordinator
@@ -74,6 +75,13 @@ def _make_coordinator(
     )
     # The per-entity dispatch seam is identity for a blind (no rail remap).
     coordinator._entity_target = lambda cover, state: state
+    # No hold in play by default; bind the real hold-aware dispatch seam so
+    # honor_holds=True runs the production code rather than a bare MagicMock.
+    coordinator._pipeline_result = None
+    coordinator.position_axis_inverted = False
+    coordinator._dispatch_to_cover = (
+        AdaptiveDataUpdateCoordinator._dispatch_to_cover.__get__(coordinator)
+    )
     return coordinator
 
 
@@ -207,6 +215,29 @@ async def test_force_send_filters_override_before_building_context():
     await _force_send(coordinator, respect_manual_override=True)
 
     assert _context_entities(coordinator) == ["cover.b"]
+
+
+@pytest.mark.asyncio
+async def test_force_send_records_skip_for_manually_overridden_cover():
+    """A pre-filtered cover must leave the same diagnostic trace as the gate.
+
+    The non-forced path records ``manual_override`` from apply_position's gate,
+    so ``last_skipped_action`` / diagnostics / the Lovelace card explain why the
+    cover stayed put.  A silent ``continue`` here would make the button look
+    broken for that cover.
+    """
+    coordinator = _make_coordinator(
+        entities=["cover.a", "cover.b"], manual_covers=("cover.a",)
+    )
+    coordinator._inverse_state = False
+
+    await _force_send(coordinator, respect_manual_override=True, trigger="press")
+
+    recorded = coordinator._cmd_svc.record_skipped_action.call_args_list
+    assert [call.args[0] for call in recorded] == ["cover.a"]
+    # Same reason code the manual-override gate inside apply_position emits.
+    assert recorded[0].args[1] == "manual_override"
+    assert recorded[0].kwargs["trigger"] == "press"
 
 
 # ---------------------------------------------------------------------------
@@ -493,6 +524,145 @@ async def test_press_still_deduped_by_same_position_gate():
 
     assert outcomes == [("skipped", "same_position")]
     hass.services.async_call.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Step 7b — honor_holds: pipeline holds must survive the press
+#
+# GroupLockHandler and MotionTimeoutHandler's hold_position mode both emit
+# skip_command=True with position = snapshot.current_cover_position, which for
+# a multi-cover instance is the arithmetic MEAN of every cover's position.
+# Dispatching that value punches through the hold AND sends a number that is
+# not the calculated position for any single cover.
+# ---------------------------------------------------------------------------
+
+
+def _make_hold_coordinator(*, positions: dict[str, int], control_method, state: int):
+    """Real CoverCommandService + a hold-mode (skip_command) pipeline result."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    state_obj = MagicMock()
+    state_obj.state = "open"
+    hass.states.get = MagicMock(return_value=state_obj)
+
+    svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        check_interval_minutes=1,
+        position_tolerance=3,
+        max_retries=3,
+    )
+    svc._get_current_position = MagicMock(side_effect=lambda entity: positions[entity])
+    svc.apply_position = AsyncMock(wraps=svc.apply_position)
+    svc.record_skipped_action = MagicMock(wraps=svc.record_skipped_action)
+
+    coordinator = _make_apply_coordinator(entities=list(positions))
+    coordinator.state = state
+    coordinator._cmd_svc = svc
+    coordinator.min_change = 2
+    coordinator.time_threshold = 2
+    coordinator._inverse_state = False
+    coordinator.position_axis_inverted = False
+    coordinator._pipeline_bypasses_auto_control = False
+    coordinator._pipeline_result = PipelineResult(
+        position=state,
+        control_method=control_method,
+        skip_command=True,
+    )
+    return coordinator, svc, hass
+
+
+async def _press_raw(coordinator):
+    """Press the button with the real service wired, no apply_position spy."""
+    with (
+        _patch_caps(),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.get_last_updated",
+            return_value=dt.datetime(2020, 1, 1, tzinfo=dt.UTC),
+        ),
+    ):
+        await _apply(coordinator)
+
+
+@pytest.mark.asyncio
+async def test_press_honors_group_lock_hold():
+    """A live group lock outranks everything — the press must not break it.
+
+    GroupLockHandler sits at CUSTOM_POSITION_SAFETY_PRIORITY and is documented
+    as outranking every other handler, weather included.  Its position is the
+    mean of the members' positions, so punching through would drive a two-cover
+    instance at 20/80 to 50/50.
+    """
+    coordinator, svc, hass = _make_hold_coordinator(
+        positions={"cover.a": 20, "cover.b": 80},
+        control_method=const.ControlMethod.GROUP_LOCK,
+        state=50,
+    )
+
+    await _press_raw(coordinator)
+
+    svc.apply_position.assert_not_called()
+    hass.services.async_call.assert_not_awaited()
+    assert [call.args[0] for call in svc.record_skipped_action.call_args_list] == [
+        "cover.a",
+        "cover.b",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_press_honors_motion_hold():
+    """MotionTimeoutHandler hold_position mode is the same shape as group lock."""
+    coordinator, svc, hass = _make_hold_coordinator(
+        positions={"cover.a": 20, "cover.b": 80},
+        control_method=const.ControlMethod.MOTION,
+        state=50,
+    )
+
+    await _press_raw(coordinator)
+
+    svc.apply_position.assert_not_called()
+    hass.services.async_call.assert_not_awaited()
+    assert [call.args[1] for call in svc.record_skipped_action.call_args_list] == [
+        "motion_hold",
+        "motion_hold",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_force_send_bypasses_holds_by_default():
+    """Safe-default lock: forced transitions still ignore hold mode.
+
+    _dispatch_to_cover's docstring records that forced transitions, override
+    clears and window events deliberately bypass it.  Without ``honor_holds``
+    the two pre-existing callers must keep that behaviour exactly.
+    """
+    coordinator = _make_coordinator()
+    coordinator._pipeline_result = PipelineResult(
+        position=50,
+        control_method=const.ControlMethod.GROUP_LOCK,
+        skip_command=True,
+    )
+
+    result = await _force_send(coordinator)
+
+    coordinator._cmd_svc.apply_position.assert_called_once()
+    coordinator._cmd_svc.record_skipped_action.assert_not_called()
+    assert result == {"cover.test"}
+
+
+@pytest.mark.asyncio
+async def test_async_force_apply_delegates_with_honor_holds():
+    """The public entry point must ask the shared helper to honour holds."""
+    coordinator = _make_apply_coordinator()
+    coordinator._async_force_send_pipeline_position = AsyncMock(return_value=set())
+
+    await _apply(coordinator)
+
+    kwargs = coordinator._async_force_send_pipeline_position.call_args.kwargs
+    assert kwargs["honor_holds"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_756_override_dispatch_during_sequence.py
+++ b/tests/test_issue_756_override_dispatch_during_sequence.py
@@ -48,7 +48,7 @@ def _make_dispatch_coordinator(
     coordinator._last_dispatched_target_sig = last_sig
     coordinator._resolved_target_signature = MagicMock(return_value=current_sig)
     coordinator.async_handle_state_change = AsyncMock()
-    coordinator._async_send_after_override_clear = AsyncMock()
+    coordinator._async_force_send_pipeline_position = AsyncMock()
     coordinator._policy = MagicMock()
     coordinator._policy.has_pending_secondary_axis = MagicMock(return_value=has_pending)
     return coordinator
@@ -80,7 +80,7 @@ async def test_override_dispatches_when_target_changed_despite_lost_state_change
     coordinator.async_handle_state_change.assert_awaited_once()
     _, kwargs = coordinator.async_handle_state_change.call_args
     assert kwargs.get("target_changed") is True
-    coordinator._async_send_after_override_clear.assert_not_awaited()
+    coordinator._async_force_send_pipeline_position.assert_not_awaited()
     # Nothing pending → the new target signature is recorded as last-dispatched.
     assert coordinator._last_dispatched_target_sig == winner_sig
 
@@ -106,7 +106,7 @@ async def test_no_dispatch_when_target_unchanged_and_no_state_change():
     )
 
     coordinator.async_handle_state_change.assert_not_awaited()
-    coordinator._async_send_after_override_clear.assert_not_awaited()
+    coordinator._async_force_send_pipeline_position.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -161,7 +161,7 @@ async def test_auto_expired_branch_unchanged():
         template_release=False,
     )
 
-    coordinator._async_send_after_override_clear.assert_awaited_once()
+    coordinator._async_force_send_pipeline_position.assert_awaited_once()
     coordinator.async_handle_state_change.assert_not_awaited()
 
 

--- a/tests/test_manual_override.py
+++ b/tests/test_manual_override.py
@@ -212,7 +212,7 @@ def test_cancel_grace_period_handles_missing_entity():
 async def test_reset_clears_manual_override_and_sends_post_refresh_position():
     """Reset must clear override, refresh, then delegate to the shared send path.
 
-    The shared path (_async_send_after_override_clear) owns force=True and the
+    The shared path (_async_force_send_pipeline_position) owns force=True and the
     time-window / auto-control gates.  async_reset_manual_overrides supplies the
     post-refresh state, the options dict, the target entities, and the
     "manual_reset" trigger.  (Sequence moved from the button in issue #790.)
@@ -231,7 +231,9 @@ async def test_reset_clears_manual_override_and_sends_post_refresh_position():
     coordinator.cover_state_change = False
     coordinator.state = POST_REFRESH_STATE
     coordinator.async_refresh = AsyncMock()
-    coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
+    coordinator._async_force_send_pipeline_position = AsyncMock(
+        return_value={entity_id}
+    )
 
     await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
         coordinator, [entity_id]
@@ -242,8 +244,8 @@ async def test_reset_clears_manual_override_and_sends_post_refresh_position():
     coordinator.async_refresh.assert_called_once()
 
     # Must delegate to the shared send path with correct args
-    coordinator._async_send_after_override_clear.assert_called_once()
-    call = coordinator._async_send_after_override_clear.call_args
+    coordinator._async_force_send_pipeline_position.assert_called_once()
+    call = coordinator._async_force_send_pipeline_position.call_args
     assert call[0][0] == POST_REFRESH_STATE  # post-refresh state
     assert call[0][1] == options  # options dict
     assert call[1].get("entities") == [entity_id]
@@ -283,7 +285,9 @@ async def test_reset_suppresses_redetection_during_refresh():
     coordinator._cmd_svc.set_waiting = MagicMock(side_effect=_set_waiting)
     coordinator._cmd_svc.is_waiting_for_target = MagicMock(side_effect=_is_waiting)
     coordinator.cover_state_change = False
-    coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
+    coordinator._async_force_send_pipeline_position = AsyncMock(
+        return_value={entity_id}
+    )
 
     await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
         coordinator, [entity_id]
@@ -297,7 +301,7 @@ async def test_reset_suppresses_redetection_during_refresh():
 async def test_reset_clears_wait_for_target_when_no_command_sent():
     """wait_for_target must be False after reset when the shared send path skips the entity.
 
-    The shared method (_async_send_after_override_clear) returns a set of sent
+    The shared method (_async_force_send_pipeline_position) returns a set of sent
     entity_ids.  If an entity is absent (gated by time window, auto-control off,
     or no positioning capability), the button must clear wait_for_target.
     """
@@ -312,7 +316,7 @@ async def test_reset_clears_wait_for_target_when_no_command_sent():
     coordinator.state = 50
     coordinator.config_entry.options = {}
     # Shared method returns empty set — entity was not sent to
-    coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
+    coordinator._async_force_send_pipeline_position = AsyncMock(return_value=set())
     coordinator.async_refresh = AsyncMock()
     coordinator.cover_state_change = False
 
@@ -405,14 +409,16 @@ async def test_reset_sends_correct_position_with_climate_mode():
     # Simulate: after refresh the pipeline now returns the climate position
     coordinator.state = CLIMATE_POSITION
     coordinator.async_refresh = AsyncMock()
-    coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
+    coordinator._async_force_send_pipeline_position = AsyncMock(
+        return_value={entity_id}
+    )
 
     await AdaptiveDataUpdateCoordinator.async_reset_manual_overrides(
         coordinator, [entity_id]
     )
 
     # The state passed to the shared method must be the post-refresh climate position
-    call = coordinator._async_send_after_override_clear.call_args
+    call = coordinator._async_force_send_pipeline_position.call_args
     sent_position = call[0][0]
     assert sent_position == CLIMATE_POSITION
     assert sent_position != SOLAR_POSITION

--- a/tests/test_my_position_toggle.py
+++ b/tests/test_my_position_toggle.py
@@ -48,7 +48,9 @@ async def test_my_position_button_not_created_when_toggle_default_false():
     assert (
         len(reset) == 1
     ), "Reset Manual Override button must remain always-on regardless of toggle"
-    assert len(added) == 1
+    # Reset Manual Override + Apply Calculated Position (#1045) are both
+    # always-on; only My Position is behind the toggle.
+    assert len(added) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -35,7 +35,7 @@ def _make_coordinator(
     automatic_control: bool = True,
     clock_window_open: bool | None = None,
 ):
-    """Build a minimal mock coordinator for testing _async_send_after_override_clear.
+    """Build a minimal mock coordinator for testing _async_force_send_pipeline_position.
 
     ``clock_window_open`` defaults to mirror ``check_adaptive_time`` because every
     scenario in this file models "outside the window" as a genuinely closed clock
@@ -63,7 +63,7 @@ def _make_coordinator(
 
 
 # ---------------------------------------------------------------------------
-# _async_send_after_override_clear — time-window guard
+# _async_force_send_pipeline_position — time-window guard
 # ---------------------------------------------------------------------------
 
 
@@ -82,7 +82,7 @@ async def test_override_clear_skips_send_outside_time_window():
 
     coordinator = _make_coordinator(check_adaptive_time=False)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -103,7 +103,7 @@ async def test_override_clear_sends_position_inside_time_window():
 
     coordinator = _make_coordinator(check_adaptive_time=True)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=50, options={}
     )
 
@@ -136,7 +136,7 @@ async def test_override_clear_sends_when_gate_dark_but_clock_open():
         automatic_control=True,
     )
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -158,7 +158,7 @@ async def test_override_clear_logs_debug_when_outside_window():
 
     coordinator = _make_coordinator(check_adaptive_time=False)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -184,7 +184,7 @@ async def test_override_clear_uses_force_true_inside_window():
 
     coordinator = _make_coordinator(check_adaptive_time=True)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=75, options={"test_option": True}
     )
 
@@ -194,11 +194,14 @@ async def test_override_clear_uses_force_true_inside_window():
         "cover.test_blind",
         {"test_option": True},
         force=True,
+        # Default for this caller — the auto-control bypass is opt-in and only
+        # the Apply Calculated Position button (#1045) requests it.
+        bypass_auto_control=False,
         sun_just_appeared=coordinator._check_sun_validity_transition.return_value,
     )
     ctx = coordinator._build_position_context.call_args
     assert not ctx.kwargs.get("is_safety", False), (
-        "_async_send_after_override_clear must NOT pass is_safety=True — "
+        "_async_force_send_pipeline_position must NOT pass is_safety=True — "
         "override-clear targets are NOT safety targets and must not persist "
         "across window boundaries (fix for issue #223)"
     )
@@ -217,7 +220,7 @@ async def test_override_clear_outside_window_multiple_covers():
     coordinator = _make_coordinator(check_adaptive_time=False)
     coordinator.entities = ["cover.blind_1", "cover.blind_2", "cover.blind_3"]
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -239,7 +242,7 @@ async def test_override_clear_inside_window_multiple_covers():
     coordinator = _make_coordinator(check_adaptive_time=True)
     coordinator.entities = ["cover.blind_1", "cover.blind_2"]
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=50, options={}
     )
 
@@ -253,7 +256,7 @@ async def test_override_clear_inside_window_multiple_covers():
 
 
 # ---------------------------------------------------------------------------
-# _async_send_after_override_clear — automatic-control guard (issue #139)
+# _async_force_send_pipeline_position — automatic-control guard (issue #139)
 # ---------------------------------------------------------------------------
 
 
@@ -272,7 +275,7 @@ async def test_override_clear_skips_send_when_auto_control_off():
 
     coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=False)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -289,7 +292,7 @@ async def test_override_clear_logs_debug_when_auto_control_off():
 
     coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=False)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -311,7 +314,7 @@ async def test_override_clear_sends_when_auto_control_on_inside_window():
 
     coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=True)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=40, options={}
     )
 
@@ -333,7 +336,7 @@ async def test_override_clear_auto_control_off_multiple_covers():
     coordinator = _make_coordinator(check_adaptive_time=True, automatic_control=False)
     coordinator.entities = ["cover.blind_a", "cover.blind_b", "cover.blind_c"]
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -355,7 +358,7 @@ async def test_override_clear_outside_window_takes_precedence_over_auto_control(
 
     coordinator = _make_coordinator(check_adaptive_time=False, automatic_control=False)
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, state=0, options={}
     )
 
@@ -660,7 +663,7 @@ class TestIssue215EuropeParisSunsetConfig:
         coordinator = _make_coordinator(check_adaptive_time=False)
 
         # state=0 simulates the pipeline's correct answer (sunset_pos)
-        await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+        await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
             coordinator, state=0, options={}
         )
 
@@ -1003,7 +1006,7 @@ class TestIssue215StaleSafetyTarget:
 class TestIssue223OverrideClearSafetyTag:
     """Regression tests for issue #223.
 
-    Root cause: _async_send_after_override_clear called apply_position with
+    Root cause: _async_force_send_pipeline_position called apply_position with
     force=True (to bypass delta gates), but force=True was conflated with
     is_safety=True, adding the entity to _safety_targets.  When the window
     later closed, clear_non_safety_targets() preserved the entity and
@@ -1011,7 +1014,7 @@ class TestIssue223OverrideClearSafetyTag:
 
     Fix: decouple force (bypass gates) from is_safety (safety target
     classification) by adding an explicit is_safety field to PositionContext.
-    _async_send_after_override_clear still uses force=True but is_safety
+    _async_force_send_pipeline_position still uses force=True but is_safety
     defaults to False, so the target is cleaned up normally when the window
     closes.
     """

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -814,7 +814,7 @@ async def test_force_without_is_safety_does_not_mark_safety_target(svc, mock_has
 
     force=True only bypasses gate checks (delta, time, manual override).
     Safety target classification is controlled exclusively by is_safety.
-    Callers like _async_send_after_override_clear use force=True to bypass
+    Callers like _async_force_send_pipeline_position use force=True to bypass
     gates but is_safety=False so the target does not persist across window
     boundaries (fix for issue #223).
     """
@@ -1558,7 +1558,7 @@ async def test_force_true_bypasses_time_delta_and_position_delta(svc, mock_hass)
 async def test_manual_override_expiry_force_true_bypasses_time_delta(svc, mock_hass):
     """Manual override expiry (force=True) also bypasses time delta.
 
-    Manual override expiry already uses force=True (_async_send_after_override_clear).
+    Manual override expiry already uses force=True (_async_force_send_pipeline_position).
     This test confirms the gate behavior is identical to force override release.
     """
     _patch_position(svc, 30)

--- a/tests/test_reset_button_time_window.py
+++ b/tests/test_reset_button_time_window.py
@@ -4,7 +4,7 @@ When the user presses Reset Manual Override outside the active-hours window,
 the override flag must still be cleared but the cover must NOT be repositioned.
 The next normal update cycle (when the window opens) sends the correct position.
 
-These tests also verify that _async_send_after_override_clear is the single
+These tests also verify that _async_force_send_pipeline_position is the single
 shared gate for both the auto-expiry path and the button path.
 """
 
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 def _make_coordinator(
     *, check_adaptive_time=True, automatic_control=True, clock_window_open=None
 ):
-    """Minimal coordinator mock for testing _async_send_after_override_clear.
+    """Minimal coordinator mock for testing _async_force_send_pipeline_position.
 
     ``clock_window_open`` defaults to mirror ``check_adaptive_time`` (closed clock
     when outside the window). Pass ``clock_window_open=True`` to model the
@@ -67,7 +67,7 @@ def _make_button(coordinator, entities):
 
 
 # ---------------------------------------------------------------------------
-# _async_send_after_override_clear — direct method tests
+# _async_force_send_pipeline_position — direct method tests
 # ---------------------------------------------------------------------------
 
 
@@ -85,7 +85,7 @@ async def test_send_after_override_clear_skips_when_clock_window_closed():
 
     coordinator = _make_coordinator(check_adaptive_time=False, clock_window_open=False)
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 75, {}
     )
 
@@ -112,7 +112,7 @@ async def test_send_after_override_clear_sends_when_gate_dark_but_clock_open():
         automatic_control=True,
     )
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 0, {}
     )
 
@@ -131,7 +131,7 @@ async def test_send_after_override_clear_skips_when_auto_control_off():
 
     coordinator = _make_coordinator(automatic_control=False)
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 75, {}
     )
 
@@ -149,7 +149,7 @@ async def test_send_after_override_clear_sends_to_specified_entities_only():
     coordinator = _make_coordinator()
     coordinator.entities = ["cover.all_a", "cover.all_b"]
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 60, {}, entities=["cover.only_this"]
     )
 
@@ -169,7 +169,7 @@ async def test_send_after_override_clear_defaults_to_all_entities():
     coordinator = _make_coordinator()
     coordinator.entities = ["cover.a", "cover.b"]
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 50, {}
     )
 
@@ -187,7 +187,7 @@ async def test_send_after_override_clear_uses_custom_trigger():
     coordinator = _make_coordinator()
     coordinator.entities = ["cover.test"]
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 50, {}, trigger="manual_reset"
     )
 
@@ -205,7 +205,7 @@ async def test_send_after_override_clear_default_trigger_is_manual_override_clea
     coordinator = _make_coordinator()
     coordinator.entities = ["cover.test"]
 
-    await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 50, {}
     )
 
@@ -230,7 +230,7 @@ async def test_send_after_override_clear_returns_only_sent_entities():
 
     coordinator._cmd_svc.apply_position = AsyncMock(side_effect=side_effect)
 
-    result = await AdaptiveDataUpdateCoordinator._async_send_after_override_clear(
+    result = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
         coordinator, 50, {}
     )
 
@@ -243,7 +243,7 @@ async def test_send_after_override_clear_returns_only_sent_entities():
 # The sequence historically lived in the button's async_press; it moved to
 # AdaptiveDataUpdateCoordinator.async_reset_manual_overrides (issue #790) so
 # the cover-group bulk clear shares it. Tests exercise the method unbound,
-# same pattern as the _async_send_after_override_clear tests above.
+# same pattern as the _async_force_send_pipeline_position tests above.
 # ---------------------------------------------------------------------------
 
 
@@ -273,7 +273,7 @@ async def test_reset_skips_send_when_outside_time_window():
     coordinator.config_entry.options = {}
     coordinator.async_refresh = AsyncMock()
     # The shared send path handles the gate; the reset must delegate to it
-    coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
+    coordinator._async_force_send_pipeline_position = AsyncMock(return_value=set())
 
     await _reset_via_coordinator(coordinator, [entity_id])
 
@@ -296,7 +296,7 @@ async def test_reset_skips_send_when_auto_control_off():
     coordinator.state = 0
     coordinator.config_entry.options = {}
     coordinator.async_refresh = AsyncMock()
-    coordinator._async_send_after_override_clear = AsyncMock(return_value=set())
+    coordinator._async_force_send_pipeline_position = AsyncMock(return_value=set())
 
     await _reset_via_coordinator(coordinator, [entity_id])
 
@@ -307,7 +307,7 @@ async def test_reset_skips_send_when_auto_control_off():
 
 @pytest.mark.asyncio
 async def test_reset_delegates_to_shared_method_with_correct_args():
-    """The reset must call _async_send_after_override_clear with entities and trigger kwargs."""
+    """The reset must call _async_force_send_pipeline_position with entities and trigger kwargs."""
     entity_id = "cover.kitchen"
     options = {"some_opt": True}
 
@@ -317,13 +317,15 @@ async def test_reset_delegates_to_shared_method_with_correct_args():
     coordinator.state = 55
     coordinator.config_entry.options = options
     coordinator.async_refresh = AsyncMock()
-    coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
+    coordinator._async_force_send_pipeline_position = AsyncMock(
+        return_value={entity_id}
+    )
 
     reset = await _reset_via_coordinator(coordinator, [entity_id])
 
     assert reset == [entity_id]
-    coordinator._async_send_after_override_clear.assert_called_once()
-    call = coordinator._async_send_after_override_clear.call_args
+    coordinator._async_force_send_pipeline_position.assert_called_once()
+    call = coordinator._async_force_send_pipeline_position.call_args
     assert call[0][0] == 55  # state
     assert call[0][1] == options  # options
     assert call[1].get("entities") == [entity_id]
@@ -343,7 +345,7 @@ async def test_reset_clears_wait_for_target_for_unsent_entities():
     coordinator.config_entry.options = {}
     coordinator.async_refresh = AsyncMock()
     # Simulate: shared method sent to entity_a but not entity_b
-    coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_a})
+    coordinator._async_force_send_pipeline_position = AsyncMock(return_value={entity_a})
 
     await _reset_via_coordinator(coordinator, [entity_a, entity_b])
 
@@ -366,14 +368,16 @@ async def test_reset_happy_path_inside_window():
     coordinator.state = 42
     coordinator.config_entry.options = {}
     coordinator.async_refresh = AsyncMock()
-    coordinator._async_send_after_override_clear = AsyncMock(return_value={entity_id})
+    coordinator._async_force_send_pipeline_position = AsyncMock(
+        return_value={entity_id}
+    )
 
     reset = await _reset_via_coordinator(coordinator, [entity_id])
 
     assert reset == [entity_id]
     coordinator.manager.reset.assert_called_once_with(entity_id)
     coordinator.async_refresh.assert_called_once()
-    coordinator._async_send_after_override_clear.assert_called_once()
+    coordinator._async_force_send_pipeline_position.assert_called_once()
     # entity was sent — reset must NOT clear waiting (apply_position set it)
     set_waiting_calls = coordinator._cmd_svc.set_waiting.call_args_list
     cleared = [call for call in set_waiting_calls if call.args == (entity_id, False)]

--- a/tests/test_sensor_availability.py
+++ b/tests/test_sensor_availability.py
@@ -69,6 +69,7 @@ from custom_components.adaptive_cover_pro.binary_sensor import (
 )
 from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
 from custom_components.adaptive_cover_pro.button import (
+    AdaptiveCoverApplyCalculatedPositionButton,
     AdaptiveCoverButton,
     AdaptiveCoverMyPositionButton,
 )
@@ -240,6 +241,12 @@ ENTITY_FACTORIES: dict[type, object] = {
         coordinator=_make_coordinator(),
     ),
     AdaptiveCoverMyPositionButton: lambda: AdaptiveCoverMyPositionButton(
+        entry_id="test_avail_entry",
+        hass=_make_hass(),
+        config_entry=_make_config_entry(),
+        coordinator=_make_coordinator(),
+    ),
+    AdaptiveCoverApplyCalculatedPositionButton: lambda: AdaptiveCoverApplyCalculatedPositionButton(
         entry_id="test_avail_entry",
         hass=_make_hass(),
         config_entry=_make_config_entry(),

--- a/tests/test_unique_id_snapshot.py
+++ b/tests/test_unique_id_snapshot.py
@@ -115,6 +115,7 @@ EXPECTED_UNIQUE_ID_SUFFIXES = sorted(
         # --- button platform ---
         "Reset Manual Override",
         "my_position",
+        "apply_calculated_position",
         # --- number platform ---
         "my_position_value",
     ]


### PR DESCRIPTION
## Summary

Adds an **Apply Calculated Position** button to every Adaptive Cover Pro instance. A press recomputes the pipeline position and dispatches it immediately, past the `delta_position` and `delta_time` hysteresis gates. Until now `set_position` could force an *arbitrary* position but nothing could force the *computed* one.

It also bypasses the `auto_control` gate and the clock window, following the My Position precedent from #430: an explicit press is a user command, and a button that silently does nothing half the day is a support ticket. The bypass rides the existing `bypass_auto_control` channel, never `is_safety`, so no target gets tagged for reconciliation resend (#215/#216).

Every other guard survives: the master kill switch, the cover-unavailable boundary (#342), and the same-position relay-click gate (#290/#507/#567/#779). Covers under a live manual override are skipped by a coordinator-side pre-filter, since `force=True` disables the in-service override gate.

Pipeline holds whose held position is the instance mean (group lock, motion hold) are honoured rather than punched through, and those covers get the usual hold-skip diagnostic. The manual-override hold is deliberately excluded from that routing: it is instance-wide while the pre-filter is per-cover, and its position is the genuine calculated value, not the mean.

Rather than add a second bypass path, `_async_send_after_override_clear` was generalized into `_async_force_send_pipeline_position` with four optional flags, each defaulting to the prior behaviour, so both existing override-clear callers are unchanged.

Two rounds of automated audit findings were fixed on the branch: the button initially punched through group-lock and motion holds and sent the arithmetic mean of the covers' positions, and the first correction over-reached by also honouring the instance-wide manual-override hold.

## Testing

- ✅ 8732 tests passing (baseline was 8700)
- Includes a control-gate matrix row and a force-apply allowlist entry so the repo's two static backstops cover the new path

## Related Issues

Refs #1045