### PR TITLE
fix: clear building-profile sensor and template fields (#1085)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -792,6 +792,11 @@ async def _async_profile_propagate(hass: HomeAssistant, entry: ConfigEntry) -> N
     subset into every linked cover via the shared copier — the ``async_update_entry``
     it performs fires each cover's self-reload listener, so linked covers pick up
     the changed sensor IDs immediately.
+
+    Copy-only: a blank profile key is left alone, because from here a field the
+    user just cleared looks exactly like one they never filled in. Removing a
+    cleared key from the linked covers happens at save time instead, where the
+    transition is still visible — ``propagate_profile_clears`` (issue #1085).
     """
     # Guard: only profiles (virtual, controls_cover == False) propagate. A real
     # cover reaching here would be a wiring bug — its own listener handles reloads.

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -33,6 +33,7 @@ from .const import (
     resolve_fov_left,
     DEFAULT_AUTO_RESOLVE_TEMP_FROM_AREA,
     DEFAULT_BLIND_SPOT_ELEVATION_MODE,
+    BUILDING_PROFILE_SENSOR_KEYS,
     LIGHT_CLOUD_SENSOR_KEYS,
     WEATHER_OVERRIDE_SENSOR_KEYS,
     CONF_AUTO_RESOLVE_TEMP_FROM_AREA,
@@ -5425,6 +5426,7 @@ class OptionsFlowHandler(OptionsFlow):
         actually saves and closes the dialog.
         """
         if user_input is not None:
+            self.optional_entities(list(BUILDING_PROFILE_SENSOR_KEYS), user_input)
             self.options.update(user_input)
             return await self.async_step_init()
 

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -368,9 +368,11 @@ from .profile_link import (  # noqa: E402
     _cover_entries,
     _covers_linked_to,
     clear_cover_override,
+    cleared_profile_keys,
     compute_override_keys,
     merge_profile_into_config,
     profile_for_cover,
+    propagate_profile_clears,
 )
 
 # Local Overrides step: the multi-select field key and the empty-state message.
@@ -5424,6 +5426,12 @@ class OptionsFlowHandler(OptionsFlow):
         ``async_step_create_building_profile`` sensor section.  Submitting
         returns to the profile menu (issue #1003) — only ``async_step_done``
         actually saves and closes the dialog.
+
+        Every field here is a bare no-default ``vol.Optional``, so the frontend
+        omits a cleared one from ``user_input`` rather than sending it empty;
+        ``optional_entities`` nulls those so the clear sticks (issue #1085).
+        Reaching the linked covers is ``async_step_done``'s job — see
+        ``_propagate_profile_clears``.
         """
         if user_input is not None:
             self.optional_entities(list(BUILDING_PROFILE_SENSOR_KEYS), user_input)
@@ -5862,6 +5870,7 @@ class OptionsFlowHandler(OptionsFlow):
     async def _update_options(self) -> FlowResult:
         """Update config entry options."""
         self._recompute_profile_overrides()
+        self._propagate_profile_clears()
         return self.async_create_entry(title="", data=self.options)  # type: ignore[return-value]
 
     def _recompute_profile_overrides(self) -> None:
@@ -5880,6 +5889,25 @@ class OptionsFlowHandler(OptionsFlow):
             self.options[CONF_PROFILE_SENSOR_OVERRIDES] = overrides
         else:
             self.options.pop(CONF_PROFILE_SENSOR_OVERRIDES, None)
+
+    def _propagate_profile_clears(self) -> None:
+        """Push the shared sensors this dialog emptied out to the linked covers.
+
+        Only a Building Profile has linked covers, so this is a no-op for a
+        cover's own options flow. A saved profile carries every shared key with
+        most of them blank (``optional_entities`` writes ``None`` for each field
+        the user did not fill in), so the stored value alone cannot say which
+        one the user just cleared — the set → blank transition between the
+        entry as the dialog opened it and the options about to be written can,
+        and this is the last point where both halves are in hand (issue #1085).
+        ``_async_profile_propagate`` handles the rest of the save: it re-copies
+        the profile's non-empty keys but can never remove one.
+        """
+        propagate_profile_clears(
+            self.hass,
+            self._config_entry,
+            cleared_profile_keys(self._config_entry.options, self.options),
+        )
 
     def optional_entities(self, keys: list, user_input: dict[str, Any]):
         """Set value to None if key does not exist."""

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -131,20 +131,30 @@ def merge_profile_into_config(
     *,
     overridden: frozenset[str] = frozenset(),
 ) -> None:
-    """Merge a profile's non-empty shared-sensor keys into a plain dict.
+    """Merge a profile's shared-sensor keys into a plain dict.
 
-    Skips keys the cover has locally overridden. Safe to call from both the
-    create flow (no existing entry, no overrides) and ``_copy_profile_to_cover``
-    (existing entry, may have overrides). Does NOT stamp
-    ``CONF_BUILDING_PROFILE_ID`` — callers handle that so each context can
-    write it in the right place.
+    Skips keys the cover has locally overridden. A key ABSENT from the
+    profile's options is left untouched on ``config_dict`` — a profile that
+    has never set a field must not touch the cover's own value. A key the
+    profile HAS set (even to an explicitly-cleared empty value — issue #1085)
+    is applied: copied when non-empty, removed when empty. That set-or-remove
+    shape mirrors ``clear_cover_override``'s handling of a single key, kept
+    consistent here for the whole subset so "profile defines this key" has one
+    meaning project-wide: present in ``profile_entry.options``, not merely
+    non-empty.
+
+    Safe to call from both the create flow (no existing entry, no overrides)
+    and ``_copy_profile_to_cover`` (existing entry, may have overrides). Does
+    NOT stamp ``CONF_BUILDING_PROFILE_ID`` — callers handle that so each
+    context can write it in the right place.
     """
-    subset = {
-        k: v
-        for k, v in profile_entry.options.items()
-        if k in BUILDING_PROFILE_SENSOR_KEYS and _is_set(v) and k not in overridden
-    }
-    config_dict.update(subset)
+    for key, value in profile_entry.options.items():
+        if key not in BUILDING_PROFILE_SENSOR_KEYS or key in overridden:
+            continue
+        if _is_set(value):
+            config_dict[key] = value
+        else:
+            config_dict.pop(key, None)
 
 
 def _copy_profile_to_cover(

--- a/custom_components/adaptive_cover_pro/profile_link.py
+++ b/custom_components/adaptive_cover_pro/profile_link.py
@@ -1,9 +1,10 @@
 """Shared Building Profile link helpers.
 
 A neutral home for the profile/cover linkage helpers so both ``config_flow``
-(link/unlink UI) and ``__init__`` (live propagation + deletion cleanup) can
-reuse a single source. It must not live in ``helpers.py`` — that module is
-imported by ``cover_types.base``, and these helpers need ``get_policy`` from
+(link/unlink UI, plus the clear propagation a profile save drives) and
+``__init__`` (live propagation + deletion cleanup) can reuse a single source.
+It must not live in ``helpers.py`` — that module is imported by
+``cover_types.base``, and these helpers need ``get_policy`` from
 ``cover_types``, which would create an import cycle.
 """
 
@@ -131,30 +132,80 @@ def merge_profile_into_config(
     *,
     overridden: frozenset[str] = frozenset(),
 ) -> None:
-    """Merge a profile's shared-sensor keys into a plain dict.
+    """Merge a profile's non-empty shared-sensor keys into a plain dict.
 
-    Skips keys the cover has locally overridden. A key ABSENT from the
-    profile's options is left untouched on ``config_dict`` — a profile that
-    has never set a field must not touch the cover's own value. A key the
-    profile HAS set (even to an explicitly-cleared empty value — issue #1085)
-    is applied: copied when non-empty, removed when empty. That set-or-remove
-    shape mirrors ``clear_cover_override``'s handling of a single key, kept
-    consistent here for the whole subset so "profile defines this key" has one
-    meaning project-wide: present in ``profile_entry.options``, not merely
-    non-empty.
+    Skips keys the cover has locally overridden. Safe to call from both the
+    create flow (no existing entry, no overrides) and ``_copy_profile_to_cover``
+    (existing entry, may have overrides). Does NOT stamp
+    ``CONF_BUILDING_PROFILE_ID`` — callers handle that so each context can
+    write it in the right place.
 
-    Safe to call from both the create flow (no existing entry, no overrides)
-    and ``_copy_profile_to_cover`` (existing entry, may have overrides). Does
-    NOT stamp ``CONF_BUILDING_PROFILE_ID`` — callers handle that so each
-    context can write it in the right place.
+    Copy-only, never remove: a blank profile key means "the profile does not
+    define this", which is indistinguishable from "the user never filled it
+    in" once stored, so it must leave the cover's own value alone. Removing
+    the key a profile save actually emptied is a separate, save-time job —
+    ``propagate_profile_clears`` (issue #1085).
     """
-    for key, value in profile_entry.options.items():
-        if key not in BUILDING_PROFILE_SENSOR_KEYS or key in overridden:
+    subset = {
+        k: v
+        for k, v in profile_entry.options.items()
+        if k in BUILDING_PROFILE_SENSOR_KEYS and _is_set(v) and k not in overridden
+    }
+    config_dict.update(subset)
+
+
+def cleared_profile_keys(previous_options: dict, new_options: dict) -> frozenset[str]:
+    """Shared-sensor keys a profile save emptied: set before, blank after.
+
+    A stored option cannot say whether a blank field was cleared or simply
+    never filled in — the profile form writes ``None`` for both (issue #1085).
+    The transition can, so the profile's stored options are diffed against the
+    ones the options dialog is about to write. Blank in either shape counts
+    (``None``, ``""``, ``[]`` — the multi-selects clear to the last), and a key
+    that was already blank, or that the dialog re-filled before saving, is not
+    a clear.
+    """
+    return frozenset(
+        key
+        for key in BUILDING_PROFILE_SENSOR_KEYS
+        if _is_set((previous_options or {}).get(key))
+        and not _is_set((new_options or {}).get(key))
+    )
+
+
+def propagate_profile_clears(
+    hass: HomeAssistant, profile_entry: ConfigEntry, cleared: frozenset[str]
+) -> None:
+    """Drop the keys a profile save emptied from the covers inheriting them.
+
+    The counterpart to ``_copy_profile_to_cover``: that copier only ever
+    applies the profile's non-empty keys, so on its own a cleared field would
+    leave the last-copied sensor sitting on every linked cover. Only keys in
+    ``cleared`` are touched, and only where the cover was inheriting — a key in
+    the cover's ``CONF_PROFILE_SENSOR_OVERRIDES`` is that cover's own
+    deliberate choice and stays. Removing rather than blanking keeps a dropped
+    key indistinguishable from one never configured, which is what the
+    diagnostics and overview classification already expects.
+
+    Driven from the options flow's save, not from the propagation listener:
+    the listener sees only the profile's new options, where a cleared field is
+    indistinguishable from an unfilled one. Scoped by ``_covers_linked_to``, so
+    calling it for a non-profile entry is a no-op — only a Building Profile's
+    ``entry_id`` ever appears in a cover's ``CONF_BUILDING_PROFILE_ID``. Writes
+    nothing when nothing was cleared, which is the overwhelmingly common save.
+    """
+    if not cleared:
+        return
+    for cover in _covers_linked_to(hass, profile_entry):
+        drop = {
+            key
+            for key in cleared - effective_profile_overrides(cover.options)
+            if key in cover.options
+        }
+        if not drop:
             continue
-        if _is_set(value):
-            config_dict[key] = value
-        else:
-            config_dict.pop(key, None)
+        options = {k: v for k, v in cover.options.items() if k not in drop}
+        hass.config_entries.async_update_entry(cover, options=options)
 
 
 def _copy_profile_to_cover(

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -27,6 +27,8 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_PROFILE_SENSOR_OVERRIDES,
     CONF_SENSOR_TYPE,
     CONF_WEATHER_ENTITY,
+    CONF_WEATHER_IS_RAINING_TEMPLATE,
+    CONF_WEATHER_RAIN_SENSOR,
     CONF_WEATHER_WIND_SPEED_SENSOR,
     DOMAIN,
     CoverType,
@@ -373,6 +375,40 @@ async def test_building_profile_options_flow_saves_sensors(
     result2 = await flow.async_step_done()
     assert result2["type"] == "create_entry"
     assert result2["data"][CONF_LUX_ENTITY] == "sensor.new_lux"
+
+
+@pytest.mark.integration
+async def test_building_profile_sensors_step_clears_previously_set_field(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing a previously-set sensor/template field must not survive a
+    submit with the key simply absent from user_input — HA's frontend omits
+    a cleared no-default vol.Optional key rather than sending "" (issue #1085).
+    """
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={
+            CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
+            CONF_WEATHER_IS_RAINING_TEMPLATE: "{{ 'off' }}",
+        },
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+
+    flow = OptionsFlowHandler(profile)
+    flow.hass = hass
+
+    # Empty dict mirrors the frontend submission when every field is cleared —
+    # none of these keys carry a schema default, so HA never sends them back.
+    await flow.async_step_profile_sensors({})
+    assert flow.options.get(CONF_WEATHER_RAIN_SENSOR) is None
+    assert flow.options.get(CONF_WEATHER_IS_RAINING_TEMPLATE) is None
+
+    result2 = await flow.async_step_done()
+    assert result2["data"].get(CONF_WEATHER_RAIN_SENSOR) is None
+    assert result2["data"].get(CONF_WEATHER_IS_RAINING_TEMPLATE) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_building_profile_config_flow.py
+++ b/tests/test_building_profile_config_flow.py
@@ -411,6 +411,159 @@ async def test_building_profile_sensors_step_clears_previously_set_field(
     assert result2["data"].get(CONF_WEATHER_IS_RAINING_TEMPLATE) is None
 
 
+def _linked_cover(hass: HomeAssistant, entry_id: str, options: dict) -> MockConfigEntry:
+    """Add a cover entry linked to ``profile_1``."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": entry_id, CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={CONF_BUILDING_PROFILE_ID: "profile_1", **options},
+        entry_id=entry_id,
+        title=entry_id,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+@pytest.mark.integration
+async def test_building_profile_clear_reaches_linked_covers_on_save(
+    hass: HomeAssistant,
+) -> None:
+    """Clearing a profile field also stops the linked covers using it (#1085).
+
+    Saving the profile with the field blank is only half the fix — every cover
+    that inherited the sensor still carries the last-copied value, and the
+    propagation listener can only copy non-empty keys, never remove one. The
+    save is where the set → cleared transition is still visible, so that is
+    where the removal is driven from.
+    """
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={
+            CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
+            CONF_LUX_ENTITY: "sensor.lux",
+        },
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+    inheriting = _linked_cover(
+        hass,
+        "cover_a",
+        {CONF_WEATHER_RAIN_SENSOR: "sensor.rain", CONF_LUX_ENTITY: "sensor.lux"},
+    )
+    overriding = _linked_cover(
+        hass,
+        "cover_b",
+        {
+            CONF_WEATHER_RAIN_SENSOR: "sensor.own_rain",
+            CONF_PROFILE_SENSOR_OVERRIDES: [CONF_WEATHER_RAIN_SENSOR],
+        },
+    )
+
+    flow = OptionsFlowHandler(profile)
+    flow.hass = hass
+    # Rain cleared, lux left as it was — the frontend omits the cleared key.
+    await flow.async_step_profile_sensors({CONF_LUX_ENTITY: "sensor.lux"})
+    await flow.async_step_done()
+
+    assert CONF_WEATHER_RAIN_SENSOR not in inheriting.options
+    assert inheriting.options[CONF_LUX_ENTITY] == "sensor.lux"
+    assert overriding.options[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
+
+
+@pytest.mark.integration
+async def test_building_profile_save_without_clearing_leaves_covers_alone(
+    hass: HomeAssistant,
+) -> None:
+    """The common save — nothing cleared — writes no linked-cover entry."""
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={CONF_LUX_ENTITY: "sensor.lux"},
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+    _linked_cover(
+        hass,
+        "cover_a",
+        {CONF_LUX_ENTITY: "sensor.lux", CONF_OUTSIDETEMP_ENTITY: "sensor.local_out"},
+    )
+
+    flow = OptionsFlowHandler(profile)
+    flow.hass = hass
+
+    real_update = hass.config_entries.async_update_entry
+    updated: list[str] = []
+
+    def _spy(entry, **kwargs):
+        updated.append(entry.entry_id)
+        return real_update(entry, **kwargs)
+
+    hass.config_entries.async_update_entry = _spy
+    try:
+        await flow.async_step_profile_sensors(
+            {CONF_LUX_ENTITY: "sensor.lux", CONF_WEATHER_ENTITY: "weather.home"}
+        )
+        await flow.async_step_done()
+    finally:
+        hass.config_entries.async_update_entry = real_update
+
+    assert updated == []
+
+
+@pytest.mark.integration
+async def test_local_override_survives_clear_then_cover_save_then_propagation(
+    hass: HomeAssistant,
+) -> None:
+    """A cover's own sensor survives the whole clear → resave → repropagate run.
+
+    The profile clear leaves the override alone, but the cover's next save
+    recomputes its override list against the now-blank profile and drops the
+    key from it (the profile no longer defines it, so the cover simply owns it
+    outright). The following propagation must still not touch the value.
+    """
+    from custom_components.adaptive_cover_pro import _async_profile_propagate
+
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={CONF_WEATHER_RAIN_SENSOR: "sensor.rain"},
+        entry_id="profile_1",
+        title="Main Building",
+    )
+    profile.add_to_hass(hass)
+    cover = _linked_cover(
+        hass,
+        "cover_b",
+        {
+            CONF_WEATHER_RAIN_SENSOR: "sensor.own_rain",
+            CONF_PROFILE_SENSOR_OVERRIDES: [CONF_WEATHER_RAIN_SENSOR],
+        },
+    )
+
+    # 1. The profile clears the rain sensor and saves.
+    profile_flow = OptionsFlowHandler(profile)
+    profile_flow.hass = hass
+    await profile_flow.async_step_profile_sensors({})
+    saved = await profile_flow.async_step_done()
+    hass.config_entries.async_update_entry(profile, options=saved["data"])
+    assert cover.options[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
+
+    # 2. The cover is saved again — its override list is recomputed against
+    #    the now-blank profile.
+    cover_flow = OptionsFlowHandler(cover)
+    cover_flow.hass = hass
+    resaved = await cover_flow.async_step_done()
+    hass.config_entries.async_update_entry(cover, options=resaved["data"])
+    assert CONF_PROFILE_SENSOR_OVERRIDES not in cover.options
+
+    # 3. A later profile save propagates again — the cover keeps its sensor.
+    await _async_profile_propagate(hass, profile)
+    assert cover.options[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
+
+
 # ---------------------------------------------------------------------------
 # profile_line placeholder in options init step (issue #720 Part 3)
 # ---------------------------------------------------------------------------

--- a/tests/test_building_profile_link.py
+++ b/tests/test_building_profile_link.py
@@ -25,6 +25,7 @@ from custom_components.adaptive_cover_pro.config_dynamic import (
 )
 from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
 from custom_components.adaptive_cover_pro.const import (
+    BUILDING_PROFILE_SENSOR_KEYS,
     CONF_BUILDING_PROFILE_ID,
     CONF_CLIMATE_MODE,
     CONF_CLOUDY_POSITION,
@@ -122,6 +123,41 @@ def test_linked_cover_shows_profile_pickers() -> None:
     assert CONF_LUX_ENTITY in lc_unlinked
     assert CONF_LUX_ENTITY in lc_linked
     assert CONF_CLOUDY_POSITION in lc_linked
+
+
+# ---------------------------------------------------------------------------
+# const ⇄ schema equality lock (issue #1085)
+# ---------------------------------------------------------------------------
+
+
+def test_profile_sensor_keys_match_schema_so_saves_never_clear_a_key() -> None:
+    """Every ``BUILDING_PROFILE_SENSOR_KEYS`` entry must render in the schema.
+
+    ``async_step_profile_sensors`` hands the whole const to
+    ``optional_entities``, which nulls every listed key the frontend did not
+    send back (that is what makes a cleared field stick — issue #1085). A key
+    in the const that ``building_profile_sensors_schema()`` never renders can
+    never be in ``user_input``, so it is nulled on *every* profile save,
+    ``cleared_profile_keys`` reports it as a clear, and
+    ``propagate_profile_clears`` then deletes it from every linked cover.
+
+    The reverse direction matters too: the schema filters its selectors on the
+    const today, but a rendered key the const does not own would be silently
+    dropped from copy-on-link and propagation.
+    """
+    rendered = _schema_keys(building_profile_sensors_schema())
+    owned = set(BUILDING_PROFILE_SENSOR_KEYS)
+
+    assert rendered == owned, (
+        "BUILDING_PROFILE_SENSOR_KEYS and building_profile_sensors_schema() have "
+        f"diverged.\n  Owned but not rendered: {sorted(owned - rendered)} — add a "
+        "selector for each to building_profile_sensors_schema() "
+        "(config_dynamic.py), or drop the key from BUILDING_PROFILE_SENSOR_KEYS "
+        "(const.py). Left as-is, every profile save nulls the key and propagates "
+        "that as a clear to every linked cover.\n  Rendered but not owned: "
+        f"{sorted(rendered - owned)} — add each to BUILDING_PROFILE_SENSOR_KEYS, "
+        "or the profile screen will collect a value nothing ever copies."
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_building_profile_link.py
+++ b/tests/test_building_profile_link.py
@@ -57,18 +57,11 @@ def _schema_keys(schema):
 
 @pytest.mark.integration
 async def test_link_copies_nonempty_subset(hass) -> None:
-    """Linking copies non-empty profile keys; a never-set key falls back.
-
-    ``CONF_IRRADIANCE_ENTITY`` is absent from the profile's options entirely —
-    the real config-flow schema never submits an explicit "" for a cleared
-    key (it omits the key, or since issue #1085 stores an explicit ``None``);
-    absence, not an empty string, is what "the profile never touched this
-    field" looks like on a config entry (issue #1085).
-    """
+    """Linking copies non-empty profile keys; blank profile fields fall back."""
     profile = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
-        options={CONF_LUX_ENTITY: "sensor.lux"},
+        options={CONF_LUX_ENTITY: "sensor.lux", CONF_IRRADIANCE_ENTITY: ""},
         entry_id="profile_1",
         title="Bldg Profile",
     )
@@ -101,7 +94,7 @@ async def test_link_copies_nonempty_subset(hass) -> None:
 
     # Copied (profile non-empty).
     assert cover.options[CONF_LUX_ENTITY] == "sensor.lux"
-    # Retained (profile never set this key → fallback to local value).
+    # Retained (profile blank → fallback to local value).
     assert cover.options[CONF_IRRADIANCE_ENTITY] == "sensor.local_irr"
     # Link stamped.
     assert cover.options[CONF_BUILDING_PROFILE_ID] == "profile_1"
@@ -255,12 +248,15 @@ def test_copy_profile_to_cover_skips_overrides() -> None:
     assert opts[CONF_PROFILE_SENSOR_OVERRIDES] == [CONF_LUX_ENTITY]
 
 
-def test_merge_profile_into_config_removes_explicitly_cleared_key() -> None:
-    """A profile key present-but-None (explicitly cleared) removes the cover's
-    value; a key ABSENT from the profile's options is left untouched — the
-    "a profile that leaves a field blank never wipes the cover's own value"
-    contract must survive alongside the new "clear reaches the cover" fix
-    (issue #1085).
+def test_merge_profile_into_config_keeps_local_value_for_a_blank_profile_key() -> None:
+    """A blank profile key never wipes the cover's own value (issue #1085).
+
+    ``optional_entities`` writes ``None`` for every field the profile form
+    leaves blank, so a saved profile carries the whole shared-sensor key set
+    with most values empty in every shape blankness takes — ``None``, ``""``
+    and ``[]``. Those blanks mean "the profile does not define this", which is
+    indistinguishable from "the user never filled it in", so the merge must
+    leave the cover's value alone for all of them.
     """
     from custom_components.adaptive_cover_pro.profile_link import (
         merge_profile_into_config,
@@ -270,45 +266,60 @@ def test_merge_profile_into_config_removes_explicitly_cleared_key() -> None:
         domain=DOMAIN,
         data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
         options={
-            CONF_WEATHER_RAIN_SENSOR: None,  # explicitly cleared
-            CONF_LUX_ENTITY: "sensor.new_lux",  # set
-            # CONF_IRRADIANCE_ENTITY intentionally absent — never touched by
-            # the profile at all.
+            CONF_LUX_ENTITY: "sensor.profile_lux",
+            CONF_OUTSIDETEMP_ENTITY: None,
+            CONF_WEATHER_RAIN_SENSOR: "",
+            CONF_DAYTIME_GATE_SENSORS: [],
         },
         entry_id="profile_1",
     )
 
     config: dict = {
-        CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
-        CONF_LUX_ENTITY: "sensor.old_lux",
-        CONF_IRRADIANCE_ENTITY: "sensor.local_irr",
+        CONF_OUTSIDETEMP_ENTITY: "sensor.local_outside",
+        CONF_WEATHER_RAIN_SENSOR: "sensor.local_rain",
+        CONF_DAYTIME_GATE_SENSORS: ["binary_sensor.daylight"],
     }
     merge_profile_into_config(profile, config)
 
-    assert CONF_WEATHER_RAIN_SENSOR not in config
-    assert config[CONF_LUX_ENTITY] == "sensor.new_lux"
-    assert config[CONF_IRRADIANCE_ENTITY] == "sensor.local_irr"
+    assert config[CONF_LUX_ENTITY] == "sensor.profile_lux"
+    assert config[CONF_OUTSIDETEMP_ENTITY] == "sensor.local_outside"
+    assert config[CONF_WEATHER_RAIN_SENSOR] == "sensor.local_rain"
+    assert config[CONF_DAYTIME_GATE_SENSORS] == ["binary_sensor.daylight"]
 
 
-def test_merge_profile_into_config_skips_overridden_key_even_when_cleared() -> None:
-    """A cover's genuine local override survives a profile clear on that key."""
-    from custom_components.adaptive_cover_pro.profile_link import (
-        merge_profile_into_config,
+def test_cleared_profile_keys_reports_only_set_to_blank_transitions() -> None:
+    """Only a set → blank move counts as a clear (issue #1085).
+
+    The saved options alone cannot tell a cleared field from one that was
+    never filled in — both end up blank. The transition can, so the profile's
+    stored options are diffed against the ones the dialog is about to write.
+    """
+    from custom_components.adaptive_cover_pro.profile_link import cleared_profile_keys
+
+    previous = {
+        CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
+        CONF_DAYTIME_GATE_SENSORS: ["binary_sensor.daylight"],
+        CONF_IS_SUNNY_TEMPLATE_MODE: "or",
+        CONF_LUX_ENTITY: "sensor.lux",
+        CONF_IRRADIANCE_ENTITY: None,
+        CONF_CLOUDY_POSITION: 40,
+    }
+    new = {
+        CONF_WEATHER_RAIN_SENSOR: None,  # cleared
+        CONF_DAYTIME_GATE_SENSORS: [],  # multi-select clears to []
+        CONF_IS_SUNNY_TEMPLATE_MODE: None,  # combine mode cleared
+        CONF_LUX_ENTITY: "sensor.lux",  # untouched
+        CONF_IRRADIANCE_ENTITY: None,  # blank before and after → never set
+        CONF_CLOUDY_POSITION: None,  # not a shared key at all
+    }
+
+    assert cleared_profile_keys(previous, new) == frozenset(
+        {
+            CONF_WEATHER_RAIN_SENSOR,
+            CONF_DAYTIME_GATE_SENSORS,
+            CONF_IS_SUNNY_TEMPLATE_MODE,
+        }
     )
-
-    profile = MockConfigEntry(
-        domain=DOMAIN,
-        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
-        options={CONF_WEATHER_RAIN_SENSOR: None},
-        entry_id="profile_1",
-    )
-
-    config: dict = {CONF_WEATHER_RAIN_SENSOR: "sensor.own_rain"}
-    merge_profile_into_config(
-        profile, config, overridden=frozenset({CONF_WEATHER_RAIN_SENSOR})
-    )
-
-    assert config[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
 
 
 def test_clear_cover_override_reinherits_and_removes() -> None:

--- a/tests/test_building_profile_link.py
+++ b/tests/test_building_profile_link.py
@@ -57,11 +57,18 @@ def _schema_keys(schema):
 
 @pytest.mark.integration
 async def test_link_copies_nonempty_subset(hass) -> None:
-    """Linking copies non-empty profile keys; blank profile fields fall back."""
+    """Linking copies non-empty profile keys; a never-set key falls back.
+
+    ``CONF_IRRADIANCE_ENTITY`` is absent from the profile's options entirely —
+    the real config-flow schema never submits an explicit "" for a cleared
+    key (it omits the key, or since issue #1085 stores an explicit ``None``);
+    absence, not an empty string, is what "the profile never touched this
+    field" looks like on a config entry (issue #1085).
+    """
     profile = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
-        options={CONF_LUX_ENTITY: "sensor.lux", CONF_IRRADIANCE_ENTITY: ""},
+        options={CONF_LUX_ENTITY: "sensor.lux"},
         entry_id="profile_1",
         title="Bldg Profile",
     )
@@ -94,7 +101,7 @@ async def test_link_copies_nonempty_subset(hass) -> None:
 
     # Copied (profile non-empty).
     assert cover.options[CONF_LUX_ENTITY] == "sensor.lux"
-    # Retained (profile blank → fallback to local value).
+    # Retained (profile never set this key → fallback to local value).
     assert cover.options[CONF_IRRADIANCE_ENTITY] == "sensor.local_irr"
     # Link stamped.
     assert cover.options[CONF_BUILDING_PROFILE_ID] == "profile_1"
@@ -246,6 +253,62 @@ def test_copy_profile_to_cover_skips_overrides() -> None:
     assert opts[CONF_LUX_ENTITY] == "sensor.office"  # override preserved
     assert opts[CONF_OUTSIDETEMP_ENTITY] == "sensor.out"  # inherited key copied
     assert opts[CONF_PROFILE_SENSOR_OVERRIDES] == [CONF_LUX_ENTITY]
+
+
+def test_merge_profile_into_config_removes_explicitly_cleared_key() -> None:
+    """A profile key present-but-None (explicitly cleared) removes the cover's
+    value; a key ABSENT from the profile's options is left untouched — the
+    "a profile that leaves a field blank never wipes the cover's own value"
+    contract must survive alongside the new "clear reaches the cover" fix
+    (issue #1085).
+    """
+    from custom_components.adaptive_cover_pro.profile_link import (
+        merge_profile_into_config,
+    )
+
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={
+            CONF_WEATHER_RAIN_SENSOR: None,  # explicitly cleared
+            CONF_LUX_ENTITY: "sensor.new_lux",  # set
+            # CONF_IRRADIANCE_ENTITY intentionally absent — never touched by
+            # the profile at all.
+        },
+        entry_id="profile_1",
+    )
+
+    config: dict = {
+        CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
+        CONF_LUX_ENTITY: "sensor.old_lux",
+        CONF_IRRADIANCE_ENTITY: "sensor.local_irr",
+    }
+    merge_profile_into_config(profile, config)
+
+    assert CONF_WEATHER_RAIN_SENSOR not in config
+    assert config[CONF_LUX_ENTITY] == "sensor.new_lux"
+    assert config[CONF_IRRADIANCE_ENTITY] == "sensor.local_irr"
+
+
+def test_merge_profile_into_config_skips_overridden_key_even_when_cleared() -> None:
+    """A cover's genuine local override survives a profile clear on that key."""
+    from custom_components.adaptive_cover_pro.profile_link import (
+        merge_profile_into_config,
+    )
+
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bldg", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={CONF_WEATHER_RAIN_SENSOR: None},
+        entry_id="profile_1",
+    )
+
+    config: dict = {CONF_WEATHER_RAIN_SENSOR: "sensor.own_rain"}
+    merge_profile_into_config(
+        profile, config, overridden=frozenset({CONF_WEATHER_RAIN_SENSOR})
+    )
+
+    assert config[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
 
 
 def test_clear_cover_override_reinherits_and_removes() -> None:

--- a/tests/test_building_profile_propagation.py
+++ b/tests/test_building_profile_propagation.py
@@ -22,7 +22,10 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_BUILDING_PROFILE_ID,
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
+    CONF_PROFILE_SENSOR_OVERRIDES,
     CONF_SENSOR_TYPE,
+    CONF_WEATHER_IS_WINDY_TEMPLATE,
+    CONF_WEATHER_RAIN_SENSOR,
     DOMAIN,
     CoverType,
 )
@@ -91,6 +94,48 @@ async def test_profile_change_propagates_to_linked_covers(hass) -> None:
     # Unlinked cover untouched.
     assert unlinked.options[CONF_LUX_ENTITY] == "sensor.local"
     assert "cover_c" not in updated
+
+
+async def test_profile_clear_propagates_to_linked_covers(hass) -> None:
+    """Clearing a shared sensor on the profile must reach linked covers (#1085).
+
+    The profile now stores an explicitly-cleared key as ``None`` (key present,
+    value empty) rather than omitting it — that is what makes the clear
+    reachable in the config-flow form at all. Propagation must remove that key
+    from a linked cover that was simply inheriting it, so the cover stops
+    reading the stale sensor. A cover with its own genuine local override on
+    the same key must keep its override untouched.
+    """
+    profile = _profile(
+        hass,
+        {CONF_WEATHER_RAIN_SENSOR: None, CONF_WEATHER_IS_WINDY_TEMPLATE: None},
+    )
+    inheriting = _cover(
+        hass,
+        "cover_a",
+        {
+            CONF_BUILDING_PROFILE_ID: "profile_1",
+            CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
+            CONF_WEATHER_IS_WINDY_TEMPLATE: "{{ 'off' }}",
+        },
+    )
+    overriding = _cover(
+        hass,
+        "cover_b",
+        {
+            CONF_BUILDING_PROFILE_ID: "profile_1",
+            CONF_WEATHER_RAIN_SENSOR: "sensor.own_rain",
+            CONF_PROFILE_SENSOR_OVERRIDES: [CONF_WEATHER_RAIN_SENSOR],
+        },
+    )
+
+    await _async_profile_propagate(hass, profile)
+
+    # Inheriting cover: the cleared keys are gone, not merely stale.
+    assert CONF_WEATHER_RAIN_SENSOR not in inheriting.options
+    assert CONF_WEATHER_IS_WINDY_TEMPLATE not in inheriting.options
+    # Overriding cover: its genuine local override survives a profile clear.
+    assert overriding.options[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
 
 
 async def test_profile_delete_clears_linked_cover_ids(hass) -> None:

--- a/tests/test_building_profile_propagation.py
+++ b/tests/test_building_profile_propagation.py
@@ -19,11 +19,14 @@ from custom_components.adaptive_cover_pro import (
     async_remove_entry,
 )
 from custom_components.adaptive_cover_pro.const import (
+    BUILDING_PROFILE_SENSOR_KEYS,
     CONF_BUILDING_PROFILE_ID,
     CONF_IRRADIANCE_ENTITY,
     CONF_LUX_ENTITY,
+    CONF_OUTSIDETEMP_ENTITY,
     CONF_PROFILE_SENSOR_OVERRIDES,
     CONF_SENSOR_TYPE,
+    CONF_WEATHER_ENTITY,
     CONF_WEATHER_IS_WINDY_TEMPLATE,
     CONF_WEATHER_RAIN_SENSOR,
     DOMAIN,
@@ -96,20 +99,50 @@ async def test_profile_change_propagates_to_linked_covers(hass) -> None:
     assert "cover_c" not in updated
 
 
-async def test_profile_clear_propagates_to_linked_covers(hass) -> None:
-    """Clearing a shared sensor on the profile must reach linked covers (#1085).
+async def test_propagate_keeps_cover_values_for_never_set_profile_keys(hass) -> None:
+    """A profile that leaves a field blank never wipes a cover's own value.
 
-    The profile now stores an explicitly-cleared key as ``None`` (key present,
-    value empty) rather than omitting it — that is what makes the clear
-    reachable in the config-flow form at all. Propagation must remove that key
-    from a linked cover that was simply inheriting it, so the cover stops
-    reading the stale sensor. A cover with its own genuine local override on
-    the same key must keep its override untouched.
+    After one submit of the profile's sensor form every shared key is present
+    in the profile's options, almost all of them ``None`` — that is what
+    ``optional_entities`` writes for a field the user did not fill in. The
+    listener must not read those blanks as instructions to clear (issue #1085).
     """
     profile = _profile(
         hass,
-        {CONF_WEATHER_RAIN_SENSOR: None, CONF_WEATHER_IS_WINDY_TEMPLATE: None},
+        dict.fromkeys(BUILDING_PROFILE_SENSOR_KEYS)
+        | {CONF_WEATHER_ENTITY: "weather.home"},
     )
+    linked = _cover(
+        hass,
+        "cover_a",
+        {
+            CONF_BUILDING_PROFILE_ID: "profile_1",
+            CONF_LUX_ENTITY: "sensor.local_lux",
+            CONF_OUTSIDETEMP_ENTITY: "sensor.local_outside",
+        },
+    )
+
+    await _async_profile_propagate(hass, profile)
+
+    assert linked.options[CONF_WEATHER_ENTITY] == "weather.home"
+    assert linked.options[CONF_LUX_ENTITY] == "sensor.local_lux"
+    assert linked.options[CONF_OUTSIDETEMP_ENTITY] == "sensor.local_outside"
+
+
+async def test_propagate_profile_clears_removes_only_inherited_keys(hass) -> None:
+    """A key the profile save emptied leaves the covers inheriting it (#1085).
+
+    ``_copy_profile_to_cover`` only ever applies non-empty profile keys, so
+    on its own a cleared field would leave the last-copied sensor sitting on
+    every linked cover. A cover carrying a genuine local override on the same
+    key keeps its own choice, and an unlinked cover is never touched.
+    """
+    from custom_components.adaptive_cover_pro.profile_link import (
+        classify_profile_sensor_source,
+        propagate_profile_clears,
+    )
+
+    profile = _profile(hass, {CONF_LUX_ENTITY: "sensor.lux"})
     inheriting = _cover(
         hass,
         "cover_a",
@@ -117,6 +150,7 @@ async def test_profile_clear_propagates_to_linked_covers(hass) -> None:
             CONF_BUILDING_PROFILE_ID: "profile_1",
             CONF_WEATHER_RAIN_SENSOR: "sensor.rain",
             CONF_WEATHER_IS_WINDY_TEMPLATE: "{{ 'off' }}",
+            CONF_LUX_ENTITY: "sensor.lux",
         },
     )
     overriding = _cover(
@@ -128,14 +162,61 @@ async def test_profile_clear_propagates_to_linked_covers(hass) -> None:
             CONF_PROFILE_SENSOR_OVERRIDES: [CONF_WEATHER_RAIN_SENSOR],
         },
     )
+    unlinked = _cover(hass, "cover_c", {CONF_WEATHER_RAIN_SENSOR: "sensor.rain"})
 
-    await _async_profile_propagate(hass, profile)
+    propagate_profile_clears(
+        hass,
+        profile,
+        frozenset({CONF_WEATHER_RAIN_SENSOR, CONF_WEATHER_IS_WINDY_TEMPLATE}),
+    )
 
-    # Inheriting cover: the cleared keys are gone, not merely stale.
+    # Inheriting cover: the cleared keys are gone, not merely stale. Keys the
+    # save did not touch stay put.
     assert CONF_WEATHER_RAIN_SENSOR not in inheriting.options
     assert CONF_WEATHER_IS_WINDY_TEMPLATE not in inheriting.options
+    assert inheriting.options[CONF_LUX_ENTITY] == "sensor.lux"
     # Overriding cover: its genuine local override survives a profile clear.
     assert overriding.options[CONF_WEATHER_RAIN_SENSOR] == "sensor.own_rain"
+    # Unlinked cover: out of scope entirely.
+    assert unlinked.options[CONF_WEATHER_RAIN_SENSOR] == "sensor.rain"
+    # Nothing holds the sensor any more, so diagnostics and the Building
+    # Overview classify it exactly as one that was never configured.
+    assert classify_profile_sensor_source(
+        CONF_WEATHER_RAIN_SENSOR, dict(inheriting.options), dict(profile.options)
+    ) == ("local", None)
+
+
+async def test_propagate_profile_clears_writes_nothing_when_nothing_cleared(
+    hass,
+) -> None:
+    """The common save — nothing cleared — must not write a single entry."""
+    from custom_components.adaptive_cover_pro.profile_link import (
+        propagate_profile_clears,
+    )
+
+    profile = _profile(hass, {CONF_LUX_ENTITY: "sensor.lux"})
+    _cover(
+        hass,
+        "cover_a",
+        {CONF_BUILDING_PROFILE_ID: "profile_1", CONF_LUX_ENTITY: "sensor.lux"},
+    )
+
+    real_update = hass.config_entries.async_update_entry
+    updated: list[str] = []
+
+    def _spy(entry, **kwargs):
+        updated.append(entry.entry_id)
+        return real_update(entry, **kwargs)
+
+    hass.config_entries.async_update_entry = _spy
+    try:
+        propagate_profile_clears(hass, profile, frozenset())
+        # A cleared key no cover actually holds is not a reason to write either.
+        propagate_profile_clears(hass, profile, frozenset({CONF_WEATHER_RAIN_SENSOR}))
+    finally:
+        hass.config_entries.async_update_entry = real_update
+
+    assert updated == []
 
 
 async def test_profile_delete_clears_linked_cover_ids(hass) -> None:


### PR DESCRIPTION
## Summary

Clearing a sensor or a Jinja template in the Building Profile never stuck. Reopen the profile and the old value was back. The report named the rain sensor and the `is_windy` template; it applied to every key in `BUILDING_PROFILE_SENSOR_KEYS`.

`building_profile_sensors_schema()` renders each field as a bare no-default `vol.Optional`, so HA's frontend omits a cleared field from `user_input` entirely. `async_step_profile_sensors` then merged with a plain `self.options.update(user_input)`, and `dict.update` never removes a key absent from its argument. Every sibling step with the same field family already guards this with `self.optional_entities(<KEYS>, user_input)`, the convention added for #323. The profile-sensors step was the one that never got it.

Fixing the form exposed the other half: a cleared shared sensor still reached every linked cover, which kept reading it while diagnostics re-classified the leftover as a cover-local value. The stored options can never separate "cleared" from "never set", so the clear is computed as a save-time delta instead. At `_update_options` the handler holds the entry as the dialog opened it and the options it is about to write; a key that was set before and is blank after is an unambiguous transition. `cleared_profile_keys` computes that set and `propagate_profile_clears` removes exactly those keys from each linked cover, minus anything the cover overrides. Nothing cleared means no writes.

Also locks the invariant this made load-bearing: every key in `BUILDING_PROFILE_SENSOR_KEYS` must be rendered by `building_profile_sensors_schema()`, or a future key added to the const without a selector would be nulled on every save and propagated as a clear.

## Testing
- ✅ 9140 tests passing

## Related Issues
Refs #1085