### PR TITLE
fix: give the effective-default read one computation (#1055)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -38,9 +38,9 @@ from homeassistant.util import dt as dt_util
 
 from .config_types import CoverConfig, RuntimeConfig
 from .helpers import (
+    _read_current_effective_default,
     _read_sun_boundary_options,
     check_cover_features,
-    compute_effective_default,
     custom_position_slot_delivers_fixed_position,
     custom_position_slot_sensors,
     has_configured_window_end,
@@ -452,6 +452,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Cover entity state provider
         self._cover_provider = CoverProvider(hass=self.hass, logger=self.logger)
 
+        # Time window manager (start/end time checks). Built here, ahead of the
+        # snapshot builder, because the builder's effective-default fallback
+        # reads the live window state off it (issue #1055).
+        self._time_mgr = TimeWindowManager(
+            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+        )
+
         # Pipeline snapshot builder — owns the HA reads + assembly for each
         # PipelineSnapshot.  Coordinator drives it once per cycle in
         # _calculate_cover_state and again from async_apply_user_position for
@@ -463,6 +470,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             toggles=self._toggles,
             policy=self._policy,
             config_service=self._config_service,
+            time_mgr=self._time_mgr,
         )
 
         # Current state snapshot (built at start of each update cycle)
@@ -568,8 +576,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # resets or a real numeric position read arrives.
         self.manager.set_assumed_invalidator(self._cmd_svc.clear_assumed_position)
         # Issue #1044: supply the duration mode's deadline. Wired here rather
-        # than passed to the constructor because the resolver reads the time
-        # window, which is built further down.
+        # than passed to the constructor because the resolver is a coordinator
+        # bound method — it resolves lazily at call time, so the wiring stays
+        # post-construction regardless of where its collaborators are built.
         self.manager.set_deadline_resolver(self._resolve_override_deadline)
 
         # Late-bind cover-type policy dependencies (e.g. VenetianPolicy
@@ -606,11 +615,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # tilt-only update fires promptly (issue #756). No-op for
             # single-axis policies (base attach ignores it).
             schedule_refresh_after=self._schedule_refresh_after,
-        )
-
-        # Time window manager (start/end time checks)
-        self._time_mgr = TimeWindowManager(
-            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
         )
 
         # Window-transition tracker — owns sun-visibility and astronomical
@@ -4285,53 +4289,28 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     ) -> tuple[int, bool]:
         """Return (effective_pos, is_sunset_active) for the current moment.
 
-        Single source of truth for calling ``compute_effective_default``. Shared
-        by the main update cycle (``_calculate_cover_state``),
-        ``_on_window_closed`` and ``_check_sunset_window_transition`` so the
-        ``window_explicitly_started`` signal is not duplicated. The sunset /
-        sunrise inputs themselves come from
-        :func:`_read_sun_boundary_options`, which the manual-override deadline
-        resolver reads through too.
+        A thin wrapper over :func:`helpers._read_current_effective_default`, the
+        single source of truth for that computation — shared with
+        ``PipelineSnapshotBuilder.build``'s fallback so the update cycle and the
+        ad-hoc ``async_apply_user_position`` path can never disagree about the
+        same instant (issue #1055).
+
+        All this adds is the cover-data resolution: the transition call sites
+        (``_on_window_closed``, ``_check_sunset_window_transition``) have none in
+        hand, and ``get_blind_data`` is coordinator business the helper must not
+        reach into.
 
         Args:
             options: The config-entry options dict.
             cover_data: An already-computed cover-data object whose ``sun_data``
                 is reused. When ``None`` the cover data is computed fresh via
-                ``get_blind_data`` (the transition call sites have no cover_data
-                in hand).
+                ``get_blind_data``.
 
         """
-        h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
-        sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-        bounds = _read_sun_boundary_options(self.hass, options)
         if cover_data is None:
             cover_data = self.get_blind_data(options=options)
-        # A configured daytime gate (issue #632) OWNS the day/night boundary:
-        # ``effective_daytime_gate`` is the single tri-state verdict to forward —
-        # True=daytime→no sunset, False=dark→apply sunset position, None=defer to
-        # the astronomical decision. None covers both an unconfigured gate and the
-        # graceful fallback after every gate source has been indeterminate past the
-        # grace window (issue #742).
-        daytime_gate = self._time_mgr.effective_daytime_gate
-        # End-of-window position (issue #625): an optional, clearable position
-        # applied once the operating window is clock-closed. ``before_end_time``
-        # is True all morning (end is later today), so the override only fires in
-        # the evening — never before the start time. compute_effective_default
-        # owns the two-phase astral handoff; here we only read the inputs.
-        eow_pos = options.get(CONF_END_OF_WINDOW_POS)
-        window_is_closed = not self._time_mgr.before_end_time
-        return compute_effective_default(
-            h_def=h_def,
-            sunset_pos=sunset_pos_cfg,
-            sun_data=cover_data.sun_data,
-            sunset_off=bounds.sunset_off,
-            sunrise_off=bounds.sunrise_off,
-            sunset_time=bounds.sunset_time,
-            sunrise_time=bounds.sunrise_time,
-            window_explicitly_started=self.window_explicitly_started,
-            daytime_gate=daytime_gate,
-            end_of_window_pos=eow_pos,
-            end_of_window_active=window_is_closed,
+        return _read_current_effective_default(
+            self.hass, options, cover_data.sun_data, self._time_mgr
         )
 
     @callback

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -23,9 +23,11 @@ from homeassistant.util import dt as dt_util
 from .const import (
     BLANK_TIME,
     CONF_CLIMATE_MODE,
+    CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_MAX_POSITION,
     CONF_ENABLE_MIN_POSITION,
     CONF_END_ENTITY,
+    CONF_END_OF_WINDOW_POS,
     CONF_END_TIME,
     CONF_ENTITIES,
     CONF_MANUAL_OVERRIDE_DURATION_MODE,
@@ -37,6 +39,7 @@ from .const import (
     CONF_SUNRISE_OFFSET,
     CONF_SUNRISE_TIME_ENTITY,
     CONF_SUNSET_OFFSET,
+    CONF_SUNSET_POS,
     CONF_SUNSET_TIME_ENTITY,
     CUSTOM_POSITION_SLOTS,
     DEFAULT_CUSTOM_POSITION_TILT_ONLY,
@@ -53,6 +56,9 @@ from .templates import is_template_string
 if TYPE_CHECKING:
     from homeassistant.core import State
 
+    # TYPE_CHECKING only: managers.time_window imports from this module at
+    # runtime, so a real import here is a hard circular import.
+    from .managers.time_window import TimeWindowManager
     from .sun import SunData
 
 _LOGGER = logging.getLogger(__name__)
@@ -847,12 +853,14 @@ def _read_sun_boundary_options(
     """Read the four HA-side inputs that define sunset/sunrise for this instance.
 
     The single source of truth for the *reads* feeding :func:`resolve_sun_boundaries`'
-    arithmetic: the day/night position boundary
-    (``_compute_current_effective_default``), the manual-override sun deadline
-    (``_resolve_override_deadline``), and the pipeline snapshot builder's fallback
-    branch (``PipelineSnapshotBuilder.build``) all delegate here, so a later fifth
-    input lands in one place and those callers can never disagree about what
-    "sunset" means (CODING_GUIDELINES.md § no-duplication).
+    arithmetic. Two direct callers: the day/night position boundary
+    (:func:`_read_current_effective_default`) and the manual-override sun deadline
+    (``_resolve_override_deadline``). Both consumers of the day/night boundary —
+    the coordinator's ``_compute_current_effective_default`` and
+    ``PipelineSnapshotBuilder.build``'s fallback branch — reach here indirectly
+    through that first caller (issue #1055). So a later fifth input lands in one
+    place and no call site can disagree about what "sunset" means
+    (CODING_GUIDELINES.md § no-duplication).
 
     The offset arithmetic itself lives in :func:`resolve_sunset_offset` /
     :func:`resolve_sunrise_offset`, which the hass-less consumers
@@ -1130,6 +1138,81 @@ def compute_effective_default(
 
     effective = int(sunset_pos) if is_sunset_active else int(h_def)
     return effective, is_sunset_active
+
+
+def _read_current_effective_default(
+    hass: HomeAssistant,
+    options: Mapping,
+    sun_data: "SunData",
+    time_mgr: "TimeWindowManager | None" = None,
+) -> tuple[int, bool]:
+    """Return ``(effective_pos, is_sunset_active)`` for the current moment.
+
+    The single source of truth for *calling* :func:`compute_effective_default`
+    with live state. Both consumers delegate here: the coordinator's
+    ``_compute_current_effective_default`` (the update cycle and the window
+    transitions) and ``PipelineSnapshotBuilder.build``'s fallback, which
+    ``async_apply_user_position`` reaches when it assembles an ad-hoc snapshot
+    outside the cycle.
+
+    The builder used to re-derive the answer from a narrower input set, so four
+    live window-state inputs — ``window_explicitly_started`` (#438/#492),
+    ``daytime_gate`` (#632), and ``end_of_window_pos`` /
+    ``end_of_window_active`` (#625) — silently took the formula's own defaults
+    there and the two paths could disagree about the very same instant
+    (issue #1055, CODING_GUIDELINES.md § no-duplication).
+
+    Every ``time_mgr`` read below is a pure property read — nothing advances
+    manager state, so the ad-hoc path calls this without perturbing the cycle.
+
+    Args:
+        hass: Used only for the boundary-entity reads in
+            :func:`_read_sun_boundary_options`. An instance with neither time
+            entity configured reads no state at all.
+        options: The config-entry options mapping.
+        sun_data: Already-resolved ``SunData``. Callers own how they get it —
+            the coordinator falls back to ``get_blind_data`` when it has none
+            in hand, which is coordinator business and stays there.
+        time_mgr: The live ``TimeWindowManager``, or ``None``. ``None`` is the
+            contract for a builder constructed without one (tests, legacy call
+            sites): each read degrades to exactly the default
+            :func:`compute_effective_default` would have applied anyway.
+            Production always injects the live manager.
+
+    """
+    h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
+    sunset_pos_cfg = options.get(CONF_SUNSET_POS)
+    bounds = _read_sun_boundary_options(hass, options)
+    # A configured daytime gate (issue #632) OWNS the day/night boundary:
+    # ``effective_daytime_gate`` is the single tri-state verdict to forward —
+    # True=daytime→no sunset, False=dark→apply sunset position, None=defer to
+    # the astronomical decision. None covers both an unconfigured gate and the
+    # graceful fallback after every gate source has been indeterminate past the
+    # grace window (issue #742).
+    daytime_gate = time_mgr.effective_daytime_gate if time_mgr is not None else None
+    window_started = (
+        time_mgr.window_explicitly_started if time_mgr is not None else False
+    )
+    # End-of-window position (issue #625): an optional, clearable position
+    # applied once the operating window is clock-closed. ``before_end_time``
+    # is True all morning (end is later today), so the override only fires in
+    # the evening — never before the start time. compute_effective_default
+    # owns the two-phase astral handoff; here we only read the inputs.
+    eow_pos = options.get(CONF_END_OF_WINDOW_POS)
+    window_is_closed = (not time_mgr.before_end_time) if time_mgr is not None else False
+    return compute_effective_default(
+        h_def=h_def,
+        sunset_pos=sunset_pos_cfg,
+        sun_data=sun_data,
+        sunset_off=bounds.sunset_off,
+        sunrise_off=bounds.sunrise_off,
+        sunset_time=bounds.sunset_time,
+        sunrise_time=bounds.sunrise_time,
+        window_explicitly_started=window_started,
+        daytime_gate=daytime_gate,
+        end_of_window_pos=eow_pos,
+        end_of_window_active=window_is_closed,
+    )
 
 
 def should_use_tilt(is_tilt_cover: bool, caps) -> bool:

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -1175,9 +1175,13 @@ def _read_current_effective_default(
             in hand, which is coordinator business and stays there.
         time_mgr: The live ``TimeWindowManager``, or ``None``. ``None`` is the
             contract for a builder constructed without one (tests, legacy call
-            sites): each read degrades to exactly the default
-            :func:`compute_effective_default` would have applied anyway.
-            Production always injects the live manager.
+            sites): the three manager-derived kwargs degrade to exactly the
+            defaults :func:`compute_effective_default` would have applied
+            anyway. ``end_of_window_pos`` is options-derived, so it is still
+            read — but every end-of-window branch in that function also
+            requires ``end_of_window_active``, which is ``False`` here, so the
+            value is inert rather than defaulted. Production always injects
+            the live manager.
 
     """
     h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -12,6 +12,11 @@ as a method argument.  The coordinator remains the single owner of
 ``_weather_readings`` — the builder returns ``ClimateReadings`` from
 :meth:`read_climate` and the coordinator stores it.
 
+The one manager it holds a reference to is ``TimeWindowManager``: the
+effective-default fallback needs live window state (grace windows, latched
+gate holds) that cannot be recomputed from ``hass`` + ``options``, so the
+manager itself is injected and read through pure properties (issue #1055).
+
 Background: this code lived inline on the coordinator as five private
 methods (``_read_climate_state``, ``_build_climate_options``,
 ``_read_force_sensor_states``, ``_read_custom_position_sensor_states``,
@@ -34,7 +39,6 @@ from ..const import (
     CONF_CLOUD_COVERAGE_THRESHOLD,
     CONF_CLOUD_SUPPRESSION,
     CONF_CLOUDY_POSITION,
-    CONF_DEFAULT_HEIGHT,
     CONF_DEFAULT_TILT,
     CONF_DELTA_TIME,
     CONF_DEVICE_ID,
@@ -65,7 +69,6 @@ from ..const import (
     CONF_PRESENCE_TEMPLATE_MODE,
     CONF_EXTREME_HEAT_POSITION,
     CONF_SUMMER_CLOSE_BYPASS_SUN_FLOOR,
-    CONF_SUNSET_POS,
     CONF_SUNSET_TILT,
     CONF_SUNSET_USE_MY,
     CONF_TEMP_ENTITY,
@@ -101,8 +104,7 @@ from ..const import (
 )
 from ..cover_types.base import axis_inverted
 from ..helpers import (
-    _read_sun_boundary_options,
-    compute_effective_default,
+    _read_current_effective_default,
     custom_position_slot_configured,
     custom_position_slot_name,
     custom_position_slot_sensors,
@@ -123,6 +125,7 @@ if TYPE_CHECKING:
     from ..config_types import ConfigContextAdapter
     from ..cover_types.base import CoverTypePolicy
     from ..engine.covers.base import AdaptiveGeneralCover
+    from ..managers.time_window import TimeWindowManager
     from ..managers.toggles import ToggleManager
     from ..services.configuration_service import ConfigurationService
     from ..state.climate_provider import ClimateProvider, ClimateReadings
@@ -156,7 +159,14 @@ def _opt_int(options: dict, key: str) -> int | None:
 
 
 class PipelineSnapshotBuilder:
-    """Aggregate HA reads + manager state into a :class:`PipelineSnapshot`."""
+    """Aggregate HA reads + manager state into a :class:`PipelineSnapshot`.
+
+    ``time_mgr`` is the one manager the builder holds a reference to, for
+    :meth:`build`'s effective-default fallback (issue #1055). It is read
+    through pure properties only — never advanced — which is the same contract
+    ``async_apply_user_position`` already relies on for every other manager
+    flag it threads in: an ad-hoc build must not re-evaluate the managers.
+    """
 
     def __init__(
         self,
@@ -167,6 +177,7 @@ class PipelineSnapshotBuilder:
         toggles: ToggleManager,
         policy: CoverTypePolicy,
         config_service: ConfigurationService,
+        time_mgr: TimeWindowManager | None = None,
     ) -> None:
         """Bind the builder to its long-lived collaborators."""
         self._hass = hass
@@ -175,6 +186,7 @@ class PipelineSnapshotBuilder:
         self._toggles = toggles
         self._policy = policy
         self._config_service = config_service
+        self._time_mgr = time_mgr
         # Last VALID per-slot read, keyed by slot number (issue #1005). Written
         # only on a valid read; on an invalid read (transient unavailable /
         # unknown / missing sensor) the slot's activation is held to this so a
@@ -474,17 +486,23 @@ class PipelineSnapshotBuilder:
     ) -> PipelineSnapshot:
         """Assemble the per-cycle :class:`PipelineSnapshot`.
 
-        ``effective_default`` / ``is_sunset_active`` are recomputed from
-        ``options``, ``cover_data.sun_data``, and — via
-        ``_read_sun_boundary_options`` — up to two ``hass.states.get()`` reads
-        resolving the configured sunrise/sunset time entities, when omitted.
-        An instance with neither entity configured reads no state at all.
-        This fallback exists so that ``async_apply_user_position`` (which
+        ``effective_default`` / ``is_sunset_active``, when omitted, come from
+        :func:`helpers._read_current_effective_default` — the single source of
+        truth the coordinator's own ``_compute_current_effective_default``
+        delegates to as well. That covers the configured sunrise/sunset time
+        entities (issue #1048, up to two ``hass.states.get()`` reads; an
+        instance with neither configured reads no state at all) *and* the four
+        live window-state inputs this branch used to drop: the daytime gate
+        (#632), the explicit window-start signal (#438/#492), and the
+        end-of-window position with its active flag (#625). Until issue #1055
+        the branch hand-rolled a narrower call, so it could report a different
+        position than the update cycle for the very same instant.
+
+        The fallback exists so that ``async_apply_user_position`` (which
         evaluates a preemption check outside the update cycle) can still build
-        a valid snapshot without knowing those values. Its inputs are
-        deliberately *wider* than the original ``_build_pipeline_snapshot``'s,
-        which read only ``options`` and ``sun_data`` and so silently dropped
-        the time entities (issue #1048).
+        a valid snapshot without knowing those values. A ``None`` ``time_mgr``
+        (test / legacy construction) degrades each window-state input to the
+        pure formula's own default.
 
         ``is_glare_zone_enabled(idx)`` returns the current state of the
         per-instance glare-zone master switch for zone ``idx``.  The coordinator
@@ -500,17 +518,8 @@ class PipelineSnapshotBuilder:
         / empty leaves the floor active.
         """
         if effective_default is None or is_sunset_active is None:
-            h_def = int(options.get(CONF_DEFAULT_HEIGHT, 0))
-            sunset_pos_cfg = options.get(CONF_SUNSET_POS)
-            bounds = _read_sun_boundary_options(self._hass, options)
-            effective_default, is_sunset_active = compute_effective_default(
-                h_def=h_def,
-                sunset_pos=sunset_pos_cfg,
-                sun_data=cover_data.sun_data,
-                sunset_off=bounds.sunset_off,
-                sunrise_off=bounds.sunrise_off,
-                sunset_time=bounds.sunset_time,
-                sunrise_time=bounds.sunrise_time,
+            effective_default, is_sunset_active = _read_current_effective_default(
+                self._hass, options, cover_data.sun_data, self._time_mgr
             )
 
         glare_zones_cfg = self._policy.glare_zones_config(self._config_service, options)

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -541,7 +541,7 @@ async def test_window_close_sends_reposition_when_auto_control_on():
     coord._window_tracker = tracker
 
     with patch(
-        "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+        "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
         return_value=(0, False),
     ):
         time_mgr = MagicMock()
@@ -634,7 +634,7 @@ async def test_window_close_skips_reposition_when_custom_position_active():
     coord._window_tracker = tracker
 
     with patch(
-        "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+        "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
         return_value=(0, False),
     ):
         time_mgr = MagicMock()
@@ -1072,7 +1072,7 @@ def test_compute_current_effective_default_passes_sunset_entity_time():
             return_value=fake_sunset_dt,
         ) as mock_read,
         patch(
-            "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+            "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
             return_value=(80, True),
         ) as mock_ced,
     ):
@@ -1121,7 +1121,7 @@ def test_compute_current_effective_default_passes_sunrise_entity_time():
             return_value=fake_sunrise_dt,
         ) as mock_read,
         patch(
-            "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+            "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
             return_value=(0, False),
         ) as mock_ced,
     ):
@@ -1132,3 +1132,36 @@ def test_compute_current_effective_default_passes_sunrise_entity_time():
     # compute_effective_default received the override datetime
     call_kwargs = mock_ced.call_args.kwargs
     assert call_kwargs["sunrise_time"] == fake_sunrise_dt
+
+
+@pytest.mark.unit
+def test_compute_current_effective_default_forwards_window_explicitly_started():
+    """The live start-time signal reaches the formula (#438/#492, gap from #1055).
+
+    Every other coordinator-wiring test hardcodes this False, so nothing pinned
+    that an explicitly-started window actually reaches ``compute_effective_default``
+    and suppresses the overnight position.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DEFAULT_HEIGHT,
+        CONF_SUNSET_POS,
+    )
+
+    coord = _make_coordinator()
+    cover_data = MagicMock()
+    cover_data.sun_data = MagicMock()
+    coord.get_blind_data = MagicMock(return_value=cover_data)
+    coord.hass = MagicMock()
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.window_explicitly_started = True
+
+    options = {CONF_DEFAULT_HEIGHT: 0, CONF_SUNSET_POS: 80}
+
+    with patch(
+        "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
+        return_value=(0, False),
+    ) as m:
+        coord._compute_current_effective_default(options)
+
+    m.assert_called_once()
+    assert m.call_args.kwargs["window_explicitly_started"] is True

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -366,6 +366,38 @@ async def test_manager_covers_populated_at_init_for_restore(
     assert "cover.test_blind" in coordinator.manager.covers
 
 
+async def test_coordinator_injects_time_mgr_into_snapshot_builder(
+    hass: HomeAssistant,
+) -> None:
+    """The builder gets the live TimeWindowManager at construction (#1055).
+
+    The builder's effective-default fallback reads the gate, the start-time
+    signal and the window-end flag off this collaborator. Its ``None`` default
+    exists only for tests, so production must never be left on it — a refactor
+    that drops the injection, or reorders ``__init__`` back so ``_time_mgr`` is
+    built after the builder, silently reverts the ad-hoc path to the pure
+    defaults.
+    """
+    from homeassistant import config_entries as ha_config_entries
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "TW Cover", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="tw_inject_01",
+        title="TW Cover",
+    )
+    entry.add_to_hass(hass)
+
+    token = ha_config_entries.current_entry.set(entry)
+    try:
+        coordinator = AdaptiveDataUpdateCoordinator(hass)
+    finally:
+        ha_config_entries.current_entry.reset(token)
+
+    assert coordinator._snapshot_builder._time_mgr is coordinator._time_mgr
+
+
 # ---------------------------------------------------------------------------
 # Venetian mode wiring
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_632_daytime_gate.py
+++ b/tests/test_issue_632_daytime_gate.py
@@ -298,7 +298,7 @@ def test_coordinator_forwards_effective_daytime_gate_when_fell_back():
     coord._time_mgr.effective_daytime_gate = None
     options = {CONF_SUNSET_POS: 20, "default_percentage": 80}
     with patch(
-        "custom_components.adaptive_cover_pro.coordinator.compute_effective_default",
+        "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
         return_value=(80, False),
     ) as m:
         coord._compute_current_effective_default(options)

--- a/tests/test_manual_override_duration_mode.py
+++ b/tests/test_manual_override_duration_mode.py
@@ -644,9 +644,18 @@ class TestCoordinatorResolver:
 # One reader owns the sunset/sunrise HA reads
 # ---------------------------------------------------------------------------
 
-_CED = "custom_components.adaptive_cover_pro.coordinator.compute_effective_default"
+_CED = "custom_components.adaptive_cover_pro.helpers.compute_effective_default"
+# One function object, two live bindings. The deadline path calls it through
+# ``coordinator``'s from-import; the effective-default path reaches it as a
+# module global inside ``helpers._read_current_effective_default`` (issue
+# #1055). Still one source of truth — ``helpers._read_sun_boundary_options`` —
+# but no single patch target intercepts both namespaces, so a test proving both
+# consumers move together has to enter both.
 _READ_BOUNDS = (
     "custom_components.adaptive_cover_pro.coordinator._read_sun_boundary_options"
+)
+_READ_BOUNDS_HELPERS = (
+    "custom_components.adaptive_cover_pro.helpers._read_sun_boundary_options"
 )
 
 
@@ -696,6 +705,7 @@ class TestSunBoundarySource:
         with (
             patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", dt.UTC),
             patch(_READ_BOUNDS, return_value=patched),
+            patch(_READ_BOUNDS_HELPERS, return_value=patched),
             patch(_CED, return_value=(0, False)) as ced,
         ):
             coord._compute_current_effective_default(

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -863,7 +863,8 @@ class TestEffectiveDefaultSingleSource:
         """No ``time_mgr`` (test/legacy construction) degrades to the pure defaults.
 
         Production always injects one; this pins the optional-collaborator
-        contract so the seven builders constructed without it stay valid.
+        contract so the test modules that construct a builder without it stay
+        valid.
         """
         builder, _, _ = _make_builder()
         snapshot = _build_at(

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -19,6 +19,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_CLOUDY_POSITION,
     CONF_DEFAULT_HEIGHT,
     CONF_DEFAULT_TILT,
+    CONF_END_OF_WINDOW_POS,
     CONF_LUX_ENTITY,
     CONF_MAX_TILT,
     CONF_MAX_TILT_SUN_ONLY,
@@ -74,6 +75,7 @@ def _make_builder(
     switch_mode: bool = False,
     motion_control: bool = False,
     states: dict | None = None,
+    time_mgr=None,
 ):
     hass = MagicMock()
     states_map = states or {}
@@ -103,6 +105,7 @@ def _make_builder(
         toggles=toggles,
         policy=policy,
         config_service=MagicMock(),
+        time_mgr=time_mgr,
     )
     return builder, climate_provider, hass
 
@@ -625,6 +628,253 @@ def test_build_fallback_uses_configured_sunrise_time_entity():
 
     assert snapshot.is_sunset_active is False
     assert snapshot.default_position == 10
+
+
+# ---------------------------------------------------------------------------
+# Fallback branch reads the live window state too (issue #1055)
+#
+# #1048 widened this branch to the two boundary time entities but left the four
+# window-state inputs on their pure-function defaults, so the ad-hoc
+# ``async_apply_user_position`` path could disagree with the update cycle about
+# the very same moment.  These drive the branch with a live ``TimeWindowManager``
+# stub and assert it lands where the coordinator would.
+# ---------------------------------------------------------------------------
+
+
+def _fallback_cover_data(*, sunset_hour: int, sunrise_hour: int = 6):
+    """Cover data whose astral sunset/sunrise sit at fixed hours on 2026-07-02."""
+    cover_data = MagicMock()
+    cover_data.config = MagicMock()
+    cover_data.sun_data = MagicMock()
+    cover_data.sun_data.sunset.return_value = dt.datetime(
+        2026, 7, 2, sunset_hour, 0, tzinfo=dt.UTC
+    )
+    cover_data.sun_data.sunrise.return_value = dt.datetime(
+        2026, 7, 2, sunrise_hour, 0, tzinfo=dt.UTC
+    )
+    return cover_data
+
+
+def _fallback_time_mgr(
+    *,
+    effective_daytime_gate=None,
+    before_end_time=True,
+    window_explicitly_started=False,
+):
+    """Stub exposing only the three ``TimeWindowManager`` properties read here."""
+    time_mgr = MagicMock()
+    time_mgr.effective_daytime_gate = effective_daytime_gate
+    time_mgr.before_end_time = before_end_time
+    time_mgr.window_explicitly_started = window_explicitly_started
+    return time_mgr
+
+
+def _build_at(builder, opts, cover_data, *, frozen: str):
+    """Drive ``build()`` down the fallback branch at a frozen UTC instant.
+
+    ``effective_default`` / ``is_sunset_active`` are deliberately omitted — that
+    is what makes the fallback the code under test.
+    """
+    with (
+        patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", dt.UTC),
+        freeze_time(frozen),
+    ):
+        return builder.build(
+            opts,
+            cover_data=cover_data,
+            cover_type="cover_blind",
+            climate_readings=None,
+            manual_override_active=False,
+            motion_timeout_active=False,
+            weather_override_active=False,
+            in_time_window=True,
+            current_cover_position=None,
+            is_glare_zone_enabled=lambda idx: True,
+        )
+
+
+@pytest.mark.unit
+def test_build_fallback_honors_dark_daytime_gate():
+    """A gate reading dark forces the sunset position mid-afternoon (#632).
+
+    Astral says 12:00 is broad daylight, so a fallback that drops the gate
+    reports the daytime default. The gate says dark and OWNS the boundary.
+    """
+    builder, _, _ = _make_builder(
+        time_mgr=_fallback_time_mgr(effective_daytime_gate=False)
+    )
+    snapshot = _build_at(
+        builder,
+        {CONF_DEFAULT_HEIGHT: 10, CONF_SUNSET_POS: 80},
+        _fallback_cover_data(sunset_hour=20),
+        frozen="2026-07-02 12:00:00",
+    )
+
+    assert snapshot.is_sunset_active is True
+    assert snapshot.default_position == 80
+
+
+@pytest.mark.unit
+def test_build_fallback_honors_daytime_gate_suppressing_sunset():
+    """A gate reading daytime suppresses the sunset position past astral dusk (#632).
+
+    The mirror case: 21:00 is after astral sunset, so a fallback that drops the
+    gate reports the night position on a still-bright evening.
+    """
+    builder, _, _ = _make_builder(
+        time_mgr=_fallback_time_mgr(effective_daytime_gate=True)
+    )
+    snapshot = _build_at(
+        builder,
+        {CONF_DEFAULT_HEIGHT: 10, CONF_SUNSET_POS: 80},
+        _fallback_cover_data(sunset_hour=20),
+        frozen="2026-07-02 21:00:00",
+    )
+
+    assert snapshot.is_sunset_active is False
+    assert snapshot.default_position == 10
+
+
+@pytest.mark.unit
+def test_build_fallback_applies_end_of_window_position():
+    """A clock-closed window applies the end-of-window position (#625).
+
+    21:00 is past the window end but before astral sunset (22:00), so this is
+    end-of-window phase 1 — the position must hold until the astral handoff.
+    """
+    builder, _, _ = _make_builder(time_mgr=_fallback_time_mgr(before_end_time=False))
+    snapshot = _build_at(
+        builder,
+        {CONF_DEFAULT_HEIGHT: 10, CONF_SUNSET_POS: 80, CONF_END_OF_WINDOW_POS: 40},
+        _fallback_cover_data(sunset_hour=22),
+        frozen="2026-07-02 21:00:00",
+    )
+
+    assert snapshot.default_position == 40
+    assert snapshot.is_sunset_active is True
+
+
+@pytest.mark.unit
+def test_build_fallback_honors_window_explicitly_started():
+    """An explicitly-started window ends nighttime rules before sunrise (#438/#492).
+
+    05:00 is before astral sunrise (06:00), so a fallback that drops the signal
+    reports the night position even though the user's window is already open.
+    """
+    builder, _, _ = _make_builder(
+        time_mgr=_fallback_time_mgr(window_explicitly_started=True)
+    )
+    snapshot = _build_at(
+        builder,
+        {CONF_DEFAULT_HEIGHT: 10, CONF_SUNSET_POS: 80},
+        _fallback_cover_data(sunset_hour=20),
+        frozen="2026-07-02 05:00:00",
+    )
+
+    assert snapshot.is_sunset_active is False
+    assert snapshot.default_position == 10
+
+
+class TestEffectiveDefaultSingleSource:
+    """One reader owns the effective default — the builder holds no second copy.
+
+    The update cycle precomputes ``effective_default``/``is_sunset_active`` and
+    passes them in; ``async_apply_user_position`` does not and lands on the
+    fallback. Two hand-rolled copies of that computation let the two paths
+    disagree about the same moment (issue #1055).
+    """
+
+    def _coord_and_builder(self, *, time_mgr, cover_data):
+        """Both consumers over one shared ``hass`` / ``time_mgr`` / cover data."""
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        builder, _, hass = _make_builder(time_mgr=time_mgr)
+        coord = object.__new__(AdaptiveDataUpdateCoordinator)
+        coord.logger = MagicMock()
+        coord.hass = hass
+        coord._time_mgr = time_mgr
+        coord.get_blind_data = MagicMock(return_value=cover_data)
+        return coord, builder
+
+    # The end-of-window config: the widest gap between the two paths today,
+    # since it moves both the position and the sunset flag at once.
+    _OPTS = {
+        CONF_DEFAULT_HEIGHT: 10,
+        CONF_SUNSET_POS: 80,
+        CONF_END_OF_WINDOW_POS: 40,
+    }
+
+    def test_both_paths_agree_on_the_effective_default(self):
+        """The fallback must land exactly where the coordinator's read lands."""
+        time_mgr = _fallback_time_mgr(before_end_time=False)
+        cover_data = _fallback_cover_data(sunset_hour=22)
+        coord, builder = self._coord_and_builder(
+            time_mgr=time_mgr, cover_data=cover_data
+        )
+
+        snapshot = _build_at(
+            builder, self._OPTS, cover_data, frozen="2026-07-02 21:00:00"
+        )
+        with (
+            patch("homeassistant.util.dt.DEFAULT_TIME_ZONE", dt.UTC),
+            freeze_time("2026-07-02 21:00:00"),
+        ):
+            coord_result = coord._compute_current_effective_default(
+                self._OPTS, cover_data=cover_data
+            )
+
+        assert (snapshot.default_position, snapshot.is_sunset_active) == coord_result
+
+    def test_patching_the_single_reader_moves_both_effective_default_consumers(self):
+        """Patching one definition must move both — proof of one shared source."""
+        time_mgr = _fallback_time_mgr(before_end_time=False)
+        cover_data = _fallback_cover_data(sunset_hour=22)
+        coord, builder = self._coord_and_builder(
+            time_mgr=time_mgr, cover_data=cover_data
+        )
+
+        with patch(
+            "custom_components.adaptive_cover_pro.helpers.compute_effective_default",
+            return_value=(55, True),
+        ) as ced:
+            coord_result = coord._compute_current_effective_default(
+                self._OPTS, cover_data=cover_data
+            )
+            snapshot = _build_at(
+                builder, self._OPTS, cover_data, frozen="2026-07-02 21:00:00"
+            )
+
+        assert ced.call_count == 2
+        # Same inputs in, same call out — a second reader would drift here first.
+        assert ced.call_args_list[0].kwargs == ced.call_args_list[1].kwargs
+        assert coord_result == (55, True)
+        assert (snapshot.default_position, snapshot.is_sunset_active) == (55, True)
+
+    def test_snapshot_builder_holds_no_second_effective_default_reader(self):
+        """The builder must not import the formula or the boundary reader itself."""
+        import custom_components.adaptive_cover_pro.pipeline.snapshot_builder as mod
+
+        assert not hasattr(mod, "compute_effective_default")
+        assert not hasattr(mod, "_read_sun_boundary_options")
+
+    def test_build_fallback_without_time_mgr_uses_astral_defaults(self):
+        """No ``time_mgr`` (test/legacy construction) degrades to the pure defaults.
+
+        Production always injects one; this pins the optional-collaborator
+        contract so the seven builders constructed without it stay valid.
+        """
+        builder, _, _ = _make_builder()
+        snapshot = _build_at(
+            builder,
+            {CONF_DEFAULT_HEIGHT: 10, CONF_SUNSET_POS: 80},
+            _fallback_cover_data(sunset_hour=20),
+            frozen="2026-07-02 21:00:00",
+        )
+
+        assert snapshot.is_sunset_active is True
+        assert snapshot.default_position == 80
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
`PipelineSnapshotBuilder.build()`'s fallback and `coordinator._compute_current_effective_default` disagreed about what they feed `compute_effective_default`. #1048 fixed the `sunset_time`/`sunrise_time` pair in that same branch; four kwargs were still dropped — `window_explicitly_started` (#438/#492), `daytime_gate` (#632), and `end_of_window_pos`/`end_of_window_active` (#625). They silently took the pure function's defaults, so an install using a daytime gate or a mode-driven end-of-window position got a wrong snapshot and a misleading decision trace on the ad-hoc path behind the `set_position` service and the preemption check.

Rather than thread four more kwargs into the fallback and let the two paths drift a fourth time, both now delegate to one shared reader, `helpers._read_current_effective_default`. Three of the four inputs come from `TimeWindowManager`, which the builder did not hold, so `PipelineSnapshotBuilder` gains `time_mgr` as an optional collaborator and `_time_mgr` is now constructed ahead of `_snapshot_builder` in the coordinator. The properties it reads are pure — nothing advances the window state.

The fallback stays alive rather than becoming dead code: it is still the branch the ad-hoc path takes, it just can no longer compute a different answer than the main cycle. Two contract tests lock that — patching the single reader must move both consumers with identical kwargs, and `snapshot_builder` must hold no second reader in its namespace.

`forecast.py` is deliberately untouched: it projects at future `eval_time` values where no live manager state applies, so it is not a drifting copy.

## Testing
- ✅ 9060 tests passing (baseline 9050 + 10 new), 1 pre-existing xfail
- Deep pre-merge audit: no defects; two docstring nits fixed in the follow-up commit
- Regression guards green and unmodified for #632, #625, #438/#492, #1048

## Related Issues
Refs #1055