### PR TITLE
fix: round the tilt axis away from horizontal (#1090)

### DIFF
--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from math import cos, radians
+from math import ceil, cos, floor, radians
 
 from ...config_context_adapter import ConfigContextAdapter
 from ...config_types import CoverConfig
@@ -332,3 +332,22 @@ class AdaptiveGeneralCover(ABC):
         direction signal.
         """
         return float(self.calculate_percentage())
+
+    def round_toward_coverage(self, pct: float, *, full_coverage_at_zero: bool) -> int:
+        """Quantise a raw geometry percentage toward MORE sun coverage (#978).
+
+        Polymorphic hook — the single definition of "which way do we round" for
+        both the solar branch (:func:`pipeline.helpers.solar_position_from_geometry`)
+        and venetian's dual-axis tilt sub-path
+        (``VenetianCoverCalculation._compute_tilt``), so the two can never drift
+        apart again (issue #1090).
+
+        *full_coverage_at_zero* is the axis-level semantic the caller reads off
+        ``CoverTypePolicy.axes[n].open_blocks_sun``: ``True`` means 0 % is the
+        fully-covering end (blind / tilt / venetian) so we round down, ``False``
+        means 100 % is (awning) so we round up. That holds for every axis whose
+        coverage is MONOTONIC in the percentage — which is every axis except a
+        bi-directional slat, where :class:`~.tilt.AdaptiveTiltCover` overrides
+        this with an angle-aware direction.
+        """
+        return floor(pct) if full_coverage_at_zero else ceil(pct)

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -14,6 +14,7 @@ from ...const import (
     TRACE_KEY_GAMMA_DEG,
     TRACE_KEY_POSITION_PCT,
     TRACE_KEY_SOL_ELEV_DEG,
+    VENETIAN_TILT_TRANSFORM_CLAMP,
     TiltMode,
 )
 from ...geometry import SafetyMarginCalculator
@@ -423,15 +424,65 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         consistency with the position axis. In practice the tie is invisible on
         the shipped modes: MODE1 pivots at 100 % and MODE2 at 50 %, both whole
         percentages, where ``floor`` and ``ceil`` already agree.
+
+        The quantised integer is then re-banded, because on this path the
+        ``[min_tilt, max_tilt]`` band was applied to the FLOAT back in
+        :meth:`calculate_raw_percentage` and that pass predicts the final
+        integer with ``int(round(pct))`` — a prediction the away-from-horizontal
+        rule invalidates. A raw percentage inside ``(max_tilt, max_tilt + 0.5)``
+        survives the band check and would leave here one point past the cap
+        (mirror-image below ``min_tilt`` under ``floor``). Re-banding is a clamp
+        only, so it is idempotent: the proportional remap has already landed
+        inside the band and is not re-applied, and the shipped ``0``/``100``
+        default is a provable no-op. Venetian clears
+        ``apply_tilt_axis_limits``, so its sub-engine skips this and
+        ``VenetianCoverCalculation._clamp_tilt`` stays the single band owner
+        there.
         """
         horizontal_pct = self._horizontal_percentage()
         if horizontal_pct is None:
-            return super().round_toward_coverage(
+            quantised = super().round_toward_coverage(
                 pct, full_coverage_at_zero=full_coverage_at_zero
             )
-        if pct > horizontal_pct:
-            return ceil(pct)
-        return floor(pct)
+        elif pct > horizontal_pct:
+            quantised = ceil(pct)
+        else:
+            quantised = floor(pct)
+        if not self.apply_tilt_axis_limits:
+            return quantised
+        return self._limit_tilt(quantised, transform=VENETIAN_TILT_TRANSFORM_CLAMP)
+
+    def _limit_tilt(self, value: int, *, transform: str) -> int:
+        """Fit an integer tilt % to this engine's ``[min_tilt, max_tilt]`` band.
+
+        Sole owner of the band argument bundle, shared by the pre-quantisation
+        transform seam (:meth:`_apply_tilt_axis_limits`) and the
+        post-quantisation band guard (:meth:`round_toward_coverage`). The two
+        differ only in *transform*: the former honours the user's
+        ``tilt_transform``, the latter always clamps because the transform has
+        already run and remapping twice would compress the band twice — the same
+        double-application venetian avoids by clearing
+        ``apply_tilt_axis_limits``.
+
+        That flag is checked by the callers rather than here, because "not my
+        band" means handing back a different thing in each: the float seam owes
+        its caller the untouched ``pct`` (including a NaN it must stay
+        transparent to), the integer seam owes it the untouched quantised value.
+
+        The engine path is always sun-tracking, so ``sun_valid=True`` and the
+        ``*_sun_only`` toggles are unconditional; they are passed through anyway
+        so the shared primitive keeps deciding that, not this call site.
+        """
+        cfg = self.tilt_config
+        return PositionConverter.apply_tilt_limits(
+            value,
+            cfg.min_tilt,
+            cfg.max_tilt,
+            cfg.min_tilt_sun_only,
+            cfg.max_tilt_sun_only,
+            sun_valid=True,
+            transform=transform,
+        )
 
     def _apply_tilt_axis_limits(self, pct: float) -> float:
         """Clamp the sun-derived tilt % to the configured tilt-axis band.
@@ -448,26 +499,27 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         tilt engine's trace untouched.
 
         Venetian's composed sub-engine sets ``apply_tilt_axis_limits=False`` and
-        applies the identical limits itself, so this is skipped there.
+        applies the identical limits itself, so this is skipped there — before
+        ``round()`` is reached, keeping the seam transparent to the NaN
+        ``VenetianCoverCalculation._compute_tilt`` explicitly tests for.
         """
         if not self.apply_tilt_axis_limits:
             return pct
-        cfg = self.tilt_config
-        limited = PositionConverter.apply_tilt_limits(
-            int(round(pct)),
-            cfg.min_tilt,
-            cfg.max_tilt,
-            cfg.min_tilt_sun_only,
-            cfg.max_tilt_sun_only,
-            sun_valid=True,
-            transform=cfg.tilt_transform,
-        )
+        rounded = int(round(pct))
+        limited = self._limit_tilt(rounded, transform=self.tilt_config.tilt_transform)
         # The shared primitive is int-valued, but ``calculate_percentage`` has
         # always returned a float — specify-angles yields a fractional percent
         # the pipeline rounds downstream. When the band leaves the rounded value
         # untouched (a no-op / within-band clamp), keep the exact float so that
         # precision is preserved byte-for-byte; only substitute the primitive's
         # value when it actually moved the tilt (a cap, floor, or transform bit).
-        if limited == int(round(pct)):
+        #
+        # ``rounded`` is only a PREDICTION of the integer this float becomes, and
+        # the away-from-horizontal rule can beat it by one at a band edge — which
+        # is why :meth:`round_toward_coverage` re-bands the real integer (#1090)
+        # rather than this prediction being sharpened here: sharpening it would
+        # feed a different value into the proportional remap and move
+        # in-band results that have nothing to do with the escape.
+        if limited == rounded:
             return pct
         return float(limited)

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -126,18 +126,43 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         """Return the useful raw target angle for explicit endpoint calibration."""
         return max(0.0, min(180.0, float(raw_angle)))
 
-    def _percentage_from_specified_angles(self, raw_angle: float) -> float:
-        """Map a target raw slat angle to the configured tilt percentage.
+    def _percentage_from_angle(self, angle: float) -> float | None:
+        """Map a raw slat angle onto this engine's tilt percentage scale.
+
+        Sole owner of the angle→percentage map. Three callers need it and they
+        MUST agree: the solved position (:meth:`calculate_raw_percentage`), the
+        calibrated endpoint mapping (:meth:`calculate_percentage`), and the
+        horizontal pivot (:meth:`_horizontal_percentage`). The pivot is what
+        makes sharing load-bearing rather than merely tidy — it points at
+        maximum openness only while it is divided by the SAME denominator the
+        position is, and :meth:`_effective_max_degrees` lets the louvered roof
+        move that denominator to a configurable ``max_slat_angle``. Re-deriving
+        either map at a second site is exactly how the pivot drifts off the
+        scale it is supposed to sit on.
 
         The solver and the configured endpoints both use ACP's raw/card angle
-        convention: 0° closed downward, 90° horizontal, 180° closed upward.
-        """
-        travel = self.angle_100 - self.angle_0
-        if travel == 0:
-            return 0.0
+        convention: 0° closed downward, 90° horizontal, 180° closed upward. Two
+        affine maps, selected by the configured mode:
 
-        target_angle = self._specified_target_angle(raw_angle)
-        return ((target_angle - self.angle_0) / travel) * 100.0
+        * legacy / custom-max — ``pct = angle / max_degrees × 100``.
+        * ``specify_angles`` — ``pct = (angle − angle_0) / travel × 100``, which
+          may run BACKWARDS (``travel < 0``, an inverted calibration where 0 %
+          is the upward-closed slat). Affine either way, so the pivot's image
+          moves with the map and the sign never has to be tested.
+
+        ``None`` means the scale is degenerate — zero width — so no percentage
+        exists at all. Each caller decides what to do about that.
+        """
+        if self._is_specify_angles():
+            travel = self.angle_100 - self.angle_0
+            if travel == 0:
+                return None
+            target_angle = self._specified_target_angle(angle)
+            return ((target_angle - self.angle_0) / travel) * 100.0
+        max_degrees = float(self._effective_max_degrees())
+        if max_degrees <= 0:
+            return None
+        return (float(angle) / max_degrees) * 100.0
 
     def _effective_max_degrees(self) -> float:
         """Ceiling + percentage denominator for the slat angle.
@@ -332,7 +357,12 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         # below cannot express. Handle it here, before the polymorphic base
         # path, and correct the trace's position percentage in place.
         if self._is_specify_angles():
-            percentage = self._percentage_from_specified_angles(position)
+            percentage = self._percentage_from_angle(position)
+            if percentage is None:
+                # Degenerate calibration (``angle_0 == angle_100``): no width to
+                # interpolate into, and 0 % is what this path has always
+                # answered for it.
+                percentage = 0.0
             if hasattr(self, "_last_calc_details"):
                 self._last_calc_details[TRACE_KEY_POSITION_PCT] = float(percentage)
                 self._last_calc_details["target_angle_deg"] = (
@@ -366,7 +396,16 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         if self._is_specify_angles():
             return self.calculate_percentage()
         position = self.calculate_position()
-        pct = (float(position) / self._effective_max_degrees()) * 100.0
+        pct = self._percentage_from_angle(position)
+        if pct is None:
+            # A zero-width scale has no percentage to report. Unreachable from
+            # config — both tilt-mode maxima are nonzero and ``max_slat_angle``
+            # is bounded to [0, 180] with 0 meaning "use the mode max" — and a
+            # zero denominator already raises inside ``calculate_position``
+            # above while it builds its trace. Raising keeps the contract
+            # ``VenetianCoverCalculation._compute_tilt`` relies on: a tilt
+            # geometry that does not resolve falls back to the default position.
+            raise ZeroDivisionError("tilt percentage scale has zero width")
         return self._apply_tilt_axis_limits(pct)
 
     def _horizontal_percentage(self) -> float | None:
@@ -380,27 +419,17 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         :meth:`round_toward_coverage` decide direction without reconstructing
         the angle or branching on the tilt mode.
 
-        Both percentage maps are affine, so this is just the pivot's image:
-
-        * legacy / custom-max: ``pct = angle / max_degrees × 100``.
-        * ``specify_angles``: ``pct = (angle − angle_0) / travel × 100``, which
-          may run BACKWARDS (``travel < 0``, an inverted calibration where 0 %
-          is the upward-closed slat). That is fine — the pivot's image moves
-          with the map, so "away from horizontal" stays "away from the pivot"
-          in percentage space either way and the sign never has to be tested.
+        Nothing here but the pivot's image under :meth:`_percentage_from_angle`
+        — the very map the solved position goes through — and deliberately so:
+        "away from horizontal" is only "away from this percentage" while the
+        two share a scale. A second copy of either map would let a new mode, or
+        an ``_effective_max_degrees`` override, move the position without moving
+        the pivot, and the rounding would quietly start closing the wrong way.
 
         ``None`` means the pivot is undefined (a degenerate zero-width scale),
         and callers fall back to the monotonic axis rule.
         """
-        if self._is_specify_angles():
-            travel = self.angle_100 - self.angle_0
-            if travel == 0:
-                return None
-            return ((TILT_HORIZONTAL_DEG - self.angle_0) / travel) * 100.0
-        max_degrees = float(self._effective_max_degrees())
-        if max_degrees <= 0:
-            return None
-        return (TILT_HORIZONTAL_DEG / max_degrees) * 100.0
+        return self._percentage_from_angle(TILT_HORIZONTAL_DEG)
 
     def round_toward_coverage(self, pct: float, *, full_coverage_at_zero: bool) -> int:
         """Quantise the slat percentage AWAY from horizontal (issue #1090).
@@ -421,9 +450,16 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
 
         Exactly ON the pivot, both directions increase coverage equally, so
         there is no conservative answer to pick — ``floor`` wins the tie for
-        consistency with the position axis. In practice the tie is invisible on
-        the shipped modes: MODE1 pivots at 100 % and MODE2 at 50 %, both whole
-        percentages, where ``floor`` and ``ceil`` already agree.
+        consistency with the position axis. That tie is genuinely reachable, not
+        a theoretical edge: a louvered roof with a configured ``max_slat_angle``
+        has a FRACTIONAL pivot (140° → 64.2857 %), and its ``_resolve_slat_angle``
+        returns exactly ``TILT_HORIZONTAL_DEG`` whenever the slats self-block,
+        so the raw percentage lands bit-exactly on the pivot rather than near
+        it. Nothing rides on which side wins there — at 140° the neighbours are
+        89.6° and 91.0°, both farther from horizontal than the 90.0° solve — but
+        the choice is pinned by test so the boundary cannot drift unnoticed. On
+        the two whole-percentage pivots (MODE1's 100 %, MODE2's 50 %) ``floor``
+        and ``ceil`` agree anyway.
 
         The quantised integer is then re-banded, because on this path the
         ``[min_tilt, max_tilt]`` band was applied to the FLOAT back in
@@ -437,7 +473,7 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         default is a provable no-op. Venetian clears
         ``apply_tilt_axis_limits``, so its sub-engine skips this and
         ``VenetianCoverCalculation._clamp_tilt`` stays the single band owner
-        there.
+        there — applying the band through the same :meth:`_limit_tilt` seam.
         """
         horizontal_pct = self._horizontal_percentage()
         if horizontal_pct is None:
@@ -455,19 +491,24 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
     def _limit_tilt(self, value: int, *, transform: str) -> int:
         """Fit an integer tilt % to this engine's ``[min_tilt, max_tilt]`` band.
 
-        Sole owner of the band argument bundle, shared by the pre-quantisation
-        transform seam (:meth:`_apply_tilt_axis_limits`) and the
-        post-quantisation band guard (:meth:`round_toward_coverage`). The two
-        differ only in *transform*: the former honours the user's
-        ``tilt_transform``, the latter always clamps because the transform has
-        already run and remapping twice would compress the band twice — the same
+        Sole owner of the band argument bundle — genuinely sole, across all
+        three seams that apply it: the pre-quantisation transform
+        (:meth:`_apply_tilt_axis_limits`), the post-quantisation band guard
+        (:meth:`round_toward_coverage`), and venetian's dual-axis band
+        (``VenetianCoverCalculation._clamp_tilt``, which reaches in here rather
+        than rebuilding the same call). They differ only in *transform*: the
+        first and last honour the user's ``tilt_transform``, the band guard
+        always clamps because the transform has already run by then and
+        remapping twice would compress the band twice — the same
         double-application venetian avoids by clearing
         ``apply_tilt_axis_limits``.
 
         That flag is checked by the callers rather than here, because "not my
         band" means handing back a different thing in each: the float seam owes
         its caller the untouched ``pct`` (including a NaN it must stay
-        transparent to), the integer seam owes it the untouched quantised value.
+        transparent to), the integer seam owes it the untouched quantised value
+        — and venetian never asks the question at all, because clearing the flag
+        on its sub-engine is exactly how it claims the band for itself.
 
         The engine path is always sun-tracking, so ``sun_valid=True`` and the
         ``*_sun_only`` toggles are unconditional; they are passed through anyway

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -398,13 +398,18 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         position = self.calculate_position()
         pct = self._percentage_from_angle(position)
         if pct is None:
-            # A zero-width scale has no percentage to report. Unreachable from
-            # config — both tilt-mode maxima are nonzero and ``max_slat_angle``
-            # is bounded to [0, 180] with 0 meaning "use the mode max" — and a
-            # zero denominator already raises inside ``calculate_position``
-            # above while it builds its trace. Raising keeps the contract
-            # ``VenetianCoverCalculation._compute_tilt`` relies on: a tilt
-            # geometry that does not resolve falls back to the default position.
+            # A zero-width scale has no percentage to report. A *negative*
+            # denominator is unreachable from config: both tilt-mode maxima are
+            # nonzero and ``max_slat_angle`` is bounded to [0, 180]. A *zero*
+            # one is reachable, though — ``AdaptiveLouveredRoofCover``
+            # truncates ``max_slat_angle`` with ``int()``, so a fractional
+            # value in (0, 1) lands on 0 rather than on the "use the mode max"
+            # sentinel. That case already raises inside ``calculate_position``
+            # above while it builds its trace, so this is the same failure
+            # surfaced at a second seam rather than a new one. Raising keeps
+            # the contract ``VenetianCoverCalculation._compute_tilt`` relies
+            # on: a tilt geometry that does not resolve falls back to the
+            # default position.
             raise ZeroDivisionError("tilt percentage scale has zero width")
         return self._apply_tilt_axis_limits(pct)
 

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import ceil, floor
 
 import numpy as np
 from numpy import tan
@@ -366,6 +367,71 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         position = self.calculate_position()
         pct = (float(position) / self._effective_max_degrees()) * 100.0
         return self._apply_tilt_axis_limits(pct)
+
+    def _horizontal_percentage(self) -> float | None:
+        """Tilt percentage that maps to the horizontal slat, or ``None``.
+
+        ``TILT_HORIZONTAL_DEG`` is the maximum-openness angle on every tilt
+        scale this engine drives — it is the pivot the safety margin already
+        scales the closure away from in :meth:`calculate_position`, and the
+        angle the louvered-roof override drives *toward* when it wants the
+        slats as open as possible. Expressing it as a percentage lets
+        :meth:`round_toward_coverage` decide direction without reconstructing
+        the angle or branching on the tilt mode.
+
+        Both percentage maps are affine, so this is just the pivot's image:
+
+        * legacy / custom-max: ``pct = angle / max_degrees × 100``.
+        * ``specify_angles``: ``pct = (angle − angle_0) / travel × 100``, which
+          may run BACKWARDS (``travel < 0``, an inverted calibration where 0 %
+          is the upward-closed slat). That is fine — the pivot's image moves
+          with the map, so "away from horizontal" stays "away from the pivot"
+          in percentage space either way and the sign never has to be tested.
+
+        ``None`` means the pivot is undefined (a degenerate zero-width scale),
+        and callers fall back to the monotonic axis rule.
+        """
+        if self._is_specify_angles():
+            travel = self.angle_100 - self.angle_0
+            if travel == 0:
+                return None
+            return ((TILT_HORIZONTAL_DEG - self.angle_0) / travel) * 100.0
+        max_degrees = float(self._effective_max_degrees())
+        if max_degrees <= 0:
+            return None
+        return (TILT_HORIZONTAL_DEG / max_degrees) * 100.0
+
+    def round_toward_coverage(self, pct: float, *, full_coverage_at_zero: bool) -> int:
+        """Quantise the slat percentage AWAY from horizontal (issue #1090).
+
+        Coverage on a slat axis is NOT monotonic in the percentage, which is the
+        assumption the base implementation encodes. On MODE2 — the shipped
+        default for tilt-only and venetian covers — 0° is closed downward, 90°
+        is horizontal, and 180° is closed upward, so 50 % is the single most
+        sun-permissive position and coverage grows as the angle leaves it in
+        EITHER direction. :meth:`calculate_position` returns the exact grazing
+        angle (the most-open slat that still blocks the beam), so any
+        quantisation toward horizontal leaks direct sun.
+
+        Rounding away from :meth:`_horizontal_percentage` is therefore the
+        conservative direction, and it subsumes the monotonic case rather than
+        special-casing it: MODE1 spans 0–90°, so its pivot is 100 % and every
+        reachable percentage rounds down exactly as before.
+
+        Exactly ON the pivot, both directions increase coverage equally, so
+        there is no conservative answer to pick — ``floor`` wins the tie for
+        consistency with the position axis. In practice the tie is invisible on
+        the shipped modes: MODE1 pivots at 100 % and MODE2 at 50 %, both whole
+        percentages, where ``floor`` and ``ceil`` already agree.
+        """
+        horizontal_pct = self._horizontal_percentage()
+        if horizontal_pct is None:
+            return super().round_toward_coverage(
+                pct, full_coverage_at_zero=full_coverage_at_zero
+            )
+        if pct > horizontal_pct:
+            return ceil(pct)
+        return floor(pct)
 
     def _apply_tilt_axis_limits(self, pct: float) -> float:
         """Clamp the sun-derived tilt % to the configured tilt-axis band.

--- a/custom_components/adaptive_cover_pro/engine/covers/venetian.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/venetian.py
@@ -6,7 +6,6 @@ import math
 from dataclasses import dataclass
 
 from ...config_types import CoverConfig, TiltConfig, VerticalConfig
-from ...position_utils import PositionConverter
 from ...sun import SunData
 from .tilt import AdaptiveTiltCover
 from .vertical import AdaptiveVerticalCover
@@ -95,28 +94,26 @@ class VenetianCoverCalculation:
         Applied to every engine-derived tilt — including the NaN fallback — so
         ``min_tilt`` is a true floor, not just "applied when geometry resolves".
 
-        Delegates to the shared :meth:`PositionConverter.apply_tilt_limits`
-        primitive with ``sun_valid=True`` (this is the sun-tracking engine
-        path), so the clamp policy lives in exactly one place shared with the
-        DefaultHandler default-tilt clamp (#503). With ``sun_valid=True`` the
-        limits always apply regardless of the ``*_sun_only`` toggles, preserving
-        the original unconditional ``max(min, min(v, max))`` behavior.
+        Delegates to the tilt engine's own :meth:`AdaptiveTiltCover._limit_tilt`
+        band seam rather than rebuilding the argument bundle here. That seam
+        owns the bounds, the two ``*_sun_only`` toggles and ``sun_valid=True``
+        (the engine path is always sun-tracking, so the limits apply
+        unconditionally — the original ``max(min, min(v, max))`` behavior), and
+        routes them to the shared :meth:`PositionConverter.apply_tilt_limits`
+        primitive the DefaultHandler default-tilt clamp also uses (#503). A
+        hand-rolled copy here is a band that only *happens* to match.
 
         ``cfg.tilt_transform`` selects clamp (default, unchanged) vs the
         proportional remap into ``[min_tilt, max_tilt]`` (#957). This is the only
         seam that opts into the proportional transform; the default-tilt path
         stays on clamp.
+
+        The sub-engine's ``apply_tilt_axis_limits=False`` does not suppress
+        this, and must not: that flag answers "does the engine own the band?",
+        and clearing it is precisely how this method claims ownership.
         """
         cfg = self._tilt.tilt_config
-        return PositionConverter.apply_tilt_limits(
-            value,
-            cfg.min_tilt,
-            cfg.max_tilt,
-            cfg.min_tilt_sun_only,
-            cfg.max_tilt_sun_only,
-            sun_valid=True,
-            transform=cfg.tilt_transform,
-        )
+        return self._tilt._limit_tilt(value, transform=cfg.tilt_transform)
 
     def _compute_tilt(self) -> int:
         try:

--- a/custom_components/adaptive_cover_pro/engine/covers/venetian.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/venetian.py
@@ -125,7 +125,17 @@ class VenetianCoverCalculation:
             return self._tilt.config.h_def
         if math.isnan(raw_tilt):
             return self._clamp_tilt(0)
-        return self._clamp_tilt(math.floor(raw_tilt))
+        # Same seam the tilt-only solar branch uses
+        # (``pipeline.helpers.solar_position_from_geometry``), so this sub-path
+        # can never drift from it again (issue #1090). ``full_coverage_at_zero``
+        # is the venetian TILT_AXIS semantic (``open_blocks_sun=False``); the
+        # tilt engine refines it into an angle-aware direction, because on the
+        # shipped MODE2 scale coverage is not monotonic in the percentage.
+        # ``_clamp_tilt`` runs after, on the already-integer value, so the band
+        # and the proportional remap see exactly what they always did.
+        return self._clamp_tilt(
+            self._tilt.round_toward_coverage(raw_tilt, full_coverage_at_zero=True)
+        )
 
     @property
     def direct_sun_valid(self) -> bool:

--- a/custom_components/adaptive_cover_pro/engine/covers/venetian.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/venetian.py
@@ -120,12 +120,12 @@ class VenetianCoverCalculation:
 
     def _compute_tilt(self) -> int:
         try:
-            raw_tilt = self._tilt.calculate_percentage()
+            raw_tilt = self._tilt.calculate_raw_percentage()
         except (ValueError, ZeroDivisionError):
             return self._tilt.config.h_def
         if math.isnan(raw_tilt):
             return self._clamp_tilt(0)
-        return self._clamp_tilt(round(raw_tilt))
+        return self._clamp_tilt(math.floor(raw_tilt))
 
     @property
     def direct_sun_valid(self) -> bool:

--- a/custom_components/adaptive_cover_pro/engine/covers/venetian.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/venetian.py
@@ -131,8 +131,15 @@ class VenetianCoverCalculation:
         # is the venetian TILT_AXIS semantic (``open_blocks_sun=False``); the
         # tilt engine refines it into an angle-aware direction, because on the
         # shipped MODE2 scale coverage is not monotonic in the percentage.
-        # ``_clamp_tilt`` runs after, on the already-integer value, so the band
-        # and the proportional remap see exactly what they always did.
+        # ``_clamp_tilt`` still runs after, and still on an integer — but not
+        # necessarily the SAME integer: above horizontal it now receives the
+        # ceil where it used to receive the floor, one point higher, which is
+        # precisely the difference this fix exists to make. Both the flat clamp
+        # and the proportional remap are monotonic, so a one-point-more-covering
+        # input yields a no-less-covering output. The sub-engine is built with
+        # ``apply_tilt_axis_limits=False``, so ``round_toward_coverage`` does not
+        # re-band on its way out either — ``_clamp_tilt`` stays the single band
+        # owner on this path.
         return self._clamp_tilt(
             self._tilt.round_toward_coverage(raw_tilt, full_coverage_at_zero=True)
         )

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -15,7 +15,6 @@ registry — see issue #463.
 from __future__ import annotations
 
 import dataclasses
-import math
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -134,11 +133,14 @@ def solar_position_from_geometry(
     Snapshot-free single source of truth for the solar branch, shared by the
     live pipeline (:func:`compute_solar_position`) and the forecast:
 
-    1. Calls ``cover.calculate_raw_percentage()`` (pure geometry, unrounded float).
-       Rounds toward full coverage (issue #978): floor() for blinds/tilt/venetian
-       (0%=closed=full coverage), ceil() for awnings (100%=extended=full coverage).
-       Requires *policy* to determine the coverage direction; falls back to
-       round() when policy is None.
+    1. Calls ``cover.calculate_raw_percentage()`` (pure geometry, unrounded float),
+       then quantizes toward full coverage (issue #978) via the engine's
+       ``round_toward_coverage`` hook. *policy* supplies the axis-level direction
+       — floor() when 0% is full coverage (blind/tilt/venetian), ceil() when 100%
+       is (awning) — and the engine refines it where coverage is not monotonic in
+       the percentage: a bi-directional slat axis rounds away from horizontal in
+       whichever arithmetic direction that is (issue #1090). Falls back to round()
+       when policy is None.
     2. Optionally quantizes into the configured number of discrete coverage
        levels (movement minimization — opt-in, rounds toward coverage).
     3. Floors at ``SOLAR_TRACKING_FLOOR_PCT`` (1 %) so open/close-only covers
@@ -159,8 +161,18 @@ def solar_position_from_geometry(
         # → round DOWN (floor) toward 0 to keep more coverage.
         # full_coverage_at_zero=False means 100% = extended = full coverage (awning)
         # → round UP (ceil) toward 100 to keep more coverage.
+        #
+        # That axis-level answer is only the whole story when coverage is
+        # MONOTONIC in the percentage. A bi-directional slat axis (MODE2 tilt,
+        # the shipped default) peaks in openness at horizontal and closes again
+        # past it, so the engine gets the final say via the polymorphic
+        # ``round_toward_coverage`` hook — see issue #1090. The engine, not this
+        # module, is the only object that knows the tilt scale, which keeps the
+        # cover-type branch out of the pipeline layer.
         full_coverage_at_zero = not policy.axes[0].open_blocks_sun
-        state = math.floor(pct) if full_coverage_at_zero else math.ceil(pct)
+        state = cover.round_toward_coverage(
+            pct, full_coverage_at_zero=full_coverage_at_zero
+        )
     else:
         state = int(round(pct))
     if minimize_movements and policy is not None:

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -14,6 +14,27 @@ from custom_components.adaptive_cover_pro.config_types import (
     TiltConfig,
     VerticalConfig,
 )
+from custom_components.adaptive_cover_pro.engine.covers.base import (
+    AdaptiveGeneralCover,
+)
+
+
+def attach_coverage_rounding(cover):
+    """Give a cover *double* the real base ``round_toward_coverage`` (#1090).
+
+    The solar branch asks the cover which way to quantise its raw percentage,
+    because only the engine knows whether coverage is monotonic in the
+    percentage (it is not on a bi-directional slat axis). Doubles standing in
+    for an ``AdaptiveGeneralCover`` therefore have to answer that call.
+
+    Binds the production implementation to the double rather than
+    reimplementing floor/ceil in test-land, so a double can never quietly
+    disagree with the rule it is standing in for. Returns *cover* for chaining.
+    """
+    cover.round_toward_coverage = AdaptiveGeneralCover.round_toward_coverage.__get__(
+        cover
+    )
+    return cover
 
 
 def make_daytime_sun_data() -> MagicMock:

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -17,11 +17,18 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.const import TILT_HORIZONTAL_DEG, TiltMode
+from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
     compute_solar_position,
     solar_position_from_geometry,
 )
-from tests.cover_helpers import build_tilt_cover
+from tests.cover_helpers import (
+    attach_coverage_rounding,
+    build_tilt_cover,
+    make_cover_config,
+    make_tilt_config,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -55,10 +62,12 @@ def _snapshot(
     floor behaviour can opt in.
     """
     return SimpleNamespace(
-        cover=SimpleNamespace(
-            direct_sun_valid=True,
-            calculate_percentage=lambda: int(round(calc_pct)),
-            calculate_raw_percentage=lambda: calc_pct,
+        cover=attach_coverage_rounding(
+            SimpleNamespace(
+                direct_sun_valid=True,
+                calculate_percentage=lambda: int(round(calc_pct)),
+                calculate_raw_percentage=lambda: calc_pct,
+            )
         ),
         config=_config(),
         policy=_policy(open_blocks_sun=open_blocks_sun),
@@ -149,9 +158,11 @@ class TestSolarPositionFromGeometryPrimitive:
     """Test the lower-level primitive that compute_solar_position delegates to."""
 
     def _cover(self, pct: float):
-        return SimpleNamespace(
-            calculate_percentage=lambda: int(round(pct)),
-            calculate_raw_percentage=lambda: pct,
+        return attach_coverage_rounding(
+            SimpleNamespace(
+                calculate_percentage=lambda: int(round(pct)),
+                calculate_raw_percentage=lambda: pct,
+            )
         )
 
     def test_blind_floor(self):
@@ -265,3 +276,191 @@ class TestTiltRawPercentage:
         """The tilt class carries its own override, not the base delegation."""
         cover = self._mode1_tilt()
         assert "calculate_raw_percentage" in type(cover).__dict__
+
+
+# ---------------------------------------------------------------------------
+# Tilt direction: coverage is NOT monotonic in the tilt percentage (issue #1090)
+# ---------------------------------------------------------------------------
+# MODE2 — the shipped default for tilt-only and venetian covers — maps the slat
+# angle 0–180° onto 0–100%, where 0° is closed downward, 90° is horizontal, and
+# 180° is closed upward. Horizontal is MAXIMUM openness, so coverage increases
+# as the angle moves away from 90° in EITHER direction, and the "round toward
+# full coverage" rule of #978 cannot be a plain floor.
+#
+# The tilt engine returns the EXACT grazing angle — the most-open slat angle
+# that still blocks the beam — so a quantisation that moves toward 90° always
+# leaks a sliver of direct sun.
+# ---------------------------------------------------------------------------
+
+
+def _tilt_cover(*, sol_elev: float, **tilt_overrides) -> AdaptiveTiltCover:
+    """Build a real ``AdaptiveTiltCover`` facing the sun at *sol_elev*.
+
+    ``slat_distance``/``depth`` are the shipped venetian defaults (2 cm spacing,
+    3 cm chord); with the sun on the window normal the solved slat angle sweeps
+    from well below horizontal at low elevations to well above it by midday.
+    """
+    return AdaptiveTiltCover(
+        logger=MagicMock(),
+        sol_azi=180.0,
+        sol_elev=sol_elev,
+        sun_data=MagicMock(),
+        config=make_cover_config(win_azi=180),
+        tilt_config=make_tilt_config(
+            slat_distance=0.02, depth=0.03, **{"mode": "mode2", **tilt_overrides}
+        ),
+    )
+
+
+def _tilt_solar_position(cover) -> int:
+    """Run *cover* through the tilt-only solar branch of the pipeline."""
+    return solar_position_from_geometry(
+        cover,
+        _config(),
+        minimize_movements=False,
+        max_coverage_steps=1,
+        # TILT_AXIS_PRIMARY (cover_tilt / cover_louvered_roof) declares
+        # open_blocks_sun=False, so the axis-level rule is "0 % is full
+        # coverage" — exactly the input that used to force a blanket floor().
+        policy=_policy(open_blocks_sun=False),
+        floor_active=False,
+    )
+
+
+class TestTiltMode2DirectionalRounding:
+    """MODE2 tilt quantises AWAY from horizontal, not always downward."""
+
+    @pytest.mark.parametrize(
+        ("sol_elev", "raw", "expected"),
+        [
+            # --- below horizontal: closing means a SMALLER angle → floor ---
+            (10.0, 32.757550, 32),  # solves 58.96°
+            (20.0, 39.561358, 39),  # solves 71.21°
+            (30.0, 47.075339, 47),  # solves 84.74°
+            # --- above horizontal: closing means a LARGER angle → ceil ---
+            (35.0, 51.055578, 52),  # solves 91.90°
+            (45.0, 59.374719, 60),  # solves 106.87°
+            (60.0, 72.515989, 73),  # solves 130.53°
+            (85.0, 95.371678, 96),  # solves 171.67°
+        ],
+    )
+    def test_quantises_away_from_horizontal(self, sol_elev, raw, expected):
+        cover = _tilt_cover(sol_elev=sol_elev)
+        assert cover.calculate_raw_percentage() == pytest.approx(raw, abs=1e-5)
+        assert _tilt_solar_position(cover) == expected
+
+    def test_floor_at_the_boundary_would_command_exactly_horizontal(self):
+        """The worst case: floor() lands the slats on 90.00° = maximum openness.
+
+        At 34.4° elevation the engine solves 91.03° — just past horizontal. The
+        raw percentage is 50.57 %, so flooring gives 50 %, which on the MODE2
+        0–180° scale is *precisely* the horizontal slat: the single most
+        sun-permissive angle the cover can hold, commanded in the name of
+        conservative rounding.
+        """
+        cover = _tilt_cover(sol_elev=34.4)
+        raw = cover.calculate_raw_percentage()
+        assert raw == pytest.approx(50.570998, abs=1e-5)
+
+        max_degrees = float(TiltMode.MODE2.max_degrees)
+        assert math.floor(raw) / 100.0 * max_degrees == pytest.approx(
+            TILT_HORIZONTAL_DEG
+        )
+
+        assert _tilt_solar_position(cover) == 51
+
+    @pytest.mark.parametrize(
+        "sol_elev", [5.0, 12.5, 21.0, 29.0, 34.4, 37.5, 44.0, 52.0, 68.0, 79.0, 88.0]
+    )
+    def test_commanded_angle_is_never_closer_to_horizontal_than_the_solve(
+        self, sol_elev
+    ):
+        """Invariant behind the whole fix, swept across the tracking day.
+
+        The solve is the most-open blocking angle, so the commanded integer
+        percentage must sit at least as far from horizontal as the solve does.
+        Any quantisation toward 90° violates this and lets direct sun through.
+        """
+        cover = _tilt_cover(sol_elev=sol_elev)
+        exact_angle = cover.calculate_position()
+        max_degrees = float(TiltMode.MODE2.max_degrees)
+        commanded_angle = _tilt_solar_position(cover) / 100.0 * max_degrees
+
+        assert abs(commanded_angle - TILT_HORIZONTAL_DEG) >= abs(
+            exact_angle - TILT_HORIZONTAL_DEG
+        )
+
+    def test_mode1_still_floors_everywhere(self):
+        """#978 regression guard: MODE1 spans 0–90°, so horizontal is 100 %.
+
+        Every reachable MODE1 percentage is therefore at or below the pivot and
+        the away-from-horizontal rule collapses to the plain floor MODE1 always
+        had — the direction must fall out of the geometry, not a mode branch.
+        """
+        cover = _tilt_cover(sol_elev=45.0, mode="mode1")
+        cover.calculate_position = MagicMock(return_value=41.0)
+
+        raw = cover.calculate_raw_percentage()
+        assert raw == pytest.approx(41.0 / 90.0 * 100.0)
+        assert _tilt_solar_position(cover) == 45  # round() would give 46
+
+
+class TestTiltSpecifyAnglesDirectionalRounding:
+    """``specify_angles`` calibration keeps the away-from-horizontal rule (#1090).
+
+    The endpoint mapping is affine, so "away from horizontal in angle space" is
+    "away from the percentage that represents horizontal" whichever way the
+    calibration runs. An inverted calibration (``angle_0`` above ``angle_100``)
+    therefore flips which arithmetic direction is conservative, and the pivot
+    handles that without a sign test at the call site.
+    """
+
+    def test_forward_calibration(self):
+        """0 % = 0°, 100 % = 180° — the pivot lands on 50 %, same as MODE2."""
+        below = _tilt_cover(
+            sol_elev=30.0, mode="specify_angles", angle_0=0.0, angle_100=180.0
+        )
+        assert below.calculate_raw_percentage() == pytest.approx(47.075339, abs=1e-5)
+        assert _tilt_solar_position(below) == 47
+
+        above = _tilt_cover(
+            sol_elev=45.0, mode="specify_angles", angle_0=0.0, angle_100=180.0
+        )
+        assert above.calculate_raw_percentage() == pytest.approx(59.374719, abs=1e-5)
+        assert _tilt_solar_position(above) == 60
+
+    def test_inverted_calibration_reverses_the_arithmetic_direction(self):
+        """0 % = 180°, 100 % = 0° — a higher percentage now means a LOWER angle.
+
+        The pivot is still 50 %, but the conservative arithmetic swaps: the
+        84.74° solve sits ABOVE the pivot here (52.92 %) and must round UP to
+        stay below horizontal, while the 106.87° solve sits BELOW it (40.63 %)
+        and must round DOWN to stay above horizontal.
+        """
+        below_horizontal = _tilt_cover(
+            sol_elev=30.0, mode="specify_angles", angle_0=180.0, angle_100=0.0
+        )
+        assert below_horizontal.calculate_position() == pytest.approx(84.7356, abs=1e-4)
+        assert below_horizontal.calculate_raw_percentage() == pytest.approx(
+            52.924661, abs=1e-5
+        )
+        assert _tilt_solar_position(below_horizontal) == 53  # 84.60°, floor → 86.40°
+
+        above_horizontal = _tilt_cover(
+            sol_elev=45.0, mode="specify_angles", angle_0=180.0, angle_100=0.0
+        )
+        assert above_horizontal.calculate_position() == pytest.approx(
+            106.8745, abs=1e-4
+        )
+        assert above_horizontal.calculate_raw_percentage() == pytest.approx(
+            40.625281, abs=1e-5
+        )
+        assert _tilt_solar_position(above_horizontal) == 40  # 108.00°, ceil → 106.20°
+
+    def test_degenerate_calibration_falls_back_to_the_axis_rule(self):
+        """``angle_0 == angle_100`` has no pivot; the base floor/ceil still applies."""
+        cover = _tilt_cover(
+            sol_elev=45.0, mode="specify_angles", angle_0=90.0, angle_100=90.0
+        )
+        assert cover.calculate_raw_percentage() == 0.0
+        assert _tilt_solar_position(cover) == 0

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -20,6 +20,13 @@ the nearest integer. Always-on, no opt-in flag, and decided in two layers:
    it — which subsumes the monotonic rule rather than special-casing it, since
    MODE1's pivot is 100 % and everything below it still floors.
 
+That pivot is computed, not tabulated: it is ``TILT_HORIZONTAL_DEG`` pushed
+through the engine's own angle→percentage map. The louvered roof is what proves
+the difference matters — a configured ``max_slat_angle`` puts the pivot at 75 %
+(120°) or a fractional 64.2857 % (140°), so a hardcoded 50 %/100 % would round
+hundreds of real solves the wrong way. See
+``TestLouveredRoofPivotFollowsMaxSlatAngle``.
+
 So the direction is never a cover-type string test, and never a blanket
 ``floor()`` for "blind / tilt / venetian". The pipeline layer supplies the axis
 semantic; only the engine knows the tilt scale, so only the engine can say which
@@ -38,6 +45,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
 from custom_components.adaptive_cover_pro.const import (
     TILT_HORIZONTAL_DEG,
     VENETIAN_TILT_TRANSFORM_CLAMP,
@@ -45,6 +53,9 @@ from custom_components.adaptive_cover_pro.const import (
     TiltMode,
 )
 from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
+from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
+    AdaptiveLouveredRoofCover,
+)
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
     compute_solar_position,
     solar_position_from_geometry,
@@ -338,6 +349,32 @@ def _tilt_cover(*, sol_elev: float, **tilt_overrides) -> AdaptiveTiltCover:
     )
 
 
+def _louvered_cover(
+    *, sol_elev: float, sol_azi: float = 180.0, max_slat_angle: float = 0.0
+) -> AdaptiveLouveredRoofCover:
+    """Build a flat-roof ``AdaptiveLouveredRoofCover`` at the given sun position.
+
+    ``roof_pitch=0`` is the shipped pergola default, and the pitch at which
+    ``_resolve_slat_angle`` drives the slats toward maximum openness: near-side
+    sun (``sol_azi=180``, on the window normal) is realized ABOVE horizontal as
+    ``180° − θ``, far-side sun (``sol_azi=0``) BELOW it as ``θ``. That is what
+    puts real solves on both sides of the pivot on one cover type.
+
+    Same slat geometry as :func:`_tilt_cover` so the two are comparable; only
+    ``max_slat_angle`` — the whole reason the pivot denominator is a
+    polymorphic hook rather than a constant — varies.
+    """
+    return AdaptiveLouveredRoofCover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sun_data=MagicMock(),
+        config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
+        tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+        roof_config=LouveredRoofConfig(roof_pitch=0.0, max_slat_angle=max_slat_angle),
+    )
+
+
 def _tilt_solar_position(cover) -> int:
     """Run *cover* through the tilt-only solar branch of the pipeline."""
     return solar_position_from_geometry(
@@ -435,7 +472,45 @@ class TestTiltMode2DirectionalRounding:
         assert cover.round_toward_coverage(45.6, full_coverage_at_zero=True) == 45
         assert cover.round_toward_coverage(45.6, full_coverage_at_zero=False) == 46
 
-    def test_mode1_still_floors_everywhere(self):
+    def test_degenerate_scale_leaves_no_raw_percentage_either(self):
+        """A scale with no pivot has no raw percentage either.
+
+        The pivot and the solved position go through ONE map, so a scale that
+        map cannot express is a scale neither of them can express.
+        ``VenetianCoverCalculation._compute_tilt`` already catches
+        ``ZeroDivisionError`` and falls back to the default position, which is
+        what a zero denominator has always produced on this path.
+
+        ``calculate_position`` is stubbed because it divides by the same
+        denominator while building its diagnostics trace, and would otherwise
+        raise first — making this pass for the wrong reason.
+        """
+        cover = _tilt_cover(sol_elev=45.0)
+        cover._effective_max_degrees = MagicMock(return_value=0.0)
+        cover.calculate_position = MagicMock(return_value=45.0)
+
+        with pytest.raises(ZeroDivisionError):
+            cover.calculate_raw_percentage()
+
+    @pytest.mark.parametrize(
+        ("solved_angle", "raw", "expected"),
+        [
+            # 45.5556 % — the #978 floor-vs-round anchor (round() would say 46).
+            # It sits below BOTH the real MODE1 pivot and the 50 % one a MODE2
+            # denominator would produce, so on its own it cannot see the
+            # denominator at all.
+            (41.0, 45.555556, 45),
+            # 91.0889 % — ABOVE 50 %, which is the case that pins the
+            # DENOMINATOR. It only floors while ``_horizontal_percentage``
+            # divides ``TILT_HORIZONTAL_DEG`` by THIS engine's
+            # ``_effective_max_degrees()`` (90 → a 100 % pivot). Hardcode the
+            # MODE2 180° instead and the pivot drops to 50 %, putting this
+            # percentage above it and turning the floor into a ceil (92) —
+            # commanding a slat one point CLOSER to horizontal than the solve.
+            (81.98, 91.088889, 91),
+        ],
+    )
+    def test_mode1_still_floors_everywhere(self, solved_angle, raw, expected):
         """#978 regression guard: MODE1 spans 0–90°, so horizontal is 100 %.
 
         Every reachable MODE1 percentage is therefore at or below the pivot and
@@ -443,11 +518,94 @@ class TestTiltMode2DirectionalRounding:
         had — the direction must fall out of the geometry, not a mode branch.
         """
         cover = _tilt_cover(sol_elev=45.0, mode="mode1")
-        cover.calculate_position = MagicMock(return_value=41.0)
+        cover.calculate_position = MagicMock(return_value=solved_angle)
 
-        raw = cover.calculate_raw_percentage()
-        assert raw == pytest.approx(41.0 / 90.0 * 100.0)
-        assert _tilt_solar_position(cover) == 45  # round() would give 46
+        assert cover.calculate_raw_percentage() == pytest.approx(raw, abs=1e-5)
+        assert _tilt_solar_position(cover) == expected
+
+
+class TestLouveredRoofPivotFollowsMaxSlatAngle:
+    """A configured ``max_slat_angle`` moves the pivot off 50 %/100 % (#1090).
+
+    ``AdaptiveLouveredRoofCover`` overrides ``_effective_max_degrees`` so a
+    pergola drive whose mechanical travel is neither 90° nor 180° maps its OWN
+    ceiling onto 100 %. That override is the entire reason
+    ``_horizontal_percentage`` divides ``TILT_HORIZONTAL_DEG`` by a polymorphic
+    hook instead of a literal: at ``max_slat_angle = 120`` horizontal is 75 %,
+    so every percentage in ``(50, 75)`` has to round DOWN — the exact opposite
+    of what a hardcoded MODE2 denominator would say. Neither the tilt-only nor
+    the venetian suite can see that, because both of their pivots are whole
+    numbers fixed by the mode.
+    """
+
+    @pytest.mark.parametrize(
+        ("max_slat_angle", "pivot"),
+        [
+            (0.0, 50.0),  # sentinel → the tilt mode's max, i.e. the MODE2 pivot
+            (90.0, 100.0),  # coincides with MODE1's pivot
+            (120.0, 75.0),
+            (140.0, 90.0 / 140.0 * 100.0),  # fractional — no whole-% pivot here
+            (160.0, 56.25),
+        ],
+    )
+    def test_pivot_is_the_horizontal_slat_on_the_configured_scale(
+        self, max_slat_angle, pivot
+    ):
+        cover = _louvered_cover(sol_elev=45.0, max_slat_angle=max_slat_angle)
+        assert cover._horizontal_percentage() == pytest.approx(pivot)
+
+    @pytest.mark.parametrize(
+        ("max_slat_angle", "sol_azi", "position", "raw", "expected"),
+        [
+            # --- below the pivot but ABOVE 50 % → floor ---------------------
+            # Far-side sun realizes the cut-off BELOW horizontal, so the slat is
+            # tilted down and closing means a smaller percentage. These are the
+            # cases a 50 % pivot gets wrong: it would ceil them to 69 / 52,
+            # landing one point CLOSER to horizontal than the exact solve.
+            (120.0, 0.0, 81.975679, 68.313066, 68),
+            (160.0, 0.0, 81.975679, 51.234800, 51),
+            # --- above the pivot → ceil -------------------------------------
+            # Near-side sun opens past horizontal (``180° − θ``), so closing now
+            # means a larger percentage.
+            (120.0, 180.0, 98.024321, 81.686934, 82),
+        ],
+    )
+    def test_quantises_away_from_the_configured_pivot(
+        self, max_slat_angle, sol_azi, position, raw, expected
+    ):
+        cover = _louvered_cover(
+            sol_elev=70.0, sol_azi=sol_azi, max_slat_angle=max_slat_angle
+        )
+        assert cover.calculate_position() == pytest.approx(position, abs=1e-5)
+        assert cover.calculate_raw_percentage() == pytest.approx(raw, abs=1e-5)
+        assert _tilt_solar_position(cover) == expected
+
+    def test_a_percentage_exactly_on_the_pivot_floors(self):
+        """The tie is reachable in production, so the ``>`` boundary is pinned.
+
+        ``_resolve_slat_angle`` returns exactly ``TILT_HORIZONTAL_DEG`` whenever
+        the slats self-block (``cutoff >= 90°``) — on this geometry, every
+        elevation up to ~62°. With ``max_slat_angle = 140`` the pivot is the
+        fractional 64.2857 %, and the raw percentage is that same expression, so
+        ``pct == horizontal_pct`` holds BIT-exactly rather than approximately.
+
+        Neither direction is more conservative at the tie: 64 % is 89.6° and
+        65 % is 91.0°, both farther from horizontal than the 90.0° solve. So the
+        tie only has to be STABLE, not correct — it is pinned here so relaxing
+        ``>`` to ``>=`` cannot pass unnoticed.
+        """
+        cover = _louvered_cover(sol_elev=45.0, max_slat_angle=140)
+        solve = cover.calculate_position()
+
+        assert solve == TILT_HORIZONTAL_DEG
+        assert cover.calculate_raw_percentage() == cover._horizontal_percentage()
+
+        assert _tilt_solar_position(cover) == 64
+        for candidate in (64, 65):
+            commanded = candidate / 100.0 * 140.0
+            assert abs(commanded - TILT_HORIZONTAL_DEG) >= abs(
+                solve - TILT_HORIZONTAL_DEG
+            )
 
 
 class TestTiltSpecifyAnglesDirectionalRounding:

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -1,12 +1,33 @@
-"""Tests for directional (conservative) position rounding (issue #978).
+"""Tests for directional (conservative) position rounding (issues #978, #1090).
 
 Conservative rounding biases the solar position toward full coverage instead of
-nearest integer:
-  - Blind / tilt / venetian  (0% = closed = full coverage): floor()
-  - Awning                   (100% = extended = full coverage): ceil()
+the nearest integer. Always-on, no opt-in flag, and decided in two layers:
 
-This is now always-on behavior (no opt-in flag) keyed off the policy's
-``open_blocks_sun`` axis attribute.
+1. **The policy states the axis-level direction.** ``CoverAxis.open_blocks_sun``
+   says which END of the 0–100 % travel blocks the sun, and
+   ``solar_position_from_geometry`` turns that into ``full_coverage_at_zero``:
+   True for a blind / tilt / venetian axis (0 % is the covering end), False for
+   an awning (100 % is). That answer is complete only where coverage is
+   MONOTONIC in the percentage.
+2. **The engine refines it where coverage is not monotonic.** The percentage is
+   handed to ``AdaptiveGeneralCover.round_toward_coverage``, whose base
+   implementation is exactly the monotonic rule — ``floor()`` when
+   ``full_coverage_at_zero``, ``ceil()`` otherwise. ``AdaptiveTiltCover``
+   overrides it, because a bi-directional slat is not monotonic: on MODE2 (the
+   shipped tilt/venetian default) 0° is closed downward, 90° is horizontal and
+   180° is closed upward, so openness PEAKS mid-travel. That axis rounds away
+   from the percentage representing horizontal — up above the pivot, down below
+   it — which subsumes the monotonic rule rather than special-casing it, since
+   MODE1's pivot is 100 % and everything below it still floors.
+
+So the direction is never a cover-type string test, and never a blanket
+``floor()`` for "blind / tilt / venetian". The pipeline layer supplies the axis
+semantic; only the engine knows the tilt scale, so only the engine can say which
+arithmetic direction is conservative on it.
+
+``AdaptiveTiltCover`` additionally re-bands the quantised integer, because the
+tilt-only path applies ``[min_tilt, max_tilt]`` to the float BEFORE this rounding
+runs — see ``TestTiltOnlyBandSurvivesTheQuantisation``.
 """
 
 from __future__ import annotations
@@ -17,7 +38,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from custom_components.adaptive_cover_pro.const import TILT_HORIZONTAL_DEG, TiltMode
+from custom_components.adaptive_cover_pro.const import (
+    TILT_HORIZONTAL_DEG,
+    VENETIAN_TILT_TRANSFORM_CLAMP,
+    VENETIAN_TILT_TRANSFORM_PROPORTIONAL,
+    TiltMode,
+)
 from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
     compute_solar_position,
@@ -390,6 +416,25 @@ class TestTiltMode2DirectionalRounding:
             exact_angle - TILT_HORIZONTAL_DEG
         )
 
+    def test_degenerate_scale_falls_back_to_the_axis_rule(self):
+        """A zero-width legacy scale has no pivot; the base floor/ceil stands.
+
+        Unreachable from config — the tilt modes are 90°/180° and the louvered
+        roof's ``max_slat_angle`` override is bounded away from zero — but
+        ``_horizontal_percentage`` is the one place that division happens, so the
+        guard is exercised head-on instead of left as an untested branch. It is
+        the legacy/custom-max twin of the ``angle_0 == angle_100`` guard covered
+        by ``TestTiltSpecifyAnglesDirectionalRounding``.
+        """
+        cover = _tilt_cover(sol_elev=45.0)
+        cover._effective_max_degrees = MagicMock(return_value=0.0)
+
+        assert cover._horizontal_percentage() is None
+        # With no pivot the caller's axis-level answer is all there is, so the
+        # two directions must now actually differ.
+        assert cover.round_toward_coverage(45.6, full_coverage_at_zero=True) == 45
+        assert cover.round_toward_coverage(45.6, full_coverage_at_zero=False) == 46
+
     def test_mode1_still_floors_everywhere(self):
         """#978 regression guard: MODE1 spans 0–90°, so horizontal is 100 %.
 
@@ -464,3 +509,109 @@ class TestTiltSpecifyAnglesDirectionalRounding:
         )
         assert cover.calculate_raw_percentage() == 0.0
         assert _tilt_solar_position(cover) == 0
+
+
+class TestTiltOnlyBandSurvivesTheQuantisation:
+    """The quantised tilt stays inside ``[min_tilt, max_tilt]`` (issue #1090).
+
+    The tilt-only / louvered-roof path applies the band INSIDE
+    ``calculate_raw_percentage`` — before the solar branch quantises — and
+    ``_apply_tilt_axis_limits`` deliberately hands back the exact float whenever
+    ``round()`` of it is still in band, to preserve precision. That prediction
+    stopped matching the quantiser once the tilt axis started rounding away from
+    horizontal: a raw percentage inside ``(max_tilt, max_tilt + 0.5)`` passes the
+    band check and is then pushed one point past the cap by ``ceil``. The mirror
+    window ``(min_tilt - 0.5, min_tilt)`` escapes downward under ``floor``.
+
+    Venetian never had either problem — its ``_clamp_tilt`` runs after the
+    rounding — so the guard belongs on the integer this engine hands out rather
+    than mirrored at each call site.
+    """
+
+    def test_raw_percentage_can_sit_just_past_the_cap(self):
+        """Pre-condition: the pre-quantisation band check cannot see 55.003 %.
+
+        At 39.81° the MODE2 solve is 99.005°, i.e. 55.0029 % — above ``max_tilt``
+        but under ``max_tilt + 0.5``, so ``int(round(pct))`` is exactly the cap
+        and the band leaves the float untouched.
+        """
+        cover = _tilt_cover(sol_elev=39.81, max_tilt=55)
+        raw = cover.calculate_raw_percentage()
+        assert raw == pytest.approx(55.002900, abs=1e-5)
+        assert 55 < raw < 55.5
+        assert int(round(raw)) == 55
+
+    @pytest.mark.parametrize(
+        ("transform", "expected"),
+        [
+            # clamp: ceil(55.0029) = 56 must be pulled back onto the cap.
+            (VENETIAN_TILT_TRANSFORM_CLAMP, 55),
+            # proportional: the remap already lands the demand inside [0, 55]
+            # (round(55 × 0.55) = 30) and re-banding an in-band value is a no-op,
+            # so this path is unchanged by the guard.
+            (VENETIAN_TILT_TRANSFORM_PROPORTIONAL, 30),
+        ],
+    )
+    def test_ceil_cannot_command_past_max_tilt(self, transform, expected):
+        cover = _tilt_cover(sol_elev=39.81, max_tilt=55, tilt_transform=transform)
+        assert _tilt_solar_position(cover) == expected
+
+    def test_raw_percentage_can_sit_just_under_the_floor(self):
+        """Pre-condition mirror: 44.7546 % rounds to the ``min_tilt`` of 45."""
+        cover = _tilt_cover(sol_elev=27.0, min_tilt=45)
+        raw = cover.calculate_raw_percentage()
+        assert raw == pytest.approx(44.754618, abs=1e-5)
+        assert 44.5 < raw < 45
+        assert int(round(raw)) == 45
+
+    @pytest.mark.parametrize(
+        ("transform", "expected"),
+        [
+            # clamp: floor(44.7546) = 44 must be lifted back onto the floor.
+            (VENETIAN_TILT_TRANSFORM_CLAMP, 45),
+            # proportional: round(45 + 55 × 0.45) = 70, already inside [45, 100].
+            (VENETIAN_TILT_TRANSFORM_PROPORTIONAL, 70),
+        ],
+    )
+    def test_floor_cannot_command_below_min_tilt(self, transform, expected):
+        cover = _tilt_cover(sol_elev=27.0, min_tilt=45, tilt_transform=transform)
+        assert _tilt_solar_position(cover) == expected
+
+    @pytest.mark.parametrize(
+        "transform",
+        [VENETIAN_TILT_TRANSFORM_CLAMP, VENETIAN_TILT_TRANSFORM_PROPORTIONAL],
+    )
+    @pytest.mark.parametrize(
+        ("min_tilt", "max_tilt"), [(0, 100), (0, 55), (45, 100), (45, 55)]
+    )
+    @pytest.mark.parametrize(
+        "sol_elev", [5.0, 21.0, 27.0, 34.4, 39.81, 45.0, 68.0, 88.0]
+    )
+    def test_commanded_tilt_always_lands_inside_the_band(
+        self, sol_elev, min_tilt, max_tilt, transform
+    ):
+        """Swept invariant: no band, elevation, or transform escapes by a point."""
+        cover = _tilt_cover(
+            sol_elev=sol_elev,
+            min_tilt=min_tilt,
+            max_tilt=max_tilt,
+            tilt_transform=transform,
+        )
+        assert min_tilt <= _tilt_solar_position(cover) <= max_tilt
+
+    def test_default_band_is_untouched(self):
+        """0/100 is a no-op — the guard must not perturb the shipped default."""
+        for sol_elev, expected in ((27.0, 44), (34.4, 51), (39.81, 56), (45.0, 60)):
+            assert _tilt_solar_position(_tilt_cover(sol_elev=sol_elev)) == expected
+
+    def test_venetian_ownership_flag_still_suppresses_the_band(self):
+        """Venetian's sub-engine owns no band — ``_clamp_tilt`` applies it after.
+
+        The composed engine is built with ``apply_tilt_axis_limits=False``, which
+        must keep the post-quantisation guard out of the way exactly as it keeps
+        the pre-quantisation transform out of the way; otherwise the band (and,
+        on the proportional transform, the remap) would be applied twice.
+        """
+        cover = _tilt_cover(sol_elev=39.81, max_tilt=55)
+        cover.apply_tilt_axis_limits = False
+        assert cover.round_toward_coverage(55.0029, full_coverage_at_zero=True) == 56

--- a/tests/test_coverage_steps.py
+++ b/tests/test_coverage_steps.py
@@ -109,6 +109,7 @@ from types import SimpleNamespace  # noqa: E402
 from custom_components.adaptive_cover_pro.pipeline.helpers import (  # noqa: E402
     compute_solar_position,
 )
+from tests.cover_helpers import attach_coverage_rounding  # noqa: E402
 
 
 def _snapshot(*, calc_pct, minimize, steps, open_blocks_sun=False):
@@ -121,10 +122,12 @@ def _snapshot(*, calc_pct, minimize, steps, open_blocks_sun=False):
     )
     policy = SimpleNamespace(axes=[SimpleNamespace(open_blocks_sun=open_blocks_sun)])
     return SimpleNamespace(
-        cover=SimpleNamespace(
-            direct_sun_valid=True,
-            calculate_percentage=lambda: int(round(calc_pct)),
-            calculate_raw_percentage=lambda: calc_pct,
+        cover=attach_coverage_rounding(
+            SimpleNamespace(
+                direct_sun_valid=True,
+                calculate_percentage=lambda: int(round(calc_pct)),
+                calculate_raw_percentage=lambda: calc_pct,
+            )
         ),
         config=config,
         policy=policy,

--- a/tests/test_engine/test_venetian_engine.py
+++ b/tests/test_engine/test_venetian_engine.py
@@ -463,9 +463,14 @@ class TestVenetianMode2DirectionalRounding:
         The 45° solve raw is 59.3747 %, so the conservative direction now hands
         ``_clamp_tilt`` a 60 where it used to get a 59. Both the flat clamp and
         the proportional remap are monotonic, so the band edge is the ceiling
-        either way — the up-rounding cannot escape ``max_tilt`` and cannot skip
-        past ``min_tilt``. ``max_tilt=60`` is the interesting case: the ceil
-        result sits exactly ON the cap.
+        either way — on THIS path the up-rounding cannot escape ``max_tilt`` and
+        cannot skip past ``min_tilt``. ``max_tilt=60`` is the interesting case:
+        the ceil result sits exactly ON the cap.
+
+        The guarantee is the ordering, not the rounding: the tilt-only path
+        bands the float BEFORE quantising and had to grow its own
+        post-quantisation guard to get here — see
+        ``tests/test_conservative_rounding.py::TestTiltOnlyBandSurvivesTheQuantisation``.
         """
         from custom_components.adaptive_cover_pro.const import (
             VENETIAN_TILT_TRANSFORM_PROPORTIONAL,
@@ -731,6 +736,35 @@ class TestMinTiltFloor:
             logger=_make_logger(),
         )
         calc._tilt.calculate_raw_percentage = Mock(return_value=math.nan)
+        assert calc.calculate_dual().tilt == floor
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_nan_survives_the_real_raw_percentage_seam(self, mock_datetime):
+        """The composed sub-engine's float seam stays NaN-transparent (#1090).
+
+        Every sibling guard mocks ``calculate_raw_percentage`` itself, so nothing
+        pinned the seam UNDERNEATH it. ``_apply_tilt_axis_limits`` rounds the
+        float to predict the banded integer, and ``round()`` raises on NaN — so
+        if that round ran before the ``apply_tilt_axis_limits=False``
+        pass-through, a NaN would surface as a ValueError and ``_compute_tilt``
+        would fall to ``h_def`` instead of the clamped 0 its ``isnan`` branch
+        promises. ``h_def`` is set well away from the floor here so the two
+        outcomes cannot be confused.
+        """
+        mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        floor = 15
+        calc = VenetianCoverCalculation(
+            config=make_cover_config(win_azi=180, h_def=90),
+            vert_config=make_vertical_config(),
+            tilt_config=make_tilt_config(min_tilt=floor),
+            sun_data=_make_sun_data(),
+            sol_azi=180.0,
+            sol_elev=45.0,
+            logger=_make_logger(),
+        )
+        calc._tilt.calculate_position = Mock(return_value=math.nan)
+
+        assert math.isnan(calc._tilt.calculate_raw_percentage())
         assert calc.calculate_dual().tilt == floor
 
 

--- a/tests/test_engine/test_venetian_engine.py
+++ b/tests/test_engine/test_venetian_engine.py
@@ -137,16 +137,25 @@ class TestVenetianCoverCalculation:
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_calculate_dual_delegates_to_tilt(self, mock_datetime):
-        """Tilt matches floor(AdaptiveTiltCover.calculate_raw_percentage()) (issue #1090)."""
+        """Dual-path tilt equals the standalone tilt engine's quantised angle.
+
+        The fixture deliberately uses the shipped venetian slat geometry (2 cm
+        spacing over a 3 cm chord) in the shipped MODE2, at an elevation whose
+        cut-off solve is genuinely fractional (106.87° → 59.3747 %). The old
+        fixture used ``make_tilt_config()``'s 3 cm/2 cm MODE1 defaults, whose
+        discriminant is negative at every elevation here, so the engine short-
+        circuited to 0.0 and the assertion read ``0 == 0`` — it would have
+        passed against a ``_compute_tilt`` that returned a hardcoded zero.
+        """
         from custom_components.adaptive_cover_pro.calculation import AdaptiveTiltCover
 
         mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
 
         logger = _make_logger()
         sun_data = _make_sun_data()
-        config = make_cover_config()
+        config = make_cover_config(win_azi=180)
         vert_config = make_vertical_config()
-        tilt_config = make_tilt_config()
+        tilt_config = make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2")
 
         sol_azi = 180.0
         sol_elev = 45.0
@@ -171,32 +180,31 @@ class TestVenetianCoverCalculation:
             tilt_config=tilt_config,
         )
 
+        raw_tilt = standalone.calculate_raw_percentage()
+        # Guard the fixture itself: a whole number (or the negative-discriminant
+        # 0.0) would make every rounding direction agree and the test inert.
+        assert raw_tilt == pytest.approx(59.374719, abs=1e-5)
+        assert raw_tilt % 1 != 0
+
         result = calc.calculate_dual()
 
-        # Tilt percentage may be NaN (invalid geometry) — check both paths
-        try:
-            raw_tilt = standalone.calculate_raw_percentage()
-            if math.isnan(raw_tilt):
-                expected_tilt = 0
-            else:
-                expected_tilt = math.floor(raw_tilt)
-        except (ValueError, ZeroDivisionError):
-            expected_tilt = config.h_def
-
-        assert result.tilt == expected_tilt
+        # 59.3747 % of 180° is 106.87°, ABOVE horizontal, so the conservative
+        # direction is up: floor() would walk the slats back toward 90° (open).
+        assert result.tilt == math.ceil(raw_tilt) == 60
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_compute_tilt_floors_fractional_raw_percentage(self, mock_datetime):
-        """A fractional raw tilt rounds DOWN, not to nearest (issue #1090).
+        """A fractional below-horizontal raw tilt rounds DOWN (issue #1090).
 
         Mirrors ``TestTiltRawPercentage``'s mode1 fixture in
         ``test_conservative_rounding.py`` (41° in a 0-90° range -> 45.5556%):
-        ``round()`` would give 46, but ``TILT_AXIS.open_blocks_sun=False``
-        means 0% is full coverage, so the conservative/safe direction is to
-        round down. Before the #1090 fix, ``_compute_tilt`` called
-        ``calculate_percentage()`` + ``round()`` and returned 46 here; the
-        fix calls ``calculate_raw_percentage()`` + ``math.floor()`` and must
-        return 45.
+        ``round()`` would give 46, but the slat angle is below horizontal, so
+        the conservative/safe direction is to round down toward closed.
+
+        Before the #1090 fix, ``_compute_tilt`` called ``calculate_percentage()``
+        + ``round()`` — it never consulted ``calculate_raw_percentage`` at all,
+        so this mock was inert and the real MODE1 geometry (a negative
+        discriminant here) returned 0.
         """
         mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
         calc = _make_venetian(sol_azi=180.0, sol_elev=45.0)
@@ -205,7 +213,6 @@ class TestVenetianCoverCalculation:
         result = calc.calculate_dual()
 
         assert result.tilt == 45
-        assert result.tilt != 46
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_direct_sun_valid_delegation(self, mock_datetime):
@@ -292,7 +299,14 @@ class TestVenetianTiltSafetyMargin:
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_safety_margin_delegates_to_tilt_engine(self, mock_datetime):
-        """Dual-path tilt equals the standalone tilt engine with the same margin."""
+        """Dual-path tilt equals the standalone tilt engine with the same margin.
+
+        Runs in the shipped MODE2 so the margin-adjusted raw (45.5458 %) has a
+        fraction above a half: ``round()`` would give 46 and only ``floor()``
+        gives 45. Under the old MODE1 fixture the raw was 91.0916 %, where
+        floor, round and the pre-#978 behaviour all agreed on 91 — the
+        assertion could not see a rounding direction at all.
+        """
         from custom_components.adaptive_cover_pro.calculation import AdaptiveTiltCover
 
         mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
@@ -302,7 +316,7 @@ class TestVenetianTiltSafetyMargin:
         vert_config = make_vertical_config()
         # Extreme geometry (low elev, high gamma) so the margin actually bites.
         tilt_config = make_tilt_config(
-            slat_distance=0.02, depth=0.03, mode="mode1", safety_margin=0.5
+            slat_distance=0.02, depth=0.03, mode="mode2", safety_margin=0.5
         )
         sol_azi, sol_elev = 255.0, 8.0
 
@@ -323,9 +337,11 @@ class TestVenetianTiltSafetyMargin:
             config=config,
             tilt_config=tilt_config,
         )
-        assert calc.calculate_dual().tilt == math.floor(
-            standalone.calculate_raw_percentage()
-        )
+        raw = standalone.calculate_raw_percentage()
+        # 81.98° is below horizontal, so the conservative direction is down.
+        assert raw == pytest.approx(45.545797, abs=1e-5)
+        assert round(raw) == 46, "fixture must distinguish floor() from round()"
+        assert calc.calculate_dual().tilt == math.floor(raw) == 45
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_safety_margin_respects_max_tilt_clamp(self, mock_datetime):
@@ -364,6 +380,126 @@ class TestVenetianTiltSafetyMargin:
             uncapped_tilt > cap
         ), f"test setup: margin-adjusted tilt {uncapped_tilt} must exceed cap {cap}"
         assert capped.calculate_dual().tilt == cap
+
+
+class TestVenetianMode2DirectionalRounding:
+    """MODE2 dual-axis tilt quantises away from horizontal (issue #1090).
+
+    MODE2 is the shipped venetian default (``CONF_TILT_MODE`` default
+    ``"mode2"``, reached through ``geometry_venetian_schema`` →
+    ``geometry_tilt_schema``). On that scale 50 % is the horizontal slat —
+    maximum openness — so a blanket ``floor()`` walks any above-horizontal
+    solve back toward open and leaks the sliver of direct sun the conservative
+    rounding exists to block.
+
+    Uses the shipped slat geometry (2 cm spacing over a 3 cm chord) and a real
+    solve, not a mocked scalar, so the fixture pins the direction against the
+    actual engine output rather than an assumed one.
+    """
+
+    def _mode2(self, sol_elev: float) -> VenetianCoverCalculation:
+        return VenetianCoverCalculation(
+            config=make_cover_config(win_azi=180),
+            vert_config=make_vertical_config(),
+            tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+            sun_data=_make_sun_data(),
+            sol_azi=180.0,
+            sol_elev=sol_elev,
+            logger=_make_logger(),
+        )
+
+    @pytest.mark.parametrize(
+        ("sol_elev", "raw", "expected"),
+        [
+            # below horizontal — closing means a smaller angle → floor
+            (10.0, 32.757550, 32),  # 58.96°
+            (30.0, 47.075339, 47),  # 84.74°
+            # above horizontal — closing means a larger angle → ceil
+            (35.0, 51.055578, 52),  # 91.90°
+            (45.0, 59.374719, 60),  # 106.87°
+            (85.0, 95.371678, 96),  # 171.67°
+        ],
+    )
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_quantises_away_from_horizontal(
+        self, mock_datetime, sol_elev, raw, expected
+    ):
+        mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        calc = self._mode2(sol_elev)
+        assert calc._tilt.calculate_raw_percentage() == pytest.approx(raw, abs=1e-5)
+        assert calc.calculate_dual().tilt == expected
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_floor_at_the_boundary_would_command_exactly_horizontal(
+        self, mock_datetime
+    ):
+        """At 34.4° elevation floor(50.57 %) is 50 % — precisely 90.00°.
+
+        Above roughly this elevation the solve stays past horizontal for the
+        rest of the tracking day, so ``floor()`` is the leaking direction for
+        every remaining update, starting from the worst possible case: the
+        maximum-openness slat commanded as the "conservative" choice.
+        """
+        mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        calc = self._mode2(34.4)
+
+        raw = calc._tilt.calculate_raw_percentage()
+        assert raw == pytest.approx(50.570998, abs=1e-5)
+        assert math.floor(raw) / 100.0 * 180.0 == pytest.approx(90.0)
+
+        assert calc.calculate_dual().tilt == 51
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_tilt_for_position_shares_the_direction(self, mock_datetime):
+        """``tilt_for_position`` routes through the same ``_compute_tilt`` seam."""
+        mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        calc = self._mode2(45.0)
+        assert calc.tilt_for_position(50) == calc.calculate_dual().tilt == 60
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_rounding_up_still_lands_inside_the_tilt_band(self, mock_datetime):
+        """``_clamp_tilt`` runs after the rounding, so the band still governs.
+
+        The 45° solve raw is 59.3747 %, so the conservative direction now hands
+        ``_clamp_tilt`` a 60 where it used to get a 59. Both the flat clamp and
+        the proportional remap are monotonic, so the band edge is the ceiling
+        either way — the up-rounding cannot escape ``max_tilt`` and cannot skip
+        past ``min_tilt``. ``max_tilt=60`` is the interesting case: the ceil
+        result sits exactly ON the cap.
+        """
+        from custom_components.adaptive_cover_pro.const import (
+            VENETIAN_TILT_TRANSFORM_PROPORTIONAL,
+        )
+
+        mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+
+        def _banded(**tilt_overrides):
+            return VenetianCoverCalculation(
+                config=make_cover_config(win_azi=180),
+                vert_config=make_vertical_config(),
+                tilt_config=make_tilt_config(
+                    slat_distance=0.02, depth=0.03, mode="mode2", **tilt_overrides
+                ),
+                sun_data=_make_sun_data(),
+                sol_azi=180.0,
+                sol_elev=45.0,
+                logger=_make_logger(),
+            )
+
+        # Exactly on the cap — the ceil lands on the band edge, not past it.
+        assert _banded(max_tilt=60).calculate_dual().tilt == 60
+        # Below the cap — the clamp still bites (floor would have given 55 too).
+        assert _banded(max_tilt=55).calculate_dual().tilt == 55
+        # Above the floor — min_tilt still lifts it.
+        assert _banded(min_tilt=70).calculate_dual().tilt == 70
+        # Proportional remap of the ceil'd 60 onto [0,40] → 24 (floor'd 59 → 24
+        # as well; the transform absorbs the one-percent difference here).
+        assert (
+            _banded(max_tilt=40, tilt_transform=VENETIAN_TILT_TRANSFORM_PROPORTIONAL)
+            .calculate_dual()
+            .tilt
+            == 24
+        )
 
 
 class TestMaxTiltCap:

--- a/tests/test_engine/test_venetian_engine.py
+++ b/tests/test_engine/test_venetian_engine.py
@@ -137,7 +137,7 @@ class TestVenetianCoverCalculation:
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_calculate_dual_delegates_to_tilt(self, mock_datetime):
-        """Tilt matches what AdaptiveTiltCover.calculate_percentage() returns (when valid)."""
+        """Tilt matches floor(AdaptiveTiltCover.calculate_raw_percentage()) (issue #1090)."""
         from custom_components.adaptive_cover_pro.calculation import AdaptiveTiltCover
 
         mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
@@ -175,15 +175,37 @@ class TestVenetianCoverCalculation:
 
         # Tilt percentage may be NaN (invalid geometry) — check both paths
         try:
-            raw_tilt = standalone.calculate_percentage()
+            raw_tilt = standalone.calculate_raw_percentage()
             if math.isnan(raw_tilt):
                 expected_tilt = 0
             else:
-                expected_tilt = round(raw_tilt)
+                expected_tilt = math.floor(raw_tilt)
         except (ValueError, ZeroDivisionError):
             expected_tilt = config.h_def
 
         assert result.tilt == expected_tilt
+
+    @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
+    def test_compute_tilt_floors_fractional_raw_percentage(self, mock_datetime):
+        """A fractional raw tilt rounds DOWN, not to nearest (issue #1090).
+
+        Mirrors ``TestTiltRawPercentage``'s mode1 fixture in
+        ``test_conservative_rounding.py`` (41° in a 0-90° range -> 45.5556%):
+        ``round()`` would give 46, but ``TILT_AXIS.open_blocks_sun=False``
+        means 0% is full coverage, so the conservative/safe direction is to
+        round down. Before the #1090 fix, ``_compute_tilt`` called
+        ``calculate_percentage()`` + ``round()`` and returned 46 here; the
+        fix calls ``calculate_raw_percentage()`` + ``math.floor()`` and must
+        return 45.
+        """
+        mock_datetime.now.return_value = datetime(2024, 1, 1, 12, 0, 0)
+        calc = _make_venetian(sol_azi=180.0, sol_elev=45.0)
+        calc._tilt.calculate_raw_percentage = Mock(return_value=45.5556)
+
+        result = calc.calculate_dual()
+
+        assert result.tilt == 45
+        assert result.tilt != 46
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_direct_sun_valid_delegation(self, mock_datetime):
@@ -301,7 +323,9 @@ class TestVenetianTiltSafetyMargin:
             config=config,
             tilt_config=tilt_config,
         )
-        assert calc.calculate_dual().tilt == round(standalone.calculate_percentage())
+        assert calc.calculate_dual().tilt == math.floor(
+            standalone.calculate_raw_percentage()
+        )
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_safety_margin_respects_max_tilt_clamp(self, mock_datetime):
@@ -570,7 +594,7 @@ class TestMinTiltFloor:
             sol_elev=45.0,
             logger=_make_logger(),
         )
-        calc._tilt.calculate_percentage = Mock(return_value=math.nan)
+        calc._tilt.calculate_raw_percentage = Mock(return_value=math.nan)
         assert calc.calculate_dual().tilt == floor
 
 
@@ -595,7 +619,7 @@ class TestClampTiltDelegation:
             sol_elev=80.0,
             logger=_make_logger(),
         )
-        calc._tilt.calculate_percentage = Mock(return_value=80.0)
+        calc._tilt.calculate_raw_percentage = Mock(return_value=80.0)
         assert calc.calculate_dual().tilt == 60
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
@@ -611,7 +635,7 @@ class TestClampTiltDelegation:
             sol_elev=45.0,
             logger=_make_logger(),
         )
-        calc._tilt.calculate_percentage = Mock(return_value=math.nan)
+        calc._tilt.calculate_raw_percentage = Mock(return_value=math.nan)
         assert calc.calculate_dual().tilt == 20
 
 
@@ -653,8 +677,8 @@ class TestProportionalTiltTransform:
             sol_elev=45.0,
             logger=_make_logger(),
         )
-        proportional._tilt.calculate_percentage = Mock(return_value=50.0)
-        clamp._tilt.calculate_percentage = Mock(return_value=50.0)
+        proportional._tilt.calculate_raw_percentage = Mock(return_value=50.0)
+        clamp._tilt.calculate_raw_percentage = Mock(return_value=50.0)
         assert proportional.calculate_dual().tilt == 20
         assert clamp.calculate_dual().tilt == 40
 
@@ -678,7 +702,7 @@ class TestProportionalTiltTransform:
                 sol_elev=45.0,
                 logger=_make_logger(),
             )
-            proportional._tilt.calculate_percentage = Mock(return_value=raw)
+            proportional._tilt.calculate_raw_percentage = Mock(return_value=raw)
             assert proportional.calculate_dual().tilt == round(raw)
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
@@ -702,7 +726,7 @@ class TestProportionalTiltTransform:
                 sol_elev=45.0,
                 logger=_make_logger(),
             )
-            calc._tilt.calculate_percentage = Mock(return_value=float(raw))
+            calc._tilt.calculate_raw_percentage = Mock(return_value=float(raw))
             results.append(calc.calculate_dual().tilt)
         assert all(b >= a for a, b in zip(results, results[1:]))
         assert results[0] == 0
@@ -729,7 +753,7 @@ class TestProportionalTiltTransform:
             sol_elev=45.0,
             logger=_make_logger(),
         )
-        calc._tilt.calculate_percentage = Mock(return_value=math.nan)
+        calc._tilt.calculate_raw_percentage = Mock(return_value=math.nan)
         assert calc.calculate_dual().tilt == 10
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
@@ -751,5 +775,5 @@ class TestProportionalTiltTransform:
             sol_elev=45.0,
             logger=_make_logger(),
         )
-        calc._tilt.calculate_percentage = Mock(return_value=80.0)
+        calc._tilt.calculate_raw_percentage = Mock(return_value=80.0)
         assert calc.calculate_dual().tilt == 40

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -21,6 +21,7 @@ from custom_components.adaptive_cover_pro.forecast import (
     ForecastSample,
     build_forecast,
 )
+from tests.cover_helpers import attach_coverage_rounding
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -72,7 +73,7 @@ def _make_cover_factory(*, solar_valid: bool, percentage: int = 40):
     """
 
     def factory(azi: float, ele: float):  # noqa: ARG001
-        cover = MagicMock()
+        cover = attach_coverage_rounding(MagicMock())
         cover.direct_sun_valid = solar_valid
         cover.calculate_percentage = MagicMock(return_value=percentage)
         cover.calculate_raw_percentage = MagicMock(return_value=float(percentage))
@@ -336,7 +337,7 @@ class TestBuildForecastEvents:
         valid_window_end = _NOW + timedelta(minutes=90)
 
         def factory(_azi, _ele):
-            cover = MagicMock()
+            cover = attach_coverage_rounding(MagicMock())
             cover.calculate_percentage = MagicMock(return_value=50)
             # Mutated per call via closure to time-of-call check is awkward; the
             # forecast walker passes (azi, ele) at *target* time, so we need a
@@ -351,7 +352,7 @@ class TestBuildForecastEvents:
         def toggling_factory(_azi, _ele):
             idx = call_state["calls"]
             call_state["calls"] += 1
-            cover = MagicMock()
+            cover = attach_coverage_rounding(MagicMock())
             cover.direct_sun_valid = toggle_points[0] <= idx < toggle_points[1]
             cover.calculate_percentage = MagicMock(return_value=50)
             cover.calculate_raw_percentage = MagicMock(return_value=50.0)
@@ -396,7 +397,7 @@ class TestBuildForecastEvents:
         crossing_time = _DAY_START + timedelta(minutes=crossing_idx * 5)
 
         def factory(azi, _ele):
-            cover = MagicMock()
+            cover = attach_coverage_rounding(MagicMock())
             cover.direct_sun_valid = azi >= crossing_idx
             cover.calculate_percentage = MagicMock(return_value=50)
             cover.calculate_raw_percentage = MagicMock(return_value=50.0)
@@ -568,7 +569,7 @@ def _solar_cover_factory(percentage):
     """Cover factory: direct sun valid, calculate_percentage() → *percentage*."""
 
     def factory(_azi, _ele):
-        cover = MagicMock()
+        cover = attach_coverage_rounding(MagicMock())
         cover.direct_sun_valid = True
         cover.calculate_percentage = MagicMock(return_value=percentage)
         cover.calculate_raw_percentage = MagicMock(return_value=float(percentage))


### PR DESCRIPTION
## Summary

#978 gave the position axis conservative rounding - bias toward coverage instead of nearest integer - but it never reached the tilt axis. #1090 reported that and prescribed `floor()`. The mechanism was real; the prescribed direction was wrong.

MODE2, the shipped default tilt mode, maps slat angle 0-180 degrees onto 0-100% with **90 degrees (horizontal) as maximum openness**. Coverage is therefore not monotonic in the percentage - it bottoms out at 50% and grows toward both ends. `calculate_position()` returns the exact grazing angle, so flooring a percentage above 50% moves the slat *toward* horizontal and leaks direct sun. At ~34.4 degrees elevation `floor()` would have commanded exactly 50% - the single most sun-permissive slat angle - as its "conservative" choice. The engine already encoded the right rule elsewhere: the tilt safety margin scales closure *away from horizontal* in both directions.

### What changed

- **`round_toward_coverage(pct, *, full_coverage_at_zero) -> int`** - a polymorphic hook on `AdaptiveGeneralCover` holding the monotonic rule (floor when 0% is full coverage, ceil when 100% is), overridden on `AdaptiveTiltCover` to round away from the percentage that maps to horizontal. MODE1 needs no special case: its pivot is 100%, so every reachable percentage still floors.
- **Both tilt call sites go through it** - venetian's dual-axis sub-path and the tilt-only solar branch in `pipeline/helpers.py`, which carried the identical bug already shipped via #978. The policy still supplies the axis-level direction and the engine refines it, so no cover-type branch enters the pipeline layer.
- **`_limit_tilt`** re-bands the quantised integer, closing a `max_tilt` escape the ceil branch introduced on the tilt-only path (where the band is applied *before* quantisation) and the mirror `min_tilt` breach that came in with #978's blanket floor.
- **`_percentage_from_angle`** unifies the three places the angle-to-percentage maps were derived by hand, so the pivot can no longer drift from the map it is computed on.

### Behaviour change

Tilt-only, louvered-roof, and venetian **tilt** axes on MODE2 command **one percent more closure** whenever the solved slat sits above horizontal - above roughly 34 degrees solar elevation at the shipped slat geometry, i.e. most of the tracking day. With a configured tilt band, the `min_tilt`/`max_tilt` edges shift by one point toward the configured bound.

**MODE1 tilt, every position-axis cover, and venetian's position axis are byte-for-byte unchanged** - verified across 8,019 pipeline cases, plus a 57,132,720-probe differential over the final refactor showing zero divergence.

### Deferred

`quantize_to_coverage_steps` (behind the opt-in `minimize_movements` flag) and `more_protective_position` still carry the same non-monotonicity assumption. Both are pre-existing and tracked separately.

## Testing

- ✅ 9561 tests passing

## Related Issues

Refs #1090