### PR TITLE
test: make the unit/integration marker taxonomy real, and honour it

### DIFF
--- a/tests/_helpers/markers.py
+++ b/tests/_helpers/markers.py
@@ -1,0 +1,35 @@
+"""Shared predicate behind the `unit` / `integration` marker taxonomy.
+
+Used by the auto-marking hook in ``tests/conftest.py`` and by the guard test in
+``tests/test_marker_taxonomy.py``. Per CODING_GUIDELINES § No Duplication +
+"cross-file test helpers live in ``tests/_helpers/``", it lives here rather than
+being spelled twice.
+"""
+
+PHCC_PLUGIN = "pytest_homeassistant_custom_component"
+
+
+def uses_real_hass(item) -> bool:
+    """Return True when ``item`` resolves the real Home Assistant ``hass`` fixture.
+
+    Building a ``HomeAssistant`` is what separates an integration test from a
+    unit test — it costs ~8 registry loads and dominates the suite's runtime.
+
+    A bare ``"hass" in item.fixturenames`` check is *not* good enough. Eight test
+    modules define their own module-level ``hass`` fixture returning a
+    ``MagicMock`` (``tests/test_cover_command_venetian.py``,
+    ``tests/test_area_temp_resolution.py``, and six others). That shadows PHCC's
+    fixture for those 64 tests, so the naive check would classify them as
+    integration tests and hand a ``MagicMock`` to the autouse cleanup fixtures,
+    which call ``hass.config_entries.async_entries()`` on it.
+
+    So resolve the fixture and check where it was defined instead.
+    ``name2fixturedefs`` lists overrides in definition order with the effective
+    one last, so the tail entry is the fixture the item will actually receive.
+    """
+    if "hass" not in item.fixturenames:
+        return False
+    defs = item._fixtureinfo.name2fixturedefs.get("hass")
+    if not defs:
+        return False
+    return defs[-1].func.__module__.startswith(PHCC_PLUGIN)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,8 +106,17 @@ async def _auto_unload_config_entries(request, verify_cleanup):
     Explicitly depends on verify_cleanup so this fixture is set up AFTER it and
     therefore tears down BEFORE it — guaranteeing entries are unloaded before
     verify_cleanup checks for lingering timer handles.
+
+    Gated on the test actually resolving the real ``hass`` fixture, not just on
+    the marker. 160 ``integration``-marked tests never build a HomeAssistant —
+    they call validators or schema builders directly — and the bare
+    ``getfixturevalue("hass")`` below was *creating* one for them purely to have
+    something to clean up. There is nothing to unload in that case: without
+    ``hass`` in the fixture closure a test has no route to create a config entry.
     """
-    if not request.node.get_closest_marker("integration"):
+    if not (
+        request.node.get_closest_marker("integration") and uses_real_hass(request.node)
+    ):
         yield
         return
 
@@ -182,10 +191,13 @@ def neutralize_venetian_delays(monkeypatch):
 def _auto_enable_custom_integrations(request):
     """Auto-enable custom integration discovery for real HA integration tests.
 
-    Only activates when the test is marked @pytest.mark.integration,
-    avoiding overhead for the fast mock-hass unit tests.
+    Gated on the test actually resolving the real ``hass`` fixture as well as on
+    the marker. PHCC's ``enable_custom_integrations`` takes ``hass``, so
+    requesting it forces a HomeAssistant into existence — which is wasted work
+    for the 160 ``integration``-marked tests that never touch one, and whose
+    assertions cannot observe the effect either way.
     """
-    if request.node.get_closest_marker("integration"):
+    if request.node.get_closest_marker("integration") and uses_real_hass(request.node):
         # Request the plugin's fixture by name via indirect call
         request.getfixturevalue("enable_custom_integrations")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,7 @@ def make_snapshot_for_cover(
     )
 
 
+from ._helpers.markers import uses_real_hass
 from .cover_helpers import (  # noqa: F401 — re-exported for convenience
     build_horizontal_cover,
     build_tilt_cover,
@@ -70,6 +71,32 @@ from .cover_helpers import (  # noqa: F401 — re-exported for convenience
     make_tilt_config,
     make_vertical_config,
 )
+
+
+def pytest_collection_modifyitems(items):
+    """Give every test a `unit` or `integration` marker, derived from its fixtures.
+
+    61% of the suite carried no marker at all, which made both `-m unit` and
+    `-m "not integration"` unreliable — the first missed most unit tests, the
+    second silently swept in every unmarked one. Deriving the marker here beats
+    editing 322 files, and it cannot drift the way hand-applied markers do.
+
+    Conservative by construction: an item that already declares either marker is
+    left exactly as authored, so this hook cannot change which fixtures any
+    existing test receives. Only previously-unmarked items are touched, and of
+    those the ones that gain `integration` are precisely the ones already
+    building a real HomeAssistant — so the autouse fixtures below start firing
+    for tests that genuinely need them.
+
+    Any marker applied here must be registered in `pyproject.toml`; with
+    `--strict-markers` an unregistered one fails the whole run at collection.
+    """
+    for item in items:
+        if item.get_closest_marker("unit") or item.get_closest_marker("integration"):
+            continue
+        item.add_marker(
+            pytest.mark.integration if uses_real_hass(item) else pytest.mark.unit
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -65,7 +65,11 @@ from custom_components.adaptive_cover_pro.const import (
     CoverType,
 )
 
-pytestmark = pytest.mark.integration
+# No module-level pytestmark: most of this file drives a real config-entry flow,
+# but a handful of tests only exercise schema builders. A blanket `integration`
+# mark collided with their explicit `@pytest.mark.unit`, leaving them tagged both
+# and unreachable via either selector. The conftest hook derives the right marker
+# per test from whether it resolves the real `hass` fixture.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_manual_override_input.py
+++ b/tests/test_manual_override_input.py
@@ -18,7 +18,9 @@ from custom_components.adaptive_cover_pro.managers.manual_override import (
     AdaptiveCoverManager,
 )
 
-pytestmark = pytest.mark.unit
+# No module-level pytestmark: one test here drives a real options flow and marks
+# itself `integration`, which collided with a blanket `unit` mark. The conftest
+# hook derives the right marker per test.
 
 
 def _make_manager(covers: list[str]) -> AdaptiveCoverManager:

--- a/tests/test_marker_taxonomy.py
+++ b/tests/test_marker_taxonomy.py
@@ -1,0 +1,63 @@
+"""Locks on the `unit` / `integration` marker taxonomy.
+
+`./scripts/test unit` and CI's selectors are only trustworthy if every test
+carries exactly one of the two markers and the markers mean what they say.
+`tests/conftest.py::pytest_collection_modifyitems` establishes that; these tests
+stop it from silently regressing — e.g. if a future hook edit skips a class of
+items, or someone hand-marks a `hass` test as `unit`.
+
+`request.session.items` is the full collected list even under xdist, because
+every worker collects the whole suite before running its assigned share. It is
+*not* full when the run itself is filtered — under `-m unit` or `-k foo` these
+checks only see what survived selection. That is fine: the gate that matters is
+the unfiltered run CI and `./scripts/test` both perform.
+"""
+
+import pytest
+
+from ._helpers.markers import uses_real_hass
+
+pytestmark = pytest.mark.unit
+
+TAXONOMY = {"unit", "integration"}
+
+
+def test_every_test_carries_exactly_one_taxonomy_marker(request):
+    """No test may be unmarked, and none may claim to be both."""
+    offenders = [
+        (item.nodeid, sorted({m.name for m in item.iter_markers()} & TAXONOMY))
+        for item in request.session.items
+        if len({m.name for m in item.iter_markers()} & TAXONOMY) != 1
+    ]
+    assert not offenders, (
+        f"{len(offenders)} test(s) lack exactly one of {sorted(TAXONOMY)}: "
+        f"{offenders[:10]}"
+    )
+
+
+def test_unit_marker_never_builds_a_home_assistant(request):
+    """`unit` must mean "no HomeAssistant" — that is the whole point of the split.
+
+    A test marked `unit` that resolves the real `hass` fixture makes
+    `./scripts/test unit` slower than it claims and hides an integration test in
+    the fast lane. Mark it `integration` instead.
+    """
+    offenders = [
+        item.nodeid
+        for item in request.session.items
+        if item.get_closest_marker("unit") and uses_real_hass(item)
+    ]
+    assert not offenders, (
+        f"{len(offenders)} test(s) marked `unit` build a real HomeAssistant: "
+        f"{offenders[:10]}"
+    )
+
+
+def test_taxonomy_markers_are_registered(pytestconfig):
+    """`--strict-markers` is on, so an unregistered marker fails collection."""
+    registered = {
+        line.split(":", 1)[0].strip() for line in pytestconfig.getini("markers")
+    }
+    assert (
+        registered >= TAXONOMY
+    ), f"missing from pyproject.toml: {TAXONOMY - registered}"


### PR DESCRIPTION
> **Stacked on #1078** — base is `refactor/test-runner-parallel`, so this diff shows only the two commits added on top. Merge #1078 first; GitHub will retarget this to `develop`.

## Summary

Two commits, deliberately separate — the first is metadata-only, the second changes runtime behaviour for 160 tests.

### 1. Derive the marker from fixture usage

**5,593 of 9,119 tests (61%) carried no marker at all.** `-m unit` found only 2,828 of them; `-m "not integration"` silently swept in every unmarked test. Neither selector could be trusted, which is why `scripts/test unit` wasn't a usable inner loop.

A `pytest_collection_modifyitems` hook now derives the marker for any test that doesn't declare one. Already-marked tests are left exactly as authored, so the hook **cannot** change which fixtures an existing test receives.

The predicate is deliberately **not** `"hass" in item.fixturenames`. Eight modules define their own module-level `hass` fixture returning a `MagicMock`, shadowing PHCC's for 64 tests. The naive check would have classified those as integration tests and handed a `MagicMock` to `_auto_unload_config_entries`, which iterates `hass.config_entries.async_entries()` on it. So `uses_real_hass()` resolves the fixture and checks it came from PHCC. It lives in `tests/_helpers/` because the guard test needs the same definition.

Also dropped two overreaching module-level `pytestmark`s. **Seven tests carried _both_ markers** — six schema-builder tests in `test_config_flow_integration.py` marked `unit` under a blanket `integration`, and one options-flow test marked `integration` under a blanket `unit` — so they matched neither selector cleanly. In both cases the per-test marker was the correct one. No test loses a fixture it uses: of the 9 config-flow tests that flip to `unit`, none resolves a real `hass`.

| selector | before | after |
|---|---|---|
| `-m unit` | 2,828 | **8,376** |
| `-m integration` | 689 | **746** |
| `-m "not unit and not integration"` | 5,593 | **0** |
| `-m "unit and integration"` | 7 | **0** |

`tests/test_marker_taxonomy.py` locks it: every test carries exactly one of the two markers, and `unit` never builds a HomeAssistant.

### 2. Build a HomeAssistant only when a test actually uses one

160 `integration`-marked tests never touch Home Assistant — they call validators, schema builders or pure helpers. Both autouse fixtures gated purely on the marker, and `_auto_unload_config_entries` opened with `request.getfixturevalue("hass")` — so **the gate itself was creating a HomeAssistant** (8 registry loads, 7 nested patches) for each of them, just to have something to clean up.

Both gates now also require the test to resolve the real `hass`. This is **strictly narrowing** — new condition = old condition ∧ extra predicate — so no test gains a fixture, and the set that stops firing is exactly those 160. Nothing there can observe the difference: `enable_custom_integrations` takes `hass` and cannot run without one, and a test with no `hass` in its closure has no route to create a config entry for the unload pass to find.

| | before | after |
|---|---|---|
| 4 worst files, serial | 5.98s | **5.55s** (−7%) |
| full suite, `-n auto` | 11.3s | **10.6s** (−6%) |

Three runs each, medians.

## Testing

- ✅ 9,121 passed, 1 xfailed (3 new taxonomy guard tests)
- ✅ The 11 affected files pass in isolation and in the full parallel run
- ✅ Per-file uncovered-line diff vs baseline: no regressions, line-rate `0.9753` unchanged
- ✅ `./scripts/lint` clean

## Related Issues

None.