### PR TITLE
fix: repaint group who-won when a member's winner changes (#1082)

### DIFF
--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -32,11 +32,12 @@ from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     SERVICE_SET_COVER_TILT_POSITION,
 )
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_STOP_COVER, Platform
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -95,6 +96,19 @@ class GroupAggregates:
     member_positions: dict[str, int | None]
 
 
+@dataclass(frozen=True, slots=True)
+class _MemberSubscription:
+    """One live subscription to a member coordinator's update notifications.
+
+    The coordinator is kept alongside its unsub because *identity* is what
+    ``_sync_member_subscriptions`` diffs on — a reloaded member keeps its entry
+    id but gets a new coordinator object.
+    """
+
+    coordinator: object
+    unsub: CALLBACK_TYPE
+
+
 class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     """Runtime orchestrator for one cover-group config entry."""
 
@@ -111,6 +125,8 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         self.group_locked: bool = False
         self._unsub_state: CALLBACK_TYPE | None = None
         self._unsub_registry: list[CALLBACK_TYPE] = []
+        self._unsub_entry_state: CALLBACK_TYPE | None = None
+        self._member_subs: dict[str, _MemberSubscription] = {}
         self._roster_snapshot: tuple[tuple[str, ...], tuple[str, ...]] | None = None
         self._adopt_policy = get_policy(_ADOPT_COVER_TYPE)
         self._grace_mgr = GracePeriodManager(_LOGGER)
@@ -288,6 +304,37 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             commands += 1
             await generic_action(entity_id)
 
+    def _scene_intent(self, scene: GroupScene) -> GroupIntent:
+        """Build this group's SCENE intent — the one construction site."""
+        return GroupIntent(
+            kind=GroupIntentKind.SCENE,
+            scene=scene,
+            priority=GROUP_SCENE_PRIORITY,
+            group_id=self.entry.entry_id,
+        )
+
+    async def _push_member_intent(
+        self, coordinator: object, intent: GroupIntent | None
+    ) -> None:
+        """Set (or clear) this group's intent on one member and re-evaluate it now.
+
+        ``async_refresh``, deliberately never ``async_request_refresh``: the
+        latter goes through HA's 10-second request debouncer, so a second group
+        action inside that window leaves the member's pipeline still holding the
+        PREVIOUS winner at the instant this group publishes to its own
+        listeners. The who-won sensor snapshots that stale winner and keeps it
+        until something unrelated happens to move a cover (issue #1082). The
+        debounce also defers the member's re-evaluation itself, so the group
+        action lands up to ten seconds late.
+        """
+        coordinator.set_group_intent(self.entry.entry_id, intent)
+        await coordinator.async_refresh()
+
+    async def _push_intent_to_members(self, intent: GroupIntent | None) -> None:
+        """Push one intent — or the clear — to every resolvable ACP member."""
+        for _entry, coordinator in self.resolved_members():
+            await self._push_member_intent(coordinator, intent)
+
     async def async_activate_scene(self, scene: GroupScene) -> None:
         """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
 
@@ -296,18 +343,12 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         pipeline and are commanded directly with the adopt-policy target.
         Per-member opt-out and the stagger gap apply to both kinds.
         """
-        intent = GroupIntent(
-            kind=GroupIntentKind.SCENE,
-            scene=scene,
-            priority=GROUP_SCENE_PRIORITY,
-            group_id=self.entry.entry_id,
-        )
+        intent = self._scene_intent(scene)
         adopt_target = self._adopt_policy.position_for_scene(scene)
         trigger = f"group_scene_{scene}"
 
         async def _member(_entry, coordinator) -> None:
-            coordinator.set_group_intent(self.entry.entry_id, intent)
-            await coordinator.async_request_refresh()
+            await self._push_member_intent(coordinator, intent)
 
         async def _generic(entity_id: str) -> None:
             await self._cmd_svc.apply_position(
@@ -381,9 +422,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
     async def async_clear_scene(self) -> None:
         """Release this group's scene claim — members return to their pipeline."""
-        for _entry, coordinator in self.resolved_members():
-            coordinator.set_group_intent(self.entry.entry_id, None)
-            await coordinator.async_request_refresh()
+        await self._push_intent_to_members(None)
         self.active_scene = None
         await self.async_refresh()
 
@@ -397,21 +436,28 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """
         self.group_locked = locked
         if locked:
-            intent = GroupIntent(
-                kind=GroupIntentKind.LOCK,
-                scene=None,
-                priority=CUSTOM_POSITION_SAFETY_PRIORITY,
-                group_id=self.entry.entry_id,
+            await self._push_intent_to_members(
+                GroupIntent(
+                    kind=GroupIntentKind.LOCK,
+                    scene=None,
+                    priority=CUSTOM_POSITION_SAFETY_PRIORITY,
+                    group_id=self.entry.entry_id,
+                )
             )
-            for _entry, coordinator in self.resolved_members():
-                coordinator.set_group_intent(self.entry.entry_id, intent)
-                await coordinator.async_request_refresh()
         else:
-            for _entry, coordinator in self.resolved_members():
-                coordinator.set_group_intent(self.entry.entry_id, None)
-                await coordinator.async_request_refresh()
-            if self.active_scene is not None:
-                await self.async_activate_scene(self.active_scene)
+            # Hand each member the intent it should END on, in ONE push. Clearing
+            # first and re-pushing the scene second makes every member evaluate
+            # once un-scened — solar or default wins and commands the cover — a
+            # visible jog that the request-refresh debouncer used to swallow
+            # (issue #1082). Opt-out still applies: a member that opted out of
+            # the active scene ends on no intent rather than on the scene.
+            scene = self.active_scene
+            keep = self._scene_intent(scene) if scene is not None else None
+            for entry, coordinator in self.resolved_members():
+                opted_out = scene is not None and self._scene_opted_out(
+                    entry.entry_id, scene
+                )
+                await self._push_member_intent(coordinator, None if opted_out else keep)
         await self.async_refresh()
 
     def member_winners(self) -> dict[str, str | None]:
@@ -537,13 +583,19 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """Subscribe to member-state and (with an area) registry changes.
 
         The registry subscriptions keep area membership live: covers moved
-        into or out of the area re-resolve the rosters.
+        into or out of the area re-resolve the rosters. The config-entry
+        subscription keeps the *member coordinator* subscriptions live — see
+        :meth:`_handle_config_entry_change`.
         """
         entities = self.member_cover_entities()
         if entities:
             self._unsub_state = async_track_state_change_event(
                 self.hass, entities, self._handle_member_state_change
             )
+        self._sync_member_subscriptions()
+        self._unsub_entry_state = async_dispatcher_connect(
+            self.hass, SIGNAL_CONFIG_ENTRY_CHANGED, self._handle_config_entry_change
+        )
         if self.entry.options.get(CONF_GROUP_AREA):
             self._roster_snapshot = self._current_roster_snapshot()
             self._unsub_registry = [
@@ -581,8 +633,70 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
     @callback
     def _handle_member_state_change(self, _event: Event) -> None:
-        """Recompute aggregates when any member cover moves."""
+        """Recompute aggregates when any member cover moves.
+
+        Debounced on purpose, unlike the intent pushes: a scene fan-out emits
+        one state event per member cover, and collapsing those into a single
+        aggregate recompute is exactly what the request debouncer is for.
+        """
         self.hass.async_create_task(self.async_request_refresh())
+
+    @callback
+    def _sync_member_subscriptions(self) -> bool:
+        """Subscribe to exactly the member coordinators that exist right now.
+
+        Idempotent, so it can run on every config-entry state change. Returns
+        whether the subscription set changed. The identity check — not the entry
+        id — is what catches a member *reload*: the id is unchanged but
+        ``runtime_data`` holds a brand-new coordinator, and a listener left on
+        the old one is dead. ``resolved_members`` stays the single "is this
+        member real yet" predicate (``helpers.usable_coordinator``, #1063).
+        """
+        live = {entry.entry_id: coord for entry, coord in self.resolved_members()}
+        changed = False
+        for entry_id, sub in list(self._member_subs.items()):
+            if live.get(entry_id) is not sub.coordinator:
+                sub.unsub()
+                del self._member_subs[entry_id]
+                changed = True
+        for entry_id, coordinator in live.items():
+            if entry_id in self._member_subs:
+                continue
+            self._member_subs[entry_id] = _MemberSubscription(
+                coordinator=coordinator,
+                unsub=coordinator.async_add_listener(self._handle_member_update),
+            )
+            changed = True
+        return changed
+
+    @callback
+    def _handle_config_entry_change(self, _change: object, entry: ConfigEntry) -> None:
+        """Re-sync member subscriptions when any ACP entry changes state.
+
+        ``ConfigEntry._async_set_state`` dispatches on every transition, so this
+        one subscription covers a member finishing setup after the group did, a
+        member reload swapping its coordinator out, and an unload or removal.
+        Roster *membership* changes need no hook here: an options edit and an
+        area-registry change both reload this entry, which re-runs setup.
+        """
+        if entry.domain != DOMAIN:
+            return
+        if self._sync_member_subscriptions():
+            self.async_update_listeners()
+
+    @callback
+    def _handle_member_update(self) -> None:
+        """Repaint the group's entities when a member coordinator updates.
+
+        ``async_update_listeners``, not a refresh: ``member_winners`` and
+        ``member_climate_modes`` read live off the member coordinators, and
+        nothing in :class:`GroupAggregates` can have moved — member positions
+        come from cover states, which ``_handle_member_state_change`` already
+        watches. There is nothing to re-fetch, only to re-render, and routing
+        this through the group's own request debouncer would reintroduce the
+        staleness on the other side (issue #1082).
+        """
+        self.async_update_listeners()
 
     async def async_shutdown(self) -> None:
         """Tear down listeners, the command service, and any live intents.
@@ -590,10 +704,17 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         Clearing this group's intent from every member matters on reload and
         delete: a stale intent would keep claiming the member's pipeline for
         a group that no longer exists (#712/#714 lifecycle lesson).
+
+        Member subscriptions go first, so the refreshes the intent clear below
+        triggers cannot repaint entities that are being removed.
         """
-        for _entry, coordinator in self.resolved_members():
-            coordinator.set_group_intent(self.entry.entry_id, None)
-            await coordinator.async_request_refresh()
+        if self._unsub_entry_state is not None:
+            self._unsub_entry_state()
+            self._unsub_entry_state = None
+        for sub in self._member_subs.values():
+            sub.unsub()
+        self._member_subs = {}
+        await self._push_intent_to_members(None)
         if self._unsub_state is not None:
             self._unsub_state()
             self._unsub_state = None

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -314,9 +314,9 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         )
 
     async def _push_member_intent(
-        self, coordinator: object, intent: GroupIntent | None
+        self, coordinator: object, intent: GroupIntent | None, *, immediate: bool = True
     ) -> None:
-        """Set (or clear) this group's intent on one member and re-evaluate it now.
+        """Set (or clear) this group's intent on one member and re-evaluate it.
 
         ``async_refresh``, deliberately never ``async_request_refresh``: the
         latter goes through HA's 10-second request debouncer, so a second group
@@ -326,14 +326,24 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         until something unrelated happens to move a cover (issue #1082). The
         debounce also defers the member's re-evaluation itself, so the group
         action lands up to ten seconds late.
+
+        ``immediate=False`` is for teardown only, where the opposite holds: no
+        one will read the winner again, and a blocking refresh would run every
+        member's whole pipeline — settle sequences included — serially inside
+        HA's unload path.
         """
         coordinator.set_group_intent(self.entry.entry_id, intent)
-        await coordinator.async_refresh()
+        if immediate:
+            await coordinator.async_refresh()
+        else:
+            await coordinator.async_request_refresh()
 
-    async def _push_intent_to_members(self, intent: GroupIntent | None) -> None:
+    async def _push_intent_to_members(
+        self, intent: GroupIntent | None, *, immediate: bool = True
+    ) -> None:
         """Push one intent — or the clear — to every resolvable ACP member."""
         for _entry, coordinator in self.resolved_members():
-            await self._push_member_intent(coordinator, intent)
+            await self._push_member_intent(coordinator, intent, immediate=immediate)
 
     async def async_activate_scene(self, scene: GroupScene) -> None:
         """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
@@ -429,10 +439,15 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
     async def async_set_lock(self, locked: bool) -> None:
         """Push or release the group lock (LOCK intent at safety priority).
 
-        The lock ignores per-scene opt-out — it is a safety claim on every
-        member — and applies immediately (no stagger; nothing moves). On
-        release, an active scene is re-pushed so unlocking returns the room
-        to the scene, not to unmanaged state.
+        Engaging ignores per-scene opt-out — it is a safety claim on every
+        member — and needs no stagger, because ``GroupLockHandler`` holds
+        position and emits no command. Releasing does move covers, so it
+        staggers like any other fan-out.
+
+        On release an active scene is re-pushed to each ACP member that has
+        not opted out of it, so unlocking returns the room to the scene rather
+        than to unmanaged state. Adopted (generic) covers are left where they
+        are: the lock is a pipeline intent and never claimed them.
         """
         self.group_locked = locked
         if locked:
@@ -453,10 +468,13 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             # the active scene ends on no intent rather than on the scene.
             scene = self.active_scene
             keep = self._scene_intent(scene) if scene is not None else None
+            released = 0
             for entry, coordinator in self.resolved_members():
                 opted_out = scene is not None and self._scene_opted_out(
                     entry.entry_id, scene
                 )
+                await self._stagger_gap(released)
+                released += 1
                 await self._push_member_intent(coordinator, None if opted_out else keep)
         await self.async_refresh()
 
@@ -681,8 +699,14 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """
         if entry.domain != DOMAIN:
             return
-        if self._sync_member_subscriptions():
-            self.async_update_listeners()
+        if not self._sync_member_subscriptions():
+            return
+        # The roster itself moved, so the aggregates are stale too: a departed
+        # member's covers linger in ``member_positions`` and a new one is
+        # missing from it. Repaint the live-reading sensors now and let the
+        # (debounced) refresh catch the snapshot up.
+        self.hass.async_create_task(self.async_request_refresh())
+        self.async_update_listeners()
 
     @callback
     def _handle_member_update(self) -> None:
@@ -705,8 +729,13 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         delete: a stale intent would keep claiming the member's pipeline for
         a group that no longer exists (#712/#714 lifecycle lesson).
 
-        Member subscriptions go first, so the refreshes the intent clear below
-        triggers cannot repaint entities that are being removed.
+        EVERY listener goes first. The intent clear makes members re-evaluate
+        and command their covers, and both the member subscriptions and the
+        cover-state subscription would otherwise feed that back into a
+        coordinator that is mid-teardown. The clear itself is the one push
+        that stays debounced — nothing will read the winner again, and a
+        blocking refresh per member would run their full pipelines serially
+        inside HA's unload path.
         """
         if self._unsub_entry_state is not None:
             self._unsub_entry_state()
@@ -714,13 +743,13 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         for sub in self._member_subs.values():
             sub.unsub()
         self._member_subs = {}
-        await self._push_intent_to_members(None)
         if self._unsub_state is not None:
             self._unsub_state()
             self._unsub_state = None
         for unsub in self._unsub_registry:
             unsub()
         self._unsub_registry = []
+        await self._push_intent_to_members(None, immediate=False)
         self._cmd_svc.stop()
         await super().async_shutdown()
 

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -314,9 +314,9 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         )
 
     async def _push_member_intent(
-        self, coordinator: object, intent: GroupIntent | None, *, immediate: bool = True
+        self, coordinator: object, intent: GroupIntent | None
     ) -> None:
-        """Set (or clear) this group's intent on one member and re-evaluate it.
+        """Set (or clear) this group's intent on one member and re-evaluate it now.
 
         ``async_refresh``, deliberately never ``async_request_refresh``: the
         latter goes through HA's 10-second request debouncer, so a second group
@@ -327,23 +327,19 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         debounce also defers the member's re-evaluation itself, so the group
         action lands up to ten seconds late.
 
-        ``immediate=False`` is for teardown only, where the opposite holds: no
-        one will read the winner again, and a blocking refresh would run every
-        member's whole pipeline — settle sequences included — serially inside
-        HA's unload path.
+        Teardown uses this same path. Routing it through the request debouncer
+        instead would not actually defer anything — that debouncer is
+        ``immediate=True``, and every direct refresh cancels its cooldown timer,
+        so it runs inline anyway — it would only make the intent clear's timing
+        depend on how recently the last group action happened.
         """
         coordinator.set_group_intent(self.entry.entry_id, intent)
-        if immediate:
-            await coordinator.async_refresh()
-        else:
-            await coordinator.async_request_refresh()
+        await coordinator.async_refresh()
 
-    async def _push_intent_to_members(
-        self, intent: GroupIntent | None, *, immediate: bool = True
-    ) -> None:
+    async def _push_intent_to_members(self, intent: GroupIntent | None) -> None:
         """Push one intent — or the clear — to every resolvable ACP member."""
         for _entry, coordinator in self.resolved_members():
-            await self._push_member_intent(coordinator, intent, immediate=immediate)
+            await self._push_member_intent(coordinator, intent)
 
     async def async_activate_scene(self, scene: GroupScene) -> None:
         """Fan a scene out as a pipeline intent, resolved per member (Phase 2).
@@ -732,10 +728,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         EVERY listener goes first. The intent clear makes members re-evaluate
         and command their covers, and both the member subscriptions and the
         cover-state subscription would otherwise feed that back into a
-        coordinator that is mid-teardown. The clear itself is the one push
-        that stays debounced — nothing will read the winner again, and a
-        blocking refresh per member would run their full pipelines serially
-        inside HA's unload path.
+        coordinator that is mid-teardown.
         """
         if self._unsub_entry_state is not None:
             self._unsub_entry_state()
@@ -749,7 +742,7 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         for unsub in self._unsub_registry:
             unsub()
         self._unsub_registry = []
-        await self._push_intent_to_members(None, immediate=False)
+        await self._push_intent_to_members(None)
         self._cmd_svc.stop()
         await super().async_shutdown()
 

--- a/tests/_helpers/group_members.py
+++ b/tests/_helpers/group_members.py
@@ -1,0 +1,78 @@
+"""A cover-group member coordinator stub with the real HA update machinery.
+
+The suite's usual member stub is a bare ``MagicMock``. That swallows
+``async_add_listener`` / ``async_update_listeners`` and replaces the refresh with
+an ``AsyncMock``, so neither the group's member-notification wiring nor Home
+Assistant's 10-second request-refresh debounce is observable through one — which
+is exactly why both halves of issue #1082 went unnoticed. Tests that assert on
+either need a coordinator that really has them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from custom_components.adaptive_cover_pro.const import GroupIntentKind
+from custom_components.adaptive_cover_pro.pipeline.handlers import (
+    GroupLockHandler,
+    GroupSceneHandler,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
+
+_LOGGER = logging.getLogger(__name__)
+
+# The winner this stub's pipeline settles on when no group intent claims it.
+# Any non-group handler name works; this one matches the live system the issue
+# was reported from.
+UNCLAIMED_WINNER = "motion_timeout"
+
+
+@dataclass(frozen=True, slots=True)
+class MemberData:
+    """The one field of a member's ``coordinator.data`` the group reads."""
+
+    diagnostics: dict | None
+
+
+class RealMemberCoordinator(DataUpdateCoordinator[MemberData]):
+    """Minimal ACP member: real listeners, real debouncer, fake pipeline.
+
+    ``_async_update_data`` stands in for the pipeline closely enough for the
+    group's purposes — a live group intent wins and reports the matching group
+    handler, otherwise a local handler does. ``diagnostics`` is a plain
+    attribute so a test can move the member's climate mode and then notify.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialize with the member entry as the coordinator's config entry."""
+        super().__init__(hass, _LOGGER, name=entry.entry_id, config_entry=entry)
+        self._group_intents: dict[str, GroupIntent] = {}
+        self.pipeline_winner_name: str | None = None
+        self.diagnostics: dict | None = None
+
+    def set_group_intent(self, group_id: str, intent: GroupIntent | None) -> None:
+        """Mirror the real coordinator's per-group intent registry."""
+        if intent is None:
+            self._group_intents.pop(group_id, None)
+        else:
+            self._group_intents[group_id] = intent
+
+    async def _async_update_data(self) -> MemberData:
+        """Re-evaluate the winner from the currently-claimed intents."""
+        intent = next(iter(self._group_intents.values()), None)
+        if intent is None:
+            self.pipeline_winner_name = UNCLAIMED_WINNER
+        elif intent.kind is GroupIntentKind.LOCK:
+            self.pipeline_winner_name = GroupLockHandler.name
+        else:
+            self.pipeline_winner_name = GroupSceneHandler.name
+        return MemberData(diagnostics=self.diagnostics)

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -7,7 +7,7 @@ the position/state aggregates the group sensors read.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from homeassistant.config_entries import ConfigEntryState
@@ -36,7 +36,9 @@ from custom_components.adaptive_cover_pro.const import (
     GroupState,
 )
 from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+from custom_components.adaptive_cover_pro.pipeline.handlers import GroupLockHandler
 from custom_components.adaptive_cover_pro.pipeline.types import GroupIntent
+from tests._helpers.group_members import UNCLAIMED_WINNER, RealMemberCoordinator
 
 pytestmark = pytest.mark.integration
 
@@ -173,7 +175,7 @@ async def test_activate_scene_pushes_intent_and_refreshes(group_setup) -> None:
     )
     for member in (blind_coord, awning_coord):
         member.set_group_intent.assert_called_once_with("group_01", expected)
-        member.async_request_refresh.assert_awaited_once()
+        member.async_refresh.assert_awaited_once()
         member.async_apply_user_position.assert_not_awaited()
 
 
@@ -400,7 +402,7 @@ async def test_clear_scene_removes_intents(group_setup) -> None:
     assert coordinator.active_scene is None
     for member in (blind_coord, awning_coord):
         member.set_group_intent.assert_called_once_with("group_01", None)
-        member.async_request_refresh.assert_awaited_once()
+        member.async_refresh.assert_awaited_once()
 
 
 async def test_lock_pushes_and_clears_lock_intent(group_setup) -> None:
@@ -508,6 +510,267 @@ async def test_unlock_repushes_active_scene(group_setup) -> None:
     ]
     assert pushed and pushed[-1].kind is GroupIntentKind.SCENE
     assert pushed[-1].scene is GroupScene.PRIVACY
+
+
+# ---------------------------------------------------------------------------
+# Issue #1082 — intent pushes must re-evaluate the member immediately
+# ---------------------------------------------------------------------------
+
+
+def _group_with_real_members(hass, entry_id="group_20"):
+    """Build a group whose members carry real listener + debouncer plumbing."""
+    blind_entry = _member_entry(
+        hass, f"{entry_id}_blind", CoverType.BLIND, [BLIND_ENTITY]
+    )
+    awning_entry = _member_entry(
+        hass, f"{entry_id}_awning", CoverType.AWNING, [AWNING_ENTITY]
+    )
+    blind_coord = RealMemberCoordinator(hass, blind_entry)
+    awning_coord = RealMemberCoordinator(hass, awning_entry)
+    blind_entry.runtime_data = blind_coord
+    awning_entry.runtime_data = awning_coord
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={
+            CONF_MEMBER_ENTRIES: [f"{entry_id}_blind", f"{entry_id}_awning"],
+            CONF_MEMBER_COVERS: [],
+        },
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    group_entry.add_to_hass(hass)
+    return GroupCoordinator(hass, group_entry), blind_coord, awning_coord
+
+
+async def test_lock_release_inside_debounce_window_refreshes_members(hass) -> None:
+    """Releasing the lock seconds after engaging it still re-evaluates members.
+
+    ``async_request_refresh`` is debounced (10s cooldown, ``immediate=True``), so
+    a second push inside that window is DEFERRED: the member still reports the
+    lock as its winner at the instant the group publishes to its listeners, and
+    the who-won sensor latches that stale value (issue #1082). The two toggles
+    below are milliseconds apart — trivially inside the cooldown, which is why
+    the live report toggled at 19:23:45 and 19:23:47 and stuck.
+    """
+    coordinator, blind_coord, awning_coord = _group_with_real_members(hass)
+
+    await coordinator.async_set_lock(True)
+    assert coordinator.member_winners() == {
+        BLIND_ENTITY: GroupLockHandler.name,
+        AWNING_ENTITY: GroupLockHandler.name,
+    }
+
+    await coordinator.async_set_lock(False)
+    assert coordinator.member_winners() == {
+        BLIND_ENTITY: UNCLAIMED_WINNER,
+        AWNING_ENTITY: UNCLAIMED_WINNER,
+    }
+
+    await coordinator.async_shutdown()
+    for member in (blind_coord, awning_coord):
+        await member.async_shutdown()
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        pytest.param(
+            lambda c: c.async_activate_scene(GroupScene.PRIVACY), id="scene_activate"
+        ),
+        pytest.param(lambda c: c.async_clear_scene(), id="scene_clear"),
+        pytest.param(lambda c: c.async_set_lock(True), id="lock_engage"),
+        pytest.param(lambda c: c.async_set_lock(False), id="lock_release"),
+        pytest.param(lambda c: c.async_shutdown(), id="shutdown"),
+    ],
+)
+async def test_intent_pushes_use_the_non_debounced_refresh(group_setup, action) -> None:
+    """Every group→member intent push re-evaluates the member immediately.
+
+    ``async_request_refresh`` would route the push through HA's 10-second
+    request debouncer, which is what left the who-won sensor stale (#1082).
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await action(coordinator)
+
+    for member in (blind_coord, awning_coord):
+        member.async_refresh.assert_awaited()
+        member.async_request_refresh.assert_not_awaited()
+
+
+async def test_unlock_with_active_scene_pushes_once_per_member(group_setup) -> None:
+    """Releasing the lock hands each member its FINAL intent in one push.
+
+    Clearing and then re-pushing the scene would make every member evaluate
+    once un-scened in between — with immediate refreshes that is a visible jog
+    the request debouncer used to swallow (#1082).
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+    await coordinator.async_set_lock(True)
+
+    for member in (blind_coord, awning_coord):
+        member.reset_mock()
+    await coordinator.async_set_lock(False)
+
+    for member in (blind_coord, awning_coord):
+        assert member.set_group_intent.call_count == 1
+        assert member.async_refresh.await_count == 1
+        intent = member.set_group_intent.call_args.args[1]
+        assert intent.kind is GroupIntentKind.SCENE
+        assert intent.scene is GroupScene.PRIVACY
+
+
+async def test_unlock_leaves_opted_out_member_unscened(hass) -> None:
+    """A member opted out of the active scene ends on no intent, in one push."""
+    coordinator, blind_coord, awning_coord = _group_with_options(
+        hass, {CONF_GROUP_MEMBER_OPT_OUT: {"group_10_blind": [OPT_OUT_ALL_SCENES]}}
+    )
+    await coordinator.async_activate_scene(GroupScene.PRIVACY)
+    await coordinator.async_set_lock(True)
+
+    for member in (blind_coord, awning_coord):
+        member.reset_mock()
+    await coordinator.async_set_lock(False)
+
+    assert blind_coord.set_group_intent.call_count == 1
+    assert blind_coord.set_group_intent.call_args.args[1] is None
+    assert awning_coord.set_group_intent.call_args.args[1].scene is GroupScene.PRIVACY
+
+
+# ---------------------------------------------------------------------------
+# Issue #1082 — member-coordinator subscriptions track the roster's lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_member_loaded_after_group_setup_is_subscribed(hass) -> None:
+    """A member that finishes setup after the group did still gets subscribed.
+
+    HA loads entries independently, so the group can reach ``_async_setup``
+    while a member is still ``NOT_LOADED`` and invisible to ``resolved_members``.
+    """
+    member_entry = _member_entry(
+        hass,
+        "late_member",
+        CoverType.BLIND,
+        [BLIND_ENTITY],
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["late_member"], CONF_MEMBER_COVERS: []},
+        entry_id="group_late",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+
+    await coordinator._async_setup()
+    assert coordinator._member_subs == {}
+
+    member_coord = RealMemberCoordinator(hass, member_entry)
+    member_entry.runtime_data = member_coord
+    member_entry.mock_state(hass, ConfigEntryState.LOADED)
+    await hass.async_block_till_done()
+
+    assert list(coordinator._member_subs) == ["late_member"]
+
+    await coordinator.async_shutdown()
+    await member_coord.async_shutdown()
+
+
+async def test_member_reload_swaps_the_subscription(hass) -> None:
+    """A reloaded member keeps its entry id but gets a NEW coordinator object.
+
+    Diffing on the entry id alone would leave the listener on the dead
+    coordinator, so the group would stop hearing from the live one.
+    """
+    member_entry = _member_entry(hass, "member_a", CoverType.BLIND, [BLIND_ENTITY])
+    first = RealMemberCoordinator(hass, member_entry)
+    member_entry.runtime_data = first
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["member_a"], CONF_MEMBER_COVERS: []},
+        entry_id="group_reload",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+
+    await coordinator._async_setup()
+    assert coordinator._member_subs["member_a"].coordinator is first
+
+    member_entry.mock_state(hass, ConfigEntryState.NOT_LOADED)
+    await hass.async_block_till_done()
+    assert coordinator._member_subs == {}
+
+    second = RealMemberCoordinator(hass, member_entry)
+    member_entry.runtime_data = second
+    member_entry.mock_state(hass, ConfigEntryState.LOADED)
+    await hass.async_block_till_done()
+
+    assert coordinator._member_subs["member_a"].coordinator is second
+
+    await coordinator.async_shutdown()
+    for member in (first, second):
+        await member.async_shutdown()
+
+
+async def test_shutdown_unsubscribes_member_listeners(hass) -> None:
+    """Teardown releases the member and config-entry subscriptions."""
+    coordinator, blind_coord, awning_coord = _group_with_real_members(
+        hass, entry_id="group_21"
+    )
+    await coordinator._async_setup()
+    assert len(coordinator._member_subs) == 2
+    assert coordinator._unsub_entry_state is not None
+
+    await coordinator.async_shutdown()
+
+    assert coordinator._member_subs == {}
+    assert coordinator._unsub_entry_state is None
+    for member in (blind_coord, awning_coord):
+        assert not member._listeners
+        await member.async_shutdown()
+
+
+async def test_member_subscription_sync_is_idempotent(hass) -> None:
+    """Re-syncing an unchanged roster keeps the same subscriptions.
+
+    The config-entry signal fires on every transition of every ACP entry, so a
+    re-sync that churned subscriptions would resubscribe constantly and report
+    a change that entity listeners would then act on.
+    """
+    coordinator, blind_coord, awning_coord = _group_with_real_members(
+        hass, entry_id="group_22"
+    )
+    await coordinator._async_setup()
+    before = dict(coordinator._member_subs)
+
+    assert coordinator._sync_member_subscriptions() is False
+    assert coordinator._member_subs == before
+
+    await coordinator.async_shutdown()
+    for member in (blind_coord, awning_coord):
+        await member.async_shutdown()
+
+
+async def test_config_entry_change_ignores_other_domains(hass, group_setup) -> None:
+    """A non-ACP entry changing state is not this group's business."""
+    coordinator, _, _ = group_setup
+    await coordinator._async_setup()
+
+    other = MockConfigEntry(domain="light", entry_id="other_01", title="Other")
+    other.add_to_hass(hass)
+    with patch.object(coordinator, "_sync_member_subscriptions") as sync:
+        coordinator._handle_config_entry_change(None, other)
+
+    sync.assert_not_called()
+
+    await coordinator.async_shutdown()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -581,10 +581,11 @@ async def test_lock_release_inside_debounce_window_refreshes_members(hass) -> No
         pytest.param(lambda c: c.async_clear_scene(), id="scene_clear"),
         pytest.param(lambda c: c.async_set_lock(True), id="lock_engage"),
         pytest.param(lambda c: c.async_set_lock(False), id="lock_release"),
+        pytest.param(lambda c: c.async_shutdown(), id="shutdown"),
     ],
 )
 async def test_intent_pushes_use_the_non_debounced_refresh(group_setup, action) -> None:
-    """Every user-facing group→member intent push re-evaluates the member now.
+    """Every group→member intent push re-evaluates the member immediately.
 
     ``async_request_refresh`` would route the push through HA's 10-second
     request debouncer, which is what left the who-won sensor stale (#1082).
@@ -596,23 +597,6 @@ async def test_intent_pushes_use_the_non_debounced_refresh(group_setup, action) 
     for member in (blind_coord, awning_coord):
         member.async_refresh.assert_awaited()
         member.async_request_refresh.assert_not_awaited()
-
-
-async def test_shutdown_intent_clear_stays_debounced(group_setup) -> None:
-    """Teardown is the one push that must NOT block on a member refresh.
-
-    Nothing reads the winner after an unload, while a blocking refresh would
-    run every member's full pipeline — settle sequences included — serially
-    inside HA's unload path.
-    """
-    coordinator, blind_coord, awning_coord = group_setup
-
-    await coordinator.async_shutdown()
-
-    for member in (blind_coord, awning_coord):
-        member.set_group_intent.assert_called_once_with("group_01", None)
-        member.async_request_refresh.assert_awaited_once()
-        member.async_refresh.assert_not_awaited()
 
 
 async def test_lock_release_staggers_but_engage_does_not(hass) -> None:

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -581,11 +581,10 @@ async def test_lock_release_inside_debounce_window_refreshes_members(hass) -> No
         pytest.param(lambda c: c.async_clear_scene(), id="scene_clear"),
         pytest.param(lambda c: c.async_set_lock(True), id="lock_engage"),
         pytest.param(lambda c: c.async_set_lock(False), id="lock_release"),
-        pytest.param(lambda c: c.async_shutdown(), id="shutdown"),
     ],
 )
 async def test_intent_pushes_use_the_non_debounced_refresh(group_setup, action) -> None:
-    """Every group→member intent push re-evaluates the member immediately.
+    """Every user-facing group→member intent push re-evaluates the member now.
 
     ``async_request_refresh`` would route the push through HA's 10-second
     request debouncer, which is what left the who-won sensor stale (#1082).
@@ -597,6 +596,79 @@ async def test_intent_pushes_use_the_non_debounced_refresh(group_setup, action) 
     for member in (blind_coord, awning_coord):
         member.async_refresh.assert_awaited()
         member.async_request_refresh.assert_not_awaited()
+
+
+async def test_shutdown_intent_clear_stays_debounced(group_setup) -> None:
+    """Teardown is the one push that must NOT block on a member refresh.
+
+    Nothing reads the winner after an unload, while a blocking refresh would
+    run every member's full pipeline — settle sequences included — serially
+    inside HA's unload path.
+    """
+    coordinator, blind_coord, awning_coord = group_setup
+
+    await coordinator.async_shutdown()
+
+    for member in (blind_coord, awning_coord):
+        member.set_group_intent.assert_called_once_with("group_01", None)
+        member.async_request_refresh.assert_awaited_once()
+        member.async_refresh.assert_not_awaited()
+
+
+async def test_lock_release_staggers_but_engage_does_not(hass) -> None:
+    """Release moves covers so it staggers; engage holds position so it does not."""
+    from custom_components.adaptive_cover_pro import group_coordinator as gc_module
+
+    coordinator, _, _ = _group_with_options(
+        hass, {CONF_GROUP_STAGGER_DELAY: 1.5}, entry_id="group_12"
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        sleeper = AsyncMock()
+        mp.setattr(gc_module.asyncio, "sleep", sleeper)
+        await coordinator.async_set_lock(True)
+        assert sleeper.await_count == 0
+
+        await coordinator.async_set_lock(False)
+
+    # 2 ACP members → 1 gap. Generic covers are not touched by the lock.
+    assert sleeper.await_count == 1
+    sleeper.assert_awaited_with(1.5)
+
+
+async def test_roster_change_refreshes_aggregates(hass) -> None:
+    """A member joining mid-run must also recompute the position aggregates.
+
+    Repainting alone would publish ``member_positions`` for the old roster.
+    """
+    member_entry = _member_entry(
+        hass,
+        "joining_member",
+        CoverType.BLIND,
+        [BLIND_ENTITY],
+        state=ConfigEntryState.NOT_LOADED,
+    )
+    group_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "G", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["joining_member"], CONF_MEMBER_COVERS: []},
+        entry_id="group_join",
+        title="G",
+    )
+    group_entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, group_entry)
+    await coordinator._async_setup()
+
+    member_coord = RealMemberCoordinator(hass, member_entry)
+    member_entry.runtime_data = member_coord
+    with patch.object(coordinator, "async_request_refresh", AsyncMock()) as refresh:
+        member_entry.mock_state(hass, ConfigEntryState.LOADED)
+        await hass.async_block_till_done()
+
+    refresh.assert_awaited()
+
+    await coordinator.async_shutdown()
+    await member_coord.async_shutdown()
 
 
 async def test_unlock_with_active_scene_pushes_once_per_member(group_setup) -> None:

--- a/tests/test_group_entities.py
+++ b/tests/test_group_entities.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro import button, select, sensor, switch
 from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
     CONF_MEMBER_COVERS,
     CONF_MEMBER_ENTRIES,
     CONF_SENSOR_TYPE,
@@ -30,6 +32,8 @@ from custom_components.adaptive_cover_pro.group_coordinator import (
 from custom_components.adaptive_cover_pro.const import (
     GROUP_SCENE_SELECT_AUTO as SCENE_SELECT_AUTO,
 )
+from custom_components.adaptive_cover_pro.pipeline.handlers import GroupLockHandler
+from tests._helpers.group_members import MemberData, RealMemberCoordinator
 
 pytestmark = pytest.mark.integration
 
@@ -279,6 +283,109 @@ async def test_who_won_sensor_reads_member_winners(hass, group_entry) -> None:
         "cover.awning1": "weather_override",
         "cover.tilt1": "group_lock",
     }
+
+
+# ---------------------------------------------------------------------------
+# Issue #1082 — group entities must repaint when a MEMBER coordinator updates
+# ---------------------------------------------------------------------------
+
+
+MEMBER_COVER = "cover.member_blind1"
+
+
+@pytest.fixture
+def group_with_real_member(hass):
+    """Build a group entry backed by one member with real listener plumbing."""
+    member_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Member", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_ENTITIES: [MEMBER_COVER]},
+        entry_id="member_blind",
+        title="Member",
+        state=ConfigEntryState.LOADED,
+    )
+    member_entry.add_to_hass(hass)
+    member_coord = RealMemberCoordinator(hass, member_entry)
+    member_entry.runtime_data = member_coord
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Living Room", CONF_SENSOR_TYPE: CoverType.GROUP},
+        options={CONF_MEMBER_ENTRIES: ["member_blind"], CONF_MEMBER_COVERS: []},
+        entry_id="group_01",
+        title="Living Room",
+    )
+    entry.add_to_hass(hass)
+    coordinator = GroupCoordinator(hass, entry)
+    entry.runtime_data = coordinator
+    return entry, coordinator, member_coord
+
+
+def _member_winner_changed(member) -> None:
+    """Settle the member's pipeline on the group lock, then notify."""
+    member.pipeline_winner_name = GroupLockHandler.name
+    member.async_update_listeners()
+
+
+def _member_climate_changed(member) -> None:
+    """Publish winter-mode diagnostics from the member (this notifies)."""
+    member.async_set_updated_data(
+        MemberData(diagnostics={"climate_conditions": {"is_winter": True}})
+    )
+
+
+@pytest.mark.parametrize(
+    ("unique_id", "mutate", "expected"),
+    [
+        pytest.param("group_01_group_who_won", _member_winner_changed, 1, id="who_won"),
+        pytest.param(
+            "group_01_group_climate_mode",
+            _member_climate_changed,
+            "winter_mode",
+            id="climate_mode",
+        ),
+    ],
+)
+async def test_member_update_repaints_group_sensor(
+    hass, group_with_real_member, unique_id, mutate, expected
+) -> None:
+    """A member's own update must reach the group's live-reading sensors.
+
+    Both sensors read straight off the MEMBER coordinator but subscribe to the
+    GROUP one, and a member's winner or climate mode can change with no cover
+    movement at all — a lock release, a motion timeout expiring. Without the
+    group subscribing to its members, nothing ever triggers the write (#1082).
+
+    Assert on the WRITE, not on ``native_value``: the value is a live read off
+    the member and is already correct today even while the entity shows a stale
+    state. That is exactly why the mocked
+    ``test_who_won_sensor_reads_member_winners`` above cannot catch this.
+    """
+    entry, coordinator, member = group_with_real_member
+    await coordinator._async_setup()
+    await coordinator.async_refresh()
+
+    sensors = {e.unique_id: e for e in await _added_entities(sensor, hass, entry)}
+    target = sensors[unique_id]
+    target.hass = hass
+    target.entity_id = f"sensor.{unique_id}"
+    await target.async_added_to_hass()
+
+    # Prime the render-signature cache: the FIRST coordinator update always
+    # writes (the cache starts on a sentinel), so without a baseline the
+    # assertion below would pass on any notification at all rather than on one
+    # caused by the change.
+    target.async_write_ha_state = MagicMock()
+    member.async_update_listeners()
+    target.async_write_ha_state.reset_mock()
+
+    mutate(member)
+
+    target.async_write_ha_state.assert_called()
+    assert target.native_value == expected
+
+    await coordinator.async_shutdown()
+    await member.async_shutdown()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Group-Driven Members sensor latched a stale value and never recovered — it read `2` with both members showing `group_lock` while the group was unlocked and both members' real winners were `motion_timeout`. The Lovelace card builds its group badge from that sensor, so the tile showed `2/2` with nothing group-controlled.

Two defects combined:

- The group subscribed only to member **cover state** changes and sets no `update_interval`, so a member winner that changed with no cover movement — a lock release, a motion timeout expiring — never reached the group. `GroupWhoWonSensor` and `GroupClimateSensor` read live off *member* coordinators but are `CoordinatorEntity` on the *group* one.
- The intent pushes used `async_request_refresh`, which goes through HA's 10-second request debouncer. A second group action inside that window left the member holding the previous winner at the instant the group published.

Recorder history from the reporting install pins it: lock toggled 24s apart recovered; toggled 7s and 2.5s apart did not.

## What changed

`GroupCoordinator` now subscribes to each resolvable member coordinator, re-syncing on `SIGNAL_CONFIG_ENTRY_CHANGED` so late-loading members, reloads (same entry id, new coordinator object) and unloads are tracked. The diff is on coordinator **identity**, which is what catches a reload. The callback only calls `async_update_listeners()` — nothing in `GroupAggregates` can have moved, so there is nothing to re-fetch, only to re-render — plus a debounced refresh when the roster itself changed, since `member_positions` then describes the old roster.

The five duplicated intent pushes collapse into one `_push_member_intent` on the non-debounced `async_refresh`, matching what `async_set_automation` and `async_set_climate_mode` already did. That also stops group actions themselves from landing up to ten seconds late, and makes the scene stagger real — previously the debouncer coalesced the per-member refreshes, so members re-evaluated together regardless of the configured gap.

Making the refreshes immediate exposed a latent double-move on lock release, which cleared every intent and then re-pushed the active scene; the debouncer had been hiding the intermediate un-scened evaluation. Release now computes each member's final intent and pushes it once, still honouring per-scene opt-out, and staggers (engage does not — `GroupLockHandler` sets `skip_command=True`, so nothing moves). Teardown drops every listener before clearing intents.

## Why the suite missed this

The who-won test mocked `member_winners` outright, and the member stub is a `MagicMock` that swallows `async_add_listener` and stubs the refresh. Added `tests/_helpers/group_members.py` with real listener and debouncer plumbing. The repaint test asserts on the state **write**, not `native_value` — the value is a live read and is already correct while the entity shows a stale state — and primes the render-signature cache first, since the first coordinator update always writes.

## Testing

- ✅ 9130 tests passing, 1 xfailed
- 100% coverage on `group_coordinator.py`
- Every new test verified to fail with the fix reverted; two opus audit passes

## Out of scope

- The group lock only pushes a pipeline intent, so it does nothing to generic adopted covers — a whole-room lock leaves them freely controllable.
- The card badge's denominator counts ACP + generic members while the numerator counts ACP only, so a group with any generic cover can never read `M/M`.
- Half the group's view is snapshotted into `GroupAggregates` and half is read live off member coordinators. The live half is exactly the half that broke.

## Related Issues

Refs #1082. Audit also surfaced #1083 (a group scene silently overwrites an engaged group lock while the lock switch still reads `on`).
