### PR TITLE
fix: skip resend when routed target is unchanged (#1095)

### DIFF
--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1307,13 +1307,18 @@ class CoverCommandService:
         # Routed decision for this cycle's target (issue #1095). Computed once
         # here, right after _current, so the same-position gate below can
         # compare against the *routed* target instead of the raw pre-routing
-        # `position` whenever the routing is not position-capable — not just
-        # threshold-routed open/close-only covers, but also a position-capable
-        # cover routed to open_cover/close_cover at a mechanical endpoint
-        # (endpoint_use_open_close), the My-preset stop_cover route, and the
-        # no-capable-service case. route_service_call is pure/no-side-effects
-        # (see routing.py's module docstring) — it gets recomputed again by
-        # _prepare_service_call at actual dispatch time, same as today.
+        # `position` whenever the routing is not position-capable. "Not
+        # position-capable" covers four routes (open/close endpoint under
+        # endpoint_use_open_close, the My-preset stop_cover route, the
+        # no-capable-service case, and the open/close threshold route), but
+        # route_service_call sets routed_target == position on the first
+        # three by construction (routing.py) — only the threshold route
+        # collapses a range of positions onto one 0/100 routed_target, so
+        # that's the only route where comparing against routed_target differs
+        # from the plain `_current == position` check. route_service_call is
+        # pure/no-side-effects (see routing.py's module docstring) — it gets
+        # recomputed again by _prepare_service_call at actual dispatch time,
+        # same as today.
         _caps_for_plan = self.get_cover_capabilities(entity_id)
         _plan = route_service_call(
             entity_id,
@@ -1418,27 +1423,28 @@ class CoverCommandService:
         # feedback) sit at HA state unknown/unavailable forever, so _current
         # never resolves and the numeric comparison above would never fire —
         # the same command gets resent every cycle (#779). "not
-        # supports_position" is broader than just "threshold-routed": it also
-        # covers a position-capable cover routed to open_cover/close_cover at
-        # a mechanical endpoint under endpoint_use_open_close (the default),
-        # the My-preset stop_cover route, and the no-capable-service
-        # (service=None) case. Any of those whose _current DOES resolve has
-        # the #779 problem in a different shape (#1095): every calculated
-        # position on one side of the routing decision collapses to the same
-        # routed_target, but the numeric comparison above compares _current
-        # against the raw pre-routing `position`, which drifts even though
-        # the routed decision hasn't changed. _plan.routed_target (computed
-        # once above, right after _current) is compared against _current
-        # directly when it resolved — a resolved reading that CONTRADICTS the
-        # stored target must fall through to dispatch, never be masked by a
-        # stale commanded target (issue #1095 audit finding 1), so
-        # _same_position_via_target_fallback (which compares the last
+        # supports_position" is broader than just "threshold-routed": entry
+        # also comes from a position-capable cover routed to
+        # open_cover/close_cover at a mechanical endpoint under
+        # endpoint_use_open_close (the default), the My-preset stop_cover
+        # route, and the no-capable-service (service=None) case. But
+        # route_service_call sets routed_target == position on those three
+        # routes by construction (routing.py), so once _current resolves,
+        # comparing it against _plan.routed_target there is identical to the
+        # `_current == position` check already done above — behaviorally
+        # inert, not a broadening. The open/close-threshold route is the only
+        # one where routed_target genuinely diverges from position (every
+        # state on one side of open_close_threshold collapses to the same
+        # 0/100 routed_target); it's the only route where this arm changes
+        # behavior — it fires when a resolved _current already sits at the
+        # routed 0/100 target even though the raw calculated position drifted
+        # within the sub-threshold band. A resolved reading that CONTRADICTS
+        # the routed target must still fall through to dispatch, never be
+        # masked by a stale commanded target (issue #1095 audit finding 1),
+        # so _same_position_via_target_fallback (which compares the last
         # *commanded* target against this cycle's *routed* decision via
         # route_service_call, see its docstring) is consulted only when
-        # _current is still None — position-capable, My-preset stop_cover,
-        # and open/close endpoint covers are all handled by the one routing
-        # source of truth, but only the unresolved-reading case is allowed to
-        # fall back to the stored target. Delta/time gates and reconciliation
+        # _current is still None. Delta/time gates and reconciliation
         # deliberately keep reading the real _current — this broadened
         # comparison is scoped to the same-position gate only.
         # An explicit user command (context.user_command) must ALWAYS dispatch —

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1132,7 +1132,7 @@ class CoverCommandService:
         position: int,
         context: PositionContext,
     ) -> bool:
-        """Same-position gate fallback for an unresolved current position (issue #779).
+        """Same-position gate fallback for a target-vs-routing comparison (issues #779, #1095).
 
         Somfy RTS (and any open/close-only cover without genuine position
         feedback) reports HA state ``unknown``/``unavailable`` forever, so
@@ -1140,7 +1140,17 @@ class CoverCommandService:
         same-position gate in ``apply_position`` never sees a genuine
         reading to compare against — the exact same command gets resent on
         every update cycle even though the cover was already commanded to
-        (and mechanically at) that state.
+        (and mechanically at) that state (issue #779).
+
+        A threshold-routed cover (``supports_position: False``) whose
+        ``_current`` genuinely resolves hits the same problem in a different
+        shape (issue #1095): every calculated position on one side of
+        ``open_close_threshold`` collapses to the same routed decision, but a
+        raw numeric comparison against ``_current`` never sees that — it only
+        sees the pre-routing ``position`` drifting inside the sub-threshold
+        band. The caller compares ``_current`` against the routed target
+        directly in that case; this fallback additionally covers the case
+        where ``_current`` never resolved at all.
 
         Falls back to the last *commanded* target (``get_target``) compared
         against this cycle's *routed decision* rather than the raw
@@ -1152,9 +1162,11 @@ class CoverCommandService:
         (issue #779 follow-up regression from PR #781, which hand-rolled a
         partial copy of this math and ignored ``use_my_position``).
 
-        Only consulted when ``_current is None``; the delta/time gates and
-        reconciliation intentionally keep reading the real (unknown) current
-        position and are untouched by this fallback.
+        Consulted when ``_current is None`` OR the routed plan is not
+        position-capable (``not plan.supports_position``) — see the caller in
+        ``apply_position``. The delta/time gates and reconciliation
+        intentionally keep reading the real current position and are
+        untouched by this fallback.
         """
         last_target = self.get_target(entity_id)
         if last_target is None:
@@ -1279,6 +1291,24 @@ class CoverCommandService:
 
         _current = self._get_current_position(entity_id)
 
+        # Routed decision for this cycle's target (issue #1095). Computed once
+        # here, right after _current, so the same-position gate below can
+        # compare against the *routed* target instead of the raw pre-routing
+        # `position` for threshold-routed (supports_position=False) covers.
+        # route_service_call is pure/no-side-effects (see routing.py's module
+        # docstring) — it gets recomputed again by _prepare_service_call at
+        # actual dispatch time, same as today.
+        _caps_for_plan = self.get_cover_capabilities(entity_id)
+        _plan = route_service_call(
+            entity_id,
+            position,
+            _caps_for_plan,
+            axis=self._policy.select_default_axis(_caps_for_plan),
+            use_my_position=context.use_my_position,
+            open_close_threshold=self._open_close_threshold,
+            endpoint_use_open_close=self._endpoint_use_open_close,
+        )
+
         # Full mechanical endpoint forcing (issue #755, generalized to any
         # position-capable cover by #897). When the owning cover-type policy
         # flagged this update as a full endpoint (single-axis 0/100, or a
@@ -1366,17 +1396,27 @@ class CoverCommandService:
         # mechanical state), not by tolerance, so the gap can't be reintroduced
         # here nor can it relay-click every cycle.
         #
-        # _current is None is its own exception (issue #779): Somfy RTS covers
-        # (and any open/close-only cover without genuine position feedback) sit
-        # at HA state unknown/unavailable forever, so _current never resolves
-        # and this gate would never fire — the same command gets resent every
-        # cycle. _same_position_via_target_fallback compares the last
-        # *commanded* target against this cycle's *routed* decision (via
-        # route_service_call, see its docstring) instead of a live reading, so
+        # _current is None OR the routed plan is not position-capable is its
+        # own exception (issue #779, broadened by #1095). Somfy RTS covers
+        # (and any open/close-only cover without genuine position feedback)
+        # sit at HA state unknown/unavailable forever, so _current never
+        # resolves and the numeric comparison above would never fire — the
+        # same command gets resent every cycle (#779). A threshold-routed
+        # cover (supports_position=False) whose _current DOES resolve has the
+        # same problem in a different shape (#1095): every calculated
+        # position on one side of open_close_threshold collapses to the same
+        # routed_target, but the numeric comparison above compares _current
+        # against the raw pre-routing `position`, which drifts inside the
+        # sub-threshold band even though the routed decision hasn't changed.
+        # _plan.routed_target (computed once above, right after _current) is
+        # compared against _current directly when it resolved, and
+        # _same_position_via_target_fallback compares the last *commanded*
+        # target against this cycle's *routed* decision (via
+        # route_service_call, see its docstring) when it hasn't — so
         # position-capable, My-preset stop_cover, and open/close endpoint
         # covers are all handled by the one routing source of truth. Delta/time
-        # gates and reconciliation deliberately keep reading the real (unknown)
-        # _current — this fallback is scoped to the same-position gate only.
+        # gates and reconciliation deliberately keep reading the real _current
+        # — this broadened comparison is scoped to the same-position gate only.
         # An explicit user command (context.user_command) must ALWAYS dispatch —
         # a user pressing Open/Close/Set from the card is never "already there"
         # as far as ACP is entitled to decide, especially on a no-feedback cover
@@ -1421,9 +1461,12 @@ class CoverCommandService:
                     )
                 )
                 or (
-                    _current is None
-                    and self._same_position_via_target_fallback(
-                        entity_id, position, context
+                    (_current is None or not _plan.supports_position)
+                    and (
+                        (_current is not None and _current == _plan.routed_target)
+                        or self._same_position_via_target_fallback(
+                            entity_id, position, context
+                        )
                     )
                 )
             )

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1131,8 +1131,10 @@ class CoverCommandService:
         entity_id: str,
         position: int,
         context: PositionContext,
+        *,
+        plan: ServiceCallPlan | None = None,
     ) -> bool:
-        """Same-position gate fallback for a target-vs-routing comparison (issues #779, #1095).
+        """Same-position gate fallback for a target-vs-routing comparison (issue #779).
 
         Somfy RTS (and any open/close-only cover without genuine position
         feedback) reports HA state ``unknown``/``unavailable`` forever, so
@@ -1141,16 +1143,6 @@ class CoverCommandService:
         reading to compare against — the exact same command gets resent on
         every update cycle even though the cover was already commanded to
         (and mechanically at) that state (issue #779).
-
-        A threshold-routed cover (``supports_position: False``) whose
-        ``_current`` genuinely resolves hits the same problem in a different
-        shape (issue #1095): every calculated position on one side of
-        ``open_close_threshold`` collapses to the same routed decision, but a
-        raw numeric comparison against ``_current`` never sees that — it only
-        sees the pre-routing ``position`` drifting inside the sub-threshold
-        band. The caller compares ``_current`` against the routed target
-        directly in that case; this fallback additionally covers the case
-        where ``_current`` never resolved at all.
 
         Falls back to the last *commanded* target (``get_target``) compared
         against this cycle's *routed decision* rather than the raw
@@ -1162,40 +1154,52 @@ class CoverCommandService:
         (issue #779 follow-up regression from PR #781, which hand-rolled a
         partial copy of this math and ignored ``use_my_position``).
 
-        Consulted only when ``_current is None``. The caller in
-        ``apply_position`` also widens *entry* into this whole branch to
-        ``_current is None or not plan.supports_position`` — "not
-        position-capable" covers more than a threshold-routed cover, e.g. a
-        position-capable cover routed to ``open_cover``/``close_cover`` at a
-        mechanical endpoint under ``endpoint_use_open_close`` (the default),
-        the My-preset ``stop_cover`` route, and the no-capable-service case
-        — but once inside that branch, a *resolved* ``_current`` is compared
-        directly against ``plan.routed_target`` by the caller, never through
-        this fallback. A resolved live reading that contradicts the stored
-        target (e.g. the cover reports mechanically closed while the last
-        commanded target was "open") must be free to fall through and
+        Consulted only when ``_current is None`` — a *resolved* ``_current``
+        is compared directly against ``plan.routed_target`` by the caller
+        instead (issue #1095; see the same-position gate's comment in
+        ``apply_position`` for the "not position-capable" routing-algebra
+        explanation of which routes ``routed_target`` can actually diverge
+        from ``position`` on). A resolved live reading that contradicts the
+        stored target (e.g. the cover reports mechanically closed while the
+        last commanded target was "open") must be free to fall through and
         dispatch; routing it through the last-*commanded*-target comparison
-        would let a stale stored target mask a genuine state change (issue
-        #1095 audit finding). This fallback exists solely for the case where
-        there is no live reading to compare at all. The delta/time gates and
-        reconciliation intentionally keep reading the real current position
-        and are untouched by this fallback.
+        here would let a stale stored target mask a genuine state change.
+        This fallback exists solely for the case where there is no live
+        reading to compare at all. The delta/time gates and reconciliation
+        intentionally keep reading the real current position and are
+        untouched by this fallback.
+
+        Args:
+            entity_id: Cover entity ID.
+            position: This cycle's pre-routing calculated target.
+            context: Current coordinator state (``use_my_position`` feeds
+                routing when ``plan`` is not supplied).
+            plan: Pre-computed routing plan for this ``(entity_id,
+                position)`` pair — e.g. ``apply_position``'s gate-level
+                ``_plan``. Reused as-is when given, instead of calling
+                ``route_service_call`` again, so the gate's plan and this
+                fallback's plan are provably the same object rather than two
+                independent computations that happen to agree (issue #1095
+                audit finding 5). Recomputed internally when omitted,
+                preserving the original call contract for any other caller.
+
         """
         last_target = self.get_target(entity_id)
         if last_target is None:
             return False
 
-        caps = self.get_cover_capabilities(entity_id)
-        axis = self._policy.select_default_axis(caps)
-        plan = route_service_call(
-            entity_id,
-            position,
-            caps,
-            axis=axis,
-            use_my_position=context.use_my_position,
-            open_close_threshold=self._open_close_threshold,
-            endpoint_use_open_close=self._endpoint_use_open_close,
-        )
+        if plan is None:
+            caps = self.get_cover_capabilities(entity_id)
+            axis = self._policy.select_default_axis(caps)
+            plan = route_service_call(
+                entity_id,
+                position,
+                caps,
+                axis=axis,
+                use_my_position=context.use_my_position,
+                open_close_threshold=self._open_close_threshold,
+                endpoint_use_open_close=self._endpoint_use_open_close,
+            )
         return last_target == plan.routed_target
 
     async def _service_secondary_axis(
@@ -1304,32 +1308,6 @@ class CoverCommandService:
 
         _current = self._get_current_position(entity_id)
 
-        # Routed decision for this cycle's target (issue #1095). Computed once
-        # here, right after _current, so the same-position gate below can
-        # compare against the *routed* target instead of the raw pre-routing
-        # `position` whenever the routing is not position-capable. "Not
-        # position-capable" covers four routes (open/close endpoint under
-        # endpoint_use_open_close, the My-preset stop_cover route, the
-        # no-capable-service case, and the open/close threshold route), but
-        # route_service_call sets routed_target == position on the first
-        # three by construction (routing.py) — only the threshold route
-        # collapses a range of positions onto one 0/100 routed_target, so
-        # that's the only route where comparing against routed_target differs
-        # from the plain `_current == position` check. route_service_call is
-        # pure/no-side-effects (see routing.py's module docstring) — it gets
-        # recomputed again by _prepare_service_call at actual dispatch time,
-        # same as today.
-        _caps_for_plan = self.get_cover_capabilities(entity_id)
-        _plan = route_service_call(
-            entity_id,
-            position,
-            _caps_for_plan,
-            axis=self._policy.select_default_axis(_caps_for_plan),
-            use_my_position=context.use_my_position,
-            open_close_threshold=self._open_close_threshold,
-            endpoint_use_open_close=self._endpoint_use_open_close,
-        )
-
         # Full mechanical endpoint forcing (issue #755, generalized to any
         # position-capable cover by #897). When the owning cover-type policy
         # flagged this update as a full endpoint (single-axis 0/100, or a
@@ -1417,36 +1395,46 @@ class CoverCommandService:
         # mechanical state), not by tolerance, so the gap can't be reintroduced
         # here nor can it relay-click every cycle.
         #
-        # _current is None OR the routed plan is not position-capable widens
-        # ENTRY into this exception (issue #779, broadened by #1095). Somfy
-        # RTS covers (and any open/close-only cover without genuine position
-        # feedback) sit at HA state unknown/unavailable forever, so _current
-        # never resolves and the numeric comparison above would never fire —
+        # `_plan` (computed directly below, right before this gate) drives a
+        # second arm that widens ENTRY into this exception beyond the numeric
+        # `_current == position` check (issue #779, broadened by #1095).
+        # Somfy RTS covers (and any open/close-only cover without genuine
+        # position feedback) sit at HA state unknown/unavailable forever, so
+        # `_current` never resolves and the numeric arm above never fires —
         # the same command gets resent every cycle (#779). "not
-        # supports_position" is broader than just "threshold-routed": entry
-        # also comes from a position-capable cover routed to
+        # `_plan.supports_position`" is broader than just "threshold-routed":
+        # it also covers a position-capable cover routed to
         # open_cover/close_cover at a mechanical endpoint under
         # endpoint_use_open_close (the default), the My-preset stop_cover
         # route, and the no-capable-service (service=None) case. But
         # route_service_call sets routed_target == position on those three
-        # routes by construction (routing.py), so once _current resolves,
-        # comparing it against _plan.routed_target there is identical to the
-        # `_current == position` check already done above — behaviorally
-        # inert, not a broadening. The open/close-threshold route is the only
-        # one where routed_target genuinely diverges from position (every
-        # state on one side of open_close_threshold collapses to the same
-        # 0/100 routed_target); it's the only route where this arm changes
-        # behavior — it fires when a resolved _current already sits at the
-        # routed 0/100 target even though the raw calculated position drifted
-        # within the sub-threshold band. A resolved reading that CONTRADICTS
-        # the routed target must still fall through to dispatch, never be
-        # masked by a stale commanded target (issue #1095 audit finding 1),
-        # so _same_position_via_target_fallback (which compares the last
-        # *commanded* target against this cycle's *routed* decision via
-        # route_service_call, see its docstring) is consulted only when
-        # _current is still None. Delta/time gates and reconciliation
-        # deliberately keep reading the real _current — this broadened
-        # comparison is scoped to the same-position gate only.
+        # routes by construction (routing.py), so once `_current` resolves,
+        # comparing it against `_plan.routed_target` is identical to the
+        # `_current == position` check above — behaviorally inert, not a
+        # broadening. The open/close-threshold route is the only one where
+        # routed_target genuinely diverges from position: every state on ONE
+        # SIDE of open_close_threshold — above OR below, symmetrically —
+        # collapses onto the same 0/100 routed_target, so the second arm
+        # fires whenever a resolved `_current` already sits at that
+        # collapsed target even though the raw calculated `position` drifted
+        # elsewhere on the same side (issue #1095). A resolved reading that
+        # CONTRADICTS the routed target must still fall through to dispatch,
+        # never be masked by a stale commanded target, so the second arm
+        # below only ever compares a *resolved* `_current` directly against
+        # `_plan.routed_target` — it never calls
+        # _same_position_via_target_fallback. That fallback (see its
+        # docstring) is reserved for the third arm, `_current is None`,
+        # where there is no live reading to compare at all. Delta/time gates
+        # and reconciliation deliberately keep reading the real `_current` —
+        # this routed comparison is scoped to the same-position gate only.
+        #
+        # The second arm keeps `not _plan.supports_position` even though it
+        # is currently provably redundant there (a position-capable route's
+        # `_current == routed_target` always agrees with the first arm's
+        # `_current == position`, by the invariant above) — kept as one
+        # cheap, explicit boolean check that states the case up front and
+        # defends against a future route_service_call change breaking that
+        # invariant on a position-capable route.
         # An explicit user command (context.user_command) must ALWAYS dispatch —
         # a user pressing Open/Close/Set from the card is never "already there"
         # as far as ACP is entitled to decide, especially on a no-feedback cover
@@ -1476,6 +1464,27 @@ class CoverCommandService:
             position in (POSITION_CLOSED, POSITION_OPEN)
             and self._is_at_mechanical_stop(state_obj, position)
         )
+
+        # Routed decision for this cycle's target (issue #1095), consumed by
+        # the gate's second arm just below. Computed here — after the
+        # kill-switch and auto_control short-circuits above, but still ahead
+        # of every use — so a disabled/auto-control-off cover skips the
+        # check_cover_features + route_service_call work entirely for a
+        # value it would never read (issue #1095 audit finding 4).
+        # route_service_call is pure/side-effect-free (routing.py's module
+        # docstring); no `await` occurs between this line and either of its
+        # uses (this gate, and the dispatch call further down that reuses
+        # this same `_plan`/`_caps_for_plan`), so both stay valid for both.
+        _caps_for_plan = self.get_cover_capabilities(entity_id)
+        _plan = route_service_call(
+            entity_id,
+            position,
+            _caps_for_plan,
+            axis=self._policy.select_default_axis(_caps_for_plan),
+            use_my_position=context.use_my_position,
+            open_close_threshold=self._open_close_threshold,
+            endpoint_use_open_close=self._endpoint_use_open_close,
+        )
         if (
             not sun_reconfirm
             and not force_endpoint
@@ -1491,15 +1500,14 @@ class CoverCommandService:
                     )
                 )
                 or (
-                    (_current is None or not _plan.supports_position)
-                    and (
-                        (_current is not None and _current == _plan.routed_target)
-                        or (
-                            _current is None
-                            and self._same_position_via_target_fallback(
-                                entity_id, position, context
-                            )
-                        )
+                    _current is not None
+                    and not _plan.supports_position
+                    and _current == _plan.routed_target
+                )
+                or (
+                    _current is None
+                    and self._same_position_via_target_fallback(
+                        entity_id, position, context, plan=_plan
                     )
                 )
             )
@@ -1601,10 +1609,17 @@ class CoverCommandService:
                 )
 
         # ----- send command -----
+        # Reuses _caps_for_plan/_plan from the gate above (issue #1095 audit
+        # finding 5) instead of a fresh get_cover_capabilities +
+        # route_service_call — safe because nothing between that computation
+        # and this call awaits (confirmed above and in apply_position's
+        # docstring-adjacent comment on `_plan`).
         service, service_data, supports_position = self._prepare_service_call(
             entity_id,
             position,
             context.inverse_state,
+            caps=_caps_for_plan,
+            plan=_plan,
             is_safety=context.is_safety,
             use_my_position=context.use_my_position,
         )
@@ -2209,6 +2224,7 @@ class CoverCommandService:
         reset_retries: bool = True,
         is_safety: bool = False,
         use_my_position: bool = False,  # noqa: FBT001
+        plan: ServiceCallPlan | None = None,
     ) -> tuple[str | None, dict | None, bool]:
         """Build the HA service call for this cover/state.
 
@@ -2232,6 +2248,16 @@ class CoverCommandService:
             use_my_position: If True and the cover lacks set_cover_position,
                 send cover.stop_cover to trigger the hardware My preset instead
                 of falling back to open/close threshold routing.
+            plan: Pre-computed routing plan for this ``(entity, state, caps,
+                use_my_position)`` combination — e.g. ``apply_position``'s
+                gate-level ``_plan``. Reused as-is when given instead of
+                calling ``route_service_call`` again (issue #1095 audit
+                finding 5). Caller must guarantee no HA state change (no
+                ``await``) occurred between building `plan` and this call,
+                or the reused plan may not reflect current capabilities.
+                Recomputed internally when omitted, preserving the original
+                call contract for every other caller (e.g.
+                ``_execute_command``).
 
         Returns:
             (service_name, service_data, supports_position).
@@ -2241,21 +2267,22 @@ class CoverCommandService:
         if caps is None:
             caps = self.get_cover_capabilities(entity)
 
-        # Pick the axis the policy targets by default for this entity. Single-axis
-        # policies (blind/awning/tilt) always return the same axis; venetian
-        # returns its position axis here — its tilt axis is dispatched separately
-        # through ``after_position_command`` and the DualAxisSequencer.
-        axis = self._policy.select_default_axis(caps)
-
-        plan = route_service_call(
-            entity,
-            state,
-            caps,
-            axis=axis,
-            use_my_position=use_my_position,
-            open_close_threshold=self._open_close_threshold,
-            endpoint_use_open_close=self._endpoint_use_open_close,
-        )
+        if plan is None:
+            # Pick the axis the policy targets by default for this entity.
+            # Single-axis policies (blind/awning/tilt) always return the
+            # same axis; venetian returns its position axis here — its tilt
+            # axis is dispatched separately through ``after_position_command``
+            # and the DualAxisSequencer.
+            axis = self._policy.select_default_axis(caps)
+            plan = route_service_call(
+                entity,
+                state,
+                caps,
+                axis=axis,
+                use_my_position=use_my_position,
+                open_close_threshold=self._open_close_threshold,
+                endpoint_use_open_close=self._endpoint_use_open_close,
+            )
 
         self._logger.debug(
             "Prepare service call: %s supports_position=%s caps=%s",

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1162,11 +1162,24 @@ class CoverCommandService:
         (issue #779 follow-up regression from PR #781, which hand-rolled a
         partial copy of this math and ignored ``use_my_position``).
 
-        Consulted when ``_current is None`` OR the routed plan is not
-        position-capable (``not plan.supports_position``) — see the caller in
-        ``apply_position``. The delta/time gates and reconciliation
-        intentionally keep reading the real current position and are
-        untouched by this fallback.
+        Consulted only when ``_current is None``. The caller in
+        ``apply_position`` also widens *entry* into this whole branch to
+        ``_current is None or not plan.supports_position`` — "not
+        position-capable" covers more than a threshold-routed cover, e.g. a
+        position-capable cover routed to ``open_cover``/``close_cover`` at a
+        mechanical endpoint under ``endpoint_use_open_close`` (the default),
+        the My-preset ``stop_cover`` route, and the no-capable-service case
+        — but once inside that branch, a *resolved* ``_current`` is compared
+        directly against ``plan.routed_target`` by the caller, never through
+        this fallback. A resolved live reading that contradicts the stored
+        target (e.g. the cover reports mechanically closed while the last
+        commanded target was "open") must be free to fall through and
+        dispatch; routing it through the last-*commanded*-target comparison
+        would let a stale stored target mask a genuine state change (issue
+        #1095 audit finding). This fallback exists solely for the case where
+        there is no live reading to compare at all. The delta/time gates and
+        reconciliation intentionally keep reading the real current position
+        and are untouched by this fallback.
         """
         last_target = self.get_target(entity_id)
         if last_target is None:
@@ -1294,10 +1307,13 @@ class CoverCommandService:
         # Routed decision for this cycle's target (issue #1095). Computed once
         # here, right after _current, so the same-position gate below can
         # compare against the *routed* target instead of the raw pre-routing
-        # `position` for threshold-routed (supports_position=False) covers.
-        # route_service_call is pure/no-side-effects (see routing.py's module
-        # docstring) — it gets recomputed again by _prepare_service_call at
-        # actual dispatch time, same as today.
+        # `position` whenever the routing is not position-capable — not just
+        # threshold-routed open/close-only covers, but also a position-capable
+        # cover routed to open_cover/close_cover at a mechanical endpoint
+        # (endpoint_use_open_close), the My-preset stop_cover route, and the
+        # no-capable-service case. route_service_call is pure/no-side-effects
+        # (see routing.py's module docstring) — it gets recomputed again by
+        # _prepare_service_call at actual dispatch time, same as today.
         _caps_for_plan = self.get_cover_capabilities(entity_id)
         _plan = route_service_call(
             entity_id,
@@ -1396,27 +1412,35 @@ class CoverCommandService:
         # mechanical state), not by tolerance, so the gap can't be reintroduced
         # here nor can it relay-click every cycle.
         #
-        # _current is None OR the routed plan is not position-capable is its
-        # own exception (issue #779, broadened by #1095). Somfy RTS covers
-        # (and any open/close-only cover without genuine position feedback)
-        # sit at HA state unknown/unavailable forever, so _current never
-        # resolves and the numeric comparison above would never fire — the
-        # same command gets resent every cycle (#779). A threshold-routed
-        # cover (supports_position=False) whose _current DOES resolve has the
-        # same problem in a different shape (#1095): every calculated
-        # position on one side of open_close_threshold collapses to the same
+        # _current is None OR the routed plan is not position-capable widens
+        # ENTRY into this exception (issue #779, broadened by #1095). Somfy
+        # RTS covers (and any open/close-only cover without genuine position
+        # feedback) sit at HA state unknown/unavailable forever, so _current
+        # never resolves and the numeric comparison above would never fire —
+        # the same command gets resent every cycle (#779). "not
+        # supports_position" is broader than just "threshold-routed": it also
+        # covers a position-capable cover routed to open_cover/close_cover at
+        # a mechanical endpoint under endpoint_use_open_close (the default),
+        # the My-preset stop_cover route, and the no-capable-service
+        # (service=None) case. Any of those whose _current DOES resolve has
+        # the #779 problem in a different shape (#1095): every calculated
+        # position on one side of the routing decision collapses to the same
         # routed_target, but the numeric comparison above compares _current
-        # against the raw pre-routing `position`, which drifts inside the
-        # sub-threshold band even though the routed decision hasn't changed.
-        # _plan.routed_target (computed once above, right after _current) is
-        # compared against _current directly when it resolved, and
-        # _same_position_via_target_fallback compares the last *commanded*
-        # target against this cycle's *routed* decision (via
-        # route_service_call, see its docstring) when it hasn't — so
-        # position-capable, My-preset stop_cover, and open/close endpoint
-        # covers are all handled by the one routing source of truth. Delta/time
-        # gates and reconciliation deliberately keep reading the real _current
-        # — this broadened comparison is scoped to the same-position gate only.
+        # against the raw pre-routing `position`, which drifts even though
+        # the routed decision hasn't changed. _plan.routed_target (computed
+        # once above, right after _current) is compared against _current
+        # directly when it resolved — a resolved reading that CONTRADICTS the
+        # stored target must fall through to dispatch, never be masked by a
+        # stale commanded target (issue #1095 audit finding 1), so
+        # _same_position_via_target_fallback (which compares the last
+        # *commanded* target against this cycle's *routed* decision via
+        # route_service_call, see its docstring) is consulted only when
+        # _current is still None — position-capable, My-preset stop_cover,
+        # and open/close endpoint covers are all handled by the one routing
+        # source of truth, but only the unresolved-reading case is allowed to
+        # fall back to the stored target. Delta/time gates and reconciliation
+        # deliberately keep reading the real _current — this broadened
+        # comparison is scoped to the same-position gate only.
         # An explicit user command (context.user_command) must ALWAYS dispatch —
         # a user pressing Open/Close/Set from the card is never "already there"
         # as far as ACP is entitled to decide, especially on a no-feedback cover
@@ -1464,8 +1488,11 @@ class CoverCommandService:
                     (_current is None or not _plan.supports_position)
                     and (
                         (_current is not None and _current == _plan.routed_target)
-                        or self._same_position_via_target_fallback(
-                            entity_id, position, context
+                        or (
+                            _current is None
+                            and self._same_position_via_target_fallback(
+                                entity_id, position, context
+                            )
                         )
                     )
                 )

--- a/tests/test_cover_command_force_gate.py
+++ b/tests/test_cover_command_force_gate.py
@@ -246,3 +246,27 @@ class TestUserCommandBypassesSamePosition:
         assert outcome == "skipped"
         assert detail == "same_position"
         hass.services.async_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_user_command_threshold_routed_already_at_target_still_sent(
+        self, svc, hass
+    ):
+        """Issue #1095 regression guard: broadening the same-position gate to
+        consult the routed-target comparison for threshold-routed covers must
+        not let a cover already at its routed target block an explicit user
+        command. The top-level ``not context.user_command`` guard must still
+        short-circuit ahead of both same-position arms (#900).
+        """
+        with (
+            _patch_caps(has_set_position=False),
+            patch.object(svc, "_get_current_position", return_value=0),
+        ):
+            outcome, _detail = await svc.apply_position(
+                "cover.test",
+                20,
+                "set_axes",
+                _ctx(force=True, user_command=True, auto_control=True),
+            )
+
+        assert outcome == "sent"
+        hass.services.async_call.assert_awaited_once()

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1494,7 +1494,13 @@ async def test_force_endpoint_within_tolerance_skips_command_gate(
 
 
 def _endpoint_service(
-    entity_id, position, inverse_state=False, is_safety=False, use_my_position=False
+    entity_id,
+    position,
+    inverse_state=False,
+    caps=None,
+    is_safety=False,
+    use_my_position=False,
+    plan=None,
 ):
     """_prepare_service_call side_effect: route 0→close, 100→open, else set_position."""
     if position == 0:

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -2308,12 +2308,20 @@ async def test_apply_position_position_capable_still_dispatches_on_change(
 ):
     """Issue #1095 regression guard: broadening the fallback trigger to
     `_current is None or not plan.supports_position` must not over-suppress
-    a position-capable cover.
+    a position-capable cover -- for NON-endpoint targets.
 
-    supports_position=True keeps the broadened OR arm unreachable, so exact
-    equality against the raw position stays the only comparison for a
-    position-capable axis -- a resolved _current that differs from the new
-    target must still dispatch every cycle, exactly as before this change.
+    93 and 78 are mid-range, so routing stays supports_position=True and the
+    broadened OR arm is unreachable here: exact equality against the raw
+    position stays the only comparison, and a resolved _current that differs
+    from the new target must still dispatch every cycle, exactly as before
+    this change.
+
+    This does NOT cover a position-capable cover commanded to a mechanical
+    ENDPOINT (0/100) under endpoint_use_open_close -- that routes through
+    open_cover/close_cover, which is `supports_position=False` just like a
+    threshold-routed cover, and DOES reach the broadened arm. See
+    test_apply_position_endpoint_contradicted_by_current_dispatches_after_latch
+    (audit finding-1 scenario B) for that case.
     """
     mock_hass.states.get.return_value = MagicMock(
         state="open", attributes={"current_position": 50, "supported_features": 15}
@@ -2349,6 +2357,152 @@ async def test_apply_position_position_capable_still_dispatches_on_change(
         )
 
     assert (outcome2, reason2) == ("sent", "set_cover_position")
+    mock_hass.services.async_call.assert_called_once()
+
+
+# --- same-position gate: broadened-arm reachable but must still dispatch
+# when the live reading CONTRADICTS the routed/stored target (issue #1095
+# audit findings 1-3) ---
+#
+# The tests above (`test_apply_position_threshold_routed_resend_suppressed_
+# when_current_resolves`, `..._crossing_dispatches`) only ever suppress via
+# `_current == _plan.routed_target` -- the live reading always AGREES with
+# the routed decision. None of them exercise the case where a resolved
+# `_current` genuinely contradicts a *stored* target that still matches the
+# newly routed decision: before the finding-1 fix, that fell through to
+# `_same_position_via_target_fallback`, which compares only the last
+# *commanded* target against the routed decision and never looks at
+# `_current` at all -- so a stale stored target could mask a live state
+# change and swallow a command that must dispatch.
+
+
+@pytest.mark.asyncio
+async def test_apply_position_threshold_routed_current_contradicts_stored_target_dispatches(
+    threshold_cmd_svc, mock_hass
+):
+    """Audit finding-1 scenario A: current reading contradicts a matching
+    stored target -- must dispatch, not suppress.
+
+    The cover reports mechanically `closed` (_current=0) but the last
+    *commanded* target was already 100 (e.g. a prior open command that
+    hasn't mechanically landed, or a stale target from before an option
+    change). ACP now calculates 100 again, which routes to
+    open_cover/routed_target=100 -- the SAME routed decision as the stored
+    target, so the pre-fix code's `last_target == plan.routed_target`
+    fallback said "same_position" and swallowed the command. But the live
+    reading directly contradicts that: the cover is NOT open. The fix
+    requires `_current is None` to consult that fallback at all, so a
+    resolved, contradicting `_current` falls through to dispatch.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="closed", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    threshold_cmd_svc.set_target("cover.thresh_contradict", 100)
+
+    with (
+        patch.object(threshold_cmd_svc, "_get_current_position", return_value=0),
+        patch.object(threshold_cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await threshold_cmd_svc.apply_position(
+            "cover.thresh_contradict", 100, "solar", _ctx_with_special()
+        )
+
+    assert (outcome, reason) == ("sent", "open_cover")
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_threshold_routed_current_contradicts_stored_close_dispatches(
+    threshold_cmd_svc, mock_hass
+):
+    """Audit finding-1 scenario E: same contradiction, mirrored at the close
+    side, with the calculated position mid-band rather than a literal
+    endpoint.
+
+    The cover reports mechanically `open` (_current=100) but the last
+    *commanded* target was already 0. ACP now calculates 67, which -- with
+    `open_close_threshold=99` -- routes to close_cover/routed_target=0, the
+    SAME routed decision as the stored target. The live reading contradicts
+    it (the cover is not closed), so this must dispatch close_cover, not be
+    suppressed as same_position.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="open", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    threshold_cmd_svc.set_target("cover.thresh_contradict_close", 0)
+
+    with (
+        patch.object(threshold_cmd_svc, "_get_current_position", return_value=100),
+        patch.object(threshold_cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await threshold_cmd_svc.apply_position(
+            "cover.thresh_contradict_close", 67, "solar", _ctx_with_special()
+        )
+
+    assert (outcome, reason) == ("sent", "close_cover")
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_endpoint_contradicted_by_current_dispatches_after_latch(
+    mock_hass, logger, grace_mgr
+):
+    """Audit finding-1 scenario B: a position-capable cover routed to an
+    endpoint (supports_position=False, same routing shape as a
+    threshold-routed cover) must not be over-suppressed once the anti-relay
+    latch (#897) has already armed -- the largest blast-radius regression,
+    since endpoint_use_open_close defaults ON and this is not a
+    threshold-routed cover at all.
+
+    Setup: endpoint_use_open_close ON (default), target=0, _current=45 (well
+    outside `_position_tolerance`), stored target already 0, and the
+    `forced_endpoint` latch already armed at 0. Because the latch already
+    equals the target, `force_endpoint` computes False on this cycle (the
+    `!= position` check fails) -- the force_endpoint bypass does NOT fire,
+    so the same-position band is the only thing standing between "must
+    dispatch" (the cover is nowhere near closed) and "must skip". Before the
+    finding-1 fix, `not _plan.supports_position` let a resolved,
+    contradicting `_current` fall through to
+    `_same_position_via_target_fallback`, which only compares the *stored*
+    target (0) against the routed decision (0) and ignores `_current`
+    entirely -- so it wrongly reported same_position. This also serves as
+    the endpoint counterpart to
+    `test_apply_position_position_capable_still_dispatches_on_change`,
+    which only covers non-endpoint targets.
+    """
+    svc = _make_svc_with_tolerance(mock_hass, logger, grace_mgr, tolerance=3)
+    _stub_state(mock_hass, current_position=45, state="open")
+    svc.set_target("cover.endpoint_pos", 0)
+    svc.state("cover.endpoint_pos").forced_endpoint = 0
+
+    with (
+        patch.object(svc, "_get_current_position", return_value=45),
+        patch.object(svc, "_check_time_delta", return_value=True),
+    ):
+        outcome, reason = await svc.apply_position(
+            "cover.endpoint_pos", 0, "solar", _ctx_with_special()
+        )
+
+    assert (outcome, reason) == ("sent", "close_cover")
+    mock_hass.services.async_call.assert_called_once()
 
 
 # --- is_target_unreached: A2 read-only "commanded but not reached" predicate ---

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -61,6 +61,23 @@ def tilt_cmd_svc(mock_hass, logger, grace_mgr):
     )
 
 
+@pytest.fixture
+def threshold_cmd_svc(mock_hass, logger, grace_mgr):
+    """CoverCommandService for a vertical blind with a high open/close threshold.
+
+    Mirrors ``cmd_svc`` but with ``open_close_threshold=99`` (issue #1095) so
+    a wide sub-threshold band (any calculated position below 99) collapses to
+    the same ``close_cover``/``routed_target=0`` decision.
+    """
+    return CoverCommandService(
+        hass=mock_hass,
+        logger=logger,
+        cover_type="cover_blind",
+        grace_mgr=grace_mgr,
+        open_close_threshold=99,
+    )
+
+
 # --- Initial state ---
 
 
@@ -2173,6 +2190,165 @@ async def test_apply_position_repeated_my_preset_suppressed_when_current_unknown
 
     assert (outcome2, reason2) == ("skipped", "same_position")
     mock_hass.services.async_call.assert_not_called()
+
+
+# --- same-position gate: threshold-routed cover with a resolved current
+# position (issue #1095) ---
+#
+# The #779 fallback above is reachable only when `_current is None`. A
+# threshold-routed cover (supports_position=False) whose HA state genuinely
+# resolves to closed/open (_current = 0/100, not None) never takes that
+# branch, so the gate falls back to comparing the raw pre-routing `position`
+# against `_current` -- two numbers that are never comparable once the
+# calculated position drifts inside the sub-threshold band, since every
+# state below the threshold collapses to the same routed_target=0. The fix
+# broadens the fallback trigger to `_current is None OR not
+# plan.supports_position` so the routed decision is consulted whenever the
+# routing is not position-capable, not just when the reading is unresolved.
+
+
+@pytest.mark.asyncio
+async def test_apply_position_threshold_routed_resend_suppressed_when_current_resolves(
+    threshold_cmd_svc, mock_hass
+):
+    """Issue #1095: a threshold-routed cover with a resolved _current must not
+    be commanded every cycle just because the calculated position drifts
+    inside the sub-threshold band while the cover is already mechanically at
+    the routed decision.
+
+    open_close_threshold=99 collapses every calculated position below 99
+    into the same close_cover/routed_target=0 decision. With _current
+    resolved to 0 (mechanically closed, state-derived -- not None) and no
+    prior ACP-commanded target, successive solar cycles walking the
+    calculated position through the sub-threshold band (93 -> 88 -> 67) must
+    all be recognised as already matching the routed decision and suppressed
+    as same_position -- not dispatched as a redundant close_cover every
+    cycle (the reported relay-click bug).
+    """
+    mock_hass.states.get.return_value = MagicMock(state="closed", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+
+    with (
+        patch.object(threshold_cmd_svc, "_get_current_position", return_value=0),
+        patch.object(threshold_cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        for target_position in (93, 88, 67):
+            outcome, reason = await threshold_cmd_svc.apply_position(
+                "cover.thresh", target_position, "solar", _ctx_with_special()
+            )
+            assert (outcome, reason) == ("skipped", "same_position")
+
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_threshold_routed_crossing_dispatches(
+    threshold_cmd_svc, mock_hass
+):
+    """Issue #1095: the broadened gate is not a one-way latch -- once the
+    calculated position genuinely crosses back over open_close_threshold,
+    the routed decision changes and the gate must let the command through.
+
+    The cover starts mechanically closed (_current=0, resolved). Calculated
+    positions in the sub-threshold band (67 -> 88) route to the same
+    close_cover/routed_target=0 decision the cover already occupies, so both
+    are correctly suppressed as same_position (see the resend-suppressed
+    test above). Once the calculated position crosses the threshold to 100,
+    the routed decision flips to open_cover/routed_target=100 -- a real
+    state change the gate must let through.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="closed", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+
+    with (
+        patch.object(threshold_cmd_svc, "_get_current_position", return_value=0),
+        patch.object(threshold_cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await threshold_cmd_svc.apply_position(
+            "cover.thresh_cross", 67, "solar", _ctx_with_special()
+        )
+        assert (outcome, reason) == ("skipped", "same_position")
+
+        outcome2, reason2 = await threshold_cmd_svc.apply_position(
+            "cover.thresh_cross", 88, "solar", _ctx_with_special()
+        )
+        assert (outcome2, reason2) == ("skipped", "same_position")
+        mock_hass.services.async_call.assert_not_called()
+
+        outcome3, reason3 = await threshold_cmd_svc.apply_position(
+            "cover.thresh_cross", 100, "solar", _ctx_with_special()
+        )
+
+    assert (outcome3, reason3) == ("sent", "open_cover")
+
+
+@pytest.mark.asyncio
+async def test_apply_position_position_capable_still_dispatches_on_change(
+    cmd_svc, mock_hass
+):
+    """Issue #1095 regression guard: broadening the fallback trigger to
+    `_current is None or not plan.supports_position` must not over-suppress
+    a position-capable cover.
+
+    supports_position=True keeps the broadened OR arm unreachable, so exact
+    equality against the raw position stays the only comparison for a
+    position-capable axis -- a resolved _current that differs from the new
+    target must still dispatch every cycle, exactly as before this change.
+    """
+    mock_hass.states.get.return_value = MagicMock(
+        state="open", attributes={"current_position": 50, "supported_features": 15}
+    )
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": True,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+    }
+    current_state = {"value": 10}
+
+    with (
+        patch.object(cmd_svc, "_get_current_position") as mock_current,
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        mock_current.side_effect = lambda entity: current_state["value"]
+
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.pos_capable", 93, "solar", _ctx_with_special()
+        )
+        assert (outcome, reason) == ("sent", "set_cover_position")
+
+        mock_hass.services.async_call.reset_mock()
+        current_state["value"] = 40
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.pos_capable", 78, "solar", _ctx_with_special()
+        )
+
+    assert (outcome2, reason2) == ("sent", "set_cover_position")
 
 
 # --- is_target_unreached: A2 read-only "commanded but not reached" predicate ---


### PR DESCRIPTION
## Summary

On a cover routed through the open/close threshold (`supports_position` False), the same-position gate compared the pre-routing target against the current position reading. Those never match once the calculated position drifts inside the sub-threshold band, so an identical `close_cover` went out every cycle even though the routed target had not moved. On the reporting install that was about fifteen unnecessary RF commands an hour for as long as the sun tracked below the threshold.

The routed comparison that catches this already existed in `_same_position_via_target_fallback`, but it was gated on `_current is None` - a guard written for Somfy RTS covers that report `unknown` forever (#779). A cover reporting `closed`/`open` gets a state-derived 0/100 back, so `_current` resolves and the fallback was skipped.

`apply_position` now computes the routed plan once and compares `_current` against `plan.routed_target` when the plan is not position-capable. The stored-target fallback stays scoped to an unresolved reading, which keeps #779 intact and, more importantly, keeps a resolved reading that *contradicts* the stored target from being suppressed. That second point matters beyond threshold-routed covers: a position-capable cover at an endpoint under `endpoint_use_open_close` (on by default) also reports `supports_position` False, so a broader skip would have dropped its final approach to 0/100 once the anti-relay latch armed.

Also flattens the same-position arms so each states one complete case, and threads the one routed plan into the fallback and `_prepare_service_call` instead of recomputing plans that happen to agree.

## Testing
- ✅ 9451 tests passing

Seven new tests: the threshold-routed resend chain, the threshold crossing, a position-capable non-endpoint control, and three contradiction scenarios (threshold cover reporting closed while ACP wants open, reporting open while ACP wants close, and a position-capable endpoint cover contradicted by its own reading after the latch armed).

## Related Issues
Refs #1095