### PR TITLE
feat: add get_troubleshooting service (#1059)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4411,20 +4411,6 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return f"{name} ({suffix} {counter})"
 
 
-# Server-rendered wrapper lines for the read-only Troubleshoot step (issue
-# #970). The per-finding bullets are translated via the troubleshoot_i18n
-# bundle; these two "envelope" states are not finding codes, so they are not in
-# that bundle (its parity lock is strictly TriageCode-keyed) and stay here.
-_TROUBLESHOOT_NO_ISSUES = (
-    "✅ No configuration or runtime issues detected — everything looks correctly "
-    "set up."
-)
-_TROUBLESHOOT_UNAVAILABLE = (
-    "ℹ️ Diagnostics aren't available yet for this cover — it may not have "
-    "completed a first update cycle. Re-check once it has run at least once."
-)
-
-
 class OptionsFlowHandler(OptionsFlow):
     """Options to adjust parameters."""
 
@@ -4613,66 +4599,40 @@ class OptionsFlowHandler(OptionsFlow):
 
         Resolves diagnostics WITHOUT running an update cycle — it never calls
         ``async_refresh`` (which runs the full pipeline and can move a cover).
-        Options, per-entity capabilities, and the resolved payload are folded
-        into one view, the triage engine runs, and the findings render as a
-        bullet report into ``description_placeholders``. The menu routes each
-        finding's ``fix_step`` to the options step that fixes it (deduped,
-        first-seen order), then a re-check (``troubleshoot``) and a back
-        (``init``) entry — a list so HA translates labels client-side (#227).
+        The view-build → triage → render sequence lives in
+        :func:`~.diagnostics.resolve.build_troubleshoot_result` (issue #1059) —
+        the single seam this step shares with the ``get_troubleshooting``
+        service, so they can never diverge. This step only adds its own
+        menu-building on top: each finding's ``fix_step`` routes to the options
+        step that fixes it (deduped, first-seen order), then a re-check
+        (``troubleshoot``) and a back (``init``) entry — a list so HA
+        translates labels client-side (#227).
         """
         from .diagnostics import resolve
-        from .diagnostics.triage import RuleInput, render_report, run_triage
         from .troubleshoot_i18n import load_troubleshoot_labels
 
-        from .cover_types import get_policy
-
         read = resolve.read_diagnostics(self.hass, self._config_entry.entry_id)
-        cap_map, _ = _check_cover_capabilities(
-            self.options, self.sensor_type, self.hass
-        )
-        view: dict[str, Any] = {
-            "options": dict(self.options),
-            "capabilities": cap_map,
-            # Policy-derived capability requirements for rule 13
-            # (COVER_FEATURE_MISMATCH): the triage engine reads these as plain
-            # data so it never branches on the cover-type string (§ cover-type
-            # boundary). Folded in here at the HA boundary where get_policy lives.
-            "axis_requirements": get_policy(self.sensor_type).axis_requirements(),
-            **(read.payload or {}),
-        }
-        # When diagnostics are unavailable there is no runtime payload, so only
-        # the CONFIG rules can run (they read options + capabilities alone). Run
-        # just those so every fix route in the menu corresponds to a finding the
-        # user actually sees in the report — never a route for an unshown,
-        # never-evaluated runtime finding (issue #970, MINOR 3).
-        unavailable = read.source == "unavailable"
-        findings = run_triage(view, only=RuleInput.CONFIG if unavailable else None)
-
         labels = await self.hass.async_add_executor_job(
             load_troubleshoot_labels,
             _resolve_summary_language(self.hass, self.context),
         )
-
-        if unavailable:
-            # Lead with the note that runtime checks need diagnostics, then list
-            # any config findings that could still be evaluated.
-            report = _TROUBLESHOOT_UNAVAILABLE
-            if findings:
-                report = f"{report}\n\n{render_report(findings, labels)}"
-        elif findings:
-            report = render_report(findings, labels)
-        else:
-            report = _TROUBLESHOOT_NO_ISSUES
+        result = resolve.build_troubleshoot_result(
+            self.hass,
+            read,
+            options=self.options,
+            sensor_type=self.sensor_type,
+            labels=labels,
+        )
 
         menu_options = [
-            *dict.fromkeys(f.fix_step for f in findings if f.fix_step),
+            *dict.fromkeys(f.fix_step for f in result.findings if f.fix_step),
             "troubleshoot",
             "init",
         ]
         return self.async_show_menu(  # type: ignore[return-value]
             step_id="troubleshoot",
             menu_options=menu_options,
-            description_placeholders={"report": report},
+            description_placeholders={"report": result.report},
         )
 
     async def async_step_cover_entities(self, user_input: dict[str, Any] | None = None):

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -252,6 +252,7 @@ from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
 from .troubleshoot_i18n import load_troubleshoot_labels
 from .helpers import (
+    check_cover_capabilities,
     custom_position_slot_configured,
     custom_position_slot_name,
     custom_position_slot_sensors,
@@ -1207,113 +1208,6 @@ def _format_duration(dur: dict | int | float | None) -> str:
     return " ".join(parts) if parts else "0 min"
 
 
-def _check_cover_capabilities(
-    config: dict,
-    sensor_type: str | None,
-    hass: HomeAssistant | None,
-) -> tuple[dict[str, dict[str, bool] | None], list[str]]:
-    """Inspect bound cover entities and return capabilities + warning lines.
-
-    Returns:
-        cap_map:  entity_id → feature dict (None if entity unavailable)
-        warnings: list of ⚠️ strings — per-entity and cross-entity issues
-
-    """
-    entities: list[str] = config.get(CONF_ENTITIES) or []
-    if hass is None or not entities:
-        return {}, []
-
-    from .helpers import check_cover_features
-
-    warnings: list[str] = []
-
-    from .cover_types.base import CAP_HAS_SET_POSITION, caps_get
-
-    # The "not ready (unavailable)" line (rule 8a) is rendered from the shared
-    # triage engine so the summary and troubleshoot surfaces share one rule and
-    # one string (issue #970). Build the capability map up front, then index the
-    # COVER_NOT_READY findings by entity so the per-entity warning loop below
-    # keeps its exact ordering (and its interleaving with the open/close-only and
-    # assumed_state lines). Rendered in English to match the legacy raw f-string,
-    # which was hardcoded English regardless of the summary language.
-    from .const import TriageCode
-    from .diagnostics.triage import RuleInput, run_triage
-    from .reason_i18n import render
-    from .troubleshoot_i18n import load_troubleshoot_labels
-
-    cap_map: dict[str, dict[str, bool] | None] = {
-        eid: check_cover_features(hass, eid) for eid in entities
-    }
-    _not_ready = {
-        f.reason.params["eid"]: f
-        for f in run_triage({"capabilities": cap_map}, only=RuleInput.CONFIG)
-        if f.reason.code == TriageCode.COVER_NOT_READY
-    }
-    _triage_labels = load_troubleshoot_labels("en")
-
-    for eid in entities:
-        caps = cap_map[eid]
-        if caps is None:
-            warnings.append(render(_not_ready[eid].reason, _triage_labels))
-        else:
-            if not caps_get(caps, CAP_HAS_SET_POSITION):
-                warnings.append(
-                    f"⚠️ {eid} is open/close-only — will be driven via "
-                    "threshold compare, not set_position."
-                )
-            state = hass.states.get(eid)
-            if state and state.attributes.get("assumed_state"):
-                warnings.append(
-                    f"⚠️ {eid} has assumed_state — real position cannot be "
-                    "read back, which may affect position verification and delta-bypass."
-                )
-
-    known: dict[str, dict[str, bool]] = {
-        eid: caps for eid, caps in cap_map.items() if caps is not None
-    }
-
-    if known:
-        has_pos = {
-            eid for eid, caps in known.items() if caps_get(caps, CAP_HAS_SET_POSITION)
-        }
-        no_pos = {
-            eid
-            for eid, caps in known.items()
-            if not caps_get(caps, CAP_HAS_SET_POSITION)
-        }
-
-        if has_pos and no_pos:
-            warnings.append(
-                "⚠️ Mixed capabilities: some covers support set_position, "
-                "others are open/close-only — they will be driven differently."
-            )
-
-        if sensor_type is not None:
-            warnings.extend(
-                get_policy(sensor_type).capability_warnings_for_options(known, config)
-            )
-
-        min_pos_val = config.get(CONF_MIN_POSITION)
-        max_pos_val = config.get(CONF_MAX_POSITION)
-        enable_min_val = config.get(CONF_ENABLE_MIN_POSITION)
-        enable_max_val = config.get(CONF_ENABLE_MAX_POSITION)
-        limits_in_use = (
-            (min_pos_val is not None and min_pos_val != 0)
-            or (max_pos_val is not None and max_pos_val != 100)
-            or enable_min_val
-            or enable_max_val
-        )
-        oc_only = [eid for eid in no_pos if eid in known]
-        if limits_in_use and oc_only:
-            oc_str = ", ".join(oc_only)
-            warnings.append(
-                f"⚠️ Position limits are configured but {oc_str} "
-                "is open/close-only — limits will be ignored on that cover."
-            )
-
-    return cap_map, warnings
-
-
 def _build_cover_capabilities_text(
     config: dict,
     sensor_type: str | None,
@@ -1328,7 +1222,7 @@ def _build_cover_capabilities_text(
     if hass is None or not entities:
         return ""
 
-    cap_map, warnings = _check_cover_capabilities(config, sensor_type, hass)
+    cap_map, warnings = check_cover_capabilities(config, sensor_type, hass)
 
     from .cover_types.base import (
         CAP_HAS_CLOSE,
@@ -1465,7 +1359,7 @@ def _cover_type_label(
 #   * cover-type label (``policy.display_label()``)
 #   * physical-dimension block (``policy.summary_geometry_lines()``)
 #   * decision-priority short labels (Force/Weather/...) and the ✅/❌/→ marks
-#   * cover-capability warning lines built in ``_check_cover_capabilities``
+#   * cover-capability warning lines built in ``helpers.check_cover_capabilities``
 _SUMMARY_LABELS_EN: dict[str, str] = {
     # --- banners / section headers ---
     "banner.dry_run": (
@@ -2167,7 +2061,7 @@ def _build_config_summary(  # noqa: C901, PLR0912, PLR0915
     # =========================================================================
     # Section 1c: Cover Capability Warnings
     # =========================================================================
-    _, cap_warnings = _check_cover_capabilities(config, sensor_type, hass)
+    _, cap_warnings = check_cover_capabilities(config, sensor_type, hass)
     if cap_warnings:
         lines.append("")
         lines.append(L["headers.cover_warnings"])

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -1087,7 +1087,7 @@ class CoverTypePolicy(ABC):
         """Return user-facing warnings about the bound covers' capabilities.
 
         Default: no warnings — vertical / awning / tilt logic still lives in
-        ``config_flow._check_cover_capabilities``. ``VenetianPolicy``
+        ``helpers.check_cover_capabilities``. ``VenetianPolicy``
         overrides to express its dual-axis capability requirement.
         """
         return []
@@ -1102,7 +1102,7 @@ class CoverTypePolicy(ABC):
         day/night shade's control model relaxes the tilt requirement in its
         single-axis split-range mode). The Liskov-safe default delegates to
         :meth:`cover_capability_warnings`, so every other policy is unchanged —
-        the single ``config_flow._check_cover_capabilities`` call site can move
+        the single ``helpers.check_cover_capabilities`` call site can move
         to this hook without touching any existing behaviour.
         """
         return self.cover_capability_warnings(known)

--- a/custom_components/adaptive_cover_pro/diagnostics/resolve.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/resolve.py
@@ -44,16 +44,33 @@ TROUBLESHOOT_UNAVAILABLE = (
     "ℹ️ Diagnostics aren't available yet for this cover — it may not have "
     "completed a first update cycle. Re-check once it has run at least once."
 )
+# A third envelope string, alongside the two above: the get_troubleshooting
+# service's per-entry failure text for an instance where building the
+# troubleshoot result raised entirely (a bad options shape, an unexpected
+# exception, or an explicitly-targeted config entry with no cover coordinator
+# — issue #1059 audit round 3, nit #3). ``{reason}`` is filled in at the call
+# site with the human-readable form of whatever went wrong, so the same
+# representation appears in both the ``report`` and ``error`` fields of the
+# degraded entry rather than one carrying ``str(exc)`` and the other ``repr(exc)``.
+TROUBLESHOOT_BUILD_FAILED = "⚠️ Troubleshooting could not run for this cover: {reason}"
+
+# The vocabulary of resolve-layer "source" values (issue #1059 audit round 3,
+# nit #4): every :class:`DiagnosticsRead` and :class:`TroubleshootResult` this
+# module produces has a ``source`` drawn from exactly these four. The
+# get_troubleshooting service response adds one more, service-layer-only value
+# — ``"error"`` — that this module's dataclasses can never carry (see
+# ``troubleshoot_service.async_handle_get_troubleshooting``'s docstring).
+RESOLVE_READ_SOURCES: tuple[str, ...] = ("coordinator", "built", "cache", "unavailable")
 
 
 @dataclass(frozen=True, slots=True)
 class DiagnosticsRead:
     """The outcome of a read-only diagnostics resolution.
 
-    ``source`` is one of ``"coordinator"`` (live ``coordinator.data``),
-    ``"built"`` (a read-only rebuild), ``"cache"`` (the stale snapshot), or
-    ``"unavailable"`` (nothing answered / a rebuild raised). ``error`` carries a
-    formatted message only when a rebuild raised.
+    ``source`` is one of :data:`RESOLVE_READ_SOURCES` — ``"coordinator"``
+    (live ``coordinator.data``), ``"built"`` (a read-only rebuild), ``"cache"``
+    (the stale snapshot), or ``"unavailable"`` (nothing answered / a rebuild
+    raised). ``error`` carries a formatted message only when a rebuild raised.
     """
 
     payload: dict | None
@@ -103,8 +120,12 @@ class TroubleshootResult:
 
     ``findings`` are the raw :class:`~.triage.Finding` objects (code + params +
     severity + fix_step), ``report`` is the rendered bullet report (or one of
-    the envelope strings when there is nothing to show), and ``source`` mirrors
-    the :class:`DiagnosticsRead` that fed it.
+    the envelope strings when there is nothing to show), and ``source`` is
+    copied verbatim from the :class:`DiagnosticsRead` that fed it — so it is
+    always one of :data:`RESOLVE_READ_SOURCES`, never the
+    ``get_troubleshooting`` service response's service-layer-only ``"error"``
+    value, which this dataclass is never even constructed for (that case
+    short-circuits before :func:`build_troubleshoot_result` returns anything).
     """
 
     findings: list[Finding]

--- a/custom_components/adaptive_cover_pro/diagnostics/resolve.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/resolve.py
@@ -17,6 +17,7 @@ Home Assistant collaborators.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,23 @@ from ..const import DIAG_CACHE_KEY
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+    from .triage import Finding
+
+# Server-rendered wrapper lines for the read-only Troubleshoot step (issue
+# #970, moved here for issue #1059 so the options-flow menu and the
+# get_troubleshooting service share exactly one copy). The per-finding
+# bullets are translated via the troubleshoot_i18n bundle; these two
+# "envelope" states are not finding codes, so they are not in that bundle
+# (its parity lock is strictly TriageCode-keyed) and live here instead.
+TROUBLESHOOT_NO_ISSUES = (
+    "✅ No configuration or runtime issues detected — everything looks correctly "
+    "set up."
+)
+TROUBLESHOOT_UNAVAILABLE = (
+    "ℹ️ Diagnostics aren't available yet for this cover — it may not have "
+    "completed a first update cycle. Re-check once it has run at least once."
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,3 +93,74 @@ def read_diagnostics(hass: HomeAssistant, entry_id: str) -> DiagnosticsRead:
     if cached is not None:
         return DiagnosticsRead(cached, "cache")
     return DiagnosticsRead(None, "unavailable")
+
+
+@dataclass(frozen=True, slots=True)
+class TroubleshootResult:
+    """The outcome of a troubleshoot triage run.
+
+    ``findings`` are the raw :class:`~.triage.Finding` objects (code + params +
+    severity + fix_step), ``report`` is the rendered bullet report (or one of
+    the envelope strings when there is nothing to show), and ``source`` mirrors
+    the :class:`DiagnosticsRead` that fed it.
+    """
+
+    findings: list[Finding]
+    report: str
+    source: str
+
+
+def build_troubleshoot_result(
+    hass: HomeAssistant,
+    read: DiagnosticsRead,
+    *,
+    options: Mapping,
+    sensor_type: str | None,
+    labels: Mapping[str, str] | None,
+) -> TroubleshootResult:
+    """Run the triage engine against ``read`` and render the report.
+
+    The single seam shared by ``OptionsFlowHandler.async_step_troubleshoot``
+    and the ``get_troubleshooting`` service, so view-building/gating/rendering
+    never diverge (issue #1059). ``read`` is resolved by the caller (via
+    :func:`read_diagnostics` or :func:`read_from_coordinator`) — this function
+    never triggers an update cycle itself. ``labels`` is the already-loaded
+    translated ``troubleshoot_i18n`` bundle (or ``None`` for English); language
+    resolution is the caller's concern.
+
+    When ``read.source == "unavailable"`` there is no runtime payload, so only
+    the CONFIG rules run (they read options + capabilities alone) and the
+    report leads with the "diagnostics aren't available" preamble, followed by
+    any CONFIG findings that could still be evaluated. Otherwise every rule
+    runs and the report is either the rendered findings or the "all good" text.
+    """
+    from ..config_flow import _check_cover_capabilities  # noqa: PLC0415
+    from ..cover_types import get_policy  # noqa: PLC0415
+    from .triage import RuleInput, render_report, run_triage  # noqa: PLC0415
+
+    cap_map, _ = _check_cover_capabilities(options, sensor_type, hass)
+    view: dict = {
+        "options": dict(options),
+        "capabilities": cap_map,
+        # Policy-derived capability requirements for rule 13
+        # (COVER_FEATURE_MISMATCH): folded in here at the HA boundary where
+        # get_policy lives, so the pure triage engine never branches on the
+        # cover-type string (CODING_GUIDELINES § cover-type boundary).
+        "axis_requirements": get_policy(sensor_type).axis_requirements(),
+        **(read.payload or {}),
+    }
+    unavailable = read.source == "unavailable"
+    findings = run_triage(view, only=RuleInput.CONFIG if unavailable else None)
+
+    if unavailable:
+        # Lead with the note that runtime checks need diagnostics, then list
+        # any config findings that could still be evaluated.
+        report = TROUBLESHOOT_UNAVAILABLE
+        if findings:
+            report = f"{report}\n\n{render_report(findings, labels)}"
+    elif findings:
+        report = render_report(findings, labels)
+    else:
+        report = TROUBLESHOOT_NO_ISSUES
+
+    return TroubleshootResult(findings=findings, report=report, source=read.source)

--- a/custom_components/adaptive_cover_pro/diagnostics/resolve.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/resolve.py
@@ -21,7 +21,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from ..const import DIAG_CACHE_KEY
+from ..const import DIAG_CACHE_KEY, CoverType
 from ..helpers import check_cover_capabilities
 from . import triage
 
@@ -130,6 +130,15 @@ def build_troubleshoot_result(
     translated ``troubleshoot_i18n`` bundle (or ``None`` for English); language
     resolution is the caller's concern.
 
+    A falsy ``sensor_type`` falls back to ``CoverType.BLIND`` — the same
+    default ``OptionsFlowHandler.__init__`` applies to ``self.sensor_type`` —
+    so ``get_policy(None)`` never raises here. The fallback lives here, once,
+    rather than in each caller (issue #1059 audit, nit A): the options flow
+    already resolves a real ``sensor_type`` before this function ever runs, so
+    the fallback is a no-op there; it only matters for the
+    ``get_troubleshooting`` service, which passes a raw config-entry value
+    through unchanged.
+
     When ``read.source == "unavailable"`` there is no runtime payload, so only
     the CONFIG rules run (they read options + capabilities alone) and the
     report leads with the "diagnostics aren't available" preamble, followed by
@@ -138,6 +147,7 @@ def build_troubleshoot_result(
     """
     from ..cover_types import get_policy  # noqa: PLC0415
 
+    sensor_type = sensor_type or CoverType.BLIND
     cap_map, _ = check_cover_capabilities(options, sensor_type, hass)
     view: dict = {
         "options": dict(options),

--- a/custom_components/adaptive_cover_pro/diagnostics/resolve.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/resolve.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from ..const import DIAG_CACHE_KEY
+from ..helpers import check_cover_capabilities
+from . import triage
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -134,11 +136,9 @@ def build_troubleshoot_result(
     any CONFIG findings that could still be evaluated. Otherwise every rule
     runs and the report is either the rendered findings or the "all good" text.
     """
-    from ..config_flow import _check_cover_capabilities  # noqa: PLC0415
     from ..cover_types import get_policy  # noqa: PLC0415
-    from .triage import RuleInput, render_report, run_triage  # noqa: PLC0415
 
-    cap_map, _ = _check_cover_capabilities(options, sensor_type, hass)
+    cap_map, _ = check_cover_capabilities(options, sensor_type, hass)
     view: dict = {
         "options": dict(options),
         "capabilities": cap_map,
@@ -150,16 +150,18 @@ def build_troubleshoot_result(
         **(read.payload or {}),
     }
     unavailable = read.source == "unavailable"
-    findings = run_triage(view, only=RuleInput.CONFIG if unavailable else None)
+    findings = triage.run_triage(
+        view, only=triage.RuleInput.CONFIG if unavailable else None
+    )
 
     if unavailable:
         # Lead with the note that runtime checks need diagnostics, then list
         # any config findings that could still be evaluated.
         report = TROUBLESHOOT_UNAVAILABLE
         if findings:
-            report = f"{report}\n\n{render_report(findings, labels)}"
+            report = f"{report}\n\n{triage.render_report(findings, labels)}"
     elif findings:
-        report = render_report(findings, labels)
+        report = triage.render_report(findings, labels)
     else:
         report = TROUBLESHOOT_NO_ISSUES
 

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -1183,3 +1183,18 @@ TRIAGE_RULES: tuple[TriageRule, ...] = (
         check=_check_stale_version,
     ),
 )
+
+
+# ---------------------------------------------------------------------------
+# Wiki-anchor lookup (issue #1059) — the single ``code -> wiki`` accessor for
+# every caller that wants a finding's deep link (``scripts/triage_json.py`` and
+# the ``get_troubleshooting`` service), so the map is never hand-duplicated a
+# second or third time (CODING_GUIDELINES § "Single-Source-of-Truth Helpers").
+# ---------------------------------------------------------------------------
+
+_RULE_WIKI_BY_CODE: dict[str, str] = {rule.code: rule.wiki for rule in TRIAGE_RULES}
+
+
+def wiki_anchor_for(code: str) -> str | None:
+    """Return the wiki anchor for a rule code, or None."""
+    return _RULE_WIKI_BY_CODE.get(code)

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -37,6 +37,7 @@ from .const import (
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_SUNSET,
     MANUAL_OVERRIDE_DURATION_MODE_UNTIL_WINDOW_END,
     TIME_STRING_RE,
+    TriageCode,
 )
 from .templates import is_template_string
 
@@ -483,7 +484,6 @@ def check_cover_capabilities(
 
     warnings: list[str] = []
 
-    from .const import TriageCode
     from .cover_types import get_policy
     from .cover_types.base import CAP_HAS_SET_POSITION, caps_get
     from .diagnostics.triage import RuleInput, run_triage

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -16,9 +16,14 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     BLANK_TIME,
+    CONF_ENABLE_MAX_POSITION,
+    CONF_ENABLE_MIN_POSITION,
     CONF_END_ENTITY,
     CONF_END_TIME,
+    CONF_ENTITIES,
     CONF_MANUAL_OVERRIDE_INPUT_ENTITIES,
+    CONF_MAX_POSITION,
+    CONF_MIN_POSITION,
     CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
     CONF_SUNRISE_OFFSET,
@@ -449,6 +454,120 @@ def check_cover_features(hass: HomeAssistant, entity_id: str) -> dict[str, bool]
         "has_close": bool(supported_features & CoverEntityFeature.CLOSE),
         "has_stop": bool(supported_features & CoverEntityFeature.STOP),
     }
+
+
+def check_cover_capabilities(
+    config: dict,
+    sensor_type: str | None,
+    hass: HomeAssistant | None,
+) -> tuple[dict[str, dict[str, bool] | None], list[str]]:
+    """Inspect bound cover entities and return capabilities + warning lines.
+
+    Returns:
+        cap_map:  entity_id → feature dict (None if entity unavailable)
+        warnings: list of ⚠️ strings — per-entity and cross-entity issues
+
+    Moved here from ``config_flow.py`` (issue #1059) so ``diagnostics/resolve.py``
+    can import it at module level instead of reaching into ``config_flow`` —
+    ``config_flow`` already imports ``diagnostics.triage``, so the old
+    ``diagnostics -> config_flow`` edge made the two modules mutually dependent
+    (working only because both directions deferred the import). The
+    ``cover_types`` import below stays function-local: ``cover_types.base``
+    imports THIS module at module level, so importing ``cover_types`` back from
+    here at module scope would be circular.
+
+    """
+    entities: list[str] = config.get(CONF_ENTITIES) or []
+    if hass is None or not entities:
+        return {}, []
+
+    warnings: list[str] = []
+
+    from .const import TriageCode
+    from .cover_types import get_policy
+    from .cover_types.base import CAP_HAS_SET_POSITION, caps_get
+    from .diagnostics.triage import RuleInput, run_triage
+    from .reason_i18n import render
+    from .troubleshoot_i18n import load_troubleshoot_labels
+
+    # The "not ready (unavailable)" line (rule 8a) is rendered from the shared
+    # triage engine so the summary and troubleshoot surfaces share one rule and
+    # one string (issue #970). Build the capability map up front, then index the
+    # COVER_NOT_READY findings by entity so the per-entity warning loop below
+    # keeps its exact ordering (and its interleaving with the open/close-only and
+    # assumed_state lines). Rendered in English to match the legacy raw f-string,
+    # which was hardcoded English regardless of the summary language.
+    cap_map: dict[str, dict[str, bool] | None] = {
+        eid: check_cover_features(hass, eid) for eid in entities
+    }
+    _not_ready = {
+        f.reason.params["eid"]: f
+        for f in run_triage({"capabilities": cap_map}, only=RuleInput.CONFIG)
+        if f.reason.code == TriageCode.COVER_NOT_READY
+    }
+    _triage_labels = load_troubleshoot_labels("en")
+
+    for eid in entities:
+        caps = cap_map[eid]
+        if caps is None:
+            warnings.append(render(_not_ready[eid].reason, _triage_labels))
+        else:
+            if not caps_get(caps, CAP_HAS_SET_POSITION):
+                warnings.append(
+                    f"⚠️ {eid} is open/close-only — will be driven via "
+                    "threshold compare, not set_position."
+                )
+            state = hass.states.get(eid)
+            if state and state.attributes.get("assumed_state"):
+                warnings.append(
+                    f"⚠️ {eid} has assumed_state — real position cannot be "
+                    "read back, which may affect position verification and delta-bypass."
+                )
+
+    known: dict[str, dict[str, bool]] = {
+        eid: caps for eid, caps in cap_map.items() if caps is not None
+    }
+
+    if known:
+        has_pos = {
+            eid for eid, caps in known.items() if caps_get(caps, CAP_HAS_SET_POSITION)
+        }
+        no_pos = {
+            eid
+            for eid, caps in known.items()
+            if not caps_get(caps, CAP_HAS_SET_POSITION)
+        }
+
+        if has_pos and no_pos:
+            warnings.append(
+                "⚠️ Mixed capabilities: some covers support set_position, "
+                "others are open/close-only — they will be driven differently."
+            )
+
+        if sensor_type is not None:
+            warnings.extend(
+                get_policy(sensor_type).capability_warnings_for_options(known, config)
+            )
+
+        min_pos_val = config.get(CONF_MIN_POSITION)
+        max_pos_val = config.get(CONF_MAX_POSITION)
+        enable_min_val = config.get(CONF_ENABLE_MIN_POSITION)
+        enable_max_val = config.get(CONF_ENABLE_MAX_POSITION)
+        limits_in_use = (
+            (min_pos_val is not None and min_pos_val != 0)
+            or (max_pos_val is not None and max_pos_val != 100)
+            or enable_min_val
+            or enable_max_val
+        )
+        oc_only = [eid for eid in no_pos if eid in known]
+        if limits_in_use and oc_only:
+            oc_str = ", ".join(oc_only)
+            warnings.append(
+                f"⚠️ Position limits are configured but {oc_str} "
+                "is open/close-only — limits will be ignored on that cover."
+            )
+
+    return cap_map, warnings
 
 
 def _eval_time_to_utc_naive(eval_time: dt.datetime) -> dt.datetime:

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1392,6 +1392,28 @@ get_diagnostics:
         config_entry:
           integration: adaptive_cover_pro
 
+get_troubleshooting:
+  name: Get troubleshooting
+  description: >-
+    Returns the Troubleshoot step's triage findings for the targeted Adaptive
+    Cover Pro instances — the same checks the options-flow Troubleshoot menu
+    runs, as structured data (code, severity, fix step, wiki link, rendered
+    message) plus the rendered report text. Designed to be called from the ACP
+    Lovelace card via hass.callService(..., { return_response: true }).
+  target:
+    entity:
+      integration: adaptive_cover_pro
+  fields:
+    config_entry_id:
+      name: Config entry
+      description: >-
+        Explicit config entry id(s) to query. When omitted, standard target
+        (entity / device / area) selection applies. No target at all returns
+        all ACP instances.
+      selector:
+        config_entry:
+          integration: adaptive_cover_pro
+
 group_activate_scene:
   name: "Group: activate scene"
   description: >-

--- a/custom_components/adaptive_cover_pro/services.yaml
+++ b/custom_components/adaptive_cover_pro/services.yaml
@@ -1396,10 +1396,7 @@ get_troubleshooting:
   name: Get troubleshooting
   description: >-
     Returns the Troubleshoot step's triage findings for the targeted Adaptive
-    Cover Pro instances — the same checks the options-flow Troubleshoot menu
-    runs, as structured data (code, severity, fix step, wiki link, rendered
-    message) plus the rendered report text. Designed to be called from the ACP
-    Lovelace card via hass.callService(..., { return_response: true }).
+    Cover Pro instances as structured data, plus the rendered report text.
   target:
     entity:
       integration: adaptive_cover_pro

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
@@ -86,30 +87,56 @@ def cover_coordinators(
     }
 
 
+@dataclass(frozen=True, slots=True)
+class UnresolvedConfigEntry:
+    """An explicitly-targeted ACP config entry with no cover coordinator.
+
+    ``name`` is the entry's title — the same human-readable label
+    ``export_config``/``diagnostics/__init__.py`` already show for a raw
+    config entry with no coordinator to read a ``data["name"]`` off of.
+    ``reason`` is a per-case, human-readable explanation of why this id
+    produced no coordinator (a cover group, a Building Profile, or an entry
+    that isn't currently loaded — issue #1059 audit round 3, defect #1).
+    """
+
+    name: str
+    reason: str
+
+
 def _resolve_by_config_entry(
     hass: HomeAssistant, entry_ids: list[str]
-) -> dict[str, AdaptiveDataUpdateCoordinator]:
-    """Resolve explicit config entry IDs to {entry_id: coordinator}.
+) -> tuple[dict[str, AdaptiveDataUpdateCoordinator], dict[str, UnresolvedConfigEntry]]:
+    """Resolve explicit config entry IDs to (resolved, unresolved).
 
     Shared by ``get_diagnostics`` and ``get_troubleshooting`` — both accept an
     explicit ``config_entry_id`` escape hatch that bypasses the standard
-    entity/device/area target block. Resolves through :func:`cover_coordinators`
-    (not :func:`loaded_coordinators`) so a cover group or building profile is
-    never handed to a reader that expects a real cover coordinator's
+    entity/device/area target block. ``resolved`` maps entry_id → coordinator
+    for every id that is a real, loaded cover coordinator (resolved through
+    :func:`cover_coordinators`, never :func:`loaded_coordinators`, so a cover
+    group is never handed to a reader that expects a real cover coordinator's
     ``.data.diagnostics`` shape — a ``GroupCoordinator``'s ``.data`` is
-    ``GroupAggregates``, which has no ``diagnostics`` attribute (issue #1059).
+    ``GroupAggregates``, which has no ``diagnostics`` attribute, issue #1059).
 
-    Raises ``ServiceValidationError`` for any ID that doesn't exist, isn't
-    owned by this domain, or resolves to no cover coordinator at all — a cover
-    group, a Building Profile (a virtual entry that reaches ``LOADED`` without
-    ever setting ``runtime_data``, so it is absent from
-    :func:`loaded_coordinators` too), or any other ACP entry that isn't
-    currently usable — the same "explain the specific mistake" shape this
-    function already uses for an unknown ID, rather than silently dropping the
-    entry from the response (issue #1059 audit, finding #3).
+    ``unresolved`` maps entry_id → :class:`UnresolvedConfigEntry` for every id
+    that IS an ACP config entry but has no cover coordinator to read from — a
+    cover group, a Building Profile (a virtual entry that reaches ``LOADED``
+    without ever setting ``runtime_data``, so it is absent from
+    :func:`loaded_coordinators` too), or an entry that isn't currently
+    ``LOADED`` at all (mid-reload, ``SETUP_RETRY``, disabled). Callers degrade
+    these to a per-entry error rather than losing the whole response — a
+    single targeted instance being unresolvable must not sink an explicit
+    multi-entry call (issue #1059 audit round 3, defect #1: an ``else: raise``
+    here previously made the whole batch all-or-nothing).
+
+    An id that is not an ACP config entry at all (typo, wrong integration,
+    nonexistent) is a different class of mistake with no instance to attach a
+    degraded entry to — that still raises ``ServiceValidationError``
+    immediately, unchanged from before.
     """
     cover_coords = cover_coordinators(hass)
-    result = {}
+    all_loaded = loaded_coordinators(hass)
+    resolved: dict[str, AdaptiveDataUpdateCoordinator] = {}
+    unresolved: dict[str, UnresolvedConfigEntry] = {}
     for entry_id in entry_ids:
         entry = hass.config_entries.async_get_entry(entry_id)
         if entry is None or entry.domain != DOMAIN:
@@ -118,14 +145,30 @@ def _resolve_by_config_entry(
             )
         coord = cover_coords.get(entry_id)
         if coord is not None:
-            result[entry_id] = coord
-        else:
-            raise ServiceValidationError(
-                f"Config entry '{entry_id}' has no diagnostics or "
-                "troubleshooting data — it may be a cover group, a Building "
-                "Profile, or not currently loaded"
+            resolved[entry_id] = coord
+            continue
+        if entry_id in all_loaded:
+            # Loaded, but excluded from cover_coordinators() → a cover group.
+            reason = (
+                "This config entry is a cover group, not a single cover "
+                "instance — it has no per-instance diagnostics or "
+                "troubleshooting data."
             )
-    return result
+        elif entry.state is ConfigEntryState.LOADED:
+            # LOADED but never set runtime_data → a virtual Building Profile.
+            reason = (
+                "This config entry has no cover coordinator — it is likely "
+                "a Building Profile (a virtual entry with no cover to "
+                "control)."
+            )
+        else:
+            reason = (
+                f"This config entry is not currently loaded (state: "
+                f"{entry.state.value}) — it may be mid-reload, in a setup "
+                "retry, or disabled."
+            )
+        unresolved[entry_id] = UnresolvedConfigEntry(name=entry.title, reason=reason)
+    return resolved, unresolved
 
 
 def _resolve_targets(
@@ -240,20 +283,22 @@ TARGET_WITH_CONFIG_ENTRY_SCHEMA = vol.Schema(
 
 def _resolve_service_targets(
     hass: HomeAssistant, call: ServiceCall
-) -> dict[str, AdaptiveDataUpdateCoordinator]:
-    """Resolve a response-service call to {entry_id: coordinator}.
+) -> tuple[dict[str, AdaptiveDataUpdateCoordinator], dict[str, UnresolvedConfigEntry]]:
+    """Resolve a response-service call to (resolved, unresolved).
 
     Shared targeting preamble for ``get_diagnostics`` and
     ``get_troubleshooting`` (issue #1059): an explicit ``config_entry_id``
     list bypasses the standard entity/device/area target block via
-    :func:`_resolve_by_config_entry`; otherwise falls back to the standard
-    target block via :func:`_resolve_targets`.
+    :func:`_resolve_by_config_entry` — the only path that can produce
+    ``unresolved`` entries. The standard entity/device/area target block
+    (:func:`_resolve_targets`) only ever discovers real, loaded cover
+    coordinators, so it always pairs with an empty unresolved map.
     """
     explicit_entry_ids: list[str] = call.data.get("config_entry_id") or []
     if explicit_entry_ids:
         return _resolve_by_config_entry(hass, explicit_entry_ids)
     target_map = _resolve_targets(hass, call)
-    return {coord.config_entry.entry_id: coord for coord in target_map}
+    return {coord.config_entry.entry_id: coord for coord in target_map}, {}
 
 
 def _build_response_envelope(entries: dict) -> dict:

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import datetime as dt
 import logging
 from typing import TYPE_CHECKING
 
+import voluptuous as vol
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import ServiceCall, SupportsResponse
 from homeassistant.exceptions import ServiceValidationError
@@ -18,7 +20,7 @@ if TYPE_CHECKING:
     from ..coordinator import AdaptiveDataUpdateCoordinator
 
 from ..const import DOMAIN
-from .diagnostics_service import GET_DIAGNOSTICS_SCHEMA, async_handle_get_diagnostics
+from .diagnostics_service import async_handle_get_diagnostics
 from .group_service import GROUP_SERVICE_NAMES, register_group_services
 from .engage_manual_override_service import (
     ENGAGE_MANUAL_OVERRIDE_SCHEMA,
@@ -36,10 +38,7 @@ from .set_axes_service import SET_AXES_SCHEMA, async_handle_set_axes
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
 from .set_tilt_service import SET_TILT_SCHEMA, async_handle_set_tilt
 from .stop_service import async_handle_stop
-from .troubleshoot_service import (
-    GET_TROUBLESHOOTING_SCHEMA,
-    async_handle_get_troubleshooting,
-)
+from .troubleshoot_service import async_handle_get_troubleshooting
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -94,10 +93,19 @@ def _resolve_by_config_entry(
 
     Shared by ``get_diagnostics`` and ``get_troubleshooting`` — both accept an
     explicit ``config_entry_id`` escape hatch that bypasses the standard
-    entity/device/area target block. Raises ``ServiceValidationError`` for any
-    ID that doesn't exist or isn't owned by this domain.
+    entity/device/area target block. Resolves through :func:`cover_coordinators`
+    (not :func:`loaded_coordinators`) so a cover group or building profile is
+    never handed to a reader that expects a real cover coordinator's
+    ``.data.diagnostics`` shape — a ``GroupCoordinator``'s ``.data`` is
+    ``GroupAggregates``, which has no ``diagnostics`` attribute (issue #1059).
+
+    Raises ``ServiceValidationError`` for any ID that doesn't exist, isn't
+    owned by this domain, or names a cover group/building profile — the same
+    "explain the specific mistake" shape this function already uses for an
+    unknown ID, rather than silently dropping the entry from the response.
     """
-    all_coordinators = loaded_coordinators(hass)
+    cover_coords = cover_coordinators(hass)
+    all_coords = loaded_coordinators(hass)
     result = {}
     for entry_id in entry_ids:
         entry = hass.config_entries.async_get_entry(entry_id)
@@ -105,9 +113,17 @@ def _resolve_by_config_entry(
             raise ServiceValidationError(
                 f"Config entry '{entry_id}' not found or does not belong to {DOMAIN}"
             )
-        coord = all_coordinators.get(entry_id)
+        coord = cover_coords.get(entry_id)
         if coord is not None:
             result[entry_id] = coord
+        elif entry_id in all_coords:
+            # Loaded, but filtered out of cover_coordinators — a cover group or
+            # building profile, which has no diagnostics/troubleshoot findings
+            # of its own.
+            raise ServiceValidationError(
+                f"Config entry '{entry_id}' is a cover group or building "
+                "profile, which has no diagnostics"
+            )
     return result
 
 
@@ -206,6 +222,54 @@ def _resolve_targets(
     return result
 
 
+# Shared schema for the response-services that each return a per-instance
+# payload on demand (``get_diagnostics``, ``get_troubleshooting`` — issue
+# #1059): the standard entity/device/area target block plus an explicit
+# ``config_entry_id`` escape hatch. Defined once here so neither service
+# module hand-duplicates it (CODING_GUIDELINES "No Code Duplication").
+TARGET_WITH_CONFIG_ENTRY_SCHEMA = vol.Schema(
+    {
+        vol.Optional("entity_id"): vol.All(cv.ensure_list, [cv.entity_id]),
+        vol.Optional("device_id"): vol.All(cv.ensure_list, [str]),
+        vol.Optional("area_id"): vol.All(cv.ensure_list, [str]),
+        vol.Optional("config_entry_id"): vol.All(cv.ensure_list, [str]),
+    }
+)
+
+
+def _resolve_service_targets(
+    hass: HomeAssistant, call: ServiceCall
+) -> dict[str, AdaptiveDataUpdateCoordinator]:
+    """Resolve a response-service call to {entry_id: coordinator}.
+
+    Shared targeting preamble for ``get_diagnostics`` and
+    ``get_troubleshooting`` (issue #1059): an explicit ``config_entry_id``
+    list bypasses the standard entity/device/area target block via
+    :func:`_resolve_by_config_entry`; otherwise falls back to the standard
+    target block via :func:`_resolve_targets`.
+    """
+    explicit_entry_ids: list[str] = call.data.get("config_entry_id") or []
+    if explicit_entry_ids:
+        return _resolve_by_config_entry(hass, explicit_entry_ids)
+    target_map = _resolve_targets(hass, call)
+    return {coord.config_entry.entry_id: coord for coord in target_map}
+
+
+def _build_response_envelope(entries: dict) -> dict:
+    """Build the standard ``{version, generated_at, count, entries}`` envelope.
+
+    Shared response shape for every response-service that returns a
+    per-instance payload (``get_diagnostics``, ``get_troubleshooting`` — issue
+    #1059), so the envelope is never hand-duplicated a second time.
+    """
+    return {
+        "version": 1,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "count": len(entries),
+        "entries": entries,
+    }
+
+
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Register integration services (idempotent — safe to call per config entry)."""
     if hass.services.has_service(DOMAIN, "export_config"):
@@ -222,7 +286,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             DOMAIN,
             "get_diagnostics",
             async_handle_get_diagnostics,
-            schema=GET_DIAGNOSTICS_SCHEMA,
+            schema=TARGET_WITH_CONFIG_ENTRY_SCHEMA,
             supports_response=SupportsResponse.ONLY,
         )
     if not hass.services.has_service(DOMAIN, "get_troubleshooting"):
@@ -230,7 +294,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             DOMAIN,
             "get_troubleshooting",
             async_handle_get_troubleshooting,
-            schema=GET_TROUBLESHOOTING_SCHEMA,
+            schema=TARGET_WITH_CONFIG_ENTRY_SCHEMA,
             supports_response=SupportsResponse.ONLY,
         )
     if not hass.services.has_service(DOMAIN, "export_all_config"):

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -91,12 +91,18 @@ def cover_coordinators(
 class UnresolvedConfigEntry:
     """An explicitly-targeted ACP config entry with no cover coordinator.
 
-    ``name`` is the entry's title — the same human-readable label
-    ``export_config``/``diagnostics/__init__.py`` already show for a raw
-    config entry with no coordinator to read a ``data["name"]`` off of.
-    ``reason`` is a per-case, human-readable explanation of why this id
-    produced no coordinator (a cover group, a Building Profile, or an entry
-    that isn't currently loaded — issue #1059 audit round 3, defect #1).
+    ``name`` is ``entry.data["name"]`` — the same bare name every healthy
+    branch reads (``config_entry.data.get("name")`` in both
+    ``diagnostics_service.py`` and ``troubleshoot_service.py``), falling back
+    to ``entry.title`` only for an entry type that doesn't carry a
+    ``data["name"]`` at all. ``entry.title`` is a *different* string by
+    construction — ``config_flow.py`` builds every entry with
+    ``title=f"{cover_type_label} {name}"`` alongside ``data["name"]=name`` — so
+    using ``title`` here would give a degraded entry a different naming scheme
+    than a healthy one (issue #1059 audit round 4, N2). ``reason`` is a
+    per-case, human-readable explanation of why this id produced no
+    coordinator (a cover group, a Building Profile, or an entry that isn't
+    currently loaded — issue #1059 audit round 3, defect #1).
     """
 
     name: str
@@ -167,7 +173,9 @@ def _resolve_by_config_entry(
                 f"{entry.state.value}) — it may be mid-reload, in a setup "
                 "retry, or disabled."
             )
-        unresolved[entry_id] = UnresolvedConfigEntry(name=entry.title, reason=reason)
+        unresolved[entry_id] = UnresolvedConfigEntry(
+            name=entry.data.get("name") or entry.title, reason=reason
+        )
     return resolved, unresolved
 
 

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import ServiceCall, SupportsResponse
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -35,6 +36,10 @@ from .set_axes_service import SET_AXES_SCHEMA, async_handle_set_axes
 from .set_position_service import SET_POSITION_SCHEMA, async_handle_set_position
 from .set_tilt_service import SET_TILT_SCHEMA, async_handle_set_tilt
 from .stop_service import async_handle_stop
+from .troubleshoot_service import (
+    GET_TROUBLESHOOTING_SCHEMA,
+    async_handle_get_troubleshooting,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -80,6 +85,30 @@ def cover_coordinators(
         for entry_id, coordinator in loaded_coordinators(hass).items()
         if not isinstance(coordinator, GroupCoordinator)
     }
+
+
+def _resolve_by_config_entry(
+    hass: HomeAssistant, entry_ids: list[str]
+) -> dict[str, AdaptiveDataUpdateCoordinator]:
+    """Resolve explicit config entry IDs to {entry_id: coordinator}.
+
+    Shared by ``get_diagnostics`` and ``get_troubleshooting`` — both accept an
+    explicit ``config_entry_id`` escape hatch that bypasses the standard
+    entity/device/area target block. Raises ``ServiceValidationError`` for any
+    ID that doesn't exist or isn't owned by this domain.
+    """
+    all_coordinators = loaded_coordinators(hass)
+    result = {}
+    for entry_id in entry_ids:
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if entry is None or entry.domain != DOMAIN:
+            raise ServiceValidationError(
+                f"Config entry '{entry_id}' not found or does not belong to {DOMAIN}"
+            )
+        coord = all_coordinators.get(entry_id)
+        if coord is not None:
+            result[entry_id] = coord
+    return result
 
 
 def _resolve_targets(
@@ -196,6 +225,14 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             schema=GET_DIAGNOSTICS_SCHEMA,
             supports_response=SupportsResponse.ONLY,
         )
+    if not hass.services.has_service(DOMAIN, "get_troubleshooting"):
+        hass.services.async_register(
+            DOMAIN,
+            "get_troubleshooting",
+            async_handle_get_troubleshooting,
+            schema=GET_TROUBLESHOOTING_SCHEMA,
+            supports_response=SupportsResponse.ONLY,
+        )
     if not hass.services.has_service(DOMAIN, "export_all_config"):
         hass.services.async_register(
             DOMAIN,
@@ -287,6 +324,7 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     hass.services.async_remove(DOMAIN, "export_all_config")
     hass.services.async_remove(DOMAIN, "import_config")
     hass.services.async_remove(DOMAIN, "get_diagnostics")
+    hass.services.async_remove(DOMAIN, "get_troubleshooting")
     hass.services.async_remove(DOMAIN, "integration_enable")
     hass.services.async_remove(DOMAIN, "integration_disable")
     hass.services.async_remove(DOMAIN, "emergency_stop")

--- a/custom_components/adaptive_cover_pro/services/__init__.py
+++ b/custom_components/adaptive_cover_pro/services/__init__.py
@@ -100,12 +100,15 @@ def _resolve_by_config_entry(
     ``GroupAggregates``, which has no ``diagnostics`` attribute (issue #1059).
 
     Raises ``ServiceValidationError`` for any ID that doesn't exist, isn't
-    owned by this domain, or names a cover group/building profile — the same
-    "explain the specific mistake" shape this function already uses for an
-    unknown ID, rather than silently dropping the entry from the response.
+    owned by this domain, or resolves to no cover coordinator at all — a cover
+    group, a Building Profile (a virtual entry that reaches ``LOADED`` without
+    ever setting ``runtime_data``, so it is absent from
+    :func:`loaded_coordinators` too), or any other ACP entry that isn't
+    currently usable — the same "explain the specific mistake" shape this
+    function already uses for an unknown ID, rather than silently dropping the
+    entry from the response (issue #1059 audit, finding #3).
     """
     cover_coords = cover_coordinators(hass)
-    all_coords = loaded_coordinators(hass)
     result = {}
     for entry_id in entry_ids:
         entry = hass.config_entries.async_get_entry(entry_id)
@@ -116,13 +119,11 @@ def _resolve_by_config_entry(
         coord = cover_coords.get(entry_id)
         if coord is not None:
             result[entry_id] = coord
-        elif entry_id in all_coords:
-            # Loaded, but filtered out of cover_coordinators — a cover group or
-            # building profile, which has no diagnostics/troubleshoot findings
-            # of its own.
+        else:
             raise ServiceValidationError(
-                f"Config entry '{entry_id}' is a cover group or building "
-                "profile, which has no diagnostics"
+                f"Config entry '{entry_id}' has no diagnostics or "
+                "troubleshooting data — it may be a cover group, a Building "
+                "Profile, or not currently loaded"
             )
     return result
 

--- a/custom_components/adaptive_cover_pro/services/diagnostics_service.py
+++ b/custom_components/adaptive_cover_pro/services/diagnostics_service.py
@@ -15,14 +15,33 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_handle_get_diagnostics(call: ServiceCall) -> dict:
-    """Handle the get_diagnostics service call and return live diagnostics."""
+    """Handle the get_diagnostics service call and return live diagnostics.
+
+    An explicitly-named ``config_entry_id`` that resolves to no cover
+    coordinator (a cover group, a Building Profile, or an entry that isn't
+    currently loaded) degrades to a per-entry ``diagnostics: {"error": ...}``
+    entry rather than raising — a single unresolvable instance must not blank
+    an explicit multi-entry call (issue #1059 audit round 3, defect #1). An id
+    that isn't an ACP config entry at all still raises ``ServiceValidationError``
+    (see :func:`~..services._resolve_by_config_entry`).
+    """
     hass: HomeAssistant = call.hass
 
     from . import _resolve_service_targets  # noqa: PLC0415
 
-    coords_by_entry = _resolve_service_targets(hass, call)
+    coords_by_entry, unresolved = _resolve_service_targets(hass, call)
 
     entries: dict[str, dict] = {}
+    for entry_id, unresolved_entry in unresolved.items():
+        entries[entry_id] = {
+            "config_entry_id": entry_id,
+            "name": unresolved_entry.name,
+            "cover_type": None,
+            "last_update_success": False,
+            "last_update_success_time": None,
+            "diagnostics": {"error": unresolved_entry.reason},
+        }
+
     for entry_id, coord in coords_by_entry.items():
         # Read-only resolution (prefers coord.data, else a live build) — never an
         # update cycle. Unified with the download path via diagnostics.resolve.

--- a/custom_components/adaptive_cover_pro/services/diagnostics_service.py
+++ b/custom_components/adaptive_cover_pro/services/diagnostics_service.py
@@ -2,12 +2,8 @@
 
 from __future__ import annotations
 
-import datetime as dt
 import logging
 from typing import TYPE_CHECKING
-
-import voluptuous as vol
-from homeassistant.helpers import config_validation as cv
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
@@ -17,32 +13,14 @@ from ..diagnostics.resolve import read_from_coordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-GET_DIAGNOSTICS_SCHEMA = vol.Schema(
-    {
-        vol.Optional("entity_id"): vol.All(cv.ensure_list, [cv.entity_id]),
-        vol.Optional("device_id"): vol.All(cv.ensure_list, [str]),
-        vol.Optional("area_id"): vol.All(cv.ensure_list, [str]),
-        vol.Optional("config_entry_id"): vol.All(cv.ensure_list, [str]),
-    }
-)
-
 
 async def async_handle_get_diagnostics(call: ServiceCall) -> dict:
     """Handle the get_diagnostics service call and return live diagnostics."""
     hass: HomeAssistant = call.hass
 
-    explicit_entry_ids: list[str] = call.data.get("config_entry_id") or []
+    from . import _resolve_service_targets  # noqa: PLC0415
 
-    if explicit_entry_ids:
-        from . import _resolve_by_config_entry  # noqa: PLC0415
-
-        coords_by_entry = _resolve_by_config_entry(hass, explicit_entry_ids)
-    else:
-        # Standard target resolution (entity_id / device_id / area_id / no target)
-        from . import _resolve_targets  # noqa: PLC0415
-
-        target_map = _resolve_targets(hass, call)
-        coords_by_entry = {coord.config_entry.entry_id: coord for coord in target_map}
+    coords_by_entry = _resolve_service_targets(hass, call)
 
     entries: dict[str, dict] = {}
     for entry_id, coord in coords_by_entry.items():
@@ -71,9 +49,6 @@ async def async_handle_get_diagnostics(call: ServiceCall) -> dict:
             "diagnostics": _sanitize(diag) if diag is not None else None,
         }
 
-    return {
-        "version": 1,
-        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
-        "count": len(entries),
-        "entries": entries,
-    }
+    from . import _build_response_envelope  # noqa: PLC0415
+
+    return _build_response_envelope(entries)

--- a/custom_components/adaptive_cover_pro/services/diagnostics_service.py
+++ b/custom_components/adaptive_cover_pro/services/diagnostics_service.py
@@ -7,13 +7,11 @@ import logging
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
-from ..const import DOMAIN
 from ..diagnostics import _sanitize
 from ..diagnostics.resolve import read_from_coordinator
 
@@ -29,29 +27,6 @@ GET_DIAGNOSTICS_SCHEMA = vol.Schema(
 )
 
 
-def _resolve_by_config_entry(
-    hass: HomeAssistant, entry_ids: list[str]
-) -> dict[str, object]:
-    """Resolve explicit config entry IDs to {entry_id: coordinator}.
-
-    Raises ServiceValidationError for any ID that doesn't exist or isn't ACP.
-    """
-    from . import loaded_coordinators  # noqa: PLC0415
-
-    all_coordinators = loaded_coordinators(hass)
-    result = {}
-    for entry_id in entry_ids:
-        entry = hass.config_entries.async_get_entry(entry_id)
-        if entry is None or entry.domain != DOMAIN:
-            raise ServiceValidationError(
-                f"Config entry '{entry_id}' not found or does not belong to {DOMAIN}"
-            )
-        coord = all_coordinators.get(entry_id)
-        if coord is not None:
-            result[entry_id] = coord
-    return result
-
-
 async def async_handle_get_diagnostics(call: ServiceCall) -> dict:
     """Handle the get_diagnostics service call and return live diagnostics."""
     hass: HomeAssistant = call.hass
@@ -59,6 +34,8 @@ async def async_handle_get_diagnostics(call: ServiceCall) -> dict:
     explicit_entry_ids: list[str] = call.data.get("config_entry_id") or []
 
     if explicit_entry_ids:
+        from . import _resolve_by_config_entry  # noqa: PLC0415
+
         coords_by_entry = _resolve_by_config_entry(hass, explicit_entry_ids)
     else:
         # Standard target resolution (entity_id / device_id / area_id / no target)

--- a/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
+++ b/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
@@ -1,0 +1,108 @@
+"""Troubleshoot service for Adaptive Cover Pro — returns triage findings (issue #1059)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import TYPE_CHECKING
+
+import voluptuous as vol
+from homeassistant.helpers import config_validation as cv
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+    from ..diagnostics.triage import Finding
+
+from ..diagnostics.resolve import build_troubleshoot_result, read_from_coordinator
+from ..diagnostics.triage import wiki_anchor_for
+from ..reason_i18n import reason_to_dict, render
+from ..troubleshoot_i18n import load_troubleshoot_labels
+
+_LOGGER = logging.getLogger(__name__)
+
+GET_TROUBLESHOOTING_SCHEMA = vol.Schema(
+    {
+        vol.Optional("entity_id"): vol.All(cv.ensure_list, [cv.entity_id]),
+        vol.Optional("device_id"): vol.All(cv.ensure_list, [str]),
+        vol.Optional("area_id"): vol.All(cv.ensure_list, [str]),
+        vol.Optional("config_entry_id"): vol.All(cv.ensure_list, [str]),
+    }
+)
+
+
+def _finding_to_dict(
+    finding: Finding, labels: dict[str, str] | None
+) -> dict[str, object]:
+    """Serialize a Finding into the JSON-safe shape the service returns.
+
+    Reuses :func:`..reason_i18n.reason_to_dict` — the single JSON-serialization
+    path for a ``Reason`` (it already handles nested ``Reason`` fragments, e.g.
+    ``TriageCode.SKIP_AGE``) — rather than hand-rolling a second one. ``severity``
+    is emitted as its plain string value so the response stays JSON-serializable
+    for the HA websocket API.
+    """
+    payload = reason_to_dict(finding.reason)
+    return {
+        "code": payload["code"],
+        "params": payload["params"],
+        "severity": finding.severity.value,
+        "fix_step": finding.fix_step,
+        "wiki": wiki_anchor_for(finding.reason.code),
+        "message": render(finding.reason, labels),
+    }
+
+
+async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
+    """Handle the get_troubleshooting service call and return triage findings.
+
+    Mirrors ``get_diagnostics``'s targeting contract exactly (entity/device/area
+    target block, or an explicit ``config_entry_id`` list) and delegates the
+    view-build/triage/render sequence to
+    :func:`~..diagnostics.resolve.build_troubleshoot_result` — the same seam
+    the options-flow Troubleshoot step uses, so findings never diverge between
+    the two surfaces. Never triggers an update cycle.
+    """
+    hass: HomeAssistant = call.hass
+
+    explicit_entry_ids: list[str] = call.data.get("config_entry_id") or []
+
+    if explicit_entry_ids:
+        from . import _resolve_by_config_entry  # noqa: PLC0415
+
+        coords_by_entry = _resolve_by_config_entry(hass, explicit_entry_ids)
+    else:
+        from . import _resolve_targets  # noqa: PLC0415
+
+        target_map = _resolve_targets(hass, call)
+        coords_by_entry = {coord.config_entry.entry_id: coord for coord in target_map}
+
+    language = hass.config.language or "en"
+    labels = await hass.async_add_executor_job(load_troubleshoot_labels, language)
+
+    entries: dict[str, dict] = {}
+    for entry_id, coord in coords_by_entry.items():
+        # Read-only resolution (prefers coord.data, else a live build) — never an
+        # update cycle. Same reader get_diagnostics uses.
+        read = read_from_coordinator(coord)
+        result = build_troubleshoot_result(
+            hass,
+            read,
+            options=coord.config_entry.options,
+            sensor_type=coord.config_entry.data.get("sensor_type"),
+            labels=labels,
+        )
+        entries[entry_id] = {
+            "config_entry_id": entry_id,
+            "name": coord.config_entry.data.get("name"),
+            "source": result.source,
+            "report": result.report,
+            "findings": [_finding_to_dict(f, labels) for f in result.findings],
+        }
+
+    return {
+        "version": 1,
+        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
+        "count": len(entries),
+        "entries": entries,
+    }

--- a/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
+++ b/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
@@ -145,7 +145,7 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
                 labels=labels,
             )
         except Exception as exc:  # noqa: BLE001 - one bad entry must not sink the batch
-            reason = str(exc)
+            reason = f"{type(exc).__name__}: {exc}"
             _LOGGER.warning(
                 "get_troubleshooting: could not build results for %s: %s",
                 entry_id,

--- a/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
+++ b/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
 
     from ..diagnostics.triage import Finding
 
-from ..const import CONF_SENSOR_TYPE, CoverType
+from ..const import CONF_SENSOR_TYPE
 from ..diagnostics.resolve import build_troubleshoot_result, read_from_coordinator
 from ..diagnostics.triage import wiki_anchor_for
 from ..reason_i18n import reason_to_dict, render
@@ -51,10 +51,24 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
     the options-flow Troubleshoot step uses, so findings never diverge between
     the two surfaces. Never triggers an update cycle.
 
-    A single targeted instance failing (a bad options shape, an unexpected
-    ``build_troubleshoot_result`` exception) degrades that one entry to an
-    ``error`` entry rather than losing the whole response — the other
-    targeted instances still come back (issue #1059).
+    Every entry has exactly one shape — ``config_entry_id``, ``name``,
+    ``source``, ``report``, ``findings``, ``error`` — regardless of whether
+    the read succeeded (issue #1059 audit, findings #1/#2). ``error`` is
+    ``None`` on a fully healthy entry; any other value means something
+    degraded, and ``source`` says how far triage got:
+
+    - ``"coordinator"`` / ``"built"`` / ``"cache"`` — a full, trustworthy
+      read; ``error`` is ``None``.
+    - ``"unavailable"`` — diagnostics weren't ready yet, so only the CONFIG
+      rules ran; ``findings``/``report`` reflect that partial (but valid)
+      result, and ``error`` carries the read failure that produced it.
+    - ``"error"`` — building the troubleshoot result itself raised (a bad
+      options shape, an unexpected exception): nothing ran at all, so
+      ``findings`` is ``[]`` and ``report`` is a human-readable failure
+      message rather than blank.
+
+    A single targeted instance failing must not sink the whole response — the
+    other targeted instances still come back (issue #1059).
     """
     hass: HomeAssistant = call.hass
 
@@ -78,18 +92,11 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
                     entry_id,
                     read.error,
                 )
-            # A group/orchestrator or a not-yet-configured cover can carry no
-            # sensor_type; get_policy(None) raises, so fall back to BLIND —
-            # the same default the options flow uses (config_flow.py
-            # OptionsFlowHandler.__init__).
-            sensor_type = (
-                coord.config_entry.data.get(CONF_SENSOR_TYPE) or CoverType.BLIND
-            )
             result = build_troubleshoot_result(
                 hass,
                 read,
                 options=coord.config_entry.options,
-                sensor_type=sensor_type,
+                sensor_type=coord.config_entry.data.get(CONF_SENSOR_TYPE),
                 labels=labels,
             )
         except Exception as exc:  # noqa: BLE001 - one bad entry must not sink the batch
@@ -101,20 +108,21 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
             entries[entry_id] = {
                 "config_entry_id": entry_id,
                 "name": name,
+                "source": "error",
+                "report": f"⚠️ Troubleshooting could not run for this cover: {exc}",
+                "findings": [],
                 "error": f"troubleshoot_unavailable: {exc!r}",
             }
             continue
 
-        entry: dict[str, object] = {
+        entries[entry_id] = {
             "config_entry_id": entry_id,
             "name": name,
             "source": result.source,
             "report": result.report,
             "findings": [_finding_to_dict(f, labels) for f in result.findings],
+            "error": read.error,
         }
-        if read.error is not None:
-            entry["error"] = read.error
-        entries[entry_id] = entry
 
     from . import _build_response_envelope  # noqa: PLC0415
 

--- a/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
+++ b/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
@@ -2,33 +2,21 @@
 
 from __future__ import annotations
 
-import datetime as dt
 import logging
 from typing import TYPE_CHECKING
-
-import voluptuous as vol
-from homeassistant.helpers import config_validation as cv
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
     from ..diagnostics.triage import Finding
 
+from ..const import CONF_SENSOR_TYPE, CoverType
 from ..diagnostics.resolve import build_troubleshoot_result, read_from_coordinator
 from ..diagnostics.triage import wiki_anchor_for
 from ..reason_i18n import reason_to_dict, render
 from ..troubleshoot_i18n import load_troubleshoot_labels
 
 _LOGGER = logging.getLogger(__name__)
-
-GET_TROUBLESHOOTING_SCHEMA = vol.Schema(
-    {
-        vol.Optional("entity_id"): vol.All(cv.ensure_list, [cv.entity_id]),
-        vol.Optional("device_id"): vol.All(cv.ensure_list, [str]),
-        vol.Optional("area_id"): vol.All(cv.ensure_list, [str]),
-        vol.Optional("config_entry_id"): vol.All(cv.ensure_list, [str]),
-    }
-)
 
 
 def _finding_to_dict(
@@ -62,47 +50,72 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
     :func:`~..diagnostics.resolve.build_troubleshoot_result` — the same seam
     the options-flow Troubleshoot step uses, so findings never diverge between
     the two surfaces. Never triggers an update cycle.
+
+    A single targeted instance failing (a bad options shape, an unexpected
+    ``build_troubleshoot_result`` exception) degrades that one entry to an
+    ``error`` entry rather than losing the whole response — the other
+    targeted instances still come back (issue #1059).
     """
     hass: HomeAssistant = call.hass
 
-    explicit_entry_ids: list[str] = call.data.get("config_entry_id") or []
+    from . import _resolve_service_targets  # noqa: PLC0415
 
-    if explicit_entry_ids:
-        from . import _resolve_by_config_entry  # noqa: PLC0415
-
-        coords_by_entry = _resolve_by_config_entry(hass, explicit_entry_ids)
-    else:
-        from . import _resolve_targets  # noqa: PLC0415
-
-        target_map = _resolve_targets(hass, call)
-        coords_by_entry = {coord.config_entry.entry_id: coord for coord in target_map}
+    coords_by_entry = _resolve_service_targets(hass, call)
 
     language = hass.config.language or "en"
     labels = await hass.async_add_executor_job(load_troubleshoot_labels, language)
 
     entries: dict[str, dict] = {}
     for entry_id, coord in coords_by_entry.items():
-        # Read-only resolution (prefers coord.data, else a live build) — never an
-        # update cycle. Same reader get_diagnostics uses.
-        read = read_from_coordinator(coord)
-        result = build_troubleshoot_result(
-            hass,
-            read,
-            options=coord.config_entry.options,
-            sensor_type=coord.config_entry.data.get("sensor_type"),
-            labels=labels,
-        )
-        entries[entry_id] = {
+        name = coord.config_entry.data.get("name")
+        try:
+            # Read-only resolution (prefers coord.data, else a live build) —
+            # never an update cycle. Same reader get_diagnostics uses.
+            read = read_from_coordinator(coord)
+            if read.error is not None:
+                _LOGGER.warning(
+                    "get_troubleshooting: could not read diagnostics for %s: %s",
+                    entry_id,
+                    read.error,
+                )
+            # A group/orchestrator or a not-yet-configured cover can carry no
+            # sensor_type; get_policy(None) raises, so fall back to BLIND —
+            # the same default the options flow uses (config_flow.py
+            # OptionsFlowHandler.__init__).
+            sensor_type = (
+                coord.config_entry.data.get(CONF_SENSOR_TYPE) or CoverType.BLIND
+            )
+            result = build_troubleshoot_result(
+                hass,
+                read,
+                options=coord.config_entry.options,
+                sensor_type=sensor_type,
+                labels=labels,
+            )
+        except Exception as exc:  # noqa: BLE001 - one bad entry must not sink the batch
+            _LOGGER.warning(
+                "get_troubleshooting: could not build results for %s: %s",
+                entry_id,
+                exc,
+            )
+            entries[entry_id] = {
+                "config_entry_id": entry_id,
+                "name": name,
+                "error": f"troubleshoot_unavailable: {exc!r}",
+            }
+            continue
+
+        entry: dict[str, object] = {
             "config_entry_id": entry_id,
-            "name": coord.config_entry.data.get("name"),
+            "name": name,
             "source": result.source,
             "report": result.report,
             "findings": [_finding_to_dict(f, labels) for f in result.findings],
         }
+        if read.error is not None:
+            entry["error"] = read.error
+        entries[entry_id] = entry
 
-    return {
-        "version": 1,
-        "generated_at": dt.datetime.now(dt.UTC).isoformat(),
-        "count": len(entries),
-        "entries": entries,
-    }
+    from . import _build_response_envelope  # noqa: PLC0415
+
+    return _build_response_envelope(entries)

--- a/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
+++ b/custom_components/adaptive_cover_pro/services/troubleshoot_service.py
@@ -11,7 +11,11 @@ if TYPE_CHECKING:
     from ..diagnostics.triage import Finding
 
 from ..const import CONF_SENSOR_TYPE
-from ..diagnostics.resolve import build_troubleshoot_result, read_from_coordinator
+from ..diagnostics.resolve import (
+    TROUBLESHOOT_BUILD_FAILED,
+    build_troubleshoot_result,
+    read_from_coordinator,
+)
 from ..diagnostics.triage import wiki_anchor_for
 from ..reason_i18n import reason_to_dict, render
 from ..troubleshoot_i18n import load_troubleshoot_labels
@@ -41,6 +45,33 @@ def _finding_to_dict(
     }
 
 
+def _build_error_entry(
+    entry_id: str, name: str | None, reason: str
+) -> dict[str, object]:
+    """Build the degraded, six-key entry shape for a total-failure instance.
+
+    Shared by two producers of the same "total failure" shape (issue #1059
+    audit round 3, defect #1 / nit #3): an explicitly-targeted config entry
+    with no cover coordinator (a cover group, a Building Profile, or an entry
+    that isn't currently loaded), and an unexpected exception raised while
+    building the result for an otherwise-resolved coordinator. Both give the
+    caller exactly the same six keys a healthy entry has — ``config_entry_id``,
+    ``name``, ``source``, ``report``, ``findings``, ``error`` — so nothing
+    downstream has to branch on which producer built it. ``reason`` is used,
+    unchanged, as the single human-readable representation of what went wrong
+    in both ``report`` and ``error`` — never a mix of ``str(exc)`` in one and
+    ``repr(exc)`` in the other.
+    """
+    return {
+        "config_entry_id": entry_id,
+        "name": name,
+        "source": "error",
+        "report": TROUBLESHOOT_BUILD_FAILED.format(reason=reason),
+        "findings": [],
+        "error": f"troubleshoot_unavailable: {reason}",
+    }
+
+
 async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
     """Handle the get_troubleshooting service call and return triage findings.
 
@@ -55,17 +86,26 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
     ``source``, ``report``, ``findings``, ``error`` — regardless of whether
     the read succeeded (issue #1059 audit, findings #1/#2). ``error`` is
     ``None`` on a fully healthy entry; any other value means something
-    degraded, and ``source`` says how far triage got:
+    degraded, and ``source`` says how far triage got. This function only ever
+    reads via :func:`~..diagnostics.resolve.read_from_coordinator` (never
+    :func:`~..diagnostics.resolve.read_diagnostics`), so of the vocabulary in
+    :data:`~..diagnostics.resolve.RESOLVE_READ_SOURCES` it can only ever
+    produce ``"coordinator"`` or ``"built"`` — ``"cache"`` is reachable only
+    through the options-flow Troubleshoot step, which resolves via
+    ``read_diagnostics`` instead:
 
-    - ``"coordinator"`` / ``"built"`` / ``"cache"`` — a full, trustworthy
-      read; ``error`` is ``None``.
+    - ``"coordinator"`` / ``"built"`` — a full, trustworthy read; ``error``
+      is ``None``.
     - ``"unavailable"`` — diagnostics weren't ready yet, so only the CONFIG
       rules ran; ``findings``/``report`` reflect that partial (but valid)
       result, and ``error`` carries the read failure that produced it.
-    - ``"error"`` — building the troubleshoot result itself raised (a bad
-      options shape, an unexpected exception): nothing ran at all, so
-      ``findings`` is ``[]`` and ``report`` is a human-readable failure
-      message rather than blank.
+    - ``"error"`` — a value this function adds itself, not part of
+      :data:`~..diagnostics.resolve.RESOLVE_READ_SOURCES`: either building the
+      troubleshoot result raised (a bad options shape, an unexpected
+      exception), or an explicitly-targeted ``config_entry_id`` resolved to no
+      cover coordinator at all (a cover group, a Building Profile, or an entry
+      that isn't currently loaded). Nothing ran, so ``findings`` is ``[]`` and
+      ``report`` is a human-readable failure message rather than blank.
 
     A single targeted instance failing must not sink the whole response — the
     other targeted instances still come back (issue #1059).
@@ -74,12 +114,17 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
 
     from . import _resolve_service_targets  # noqa: PLC0415
 
-    coords_by_entry = _resolve_service_targets(hass, call)
+    coords_by_entry, unresolved = _resolve_service_targets(hass, call)
 
     language = hass.config.language or "en"
     labels = await hass.async_add_executor_job(load_troubleshoot_labels, language)
 
     entries: dict[str, dict] = {}
+    for entry_id, unresolved_entry in unresolved.items():
+        entries[entry_id] = _build_error_entry(
+            entry_id, unresolved_entry.name, unresolved_entry.reason
+        )
+
     for entry_id, coord in coords_by_entry.items():
         name = coord.config_entry.data.get("name")
         try:
@@ -100,19 +145,14 @@ async def async_handle_get_troubleshooting(call: ServiceCall) -> dict:
                 labels=labels,
             )
         except Exception as exc:  # noqa: BLE001 - one bad entry must not sink the batch
+            reason = str(exc)
             _LOGGER.warning(
                 "get_troubleshooting: could not build results for %s: %s",
                 entry_id,
-                exc,
+                reason,
+                exc_info=True,
             )
-            entries[entry_id] = {
-                "config_entry_id": entry_id,
-                "name": name,
-                "source": "error",
-                "report": f"⚠️ Troubleshooting could not run for this cover: {exc}",
-                "findings": [],
-                "error": f"troubleshoot_unavailable: {exc!r}",
-            }
+            entries[entry_id] = _build_error_entry(entry_id, name, reason)
             continue
 
         entries[entry_id] = {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1941,7 +1941,7 @@
       "fields": {
         "config_entry_id": {
           "name": "Konfigurationseintrag",
-          "description": "Explizite Konfigurations-Eintrags-IDs zum Abfragen. Wenn weggelassen, gilt die standardmäßige Zielauswahl. Kein Ziel gibt alle ACP-Instanzen zurück."
+          "description": "Explizite Konfigurations-Eintrags-ID(s) zum Abfragen. Wenn weggelassen, gilt die standardmäßige Zielauswahl (Entität/Gerät/Bereich). Ganz ohne Ziel werden alle ACP-Instanzen zurückgegeben."
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1945,6 +1945,16 @@
         }
       }
     },
+    "get_troubleshooting": {
+      "name": "Fehlerbehebung abrufen",
+      "description": "Gibt die Ergebnisse des Fehlerbehebungsschritts für die gezielten Adaptive Cover Pro Instanzen als strukturierte Daten zurück, zusätzlich zum gerenderten Berichtstext.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Konfigurationseintrag",
+          "description": "Explizite Konfigurations-Eintrags-IDs zum Abfragen. Wenn weggelassen, gilt die standardmäßige Zielauswahl. Kein Ziel gibt alle ACP-Instanzen zurück."
+        }
+      }
+    },
     "set_venetian": {
       "name": "Jalousie-Optionen setzen",
       "description": "Jalousie-spezifische Optionen aktualisieren: Betriebsmodus, Neigungsschwellenwert und Wartezeit nach Fahrt.",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1951,7 +1951,7 @@
       "fields": {
         "config_entry_id": {
           "name": "Konfigurationseintrag",
-          "description": "Explizite Konfigurations-Eintrags-IDs zum Abfragen. Wenn weggelassen, gilt die standardmäßige Zielauswahl. Kein Ziel gibt alle ACP-Instanzen zurück."
+          "description": "Explizite Konfigurations-Eintrags-ID(s) zum Abfragen. Wenn weggelassen, gilt die standardmäßige Zielauswahl (Entität/Gerät/Bereich). Ganz ohne Ziel werden alle ACP-Instanzen zurückgegeben."
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1441,6 +1441,16 @@
         }
       }
     },
+    "get_troubleshooting": {
+      "name": "Get troubleshooting",
+      "description": "Returns the Troubleshoot step's triage findings for the targeted Adaptive Cover Pro instances as structured data, plus the rendered report text.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Config entry",
+          "description": "Explicit config entry id(s) to query. When omitted, standard target selection applies. No target returns all ACP instances."
+        }
+      }
+    },
     "set_position_limits": {
       "name": "Set position limits",
       "description": "Update default height, min/max position, open/close threshold, and inverse state.",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1437,7 +1437,7 @@
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
-          "description": "Explicit config entry id(s) to query. When omitted, standard target selection applies. No target returns all ACP instances."
+          "description": "Explicit config entry id(s) to query. When omitted, standard target (entity / device / area) selection applies. No target at all returns all ACP instances."
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1447,7 +1447,7 @@
       "fields": {
         "config_entry_id": {
           "name": "Config entry",
-          "description": "Explicit config entry id(s) to query. When omitted, standard target selection applies. No target returns all ACP instances."
+          "description": "Explicit config entry id(s) to query. When omitted, standard target (entity / device / area) selection applies. No target at all returns all ACP instances."
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1941,7 +1941,7 @@
       "fields": {
         "config_entry_id": {
           "name": "Entrée de configuration",
-          "description": "ID(s) d'entrée de configuration explicite(s) à interroger. Lorsqu'omis, la sélection de cible standard s'applique. Aucune cible retourne toutes les instances ACP."
+          "description": "ID(s) d'entrée de configuration explicite(s) à interroger. Lorsqu'omis, la sélection de cible standard (entité / appareil / zone) s'applique. Sans aucune cible, toutes les instances ACP sont retournées."
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1951,7 +1951,7 @@
       "fields": {
         "config_entry_id": {
           "name": "Entrée de configuration",
-          "description": "ID(s) d'entrée de configuration explicite(s) à interroger. Lorsqu'omis, la sélection de cible standard s'applique. Aucune cible retourne toutes les instances ACP."
+          "description": "ID(s) d'entrée de configuration explicite(s) à interroger. Lorsqu'omis, la sélection de cible standard (entité / appareil / zone) s'applique. Sans aucune cible, toutes les instances ACP sont retournées."
         }
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1945,6 +1945,16 @@
         }
       }
     },
+    "get_troubleshooting": {
+      "name": "Obtenir le dépannage",
+      "description": "Retourne les résultats de l'étape de dépannage pour les instances Adaptive Cover Pro ciblées sous forme de données structurées, ainsi que le texte du rapport généré.",
+      "fields": {
+        "config_entry_id": {
+          "name": "Entrée de configuration",
+          "description": "ID(s) d'entrée de configuration explicite(s) à interroger. Lorsqu'omis, la sélection de cible standard s'applique. Aucune cible retourne toutes les instances ACP."
+        }
+      }
+    },
     "set_venetian": {
       "name": "Définir les options store vénitien",
       "description": "Mettre à jour les options spécifiques au store vénitien : mode de fonctionnement, seuil d'inclinaison et délai post-arrêt.",

--- a/scripts/triage_json.py
+++ b/scripts/triage_json.py
@@ -35,17 +35,16 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
 from custom_components.adaptive_cover_pro.diagnostics.triage import (  # noqa: E402
-    TRIAGE_RULES,
     build_offline_view,
     render_report,
     run_triage,
+    wiki_anchor_for,
 )
 from custom_components.adaptive_cover_pro.troubleshoot_i18n import (  # noqa: E402
     load_troubleshoot_labels,
 )
 
 _WIKI_BASE = "https://github.com/jrhubott/adaptive-cover-pro/wiki/"
-_RULE_WIKI_BY_CODE = {rule.code: rule.wiki for rule in TRIAGE_RULES}
 
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
@@ -88,7 +87,7 @@ def main(argv: list[str]) -> int:
     print(render_report(findings, labels))
     print("\nWiki:")
     for finding in findings:
-        wiki = _RULE_WIKI_BY_CODE.get(finding.reason.code)
+        wiki = wiki_anchor_for(finding.reason.code)
         if wiki:
             print(f"  - {finding.reason.code}: {_WIKI_BASE}{wiki}")
     return 0

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -3610,7 +3610,7 @@ def test_summary_building_profile_line_when_linked() -> None:
             self.title = title
 
     class _FakeStates:
-        """Minimal hass.states stub so _check_cover_capabilities doesn't crash."""
+        """Minimal hass.states stub so check_cover_capabilities doesn't crash."""
 
         def get(self, entity_id: str):  # noqa: D102
             return None

--- a/tests/test_diagnostics_resolve.py
+++ b/tests/test_diagnostics_resolve.py
@@ -16,6 +16,7 @@ import pytest
 import custom_components.adaptive_cover_pro.services as services
 from custom_components.adaptive_cover_pro.const import DIAG_CACHE_KEY, CoverType
 from custom_components.adaptive_cover_pro.diagnostics.resolve import (
+    RESOLVE_READ_SOURCES,
     DiagnosticsRead,
     build_troubleshoot_result,
     read_diagnostics,
@@ -44,6 +45,15 @@ def test_diagnostics_read_error_defaults_none():
     """Error defaults to None when omitted."""
     read = DiagnosticsRead(payload={"a": 1}, source="coordinator")
     assert read.error is None
+
+
+def test_resolve_read_sources_enumerates_the_vocabulary():
+    """RESOLVE_READ_SOURCES is the one authoritative list of every value
+    DiagnosticsRead/TroubleshootResult ``source`` can carry (issue #1059
+    audit round 3, nit #4) — locked against a literal so a new source value
+    added to one docstring but not the other can't slip through silently.
+    """
+    assert RESOLVE_READ_SOURCES == ("coordinator", "built", "cache", "unavailable")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diagnostics_resolve.py
+++ b/tests/test_diagnostics_resolve.py
@@ -221,3 +221,44 @@ def test_build_troubleshoot_result_renders_findings_via_labels():
     assert len(result.findings) == 1
     assert result.findings[0].reason.code == "triage.dry_run_left_on"
     assert "Dry-run mode is on" in result.report
+
+
+def test_build_troubleshoot_result_unavailable_gates_out_mixed_config_runtime_rule():
+    """The ``only=RuleInput.CONFIG if unavailable else None`` gate (resolve.py)
+    actually suppresses a mixed ``CONFIG | RUNTIME`` rule when the source is
+    unavailable — the exact extraction risk the evidence packet's
+    REGRESSION_CHECK names, previously unexercised by any test (issue #1059,
+    finding #2). CLOUD_OR_SEMANTICS (rule 7) is tagged ``CONFIG | RUNTIME`` and
+    fires off options alone (more than one cloud/low-light input configured),
+    so it is a rule that COULD run with only options data but must not when
+    ``only=RuleInput.CONFIG`` drops any rule that also reads RUNTIME.
+    """
+    options = {
+        "entities": [],
+        "lux_entity": "sensor.lux",
+        "irradiance_entity": "sensor.irr",
+    }
+
+    # Gated: source is unavailable → only=RuleInput.CONFIG drops this mixed rule.
+    unavailable_result = build_troubleshoot_result(
+        MagicMock(),
+        DiagnosticsRead(payload=None, source="unavailable"),
+        options=options,
+        sensor_type=CoverType.BLIND,
+        labels=None,
+    )
+    unavailable_codes = [f.reason.code for f in unavailable_result.findings]
+    assert "triage.cloud_or_semantics" not in unavailable_codes
+
+    # Sibling assertion: the SAME options fire the same rule when the source is
+    # NOT unavailable (only=None, every rule runs) — proves the gate itself is
+    # what suppressed the finding above, not merely an absence of data.
+    available_result = build_troubleshoot_result(
+        MagicMock(),
+        DiagnosticsRead(payload={}, source="coordinator"),
+        options=options,
+        sensor_type=CoverType.BLIND,
+        labels=None,
+    )
+    available_codes = [f.reason.code for f in available_result.findings]
+    assert "triage.cloud_or_semantics" in available_codes

--- a/tests/test_diagnostics_resolve.py
+++ b/tests/test_diagnostics_resolve.py
@@ -14,9 +14,10 @@ from unittest.mock import MagicMock
 import pytest
 
 import custom_components.adaptive_cover_pro.services as services
-from custom_components.adaptive_cover_pro.const import DIAG_CACHE_KEY
+from custom_components.adaptive_cover_pro.const import DIAG_CACHE_KEY, CoverType
 from custom_components.adaptive_cover_pro.diagnostics.resolve import (
     DiagnosticsRead,
+    build_troubleshoot_result,
     read_diagnostics,
     read_from_coordinator,
 )
@@ -168,3 +169,55 @@ def test_async_refresh_never_called_on_any_path(monkeypatch):
     monkeypatch.setattr(services, "cover_coordinators", lambda hass: {"e1": spy})
     read_diagnostics(MagicMock(), "e1")
     spy.async_refresh.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# build_troubleshoot_result — the shared troubleshoot seam (issue #1059)
+# ---------------------------------------------------------------------------
+
+
+def test_build_troubleshoot_result_no_findings_uses_no_issues_text():
+    """No findings and a live source renders the "all good" envelope text."""
+    read = DiagnosticsRead(payload={}, source="coordinator")
+    result = build_troubleshoot_result(
+        MagicMock(),
+        read,
+        options={},
+        sensor_type=CoverType.BLIND,
+        labels=None,
+    )
+    assert result.findings == []
+    assert result.source == "coordinator"
+    assert "No configuration or runtime issues detected" in result.report
+
+
+def test_build_troubleshoot_result_unavailable_source_uses_unavailable_text():
+    """An unavailable read with no CONFIG findings renders only the preamble."""
+    read = DiagnosticsRead(payload=None, source="unavailable")
+    result = build_troubleshoot_result(
+        MagicMock(),
+        read,
+        options={},
+        sensor_type=CoverType.BLIND,
+        labels=None,
+    )
+    assert result.findings == []
+    assert result.source == "unavailable"
+    assert "Diagnostics aren't available" in result.report
+
+
+def test_build_troubleshoot_result_renders_findings_via_labels():
+    """A firing rule (dry-run left on) produces a Finding and shows in the report."""
+    read = DiagnosticsRead(
+        payload={"debug_config": {"dry_run": True}}, source="coordinator"
+    )
+    result = build_troubleshoot_result(
+        MagicMock(),
+        read,
+        options={},
+        sensor_type=CoverType.BLIND,
+        labels=None,
+    )
+    assert len(result.findings) == 1
+    assert result.findings[0].reason.code == "triage.dry_run_left_on"
+    assert "Dry-run mode is on" in result.report

--- a/tests/test_get_diagnostics_service.py
+++ b/tests/test_get_diagnostics_service.py
@@ -132,6 +132,41 @@ async def test_unknown_explicit_entry_raises():
 
 
 @pytest.mark.asyncio
+async def test_group_config_entry_id_raises_service_validation_error():
+    """Explicitly targeting a cover group's config_entry_id raises a clear
+    ServiceValidationError instead of an AttributeError from ``coord.data.diagnostics``
+    (issue #1059, finding #1). ``_resolve_by_config_entry`` must resolve through
+    ``cover_coordinators`` (which filters out groups/building profiles) rather
+    than ``loaded_coordinators`` (which does not) — a ``GroupCoordinator``'s
+    ``.data`` is ``GroupAggregates``, which has no ``diagnostics`` attribute.
+    """
+    from homeassistant.exceptions import ServiceValidationError
+
+    from custom_components.adaptive_cover_pro.group_coordinator import (
+        GroupCoordinator,
+    )
+
+    group_coord = MagicMock()
+    group_coord.__class__ = GroupCoordinator  # isinstance(..., GroupCoordinator) → True
+    group_coord.config_entry.entry_id = "group-1"
+
+    entry = MagicMock()
+    entry.entry_id = "group-1"
+    entry.runtime_data = group_coord
+    entry.state = ConfigEntryState.LOADED
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+    hass.config_entries.async_get_entry.return_value = MagicMock(
+        domain=DOMAIN, entry_id="group-1"
+    )
+    call = make_call(hass, data={"config_entry_id": ["group-1"]})
+
+    with pytest.raises(ServiceValidationError):
+        await async_handle_get_diagnostics(call)
+
+
+@pytest.mark.asyncio
 async def test_sanitizer_handles_numpy_datetime_enum_dataclass():
     """Diagnostics containing numpy scalars, datetimes, enums, and dataclasses are JSON-serializable."""
     try:

--- a/tests/test_get_diagnostics_service.py
+++ b/tests/test_get_diagnostics_service.py
@@ -134,10 +134,17 @@ async def test_unknown_explicit_entry_raises():
 def _make_unresolvable_entry(entry_id, state, runtime_data=None):
     """Build a MagicMock ``ConfigEntry`` for an id that must NOT resolve to a
     cover coordinator — used by the three degrade-not-raise cases below.
+
+    ``data`` is set to a real (empty) dict, not left as an auto-``MagicMock``
+    attribute — ``_resolve_by_config_entry`` now reads ``entry.data.get("name")``
+    before falling back to ``entry.title`` (issue #1059 audit round 4, N2), and
+    an unset ``MagicMock`` attribute's ``.get(...)`` returns a truthy child
+    mock rather than ``None``, which would silently defeat that fallback here.
     """
     entry = MagicMock()
     entry.entry_id = entry_id
     entry.domain = DOMAIN
+    entry.data = {}
     entry.title = entry_id
     entry.state = state
     entry.runtime_data = runtime_data
@@ -369,6 +376,39 @@ async def test_explicit_config_entry_id_targets_single_coordinator():
     assert result["count"] == 1
     assert "e1" in result["entries"]
     assert "e2" not in result["entries"]
+
+
+@pytest.mark.asyncio
+async def test_entry_key_contract_locked_for_healthy_and_degraded():
+    """Every entry — healthy or degraded — has exactly the same six keys:
+    ``config_entry_id``, ``name``, ``cover_type``, ``last_update_success``,
+    ``last_update_success_time``, ``diagnostics``. Locked against a literal set
+    rather than comparing the two branches' key sets against each other (which
+    would only prove they agree, not that the contract itself holds) — a
+    seventh key added to the healthy entry with the degraded block forgotten
+    would otherwise go unnoticed with the suite green (issue #1059 audit round
+    4, N4 — mirrors the six-key lock in
+    ``tests/test_troubleshoot_service.py::test_one_bad_entry_does_not_blank_the_others``).
+    """
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    profile_entry = _make_unresolvable_entry(
+        "profile-1", ConfigEntryState.LOADED, runtime_data=None
+    )
+    hass = _make_multi_entry_hass(good, profile_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "profile-1"]})
+
+    result = await async_handle_get_diagnostics(call)
+
+    six_key_contract = {
+        "config_entry_id",
+        "name",
+        "cover_type",
+        "last_update_success",
+        "last_update_success_time",
+        "diagnostics",
+    }
+    assert set(result["entries"]["good-1"].keys()) == six_key_contract
+    assert set(result["entries"]["profile-1"].keys()) == six_key_contract
 
 
 def test_translations_contain_get_diagnostics_key():

--- a/tests/test_get_diagnostics_service.py
+++ b/tests/test_get_diagnostics_service.py
@@ -167,6 +167,38 @@ async def test_group_config_entry_id_raises_service_validation_error():
 
 
 @pytest.mark.asyncio
+async def test_building_profile_config_entry_id_raises_service_validation_error():
+    """Explicitly targeting a Building Profile's config_entry_id raises
+    ``ServiceValidationError`` instead of silently resolving to no entries
+    (issue #1059 audit, finding #3).
+
+    A Building Profile is a virtual config entry: ``async_setup_entry``
+    returns early for it (``not policy.controls_cover``) without ever setting
+    ``entry.runtime_data``, so it is absent from BOTH ``cover_coordinators``
+    AND ``loaded_coordinators`` — unlike a cover group, which sets
+    ``runtime_data`` to a ``GroupCoordinator`` and is only filtered out of the
+    former. Before this fix, ``_resolve_by_config_entry`` had no branch
+    covering this case and silently dropped the entry from the response.
+    """
+    from homeassistant.exceptions import ServiceValidationError
+
+    entry = MagicMock()
+    entry.entry_id = "profile-1"
+    entry.runtime_data = None  # never set, per async_setup_entry for a profile
+    entry.state = ConfigEntryState.LOADED
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+    hass.config_entries.async_get_entry.return_value = MagicMock(
+        domain=DOMAIN, entry_id="profile-1"
+    )
+    call = make_call(hass, data={"config_entry_id": ["profile-1"]})
+
+    with pytest.raises(ServiceValidationError):
+        await async_handle_get_diagnostics(call)
+
+
+@pytest.mark.asyncio
 async def test_sanitizer_handles_numpy_datetime_enum_dataclass():
     """Diagnostics containing numpy scalars, datetimes, enums, and dataclasses are JSON-serializable."""
     try:

--- a/tests/test_get_diagnostics_service.py
+++ b/tests/test_get_diagnostics_service.py
@@ -131,68 +131,149 @@ async def test_unknown_explicit_entry_raises():
         await async_handle_get_diagnostics(call)
 
 
+def _make_unresolvable_entry(entry_id, state, runtime_data=None):
+    """Build a MagicMock ``ConfigEntry`` for an id that must NOT resolve to a
+    cover coordinator — used by the three degrade-not-raise cases below.
+    """
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.domain = DOMAIN
+    entry.title = entry_id
+    entry.state = state
+    entry.runtime_data = runtime_data
+    return entry
+
+
+def _make_multi_entry_hass(good_coord, *unresolvable_entries):
+    """Build a hass whose ``config_entries`` roster mixes one real cover
+    coordinator with one or more unresolvable entries (issue #1059 audit
+    round 3, defect #1: multiple entries in one explicit ``config_entry_id``
+    call — a single unresolvable one must not sink the others).
+    """
+    good_entry = MagicMock()
+    good_entry.entry_id = good_coord.config_entry.entry_id
+    good_entry.domain = DOMAIN
+    good_entry.title = good_coord.config_entry.data.get("name")
+    good_entry.runtime_data = good_coord
+    good_entry.state = ConfigEntryState.LOADED
+
+    all_entries = [good_entry, *unresolvable_entries]
+    by_id = {entry.entry_id: entry for entry in all_entries}
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=all_entries)
+    hass.config_entries.async_get_entry.side_effect = lambda eid: by_id.get(eid)
+    return hass
+
+
 @pytest.mark.asyncio
-async def test_group_config_entry_id_raises_service_validation_error():
-    """Explicitly targeting a cover group's config_entry_id raises a clear
-    ServiceValidationError instead of an AttributeError from ``coord.data.diagnostics``
-    (issue #1059, finding #1). ``_resolve_by_config_entry`` must resolve through
+async def test_group_config_entry_id_degrades_instead_of_raising():
+    """Explicitly targeting a cover group's config_entry_id degrades to a
+    per-entry error entry instead of raising ``ServiceValidationError`` for
+    the WHOLE call — and the other explicitly-targeted, resolvable entry in
+    the same call still comes back (issue #1059 audit round 3, defect #1: an
+    ``else: raise`` here previously made an explicit multi-entry call
+    all-or-nothing). ``_resolve_by_config_entry`` must resolve through
     ``cover_coordinators`` (which filters out groups/building profiles) rather
     than ``loaded_coordinators`` (which does not) — a ``GroupCoordinator``'s
     ``.data`` is ``GroupAggregates``, which has no ``diagnostics`` attribute.
     """
-    from homeassistant.exceptions import ServiceValidationError
-
     from custom_components.adaptive_cover_pro.group_coordinator import (
         GroupCoordinator,
     )
 
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
     group_coord = MagicMock()
     group_coord.__class__ = GroupCoordinator  # isinstance(..., GroupCoordinator) → True
     group_coord.config_entry.entry_id = "group-1"
-
-    entry = MagicMock()
-    entry.entry_id = "group-1"
-    entry.runtime_data = group_coord
-    entry.state = ConfigEntryState.LOADED
-
-    hass = MagicMock()
-    hass.config_entries.async_entries = MagicMock(return_value=[entry])
-    hass.config_entries.async_get_entry.return_value = MagicMock(
-        domain=DOMAIN, entry_id="group-1"
+    group_entry = _make_unresolvable_entry(
+        "group-1", ConfigEntryState.LOADED, runtime_data=group_coord
     )
-    call = make_call(hass, data={"config_entry_id": ["group-1"]})
+    hass = _make_multi_entry_hass(good, group_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "group-1"]})
 
-    with pytest.raises(ServiceValidationError):
-        await async_handle_get_diagnostics(call)
+    result = await async_handle_get_diagnostics(call)
+
+    assert result["count"] == 2
+    assert "error" not in result["entries"]["good-1"]["diagnostics"]
+    group_result = result["entries"]["group-1"]
+    assert group_result["config_entry_id"] == "group-1"
+    assert group_result["diagnostics"]["error"]
+    assert "cover group" in group_result["diagnostics"]["error"].lower()
 
 
 @pytest.mark.asyncio
-async def test_building_profile_config_entry_id_raises_service_validation_error():
-    """Explicitly targeting a Building Profile's config_entry_id raises
-    ``ServiceValidationError`` instead of silently resolving to no entries
-    (issue #1059 audit, finding #3).
+async def test_building_profile_config_entry_id_degrades_instead_of_raising():
+    """Explicitly targeting a Building Profile's config_entry_id degrades to a
+    per-entry error entry instead of raising (issue #1059 audit round 3,
+    defect #1) — and the other explicitly-targeted, resolvable entry in the
+    same call still comes back.
 
     A Building Profile is a virtual config entry: ``async_setup_entry``
     returns early for it (``not policy.controls_cover``) without ever setting
     ``entry.runtime_data``, so it is absent from BOTH ``cover_coordinators``
     AND ``loaded_coordinators`` — unlike a cover group, which sets
     ``runtime_data`` to a ``GroupCoordinator`` and is only filtered out of the
-    former. Before this fix, ``_resolve_by_config_entry`` had no branch
-    covering this case and silently dropped the entry from the response.
+    former.
+    """
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    profile_entry = _make_unresolvable_entry(
+        "profile-1", ConfigEntryState.LOADED, runtime_data=None
+    )
+    hass = _make_multi_entry_hass(good, profile_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "profile-1"]})
+
+    result = await async_handle_get_diagnostics(call)
+
+    assert result["count"] == 2
+    assert "error" not in result["entries"]["good-1"]["diagnostics"]
+    profile_result = result["entries"]["profile-1"]
+    assert profile_result["config_entry_id"] == "profile-1"
+    assert profile_result["diagnostics"]["error"]
+    assert "building profile" in profile_result["diagnostics"]["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_not_loaded_config_entry_id_degrades_instead_of_raising():
+    """Explicitly targeting a config entry that is mid-reload / ``SETUP_RETRY``
+    / disabled (state is not ``LOADED``) degrades to a per-entry error entry
+    instead of raising — and the other explicitly-targeted, resolvable entry
+    in the same call still comes back (issue #1059 audit round 3, defect #1:
+    the widened ``else: raise`` regressed exactly this case, which shipped
+    working on ``develop`` — a single mid-reload instance used to zero the
+    whole multi-entry response; ``get_diagnostics`` must be no worse than
+    ``develop`` here).
+    """
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    retry_entry = _make_unresolvable_entry(
+        "retry-1", ConfigEntryState.SETUP_RETRY, runtime_data=None
+    )
+    hass = _make_multi_entry_hass(good, retry_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "retry-1"]})
+
+    result = await async_handle_get_diagnostics(call)
+
+    assert result["count"] == 2
+    assert "error" not in result["entries"]["good-1"]["diagnostics"]
+    retry_result = result["entries"]["retry-1"]
+    assert retry_result["config_entry_id"] == "retry-1"
+    assert "not currently loaded" in retry_result["diagnostics"]["error"].lower()
+    assert "setup_retry" in retry_result["diagnostics"]["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_explicit_entry_still_raises_alongside_other_entries():
+    """An id that is not an ACP config entry at all (typo, wrong integration,
+    nonexistent) is a genuine caller error with no instance to attach a
+    degraded entry to — it still raises ``ServiceValidationError`` immediately,
+    unlike the three degrade-not-raise cases above (issue #1059 audit round 3,
+    defect #1 design decision).
     """
     from homeassistant.exceptions import ServiceValidationError
 
-    entry = MagicMock()
-    entry.entry_id = "profile-1"
-    entry.runtime_data = None  # never set, per async_setup_entry for a profile
-    entry.state = ConfigEntryState.LOADED
-
-    hass = MagicMock()
-    hass.config_entries.async_entries = MagicMock(return_value=[entry])
-    hass.config_entries.async_get_entry.return_value = MagicMock(
-        domain=DOMAIN, entry_id="profile-1"
-    )
-    call = make_call(hass, data={"config_entry_id": ["profile-1"]})
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    hass = _make_multi_entry_hass(good)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "nonexistent-id"]})
 
     with pytest.raises(ServiceValidationError):
         await async_handle_get_diagnostics(call)

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -50,6 +50,19 @@ def test_set_blind_spot_service_description_mentions_window_normal():
     assert "window normal" in desc
 
 
+def test_get_diagnostics_and_get_troubleshooting_config_entry_id_descriptions_match():
+    """Both services expose the identical config_entry_id escape hatch — the
+    field description must read identically in the action picker rather than
+    presenting two texts for the same thing (issue #1059 audit round 3, nit #5).
+    """
+    services = _load()
+    diag_desc = services["get_diagnostics"]["fields"]["config_entry_id"]["description"]
+    troubleshoot_desc = services["get_troubleshooting"]["fields"]["config_entry_id"][
+        "description"
+    ]
+    assert diag_desc == troubleshoot_desc
+
+
 def test_set_blind_spot_en_json_fields_match_services_yaml():
     """en.json set_blind_spot.fields must document exactly the yaml fields.
 

--- a/tests/test_services_yaml_docs.py
+++ b/tests/test_services_yaml_docs.py
@@ -162,6 +162,7 @@ def test_set_position_has_position_field_with_correct_range():
 REGISTERED_SERVICES = {
     "export_config",
     "get_diagnostics",
+    "get_troubleshooting",
     "integration_enable",
     "integration_disable",
     "emergency_stop",

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -658,6 +658,25 @@ def test_service_field_descriptions_icu_safe(lang_file: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("lang_file", TRANSLATION_FILES, ids=LANGUAGE_CODES)
+def test_get_diagnostics_and_get_troubleshooting_config_entry_id_descriptions_match(
+    lang_file: Path,
+) -> None:
+    """get_diagnostics and get_troubleshooting expose the identical
+    config_entry_id escape hatch, so the action picker must show one text for
+    it, not two (issue #1059 audit round 3, nit #5).
+    """
+    services = _load(lang_file)["services"]
+    diag_desc = services["get_diagnostics"]["fields"]["config_entry_id"]["description"]
+    troubleshoot_desc = services["get_troubleshooting"]["fields"]["config_entry_id"][
+        "description"
+    ]
+    assert diag_desc == troubleshoot_desc, (
+        f"{lang_file.name}: get_diagnostics and get_troubleshooting "
+        "config_entry_id descriptions must be identical"
+    )
+
+
 @pytest.mark.unit
 def test_manual_override_duration_mode_options_translated_in_en():
     """All five duration-mode values need a non-empty English selector label (#1044)."""

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -1434,12 +1434,15 @@ def test_rule_wiki_points_at_canonical_findings_page(rule) -> None:
     assert rule.wiki == f"Troubleshooting-Findings#{_canonical_anchor(rule.code)}"
 
 
-@pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
-def test_wiki_anchor_for_returns_rule_wiki(rule) -> None:
+def test_wiki_anchor_for_agrees_with_every_rule_wiki() -> None:
     # The single-source-of-truth accessor (issue #1059) must agree with the
     # rule table itself for every code — the same map ``scripts/triage_json.py``
-    # and the ``get_troubleshooting`` service both point at.
-    assert wiki_anchor_for(rule.code) == rule.wiki
+    # and the ``get_troubleshooting`` service both point at. A single loop
+    # (rather than 27 parametrized cases against a `dict.get` built from this
+    # very table) is enough signal — a mismatch names the offending code in
+    # the assertion message.
+    for rule in TRIAGE_RULES:
+        assert wiki_anchor_for(rule.code) == rule.wiki, rule.code
 
 
 def test_wiki_anchor_for_unknown_code_returns_none() -> None:

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -21,6 +21,7 @@ from custom_components.adaptive_cover_pro.diagnostics.triage import (
     RuleInput,
     Severity,
     run_triage,
+    wiki_anchor_for,
 )
 from custom_components.adaptive_cover_pro.reason_i18n import Reason, render
 from custom_components.adaptive_cover_pro.troubleshoot_i18n import (
@@ -1431,6 +1432,18 @@ def test_rule_wiki_points_at_canonical_findings_page(rule) -> None:
     # per-code anchor (the deliverable-D contract), not a scattering of config
     # pages with dangling anchors.
     assert rule.wiki == f"Troubleshooting-Findings#{_canonical_anchor(rule.code)}"
+
+
+@pytest.mark.parametrize("rule", TRIAGE_RULES, ids=lambda r: r.code)
+def test_wiki_anchor_for_returns_rule_wiki(rule) -> None:
+    # The single-source-of-truth accessor (issue #1059) must agree with the
+    # rule table itself for every code — the same map ``scripts/triage_json.py``
+    # and the ``get_troubleshooting`` service both point at.
+    assert wiki_anchor_for(rule.code) == rule.wiki
+
+
+def test_wiki_anchor_for_unknown_code_returns_none() -> None:
+    assert wiki_anchor_for("triage.not_a_real_code") is None
 
 
 def _find_wiki_checkout() -> Path | None:

--- a/tests/test_troubleshoot_service.py
+++ b/tests/test_troubleshoot_service.py
@@ -153,14 +153,21 @@ async def test_unknown_explicit_entry_raises():
         await async_handle_get_troubleshooting(call)
 
 
-def _make_unresolvable_entry(entry_id, title, state, runtime_data=None):
+def _make_unresolvable_entry(entry_id, name, state, runtime_data=None):
     """Build a MagicMock ``ConfigEntry`` for an id that must NOT resolve to a
     cover coordinator — used by the three degrade-not-raise cases below.
+
+    ``title`` is deliberately type-prefixed and different from ``data["name"]``
+    — mirroring how ``config_flow.py`` builds every real entry
+    (``title=f"{cover_type_label} {name}"``, ``data["name"]=name``) — so a
+    degraded entry's reported ``"name"`` can only match ``name`` if it is read
+    from ``data["name"]``, not ``title`` (issue #1059 audit round 4, N2).
     """
     entry = MagicMock()
     entry.entry_id = entry_id
     entry.domain = DOMAIN
-    entry.title = title
+    entry.data = {"name": name}
+    entry.title = f"Some Cover Type {name}"
     entry.state = state
     entry.runtime_data = runtime_data
     return entry

--- a/tests/test_troubleshoot_service.py
+++ b/tests/test_troubleshoot_service.py
@@ -153,68 +153,209 @@ async def test_unknown_explicit_entry_raises():
         await async_handle_get_troubleshooting(call)
 
 
+def _make_unresolvable_entry(entry_id, title, state, runtime_data=None):
+    """Build a MagicMock ``ConfigEntry`` for an id that must NOT resolve to a
+    cover coordinator — used by the three degrade-not-raise cases below.
+    """
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.domain = DOMAIN
+    entry.title = title
+    entry.state = state
+    entry.runtime_data = runtime_data
+    return entry
+
+
+def _make_multi_entry_hass(good_coord, *unresolvable_entries):
+    """Build a hass whose ``config_entries`` roster mixes one real cover
+    coordinator with one or more unresolvable entries (issue #1059 audit
+    round 3, defect #1: multiple entries in one explicit ``config_entry_id``
+    call — a single unresolvable one must not sink the others).
+    """
+    good_entry = MagicMock()
+    good_entry.entry_id = good_coord.config_entry.entry_id
+    good_entry.domain = DOMAIN
+    good_entry.title = good_coord.config_entry.data.get("name")
+    good_entry.runtime_data = good_coord
+    good_entry.state = ConfigEntryState.LOADED
+
+    all_entries = [good_entry, *unresolvable_entries]
+    by_id = {entry.entry_id: entry for entry in all_entries}
+
+    hass = MagicMock()
+    hass.config.language = "en"
+    hass.config_entries.async_entries = MagicMock(return_value=all_entries)
+    hass.config_entries.async_get_entry.side_effect = lambda eid: by_id.get(eid)
+
+    async def _run_executor(func, *args):
+        return func(*args)
+
+    hass.async_add_executor_job = _run_executor
+    return hass
+
+
 @pytest.mark.asyncio
-async def test_group_config_entry_id_raises_service_validation_error():
-    """Explicitly targeting a cover group's config_entry_id raises a clear
-    ServiceValidationError instead of an AttributeError from ``coord.data.diagnostics``
-    (issue #1059, finding #1). ``_resolve_by_config_entry`` must resolve through
+async def test_group_config_entry_id_degrades_instead_of_raising():
+    """Explicitly targeting a cover group's config_entry_id degrades to a
+    per-entry error entry instead of raising ``ServiceValidationError`` for
+    the WHOLE call — and the other explicitly-targeted, resolvable entry in
+    the same call still comes back (issue #1059 audit round 3, defect #1: an
+    ``else: raise`` here previously made an explicit multi-entry call
+    all-or-nothing). ``_resolve_by_config_entry`` must resolve through
     ``cover_coordinators`` (which filters out groups/building profiles) rather
     than ``loaded_coordinators`` (which does not) — a ``GroupCoordinator``'s
     ``.data`` is ``GroupAggregates``, which has no ``diagnostics`` attribute.
     """
-    from homeassistant.exceptions import ServiceValidationError
-
     from custom_components.adaptive_cover_pro.group_coordinator import (
         GroupCoordinator,
     )
 
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
     group_coord = MagicMock()
     group_coord.__class__ = GroupCoordinator  # isinstance(..., GroupCoordinator) → True
     group_coord.config_entry.entry_id = "group-1"
-
-    entry = MagicMock()
-    entry.entry_id = "group-1"
-    entry.runtime_data = group_coord
-    entry.state = ConfigEntryState.LOADED
-
-    hass = MagicMock()
-    hass.config_entries.async_entries = MagicMock(return_value=[entry])
-    hass.config_entries.async_get_entry.return_value = MagicMock(
-        domain=DOMAIN, entry_id="group-1"
+    group_entry = _make_unresolvable_entry(
+        "group-1", "Group Cover", ConfigEntryState.LOADED, runtime_data=group_coord
     )
-    call = make_call(hass, data={"config_entry_id": ["group-1"]})
+    hass = _make_multi_entry_hass(good, group_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "group-1"]})
 
-    with pytest.raises(ServiceValidationError):
-        await async_handle_get_troubleshooting(call)
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 2
+    assert result["entries"]["good-1"]["error"] is None
+    group_result = result["entries"]["group-1"]
+    assert group_result["config_entry_id"] == "group-1"
+    assert group_result["name"] == "Group Cover"
+    assert group_result["source"] == "error"
+    assert group_result["findings"] == []
+    assert "cover group" in group_result["error"].lower()
+    assert "cover group" in group_result["report"].lower()
 
 
 @pytest.mark.asyncio
-async def test_building_profile_config_entry_id_raises_service_validation_error():
-    """Explicitly targeting a Building Profile's config_entry_id raises
-    ``ServiceValidationError`` instead of silently resolving to no entries
-    (issue #1059 audit, finding #3).
+async def test_building_profile_config_entry_id_degrades_instead_of_raising():
+    """Explicitly targeting a Building Profile's config_entry_id degrades to a
+    per-entry error entry instead of raising (issue #1059 audit round 3,
+    defect #1) — and the other explicitly-targeted, resolvable entry in the
+    same call still comes back.
 
     A Building Profile is a virtual config entry: ``async_setup_entry``
     returns early for it (``not policy.controls_cover``) without ever setting
     ``entry.runtime_data``, so it is absent from BOTH ``cover_coordinators``
     AND ``loaded_coordinators`` — unlike a cover group, which sets
     ``runtime_data`` to a ``GroupCoordinator`` and is only filtered out of the
-    former. Before this fix, ``_resolve_by_config_entry`` had no branch
-    covering this case and silently dropped the entry from the response.
+    former.
+    """
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    profile_entry = _make_unresolvable_entry(
+        "profile-1", "Profile Cover", ConfigEntryState.LOADED, runtime_data=None
+    )
+    hass = _make_multi_entry_hass(good, profile_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "profile-1"]})
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 2
+    assert result["entries"]["good-1"]["error"] is None
+    profile_result = result["entries"]["profile-1"]
+    assert profile_result["config_entry_id"] == "profile-1"
+    assert profile_result["name"] == "Profile Cover"
+    assert profile_result["source"] == "error"
+    assert profile_result["findings"] == []
+    assert "building profile" in profile_result["error"].lower()
+    assert "building profile" in profile_result["report"].lower()
+
+
+@pytest.mark.asyncio
+async def test_not_loaded_config_entry_id_degrades_instead_of_raising():
+    """Explicitly targeting a config entry that is mid-reload / ``SETUP_RETRY``
+    / disabled (state is not ``LOADED``) degrades to a per-entry error entry
+    instead of raising — and the other explicitly-targeted, resolvable entry
+    in the same call still comes back (issue #1059 audit round 3, defect #1:
+    the widened ``else: raise`` regressed exactly this case, which shipped
+    working on ``develop`` — a single mid-reload instance used to zero the
+    whole multi-entry response).
+    """
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    retry_entry = _make_unresolvable_entry(
+        "retry-1", "Retry Cover", ConfigEntryState.SETUP_RETRY, runtime_data=None
+    )
+    hass = _make_multi_entry_hass(good, retry_entry)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "retry-1"]})
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 2
+    assert result["entries"]["good-1"]["error"] is None
+    retry_result = result["entries"]["retry-1"]
+    assert retry_result["config_entry_id"] == "retry-1"
+    assert retry_result["name"] == "Retry Cover"
+    assert retry_result["source"] == "error"
+    assert retry_result["findings"] == []
+    assert "not currently loaded" in retry_result["error"].lower()
+    assert "setup_retry" in retry_result["error"].lower()
+    assert "not currently loaded" in retry_result["report"].lower()
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_config_entry_reasons_are_distinguishable_per_case():
+    """The three ways an explicit ``config_entry_id`` can fail to resolve to a
+    cover coordinator — cover group, Building Profile, not currently loaded —
+    must each carry their own accurate, distinguishable reason text, not one
+    generic message (issue #1059 audit round 3, defect #1 design requirement).
+    """
+    from custom_components.adaptive_cover_pro.group_coordinator import (
+        GroupCoordinator,
+    )
+
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+
+    group_coord = MagicMock()
+    group_coord.__class__ = GroupCoordinator
+    group_coord.config_entry.entry_id = "group-1"
+    group_entry = _make_unresolvable_entry(
+        "group-1", "Group Cover", ConfigEntryState.LOADED, runtime_data=group_coord
+    )
+    profile_entry = _make_unresolvable_entry(
+        "profile-1", "Profile Cover", ConfigEntryState.LOADED, runtime_data=None
+    )
+    retry_entry = _make_unresolvable_entry(
+        "retry-1", "Retry Cover", ConfigEntryState.SETUP_RETRY, runtime_data=None
+    )
+    hass = _make_multi_entry_hass(good, group_entry, profile_entry, retry_entry)
+    call = make_call(
+        hass, data={"config_entry_id": ["good-1", "group-1", "profile-1", "retry-1"]}
+    )
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 4
+    reasons = {
+        entry_id: result["entries"][entry_id]["error"]
+        for entry_id in ("group-1", "profile-1", "retry-1")
+    }
+    # All three reasons are distinct strings...
+    assert len(set(reasons.values())) == 3
+    # ...and each names its own specific case accurately.
+    assert "cover group" in reasons["group-1"].lower()
+    assert "building profile" in reasons["profile-1"].lower()
+    assert "not currently loaded" in reasons["retry-1"].lower()
+
+
+@pytest.mark.asyncio
+async def test_unknown_explicit_entry_still_raises_alongside_other_entries():
+    """An id that is not an ACP config entry at all (typo, wrong integration,
+    nonexistent) is a genuine caller error with no instance to attach a
+    degraded entry to — it still raises ``ServiceValidationError`` immediately,
+    unlike the three degrade-not-raise cases above (issue #1059 audit round 3,
+    defect #1 design decision).
     """
     from homeassistant.exceptions import ServiceValidationError
 
-    entry = MagicMock()
-    entry.entry_id = "profile-1"
-    entry.runtime_data = None  # never set, per async_setup_entry for a profile
-    entry.state = ConfigEntryState.LOADED
-
-    hass = MagicMock()
-    hass.config_entries.async_entries = MagicMock(return_value=[entry])
-    hass.config_entries.async_get_entry.return_value = MagicMock(
-        domain=DOMAIN, entry_id="profile-1"
-    )
-    call = make_call(hass, data={"config_entry_id": ["profile-1"]})
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    hass = _make_multi_entry_hass(good)
+    call = make_call(hass, data={"config_entry_id": ["good-1", "nonexistent-id"]})
 
     with pytest.raises(ServiceValidationError):
         await async_handle_get_troubleshooting(call)
@@ -274,8 +415,21 @@ async def test_one_bad_entry_does_not_blank_the_others():
     assert "Troubleshooting could not run" in bad_entry["report"]
     assert "error" in bad_entry
     assert "troubleshoot_unavailable" in bad_entry["error"]
-    # Every entry has the same key set, whichever branch produced it.
-    assert set(good_entry.keys()) == set(bad_entry.keys())
+    # Every entry has exactly the documented six-key contract, whichever
+    # branch produced it — locked against a literal so dropping a key from
+    # BOTH branches in lockstep can't slip through (issue #1059 audit round
+    # 3, nit #7: comparing the two branches' key sets against each other only
+    # proves they agree, not that the contract itself holds).
+    six_key_contract = {
+        "config_entry_id",
+        "name",
+        "source",
+        "report",
+        "findings",
+        "error",
+    }
+    assert set(good_entry.keys()) == six_key_contract
+    assert set(bad_entry.keys()) == six_key_contract
 
 
 @pytest.mark.asyncio
@@ -325,11 +479,18 @@ async def test_response_is_json_serializable_in_every_shape():
     every shape the service can produce: a fully healthy entry, a
     degraded-by-exception entry (``source == "error"``), and a
     degraded-by-read-error entry (``source == "unavailable"``) — issue #1059
-    audit findings #1/#2. Uses ``homeassistant.helpers.json.json_dumps``, the
-    same serializer the websocket API uses, rather than the stdlib ``json``
-    module.
+    audit findings #1/#2.
+
+    Uses the stdlib ``json`` module deliberately, NOT
+    ``homeassistant.helpers.json.json_dumps`` (issue #1059 audit round 3,
+    defect #2): HA's serializer is orjson-backed and serializes a raw
+    ``enum.Enum`` natively, so it would pass even if ``_finding_to_dict``
+    forgot ``.value`` and put a raw ``Severity`` member into the response —
+    exactly the invariant this test exists to protect. Stdlib ``json`` is
+    strict and raises ``TypeError`` on a raw ``Enum``, so it actually catches
+    that regression.
     """
-    from homeassistant.helpers.json import json_dumps
+    import json
 
     healthy = make_coordinator(
         entry_id="healthy-1", diagnostics={"debug_config": {"dry_run": True}}
@@ -347,7 +508,7 @@ async def test_response_is_json_serializable_in_every_shape():
     assert result["entries"]["unavailable-1"]["source"] == "unavailable"
     assert result["entries"]["errored-1"]["source"] == "error"
 
-    serialized = json_dumps(result)
+    serialized = json.dumps(result)
     assert isinstance(serialized, str)
 
 

--- a/tests/test_troubleshoot_service.py
+++ b/tests/test_troubleshoot_service.py
@@ -1,0 +1,189 @@
+"""Tests for the get_troubleshooting service (issue #1059)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+
+from custom_components.adaptive_cover_pro.const import DOMAIN, CoverType
+from custom_components.adaptive_cover_pro.services.troubleshoot_service import (
+    async_handle_get_troubleshooting,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_coordinator(
+    entry_id="entry-1",
+    name="Test Cover",
+    cover_type=CoverType.BLIND,
+    options=None,
+    diagnostics=None,
+):
+    coord = MagicMock()
+    coord.config_entry.entry_id = entry_id
+    coord.config_entry.data = {"name": name, "sensor_type": cover_type}
+    coord.config_entry.options = options if options is not None else {}
+    coord.config_entry.domain = DOMAIN
+    coord.entities = [f"cover.{name.lower().replace(' ', '_')}"]
+    coord.data = MagicMock()
+    coord.data.diagnostics = {} if diagnostics is None else diagnostics
+    return coord
+
+
+def make_hass(*coordinators, language="en"):
+    hass = MagicMock()
+    hass.config.language = language
+    entries = []
+    for coord in coordinators:
+        entry = MagicMock()
+        entry.entry_id = coord.config_entry.entry_id
+        entry.runtime_data = coord
+        entry.state = ConfigEntryState.LOADED
+        entries.append(entry)
+    hass.config_entries.async_entries = MagicMock(return_value=entries)
+    hass.config_entries.async_get_entry.side_effect = lambda eid: next(
+        (
+            MagicMock(domain=DOMAIN, entry_id=eid)
+            for coord in coordinators
+            if coord.config_entry.entry_id == eid
+        ),
+        None,
+    )
+
+    async def _run_executor(func, *args):
+        return func(*args)
+
+    hass.async_add_executor_job = _run_executor
+    return hass
+
+
+def make_call(hass, data=None):
+    call = MagicMock()
+    call.hass = hass
+    call.data = data or {}
+    return call
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_versioned_envelope():
+    """Response always has version, generated_at, count, entries."""
+    coord = make_coordinator()
+    hass = make_hass(coord)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["version"] == 1
+    assert "generated_at" in result
+    assert "count" in result
+    assert "entries" in result
+
+
+@pytest.mark.asyncio
+async def test_entry_keyed_by_config_entry_id():
+    """Single coordinator -> one entry keyed by its config entry ID."""
+    coord = make_coordinator(entry_id="abc-123")
+    hass = make_hass(coord)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 1
+    assert "abc-123" in result["entries"]
+    assert result["entries"]["abc-123"]["config_entry_id"] == "abc-123"
+    assert result["entries"]["abc-123"]["name"] == "Test Cover"
+
+
+@pytest.mark.asyncio
+async def test_findings_include_code_severity_fix_step_wiki_message():
+    """A firing rule renders a fully-shaped finding dict."""
+    coord = make_coordinator(diagnostics={"debug_config": {"dry_run": True}})
+    hass = make_hass(coord)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    findings = result["entries"]["entry-1"]["findings"]
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding["code"] == "triage.dry_run_left_on"
+    assert isinstance(finding["params"], dict)
+    assert finding["severity"] == "warning"
+    assert isinstance(finding["severity"], str)
+    assert finding["fix_step"] == "debug"
+    assert finding["wiki"] == "Troubleshooting-Findings#dry-run-left-on"
+    assert "Dry-run mode is on" in finding["message"]
+
+
+@pytest.mark.asyncio
+async def test_no_findings_returns_empty_list_and_no_issues_report():
+    """No findings -> empty findings list and the "all good" report text."""
+    coord = make_coordinator()
+    hass = make_hass(coord)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    entry = result["entries"]["entry-1"]
+    assert entry["findings"] == []
+    assert "No configuration or runtime issues detected" in entry["report"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_explicit_entry_raises():
+    """Explicit config_entry_id that doesn't exist raises ServiceValidationError."""
+    from homeassistant.exceptions import ServiceValidationError
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[])
+    hass.config_entries.async_get_entry.return_value = None
+    call = make_call(hass, data={"config_entry_id": ["nonexistent-id"]})
+
+    with pytest.raises(ServiceValidationError):
+        await async_handle_get_troubleshooting(call)
+
+
+@pytest.mark.asyncio
+async def test_explicit_config_entry_id_targets_single_coordinator():
+    """config_entry_id field bypasses entity/device target resolution."""
+    coord1 = make_coordinator(entry_id="e1", name="North")
+    coord2 = make_coordinator(entry_id="e2", name="South")
+    hass = make_hass(coord1, coord2)
+    hass.config_entries.async_get_entry.side_effect = lambda eid: (
+        MagicMock(domain=DOMAIN, entry_id=eid) if eid == "e1" else None
+    )
+    call = make_call(hass, data={"config_entry_id": ["e1"]})
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 1
+    assert "e1" in result["entries"]
+    assert "e2" not in result["entries"]
+
+
+def test_translations_contain_get_troubleshooting_key():
+    """en.json, de.json, and fr.json all contain the services.get_troubleshooting key."""
+    import json
+    from pathlib import Path
+
+    translations_dir = (
+        Path(__file__).parent.parent
+        / "custom_components"
+        / "adaptive_cover_pro"
+        / "translations"
+    )
+    for lang in ("en", "de", "fr"):
+        data = json.loads((translations_dir / f"{lang}.json").read_text())
+        assert "get_troubleshooting" in data.get(
+            "services", {}
+        ), f"{lang}.json missing services.get_troubleshooting"

--- a/tests/test_troubleshoot_service.py
+++ b/tests/test_troubleshoot_service.py
@@ -189,6 +189,38 @@ async def test_group_config_entry_id_raises_service_validation_error():
 
 
 @pytest.mark.asyncio
+async def test_building_profile_config_entry_id_raises_service_validation_error():
+    """Explicitly targeting a Building Profile's config_entry_id raises
+    ``ServiceValidationError`` instead of silently resolving to no entries
+    (issue #1059 audit, finding #3).
+
+    A Building Profile is a virtual config entry: ``async_setup_entry``
+    returns early for it (``not policy.controls_cover``) without ever setting
+    ``entry.runtime_data``, so it is absent from BOTH ``cover_coordinators``
+    AND ``loaded_coordinators`` — unlike a cover group, which sets
+    ``runtime_data`` to a ``GroupCoordinator`` and is only filtered out of the
+    former. Before this fix, ``_resolve_by_config_entry`` had no branch
+    covering this case and silently dropped the entry from the response.
+    """
+    from homeassistant.exceptions import ServiceValidationError
+
+    entry = MagicMock()
+    entry.entry_id = "profile-1"
+    entry.runtime_data = None  # never set, per async_setup_entry for a profile
+    entry.state = ConfigEntryState.LOADED
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+    hass.config_entries.async_get_entry.return_value = MagicMock(
+        domain=DOMAIN, entry_id="profile-1"
+    )
+    call = make_call(hass, data={"config_entry_id": ["profile-1"]})
+
+    with pytest.raises(ServiceValidationError):
+        await async_handle_get_troubleshooting(call)
+
+
+@pytest.mark.asyncio
 async def test_explicit_config_entry_id_targets_single_coordinator():
     """config_entry_id field bypasses entity/device target resolution."""
     coord1 = make_coordinator(entry_id="e1", name="North")
@@ -213,6 +245,13 @@ async def test_one_bad_entry_does_not_blank_the_others():
     other targeted coordinator still comes back, and the failing one degrades
     to an error entry rather than losing the whole response (issue #1059,
     finding #3).
+
+    Both entries share exactly one shape (issue #1059 audit, finding #1): every
+    key — ``config_entry_id``, ``name``, ``source``, ``report``, ``findings``,
+    ``error`` — is always present. The degraded entry's ``source`` is
+    ``"error"`` (nothing ran at all), distinct from ``"unavailable"`` (a
+    partial-but-valid CONFIG-only result) — finding #2's structural
+    discriminator.
     """
     good = make_coordinator(entry_id="good-1", name="Good Cover")
     bad = make_coordinator(
@@ -226,12 +265,17 @@ async def test_one_bad_entry_does_not_blank_the_others():
     assert result["count"] == 2
     good_entry = result["entries"]["good-1"]
     assert "findings" in good_entry
-    assert "error" not in good_entry
+    assert good_entry["error"] is None
     bad_entry = result["entries"]["bad-1"]
     assert bad_entry["config_entry_id"] == "bad-1"
     assert bad_entry["name"] == "Bad Cover"
+    assert bad_entry["source"] == "error"
+    assert bad_entry["findings"] == []
+    assert "Troubleshooting could not run" in bad_entry["report"]
     assert "error" in bad_entry
-    assert "findings" not in bad_entry
+    assert "troubleshoot_unavailable" in bad_entry["error"]
+    # Every entry has the same key set, whichever branch produced it.
+    assert set(good_entry.keys()) == set(bad_entry.keys())
 
 
 @pytest.mark.asyncio
@@ -248,7 +292,7 @@ async def test_missing_sensor_type_falls_back_to_blind_without_raising():
     result = await async_handle_get_troubleshooting(call)
 
     entry = result["entries"]["e1"]
-    assert "error" not in entry
+    assert entry["error"] is None
     assert entry["findings"] == []
 
 
@@ -273,6 +317,38 @@ async def test_read_error_is_surfaced_not_discarded():
     assert "error" in entry
     assert "diagnostics_unavailable" in entry["error"]
     assert "Diagnostics aren't available" in entry["report"]
+
+
+@pytest.mark.asyncio
+async def test_response_is_json_serializable_in_every_shape():
+    """The response crosses the HA websocket API, so it must be JSON-safe in
+    every shape the service can produce: a fully healthy entry, a
+    degraded-by-exception entry (``source == "error"``), and a
+    degraded-by-read-error entry (``source == "unavailable"``) — issue #1059
+    audit findings #1/#2. Uses ``homeassistant.helpers.json.json_dumps``, the
+    same serializer the websocket API uses, rather than the stdlib ``json``
+    module.
+    """
+    from homeassistant.helpers.json import json_dumps
+
+    healthy = make_coordinator(
+        entry_id="healthy-1", diagnostics={"debug_config": {"dry_run": True}}
+    )
+    unavailable = make_coordinator(entry_id="unavailable-1")
+    unavailable.data = None
+    unavailable.build_diagnostic_data.side_effect = RuntimeError("update in progress")
+    errored = make_coordinator(entry_id="errored-1", cover_type="not_a_real_cover_type")
+    hass = make_hass(healthy, unavailable, errored)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["entries"]["healthy-1"]["error"] is None
+    assert result["entries"]["unavailable-1"]["source"] == "unavailable"
+    assert result["entries"]["errored-1"]["source"] == "error"
+
+    serialized = json_dumps(result)
+    assert isinstance(serialized, str)
 
 
 def test_translations_contain_get_troubleshooting_key():

--- a/tests/test_troubleshoot_service.py
+++ b/tests/test_troubleshoot_service.py
@@ -154,6 +154,41 @@ async def test_unknown_explicit_entry_raises():
 
 
 @pytest.mark.asyncio
+async def test_group_config_entry_id_raises_service_validation_error():
+    """Explicitly targeting a cover group's config_entry_id raises a clear
+    ServiceValidationError instead of an AttributeError from ``coord.data.diagnostics``
+    (issue #1059, finding #1). ``_resolve_by_config_entry`` must resolve through
+    ``cover_coordinators`` (which filters out groups/building profiles) rather
+    than ``loaded_coordinators`` (which does not) — a ``GroupCoordinator``'s
+    ``.data`` is ``GroupAggregates``, which has no ``diagnostics`` attribute.
+    """
+    from homeassistant.exceptions import ServiceValidationError
+
+    from custom_components.adaptive_cover_pro.group_coordinator import (
+        GroupCoordinator,
+    )
+
+    group_coord = MagicMock()
+    group_coord.__class__ = GroupCoordinator  # isinstance(..., GroupCoordinator) → True
+    group_coord.config_entry.entry_id = "group-1"
+
+    entry = MagicMock()
+    entry.entry_id = "group-1"
+    entry.runtime_data = group_coord
+    entry.state = ConfigEntryState.LOADED
+
+    hass = MagicMock()
+    hass.config_entries.async_entries = MagicMock(return_value=[entry])
+    hass.config_entries.async_get_entry.return_value = MagicMock(
+        domain=DOMAIN, entry_id="group-1"
+    )
+    call = make_call(hass, data={"config_entry_id": ["group-1"]})
+
+    with pytest.raises(ServiceValidationError):
+        await async_handle_get_troubleshooting(call)
+
+
+@pytest.mark.asyncio
 async def test_explicit_config_entry_id_targets_single_coordinator():
     """config_entry_id field bypasses entity/device target resolution."""
     coord1 = make_coordinator(entry_id="e1", name="North")
@@ -169,6 +204,75 @@ async def test_explicit_config_entry_id_targets_single_coordinator():
     assert result["count"] == 1
     assert "e1" in result["entries"]
     assert "e2" not in result["entries"]
+
+
+@pytest.mark.asyncio
+async def test_one_bad_entry_does_not_blank_the_others():
+    """One coordinator has a corrupt ``sensor_type`` that ``get_policy`` can't
+    resolve (raises ``ValueError`` inside ``build_troubleshoot_result``) — the
+    other targeted coordinator still comes back, and the failing one degrades
+    to an error entry rather than losing the whole response (issue #1059,
+    finding #3).
+    """
+    good = make_coordinator(entry_id="good-1", name="Good Cover")
+    bad = make_coordinator(
+        entry_id="bad-1", name="Bad Cover", cover_type="not_a_real_cover_type"
+    )
+    hass = make_hass(good, bad)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    assert result["count"] == 2
+    good_entry = result["entries"]["good-1"]
+    assert "findings" in good_entry
+    assert "error" not in good_entry
+    bad_entry = result["entries"]["bad-1"]
+    assert bad_entry["config_entry_id"] == "bad-1"
+    assert bad_entry["name"] == "Bad Cover"
+    assert "error" in bad_entry
+    assert "findings" not in bad_entry
+
+
+@pytest.mark.asyncio
+async def test_missing_sensor_type_falls_back_to_blind_without_raising():
+    """A falsy ``sensor_type`` (group/orchestrator or not-yet-configured cover)
+    falls back to ``CoverType.BLIND`` — the same default the options flow uses
+    — instead of raising when ``get_policy(None)`` is called (issue #1059,
+    finding #3).
+    """
+    coord = make_coordinator(entry_id="e1", cover_type=None)
+    hass = make_hass(coord)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    entry = result["entries"]["e1"]
+    assert "error" not in entry
+    assert entry["findings"] == []
+
+
+@pytest.mark.asyncio
+async def test_read_error_is_surfaced_not_discarded():
+    """When ``read_from_coordinator`` reports an error (``coord.data`` is None
+    and a rebuild raises), the entry still gets a normal troubleshoot result
+    (CONFIG rules can still run against the empty payload) AND carries the raw
+    error string — mirroring ``get_diagnostics``'s existing ``read.error``
+    surfacing rather than silently discarding it (issue #1059, finding #3).
+    """
+    coord = make_coordinator(entry_id="e1")
+    coord.data = None
+    coord.build_diagnostic_data.side_effect = RuntimeError("update in progress")
+    hass = make_hass(coord)
+    call = make_call(hass)
+
+    result = await async_handle_get_troubleshooting(call)
+
+    entry = result["entries"]["e1"]
+    assert entry["source"] == "unavailable"
+    assert "error" in entry
+    assert "diagnostics_unavailable" in entry["error"]
+    assert "Diagnostics aren't available" in entry["report"]
 
 
 def test_translations_contain_get_troubleshooting_key():


### PR DESCRIPTION
## Summary

The triage engine already produced a full findings list, but the only way to see it was to open the options menu and click through to the Troubleshoot step. This adds `adaptive_cover_pro.get_troubleshooting` (`SupportsResponse.ONLY`) so the companion Lovelace card, automations, and offline triage can read the same list directly.

Rather than duplicate the step's logic, the view-build to `run_triage` to `render_report` sequence moved into `diagnostics/resolve.py::build_troubleshoot_result()`, which the options flow and the service now both call. Two smaller dedups came along with it: `wiki_anchor_for()` in `triage.py` replaces the copy of the rule-wiki map that `scripts/triage_json.py` was carrying, and the shared service schema, targeting preamble, and response envelope moved into `services/__init__.py`.

Each entry in the response carries `config_entry_id`, `name`, `source`, `report`, `findings`, and `error`. `source` discriminates the three cases so a consumer never has to parse the error text: a healthy read, a partial CONFIG-only result when diagnostics are not yet available, and a total failure. Findings carry the raw `code`, `params`, and `severity` alongside a rendered `message`, following the precedent set for the card in `sensor.py`.

## Behavior change to `get_diagnostics`

Naming a cover group's config entry used to crash with an `AttributeError` (a `GroupCoordinator` has no `.data.diagnostics`); naming a Building Profile or an unloaded entry returned nothing with no explanation. Both services now degrade those to a labeled per-entry error while the other targeted covers still come back, so `get_diagnostics` can emit an entry where it previously emitted none. The companion card calls this service, so it is worth a release-note line.

`_check_cover_capabilities` also moved from `config_flow.py` to `helpers.check_cover_capabilities`, which breaks the mutual dependency the extraction would otherwise have created between `diagnostics/` and `config_flow`.

## Testing

- ✅ 8952 tests passing

Four opus audit passes ran over the branch. The first found nine items, the second four, the third two defects plus five nits, and the fourth declared it converged with no defects remaining.

## Related Issues

Refs #1059
