### PR TITLE
fix: resolve the #1044 audit follow-ups (#1051)

### DIFF
--- a/custom_components/adaptive_cover_pro/building_overview.py
+++ b/custom_components/adaptive_cover_pro/building_overview.py
@@ -92,13 +92,12 @@ from .const import (
     DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE,
     DEFAULT_WEATHER_WIND_SPEED_THRESHOLD,
     MANUAL_OVERRIDE_DURATION_MODE_FIXED,
-    MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END,
 )
 from .cover_types import get_policy
 from .helpers import (
     custom_position_slot_configured,
-    has_configured_window_end,
     is_template_string,
+    manual_hold_is_unanchored,
     motion_entities,
 )
 from .profile_link import classify_profile_sensor_source
@@ -414,20 +413,18 @@ def _manual_override_hold(options: Mapping) -> str:
 
     * A mode with no label: one this build does not know — a hand-edited
       ``.storage``, or a value written by a newer build.
-    * ``until_window_end`` with no window end configured. Decided by the same
-      ``has_configured_window_end`` predicate the resolver and the config
-      summary's ⚠️ use, so all three agree on which configs have no anchor —
-      including the truthy-but-unset ``BLANK_TIME`` sentinel.
+    * A mode whose boundary this config cannot resolve. Decided by
+      ``manual_hold_is_unanchored``, the one predicate the config summary's ⚠️
+      reads too, so the two surfaces cannot describe the same config
+      differently — the truthy-but-unset ``BLANK_TIME`` sentinel included.
     """
     mode = (
         _eff(options, CONF_MANUAL_OVERRIDE_DURATION_MODE, None)
         or DEFAULT_MANUAL_OVERRIDE_DURATION_MODE
     )
-    unanchored_window_end = (
-        mode == MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END
-        and not has_configured_window_end(options)
-    )
-    if mode != MANUAL_OVERRIDE_DURATION_MODE_FIXED and not unanchored_window_end:
+    if mode != MANUAL_OVERRIDE_DURATION_MODE_FIXED and not manual_hold_is_unanchored(
+        options
+    ):
         label = _LABELS.get(f"manual_hold.{mode}")
         if label is not None:
             return label

--- a/custom_components/adaptive_cover_pro/building_overview.py
+++ b/custom_components/adaptive_cover_pro/building_overview.py
@@ -135,6 +135,15 @@ _LABELS: dict[str, str] = {
     "inherit_from_profile": "- {label}: `{value}` (from profile)",
     "inherit_overridden": "- {label}: `{value}` — overridden (profile: `{profile}`)",
     "inherit_local": "- {label}: `{value}` (profile not set — local)",
+    # What the manual-override hold is measured against (issue #1044). Verbatim
+    # copies of the selector option labels in translations/en.json — this module
+    # is English-only and cannot read the bundle, so the copy is deliberate and
+    # locked against drift by test_mode_labels_match_the_selector_translations.
+    # ``fixed`` has no entry: it renders the numeric duration instead.
+    "manual_hold.until_sunset": "Until the next sunset",
+    "manual_hold.until_sunrise": "Until the next sunrise",
+    "manual_hold.until_next_sun_event": "Until the next sunrise or sunset",
+    "manual_hold.until_window_end": "Until the time window ends",
 }
 
 # Friendly labels for the shared-sensor keys. Falls back to a humanized key.
@@ -392,16 +401,25 @@ def _manual_override_hold(options: Mapping) -> str:
     """Render what the manual-override hold is measured against (issue #1044).
 
     ``fixed`` — the default — prints the numeric duration exactly as it always
-    has. Any other mode prints the mode instead: the duration is then only the
+    has. Any other mode prints its label instead: the duration is then only the
     fallback for an unresolvable boundary, so showing it would misrepresent the
     configured behaviour in a side-by-side comparison.
+
+    A mode with no label is one this build does not know — a hand-edited
+    ``.storage``, or a value written by a newer build. It degrades to the
+    numeric duration rather than leaking the raw identifier into the table
+    (issue #1051), which is also what actually happens at runtime:
+    ``resolve_override_deadline`` returns ``None`` for an unrecognised mode, so
+    the hold really is the numeric duration.
     """
     mode = (
         _eff(options, CONF_MANUAL_OVERRIDE_DURATION_MODE, None)
         or DEFAULT_MANUAL_OVERRIDE_DURATION_MODE
     )
     if mode != MANUAL_OVERRIDE_DURATION_MODE_FIXED:
-        return mode
+        label = _LABELS.get(f"manual_hold.{mode}")
+        if label is not None:
+            return label
     return _fmt_duration(
         _eff(options, CONF_MANUAL_OVERRIDE_DURATION, DEFAULT_MANUAL_OVERRIDE_DURATION)
     )

--- a/custom_components/adaptive_cover_pro/building_overview.py
+++ b/custom_components/adaptive_cover_pro/building_overview.py
@@ -92,10 +92,12 @@ from .const import (
     DEFAULT_WEATHER_WIND_DIRECTION_TOLERANCE,
     DEFAULT_WEATHER_WIND_SPEED_THRESHOLD,
     MANUAL_OVERRIDE_DURATION_MODE_FIXED,
+    MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END,
 )
 from .cover_types import get_policy
 from .helpers import (
     custom_position_slot_configured,
+    has_configured_window_end,
     is_template_string,
     motion_entities,
 )
@@ -405,18 +407,27 @@ def _manual_override_hold(options: Mapping) -> str:
     fallback for an unresolvable boundary, so showing it would misrepresent the
     configured behaviour in a side-by-side comparison.
 
-    A mode with no label is one this build does not know — a hand-edited
-    ``.storage``, or a value written by a newer build. It degrades to the
-    numeric duration rather than leaking the raw identifier into the table
-    (issue #1051), which is also what actually happens at runtime:
-    ``resolve_override_deadline`` returns ``None`` for an unrecognised mode, so
-    the hold really is the numeric duration.
+    Two cases degrade back to the numeric duration rather than printing a
+    boundary the hold will never reach (issue #1051). Both mirror what the
+    runtime actually does — ``resolve_override_deadline`` returns ``None``, and
+    the caller falls back to the duration:
+
+    * A mode with no label: one this build does not know — a hand-edited
+      ``.storage``, or a value written by a newer build.
+    * ``until_window_end`` with no window end configured. Decided by the same
+      ``has_configured_window_end`` predicate the resolver and the config
+      summary's ⚠️ use, so all three agree on which configs have no anchor —
+      including the truthy-but-unset ``BLANK_TIME`` sentinel.
     """
     mode = (
         _eff(options, CONF_MANUAL_OVERRIDE_DURATION_MODE, None)
         or DEFAULT_MANUAL_OVERRIDE_DURATION_MODE
     )
-    if mode != MANUAL_OVERRIDE_DURATION_MODE_FIXED:
+    unanchored_window_end = (
+        mode == MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END
+        and not has_configured_window_end(options)
+    )
+    if mode != MANUAL_OVERRIDE_DURATION_MODE_FIXED and not unanchored_window_end:
         label = _LABELS.get(f"manual_hold.{mode}")
         if label is not None:
             return label

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -228,7 +228,6 @@ from .const import (
     GLARE_ZONE_SLOTS,
     GROUP_SCENE_PRIORITY,
     MANUAL_OVERRIDE_DURATION_MODE_FIXED,
-    MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END,
     MANUAL_OVERRIDE_DURATION_MODES,
     OPT_OUT_ALL_SCENES,
     CONF_DEBUG_CATEGORIES,
@@ -255,7 +254,7 @@ from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_name,
     custom_position_slot_sensors,
-    has_configured_window_end,
+    manual_hold_is_unanchored,
     mirror_legacy_slot_sensor_keys,
     normalize_time_string,
     resolve_sunrise_offset,
@@ -2293,10 +2292,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # Same predicate the runtime resolver uses, so the ⚠️ fires for exactly the
     # configs whose hold falls back to the numeric duration — including the
     # truthy-but-unset ``BLANK_TIME`` sentinel (issue #1044).
-    manual_window_end_missing = (
-        manual_mode == MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END
-        and not has_configured_window_end(config)
-    )
+    manual_window_end_missing = manual_hold_is_unanchored(config)
     # The summary's only computed-key label lookup. An out-of-schema stored mode
     # (hand-edited .storage, a value from a build that knew a mode this one
     # doesn't) must degrade to the fixed rendering the way the runtime half

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -516,8 +516,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Seeded so the end-time sensor and the reboot-restore path — both of
         # which can reach expiry_for() before the first _update_options cycle —
         # read a real mode rather than raising AttributeError; refreshed each
-        # cycle (issue #1051). ManualOverrideSlice is the single source: no
-        # consumer re-reads CONF_MANUAL_OVERRIDE_DURATION_MODE from options.
+        # cycle (issue #1051). ManualOverrideSlice is the single source for the
+        # coordinator: no *runtime* consumer re-reads
+        # CONF_MANUAL_OVERRIDE_DURATION_MODE from options. The config/options
+        # flow, the field schema and the service validator still read the raw
+        # key — correctly, since none of them has a coordinator to read from.
         self.manual_override_duration_mode = _rc_attach.manual_override.duration_mode
 
         # Cover command service — self-contained: owns positioning, target tracking,

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -81,7 +81,6 @@ from .const import (
     CONF_MANUAL_IGNORE_EXTERNAL,
     CONF_MANUAL_IGNORE_INTERMEDIATE,
     CONF_MANUAL_OVERRIDE_DURATION,
-    CONF_MANUAL_OVERRIDE_DURATION_MODE,
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MANUAL_OVERRIDE_STRATEGY,
     CONF_MANUAL_THRESHOLD,
@@ -96,7 +95,6 @@ from .const import (
     DEFAULT_CUSTOM_POSITION_ENABLED,
     DEFAULT_CUSTOM_POSITION_PRIORITY,
     DEFAULT_DEBUG_EVENT_BUFFER_SIZE,
-    DEFAULT_MANUAL_OVERRIDE_DURATION_MODE,
     DEFAULT_MANUAL_OVERRIDE_STRATEGY,
     DEFAULT_TRANSIT_TIMEOUT_SECONDS,
     DIAG_CACHE_KEY,
@@ -515,6 +513,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # passed to policy.attach reads a value before the first _update_options
         # cycle; refreshed each cycle (issue #808).
         self._venetian_tilt_reset_scope = _rc_attach.venetian.tilt_reset_scope
+        # Seeded so the end-time sensor and the reboot-restore path — both of
+        # which can reach expiry_for() before the first _update_options cycle —
+        # read a real mode rather than raising AttributeError; refreshed each
+        # cycle (issue #1051). ManualOverrideSlice is the single source: no
+        # consumer re-reads CONF_MANUAL_OVERRIDE_DURATION_MODE from options.
+        self.manual_override_duration_mode = _rc_attach.manual_override.duration_mode
 
         # Cover command service — self-contained: owns positioning, target tracking,
         # and the reconciliation timer (started in async_config_entry_first_refresh).
@@ -3087,6 +3091,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # reload; the template-change handler re-renders this live to engage on
         # the truthy edge.
         self.manual_override_input_template = rc.manual_override.input_template
+        # Per-cycle snapshot of what the hold is measured against (issue #1044).
+        # The diagnostics block and the deadline resolver both read this mirror
+        # — neither re-reads the option (issue #1051). Safe as a mirror: the key
+        # is not in _RUNTIME_APPLICABLE_OPTIONS, so changing it reloads the
+        # config entry outright rather than patching a live coordinator.
+        self.manual_override_duration_mode = rc.manual_override.duration_mode
         self.manual_threshold = rc.tracking.manual_threshold
         # Mirror the reconciliation tolerance coordinator-side so the cover
         # state-change handler can lower the override-detection threshold when
@@ -4196,10 +4206,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             }
         return {
             "reset_duration_seconds": int(reset_secs),
-            "duration_mode": (
-                self.config_entry.options.get(CONF_MANUAL_OVERRIDE_DURATION_MODE)
-                or DEFAULT_MANUAL_OVERRIDE_DURATION_MODE
-            ),
+            "duration_mode": self.manual_override_duration_mode,
             "tracked_covers": sorted(self.manager.covers),
             "entries": entries,
         }
@@ -4208,10 +4215,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Resolve a manual override's end time for the configured mode (issue #1044).
 
         The HA-side half of the rule, injected into ``AdaptiveCoverManager`` via
-        ``set_deadline_resolver`` so the manager itself stays HA-free: it reads
-        the duration mode, the sunset/sunrise override entities and offsets, and
-        the operating window's resolved end, then hands the arithmetic to the
-        pure :func:`.helpers.resolve_override_deadline`.
+        ``set_deadline_resolver`` so the manager itself stays HA-free: it takes
+        the duration mode from the per-cycle ``RuntimeConfig`` mirror, reads the
+        sunset/sunrise override entities and offsets and the operating window's
+        resolved end, then hands the arithmetic to the pure
+        :func:`.helpers.resolve_override_deadline`.
 
         ``fixed`` — the default, and what an install that never touched the
         option gets — short-circuits before any state read, so the common case
@@ -4229,10 +4237,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         """
         options = self.config_entry.options
-        mode = (
-            options.get(CONF_MANUAL_OVERRIDE_DURATION_MODE)
-            or DEFAULT_MANUAL_OVERRIDE_DURATION_MODE
-        )
+        mode = self.manual_override_duration_mode
         if mode == MANUAL_OVERRIDE_DURATION_MODE_FIXED:
             return None
 

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -18,6 +18,7 @@ from .const import (
     BLANK_TIME,
     CONF_END_ENTITY,
     CONF_END_TIME,
+    CONF_MANUAL_OVERRIDE_DURATION_MODE,
     CONF_MANUAL_OVERRIDE_INPUT_ENTITIES,
     CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
@@ -27,6 +28,7 @@ from .const import (
     CONF_SUNSET_TIME_ENTITY,
     CUSTOM_POSITION_SLOTS,
     DEFAULT_CUSTOM_POSITION_TILT_ONLY,
+    DEFAULT_MANUAL_OVERRIDE_DURATION_MODE,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_NEXT_SUN_EVENT,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET,
@@ -94,6 +96,29 @@ def has_configured_window_end(options: Mapping) -> bool:
     return any(
         options.get(key) not in (None, "", BLANK_TIME)
         for key in (CONF_END_TIME, CONF_END_ENTITY)
+    )
+
+
+def manual_hold_is_unanchored(options: Mapping) -> bool:
+    """Return True when the configured manual-override hold has no boundary.
+
+    Single source of truth for "does this config's hold fall back to the numeric
+    ``manual_override_duration``?", shared by the configuration summary's ⚠️ and
+    the Building Profile overview's comparison table so the two surfaces can
+    never describe the same config differently (issue #1051).
+
+    Today that is exactly ``until_window_end`` with no operating-window end:
+    :func:`resolve_override_deadline` finds no anchor and the caller falls back
+    to the duration. A future mode that also needs an anchor belongs **here**,
+    not in either surface's own render — two hand-rolled copies are how the
+    overview came to print a boundary the hold never reaches.
+    """
+    mode = (
+        options.get(CONF_MANUAL_OVERRIDE_DURATION_MODE)
+        or DEFAULT_MANUAL_OVERRIDE_DURATION_MODE
+    )
+    return mode == MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END and (
+        not has_configured_window_end(options)
     )
 
 

--- a/tests/test_building_overview.py
+++ b/tests/test_building_overview.py
@@ -383,6 +383,48 @@ def test_window_end_mode_treats_the_blank_sentinel_as_unset():
     assert "Until the time window ends" not in row
 
 
+def test_unanchored_hold_agrees_with_the_config_flow_summary():
+    """Both surfaces decide "this hold has no anchor" from one predicate.
+
+    A mode that needs an anchor and has none falls back to the numeric duration
+    at runtime, so both surfaces must print the duration. Two hand-rolled copies
+    of that rule would let a future anchored mode land on one surface only —
+    which is exactly how the overview came to print a boundary the hold never
+    reaches. This walks every mode against every end-time shape and asserts the
+    two agree, whatever rule either one implements.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import _build_config_summary
+    from custom_components.adaptive_cover_pro.const import BLANK_TIME, CONF_END_ENTITY
+
+    end_shapes = (
+        {},
+        {CONF_END_TIME: None},
+        {CONF_END_TIME: ""},
+        {CONF_END_TIME: BLANK_TIME},
+        {CONF_END_TIME: "20:00:00"},
+        {CONF_END_ENTITY: "input_datetime.end"},
+        {CONF_END_TIME: BLANK_TIME, CONF_END_ENTITY: "input_datetime.end"},
+    )
+    for mode in MANUAL_OVERRIDE_DURATION_MODES:
+        for shape in end_shapes:
+            cfg = {
+                CONF_MANUAL_OVERRIDE_DURATION_MODE: mode,
+                CONF_MANUAL_OVERRIDE_DURATION: {"hours": 7},
+                **shape,
+            }
+            overview_shows_duration = "7h" in _manual_row(
+                [
+                    _cover("A", options=cfg),
+                    _cover("B", options={CONF_MANUAL_OVERRIDE_DURATION: {"hours": 9}}),
+                ]
+            )
+            summary_shows_duration = "pauses for 7 h" in _build_config_summary(
+                cfg, CoverType.BLIND
+            )
+
+            assert overview_shows_duration == summary_shows_duration, (mode, shape)
+
+
 def test_window_end_mode_with_a_configured_end_shows_the_label():
     """A genuinely configured end resolves, so the label is the honest render."""
     anchored = _cover(

--- a/tests/test_building_overview.py
+++ b/tests/test_building_overview.py
@@ -17,6 +17,9 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_DELTA_POSITION,
     CONF_ENTITIES,
     CONF_LUX_ENTITY,
+    CONF_MANUAL_OVERRIDE_DURATION,
+    CONF_MANUAL_OVERRIDE_DURATION_MODE,
+    CONF_MANUAL_THRESHOLD,
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PROFILE_SENSOR_OVERRIDES,
     CONF_SENSOR_TYPE,
@@ -24,6 +27,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_WIND_SPEED_SENSOR,
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
     DEFAULT_DELTA_POSITION,
+    MANUAL_OVERRIDE_DURATION_MODE_FIXED,
+    MANUAL_OVERRIDE_DURATION_MODES,
     CoverType,
 )
 
@@ -281,6 +286,90 @@ def test_build_override_records():
     assert by_key[CONF_WEATHER_ENTITY].profile_text == "weather.home"
     assert by_key[CONF_LUX_ENTITY].profile_sets_it is False
     assert by_key[CONF_LUX_ENTITY].entry_id == "bedroom"
+
+
+def _manual_row(covers):
+    """Return the Manual override comparison row for ``covers``."""
+    text = build_building_overview(_profile({}), covers)
+    return next(line for line in text.splitlines() if "Manual override" in line)
+
+
+def test_manual_override_mode_renders_a_label_not_the_wire_value():
+    """The comparison table must not print the raw mode identifier (#1051).
+
+    Every other cell in the table goes through a formatter, and this same value
+    renders as a translated label on every other surface.
+    """
+    sun = _cover(
+        "Sun", options={CONF_MANUAL_OVERRIDE_DURATION_MODE: "until_next_sun_event"}
+    )
+    fixed = _cover("Fixed", options={CONF_MANUAL_OVERRIDE_DURATION: {"hours": 2}})
+
+    row = _manual_row([sun, fixed])
+
+    assert "Until the next sunrise or sunset" in row
+    assert "until_next_sun_event" not in row
+
+
+def test_every_sun_mode_has_a_label():
+    """No mode may fall through to the raw identifier."""
+    for mode in MANUAL_OVERRIDE_DURATION_MODES:
+        if mode == MANUAL_OVERRIDE_DURATION_MODE_FIXED:
+            continue
+        row = _manual_row(
+            [
+                _cover("Sun", options={CONF_MANUAL_OVERRIDE_DURATION_MODE: mode}),
+                _cover("Other", options={CONF_MANUAL_THRESHOLD: 20}),
+            ]
+        )
+        assert mode not in row
+
+
+def test_unknown_mode_degrades_to_the_numeric_duration():
+    """An out-of-schema stored mode renders as the fixed hold, and never raises.
+
+    Mirrors the config-flow summary's degrade, and matches runtime truth:
+    ``resolve_override_deadline`` returns ``None`` for a mode it does not know,
+    so the hold really is the numeric duration.
+    """
+    weird = _cover(
+        "Weird",
+        options={
+            CONF_MANUAL_OVERRIDE_DURATION_MODE: "until_the_cows_come_home",
+            CONF_MANUAL_OVERRIDE_DURATION: {"hours": 3},
+        },
+    )
+    other = _cover("Other", options={CONF_MANUAL_OVERRIDE_DURATION: {"hours": 9}})
+
+    row = _manual_row([weird, other])
+
+    assert "3h" in row
+    assert "until_the_cows_come_home" not in row
+
+
+def test_mode_labels_match_the_selector_translations():
+    """The English labels are a copy of ``en.json`` — lock them against drift.
+
+    ``building_overview`` is English-only by design and cannot read the
+    translation bundle, so the strings are duplicated. This is what stops the
+    two copies diverging the next time one is reworded.
+    """
+    import json
+    from pathlib import Path
+
+    from custom_components.adaptive_cover_pro import building_overview
+
+    en = json.loads(
+        (
+            Path(building_overview.__file__).parent / "translations" / "en.json"
+        ).read_text(encoding="utf-8")
+    )
+    options = en["selector"][CONF_MANUAL_OVERRIDE_DURATION_MODE]["options"]
+
+    for mode in MANUAL_OVERRIDE_DURATION_MODES:
+        if mode == MANUAL_OVERRIDE_DURATION_MODE_FIXED:
+            continue
+        assert building_overview._LABELS[f"manual_hold.{mode}"] == options[mode]
 
 
 def test_overridden_empty_value_reads_none():

--- a/tests/test_building_overview.py
+++ b/tests/test_building_overview.py
@@ -15,6 +15,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_CLIMATE_MODE,
     CONF_CLOUD_COVERAGE_THRESHOLD,
     CONF_DELTA_POSITION,
+    CONF_END_TIME,
     CONF_ENTITIES,
     CONF_LUX_ENTITY,
     CONF_MANUAL_OVERRIDE_DURATION,
@@ -311,18 +312,91 @@ def test_manual_override_mode_renders_a_label_not_the_wire_value():
     assert "until_next_sun_event" not in row
 
 
-def test_every_sun_mode_has_a_label():
-    """No mode may fall through to the raw identifier."""
+def test_every_sun_mode_renders_its_label():
+    """Every mode reaches its label — none falls through to the identifier.
+
+    Asserting the label is *present* is the load-bearing half: the degrade path
+    means a missing label silently prints the numeric duration instead, so
+    ``mode not in row`` alone would pass for a mode with no label at all.
+    """
+    from custom_components.adaptive_cover_pro.building_overview import _LABELS
+
     for mode in MANUAL_OVERRIDE_DURATION_MODES:
         if mode == MANUAL_OVERRIDE_DURATION_MODE_FIXED:
             continue
         row = _manual_row(
             [
-                _cover("Sun", options={CONF_MANUAL_OVERRIDE_DURATION_MODE: mode}),
+                _cover(
+                    "Sun",
+                    options={
+                        CONF_MANUAL_OVERRIDE_DURATION_MODE: mode,
+                        # ``until_window_end`` only has an anchor when a window
+                        # end exists; the other modes ignore this.
+                        CONF_END_TIME: "20:00:00",
+                    },
+                ),
                 _cover("Other", options={CONF_MANUAL_THRESHOLD: 20}),
             ]
         )
+        assert _LABELS[f"manual_hold.{mode}"] in row
         assert mode not in row
+
+
+def test_window_end_mode_without_a_window_end_shows_the_duration():
+    """No window end → no anchor → the hold really is the numeric duration.
+
+    ``config_flow``'s summary already degrades this case; the overview must
+    agree, or the two surfaces describe the same config differently.
+    """
+    unanchored = _cover(
+        "Unanchored",
+        options={
+            CONF_MANUAL_OVERRIDE_DURATION_MODE: "until_window_end",
+            CONF_MANUAL_OVERRIDE_DURATION: {"hours": 4},
+        },
+    )
+    other = _cover("Other", options={CONF_MANUAL_OVERRIDE_DURATION: {"hours": 9}})
+
+    row = _manual_row([unanchored, other])
+
+    assert "4h" in row
+    assert "Until the time window ends" not in row
+
+
+def test_window_end_mode_treats_the_blank_sentinel_as_unset():
+    """``BLANK_TIME`` is the project's UNSET sentinel, and it is truthy."""
+    from custom_components.adaptive_cover_pro.const import BLANK_TIME
+
+    unanchored = _cover(
+        "Unanchored",
+        options={
+            CONF_MANUAL_OVERRIDE_DURATION_MODE: "until_window_end",
+            CONF_END_TIME: BLANK_TIME,
+            CONF_MANUAL_OVERRIDE_DURATION: {"hours": 4},
+        },
+    )
+    other = _cover("Other", options={CONF_MANUAL_OVERRIDE_DURATION: {"hours": 9}})
+
+    row = _manual_row([unanchored, other])
+
+    assert "4h" in row
+    assert "Until the time window ends" not in row
+
+
+def test_window_end_mode_with_a_configured_end_shows_the_label():
+    """A genuinely configured end resolves, so the label is the honest render."""
+    anchored = _cover(
+        "Anchored",
+        options={
+            CONF_MANUAL_OVERRIDE_DURATION_MODE: "until_window_end",
+            CONF_END_TIME: "20:00:00",
+        },
+    )
+    other = _cover("Other", options={CONF_MANUAL_OVERRIDE_DURATION: {"hours": 9}})
+
+    row = _manual_row([anchored, other])
+
+    assert "Until the time window ends" in row
 
 
 def test_unknown_mode_degrades_to_the_numeric_duration():

--- a/tests/test_manual_override_duration_mode.py
+++ b/tests/test_manual_override_duration_mode.py
@@ -13,6 +13,7 @@ instead of a fixed clock duration. Covered here:
 from __future__ import annotations
 
 import datetime as dt
+import inspect
 import zoneinfo
 from unittest.mock import MagicMock, patch
 
@@ -449,12 +450,19 @@ def _coordinator(
     time_entity_state: str | None = None,
 ):
     """Return a coordinator stub with only what ``_resolve_override_deadline`` reads."""
+    from custom_components.adaptive_cover_pro.config_types import RuntimeConfig
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
 
     coord = MagicMock()
     coord.config_entry.options = options
+    # The duration mode reaches the resolver through the per-cycle
+    # ``RuntimeConfig`` mirror, never the options dict (issue #1051) — publish
+    # it here exactly as ``_update_options`` does.
+    coord.manual_override_duration_mode = RuntimeConfig.from_options(
+        options
+    ).manual_override.duration_mode
     coord.logger = MagicMock()
     coord._cover_data = None if sun_data is None else MagicMock(sun_data=sun_data)
     coord._time_mgr.end_time = window_end
@@ -944,6 +952,110 @@ class TestConfigSurface:
         assert CONF_MANUAL_OVERRIDE_DURATION_MODE in _SECTION_MANUAL_OVERRIDE
 
 
+class TestSliceIsTheSingleModeSource:
+    """``ManualOverrideSlice.duration_mode`` is the one read of the mode.
+
+    Issue #1051 item 1: the slice field was declared and written but never
+    read, while both runtime consumers went to ``config_entry.options``
+    themselves — two sources for one value, contrary to the "read options once
+    per cycle into ``RuntimeConfig``" rule. These pin the slice as the source
+    and the coordinator mirror as the only way either consumer sees the mode.
+
+    Each test deliberately sets a mirror that *contradicts* the options dict:
+    a consumer that still reads options would return the options value and
+    fail, which is what makes these tests about the wiring and not the value.
+    """
+
+    def test_update_options_publishes_the_mode_mirror(self):
+        """``_update_options`` propagates the slice like every other mirror."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = MagicMock()
+        AdaptiveDataUpdateCoordinator._update_options(
+            coord,
+            {
+                CONF_MANUAL_OVERRIDE_DURATION_MODE: (
+                    MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET
+                )
+            },
+        )
+
+        assert coord.manual_override_duration_mode == (
+            MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET
+        )
+
+    def test_mirror_is_seeded_before_the_first_update_cycle(self):
+        """The end-time sensor can reach ``expiry_for`` before cycle 1.
+
+        Same reason the venetian drift-reset mirrors are seeded in ``__init__``
+        from ``_rc_attach``: an unseeded attribute is an ``AttributeError``, not
+        a stale value.
+        """
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        source = inspect.getsource(AdaptiveDataUpdateCoordinator.__init__)
+        assert "self.manual_override_duration_mode" in source
+        assert "_rc_attach.manual_override.duration_mode" in source
+
+    def test_resolver_reads_the_mirror_not_the_options_dict(self):
+        """``_resolve_override_deadline`` resolves off the slice mirror."""
+        coord = _coordinator({}, sun_data=_astral_sun_data())
+        coord.manual_override_duration_mode = MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET
+
+        deadline = coord._resolve_override_deadline(
+            dt.datetime(2026, 7, 2, 12, 0, tzinfo=dt.UTC)
+        )
+
+        assert deadline == dt.datetime(2026, 7, 2, 21, 0, tzinfo=dt.UTC)
+
+    def test_resolver_short_circuits_on_a_fixed_mirror(self):
+        """A ``fixed`` mirror short-circuits even when options say otherwise."""
+        coord = _coordinator(
+            {
+                CONF_MANUAL_OVERRIDE_DURATION_MODE: (
+                    MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET
+                )
+            },
+            sun_data=_astral_sun_data(),
+        )
+        coord.manual_override_duration_mode = MANUAL_OVERRIDE_DURATION_MODE_FIXED
+
+        assert (
+            coord._resolve_override_deadline(
+                dt.datetime(2026, 7, 2, 12, 0, tzinfo=dt.UTC)
+            )
+            is None
+        )
+
+    def test_diagnostics_reports_the_mirror_not_the_options_dict(self):
+        """The diagnostics block reports the slice mirror."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        mgr = _manager(["cover.a"], reset_duration={"hours": 2})
+        mgr.set_last_updated(
+            "cover.a", _state(dt.datetime(2026, 7, 2, 12, 0, tzinfo=dt.UTC)), True
+        )
+        mgr.mark_manual_control("cover.a")
+
+        coord = MagicMock()
+        coord.manager = mgr
+        coord.config_entry.options = {}
+        coord.manual_override_duration_mode = (
+            MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE
+        )
+
+        with freeze_time("2026-07-02 13:00:00"):
+            state = AdaptiveDataUpdateCoordinator._manual_override_diagnostics(coord)
+
+        assert state["duration_mode"] == MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE
+
+
 # ---------------------------------------------------------------------------
 # Sensor / diagnostics / restore surfaces
 # ---------------------------------------------------------------------------
@@ -1141,6 +1253,7 @@ class TestStartedAtProvenance:
 
 def _build_manual_override_diagnostics(manager, options: dict) -> dict:
     """Drive the coordinator's manual-override diagnostics block in isolation."""
+    from custom_components.adaptive_cover_pro.config_types import RuntimeConfig
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
@@ -1148,4 +1261,9 @@ def _build_manual_override_diagnostics(manager, options: dict) -> dict:
     coord = MagicMock()
     coord.manager = manager
     coord.config_entry.options = options
+    # Same mirror the resolver reads — the diagnostics block reports the slice,
+    # not a second read of the option (issue #1051).
+    coord.manual_override_duration_mode = RuntimeConfig.from_options(
+        options
+    ).manual_override.duration_mode
     return AdaptiveDataUpdateCoordinator._manual_override_diagnostics(coord)

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -20,6 +20,7 @@ import datetime as dt
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from freezegun import freeze_time
 
 UTC = dt.UTC
 
@@ -1202,3 +1203,152 @@ class TestIssue223OverrideClearSafetyTag:
                 "when the window closed (fix for issue #223)."
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# Sun-mode expiry driven through the real coordinator guards (issue #1051)
+# ---------------------------------------------------------------------------
+
+
+def _sun_data(
+    *,
+    sunrise=dt.datetime(2026, 7, 2, 4, 0),
+    sunset=dt.datetime(2026, 7, 2, 21, 0),
+    next_sunrise=dt.datetime(2026, 7, 3, 4, 1),
+    next_sunset=dt.datetime(2026, 7, 3, 20, 59),
+):
+    """Return a mid-latitude summer day: sunrise 04:00, sunset 21:00 UTC."""
+    sun_data = MagicMock()
+    sun_data.sunrise.return_value = sunrise.replace(tzinfo=UTC)
+    sun_data.sunset.return_value = sunset.replace(tzinfo=UTC)
+    sun_data.next_sunrise.return_value = next_sunrise.replace(tzinfo=UTC)
+    sun_data.next_sunset.return_value = next_sunset.replace(tzinfo=UTC)
+    return sun_data
+
+
+def _sunrise_mode_coordinator(**kwargs):
+    """Coordinator with the REAL resolver, manager, and force-send path wired.
+
+    Everything between "the resolver picks a sunrise deadline" and "the guard
+    decides whether to reposition" is production code here: only the HA reads
+    (sun data, cover command service, position context) are stubbed.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MANUAL_OVERRIDE_DURATION_MODE,
+        MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE,
+    )
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+    from custom_components.adaptive_cover_pro.managers.manual_override import (
+        AdaptiveCoverManager,
+    )
+
+    coord = _make_coordinator(**kwargs)
+    coord.config_entry.options = {
+        CONF_MANUAL_OVERRIDE_DURATION_MODE: (
+            MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE
+        )
+    }
+    coord.manual_override_duration_mode = MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNRISE
+    # No sunrise-time entity configured — the resolver falls through to astral.
+    coord.hass.states.get.return_value = None
+    coord._cover_data = MagicMock(sun_data=_sun_data())
+    coord._time_mgr.end_time = None
+    coord._resolve_override_deadline = (
+        AdaptiveDataUpdateCoordinator._resolve_override_deadline.__get__(coord)
+    )
+    coord._async_force_send_pipeline_position = (
+        AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position.__get__(coord)
+    )
+
+    manager = AdaptiveCoverManager(
+        hass=MagicMock(), reset_duration={"hours": 2}, logger=MagicMock()
+    )
+    manager.add_covers(["cover.test_blind"])
+    manager.set_deadline_resolver(coord._resolve_override_deadline)
+    coord.manager = manager
+    return coord
+
+
+def _engage_override_at_dusk(coord):
+    """Engage a manual override at 22:00 — the close-the-blind-at-dusk case."""
+    coord.manager.set_last_updated(
+        "cover.test_blind",
+        MagicMock(last_updated=dt.datetime(2026, 7, 2, 22, 0, tzinfo=UTC)),
+        allow_reset=True,
+    )
+    coord.manager.mark_manual_control("cover.test_blind")
+
+
+class TestSunModeExpiryThroughCoordinatorGuards:
+    """A sun-anchored expiry lands on the guards #215/#223 were written for.
+
+    Issue #1051 item 3. Everything else in this file drives
+    ``_async_force_send_pipeline_position`` directly; nothing walked the whole
+    path — resolver resolves a sunrise deadline, ``reset_if_needed`` returns the
+    entity, the guards suppress the reposition. The sun modes relocate expiry
+    onto exactly the dawn/dusk moments those issues were about, so a
+    ``until_sunrise`` deadline fires inside #215's literal timeline.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sunrise_expiry_outside_window_does_not_reposition(self):
+        """Expiry at sunrise, hours before the window opens → stay put."""
+        coord = _sunrise_mode_coordinator(check_adaptive_time=False)
+        _engage_override_at_dusk(coord)
+
+        # 02:00 — the fixed 2 h duration would have expired at midnight, and
+        # #215's "reopening at 2 a.m." is exactly this moment. The sun deadline
+        # holds, which is what proves the resolver set it and not the duration.
+        with freeze_time("2026-07-03 02:00:00"):
+            assert await coord.manager.reset_if_needed() == set()
+        assert coord.manager.is_cover_manual("cover.test_blind") is True
+
+        # Just past the resolved sunrise (04:01) the override clears.
+        with freeze_time("2026-07-03 04:01:01"):
+            expired = await coord.manager.reset_if_needed()
+        assert expired == {"cover.test_blind"}
+
+        sent = await coord._async_force_send_pipeline_position(60, {})
+
+        assert sent == set()
+        coord._cmd_svc.apply_position.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sunrise_expiry_with_auto_control_off_does_not_reposition(self):
+        """Same expiry inside the window, automatic control OFF → stay put."""
+        coord = _sunrise_mode_coordinator(
+            check_adaptive_time=True,
+            clock_window_open=True,
+            automatic_control=False,
+        )
+        _engage_override_at_dusk(coord)
+
+        with freeze_time("2026-07-03 04:01:01"):
+            expired = await coord.manager.reset_if_needed()
+        assert expired == {"cover.test_blind"}
+
+        sent = await coord._async_force_send_pipeline_position(60, {})
+
+        assert sent == set()
+        coord._cmd_svc.apply_position.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sunrise_expiry_inside_window_does_reposition(self):
+        """Positive control: with both guards open the same expiry DOES send.
+
+        Without this the two guard tests above would pass against an inert
+        harness that never dispatches for any reason.
+        """
+        coord = _sunrise_mode_coordinator(check_adaptive_time=True)
+        _engage_override_at_dusk(coord)
+
+        with freeze_time("2026-07-03 04:01:01"):
+            expired = await coord.manager.reset_if_needed()
+        assert expired == {"cover.test_blind"}
+
+        sent = await coord._async_force_send_pipeline_position(60, {})
+
+        assert sent == {"cover.test_blind"}
+        coord._cmd_svc.apply_position.assert_awaited_once()


### PR DESCRIPTION
## Summary
The three follow-ups the pre-merge audit on #1044 deliberately deferred.

**Dead slice field.** `ManualOverrideSlice.duration_mode` was declared and written but never read, while both runtime consumers went to `config_entry.options` themselves — two sources for one value. The diagnostics block and the deadline resolver now read a per-cycle mirror published by `_update_options` from the slice, seeded in `__init__` like the other pre-first-cycle mirrors. Safe as a mirror: the key is not in `_RUNTIME_APPLICABLE_OPTIONS`, so changing it reloads the config entry outright.

**Raw mode label.** The Building Profile comparison table printed the wire value (`until_next_sun_event`) where every other cell goes through a formatter. It now renders the same English label the selector uses, with a parity lock against `en.json` so the two copies cannot drift. A mode whose boundary the config cannot resolve — an out-of-schema value, or `until_window_end` with no window end — degrades to the numeric duration, which is what it actually resolves to at runtime.

**Expiry-guard coverage.** Adds the end-to-end path that was missing: a sunrise-anchored expiry driven through `reset_if_needed` into the #215/#223 coordinator guards, one test per guard plus a positive control.

Also extracts `manual_hold_is_unanchored()` into `helpers.py` so the config summary's ⚠️ and the overview's degrade read one predicate instead of two copies, with a cross-surface test that walks every mode against every end-time shape and asserts the two agree.

## Testing
- ✅ 8936 tests passing

## Related Issues
Refs #1051