### PR TITLE
fix: normalize time keys when copying shared options (#1057)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -243,6 +243,8 @@ from .const import (
     MIN_TRANSIT_TIMEOUT,
     MODE2_OPEN_HORIZONTAL_PERCENT,
     DOMAIN,
+    TIME_OPTION_KEYS,
+    TIME_STRING_RE,
     CoverType,
     GroupScene,
     TemplateCombineMode,
@@ -3659,15 +3661,36 @@ def _extract_shared_options(
     Excludes per-window fields: CONF_ENTITIES, CONF_AZIMUTH, CONF_DEVICE_ID.
     When categories is None, returns all shared options (used by duplicate flow).
     When categories is a list, returns only options belonging to those categories.
+
+    Also canonicalizes any time-typed option (``TIME_OPTION_KEYS``) that isn't
+    already in the one accepted wire format: a source entry predating the
+    v3.11 -> v3.12 repair, or one that was ``disabled_by``-set before that
+    migration shipped (so it never ran), can still carry a raw value like
+    ``"7:30"``. Values ``normalize_time_string`` can't rescue are dropped
+    rather than copied verbatim into the new entry (issue #1057).
     """
     if categories is None:
-        return {
+        result = {
             k: v for k, v in entry.options.items() if k not in _SHARED_OPTIONS_EXCLUDED
         }
-    allowed_keys = frozenset().union(
-        *(SYNC_CATEGORIES[c] for c in categories if c in SYNC_CATEGORIES)
-    )
-    return {k: v for k, v in entry.options.items() if k in allowed_keys}
+    else:
+        allowed_keys = frozenset().union(
+            *(SYNC_CATEGORIES[c] for c in categories if c in SYNC_CATEGORIES)
+        )
+        result = {k: v for k, v in entry.options.items() if k in allowed_keys}
+
+    for key in TIME_OPTION_KEYS:
+        if key not in result:
+            continue
+        value = result[key]
+        if value is None or TIME_STRING_RE.match(str(value)):
+            continue  # absent-equivalent or already canonical
+        canonical = normalize_time_string(value)
+        if TIME_STRING_RE.match(str(canonical)):
+            result[key] = canonical
+        else:
+            del result[key]  # unrescuable — drop rather than copy garbage
+    return result
 
 
 def _build_cover_entity_schema(

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3667,7 +3667,11 @@ def _extract_shared_options(
     v3.11 -> v3.12 repair, or one that was ``disabled_by``-set before that
     migration shipped (so it never ran), can still carry a raw value like
     ``"7:30"``. Values ``normalize_time_string`` can't rescue are dropped
-    rather than copied verbatim into the new entry (issue #1057).
+    rather than copied — on Duplicate that means the key is simply absent
+    from the new entry; on Sync, where the result is merged as
+    ``{**target.options, **shared_options}``, a dropped key leaves the
+    target's own existing value in place rather than clearing it (issue
+    #1057).
     """
     if categories is None:
         result = {
@@ -3687,8 +3691,22 @@ def _extract_shared_options(
             continue  # absent-equivalent or already canonical
         canonical = normalize_time_string(value)
         if TIME_STRING_RE.match(str(canonical)):
+            _LOGGER.debug(
+                "_extract_shared_options: entry '%s' %s=%r stored as %r",
+                entry.entry_id,
+                key,
+                value,
+                canonical,
+            )
             result[key] = canonical
         else:
+            _LOGGER.warning(
+                "_extract_shared_options: entry '%s' %s=%r is not a valid time "
+                "(expected HH:MM:SS) and was dropped rather than copied",
+                entry.entry_id,
+                key,
+                value,
+            )
             del result[key]  # unrescuable — drop rather than copy garbage
     return result
 

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1254,7 +1254,10 @@ BLANK_TIME = "00:00:00"
 #     source entry disabled since before the v3.12 migration shipped never
 #     ran it and can still hold a raw value (issue #1057).
 # Entries written before any of this existed are repaired by the v3.11 → v3.12
-# migration in ``__init__.py``.
+# migration in ``__init__.py`` — but only once HA sets the entry up; one
+# ``disabled_by``-set before v3.12 shipped never reaches that setup call, so
+# the migration never runs for it. That is exactly why the copy site above
+# carries its own guard instead of trusting the migration to have run first.
 #
 # Three deliberate choices, each closing a way a near-miss value slips through:
 #   * ``\Z``, not ``$`` — ``$`` also matches before a trailing newline, so

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1256,7 +1256,8 @@ BLANK_TIME = "00:00:00"
 # Entries written before any of this existed are repaired by the v3.11 → v3.12
 # migration in ``__init__.py`` — but only once HA sets the entry up; one
 # ``disabled_by``-set before v3.12 shipped never reaches that setup call, so
-# the migration never runs for it. That is exactly why the copy site above
+# the migration does not run while it stays disabled (re-enabling it reloads
+# the entry and does run the repair). That is exactly why the copy site above
 # carries its own guard instead of trusting the migration to have run first.
 #
 # Three deliberate choices, each closing a way a near-miss value slips through:

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1248,9 +1248,11 @@ BLANK_TIME = "00:00:00"
 #   * the options flow's automation step (``config_flow``) — canonicalises; the
 #     user picked a real time, just in a shape the picker never emits. It is
 #     the only flow step rendering a TimeSelector.
-#   * the flow's Sync and Duplicate steps (``config_flow``) — copy a time key
-#     verbatim between entries. Safe only because the source is already
-#     canonical; they add no guard of their own.
+#   * the flow's Sync and Duplicate steps (``config_flow``) — both delegate to
+#     ``_extract_shared_options``, which canonicalises what
+#     ``helpers.normalize_time_string`` can parse and drops the rest; a
+#     source entry disabled since before the v3.12 migration shipped never
+#     ran it and can still hold a raw value (issue #1057).
 # Entries written before any of this existed are repaired by the v3.11 → v3.12
 # migration in ``__init__.py``.
 #

--- a/tests/test_duplicate_sync.py
+++ b/tests/test_duplicate_sync.py
@@ -25,6 +25,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_DEVICE_ID,
     CONF_DISTANCE,
     CONF_ENABLE_BLIND_SPOT,
+    CONF_END_TIME,
     CONF_ENTITIES,
     CONF_FORCE_OVERRIDE_MIN_MODE,
     CONF_FORCE_OVERRIDE_POSITION,
@@ -45,6 +46,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_OUTSIDETEMP_ENTITY,
     CONF_PRESENCE_ENTITY,
     CONF_SENSOR_TYPE,
+    CONF_START_TIME,
     CONF_SUNSET_TILT,
     CONF_TEMP_ENTITY,
     CONF_TEMP_HIGH,
@@ -164,6 +166,53 @@ class TestExtractSharedOptions:
         result = _extract_shared_options(entry)
         result[CONF_HEIGHT_WIN] = 99.0
         assert entry.options[CONF_HEIGHT_WIN] == 2.1
+
+
+class TestExtractSharedOptionsTimeNormalization:
+    """Tests for time-key normalization in _extract_shared_options (#1057).
+
+    Duplicate and Sync both copy options through this function. A source
+    entry that predates the v3.11 -> v3.12 repair (or was disabled_by-set
+    before that migration shipped, so it never ran) can still carry a
+    non-canonical start_time/end_time. This normalizes on the way out so
+    neither call site copies a malformed value into a fresh entry.
+    """
+
+    def test_normalizes_noncanonical_start_time(self):
+        """A shorthand start_time is canonicalized to HH:MM:SS."""
+        entry = _make_entry({CONF_START_TIME: "7:30", CONF_HEIGHT_WIN: 2.1})
+        result = _extract_shared_options(entry)
+        assert result[CONF_START_TIME] == "07:30:00"
+
+    def test_normalizes_noncanonical_end_time(self):
+        """A shorthand end_time is canonicalized to HH:MM:SS."""
+        entry = _make_entry({CONF_END_TIME: "00:00", CONF_HEIGHT_WIN: 2.1})
+        result = _extract_shared_options(entry)
+        assert result[CONF_END_TIME] == "00:00:00"
+
+    def test_drops_unrescuable_time(self):
+        """A time value normalize_time_string can't parse is dropped, not copied."""
+        entry = _make_entry({CONF_START_TIME: "not-a-time", CONF_HEIGHT_WIN: 2.1})
+        result = _extract_shared_options(entry)
+        assert CONF_START_TIME not in result
+        assert result[CONF_HEIGHT_WIN] == 2.1
+
+    def test_leaves_canonical_time_untouched(self):
+        """An already-canonical time value passes through unchanged."""
+        entry = _make_entry({CONF_END_TIME: "07:30:00"})
+        result = _extract_shared_options(entry)
+        assert result[CONF_END_TIME] == "07:30:00"
+
+    def test_sync_category_path_also_normalizes(self):
+        """Sync (categories=[...]) inherits the same guard as Duplicate.
+
+        This is the test that must fail if normalization were bolted onto
+        only one call site instead of the shared _extract_shared_options
+        function both Duplicate and Sync delegate to.
+        """
+        entry = _make_entry({CONF_START_TIME: "7:30", CONF_HEIGHT_WIN: 2.1})
+        result = _extract_shared_options(entry, categories=["automation"])
+        assert result[CONF_START_TIME] == "07:30:00"
 
 
 class TestSyncCategorySplit:

--- a/tests/test_duplicate_sync.py
+++ b/tests/test_duplicate_sync.py
@@ -1,7 +1,9 @@
 """Tests for duplicate and sync cover features."""
 
-import pytest
+import types
 from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.adaptive_cover_pro.config_flow import (
     SYNC_CATEGORIES,
@@ -65,7 +67,11 @@ from custom_components.adaptive_cover_pro.const import (
 
 def _make_entry(options: dict) -> MagicMock:
     entry = MagicMock()
-    entry.options = options
+    # MappingProxyType matches the real HA ConfigEntry.options type (see
+    # homeassistant.config_entries.ConfigEntry.options: MappingProxyType) —
+    # a read-only view catches any code under test that tries to normalize
+    # the source in place instead of returning a new dict.
+    entry.options = types.MappingProxyType(dict(options))
     return entry
 
 
@@ -183,6 +189,8 @@ class TestExtractSharedOptionsTimeNormalization:
         entry = _make_entry({CONF_START_TIME: "7:30", CONF_HEIGHT_WIN: 2.1})
         result = _extract_shared_options(entry)
         assert result[CONF_START_TIME] == "07:30:00"
+        # The source entry's own options must not be mutated by extraction.
+        assert entry.options[CONF_START_TIME] == "7:30"
 
     def test_normalizes_noncanonical_end_time(self):
         """A shorthand end_time is canonicalized to HH:MM:SS."""
@@ -196,6 +204,8 @@ class TestExtractSharedOptionsTimeNormalization:
         result = _extract_shared_options(entry)
         assert CONF_START_TIME not in result
         assert result[CONF_HEIGHT_WIN] == 2.1
+        # The source entry's own options must not be mutated by extraction.
+        assert entry.options[CONF_START_TIME] == "not-a-time"
 
     def test_leaves_canonical_time_untouched(self):
         """An already-canonical time value passes through unchanged."""


### PR DESCRIPTION
## Summary
`_extract_shared_options` copied `entry.options` verbatim into both the Duplicate flow (`categories=None`) and the Sync flow (`categories=[...]`) with no time-format normalization. That was safe only because the v3.11 to v3.12 repair canonicalizes every entry HA loads, and a `disabled_by` entry never reaches setup, so it never gets repaired. Duplicating from such an entry copied a pre-#1049 value like `"00:00"` into a fresh entry stamped at the current `MINOR_VERSION`, which HA then never migrates: `has_configured_window_end` reads it as a configured window end, `TimeWindowManager` maps it to tomorrow's midnight, and an `until_window_end` override never expires.

The guard now lives in `_extract_shared_options` itself, so Duplicate and Sync both inherit it from the one function they already call through. It canonicalizes what `normalize_time_string` can rescue and drops what it cannot, operating on the result dict and never on the source entry's options. The key set comes from `TIME_OPTION_KEYS` rather than a third hardcoded copy of `(CONF_START_TIME, CONF_END_TIME)`.

`_cover_entries` is deliberately unchanged: the normalization is entry-state independent, so filtering disabled entries out of the Duplicate source list buys no extra safety here, and that helper feeds four other pickers.

Also updates the `const.py` write-path table, which claimed the copy sites were safe because the source is already canonical, and adds debug/warning logging on canonicalize and drop to match the `import_service` and `_repair_malformed_times` precedents.

## Testing
- ✅ 8941 tests passing (1 xfailed), including 5 new tests in `tests/test_duplicate_sync.py`
- Reviewed over three automated audit rounds; bug-injection probes confirmed the new tests fail against the pre-fix code and that `test_sync_category_path_also_normalizes` fails if the guard is added to only one call site

## Related Issues
Refs #1057