### PR TITLE
perf: run all test modes under -n auto, scope coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,7 @@ jobs:
   lint:
     name: Lint (Ruff + Black)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -50,6 +51,7 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }} / HA ${{ matrix.ha-channel }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -116,10 +118,13 @@ jobs:
           )
           PY
 
-      - name: Run tests with coverage
-        run: |
-          pytest -n auto --cov --cov-report=xml --cov-report=term \
-            --junitxml=junit.xml -o junit_family=legacy
+      # Coverage and junit output are consumed only by the Codecov upload steps
+      # below, which run on the stable leg alone. Tracing costs ~29% of the run,
+      # so the min and dev legs go bare and report pass/fail sooner.
+      - name: Run tests
+        env:
+          REPORT_ARGS: "${{ matrix.ha-channel == 'stable' && '--cov --cov-report=xml --cov-report=term --junitxml=junit.xml -o junit_family=legacy' || '' }}"
+        run: pytest -n auto $REPORT_ARGS
 
       - name: Upload coverage to Codecov (stable only)
         if: matrix.python-version == '3.14' && matrix.ha-channel == 'stable'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,10 +27,16 @@
   "python.linting.flake8Enabled": false,
 
   // Pytest Configuration
+  // Deliberately no `-n auto` here: these args are reused by "Debug Test", and
+  // debugpy cannot attach through an xdist worker, so breakpoints would stop
+  // working. For a fast full-suite run use the "Run All Tests" task, which goes
+  // through ./scripts/test (parallel, ~13s vs ~49s).
   "python.testing.pytestEnabled": true,
   "python.testing.unittestEnabled": false,
-  "python.testing.pytestArgs": ["tests", "-v", "--no-cov"],
-  "python.testing.autoTestDiscoverOnSaveEnabled": true,
+  "python.testing.pytestArgs": ["tests", "--no-cov"],
+  // Re-collecting 322 test modules costs ~4s, which is too much to pay on
+  // every save. Discovery still runs on demand from the Test Explorer.
+  "python.testing.autoTestDiscoverOnSaveEnabled": false,
 
   // Terminal Integration (macOS/Linux)
   "terminal.integrated.env.osx": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -54,7 +54,7 @@
     {
       "label": "Run All Tests",
       "type": "shell",
-      "command": "source venv/bin/activate && python -m pytest tests/ -v",
+      "command": "${workspaceFolder}/scripts/test",
       "problemMatcher": {
         "owner": "python",
         "fileLocation": ["relative", "${workspaceFolder}"],
@@ -74,7 +74,7 @@
     {
       "label": "Run Tests with Coverage",
       "type": "shell",
-      "command": "source venv/bin/activate && python -m pytest tests/ --cov=custom_components/adaptive_cover_pro --cov-report=term --cov-report=html",
+      "command": "${workspaceFolder}/scripts/test coverage",
       "problemMatcher": [],
       "group": "testing",
       "presentation": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,17 @@ markers = [
     "integration: Integration tests (slower, may require Home Assistant)",
     "perf: Wall-clock performance-budget tests (flaky on loaded hosts; skip with -m 'not perf')",
 ]
+# Hang watchdog. The whole suite runs in ~13s parallel and ~50s serially, so
+# nothing legitimate comes near this — it exists so a deadlocked test fails with
+# a traceback in two minutes instead of burning a CI job's full timeout.
+# Signal-based (the default on Unix); do NOT switch to timeout_method = "thread",
+# which would spawn a timer thread for each of the 9,000+ tests.
+timeout = 120
+
+[tool.coverage.run]
+# Without this, `--cov` has no source filter and measures whatever gets imported
+# — which means tests/ supplies ~78% of the denominator and the reported number
+# mostly reflects tests executing their own lines. Scoping to the integration is
+# what makes the Codecov project gate, and any before/after coverage diff,
+# actually mean something.
+source = ["custom_components/adaptive_cover_pro"]

--- a/scripts/_venv.sh
+++ b/scripts/_venv.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Shared virtualenv resolution. Sourced by scripts/{test,lint,develop} — not
+# meant to be executed directly.
+#
+# Call activate_venv from a script that has already cd'd to the repo root.
+# Returns non-zero when no venv could be found, so each caller decides whether
+# that is fatal (develop) or merely a fallback to whatever is on PATH (lint).
+
+activate_venv() {
+    if [[ -d "venv" ]]; then
+        # shellcheck disable=SC1091
+        source venv/bin/activate
+        return 0
+    fi
+
+    # A linked worktree has no venv/ of its own, so fall back to the main
+    # checkout's — git-common-dir points at the shared .git directory, whose
+    # parent is the main working tree.
+    local main_checkout
+    main_checkout="$(dirname "$(git rev-parse --git-common-dir)")"
+    if [[ -d "$main_checkout/venv" ]]; then
+        # shellcheck disable=SC1091
+        source "$main_checkout/venv/bin/activate"
+        return 0
+    fi
+
+    return 1
+}

--- a/scripts/develop
+++ b/scripts/develop
@@ -9,12 +9,12 @@ echo "Stopping any running Home Assistant instances..."
 "${PWD}/scripts/stop"
 
 # Activate virtual environment
-if [[ ! -d "venv" ]]; then
+# shellcheck source=scripts/_venv.sh
+source scripts/_venv.sh
+if ! activate_venv; then
     echo "Error: venv directory not found. Run ./scripts/setup first."
     exit 1
 fi
-
-source venv/bin/activate
 
 # Create config dir if not present
 if [[ ! -d "${PWD}/config" ]]; then

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,17 +4,9 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-# Activate the virtual environment. A linked worktree has no venv/ of its own,
-# so fall back to the main checkout's — git-common-dir points at the shared
-# .git directory, whose parent is the main working tree.
-if [[ -d "venv" ]]; then
-    source venv/bin/activate
-else
-    main_checkout="$(dirname "$(git rev-parse --git-common-dir)")"
-    if [[ -d "$main_checkout/venv" ]]; then
-        source "$main_checkout/venv/bin/activate"
-    fi
-fi
+# shellcheck source=scripts/_venv.sh
+source scripts/_venv.sh
+activate_venv || true
 
 for tool in ruff black; do
     if ! command -v "$tool" >/dev/null 2>&1; then

--- a/scripts/test
+++ b/scripts/test
@@ -3,14 +3,30 @@
 # Test runner for Adaptive Cover Pro
 #
 # Usage:
-#   ./scripts/test              # Run all tests
-#   ./scripts/test fast         # Parallel, skip wall-clock perf-budget tests (inner loop)
-#   ./scripts/test unit         # Run only unit tests
-#   ./scripts/test coverage     # Run with detailed coverage
+#   ./scripts/test              # Everything
+#   ./scripts/test fast         # Skip wall-clock perf budgets (inner loop)
+#   ./scripts/test unit         # Only tests that need no Home Assistant instance
+#   ./scripts/test coverage     # Everything, plus a coverage report
+#   ./scripts/test serial       # Escape hatch — no xdist, so -s/--pdb/--lf work
+#
+# Extra args pass through: ./scripts/test serial -k my_test --pdb
+#
+# Every mode but `serial` runs under `pytest -n auto`. This suite takes ~50s
+# serially and ~13s parallel, and roughly two thirds of even that is per-worker
+# interpreter and homeassistant import cost, so it will not go much lower.
 
 set -e
 
 cd "$(dirname "$0")/.."
+
+# shellcheck source=scripts/_venv.sh
+source scripts/_venv.sh
+activate_venv || true
+
+if ! command -v pytest >/dev/null 2>&1; then
+    echo "pytest not found. Run ./scripts/setup, or activate a venv that has it." >&2
+    exit 1
+fi
 
 GREEN='\033[0;32m'
 RESET='\033[0m'
@@ -18,23 +34,39 @@ RESET='\033[0m'
 echo -e "${GREEN}Adaptive Cover Pro Test Runner${RESET}"
 echo ""
 
-case "${1:-all}" in
+# Consume the first argument only when it names a mode, so anything else
+# (`./scripts/test -k my_test`) passes straight through to pytest.
+mode="all"
+case "${1:-}" in
+  fast | unit | coverage | serial | all)
+    mode="$1"
+    shift
+    ;;
+esac
+
+case "$mode" in
   fast)
-    echo "Running fast inner loop (parallel, no perf budgets)..."
-    pytest -n auto -m "not perf" -q
+    echo "Running fast inner loop (no perf budgets)..."
+    pytest -n auto -m "not perf" -q "$@"
     ;;
   unit)
-    echo "Running unit tests only..."
-    pytest -m unit -v
+    # `not integration` rather than `unit`: it selects every test that does not
+    # build a HomeAssistant, which is the distinction that costs time.
+    echo "Running tests that need no Home Assistant instance..."
+    pytest -n auto -m "not integration" -q "$@"
     ;;
   coverage)
     echo "Running all tests with detailed coverage..."
-    pytest --cov --cov-report=term-missing --cov-report=html
+    pytest -n auto --cov --cov-report=term-missing --cov-report=html "$@"
     echo ""
     echo "Coverage report: htmlcov/index.html"
     ;;
-  all|*)
+  serial)
+    echo "Running serially (xdist off — -s, --pdb and --lf work here)..."
+    pytest "$@"
+    ;;
+  all)
     echo "Running all tests..."
-    pytest -v
+    pytest -n auto -q "$@"
     ;;
 esac


### PR DESCRIPTION
## Summary

Three of the four `scripts/test` modes and both VS Code test tasks ran serially. The suite takes ~49s that way and ~12s under `-n auto`, so the default `./scripts/test` was paying 37s for nothing.

I measured where the parallel wall clock actually goes before changing anything:

| Component | Time | Share |
|---|---|---|
| 18 workers × (interpreter start + `homeassistant` import) | 5.8s | 41% |
| each worker executing 322 test-module bodies | 3.6s | 25% |
| the 689 `integration` tests (7.6% of suite) | 3.4s | 24% |
| **the other 8,410 tests (92% of suite)** | **1.4s** | **10%** |

Two thirds of the run is fixed cost, so the test count was never the lever — the invocation was.

**Results**

| | Before | After |
|---|---|---|
| `./scripts/test` (default) | 49.2s | **11.9s** |
| `./scripts/test coverage` | 57.7s | **15.6s** |
| `./scripts/test unit` | 11.1s | **9.2s** |
| VS Code, per file save | 3.9s re-collect | **0s** |

**What changed**

- **`scripts/test`** — every mode gets `-n auto`, plus a `serial` escape hatch since `-s`/`--pdb`/`--lf` don't work under xdist. Extra args pass through (`./scripts/test serial -k my_test --pdb`). `unit` now selects `not integration` — the distinction that actually costs time — rather than the `unit` marker, which 61% of tests don't carry.
- **`scripts/_venv.sh`** — `lint`, `develop` and `test` each carried their own copy of the venv resolution. Extracted to one sourced helper. Side effect: `scripts/test` now works from a worktree, which has no `venv/` of its own and where bare `pytest` isn't on `PATH`.
- **`.vscode`** — discovery-on-save re-collected 322 modules on every file save; turned off. `pytestArgs` deliberately keeps **no** `-n auto`, because those args are reused by "Debug Test" and debugpy cannot attach through an xdist worker. The two tasks route through `scripts/test` instead, matching how "Lint with Ruff" already calls `scripts/lint`.
- **CI** — `--cov` ran on all three matrix legs but is only uploaded from `stable`. Tracing costs ~29% per leg, so `min` and `dev` now run bare. Added `timeout-minutes` to both jobs, which had none.
- **`pyproject.toml`** — added a 120s per-test hang watchdog, and scoped coverage (below).

## ⚠️ One-time Codecov project drop — needs a waive

`--cov` had no source filter, so `tests/` supplied **78% of the coverage denominator** (56,390 of 72,278 statements). The reported ~99.15% mostly measured tests executing their own lines.

```
custom_components:  15,888 stmts,  387 missing  ->  97.56%   <- real
tests/           :  56,390 stmts,  225 missing  ->  99.60%   <- 78% of the denominator
```

Scoping to `custom_components/adaptive_cover_pro` reports the real **97.56%** — a one-time **-1.59pp** drop that exceeds the 0.5pp project gate and will show red once. After that the gate measures the integration for the first time, and `coverage.xml` shrinks from 487 files to 149.

## Testing

- ✅ 9,118 passed, 1 xfailed — identical before and after
- ✅ Collected test IDs byte-identical (9,119)
- ✅ Per-file uncovered-line diff: no line became uncovered; line-rate `0.9753` both sides
- ✅ `./scripts/lint` clean
- ✅ Verified `./scripts/test` works from a linked worktree with no venv

## Related Issues

None — follow-up work on marker hygiene and integration-test provisioning will land separately.