### PR TITLE
feat: consolidate the sunrise-offset fallback (#1050)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -258,6 +258,8 @@ from .helpers import (
     has_configured_window_end,
     mirror_legacy_slot_sensor_keys,
     normalize_time_string,
+    resolve_sunrise_offset,
+    resolve_sunset_offset,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -2825,8 +2827,8 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     end_entity = config.get(CONF_END_ENTITY)
     sunset_pos = config.get(CONF_SUNSET_POS)
     eow_pos = config.get(CONF_END_OF_WINDOW_POS)
-    sunset_off = config.get(CONF_SUNSET_OFFSET, 0) or 0
-    sunrise_off = config.get(CONF_SUNRISE_OFFSET, 0) or 0
+    sunset_off = resolve_sunset_offset(config)
+    sunrise_off = resolve_sunrise_offset(config)
     sunset_time_entity = config.get(CONF_SUNSET_TIME_ENTITY)
     sunrise_time_entity = config.get(CONF_SUNRISE_TIME_ENTITY)
     timing_parts = []

--- a/custom_components/adaptive_cover_pro/config_types.py
+++ b/custom_components/adaptive_cover_pro/config_types.py
@@ -220,12 +220,11 @@ class CoverConfig:
             CONF_MIN_ELEVATION,
             CONF_MIN_POSITION,
             CONF_MIN_POSITION_SUN_TRACKING,
-            CONF_SUNRISE_OFFSET,
-            CONF_SUNSET_OFFSET,
             CONF_SUNSET_POS,
             DEFAULT_FOV_LEFT,
             DEFAULT_FOV_RIGHT,
         )
+        from .helpers import resolve_sunrise_offset, resolve_sunset_offset
 
         fov_left = (
             options[CONF_FOV_LEFT]
@@ -248,11 +247,8 @@ class CoverConfig:
             ),
             h_def=options.get(CONF_DEFAULT_HEIGHT) or 0,
             sunset_pos=options.get(CONF_SUNSET_POS),
-            sunset_off=options.get(CONF_SUNSET_OFFSET) or 0,
-            sunrise_off=options.get(
-                CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET)
-            )
-            or 0,
+            sunset_off=resolve_sunset_offset(options),
+            sunrise_off=resolve_sunrise_offset(options),
             max_pos=(  # no `or` — 0 ("always closed", #806) must survive, not fall back to 100
                 options[CONF_MAX_POSITION]
                 if options.get(CONF_MAX_POSITION) is not None

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -605,6 +605,32 @@ def _read_time_entity(hass: HomeAssistant, entity_id: str | None) -> dt.datetime
         return None
 
 
+def resolve_sunset_offset(options: Mapping) -> int:
+    """Return the configured sunset offset in minutes, 0 when unset.
+
+    A stored ``None`` counts as unset — the key can exist with no value on an
+    entry whose form field was never filled in.
+    """
+    return int(options.get(CONF_SUNSET_OFFSET) or 0)
+
+
+def resolve_sunrise_offset(options: Mapping) -> int:
+    """Return the configured sunrise offset in minutes.
+
+    Falls back to :func:`resolve_sunset_offset` when unset, so an install that
+    only ever set one offset gets a symmetric night window. An explicit ``0`` is
+    a real choice and does *not* fall back; a stored ``None`` does, matching
+    :func:`resolve_sunset_offset`.
+
+    The single source of truth for this rule, which used to be spelled out
+    independently in five places — one of them defaulting to ``0`` instead of to
+    the sunset offset, so the Configuration Summary described a night window the
+    runtime never used (issue #1050, CODING_GUIDELINES.md § no-duplication).
+    """
+    raw = options.get(CONF_SUNRISE_OFFSET)
+    return resolve_sunset_offset(options) if raw is None else int(raw)
+
+
 def _read_sun_boundary_options(
     hass: HomeAssistant, options: Mapping
 ) -> SunBoundaryOptions:
@@ -618,22 +644,16 @@ def _read_sun_boundary_options(
     input lands in one place and those callers can never disagree about what
     "sunset" means (CODING_GUIDELINES.md § no-duplication).
 
-    Not yet exhaustive across the integration: ``config_types.py``,
-    ``services/export_service.py``, and ``config_flow.py`` each carry their own
-    copy of the offset fallback. ``config_flow.py``'s is semantically divergent —
-    it defaults ``sunrise_offset`` to ``0`` instead of falling back to
-    ``sunset_off``. Fold them in here when you next touch them (tracked in
-    issue #1050).
-
-    ``sunrise_offset`` falls back to ``sunset_offset`` when unset, so an install
-    that only ever set one offset gets a symmetric night window.
+    The offset arithmetic itself lives in :func:`resolve_sunset_offset` /
+    :func:`resolve_sunrise_offset`, which the hass-less consumers
+    (``CoverConfig.from_options``, the export service, the config-flow summary)
+    share — see issue #1050.
     """
-    sunset_off = int(options.get(CONF_SUNSET_OFFSET) or 0)
     return SunBoundaryOptions(
         sunset_time=_read_time_entity(hass, options.get(CONF_SUNSET_TIME_ENTITY)),
         sunrise_time=_read_time_entity(hass, options.get(CONF_SUNRISE_TIME_ENTITY)),
-        sunset_off=sunset_off,
-        sunrise_off=int(options.get(CONF_SUNRISE_OFFSET, sunset_off)),
+        sunset_off=resolve_sunset_offset(options),
+        sunrise_off=resolve_sunrise_offset(options),
     )
 
 

--- a/custom_components/adaptive_cover_pro/services/export_service.py
+++ b/custom_components/adaptive_cover_pro/services/export_service.py
@@ -52,6 +52,7 @@ from ..const import (
     DEFAULT_BLIND_SPOT_ELEVATION_MODE,
     DOMAIN,
 )
+from ..helpers import resolve_sunrise_offset, resolve_sunset_offset
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,10 +102,8 @@ async def async_handle_export(call: ServiceCall) -> dict:
             CONF_FOV_RIGHT: options.get(CONF_FOV_RIGHT),
             CONF_DEFAULT_HEIGHT: options.get(CONF_DEFAULT_HEIGHT),
             CONF_SUNSET_POS: options.get(CONF_SUNSET_POS),
-            CONF_SUNSET_OFFSET: options.get(CONF_SUNSET_OFFSET, 0),
-            CONF_SUNRISE_OFFSET: options.get(
-                CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET, 0)
-            ),
+            CONF_SUNSET_OFFSET: resolve_sunset_offset(options),
+            CONF_SUNRISE_OFFSET: resolve_sunrise_offset(options),
             CONF_MAX_POSITION: options.get(CONF_MAX_POSITION, 100),
             CONF_MIN_POSITION: options.get(CONF_MIN_POSITION, 0),
             CONF_MIN_POSITION_SUN_TRACKING: options.get(CONF_MIN_POSITION_SUN_TRACKING),

--- a/tests/test_sunrise_offset_fallback.py
+++ b/tests/test_sunrise_offset_fallback.py
@@ -1,0 +1,155 @@
+"""Pins the sunrise-offset fallback semantic across every consumer (issue #1050).
+
+"Sunrise offset falls back to the sunset offset when unset" used to be spelled out
+independently in five places, and ``config_flow._build_config_summary`` defaulted to
+``0`` instead — so the Configuration Summary described a night window the runtime did
+not use. Every call site now routes through ``helpers.resolve_sunrise_offset``.
+
+The parity tests below exercise each consumer with the same options dict, so a sixth
+copy that reintroduces a sixth variant fails here rather than shipping.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.config_flow import (
+    _build_config_summary,
+)
+from custom_components.adaptive_cover_pro.config_types import CoverConfig
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
+    CONF_SENSOR_TYPE,
+    CONF_SUNRISE_OFFSET,
+    CONF_SUNSET_OFFSET,
+    CONF_SUNSET_POS,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.helpers import (
+    _read_sun_boundary_options,
+    resolve_sunrise_offset,
+    resolve_sunset_offset,
+)
+from custom_components.adaptive_cover_pro.services.export_service import (
+    async_handle_export,
+)
+
+# The case the fallback exists to serve: only a sunset offset was ever configured.
+SUNSET_ONLY = {CONF_SUNSET_OFFSET: 30}
+
+
+# ---------------------------------------------------------------------------
+# The pure helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sunset_offset_defaults_to_zero():
+    """An unset sunset offset resolves to 0, not None."""
+    assert resolve_sunset_offset({}) == 0
+
+
+@pytest.mark.unit
+def test_sunset_offset_coerces_float_to_int():
+    """HA's NumberSelector hands back floats; the offset is minutes as int."""
+    assert resolve_sunset_offset({CONF_SUNSET_OFFSET: 30.0}) == 30
+
+
+@pytest.mark.unit
+def test_sunset_offset_none_reads_as_zero():
+    """A stored ``None`` is treated as unset rather than crashing on int(None)."""
+    assert resolve_sunset_offset({CONF_SUNSET_OFFSET: None}) == 0
+
+
+@pytest.mark.unit
+def test_sunrise_offset_falls_back_to_sunset():
+    """Unset sunrise offset inherits the sunset offset — a symmetric night window."""
+    assert resolve_sunrise_offset(SUNSET_ONLY) == 30
+
+
+@pytest.mark.unit
+def test_sunrise_offset_explicit_value_wins():
+    """A configured sunrise offset is used verbatim, never the sunset offset."""
+    assert (
+        resolve_sunrise_offset({CONF_SUNSET_OFFSET: 30, CONF_SUNRISE_OFFSET: -15})
+        == -15
+    )
+
+
+@pytest.mark.unit
+def test_sunrise_offset_explicit_zero_wins():
+    """An explicit 0 is a real choice, not "unset" — it must not fall back to 30."""
+    assert resolve_sunrise_offset({CONF_SUNSET_OFFSET: 30, CONF_SUNRISE_OFFSET: 0}) == 0
+
+
+@pytest.mark.unit
+def test_sunrise_offset_none_falls_back_to_sunset():
+    """A stored ``None`` is unset, so it takes the sunset offset like an absent key."""
+    assert (
+        resolve_sunrise_offset({CONF_SUNSET_OFFSET: 30, CONF_SUNRISE_OFFSET: None})
+        == 30
+    )
+
+
+@pytest.mark.unit
+def test_sunrise_offset_zero_when_neither_configured():
+    """Nothing configured means no offset on either boundary."""
+    assert resolve_sunrise_offset({}) == 0
+
+
+# ---------------------------------------------------------------------------
+# Every consumer agrees for the same options dict
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_sun_boundary_reader_applies_the_fallback():
+    """The coordinator/snapshot reader (helpers._read_sun_boundary_options)."""
+    hass = MagicMock()
+    hass.states.get.return_value = None
+    bounds = _read_sun_boundary_options(hass, SUNSET_ONLY)
+    assert (bounds.sunset_off, bounds.sunrise_off) == (30, 30)
+
+
+@pytest.mark.unit
+def test_cover_config_applies_the_fallback():
+    """The pure calc engine's CoverConfig.from_options."""
+    cfg = CoverConfig.from_options(dict(SUNSET_ONLY))
+    assert (cfg.sunset_off, cfg.sunrise_off) == (30, 30)
+
+
+@pytest.mark.asyncio
+async def test_export_service_applies_the_fallback():
+    """The export_config service payload."""
+    entry = MagicMock()
+    entry.domain = DOMAIN
+    entry.data = {"name": "Test Cover", CONF_SENSOR_TYPE: CoverType.BLIND}
+    entry.options = dict(SUNSET_ONLY)
+
+    hass = MagicMock()
+    hass.config.latitude = 32.939
+    hass.config.longitude = -117.156
+    hass.config.elevation = 10
+    hass.config.time_zone = "America/Los_Angeles"
+    hass.config_entries.async_get_entry.return_value = entry
+
+    call = MagicMock()
+    call.data = {"config_entry_id": "test-entry-id"}
+    call.hass = hass
+
+    common = (await async_handle_export(call))["common"]
+    assert (common[CONF_SUNSET_OFFSET], common[CONF_SUNRISE_OFFSET]) == (30, 30)
+
+
+@pytest.mark.unit
+def test_config_summary_applies_the_fallback():
+    """The Configuration Summary's After sunrise line (the divergent copy)."""
+    summary = _build_config_summary(
+        {**SUNSET_ONLY, CONF_SUNSET_POS: 80, CONF_DEFAULT_HEIGHT: 0},
+        CoverType.BLIND,
+    )
+    assert "After sunset (+30 min)" in summary
+    assert "After sunrise (+30 min)" in summary


### PR DESCRIPTION
## Summary
The "sunrise offset falls back to the sunset offset" rule was written out independently in five places. `config_flow.py`'s copy defaulted `sunrise_off` to **0** instead of to the sunset offset, so for an install that set only a sunset offset — exactly the case the fallback exists to serve — the Configuration Summary described a night window the runtime never used.

I added `resolve_sunset_offset` / `resolve_sunrise_offset` to `helpers.py` as the single source of the rule and routed every consumer through them:

- `helpers._read_sun_boundary_options` (coordinator + snapshot builder)
- `config_types.CoverConfig.from_options` (pure calc engine)
- `services/export_service.py` (export payload)
- `config_flow._build_config_summary` — the behavior fix

One semantic change beyond the config_flow fix: a stored `None` now reads as *unset* everywhere, so the sunrise fallback applies instead of `int(None)` raising. The `snapshot_builder.py` copy the issue lists was already folded in by #1048.

The schema selector defaults at `config_dynamic.py:807` and `config_flow.py:703` are untouched, per the issue — those are form defaults, not the runtime fallback.

## Testing
- ✅ 8,920 tests passing
- New `tests/test_sunrise_offset_fallback.py` pins the semantic once and exercises each consumer with the same options dict, so a sixth copy can't quietly reintroduce a sixth variant.

## Related Issues
Refs #1050