### PR TITLE
refactor: give the frame converters a pure home and rename floor_clamp_applied (#1042)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -125,7 +125,6 @@ from .managers.manual_override import (
     AdaptiveCoverManager,
     DetectorConfig,
     get_detector,
-    inverse_state,
 )
 from .managers.climate_smoothing import ClimateSmoothingManager
 from .managers.cloud_suppression import CloudSuppressionManager
@@ -135,7 +134,7 @@ from .managers.sensor_health import SensorHealthManager
 from .managers.weather import WeatherManager
 from .managers.time_window import TimeWindowManager
 from .managers.toggles import ToggleManager
-from .position_utils import interpolate_position
+from .position_utils import flip_if, interpolate_position, inverse_state
 from .pipeline.handlers import (
     ManualOverrideHandler,
     build_handlers,
@@ -2217,11 +2216,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # itself, at the one site that compares it against a floor (#1036).
             held = result.held_position
             if held is None:
-                held = (
-                    inverse_state(result.position)
-                    if self.position_axis_inverted
-                    else result.position
-                )
+                held = flip_if(result.position, inverted=self.position_axis_inverted)
             self._cmd_svc.record_skipped_action(
                 cover,
                 label,
@@ -4117,9 +4112,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             # inverse-state is configured — unconditional of bypass, floor
             # clamp, and interpolation — and never interpolates. #993's
             # middle-rail invariant depends on that divergence.
-            pos_to_send = (
-                inverse_state(effective_pos) if self._inverse_state else effective_pos
-            )
+            pos_to_send = flip_if(effective_pos, inverted=self._inverse_state)
             self.logger.info(
                 "End time reached — sending effective default %s%% "
                 "(sunset_active=%s) to %s cover(s)",
@@ -4464,5 +4457,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.logger.debug("Coordinator shutdown complete")
 
 
-# AdaptiveCoverManager and inverse_state live in the managers/manual_override
-# package. They are re-imported above to maintain backward compatibility.
+# AdaptiveCoverManager lives in the managers/manual_override package and the
+# frame converters (``inverse_state`` / ``flip_if``) in ``position_utils``
+# (#1042). Both are re-imported above to maintain backward compatibility.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2624,7 +2624,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             result.is_safety,
             result.bypass_auto_control,
             result.skip_command,
-            result.floor_clamp_applied,
+            result.position_constraint_applied,
         )
 
     async def _dispatch_for_cycle(
@@ -2762,13 +2762,15 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.logger.debug("Outside the clock window — skipping position update")
             return
 
-        # A floor-clamp raised the winner this cycle (#534).  When manual
-        # override holds the cover below an active floor, the clamped value is
-        # already in cover-position space and must bypass the time/position
-        # delta gates so the raise reaches the cover.
+        # A user-configured bound clamped the winner this cycle (#534).  When
+        # manual override holds the cover below an active floor, the clamp must
+        # bypass the time/position delta gates so the raise still reaches the
+        # cover.  The clamped value is not special in any other way — it is a
+        # logical position that `state` interpolates and inverts exactly like
+        # any other winner's (#1036).
         floor_clamp = bool(
             self._pipeline_result is not None
-            and self._pipeline_result.floor_clamp_applied
+            and self._pipeline_result.position_constraint_applied
         )
         # target_changed alone must not defeat the user's delta_position/
         # delta_time throttle for routine solar/climate tracking (issue #853)
@@ -3879,13 +3881,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
           applied even when Automatic Control is OFF and outside the start/end
           window (issue #767). A safety close of logical 0 must still reach an
           inverse cover as wire 100, or the safety override opens the cover.
-        - ``floor_clamp_applied`` records that a user-configured bound clamped
-          this winner, which drives reason labelling and forces the dispatch
-          through a hold (issues #534 / #809). A configured floor is a logical
-          value like any other, so it is calibrated and inverted like any other
-          — issue #469 skipped both transforms for it, which made a "minimum
-          25% open" floor drive an inverse cover to 75% open and made dispatch
-          non-monotonic in the logical request.
+        - ``position_constraint_applied`` records that a user-configured bound
+          clamped this winner, which drives reason labelling and forces the
+          dispatch through a hold (issues #534 / #809). A configured floor is a
+          logical value like any other, so it is calibrated and inverted like
+          any other — issue #469 skipped both transforms for it, which made a
+          "minimum 25% open" floor drive an inverse cover to 75% open and made
+          dispatch non-monotonic in the logical request.
         """
         return self._to_cover_frame(self._pipeline_result.position)
 

--- a/custom_components/adaptive_cover_pro/cover.py
+++ b/custom_components/adaptive_cover_pro/cover.py
@@ -49,7 +49,7 @@ from .cover_types.base import (
     caps_get,
 )
 from .entity_base import _SENTINEL, AdaptiveCoverBaseEntity
-from .managers import inverse_state
+from .position_utils import flip_if
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -196,7 +196,7 @@ class AdaptiveProxyCover(AdaptiveCoverBaseEntity, CoverEntity):
         value = state.attributes.get(attr)
         if value is None:
             return None
-        return inverse_state(int(value)) if inverted else int(value)
+        return flip_if(int(value), inverted=inverted)
 
     @property
     def current_cover_position(self) -> int | None:

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -56,11 +56,11 @@ from ...engine.covers.day_night_shade import (
 )
 from ...managers.manual_override import (
     SecondaryAxisCheck,
-    inverse_state,
     resolve_dispatched_secondary_expected,
 )
 from ...pipeline.axis_constraints import clamp_to_bounds, tilt_clamp_step
 from ...pipeline.types import DecisionStep
+from ...position_utils import flip_if
 from .._helpers import window_dimensions_lines
 from .._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from ..base import (
@@ -661,13 +661,13 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             return position
         blend = self._dual_entity_blend
         inverse = self._dual_entity_inverse if inverted is None else inverted
-        p_open = inverse_state(position) if inverse else position
+        p_open = flip_if(position, inverted=inverse)
         m_open = round(
             POSITION_OPEN - blend * (POSITION_OPEN - p_open) / DAY_NIGHT_SHEER
         )
         # Belt-and-braces no-pass clamp (the arithmetic already guarantees it).
         m_open = max(m_open, p_open)
-        return inverse_state(m_open) if inverse else m_open
+        return flip_if(m_open, inverted=inverse)
 
     def _apply_split_range(self, resolved: PipelineResult) -> PipelineResult:
         """Fold the abstract ``(position, blend)`` pair into the split-range wire.

--- a/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/dual_panel/policy.py
@@ -38,9 +38,8 @@ from ...const import (
 )
 from ...engine.covers import AdaptiveVerticalCover
 from ...engine.covers.layered import blackout_should_deploy, compute_layered
-from ...managers.manual_override import inverse_state
 from ...pipeline.types import DecisionStep
-from ...position_utils import interpolate_position
+from ...position_utils import flip_if, interpolate_position
 from .._helpers import window_dimensions_lines
 from .._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from ..base import (
@@ -477,4 +476,4 @@ class DualPanelPolicy(CoverTypePolicy, register=True):
         # about how the back is wired (#1035).
         if self._back_interp:
             return self._calibrated_back(back)
-        return inverse_state(back) if self._back_inverse else back
+        return flip_if(back, inverted=self._back_inverse)

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -63,7 +63,7 @@ from ...managers.cover_command.gates import (
     filter_endpoint_specials,
 )
 from ...managers.cover_command.transit import is_state_in_transit
-from ...managers.manual_override import inverse_state
+from ...position_utils import inverse_state
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -71,11 +71,11 @@ from .helpers import (
     climate_mode_from_diagnostics,
     usable_coordinator,
 )
-from .managers import inverse_state
 from .managers.cover_command import CoverCommandService
 from .managers.cover_command.state_store import PositionContext
 from .managers.grace_period import GracePeriodManager
 from .pipeline.types import GroupIntent
+from .position_utils import flip_if
 from .state.area_resolver import device_area_id
 
 _LOGGER = logging.getLogger(__name__)
@@ -628,7 +628,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             for entity_id in entry.options.get(CONF_ENTITIES, []):
                 raw = policy.read_axis_value(self.hass, entity_id, caps=None)
                 member_positions[entity_id] = (
-                    inverse_state(raw) if inverted and raw is not None else raw
+                    flip_if(raw, inverted=inverted) if raw is not None else raw
                 )
         # Generic (non-ACP) covers are adopted as-is — ACP holds no inversion
         # config for them, so their reading is already the logical one.

--- a/custom_components/adaptive_cover_pro/managers/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/__init__.py
@@ -1,8 +1,9 @@
 """Manager classes extracted from the coordinator."""
 
+from ..position_utils import inverse_state
 from .cover_command import CoverCommandService, PositionContext
 from .grace_period import GracePeriodManager
-from .manual_override import AdaptiveCoverManager, inverse_state, to_logical
+from .manual_override import AdaptiveCoverManager
 from .motion import MotionManager
 from .time_window import TimeWindowManager
 from .toggles import ToggleManager
@@ -16,5 +17,4 @@ __all__ = [
     "TimeWindowManager",
     "ToggleManager",
     "inverse_state",
-    "to_logical",
 ]

--- a/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/__init__.py
@@ -7,6 +7,7 @@ unchanged, and so new detection patterns are reachable from one place.
 
 from __future__ import annotations
 
+from ...position_utils import inverse_state
 from .detector import (
     DetectionContext,
     DetectorConfig,
@@ -18,7 +19,7 @@ from .detector import (
     default_user_context_decision,
 )
 from .expiry import STARTED_AT_SOURCE_DERIVED, STARTED_AT_SOURCE_ENGAGED
-from .manager import AdaptiveCoverManager, inverse_state, to_logical
+from .manager import AdaptiveCoverManager
 from .position_delta import PositionDeltaDetector
 from .registry import DEFAULT_DETECTOR, DETECTOR_REGISTRY, get_detector
 from .secondary_axis import (
@@ -51,5 +52,4 @@ __all__ = [
     "get_detector",
     "inverse_state",
     "resolve_dispatched_secondary_expected",
-    "to_logical",
 ]

--- a/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
+++ b/custom_components/adaptive_cover_pro/managers/manual_override/manager.py
@@ -1076,26 +1076,3 @@ class AdaptiveCoverManager:
 
         """
         return [k for k, v in self.manual_control.items() if v]
-
-
-def inverse_state(state: int) -> int:
-    """Inverse state."""
-    return 100 - state
-
-
-def to_logical(value: int, *, inverted: bool) -> int:
-    """Map a RAW cover-frame reading into the logical (pre-inversion) frame.
-
-    Single source of truth for the ``inverse_state(v) if inverted else v``
-    conditional (issue #1036). Every producer that reads a physical position off
-    an entity and then hands it to a logical-frame field needs exactly this:
-    ``PipelineResult.position`` is logical for every winner, so a handler
-    holding a raw read (``MotionTimeoutHandler``'s hold, ``GroupLockHandler``'s
-    freeze) must convert first, and the registry must convert before comparing a
-    held position against a user-configured bound.
-
-    Lives beside :func:`inverse_state` so the involution is written once — the
-    caller supplies the "is this axis inverted right now?" answer, which is
-    itself sourced from ``cover_types.base.axis_inverted``.
-    """
-    return inverse_state(value) if inverted else value

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/group_lock.py
@@ -16,7 +16,7 @@ from ...const import (
     GroupIntentKind,
     ReasonCode,
 )
-from ...managers.manual_override import to_logical
+from ...position_utils import flip_if
 from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_raw_calculated_position
@@ -56,7 +56,7 @@ class GroupLockHandler(OverrideHandler):
         # instead and leave the flag alone. ``default_position`` is already
         # logical, so only the entity read needs it.
         if held is not None:
-            position = to_logical(held, inverted=snapshot.position_axis_inverted)
+            position = flip_if(held, inverted=snapshot.position_axis_inverted)
             # The raw read stays in the reason payload / diagnostics, beside
             # ``held_position`` — both describe where the cover physically is.
             reported = held

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/motion_timeout.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ...const import ControlMethod, ReasonCode
-from ...managers.manual_override import to_logical
+from ...position_utils import flip_if
 from ...reason_i18n import Reason
 from ..handler import OverrideHandler
 from ..helpers import compute_default_position, compute_raw_calculated_position
@@ -54,7 +54,7 @@ class MotionTimeoutHandler(OverrideHandler):
             # interpolation ``coordinator.state`` re-interpolates the held motor
             # read, so the published target still drifts. Pre-existing.
             return PipelineResult(
-                position=to_logical(held, inverted=snapshot.position_axis_inverted),
+                position=flip_if(held, inverted=snapshot.position_axis_inverted),
                 control_method=ControlMethod.MOTION,
                 # The raw read stays in the reason payload / diagnostics.
                 reason_payload=Reason(ReasonCode.OCCUPANCY_HOLDING, {"held": held}),

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -600,15 +600,16 @@ class PipelineRegistry:
             # A position clamp must reach the cover even when the winner is a
             # hold (manual-override / motion): clear skip_command so the composed
             # result is dispatched, not suppressed (issue #809 / #534).
-            # floor_clamp_applied records only that a user-configured bound
-            # clamped this winner — a floor raise (#463) or a ceiling lower
-            # (#943) — which is what drives that forced dispatch and the reason
-            # labelling. It makes NO claim about the value's frame: the composed
-            # position is logical, exactly like the winner's own was (#1036).
+            # position_constraint_applied records only that a user-configured
+            # bound clamped this winner — a floor raise (#463) or a ceiling
+            # lower (#943) — which is what drives that forced dispatch and the
+            # reason labelling. It makes NO claim about the value's frame: the
+            # composed position is logical, exactly like the winner's own was
+            # (#1036).
             winner = dataclasses.replace(
                 winner,
                 position=clamped_position,
-                floor_clamp_applied=True,
+                position_constraint_applied=True,
                 skip_command=False,
             )
         if tilt_clamped:
@@ -647,7 +648,7 @@ class PipelineRegistry:
                     "position": result.position,
                     "reason": result.reason,
                     "bypass_auto_control": result.bypass_auto_control,
-                    "floor_clamp_applied": result.floor_clamp_applied,
+                    "position_constraint_applied": result.position_constraint_applied,
                     "is_sunset_active": result.is_sunset_active,
                 }
             )

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -8,7 +8,7 @@ import datetime as dt
 from ..const import AxisConstraintMode, ReasonCode
 from ..cover_types.base import AXIS_NAME_POSITION, AXIS_NAME_TILT
 from ..diagnostics.event_buffer import EventBuffer
-from ..managers.manual_override import to_logical
+from ..position_utils import flip_if
 from ..reason_i18n import Reason, render_en
 from .axis_constraints import (
     bound_label,
@@ -348,7 +348,7 @@ class PipelineRegistry:
         # directions: a compliant cover held at logical 80 gets *lowered* to a
         # logical-25 floor (#1036). A no-op on non-inverse installs.
         effective_winner_pos = (
-            to_logical(winner.held_position, inverted=snapshot.position_axis_inverted)
+            flip_if(winner.held_position, inverted=snapshot.position_axis_inverted)
             if winner.held_position is not None
             else winner.position
         )

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -541,17 +541,17 @@ class PipelineResult:
 
     # When True, the registry's axis-constraint composition pass clamped this
     # winner's position to a user-configured bound — a floor raise (issue #463)
-    # or, since issue #943, a ceiling lower. Drives the reason/trace labelling
-    # and clears `skip_command` so the clamp still reaches a cover the winner
-    # was merely holding (issues #534 / #809).
+    # or, since issue #943, a ceiling lower. The flag has exactly three jobs:
+    #
+    #   1. reason/trace labelling (the `floor_clamp` / `ceiling_clamp` steps),
+    #   2. clearing `skip_command` so the clamp still reaches a cover the winner
+    #      was merely holding (issues #534 / #809),
+    #   3. riding the diagnostics and event-timeline payloads.
     #
     # It makes NO claim about the value's frame: `position` stays logical, and
     # `coordinator.state` interpolates/inverts a clamped winner exactly like any
-    # other (issue #1036 removed the #469 carve-out that skipped both). The name
-    # predates that and is due a rename to `position_constraint_applied` in a
-    # follow-up — it is a rename only, deliberately kept out of a
-    # behaviour-changing PR.
-    floor_clamp_applied: bool = False
+    # other (issue #1036 removed the #469 carve-out that skipped both).
+    position_constraint_applied: bool = False
 
     # Composed tilt bounds that could not be applied during evaluation because
     # the winner had no tilt to clamp yet (issue #943). Tilt can resolve *after*

--- a/custom_components/adaptive_cover_pro/pipeline/types.py
+++ b/custom_components/adaptive_cover_pro/pipeline/types.py
@@ -388,8 +388,8 @@ class PipelineSnapshot:
     # (inverse-state configured and not suppressed by interpolation, per
     # ``cover_types.base.axis_inverted``). A handler that puts a raw cover read
     # such as ``current_cover_position`` into ``PipelineResult.position`` must
-    # convert it to the logical frame first (``managers.manual_override
-    # .to_logical``), because ``coordinator.state`` maps every winner through
+    # convert it to the logical frame first (``position_utils.flip_if``),
+    # because ``coordinator.state`` maps every winner through
     # ``_to_cover_frame`` on the way out — no flag exempts one (#1028 / #1036).
     position_axis_inverted: bool = False
 

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -12,6 +12,38 @@ from .const import (
 )
 
 
+def inverse_state(state: int) -> int:
+    """Inverse state."""
+    return 100 - state
+
+
+def flip_if(value: int, *, inverted: bool) -> int:
+    """Map a position between the cover frame and the logical frame.
+
+    Single source of truth for the ``inverse_state(v) if inverted else v``
+    conditional (issues #1036 / #1042). The involution ``100 - x`` is its own
+    inverse, so ONE primitive serves both directions:
+
+    * **cover → logical** — a producer that reads a physical position off an
+      entity and hands it to a logical-frame field.
+      ``PipelineResult.position`` is logical for every winner, so a handler
+      holding a raw read (``MotionTimeoutHandler``'s hold,
+      ``GroupLockHandler``'s freeze) must convert first, and the registry must
+      convert before comparing a held position against a user-configured bound.
+    * **logical → cover** — a consumer turning a pipeline value into the number
+      actually dispatched to, or recorded as held on, the entity.
+
+    The name is deliberately direction-free: while this helper carried a
+    directional name, every caller converting the other way hand-rolled the
+    same ternary instead of delegating. Lives beside :func:`inverse_state` in this
+    pure module so the arithmetic is written once and the pipeline layer can
+    reach it without importing a manager. The caller supplies the "is this axis
+    inverted right now?" answer, which is itself sourced from
+    ``cover_types.base.axis_inverted``.
+    """
+    return inverse_state(value) if inverted else value
+
+
 def _proportional_remap(value: int, lo: int, hi: int) -> int:
     """Linearly remap the full 0–100% demand onto the ``[lo, hi]`` band (#957).
 

--- a/custom_components/adaptive_cover_pro/sensor.py
+++ b/custom_components/adaptive_cover_pro/sensor.py
@@ -48,7 +48,7 @@ from .const import (
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .entity_base import AdaptiveCoverDiagnosticSensorBase, AdaptiveCoverSensorBase
 from .const import ControlMethod
-from .managers.manual_override import inverse_state
+from .position_utils import flip_if
 from .helpers import (
     custom_position_slot_configured,
     custom_position_slot_name,
@@ -386,7 +386,7 @@ def _compute_distance_attrs(
 
     def _display_distance(pct: float) -> float:
         """Physical travel for *pct*, rebased onto the logical frame if needed."""
-        logical = inverse_state(pct) if inverted else pct
+        logical = flip_if(pct, inverted=inverted)
         return round(to_display_length(dim_m * logical / 100.0, hass), 2)
 
     attrs: dict[str, Any] = {
@@ -450,7 +450,7 @@ def _cover_position_attrs(s: _ACPSensor) -> Mapping[str, Any] | None:
         # on one scale. Identity when the axis is not effectively inverted.
         inverted = s.coordinator.position_axis_inverted
         attrs["linear_actual_positions"] = {
-            eid: (inverse_state(pos) if inverted and pos is not None else pos)
+            eid: (flip_if(pos, inverted=inverted) if pos is not None else pos)
             for eid, pos in actual_positions.items()
         }
 

--- a/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
+++ b/custom_components/adaptive_cover_pro/state/window_transition_tracker.py
@@ -35,7 +35,7 @@ import datetime as dt
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
-from ..managers.manual_override import inverse_state
+from ..position_utils import flip_if
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -181,11 +181,7 @@ class WindowTransitionTracker:
         if not just_opened:
             return
 
-        pos_to_send = (
-            inverse_state(int(sunset_pos_cfg))
-            if inverse_state_enabled
-            else int(sunset_pos_cfg)
-        )
+        pos_to_send = flip_if(int(sunset_pos_cfg), inverted=inverse_state_enabled)
         self._logger.info(
             "Sunset window opened after end_time — dispatching sunset position %s%% "
             "to %s cover(s) (issue #266)",

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -30,7 +30,7 @@ def _make_pipeline_result(
     position: int = 50,
     control_method: ControlMethod = ControlMethod.SOLAR,
     bypass_auto_control: bool = False,
-    floor_clamp_applied: bool = False,
+    position_constraint_applied: bool = False,
     is_safety: bool = False,
 ) -> PipelineResult:
     return PipelineResult(
@@ -38,7 +38,7 @@ def _make_pipeline_result(
         control_method=control_method,
         reason="test",
         bypass_auto_control=bypass_auto_control,
-        floor_clamp_applied=floor_clamp_applied,
+        position_constraint_applied=position_constraint_applied,
         is_safety=is_safety,
     )
 
@@ -439,7 +439,7 @@ class TestFloorClampUnderManualOverride:
         result = _make_pipeline_result(
             position=80,
             control_method=ControlMethod.MANUAL,
-            floor_clamp_applied=True,
+            position_constraint_applied=True,
         )
         coordinator = _make_coordinator(
             entities=["cover.blind"],
@@ -475,7 +475,7 @@ class TestFloorClampUnderManualOverride:
         result = _make_pipeline_result(
             position=90,
             control_method=ControlMethod.MANUAL,
-            floor_clamp_applied=False,
+            position_constraint_applied=False,
         )
         coordinator = _make_coordinator(
             entities=["cover.blind"],

--- a/tests/test_cover_types/test_dual_panel.py
+++ b/tests/test_cover_types/test_dual_panel.py
@@ -255,7 +255,7 @@ def _resolve(
         control_method=control_method,
         reason="test",
         bypass_auto_control=bypass,
-        floor_clamp_applied=floor_clamp,
+        position_constraint_applied=floor_clamp,
     )
     return policy.post_pipeline_resolve(result, cover=_sunset_cover(sunset_valid), **kw)
 

--- a/tests/test_day_night_deep_audit_fixes.py
+++ b/tests/test_day_night_deep_audit_fixes.py
@@ -269,7 +269,7 @@ def _cache_dual(
         control_method=ControlMethod.CUSTOM_POSITION,
         reason="custom",
         tilt=blend,
-        floor_clamp_applied=floor_clamp,
+        position_constraint_applied=floor_clamp,
         bypass_auto_control=bypass,
     )
     policy.post_pipeline_resolve(result, cover=None, **kw)

--- a/tests/test_day_night_dual_entity.py
+++ b/tests/test_day_night_dual_entity.py
@@ -341,7 +341,7 @@ def _dual_policy_primed(
         control_method=ControlMethod.CUSTOM_POSITION,
         reason="custom",
         tilt=blend,
-        floor_clamp_applied=floor_clamp,
+        position_constraint_applied=floor_clamp,
         bypass_auto_control=bypass,
     )
     policy.post_pipeline_resolve(

--- a/tests/test_diagnostics/test_builder.py
+++ b/tests/test_diagnostics/test_builder.py
@@ -76,7 +76,7 @@ def _make_pr(
     configured_sunset_pos: int | None = None,
     configured_cloudy_pos: int | None = None,
     bypass_auto_control: bool = False,
-    floor_clamp_applied: bool = False,
+    position_constraint_applied: bool = False,
     is_safety: bool = False,
     tilt: int | None = None,
     tilt_only_slot: int | None = None,
@@ -96,7 +96,7 @@ def _make_pr(
         configured_sunset_pos=configured_sunset_pos,
         configured_cloudy_pos=configured_cloudy_pos,
         bypass_auto_control=bypass_auto_control,
-        floor_clamp_applied=floor_clamp_applied,
+        position_constraint_applied=position_constraint_applied,
         is_safety=is_safety,
         tilt=tilt,
         tilt_only_slot=tilt_only_slot,
@@ -1893,7 +1893,7 @@ class TestLinearPosition:
         """
         diag, _ = builder.build(
             _base_ctx(
-                pipeline_result=_make_pr(position=25, floor_clamp_applied=True),
+                pipeline_result=_make_pr(position=25, position_constraint_applied=True),
                 position_axis_inverted=True,
             )
         )

--- a/tests/test_display_rounding.py
+++ b/tests/test_display_rounding.py
@@ -41,7 +41,7 @@ class TestCoordinatorStateIntCoercion:
         pr = SimpleNamespace(
             position=pipeline_position,
             bypass_auto_control=False,
-            floor_clamp_applied=False,
+            position_constraint_applied=False,
         )
         coord._pipeline_result = pr
         coord._use_interpolation = True
@@ -86,7 +86,7 @@ class TestCoordinatorStateIntCoercion:
 
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
         pr = SimpleNamespace(
-            position=55, bypass_auto_control=False, floor_clamp_applied=False
+            position=55, bypass_auto_control=False, position_constraint_applied=False
         )
         coord._pipeline_result = pr
         coord._use_interpolation = False
@@ -106,7 +106,7 @@ class TestCoordinatorStateIntCoercion:
 
         coord = object.__new__(AdaptiveDataUpdateCoordinator)
         pr = SimpleNamespace(
-            position=0, bypass_auto_control=True, floor_clamp_applied=False
+            position=0, bypass_auto_control=True, position_constraint_applied=False
         )
         coord._pipeline_result = pr
         # A safety winner runs the same frame transform as any other (#1036),

--- a/tests/test_dual_panel_dispatch.py
+++ b/tests/test_dual_panel_dispatch.py
@@ -106,7 +106,7 @@ def _primed_policy(
         position=40,
         control_method=control_method,
         reason="test",
-        floor_clamp_applied=floor_clamp,
+        position_constraint_applied=floor_clamp,
     )
     policy.post_pipeline_resolve(
         result,

--- a/tests/test_extreme_heat.py
+++ b/tests/test_extreme_heat.py
@@ -157,7 +157,7 @@ def test_extreme_heat_result_is_ordinary_not_a_bypass_path():
     """The extreme-heat PipelineResult rides the standard interpolation/inverse path.
 
     It carries none of the short-circuit flags the coordinator's ``state``
-    property honors (``is_safety`` / ``floor_clamp_applied`` /
+    property honors (``is_safety`` / ``position_constraint_applied`` /
     ``bypass_auto_control``), so its position is post-processed like every other
     climate position — no parallel path.
     """
@@ -188,7 +188,7 @@ def test_extreme_heat_result_is_ordinary_not_a_bypass_path():
     # None of the short-circuit flags are set → coordinator.state will
     # interpolate + inverse this position exactly like summer/winter/glare.
     assert result.is_safety is False
-    assert result.floor_clamp_applied is False
+    assert result.position_constraint_applied is False
     assert result.bypass_auto_control is False
 
 

--- a/tests/test_issue_756_override_dispatch_during_sequence.py
+++ b/tests/test_issue_756_override_dispatch_during_sequence.py
@@ -218,7 +218,7 @@ def test_resolved_target_signature_tuple_content():
         is_safety=False,
         bypass_auto_control=True,
         skip_command=False,
-        floor_clamp_applied=False,
+        position_constraint_applied=False,
     )
 
     sig = AdaptiveDataUpdateCoordinator._resolved_target_signature(coordinator)
@@ -230,7 +230,7 @@ def test_resolved_target_signature_tuple_content():
         False,  # is_safety
         True,  # bypass_auto_control
         False,  # skip_command
-        False,  # floor_clamp_applied
+        False,  # position_constraint_applied
     )
 
 

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -173,10 +173,10 @@ class TestPositionCeiling:
         res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(80))
         assert res.position == 60
 
-    def test_ceiling_sets_floor_clamp_applied(self) -> None:
+    def test_ceiling_sets_position_constraint_applied(self) -> None:
         """A ceiling clamp is a user-configured cover-space value (#469)."""
         res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(80))
-        assert res.floor_clamp_applied is True
+        assert res.position_constraint_applied is True
 
     def test_ceiling_clears_skip_command(self) -> None:
         """A clamp must reach the cover even when the winner was a hold."""
@@ -206,7 +206,7 @@ class TestPositionCeiling:
         """An inert ceiling leaves the winner's own position exactly as-is."""
         res = _evaluate([_slot(1, position_max=60)], winner=_StubWinner(40))
         assert res.position == 40
-        assert res.floor_clamp_applied is False
+        assert res.position_constraint_applied is False
 
     def test_inert_ceiling_emits_inactive_step(self) -> None:
         """An inert ceiling still explains itself rather than a stale skip."""
@@ -252,7 +252,7 @@ class TestCeilingVersusHeldPosition:
             [_slot(1, position_max=60)],
             winner=_StubWinner(50, held_position=50, skip_command=True),
         )
-        assert res.floor_clamp_applied is False
+        assert res.position_constraint_applied is False
         assert ReasonCode.REGISTRY_CEILING_INACTIVE in _codes(res)
 
 

--- a/tests/test_pipeline/test_floor_composition.py
+++ b/tests/test_pipeline/test_floor_composition.py
@@ -612,8 +612,8 @@ def test_floor_inactive_when_sensor_off() -> None:
     assert not any(s.handler == "floor_clamp" for s in result.decision_trace)
 
 
-def test_floor_clamp_sets_floor_clamp_applied_flag() -> None:
-    """Active floor that raises the winner sets ``floor_clamp_applied=True`` (issue #469)."""
+def test_floor_clamp_sets_position_constraint_applied_flag() -> None:
+    """Active floor raising the winner sets ``position_constraint_applied`` (#469)."""
     cover = _climate_cover(direct_sun_valid=False)
     snap = make_snapshot(
         cover=cover,
@@ -634,11 +634,11 @@ def test_floor_clamp_sets_floor_clamp_applied_flag() -> None:
     handlers = [_cp_handler(1, 60)]
     registry = _registry_with_custom(handlers)
     result = registry.evaluate(snap)
-    assert result.floor_clamp_applied is True
+    assert result.position_constraint_applied is True
 
 
-def test_no_clamp_keeps_floor_clamp_applied_false() -> None:
-    """With no active floors, ``floor_clamp_applied`` stays False (issue #469)."""
+def test_no_clamp_keeps_position_constraint_applied_false() -> None:
+    """With no active floors, ``position_constraint_applied`` stays False (issue #469)."""
     cover = _climate_cover(direct_sun_valid=False)
     snap = make_snapshot(
         cover=cover,
@@ -649,7 +649,7 @@ def test_no_clamp_keeps_floor_clamp_applied_false() -> None:
     )
     registry = _registry_with_custom([])
     result = registry.evaluate(snap)
-    assert result.floor_clamp_applied is False
+    assert result.position_constraint_applied is False
 
 
 def test_inactive_floor_below_winner_keeps_flag_false() -> None:
@@ -684,7 +684,7 @@ def test_inactive_floor_below_winner_keeps_flag_false() -> None:
     registry = _registry_with_custom(handlers)
     result = registry.evaluate(snap)
     assert result.position == 80
-    assert result.floor_clamp_applied is False
+    assert result.position_constraint_applied is False
 
 
 def test_floor_raises_manual_override_held_below_floor() -> None:
@@ -723,7 +723,7 @@ def test_floor_raises_manual_override_held_below_floor() -> None:
     )
     assert winner_step.handler == "manual_override"
     assert result.position == 80
-    assert result.floor_clamp_applied is True
+    assert result.position_constraint_applied is True
     # The floor raise must reach the cover: a manual-override hold sets
     # skip_command=True, but the composed floor result clears it (#809/#534).
     assert result.skip_command is False
@@ -767,7 +767,7 @@ def test_floor_above_held_position_is_inert_under_manual_override() -> None:
     )
     assert winner_step.handler == "manual_override"
     # No clamp: the held physical position (85) is already above the floor (80).
-    assert result.floor_clamp_applied is False
+    assert result.position_constraint_applied is False
     # The manual-override hold is inert-floor: it genuinely holds the cover, so
     # skip_command stays set (no floor raise to clear it)  (#809).
     assert result.skip_command is True
@@ -812,7 +812,7 @@ def test_floor_equal_to_would_be_but_above_held_still_raises() -> None:
     )
     assert winner_step.handler == "manual_override"
     assert result.position == 100
-    assert result.floor_clamp_applied is True
+    assert result.position_constraint_applied is True
     assert result.skip_command is False
 
 
@@ -1059,7 +1059,7 @@ class TestFloorComparesInLogicalFrame:
         result = self._registry().evaluate(self._snapshot(current_cover_position=20))
 
         assert result.position == 80
-        assert result.floor_clamp_applied is False
+        assert result.position_constraint_applied is False
 
     def test_non_compliant_hold_is_still_raised_by_the_floor(self) -> None:
         """Mirror case, so the fix cannot be "never clamp a held cover".
@@ -1070,4 +1070,4 @@ class TestFloorComparesInLogicalFrame:
         result = self._registry().evaluate(self._snapshot(current_cover_position=90))
 
         assert result.position == 25
-        assert result.floor_clamp_applied is True
+        assert result.position_constraint_applied is True

--- a/tests/test_pipeline/test_floor_dispatch_integration.py
+++ b/tests/test_pipeline/test_floor_dispatch_integration.py
@@ -5,7 +5,7 @@ contractually a LOGICAL (pre-inversion canonical) value for *every* winner —
 ``pipeline/types.py`` says so at the field's definition site and requires any
 handler holding a raw cover read to convert it first. So
 ``coordinator.state`` must never decide "which frame is this number in?" from
-provenance flags (``bypass_auto_control`` / ``floor_clamp_applied``): it maps
+provenance flags (``bypass_auto_control`` / ``position_constraint_applied``): it maps
 every winner through :meth:`_to_cover_frame`, unconditionally.
 
 #469's genuine requirement survives, asserted harder than before: **the
@@ -53,7 +53,7 @@ def _make_pipeline_result(
     position: int,
     control_method: ControlMethod = ControlMethod.DEFAULT,
     bypass_auto_control: bool = False,
-    floor_clamp_applied: bool = False,
+    position_constraint_applied: bool = False,
     is_safety: bool = False,
 ) -> PipelineResult:
     return PipelineResult(
@@ -61,7 +61,7 @@ def _make_pipeline_result(
         control_method=control_method,
         reason="test",
         bypass_auto_control=bypass_auto_control,
-        floor_clamp_applied=floor_clamp_applied,
+        position_constraint_applied=position_constraint_applied,
         is_safety=is_safety,
     )
 
@@ -128,12 +128,12 @@ _CURVE = {
 # the auto-control gate) — none of them says anything about the value's frame.
 _WINNER_SHAPES: dict[str, dict] = {
     "plain": {},
-    "floor_clamped": {"floor_clamp_applied": True},
+    "floor_clamped": {"position_constraint_applied": True},
     "bypass": {"bypass_auto_control": True},
     "bypass+safety": {"bypass_auto_control": True, "is_safety": True},
     "bypass+floor_clamped": {
         "bypass_auto_control": True,
-        "floor_clamp_applied": True,
+        "position_constraint_applied": True,
     },
 }
 
@@ -179,7 +179,7 @@ def test_floor_clamped_winner_is_inverted_like_any_other() -> None:
         position=25,
         control_method=ControlMethod.DEFAULT,
         bypass_auto_control=False,
-        floor_clamp_applied=True,
+        position_constraint_applied=True,
     )
     coord = _make_coordinator(
         pipeline_result=result,
@@ -204,7 +204,7 @@ def test_floor_clamped_winner_is_interpolated_like_any_other() -> None:
         position=25,
         control_method=ControlMethod.DEFAULT,
         bypass_auto_control=False,
-        floor_clamp_applied=True,
+        position_constraint_applied=True,
     )
     coord = _make_coordinator(pipeline_result=result, **_CURVE)
 
@@ -224,7 +224,7 @@ def test_bypass_winner_is_transformed_like_any_other() -> None:
         position=42,
         control_method=ControlMethod.FORCE,
         bypass_auto_control=True,
-        floor_clamp_applied=False,
+        position_constraint_applied=False,
     )
     coord = _make_coordinator(
         pipeline_result=result,
@@ -243,7 +243,7 @@ def test_non_floor_winner_still_runs_interpolation():
         position=25,
         control_method=ControlMethod.DEFAULT,
         bypass_auto_control=False,
-        floor_clamp_applied=False,
+        position_constraint_applied=False,
     )
     coord = _make_coordinator(
         pipeline_result=result,
@@ -265,7 +265,7 @@ def test_non_floor_winner_still_runs_inverse_state():
         position=25,
         control_method=ControlMethod.DEFAULT,
         bypass_auto_control=False,
-        floor_clamp_applied=False,
+        position_constraint_applied=False,
     )
     coord = _make_coordinator(
         pipeline_result=result,
@@ -303,7 +303,7 @@ def test_dispatch_is_monotone_in_the_logical_request(frame_name: str) -> None:
     """Sweeping the logical request with an active floor yields a monotone curve.
 
     Built through the REAL ``PipelineRegistry`` so composition and dispatch are
-    both exercised — a hand-set ``floor_clamp_applied`` would only test half of
+    both exercised — a hand-set ``position_constraint_applied`` would only test half of
     it. Under #469 the inverse-state curve was
     ``[25, 25, 25, 75, 74, 70, ..., 0]``: asking for logical 10 opened the cover
     further than asking for logical 30. No restatement of any transform can

--- a/tests/test_position_utils.py
+++ b/tests/test_position_utils.py
@@ -1,0 +1,91 @@
+"""Tests for the pure position-frame converters in ``position_utils``.
+
+``inverse_state`` and ``flip_if`` are the canonical position-frame primitives
+for the whole integration (issues #1036 / #1042). They used to live at the
+bottom of ``managers/manual_override/manager.py`` — a module that imports
+``homeassistant.core.HomeAssistant`` — which forced the pipeline layer to
+import a manager module purely to reach two ``int -> int`` functions. This file
+pins both the arithmetic contract and the purity of their new home so the
+converters can't drift back across the HA boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from custom_components.adaptive_cover_pro.position_utils import flip_if, inverse_state
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_POSITION_UTILS = (
+    _REPO_ROOT / "custom_components" / "adaptive_cover_pro" / "position_utils.py"
+)
+
+
+@pytest.mark.unit
+def test_flip_if_inverts_when_inverted() -> None:
+    """``inverted=True`` applies the ``100 - x`` involution."""
+    assert flip_if(30, inverted=True) == 70
+
+
+@pytest.mark.unit
+def test_flip_if_is_identity_when_not_inverted() -> None:
+    """``inverted=False`` returns the value untouched — a no-op on normal installs."""
+    assert flip_if(30, inverted=False) == 30
+
+
+@pytest.mark.unit
+def test_flip_if_is_its_own_inverse() -> None:
+    """The involution property is what makes one primitive serve both directions.
+
+    ``flip_if`` converts cover→logical (a raw entity read on its way into
+    ``PipelineResult.position``) and logical→cover (a pipeline value on its way
+    to a dispatched or held number) with the same call, because ``100 - x``
+    round-trips. Any future "optimisation" that breaks this breaks every
+    round-tripping caller (``day_night_shade`` remaps a position out and back
+    inside one function).
+    """
+    for value in range(101):
+        assert flip_if(flip_if(value, inverted=True), inverted=True) == value
+
+
+@pytest.mark.unit
+def test_inverse_state_is_importable_from_position_utils() -> None:
+    """``inverse_state`` is the raw involution, published from the pure module.
+
+    Several call sites apply it unconditionally or inside an imperative guard
+    rather than the ternary ``flip_if`` replaces, so it stays a public function
+    in its own right.
+    """
+    assert inverse_state(30) == 70
+
+
+@pytest.mark.unit
+def test_position_utils_has_no_direct_homeassistant_import() -> None:
+    """``position_utils`` must stay free of direct ``homeassistant.*`` imports.
+
+    Same purity bar CLAUDE.md applies to ``engine/covers/base.py`` — direct
+    imports only, not the full transitive graph (``.const`` pulls HA in
+    transitively for both modules). This is the property that lets the pipeline
+    layer reach the frame converters without importing a manager (#1042).
+    """
+    tree = ast.parse(_POSITION_UTILS.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            offenders += [
+                f"line {node.lineno}: import {alias.name}"
+                for alias in node.names
+                if alias.name == "homeassistant"
+                or alias.name.startswith("homeassistant.")
+            ]
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module == "homeassistant" or module.startswith("homeassistant."):
+                offenders.append(f"line {node.lineno}: from {module} import ...")
+    assert not offenders, (
+        "position_utils.py must not import homeassistant directly — it is the "
+        "pure home for position-value transforms:\n  " + "\n  ".join(offenders)
+    )

--- a/tests/test_user_auto_dispatch_parity.py
+++ b/tests/test_user_auto_dispatch_parity.py
@@ -137,7 +137,7 @@ def _dual_panel_case(frame_options: dict, logical: int, *, floor: int | None = N
             position=logical,
             control_method=ControlMethod.SOLAR,
             reason="solar",
-            floor_clamp_applied=floor is not None,
+            position_constraint_applied=floor is not None,
         ),
         options,
         _sunset_cover(False),
@@ -160,7 +160,7 @@ def _day_night_case(frame_options: dict, logical: int, *, floor: int | None = No
             control_method=ControlMethod.CUSTOM_POSITION,
             reason="custom",
             tilt=50,
-            floor_clamp_applied=floor is not None,
+            position_constraint_applied=floor is not None,
         ),
         options,
         None,
@@ -214,7 +214,7 @@ def _make_coord(
         position=logical,
         control_method=ControlMethod.SOLAR,
         reason="solar",
-        floor_clamp_applied=floor is not None,
+        position_constraint_applied=floor is not None,
         decision_trace=[
             DecisionStep(
                 handler="solar", matched=True, reason="solar", position=logical


### PR DESCRIPTION
## Summary
Two cleanups deliberately kept out of #1036 so that behaviour-reversing diff stayed reviewable.

**1. The frame converters now live in a pure module.** `inverse_state` and `to_logical` moved out of `managers/manual_override/manager.py` into `position_utils.py`, which imports only `math`, `numpy`, and `.const`. `managers/` re-exports `inverse_state` so every existing caller keeps working.

`to_logical` is renamed `flip_if(value, *, inverted)`. The old name read as one-directional, which is why two call sites hand-rolled the same ternary in the opposite direction instead of delegating to it. `100 - x` is an involution, so one direction-neutral helper serves both frames.

Every hand-rolled `inverse_state(x) if inverted else x` is swept onto `flip_if`: `coordinator.py` (held-position and end-time seams), `sensor.py` x2, `cover.py`, `group_coordinator.py`, `cover_types/day_night_shade/policy.py` (both ends of its round trip), `state/window_transition_tracker.py`, and `cover_types/dual_panel/policy.py`. Each is a byte-identical substitution at the same point in the same function, so the inversion-then-threshold ordering is untouched.

`tests/test_position_utils.py` adds a purity lock that AST-parses the module and fails on a direct `homeassistant` import. Purity pressure is why #1036 deferred this move, so the lock keeps the layering from re-forming.

**2. `floor_clamp_applied` is renamed `position_constraint_applied`.** The flag used to mean, among other things, "this value is already in cover-position space", which is what `coordinator.state` read it for. #1036 removed the frame use entirely but the name kept implying it, and a comment in `coordinator.py` was still asserting the dead claim. The new name describes the three jobs it actually has: reason labelling, `skip_command=False` so a clamp reaches the cover even under a hold (#534/#809), and the trace payload.

The diagnostics `event_timeline` event key renames with the field. The companion Lovelace card reads the `floor_clamp` trace step, not this boolean, so nothing downstream breaks. The `floor_clamp` reason/trace string itself is unchanged.

Zero behaviour change: pure move, rename, and 1:1 substitution.

## Testing
- ✅ 9055 tests passing (9050 baseline + 5 new `position_utils` tests), 1 xfailed
- Regression guards green: `test_floor_clamped_winner_is_inverted_like_any_other`, `test_floor_clamped_winner_is_interpolated_like_any_other`, `test_dispatch_is_monotone_in_the_logical_request` (#1036/#1043 frame invariance); `test_floor_clamp_sets_position_constraint_applied_flag`, `test_floor_raises_manual_override_held_below_floor`, `test_floor_above_held_position_is_inert_under_manual_override` (#534/#809 forced dispatch under a hold)
- `./scripts/lint` clean

## Related Issues
Refs #1042