### PR TITLE
fix: discard latched target when manual override clears (#1052)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -632,9 +632,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # detection channel that flips a cover into manual override fires
         # on_engaged → discard the latched command target (issue #215/#216);
         # every current and future detector inherits this without coordinator
-        # changes. The ACP-origin predicate lets detectors distinguish
-        # ACP-issued context ids from genuine user actions.
-        self.manager.set_transition_callbacks(on_engaged=self._cmd_svc.discard_target)
+        # changes. Clearing an override discards it too (issue #1052) — the
+        # target the override itself latched must not survive the cancel, or
+        # reconciliation drives the cover back to it whenever the post-cancel
+        # cycle's corrective command is suppressed by the delta gates. The
+        # ACP-origin predicate lets detectors distinguish ACP-issued context
+        # ids from genuine user actions.
+        self.manager.set_transition_callbacks(
+            on_engaged=self._cmd_svc.discard_target,
+            on_cleared=self._cmd_svc.discard_targets,
+        )
         self.manager.set_acp_context_predicate(self._cmd_svc.was_acp_position_context)
         # Issue #888: drop the display-only assumed position when the override
         # resets or a real numeric position read arrives.

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from homeassistant.components.cover.const import DOMAIN as COVER_DOMAIN
@@ -725,10 +725,18 @@ class CoverCommandService:
     def discard_target(self, entity_id: str) -> None:
         """Remove all tracking state for an entity, including safety targets.
 
-        Called when a manual override starts for an entity so that any
-        pre-existing integration target (including safety-tagged end-time
-        defaults) cannot be resurrected by reconciliation while — or after
-        — the user is controlling the cover.
+        Called on both manual-override edges — start (``on_engaged``) and
+        clear (``on_cleared``, via :meth:`discard_targets`) — so that no
+        integration target (including safety-tagged end-time defaults) can be
+        resurrected by reconciliation while, or after, the user is controlling
+        the cover.
+
+        Clearing on the *cleared* edge matters because the override's own
+        command target outlives it otherwise (issue #1052): when the
+        post-cancel cycle recomputes a position the delta gates suppress —
+        the cover is already within ``min_change`` of it — nothing overwrites
+        ``target``, and the next reconcile tick drives the cover back to the
+        cancelled override's position.
 
         Args:
             entity_id: Cover entity ID to clear.
@@ -737,9 +745,23 @@ class CoverCommandService:
         existing = self._state.pop(entity_id, None)
         if existing is not None and existing.target is not None:
             self._logger.debug(
-                "Discarded stale target for %s on manual override start",
+                "Discarded stale target for %s on manual override edge",
                 entity_id,
             )
+
+    def discard_targets(self, entity_ids: Iterable[str]) -> None:
+        """Discard targets for several entities — the ``on_cleared`` edge shape.
+
+        ``ManualOverrideManager`` fires ``on_cleared`` with a list, so this is
+        the plural adapter over :meth:`discard_target` that the coordinator
+        subscribes to. Entities with no tracked state are a no-op.
+
+        Args:
+            entity_ids: Cover entity IDs whose override just cleared.
+
+        """
+        for entity_id in entity_ids:
+            self.discard_target(entity_id)
 
     # ------------------------------------------------------------------ #
     # Progress-aware transit tracking

--- a/tests/test_issue_1052_override_clear_discards_target.py
+++ b/tests/test_issue_1052_override_clear_discards_target.py
@@ -1,0 +1,168 @@
+"""Regression tests for issue #1052 — clearing a manual override must discard
+the latched command target.
+
+``ManualOverrideManager.set_transition_callbacks()`` exposes two edges:
+``on_engaged`` (wired to ``CoverCommandService.discard_target``) and
+``on_cleared``. Only ``on_engaged`` was wired, so a target latched *by* an
+override outlived the override:
+
+1. ``set_axes`` engages an override with target 0; ACP sends close_cover and
+   latches ``target_call`` = 0.
+2. The user stops the cover at 99.
+3. The user cancels the override. The pipeline recomputes 100, but 100 vs 99
+   is inside ``delta_position_threshold`` so the corrective command is gated
+   away as ``same_position`` — ``target_call`` stays 0.
+4. The entity leaves ``_manual_override_entities``, so the next reconcile tick
+   stops skipping it, sees actual 99 against target 0, and resends 0.
+
+The cover closes with no ``last_cover_action`` entry, because a reconcile
+resend is not a pipeline command.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant import config_entries as ha_config_entries
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_mock_service,
+)
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.managers.cover_command import (
+    CoverCommandService,
+)
+from tests.ha_helpers import VERTICAL_OPTIONS
+
+pytestmark = pytest.mark.integration
+
+ENTITY_ID = "cover.family_room_side_yard_shade"
+
+
+def _build_coordinator(hass: HomeAssistant, entry_id: str):
+    """Construct a real coordinator so the shipped callback wiring is exercised."""
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Side Yard Shade", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id=entry_id,
+        title="Side Yard Shade",
+    )
+    entry.add_to_hass(hass)
+
+    token = ha_config_entries.current_entry.set(entry)
+    try:
+        return AdaptiveDataUpdateCoordinator(hass)
+    finally:
+        ha_config_entries.current_entry.reset(token)
+
+
+async def test_coordinator_wires_on_cleared_edge(hass: HomeAssistant) -> None:
+    """The coordinator must subscribe to the override-cleared edge.
+
+    ``on_cleared`` fires on every ``reset()`` but had no subscriber, which is
+    what let the stale target survive the cancel.
+    """
+    coordinator = _build_coordinator(hass, "issue_1052_wiring")
+
+    assert coordinator.manager._on_cleared is not None, (
+        "coordinator must wire ManualOverrideManager.on_cleared — without a "
+        "subscriber, cancelling an override leaves target_call latched and "
+        "reconciliation resends it (#1052)"
+    )
+
+
+async def test_clearing_override_discards_latched_target(
+    hass: HomeAssistant,
+) -> None:
+    """Cancelling an override drops the target that override latched."""
+    coordinator = _build_coordinator(hass, "issue_1052_discard")
+    manager = coordinator.manager
+    cmd_svc = coordinator._cmd_svc
+
+    manager.add_covers([ENTITY_ID])
+
+    # The override's own command target: set_axes asked for 0, ACP sent
+    # close_cover and latched it.
+    cmd_svc.set_target(ENTITY_ID, 0)
+    manager.manual_control[ENTITY_ID] = True
+
+    manager.reset(ENTITY_ID)
+
+    assert not cmd_svc.has_target(ENTITY_ID), (
+        "clearing a manual override must discard the target the override "
+        "latched — otherwise reconciliation chases it (#1052)"
+    )
+
+
+async def test_reconcile_does_not_resend_after_override_cleared(
+    hass: HomeAssistant,
+) -> None:
+    """End-to-end: the reported failure, driven through a real reconcile pass.
+
+    Cover parked at 99 with a stale target of 0. Before the fix the reconcile
+    tick resent 0 and closed the shade.
+    """
+    coordinator = _build_coordinator(hass, "issue_1052_reconcile")
+    manager = coordinator.manager
+    cmd_svc = coordinator._cmd_svc
+
+    manager.add_covers([ENTITY_ID])
+
+    # Reconciliation only resends when position matching is on — the config
+    # the reporting instance ran with.
+    cmd_svc.enable_position_matching = True
+    cmd_svc.auto_control_enabled = True
+    cmd_svc.in_time_window = True
+
+    cmd_svc.set_target(ENTITY_ID, 0)
+    manager.manual_control[ENTITY_ID] = True
+    cmd_svc.manual_override_entities = {ENTITY_ID}
+
+    # User stops the cover at 99, then cancels the override.
+    cmd_svc._get_current_position = MagicMock(return_value=99)
+    cmd_svc._is_cover_in_transit = MagicMock(return_value=False)
+    manager.reset(ENTITY_ID)
+    cmd_svc.manual_override_entities = set(manager.manual_controlled)
+
+    recorded = [
+        async_mock_service(hass, "cover", service)
+        for service in ("set_cover_position", "close_cover", "open_cover")
+    ]
+
+    await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    calls = [call for bucket in recorded for call in bucket]
+    assert not calls, (
+        "reconciliation resent the cancelled override's target — the shade "
+        f"closes to 0 instead of holding the pipeline's 100 (#1052): {calls}"
+    )
+
+
+def test_discard_target_is_idempotent_for_untracked_entity() -> None:
+    """``on_cleared`` fires for auto-expiry too, including entities that never
+    had a target. The discard must be a no-op rather than raise.
+    """
+    svc = CoverCommandService(
+        hass=MagicMock(),
+        logger=logging.getLogger("test"),
+        cover_type="cover_blind",
+        grace_mgr=MagicMock(),
+    )
+
+    svc.discard_target(ENTITY_ID)  # never tracked
+
+    assert not svc.has_target(ENTITY_ID)


### PR DESCRIPTION
## Summary

Cancelling a manual override could send the cover to the override's own target instead of the pipeline's calculated position. On my Side Yard Shade a cover cancelled at 99% closed to 0% about 20 seconds later, with no entry in `last_cover_action` — the move came from the reconcile timer, not a pipeline command.

`ManualOverrideManager.set_transition_callbacks()` exposes `on_engaged` and `on_cleared`, but only `on_engaged` was wired to `discard_target`, so a target latched *by* an override outlived it:

1. `set_axes` engages an override with target 0; ACP sends `close_cover` and latches `target_call` = 0.
2. The user stops the cover at 99.
3. The user cancels. The pipeline recomputes 100, but 100 vs 99 is inside `delta_position_threshold`, so the corrective command is gated away as `same_position` and nothing overwrites `target_call`.
4. The entity leaves `_manual_override_entities`, so the next reconcile tick stops skipping it, sees actual 99 against target 0, and resends 0.

The second cancel worked because the cover had been stopped at 90 — a delta of 10 clears both gates, so a real `open_cover` went out and overwrote `target_call` with 100. That gate-dependence is why it looks intermittent.

`on_cleared` has had no subscriber since #522 introduced it.

## Changes

- `coordinator.py` subscribes to both override edges rather than one.
- `CoverCommandService.discard_targets(entity_ids)` — a plural adapter over the existing `discard_target`, matching the `list[str]` shape `on_cleared` fires with. Keeps the lambda out of the constructor and the discard logic in one place.
- Corrected `discard_target`'s docstring, which already claimed coverage for "after the user is controlling the cover" that it did not have.

Auto-expiry (`check_and_reset_if_expired` → `reset()`) goes through the same edge, so an expired override no longer leaves its target behind either. Same class of staleness; the expiry suite is unchanged and green.

Safety targets are unaffected in practice — they re-apply on the next cycle because they bypass the delta gates.

## Testing

- ✅ 8,805 passing, 1 xfailed — no regressions
- ✅ New `tests/test_issue_1052_override_clear_discards_target.py`, 4 cases, built on a real coordinator so they exercise the shipped wiring instead of a re-implementation of it: the edge is wired; `reset()` drops the latched target; end-to-end, a real `run_reconciliation_pass` sends nothing after a cancel; `discard_target` is a no-op for an untracked entity.
- ✅ Red-then-green: the first three fail on `develop`, and the end-to-end case fails with `ServiceCall cover.close_cover` — the production failure reproduced.
- ✅ `./scripts/lint` and `black` clean

The end-to-end test also raised a lingering-task teardown error before the fix that disappears after it. Not flakiness: the spurious resend was spawning the service-call task.

## Related Issues

Refs #1052
