### PR TITLE
fix: forecast now uses anticipated solar position (#1091)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -67,7 +67,7 @@ class AdaptiveGeneralCover(ABC):
         so its time-dependent gates are evaluated at the projected time. The
         live anticipation look-ahead
         (:func:`pipeline.helpers.anticipated_solar_position_from_geometry`,
-        since #617) sets it the same way on the ``dataclasses.replace`` copies
+        since PR #617) sets it the same way on the ``dataclasses.replace`` copies
         it probes; the *current* cover instance is never given an
         ``eval_time`` of its own, so its gates still evaluate at wall-clock
         now.

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -64,8 +64,13 @@ class AdaptiveGeneralCover(ABC):
         field: the base carries no default field of its own (subclasses add
         non-default config fields after it, which would break dataclass field
         ordering). The forecast sets ``cover.eval_time`` dynamically per sample
-        so its time-dependent gates are evaluated at the projected time; the
-        live path never sets it, so it stays ``None`` → wall-clock now.
+        so its time-dependent gates are evaluated at the projected time. The
+        live anticipation look-ahead
+        (:func:`pipeline.helpers.anticipated_solar_position_from_geometry`,
+        since #617) sets it the same way on the ``dataclasses.replace`` copies
+        it probes; the *current* cover instance is never given an
+        ``eval_time`` of its own, so its gates still evaluate at wall-clock
+        now.
         """
         return SunGeometry(
             self.sol_azi,

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 from collections.abc import Callable
 
 from .const import (
+    CONF_DELTA_TIME,
     CONF_END_OF_WINDOW_POS,
     CONF_MAX_COVERAGE_STEPS,
     CONF_MINIMIZE_MOVEMENTS,
@@ -37,9 +38,10 @@ from .const import (
 )
 from .helpers import compute_effective_default
 from .pipeline.helpers import (
+    anticipated_solar_position_from_geometry,
     default_position_with_limits,
-    solar_position_from_geometry,
 )
+from .pipeline.snapshot_builder import _delta_time_minutes
 
 if TYPE_CHECKING:
     from .config_types import CoverConfig
@@ -129,6 +131,7 @@ def build_forecast(
     end_of_window_pos: int | None = None,
     end_of_window_time: datetime | None = None,
     secondary_axis_factory: SecondaryAxisFactory | None = None,
+    time_threshold_minutes: int = 0,
 ) -> Forecast:
     """Compute the forecast for one cover.
 
@@ -137,12 +140,15 @@ def build_forecast(
     and sample strip share the same time axis.
 
     Each sample's position is computed through the **same** shared primitives
-    the live pipeline uses (``solar_position_from_geometry`` /
+    the live pipeline uses (``anticipated_solar_position_from_geometry`` /
     ``default_position_with_limits`` in :mod:`pipeline.helpers`), so the
     forecast strip matches what the cover is actually commanded to — including
-    min/max position limits, the 1 % floor, movement minimization, and the
-    sunset-aware effective default. *config* and *policy* supply everything
-    those primitives need.
+    min/max position limits, the 1 % floor, movement minimization, the
+    look-ahead anticipation horizon, and the sunset-aware effective default.
+    *config* and *policy* supply everything those primitives need;
+    *time_threshold_minutes* supplies the anticipation look-ahead horizon
+    (mirrors the live path's ``PipelineSnapshot.time_threshold_minutes``,
+    sourced from ``CONF_DELTA_TIME`` — see :func:`build_forecast_for_coord`).
 
     ``cover_factory`` is a closure that builds a cover engine for an
     arbitrary (sol_azi, sol_elev) pair; the caller is responsible for
@@ -177,6 +183,7 @@ def build_forecast(
         end_of_window_pos=end_of_window_pos,
         end_of_window_time=end_of_window_time,
         secondary_axis_factory=secondary_axis_factory,
+        time_threshold_minutes=time_threshold_minutes,
     )
     events = _build_events(
         sun_data=sun_data, cover_factory=cover_factory, samples=samples
@@ -197,6 +204,7 @@ def _build_samples(
     end_of_window_pos: int | None = None,
     end_of_window_time: datetime | None = None,
     secondary_axis_factory: SecondaryAxisFactory | None = None,
+    time_threshold_minutes: int = 0,
 ) -> list[ForecastSample]:
     """Walk the sun_data table at *step_minutes* cadence over the full calendar day.
 
@@ -206,11 +214,17 @@ def _build_samples(
     elevation chart regardless of what time ``build_forecast`` is called.
 
     Each sample routes through the same ``pipeline.helpers`` primitives the live
-    pipeline uses, so positions are identical to runtime. The effective default
-    (and whether the sunset position is active) is recomputed at *each sample's*
-    time via :func:`compute_effective_default`, mirroring the live snapshot
-    builder rather than holding a static default. Note: the forecast projects
-    solar tracking whenever the sun is in the FOV regardless of the
+    pipeline uses, so positions are identical to runtime — including the
+    look-ahead anticipation horizon (``time_threshold_minutes``, issue #1091):
+    solar samples call :func:`~.pipeline.helpers.anticipated_solar_position_from_geometry`,
+    the same primitive the live ``SolarHandler`` calls via
+    :func:`~.pipeline.helpers.anticipated_solar_position`. At horizon 0 (the
+    default) that primitive is identical to the plain, non-anticipated
+    ``solar_position_from_geometry``. The effective default (and whether the
+    sunset position is active) is recomputed at *each sample's* time via
+    :func:`compute_effective_default`, mirroring the live snapshot builder
+    rather than holding a static default. Note: the forecast projects solar
+    tracking whenever the sun is in the FOV regardless of the
     ``enable_sun_tracking`` toggle — the card's purpose is to show where the
     cover *would* sit, so that mode gate is deliberately not applied here.
     For the same reason the operational *start*-time window is not modeled,
@@ -246,9 +260,10 @@ def _build_samples(
         # and every sample collapses to the default position (issue #516).
         cover.eval_time = t
         if cover.direct_sun_valid:
-            pos = solar_position_from_geometry(
+            pos = anticipated_solar_position_from_geometry(
                 cover,
                 config,
+                horizon_minutes=time_threshold_minutes,
                 minimize_movements=minimize_movements,
                 max_coverage_steps=max_coverage_steps,
                 policy=policy,
@@ -474,6 +489,13 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
         options.get(CONF_MAX_COVERAGE_STEPS, DEFAULT_MAX_COVERAGE_STEPS)
     )
 
+    # Anticipation look-ahead horizon (issue #1091): the same
+    # CONF_DELTA_TIME-derived horizon the live SolarHandler anticipates
+    # across via PipelineSnapshot.time_threshold_minutes, coerced with the
+    # single shared helper so the forecast never drifts from the live
+    # coercion rules (non-numeric / bool values safely disable anticipation).
+    time_threshold_minutes = _delta_time_minutes(options.get(CONF_DELTA_TIME))
+
     # Secondary-axis projection (#724): build the closure from the polymorphic
     # policy hook — the shim never branches on the cover type. Single-axis
     # policies inherit the base no-op returning ``{}``; venetian projects tilt.
@@ -508,4 +530,5 @@ def build_forecast_for_coord(coord: AdaptiveDataUpdateCoordinator) -> Forecast:
         end_of_window_pos=eow_pos,
         end_of_window_time=eow_time,
         secondary_axis_factory=make_secondary_axes,
+        time_threshold_minutes=time_threshold_minutes,
     )

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -144,7 +144,9 @@ def build_forecast(
     ``default_position_with_limits`` in :mod:`pipeline.helpers`), so the
     forecast strip matches what the cover is actually commanded to — including
     min/max position limits, the 1 % floor, movement minimization, the
-    look-ahead anticipation horizon, and the sunset-aware effective default.
+    look-ahead anticipation horizon (a grid-resolution approximation, not an
+    exact match — see :func:`_build_samples`), and the sunset-aware effective
+    default.
     *config* and *policy* supply everything those primitives need;
     *time_threshold_minutes* supplies the anticipation look-ahead horizon
     (mirrors the live path's ``PipelineSnapshot.time_threshold_minutes``,

--- a/custom_components/adaptive_cover_pro/forecast.py
+++ b/custom_components/adaptive_cover_pro/forecast.py
@@ -214,14 +214,23 @@ def _build_samples(
     elevation chart regardless of what time ``build_forecast`` is called.
 
     Each sample routes through the same ``pipeline.helpers`` primitives the live
-    pipeline uses, so positions are identical to runtime — including the
-    look-ahead anticipation horizon (``time_threshold_minutes``, issue #1091):
-    solar samples call :func:`~.pipeline.helpers.anticipated_solar_position_from_geometry`,
-    the same primitive the live ``SolarHandler`` calls via
-    :func:`~.pipeline.helpers.anticipated_solar_position`. At horizon 0 (the
-    default) that primitive is identical to the plain, non-anticipated
-    ``solar_position_from_geometry``. The effective default (and whether the
-    sunset position is active) is recomputed at *each sample's* time via
+    pipeline uses — solar samples call
+    :func:`~.pipeline.helpers.anticipated_solar_position_from_geometry`, the same
+    primitive the live ``SolarHandler`` calls via
+    :func:`~.pipeline.helpers.anticipated_solar_position`, with the same
+    look-ahead anticipation horizon (``time_threshold_minutes``, issue #1091).
+    This is a grid-resolution approximation of runtime, not an exact match:
+    each probe time is quantized via :func:`_nearest_index` to the same
+    5-minute ``SunData`` grid this walk is itself aligned to, so at small
+    horizons (e.g. the default ``CONF_DELTA_TIME`` of 2 minutes) every probe
+    collapses onto the sample's own grid index and the anticipation is a
+    no-op — whereas the live path anticipates from an arbitrary wall-clock
+    ``now`` and can land on a later grid index the forecast never reaches. At
+    horizon 0 (the default parameter) the primitive is identical to the
+    plain, non-anticipated ``solar_position_from_geometry``.
+
+    The effective default (and whether the sunset position is active) is
+    recomputed at *each sample's* time via
     :func:`compute_effective_default`, mirroring the live snapshot builder
     rather than holding a static default. Note: the forecast projects solar
     tracking whenever the sun is in the FOV regardless of the

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -196,20 +196,35 @@ def compute_solar_position(snapshot: PipelineSnapshot) -> int:
     )
 
 
-def anticipated_solar_position(snapshot: PipelineSnapshot) -> int:
-    """Most-protective sun-tracked position across the upcoming throttle window.
+def anticipated_solar_position_from_geometry(
+    cover: AdaptiveGeneralCover,
+    config: CoverConfig,
+    *,
+    horizon_minutes: int,
+    minimize_movements: bool,
+    max_coverage_steps: int,
+    policy: CoverTypePolicy | None,
+    floor_active: bool = True,
+) -> int:
+    """Most-protective sun-tracked position across an upcoming look-ahead window.
+
+    Snapshot-free single source of truth for the anticipation algorithm,
+    shared by the live pipeline (:func:`anticipated_solar_position`) and the
+    forecast (:func:`..forecast.build_forecast`) — see issue #1091, the
+    forecast/live drift this extraction closes (the forecast previously called
+    the plain :func:`solar_position_from_geometry` with no look-ahead at all).
 
     The live solar target is computed from the *current* sun position, but the
     "Minimum interval between position changes" (``CONF_DELTA_TIME``, minutes)
     holds any queued move for that long. While it is held the sun keeps moving,
     so a position that just covers "now" can drift out of coverage before the
     next allowed move. This helper looks ahead across
-    ``(now, now + time_threshold_minutes]`` and returns the most-protective
+    ``(now, now + horizon_minutes]`` and returns the most-protective
     sun-tracked position needed anywhere in that window, so coverage is
     guaranteed until the cover is next allowed to move (issue #616).
 
     The look-ahead reuses the forecast's sampling machinery: future sun angles
-    come from ``snapshot.cover.sun_data`` (the per-day 5-minute table) via
+    come from ``cover.sun_data`` (the per-day 5-minute table) via
     ``forecast._nearest_index``, each sample is a ``dataclasses.replace`` of the
     live cover with the projected angles and ``eval_time`` (so the sunset gate
     evaluates at the projected moment), and only samples where the sun is still
@@ -220,27 +235,31 @@ def anticipated_solar_position(snapshot: PipelineSnapshot) -> int:
     "now" target seeds the fold, so the result can only ever *increase*
     protection relative to the current position.
 
-    When the horizon is ``<= 0`` (anticipation disabled / no throttle) this is
-    exactly :func:`compute_solar_position`.
+    When ``horizon_minutes <= 0`` (anticipation disabled / no throttle) or
+    *policy* is ``None``, this is exactly :func:`solar_position_from_geometry`.
 
-    Should only be called when ``snapshot.cover.direct_sun_valid`` is True.
+    Should only be called when ``cover.direct_sun_valid`` is True.
 
     Returns:
         The most-protective sun-tracked position (limited) across the window.
 
     """
-    live = compute_solar_position(snapshot)
+    live = solar_position_from_geometry(
+        cover,
+        config,
+        minimize_movements=minimize_movements,
+        max_coverage_steps=max_coverage_steps,
+        policy=policy,
+        floor_active=floor_active,
+    )
 
-    horizon = getattr(snapshot, "time_threshold_minutes", 0)
-    policy: CoverTypePolicy | None = getattr(snapshot, "policy", None)
-    if horizon <= 0 or policy is None:
+    if horizon_minutes <= 0 or policy is None:
         return live
 
     # Lazy import: ``forecast`` imports from this module, so importing it at
     # module scope would be circular.
     from ..forecast import _nearest_index
 
-    cover = snapshot.cover
     sun_data = cover.sun_data
     times = list(sun_data.times)
     if not times:
@@ -255,7 +274,7 @@ def anticipated_solar_position(snapshot: PipelineSnapshot) -> int:
     seen_indices: set[int] = set()
     for n in range(1, SOLAR_ANTICIPATION_SAMPLES + 1):
         fraction = n / SOLAR_ANTICIPATION_SAMPLES
-        sample_time = now + timedelta(minutes=horizon * fraction)
+        sample_time = now + timedelta(minutes=horizon_minutes * fraction)
         idx = _nearest_index(times, sample_time)
         if idx is None or idx in seen_indices:
             continue
@@ -272,15 +291,38 @@ def anticipated_solar_position(snapshot: PipelineSnapshot) -> int:
 
         candidate = solar_position_from_geometry(
             future,
-            snapshot.config,
-            minimize_movements=getattr(snapshot, "minimize_movements", False),
-            max_coverage_steps=getattr(snapshot, "max_coverage_steps", 1),
+            config,
+            minimize_movements=minimize_movements,
+            max_coverage_steps=max_coverage_steps,
             policy=policy,
-            floor_active=getattr(snapshot, "solar_floor_active", True),
+            floor_active=floor_active,
         )
         best = policy.more_protective_position(best, candidate)
 
     return best
+
+
+def anticipated_solar_position(snapshot: PipelineSnapshot) -> int:
+    """Most-protective sun-tracked position across the upcoming throttle window.
+
+    Thin adapter over :func:`anticipated_solar_position_from_geometry` using
+    the snapshot's cover, config, and horizon (``time_threshold_minutes``).
+
+    Should only be called when ``snapshot.cover.direct_sun_valid`` is True.
+
+    Returns:
+        The most-protective sun-tracked position (limited) across the window.
+
+    """
+    return anticipated_solar_position_from_geometry(
+        snapshot.cover,
+        snapshot.config,
+        horizon_minutes=getattr(snapshot, "time_threshold_minutes", 0),
+        minimize_movements=getattr(snapshot, "minimize_movements", False),
+        max_coverage_steps=getattr(snapshot, "max_coverage_steps", 1),
+        policy=getattr(snapshot, "policy", None),
+        floor_active=getattr(snapshot, "solar_floor_active", True),
+    )
 
 
 def compute_raw_calculated_position(snapshot: PipelineSnapshot) -> int:

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -769,30 +769,99 @@ class TestForecastEndOfWindowPosition:
 class TestForecastMatchesLivePipeline:
     """Anti-drift lock: forecast samples == the live snapshot-based helpers."""
 
-    def test_solar_sample_equals_compute_solar_position(self):
+    def test_solar_sample_equals_anticipated_solar_position(self):
+        """Anti-drift lock (#1091): forecast solar branch must match the live
+        anticipation-aware primitive, at a nonzero look-ahead horizon.
+
+        PR #556's original lock (``test_solar_sample_equals_compute_solar_position``)
+        compared against the non-anticipated ``compute_solar_position`` using a
+        snapshot that never set ``time_threshold_minutes`` (defaulting to 0), so
+        anticipation was a no-op inside the lock itself — it kept passing straight
+        through PR #617 switching the live handler to the anticipation-aware
+        primitive while the forecast was never updated to match (#1091). This
+        lock uses a nonzero horizon and a sun sweep where anticipation provably
+        changes the result, so a future primitive swap on either side breaks it.
+        """
+        from custom_components.adaptive_cover_pro.cover_types import get_policy
         from custom_components.adaptive_cover_pro.pipeline.helpers import (
+            anticipated_solar_position,
             compute_solar_position,
         )
 
         from tests.conftest import make_snapshot_for_cover
+        from tests.cover_helpers import build_vertical_cover
 
-        config = _make_config(min_pos=30, max_pos=90)
-        # Live snapshot over an equivalent cover at the same geometry/config.
-        live_cover = MagicMock()
-        live_cover.config = config
-        live_cover.calculate_percentage = MagicMock(return_value=10)
-        live_cover.calculate_raw_percentage = MagicMock(return_value=10.0)
+        # Sun sweeps from off-axis (220 deg) toward the window centre (180 deg)
+        # over the horizon — the same divergence geometry as
+        # test_solar_anticipation.py::test_vertical_anticipates_more_protective_future_sample,
+        # anchored at 10:00 (mid-day) so the sunset/sunrise gate never trips.
+        day_start = datetime(2026, 6, 1, 10, 0, tzinfo=UTC)
+        step = timedelta(minutes=5)
+        azimuths = [220.0, 210.0, 200.0, 190.0, 180.0, 180.0]
+        elevations = [45.0] * 6
+        sd = MagicMock()
+        sd.times = [day_start + i * step for i in range(6)]
+        sd.solar_azimuth = azimuths
+        sd.solar_elevation = elevations
+        sd.sunrise = MagicMock(return_value=day_start.replace(hour=5))
+        sd.sunset = MagicMock(return_value=day_start.replace(hour=21))
+        sd.next_sunrise = MagicMock(return_value=None)
+
+        def make_cover(azi: float, ele: float):
+            return build_vertical_cover(
+                logger=MagicMock(),
+                sol_azi=azi,
+                sol_elev=ele,
+                sunset_pos=0,
+                sunset_off=0,
+                sunrise_off=0,
+                sun_data=sd,
+                fov_left=90,
+                fov_right=90,
+                win_azi=180,
+                h_def=50,
+                max_pos=100,
+                min_pos=0,
+                max_pos_bool=False,
+                min_pos_bool=False,
+                blind_spot_left=None,
+                blind_spot_right=None,
+                blind_spot_elevation=None,
+                blind_spot_on=False,
+                min_elevation=None,
+                max_elevation=None,
+                distance=0.5,
+                h_win=2.0,
+            )
+
+        policy = get_policy("cover_blind")
+        horizon = 25
+
+        live_cover = make_cover(220.0, 45.0)
+        live_cover.eval_time = sd.times[0]
         snapshot = make_snapshot_for_cover(live_cover)
-        live = compute_solar_position(snapshot)
+        snapshot.policy = policy
+        snapshot.minimize_movements = False
+        snapshot.max_coverage_steps = 1
+        snapshot.solar_floor_active = True
+        snapshot.time_threshold_minutes = horizon
+        live_anticipated = anticipated_solar_position(snapshot)
 
-        sd = _make_sun_data()
+        # Sanity: the horizon must make anticipation diverge from the plain
+        # (non-anticipated) primitive, or this lock would be inert (#1091).
+        assert live_anticipated != compute_solar_position(snapshot)
+
         f = build_forecast(
             sun_data=sd,
-            cover_factory=_solar_cover_factory(10),
-            config=config,
-            now=_NOW,
+            cover_factory=make_cover,
+            config=live_cover.config,
+            policy=policy,
+            now=sd.times[0],
+            step_minutes=5,
+            time_threshold_minutes=horizon,
         )
-        assert all(s.position == live for s in f.samples)
+        first_solar_sample = next(s for s in f.samples if s.handler == "solar")
+        assert first_solar_sample.position == live_anticipated
 
     def test_default_sample_equals_compute_default_position(self):
         from custom_components.adaptive_cover_pro.pipeline.helpers import (

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1020,45 +1020,86 @@ async def test_async_recompute_forecast_swallows_exceptions(monkeypatch):
     assert coord.data.position_forecast is None
 
 
+def _stub_forecast_coord(
+    *,
+    options: dict | None = None,
+    policy=None,
+    end_time: datetime | None = None,
+    config=None,
+    sun_data=None,
+):
+    """Build a MagicMock coordinator stub for build_forecast_for_coord tests.
+
+    Shared scaffolding for the TestForecastShim* classes below — they all
+    stub the same coordinator surface (config_entry.options, hass, the sun
+    provider, config service, policy, snapshot, and time manager) and only
+    vary a handful of inputs. Defaults reproduce the plain-vanilla case: no
+    options, a single-axis policy, no end-of-window gate, and a default
+    config/sun_data pair. Callers override only the parameters their
+    scenario cares about. Returns ``(coord, sun_data)`` since some tests
+    assert against the sun_data instance passed through to the policy hook.
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+    coord.config_entry = MagicMock()
+    coord.config_entry.options = {} if options is None else options
+    coord.logger = MagicMock()
+    coord.hass = MagicMock()
+    coord.hass.config.time_zone = "UTC"
+    if sun_data is None:
+        sun_data = _make_sun_data()
+    coord._sun_provider = MagicMock()
+    coord._sun_provider.create_sun_data = MagicMock(return_value=sun_data)
+    coord._config_service = MagicMock()
+    coord._config_service.get_common_data = MagicMock(
+        return_value=_make_config() if config is None else config
+    )
+    if policy is None:
+        policy = MagicMock()
+        policy.position_axis_supported = MagicMock(return_value=False)
+    coord._policy = policy
+    coord._snapshot = MagicMock()
+    coord._snapshot.cover_capabilities = {}
+    coord._time_mgr = MagicMock()
+    coord._time_mgr.end_time = end_time
+    return coord, sun_data
+
+
+def _run_shim_spy(coord):
+    """Run build_forecast_for_coord with build_forecast replaced by a spy.
+
+    Returns the spy so callers can inspect the kwargs the shim threaded
+    through to build_forecast.
+    """
+    from custom_components.adaptive_cover_pro import forecast as fc_mod
+
+    spy = MagicMock(return_value=MagicMock(name="Forecast"))
+    with patch.object(fc_mod, "build_forecast", spy):
+        fc_mod.build_forecast_for_coord(coord)
+    return spy
+
+
 class TestForecastShimEndOfWindow:
     """build_forecast_for_coord threads the eow option through, gated on return_sunset."""
 
     def _stub_coord(self, *, options, end_time):
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
-        coord.config_entry = MagicMock()
-        coord.config_entry.options = options
-        coord.logger = MagicMock()
-        coord.hass = MagicMock()
-        coord.hass.config.time_zone = "UTC"
         sun_data = _make_sun_data(
             sunrise=_DAY_START + timedelta(hours=6),
             sunset=_DAY_START + timedelta(hours=20),
         )
-        coord._sun_provider = MagicMock()
-        coord._sun_provider.create_sun_data = MagicMock(return_value=sun_data)
-        coord._config_service = MagicMock()
-        coord._config_service.get_common_data = MagicMock(
-            return_value=_make_config(h_def=80, sunset_pos=20)
+        coord, _ = _stub_forecast_coord(
+            options=options,
+            end_time=end_time,
+            config=_make_config(h_def=80, sunset_pos=20),
+            sun_data=sun_data,
         )
-        coord._policy = MagicMock()
-        coord._policy.position_axis_supported = MagicMock(return_value=False)
-        coord._snapshot = MagicMock()
-        coord._snapshot.cover_capabilities = {}
-        coord._time_mgr = MagicMock()
-        coord._time_mgr.end_time = end_time
         return coord
 
     def _run(self, coord):
-        from custom_components.adaptive_cover_pro import forecast as fc_mod
-
-        spy = MagicMock(return_value=MagicMock(name="Forecast"))
-        with patch.object(fc_mod, "build_forecast", spy):
-            fc_mod.build_forecast_for_coord(coord)
-        return spy
+        return _run_shim_spy(coord)
 
     def test_passes_eow_pos_and_time_when_gate_on(self):
         from custom_components.adaptive_cover_pro.const import (
@@ -1118,35 +1159,10 @@ class TestForecastShimSecondaryAxes:
     """
 
     def _stub_coord(self, *, policy):
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
-        coord.config_entry = MagicMock()
-        coord.config_entry.options = {}
-        coord.logger = MagicMock()
-        coord.hass = MagicMock()
-        coord.hass.config.time_zone = "UTC"
-        sun_data = _make_sun_data()
-        coord._sun_provider = MagicMock()
-        coord._sun_provider.create_sun_data = MagicMock(return_value=sun_data)
-        coord._config_service = MagicMock()
-        coord._config_service.get_common_data = MagicMock(return_value=_make_config())
-        coord._policy = policy
-        coord._snapshot = MagicMock()
-        coord._snapshot.cover_capabilities = {}
-        coord._time_mgr = MagicMock()
-        coord._time_mgr.end_time = None
-        return coord, sun_data
+        return _stub_forecast_coord(policy=policy)
 
     def _run(self, coord):
-        from custom_components.adaptive_cover_pro import forecast as fc_mod
-
-        spy = MagicMock(return_value=MagicMock(name="Forecast"))
-        with patch.object(fc_mod, "build_forecast", spy):
-            fc_mod.build_forecast_for_coord(coord)
-        return spy
+        return _run_shim_spy(coord)
 
     def test_shim_passes_secondary_axis_factory_for_venetian(self):
         policy = MagicMock()
@@ -1193,36 +1209,11 @@ class TestForecastShimAnticipationHorizon:
     """
 
     def _stub_coord(self, *, options):
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
-        coord.config_entry = MagicMock()
-        coord.config_entry.options = options
-        coord.logger = MagicMock()
-        coord.hass = MagicMock()
-        coord.hass.config.time_zone = "UTC"
-        sun_data = _make_sun_data()
-        coord._sun_provider = MagicMock()
-        coord._sun_provider.create_sun_data = MagicMock(return_value=sun_data)
-        coord._config_service = MagicMock()
-        coord._config_service.get_common_data = MagicMock(return_value=_make_config())
-        coord._policy = MagicMock()
-        coord._policy.position_axis_supported = MagicMock(return_value=False)
-        coord._snapshot = MagicMock()
-        coord._snapshot.cover_capabilities = {}
-        coord._time_mgr = MagicMock()
-        coord._time_mgr.end_time = None
+        coord, _ = _stub_forecast_coord(options=options)
         return coord
 
     def _run(self, coord):
-        from custom_components.adaptive_cover_pro import forecast as fc_mod
-
-        spy = MagicMock(return_value=MagicMock(name="Forecast"))
-        with patch.object(fc_mod, "build_forecast", spy):
-            fc_mod.build_forecast_for_coord(coord)
-        return spy
+        return _run_shim_spy(coord)
 
     def test_passes_delta_time_as_horizon(self):
         from custom_components.adaptive_cover_pro.const import CONF_DELTA_TIME

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1181,6 +1181,66 @@ class TestForecastShimSecondaryAxes:
         assert factory(40, 0.0, 0.0, _NOW) == {}
 
 
+class TestForecastShimAnticipationHorizon:
+    """build_forecast_for_coord threads CONF_DELTA_TIME through as time_threshold_minutes (#1091).
+
+    The shim coerces the raw option with the same helper the live snapshot
+    builder uses (``pipeline.snapshot_builder._delta_time_minutes``), so a
+    malformed value (e.g. a legacy duration dict) safely disables
+    anticipation instead of crashing the forecast — mirrored here rather
+    than re-derived, so a future coercion-rule change can't drift between
+    the live path and the forecast.
+    """
+
+    def _stub_coord(self, *, options):
+        from custom_components.adaptive_cover_pro.coordinator import (
+            AdaptiveDataUpdateCoordinator,
+        )
+
+        coord = MagicMock(spec=AdaptiveDataUpdateCoordinator)
+        coord.config_entry = MagicMock()
+        coord.config_entry.options = options
+        coord.logger = MagicMock()
+        coord.hass = MagicMock()
+        coord.hass.config.time_zone = "UTC"
+        sun_data = _make_sun_data()
+        coord._sun_provider = MagicMock()
+        coord._sun_provider.create_sun_data = MagicMock(return_value=sun_data)
+        coord._config_service = MagicMock()
+        coord._config_service.get_common_data = MagicMock(return_value=_make_config())
+        coord._policy = MagicMock()
+        coord._policy.position_axis_supported = MagicMock(return_value=False)
+        coord._snapshot = MagicMock()
+        coord._snapshot.cover_capabilities = {}
+        coord._time_mgr = MagicMock()
+        coord._time_mgr.end_time = None
+        return coord
+
+    def _run(self, coord):
+        from custom_components.adaptive_cover_pro import forecast as fc_mod
+
+        spy = MagicMock(return_value=MagicMock(name="Forecast"))
+        with patch.object(fc_mod, "build_forecast", spy):
+            fc_mod.build_forecast_for_coord(coord)
+        return spy
+
+    def test_passes_delta_time_as_horizon(self):
+        from custom_components.adaptive_cover_pro.const import CONF_DELTA_TIME
+
+        coord = self._stub_coord(options={CONF_DELTA_TIME: 15})
+        spy = self._run(coord)
+        _, kwargs = spy.call_args
+        assert kwargs["time_threshold_minutes"] == 15
+
+    def test_malformed_delta_time_disables_anticipation(self):
+        from custom_components.adaptive_cover_pro.const import CONF_DELTA_TIME
+
+        coord = self._stub_coord(options={CONF_DELTA_TIME: {"hours": 1}})
+        spy = self._run(coord)
+        _, kwargs = spy.call_args
+        assert kwargs["time_threshold_minutes"] == 0
+
+
 # ---------------------------------------------------------------------------
 # Phase D: forecast is scheduled, not recomputed on every refresh
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Since #617 the live `SolarHandler` has computed its target with `anticipated_solar_position`, the most protective position across the upcoming throttle window. `forecast.py` kept calling the raw `solar_position_from_geometry`, so the projected target has been the instantaneous geometry result rather than what the pipeline would actually calculate.

`anticipated_solar_position_from_geometry` is extracted in `pipeline/helpers.py` from the existing body, and `anticipated_solar_position(snapshot)` becomes a thin adapter over it, so the live path is unchanged. The forecast takes the horizon from `build_forecast_for_coord`, sourced from `CONF_DELTA_TIME` through the same `_delta_time_minutes` coercion the snapshot builder uses, so an absent key resolves identically on both paths.

The #556 anti-drift lock is replaced rather than deleted. It compared against `compute_solar_position`, and its snapshot left `time_threshold_minutes` at 0, so anticipation was a no-op inside the test itself: it would have passed even if it had named the right primitive. The replacement asserts against `anticipated_solar_position` at a nonzero horizon and guards that the geometry genuinely diverges, so re-pointing the forecast back at the raw primitive now fails it.

The option plumbing gets its own guard too. `TestForecastShimAnticipationHorizon` pins that `CONF_DELTA_TIME` reaches `build_forecast` as `time_threshold_minutes`. Without it, stubbing the coercion to return 0, an exact revert to the old behaviour, left the whole suite green.

Two docstrings were overstating what the forecast delivers. Sample times quantize to the 5-minute `SunData` grid, so at the default `delta_time` of 2 every probe collapses onto the sample's own index and the anticipation is a no-op, while the live path anticipates from arbitrary wall-clock now. Both `build_forecast` and `_build_samples` now say so.

Supersedes #1096, which was mistargeted at `main` and reverted by #1097.

## Testing
- ✅ 9403 tests passing

## Related Issues
Refs #1091