### PR TITLE
test: restore the day/night seam sweep's diverging cache (#1041)

### DIFF
--- a/tests/test_day_night_deep_audit_fixes.py
+++ b/tests/test_day_night_deep_audit_fixes.py
@@ -413,10 +413,8 @@ class TestBroadcastSeamInverseSpace:
         # physically pass below the bottom rail. The seam's wire value is the
         # logical position mapped into its OWN inversion space.
         policy = DayNightShadePolicy()
-        if cached_true:
-            _cache_dual(policy, position=logical_pos, blend=blend, inverse=True)
-        else:
-            _cache_dual(policy, position=logical_pos, blend=blend, inverse=False)
+        _cache_dual(policy, position=logical_pos, blend=blend, inverse=cached_true)
+        assert policy._dual_entity_inverse is cached_true
 
         bottom_wire = inverse_state(logical_pos) if seam_inverted else logical_pos
         middle_wire = policy.resolve_entity_target(

--- a/tests/test_day_night_deep_audit_fixes.py
+++ b/tests/test_day_night_deep_audit_fixes.py
@@ -8,7 +8,13 @@ Guards the behavioral corrections layered on top of Models A/B/C:
 * MED — a deferred blend update landing in the back-rotate suppression window is
   RECORDED pending + a refresh scheduled, never dropped (#756 parity).
 * MED — the Model C middle-rail remap stays consistent with the ACTUAL space of
-  the dispatched value (bypass / floor-clamp / interpolation skip inversion).
+  the dispatched value. The cached ``_dual_entity_inverse`` mirrors only the
+  main dispatch, and post-#1036/#1043 ``interp`` is the only lever left that
+  forces ``axis_inverted`` False while inverse is configured —
+  ``_cache_dual_entity`` derives the flag from ``axis_inverted(...)`` alone,
+  dropping the floor-clamp/bypass exclusion it used to carry. The broadcast
+  seams keep their own space regardless: pass ``inverted=`` explicitly rather
+  than letting ``resolve_entity_target`` fall back to the cache.
 * LOW — the ``dual_entity`` capability warning names the dual-entity model.
 """
 

--- a/tests/test_day_night_deep_audit_fixes.py
+++ b/tests/test_day_night_deep_audit_fixes.py
@@ -416,13 +416,7 @@ class TestBroadcastSeamInverseSpace:
         if cached_true:
             _cache_dual(policy, position=logical_pos, blend=blend, inverse=True)
         else:
-            _cache_dual(
-                policy,
-                position=logical_pos,
-                blend=blend,
-                inverse=True,
-                floor_clamp=True,
-            )
+            _cache_dual(policy, position=logical_pos, blend=blend, inverse=False)
 
         bottom_wire = inverse_state(logical_pos) if seam_inverted else logical_pos
         middle_wire = policy.resolve_entity_target(
@@ -439,7 +433,7 @@ class TestBroadcastSeamInverseSpace:
         # inverse_state(100)=0; the middle must stay physically >= the bottom
         # rail (open-space 100), never drop to open-space 50 (the buggy cross).
         policy = DayNightShadePolicy()
-        _cache_dual(policy, position=100, blend=50, inverse=True, floor_clamp=True)
+        _cache_dual(policy, position=100, blend=50, inverse=True)
         middle_wire = policy.resolve_entity_target(_MIDDLE, 0, inverted=True)
         assert inverse_state(middle_wire) >= 100
 

--- a/tests/test_day_night_dual_entity.py
+++ b/tests/test_day_night_dual_entity.py
@@ -317,9 +317,15 @@ def _dual_policy_primed(
 ) -> DayNightShadePolicy:
     """Prime a Model C policy's dispatch cache (blend + role map + inverse flag).
 
-    ``floor_clamp``/``bypass``/``interp`` drive the cached ``_dual_entity_inverse``
-    to False even with inverse configured — reproducing the main-pipeline space
-    that DIVERGES from the unconditional broadcast seams.
+    Only ``interp`` drives the cached ``_dual_entity_inverse`` to False even
+    with inverse configured — reproducing the main-pipeline space that
+    DIVERGES from the unconditional broadcast seams. ``floor_clamp`` and
+    ``bypass`` no longer have that effect: #1036/#1043 made
+    ``_cache_dual_entity`` derive the flag from ``axis_inverted(...)`` alone,
+    dropping the ``floor_clamp_applied``/``bypass_auto_control`` exclusion it
+    used to carry. Both kwargs stay on this helper so callers can still set
+    those ``PipelineResult`` fields for other assertions, but they no longer
+    diverge the cache.
     """
     policy = DayNightShadePolicy()
     from tests.cover_helpers import make_cover_config, make_vertical_config
@@ -363,19 +369,19 @@ async def test_sunset_seam_inverse_uses_seam_space_not_cached_flag() -> None:
     """Sunset-window broadcast under inverse_state → middle rail physically OPEN.
 
     Audit repro: sunset_pos=0, blend 0 (all blackout), inverse_state ON, and a
-    prior main cycle that was floor-clamped (cached inverse flag → False). The
-    sunset seam inverts unconditionally (sends wire 100), so the middle-rail
-    remap must un-invert 100 → open 0, yielding wire 0 (physically OPEN). Using
-    the stale cached flag (False) would leave the middle at wire 100 →
-    physically CLOSED, crossing the bottom rail.
+    prior main cycle that had interpolation enabled (cached inverse flag →
+    False — post-#1036/#1043, ``interp`` is the only lever left that forces
+    ``axis_inverted`` False while inverse is configured; floor-clamp/bypass no
+    longer do). The sunset seam inverts unconditionally (sends wire 100), so
+    the middle-rail remap must un-invert 100 → open 0, yielding wire 0
+    (physically OPEN). Using the stale cached flag (False) would leave the
+    middle at wire 100 → physically CLOSED, crossing the bottom rail.
     """
     from custom_components.adaptive_cover_pro.state.window_transition_tracker import (
         WindowTransitionTracker,
     )
 
-    policy = _dual_policy_primed(
-        position=0, blend=0, inverse_cfg=True, floor_clamp=True
-    )
+    policy = _dual_policy_primed(position=0, blend=0, inverse_cfg=True, interp=True)
 
     coord = MagicMock()
     coord._policy = policy
@@ -425,11 +431,12 @@ async def test_end_time_default_seam_inverse_uses_seam_space() -> None:
 
     Same divergence as the sunset seam: the end-time loop inverts the effective
     default unconditionally when inverse_state is configured, while the cached
-    flag reflects a floor-clamped main cycle (False). effective_pos=0, blend 0.
+    flag reflects a main cycle with interpolation enabled (False —
+    post-#1036/#1043, ``interp`` is the only lever left that forces
+    ``axis_inverted`` False while inverse is configured; floor-clamp/bypass no
+    longer do). effective_pos=0, blend 0.
     """
-    policy = _dual_policy_primed(
-        position=0, blend=0, inverse_cfg=True, floor_clamp=True
-    )
+    policy = _dual_policy_primed(position=0, blend=0, inverse_cfg=True, interp=True)
 
     coord = MagicMock()
     coord._policy = policy


### PR DESCRIPTION
## Summary
#1036 removed the lever two tests in `tests/test_day_night_deep_audit_fixes.py` leaned on:
`_cache_dual_entity` now derives `_dual_entity_inverse` from `axis_inverted()` alone, so
`floor_clamp=True` no longer pushes the cached flag away from the seam's explicit `inverted=`.
Both parametrize branches of `test_no_pass_holds_across_seam_spaces` cached `True`, making 24 of
the 48 sweep cases duplicates of the other 24, and the same inert argument in
`test_audit_repro_sunset_100_blend_50_no_cross` set up no divergence either.

I primed the `cached_true=False` branch with `inverse=False` so the cached flag genuinely differs
from the seam's `inverted=True`, and dropped the dead `floor_clamp` arguments from both.

The pre-merge audit then found the same dead lever in a second file. In
`tests/test_day_night_dual_entity.py`, `test_sunset_seam_inverse_uses_seam_space_not_cached_flag`
and `test_end_time_default_seam_inverse_uses_seam_space` primed with `floor_clamp=True`, which now
caches `True` - the sunset/end-time seams' own space. Both guards had gone inert: a mutant
`resolve_entity_target` that ignores the explicit `inverted=` and falls back to the cache passed
both tests, so the #993 bottom-rail cross could have shipped green through the two coordinator
broadcast paths. `interp` is the only lever that still forces `axis_inverted` False while inverse
is configured, so those two now prime with that instead. Under the mutant both fail on
`assert 0 == 100`.

I also pinned the cached flag in the sweep (`inverse=cached_true` plus
`assert policy._dual_entity_inverse is cached_true`), which collapses the mirrored if/else and
gives a future re-collapse something to trip over, and corrected the module header, which still
named floor-clamp and bypass as divergence levers.

No production code changed.

## Testing
- ✅ 9050 tests passing (1 xfailed)

## Related Issues
Refs #1041