### PR TITLE
fix: honor sunrise/sunset time entities in set_position (#1048)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -39,7 +39,6 @@ from homeassistant.util import dt as dt_util
 from .config_types import CoverConfig, RuntimeConfig
 from .helpers import (
     _read_sun_boundary_options,
-    _read_time_entity,  # noqa: F401 - re-exported: tests patch/import it here
     check_cover_features,
     compute_effective_default,
     custom_position_slot_delivers_fixed_position,

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -7,9 +7,9 @@ import datetime as dt
 import dataclasses
 import json
 import pathlib
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .forecast import Forecast
@@ -38,12 +38,12 @@ from homeassistant.util import dt as dt_util
 
 from .config_types import CoverConfig, RuntimeConfig
 from .helpers import (
+    _read_sun_boundary_options,
+    _read_time_entity,  # noqa: F401 - re-exported: tests patch/import it here
     check_cover_features,
     compute_effective_default,
     custom_position_slot_delivers_fixed_position,
     custom_position_slot_sensors,
-    get_datetime_from_str,
-    get_safe_state,
     has_configured_window_end,
     resolve_override_deadline,
     resolve_sun_boundaries,
@@ -89,11 +89,8 @@ from .const import (
     CONF_MY_POSITION_VALUE,
     CONF_OPEN_CLOSE_THRESHOLD,
     CONF_RETURN_SUNSET,
-    CONF_SUNRISE_OFFSET,
-    CONF_SUNRISE_TIME_ENTITY,
     CONF_SUNSET_OFFSET,
     CONF_SUNSET_POS,
-    CONF_SUNSET_TIME_ENTITY,
     CONF_TRANSIT_TIMEOUT,
     CUSTOM_POSITION_SAFETY_PRIORITY,
     CUSTOM_POSITION_SLOTS,
@@ -161,88 +158,6 @@ from .state.window_transition_tracker import WindowTransitionTracker
 _MANIFEST_VERSION: str = json.loads(
     (pathlib.Path(__file__).parent / "manifest.json").read_text()
 )["version"]
-
-
-class SunBoundaryOptions(NamedTuple):
-    """The four HA-side inputs that define what "sunset"/"sunrise" mean here.
-
-    Produced by :func:`_read_sun_boundary_options`
-    and consumed by both the day/night position boundary and the manual-override
-    sun deadline. Field names match :func:`.helpers.resolve_sun_boundaries`'
-    keyword arguments.
-    """
-
-    sunset_time: dt.datetime | None
-    sunrise_time: dt.datetime | None
-    sunset_off: int
-    sunrise_off: int
-
-
-def _read_time_entity(hass: HomeAssistant, entity_id: str | None) -> dt.datetime | None:
-    """Read an entity whose state is an ISO-8601 datetime.
-
-    Returns naive-local datetime on success; None if entity_id is None,
-    the entity is unavailable, or the state cannot be parsed.
-
-    The entity's *time-of-day* is re-anchored onto today's local date and the
-    original date component is discarded. This makes a "next-event" sensor
-    (e.g. ``sensor.sun_next_setting``, which rolls over to *tomorrow's*
-    setting the instant today's sun sets) behave like a fixed daily wall-clock
-    time. ``compute_effective_default`` already compares the boundary against
-    *today's* clock, so a future-dated boundary would otherwise make the
-    ``after_sunset`` comparison structurally unreachable (issue #531 follow-up).
-    """
-    if entity_id is None:
-        return None
-    raw = get_safe_state(hass, entity_id)
-    if raw is None:
-        return None
-    try:
-        parsed = get_datetime_from_str(raw)
-        today_local = dt_util.now().date()
-        return parsed.replace(
-            year=today_local.year,
-            month=today_local.month,
-            day=today_local.day,
-        )
-    except Exception:  # noqa: BLE001
-        _LOGGER.debug(
-            "Could not parse time entity %s state %r as datetime",
-            entity_id,
-            raw,
-        )
-        return None
-
-
-def _read_sun_boundary_options(
-    hass: HomeAssistant, options: Mapping
-) -> SunBoundaryOptions:
-    """Read the four HA-side inputs that define sunset/sunrise for this instance.
-
-    The single source of truth for the *reads* on the coordinator's own two
-    boundary consumers, as :func:`.helpers.resolve_sun_boundaries` is for the
-    arithmetic they feed: the day/night position boundary
-    (``_compute_current_effective_default``) and the manual-override sun deadline
-    (``_resolve_override_deadline``) both delegate here, so a later fifth input
-    lands in one place and those two can never disagree about what "sunset" means
-    (CODING_GUIDELINES.md § no-duplication).
-
-    Not yet exhaustive across the integration: ``pipeline/snapshot_builder.py``
-    re-derives the offsets itself and calls ``compute_effective_default`` without
-    the sunset/sunrise *time entities*, so its fallback path drops the #411/#415
-    overrides; ``config_types.py`` and ``services/export_service.py`` carry their
-    own copies of the offset fallback. Fold them in here when you next touch them.
-
-    ``sunrise_offset`` falls back to ``sunset_offset`` when unset, so an install
-    that only ever set one offset gets a symmetric night window.
-    """
-    sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
-    return SunBoundaryOptions(
-        sunset_time=_read_time_entity(hass, options.get(CONF_SUNSET_TIME_ENTITY)),
-        sunrise_time=_read_time_entity(hass, options.get(CONF_SUNRISE_TIME_ENTITY)),
-        sunset_off=sunset_off,
-        sunrise_off=int(options.get(CONF_SUNRISE_OFFSET, sunset_off)),
-    )
 
 
 # Cover states that carry no usable position. A transition whose *old* state is

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -585,9 +585,12 @@ def _read_sun_boundary_options(
     input lands in one place and those callers can never disagree about what
     "sunset" means (CODING_GUIDELINES.md § no-duplication).
 
-    Not yet exhaustive across the integration: ``config_types.py`` and
-    ``services/export_service.py`` carry their own copies of the offset fallback.
-    Fold them in here when you next touch them (tracked in issue #1050).
+    Not yet exhaustive across the integration: ``config_types.py``,
+    ``services/export_service.py``, and ``config_flow.py`` each carry their own
+    copy of the offset fallback. ``config_flow.py``'s is semantically divergent —
+    it defaults ``sunrise_offset`` to ``0`` instead of falling back to
+    ``sunset_off``. Fold them in here when you next touch them (tracked in
+    issue #1050).
 
     ``sunrise_offset`` falls back to ``sunset_offset`` when unset, so an install
     that only ever set one offset gets a symmetric night window.

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, timedelta
 from functools import partial
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import pandas as pd
 from dateutil import parser
@@ -21,6 +21,10 @@ from .const import (
     CONF_MANUAL_OVERRIDE_INPUT_ENTITIES,
     CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
+    CONF_SUNRISE_OFFSET,
+    CONF_SUNRISE_TIME_ENTITY,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_TIME_ENTITY,
     CUSTOM_POSITION_SLOTS,
     DEFAULT_CUSTOM_POSITION_TILT_ONLY,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_NEXT_SUN_EVENT,
@@ -515,6 +519,86 @@ def _next_boundary_resolver(
         )
         return lambda: resolved
     return partial(_resolve_boundary, None, astral_next, offset_minutes)
+
+
+class SunBoundaryOptions(NamedTuple):
+    """The four HA-side inputs that define what "sunset"/"sunrise" mean here.
+
+    Produced by :func:`_read_sun_boundary_options`
+    and consumed by both the day/night position boundary and the manual-override
+    sun deadline. Field names match :func:`resolve_sun_boundaries`'
+    keyword arguments.
+    """
+
+    sunset_time: dt.datetime | None
+    sunrise_time: dt.datetime | None
+    sunset_off: int
+    sunrise_off: int
+
+
+def _read_time_entity(hass: HomeAssistant, entity_id: str | None) -> dt.datetime | None:
+    """Read an entity whose state is an ISO-8601 datetime.
+
+    Returns naive-local datetime on success; None if entity_id is None,
+    the entity is unavailable, or the state cannot be parsed.
+
+    The entity's *time-of-day* is re-anchored onto today's local date and the
+    original date component is discarded. This makes a "next-event" sensor
+    (e.g. ``sensor.sun_next_setting``, which rolls over to *tomorrow's*
+    setting the instant today's sun sets) behave like a fixed daily wall-clock
+    time. ``compute_effective_default`` already compares the boundary against
+    *today's* clock, so a future-dated boundary would otherwise make the
+    ``after_sunset`` comparison structurally unreachable (issue #531 follow-up).
+    """
+    if entity_id is None:
+        return None
+    raw = get_safe_state(hass, entity_id)
+    if raw is None:
+        return None
+    try:
+        parsed = get_datetime_from_str(raw)
+        today_local = dt_util.now().date()
+        return parsed.replace(
+            year=today_local.year,
+            month=today_local.month,
+            day=today_local.day,
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug(
+            "Could not parse time entity %s state %r as datetime",
+            entity_id,
+            raw,
+        )
+        return None
+
+
+def _read_sun_boundary_options(
+    hass: HomeAssistant, options: Mapping
+) -> SunBoundaryOptions:
+    """Read the four HA-side inputs that define sunset/sunrise for this instance.
+
+    The single source of truth for the *reads* feeding :func:`resolve_sun_boundaries`'
+    arithmetic: the day/night position boundary
+    (``_compute_current_effective_default``), the manual-override sun deadline
+    (``_resolve_override_deadline``), and the pipeline snapshot builder's fallback
+    branch (``PipelineSnapshotBuilder.build``) all delegate here, so a later fifth
+    input lands in one place and those callers can never disagree about what
+    "sunset" means (CODING_GUIDELINES.md § no-duplication).
+
+    Not yet exhaustive across the integration: ``config_types.py`` and
+    ``services/export_service.py`` carry their own copies of the offset fallback.
+    Fold them in here when you next touch them (tracked in issue #1050).
+
+    ``sunrise_offset`` falls back to ``sunset_offset`` when unset, so an install
+    that only ever set one offset gets a symmetric night window.
+    """
+    sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
+    return SunBoundaryOptions(
+        sunset_time=_read_time_entity(hass, options.get(CONF_SUNSET_TIME_ENTITY)),
+        sunrise_time=_read_time_entity(hass, options.get(CONF_SUNRISE_TIME_ENTITY)),
+        sunset_off=sunset_off,
+        sunrise_off=int(options.get(CONF_SUNRISE_OFFSET, sunset_off)),
+    )
 
 
 def resolve_sun_boundaries(

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -475,11 +475,13 @@ class PipelineSnapshotBuilder:
         """Assemble the per-cycle :class:`PipelineSnapshot`.
 
         ``effective_default`` / ``is_sunset_active`` are recomputed from
-        ``options`` and ``cover_data.sun_data`` when omitted — preserving the
-        fallback the original ``_build_pipeline_snapshot`` used so that
-        ``async_apply_user_position`` (which evaluates a preemption check
-        outside the update cycle) can still build a valid snapshot without
-        knowing those values.
+        ``options``, ``cover_data.sun_data``, and (via
+        ``_read_sun_boundary_options``) two ``hass.states.get()`` reads
+        resolving the configured sunrise/sunset time entities, when omitted —
+        preserving the fallback the original ``_build_pipeline_snapshot`` used
+        so that ``async_apply_user_position`` (which evaluates a preemption
+        check outside the update cycle) can still build a valid snapshot
+        without knowing those values.
 
         ``is_glare_zone_enabled(idx)`` returns the current state of the
         per-instance glare-zone master switch for zone ``idx``.  The coordinator

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -65,8 +65,6 @@ from ..const import (
     CONF_PRESENCE_TEMPLATE_MODE,
     CONF_EXTREME_HEAT_POSITION,
     CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR,
-    CONF_SUNRISE_OFFSET,
-    CONF_SUNSET_OFFSET,
     CONF_SUNSET_POS,
     CONF_SUNSET_TILT,
     CONF_SUNSET_USE_MY,
@@ -103,6 +101,7 @@ from ..const import (
 )
 from ..cover_types.base import axis_inverted
 from ..helpers import (
+    _read_sun_boundary_options,
     compute_effective_default,
     custom_position_slot_configured,
     custom_position_slot_name,
@@ -498,16 +497,15 @@ class PipelineSnapshotBuilder:
         if effective_default is None or is_sunset_active is None:
             h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
             sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-            sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
-            sunrise_off = int(
-                options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET) or 0)
-            )
+            bounds = _read_sun_boundary_options(self._hass, options)
             effective_default, is_sunset_active = compute_effective_default(
                 h_def=h_def,
                 sunset_pos=sunset_pos_cfg,
                 sun_data=cover_data.sun_data,
-                sunset_off=sunset_off,
-                sunrise_off=sunrise_off,
+                sunset_off=bounds.sunset_off,
+                sunrise_off=bounds.sunrise_off,
+                sunset_time=bounds.sunset_time,
+                sunrise_time=bounds.sunrise_time,
             )
 
         glare_zones_cfg = self._policy.glare_zones_config(self._config_service, options)

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -475,13 +475,16 @@ class PipelineSnapshotBuilder:
         """Assemble the per-cycle :class:`PipelineSnapshot`.
 
         ``effective_default`` / ``is_sunset_active`` are recomputed from
-        ``options``, ``cover_data.sun_data``, and (via
-        ``_read_sun_boundary_options``) two ``hass.states.get()`` reads
-        resolving the configured sunrise/sunset time entities, when omitted —
-        preserving the fallback the original ``_build_pipeline_snapshot`` used
-        so that ``async_apply_user_position`` (which evaluates a preemption
-        check outside the update cycle) can still build a valid snapshot
-        without knowing those values.
+        ``options``, ``cover_data.sun_data``, and — via
+        ``_read_sun_boundary_options`` — up to two ``hass.states.get()`` reads
+        resolving the configured sunrise/sunset time entities, when omitted.
+        An instance with neither entity configured reads no state at all.
+        This fallback exists so that ``async_apply_user_position`` (which
+        evaluates a preemption check outside the update cycle) can still build
+        a valid snapshot without knowing those values. Its inputs are
+        deliberately *wider* than the original ``_build_pipeline_snapshot``'s,
+        which read only ``options`` and ``sun_data`` and so silently dropped
+        the time entities (issue #1048).
 
         ``is_glare_zone_enabled(idx)`` returns the current state of the
         per-instance glare-zone master switch for zone ``idx``.  The coordinator

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -807,7 +807,7 @@ def test_read_custom_position_sensor_states_tilt_none_when_absent():
 @pytest.mark.unit
 def test_read_time_entity_returns_none_for_none_entity_id():
     """_read_time_entity returns None immediately when entity_id is None."""
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     mock_hass = MagicMock()
     result = _read_time_entity(mock_hass, None)
@@ -818,7 +818,7 @@ def test_read_time_entity_returns_none_for_none_entity_id():
 @pytest.mark.unit
 def test_read_time_entity_returns_none_for_unavailable():
     """_read_time_entity returns None when entity state is unavailable."""
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     mock_state = MagicMock()
     mock_state.state = "unavailable"
@@ -838,7 +838,7 @@ def test_read_time_entity_parses_iso_datetime():
     """
     import datetime as dt
 
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     # Use a tz-naive ISO string so get_datetime_from_str returns it unchanged
     mock_state = MagicMock()
@@ -873,7 +873,7 @@ def test_read_time_entity_reanchors_future_next_setting_to_today():
     import datetime as dt
     from zoneinfo import ZoneInfo
 
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     paris = ZoneInfo("Europe/Paris")
     mock_state = MagicMock()
@@ -904,7 +904,7 @@ def test_read_time_entity_reanchors_future_next_rising_to_today():
     import datetime as dt
     from zoneinfo import ZoneInfo
 
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     paris = ZoneInfo("Europe/Paris")
     mock_state = MagicMock()
@@ -935,7 +935,7 @@ def test_read_time_entity_today_dated_entity_unchanged_time_of_day():
     import datetime as dt
     from zoneinfo import ZoneInfo
 
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     paris = ZoneInfo("Europe/Paris")
     mock_state = MagicMock()
@@ -970,7 +970,7 @@ def test_read_time_entity_dst_spring_forward_boundary():
     import datetime as dt
     from zoneinfo import ZoneInfo
 
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
     from custom_components.adaptive_cover_pro.helpers import _local_naive_to_utc_naive
 
     paris = ZoneInfo("Europe/Paris")
@@ -1005,7 +1005,7 @@ def test_read_time_entity_near_midnight_sunset_projects_to_today():
     import datetime as dt
     from zoneinfo import ZoneInfo
 
-    from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+    from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
     paris = ZoneInfo("Europe/Paris")
     mock_state = MagicMock()

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -1068,7 +1068,7 @@ def test_compute_current_effective_default_passes_sunset_entity_time():
 
     with (
         patch(
-            "custom_components.adaptive_cover_pro.coordinator._read_time_entity",
+            "custom_components.adaptive_cover_pro.helpers._read_time_entity",
             return_value=fake_sunset_dt,
         ) as mock_read,
         patch(
@@ -1117,7 +1117,7 @@ def test_compute_current_effective_default_passes_sunrise_entity_time():
 
     with (
         patch(
-            "custom_components.adaptive_cover_pro.coordinator._read_time_entity",
+            "custom_components.adaptive_cover_pro.helpers._read_time_entity",
             return_value=fake_sunrise_dt,
         ) as mock_read,
         patch(

--- a/tests/test_effective_default.py
+++ b/tests/test_effective_default.py
@@ -807,7 +807,7 @@ class TestEntityOverrideTimezone:
         """
         from unittest.mock import MagicMock as _MagicMock
 
-        from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+        from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
         paris = self._paris_tz()
         sun = _make_sun_data(sunset_hour=20, sunrise_hour=4, day=dt.date(2026, 6, 7))
@@ -856,7 +856,7 @@ class TestEntityOverrideTimezone:
         """
         from unittest.mock import MagicMock as _MagicMock
 
-        from custom_components.adaptive_cover_pro.coordinator import _read_time_entity
+        from custom_components.adaptive_cover_pro.helpers import _read_time_entity
 
         paris = self._paris_tz()
         sun = _make_sun_data(sunset_hour=21, sunrise_hour=5, day=dt.date(2026, 6, 7))

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -8,9 +8,11 @@ involve a coordinator at all.
 
 from __future__ import annotations
 
+import datetime as dt
 from unittest.mock import MagicMock, patch
 
 import pytest
+from freezegun import freeze_time
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_CLOUD_SUPPRESSION,
@@ -22,6 +24,9 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MAX_TILT_SUN_ONLY,
     CONF_OUTSIDE_THRESHOLD,
     CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR,
+    CONF_SUNRISE_TIME_ENTITY,
+    CONF_SUNSET_POS,
+    CONF_SUNSET_TIME_ENTITY,
     CONF_TEMP_HIGH,
     CONF_TEMP_LOW,
     CONF_TRACKING_SEASONS,
@@ -520,6 +525,106 @@ def test_build_recomputes_effective_default_when_omitted():
     )
     assert snapshot.default_position == 55
     assert snapshot.is_sunset_active is False
+
+
+@pytest.mark.unit
+def test_build_fallback_uses_configured_sunset_time_entity():
+    """The fallback branch must honor CONF_SUNSET_TIME_ENTITY, not astral (#1048).
+
+    Astral sunset (22:00) hasn't happened yet at 20:00, so a fallback that
+    drops the configured entity would report the daytime default. The
+    entity says sunset was at 18:00 — already past — so the fix must report
+    the sunset position instead.
+    """
+    sunset_state = MagicMock()
+    sunset_state.state = "2026-07-02T18:00:00+00:00"
+    builder, _, _ = _make_builder(states={"sensor.sun2_dusk": sunset_state})
+
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    cover_data.sun_data.sunset.return_value = dt.datetime(
+        2026, 7, 2, 22, 0, tzinfo=dt.UTC
+    )
+    cover_data.sun_data.sunrise.return_value = dt.datetime(
+        2026, 7, 2, 6, 0, tzinfo=dt.UTC
+    )
+
+    opts = {
+        CONF_DEFAULT_HEIGHT: 10,
+        CONF_SUNSET_POS: 80,
+        CONF_SUNSET_TIME_ENTITY: "sensor.sun2_dusk",
+    }
+
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", dt.UTC),
+        freeze_time("2026-07-02 20:00:00"),
+    ):
+        snapshot = builder.build(
+            opts,
+            cover_data=cover_data,
+            cover_type="cover_blind",
+            climate_readings=None,
+            manual_override_active=False,
+            motion_timeout_active=False,
+            weather_override_active=False,
+            in_time_window=True,
+            current_cover_position=None,
+            is_glare_zone_enabled=lambda idx: True,
+        )
+
+    assert snapshot.is_sunset_active is True
+    assert snapshot.default_position == 80
+
+
+@pytest.mark.unit
+def test_build_fallback_uses_configured_sunrise_time_entity():
+    """The fallback branch must honor CONF_SUNRISE_TIME_ENTITY, not astral (#1048).
+
+    Astral sunrise (04:00) hasn't happened yet at 03:00, so a fallback that
+    drops the configured entity would report the sunset/night position. The
+    entity says sunrise was at 02:00 — already past — so the fix must report
+    the daytime default instead.
+    """
+    sunrise_state = MagicMock()
+    sunrise_state.state = "2026-07-02T02:00:00+00:00"
+    builder, _, _ = _make_builder(states={"sensor.sun2_dawn": sunrise_state})
+
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    cover_data.sun_data.sunset.return_value = dt.datetime(
+        2026, 7, 2, 20, 0, tzinfo=dt.UTC
+    )
+    cover_data.sun_data.sunrise.return_value = dt.datetime(
+        2026, 7, 2, 4, 0, tzinfo=dt.UTC
+    )
+
+    opts = {
+        CONF_DEFAULT_HEIGHT: 10,
+        CONF_SUNSET_POS: 80,
+        CONF_SUNRISE_TIME_ENTITY: "sensor.sun2_dawn",
+    }
+
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", dt.UTC),
+        freeze_time("2026-07-02 03:00:00"),
+    ):
+        snapshot = builder.build(
+            opts,
+            cover_data=cover_data,
+            cover_type="cover_blind",
+            climate_readings=None,
+            manual_override_active=False,
+            motion_timeout_active=False,
+            weather_override_active=False,
+            in_time_window=True,
+            current_cover_position=None,
+            is_glare_zone_enabled=lambda idx: True,
+        )
+
+    assert snapshot.is_sunset_active is False
+    assert snapshot.default_position == 10
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

`PipelineSnapshotBuilder.build()`'s fallback branch recomputed `effective_default` / `is_sunset_active` without passing `sunset_time` / `sunrise_time`, so the custom sunrise/sunset time entities from #411 were silently dropped. `compute_effective_default` reads the missing kwargs as "no entity configured" and falls through to astral.

Only the ad-hoc build path reaches that branch — `coordinator.async_apply_user_position`, behind the `adaptive_cover_pro.set_position` service and the preemption check. The main update cycle passes both values explicitly. So an install with a custom sunset entity got its own boundary during tracking and the astral one whenever `set_position` or preemption ran.

I moved `SunBoundaryOptions`, `_read_time_entity` and `_read_sun_boundary_options` out of `coordinator.py` into `helpers.py`, next to the `resolve_sun_boundaries` / `compute_effective_default` arithmetic they already feed, and routed the builder's fallback through that shared reader. Both coordinator consumers and the builder now read the same four inputs from one place, so they cannot disagree about what "sunset" means. This also removes the fallback's private copy of the offset formula.

The remaining offset-fallback copies (`config_types.py`, `services/export_service.py`, and the semantically divergent `config_flow.py`, which defaults `sunrise_offset` to 0 rather than to `sunset_off`) stay with #1050.

### Follow-up commits

The pre-merge audit flagged the `# noqa: F401` re-export I initially left on `coordinator._read_time_entity`. Coordinator has no call sites for it, and `_read_sun_boundary_options` now resolves the name in the `helpers` namespace — so a future `patch("...coordinator._read_time_entity")` would have succeeded against a symbol nothing calls and guarded nothing. That exact trap already cost a debugging cycle on this branch (a stale patch let the real function run against a `MagicMock` hass, which sent `dateutil.parser` into an infinite loop). I dropped the re-export and repointed the ten test imports to `helpers`, so a stale patch now fails loudly with `AttributeError`.

## Testing

- ✅ 8807 tests passing (1 xfailed), stable across repeated runs
- Two new tests drive `build()`'s fallback directly with a configured time entity, picking clock times where the entity and astral boundaries diverge in **opposite** directions (sunset case: astral 22:00 vs entity 18:00 at 20:00; sunrise case: astral 04:00 vs entity 02:00 at 03:00), so a regression either way fails
- I verified both guards genuinely bite by forcing `sunset_time=None` and confirming they fail
- Regression guards green: `test_compute_current_effective_default_passes_{sunset,sunrise}_entity_time`, the 8 `test_read_time_entity_*` tests, `TestSunBoundarySource`, `test_effective_default.py`, `test_build_recomputes_effective_default_when_omitted`
- `./scripts/lint` clean and verified idempotent — ruff's `--fix` silently deleted an import on this branch once, so I checked specifically

## Related Issues

Refs #1048
