### PR TITLE
fix: respect the MODE2 coverage pivot in the quantizer and comparator (#1104)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -901,7 +901,9 @@ class CoverTypePolicy(ABC):
             return POSITION_CLOSED
         return self.position_for_intent(sun_through=False)
 
-    def more_protective_position(self, a: int, b: int) -> int:
+    def more_protective_position(
+        self, a: int, b: int, *, cover: AdaptiveGeneralCover | None = None
+    ) -> int:
         """Return whichever of two primary-axis positions blocks more sun.
 
         Polymorphic over cover type via ``axes[0].open_blocks_sun``:
@@ -914,7 +916,35 @@ class CoverTypePolicy(ABC):
         every valid future-window sample through this comparator so the
         commanded position protects against the most-shaded moment in the
         upcoming throttle interval.
+
+        That axis-level answer is the whole story only where coverage is
+        MONOTONIC in the percentage — the same assumption
+        ``round_toward_coverage`` had to give up (issue #1090). A bi-directional
+        slat closes at BOTH ends and is most open mid-travel, so ``min`` picks
+        the LESS protective of two positions above the pivot: on MODE2, 55 % is
+        99° (9° off horizontal) and 60 % is 108° (18° off) — ``min`` commands the
+        one that lets more sun through. Passing *cover* lets the comparator ask
+        the engine where coverage bottoms out and rank by DISTANCE from it
+        instead (issue #1104).
+
+        Percentage distance is the right metric because the percentage↔angle map
+        is globally linear on every scale this hook sees (MODE1, MODE2, the
+        louvered roof's ``max_slat_angle``, and the affine ``specify_angles``
+        calibration), so ``|pct − pivot_pct|`` is proportional to
+        ``|angle − 90°|`` on both sides at once — no per-side scaling needed.
+
+        *cover* is keyword-only and defaults to ``None`` so callers with no
+        engine in scope, and every monotonic axis, keep the exact behaviour they
+        had. Equal distances fall through to the axis rule rather than being
+        decided here, which keeps the symmetric straddle (``30``/``70`` on MODE2,
+        both 36° off horizontal) answering ``30`` as it always has.
         """
+        if cover is not None:
+            pivot = cover.coverage_pivot_percentage()
+            if pivot is not None:
+                distance_a, distance_b = abs(a - pivot), abs(b - pivot)
+                if distance_a != distance_b:
+                    return a if distance_a > distance_b else b
         if self.axes[0].open_blocks_sun:
             return max(a, b)
         return min(a, b)

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -932,6 +932,12 @@ class CoverTypePolicy(ABC):
         louvered roof's ``max_slat_angle``, and the affine ``specify_angles``
         calibration), so ``|pct − pivot_pct|`` is proportional to
         ``|angle − 90°|`` on both sides at once — no per-side scaling needed.
+        Linearity is also why this comparator needs no range check on the pivot:
+        proportionality does not care whether the pivot is reachable, so a scale
+        calibrated entirely to one side of horizontal (``max_slat_angle`` under
+        90°, a one-sided ``specify_angles`` pair) is still ranked correctly — and
+        an INVERTED such calibration, where ``axes[0]``'s static flag has the
+        covering end backwards, is ranked correctly only this way.
 
         *cover* is keyword-only and defaults to ``None`` so callers with no
         engine in scope, and every monotonic axis, keep the exact behaviour they

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -937,7 +937,11 @@ class CoverTypePolicy(ABC):
         calibrated entirely to one side of horizontal (``max_slat_angle`` under
         90°, a one-sided ``specify_angles`` pair) is still ranked correctly — and
         an INVERTED such calibration, where ``axes[0]``'s static flag has the
-        covering end backwards, is ranked correctly only this way.
+        covering end backwards, is ranked correctly only this way. The
+        coverage-step quantiser reaches the same conclusion from the same pivot
+        by a different route (it clamps the pivot onto the reachable travel,
+        because it anchors arithmetic on it rather than ordering by it), and the
+        two must not disagree about which end of one engine covers.
 
         *cover* is keyword-only and defaults to ``None`` so callers with no
         engine in scope, and every monotonic axis, keep the exact behaviour they

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -574,8 +574,11 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         bi-directional slat is not: on MODE2 the axis closes at BOTH ends and is
         most open at the horizontal 50 %. So the engine's coverage pivot goes
         along with the axis semantic and the quantiser measures the demand from
-        whichever of the two the axis actually has (issue #1104). Returns
-        ``(tilt, venetian_calc)`` so the
+        whichever of the two the axis actually has (issue #1104). The engine's
+        reachable travel goes along with it for the same reason: nothing re-bands
+        after this quantise, so its levels have to span ``[min_tilt, max_tilt]``
+        — the band ``_clamp_tilt`` just applied — rather than the whole scale.
+        Returns ``(tilt, venetian_calc)`` so the
         live ``post_pipeline_resolve`` can still merge the tilt engine's raw
         trace (#682) and the forecast hook can take just the scalar. BOTH the
         live path and the projected forecast flow through this one method, so
@@ -598,6 +601,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
                 max_coverage_steps,
                 full_coverage_at_zero=not self.axes[1].open_blocks_sun,
                 pivot=venetian_calc.tilt_coverage_pivot_percentage(),
+                bounds=venetian_calc.tilt_coverage_travel_bounds(),
             )
         return tilt, venetian_calc
 

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -568,8 +568,14 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         """Single source of truth for the engine slat angle + minimize quantize.
 
         Builds the tilt engine, computes the slat angle for ``position``, and
-        applies the movement-minimization quantize (the tilt axis closes at 0%,
-        so full coverage is at zero). Returns ``(tilt, venetian_calc)`` so the
+        applies the movement-minimization quantize. The tilt axis declares
+        ``open_blocks_sun=False`` — 0 % is a covering end — but that is only the
+        whole story where coverage is MONOTONIC in the percentage, which a
+        bi-directional slat is not: on MODE2 the axis closes at BOTH ends and is
+        most open at the horizontal 50 %. So the engine's coverage pivot goes
+        along with the axis semantic and the quantiser measures the demand from
+        whichever of the two the axis actually has (issue #1104). Returns
+        ``(tilt, venetian_calc)`` so the
         live ``post_pipeline_resolve`` can still merge the tilt engine's raw
         trace (#682) and the forecast hook can take just the scalar. BOTH the
         live path and the projected forecast flow through this one method, so
@@ -591,6 +597,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
                 tilt,
                 max_coverage_steps,
                 full_coverage_at_zero=not self.axes[1].open_blocks_sun,
+                pivot=venetian_calc.tilt_coverage_pivot_percentage(),
             )
         return tilt, venetian_calc
 

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -368,6 +368,20 @@ class AdaptiveGeneralCover(ABC):
         position leaves it in EITHER direction, so a distance-from-the-pivot
         measure replaces "distance from the open end".
 
+        The float is a point on this axis's SCALE, and it is NOT promised to lie
+        on the 0–100 travel: it is the maximum-openness angle pushed through the
+        engine's own angle→percentage map, and a scale calibrated entirely to one
+        side of that angle images it outside the range (a louvered roof with
+        ``max_slat_angle`` under 90°, or a one-sided ``specify_angles`` pair).
+        That is still the right answer for consumers that only ORDER by it —
+        the map is affine, so distance from the pivot stays proportional to
+        distance from maximum openness wherever the pivot sits, which is what
+        :meth:`round_toward_coverage` and
+        ``CoverTypePolicy.more_protective_position`` need. A consumer that
+        ANCHORS arithmetic on the pivot must range-check it first; the one that
+        does, ``PositionConverter.quantize_to_coverage_steps``, carries the guard
+        and its rationale.
+
         Only :class:`~.tilt.AdaptiveTiltCover` overrides it, because only the
         engine knows the tilt scale — which keeps the cover-type branch out of
         the pipeline and ``position_utils`` layers that consume the answer.

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -351,3 +351,25 @@ class AdaptiveGeneralCover(ABC):
         this with an angle-aware direction.
         """
         return floor(pct) if full_coverage_at_zero else ceil(pct)
+
+    def coverage_pivot_percentage(self) -> float | None:
+        """Percentage at which this axis blocks the LEAST sun, or ``None`` (#1104).
+
+        The companion of :meth:`round_toward_coverage`, and polymorphic for the
+        same reason: rounding needs to know which arithmetic direction adds
+        coverage, and every *other* consumer of "how much coverage does this
+        percentage carry" needs to know where coverage starts from.
+
+        ``None`` — the base answer — means coverage is MONOTONIC in the
+        percentage, so the caller's ``full_coverage_at_zero`` axis semantic is
+        already the whole story: coverage runs from one end of the travel to the
+        other and the open end is 0 % or 100 %. A float means the axis is
+        bi-directional: coverage bottoms out at that percentage and grows as the
+        position leaves it in EITHER direction, so a distance-from-the-pivot
+        measure replaces "distance from the open end".
+
+        Only :class:`~.tilt.AdaptiveTiltCover` overrides it, because only the
+        engine knows the tilt scale — which keeps the cover-type branch out of
+        the pipeline and ``position_utils`` layers that consume the answer.
+        """
+        return None

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -387,3 +387,25 @@ class AdaptiveGeneralCover(ABC):
         the pipeline and ``position_utils`` layers that consume the answer.
         """
         return None
+
+    def coverage_travel_bounds(self) -> tuple[float, float]:
+        """Lowest and highest percentage this axis can be COMMANDED to (#1104).
+
+        The companion of :meth:`coverage_pivot_percentage` for the one consumer
+        that anchors arithmetic on the pivot rather than merely ordering by it:
+        ``PositionConverter.quantize_to_coverage_steps`` spans its coverage
+        levels from the pivot outward, and the far end of that span has to be
+        the most-covering position the axis can actually reach.
+
+        The base answer is the whole travel, which makes the bound a no-op —
+        correct for every engine whose own configuration cannot narrow the
+        percentage range it emits. :class:`~.tilt.AdaptiveTiltCover` overrides
+        it, because ``[min_tilt, max_tilt]`` narrows exactly that, and the
+        quantiser runs after the last seam that applies the band.
+
+        Note this is deliberately NOT the position axis's ``min_pos``/``max_pos``:
+        those are applied by ``pipeline.helpers.apply_config_limits`` AFTER the
+        quantiser, so that band clamps the command itself and needs no help from
+        the level arithmetic to hold.
+        """
+        return (0.0, 100.0)

--- a/custom_components/adaptive_cover_pro/engine/covers/base.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/base.py
@@ -377,10 +377,13 @@ class AdaptiveGeneralCover(ABC):
         the map is affine, so distance from the pivot stays proportional to
         distance from maximum openness wherever the pivot sits, which is what
         :meth:`round_toward_coverage` and
-        ``CoverTypePolicy.more_protective_position`` need. A consumer that
-        ANCHORS arithmetic on the pivot must range-check it first; the one that
-        does, ``PositionConverter.quantize_to_coverage_steps``, carries the guard
-        and its rationale.
+        ``CoverTypePolicy.more_protective_position`` need. It is also the answer
+        that tells them which END of an off-travel scale covers, which the
+        axis's static ``open_blocks_sun`` flag gets backwards on an inverted
+        calibration. A consumer that ANCHORS arithmetic on the pivot must pull
+        it onto the reachable travel first; the one that does,
+        ``PositionConverter.quantize_to_coverage_steps``, carries the clamp and
+        its rationale.
 
         Only :class:`~.tilt.AdaptiveTiltCover` overrides it, because only the
         engine knows the tilt scale — which keeps the cover-type branch out of
@@ -394,8 +397,10 @@ class AdaptiveGeneralCover(ABC):
         The companion of :meth:`coverage_pivot_percentage` for the one consumer
         that anchors arithmetic on the pivot rather than merely ordering by it:
         ``PositionConverter.quantize_to_coverage_steps`` spans its coverage
-        levels from the pivot outward, and the far end of that span has to be
-        the most-covering position the axis can actually reach.
+        levels from the pivot outward, so BOTH ends of that span have to be
+        positions the axis can actually reach — the far one because it is where
+        the top level lands, the near one because an anchor the axis cannot
+        reach reads a zero-coverage demand as a covered one.
 
         The base answer is the whole travel, which makes the bound a no-op —
         correct for every engine whose own configuration cannot narrow the

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -466,6 +466,24 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
 
         Inherited unchanged by :class:`~.louvered_roof.AdaptiveLouveredRoofCover`.
         ``None`` on a degenerate zero-width scale, matching the base contract.
+
+        The answer can fall OUTSIDE 0–100, and deliberately is not clamped or
+        suppressed here. ``max_slat_angle = 45`` puts horizontal at 200 %, and a
+        ``specify_angles`` pair of 0°/45° or 120°/180° does the same (200 % and
+        −50 %) — the config flow only orders the endpoints. Such a slat never
+        passes through maximum openness, so the axis really is monotonic over its
+        travel; but the pivot is still the correct ORDERING reference, and the
+        one it corrects is the inverted calibration the axis flag gets backwards
+        (0 % is the OPEN end at 120°/180°, not the covering one). Reporting
+        ``None`` for it would hand those consumers back the wrong rule to fix a
+        problem only ``quantize_to_coverage_steps`` has — see the guard there.
+
+        Percentages are reported here in the same command space the engine's
+        percentage output lives in. ``[min_tilt, max_tilt]`` and
+        ``tilt_transform`` (#957) reshape the DEMAND on its way into that space;
+        they do not rescale the space itself, so horizontal stays where this map
+        puts it and the pivot needs no second transform to be compared against a
+        banded command.
         """
         return self._horizontal_percentage()
 

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -487,6 +487,38 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         """
         return self._horizontal_percentage()
 
+    def coverage_travel_bounds(self) -> tuple[float, float]:
+        """Report ``[min_tilt, max_tilt]`` as the reachable travel (#1104).
+
+        Derived by asking :meth:`_limit_tilt` — the sole owner of the band
+        argument bundle — what it does to the two ends of the scale, rather than
+        by reading ``tilt_config.min_tilt``/``max_tilt`` a second time here. The
+        band is not just those two numbers: the ``*_sun_only`` toggles and the
+        degenerate/reversed-band fallback are part of it, and a reversed band
+        pins BOTH ends to ``min_tilt``, which this probe reports as a zero-width
+        travel — exactly what the axis does there. A hand-rolled tuple would be
+        a band that only happens to match, and would drift the first time that
+        seam learns a new rule.
+
+        The probe is transform-independent by construction: the proportional
+        remap sends 0 → ``min_tilt`` and 100 → ``max_tilt``, the same two values
+        the flat clamp does, so this asks for the clamp and gets the band edges
+        under either setting.
+
+        Deliberately NOT gated on ``apply_tilt_axis_limits``. That flag answers
+        "does this engine apply the band itself?", and both answers still end in
+        a banded tilt: the tilt-only path bands it in
+        :meth:`round_toward_coverage`, and venetian — which clears the flag —
+        bands it in ``VenetianCoverCalculation._clamp_tilt``. The coverage-step
+        quantiser runs after both, so both need the same travel.
+
+        Inherited unchanged by :class:`~.louvered_roof.AdaptiveLouveredRoofCover`.
+        """
+        return (
+            float(self._limit_tilt(0, transform=VENETIAN_TILT_TRANSFORM_CLAMP)),
+            float(self._limit_tilt(100, transform=VENETIAN_TILT_TRANSFORM_CLAMP)),
+        )
+
     def round_toward_coverage(self, pct: float, *, full_coverage_at_zero: bool) -> int:
         """Quantise the slat percentage AWAY from horizontal (issue #1090).
 

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -475,8 +475,9 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         travel; but the pivot is still the correct ORDERING reference, and the
         one it corrects is the inverted calibration the axis flag gets backwards
         (0 % is the OPEN end at 120°/180°, not the covering one). Reporting
-        ``None`` for it would hand those consumers back the wrong rule to fix a
-        problem only ``quantize_to_coverage_steps`` has — see the guard there.
+        ``None`` for it would hand every consumer back exactly that wrong rule.
+        The one consumer that anchors on the pivot pulls it onto the reachable
+        travel itself — see ``quantize_to_coverage_steps``.
 
         Percentages are reported here in the same command space the engine's
         percentage output lives in. ``[min_tilt, max_tilt]`` and

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -451,6 +451,24 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         """
         return self._percentage_from_angle(TILT_HORIZONTAL_DEG)
 
+    def coverage_pivot_percentage(self) -> float | None:
+        """Report horizontal as the pivot — the slat axis is bi-directional (#1104).
+
+        Publishes the very pivot :meth:`round_toward_coverage` already rounds
+        away from, so every consumer of "how much coverage does this percentage
+        carry" measures against the same point the rounding does. Deliberately
+        the same call, not a second derivation: routing through
+        :meth:`_horizontal_percentage` means an ``_effective_max_degrees``
+        override (the louvered roof's ``max_slat_angle``, which puts the pivot at
+        a fractional 64.2857 % for a 140° drive) moves the pivot everywhere at
+        once, and MODE1's 100 % pivot keeps the monotonic behaviour it always
+        had rather than needing a special case.
+
+        Inherited unchanged by :class:`~.louvered_roof.AdaptiveLouveredRoofCover`.
+        ``None`` on a degenerate zero-width scale, matching the base contract.
+        """
+        return self._horizontal_percentage()
+
     def round_toward_coverage(self, pct: float, *, full_coverage_at_zero: bool) -> int:
         """Quantise the slat percentage AWAY from horizontal (issue #1090).
 

--- a/custom_components/adaptive_cover_pro/engine/covers/venetian.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/venetian.py
@@ -100,6 +100,21 @@ class VenetianCoverCalculation:
         """
         return self._tilt.coverage_pivot_percentage()
 
+    def tilt_coverage_travel_bounds(self) -> tuple[float, float]:
+        """Reachable travel of the composed tilt axis (#1104).
+
+        The pivot's companion, delegated the same way and for the same reason:
+        ``VenetianPolicy._compose_tilt`` quantises into coverage levels AFTER
+        :meth:`_clamp_tilt` has banded the tilt, and the levels have to span
+        the band rather than the whole scale or the quantiser hands back a tilt
+        the band just rejected.
+
+        ``_clamp_tilt`` reaches into the sub-engine's ``_limit_tilt`` for the
+        band, and so does this — one owner, one answer, whichever of the two
+        seams is asking.
+        """
+        return self._tilt.coverage_travel_bounds()
+
     def _clamp_tilt(self, value: int) -> int:
         """Clamp a tilt value to the configured ``[min_tilt, max_tilt]`` range.
 

--- a/custom_components/adaptive_cover_pro/engine/covers/venetian.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/venetian.py
@@ -88,6 +88,18 @@ class VenetianCoverCalculation:
         """
         return self._compute_tilt()
 
+    def tilt_coverage_pivot_percentage(self) -> float | None:
+        """Coverage pivot of the composed tilt axis, or ``None`` (#1104).
+
+        The public seam ``VenetianPolicy._compose_tilt`` asks before it quantises
+        into coverage levels, so the dual-axis path measures coverage from the
+        same point the tilt sub-engine rounds away from. Exposed here rather than
+        letting the policy reach into ``_tilt``: the sub-engine is this class's
+        private composition detail, and this keeps the pivot a single delegated
+        answer instead of a second reference to the same object.
+        """
+        return self._tilt.coverage_pivot_percentage()
+
     def _clamp_tilt(self, value: int) -> int:
         """Clamp a tilt value to the configured ``[min_tilt, max_tilt]`` range.
 

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -184,11 +184,19 @@ def solar_position_from_geometry(
         # on instead of being scaled against the far end of the travel, which
         # would snap the slats back toward horizontal and undo the away-from-
         # horizontal rounding above (issues #1090, #1104).
+        #
+        # The engine also says how far that side actually goes. This quantiser
+        # is the LAST thing to touch a tilt axis — ``apply_config_limits`` below
+        # carries ``min_pos``/``max_pos``, not ``[min_tilt, max_tilt]`` — so
+        # levels scaled to the end of the SCALE rather than to the end of the
+        # BAND would command straight past the user's own cap, one step after
+        # ``round_toward_coverage`` re-banded to stay inside it.
         state = PositionConverter.quantize_to_coverage_steps(
             state,
             max_coverage_steps,
             full_coverage_at_zero=full_coverage_at_zero,
             pivot=cover.coverage_pivot_percentage(),
+            bounds=cover.coverage_travel_bounds(),
         )
     state = solar_floor(state, floor_active=floor_active)
     return apply_config_limits(state, config, sun_valid=True)

--- a/custom_components/adaptive_cover_pro/pipeline/helpers.py
+++ b/custom_components/adaptive_cover_pro/pipeline/helpers.py
@@ -176,10 +176,19 @@ def solar_position_from_geometry(
     else:
         state = int(round(pct))
     if minimize_movements and policy is not None:
+        # Same division of labour as step 1, one step later: the axis states
+        # which end blocks the sun, and the engine says whether that is the
+        # whole story. A bi-directional slat hands back its horizontal pivot,
+        # and the quantiser then measures the coverage demand from THERE — so
+        # the movement-minimisation levels sit on the side the solve is already
+        # on instead of being scaled against the far end of the travel, which
+        # would snap the slats back toward horizontal and undo the away-from-
+        # horizontal rounding above (issues #1090, #1104).
         state = PositionConverter.quantize_to_coverage_steps(
             state,
             max_coverage_steps,
             full_coverage_at_zero=full_coverage_at_zero,
+            pivot=cover.coverage_pivot_percentage(),
         )
     state = solar_floor(state, floor_active=floor_active)
     return apply_config_limits(state, config, sun_valid=True)
@@ -247,6 +256,13 @@ def anticipated_solar_position_from_geometry(
     "now" target seeds the fold, so the result can only ever *increase*
     protection relative to the current position.
 
+    The cover goes to the comparator alongside the two positions, because
+    "which of these blocks more sun" is only a ``min``/``max`` on the percentage
+    while coverage is MONOTONIC in it. On a bi-directional slat the fold would
+    otherwise discard the more-protective of two above-horizontal samples and
+    quietly WEAKEN the anticipation guarantee it exists to strengthen — see
+    issue #1104.
+
     When ``horizon_minutes <= 0`` (anticipation disabled / no throttle) or
     *policy* is ``None``, this is exactly :func:`solar_position_from_geometry`.
 
@@ -309,7 +325,11 @@ def anticipated_solar_position_from_geometry(
             policy=policy,
             floor_active=floor_active,
         )
-        best = policy.more_protective_position(best, candidate)
+        # The LIVE cover is the right engine handle even though *candidate* came
+        # from a projected one: the comparator only asks where this axis's
+        # coverage bottoms out, which is a property of the tilt scale, and
+        # ``dataclasses.replace`` above changes only the sun angles.
+        best = policy.more_protective_position(best, candidate, cover=cover)
 
     return best
 

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -133,57 +133,63 @@ class PositionConverter:
 
         * ``pivot is None`` — coverage is monotonic in the percentage, so the
           axis has exactly one coverage-zero end and ``full_coverage_at_zero``
-          names it. The whole 0–100 range is one scale.
-        * ``pivot`` on the travel — the axis is bi-directional (a MODE2 slat: 0°
-          closed downward, 90° horizontal, 180° closed upward), so coverage
-          bottoms out mid-travel and grows toward BOTH ends. Each side of the
-          pivot gets its own ``n_steps`` levels, spanning that side only, and the
+          names it. The whole 0–100 range is one scale, and this is the only
+          branch that reads the flag at all.
+        * a ``pivot`` — the axis is bi-directional (a MODE2 slat: 0° closed
+          downward, 90° horizontal, 180° closed upward), so coverage bottoms out
+          at that percentage and grows toward BOTH ends. Each side of the pivot
+          gets its own ``n_steps`` levels, spanning that side only, and the
           result stays on the input's side. Two sides of a slat are physically
           distinct orientations, not a coarser version of one shared scale —
           collapsing them would command a sweep through the fully-open
           horizontal to reach "more coverage", the wasted movement this feature
           exists to avoid.
-        * ``pivot`` OFF the travel — outside 0–100, so the axis never reaches
-          maximum openness anywhere it can go and coverage is monotonic over its
-          whole range after all. Falls through to the ``None`` branch.
 
         A pivot of 100.0 (with ``full_coverage_at_zero``) or 0.0 (without) is the
         monotonic case restated, and reduces to the ``None`` branch exactly.
 
-        *bounds* is how far the axis can actually be driven. The levels are
-        ANCHORED on the pivot, so what they are spanned TO decides where the
-        top one lands — and that has to be the most-covering position the axis
-        can reach, not the end of the percentage scale. A tilt axis carries its
-        own ``[min_tilt, max_tilt]`` band, applied by the engine BEFORE this
-        function and by nothing after it, so levels spanned to 100 % put the top
-        one past the user's own cap: a ``max_tilt`` of 60 with the shipped
-        single step commanded 100 % for every above-pivot solve. Spanning them to
-        the band edge instead makes an out-of-band command unreachable by
-        construction — the result never passes the far edge, and never falls back
-        past the input — while keeping ``n_steps`` distinct levels inside the
-        band. Clamping this function's output afterwards would also stop the
-        escape, but it collapses 100 / 75 / 67 onto a single 60 and quietly
-        empties out the setting the user changed.
+        *bounds* is how far the axis can actually be driven, and the levels are
+        laid out ENTIRELY inside it — anchored on the least-covering position the
+        axis can reach and spanned to the most-covering one, per side. A tilt
+        axis carries its own ``[min_tilt, max_tilt]`` band, applied by the engine
+        BEFORE this function and by nothing after it, so a ladder spanned to the
+        end of the percentage SCALE puts its top level past the user's own cap:
+        a ``max_tilt`` of 60 with the shipped single step commanded 100 % for
+        every above-pivot solve. Spanning to the band edge instead makes an
+        out-of-band command unreachable by construction — the result never
+        passes the far edge, and never falls back past the input — while keeping
+        ``n_steps`` distinct levels inside the band. Clamping this function's
+        output afterwards would also stop the escape, but it collapses
+        100 / 75 / 67 onto a single 60 and quietly empties out the setting the
+        user changed.
 
-        The bound only bites on the pivot branch, because only that branch
-        anchors on a point and spans outward. The monotonic branch already
-        spans END to END, so the covering end is its own limit and the axis flag
-        is the whole story — leaving the ``pivot is None`` and off-travel paths
-        bit-identical, band or no band.
+        The pivot itself is clamped into *bounds* for the same reason, and that
+        is what lets the two ends of the band be the whole story here. The pivot
+        is ``TILT_HORIZONTAL_DEG``'s image under the engine's angle→percentage
+        map and NOTHING constrains that image to 0–100: a louvered roof with
+        ``max_slat_angle=45`` puts it at 200 %, a ``specify_angles`` pair of
+        0°/45° likewise, and an INVERTED 120°/180° pair at −50 %. Such a slat
+        never passes through maximum openness, so it is monotonic over its
+        travel — but WHICH end covers is then the side the pivot fell off, not
+        ``full_coverage_at_zero``: on the 120°/180° calibration 0 % is the most
+        OPEN slat the drive reaches and 100 % is the shut one, the exact
+        opposite of what every tilt axis's static flag declares. Clamping the
+        anchor answers both at once. It lands on the near band edge, so a
+        zero-coverage demand does not move (an unclamped anchor reads the
+        fully-open 100 % slat of a 200 % pivot as half-covered and commands 0),
+        and the single remaining side runs toward the covering end the pivot
+        names (an unclamped −50 % anchor still measures from below, so the flag
+        decides and gets it backwards).
 
-        The off-travel guard is here rather than on the engine hook that
-        supplies the pivot, because this is the only consumer that needs the
-        pivot to be REACHABLE. ``round_toward_coverage`` and
-        ``CoverTypePolicy.more_protective_position`` use it purely as an ordering
-        reference, and since the percentage↔angle map is affine, ``|pct − pivot|``
-        stays proportional to ``|angle − 90°|`` wherever the pivot sits — those
-        two keep answering correctly for a scale calibrated entirely to one side
-        of horizontal, which the axis flag alone gets backwards. This function
-        instead ANCHORS its levels on the pivot and spans them to the near end of
-        the travel, so an unreachable anchor reads a zero-coverage demand as a
-        half-covered one: a louvered roof with ``max_slat_angle=45`` (pivot
-        200 %) or a ``specify_angles`` calibration of 0°→0 % / 45°→100 % would
-        take the fully-open 100 % slat and command 0 — fully closed.
+        Only this consumer needs the pivot to be reachable, which is why the
+        clamp lives here rather than on the engine hook.
+        ``round_toward_coverage`` and ``CoverTypePolicy.more_protective_position``
+        use the pivot purely as an ordering reference, and since the
+        percentage↔angle map is affine, ``|pct − pivot|`` stays proportional to
+        ``|angle − 90°|`` wherever the pivot sits — clamping it would corrupt
+        that ranking. The two consumers still agree on which end covers,
+        because a clamped anchor is on the same side of every reachable
+        percentage as the pivot it came from.
 
         Args:
             percentage: Engine-orientation position (0–100) from
@@ -192,16 +198,17 @@ class PositionConverter:
             full_coverage_at_zero: True when 0% means maximum sun blocking
                 (vertical blind, tilt, venetian); False when 100% means maximum
                 blocking (awning — open/extended blocks the sun). Derived from the
-                policy's primary ``CoverAxis.open_blocks_sun`` flag. Used whenever
-                *pivot* is absent or off the travel.
+                policy's primary ``CoverAxis.open_blocks_sun`` flag. Read only
+                when *pivot* is absent — a stated pivot is the more specific
+                answer and outranks it.
             pivot: Percentage carrying zero coverage, from the engine's
                 ``coverage_pivot_percentage()`` hook. ``None`` (the default) for
                 every monotonic axis, which is every caller that does not hold a
-                bi-directional engine.
+                bi-directional engine. Not required to lie on the travel.
             bounds: ``(lowest, highest)`` percentage the axis can be commanded
                 to, from the engine's ``coverage_travel_bounds()`` hook. Defaults
-                to the full travel, which is a no-op. Ignored unless the pivot is
-                anchorable.
+                to the full travel, which is a no-op. Ignored without a pivot,
+                since there is then no anchor for it to constrain.
 
         Returns:
             The quantized position (0–100) in the same engine orientation.
@@ -209,7 +216,7 @@ class PositionConverter:
         """
         if n_steps < 1:
             return percentage
-        if pivot is None or not 0.0 <= pivot <= 100.0:
+        if pivot is None:
             # Coverage fraction: 1.0 = full coverage, 0.0 = fully open.
             coverage = (
                 (100 - percentage) / 100 if full_coverage_at_zero else percentage / 100
@@ -222,33 +229,42 @@ class PositionConverter:
             return round(coverage_pct)
         # Bi-directional axis: measure the demand as a fraction of the side the
         # input sits on, and give it back on that same side. The side runs from
-        # the pivot to the far end of the reachable travel — the most-covering
-        # position this axis has on that side, which the band may have moved in
-        # from the end of the scale.
+        # the anchor — the least-covering REACHABLE position, i.e. the pivot
+        # pulled onto the band — to the far end of that band.
         # The ``max``/``min`` widen the side back out for an input that already
         # sits past the far edge. Neither call site can produce one (both band
         # before they quantize), but "never reduce coverage" is this function's
         # contract and must not become conditional on the caller having banded
         # first.
         low, high = bounds
-        if percentage > pivot:
+        anchor = min(max(pivot, low), high)
+        if percentage > anchor:
             far = max(high, float(percentage))
             side_sign = 1.0
         else:
             far = min(low, float(percentage))
             side_sign = -1.0
-        span = abs(far - pivot)
+        span = abs(far - anchor)
         if span <= 0:
-            # The input sits on a boundary pivot, or on a band pinned to a single
-            # point, so its side has no width to quantize into — there is exactly
-            # one reachable position on it.
+            # The input sits on a boundary anchor, or on a band pinned to a
+            # single point, so its side has no width to quantize into — there is
+            # exactly one reachable position on it.
             return percentage
-        coverage = abs(percentage - pivot) / span
+        coverage = abs(percentage - anchor) / span
         level = min(math.ceil(coverage * n_steps) / n_steps, 1.0)
-        # ``level * span >= |percentage - pivot|`` by construction and
+        # ``level * span >= |percentage - anchor|`` by construction and
         # ``level <= 1``, so the answer sits between the input and the far edge:
         # never less covering than the demand, never outside the band.
-        return round(pivot + side_sign * level * span)
+        commanded = round(anchor + side_sign * level * span)
+        # Rounding the top level can add up to half a point, which escapes the
+        # band only where its edge is FRACTIONAL. No engine reports one today
+        # (``coverage_travel_bounds`` yields whole percentages), but "never
+        # passes the far edge" is stated without conditions, so hold it without
+        # conditions. The demand is an integer no farther from the anchor than
+        # ``far`` is, so this can never pull the answer back short of it.
+        if side_sign > 0:
+            return min(commanded, math.floor(far))
+        return max(commanded, math.ceil(far))
 
     @staticmethod
     def apply_limits(

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -117,23 +117,47 @@ class PositionConverter:
         percentage: int,
         n_steps: int,
         full_coverage_at_zero: bool,
+        *,
+        pivot: float | None = None,
     ) -> int:
         """Snap an engine-orientation percentage to one of N coverage levels.
 
         Rounds **toward full coverage** so sun protection is never reduced by the
-        quantization. The 0–100 range is divided into ``n_steps`` evenly-spaced
+        quantization. The travel is divided into ``n_steps`` evenly-spaced
         coverage levels; the calculated coverage is rounded *up* to the next
         level. With ``n_steps == 1`` any non-zero coverage demand snaps straight
         to full coverage, which is what the "minimize movements" feature wants.
 
+        Where the coverage is measured FROM depends on the axis (issue #1104):
+
+        * ``pivot is None`` — coverage is monotonic in the percentage, so the
+          axis has exactly one coverage-zero end and ``full_coverage_at_zero``
+          names it. The whole 0–100 range is one scale.
+        * ``pivot`` given — the axis is bi-directional (a MODE2 slat: 0° closed
+          downward, 90° horizontal, 180° closed upward), so coverage bottoms out
+          mid-travel and grows toward BOTH ends. Each side of the pivot gets its
+          own ``n_steps`` levels, spanning that side only, and the result stays
+          on the input's side. Two sides of a slat are physically distinct
+          orientations, not a coarser version of one shared scale — collapsing
+          them would command a sweep through the fully-open horizontal to reach
+          "more coverage", the wasted movement this feature exists to avoid.
+
+        A pivot of 100.0 (with ``full_coverage_at_zero``) or 0.0 (without) is the
+        monotonic case restated, and reduces to the ``None`` branch exactly.
+
         Args:
             percentage: Engine-orientation position (0–100) from
                 ``calculate_percentage()``.
-            n_steps: Number of discrete coverage levels (>= 1).
+            n_steps: Number of discrete coverage levels per side (>= 1).
             full_coverage_at_zero: True when 0% means maximum sun blocking
                 (vertical blind, tilt, venetian); False when 100% means maximum
                 blocking (awning — open/extended blocks the sun). Derived from the
-                policy's primary ``CoverAxis.open_blocks_sun`` flag.
+                policy's primary ``CoverAxis.open_blocks_sun`` flag. Ignored when
+                *pivot* is given, which states the same thing more precisely.
+            pivot: Percentage carrying zero coverage, from the engine's
+                ``coverage_pivot_percentage()`` hook. ``None`` (the default) for
+                every monotonic axis, which is every caller that does not hold a
+                bi-directional engine.
 
         Returns:
             The quantized position (0–100) in the same engine orientation.
@@ -141,16 +165,32 @@ class PositionConverter:
         """
         if n_steps < 1:
             return percentage
-        # Coverage fraction: 1.0 = full coverage, 0.0 = fully open / no blocking.
-        coverage = (
-            (100 - percentage) / 100 if full_coverage_at_zero else percentage / 100
-        )
-        # ceil → round toward more coverage; clamp guards float drift past 1.0.
+        if pivot is None:
+            # Coverage fraction: 1.0 = full coverage, 0.0 = fully open.
+            coverage = (
+                (100 - percentage) / 100 if full_coverage_at_zero else percentage / 100
+            )
+            # ceil → round toward more coverage; clamp guards float drift past 1.0.
+            level = min(math.ceil(coverage * n_steps) / n_steps, 1.0)
+            coverage_pct = level * 100
+            if full_coverage_at_zero:
+                return round(100 - coverage_pct)
+            return round(coverage_pct)
+        # Bi-directional axis: measure the demand as a fraction of the side the
+        # input sits on, and give it back on that same side.
+        if percentage > pivot:
+            span = 100.0 - pivot
+            side_sign = 1.0
+        else:
+            span = float(pivot)
+            side_sign = -1.0
+        if span <= 0:
+            # The input sits on a boundary pivot, so its side has no width to
+            # quantize into — there is exactly one reachable position on it.
+            return percentage
+        coverage = abs(percentage - pivot) / span
         level = min(math.ceil(coverage * n_steps) / n_steps, 1.0)
-        coverage_pct = level * 100
-        if full_coverage_at_zero:
-            return round(100 - coverage_pct)
-        return round(coverage_pct)
+        return round(pivot + side_sign * level * span)
 
     @staticmethod
     def apply_limits(

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -133,17 +133,35 @@ class PositionConverter:
         * ``pivot is None`` — coverage is monotonic in the percentage, so the
           axis has exactly one coverage-zero end and ``full_coverage_at_zero``
           names it. The whole 0–100 range is one scale.
-        * ``pivot`` given — the axis is bi-directional (a MODE2 slat: 0° closed
-          downward, 90° horizontal, 180° closed upward), so coverage bottoms out
-          mid-travel and grows toward BOTH ends. Each side of the pivot gets its
-          own ``n_steps`` levels, spanning that side only, and the result stays
-          on the input's side. Two sides of a slat are physically distinct
-          orientations, not a coarser version of one shared scale — collapsing
-          them would command a sweep through the fully-open horizontal to reach
-          "more coverage", the wasted movement this feature exists to avoid.
+        * ``pivot`` on the travel — the axis is bi-directional (a MODE2 slat: 0°
+          closed downward, 90° horizontal, 180° closed upward), so coverage
+          bottoms out mid-travel and grows toward BOTH ends. Each side of the
+          pivot gets its own ``n_steps`` levels, spanning that side only, and the
+          result stays on the input's side. Two sides of a slat are physically
+          distinct orientations, not a coarser version of one shared scale —
+          collapsing them would command a sweep through the fully-open
+          horizontal to reach "more coverage", the wasted movement this feature
+          exists to avoid.
+        * ``pivot`` OFF the travel — outside 0–100, so the axis never reaches
+          maximum openness anywhere it can go and coverage is monotonic over its
+          whole range after all. Falls through to the ``None`` branch.
 
         A pivot of 100.0 (with ``full_coverage_at_zero``) or 0.0 (without) is the
         monotonic case restated, and reduces to the ``None`` branch exactly.
+
+        The off-travel guard is here rather than on the engine hook that
+        supplies the pivot, because this is the only consumer that needs the
+        pivot to be REACHABLE. ``round_toward_coverage`` and
+        ``CoverTypePolicy.more_protective_position`` use it purely as an ordering
+        reference, and since the percentage↔angle map is affine, ``|pct − pivot|``
+        stays proportional to ``|angle − 90°|`` wherever the pivot sits — those
+        two keep answering correctly for a scale calibrated entirely to one side
+        of horizontal, which the axis flag alone gets backwards. This function
+        instead ANCHORS its levels on the pivot and spans them to the near end of
+        the travel, so an unreachable anchor reads a zero-coverage demand as a
+        half-covered one: a louvered roof with ``max_slat_angle=45`` (pivot
+        200 %) or a ``specify_angles`` calibration of 0°→0 % / 45°→100 % would
+        take the fully-open 100 % slat and command 0 — fully closed.
 
         Args:
             percentage: Engine-orientation position (0–100) from
@@ -152,8 +170,8 @@ class PositionConverter:
             full_coverage_at_zero: True when 0% means maximum sun blocking
                 (vertical blind, tilt, venetian); False when 100% means maximum
                 blocking (awning — open/extended blocks the sun). Derived from the
-                policy's primary ``CoverAxis.open_blocks_sun`` flag. Ignored when
-                *pivot* is given, which states the same thing more precisely.
+                policy's primary ``CoverAxis.open_blocks_sun`` flag. Used whenever
+                *pivot* is absent or off the travel.
             pivot: Percentage carrying zero coverage, from the engine's
                 ``coverage_pivot_percentage()`` hook. ``None`` (the default) for
                 every monotonic axis, which is every caller that does not hold a
@@ -165,7 +183,7 @@ class PositionConverter:
         """
         if n_steps < 1:
             return percentage
-        if pivot is None:
+        if pivot is None or not 0.0 <= pivot <= 100.0:
             # Coverage fraction: 1.0 = full coverage, 0.0 = fully open.
             coverage = (
                 (100 - percentage) / 100 if full_coverage_at_zero else percentage / 100

--- a/custom_components/adaptive_cover_pro/position_utils.py
+++ b/custom_components/adaptive_cover_pro/position_utils.py
@@ -119,6 +119,7 @@ class PositionConverter:
         full_coverage_at_zero: bool,
         *,
         pivot: float | None = None,
+        bounds: tuple[float, float] = (0.0, 100.0),
     ) -> int:
         """Snap an engine-orientation percentage to one of N coverage levels.
 
@@ -149,6 +150,27 @@ class PositionConverter:
         A pivot of 100.0 (with ``full_coverage_at_zero``) or 0.0 (without) is the
         monotonic case restated, and reduces to the ``None`` branch exactly.
 
+        *bounds* is how far the axis can actually be driven. The levels are
+        ANCHORED on the pivot, so what they are spanned TO decides where the
+        top one lands — and that has to be the most-covering position the axis
+        can reach, not the end of the percentage scale. A tilt axis carries its
+        own ``[min_tilt, max_tilt]`` band, applied by the engine BEFORE this
+        function and by nothing after it, so levels spanned to 100 % put the top
+        one past the user's own cap: a ``max_tilt`` of 60 with the shipped
+        single step commanded 100 % for every above-pivot solve. Spanning them to
+        the band edge instead makes an out-of-band command unreachable by
+        construction — the result never passes the far edge, and never falls back
+        past the input — while keeping ``n_steps`` distinct levels inside the
+        band. Clamping this function's output afterwards would also stop the
+        escape, but it collapses 100 / 75 / 67 onto a single 60 and quietly
+        empties out the setting the user changed.
+
+        The bound only bites on the pivot branch, because only that branch
+        anchors on a point and spans outward. The monotonic branch already
+        spans END to END, so the covering end is its own limit and the axis flag
+        is the whole story — leaving the ``pivot is None`` and off-travel paths
+        bit-identical, band or no band.
+
         The off-travel guard is here rather than on the engine hook that
         supplies the pivot, because this is the only consumer that needs the
         pivot to be REACHABLE. ``round_toward_coverage`` and
@@ -176,6 +198,10 @@ class PositionConverter:
                 ``coverage_pivot_percentage()`` hook. ``None`` (the default) for
                 every monotonic axis, which is every caller that does not hold a
                 bi-directional engine.
+            bounds: ``(lowest, highest)`` percentage the axis can be commanded
+                to, from the engine's ``coverage_travel_bounds()`` hook. Defaults
+                to the full travel, which is a no-op. Ignored unless the pivot is
+                anchorable.
 
         Returns:
             The quantized position (0–100) in the same engine orientation.
@@ -195,19 +221,33 @@ class PositionConverter:
                 return round(100 - coverage_pct)
             return round(coverage_pct)
         # Bi-directional axis: measure the demand as a fraction of the side the
-        # input sits on, and give it back on that same side.
+        # input sits on, and give it back on that same side. The side runs from
+        # the pivot to the far end of the reachable travel — the most-covering
+        # position this axis has on that side, which the band may have moved in
+        # from the end of the scale.
+        # The ``max``/``min`` widen the side back out for an input that already
+        # sits past the far edge. Neither call site can produce one (both band
+        # before they quantize), but "never reduce coverage" is this function's
+        # contract and must not become conditional on the caller having banded
+        # first.
+        low, high = bounds
         if percentage > pivot:
-            span = 100.0 - pivot
+            far = max(high, float(percentage))
             side_sign = 1.0
         else:
-            span = float(pivot)
+            far = min(low, float(percentage))
             side_sign = -1.0
+        span = abs(far - pivot)
         if span <= 0:
-            # The input sits on a boundary pivot, so its side has no width to
-            # quantize into — there is exactly one reachable position on it.
+            # The input sits on a boundary pivot, or on a band pinned to a single
+            # point, so its side has no width to quantize into — there is exactly
+            # one reachable position on it.
             return percentage
         coverage = abs(percentage - pivot) / span
         level = min(math.ceil(coverage * n_steps) / n_steps, 1.0)
+        # ``level * span >= |percentage - pivot|`` by construction and
+        # ``level <= 1``, so the answer sits between the input and the far edge:
+        # never less covering than the demand, never outside the band.
         return round(pivot + side_sign * level * span)
 
     @staticmethod

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -18,22 +18,25 @@ from custom_components.adaptive_cover_pro.engine.covers.base import (
     AdaptiveGeneralCover,
 )
 
+_COVERAGE_HOOKS = ("round_toward_coverage", "coverage_pivot_percentage")
+
 
 def attach_coverage_rounding(cover):
-    """Give a cover *double* the real base ``round_toward_coverage`` (#1090).
+    """Give a cover *double* the real base coverage hooks (#1090, #1104).
 
-    The solar branch asks the cover which way to quantise its raw percentage,
-    because only the engine knows whether coverage is monotonic in the
-    percentage (it is not on a bi-directional slat axis). Doubles standing in
-    for an ``AdaptiveGeneralCover`` therefore have to answer that call.
+    The solar branch asks the cover which way to quantise its raw percentage and
+    where its coverage bottoms out, because only the engine knows whether
+    coverage is monotonic in the percentage (it is not on a bi-directional slat
+    axis). Doubles standing in for an ``AdaptiveGeneralCover`` therefore have to
+    answer both calls — a ``MagicMock`` would otherwise hand back a mock where a
+    ``float | None`` is expected.
 
-    Binds the production implementation to the double rather than
+    Binds the production implementations to the double rather than
     reimplementing floor/ceil in test-land, so a double can never quietly
-    disagree with the rule it is standing in for. Returns *cover* for chaining.
+    disagree with the rules it is standing in for. Returns *cover* for chaining.
     """
-    cover.round_toward_coverage = AdaptiveGeneralCover.round_toward_coverage.__get__(
-        cover
-    )
+    for name in _COVERAGE_HOOKS:
+        setattr(cover, name, getattr(AdaptiveGeneralCover, name).__get__(cover))
     return cover
 
 

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -18,18 +18,23 @@ from custom_components.adaptive_cover_pro.engine.covers.base import (
     AdaptiveGeneralCover,
 )
 
-_COVERAGE_HOOKS = ("round_toward_coverage", "coverage_pivot_percentage")
+_COVERAGE_HOOKS = (
+    "round_toward_coverage",
+    "coverage_pivot_percentage",
+    "coverage_travel_bounds",
+)
 
 
 def attach_coverage_rounding(cover):
     """Give a cover *double* the real base coverage hooks (#1090, #1104).
 
-    The solar branch asks the cover which way to quantise its raw percentage and
-    where its coverage bottoms out, because only the engine knows whether
-    coverage is monotonic in the percentage (it is not on a bi-directional slat
-    axis). Doubles standing in for an ``AdaptiveGeneralCover`` therefore have to
-    answer both calls — a ``MagicMock`` would otherwise hand back a mock where a
-    ``float | None`` is expected.
+    The solar branch asks the cover which way to quantise its raw percentage,
+    where its coverage bottoms out, and how far it can be driven, because only
+    the engine knows whether coverage is monotonic in the percentage (it is not
+    on a bi-directional slat axis) and whether the axis carries a band of its
+    own. Doubles standing in for an ``AdaptiveGeneralCover`` therefore have to
+    answer all three calls — a ``MagicMock`` would otherwise hand back a mock
+    where a ``float | None`` or a ``(low, high)`` pair is expected.
 
     Binds the production implementations to the double rather than
     reimplementing floor/ceil in test-land, so a double can never quietly

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -390,6 +390,22 @@ def _tilt_solar_position(cover) -> int:
     )
 
 
+def _tilt_solar_position_minimized(cover, n_steps: int) -> int:
+    """Run the same branch as :func:`_tilt_solar_position`, minimisation on.
+
+    The only difference is the opt-in coverage-step quantiser that runs
+    immediately after the away-from-horizontal rounding (issue #1104).
+    """
+    return solar_position_from_geometry(
+        cover,
+        _config(),
+        minimize_movements=True,
+        max_coverage_steps=n_steps,
+        policy=_policy(open_blocks_sun=False),
+        floor_active=False,
+    )
+
+
 class TestTiltMode2DirectionalRounding:
     """MODE2 tilt quantises AWAY from horizontal, not always downward."""
 
@@ -522,6 +538,72 @@ class TestTiltMode2DirectionalRounding:
 
         assert cover.calculate_raw_percentage() == pytest.approx(raw, abs=1e-5)
         assert _tilt_solar_position(cover) == expected
+
+
+class TestTiltMode2MinimizeMovements:
+    """The coverage-step quantiser respects the horizontal pivot (issue #1104).
+
+    ``minimize_movements`` snaps the commanded position onto one of N coverage
+    levels, rounding toward MORE coverage. That quantiser used to divide the
+    whole 0–100 range around a single coverage-zero end (0 % or 100 %), which is
+    only the truth on a monotonic axis. On MODE2 the coverage-zero point is the
+    horizontal slat mid-travel, so the old scale snapped every above-pivot solve
+    back TOWARD horizontal — undoing, one step later, exactly what
+    ``round_toward_coverage`` had just done (issue #1090).
+    """
+
+    def test_quantize_does_not_snap_back_toward_horizontal(self):
+        """60 % is 10 points of coverage past the pivot, not 40 points short of it.
+
+        At 45° elevation the solve is 106.87° → 59.3747 %, which the
+        away-from-horizontal rule ceils to 60 %. With two levels per side the
+        demand (10/50 = 0.2 of the upper side) rounds up to the half-step, i.e.
+        50 % + 0.5 × 50 = 75 %. Measuring the same demand against a 100 %
+        coverage-zero end instead gives 0.4 → the half-step at 50 %, which is the
+        exactly-horizontal slat.
+        """
+        cover = _tilt_cover(sol_elev=45.0)
+        assert _tilt_solar_position(cover) == 60
+        assert _tilt_solar_position_minimized(cover, 2) == 75
+
+    def test_quantize_never_crosses_the_pivot(self):
+        """One level per side means "fully closed on THIS side", not on either.
+
+        Crossing the pivot passes a pure distance-from-horizontal check — 0 % is
+        90° from horizontal, more than the 16.87° the solve asks for — while
+        still being wrong: it sweeps the slats through fully-open horizontal to
+        get there, the wasted movement ``minimize_movements`` exists to avoid.
+        """
+        cover = _tilt_cover(sol_elev=45.0)
+        result = _tilt_solar_position_minimized(cover, 1)
+        assert result == 100
+        assert result >= 50
+
+    @pytest.mark.parametrize("n_steps", [2, 3])
+    @pytest.mark.parametrize(
+        "sol_elev", [5.0, 12.5, 21.0, 29.0, 34.4, 37.5, 44.0, 52.0, 68.0, 79.0, 88.0]
+    )
+    def test_commanded_angle_never_closer_to_horizontal_with_minimize(
+        self, sol_elev, n_steps
+    ):
+        """The #1090 invariant, now with the quantiser in the path.
+
+        Same statement as
+        ``test_commanded_angle_is_never_closer_to_horizontal_than_the_solve``:
+        the commanded slat must sit at least as far from horizontal as the
+        grazing solve. Movement minimisation is allowed to command MORE closure
+        than asked for; it is never allowed to command less.
+        """
+        cover = _tilt_cover(sol_elev=sol_elev)
+        exact_angle = cover.calculate_position()
+        max_degrees = float(TiltMode.MODE2.max_degrees)
+        commanded_angle = (
+            _tilt_solar_position_minimized(cover, n_steps) / 100.0 * max_degrees
+        )
+
+        assert abs(commanded_angle - TILT_HORIZONTAL_DEG) >= abs(
+            exact_angle - TILT_HORIZONTAL_DEG
+        )
 
 
 class TestLouveredRoofPivotFollowsMaxSlatAngle:

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -575,9 +575,7 @@ class TestTiltMode2MinimizeMovements:
         get there, the wasted movement ``minimize_movements`` exists to avoid.
         """
         cover = _tilt_cover(sol_elev=45.0)
-        result = _tilt_solar_position_minimized(cover, 1)
-        assert result == 100
-        assert result >= 50
+        assert _tilt_solar_position_minimized(cover, 1) == 100
 
     @pytest.mark.parametrize("n_steps", [2, 3])
     @pytest.mark.parametrize(
@@ -749,6 +747,172 @@ class TestTiltSpecifyAnglesDirectionalRounding:
         )
         assert cover.calculate_raw_percentage() == 0.0
         assert _tilt_solar_position(cover) == 0
+
+
+class TestOffTravelPivotIsAMonotonicAxis:
+    """A scale that never reaches horizontal is monotonic after all (#1104).
+
+    ``_horizontal_percentage`` is ``TILT_HORIZONTAL_DEG`` pushed through the
+    engine's angle→percentage map, and NOTHING constrains that map's image to
+    0–100. Two shipped configurations put the pivot off the travel:
+
+    * a louvered roof whose ``max_slat_angle`` is below 90° — the field is a
+      plain 0–180 number box, so 45° gives a 200 % pivot and 60° gives 150 %;
+    * a ``specify_angles`` calibration with both endpoints on ONE side of
+      horizontal — the config flow only enforces ``angle_0 < angle_100``.
+
+    Such a slat never passes through maximum openness anywhere in its travel,
+    so coverage IS monotonic in the percentage and the axis flag really is the
+    whole story. The comparator can still use the off-travel pivot as an
+    ordering reference (distance-from-a-point is affine-invariant, so it ranks
+    correctly wherever the point sits — see ``test_protective.py``), but the
+    coverage-step quantiser ANCHORS its levels on the pivot and spans them to
+    the nearer end of the travel. Anchored on an unreachable point, a
+    zero-coverage demand reads as a half-covered one and the single-level
+    quantiser answers "fully closed" — a full-scale move in the wrong
+    direction, which is why the guard lives in the quantiser rather than on the
+    engine hook that both consumers share.
+    """
+
+    @pytest.mark.parametrize(
+        ("max_slat_angle", "pivot"),
+        [
+            (45.0, 200.0),
+            (60.0, 150.0),
+        ],
+    )
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    def test_louvered_roof_topping_out_below_horizontal(
+        self, max_slat_angle, pivot, n_steps
+    ):
+        """The drive stops short of horizontal, so 100 % is the most-open slat.
+
+        The solve saturates at the configured ceiling, so the raw percentage is
+        100 — a demand for NO coverage. Movement minimisation must leave it
+        there; measuring it as distance from an unreachable pivot instead makes
+        it half-covered (100 is 100 of the 200 points below a 200 % pivot) and
+        commands 0 — the fully-closed slat.
+        """
+        cover = _louvered_cover(sol_elev=45.0, max_slat_angle=max_slat_angle)
+        assert cover._horizontal_percentage() == pytest.approx(pivot)
+        assert cover.calculate_raw_percentage() == 100.0
+        assert _tilt_solar_position(cover) == 100
+        assert _tilt_solar_position_minimized(cover, n_steps) == 100
+
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    def test_specify_angles_calibrated_entirely_below_horizontal(self, n_steps):
+        """0° → 0 %, 45° → 100 %: horizontal would be 200 %."""
+        cover = _tilt_cover(
+            sol_elev=45.0, mode="specify_angles", angle_0=0.0, angle_100=45.0
+        )
+        assert cover._horizontal_percentage() == pytest.approx(200.0)
+        assert cover.calculate_raw_percentage() == 100.0
+        assert _tilt_solar_position(cover) == 100
+        assert _tilt_solar_position_minimized(cover, n_steps) == 100
+
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    def test_specify_angles_calibrated_entirely_above_horizontal(self, n_steps):
+        """120° → 0 %, 180° → 100 %: horizontal would be −50 %.
+
+        The mirror image, and the one that used to move the FARTHEST: every
+        reachable percentage is at least a third of the extended span away from
+        a −50 % pivot, so a single-level quantiser answered 100 % for the whole
+        travel — the slats pinned fully closed for as long as the sun was
+        tracked.
+        """
+        cover = _tilt_cover(
+            sol_elev=45.0, mode="specify_angles", angle_0=120.0, angle_100=180.0
+        )
+        assert cover._horizontal_percentage() == pytest.approx(-50.0)
+        assert cover.calculate_raw_percentage() == 0.0
+        assert _tilt_solar_position(cover) == 0
+        assert _tilt_solar_position_minimized(cover, n_steps) == 0
+
+
+class TestProportionalBandKeepsTheCommandSpacePivot:
+    """The ``[min_tilt, max_tilt]`` transform does not move horizontal (#1104).
+
+    ``tilt_transform=proportional`` (#957) linearly remaps the full 0–100 %
+    solar DEMAND onto the configured band. What comes out is the tilt
+    percentage handed to the cover entity, and the entity's scale is whatever
+    the tilt mode declares — on MODE2, 0–100 % is 0–180°, so the horizontal
+    slat sits at 50 % of the COMMAND no matter which band the demand was
+    squeezed into. That 50 % is exactly what ``_horizontal_percentage``
+    reports, so the pivot and every value measured against it already share one
+    space: ``round_toward_coverage``'s comparison, the coverage-step quantiser
+    and the anticipation comparator all read post-transform commands, and none
+    of them wants a second remap applied to the pivot.
+
+    Remapping the pivot into the band instead (50 → 25 for ``[0, 50]``) would
+    put the pivot at 45° — a slat 45° AWAY from horizontal — and then round the
+    30 % command "away" from it to 62 %, which is both less protective than the
+    command it replaced (21.6° off horizontal versus 36.0°) and outside the
+    user's own ``max_tilt``.
+    """
+
+    def _banded(self, *, sol_elev=45.0, min_tilt=0, max_tilt=50):
+        return _tilt_cover(
+            sol_elev=sol_elev,
+            min_tilt=min_tilt,
+            max_tilt=max_tilt,
+            tilt_transform=VENETIAN_TILT_TRANSFORM_PROPORTIONAL,
+        )
+
+    def test_pivot_is_reported_in_the_command_space_the_band_produces(self):
+        """The 59.37 % demand becomes a 30 % command; horizontal is still 50 %."""
+        cover = self._banded()
+        assert cover._percentage_from_angle(
+            cover.calculate_position()
+        ) == pytest.approx(59.374719, abs=1e-5)
+        assert cover.calculate_raw_percentage() == 30.0
+        assert cover.coverage_pivot_percentage() == 50.0
+        assert _tilt_solar_position(cover) == 30
+
+    @pytest.mark.parametrize(
+        ("n_steps", "expected"),
+        [
+            # 30 % is 20 of the 50 points below the pivot → 0.4 of the lower
+            # side. One level → the bottom of it; two → the half-step at 25 %;
+            # three → ceil(1.2)/3 = 2/3 → 17 %.
+            (1, 0),
+            (2, 25),
+            (3, 17),
+        ],
+    )
+    def test_quantising_a_banded_command_increases_its_coverage(
+        self, n_steps, expected
+    ):
+        cover = self._banded()
+        commanded = _tilt_solar_position_minimized(cover, n_steps)
+        assert commanded == expected
+        # Every answer is a slat FARTHER from the horizontal 50 % than the
+        # unquantised 30 % command it replaced — never nearer.
+        assert abs(commanded - 50) >= abs(30 - 50)
+
+    def test_upper_band_mirrors_the_lower_one(self):
+        """``[50, 100]`` puts the same demand at 80 %, above the pivot."""
+        cover = self._banded(min_tilt=50, max_tilt=100)
+        assert cover.calculate_raw_percentage() == 80.0
+        assert _tilt_solar_position(cover) == 80
+        assert _tilt_solar_position_minimized(cover, 2) == 100
+        assert _tilt_solar_position_minimized(cover, 3) == 83
+
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    @pytest.mark.parametrize(
+        ("min_tilt", "max_tilt"), [(0, 50), (50, 100), (25, 75), (20, 60), (0, 100)]
+    )
+    @pytest.mark.parametrize(
+        "sol_elev", [5.0, 12.5, 21.0, 29.0, 34.4, 37.5, 44.0, 52.0, 68.0, 79.0, 88.0]
+    )
+    def test_minimisation_never_reduces_coverage_under_a_band(
+        self, sol_elev, min_tilt, max_tilt, n_steps
+    ):
+        """Swept: no band, elevation or step count lets the quantiser open up."""
+        cover = self._banded(sol_elev=sol_elev, min_tilt=min_tilt, max_tilt=max_tilt)
+        state = _tilt_solar_position(cover)
+        commanded = _tilt_solar_position_minimized(cover, n_steps)
+        pivot = cover.coverage_pivot_percentage()
+        assert abs(commanded - pivot) >= abs(state - pivot)
 
 
 class TestTiltOnlyBandSurvivesTheQuantisation:

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -913,6 +913,12 @@ class TestProportionalBandKeepsTheCommandSpacePivot:
         commanded = _tilt_solar_position_minimized(cover, n_steps)
         pivot = cover.coverage_pivot_percentage()
         assert abs(commanded - pivot) >= abs(state - pivot)
+        # Gaining coverage is not a licence to leave the band. Distance from the
+        # pivot alone cannot see that: the far end of the travel is always
+        # farther than the band edge, so "more protective" and "past max_tilt"
+        # are the same move whenever the levels are scaled to the whole scale
+        # instead of to what the user actually allows.
+        assert min_tilt <= commanded <= max_tilt
 
 
 class TestTiltOnlyBandSurvivesTheQuantisation:
@@ -930,6 +936,12 @@ class TestTiltOnlyBandSurvivesTheQuantisation:
     Venetian never had either problem — its ``_clamp_tilt`` runs after the
     rounding — so the guard belongs on the integer this engine hands out rather
     than mirrored at each call site.
+
+    The opt-in coverage-step quantiser runs after BOTH of those band owners and
+    is the last thing on the axis, so the same invariant has to survive it (the
+    #1104 audit). It does not get there by being clamped a third time: it takes
+    the reachable travel and lays its levels inside it, so an in-band demand
+    cannot produce an out-of-band command in the first place.
     """
 
     def test_raw_percentage_can_sit_just_past_the_cap(self):
@@ -1002,6 +1014,76 @@ class TestTiltOnlyBandSurvivesTheQuantisation:
             tilt_transform=transform,
         )
         assert min_tilt <= _tilt_solar_position(cover) <= max_tilt
+
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    @pytest.mark.parametrize(
+        "transform",
+        [VENETIAN_TILT_TRANSFORM_CLAMP, VENETIAN_TILT_TRANSFORM_PROPORTIONAL],
+    )
+    @pytest.mark.parametrize(
+        ("min_tilt", "max_tilt"), [(0, 100), (0, 55), (0, 60), (45, 100), (45, 55)]
+    )
+    @pytest.mark.parametrize(
+        "sol_elev", [5.0, 21.0, 27.0, 34.4, 39.81, 45.0, 68.0, 88.0]
+    )
+    def test_minimised_tilt_also_lands_inside_the_band(
+        self, sol_elev, min_tilt, max_tilt, transform, n_steps
+    ):
+        """The same invariant one step later, with ``minimize_movements`` on.
+
+        The coverage-step quantiser is the LAST thing to touch the tilt axis —
+        ``apply_config_limits`` after it carries ``min_pos``/``max_pos``, not the
+        tilt band — so whatever it hands back is what the slats are commanded
+        to. Its levels therefore have to be measured against the travel the user
+        actually allows; scaled to the full 0–100 scale instead, the top level
+        IS the far end of the scale and every above-pivot demand leaves the band.
+        """
+        cover = _tilt_cover(
+            sol_elev=sol_elev,
+            min_tilt=min_tilt,
+            max_tilt=max_tilt,
+            tilt_transform=transform,
+        )
+        assert min_tilt <= _tilt_solar_position_minimized(cover, n_steps) <= max_tilt
+
+    @pytest.mark.parametrize(
+        ("n_steps", "expected"),
+        [
+            # 51 % is 1 of the 10 points between the pivot and ``max_tilt`` —
+            # a tenth of the coverage this cover can reach on that side. One
+            # level rounds it to the cap; two put it on the half-step at 55 %;
+            # three on the first third at 53 %.
+            (1, 60),
+            (2, 55),
+            (3, 53),
+        ],
+    )
+    def test_minimisation_levels_spread_across_the_band(self, n_steps, expected):
+        """Movement minimisation keeps N distinct levels inside a capped band.
+
+        This is what a band-aware quantiser buys over clamping its output back
+        onto ``max_tilt`` afterwards: a post-hoc clamp answers 60 for all three
+        step counts, because 100 / 75 / 67 all sit above the cap. The levels a
+        user asked for would exist only on paper.
+        """
+        cover = _tilt_cover(sol_elev=34.4, max_tilt=60)
+        assert _tilt_solar_position(cover) == 51
+        assert _tilt_solar_position_minimized(cover, n_steps) == expected
+
+    @pytest.mark.parametrize(
+        ("n_steps", "expected"),
+        [(1, 0), (2, 25), (3, 33)],
+    )
+    def test_a_band_edge_on_the_travel_end_is_the_travel(self, n_steps, expected):
+        """Below the pivot the same band's edge IS 0 %, so nothing moves.
+
+        The 44 % command sits 6 of the 50 points below horizontal, and
+        ``min_tilt`` is 0, so the lower side spans the full half-scale exactly as
+        it did before the band entered the arithmetic.
+        """
+        cover = _tilt_cover(sol_elev=27.0, max_tilt=60)
+        assert _tilt_solar_position(cover) == 44
+        assert _tilt_solar_position_minimized(cover, n_steps) == expected
 
     def test_default_band_is_untouched(self):
         """0/100 is a no-op — the guard must not perturb the shipped default."""

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -46,6 +46,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.const import (
     TILT_HORIZONTAL_DEG,
     VENETIAN_TILT_TRANSFORM_CLAMP,
@@ -350,7 +351,11 @@ def _tilt_cover(*, sol_elev: float, **tilt_overrides) -> AdaptiveTiltCover:
 
 
 def _louvered_cover(
-    *, sol_elev: float, sol_azi: float = 180.0, max_slat_angle: float = 0.0
+    *,
+    sol_elev: float,
+    sol_azi: float = 180.0,
+    max_slat_angle: float = 0.0,
+    **tilt_overrides,
 ) -> AdaptiveLouveredRoofCover:
     """Build a flat-roof ``AdaptiveLouveredRoofCover`` at the given sun position.
 
@@ -370,7 +375,9 @@ def _louvered_cover(
         sol_elev=sol_elev,
         sun_data=MagicMock(),
         config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
-        tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+        tilt_config=make_tilt_config(
+            slat_distance=0.02, depth=0.03, mode="mode2", **tilt_overrides
+        ),
         roof_config=LouveredRoofConfig(roof_pitch=0.0, max_slat_angle=max_slat_angle),
     )
 
@@ -762,16 +769,24 @@ class TestOffTravelPivotIsAMonotonicAxis:
       horizontal — the config flow only enforces ``angle_0 < angle_100``.
 
     Such a slat never passes through maximum openness anywhere in its travel,
-    so coverage IS monotonic in the percentage and the axis flag really is the
-    whole story. The comparator can still use the off-travel pivot as an
-    ordering reference (distance-from-a-point is affine-invariant, so it ranks
-    correctly wherever the point sits — see ``test_protective.py``), but the
-    coverage-step quantiser ANCHORS its levels on the pivot and spans them to
-    the nearer end of the travel. Anchored on an unreachable point, a
-    zero-coverage demand reads as a half-covered one and the single-level
-    quantiser answers "fully closed" — a full-scale move in the wrong
-    direction, which is why the guard lives in the quantiser rather than on the
-    engine hook that both consumers share.
+    so coverage IS monotonic over it — but WHICH end covers is decided by the
+    SIDE the pivot fell off, not by ``axes[0].open_blocks_sun``. Above the
+    travel (``max_slat_angle`` under 90°, a 0°/45° pair) 100 % is the most-open
+    slat and 0 % covers, which is what the tilt axis flag says anyway. Below it
+    (a 120°/180° pair) the calibration is INVERTED: 0 % is the 120° slat, the
+    most open this drive has, and 100 % is the covering end — the exact
+    opposite of the flag.
+
+    So the pivot is not discarded here, it is only moved onto the travel:
+    anchored on the nearest reachable point, the ladder answers a zero-coverage
+    demand with no movement and an inverted calibration with the right end.
+    Anchored on the unreachable pivot itself, a zero-coverage demand instead
+    reads as a half-covered one and the single-level quantiser answers "fully
+    closed" — which is why the anchor is clamped into the reachable travel
+    rather than the pivot being suppressed on the engine hook that the
+    comparator shares (distance-from-a-point is affine-invariant, so the
+    comparator ranks correctly wherever the point sits — see
+    ``test_protective.py``).
     """
 
     @pytest.mark.parametrize(
@@ -810,23 +825,119 @@ class TestOffTravelPivotIsAMonotonicAxis:
         assert _tilt_solar_position(cover) == 100
         assert _tilt_solar_position_minimized(cover, n_steps) == 100
 
+    @pytest.mark.parametrize(
+        ("sol_elev", "commanded", "expected"),
+        [
+            # 55° solves 122.52° → 4.20 % raw, ceil'd to 5 % (122.99°, 33.0° off
+            # horizontal). One level → the covering end; two → its half-step.
+            (55.0, 5, {1: 100, 2: 50, 3: 33}),
+            # 60° solves 130.53° → 18 % (130.8°, 40.8° off horizontal).
+            (60.0, 18, {1: 100, 2: 50, 3: 33}),
+            # 85° solves 171.67° → 87 % (172.2°, 82.2° off) — nearly shut
+            # already, so every step count rounds it the rest of the way.
+            (85.0, 87, {1: 100, 2: 100, 3: 100}),
+        ],
+    )
     @pytest.mark.parametrize("n_steps", [1, 2, 3])
-    def test_specify_angles_calibrated_entirely_above_horizontal(self, n_steps):
+    def test_specify_angles_calibrated_entirely_above_horizontal(
+        self, sol_elev, commanded, expected, n_steps
+    ):
         """120° → 0 %, 180° → 100 %: horizontal would be −50 %.
 
-        The mirror image, and the one that used to move the FARTHEST: every
-        reachable percentage is at least a third of the extended span away from
-        a −50 % pivot, so a single-level quantiser answered 100 % for the whole
-        travel — the slats pinned fully closed for as long as the sun was
-        tracked.
+        The inverted mirror: 0 % is the 120° slat (30° off horizontal, the most
+        OPEN this drive reaches) and 100 % is the 180° shut one. Reading the
+        static axis flag instead of the pivot's side pinned every one of these
+        demands to 0 % — the most open position the cover has, commanded while
+        direct sun was being tracked, and the farther above horizontal the sun
+        drove the slats the bigger the wrong-way move got.
+
+        Each geometry is run at a NON-ZERO coverage demand deliberately: at the
+        45° elevation the solve lands below 120° and clamps to 0 %, where both
+        the right rule and the wrong one answer 0 and nothing is being tested.
         """
         cover = _tilt_cover(
-            sol_elev=45.0, mode="specify_angles", angle_0=120.0, angle_100=180.0
+            sol_elev=sol_elev, mode="specify_angles", angle_0=120.0, angle_100=180.0
         )
         assert cover._horizontal_percentage() == pytest.approx(-50.0)
-        assert cover.calculate_raw_percentage() == 0.0
-        assert _tilt_solar_position(cover) == 0
-        assert _tilt_solar_position_minimized(cover, n_steps) == 0
+        assert _tilt_solar_position(cover) == commanded
+        result = _tilt_solar_position_minimized(cover, n_steps)
+        assert result == expected[n_steps]
+        # 100 % is the covering end on this calibration, so quantising can only
+        # move the slat UP the scale, never back toward the open 120°.
+        assert result >= commanded
+
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    @pytest.mark.parametrize(
+        ("max_slat_angle", "min_tilt", "max_tilt"),
+        [(45.0, 30, 90), (60.0, 30, 90), (80.0, 30, 90)],
+    )
+    def test_a_band_still_binds_above_the_travel(
+        self, max_slat_angle, min_tilt, max_tilt, n_steps
+    ):
+        """A louvered roof has BOTH an off-travel pivot and a ``min_tilt``.
+
+        The quantiser is the last thing on the tilt axis — ``apply_config_limits``
+        after it carries ``min_pos``/``max_pos``, not the tilt band — so a ladder
+        laid over the whole 0–100 scale hands the entity a command the band
+        already rejected. The saturated 100 % solve is banded to the 90 % cap,
+        a demand for no coverage, and the single level used to answer 0: thirty
+        points below the floor the user set, at every elevation.
+        """
+        cover = _louvered_cover(
+            sol_elev=45.0,
+            max_slat_angle=max_slat_angle,
+            min_tilt=min_tilt,
+            max_tilt=max_tilt,
+        )
+        assert cover.coverage_travel_bounds() == (float(min_tilt), float(max_tilt))
+        assert _tilt_solar_position(cover) == max_tilt
+        assert _tilt_solar_position_minimized(cover, n_steps) == max_tilt
+
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    @pytest.mark.parametrize(("min_tilt", "max_tilt"), [(45, 100), (60, 100)])
+    @pytest.mark.parametrize("sol_elev", [55.0, 60.0, 70.0, 85.0])
+    def test_a_band_still_binds_below_the_travel(
+        self, sol_elev, min_tilt, max_tilt, n_steps
+    ):
+        """Inverted calibration plus a floor: the ladder starts at ``min_tilt``.
+
+        The band's OPEN end is ``min_tilt`` here, because 0 % is the open end of
+        an inverted calibration, and that is where the ladder has to be anchored
+        — a demand sitting on the floor is a demand for the least coverage this
+        cover can deliver and must not move.
+        """
+        cover = _tilt_cover(
+            sol_elev=sol_elev,
+            mode="specify_angles",
+            angle_0=120.0,
+            angle_100=180.0,
+            min_tilt=min_tilt,
+            max_tilt=max_tilt,
+        )
+        commanded = _tilt_solar_position(cover)
+        result = _tilt_solar_position_minimized(cover, n_steps)
+        assert min_tilt <= result <= max_tilt
+        assert result >= commanded
+
+    def test_the_quantiser_and_the_comparator_agree_on_the_covering_end(self):
+        """The two pivot consumers must not rank an inverted axis oppositely.
+
+        ``more_protective_position`` ranks by distance from the raw −50 % pivot
+        and calls 40 % more protective than 20 %. The quantiser reads the same
+        pivot, so whichever way it moves a demand has to be the way the
+        comparator calls protective — one engine cannot have two covering ends.
+        """
+        policy = get_policy("cover_tilt")
+        cover = _tilt_cover(
+            sol_elev=60.0, mode="specify_angles", angle_0=120.0, angle_100=180.0
+        )
+        assert policy.more_protective_position(20, 40, cover=cover) == 40
+        commanded = _tilt_solar_position(cover)
+        quantised = _tilt_solar_position_minimized(cover, 2)
+        assert (
+            policy.more_protective_position(commanded, quantised, cover=cover)
+            == quantised
+        )
 
 
 class TestProportionalBandKeepsTheCommandSpacePivot:

--- a/tests/test_cover_types/test_protective.py
+++ b/tests/test_cover_types/test_protective.py
@@ -13,12 +13,28 @@ string branch or hardcoded min/max leaks outside ``cover_types/``.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.engine.covers import AdaptiveTiltCover
+from tests.cover_helpers import make_cover_config, make_tilt_config
 
 # Cover types whose primary axis closes (lower %) to block the sun.
 _LOWER_IS_PROTECTIVE = ["cover_blind", "cover_tilt", "cover_venetian"]
+
+
+def _mode2_tilt_cover() -> AdaptiveTiltCover:
+    """Build a MODE2 slat engine — pivot at the horizontal 50 % (issue #1104)."""
+    return AdaptiveTiltCover(
+        logger=MagicMock(),
+        sol_azi=180.0,
+        sol_elev=45.0,
+        sun_data=MagicMock(),
+        config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
+        tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+    )
 
 
 @pytest.mark.unit
@@ -43,3 +59,60 @@ def test_higher_percentage_is_more_protective_for_awning() -> None:
 )
 def test_equal_values_are_idempotent(cover_type: str) -> None:
     assert get_policy(cover_type).more_protective_position(50, 50) == 50
+
+
+# ---------------------------------------------------------------------------
+# Bi-directional axis (issue #1104) — "more protective" is measured as distance
+# from the engine's coverage pivot, not as a min/max on the raw percentage.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_same_side_above_pivot_picks_farther_from_horizontal() -> None:
+    """The discriminating case the symmetric ``(30, 70)`` pair cannot reach.
+
+    On MODE2, 55 % is 99° (9° off horizontal) and 60 % is 108° (18° off), so the
+    bigger percentage is the more closed slat. ``min`` answers 55.
+    """
+    policy = get_policy("cover_tilt")
+    cover = _mode2_tilt_cover()
+    assert policy.more_protective_position(55, 60, cover=cover) == 60
+    assert policy.more_protective_position(60, 55, cover=cover) == 60
+
+
+@pytest.mark.unit
+def test_same_side_below_pivot_picks_farther_from_horizontal() -> None:
+    """Below the pivot the two rules agree — the fix must not disturb that."""
+    policy = get_policy("cover_tilt")
+    cover = _mode2_tilt_cover()
+    assert policy.more_protective_position(45, 40, cover=cover) == 40
+    assert policy.more_protective_position(40, 45, cover=cover) == 40
+
+
+@pytest.mark.unit
+def test_symmetric_straddle_tie_breaks_to_axis_rule() -> None:
+    """Equally protective in real terms (both 36° off), so the axis rule decides."""
+    policy = get_policy("cover_tilt")
+    cover = _mode2_tilt_cover()
+    assert policy.more_protective_position(30, 70, cover=cover) == 30
+    assert policy.more_protective_position(70, 30, cover=cover) == 30
+
+
+@pytest.mark.unit
+def test_no_cover_falls_back_to_monotonic_rule() -> None:
+    """Callers with no engine in scope (the glare-zone handler) are unchanged."""
+    assert get_policy("cover_tilt").more_protective_position(55, 60) == 55
+
+
+@pytest.mark.unit
+def test_pivotless_engine_falls_back() -> None:
+    """A monotonic engine reports no pivot, so the axis rule stands for both types."""
+    pivotless = MagicMock()
+    pivotless.coverage_pivot_percentage.return_value = None
+    assert (
+        get_policy("cover_tilt").more_protective_position(55, 60, cover=pivotless) == 55
+    )
+    assert (
+        get_policy("cover_awning").more_protective_position(55, 60, cover=pivotless)
+        == 60
+    )

--- a/tests/test_cover_types/test_protective.py
+++ b/tests/test_cover_types/test_protective.py
@@ -25,7 +25,7 @@ from tests.cover_helpers import make_cover_config, make_tilt_config
 _LOWER_IS_PROTECTIVE = ["cover_blind", "cover_tilt", "cover_venetian"]
 
 
-def _mode2_tilt_cover() -> AdaptiveTiltCover:
+def _mode2_tilt_cover(**tilt_overrides) -> AdaptiveTiltCover:
     """Build a MODE2 slat engine — pivot at the horizontal 50 % (issue #1104)."""
     return AdaptiveTiltCover(
         logger=MagicMock(),
@@ -33,7 +33,11 @@ def _mode2_tilt_cover() -> AdaptiveTiltCover:
         sol_elev=45.0,
         sun_data=MagicMock(),
         config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
-        tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+        tilt_config=make_tilt_config(
+            slat_distance=0.02,
+            depth=0.03,
+            **{"mode": "mode2", **tilt_overrides},
+        ),
     )
 
 
@@ -116,3 +120,56 @@ def test_pivotless_engine_falls_back() -> None:
         get_policy("cover_awning").more_protective_position(55, 60, cover=pivotless)
         == 60
     )
+
+
+@pytest.mark.unit
+def test_proportional_band_is_ranked_in_command_space() -> None:
+    """The #957 band transform does not move the pivot (#1104 audit).
+
+    ``tilt_transform=proportional`` remaps the solar DEMAND into
+    ``[min_tilt, max_tilt]``; what comes out is the percentage handed to the
+    cover entity, whose own scale is unchanged. So on MODE2 the horizontal slat
+    is still at 50 % of the COMMAND, and the two candidates here are 27 % = 48.6°
+    (41.4° off horizontal) and 30 % = 54° (36.0° off) — 27 is the more closed
+    slat, and the comparator must not be handed a band-remapped pivot that would
+    reverse that.
+    """
+    policy = get_policy("cover_tilt")
+    cover = _mode2_tilt_cover(min_tilt=0, max_tilt=50, tilt_transform="proportional")
+    assert cover.coverage_pivot_percentage() == 50.0
+    assert policy.more_protective_position(27, 30, cover=cover) == 27
+    assert policy.more_protective_position(30, 27, cover=cover) == 27
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("angle_0", "angle_100", "pivot", "a", "b", "expected"),
+    [
+        # 0° → 0 %, 45° → 100 %: horizontal is an unreachable 200 %. Every
+        # sample is below it, so distance-from-pivot and the axis ``min`` agree
+        # — 60 % is 27° (63° off horizontal), 80 % is 36° (54° off).
+        (0.0, 45.0, 200.0, 60, 80, 60),
+        # 120° → 0 %, 180° → 100 %: horizontal is an unreachable −50 %, and now
+        # the two rules DISAGREE. 20 % is 132° (42° off), 40 % is 144° (54° off),
+        # so the axis ``min`` would command the more open slat.
+        (120.0, 180.0, -50.0, 20, 40, 40),
+    ],
+)
+def test_off_travel_pivot_still_orders_the_comparator(
+    angle_0, angle_100, pivot, a, b, expected
+) -> None:
+    """An unreachable pivot is still a valid ordering reference (#1104 audit).
+
+    The percentage↔angle map is affine, so ``|pct − pivot|`` is proportional to
+    ``|angle − 90°|`` whether or not the pivot itself lies on the travel. Only
+    the coverage-step quantiser — which anchors levels ON the pivot and spans
+    them to the end of the travel — needs the pivot to be reachable, which is
+    why the range guard lives there and not on the shared engine hook.
+    """
+    policy = get_policy("cover_tilt")
+    cover = _mode2_tilt_cover(
+        mode="specify_angles", angle_0=angle_0, angle_100=angle_100
+    )
+    assert cover.coverage_pivot_percentage() == pytest.approx(pivot)
+    assert policy.more_protective_position(a, b, cover=cover) == expected
+    assert policy.more_protective_position(b, a, cover=cover) == expected

--- a/tests/test_cover_types/test_protective.py
+++ b/tests/test_cover_types/test_protective.py
@@ -164,7 +164,10 @@ def test_off_travel_pivot_still_orders_the_comparator(
     ``|angle − 90°|`` whether or not the pivot itself lies on the travel. Only
     the coverage-step quantiser — which anchors levels ON the pivot and spans
     them to the end of the travel — needs the pivot to be reachable, which is
-    why the range guard lives there and not on the shared engine hook.
+    why it pulls the anchor onto the travel itself instead of the shared engine
+    hook doing it for everyone. Both consumers still name the same covering end:
+    see ``test_conservative_rounding.py`` ::
+    ``test_the_quantiser_and_the_comparator_agree_on_the_covering_end``.
     """
     policy = get_policy("cover_tilt")
     cover = _mode2_tilt_cover(

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -1474,6 +1474,68 @@ class TestVenetianForecastSecondaryAxes:
         assert policy.forecast_secondary_axes(**kw)["tilt"] == expected
         assert abs(expected - 50) >= abs(30 - 50)
 
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    @pytest.mark.parametrize("transform", ["clamp", "proportional"])
+    @pytest.mark.parametrize(
+        ("min_tilt", "max_tilt"), [(0, 100), (0, 55), (0, 60), (45, 100), (25, 75)]
+    )
+    @pytest.mark.parametrize("sol_elev", [21.0, 27.0, 34.4, 45.0, 68.0, 88.0])
+    def test_forecast_tilt_quantize_stays_inside_the_band(
+        self, sol_elev, min_tilt, max_tilt, transform, n_steps
+    ):
+        """The second quantiser call site keeps ``[min_tilt, max_tilt]`` (#1104).
+
+        ``VenetianCoverCalculation._clamp_tilt`` bands the engine tilt, and then
+        ``_compose_tilt`` quantises it — with nothing after. Levels measured
+        against the whole 0–100 scale put the top one at the far end of the
+        scale, so every above-pivot demand was commanded past the user's cap on
+        this path exactly as it was on the tilt-only one.
+        """
+        from tests.cover_helpers import make_tilt_config
+
+        policy = VenetianPolicy()
+        tilt_config = make_tilt_config(
+            slat_distance=0.02,
+            depth=0.03,
+            mode="mode2",
+            min_tilt=min_tilt,
+            max_tilt=max_tilt,
+            tilt_transform=transform,
+        )
+        kw = self._kwargs(
+            sol_elev=sol_elev, minimize_movements=True, max_coverage_steps=n_steps
+        )
+        kw["config_service"].get_tilt_data.return_value = tilt_config
+        tilt = policy.forecast_secondary_axes(**kw)[policy.axes[1].name]
+        assert min_tilt <= tilt <= max_tilt
+
+    @pytest.mark.parametrize(
+        ("n_steps", "expected"),
+        [(1, 60), (2, 55), (3, 53)],
+    )
+    def test_forecast_tilt_levels_spread_across_the_band(self, n_steps, expected):
+        """Same ladder as the tilt-only path, through the venetian seam.
+
+        Both call sites ask their engine for the reachable travel and hand it to
+        the one quantiser, so a ``max_tilt`` of 60 gives the same three levels
+        here that ``TestTiltOnlyBandSurvivesTheQuantisation`` pins.
+        """
+        from tests.cover_helpers import make_tilt_config
+
+        policy = VenetianPolicy()
+        tilt_config = make_tilt_config(
+            slat_distance=0.02, depth=0.03, mode="mode2", min_tilt=0, max_tilt=60
+        )
+        unquantised = self._kwargs(sol_elev=34.4)
+        unquantised["config_service"].get_tilt_data.return_value = tilt_config
+        assert policy.forecast_secondary_axes(**unquantised)["tilt"] == 51
+
+        kw = self._kwargs(
+            sol_elev=34.4, minimize_movements=True, max_coverage_steps=n_steps
+        )
+        kw["config_service"].get_tilt_data.return_value = tilt_config
+        assert policy.forecast_secondary_axes(**kw)["tilt"] == expected
+
     def test_compose_tilt_matches_post_pipeline_resolve(self):
         """The forecast tilt equals what post_pipeline_resolve puts on result.tilt.
 

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -1371,6 +1371,32 @@ class TestVenetianForecastSecondaryAxes:
         # N=1 with full-coverage-at-zero → slats fully closed (tilt 0).
         assert result["tilt"] == 0
 
+    def test_forecast_tilt_quantize_respects_mode2_pivot(self, monkeypatch):
+        """The venetian quantise call site honours the bi-directional pivot (#1104).
+
+        Same defect, same fix, second call site: on MODE2 the tilt axis has its
+        coverage-zero point at the horizontal slat (50 %), so a 70 % demand is
+        20 points of coverage above the pivot. Two levels per side round that up
+        to 50 % + 0.5 × 50 = 75 %. Scaling it against a 100 % coverage-zero end
+        instead lands on 50 % — the fully-open slat.
+        """
+        from tests.cover_helpers import make_tilt_config
+
+        from custom_components.adaptive_cover_pro.engine.covers import (
+            VenetianCoverCalculation,
+        )
+
+        monkeypatch.setattr(
+            VenetianCoverCalculation,
+            "tilt_for_position",
+            lambda self, position: 70,
+        )
+        policy = VenetianPolicy()
+        kw = self._kwargs(minimize_movements=True, max_coverage_steps=2)
+        kw["config_service"].get_tilt_data.return_value = make_tilt_config(mode="mode2")
+        result = policy.forecast_secondary_axes(**kw)
+        assert result["tilt"] == 75
+
     def test_compose_tilt_matches_post_pipeline_resolve(self):
         """The forecast tilt equals what post_pipeline_resolve puts on result.tilt.
 

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -1397,29 +1397,40 @@ class TestVenetianForecastSecondaryAxes:
         result = policy.forecast_secondary_axes(**kw)
         assert result["tilt"] == 75
 
-    @pytest.mark.parametrize("n_steps", [1, 2, 3])
     @pytest.mark.parametrize(
-        ("angle_0", "angle_100", "expected"),
+        ("angle_0", "angle_100", "sol_elev", "commanded", "expected"),
         [
             # 0° → 0 %, 45° → 100 %: the slats stop short of horizontal, so
             # 100 % is the most-open orientation this calibration can reach and
-            # the solve saturates there — a demand for NO coverage.
-            (0.0, 45.0, 100),
-            # 120° → 0 %, 180° → 100 %: the mirror, most open at 0 %.
-            (120.0, 180.0, 0),
+            # the solve saturates there — a demand for NO coverage, which no
+            # step count may turn into a movement.
+            (0.0, 45.0, 45.0, 100, {1: 100, 2: 100, 3: 100}),
+            # 120° → 0 %, 180° → 100 %: the INVERTED mirror. 0 % is the 120°
+            # slat — the most open this drive reaches — and 100 % is the shut
+            # 180° one, the opposite of what the tilt axis flag declares. At 60°
+            # elevation the solve is 130.53°, an 18 % command carrying real
+            # coverage: quantising it must climb toward 100 %, and used to pin
+            # it at 0 % instead.
+            (120.0, 180.0, 60.0, 18, {1: 100, 2: 50, 3: 33}),
+            # The same calibration nearly shut already (171.67° → 87 %).
+            (120.0, 180.0, 85.0, 87, {1: 100, 2: 100, 3: 100}),
         ],
     )
-    def test_forecast_tilt_quantize_ignores_an_off_travel_pivot(
-        self, angle_0, angle_100, expected, n_steps
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    def test_forecast_tilt_quantize_follows_an_off_travel_pivots_side(
+        self, angle_0, angle_100, sol_elev, commanded, expected, n_steps
     ):
         """Second call site, second half of the pivot contract (#1104 audit).
 
         A ``specify_angles`` calibration whose endpoints sit on one side of
         horizontal never reaches maximum openness, so the pivot lands off the
         0–100 travel (200 % here, −50 % for the inverted pair) and the axis is
-        monotonic after all. Anchoring the coverage levels on the unreachable
-        point turned a zero-coverage demand into a full-scale move — at
-        ``n_steps=1`` the slats were commanded to the far end of their travel.
+        monotonic over its travel after all. Which END covers is then the
+        pivot's SIDE, not ``axes[1].open_blocks_sun``: above the travel 0 %
+        covers (the flag agrees), below it 100 % does (the flag is backwards).
+
+        Both halves matter and both are exercised at a NON-ZERO demand, because
+        a demand of 0 or 100 answers itself under either rule.
         """
         from tests.cover_helpers import make_tilt_config
 
@@ -1431,13 +1442,15 @@ class TestVenetianForecastSecondaryAxes:
             angle_0=angle_0,
             angle_100=angle_100,
         )
-        unquantised = self._kwargs()
+        unquantised = self._kwargs(sol_elev=sol_elev)
         unquantised["config_service"].get_tilt_data.return_value = tilt_config
-        assert policy.forecast_secondary_axes(**unquantised)["tilt"] == expected
+        assert policy.forecast_secondary_axes(**unquantised)["tilt"] == commanded
 
-        kw = self._kwargs(minimize_movements=True, max_coverage_steps=n_steps)
+        kw = self._kwargs(
+            sol_elev=sol_elev, minimize_movements=True, max_coverage_steps=n_steps
+        )
         kw["config_service"].get_tilt_data.return_value = tilt_config
-        assert policy.forecast_secondary_axes(**kw)["tilt"] == expected
+        assert policy.forecast_secondary_axes(**kw)["tilt"] == expected[n_steps]
 
     @pytest.mark.parametrize(
         ("n_steps", "expected"),

--- a/tests/test_cover_types/test_venetian.py
+++ b/tests/test_cover_types/test_venetian.py
@@ -1397,6 +1397,83 @@ class TestVenetianForecastSecondaryAxes:
         result = policy.forecast_secondary_axes(**kw)
         assert result["tilt"] == 75
 
+    @pytest.mark.parametrize("n_steps", [1, 2, 3])
+    @pytest.mark.parametrize(
+        ("angle_0", "angle_100", "expected"),
+        [
+            # 0° → 0 %, 45° → 100 %: the slats stop short of horizontal, so
+            # 100 % is the most-open orientation this calibration can reach and
+            # the solve saturates there — a demand for NO coverage.
+            (0.0, 45.0, 100),
+            # 120° → 0 %, 180° → 100 %: the mirror, most open at 0 %.
+            (120.0, 180.0, 0),
+        ],
+    )
+    def test_forecast_tilt_quantize_ignores_an_off_travel_pivot(
+        self, angle_0, angle_100, expected, n_steps
+    ):
+        """Second call site, second half of the pivot contract (#1104 audit).
+
+        A ``specify_angles`` calibration whose endpoints sit on one side of
+        horizontal never reaches maximum openness, so the pivot lands off the
+        0–100 travel (200 % here, −50 % for the inverted pair) and the axis is
+        monotonic after all. Anchoring the coverage levels on the unreachable
+        point turned a zero-coverage demand into a full-scale move — at
+        ``n_steps=1`` the slats were commanded to the far end of their travel.
+        """
+        from tests.cover_helpers import make_tilt_config
+
+        policy = VenetianPolicy()
+        tilt_config = make_tilt_config(
+            slat_distance=0.02,
+            depth=0.03,
+            mode="specify_angles",
+            angle_0=angle_0,
+            angle_100=angle_100,
+        )
+        unquantised = self._kwargs()
+        unquantised["config_service"].get_tilt_data.return_value = tilt_config
+        assert policy.forecast_secondary_axes(**unquantised)["tilt"] == expected
+
+        kw = self._kwargs(minimize_movements=True, max_coverage_steps=n_steps)
+        kw["config_service"].get_tilt_data.return_value = tilt_config
+        assert policy.forecast_secondary_axes(**kw)["tilt"] == expected
+
+    @pytest.mark.parametrize(
+        ("n_steps", "expected"),
+        [(1, 0), (2, 25), (3, 17)],
+    )
+    def test_forecast_tilt_quantize_keeps_the_command_space_pivot(
+        self, n_steps, expected
+    ):
+        """A proportional band does not move horizontal (#1104 audit).
+
+        ``tilt_transform=proportional`` squeezes the 59.37 % demand into
+        ``[0, 50]`` and commands 30 %. That 30 % is still read on the entity's
+        own MODE2 scale (54°), so horizontal is still the 50 % the tilt engine
+        reports — and quantising away from it lands on 0 / 25 / 17 %, every one
+        of them a slat FARTHER from horizontal than the 30 % it replaced.
+        """
+        from tests.cover_helpers import make_tilt_config
+
+        policy = VenetianPolicy()
+        tilt_config = make_tilt_config(
+            slat_distance=0.02,
+            depth=0.03,
+            mode="mode2",
+            min_tilt=0,
+            max_tilt=50,
+            tilt_transform="proportional",
+        )
+        unquantised = self._kwargs()
+        unquantised["config_service"].get_tilt_data.return_value = tilt_config
+        assert policy.forecast_secondary_axes(**unquantised)["tilt"] == 30
+
+        kw = self._kwargs(minimize_movements=True, max_coverage_steps=n_steps)
+        kw["config_service"].get_tilt_data.return_value = tilt_config
+        assert policy.forecast_secondary_axes(**kw)["tilt"] == expected
+        assert abs(expected - 50) >= abs(30 - 50)
+
     def test_compose_tilt_matches_post_pipeline_resolve(self):
         """The forecast tilt equals what post_pipeline_resolve puts on result.tilt.
 

--- a/tests/test_coverage_steps.py
+++ b/tests/test_coverage_steps.py
@@ -183,9 +183,7 @@ def test_degenerate_boundary_pivot_has_no_side_to_quantize_into():
 
 
 # ``max_coverage_steps`` is bounded to 1–10 by ``const.OPTION_RANGES``.
-@pytest.mark.parametrize("percentage", range(0, 101))
-@pytest.mark.parametrize("n", range(1, 11))
-def test_monotonic_pivot_reduces_to_the_boolean_path(percentage, n):
+def test_monotonic_pivot_reduces_to_the_boolean_path():
     """The generalization subsumes the monotonic axes rather than replacing them.
 
     A monotonic axis is a bi-directional one whose pivot sits on a boundary, so
@@ -193,8 +191,14 @@ def test_monotonic_pivot_reduces_to_the_boolean_path(percentage, n):
     that equality is what keeps every blind / awning / MODE1-tilt caller byte-
     identical across this change (issue #978's guarantee).
     """
-    assert quantize(percentage, n, True, pivot=100.0) == quantize(percentage, n, True)
-    assert quantize(percentage, n, False, pivot=0.0) == quantize(percentage, n, False)
+    for percentage in range(0, 101):
+        for n in range(1, 11):
+            assert quantize(percentage, n, True, pivot=100.0) == quantize(
+                percentage, n, True
+            )
+            assert quantize(percentage, n, False, pivot=0.0) == quantize(
+                percentage, n, False
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -210,24 +214,47 @@ def test_monotonic_pivot_reduces_to_the_boolean_path(percentage, n):
 #   horizontal — the config flow only enforces ``angle_0 < angle_100``, so
 #   0°→0 % / 45°→100 % gives 200 % and 120°/180° gives −50 %.
 #
-# A slat that never passes through horizontal is monotonic over its whole
-# travel, which is exactly what ``pivot is None`` means — anchoring the level
-# arithmetic on an unreachable point instead turns a zero-coverage demand into
-# a full-scale move.
-_OFF_TRAVEL_PIVOTS = [200.0, 150.0, 100.5, -0.5, -50.0]
+# A slat that never passes through horizontal is monotonic over its travel —
+# but WHICH end covers is then decided by the SIDE the pivot fell off, not by
+# the axis flag. Above the travel the near end is 100 % (the most open the slat
+# gets) and 0 % covers; below it the calibration is inverted and 100 % covers.
+# The static ``full_coverage_at_zero`` flag says "0 % covers" for every tilt
+# axis, so on the inverted calibration it is exactly backwards.
+_PIVOTS_ABOVE_THE_TRAVEL = [200.0, 150.0, 100.5]
+_PIVOTS_BELOW_THE_TRAVEL = [-0.5, -50.0]
+_OFF_TRAVEL_PIVOTS = [*_PIVOTS_ABOVE_THE_TRAVEL, *_PIVOTS_BELOW_THE_TRAVEL]
 
 
-@pytest.mark.parametrize("pivot", _OFF_TRAVEL_PIVOTS)
-@pytest.mark.parametrize("percentage", range(0, 101, 5))
-@pytest.mark.parametrize("n", range(1, 11))
+@pytest.mark.parametrize("pivot", _PIVOTS_ABOVE_THE_TRAVEL)
 @pytest.mark.parametrize("full_coverage_at_zero", [True, False])
-def test_off_travel_pivot_reduces_to_the_boolean_path(
-    pivot, percentage, n, full_coverage_at_zero
-):
-    """A pivot off the travel is the monotonic case, restated less precisely."""
-    assert quantize(percentage, n, full_coverage_at_zero, pivot=pivot) == quantize(
-        percentage, n, full_coverage_at_zero
-    )
+def test_a_pivot_above_the_travel_closes_toward_zero(pivot, full_coverage_at_zero):
+    """100 % is the open end, so the ladder is the ``full_coverage_at_zero`` one.
+
+    Whatever flag the caller passed: the pivot's side is the more specific
+    answer and outranks it. For a tilt axis the flag happens to agree here, so
+    this half is the regression guard rather than the fix.
+    """
+    for percentage in range(0, 101):
+        for n in range(1, 11):
+            assert quantize(
+                percentage, n, full_coverage_at_zero, pivot=pivot
+            ) == quantize(percentage, n, True)
+
+
+@pytest.mark.parametrize("pivot", _PIVOTS_BELOW_THE_TRAVEL)
+@pytest.mark.parametrize("full_coverage_at_zero", [True, False])
+def test_a_pivot_below_the_travel_closes_toward_100(pivot, full_coverage_at_zero):
+    """0 % is the open end here, so the ladder is the mirrored one.
+
+    This is the half the axis flag gets backwards: a tilt axis always declares
+    ``full_coverage_at_zero``, and on a 120°→0 % / 180°→100 % calibration 0 % is
+    the most OPEN slat the drive reaches.
+    """
+    for percentage in range(0, 101):
+        for n in range(1, 11):
+            assert quantize(
+                percentage, n, full_coverage_at_zero, pivot=pivot
+            ) == quantize(percentage, n, False)
 
 
 def test_off_travel_pivot_leaves_a_zero_coverage_demand_alone():
@@ -244,6 +271,21 @@ def test_off_travel_pivot_leaves_a_zero_coverage_demand_alone():
 def test_negative_pivot_does_not_invert_the_single_level():
     """Mirror image below the travel: 0 % must not be read as half-covered."""
     assert quantize(0, 1, full_coverage_at_zero=True, pivot=-50.0) == 0
+
+
+def test_an_inverted_calibration_closes_toward_the_far_end():
+    """A −50 % pivot puts full coverage at 100 %, not at 0 % (#1104 audit).
+
+    The demands are the two the ``specify_angles`` 120°/180° cover really
+    produces: 18 % is 130.8° (40.8° off horizontal) and 87 % is 172.2° (82.2°
+    off). Reading the axis flag instead of the pivot's side commanded 0 % for
+    both — the 120° slat, the most OPEN this drive has, while direct sun was
+    being tracked.
+    """
+    assert quantize(18, 1, full_coverage_at_zero=True, pivot=-50.0) == 100
+    assert quantize(18, 2, full_coverage_at_zero=True, pivot=-50.0) == 50
+    assert quantize(18, 3, full_coverage_at_zero=True, pivot=-50.0) == 33
+    assert quantize(87, 3, full_coverage_at_zero=True, pivot=-50.0) == 100
 
 
 # ---------------------------------------------------------------------------
@@ -314,22 +356,53 @@ def test_the_whole_travel_is_the_default_bound(full_coverage_at_zero):
             ) == quantize(percentage, n, full_coverage_at_zero, pivot=50.0)
 
 
-@pytest.mark.parametrize("pivot", [None, *_OFF_TRAVEL_PIVOTS])
 @pytest.mark.parametrize("full_coverage_at_zero", [True, False])
-def test_bounds_are_ignored_without_an_anchorable_pivot(pivot, full_coverage_at_zero):
+def test_bounds_are_ignored_without_a_pivot(full_coverage_at_zero):
     """No pivot, no ladder to constrain — the monotonic path is bit-identical.
 
-    The band matters here only because the levels are ANCHORED on the pivot.
-    Where they are not — a monotonic axis, or one whose pivot the travel never
-    reaches — the boolean path answers, exactly as it did before bounds existed.
-    Swept past both ends of the travel and past both ends of the step range so
-    the ``n_steps < 1`` short-circuit is included.
+    The band matters only because the levels are ANCHORED on the pivot; with no
+    pivot at all there is nothing to anchor, so the boolean path answers exactly
+    as it did before bounds existed. Swept past both ends of the travel and past
+    both ends of the step range so the ``n_steps < 1`` short-circuit is included.
     """
     for percentage in range(-5, 106):
         for n in range(0, 12):
             assert quantize(
-                percentage, n, full_coverage_at_zero, pivot=pivot, bounds=(45.0, 55.0)
+                percentage, n, full_coverage_at_zero, pivot=None, bounds=(45.0, 55.0)
             ) == quantize(percentage, n, full_coverage_at_zero)
+
+
+@pytest.mark.parametrize("pivot", _OFF_TRAVEL_PIVOTS)
+@pytest.mark.parametrize("n", range(1, 11))
+def test_an_off_travel_pivot_still_obeys_the_band(pivot, n):
+    """The band binds wherever the ladder is anchored, reachable pivot or not.
+
+    A louvered roof topping out below horizontal is exactly the config that has
+    BOTH — an off-travel pivot and a real ``[min_tilt, max_tilt]``. The quantiser
+    is the last thing on the tilt axis, so a ladder laid over the whole 0–100
+    scale hands the entity a command the band already rejected: at
+    ``min_tilt=30`` the single level commanded 0.
+    """
+    for percentage in range(30, 91):
+        result = quantize(
+            percentage, n, full_coverage_at_zero=True, pivot=pivot, bounds=(30.0, 90.0)
+        )
+        assert 30 <= result <= 90
+
+
+def test_an_off_travel_pivot_anchors_on_the_reachable_end():
+    """Both band edges, both sides: a zero-coverage demand still does not move."""
+    # 90 % is the most-open slat a [30, 90] band reaches when horizontal is above
+    # the travel — the anchor moves in from 100 to the cap.
+    assert (
+        quantize(90, 1, full_coverage_at_zero=True, pivot=200.0, bounds=(30.0, 90.0))
+        == 90
+    )
+    # Mirror: with horizontal below the travel the open end is the floor.
+    assert (
+        quantize(45, 1, full_coverage_at_zero=True, pivot=-50.0, bounds=(45.0, 100.0))
+        == 45
+    )
 
 
 def test_a_band_pinned_to_one_point_has_nothing_to_quantize_into():
@@ -337,6 +410,48 @@ def test_a_band_pinned_to_one_point_has_nothing_to_quantize_into():
     assert (
         quantize(70, 3, full_coverage_at_zero=True, pivot=50.0, bounds=(70.0, 70.0))
         == 70
+    )
+
+
+@pytest.mark.parametrize(
+    ("bounds", "open_end"),
+    [
+        # ``[min_tilt, max_tilt] = [60, 100]`` restricts a MODE2 slat to the
+        # upward-closing half: 60 % (108°) is the most OPEN orientation it can
+        # be driven to, even though the pivot at 50 % is more open still.
+        ((60.0, 100.0), 60),
+        # The mirror half, where the band's open end is its top edge.
+        ((0.0, 40.0), 40),
+    ],
+)
+def test_a_band_that_excludes_the_pivot_anchors_on_its_open_end(bounds, open_end):
+    """The anchor is the least-covering REACHABLE position, not the pivot.
+
+    The same rule the off-travel cases need, reached from the other direction —
+    here the pivot is on the travel and the BAND is what puts it out of reach.
+    Measured from the unreachable 50 %, the band's own open end carries a fifth
+    of a side's coverage and one step commanded the far edge: a full-travel
+    sweep in answer to a demand for the least coverage this cover can deliver.
+    """
+    for n in range(1, 11):
+        assert (
+            quantize(open_end, n, full_coverage_at_zero=True, bounds=bounds, pivot=50.0)
+            == open_end
+        )
+
+
+def test_a_fractional_band_edge_is_not_rounded_past():
+    """Rounding the top level can add half a point; the edge has to win.
+
+    ``coverage_travel_bounds`` reports whole percentages today, so this is a
+    contract test rather than a live path — but "the result never passes the far
+    edge" is stated unconditionally, and a fractional edge is the one input that
+    could make it false. The top level here sits at 7.5 and rounds to 8.
+    """
+    assert quantize(7, 1, full_coverage_at_zero=True, pivot=0.5, bounds=(0.0, 7.5)) == 7
+    # Mirror below the pivot: the top level sits at 0.5 and rounds to 0.
+    assert (
+        quantize(1, 1, full_coverage_at_zero=True, pivot=7.5, bounds=(0.5, 10.0)) == 1
     )
 
 

--- a/tests/test_coverage_steps.py
+++ b/tests/test_coverage_steps.py
@@ -101,6 +101,103 @@ def test_zero_steps_is_noop():
 
 
 # ---------------------------------------------------------------------------
+# Bi-directional axis (issue #1104) — coverage is measured from a mid-scale
+# pivot, one set of levels per side, and quantization never crosses the pivot.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("percentage", "n", "expected"),
+    [
+        # 60 % is 10 of the 50 points above the pivot → 0.2 coverage → the
+        # half-step at 75 %. The old whole-range scale said 50 % — horizontal.
+        (60, 2, 75),
+        # One level per side is "fully closed on THIS side", not on either.
+        (60, 1, 100),
+        (51, 1, 100),
+        # Below the pivot the sides mirror: 40 % is 10 of 50 → half-step at 25 %.
+        (40, 2, 25),
+        (49, 1, 0),
+    ],
+)
+def test_mode2_pivot_quantizes_per_side(percentage, n, expected):
+    assert quantize(percentage, n, full_coverage_at_zero=True, pivot=50.0) == expected
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 5, 10])
+def test_on_the_pivot_stays_on_the_pivot(n):
+    """Zero coverage demand on either side rounds up to the zero-th level."""
+    assert quantize(50, n, full_coverage_at_zero=True, pivot=50.0) == 50
+
+
+@pytest.mark.parametrize("percentage", range(0, 101))
+@pytest.mark.parametrize("n", [1, 2, 3, 5, 10])
+def test_quantization_never_crosses_the_pivot(percentage, n):
+    """The commanded slat stays on the side of horizontal the demand is on."""
+    result = quantize(percentage, n, full_coverage_at_zero=True, pivot=50.0)
+    if percentage > 50:
+        assert result >= 50
+    else:
+        assert result <= 50
+
+
+@pytest.mark.parametrize("percentage", range(0, 101))
+@pytest.mark.parametrize("n", [1, 2, 3, 5, 10])
+def test_quantization_never_reduces_coverage(percentage, n):
+    """Distance from the pivot — the coverage measure — never shrinks."""
+    result = quantize(percentage, n, full_coverage_at_zero=True, pivot=50.0)
+    assert abs(result - 50) >= abs(percentage - 50)
+
+
+# A louvered roof with ``max_slat_angle=140`` puts horizontal at 90/140 → the
+# pivot is fractional and off-centre, which is why it is an engine-supplied
+# value rather than a constant.
+_FRACTIONAL_PIVOT = 90.0 / 140.0 * 100.0  # 64.2857…
+
+
+def test_fractional_pivot_upper_side_closes_upward():
+    # 65 % is just above the pivot → one level → the top of the upper side.
+    assert quantize(65, 1, full_coverage_at_zero=True, pivot=_FRACTIONAL_PIVOT) == 100
+
+
+def test_fractional_pivot_lower_side_closes_downward():
+    # 60 % is below the pivot → one level → the bottom of the lower side.
+    assert quantize(60, 1, full_coverage_at_zero=True, pivot=_FRACTIONAL_PIVOT) == 0
+
+
+@pytest.mark.parametrize("percentage", [0, 30, 60, 64, 65, 70, 90, 100])
+@pytest.mark.parametrize("n", [1, 2, 3, 5, 10])
+def test_fractional_pivot_stays_on_its_side(percentage, n):
+    result = quantize(
+        percentage, n, full_coverage_at_zero=True, pivot=_FRACTIONAL_PIVOT
+    )
+    if percentage > _FRACTIONAL_PIVOT:
+        assert result >= _FRACTIONAL_PIVOT
+    else:
+        assert result <= _FRACTIONAL_PIVOT
+
+
+def test_degenerate_boundary_pivot_has_no_side_to_quantize_into():
+    """A 0.0 pivot leaves the "below" side zero-width; 0 % is its only position."""
+    assert quantize(0, 2, full_coverage_at_zero=False, pivot=0.0) == 0
+
+
+# ``max_coverage_steps`` is bounded to 1–10 by ``const.OPTION_RANGES``.
+@pytest.mark.parametrize("percentage", range(0, 101))
+@pytest.mark.parametrize("n", range(1, 11))
+def test_monotonic_pivot_reduces_to_the_boolean_path(percentage, n):
+    """The generalization subsumes the monotonic axes rather than replacing them.
+
+    A monotonic axis is a bi-directional one whose pivot sits on a boundary, so
+    stating the pivot explicitly must be indistinguishable from not stating it —
+    that equality is what keeps every blind / awning / MODE1-tilt caller byte-
+    identical across this change (issue #978's guarantee).
+    """
+    assert quantize(percentage, n, True, pivot=100.0) == quantize(percentage, n, True)
+    assert quantize(percentage, n, False, pivot=0.0) == quantize(percentage, n, False)
+
+
+# ---------------------------------------------------------------------------
 # Live path — compute_solar_position applies quantization on the solar branch
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coverage_steps.py
+++ b/tests/test_coverage_steps.py
@@ -198,6 +198,55 @@ def test_monotonic_pivot_reduces_to_the_boolean_path(percentage, n):
 
 
 # ---------------------------------------------------------------------------
+# Off-travel pivot (issue #1104 audit) — horizontal is not always reachable
+# ---------------------------------------------------------------------------
+# The pivot is ``TILT_HORIZONTAL_DEG``'s image under the engine's own
+# angle→percentage map, and nothing constrains that map's range to 0–100. Two
+# shipped configurations put horizontal off the travel entirely:
+#
+# * a louvered roof with ``max_slat_angle`` below 90° — the field is a plain
+#   0–180 number box, so 45° gives 90/45 → 200 % and 60° gives 150 %;
+# * a ``specify_angles`` calibration whose endpoints both sit on ONE side of
+#   horizontal — the config flow only enforces ``angle_0 < angle_100``, so
+#   0°→0 % / 45°→100 % gives 200 % and 120°/180° gives −50 %.
+#
+# A slat that never passes through horizontal is monotonic over its whole
+# travel, which is exactly what ``pivot is None`` means — anchoring the level
+# arithmetic on an unreachable point instead turns a zero-coverage demand into
+# a full-scale move.
+_OFF_TRAVEL_PIVOTS = [200.0, 150.0, 100.5, -0.5, -50.0]
+
+
+@pytest.mark.parametrize("pivot", _OFF_TRAVEL_PIVOTS)
+@pytest.mark.parametrize("percentage", range(0, 101, 5))
+@pytest.mark.parametrize("n", range(1, 11))
+@pytest.mark.parametrize("full_coverage_at_zero", [True, False])
+def test_off_travel_pivot_reduces_to_the_boolean_path(
+    pivot, percentage, n, full_coverage_at_zero
+):
+    """A pivot off the travel is the monotonic case, restated less precisely."""
+    assert quantize(percentage, n, full_coverage_at_zero, pivot=pivot) == quantize(
+        percentage, n, full_coverage_at_zero
+    )
+
+
+def test_off_travel_pivot_leaves_a_zero_coverage_demand_alone():
+    """The headline case: 100 % is the most-open slat a 0–45° scale can reach.
+
+    With horizontal at an unreachable 200 %, measuring the demand as distance
+    from it makes the fully-open slat read as HALF the extended span — one
+    level of coverage — and the single-level quantiser answers "fully closed".
+    A demand that asks for no coverage must be left where it is.
+    """
+    assert quantize(100, 1, full_coverage_at_zero=True, pivot=200.0) == 100
+
+
+def test_negative_pivot_does_not_invert_the_single_level():
+    """Mirror image below the travel: 0 % must not be read as half-covered."""
+    assert quantize(0, 1, full_coverage_at_zero=True, pivot=-50.0) == 0
+
+
+# ---------------------------------------------------------------------------
 # Live path — compute_solar_position applies quantization on the solar branch
 # ---------------------------------------------------------------------------
 

--- a/tests/test_coverage_steps.py
+++ b/tests/test_coverage_steps.py
@@ -247,6 +247,114 @@ def test_negative_pivot_does_not_invert_the_single_level():
 
 
 # ---------------------------------------------------------------------------
+# Reachable travel (issue #1104 audit) — the ladder spans the band, not the scale
+# ---------------------------------------------------------------------------
+# A tilt axis carries its own ``[min_tilt, max_tilt]`` band, applied BEFORE this
+# quantiser and by nothing after it. Anchoring the levels on the pivot and
+# spanning them to the far end of the 0–100 scale therefore makes the top level
+# unreachable-by-configuration: on a ``max_tilt`` of 60 the single level above a
+# 50 % pivot is 100 %, forty points past the cap the user set.
+
+_BANDED_LADDER = [
+    # 51 % is 1 of the 10 points between the pivot and a 60 % cap: a tenth of
+    # the coverage available on that side, not a fiftieth of the scale.
+    (51, 1, 60),
+    (51, 2, 55),
+    (51, 3, 53),
+    # A demand already at the cap is the top level at every step count.
+    (60, 1, 60),
+    (60, 3, 60),
+    # Below the pivot this band's edge IS the end of the travel, so the lower
+    # side is unchanged by the bounds.
+    (40, 1, 0),
+    (40, 2, 25),
+]
+
+
+@pytest.mark.parametrize(("percentage", "n", "expected"), _BANDED_LADDER)
+def test_bounded_levels_span_the_band(percentage, n, expected):
+    assert (
+        quantize(
+            percentage, n, full_coverage_at_zero=True, pivot=50.0, bounds=(0.0, 60.0)
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("lo", "hi"), [(0, 100), (0, 60), (0, 55), (45, 100), (45, 55), (20, 60), (25, 75)]
+)
+@pytest.mark.parametrize("n", range(1, 11))
+def test_bounded_result_never_leaves_the_band(lo, hi, n):
+    """An in-band demand can only become an in-band command, and never opens up."""
+    for percentage in range(lo, hi + 1):
+        result = quantize(
+            percentage,
+            n,
+            full_coverage_at_zero=True,
+            pivot=50.0,
+            bounds=(float(lo), float(hi)),
+        )
+        assert lo <= result <= hi
+        assert abs(result - 50.0) >= abs(percentage - 50.0)
+
+
+@pytest.mark.parametrize("full_coverage_at_zero", [True, False])
+def test_the_whole_travel_is_the_default_bound(full_coverage_at_zero):
+    """Stating the full travel explicitly must be indistinguishable from silence.
+
+    Every caller without a band — and every axis whose band is the default
+    0/100 — has to keep the behaviour issue #1104 shipped, so the bounds are an
+    added constraint on the ladder, never a reshaping of it.
+    """
+    for percentage in range(0, 101):
+        for n in range(1, 11):
+            assert quantize(
+                percentage, n, full_coverage_at_zero, pivot=50.0, bounds=(0.0, 100.0)
+            ) == quantize(percentage, n, full_coverage_at_zero, pivot=50.0)
+
+
+@pytest.mark.parametrize("pivot", [None, *_OFF_TRAVEL_PIVOTS])
+@pytest.mark.parametrize("full_coverage_at_zero", [True, False])
+def test_bounds_are_ignored_without_an_anchorable_pivot(pivot, full_coverage_at_zero):
+    """No pivot, no ladder to constrain — the monotonic path is bit-identical.
+
+    The band matters here only because the levels are ANCHORED on the pivot.
+    Where they are not — a monotonic axis, or one whose pivot the travel never
+    reaches — the boolean path answers, exactly as it did before bounds existed.
+    Swept past both ends of the travel and past both ends of the step range so
+    the ``n_steps < 1`` short-circuit is included.
+    """
+    for percentage in range(-5, 106):
+        for n in range(0, 12):
+            assert quantize(
+                percentage, n, full_coverage_at_zero, pivot=pivot, bounds=(45.0, 55.0)
+            ) == quantize(percentage, n, full_coverage_at_zero)
+
+
+def test_a_band_pinned_to_one_point_has_nothing_to_quantize_into():
+    """``min_tilt == max_tilt`` leaves the side zero-width; the demand stands."""
+    assert (
+        quantize(70, 3, full_coverage_at_zero=True, pivot=50.0, bounds=(70.0, 70.0))
+        == 70
+    )
+
+
+def test_a_demand_already_past_the_band_is_not_opened_up():
+    """Defensive: the quantiser adds coverage or nothing, never subtracts it.
+
+    Both call sites band the value before handing it over, so this is not a
+    reachable state — but "never reduce coverage" is the quantiser's whole
+    contract, and it must not become conditional on the caller getting the
+    ordering right.
+    """
+    assert (
+        quantize(80, 1, full_coverage_at_zero=True, pivot=50.0, bounds=(0.0, 60.0))
+        == 80
+    )
+
+
+# ---------------------------------------------------------------------------
 # Live path — compute_solar_position applies quantization on the solar branch
 # ---------------------------------------------------------------------------
 

--- a/tests/test_engine/test_venetian_engine.py
+++ b/tests/test_engine/test_venetian_engine.py
@@ -301,11 +301,19 @@ class TestVenetianTiltSafetyMargin:
     def test_safety_margin_delegates_to_tilt_engine(self, mock_datetime):
         """Dual-path tilt equals the standalone tilt engine with the same margin.
 
-        Runs in the shipped MODE2 so the margin-adjusted raw (45.5458 %) has a
-        fraction above a half: ``round()`` would give 46 and only ``floor()``
-        gives 45. Under the old MODE1 fixture the raw was 91.0916 %, where
+        Runs in the shipped MODE2 so the margin-adjusted raw (44.8301 %) has a
+        fraction above a half: ``round()`` would give 45 and only ``floor()``
+        gives 44. Under the old MODE1 fixture the raw was 91.0916 %, where
         floor, round and the pre-#978 behaviour all agreed on 91 — the
         assertion could not see a rounding direction at all.
+
+        The expected raw moved from 45.5458 to 44.8301 when #1089 and #1090
+        met on develop. #1090 pinned the value from a branch cut before
+        #1089 landed, and #1089 added the flat ``SAFETY_MARGIN_USER_SLACK_MAX``
+        term, which closes the slat further for the same ``safety_margin``.
+        Both were green alone and red together. At this geometry the margin
+        is monotonic: 0.0 leaves the raw at 45.9101 and 0.5 now pulls it to
+        44.8301, i.e. further from horizontal, which is what #1089 intends.
         """
         from custom_components.adaptive_cover_pro.calculation import AdaptiveTiltCover
 
@@ -339,9 +347,9 @@ class TestVenetianTiltSafetyMargin:
         )
         raw = standalone.calculate_raw_percentage()
         # 81.98° is below horizontal, so the conservative direction is down.
-        assert raw == pytest.approx(45.545797, abs=1e-5)
-        assert round(raw) == 46, "fixture must distinguish floor() from round()"
-        assert calc.calculate_dual().tilt == math.floor(raw) == 45
+        assert raw == pytest.approx(44.830065, abs=1e-5)
+        assert round(raw) == 45, "fixture must distinguish floor() from round()"
+        assert calc.calculate_dual().tilt == math.floor(raw) == 44
 
     @patch("custom_components.adaptive_cover_pro.engine.sun_geometry.datetime")
     def test_safety_margin_respects_max_tilt_clamp(self, mock_datetime):

--- a/tests/test_pipeline/test_solar_anticipation.py
+++ b/tests/test_pipeline/test_solar_anticipation.py
@@ -22,6 +22,7 @@ from custom_components.adaptive_cover_pro.const import (
 from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
     anticipated_solar_position,
+    anticipated_solar_position_from_geometry,
     compute_solar_position,
 )
 from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
@@ -30,7 +31,11 @@ from custom_components.adaptive_cover_pro.pipeline.snapshot_builder import (
 from custom_components.adaptive_cover_pro.state.climate_provider import (
     ClimateProvider,
 )
-from tests.cover_helpers import build_horizontal_cover, build_vertical_cover
+from tests.cover_helpers import (
+    build_horizontal_cover,
+    build_tilt_cover,
+    build_vertical_cover,
+)
 
 # A fixed reference day so all timestamps are deterministic.
 _DAY = datetime(2024, 6, 21, tzinfo=UTC)
@@ -119,6 +124,41 @@ def _horizontal_cover(sun_data: _FakeSunData, *, sol_azi: float, sol_elev: float
     )
     cover.eval_time = sun_data.times[0]
     return cover
+
+
+def _tilt_cover(sun_data: _FakeSunData, *, sol_azi: float, sol_elev: float):
+    """Build a MODE2 slat cover — the axis whose coverage peaks mid-travel (#1104).
+
+    Same 2 cm / 3 cm slat geometry the pinned solve table in
+    ``tests/test_conservative_rounding.py`` was computed against, so the
+    percentages the fold compares here are the documented ones.
+    """
+    cover = build_tilt_cover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sun_data=sun_data,
+        win_azi=180,
+        fov_left=90,
+        fov_right=90,
+        slat_distance=0.02,
+        depth=0.03,
+        mode="mode2",
+    )
+    cover.eval_time = sun_data.times[0]
+    return cover
+
+
+def _anticipated_tilt(cover, *, horizon_minutes: int) -> int:
+    return anticipated_solar_position_from_geometry(
+        cover,
+        cover.config,
+        horizon_minutes=horizon_minutes,
+        minimize_movements=False,
+        max_coverage_steps=1,
+        policy=get_policy("cover_tilt"),
+        floor_active=False,
+    )
 
 
 def _snapshot(cover, *, cover_type: str, time_threshold_minutes: int):
@@ -243,6 +283,38 @@ def test_awning_anticipates_higher_future_sample():
     live = compute_solar_position(snap)
     anticipated = anticipated_solar_position(snap)
     assert anticipated > live
+
+
+@pytest.mark.unit
+def test_tilt_anticipates_farther_above_horizontal_future_sample():
+    """The fold must not throw away the more-protective slat (#1104).
+
+    Every sample here sits ABOVE the MODE2 pivot, where a bigger percentage is a
+    bigger angle and therefore a slat FARTHER from horizontal — more coverage,
+    not less. The rising sun drives the solve from 106.87° (60 %) at the live
+    moment out to 130.53° (73 %) at the end of the window, so the window's
+    most-protective demand is 73.
+    """
+    sun_data = _FakeSunData([180.0] * 6, [45.0, 48.0, 51.0, 54.0, 57.0, 60.0])
+    cover = _tilt_cover(sun_data, sol_azi=180.0, sol_elev=45.0)
+
+    assert _anticipated_tilt(cover, horizon_minutes=0) == 60
+    assert _anticipated_tilt(cover, horizon_minutes=25) == 73
+
+
+@pytest.mark.unit
+def test_tilt_anticipates_farther_below_horizontal_future_sample():
+    """Guard: the already-correct side of the pivot must not move.
+
+    Below horizontal a smaller percentage IS a slat farther from horizontal, so
+    the monotonic ``min`` and the distance-from-pivot rule agree. The falling
+    sun drives the solve from 84.74° (47 %) down to 71.21° (39 %).
+    """
+    sun_data = _FakeSunData([180.0] * 6, [30.0, 28.0, 26.0, 24.0, 22.0, 20.0])
+    cover = _tilt_cover(sun_data, sol_azi=180.0, sol_elev=30.0)
+
+    assert _anticipated_tilt(cover, horizon_minutes=0) == 47
+    assert _anticipated_tilt(cover, horizon_minutes=25) == 39
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Two more places assumed cover coverage is monotonic in the position percentage. On a MODE2 tilt axis it isn't: 0-100% maps onto 0-180 degrees with 90 degrees (horizontal) as maximum openness, so coverage bottoms out at 50% and grows toward both ends.

`PositionConverter.quantize_to_coverage_steps` snapped toward a single coverage-zero endpoint, so above the pivot it moved the slat back toward horizontal and reversed #1090 in the very next statement. `CoverTypePolicy.more_protective_position` picked `min()` unconditionally, so with both candidates above the pivot it returned the slat closer to horizontal and silently weakened the #616 anticipation fold. A third site not named in the issue, `cover_types/venetian/policy.py`, had the identical quantizer defect.

Both now read two new polymorphic engine hooks, `coverage_pivot_percentage()` and `coverage_travel_bounds()`, so nothing outside `cover_types/` and `engine/` learns what a tilt cover is. A coverage level on a bi-directional axis is a slice of distance from a band-clamped anchor, taken per side, and quantization never crosses it. An axis reporting no pivot runs the original code byte for byte, so #978's blind and awning rounding is unchanged.

Three audit rounds caught two further defects, both fixed here: the first pass could command 100% to anyone running `max_tilt=60` with `minimize_movements` enabled on shipped defaults, and a `specify_angles` calibration that never reaches horizontal has its covering end on the opposite side from the static axis flag, which the quantizer was reading backwards.

One behaviour change beyond the two reported sites: a band that excludes the pivot now anchors on the band's open end, so MODE2 with `[60, 100]` and a demand of 60 stays at 60 instead of jumping to 100.

## Testing
- ✅ 11531 tests passing

## Related Issues
Refs #1104