### PR TITLE
feat: add endpoint-position-not-tracking triage rule (#1026)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -1924,6 +1924,8 @@ class TriageCode(StrEnum):
     STALE_VERSION = "triage.stale_version"
     # -- rule 14: inside/outside temperature sensors report different units
     MIXED_TEMP_UNITS = "triage.mixed_temp_units"
+    # -- rule 25: an endpoint open/close command never moved current_position
+    ENDPOINT_POSITION_NOT_TRACKING = "triage.endpoint_position_not_tracking"
     # -- fragment (NOT a rule): the localized "N minutes ago" clause the three
     # skip findings splice in when a skip timestamp is known. Rendered only as a
     # nested param of the skip templates, never emitted as a top-level finding —

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -3628,6 +3628,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 "current_position": _positions.get(eid),
                 "transit_state": self._cmd_svc.get_transit_direction(eid),
                 "available": _positions.get(eid) is not None,
+                "ha_state": getattr(self.hass.states.get(eid), "state", None),
                 "capabilities": (
                     dataclasses.asdict(_caps[eid]) if eid in _caps else None
                 ),

--- a/custom_components/adaptive_cover_pro/diagnostics/triage.py
+++ b/custom_components/adaptive_cover_pro/diagnostics/triage.py
@@ -38,6 +38,7 @@ from ..const import (
     CONF_ENABLE_POSITION_MATCHING,
     CONF_ENABLE_SUN_TRACKING,
     CONF_END_TIME,
+    CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_IRRADIANCE_ENTITY,
     CONF_IS_SUNNY_SENSOR,
     CONF_IS_SUNNY_TEMPLATE,
@@ -46,6 +47,7 @@ from ..const import (
     CONF_MAX_ELEVATION,
     CONF_MIN_POSITION,
     CONF_OUTSIDETEMP_ENTITY,
+    CONF_POSITION_TOLERANCE,
     CONF_PRESENCE_ENTITY,
     CONF_PRESENCE_TEMPLATE,
     CONF_START_ENTITY,
@@ -59,6 +61,7 @@ from ..const import (
     GLARE_ZONE_SLOTS,
     POSITION_CLOSED,
     POSITION_OPEN,
+    POSITION_TOLERANCE_PERCENT,
     ControlStatus,
     TriageCode,
 )
@@ -104,6 +107,14 @@ _NEAR_BINARY_DISTANCE_M = 0.75
 # A movement-hysteresis delta wider than this (%) is "wide" for rule 19 — a
 # special 0/100 default paired with it means fine intermediate moves are gated.
 _WIDE_DELTA_PCT = 5
+
+# Mirrors cover_types.base.CAP_HAS_SET_POSITION — duplicated because that
+# module imports Home Assistant and this one may not; see module docstring.
+_CAP_HAS_SET_POSITION = "has_set_position"
+# HA state strings for the mechanical stops this rule discriminates on. Named
+# here (not imported from homeassistant.const) for the same reason.
+_HA_STATE_OPEN = "open"
+_HA_STATE_CLOSED = "closed"
 
 
 # ---------------------------------------------------------------------------
@@ -925,6 +936,63 @@ def _check_stale_version(data: Mapping) -> Iterable[Mapping]:
         yield {"latest": latest_raw, "current": current_raw}
 
 
+def _check_endpoint_position_not_tracking(data: Mapping) -> Iterable[Mapping]:
+    """Rule 25 — an endpoint open/close command never moved current_position.
+
+    Fires when endpoint_use_open_close routed a 0/100 target to open_cover/
+    close_cover, the reconciliation loop is still waiting (not given up), the
+    reported current_position never converged within tolerance, AND the
+    entity's own HA state already claims the matching mechanical stop — the
+    "claims open but position stuck at 0" discriminator #1026 identifies.
+    Distinct from rule 18 (ENDPOINT_CHASE), which requires gave_up is True;
+    this rule requires gave_up is NOT True, so the two are mutually exclusive.
+    """
+    options = _get(data, "options")
+    if not isinstance(options, Mapping) or not options.get(
+        CONF_ENDPOINT_USE_OPEN_CLOSE
+    ):
+        return
+    commands = _get(data, "cover_commands")
+    covers = _get(data, "covers")
+    if not isinstance(commands, Mapping) or not isinstance(covers, Mapping):
+        return
+    tolerance = options.get(CONF_POSITION_TOLERANCE)
+    tolerance = (
+        int(tolerance)
+        if isinstance(tolerance, int | float) and not isinstance(tolerance, bool)
+        else POSITION_TOLERANCE_PERCENT
+    )
+    for eid, state in commands.items():
+        if not isinstance(state, Mapping):
+            continue
+        target = state.get("target_call")
+        if target not in (POSITION_CLOSED, POSITION_OPEN):
+            continue
+        if state.get("wait_for_target") is not True or state.get("gave_up") is True:
+            continue
+        cover = covers.get(eid)
+        if not isinstance(cover, Mapping):
+            continue
+        current = cover.get("current_position")
+        if not isinstance(current, int | float) or isinstance(current, bool):
+            continue
+        if abs(current - target) <= tolerance:
+            continue
+        expected = _HA_STATE_OPEN if target == POSITION_OPEN else _HA_STATE_CLOSED
+        if cover.get("ha_state") != expected:
+            continue
+        caps = cover.get("capabilities")
+        if not isinstance(caps, Mapping) or not caps.get(_CAP_HAS_SET_POSITION):
+            continue
+        yield {
+            "entity": eid,
+            "service": "open_cover" if target == POSITION_OPEN else "close_cover",
+            "target": target,
+            "state": expected,
+            "current": current,
+        }
+
+
 # ---------------------------------------------------------------------------
 # The rule table
 # ---------------------------------------------------------------------------
@@ -1181,6 +1249,15 @@ TRIAGE_RULES: tuple[TriageRule, ...] = (
         wiki="Troubleshooting-Findings#stale-version",
         issues=(972,),
         check=_check_stale_version,
+    ),
+    TriageRule(
+        code=TriageCode.ENDPOINT_POSITION_NOT_TRACKING,
+        severity=Severity.WARNING,
+        inputs=RuleInput.CONFIG | RuleInput.RUNTIME,
+        fix_step="position",
+        wiki="Troubleshooting-Findings#endpoint-position-not-tracking",
+        issues=(1026,),
+        check=_check_endpoint_position_not_tracking,
     ),
 )
 

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n.py
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n.py
@@ -196,6 +196,14 @@ _TRIAGE_TEMPLATES_EN: dict[str, str] = {
         "convert between units, so climate comparisons will be wrong. Set both "
         "temperature sensors to the same unit."
     ),
+    # Rule 25
+    TriageCode.ENDPOINT_POSITION_NOT_TRACKING: (
+        "⚠️ {entity} was sent {service} for the {target}% endpoint and reports "
+        "itself {state}, but its position attribute is still {current}%. This "
+        "cover doesn't update its reported position from open/close commands. "
+        "Turn off 'Use open/close at endpoints' so the integration sends "
+        "set_cover_position instead."
+    ),
 }
 
 

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/de.json
@@ -27,6 +27,7 @@
     "skip_cover_unavailable": "⚠️ Der letzte Befehl an {entity} wurde übersprungen{when}, weil die Beschattung nicht verfügbar war. Überprüfen Sie das Gerät – es war offline, als die Integration versuchte, es zu bewegen.",
     "skip_age": " vor {age_minutes} Minuten",
     "stale_version": "⚠️ Eine neuere Version ist verfügbar: Sie nutzen {current}, aber {latest} ist erschienen. Aktualisieren Sie die Integration über HACS, um die neuesten Fehlerbehebungen zu erhalten.",
-    "mixed_temp_units": "🛑 Der Innentemperatursensor meldet {inside_unit}, aber der Außentemperatursensor meldet {outside_unit}. Adaptive Cover Pro rechnet nicht zwischen Einheiten um, daher werden Klimavergleiche falsch. Stellen Sie beide Temperatursensoren auf dieselbe Einheit ein."
+    "mixed_temp_units": "🛑 Der Innentemperatursensor meldet {inside_unit}, aber der Außentemperatursensor meldet {outside_unit}. Adaptive Cover Pro rechnet nicht zwischen Einheiten um, daher werden Klimavergleiche falsch. Stellen Sie beide Temperatursensoren auf dieselbe Einheit ein.",
+    "endpoint_position_not_tracking": "⚠️ {entity} wurde der Befehl {service} für den {target}%-Endpunkt gesendet und meldet sich selbst als {state}, aber sein Positionsattribut steht weiterhin auf {current}%. Diese Beschattung aktualisiert ihre gemeldete Position nicht durch Öffnen/Schließen-Befehle. Schalten Sie \"Öffnen/Schließen-Befehle an den Endlagen verwenden\" aus, damit die Integration stattdessen set_cover_position sendet."
   }
 }

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/en.json
@@ -27,6 +27,7 @@
     "skip_cover_unavailable": "⚠️ The last command to {entity} was skipped{when} because the cover was unavailable. Check the device — it was offline when the integration tried to move it.",
     "skip_age": " {age_minutes} minutes ago",
     "stale_version": "⚠️ A newer release is available: you are on {current} but {latest} has shipped. Update the integration through HACS to pick up the latest fixes.",
-    "mixed_temp_units": "🛑 The inside temperature sensor reports {inside_unit} but the outside temperature sensor reports {outside_unit}. Adaptive Cover Pro does not convert between units, so climate comparisons will be wrong. Set both temperature sensors to the same unit."
+    "mixed_temp_units": "🛑 The inside temperature sensor reports {inside_unit} but the outside temperature sensor reports {outside_unit}. Adaptive Cover Pro does not convert between units, so climate comparisons will be wrong. Set both temperature sensors to the same unit.",
+    "endpoint_position_not_tracking": "⚠️ {entity} was sent {service} for the {target}% endpoint and reports itself {state}, but its position attribute is still {current}%. This cover doesn't update its reported position from open/close commands. Turn off 'Use open/close at endpoints' so the integration sends set_cover_position instead."
   }
 }

--- a/custom_components/adaptive_cover_pro/troubleshoot_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/troubleshoot_i18n/fr.json
@@ -27,6 +27,7 @@
     "skip_cover_unavailable": "⚠️ La dernière commande vers {entity} a été ignorée{when} car le store était indisponible. Vérifiez l'appareil — il était hors ligne quand l'intégration a essayé de le déplacer.",
     "skip_age": " il y a {age_minutes} minutes",
     "stale_version": "⚠️ Une version plus récente est disponible : vous êtes sur {current} mais {latest} est sortie. Mettez à jour l'intégration via HACS pour bénéficier des derniers correctifs.",
-    "mixed_temp_units": "🛑 Le capteur de température intérieure indique {inside_unit} mais le capteur de température extérieure indique {outside_unit}. Adaptive Cover Pro ne convertit pas entre les unités, les comparaisons climatiques seront donc erronées. Réglez les deux capteurs de température sur la même unité."
+    "mixed_temp_units": "🛑 Le capteur de température intérieure indique {inside_unit} mais le capteur de température extérieure indique {outside_unit}. Adaptive Cover Pro ne convertit pas entre les unités, les comparaisons climatiques seront donc erronées. Réglez les deux capteurs de température sur la même unité.",
+    "endpoint_position_not_tracking": "⚠️ La commande {service} a été envoyée à {entity} pour la fin de course {target}% et il se signale {state}, mais son attribut de position reste à {current}%. Ce store ne met pas à jour sa position signalée lors des commandes d'ouverture/fermeture. Désactivez « Utiliser les commandes d'ouverture/fermeture aux fins de course » pour que l'intégration envoie plutôt set_cover_position."
   }
 }

--- a/tests/test_assumed_position_surface.py
+++ b/tests/test_assumed_position_surface.py
@@ -339,3 +339,31 @@ async def test_assumed_cleared_on_native_position_command(
     await coordinator._cmd_svc.apply_position("cover.test_blind", 30, "solar", ctx)
 
     assert coordinator._cmd_svc.get_assumed_position("cover.test_blind") is None
+
+
+# ---------------------------------------------------------------------------
+# Coordinator wiring — covers[eid]["ha_state"] (issue #1026)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_diagnostic_data_covers_includes_ha_state(
+    hass: HomeAssistant,
+) -> None:
+    """Diagnostics ``covers[eid]`` carries the entity's raw HA state (#1026).
+
+    Distinct from ``transit_state`` (an ACP-synthetic "opening"/"closing"
+    belief) — this is the entity's own reported state string, the
+    discriminator the ENDPOINT_POSITION_NOT_TRACKING triage rule needs to
+    tell "claims open but position stuck" apart from "still catching up".
+    """
+    coordinator = await _setup_open_close_cover(hass, my_position=50)
+
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": _OPEN_CLOSE_STOP},
+    )
+
+    diag = coordinator.build_diagnostic_data()
+    assert diag["covers"]["cover.test_blind"]["ha_state"] == "open"

--- a/tests/test_triage_contract.py
+++ b/tests/test_triage_contract.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_ENDPOINT_USE_OPEN_CLOSE,
     CONF_OUTSIDETEMP_ENTITY,
+    POSITION_OPEN,
     ControlMethod,
     TriageCode,
 )
@@ -327,3 +329,69 @@ def test_mixed_temp_units_does_not_fire_when_units_match():
     )
     findings = run_triage({"options": {}, **diag})
     assert TriageCode.MIXED_TEMP_UNITS not in _codes(findings)
+
+
+# ---------------------------------------------------------------------------
+# (ix) rule 25 ENDPOINT_POSITION_NOT_TRACKING fires on real covers/cover_commands
+# ---------------------------------------------------------------------------
+
+
+def _endpoint_covers(current_position: int) -> dict:
+    return {
+        "cover.a": {
+            "current_position": current_position,
+            "available": True,
+            "transit_state": None,
+            "ha_state": "open",
+            "capabilities": {
+                "has_set_position": True,
+                "has_set_tilt_position": False,
+                "has_open": True,
+                "has_close": True,
+            },
+        }
+    }
+
+
+def _endpoint_command_state() -> dict:
+    return {
+        "cover.a": {
+            "target_call": POSITION_OPEN,
+            "wait_for_target": True,
+            "retry_count": 0,
+            "gave_up": False,
+        }
+    }
+
+
+def test_endpoint_position_not_tracking_fires_on_real_builder_output():
+    """A stuck-at-0 cover claiming "open" under endpoint routing → the new rule.
+
+    Proves rule 25's RUNTIME key path — ``covers[eid]["ha_state"]`` (the field
+    added to ``coordinator.build_diagnostic_data()`` for issue #1026) — survives
+    the real ``DiagnosticsBuilder`` passthrough, not just a hand-built dict.
+    """
+    diag, _ = DiagnosticsBuilder().build(
+        _base_ctx(
+            covers=_endpoint_covers(current_position=0),
+            cover_command_state=_endpoint_command_state(),
+        )
+    )
+
+    # Sanity: the builder really did emit the keys the rule reads.
+    assert diag["covers"]["cover.a"]["ha_state"] == "open"
+    assert diag["cover_commands"]["cover.a"]["target_call"] == POSITION_OPEN
+
+    findings = run_triage({"options": {CONF_ENDPOINT_USE_OPEN_CLOSE: True}, **diag})
+    assert TriageCode.ENDPOINT_POSITION_NOT_TRACKING in _codes(findings)
+
+
+def test_endpoint_position_not_tracking_does_not_fire_when_position_tracks():
+    diag, _ = DiagnosticsBuilder().build(
+        _base_ctx(
+            covers=_endpoint_covers(current_position=100),
+            cover_command_state=_endpoint_command_state(),
+        )
+    )
+    findings = run_triage({"options": {CONF_ENDPOINT_USE_OPEN_CLOSE: True}, **diag})
+    assert TriageCode.ENDPOINT_POSITION_NOT_TRACKING not in _codes(findings)

--- a/tests/test_triage_rules.py
+++ b/tests/test_triage_rules.py
@@ -13,7 +13,10 @@ from pathlib import Path
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_ENDPOINT_USE_OPEN_CLOSE,
     CUSTOM_POSITION_SAFETY_PRIORITY,
+    POSITION_CLOSED,
+    POSITION_OPEN,
     TriageCode,
 )
 from custom_components.adaptive_cover_pro.diagnostics.triage import (
@@ -987,6 +990,149 @@ def test_rule18_near_miss_not_gave_up() -> None:
 
 def test_rule18_near_miss_empty() -> None:
     assert _fire(TriageCode.ENDPOINT_CHASE, {"cover_commands": {}}) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 25 — ENDPOINT_POSITION_NOT_TRACKING (RUNTIME, per-entity, issue #1026)
+# ---------------------------------------------------------------------------
+
+
+def _endpoint_view(
+    *,
+    target: int = POSITION_OPEN,
+    ha_state: str = "open",
+    current: int = 0,
+    wait_for_target: bool = True,
+    gave_up: bool = False,
+    has_set_position: bool = True,
+    endpoint_use_open_close: bool = True,
+) -> dict:
+    return {
+        "options": {CONF_ENDPOINT_USE_OPEN_CLOSE: endpoint_use_open_close},
+        "cover_commands": {
+            "cover.a": {
+                "target_call": target,
+                "wait_for_target": wait_for_target,
+                "gave_up": gave_up,
+            }
+        },
+        "covers": {
+            "cover.a": {
+                "current_position": current,
+                "ha_state": ha_state,
+                "capabilities": {"has_set_position": has_set_position},
+            }
+        },
+    }
+
+
+def test_rule25_fires_when_endpoint_open_reports_stuck_position() -> None:
+    findings = _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, _endpoint_view())
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.WARNING
+    assert findings[0].fix_step == "position"
+    assert dict(findings[0].reason.params) == {
+        "entity": "cover.a",
+        "service": "open_cover",
+        "target": POSITION_OPEN,
+        "state": "open",
+        "current": 0,
+    }
+
+
+def test_rule25_fires_when_endpoint_close_reports_stuck_position() -> None:
+    view = _endpoint_view(target=POSITION_CLOSED, ha_state="closed", current=100)
+    findings = _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view)
+    assert len(findings) == 1
+    assert dict(findings[0].reason.params) == {
+        "entity": "cover.a",
+        "service": "close_cover",
+        "target": POSITION_CLOSED,
+        "state": "closed",
+        "current": 100,
+    }
+
+
+def test_rule25_fires_per_entity_n_covers() -> None:
+    view = {
+        "options": {CONF_ENDPOINT_USE_OPEN_CLOSE: True},
+        "cover_commands": {
+            "cover.a": {
+                "target_call": POSITION_OPEN,
+                "wait_for_target": True,
+                "gave_up": False,
+            },
+            "cover.b": {
+                "target_call": POSITION_OPEN,
+                "wait_for_target": True,
+                "gave_up": False,
+            },
+            "cover.c": {
+                "target_call": POSITION_OPEN,
+                "wait_for_target": True,
+                "gave_up": False,
+            },
+        },
+        "covers": {
+            "cover.a": {  # genuinely stuck — claims open, position never moved
+                "current_position": 0,
+                "ha_state": "open",
+                "capabilities": {"has_set_position": True},
+            },
+            "cover.b": {  # tracked correctly
+                "current_position": 100,
+                "ha_state": "open",
+                "capabilities": {"has_set_position": True},
+            },
+            "cover.c": {  # still catching up — transient, not yet "open"
+                "current_position": 40,
+                "ha_state": "opening",
+                "capabilities": {"has_set_position": True},
+            },
+        },
+    }
+    findings = _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view)
+    assert _params(findings) == [
+        {
+            "entity": "cover.a",
+            "service": "open_cover",
+            "target": POSITION_OPEN,
+            "state": "open",
+            "current": 0,
+        }
+    ]
+
+
+def test_rule25_near_miss_endpoint_use_open_close_off() -> None:
+    view = _endpoint_view(endpoint_use_open_close=False)
+    assert _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view) == []
+
+
+def test_rule25_near_miss_mid_range_target() -> None:
+    view = _endpoint_view(target=50)
+    assert _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view) == []
+
+
+def test_rule25_near_miss_gave_up_true() -> None:
+    # Mutually exclusive with rule 18 (ENDPOINT_CHASE), which requires gave_up
+    # is True — this rule requires gave_up is NOT True.
+    view = _endpoint_view(gave_up=True)
+    assert _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view) == []
+
+
+def test_rule25_near_miss_still_in_transit() -> None:
+    view = _endpoint_view(ha_state="opening")
+    assert _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view) == []
+
+
+def test_rule25_near_miss_no_set_position_fallback() -> None:
+    view = _endpoint_view(has_set_position=False)
+    assert _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view) == []
+
+
+def test_rule25_near_miss_within_tolerance() -> None:
+    view = _endpoint_view(current=98)
+    assert _fire(TriageCode.ENDPOINT_POSITION_NOT_TRACKING, view) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds triage rule 25, `triage.endpoint_position_not_tracking`, for covers commanded to a 0%/100% mechanical endpoint via `open_cover`/`close_cover` whose reported `current_position` never follows. This is the one-way RF bridge case (Bond to Somfy RTS/RMS, `assumed_state: true`): the entity reports `open`/`closed` while its position attribute stays stale, so ACP re-sends the endpoint command every cycle chasing a convergence that cannot happen. The existing Endpoint chase rule (18) gates on `gave_up is True`, which never becomes true here because each resend resets the reconciliation counter, so nothing in the Troubleshoot step named the failure.

The rule fires per entity when `endpoint_use_open_close` is on, `target_call` is 0 or 100, `wait_for_target` is true and `gave_up` is not true, `current_position` is outside `position_tolerance` of the target, the entity's own HA state already claims the matching mechanical stop, and `set_cover_position` exists as a fallback to recommend. The `gave_up is not True` condition makes it mutually exclusive with rule 18.

That HA-state discriminator needed a new diagnostics field, so `ha_state` was added to the `covers` section in `coordinator.build_diagnostic_data()` (the only place `hass` is already in scope; `diagnostics/builder.py:_build_covers` is a pure passthrough of `ctx.covers`).

Findings-page section published to the wiki at `Troubleshooting-Findings#endpoint-position-not-tracking`.

## Testing
- ✅ 9083 tests passing (1 xfailed, 0 failed)
- 12 new tests: 9 fires/near-miss/N-entity cases in `test_triage_rules.py`, 2 real-`DiagnosticsBuilder` contract tests in `test_triage_contract.py`, 1 coordinator-wiring test for the new `ha_state` field
- Regression guards green and untouched: rule 18's three tests, all of `test_assumed_position_surface.py`, the triage meta-test block (bijection, wiki-anchor-resolves, fix-step-reachable), and the EN/DE/FR i18n parity and placeholder locks

## Related Issues
Refs #1026