### PR TITLE
fix: enforce one time wire format across every write path (#1049)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -30,8 +30,10 @@ from .const import (
     CONF_ENABLE_POSITION_MATCHING,
     CONF_ENABLE_SUN_TRACKING,
     CONF_END_ENTITY,
+    CONF_END_TIME,
     CONF_ENTITIES,
     CONF_START_ENTITY,
+    CONF_START_TIME,
     CONF_FORCE_OVERRIDE_MIN_MODE,
     CONF_FORCE_OVERRIDE_POSITION,
     CONF_FORCE_OVERRIDE_SENSORS,
@@ -76,6 +78,7 @@ from .helpers import (
     custom_position_slot_sensors,
     manual_override_input_entities,
     motion_entities,
+    normalize_time_string,
 )
 from .profile_link import _copy_profile_to_cover, _covers_linked_to
 from .templates import is_template_string
@@ -567,6 +570,25 @@ def _seed_signed_gamma_blind_spots(options: dict) -> bool:
     return seeded
 
 
+def _repair_malformed_times(options: dict) -> list[str]:
+    """Rewrite non-canonical start/end times to ``HH:MM:SS`` (issue #1049).
+
+    Returns the keys actually changed. A value already canonical, absent, or
+    unparsable is left alone — see the v3.11 → v3.12 block in
+    ``async_migrate_entry`` for why this one migration rewrites in place and why
+    that stays rollback-safe.
+    """
+    repaired: list[str] = []
+    for key in (CONF_START_TIME, CONF_END_TIME):
+        if key not in options:
+            continue
+        canonical = normalize_time_string(options[key])
+        if canonical != options[key]:
+            options[key] = canonical
+            repaired.append(key)
+    return repaired
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old config entries to the current schema version."""
     new_options = dict(entry.options)
@@ -705,6 +727,30 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if CONF_LENGTH_AWNING in new_options:
             new_options.setdefault(CONF_AWNING_SHADE_MODE, DEFAULT_AWNING_SHADE_MODE)
         new_minor = 11
+
+    # v3.11 → v3.12: repair start_time/end_time already stored in a non-canonical
+    # shape (issue #1049). Validating the write paths stops new bad values but
+    # leaves an already-bitten entry with e.g. "00:00", which fails every literal
+    # BLANK_TIME comparison while TimeWindowManager resolves it to tomorrow's
+    # midnight — the until_window_end deadline recedes a day at every local
+    # midnight and the override never expires.
+    #
+    # This is the rare migration that rewrites an existing key rather than only
+    # seeding one, so the rollback contract (CLAUDE.md § "Rollback-Safe Config
+    # Migrations") deserves an explicit answer: the rewrite is a repair *into*
+    # the format every release — old and new — already expects. An older build
+    # reading the canonical "00:00:00" applies the unset semantics it always
+    # intended; before the repair it read a phantom configured window end. So a
+    # rollback is strictly better off, never worse, and nothing is renamed or
+    # dropped. Values no parser can rescue are left untouched.
+    if new_version == 3 and new_minor < 12:
+        if repaired := _repair_malformed_times(new_options):
+            _LOGGER.info(
+                "Repaired malformed time options of %s (%s)",
+                entry.data.get("name", entry.entry_id),
+                ", ".join(repaired),
+            )
+        new_minor = 12
 
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -64,6 +64,7 @@ from .const import (
     CUSTOM_POSITION_SLOTS,
     DIAG_CACHE_KEY,
     DOMAIN,
+    TIME_STRING_RE,
     _LOGGER,
     blind_spot_legacy_to_gamma,
     clamp_gamma_pair,
@@ -573,20 +574,33 @@ def _seed_signed_gamma_blind_spots(options: dict) -> bool:
 def _repair_malformed_times(options: dict) -> list[str]:
     """Rewrite non-canonical start/end times to ``HH:MM:SS`` (issue #1049).
 
-    Returns the keys actually changed. A value already canonical, absent, or
-    unparsable is left alone — see the v3.11 → v3.12 block in
-    ``async_migrate_entry`` for why this one migration rewrites in place and why
-    that stays rollback-safe.
+    A value that parses is canonicalised. A value that does **not** parse —
+    ``"25:00:00"``, ``"garbage"`` — is dropped rather than left alone: the old
+    ``set_options`` regex accepted shape-valid impossible clock times and import
+    validated no time at all, so both are reachable in stored options, and
+    ``get_datetime_from_str`` runs ``dateutil.parser.parse`` on them with no
+    guard — raising on every coordinator cycle. Dropping the key is the #492
+    "no time set" state, which is what an unusable window bound already means.
+
+    Returns a description of each change, for the migration log. See the
+    v3.11 → v3.12 block in ``async_migrate_entry`` for why this one migration
+    rewrites in place and why that stays rollback-safe.
     """
-    repaired: list[str] = []
+    changes: list[str] = []
     for key in (CONF_START_TIME, CONF_END_TIME):
         if key not in options:
             continue
-        canonical = normalize_time_string(options[key])
-        if canonical != options[key]:
+        original = options[key]
+        if original is None or TIME_STRING_RE.match(str(original)):
+            continue  # absent-equivalent or already canonical
+        canonical = normalize_time_string(original)
+        if TIME_STRING_RE.match(str(canonical)):
             options[key] = canonical
-            repaired.append(key)
-    return repaired
+            changes.append(f"{key}: {original!r} → {canonical!r}")
+        else:
+            del options[key]
+            changes.append(f"{key}: {original!r} → unset (unparsable)")
+    return changes
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -741,8 +755,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # the format every release — old and new — already expects. An older build
     # reading the canonical "00:00:00" applies the unset semantics it always
     # intended; before the repair it read a phantom configured window end. So a
-    # rollback is strictly better off, never worse, and nothing is renamed or
-    # dropped. Values no parser can rescue are left untouched.
+    # rollback is strictly better off, never worse, and no key is renamed.
+    # A value no parser can rescue is dropped instead — see
+    # ``_repair_malformed_times`` for why leaving it is not the safe option.
     if new_version == 3 and new_minor < 12:
         if repaired := _repair_malformed_times(new_options):
             _LOGGER.info(

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -2125,10 +2125,12 @@ def _build_time_option_keys() -> frozenset[str]:
 
 
 #: Keys whose stored value is an ``HH:MM:SS`` string (``const.TIME_STRING_RE``).
-#: Derived from the registry so a new time field is validated by every consumer
-#: the moment its ``FieldSpec`` is declared — consumed by the service write
-#: paths in ``services.options_service`` and ``services.import_service``
-#: (issue #1049).
+#: Derived from the registry, so declaring a ``ValidatorKind.TIME`` field is
+#: enough for ``services.import_service`` to validate it (issue #1049).
+#: ``services.options_service`` does NOT read this — its ``FIELD_VALIDATORS``
+#: map is hand-written, so a new time field must be added there by hand or
+#: ``set_options`` will reject it as an unknown option. The two are kept in step
+#: by ``test_every_time_field_has_a_set_options_validator``, not by derivation.
 TIME_OPTION_KEYS: frozenset[str] = _build_time_option_keys()
 
 

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -2118,6 +2118,20 @@ def _build_option_ranges() -> dict[str, tuple[float, float]]:
 OPTION_RANGES: dict[str, tuple[float, float]] = _build_option_ranges()
 
 
+def _build_time_option_keys() -> frozenset[str]:
+    return frozenset(
+        s.key for s in FIELD_SPECS.values() if s.validator is ValidatorKind.TIME
+    )
+
+
+#: Keys whose stored value is an ``HH:MM:SS`` string (``const.TIME_STRING_RE``).
+#: Derived from the registry so a new time field is validated by every consumer
+#: the moment its ``FieldSpec`` is declared — consumed by the service write
+#: paths in ``services.options_service`` and ``services.import_service``
+#: (issue #1049).
+TIME_OPTION_KEYS: frozenset[str] = _build_time_option_keys()
+
+
 # Template-support audit (issue #974). The condition-template surface was
 # extended to the severe-weather override and the manual-override input trigger.
 # Deliberately EXCLUDED from template support, and why:

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -257,6 +257,7 @@ from .helpers import (
     custom_position_slot_sensors,
     has_configured_window_end,
     mirror_legacy_slot_sensor_keys,
+    normalize_time_string,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -3967,8 +3968,15 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     # block setdefault-seeds CONF_AWNING_SHADE_MODE to the window-glass default so
     # pre-existing awnings keep the shipped overhang behaviour; an absent key
     # already reads as "window" and an older build ignores it.
-    # Rollback-safe: every migration block is additive (existing keys retained).
-    MINOR_VERSION = 11
+    # 3.12 (issue #1049): repair start_time/end_time already stored in a
+    # non-canonical shape ("00:00", "7:30", non-ASCII digits) to the HH:MM:SS
+    # wire format every literal BLANK_TIME comparison expects. The one block
+    # that rewrites an existing key rather than only seeding one — see the
+    # rollback reasoning at the block itself in __init__.py.
+    # Rollback-safe: every other migration block is additive (existing keys
+    # retained), and the v3.12 rewrite only ever moves a value into the format
+    # older builds already expect.
+    MINOR_VERSION = 12
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()
@@ -5084,7 +5092,14 @@ class OptionsFlowHandler(OptionsFlow):
             # sentinel "00:00:00". Treat both as "unset": drop the key from the
             # submission and from any previously-stored option so it never
             # persists as a literal midnight window (issue #492).
+            #
+            # Canonicalise first: TimeSelector validates via parse_time but
+            # stores the raw submission, so a non-frontend flow client can hand
+            # us "00:00" — which is midnight, yet fails the BLANK_TIME test
+            # below and every other literal sentinel check (issue #1049).
             for time_key in (CONF_START_TIME, CONF_END_TIME):
+                if time_key in user_input:
+                    user_input[time_key] = normalize_time_string(user_input[time_key])
                 if user_input.get(time_key) in (None, BLANK_TIME):
                     user_input.pop(time_key, None)
                     self.options.pop(time_key, None)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1231,11 +1231,21 @@ CONF_END_ENTITY = "end_entity"  # input_datetime overriding end_time
 # true None, so a cleared field coerces to midnight. Treated as "no time set"
 # everywhere (see issue #492).
 BLANK_TIME = "00:00:00"
-# The one accepted wire format for a time-typed option. Every service write
-# path matches against this pattern (``set_options`` and ``import_config``); the
-# config flow gets there via TimeSelector instead. A value in any other shape —
-# ``"00:00"``, ``"0:00:00"`` — compares unequal to BLANK_TIME and silently flips
-# every sentinel check that keys off it (issue #1049).
+# The one accepted wire format for a time-typed option. A value in any other
+# shape — ``"00:00"``, ``"0:00:00"`` — compares unequal to BLANK_TIME and
+# silently flips every sentinel check that keys off it (issue #1049).
+#
+# The three write paths into ``config_entry.options`` reach it differently, and
+# HA's TimeSelector is NOT one of the enforcers — it validates via
+# ``dt_util.parse_time`` and then stores the submission **unnormalized**, so it
+# happily persists ``"00:00"`` or ``"7:30"`` from any non-frontend flow client:
+#   * ``set_options`` / ``import_config`` — match against this pattern and
+#     reject, since a service caller gets a hard error it can act on.
+#   * the config/options flow — canonicalises instead, via
+#     ``helpers.normalize_time_string``; the user picked a real time, just in a
+#     shape the picker itself never emits.
+#   * entries stored before either guard existed — repaired by the v3.11 → v3.12
+#     migration in ``__init__.py``.
 #
 # Three deliberate choices, each closing a way a near-miss value slips through:
 #   * ``\Z``, not ``$`` — ``$`` also matches before a trailing newline, so
@@ -2207,7 +2217,7 @@ SLIDING_SLIDE_DIRECTIONS = tuple(d.value for d in SlideDirection)
 # name ``config_fields`` needs is already defined above. ``config_fields`` does
 # ``from . import const`` (the partially-initialised module is fine — it only
 # reads names defined before this line).
-from .config_fields import OPTION_RANGES  # noqa: E402, F401
+from .config_fields import OPTION_RANGES, TIME_OPTION_KEYS  # noqa: E402, F401
 
 # =============================================================================
 # 27. Enumerations (semantic identifiers)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -51,6 +51,7 @@ Section index
 """
 
 import logging
+import re
 from dataclasses import dataclass
 from enum import Enum, StrEnum
 from typing import Any
@@ -1230,6 +1231,12 @@ CONF_END_ENTITY = "end_entity"  # input_datetime overriding end_time
 # true None, so a cleared field coerces to midnight. Treated as "no time set"
 # everywhere (see issue #492).
 BLANK_TIME = "00:00:00"
+# The one accepted wire format for a time-typed option. Every write path must
+# enforce it: the config flow does so via TimeSelector, and both service paths
+# (``set_options`` and ``import_config``) match against this pattern. A value in
+# any other shape — ``"00:00"``, ``"0:00:00"`` — compares unequal to BLANK_TIME
+# and silently flips the sentinel checks that key off it (issue #1049).
+TIME_STRING_RE = re.compile(r"^\d{2}:\d{2}:\d{2}$")
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1231,12 +1231,21 @@ CONF_END_ENTITY = "end_entity"  # input_datetime overriding end_time
 # true None, so a cleared field coerces to midnight. Treated as "no time set"
 # everywhere (see issue #492).
 BLANK_TIME = "00:00:00"
-# The one accepted wire format for a time-typed option. Every write path must
-# enforce it: the config flow does so via TimeSelector, and both service paths
-# (``set_options`` and ``import_config``) match against this pattern. A value in
-# any other shape — ``"00:00"``, ``"0:00:00"`` — compares unequal to BLANK_TIME
-# and silently flips the sentinel checks that key off it (issue #1049).
-TIME_STRING_RE = re.compile(r"^\d{2}:\d{2}:\d{2}$")
+# The one accepted wire format for a time-typed option. Every service write
+# path matches against this pattern (``set_options`` and ``import_config``); the
+# config flow gets there via TimeSelector instead. A value in any other shape —
+# ``"00:00"``, ``"0:00:00"`` — compares unequal to BLANK_TIME and silently flips
+# every sentinel check that keys off it (issue #1049).
+#
+# Three deliberate choices, each closing a way a near-miss value slips through:
+#   * ``\Z``, not ``$`` — ``$`` also matches before a trailing newline, so
+#     ``"00:00:00\n"`` would pass while comparing unequal to BLANK_TIME.
+#   * ``[0-9]``, not ``\d`` — ``\d`` matches any Unicode decimal digit, so
+#     ``"٠٠:٠٠:٠٠"`` would pass and then parse to midnight.
+#   * real clock bounds, not ``{2}`` — the hour/minute/second alternations
+#     reject ``"25:00:00"``, which is shape-valid but raises in
+#     ``get_datetime_from_str`` on every coordinator cycle once stored.
+TIME_STRING_RE = re.compile(r"^(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\Z")
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1235,17 +1235,24 @@ BLANK_TIME = "00:00:00"
 # shape — ``"00:00"``, ``"0:00:00"`` — compares unequal to BLANK_TIME and
 # silently flips every sentinel check that keys off it (issue #1049).
 #
-# The three write paths into ``config_entry.options`` reach it differently, and
-# HA's TimeSelector is NOT one of the enforcers — it validates via
-# ``dt_util.parse_time`` and then stores the submission **unnormalized**, so it
-# happily persists ``"00:00"`` or ``"7:30"`` from any non-frontend flow client:
-#   * ``set_options`` / ``import_config`` — match against this pattern and
-#     reject, since a service caller gets a hard error it can act on.
-#   * the config/options flow — canonicalises instead, via
-#     ``helpers.normalize_time_string``; the user picked a real time, just in a
-#     shape the picker itself never emits.
-#   * entries stored before either guard existed — repaired by the v3.11 → v3.12
-#     migration in ``__init__.py``.
+# HA's TimeSelector is NOT an enforcer — it validates via ``dt_util.parse_time``
+# and then stores the submission **unnormalized**, so it happily persists
+# ``"00:00"`` or ``"7:30"`` from any non-frontend flow client. Each write path
+# into ``config_entry.options`` that can carry a time key therefore handles it
+# itself:
+#   * ``set_options`` (``services.options_service``) — matches this pattern and
+#     rejects; the caller wrote the patch by hand and can fix it.
+#   * ``import_config`` (``services.import_service``) — canonicalises what
+#     ``helpers.normalize_time_string`` can parse and errors on the rest; an
+#     export file has no caller to send back to.
+#   * the options flow's automation step (``config_flow``) — canonicalises; the
+#     user picked a real time, just in a shape the picker never emits. It is
+#     the only flow step rendering a TimeSelector.
+#   * the flow's Sync and Duplicate steps (``config_flow``) — copy a time key
+#     verbatim between entries. Safe only because the source is already
+#     canonical; they add no guard of their own.
+# Entries written before any of this existed are repaired by the v3.11 → v3.12
+# migration in ``__init__.py``.
 #
 # Three deliberate choices, each closing a way a near-miss value slips through:
 #   * ``\Z``, not ``$`` — ``$`` also matches before a trailing newline, so

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -108,12 +108,18 @@ def normalize_time_string(value: Any) -> Any:
     end while ``TimeWindowManager`` resolves them to tomorrow's midnight —
     issue #1049.
 
-    The flow normalizes rather than rejects, unlike the service write paths
-    (``set_options`` / ``import_config``, which raise): the user picked a real
-    time, only in a shape the picker itself would never emit, so canonicalising
-    it honours the intent. Values already in canonical form, and values no
-    parser can rescue, are returned unchanged — the latter have already been
-    refused by the selector, and inventing a time here would mask that.
+    Callers that have no one to send a bad value back to normalize with this
+    and keep going — the options flow (the user picked a real time, just in a
+    shape the picker never emits) and ``import_config`` (an export file predates
+    the validation). ``set_options`` is the exception: it rejects outright,
+    because its caller wrote the patch by hand and can fix it. The full
+    per-path table lives at ``const.TIME_STRING_RE``.
+
+    Values already canonical, and values no parser can rescue, are returned
+    unchanged — inventing a time for the latter would mask the problem. Callers
+    must therefore re-check the result against ``TIME_STRING_RE`` to tell
+    "canonicalised" from "could not be rescued"; what they do with the latter
+    differs (import errors, the migration drops the key).
     """
     if not isinstance(value, str) or TIME_STRING_RE.match(value):
         return value

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, timedelta
 from functools import partial
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pandas as pd
 from dateutil import parser
@@ -31,6 +31,7 @@ from .const import (
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END,
+    TIME_STRING_RE,
 )
 from .templates import is_template_string
 
@@ -94,6 +95,32 @@ def has_configured_window_end(options: Mapping) -> bool:
         options.get(key) not in (None, "", BLANK_TIME)
         for key in (CONF_END_TIME, CONF_END_ENTITY)
     )
+
+
+def normalize_time_string(value: Any) -> Any:
+    """Return *value* as a canonical ``HH:MM:SS`` string when it parses as a time.
+
+    HA's ``TimeSelector`` validates a submission via ``dt_util.parse_time`` but
+    stores it **unnormalized**, so a non-frontend flow client (websocket/REST
+    flow API, a custom card) can persist ``"00:00"``, ``"7:30"`` or
+    ``"٠٧:٣٠:٠٠"`` verbatim. None of those equal ``BLANK_TIME``, so every
+    literal sentinel comparison downstream reads them as a configured window
+    end while ``TimeWindowManager`` resolves them to tomorrow's midnight —
+    issue #1049.
+
+    The flow normalizes rather than rejects, unlike the service write paths
+    (``set_options`` / ``import_config``, which raise): the user picked a real
+    time, only in a shape the picker itself would never emit, so canonicalising
+    it honours the intent. Values already in canonical form, and values no
+    parser can rescue, are returned unchanged — the latter have already been
+    refused by the selector, and inventing a time here would mask that.
+    """
+    if not isinstance(value, str) or TIME_STRING_RE.match(value):
+        return value
+    parsed = dt_util.parse_time(value)
+    if parsed is None:
+        return value
+    return parsed.strftime("%H:%M:%S")
 
 
 def custom_position_slot_sensors(

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -142,7 +142,7 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                         validation_errors.append(
                             f"{key}={value!r} is not a valid number"
                         )
-                elif key in TIME_OPTION_KEYS and not TIME_STRING_RE.match(str(value)):
+                if key in TIME_OPTION_KEYS and not TIME_STRING_RE.match(str(value)):
                     validation_errors.append(
                         f"{key}={value!r} is not a valid time (expected HH:MM:SS)"
                     )

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -38,12 +38,17 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
     never overwritten by an older export.
 
     Numeric keys present in ``OPTION_RANGES`` are validated against their
-    declared bounds, and time keys (``TIME_OPTION_KEYS``) against the
-    ``HH:MM:SS`` wire format in ``const.TIME_STRING_RE`` — the same pattern
-    ``set_options`` enforces — before the entry is updated; a failed check
-    records ``"error: ..."`` for that entry in the result dict without aborting
-    the rest of the import. A malformed time otherwise reaches the entry
-    verbatim and defeats the literal ``BLANK_TIME`` comparisons across the
+    declared bounds before the entry is updated; a failed check records
+    ``"error: ..."`` for that entry in the result dict without aborting the
+    rest of the import.
+
+    Time keys (``TIME_OPTION_KEYS``) are **canonicalised, not rejected**, and
+    this deliberately differs from ``set_options``: a value that parses is
+    rewritten to the ``const.TIME_STRING_RE`` wire format (``"00:00"`` is
+    stored as ``"00:00:00"``) and only a value no parser can rescue records an
+    error. An export file predates this validation, so failing the entry would
+    drop every *other* option a user is restoring — while a malformed time left
+    verbatim defeats the literal ``BLANK_TIME`` comparisons across the
     integration (issue #1049). Remaining keys (booleans, strings, enums, and
     unknown future keys) are accepted as-is.
 
@@ -152,6 +157,14 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                     # no one to ask.
                     canonical = normalize_time_string(value)
                     if TIME_STRING_RE.match(str(canonical)):
+                        if canonical != value:
+                            _LOGGER.debug(
+                                "import_config: entry '%s' %s=%r stored as %r",
+                                entry_id,
+                                key,
+                                value,
+                                canonical,
+                            )
                         imported_public[key] = canonical
                     else:
                         validation_errors.append(

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
 from ..const import DOMAIN, OPTION_RANGES, TIME_OPTION_KEYS, TIME_STRING_RE
+from ..helpers import normalize_time_string
 from .export_service import DEFAULT_EXPORT_PATH
 
 _LOGGER = logging.getLogger(__name__)
@@ -126,7 +127,7 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
             # Validate numeric keys against their declared OPTION_RANGES bounds
             # and time keys against the one accepted HH:MM:SS wire format.
             validation_errors: list[str] = []
-            for key, value in imported_public.items():
+            for key, value in list(imported_public.items()):
                 if value is None:
                     continue
                 if key in OPTION_RANGES:
@@ -141,10 +142,21 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                         validation_errors.append(
                             f"{key}={value!r} is not a valid number"
                         )
-                if key in TIME_OPTION_KEYS and not TIME_STRING_RE.match(str(value)):
-                    validation_errors.append(
-                        f"{key}={value!r} is not a valid time (expected HH:MM:SS)"
-                    )
+                if key in TIME_OPTION_KEYS:
+                    # Canonicalise what parses rather than failing the entry.
+                    # An export predates this validation, so the users most
+                    # likely to hold a "00:00" are exactly the ones #1049 bit —
+                    # rejecting would drop every *other* option they are trying
+                    # to restore. ``set_options`` still refuses the same value:
+                    # it has a caller who can fix the patch, an import file has
+                    # no one to ask.
+                    canonical = normalize_time_string(value)
+                    if TIME_STRING_RE.match(str(canonical)):
+                        imported_public[key] = canonical
+                    else:
+                        validation_errors.append(
+                            f"{key}={value!r} is not a valid time (expected HH:MM:SS)"
+                        )
             if validation_errors:
                 raise ServiceValidationError(
                     f"import_config: invalid values for entry '{entry_id}': "

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -14,7 +14,8 @@ from homeassistant.exceptions import ServiceValidationError
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
-from ..const import DOMAIN, OPTION_RANGES
+from ..config_fields import TIME_OPTION_KEYS
+from ..const import DOMAIN, OPTION_RANGES, TIME_STRING_RE
 from .export_service import DEFAULT_EXPORT_PATH
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,10 +38,14 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
     never overwritten by an older export.
 
     Numeric keys present in ``OPTION_RANGES`` are validated against their
-    declared bounds before the entry is updated; a failed check records
-    ``"error: ..."`` for that entry in the result dict without aborting the
-    rest of the import. Keys absent from ``OPTION_RANGES`` (booleans, strings,
-    enums, and unknown future keys) are accepted as-is.
+    declared bounds, and time keys (``TIME_OPTION_KEYS``) against the
+    ``HH:MM:SS`` wire format the config flow and ``set_options`` both enforce,
+    before the entry is updated; a failed check records ``"error: ..."`` for
+    that entry in the result dict without aborting the rest of the import. A
+    malformed time otherwise reaches the entry verbatim and defeats the literal
+    ``BLANK_TIME`` comparisons across the integration (issue #1049). Remaining
+    keys (booleans, strings, enums, and unknown future keys) are accepted
+    as-is.
 
     Returns a per-entry result dict:
         ``{entry_id: "updated" | "skipped" | "error: <msg>"}``
@@ -119,20 +124,28 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                 k: v for k, v in file_opts.items() if not k.startswith("_")
             }
 
-            # Validate numeric keys against their declared OPTION_RANGES bounds.
+            # Validate numeric keys against their declared OPTION_RANGES bounds
+            # and time keys against the one accepted HH:MM:SS wire format.
             validation_errors: list[str] = []
             for key, value in imported_public.items():
-                if key not in OPTION_RANGES or value is None:
+                if value is None:
                     continue
-                lo, hi = OPTION_RANGES[key]
-                try:
-                    num = float(value)
-                    if not (lo <= num <= hi):
+                if key in OPTION_RANGES:
+                    lo, hi = OPTION_RANGES[key]
+                    try:
+                        num = float(value)
+                        if not (lo <= num <= hi):
+                            validation_errors.append(
+                                f"{key}={value} out of range [{lo}, {hi}]"
+                            )
+                    except (TypeError, ValueError):
                         validation_errors.append(
-                            f"{key}={value} out of range [{lo}, {hi}]"
+                            f"{key}={value!r} is not a valid number"
                         )
-                except (TypeError, ValueError):
-                    validation_errors.append(f"{key}={value!r} is not a valid number")
+                elif key in TIME_OPTION_KEYS and not TIME_STRING_RE.match(str(value)):
+                    validation_errors.append(
+                        f"{key}={value!r} is not a valid time (expected HH:MM:SS)"
+                    )
             if validation_errors:
                 raise ServiceValidationError(
                     f"import_config: invalid values for entry '{entry_id}': "

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -14,8 +14,7 @@ from homeassistant.exceptions import ServiceValidationError
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
-from ..config_fields import TIME_OPTION_KEYS
-from ..const import DOMAIN, OPTION_RANGES, TIME_STRING_RE
+from ..const import DOMAIN, OPTION_RANGES, TIME_OPTION_KEYS, TIME_STRING_RE
 from .export_service import DEFAULT_EXPORT_PATH
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,13 +38,13 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
 
     Numeric keys present in ``OPTION_RANGES`` are validated against their
     declared bounds, and time keys (``TIME_OPTION_KEYS``) against the
-    ``HH:MM:SS`` wire format the config flow and ``set_options`` both enforce,
-    before the entry is updated; a failed check records ``"error: ..."`` for
-    that entry in the result dict without aborting the rest of the import. A
-    malformed time otherwise reaches the entry verbatim and defeats the literal
-    ``BLANK_TIME`` comparisons across the integration (issue #1049). Remaining
-    keys (booleans, strings, enums, and unknown future keys) are accepted
-    as-is.
+    ``HH:MM:SS`` wire format in ``const.TIME_STRING_RE`` — the same pattern
+    ``set_options`` enforces — before the entry is updated; a failed check
+    records ``"error: ..."`` for that entry in the result dict without aborting
+    the rest of the import. A malformed time otherwise reaches the entry
+    verbatim and defeats the literal ``BLANK_TIME`` comparisons across the
+    integration (issue #1049). Remaining keys (booleans, strings, enums, and
+    unknown future keys) are accepted as-is.
 
     Returns a per-entry result dict:
         ``{entry_id: "updated" | "skipped" | "error: <msg>"}``

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -8,7 +8,6 @@ a full reload so all state-change listeners and pipeline handlers pick up new va
 from __future__ import annotations
 
 import logging
-import re
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -216,6 +215,7 @@ from ..const import (
     CUSTOM_POSITION_SLOTS,
     DOMAIN,
     OPTION_RANGES,
+    TIME_STRING_RE,
 )
 from ..helpers import CUSTOM_POSITION_CLAIM_KEYS, custom_position_slot_sensors
 from ..templates import is_template_string as _is_template_str
@@ -229,8 +229,6 @@ IDENTITY_KEYS: frozenset[str] = frozenset(
 
 # HA service call plumbing keys to strip when building a patch
 _PLUMBING_KEYS: frozenset[str] = frozenset({"entity_id", "device_id", "area_id"})
-
-_TIME_RE = re.compile(r"^\d{2}:\d{2}:\d{2}$")
 
 # ---------------------------------------------------------------------------
 # Per-field validators
@@ -341,7 +339,7 @@ def _duration_v():
 
 def _time_v():
     def _check(v):
-        if v is not None and not _TIME_RE.match(str(v)):
+        if v is not None and not TIME_STRING_RE.match(str(v)):
             raise vol.Invalid(f"Time must be HH:MM:SS, got: {v!r}")
         return v
 

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -544,30 +544,6 @@ class TestImportConfig:
         assert (await async_handle_import_config(call))["id-1"] == "updated"
 
     @pytest.mark.asyncio
-    async def test_every_time_selector_field_is_tagged_time(self):
-        """TIME_OPTION_KEYS covers every TimeSelector field in the registry.
-
-        The derivation is only as good as the ``ValidatorKind.TIME`` tagging, so
-        the guard is on the tagging itself: a new field that renders a
-        ``TimeSelector`` but is tagged something else would slip past both
-        service validators exactly as start_time/end_time did (issue #1049).
-        """
-        from homeassistant.helpers import selector
-
-        from custom_components.adaptive_cover_pro.config_fields import (
-            FIELD_SPECS,
-            TIME_OPTION_KEYS,
-        )
-
-        for key, spec in FIELD_SPECS.items():
-            if spec.make_selector is None:
-                continue
-            if isinstance(spec.make_selector(None, {}), selector.TimeSelector):
-                assert key in TIME_OPTION_KEYS
-
-        assert {"start_time", "end_time"} == TIME_OPTION_KEYS
-
-    @pytest.mark.asyncio
     async def test_mixed_results(self, tmp_path):
         """One valid entry and one unknown entry produce mixed results dict."""
         from custom_components.adaptive_cover_pro.services.import_service import (

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -12,6 +12,25 @@ import pytest
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Time values the config flow's TimeSelector can never emit. Each one compares
+# unequal to BLANK_TIME ("00:00:00") while still parsing to — or crashing on —
+# something the runtime treats as a configured window end, which is the whole
+# of issue #1049. Shared by the import tests and the set_options parity tests
+# so neither write path can quietly grow a looser format than the other.
+_BAD_TIMES = [
+    "00:00",  # HH:MM — the reported case
+    "0:00:00",  # unpadded hour
+    "8:30:00",  # unpadded hour, non-midnight
+    "not a time",
+    "",  # empty string is not the unset sentinel
+    "00:00:00\n",  # trailing newline: `$` would let this through
+    "25:00:00",  # shape-valid, impossible clock time
+    "24:99:99",  # shape-valid, impossible clock time
+    "٠٠:٠٠:٠٠",  # Arabic-Indic digits: `\d` matches
+]
+
+_GOOD_TIMES = ["00:00:00", "07:00:00", "22:30:00", "23:59:59"]
+
 
 def _make_entry(
     entry_id: str, title: str, options: dict, domain: str = "adaptive_cover_pro"
@@ -363,10 +382,11 @@ class TestImportConfig:
         # entry options must not have been modified
         assert entry.options["set_azimuth"] == 90
 
-    @pytest.mark.parametrize("bad_time", ["00:00", "0:00:00", "8:30:00", "not a time"])
+    @pytest.mark.parametrize("time_key", ["start_time", "end_time"])
+    @pytest.mark.parametrize("bad_time", _BAD_TIMES)
     @pytest.mark.asyncio
-    async def test_malformed_time_recorded_as_error(self, tmp_path, bad_time):
-        """A time key not in HH:MM:SS form records an error and leaves the entry alone.
+    async def test_malformed_time_recorded_as_error(self, tmp_path, time_key, bad_time):
+        """A time value outside the wire format errors and leaves the entry alone.
 
         Import used to skip every key absent from OPTION_RANGES, so a stray
         ``"00:00"`` reached the config entry and defeated the literal
@@ -377,13 +397,13 @@ class TestImportConfig:
             async_handle_import_config,
         )
 
-        entry = _make_entry("id-1", "Blind A", {"end_time": "22:00:00"})
+        entry = _make_entry("id-1", "Blind A", {time_key: "22:00:00"})
         hass = _make_hass([entry], config_dir=str(tmp_path))
 
         export_path = tmp_path / "import.json"
         self._write_export(
             export_path,
-            [{"entry_id": "id-1", "options": {"end_time": bad_time}}],
+            [{"entry_id": "id-1", "options": {time_key: bad_time}}],
         )
 
         call = MagicMock()
@@ -393,24 +413,25 @@ class TestImportConfig:
         result = await async_handle_import_config(call)
 
         assert result["id-1"].startswith("error:")
-        assert "end_time" in result["id-1"]
-        assert entry.options["end_time"] == "22:00:00"
+        assert time_key in result["id-1"]
+        assert entry.options[time_key] == "22:00:00"
 
-    @pytest.mark.parametrize("good_time", ["00:00:00", "22:30:00", None])
+    @pytest.mark.parametrize("time_key", ["start_time", "end_time"])
+    @pytest.mark.parametrize("good_time", [*_GOOD_TIMES, None])
     @pytest.mark.asyncio
-    async def test_well_formed_time_imports(self, tmp_path, good_time):
+    async def test_well_formed_time_imports(self, tmp_path, time_key, good_time):
         """HH:MM:SS values — including the BLANK_TIME sentinel — and None import cleanly."""
         from custom_components.adaptive_cover_pro.services.import_service import (
             async_handle_import_config,
         )
 
-        entry = _make_entry("id-1", "Blind A", {"start_time": "07:00:00"})
+        entry = _make_entry("id-1", "Blind A", {time_key: "07:00:00"})
         hass = _make_hass([entry], config_dir=str(tmp_path))
 
         export_path = tmp_path / "import.json"
         self._write_export(
             export_path,
-            [{"entry_id": "id-1", "options": {"start_time": good_time}}],
+            [{"entry_id": "id-1", "options": {time_key: good_time}}],
         )
 
         call = MagicMock()
@@ -420,16 +441,47 @@ class TestImportConfig:
         result = await async_handle_import_config(call)
 
         assert result["id-1"] == "updated"
-        assert entry.options["start_time"] == good_time
+        assert entry.options[time_key] == good_time
 
-    @pytest.mark.parametrize("bad_time", ["00:00", "0:00:00", "8:30:00", "not a time"])
     @pytest.mark.asyncio
-    async def test_time_rejection_matches_set_options(self, tmp_path, bad_time):
+    async def test_numeric_and_time_errors_reported_together(self, tmp_path):
+        """One entry carrying both a bad number and a bad time reports both keys."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Blind A", {"set_azimuth": 90})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [
+                {
+                    "entry_id": "id-1",
+                    "options": {"set_azimuth": 999, "end_time": "00:00"},
+                }
+            ],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert "set_azimuth" in result["id-1"]
+        assert "end_time" in result["id-1"]
+        assert entry.options["set_azimuth"] == 90
+
+    @pytest.mark.parametrize("bad_time", _BAD_TIMES)
+    @pytest.mark.asyncio
+    async def test_time_format_rejection_matches_set_options(self, tmp_path, bad_time):
         """import_config and set_options reject the same malformed times (issue #1049).
 
-        Both paths read ``const.TIME_STRING_RE``; this pins them together so a
-        future change to one format cannot leave the other accepting values the
-        rest of the integration never produces.
+        Both read ``const.TIME_STRING_RE``, so this pins the two service write
+        paths to one format. Scope is the *format* only — cross-field rules such
+        as the start_time/start_entity mutual exclusion stay ``set_options``-only.
         """
         from homeassistant.exceptions import ServiceValidationError
 
@@ -458,22 +510,62 @@ class TestImportConfig:
 
         assert (await async_handle_import_config(call))["id-1"].startswith("error:")
 
+    @pytest.mark.parametrize("good_time", _GOOD_TIMES)
     @pytest.mark.asyncio
-    async def test_time_option_keys_covers_every_time_field(self):
-        """TIME_OPTION_KEYS is derived from the field registry, not hand-listed."""
+    async def test_time_acceptance_matches_set_options(self, tmp_path, good_time):
+        """The accept side of the same parity — neither path is stricter (issue #1049).
+
+        Rejection parity alone would stay green if both paths went on accepting
+        a value the config flow can never emit; this is the half that catches
+        that.
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            validate_options_patch,
+        )
+
+        validate_options_patch({"end_time": good_time}, {})
+
+        entry = _make_entry("id-1", "Blind A", {})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"end_time": good_time}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        assert (await async_handle_import_config(call))["id-1"] == "updated"
+
+    @pytest.mark.asyncio
+    async def test_every_time_selector_field_is_tagged_time(self):
+        """TIME_OPTION_KEYS covers every TimeSelector field in the registry.
+
+        The derivation is only as good as the ``ValidatorKind.TIME`` tagging, so
+        the guard is on the tagging itself: a new field that renders a
+        ``TimeSelector`` but is tagged something else would slip past both
+        service validators exactly as start_time/end_time did (issue #1049).
+        """
+        from homeassistant.helpers import selector
+
         from custom_components.adaptive_cover_pro.config_fields import (
             FIELD_SPECS,
             TIME_OPTION_KEYS,
-            ValidatorKind,
         )
 
-        declared = {
-            key
-            for key, spec in FIELD_SPECS.items()
-            if spec.validator is ValidatorKind.TIME
-        }
-        assert declared == TIME_OPTION_KEYS
-        assert {"start_time", "end_time"} <= TIME_OPTION_KEYS
+        for key, spec in FIELD_SPECS.items():
+            if spec.make_selector is None:
+                continue
+            if isinstance(spec.make_selector(None, {}), selector.TimeSelector):
+                assert key in TIME_OPTION_KEYS
+
+        assert {"start_time", "end_time"} == TIME_OPTION_KEYS
 
     @pytest.mark.asyncio
     async def test_mixed_results(self, tmp_path):

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -12,21 +12,29 @@ import pytest
 # Helpers
 # ---------------------------------------------------------------------------
 
-# Time values the config flow's TimeSelector can never emit. Each one compares
-# unequal to BLANK_TIME ("00:00:00") while still parsing to — or crashing on —
-# something the runtime treats as a configured window end, which is the whole
-# of issue #1049. Shared by the import tests and the set_options parity tests
-# so neither write path can quietly grow a looser format than the other.
-_BAD_TIMES = [
-    "00:00",  # HH:MM — the reported case
-    "0:00:00",  # unpadded hour
-    "8:30:00",  # unpadded hour, non-midnight
+# Time values the config flow's TimeSelector can never emit. Each compares
+# unequal to BLANK_TIME ("00:00:00") while the runtime still treats it as a
+# configured window end — the whole of issue #1049.
+#
+# They split by whether a parser can rescue them, and import treats the halves
+# differently on purpose. An export file predates this validation, so rejecting
+# a rescuable value would drop every *other* option for that entry on a restore
+# — punishing precisely the users #1049 already bit. So import canonicalises
+# what it can and errors only on the rest.
+_RESCUABLE_TIMES = [
+    ("00:00", "00:00:00"),  # HH:MM — the reported case
+    ("0:00:00", "00:00:00"),  # unpadded hour
+    ("00:00:00\n", "00:00:00"),  # trailing newline: `$` would let this through
+    ("٠٠:٠٠:٠٠", "00:00:00"),  # Arabic-Indic digits: `\d` matches
+    ("8:30:00", "08:30:00"),  # unpadded hour, non-midnight
+    ("7:30", "07:30:00"),
+]
+
+_UNRESCUABLE_TIMES = [
     "not a time",
     "",  # empty string is not the unset sentinel
-    "00:00:00\n",  # trailing newline: `$` would let this through
     "25:00:00",  # shape-valid, impossible clock time
     "24:99:99",  # shape-valid, impossible clock time
-    "٠٠:٠٠:٠٠",  # Arabic-Indic digits: `\d` matches
 ]
 
 _GOOD_TIMES = ["00:00:00", "07:00:00", "22:30:00", "23:59:59"]
@@ -383,15 +391,83 @@ class TestImportConfig:
         assert entry.options["set_azimuth"] == 90
 
     @pytest.mark.parametrize("time_key", ["start_time", "end_time"])
-    @pytest.mark.parametrize("bad_time", _BAD_TIMES)
+    @pytest.mark.parametrize(("raw", "expected"), _RESCUABLE_TIMES)
     @pytest.mark.asyncio
-    async def test_malformed_time_recorded_as_error(self, tmp_path, time_key, bad_time):
-        """A time value outside the wire format errors and leaves the entry alone.
+    async def test_rescuable_time_is_canonicalized(
+        self, tmp_path, time_key, raw, expected
+    ):
+        """A parsable non-canonical time is stored canonically, not rejected.
 
         Import used to skip every key absent from OPTION_RANGES, so a stray
         ``"00:00"`` reached the config entry and defeated the literal
         ``BLANK_TIME`` comparisons the rest of the integration relies on
-        (issue #1049).
+        (issue #1049). Erroring instead would fail the whole entry, which is
+        worse for the one population guaranteed to have such a file: users
+        restoring a backup taken before the validation existed.
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Blind A", {time_key: "22:00:00"})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {time_key: raw}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"] == "updated"
+        assert entry.options[time_key] == expected
+
+    @pytest.mark.asyncio
+    async def test_rescuable_time_does_not_block_the_rest_of_the_entry(self, tmp_path):
+        """The whole point of canonicalising: every other option still restores."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Blind A", {"azimuth": 90})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [
+                {
+                    "entry_id": "id-1",
+                    "options": {"end_time": "00:00", "azimuth": 270, "fov_left": 45},
+                }
+            ],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        assert (await async_handle_import_config(call))["id-1"] == "updated"
+        assert entry.options["azimuth"] == 270
+        assert entry.options["fov_left"] == 45
+        assert entry.options["end_time"] == "00:00:00"
+
+    @pytest.mark.parametrize("time_key", ["start_time", "end_time"])
+    @pytest.mark.parametrize("bad_time", _UNRESCUABLE_TIMES)
+    @pytest.mark.asyncio
+    async def test_unrescuable_time_recorded_as_error(
+        self, tmp_path, time_key, bad_time
+    ):
+        """A value no parser can rescue errors and leaves the entry alone.
+
+        Nothing can be inferred from ``"25:00:00"``, and guessing would store a
+        time the user never chose — so the import reports it and the caller
+        fixes the file.
         """
         from custom_components.adaptive_cover_pro.services.import_service import (
             async_handle_import_config,
@@ -459,7 +535,7 @@ class TestImportConfig:
             [
                 {
                     "entry_id": "id-1",
-                    "options": {"set_azimuth": 999, "end_time": "00:00"},
+                    "options": {"set_azimuth": 999, "end_time": "25:00:00"},
                 }
             ],
         )
@@ -474,14 +550,35 @@ class TestImportConfig:
         assert "end_time" in result["id-1"]
         assert entry.options["set_azimuth"] == 90
 
-    @pytest.mark.parametrize("bad_time", _BAD_TIMES)
-    @pytest.mark.asyncio
-    async def test_time_format_rejection_matches_set_options(self, tmp_path, bad_time):
-        """import_config and set_options reject the same malformed times (issue #1049).
+    @pytest.mark.parametrize(
+        "bad_time", [raw for raw, _ in _RESCUABLE_TIMES] + _UNRESCUABLE_TIMES
+    )
+    def test_set_options_rejects_every_non_canonical_time(self, bad_time):
+        """``set_options`` is the strict path: no value outside the format gets in.
 
-        Both read ``const.TIME_STRING_RE``, so this pins the two service write
-        paths to one format. Scope is the *format* only — cross-field rules such
-        as the start_time/start_entity mutual exclusion stay ``set_options``-only.
+        Unlike import it has no file to salvage — the caller wrote this patch by
+        hand and can fix it, so a hard error is the useful answer (issue #1049).
+        """
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            validate_options_patch,
+        )
+
+        with pytest.raises(ServiceValidationError):
+            validate_options_patch({"end_time": bad_time}, {})
+
+    @pytest.mark.parametrize(("raw", "expected"), _RESCUABLE_TIMES)
+    @pytest.mark.asyncio
+    async def test_import_canonicalizes_what_set_options_rejects(
+        self, tmp_path, raw, expected
+    ):
+        """The two service paths diverge on rescuable values, by design.
+
+        Both end at the same stored format — ``const.TIME_STRING_RE`` — but
+        import gets there by canonicalising a file it cannot ask the user to
+        edit, while ``set_options`` refuses. Pinning the divergence here keeps
+        it a decision rather than a drift.
         """
         from homeassistant.exceptions import ServiceValidationError
 
@@ -493,7 +590,7 @@ class TestImportConfig:
         )
 
         with pytest.raises(ServiceValidationError):
-            validate_options_patch({"end_time": bad_time}, {})
+            validate_options_patch({"end_time": raw}, {})
 
         entry = _make_entry("id-1", "Blind A", {})
         hass = _make_hass([entry], config_dir=str(tmp_path))
@@ -501,14 +598,15 @@ class TestImportConfig:
         export_path = tmp_path / "import.json"
         self._write_export(
             export_path,
-            [{"entry_id": "id-1", "options": {"end_time": bad_time}}],
+            [{"entry_id": "id-1", "options": {"end_time": raw}}],
         )
 
         call = MagicMock()
         call.hass = hass
         call.data = {"filename": str(export_path)}
 
-        assert (await async_handle_import_config(call))["id-1"].startswith("error:")
+        assert (await async_handle_import_config(call))["id-1"] == "updated"
+        assert entry.options["end_time"] == expected
 
     @pytest.mark.parametrize("good_time", _GOOD_TIMES)
     @pytest.mark.asyncio

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -363,6 +363,118 @@ class TestImportConfig:
         # entry options must not have been modified
         assert entry.options["set_azimuth"] == 90
 
+    @pytest.mark.parametrize("bad_time", ["00:00", "0:00:00", "8:30:00", "not a time"])
+    @pytest.mark.asyncio
+    async def test_malformed_time_recorded_as_error(self, tmp_path, bad_time):
+        """A time key not in HH:MM:SS form records an error and leaves the entry alone.
+
+        Import used to skip every key absent from OPTION_RANGES, so a stray
+        ``"00:00"`` reached the config entry and defeated the literal
+        ``BLANK_TIME`` comparisons the rest of the integration relies on
+        (issue #1049).
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Blind A", {"end_time": "22:00:00"})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"end_time": bad_time}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"].startswith("error:")
+        assert "end_time" in result["id-1"]
+        assert entry.options["end_time"] == "22:00:00"
+
+    @pytest.mark.parametrize("good_time", ["00:00:00", "22:30:00", None])
+    @pytest.mark.asyncio
+    async def test_well_formed_time_imports(self, tmp_path, good_time):
+        """HH:MM:SS values — including the BLANK_TIME sentinel — and None import cleanly."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Blind A", {"start_time": "07:00:00"})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"start_time": good_time}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"] == "updated"
+        assert entry.options["start_time"] == good_time
+
+    @pytest.mark.parametrize("bad_time", ["00:00", "0:00:00", "8:30:00", "not a time"])
+    @pytest.mark.asyncio
+    async def test_time_rejection_matches_set_options(self, tmp_path, bad_time):
+        """import_config and set_options reject the same malformed times (issue #1049).
+
+        Both paths read ``const.TIME_STRING_RE``; this pins them together so a
+        future change to one format cannot leave the other accepting values the
+        rest of the integration never produces.
+        """
+        from homeassistant.exceptions import ServiceValidationError
+
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            validate_options_patch,
+        )
+
+        with pytest.raises(ServiceValidationError):
+            validate_options_patch({"end_time": bad_time}, {})
+
+        entry = _make_entry("id-1", "Blind A", {})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"end_time": bad_time}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        assert (await async_handle_import_config(call))["id-1"].startswith("error:")
+
+    @pytest.mark.asyncio
+    async def test_time_option_keys_covers_every_time_field(self):
+        """TIME_OPTION_KEYS is derived from the field registry, not hand-listed."""
+        from custom_components.adaptive_cover_pro.config_fields import (
+            FIELD_SPECS,
+            TIME_OPTION_KEYS,
+            ValidatorKind,
+        )
+
+        declared = {
+            key
+            for key, spec in FIELD_SPECS.items()
+            if spec.validator is ValidatorKind.TIME
+        }
+        assert declared == TIME_OPTION_KEYS
+        assert {"start_time", "end_time"} <= TIME_OPTION_KEYS
+
     @pytest.mark.asyncio
     async def test_mixed_results(self, tmp_path):
         """One valid entry and one unknown entry produce mixed results dict."""

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -1068,13 +1068,35 @@ async def test_migrate_v3_11_to_v3_12_leaves_canonical_times_alone(
     assert dict(entry.options) == options
 
 
-async def test_migrate_v3_11_to_v3_12_leaves_unparsable_times_alone(
+@pytest.mark.parametrize("stored", ["garbage", "25:00:00", "24:99:99", ""])
+async def test_migrate_v3_11_to_v3_12_drops_unrescuable_times(
+    hass: HomeAssistant, stored
+) -> None:
+    """A value no parser can rescue is dropped to the unset sentinel semantics.
+
+    Leaving it is not neutral: ``get_datetime_from_str`` calls
+    ``dateutil.parser.parse`` without a guard, so ``"25:00:00"`` raises on every
+    coordinator cycle. Both are reachable in stored options — the pre-#1049
+    ``set_options`` regex accepted "25:00:00", and import validated no time at
+    all. Dropping the key is the #492 "no time set" state, which is what an
+    unusable window bound already means in practice.
+    """
+    entry = _make_entry(hass, {"end_time": stored}, version=3, minor_version=11)
+    assert await async_migrate_entry(hass, entry) is True
+    assert "end_time" not in entry.options
+
+
+async def test_migrate_v3_11_to_v3_12_dropped_time_leaves_window_usable(
     hass: HomeAssistant,
 ) -> None:
-    """A value no parser can rescue is left as-is rather than guessed at."""
-    entry = _make_entry(hass, {"end_time": "garbage"}, version=3, minor_version=11)
+    """After the drop, the manager resolves the window instead of raising."""
+    from custom_components.adaptive_cover_pro.helpers import (
+        has_configured_window_end,
+    )
+
+    entry = _make_entry(hass, {"end_time": "25:00:00"}, version=3, minor_version=11)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.options["end_time"] == "garbage"
+    assert has_configured_window_end(entry.options) is False
 
 
 async def test_migrate_v3_12_is_idempotent(hass: HomeAssistant) -> None:

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -250,7 +250,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -286,7 +286,7 @@ async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -299,7 +299,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -326,7 +326,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -363,7 +363,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -405,7 +405,7 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
@@ -428,7 +428,7 @@ async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
@@ -441,7 +441,7 @@ async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -454,7 +454,7 @@ async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
@@ -463,7 +463,7 @@ async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> 
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 # ---------------------------------------------------------------------------
@@ -485,7 +485,7 @@ async def test_migrate_v3_6_sets_weather_enabled_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=5)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -498,7 +498,7 @@ async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is False
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
@@ -511,7 +511,7 @@ async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> None:
@@ -520,7 +520,7 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 # ---------------------------------------------------------------------------
@@ -541,7 +541,7 @@ async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     # Additive/no-op: no outside_temp_source key seeded, options untouched.
     assert "outside_temp_source" not in entry.options
     assert entry.options == before
@@ -557,9 +557,9 @@ async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert entry.options == first
 
 
@@ -575,7 +575,7 @@ async def test_migrate_v3_6_to_3_7_preserves_explicit_source(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options["outside_temp_source"] == "max_of_live_and_forecast"
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
 
 
 # ---------------------------------------------------------------------------
@@ -604,7 +604,7 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     # No dead key seeded by the v3.4→v3.5 block.
     assert "show_weather_retraction" not in entry.options
     # The only key added across the cascade is the v3.5→v3.6 weather toggle.
@@ -641,7 +641,7 @@ async def test_migrate_v3_7_to_v3_8_converts_blind_spots(hass: HomeAssistant) ->
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     opts = entry.options
     # Slot 1 converted (new_left = 45-10 = 35, new_right = 30-45 = -15).
     assert opts["blind_spot_left_gamma"] == 35
@@ -674,9 +674,9 @@ async def test_migrate_v3_7_to_v3_8_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert entry.options == first
 
 
@@ -712,7 +712,7 @@ async def test_migrate_v3_7_to_v3_8_no_blind_spot_is_noop(hass: HomeAssistant) -
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert entry.options == before
 
 
@@ -739,7 +739,7 @@ async def test_migrate_v3_7_to_v3_8_tolerates_none_fov_left(
         minor_version=7,
     )
     assert await async_migrate_entry(hass, entry) is True  # no TypeError
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert entry.options["blind_spot_left_gamma"] == 80  # 90 - 10
     assert entry.options["blind_spot_right_gamma"] == -60  # 30 - 90
 
@@ -788,13 +788,13 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 11 (the v3.10 → v3.11 block that seeds the
-    awning shade-mode default, per issue #1025).
+    Currently the highest target is 12 (the v3.11 → v3.12 block that repairs
+    malformed start_time/end_time values, per issue #1049).
     Raise this assertion whenever a new minor migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 11
+    assert ConfigFlowHandler.MINOR_VERSION == 12
 
 
 # ---------------------------------------------------------------------------
@@ -850,7 +850,7 @@ async def test_migrate_v3_8_to_v3_9_is_additive_noop(hass: HomeAssistant) -> Non
     entry = _make_entry(hass, dict(options), version=3, minor_version=8)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert dict(entry.options) == options
 
 
@@ -879,7 +879,7 @@ async def test_migrate_v3_9_to_v3_10_additive_noop_without_legacy_margin(
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=9)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert dict(entry.options) == options
 
 
@@ -903,7 +903,7 @@ async def test_migrate_v3_9_to_v3_10_copies_legacy_safety_margin(
         minor_version=9,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     # New neutral key seeded from the legacy value.
     assert entry.options[CONF_TILT_SAFETY_MARGIN] == 0.5
     # Legacy key retained unchanged (additive / rollback-safe).
@@ -942,7 +942,7 @@ async def test_migrate_v3_10_is_idempotent(hass: HomeAssistant) -> None:
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert dict(entry.options) == options
 
 
@@ -967,7 +967,7 @@ async def test_migrate_v3_10_to_v3_11_seeds_shade_mode_for_awning(
         minor_version=10,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert entry.options[CONF_AWNING_SHADE_MODE] == AWNING_SHADE_MODE_WINDOW
 
 
@@ -980,7 +980,7 @@ async def test_migrate_v3_10_to_v3_11_skips_non_awning(
     options = {"azimuth": 180, "custom_position_sensors_1": ["binary_sensor.door"]}
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 11
+    assert entry.minor_version == 12
     assert CONF_AWNING_SHADE_MODE not in entry.options
     assert dict(entry.options) == options
 
@@ -1021,6 +1021,68 @@ async def test_migrate_v3_11_is_idempotent(hass: HomeAssistant) -> None:
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
     assert entry.options[CONF_AWNING_SHADE_MODE] == "window"
+    assert await async_migrate_entry(hass, entry) is True
+    assert dict(entry.options) == first
+
+
+# ---------------------------------------------------------------------------
+# v3.11 → v3.12: repair malformed time strings (issue #1049)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("time_key", ["start_time", "end_time"])
+@pytest.mark.parametrize(
+    ("stored", "expected"),
+    [
+        ("00:00", "00:00:00"),
+        ("0:00:00", "00:00:00"),
+        ("00:00:00\n", "00:00:00"),
+        ("٠٠:٠٠:٠٠", "00:00:00"),
+        ("7:30", "07:30:00"),
+    ],
+)
+async def test_migrate_v3_11_to_v3_12_repairs_malformed_time(
+    hass: HomeAssistant, time_key, stored, expected
+) -> None:
+    """An entry already carrying a malformed time is repaired in place (#1049).
+
+    Validating the write paths stops NEW bad values but does nothing for a user
+    already bitten — their override deadline keeps receding until the stored
+    value is canonical. This is also what lets such an entry survive an
+    export→import round-trip, which the new import validation would otherwise
+    reject wholesale.
+    """
+    entry = _make_entry(hass, {time_key: stored}, version=3, minor_version=11)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 12
+    assert entry.options[time_key] == expected
+
+
+async def test_migrate_v3_11_to_v3_12_leaves_canonical_times_alone(
+    hass: HomeAssistant,
+) -> None:
+    """A well-formed window is untouched — no churn for the overwhelming majority."""
+    options = {"start_time": "07:00:00", "end_time": "22:30:00", "azimuth": 180}
+    entry = _make_entry(hass, dict(options), version=3, minor_version=11)
+    assert await async_migrate_entry(hass, entry) is True
+    assert dict(entry.options) == options
+
+
+async def test_migrate_v3_11_to_v3_12_leaves_unparsable_times_alone(
+    hass: HomeAssistant,
+) -> None:
+    """A value no parser can rescue is left as-is rather than guessed at."""
+    entry = _make_entry(hass, {"end_time": "garbage"}, version=3, minor_version=11)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.options["end_time"] == "garbage"
+
+
+async def test_migrate_v3_12_is_idempotent(hass: HomeAssistant) -> None:
+    """Re-running the migration on a repaired entry is stable."""
+    entry = _make_entry(hass, {"end_time": "00:00"}, version=3, minor_version=11)
+    assert await async_migrate_entry(hass, entry) is True
+    first = dict(entry.options)
+    assert entry.options["end_time"] == "00:00:00"
     assert await async_migrate_entry(hass, entry) is True
     assert dict(entry.options) == first
 

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -1089,14 +1089,43 @@ async def test_migrate_v3_11_to_v3_12_drops_unrescuable_times(
 async def test_migrate_v3_11_to_v3_12_dropped_time_leaves_window_usable(
     hass: HomeAssistant,
 ) -> None:
-    """After the drop, the manager resolves the window instead of raising."""
-    from custom_components.adaptive_cover_pro.helpers import (
-        has_configured_window_end,
+    """After the drop, TimeWindowManager resolves the window instead of raising.
+
+    This is the delete branch's whole justification, so assert it against the
+    real manager rather than inferring it from the key's absence:
+    ``get_datetime_from_str`` calls ``dateutil.parser.parse`` unguarded, so the
+    stored ``"25:00:00"`` raises ``ParserError`` on every coordinator cycle
+    until the migration removes it.
+    """
+    import logging
+    from unittest.mock import MagicMock
+
+    from dateutil.parser import ParserError
+
+    from custom_components.adaptive_cover_pro.managers.time_window import (
+        TimeWindowManager,
     )
 
+    def _manager(options: dict) -> TimeWindowManager:
+        manager = TimeWindowManager(hass, logging.getLogger(__name__))
+        manager.logger = MagicMock()
+        manager.update_config(
+            start_time=options.get("start_time"),
+            start_time_entity=None,
+            end_time=options.get("end_time"),
+            end_time_entity=None,
+        )
+        return manager
+
     entry = _make_entry(hass, {"end_time": "25:00:00"}, version=3, minor_version=11)
+
+    # Pre-migration state is genuinely fatal, not merely untidy.
+    with pytest.raises(ParserError):
+        _ = _manager(dict(entry.options)).end_time
+
     assert await async_migrate_entry(hass, entry) is True
-    assert has_configured_window_end(entry.options) is False
+    assert _manager(dict(entry.options)).end_time is None
+    assert _manager(dict(entry.options)).before_end_time is True
 
 
 async def test_migrate_v3_12_is_idempotent(hass: HomeAssistant) -> None:

--- a/tests/test_time_option_format.py
+++ b/tests/test_time_option_format.py
@@ -1,0 +1,183 @@
+"""The single wire format for time-typed options, across every write path (#1049).
+
+``BLANK_TIME`` is ``"00:00:00"`` and the integration compares against it by
+literal string equality in half a dozen places, so any stored time in a
+different shape reads as a *configured* window end while
+``TimeWindowManager`` maps it to tomorrow's midnight — an
+``until_window_end`` override deadline that recedes a day at every local
+midnight and never expires.
+
+Three write paths reach ``config_entry.options``, and each closes the hole its
+own way: the service paths (``import_config``, ``set_options``) reject a
+malformed value outright, while the config/options flow **normalizes** it —
+HA's ``TimeSelector`` validates via ``dt_util.parse_time`` but stores the raw
+submission, so a non-frontend flow client can hand it ``"00:00"`` or
+``"٠٧:٣٠:٠٠"`` and it persists verbatim. Rejection would be wrong there: the
+user picked a real time, only in a shape the picker itself would never emit.
+
+Service-path rejection lives in ``tests/services/test_export_import_service.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+from custom_components.adaptive_cover_pro.const import (
+    BLANK_TIME,
+    CONF_END_TIME,
+    CONF_START_TIME,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.helpers import normalize_time_string
+
+
+def _options_flow(options: dict) -> OptionsFlowHandler:
+    entry = MagicMock()
+    entry.options = dict(options)
+    entry.data = {"sensor_type": CoverType.BLIND}
+    flow = OptionsFlowHandler(entry)
+    flow.hass = MagicMock()
+    flow.hass.states.get.return_value = None
+    flow.sensor_type = CoverType.BLIND
+    flow.options = dict(options)
+    flow.async_step_init = AsyncMock(return_value={"type": "menu"})
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# normalize_time_string
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("00:00", BLANK_TIME),  # HH:MM — the reported case
+        ("0:00:00", BLANK_TIME),  # unpadded hour
+        ("00:00:00\n", BLANK_TIME),  # trailing newline
+        ("٠٠:٠٠:٠٠", BLANK_TIME),  # Arabic-Indic digits
+        ("7:30", "07:30:00"),  # unpadded hour, non-midnight
+        ("٠٧:٣٠:٠٠", "07:30:00"),
+        ("22:30", "22:30:00"),
+    ],
+)
+def test_normalizes_parsable_times_to_canonical_form(raw, expected):
+    assert normalize_time_string(raw) == expected
+
+
+@pytest.mark.parametrize("canonical", ["00:00:00", "07:00:00", "22:30:00", "23:59:59"])
+def test_leaves_canonical_values_untouched(canonical):
+    assert normalize_time_string(canonical) == canonical
+
+
+@pytest.mark.parametrize("value", [None, "", "not a time", "25:00:00", 12, True, {}])
+def test_returns_unparsable_values_unchanged(value):
+    """Anything ``parse_time`` rejects is passed through for the caller to handle.
+
+    The TimeSelector has already refused these, so normalization has nothing to
+    canonicalize; inventing a value here would mask the rejection.
+    """
+    assert normalize_time_string(value) == value
+
+
+# ---------------------------------------------------------------------------
+# Options flow — async_step_automation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("time_key", [CONF_START_TIME, CONF_END_TIME])
+@pytest.mark.parametrize("blank", ["00:00", "0:00:00", "00:00:00\n", "٠٠:٠٠:٠٠"])
+@pytest.mark.asyncio
+async def test_automation_step_treats_normalized_blank_as_unset(time_key, blank):
+    """A midnight submission in any shape must strip, exactly as BLANK_TIME does.
+
+    Without normalization the #492 blank-strip below tests ``in (None,
+    BLANK_TIME)`` and misses, so the value persists and every literal sentinel
+    check downstream reads it as a configured window end (issue #1049).
+    """
+    flow = _options_flow({time_key: "22:00:00"})
+
+    await flow.async_step_automation({time_key: blank})
+
+    assert time_key not in flow.options
+
+
+@pytest.mark.parametrize("time_key", [CONF_START_TIME, CONF_END_TIME])
+@pytest.mark.asyncio
+async def test_automation_step_canonicalizes_a_real_time(time_key):
+    flow = _options_flow({})
+
+    await flow.async_step_automation({time_key: "7:30"})
+
+    assert flow.options[time_key] == "07:30:00"
+
+
+@pytest.mark.asyncio
+async def test_automation_step_leaves_canonical_times_alone():
+    flow = _options_flow({})
+
+    await flow.async_step_automation(
+        {CONF_START_TIME: "07:00:00", CONF_END_TIME: "22:30:00"}
+    )
+
+    assert flow.options[CONF_START_TIME] == "07:00:00"
+    assert flow.options[CONF_END_TIME] == "22:30:00"
+
+
+# ---------------------------------------------------------------------------
+# Single-source guards
+# ---------------------------------------------------------------------------
+
+
+def test_time_option_keys_is_re_exported_by_const():
+    """``const`` is the documented import surface for the dedup hooks.
+
+    ``OPTION_RANGES`` is re-exported from ``config_fields`` so call sites read
+    ``from .const import …``; ``TIME_OPTION_KEYS`` is the same kind of derived
+    map and must be reachable the same way, not from two modules.
+    """
+    from custom_components.adaptive_cover_pro import config_fields, const
+
+    assert const.TIME_OPTION_KEYS is config_fields.TIME_OPTION_KEYS
+
+
+def test_every_time_selector_field_is_tagged_time():
+    """``TIME_OPTION_KEYS`` covers every TimeSelector field in the registry.
+
+    The derivation is only as good as the ``ValidatorKind.TIME`` tagging, so the
+    guard is on the tagging itself: a field rendering a ``TimeSelector`` but
+    tagged something else would slip past both service validators exactly as
+    start_time/end_time did.
+    """
+    from homeassistant.helpers import selector
+
+    from custom_components.adaptive_cover_pro.config_fields import (
+        FIELD_SPECS,
+        TIME_OPTION_KEYS,
+    )
+
+    for key, spec in FIELD_SPECS.items():
+        if spec.make_selector is None:
+            continue
+        if isinstance(spec.make_selector(None, {}), selector.TimeSelector):
+            assert key in TIME_OPTION_KEYS
+
+
+def test_every_time_field_has_a_set_options_validator():
+    """Registry-derived import validation and hand-written FIELD_VALIDATORS agree.
+
+    ``TIME_OPTION_KEYS`` is derived from ``FIELD_SPECS`` but
+    ``options_service.FIELD_VALIDATORS`` is hand-written, so a new
+    ``ValidatorKind.TIME`` field would be validated on import and rejected
+    outright by ``set_options`` ("not supported by this service"). Fail-closed,
+    but confusing — this keeps the two in step.
+    """
+    from custom_components.adaptive_cover_pro.config_fields import TIME_OPTION_KEYS
+    from custom_components.adaptive_cover_pro.services.options_service import (
+        FIELD_VALIDATORS,
+    )
+
+    assert set(FIELD_VALIDATORS) >= TIME_OPTION_KEYS

--- a/tests/test_time_option_format.py
+++ b/tests/test_time_option_format.py
@@ -7,15 +7,19 @@ different shape reads as a *configured* window end while
 ``until_window_end`` override deadline that recedes a day at every local
 midnight and never expires.
 
-Three write paths reach ``config_entry.options``, and each closes the hole its
-own way: the service paths (``import_config``, ``set_options``) reject a
-malformed value outright, while the config/options flow **normalizes** it —
-HA's ``TimeSelector`` validates via ``dt_util.parse_time`` but stores the raw
-submission, so a non-frontend flow client can hand it ``"00:00"`` or
-``"٠٧:٣٠:٠٠"`` and it persists verbatim. Rejection would be wrong there: the
-user picked a real time, only in a shape the picker itself would never emit.
+Each write path handles it differently — see ``const.TIME_STRING_RE`` for the
+full enumeration. This module covers the options flow's automation step, which
+**normalizes** rather than rejects: HA's ``TimeSelector`` validates via
+``dt_util.parse_time`` but stores the raw submission, so a non-frontend flow
+client can hand it ``"00:00"`` or ``"٠٧:٣٠:٠٠"`` and it persists verbatim.
+Rejection would be wrong there — the user picked a real time, only in a shape
+the picker itself would never emit.
 
-Service-path rejection lives in ``tests/services/test_export_import_service.py``.
+It also holds the registry guards that keep the derived ``TIME_OPTION_KEYS`` and
+the hand-written ``FIELD_VALIDATORS`` from drifting apart.
+
+The service paths live in ``tests/services/test_export_import_service.py``; the
+stored-entry repair in ``tests/test_config_entry_migration.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

`import_config` validated only numeric options, so `start_time`/`end_time` reached the config entry verbatim. `BLANK_TIME` is `"00:00:00"` and is compared by **literal string equality** in `helpers.has_configured_window_end`, `config_flow.py`, `diagnostics/triage.py`, `managers/time_window.py` and `services/options_service.py` — so an imported `"00:00"` reads as a *configured* window end everywhere, while `TimeWindowManager` resolves it to tomorrow's midnight. The `until_window_end` override deadline then recedes a day at every local midnight and never expires.

Investigating the gap showed it was not import-only. Each write path into `config_entry.options` now handles the format, and the single source for all of them is `const.TIME_STRING_RE`:

| Path | Behaviour |
|---|---|
| `set_options` | Rejects — the caller wrote the patch by hand and can fix it |
| `import_config` | Canonicalizes what parses, errors on the rest — an export file has no caller to send back |
| Options flow (automation step) | Canonicalizes — the user picked a real time, just in a shape the picker never emits |
| Stored entries | Repaired by a new v3.11 → v3.12 migration |

Three things the audit passes surfaced that are worth calling out:

- **HA's `TimeSelector` is not a validator.** It runs `dt_util.parse_time` and then stores the submission *unnormalized*, so any non-frontend flow client (websocket/REST, a custom card) can persist `"00:00"`. Earlier drafts of this PR documented that path as covered; it wasn't.
- **The regex needed `\Z`, `[0-9]` and real clock bounds.** `^\d{2}:\d{2}:\d{2}$` accepted `"00:00:00\n"` (`$` matches before a trailing newline), `"٠٠:٠٠:٠٠"` (`\d` is Unicode-aware) and `"25:00:00"`. The first two reproduce #1049 verbatim; the third stores fine and then raises in `get_datetime_from_str` on every coordinator cycle.
- **The migration drops what it cannot parse.** `"25:00:00"` is reachable in stored options — the old `set_options` regex accepted it and import validated nothing — and leaving it is not neutral, so it becomes the #492 unset state.

### Migration note

`v3.11 → v3.12` **rewrites** `start_time`/`end_time` rather than only seeding a key, which CLAUDE.md's rollback contract normally forbids. It is safe here because the rewrite moves the value *into* the format every release already expects: an older build reading the canonical `"00:00:00"` applies the unset semantics it always intended, where before it read a phantom configured window end. `VERSION` stays `3`; no key is renamed. The reasoning is recorded at the block itself.

## Testing

- ✅ 8,908 tests passing (`-n auto`), 1 pre-existing xfail
- New `tests/test_time_option_format.py` covers `normalize_time_string` and the options-flow step, plus registry guards keeping the derived `TIME_OPTION_KEYS` and the hand-written `FIELD_VALIDATORS` in step
- Service-path tests split rescuable from unrescuable values and pin the deliberate `import_config` / `set_options` divergence in both directions
- Migration tests assert the repair against the real `TimeWindowManager` — `ParserError` before, resolved window after

Four opus audit rounds ran against this branch; each found real defects, including two regressions I introduced (an entry-wide import rejection that broke backup restore, and a migration that repaired the benign values while leaving the crashing ones).

## Known gap

Round 4 flagged a narrow one left unfixed: the flow's **Sync** and **Duplicate** steps copy time keys verbatim between entries, and a *disabled* config entry never runs the v3.12 repair — so duplicating from one could carry a non-canonical value into a fresh entry stamped `MINOR_VERSION = 12` that is then never migrated. It needs a pre-#1049 malformed time on an entry disabled since before the upgrade. Filed as a follow-up.

## Related Issues

Refs #1049

https://claude.ai/code/session_01PqP9VY1P3Xts7jCt6mmGA6