### PR TITLE
fix: drop unphysical gamma-sign branch in climate tilt (#1088)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -877,12 +877,9 @@ CLIMATE_DEFAULT_TILT_ANGLE = 80  # degrees — tilt when no climate signal
 
 # Tilt MODE2 (0–180° range) uses the same percentage scale for both
 # closed-one-way (0%) and closed-other-way (100%); the open horizontal
-# slat angle (90°) maps to 50%. The negative-gamma branch flips the angle
-# by subtracting an offset of 90° before scaling so that the result lands
-# in the OTHER closed hemisphere. See engine/covers/tilt.py:120-121 for
-# the geometry-side scale derivation.
+# slat angle (90°) maps to 50%. Mirroring an angle across horizontal (the
+# sun_through / winter-heating case) adds TILT_HORIZONTAL_DEG before scaling.
 MODE2_OPEN_HORIZONTAL_PERCENT = 50  # MODE2: 50% == horizontal/open slat
-CLIMATE_TILT_PCT_NEGATIVE_HEMISPHERE_OFFSET = 90  # MODE2 hemisphere-flip offset
 
 
 # =============================================================================

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 from homeassistant.helpers import selector
 
 from ..const import (
-    CLIMATE_TILT_PCT_NEGATIVE_HEMISPHERE_OFFSET,
     CONF_MAX_TILT,
     CONF_MAX_TILT_SUN_ONLY,
     CONF_MIN_TILT,
@@ -30,6 +29,7 @@ from ..const import (
     DEFAULT_VENETIAN_TILT_TRANSFORM,
     MAX_TILT_SAFETY_MARGIN,
     MIN_TILT_SAFETY_MARGIN,
+    TILT_HORIZONTAL_DEG,
     VENETIAN_TILT_TRANSFORMS,
 )
 from ..engine.covers import AdaptiveTiltCover
@@ -242,20 +242,21 @@ class TiltPolicy(CoverTypePolicy, register=True):
         *,
         angle_deg: float,
         mode: TiltMode | str,
-        gamma_deg: float,
         sun_through: bool = False,
     ) -> int:
         """Convert a target slat angle to a tilt percentage that blocks the sun.
 
         Single source of truth for the climate handler's angle → percent
-        translation across MODE1/MODE2 and positive/negative sun hemispheres.
+        translation across MODE1/MODE2.
+
+        Takes no sun-azimuth argument on purpose. Slat tilt is even in gamma —
+        the sun's left/right offset enters the slat geometry only through the
+        profile angle, via ``cos(gamma)`` — so an answer that varied with the
+        *sign* of gamma could only be wrong on one side. It was (issue #1088).
 
         Args:
             angle_deg: Target slat angle in degrees (e.g. CLIMATE_SUMMER_TILT_ANGLE).
             mode: Tilt mode — TiltMode enum value or its string ("mode1"/"mode2").
-            gamma_deg: Sun azimuth offset from window normal, in degrees.
-                When negative, the sun is on the opposite hemisphere and MODE2 must
-                flip its answer onto the other closed side.
             sun_through: When True, return the OPEN hemisphere instead of closed
                 (winter heating: let sun reach the window).  Mirrors the
                 ``sun_through`` flag on ``position_for_intent``.
@@ -271,23 +272,21 @@ class TiltPolicy(CoverTypePolicy, register=True):
             return round((angle_deg / TiltMode.MODE1.max_degrees) * 100)
 
         # MODE2: bi-directional 0–180° scale where 50% is horizontal/open.
-        # Choose hemisphere by sun side (gamma) and intent (sun_through).
+        # Intent alone picks the hemisphere — NOT the sun's left/right side.
+        # Slats rotate about a horizontal axis parallel to the facade, so the
+        # sun's azimuth offset reaches the geometry only through the profile
+        # angle beta = arctan(tan(elev)/cos(gamma)), and cos is even. A branch on
+        # sign(gamma) is therefore unphysical; it made the answer discontinuous
+        # at gamma = 0 and, on the gamma >= 0 side, selected the hemisphere that
+        # lets direct sun through (issue #1088).
         max_degrees = TiltMode.MODE2.max_degrees
-        # Closed-hemisphere mapping for MODE2:
-        #   gamma >= 0 → angle on the positive-side closed hemisphere
-        #               → (180 - angle) / 180 * 100  (== 100 - mode1_pct/2)
-        #   gamma <  0 → angle on the negative-side closed hemisphere
-        #               → angle / 180 * 100
-        # sun_through (winter heating) flips to the open hemisphere by mirroring
-        # the angle across horizontal (+90° offset).
         if sun_through:
-            effective_angle = (
-                CLIMATE_TILT_PCT_NEGATIVE_HEMISPHERE_OFFSET + angle_deg
-                if gamma_deg >= 0
-                else CLIMATE_TILT_PCT_NEGATIVE_HEMISPHERE_OFFSET - angle_deg
-            )
+            # Winter heating: mirror the angle across horizontal, which lands the
+            # slat parallel to the beam — the exact maximum-transmission angle.
+            effective_angle = TILT_HORIZONTAL_DEG + angle_deg
         else:
-            effective_angle = max_degrees - angle_deg if gamma_deg >= 0 else angle_deg
+            # Blocking: the closed hemisphere containing the profile angle.
+            effective_angle = angle_deg
         return round((effective_angle / max_degrees) * 100)
 
     def targets_full_mechanical_endpoint(

--- a/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
+++ b/custom_components/adaptive_cover_pro/pipeline/handlers/climate_modes.py
@@ -41,6 +41,16 @@ class ClimateContext:
     covers, which never consult the tilt position fns).
     ``tracking_seasons`` mirrors the per-instance season-scope option: the set
     of seasons in which glare tracking is permitted (defaults to all).
+
+    ⚠️ **No slat-tilt rule may branch on ``gamma_deg``.** Slats rotate about a
+    horizontal axis parallel to the facade, so the sun's left/right offset
+    reaches the slat geometry only through ``beta`` (via ``cos(gamma)``, which is
+    even). A tilt answer that varies with the *sign* of gamma is unphysical and
+    can only be right on one side — issue #1088, where the ``gamma >= 0`` branch
+    picked the hemisphere that lets direct sun through. The field stays because
+    it is genuine precomputed geometry, and
+    ``tests/test_cover_types/test_tilt_aperture.py`` pins that no tilt rule reads
+    it.
     """
 
     data: Any
@@ -158,7 +168,6 @@ def _tilt_summer(ctx: ClimateContext) -> int:
     return TiltPolicy.climate_tilt_percentage(
         angle_deg=CLIMATE_SUMMER_TILT_ANGLE,
         mode=ctx.cover.mode,
-        gamma_deg=ctx.gamma_deg,
     )
 
 
@@ -166,17 +175,15 @@ def _tilt_default(ctx: ClimateContext) -> int:
     return TiltPolicy.climate_tilt_percentage(
         angle_deg=CLIMATE_DEFAULT_TILT_ANGLE,
         mode=ctx.cover.mode,
-        gamma_deg=ctx.gamma_deg,
     )
 
 
 def _tilt_winter_mode2(ctx: ClimateContext) -> int:
-    # MODE2 winter heating opens the slat toward the sun; passing gamma_deg=0.0
-    # preserves the historical positive-hemisphere answer.
+    # MODE2 winter heating mirrors the profile angle across horizontal, landing
+    # the slat parallel to the beam (maximum transmission).
     return TiltPolicy.climate_tilt_percentage(
         angle_deg=ctx.beta_deg,
         mode=ctx.cover.mode,
-        gamma_deg=0.0,
         sun_through=True,
     )
 

--- a/tests/test_climate_cover_state.py
+++ b/tests/test_climate_cover_state.py
@@ -1367,23 +1367,46 @@ class TestIssue71IrradianceSummerFix:
 
 
 class TestIssue373Mode2SummerTiltHemisphere:
-    """Regression tests for Issue #373.
+    """Regression tests for issues #373 and #1088.
 
-    MODE2 tilt blinds use a 0–180° range where >50% means the slat is tilted
-    toward the upper/blocking hemisphere.  The summer cooling angle (45°) must
-    be mapped to the far side of horizontal (135° equivalent = 75%) for MODE2,
-    not to 25% (which is on the open/wrong hemisphere).
+    MODE2 tilt blinds use a 0–180° range where 50% is horizontal/open. The
+    summer cooling angle (45°) maps to 25%, on the closed hemisphere that
+    contains the sun's profile angle — the side that actually blocks the beam.
+
+    These tests originally asserted the mirror (135° ≡ 75%) on the theory that
+    ">50% is the blocking hemisphere". That was wrong: #1088 showed 75% passes
+    direct sun at every elevation, and that the branch producing it keyed off
+    the *sign* of gamma — a quantity slat tilt is provably even in. The numbers
+    below were read off that branch, so they ratified the defect rather than
+    guarding against it.
+
+    The physical assertions now live in
+    ``tests/test_cover_types/test_tilt_aperture.py``, which scores the commanded
+    angle against an aperture oracle validated against the production cut-off
+    solver. What remains here is the *pipeline wiring*: which strategy fires and
+    what percentage reaches the cover.
+
+    #373's actual defect — the raw answer falling below a ``min_position`` floor
+    and collapsing to horizontal — was fixed by the config-summary ⚠️ warning
+    that #405 shipped alongside the hemisphere flip, and is unaffected by #1088.
+    See ``config_flow._build_config_summary`` and the ``mode2_min_position``
+    warning tests.
     """
 
     # ------------------------------------------------------------------
-    # 1a — MODE2 summer with presence must land on blocking hemisphere
+    # 1a — MODE2 summer with presence must land on the blocking hemisphere
     # ------------------------------------------------------------------
 
     @pytest.mark.unit
     def test_tilt_summer_mode2_with_presence_correct_hemisphere(
         self, tilt_cover_instance, mock_logger
     ):
-        """MODE2 summer cooling must produce >50% (blocking hemisphere), not 25%."""
+        """MODE2 summer cooling must land on the blocking hemisphere (25%).
+
+        25% is slat angle 45°, the closed side containing the sun's profile
+        angle. Its mirror (75% ≡ 135°) is the leaking side — see #1088 and the
+        aperture tests in ``tests/test_cover_types/test_tilt_aperture.py``.
+        """
         tilt_cover_instance.mode = "mode2"
 
         with (
@@ -1418,8 +1441,11 @@ class TestIssue373Mode2SummerTiltHemisphere:
             )
             result = state_handler.tilt_with_presence()
 
-            assert result > 50, f"Expected >50 (blocking hemisphere) but got {result}"
-            assert result >= 75, f"Expected >=75 but got {result}"
+            assert result < 50, (
+                f"Expected <50 (blocking hemisphere, slat below horizontal) "
+                f"but got {result}"
+            )
+            assert result == 25, f"Expected 25 but got {result}"
             assert state_handler.climate_strategy.name == "SUMMER_COOLING"
 
     # ------------------------------------------------------------------
@@ -1479,14 +1505,22 @@ class TestIssue373Mode2SummerTiltHemisphere:
     # ------------------------------------------------------------------
 
     @pytest.mark.unit
-    def test_tilt_summer_mode2_with_presence_min_pos_clamp(
+    def test_tilt_summer_mode2_with_presence_raw_answer_is_unclamped(
         self, mock_logger, mock_sun_data
     ):
-        """MODE2 summer result (75%) must survive min_pos=50 without clamping to 50.
+        """``tilt_state()`` returns the raw blocking answer, limits not applied.
 
-        Mirrors the exact user symptom: min_position=50, enable_min_position=false
-        (always enforce).  Pre-fix the raw result was 25 → clamped to 50 (horizontal).
-        Post-fix the raw result is 75 → 75 > 50 so no clamp, stays at 75.
+        Built with the exact #373 config (min_position=50,
+        enable_min_position=false) to pin *which layer clamps*: this one does
+        not. ``tilt_state()`` is below ``apply_snapshot_limits``, so it hands
+        back the helper's 25% untouched; the floor is applied by ``get_state()``
+        and by ``ClimateHandler.evaluate()`` — see the 1d test below and
+        ``test_climate_handler.py``.
+
+        The old name said "min_pos_clamp" and the old assertion was 75. Neither
+        was load-bearing: 75 > 50, so the test could not distinguish clamped
+        from unclamped, and 75 was the hemisphere that lets direct sun through
+        (#1088).
         """
         tilt = build_tilt_cover(
             logger=mock_logger,
@@ -1543,13 +1577,29 @@ class TestIssue373Mode2SummerTiltHemisphere:
             )
             result = state_handler.tilt_state()
 
+            # The helper's raw answer is the blocking hemisphere...
+            from custom_components.adaptive_cover_pro.const import (
+                CLIMATE_SUMMER_TILT_ANGLE,
+                TiltMode,
+            )
+            from custom_components.adaptive_cover_pro.cover_types.tilt import (
+                TiltPolicy,
+            )
+
             assert (
-                result > 50
-            ), f"Expected result >50 (not clamped to horizontal) but got {result}"
-            assert result == 75, f"Expected 75 but got {result}"
+                TiltPolicy.climate_tilt_percentage(
+                    angle_deg=CLIMATE_SUMMER_TILT_ANGLE, mode=TiltMode.MODE2
+                )
+                == 25
+            )
+            # ...and tilt_state() passes it through without applying min_position.
+            assert result == 25, (
+                f"Expected the raw blocking answer 25 (tilt_state() sits below "
+                f"apply_snapshot_limits) but got {result}"
+            )
 
     # ------------------------------------------------------------------
-    # 1d — Issue #373 E2E: MODE2 + min_pos=50 + out-of-FOV must not clamp
+    # 1d — Issue #373 E2E: MODE2 + min_pos=50 + out-of-FOV, GLARE_CONTROL
     # ------------------------------------------------------------------
 
     @pytest.mark.unit
@@ -1564,17 +1614,17 @@ class TestIssue373Mode2SummerTiltHemisphere:
         - sun outside FOV (so cover.valid is False, climate falls to GLARE_CONTROL)
         - summer-ish climate with presence
 
-        Pre-fix: GLARE_CONTROL fallback returns round(80/180*100) = 44, then
-        apply_limits clamps up to 50 — the cover sits horizontal and does nothing.
+        The GLARE_CONTROL fallback returns round(80/180*100) = 44 — the blocking
+        hemisphere — and apply_limits then clamps it up to the user's
+        min_position floor of 50, leaving the cover horizontal.
 
-        Post-fix: helper is gamma-aware. For positive gamma (sun east of normal
-        per ACP's gamma sign convention: gamma = win_azi - sol_azi mod 360), the
-        MODE2 closed-positive hemisphere gives raw 56% → survives the min_pos=50
-        clamp → final 56%, no longer stuck at horizontal.
-
-        The complementary negative-gamma case (raw 44 → still clamped to 50) is
-        addressed by the config-summary ⚠️ warning that teaches users to avoid
-        min_position ≥ 50 in MODE2.
+        That collapse is the ``mode2_min_position`` footgun, and the
+        config-summary ⚠️ warning #405 added is what addresses it. It is not
+        gamma-dependent and never was: #405's hemisphere flip made the *positive*
+        gamma side return 56% so it escaped the floor, but 56% points the slats
+        at the leaking hemisphere (#1088), and the negative side stayed clamped
+        regardless. Post-#1088 both sides return the same blocking 44%, so the
+        behaviour is consistent with what the warning already tells users.
         """
         tilt = build_tilt_cover(
             logger=mock_logger,
@@ -1635,30 +1685,39 @@ class TestIssue373Mode2SummerTiltHemisphere:
             # exactly what the pipeline does and what reproduces the issue.
             result = state_handler.get_state()
 
+        # Raw helper answer is the blocking hemisphere, below the floor...
+        from custom_components.adaptive_cover_pro.const import (
+            CLIMATE_DEFAULT_TILT_ANGLE,
+            TiltMode,
+        )
+        from custom_components.adaptive_cover_pro.cover_types.tilt import TiltPolicy
+
         assert (
-            result != 50
-        ), f"Expected result != 50 (horizontal floor footgun) but got {result}"
-        # Positive-gamma case: raw 56% (helper returns (180-80)/180*100 ≈ 56)
-        # survives the min_pos=50 clamp.  Pre-fix returned 44 → clamped to 50.
-        assert (
-            result > 50
-        ), f"Expected result > 50 (positive closed hemisphere) but got {result}"
+            TiltPolicy.climate_tilt_percentage(
+                angle_deg=CLIMATE_DEFAULT_TILT_ANGLE, mode=TiltMode.MODE2
+            )
+            == 44
+        )
+        # ...so the user's min_position=50 raises it to horizontal.
+        assert result == 50, (
+            f"Expected 50 (min_position floor swallows the blocking answer — "
+            f"the documented MODE2 footgun) but got {result}"
+        )
         assert state_handler.climate_strategy == ClimateStrategy.GLARE_CONTROL
 
     # ------------------------------------------------------------------
-    # 2a — MODE2 summer + presence + negative gamma: pick OTHER hemisphere
+    # 2a — MODE2 summer + presence, sun west of normal (gamma < 0)
     # ------------------------------------------------------------------
 
     @pytest.mark.unit
-    def test_tilt_summer_mode2_with_presence_negative_gamma_picks_other_hemisphere(
+    def test_tilt_summer_mode2_with_presence_negative_gamma(
         self, mock_logger, mock_sun_data
     ):
-        """MODE2 summer with negative gamma must tilt to the negative hemisphere (25%).
+        """MODE2 summer tilts to the blocking hemisphere (25%) west of normal.
 
-        With gamma ≈ −40° (sun west of window normal under ACP's gamma sign
-        convention), the open/blocking direction flips compared to positive gamma —
-        the slat must tilt to the OTHER side of horizontal.  Pre-fix the code
-        always returned 75% regardless of sun side.
+        Paired with ``…_positive_gamma`` below: the two differ only in the sign
+        of gamma and must agree. Slat tilt is even in gamma, so a mirrored sun
+        azimuth cannot change the answer — see #1088.
 
         Note: SunGeometry.gamma = (win_azi - sol_azi + 180) % 360 - 180, so
         win_azi=180 + sol_azi=220 gives gamma ≈ -40°.
@@ -1718,21 +1777,25 @@ class TestIssue373Mode2SummerTiltHemisphere:
             )
             result = state_handler.tilt_with_presence()
 
-            assert result == 25, f"Expected 25 (negative hemisphere) but got {result}"
+            assert result == 25, f"Expected 25 (blocking hemisphere) but got {result}"
             assert state_handler.climate_strategy == ClimateStrategy.SUMMER_COOLING
 
     # ------------------------------------------------------------------
-    # 2b — MODE2 summer + presence + positive gamma: keep 75% (canary)
+    # 2b — MODE2 summer + presence, sun east of normal (gamma > 0)
     # ------------------------------------------------------------------
 
     @pytest.mark.unit
-    def test_tilt_summer_mode2_with_presence_positive_gamma_picks_75(
+    def test_tilt_summer_mode2_with_presence_positive_gamma(
         self, mock_logger, mock_sun_data
     ):
         """MODE2 summer with positive gamma keeps the existing 75% answer.
 
-        Canary for the positive-side hemisphere — the fix must not regress this
-        path (which today returns 75%, the correct blocking-hemisphere answer).
+        Mirror of ``…_negative_gamma`` above. The two differ only in the sign of
+        gamma and must agree: slat tilt is even in gamma.
+
+        This asserted 75% until #1088, which showed 75% (slat angle 135°) is the
+        hemisphere that lets direct sun through at every elevation tested. The
+        answer is 25% on both sides.
 
         Note: SunGeometry.gamma = (win_azi - sol_azi + 180) % 360 - 180, so
         win_azi=180 + sol_azi=140 gives gamma ≈ +40°.
@@ -1792,7 +1855,7 @@ class TestIssue373Mode2SummerTiltHemisphere:
             )
             result = state_handler.tilt_with_presence()
 
-            assert result == 75, f"Expected 75 (positive hemisphere) but got {result}"
+            assert result == 25, f"Expected 25 (blocking hemisphere) but got {result}"
             assert state_handler.climate_strategy == ClimateStrategy.SUMMER_COOLING
 
 

--- a/tests/test_cover_types/test_tilt_aperture.py
+++ b/tests/test_cover_types/test_tilt_aperture.py
@@ -1,0 +1,306 @@
+"""Physical-blocking tests for the MODE2 climate tilt helper (issue #1088).
+
+Every pre-existing tilt test pins a *number* (``assert result == 75``). Because
+those numbers were read off the same branch they were meant to guard, the suite
+ratified a helper that pointed the slats at the open hemisphere for half the sky.
+
+These tests assert the *physics* instead: that the angle
+``TiltPolicy.climate_tilt_percentage`` returns actually blocks the direct beam,
+scored by an aperture oracle that is itself validated against the production
+cut-off solver rather than asserted.
+
+The oracle
+----------
+A slat of chord ``w`` tilted ``theta`` from horizontal, stacked at vertical
+spacing ``s``, against a beam arriving at profile angle ``beta``::
+
+    theta = 90 - phi
+    reach = w*sin(theta) + w*cos(theta)*tan(beta)
+    slack = s - abs(reach)
+
+``slack > 0`` means the aperture is still open and direct sun passes.
+
+``reach`` collapses to ``(w/cos beta) * cos(phi - beta)``, which makes the
+structure explicit: transmission peaks at ``phi = beta + 90`` (the slat lies
+parallel to the beam) and the blocked band is centred on ``phi = beta``. Both
+forms are checked against each other below.
+"""
+
+from __future__ import annotations
+
+import inspect
+import math
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CLIMATE_DEFAULT_TILT_ANGLE,
+    CLIMATE_SUMMER_TILT_ANGLE,
+    TiltMode,
+)
+from custom_components.adaptive_cover_pro.cover_types.tilt import TiltPolicy
+from custom_components.adaptive_cover_pro.engine.covers.tilt import slat_cutoff_angle
+from custom_components.adaptive_cover_pro.engine.sun_geometry import (
+    foreshortened_slope,
+)
+from custom_components.adaptive_cover_pro.pipeline.handlers.climate_modes import (
+    ClimateContext,
+    _tilt_default,
+    _tilt_summer,
+    _tilt_winter_mode2,
+)
+
+# Representative venetian/louvre geometries, in cm: (slat depth, slat spacing).
+# Spread across depth/spacing ratios so a result that only holds for one blind
+# can't pass. 17.0/15.0 mirrors the louvered-roof defaults.
+SLAT_GEOMETRIES = [(8.0, 7.5), (2.5, 2.5), (5.0, 4.0), (6.0, 5.0), (17.0, 15.0)]
+
+# Sun positions to score. Gammas are mirrored pairs on purpose — the whole point
+# of #1088 is that the answer must not depend on the sign.
+ELEVATIONS = [15.0, 20.0, 38.0, 45.0, 60.0, 75.0]
+MIRRORED_GAMMAS = [0.0, 5.0, 28.4, 40.0, 60.0, 80.0]
+
+
+def profile_angle_deg(elevation_deg: float, gamma_deg: float) -> float:
+    """Beta, via the same helper the production tilt engine uses."""
+    return math.degrees(math.atan(foreshortened_slope(elevation_deg, gamma_deg)))
+
+
+def aperture_slack(
+    phi_deg: float, beta_deg: float, depth: float, spacing: float
+) -> float:
+    """Remaining open aperture, in cm. ``> 0`` means direct sun passes."""
+    theta = math.radians(90.0 - phi_deg)
+    beta = math.radians(beta_deg)
+    reach = depth * math.sin(theta) + depth * math.cos(theta) * math.tan(beta)
+    return spacing - abs(reach)
+
+
+def _aperture_slack_closed_form(
+    phi_deg: float, beta_deg: float, depth: float, spacing: float
+) -> float:
+    """``slack`` rewritten as ``s - (w/cos beta)*|cos(phi - beta)|``."""
+    beta = math.radians(beta_deg)
+    return spacing - (depth / math.cos(beta)) * abs(
+        math.cos(math.radians(phi_deg) - beta)
+    )
+
+
+def tilt_percentage_to_angle(percentage: int) -> float:
+    """MODE2 tilt percentage back to the raw slat angle it commands."""
+    return percentage * (TiltMode.MODE2.max_degrees / 100.0)
+
+
+def commanded_angle(angle_deg: float, *, sun_through: bool = False) -> float:
+    """Raw slat angle the climate helper commands for this target angle."""
+    return tilt_percentage_to_angle(
+        TiltPolicy.climate_tilt_percentage(
+            angle_deg=angle_deg,
+            mode=TiltMode.MODE2,
+            sun_through=sun_through,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# The oracle is validated, not asserted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("depth", "spacing"), SLAT_GEOMETRIES)
+@pytest.mark.parametrize("elevation", ELEVATIONS)
+def test_oracle_agrees_with_production_cutoff_solver(depth, spacing, elevation):
+    """At the angle the engine calls "grazing", the oracle's slack must be 0.
+
+    ``slat_cutoff_angle`` is the production MDPI cut-off solve. It returns the
+    most-open slat angle that still blocks the beam, so by construction the
+    aperture is exactly closed there. If the oracle disagrees, the oracle is
+    wrong and every physical assertion below is worthless — so this runs first.
+    """
+    for gamma in (0.0, -28.4, 28.4, 60.0):
+        beta = profile_angle_deg(elevation, gamma)
+        cutoff, _discriminant, negative = slat_cutoff_angle(
+            math.radians(beta), spacing, depth
+        )
+        if negative:
+            continue  # no real cut-off for this geometry; engine returns closed
+        assert aperture_slack(cutoff, beta, depth, spacing) == pytest.approx(
+            0.0, abs=1e-9
+        ), (
+            f"Oracle disagrees with slat_cutoff_angle at elev={elevation} "
+            f"gamma={gamma} beta={beta:.4f} cutoff={cutoff:.4f}"
+        )
+
+
+@pytest.mark.unit
+def test_oracle_matches_its_closed_form():
+    """The raw and ``cos(phi - beta)`` forms must agree — they are one formula."""
+    for phi in range(0, 181, 3):
+        for beta in range(0, 90, 3):
+            raw = aperture_slack(float(phi), float(beta), 8.0, 7.5)
+            closed = _aperture_slack_closed_form(float(phi), float(beta), 8.0, 7.5)
+            assert raw == pytest.approx(closed, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1088 — the helper must be even in gamma, and must block
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_climate_tilt_percentage_takes_no_gamma_argument():
+    """Gamma-independence is structural, not a value the helper happens to ignore.
+
+    Slats rotate about a horizontal axis parallel to the facade, so the sun's
+    left/right offset reaches the geometry only through
+    ``beta = arctan(tan(elev)/cos(gamma))`` — and ``cos`` is even. An answer that
+    varied with the *sign* of gamma could only be right on one side, and
+    pre-#1088 the ``gamma >= 0`` side was the wrong one.
+
+    Keeping the parameter around as an ignored no-op would leave the same trap
+    for the next caller, so the signature is the guard.
+    """
+    params = inspect.signature(TiltPolicy.climate_tilt_percentage).parameters
+    assert "gamma_deg" not in params, (
+        "climate_tilt_percentage must not accept a sun-azimuth argument — slat "
+        f"tilt is even in gamma (issue #1088). Got: {list(params)}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("gamma", [-1e-9, +1e-9, *MIRRORED_GAMMAS, -40.0, -80.0])
+def test_live_climate_tilt_path_is_gamma_independent(gamma):
+    """The climate mode's own tilt rules must not vary with the sun's side.
+
+    Exercises the real ``climate_modes`` position functions rather than the
+    helper directly, so the invariant is pinned at the layer that reads
+    ``ctx.gamma_deg``. Pre-#1088 ``_tilt_summer`` stepped 25% -> 75% between
+    gamma -1e-9 and +1e-9.
+    """
+    cover = MagicMock()
+    cover.mode = TiltMode.MODE2
+
+    def context(gamma_deg: float) -> ClimateContext:
+        return ClimateContext(
+            data=MagicMock(),
+            cover=cover,
+            default_position=50,
+            solar_position=lambda: 50,
+            gamma_deg=gamma_deg,
+            beta_deg=30.0,
+        )
+
+    reference = context(0.0)
+    candidate = context(gamma)
+    for name, position_fn in (
+        ("_tilt_summer", _tilt_summer),
+        ("_tilt_default", _tilt_default),
+        ("_tilt_winter_mode2", _tilt_winter_mode2),
+    ):
+        assert position_fn(candidate) == position_fn(reference), (
+            f"{name} varies with gamma ({gamma} vs 0.0): "
+            f"{position_fn(candidate)}% vs {position_fn(reference)}%"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("depth", "spacing"), SLAT_GEOMETRIES)
+@pytest.mark.parametrize("gamma", MIRRORED_GAMMAS)
+@pytest.mark.parametrize("elevation", ELEVATIONS)
+def test_summer_tilt_never_picks_the_leakier_hemisphere(
+    depth, spacing, elevation, gamma
+):
+    """The commanded angle must never be the leakier of the two hemispheres.
+
+    A fixed climate angle can't block at every sun position (it isn't the
+    geometric solve — that's ``AdaptiveTiltCover.calculate_position``). What it
+    *must* never do is pick the mirror angle when the mirror leaks and the other
+    blocks. Pre-#1088 the ``gamma >= 0`` branch did exactly that.
+    """
+    for signed_gamma in (-gamma, +gamma):
+        beta = profile_angle_deg(elevation, signed_gamma)
+        commanded = commanded_angle(CLIMATE_SUMMER_TILT_ANGLE)
+        mirror = TiltMode.MODE2.max_degrees - commanded
+
+        commanded_slack = aperture_slack(commanded, beta, depth, spacing)
+        mirror_slack = aperture_slack(mirror, beta, depth, spacing)
+
+        assert commanded_slack <= mirror_slack + 1e-9, (
+            f"Commanded slat angle {commanded:.1f}deg leaks more than its mirror "
+            f"{mirror:.1f}deg at elev={elevation} gamma={signed_gamma} "
+            f"beta={beta:.2f}: slack {commanded_slack:+.3f} vs "
+            f"{mirror_slack:+.3f} (w={depth} s={spacing})"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("elevation", [20.0, 38.0, 60.0])
+@pytest.mark.parametrize("gamma", [-28.4, 28.4])
+def test_summer_tilt_blocks_the_beam_for_the_reported_geometry(elevation, gamma):
+    """The exact table in #1088 must come out blocked, both gamma signs.
+
+    Slat depth 8.0 cm / spacing 7.5 cm at elevations 20/38/60 with |gamma|=28.4
+    is the case the issue tabulates, where the pre-fix helper returned 75%
+    (phi=135deg) and let direct sun straight through (slack +4.184 / +6.867 /
+    +2.018).
+
+    Scoped to that one geometry on purpose. A *fixed* climate angle cannot block
+    at every sun position for every blind — at low beta the blocked band never
+    reaches 45deg — so "always blocks" is not a property this helper has, and
+    asserting it would be asserting something false. The universal invariant is
+    the hemisphere choice, pinned by
+    ``test_summer_tilt_never_picks_the_leakier_hemisphere`` above.
+    """
+    depth, spacing = 8.0, 7.5
+    beta = profile_angle_deg(elevation, gamma)
+    commanded = commanded_angle(CLIMATE_SUMMER_TILT_ANGLE)
+    slack = aperture_slack(commanded, beta, depth, spacing)
+    assert slack <= 0, (
+        f"Direct sun passes at elev={elevation} gamma={gamma} "
+        f"(beta={beta:.2f}, commanded phi={commanded:.1f}deg, slack={slack:+.3f}, "
+        f"w={depth} s={spacing})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The sun_through (winter heating) arm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("depth", "spacing"), SLAT_GEOMETRIES)
+@pytest.mark.parametrize("beta", [10.0, 22.48, 41.61, 63.08])
+@pytest.mark.parametrize("gamma", [-40.0, 0.0, 40.0])
+def test_sun_through_lands_on_maximum_transmission(depth, spacing, beta, gamma):
+    """Winter heating must open the aperture fully, not close it.
+
+    ``phi = 90 + beta`` puts the slat parallel to the beam, so the aperture is
+    completely unobstructed and ``slack`` equals the full spacing. The mirror
+    (``90 - beta``) is materially worse and fully blocking past ~35deg — which
+    is what the pre-#1088 ``gamma < 0`` arm commanded.
+    """
+    commanded = commanded_angle(beta, sun_through=True)
+    slack = aperture_slack(commanded, beta, depth, spacing)
+    assert slack == pytest.approx(spacing, abs=0.05 * spacing), (
+        f"Winter heating should open the aperture (slack ~= spacing {spacing}) "
+        f"but commanded phi={commanded:.1f}deg gives slack={slack:.3f} "
+        f"at beta={beta} gamma={gamma}"
+    )
+
+
+@pytest.mark.unit
+def test_mode1_is_untouched_by_the_hemisphere_fix():
+    """MODE1 returns early and has no hemisphere concept — pin that it stays so."""
+    for angle_deg in (CLIMATE_SUMMER_TILT_ANGLE, CLIMATE_DEFAULT_TILT_ANGLE):
+        expected = round((angle_deg / TiltMode.MODE1.max_degrees) * 100)
+        for sun_through in (False, True):
+            assert (
+                TiltPolicy.climate_tilt_percentage(
+                    angle_deg=angle_deg,
+                    mode=TiltMode.MODE1,
+                    sun_through=sun_through,
+                )
+                == expected
+            )

--- a/tests/test_pipeline/test_climate_handler.py
+++ b/tests/test_pipeline/test_climate_handler.py
@@ -1118,9 +1118,16 @@ class TestIssue373PipelineGlareControl:
     ) -> None:
         """Tilt MODE2 + min_pos=50 + sun out of FOV + summer climate → GLARE_CONTROL.
 
-        Pre-fix the raw helper output was 44 → clamped to 50 (horizontal floor).
-        Post-fix with positive gamma the helper returns (180-80)/180*100 ≈ 56,
-        which survives the clamp and yields a meaningful blocking position.
+        The raw helper output is 44 — the blocking hemisphere — and the user's
+        min_position=50 floor clamps it up to horizontal. That collapse is the
+        documented ``mode2_min_position`` footgun (see the config-summary ⚠️
+        warning), not a defect in the handler.
+
+        This asserted >50 until #1088. #405 had flipped the positive-gamma side
+        to 56% so it escaped the floor, but 56% points the slats at the
+        hemisphere that lets direct sun through, and the negative-gamma side
+        stayed clamped anyway. Post-#1088 the helper is gamma-independent and
+        both sides return the blocking 44%.
 
         ``inverse_state`` is applied above the handler in coordinator.py, so
         this test asserts the un-inverted handler output.  The companion
@@ -1152,14 +1159,10 @@ class TestIssue373PipelineGlareControl:
         )
         result = self.handler.evaluate(snap)
         assert result is not None
-        # Post-fix: helper returns 56 (positive hemisphere, MODE2 GLARE_CONTROL
-        # for angle=80, gamma>=0). 56 > 50 so the min_pos=50 clamp doesn't fire.
-        assert result.position != 50, (
-            f"Position must escape the horizontal floor (50%) — pre-fix was "
-            f"clamped here. Got {result.position}."
-        )
-        assert result.position > 50, (
-            f"Positive-gamma hemisphere must yield > 50 (blocking direction), "
-            f"got {result.position}."
+        # The helper's raw answer is the blocking hemisphere (44%), which sits
+        # below the user's min_position floor and is therefore raised to 50%.
+        assert result.position == 50, (
+            f"Expected 50 — min_position=50 swallows the blocking answer in "
+            f"MODE2, the documented footgun. Got {result.position}."
         )
         assert result.climate_strategy == ClimateStrategy.GLARE_CONTROL


### PR DESCRIPTION
## Summary

`TiltPolicy.climate_tilt_percentage` branched the MODE2 angle to percent mapping on `sign(gamma)`. Slats rotate about a horizontal axis parallel to the facade, so the sun's left/right offset reaches the geometry only through `beta = arctan(tan(elev)/cos(gamma))`, and `cos` is even. The branch was unphysical, and wrong twice over:

- **Discontinuous where the physics is smooth.** `gamma = -1e-9` returned 25%, `gamma = +0.0` returned 75%.
- **The `gamma >= 0` arm picked the leaking hemisphere.** At the summer angle with 8.0/7.5 cm slats, the commanded 75% (slat 135 deg) passes direct sun at every elevation tested: +4.184 / +6.867 / +2.018 cm of open aperture at elev 20 / 38 / 60.

Which hemisphere to keep was settled empirically, not by preference. Over ~16k `(elev, gamma)` points x 5 slat geometries x both climate angles, `phi = angle_deg` **strictly dominates** `phi = 180 - angle_deg`: there is no point where the mirror blocks and it does not. For the `sun_through` arm, `phi = 90 + angle` is the exact analytic maximum-transmission angle, and the only production caller (`_tilt_winter_mode2`) already hardcoded `gamma_deg=0.0` into it, so removing that branch is a provable no-op.

`gamma_deg` is dropped from the signature rather than left as an ignored no-op, so the trap cannot be re-set. `CLIMATE_TILT_PCT_NEGATIVE_HEMISPHERE_OFFSET` is consolidated into the existing `TILT_HORIZONTAL_DEG` (same value, same meaning).

### User-visible change

MODE2 tilt/venetian covers in climate mode, `gamma >= 0` side only:

| Path | Before | After |
|---|---|---|
| Summer cooling | 75% (slat 135 deg, leaks) | 25% (slat 45 deg, blocks) |
| Default / glare fallback | 56% | 44% |
| `gamma < 0` side | unchanged | unchanged |
| Winter heating | unchanged | unchanged (no-op) |

### No regression to #373

That report's actual defect, the raw answer falling below a `min_position` floor and collapsing to horizontal, was addressed by the config-summary warning #405 shipped alongside the hemisphere flip. That warning is untouched and keeps its four dedicated tests in `test_config_flow_summary.py`. The flip only ever helped half the sky; the existing test's own docstring said so.

### Test approach

Five tests encoded the old behaviour as intended and are rewritten. The physical assertions now live in `tests/test_cover_types/test_tilt_aperture.py`, which scores commanded angles against an aperture oracle **validated against the production cut-off solver** (`slack = 0` at `slat_cutoff_angle`, to machine precision) rather than pinning numbers read off the code under test. That inversion is the point: the old numbers came from the same branch they were meant to guard.

## Testing

- ✅ 9401 tests passing (28 skipped, 1 xfailed), up from 9107 on the base
- ✅ `ruff check` and `black --check` clean
- ✅ Extraction guard `test_axes.py:820-844` green, logic stayed on `TiltPolicy`

## Related Issues

Refs #1088, #1086, #373, #405