### PR TITLE
fix: make the coordinator the source of truth for switch state (#1063)

### DIFF
--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -487,9 +487,20 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         Commanding them would take real effect until the next restart and then
         silently evaporate — while this group's own switch, which restores,
         went on claiming it (issue #1063).
+
+        The predicate is "configured for climate mode", not "has a live Climate
+        Mode entity": a member whose switch the user disabled in the entity
+        registry is still commanded here and still loses the value at the next
+        restart, because a disabled entity never restores. That is an explicit
+        user opt-out rather than a case worth more machinery.
         """
         for entry, coordinator in self.resolved_members():
             if not climate_mode_configured(entry.options):
+                _LOGGER.debug(
+                    "Group %s: member %s is not configured for climate mode; skipping",
+                    self.entry.entry_id,
+                    entry.entry_id,
+                )
                 continue
             coordinator.switch_mode = enabled
             await coordinator.async_refresh()

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -66,7 +66,11 @@ from .const import (
 )
 from .cover_types import get_policy
 from .cover_types.base import axis_inverted
-from .helpers import climate_mode_from_diagnostics, usable_coordinator
+from .helpers import (
+    climate_mode_configured,
+    climate_mode_from_diagnostics,
+    usable_coordinator,
+)
 from .managers import inverse_state
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
@@ -475,8 +479,18 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             await coordinator.async_refresh()
 
     async def async_set_climate_mode(self, enabled: bool) -> None:
-        """Bulk-enable/disable climate mode on every ACP member."""
-        for _entry, coordinator in self.resolved_members():
+        """Bulk-enable/disable climate mode on every member configured for it.
+
+        Members without climate mode in their config are skipped: they expose
+        no Climate Mode switch, so nothing would persist the change, and their
+        coordinator re-seeds ``switch_mode`` from the option at every startup.
+        Commanding them would take real effect until the next restart and then
+        silently evaporate — while this group's own switch, which restores,
+        went on claiming it (issue #1063).
+        """
+        for entry, coordinator in self.resolved_members():
+            if not climate_mode_configured(entry.options):
+                continue
             coordinator.switch_mode = enabled
             await coordinator.async_refresh()
 

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -66,7 +66,7 @@ from .const import (
 )
 from .cover_types import get_policy
 from .cover_types.base import axis_inverted
-from .helpers import climate_mode_from_diagnostics
+from .helpers import climate_mode_from_diagnostics, usable_coordinator
 from .managers import inverse_state
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
@@ -201,22 +201,24 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         return ids
 
     def resolved_members(self) -> list[tuple[ConfigEntry, object]]:
-        """ACP members whose entry exists and whose coordinator is loaded.
+        """ACP members whose entry exists and whose coordinator is usable.
 
-        Every ``runtime_data`` access is null-guarded: during a member reload
-        the attribute is briefly unset, and a removed member's id may linger
-        in the roster until the next options edit. Both are silently skipped —
-        absence is non-membership for this cycle.
+        A removed member's id may linger in the roster until the next options
+        edit, and a member mid-reload exposes a coordinator whose entities are
+        not up yet. Both are silently skipped — absence is non-membership for
+        this cycle. ``helpers.usable_coordinator`` owns the predicate (and the
+        reason a half-set-up entry must not be written to); the services path
+        resolves through the same helper.
         """
         members: list[tuple[ConfigEntry, object]] = []
         for entry_id in self.member_entry_ids():
             entry = self.hass.config_entries.async_get_entry(entry_id)
             if entry is None:
                 continue
-            coordinator = getattr(entry, "runtime_data", None)
+            coordinator = usable_coordinator(entry)
             if coordinator is None:
                 _LOGGER.debug(
-                    "Group %s: member %s has no loaded coordinator; skipping",
+                    "Group %s: member %s has no usable coordinator; skipping",
                     self.entry.entry_id,
                     entry_id,
                 )

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -16,7 +16,6 @@ from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -30,6 +29,7 @@ from .const import (
     GroupState,
 )
 from .entity_base import AdaptiveCoverBaseEntity
+from .helpers import restored_bool
 from .pipeline.handlers import GroupLockHandler, GroupSceneHandler
 
 if TYPE_CHECKING:
@@ -171,9 +171,9 @@ class _GroupRestoringBulkSwitch(_GroupBulkSwitch, RestoreEntity):
         the restored ``off`` is what the next shutdown would record.
         """
         await super().async_added_to_hass()
-        last_state = await self.async_get_last_state()
-        if last_state is not None and last_state.state in (STATE_ON, STATE_OFF):
-            self._attr_is_on = last_state.state == STATE_ON
+        self._attr_is_on = restored_bool(
+            await self.async_get_last_state(), self._default_state
+        )
 
 
 class GroupAutomationSwitch(_GroupRestoringBulkSwitch):

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -16,6 +16,8 @@ from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import STATE_ON
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     CONF_GROUP_ENABLE_CLIMATE_SENSOR,
@@ -100,86 +102,103 @@ class GroupActiveSceneSensor(_GroupEntityBase, SensorEntity):
         return str(scene) if scene is not None else None
 
 
-class GroupAutomationSwitch(_GroupEntityBase, SwitchEntity):
-    """Bulk-enable/disable sun-tracking automation across all ACP members.
+class _GroupBulkSwitch(_GroupEntityBase, SwitchEntity):
+    """Shared shape for the group's bulk switches.
 
-    Reflects the last bulk command sent through this group (defaults to on),
-    not a consensus of member states — members remain individually togglable.
+    Each holds the last command pushed through this group rather than a
+    consensus of live member states — members remain individually togglable.
+    Subclasses supply the locked unique_id suffix, the no-history default, and
+    the coordinator call that fans the command out.
     """
+
+    _unique_id_suffix: str
+    _default_state: bool = False
+
+    def __init__(self, *args) -> None:
+        """Initialize at the no-history default."""
+        super().__init__(*args, self._unique_id_suffix)
+        self._attr_is_on = self._default_state
+
+    async def _async_push(self, enabled: bool) -> None:
+        """Fan the command out to the members."""
+        raise NotImplementedError  # pragma: no cover - abstract
+
+    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
+        """Push the enabled command to all members."""
+        await self._async_push(True)
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
+        """Push the disabled command to all members."""
+        await self._async_push(False)
+        self._attr_is_on = False
+        self.async_write_ha_state()
+
+
+class _GroupRestoringBulkSwitch(_GroupBulkSwitch, RestoreEntity):
+    """A bulk switch whose command outlives a restart, because its effect does.
+
+    The member toggles these drive are themselves restored at startup (issue
+    #1063), so a group switch that reinitialized to its default would sit
+    permanently at odds with its members: turn group automation off, restart,
+    and the group reads ``on`` while every member reads ``off`` and nothing
+    automates. Restoring keeps the two sides telling the same story.
+    """
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last command; keep the default when there is no history."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            self._attr_is_on = last_state.state == STATE_ON
+
+
+class GroupAutomationSwitch(_GroupRestoringBulkSwitch):
+    """Bulk-enable/disable sun-tracking automation across all ACP members."""
 
     _attr_translation_key = "group_automation"
     _attr_icon = "mdi:cog-clockwise"
+    _unique_id_suffix = "group_automation"
+    _default_state = True
 
-    def __init__(self, *args) -> None:
-        """Initialize with automation considered on."""
-        super().__init__(*args, "group_automation")
-        self._attr_is_on = True
-
-    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
-        """Bulk-enable automation on all members."""
-        await self.coordinator.async_set_automation(True)
-        self._attr_is_on = True
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
-        """Bulk-disable automation on all members."""
-        await self.coordinator.async_set_automation(False)
-        self._attr_is_on = False
-        self.async_write_ha_state()
+    async def _async_push(self, enabled: bool) -> None:
+        """Set automation on every member."""
+        await self.coordinator.async_set_automation(enabled)
 
 
-class GroupLockSwitch(_GroupEntityBase, SwitchEntity):
-    """Freeze every member in place via the LOCK intent at safety priority."""
+class GroupLockSwitch(_GroupBulkSwitch):
+    """Freeze every member in place via the LOCK intent at safety priority.
+
+    Deliberately the one bulk switch that does NOT restore: ``async_set_lock``
+    writes ``group_locked`` and a per-member ``GroupIntent``, both runtime-only.
+    Restoring to ``on`` would claim a lock no member is actually holding — the
+    inverse of the divergence #1063 fixed.
+    """
 
     _attr_translation_key = "group_lock"
     _attr_icon = "mdi:lock-outline"
+    _unique_id_suffix = "group_lock"
 
-    def __init__(self, *args) -> None:
-        """Initialize unlocked."""
-        super().__init__(*args, "group_lock")
-        self._attr_is_on = False
-
-    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
-        """Push the lock intent to every member."""
-        await self.coordinator.async_set_lock(True)
-        self._attr_is_on = True
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
-        """Release the lock (re-pushing an active scene, if any)."""
-        await self.coordinator.async_set_lock(False)
-        self._attr_is_on = False
-        self.async_write_ha_state()
+    async def _async_push(self, enabled: bool) -> None:
+        """Push or release the lock (release re-pushes an active scene)."""
+        await self.coordinator.async_set_lock(enabled)
 
 
-class GroupClimateSwitch(_GroupEntityBase, SwitchEntity):
+class GroupClimateSwitch(_GroupRestoringBulkSwitch):
     """Bulk-enable/disable climate mode across all ACP members.
 
-    Reflects the last bulk command sent through this group (defaults to off),
-    not a consensus of live member states — members remain individually
-    togglable. For the "what's actually acting" view, the read-only
+    For the "what's actually acting" view, the read-only
     ``sensor.<group>_climate_mode`` rolls up live member climate modes.
     """
 
     _attr_translation_key = "group_climate_mode"
     _attr_icon = "mdi:sun-thermometer-outline"
+    _unique_id_suffix = "group_climate_mode"
 
-    def __init__(self, *args) -> None:
-        """Initialize with climate mode considered off."""
-        super().__init__(*args, "group_climate_mode")
-        self._attr_is_on = False
-
-    async def async_turn_on(self, **kwargs) -> None:  # noqa: ARG002
-        """Bulk-enable climate mode on all members."""
-        await self.coordinator.async_set_climate_mode(True)
-        self._attr_is_on = True
-        self.async_write_ha_state()
-
-    async def async_turn_off(self, **kwargs) -> None:  # noqa: ARG002
-        """Bulk-disable climate mode on all members."""
-        await self.coordinator.async_set_climate_mode(False)
-        self._attr_is_on = False
-        self.async_write_ha_state()
+    async def _async_push(self, enabled: bool) -> None:
+        """Set climate mode on every member."""
+        await self.coordinator.async_set_climate_mode(enabled)
 
 
 class GroupWhoWonSensor(_GroupEntityBase, SensorEntity):

--- a/custom_components/adaptive_cover_pro/group_entities.py
+++ b/custom_components/adaptive_cover_pro/group_entities.py
@@ -16,7 +16,7 @@ from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -114,6 +114,19 @@ class _GroupBulkSwitch(_GroupEntityBase, SwitchEntity):
     _unique_id_suffix: str
     _default_state: bool = False
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Fail at import time if a concrete subclass forgets its locked suffix.
+
+        The suffix is half of the ``f"{entry_id}_{suffix}"`` registry key, so a
+        missing one has to be loud here rather than a bare ``AttributeError``
+        surfacing as an opaque platform-setup failure.
+        """
+        super().__init_subclass__(**kwargs)
+        if not cls.__name__.startswith("_") and not getattr(
+            cls, "_unique_id_suffix", None
+        ):
+            raise TypeError(f"{cls.__name__} must set _unique_id_suffix")
+
     def __init__(self, *args) -> None:
         """Initialize at the no-history default."""
         super().__init__(*args, self._unique_id_suffix)
@@ -147,10 +160,19 @@ class _GroupRestoringBulkSwitch(_GroupBulkSwitch, RestoreEntity):
     """
 
     async def async_added_to_hass(self) -> None:
-        """Restore the last command; keep the default when there is no history."""
+        """Restore the last command; keep the default when there is no history.
+
+        Only ``on``/``off`` count as history. Group entities go ``unavailable``
+        whenever the group coordinator's update throws (see
+        ``AdaptiveCoverBaseEntity.available``), and the restore store snapshots
+        on a timer — so an unclean shutdown during that window persists
+        ``unavailable``. Folding every non-``on`` state into ``off`` would turn
+        a crash into a silent "somebody switched this off", and a sticky one:
+        the restored ``off`` is what the next shutdown would record.
+        """
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if last_state is not None:
+        if last_state is not None and last_state.state in (STATE_ON, STATE_OFF):
             self._attr_is_on = last_state.state == STATE_ON
 
 

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -38,6 +38,7 @@ from .const import (
 from .templates import is_template_string
 
 if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import State
 
     from .sun import SunData
@@ -47,6 +48,31 @@ _LOGGER = logging.getLogger(__name__)
 # Entity states that mean "no usable value" — used by the safe-read helpers
 # below so the same set is checked everywhere instead of inline literals.
 _INVALID_STATES: frozenset[str] = frozenset({STATE_UNKNOWN, STATE_UNAVAILABLE})
+
+
+def usable_coordinator(entry: "ConfigEntry") -> Any | None:
+    """Return an entry's coordinator, or ``None`` when it is not usable yet.
+
+    Single source of truth for "may I write to this entry's coordinator?", used
+    by both ``services.loaded_coordinators`` (walks every ACP entry) and
+    ``GroupCoordinator.resolved_members`` (walks one group's roster).
+
+    Two things have to hold. The entry must have reached ``LOADED``: HA assigns
+    ``runtime_data`` *before* forwarding platform setup, so between those points
+    a reloading entry already exposes a freshly-built coordinator whose switch
+    entities have not been added yet — a toggle written onto it is silently
+    undone moments later when those switches restore their previous state
+    (issue #1063). And ``runtime_data`` must actually hold something: virtual
+    entries (e.g. the Building Profile, ``controls_cover == False``) reach
+    ``LOADED`` without building a coordinator at all. ``getattr`` is robust
+    whether the running HA leaves ``runtime_data`` unset or defaults it to
+    ``None``.
+    """
+    from homeassistant.config_entries import ConfigEntryState  # noqa: PLC0415
+
+    if entry.state is not ConfigEntryState.LOADED:
+        return None
+    return getattr(entry, "runtime_data", None)
 
 
 def motion_entities(options: Mapping) -> list[str]:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -10,12 +10,14 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pandas as pd
 from dateutil import parser
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.util import dt as dt_util
 
 from .const import (
     BLANK_TIME,
+    CONF_CLIMATE_MODE,
     CONF_END_ENTITY,
     CONF_END_TIME,
     CONF_MANUAL_OVERRIDE_DURATION_MODE,
@@ -68,11 +70,24 @@ def usable_coordinator(entry: "ConfigEntry") -> Any | None:
     whether the running HA leaves ``runtime_data`` unset or defaults it to
     ``None``.
     """
-    from homeassistant.config_entries import ConfigEntryState  # noqa: PLC0415
-
     if entry.state is not ConfigEntryState.LOADED:
         return None
     return getattr(entry, "runtime_data", None)
+
+
+def climate_mode_configured(options: Mapping) -> bool:
+    """Whether this entry is set up for climate mode at all.
+
+    Single source of truth for "may climate mode be switched on here?". The
+    pipeline gates on the runtime ``switch_mode`` toggle rather than on this
+    option, so an unconfigured entry really would start acting on climate if
+    something set the toggle — but it exposes no Climate Mode switch to persist
+    that, and its coordinator re-seeds ``switch_mode`` from this option at every
+    startup. Both the switch platform (which decides whether to create the
+    entity) and the group's bulk control (which decides whom to command) read
+    this so the two agree on who can hold the state.
+    """
+    return bool(options.get(CONF_CLIMATE_MODE))
 
 
 def motion_entities(options: Mapping) -> list[str]:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -10,8 +10,13 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pandas as pd
 from dateutil import parser
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import (
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.util import dt as dt_util
 
@@ -40,7 +45,6 @@ from .const import (
 from .templates import is_template_string
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import State
 
     from .sun import SunData
@@ -52,7 +56,7 @@ _LOGGER = logging.getLogger(__name__)
 _INVALID_STATES: frozenset[str] = frozenset({STATE_UNKNOWN, STATE_UNAVAILABLE})
 
 
-def usable_coordinator(entry: "ConfigEntry") -> Any | None:
+def usable_coordinator(entry: ConfigEntry) -> Any:
     """Return an entry's coordinator, or ``None`` when it is not usable yet.
 
     Single source of truth for "may I write to this entry's coordinator?", used
@@ -73,6 +77,27 @@ def usable_coordinator(entry: "ConfigEntry") -> Any | None:
     if entry.state is not ConfigEntryState.LOADED:
         return None
     return getattr(entry, "runtime_data", None)
+
+
+def restored_bool(last_state: "State | None", default: bool) -> bool:
+    """Read a restored switch state, ignoring anything that is not on/off.
+
+    An entity that was ``unavailable`` or ``unknown`` when HA last snapshotted
+    state carries no information about what the user wanted, so it must not be
+    read as ``off``. Any raise inside a coordinator update flips
+    ``last_update_success``, which renders every ACP entity ``unavailable``
+    (``AdaptiveCoverBaseEntity.available``), and the restore store snapshots on
+    a timer — so an unclean shutdown during that window persists it. Folding
+    that into ``off`` turns a transient error into a silent, sticky "somebody
+    switched this off": the restored ``off`` is what the next shutdown records.
+
+    Shared by the per-cover switches (where the restored value is written
+    straight onto the coordinator, so a wrong read disables the thing) and the
+    group's bulk switches (issue #1063).
+    """
+    if last_state is None or last_state.state not in (STATE_ON, STATE_OFF):
+        return default
+    return last_state.state == STATE_ON
 
 
 def climate_mode_configured(options: Mapping) -> bool:

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -177,6 +177,23 @@ def _resolve_targets(
     return result
 
 
+def _set_enabled(coord, value: bool, service: str, outcome: str) -> None:
+    """Flip a coordinator's kill switch and push the change to its switch entity.
+
+    ``switch.<entry>_integration_enabled`` reads ``coordinator.enabled_toggle``
+    (issue #1063), so the coordinator is the single source of truth — but the
+    entity still needs a listener notification to re-render. These three
+    services deliberately never refresh, and the coordinator sets no
+    ``update_interval`` (refreshes are state-change driven), so without the
+    notification the switch would keep rendering its old value until some
+    unrelated cycle happened to run. That stale render is what ``RestoreEntity``
+    would hand back at the next restart, silently re-enabling the integration.
+    """
+    coord.enabled_toggle = value
+    coord.async_update_listeners()
+    coord.logger.debug("%s service: %s", service, outcome)
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Register integration services (idempotent — safe to call per config entry)."""
     if hass.services.has_service(DOMAIN, "export_config"):
@@ -216,8 +233,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async def handle_integration_enable(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
         for coord in targets:
-            coord.enabled_toggle = True
-            coord.logger.debug("integration_enable service: enabled")
+            _set_enabled(coord, True, "integration_enable", "enabled")
 
     async def handle_integration_disable(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
@@ -228,8 +244,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             coord._cancel_weather_timeout()  # noqa: SLF001
             coord._cmd_svc.clear_non_safety_targets()  # noqa: SLF001
             coord._cmd_svc.clear_safety_targets()  # noqa: SLF001
-            coord.enabled_toggle = False
-            coord.logger.debug("integration_disable service: disabled")
+            _set_enabled(coord, False, "integration_disable", "disabled")
 
     async def handle_emergency_stop(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
@@ -244,8 +259,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             coord._cancel_weather_timeout()  # noqa: SLF001
             coord._cmd_svc.clear_non_safety_targets()  # noqa: SLF001
             coord._cmd_svc.clear_safety_targets()  # noqa: SLF001
-            coord.enabled_toggle = False
-            coord.logger.debug("emergency_stop service: stopped and disabled")
+            _set_enabled(coord, False, "emergency_stop", "stopped and disabled")
 
     hass.services.async_register(
         DOMAIN, "integration_enable", handle_integration_enable

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import ServiceCall, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
@@ -17,6 +16,7 @@ if TYPE_CHECKING:
     from ..coordinator import AdaptiveDataUpdateCoordinator
 
 from ..const import DOMAIN
+from ..helpers import usable_coordinator
 from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagnostics
 from .group_service import GROUP_SERVICE_NAMES, register_group_services
 from .engage_manual_override_service import (
@@ -47,17 +47,14 @@ def loaded_coordinators(
     Replaces the legacy ``hass.data[DOMAIN]`` registry: each loaded entry now
     stores its coordinator on ``entry.runtime_data``.
 
-    Virtual entries (e.g. the Building Profile, ``controls_cover == False``) reach
-    ``LOADED`` without setting ``runtime_data`` — they build no coordinator. Skip
-    them so callers never dereference a missing coordinator. ``getattr`` is robust
-    whether the running HA leaves ``runtime_data`` unset (raising ``AttributeError``)
-    or defaults it to ``None``.
+    The LOADED-and-has-a-coordinator predicate lives in
+    ``helpers.usable_coordinator`` so this walk and ``GroupCoordinator``'s
+    roster walk cannot drift apart.
     """
     return {
         entry.entry_id: coordinator
         for entry in hass.config_entries.async_entries(DOMAIN)
-        if entry.state is ConfigEntryState.LOADED
-        and (coordinator := getattr(entry, "runtime_data", None)) is not None
+        if (coordinator := usable_coordinator(entry)) is not None
     }
 
 
@@ -177,7 +174,12 @@ def _resolve_targets(
     return result
 
 
-def _set_enabled(coord, value: bool, service: str, outcome: str) -> None:
+def _set_enabled(
+    coord: AdaptiveDataUpdateCoordinator,
+    value: bool,
+    service: str,
+    outcome: str,
+) -> None:
     """Flip a coordinator's kill switch and push the change to its switch entity.
 
     ``switch.<entry>_integration_enabled`` reads ``coordinator.enabled_toggle``
@@ -192,6 +194,25 @@ def _set_enabled(coord, value: bool, service: str, outcome: str) -> None:
     coord.enabled_toggle = value
     coord.async_update_listeners()
     coord.logger.debug("%s service: %s", service, outcome)
+
+
+def _disable(
+    coord: AdaptiveDataUpdateCoordinator,
+    service: str,
+    outcome: str,
+) -> None:
+    """Cancel deferred work, drop reconciliation state, and close the gate.
+
+    Shared by ``integration_disable`` and ``emergency_stop`` — the two differ
+    only in how they stop in-flight moves (scoped ``stop_in_flight`` versus a
+    blanket ``stop_all``), which the caller does first; everything after that
+    is identical policy and lives here so the two cannot drift.
+    """
+    coord._cancel_motion_timeout()  # noqa: SLF001
+    coord._cancel_weather_timeout()  # noqa: SLF001
+    coord._cmd_svc.clear_non_safety_targets()  # noqa: SLF001
+    coord._cmd_svc.clear_safety_targets()  # noqa: SLF001
+    _set_enabled(coord, False, service, outcome)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
@@ -240,11 +261,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         for coord, entity_filter in targets.items():
             # Stop in-flight moves first (before gate closes)
             await coord._cmd_svc.stop_in_flight(entities=entity_filter)  # noqa: SLF001
-            coord._cancel_motion_timeout()  # noqa: SLF001
-            coord._cancel_weather_timeout()  # noqa: SLF001
-            coord._cmd_svc.clear_non_safety_targets()  # noqa: SLF001
-            coord._cmd_svc.clear_safety_targets()  # noqa: SLF001
-            _set_enabled(coord, False, "integration_disable", "disabled")
+            _disable(coord, "integration_disable", "disabled")
 
     async def handle_emergency_stop(call: ServiceCall) -> None:
         targets = _resolve_targets(hass, call)
@@ -255,11 +272,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             )
             await coord._cmd_svc.stop_all(entity_ids)  # noqa: SLF001
             # Then run full integration_disable cleanup
-            coord._cancel_motion_timeout()  # noqa: SLF001
-            coord._cancel_weather_timeout()  # noqa: SLF001
-            coord._cmd_svc.clear_non_safety_targets()  # noqa: SLF001
-            coord._cmd_svc.clear_safety_targets()  # noqa: SLF001
-            _set_enabled(coord, False, "emergency_stop", "stopped and disabled")
+            _disable(coord, "emergency_stop", "stopped and disabled")
 
     hass.services.async_register(
         DOMAIN, "integration_enable", handle_integration_enable

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
@@ -28,7 +27,7 @@ from .const import (
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
 from .entity_base import AdaptiveCoverBaseEntity
-from .helpers import climate_mode_configured, motion_entities
+from .helpers import climate_mode_configured, motion_entities, restored_bool
 from .services.options_service import apply_options_patch, validate_options_patch
 
 
@@ -432,6 +431,11 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         restored came from a local field no caller updated. With ``is_on``
         reading the coordinator, what gets recorded — and therefore what gets
         restored here — is the value the coordinator last actually held.
+
+        ``restored_bool`` guards the other half: this path *writes* the
+        coordinator, so an ``unavailable``/``unknown`` snapshot read as ``off``
+        would not merely display wrong, it would disable the toggle. Only real
+        on/off history counts; anything else keeps the spec's initial state.
         """
         await super().async_added_to_hass()
 
@@ -444,9 +448,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
 
         last_state = await self.async_get_last_state()
         self.coordinator.logger.debug("%s: last state is %s", self._name, last_state)
-        if (last_state is None and self._initial_state) or (
-            last_state is not None and last_state.state == STATE_ON
-        ):
+        if restored_bool(last_state, self._initial_state):
             await self.async_turn_on(added=True)
         else:
             await self.async_turn_off(added=True)

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -306,6 +306,17 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         ``glare_zone_N`` attributes do not exist at all until first written
         (``coordinator._is_glare_zone_enabled`` reads them defensively for the
         same reason). Both fall back to the spec's declared initial state.
+
+        That fallback deliberately does NOT model each toggle's runtime
+        ``None``-semantics, which are not uniform: ``enabled_toggle`` maps
+        ``None`` to True (``coordinator.py``, ``_cmd_svc.enabled``) and so
+        agrees with its initial state, but ``automatic_control``,
+        ``manual_toggle``, ``lux_toggle`` and ``irradiance_toggle`` are read as
+        plain falsy while declaring ``initial_state=True`` — so for those four
+        an unset coordinator renders ``on`` while the gate they feed is closed.
+        The window is the sliver before ``async_added_to_hass`` restores, which
+        is why one shared default beats a per-toggle map here; if that window
+        ever widens, the map is the fix, not a wider default.
         """
         if self._option_key is not None:
             return bool(

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
-    CONF_CLIMATE_MODE,
     CONF_CLOUD_SUPPRESSION,
     CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_GLARE_ZONES,
@@ -29,7 +28,7 @@ from .const import (
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
 from .entity_base import AdaptiveCoverBaseEntity
-from .helpers import motion_entities
+from .helpers import climate_mode_configured, motion_entities
 from .services.options_service import apply_options_patch, validate_options_patch
 
 
@@ -60,7 +59,7 @@ class _SwitchSpec:
 
 
 def _has_climate_mode(entry: ConfigEntry) -> bool:
-    return bool(entry.options.get(CONF_CLIMATE_MODE))
+    return climate_mode_configured(entry.options)
 
 
 def _has_climate_temp_source(entry: ConfigEntry) -> bool:

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -269,7 +269,6 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
     ) -> None:
         """Initialize the switch."""
         super().__init__(entry_id, hass, config_entry, coordinator)
-        self._state: bool | None = None
         self._key = key
         self._attr_translation_key = key
         self._switch_name = display_name or switch_name
@@ -292,6 +291,21 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
 
         Option-backed switches read config_entry.options so service/options-flow
         changes are reflected without RestoreEntity state drift.
+
+        Every other switch reads the coordinator attribute named by ``_key``
+        (issue #1063). A local ``_attr_is_on`` was only ever written by this
+        entity's own turn_on/turn_off, so a caller that set the coordinator
+        directly — the group's bulk controls, the integration_enable /
+        integration_disable / emergency_stop services — changed behavior while
+        the entity kept reporting its old value. Since the rendered state is
+        what RestoreEntity hands back, that stale value then won at the next
+        restart and silently undid the change.
+
+        The ``getattr`` default covers two unset cases: ``ToggleManager`` seeds
+        most toggles to ``None`` until a switch restores, and the dynamic
+        ``glare_zone_N`` attributes do not exist at all until first written
+        (``coordinator._is_glare_zone_enabled`` reads them defensively for the
+        same reason). Both fall back to the spec's declared initial state.
         """
         if self._option_key is not None:
             return bool(
@@ -300,7 +314,10 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
                     self._initial_state,
                 )
             )
-        return self._attr_is_on
+        value = getattr(self.coordinator, self._key, None)
+        if value is None:
+            return self._initial_state
+        return bool(value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -308,7 +325,6 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         if self._option_key is not None:
             await self._async_set_option(True)
             return
-        self._attr_is_on = True
         setattr(self.coordinator, self._key, True)
         if self._key == "automatic_control" and kwargs.get("added") is not True:
             # Issue #33 defense-in-depth: invalidate the venetian sequencer's
@@ -338,7 +354,6 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         if self._option_key is not None:
             await self._async_set_option(False)
             return
-        self._attr_is_on = False
         setattr(self.coordinator, self._key, False)
         if self._key == "enabled_toggle" and kwargs.get("added") is not True:
             # Stop any ACP-in-flight cover moves FIRST (before the gate closes),
@@ -395,7 +410,19 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
         self.schedule_update_ha_state()
 
     async def async_added_to_hass(self) -> None:
-        """Call when entity about to be added to hass."""
+        """Call when entity about to be added to hass.
+
+        Restored state seeds the coordinator, not the other way round — and
+        that direction is deliberate even though ``is_on`` now derives from the
+        coordinator (issue #1063). Several toggles carry a static non-``None``
+        default (``switch_mode`` from ``CONF_CLIMATE_MODE``, ``motion_control``
+        from ``ToggleManager``), so a "coordinator wins at add time" rule would
+        make those ignore the user's last runtime toggle after every restart.
+        The defect was never the direction: it was that the value being
+        restored came from a local field no caller updated. With ``is_on``
+        reading the coordinator, what gets recorded — and therefore what gets
+        restored here — is the value the coordinator last actually held.
+        """
         await super().async_added_to_hass()
 
         if self._option_key is not None:

--- a/tests/test_auto_control_gate_matrix.py
+++ b/tests/test_auto_control_gate_matrix.py
@@ -405,7 +405,6 @@ async def _trigger_switch_auto_control_off_return(coord):
     switch._key = "automatic_control"
     switch._name = "automatic_control"
     switch._initial_state = True
-    switch._attr_is_on = True
     switch.schedule_update_ha_state = MagicMock()
 
     await switch.async_turn_off()

--- a/tests/test_day_night_dual_entity.py
+++ b/tests/test_day_night_dual_entity.py
@@ -539,7 +539,6 @@ async def test_auto_control_off_seam_never_inverts_middle_rail() -> None:
     switch._key = "automatic_control"
     switch._name = "test_switch"
     switch._initial_state = True
-    switch._attr_is_on = True
     switch._option_key = None
     switch.schedule_update_ha_state = MagicMock()
 

--- a/tests/test_dual_panel_dispatch.py
+++ b/tests/test_dual_panel_dispatch.py
@@ -298,7 +298,6 @@ async def test_auto_control_off_seam_keeps_the_back_inverted() -> None:
     switch.coordinator = coord
     switch._key = "automatic_control"
     switch._name = "test_switch"
-    switch._attr_is_on = True
     switch.schedule_update_ha_state = MagicMock()
 
     await switch.async_turn_off()

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
@@ -49,13 +50,23 @@ def _member_entry(
     cover_type: CoverType,
     entities: list[str],
     extra_options: dict | None = None,
+    state: ConfigEntryState = ConfigEntryState.LOADED,
 ) -> MockConfigEntry:
+    """Build a member entry.
+
+    Defaults to ``LOADED`` because that is what a member the group can act on
+    actually looks like: ``resolved_members`` skips anything that has not
+    finished setup, since HA assigns ``runtime_data`` before platform setup and
+    a toggle written to a half-built coordinator is undone when its entities
+    restore (issue #1063).
+    """
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": entry_id, CONF_SENSOR_TYPE: cover_type},
         options={CONF_ENTITIES: entities, **(extra_options or {})},
         entry_id=entry_id,
         title=entry_id,
+        state=state,
     )
     entry.add_to_hass(hass)
     return entry

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_CLIMATE_MODE,
     CONF_ENTITIES,
     CONF_GROUP_MEMBER_OPT_OUT,
     CONF_GROUP_STAGGER_DELAY,
@@ -83,10 +84,25 @@ def _mock_member_coordinator() -> MagicMock:
 
 @pytest.fixture
 def group_setup(hass):
-    """Build a group with a blind member, an awning member, and one generic cover."""
-    blind_entry = _member_entry(hass, "member_blind", CoverType.BLIND, [BLIND_ENTITY])
+    """Build a group with a blind member, an awning member, and one generic cover.
+
+    Both members carry ``CONF_CLIMATE_MODE`` so they can hold a bulk climate
+    command — ``async_set_climate_mode`` skips members that expose no Climate
+    Mode switch to persist it (issue #1063).
+    """
+    blind_entry = _member_entry(
+        hass,
+        "member_blind",
+        CoverType.BLIND,
+        [BLIND_ENTITY],
+        extra_options={CONF_CLIMATE_MODE: True},
+    )
     awning_entry = _member_entry(
-        hass, "member_awning", CoverType.AWNING, [AWNING_ENTITY]
+        hass,
+        "member_awning",
+        CoverType.AWNING,
+        [AWNING_ENTITY],
+        extra_options={CONF_CLIMATE_MODE: True},
     )
     blind_coord = _mock_member_coordinator()
     awning_coord = _mock_member_coordinator()

--- a/tests/test_group_diagnostics.py
+++ b/tests/test_group_diagnostics.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
@@ -40,6 +41,9 @@ async def test_group_entry_diagnostics_rollup(hass) -> None:
         options={CONF_ENTITIES: ["cover.blind1"]},
         entry_id="member_blind",
         title="Living Blind",
+        # A member the group can roll up is one that finished setup —
+        # ``resolved_members`` skips anything short of LOADED (issue #1063).
+        state=ConfigEntryState.LOADED,
     )
     member.add_to_hass(hass)
     member_coord = MagicMock()

--- a/tests/test_issue_1063_coordinator_toggle_truth.py
+++ b/tests/test_issue_1063_coordinator_toggle_truth.py
@@ -15,11 +15,17 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import (
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_CLIMATE_MODE,
     CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_SUN_TRACKING,
     CONF_ENTITIES,
@@ -398,6 +404,76 @@ async def test_group_bulk_switch_restores_its_last_command(
     await switch.async_added_to_hass()
 
     assert switch.is_on is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cls", "default"),
+    [(GroupAutomationSwitch, True), (GroupClimateSwitch, False)],
+)
+@pytest.mark.parametrize("restored", [STATE_UNAVAILABLE, STATE_UNKNOWN, "garbage"])
+async def test_group_bulk_switch_ignores_an_unusable_restored_state(
+    cls, default, restored
+):
+    """Only ``on``/``off`` are real history — anything else keeps the default.
+
+    Group entities go ``unavailable`` whenever the group coordinator's update
+    throws (``AdaptiveCoverBaseEntity.available`` keys off ``coordinator.data``),
+    and the restore store snapshots on a timer, so an unclean shutdown while
+    unavailable persists that. Treating every non-``on`` state as ``off`` would
+    turn a crash into a silent, and sticky, "somebody switched this off".
+    """
+    coord = _FakeCoordinator()
+    switch = cls("group_01", coord.hass, _make_group_config_entry(), coord)
+    switch.async_write_ha_state = MagicMock()
+    switch.async_get_last_state = AsyncMock(return_value=MagicMock(state=restored))
+
+    await switch.async_added_to_hass()
+
+    assert switch.is_on is default
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_group_climate_bulk_skips_members_that_cannot_hold_it():
+    """Climate mode is only bulk-set on members configured for it.
+
+    The pipeline gates on the ``switch_mode`` toggle, not on
+    ``CONF_CLIMATE_MODE``, so setting it on an unconfigured member really does
+    switch climate on — but that member exposes no Climate Mode switch to
+    persist it, and its coordinator re-seeds ``switch_mode`` from the option at
+    every startup. The bulk command would evaporate at the next restart while
+    the group switch, which now restores, kept claiming it.
+    """
+    configured = _FakeCoordinator(switch_mode=False)
+    unconfigured = _FakeCoordinator(switch_mode=False)
+
+    configured_entry = MagicMock(options={CONF_CLIMATE_MODE: True})
+    unconfigured_entry = MagicMock(options={})
+
+    group = object.__new__(GroupCoordinator)
+    group.resolved_members = MagicMock(
+        return_value=[
+            (configured_entry, configured),
+            (unconfigured_entry, unconfigured),
+        ]
+    )
+
+    await GroupCoordinator.async_set_climate_mode(group, True)
+
+    assert configured.switch_mode is True
+    assert unconfigured.switch_mode is False
+    unconfigured.async_refresh.assert_not_called()
+
+
+@pytest.mark.unit
+def test_group_bulk_switch_subclass_must_declare_its_locked_suffix():
+    """A missing suffix fails at class creation, not deep inside platform setup."""
+    with pytest.raises(TypeError, match="_unique_id_suffix"):
+
+        class Broken(GroupAutomationSwitch):
+            _unique_id_suffix = ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_issue_1063_coordinator_toggle_truth.py
+++ b/tests/test_issue_1063_coordinator_toggle_truth.py
@@ -212,6 +212,35 @@ async def test_restart_restores_the_coordinator_set_value_not_the_stale_one():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+@pytest.mark.parametrize("spec", NON_OPTION_SPECS, ids=lambda s: s.key)
+@pytest.mark.parametrize("restored", [STATE_UNAVAILABLE, STATE_UNKNOWN, "garbage"])
+async def test_an_unusable_restored_state_does_not_write_the_coordinator(
+    spec, restored
+):
+    """Only ``on``/``off`` are history — anything else keeps the initial state.
+
+    This is the same defect as #1063 and it lands on the worst surface: the
+    restore path *writes* the coordinator, so a bogus restored state does not
+    merely display wrong, it disables the thing. Any raise inside
+    ``_async_update_data`` flips ``last_update_success``, which makes every ACP
+    switch render ``unavailable`` (``AdaptiveCoverBaseEntity.available``); HA's
+    restore store snapshots on a 15-minute timer, so an unclean shutdown in
+    that window persists ``unavailable``. Folding it into ``off`` would force
+    Integration Enabled, Automatic Control, Climate Mode and the rest to False
+    on the next start, with no user action and no self-recovery.
+    """
+    coord = _FakeCoordinator(**{spec.key: None})
+    switch = _make_switch(coord, spec.key, initial_state=spec.initial_state)
+    switch.async_get_last_state = AsyncMock(return_value=MagicMock(state=restored))
+
+    await switch.async_added_to_hass()
+
+    assert getattr(coord, spec.key) is spec.initial_state
+    assert switch.is_on is spec.initial_state
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("restored", "expected"), [(STATE_ON, True), (STATE_OFF, False)]
 )
@@ -453,6 +482,7 @@ async def test_group_climate_bulk_skips_members_that_cannot_hold_it():
     unconfigured_entry = MagicMock(options={})
 
     group = object.__new__(GroupCoordinator)
+    group.entry = MagicMock(entry_id="group_01")  # the skip logs at debug
     group.resolved_members = MagicMock(
         return_value=[
             (configured_entry, configured),

--- a/tests/test_issue_1063_coordinator_toggle_truth.py
+++ b/tests/test_issue_1063_coordinator_toggle_truth.py
@@ -1,0 +1,304 @@
+"""Issue #1063: the coordinator is the source of truth for non-option switches.
+
+``AdaptiveCoverSwitch.is_on`` used to return a local ``_attr_is_on`` that only
+the entity's own ``async_turn_on``/``async_turn_off`` ever wrote. Any caller
+that set the coordinator attribute directly (the group's bulk controls, the
+``integration_enable``/``integration_disable``/``emergency_stop`` services)
+changed behavior while the entity kept reporting its old state — and because
+the switch is a ``RestoreEntity``, that stale entity value was pushed back into
+the coordinator at the next restart, silently undoing the change.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.const import STATE_OFF, STATE_ON
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
+    CONF_ENABLE_SUN_TRACKING,
+    CONF_SENSOR_TYPE,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.services import async_setup_services
+from custom_components.adaptive_cover_pro.switch import (
+    _SWITCH_SPECS,
+    AdaptiveCoverSwitch,
+)
+
+# Every spec whose truth lives on the coordinator rather than in
+# ``config_entry.options`` — the switches exposed to the defect.
+NON_OPTION_SPECS = [spec for spec in _SWITCH_SPECS if spec.option_key is None]
+
+
+class _FakeCoordinator:
+    """Coordinator stand-in with real attribute semantics.
+
+    A ``MagicMock`` auto-vivifies any attribute into a truthy child mock, which
+    would mask both the "toggle is unset" and the "glare-zone attribute does
+    not exist yet" cases this module has to pin. A plain object raises
+    ``AttributeError`` for a missing attribute, exactly like the real
+    coordinator.
+    """
+
+    def __init__(self, **toggles: object) -> None:
+        self.logger = MagicMock()
+        self.hass = MagicMock()
+        self.async_add_listener = MagicMock(return_value=lambda: None)
+        self.async_refresh = AsyncMock()
+        self.async_update_listeners = MagicMock()
+        for key, value in toggles.items():
+            setattr(self, key, value)
+
+
+def _make_config_entry(options: dict | None = None):
+    entry = MagicMock()
+    entry.entry_id = "test_entry"
+    entry.data = {"name": "Test", CONF_SENSOR_TYPE: CoverType.BLIND}
+    entry.options = options if options is not None else {CONF_DEFAULT_HEIGHT: 60}
+    return entry
+
+
+def _make_switch(
+    coordinator: _FakeCoordinator,
+    key: str,
+    *,
+    initial_state: bool = True,
+    option_key: str | None = None,
+    config_entry=None,
+) -> AdaptiveCoverSwitch:
+    entry = config_entry or _make_config_entry()
+    switch = AdaptiveCoverSwitch(
+        entry_id="test_entry",
+        hass=coordinator.hass,
+        config_entry=entry,
+        coordinator=coordinator,
+        switch_name=key,
+        initial_state=initial_state,
+        key=key,
+        option_key=option_key,
+    )
+    switch.schedule_update_ha_state = MagicMock()
+    return switch
+
+
+# ---------------------------------------------------------------------------
+# is_on derives from the coordinator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("spec", NON_OPTION_SPECS, ids=lambda s: s.key)
+@pytest.mark.parametrize("value", [True, False])
+def test_non_option_switch_reflects_direct_coordinator_set(spec, value):
+    """A toggle set straight on the coordinator is what the switch reports."""
+    coord = _FakeCoordinator(**{spec.key: value})
+    switch = _make_switch(coord, spec.key, initial_state=spec.initial_state)
+
+    assert switch.is_on is value
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [True, False])
+def test_glare_zone_switch_reflects_direct_coordinator_set(value):
+    """Dynamic ``glare_zone_N`` attributes follow the same rule."""
+    coord = _FakeCoordinator(glare_zone_0=value)
+    switch = _make_switch(coord, "glare_zone_0")
+
+    assert switch.is_on is value
+
+
+@pytest.mark.unit
+def test_glare_zone_switch_falls_back_when_attribute_absent():
+    """Glare-zone attributes do not exist until a switch first writes them.
+
+    ``coordinator._is_glare_zone_enabled`` reads them with a ``getattr``
+    default for the same reason; the switch must not raise on a render that
+    lands before ``async_added_to_hass``.
+    """
+    coord = _FakeCoordinator()
+    switch = _make_switch(coord, "glare_zone_0", initial_state=True)
+
+    assert switch.is_on is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("initial_state", [True, False])
+def test_unset_toggle_falls_back_to_initial_state(initial_state):
+    """``ToggleManager`` seeds most toggles to ``None`` until a switch restores."""
+    coord = _FakeCoordinator(automatic_control=None)
+    switch = _make_switch(coord, "automatic_control", initial_state=initial_state)
+
+    assert switch.is_on is initial_state
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("enabled", [True, False])
+def test_option_backed_switch_still_reads_options(enabled):
+    """Sun Tracking keeps reading ``config_entry.options``, not the coordinator."""
+    coord = _FakeCoordinator(sun_tracking=not enabled)
+    switch = _make_switch(
+        coord,
+        "sun_tracking",
+        option_key=CONF_ENABLE_SUN_TRACKING,
+        config_entry=_make_config_entry({CONF_ENABLE_SUN_TRACKING: enabled}),
+    )
+
+    assert switch.is_on is enabled
+
+
+# ---------------------------------------------------------------------------
+# The restart round-trip — the damaging half of the defect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_restart_restores_the_coordinator_set_value_not_the_stale_one():
+    """A directly-set toggle survives a restart instead of being undone by it.
+
+    The entity's rendered state is what the recorder persists and what
+    ``RestoreEntity`` hands back, so deriving ``is_on`` from the coordinator is
+    what makes the restore write the *correct* value back at startup.
+    """
+    coord = _FakeCoordinator(automatic_control=True)
+    switch = _make_switch(coord, "automatic_control")
+    assert switch.is_on is True
+
+    # A caller (group bulk control, service) flips the coordinator directly.
+    coord.automatic_control = False
+    assert switch.is_on is False
+
+    # Restart: fresh coordinator, entity restores whatever it last rendered.
+    restored = STATE_ON if switch.is_on else STATE_OFF
+    new_coord = _FakeCoordinator(automatic_control=None)
+    new_switch = _make_switch(new_coord, "automatic_control")
+    new_switch.async_get_last_state = AsyncMock(return_value=MagicMock(state=restored))
+
+    await new_switch.async_added_to_hass()
+
+    assert new_coord.automatic_control is False
+    assert new_switch.is_on is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("restored", "expected"), [(STATE_ON, True), (STATE_OFF, False)]
+)
+async def test_restore_still_wins_at_add_time(restored, expected):
+    """Restored state seeds the coordinator when the entity is added.
+
+    The reconciliation direction stays as-is on purpose: several toggles carry
+    a static non-``None`` default (``switch_mode`` from ``CONF_CLIMATE_MODE``,
+    ``motion_control``), so "coordinator wins at add time" would make those two
+    ignore the user's last toggle after every restart.
+    """
+    coord = _FakeCoordinator(automatic_control=None)
+    switch = _make_switch(coord, "automatic_control")
+    switch.async_get_last_state = AsyncMock(return_value=MagicMock(state=restored))
+
+    await switch.async_added_to_hass()
+
+    assert coord.automatic_control is expected
+    assert switch.is_on is expected
+
+
+# ---------------------------------------------------------------------------
+# The callers that set toggles directly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("method", "key", "enabled"),
+    [
+        ("async_set_automation", "automatic_control", False),
+        ("async_set_automation", "automatic_control", True),
+        ("async_set_climate_mode", "switch_mode", False),
+        ("async_set_climate_mode", "switch_mode", True),
+    ],
+)
+async def test_group_bulk_control_updates_the_member_switch(method, key, enabled):
+    """The group's bulk controls no longer leave the member switch behind."""
+    member = _FakeCoordinator(**{key: not enabled})
+    switch = _make_switch(member, key)
+
+    group = object.__new__(GroupCoordinator)
+    group.resolved_members = MagicMock(return_value=[(MagicMock(), member)])
+
+    await getattr(GroupCoordinator, method)(group, enabled)
+
+    assert getattr(member, key) is enabled
+    assert switch.is_on is enabled
+
+
+def _make_service_coordinator() -> MagicMock:
+    coord = MagicMock()
+    coord.entities = ["cover.a"]
+    coord.enabled_toggle = True
+    coord.logger = MagicMock()
+    coord._cmd_svc = MagicMock()
+    coord._cmd_svc.stop_in_flight = AsyncMock(return_value=[])
+    coord._cmd_svc.stop_all = AsyncMock(return_value=[])
+    coord._cancel_motion_timeout = MagicMock()
+    coord._cancel_weather_timeout = MagicMock()
+    return coord
+
+
+def _make_service_hass(coord: MagicMock) -> MagicMock:
+    from homeassistant.config_entries import ConfigEntryState
+
+    entry = MagicMock()
+    entry.entry_id = "entry_a"
+    entry.runtime_data = coord
+    entry.state = ConfigEntryState.LOADED
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+    hass.services = MagicMock()
+    hass.services.has_service = MagicMock(return_value=False)
+    hass.services.async_register = MagicMock()
+    return hass
+
+
+def _get_handler(hass: MagicMock, service_name: str):
+    for call in hass.services.async_register.call_args_list:
+        if call[0][1] == service_name:
+            return call[0][2]
+    raise ValueError(f"Service {service_name!r} was never registered")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("service", "expected"),
+    [
+        ("integration_enable", True),
+        ("integration_disable", False),
+        ("emergency_stop", False),
+    ],
+)
+async def test_kill_switch_services_push_the_new_state_to_the_entity(service, expected):
+    """These services never refresh, so they must notify listeners themselves.
+
+    The coordinator sets no ``update_interval``; refreshes are state-change
+    driven. Without an explicit notification the switch would keep rendering
+    its old value until some unrelated cycle happened to run — and that stale
+    render is what a restart would restore.
+    """
+    coord = _make_service_coordinator()
+    coord.enabled_toggle = not expected
+    hass = _make_service_hass(coord)
+
+    await async_setup_services(hass)
+    call = MagicMock()
+    call.data = {}
+    await _get_handler(hass, service)(call)
+
+    assert coord.enabled_toggle is expected
+    coord.async_update_listeners.assert_called_once()

--- a/tests/test_issue_1063_coordinator_toggle_truth.py
+++ b/tests/test_issue_1063_coordinator_toggle_truth.py
@@ -14,15 +14,27 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers.restore_state import RestoreEntity
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_SUN_TRACKING,
+    CONF_ENTITIES,
+    CONF_MEMBER_COVERS,
+    CONF_MEMBER_ENTRIES,
     CONF_SENSOR_TYPE,
+    DOMAIN,
     CoverType,
 )
 from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.group_entities import (
+    GroupAutomationSwitch,
+    GroupClimateSwitch,
+    GroupLockSwitch,
+)
 from custom_components.adaptive_cover_pro.services import async_setup_services
 from custom_components.adaptive_cover_pro.switch import (
     _SWITCH_SPECS,
@@ -128,7 +140,15 @@ def test_glare_zone_switch_falls_back_when_attribute_absent():
 @pytest.mark.unit
 @pytest.mark.parametrize("initial_state", [True, False])
 def test_unset_toggle_falls_back_to_initial_state(initial_state):
-    """``ToggleManager`` seeds most toggles to ``None`` until a switch restores."""
+    """``ToggleManager`` seeds most toggles to ``None`` until a switch restores.
+
+    This pins the fallback, not a claim about runtime semantics: for
+    ``automatic_control`` the coordinator reads ``None`` as falsy while the
+    spec declares ``initial_state=True``, so during the sliver before
+    ``async_added_to_hass`` the switch renders ``on`` over a closed gate. See
+    the ``is_on`` docstring for why one shared default is preferred over a
+    per-toggle ``None``-semantics map.
+    """
     coord = _FakeCoordinator(automatic_control=None)
     switch = _make_switch(coord, "automatic_control", initial_state=initial_state)
 
@@ -302,3 +322,151 @@ async def test_kill_switch_services_push_the_new_state_to_the_entity(service, ex
 
     assert coord.enabled_toggle is expected
     coord.async_update_listeners.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# The render gate — the link that carries a coordinator flip to the state machine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_coordinator_flip_reaches_the_state_machine():
+    """``is_on`` only helps if the render-signature gate lets the write through.
+
+    ``entity_base._handle_coordinator_update`` suppresses a write whenever
+    ``_acp_render_signature()`` is unchanged, and that signature is built from
+    ``self.state`` — which resolves through the new ``is_on``. Without this the
+    entity would hold its old state despite reading the right value, and that
+    old state is what ``RestoreEntity`` hands back.
+    """
+    coord = _FakeCoordinator(automatic_control=True)
+    coord.data = MagicMock()
+    coord.last_update_success = True
+    switch = _make_switch(coord, "automatic_control")
+    switch.async_write_ha_state = MagicMock()
+
+    switch._handle_coordinator_update()
+    assert switch.async_write_ha_state.call_count == 1
+
+    # An unchanged cycle is still gated — the fix must not defeat the dedup.
+    switch._handle_coordinator_update()
+    assert switch.async_write_ha_state.call_count == 1
+
+    coord.automatic_control = False
+    switch._handle_coordinator_update()
+    assert switch.async_write_ha_state.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# The group side: members now persist, so the group's own switches must too
+# ---------------------------------------------------------------------------
+
+
+def _make_group_config_entry():
+    entry = MagicMock()
+    entry.entry_id = "group_01"
+    entry.data = {"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP}
+    entry.options = {}
+    return entry
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("cls", "default"),
+    [(GroupAutomationSwitch, True), (GroupClimateSwitch, False)],
+)
+@pytest.mark.parametrize(
+    ("restored", "expected"), [(STATE_ON, True), (STATE_OFF, False)]
+)
+async def test_group_bulk_switch_restores_its_last_command(
+    cls, default, restored, expected
+):
+    """A group bulk switch must not snap back to its default after a restart.
+
+    Its members now persist what the bulk command did to them (that is the
+    #1063 fix), so a group switch that reinitializes to its default would
+    permanently contradict them: the user turns group automation off, restarts,
+    and sees the group reading ``on`` while every member reads ``off``.
+    """
+    coord = _FakeCoordinator()
+    switch = cls("group_01", coord.hass, _make_group_config_entry(), coord)
+    switch.async_write_ha_state = MagicMock()
+    assert switch.is_on is default
+
+    switch.async_get_last_state = AsyncMock(return_value=MagicMock(state=restored))
+    await switch.async_added_to_hass()
+
+    assert switch.is_on is expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_group_lock_switch_does_not_restore():
+    """The lock is deliberately the exception — its effect does not survive.
+
+    ``async_set_lock`` writes ``group_locked`` and a per-member ``GroupIntent``,
+    both of which are runtime-only. Restoring the switch to ``on`` would claim
+    a lock that no member is actually holding.
+    """
+    coord = _FakeCoordinator()
+    switch = GroupLockSwitch("group_01", coord.hass, _make_group_config_entry(), coord)
+    switch.async_write_ha_state = MagicMock()
+
+    assert not isinstance(switch, RestoreEntity)
+    assert switch.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# The group's member resolution must not hand back a half-built coordinator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolved_members_skips_an_entry_that_has_not_finished_setup(hass):
+    """``runtime_data`` is assigned before platform setup, so LOADED is the gate.
+
+    A member mid-reload already exposes its new coordinator while its switch
+    entities are still being added. Writing a toggle onto it is undone moments
+    later when those switches restore their previous state — the #1063 failure
+    mode all over again, on the one direct writer that does not filter on
+    ``ConfigEntryState``.
+    """
+    ready = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "ready", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: ["cover.ready"]},
+        entry_id="member_ready",
+        state=ConfigEntryState.LOADED,
+    )
+    ready.add_to_hass(hass)
+    ready.runtime_data = _FakeCoordinator(automatic_control=True)
+
+    setting_up = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "setting_up", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: ["cover.setting_up"]},
+        entry_id="member_setting_up",
+        state=ConfigEntryState.SETUP_IN_PROGRESS,
+    )
+    setting_up.add_to_hass(hass)
+    setting_up.runtime_data = _FakeCoordinator(automatic_control=True)
+
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: ["member_ready", "member_setting_up"],
+            CONF_MEMBER_COVERS: [],
+        },
+        entry_id="group_01",
+    )
+    group_entry.add_to_hass(hass)
+
+    group = GroupCoordinator(hass, group_entry)
+
+    assert [entry.entry_id for entry, _ in group.resolved_members()] == ["member_ready"]
+
+    await group.async_set_automation(False)
+    assert ready.runtime_data.automatic_control is False
+    assert setting_up.runtime_data.automatic_control is True

--- a/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
+++ b/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
@@ -148,7 +148,6 @@ def _make_switch(coord):
     switch._key = "automatic_control"
     switch._switch_name = "Automatic Control"
     switch._initial_state = True
-    switch._attr_is_on = False
     switch.schedule_update_ha_state = MagicMock()
     return switch
 

--- a/tests/test_switch_auto_control_off_return.py
+++ b/tests/test_switch_auto_control_off_return.py
@@ -99,7 +99,6 @@ async def test_return_to_default_fires_when_auto_control_toggled_off():
     switch._key = "automatic_control"
     switch._name = "test_switch"
     switch._initial_state = True
-    switch._attr_is_on = True
     switch.schedule_update_ha_state = MagicMock()
 
     with _patch_caps():


### PR DESCRIPTION
## Summary

`AdaptiveCoverSwitch.is_on` returned a local `_attr_is_on` that only the entity's own `async_turn_on`/`async_turn_off` ever wrote. Any caller that set the coordinator toggle directly — the group's bulk automation and climate controls, the `integration_enable` / `integration_disable` / `emergency_stop` services — changed behavior while the entity kept reporting its old state. Because the switch is a `RestoreEntity`, that stale value was pushed back into the coordinator at the next restart, silently undoing the change.

Non-option switches now read the coordinator attribute named by `_key`, which closes the whole class at once including callers not yet written. The `getattr` default covers both unset cases: `ToggleManager` seeds most toggles to `None`, and the dynamic `glare_zone_N` attributes do not exist until first written.

Three audit rounds surfaced four more defects in the same family, all fixed here:

- **The kill-switch services never notified.** They deliberately do not refresh, and the coordinator sets no `update_interval`, so the switch kept rendering its old value until some unrelated cycle ran. One shared `_set_enabled` helper now pushes the change to listeners.
- **The group's own bulk switches contradicted their members after a restart.** Making member toggles persist meant `GroupAutomationSwitch`/`GroupClimateSwitch` — neither a `RestoreEntity`, both reinitializing to their default — would read `on` while every member read `off`. They now restore. `GroupLockSwitch` deliberately does not: `group_locked` and the per-member `GroupIntent` are runtime-only, so restoring would claim a lock nobody holds.
- **`resolved_members` had no `LOADED` gate.** HA assigns `runtime_data` before forwarding platform setup, so a member mid-reload exposed a coordinator whose switch entities were not up yet — a toggle written there was undone when those switches restored. That is the same defect on the one direct writer that did not filter on `ConfigEntryState`. The predicate now lives in `helpers.usable_coordinator`, shared with `services.loaded_coordinators`.
- **An `unavailable` restored state read as `off`.** Any raise inside a coordinator update flips `last_update_success`, rendering every ACP entity `unavailable`, and HA's restore store snapshots on a 15-minute timer — so an unclean shutdown in that window persisted it. On the per-cover switches that path *writes* the coordinator, so it would force Integration Enabled, Automatic Control, Climate Mode and the rest to False on the next start, with no user action and no self-recovery. Both restore paths now share `helpers.restored_bool`.

Bulk climate mode also now skips members not configured for it. The pipeline gates on the `switch_mode` toggle rather than on `CONF_CLIMATE_MODE`, so commanding an unconfigured member really did switch climate on there — but nothing persisted it, so it evaporated at the next restart while the now-restoring group switch kept claiming it.

## Behavior change worth a release note

`integration_disable` and `emergency_stop` now survive a restart. That is the point of the fix — previously an emergency stop silently self-cleared at the next restart — but it means the integration stays disabled until someone calls `integration_enable` or flips `switch.<name>_integration_enabled`.

## Testing

- ✅ 9013 tests passing (`-n auto`), 1 xfailed (pre-existing)
- New `tests/test_issue_1063_coordinator_toggle_truth.py` covers: every non-option switch reflecting a direct coordinator set, the glare-zone attribute-absent fallback, the restart round-trip, the render-signature gate that carries a coordinator flip to the state machine, the group bulk switches' restore, the `LOADED` gate, and the unusable-restored-state guard across all nine toggles
- Patch coverage 100%; `group_coordinator.py` and `group_entities.py` at 100% overall

## Related Issues

Refs #1063