### PR TITLE
fix: stop a sub-degree slat angle raising ZeroDivisionError (#1105)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -2072,6 +2072,12 @@ _RANGE_ROOF_PITCH = (0, 90)  # CONF_ROOF_PITCH, degrees (0=flat, 90=vertical)
 _RANGE_ROOF_HEIGHT_ABOVE = (0.0, 10.0)  # CONF_ROOF_HEIGHT_ABOVE, metres
 # Geometry — louvered roof (#830 follow-up).
 _RANGE_MAX_SLAT_ANGLE = (0, 180)  # CONF_MAX_SLAT_ANGLE, degrees (0 = use tilt mode)
+# Smallest nonzero ``max_slat_angle`` treated as a usable physical angle rather
+# than a stray value in the sub-degree dead zone between "unset" and "real"
+# (issue #1105). Single source of truth for the bespoke bound enforced by
+# ``services.options_service._max_slat_angle_v`` — keep it here, not repeated
+# at the call site.
+MIN_USABLE_SLAT_ANGLE_DEG = 1
 
 # Geometry — tilt / venetian slats.
 _RANGE_TILT_DEPTH = (0.1, 30.0)  # CONF_TILT_DEPTH, cm (raised to 300 mm for #830)

--- a/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
@@ -167,14 +167,17 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
 
         ``0`` (the sentinel default) falls back to the mode's 90°/180°; a nonzero
         value becomes BOTH the clamp ceiling and the tilt%→angle denominator.
-        No truncation: the base hook ``_max_degrees()`` is typed ``-> float``,
-        the denominator wants the precision, and an ``int()`` cast here bought
-        nothing except disagreeing with the ``0`` sentinel — truncating a
-        fractional value in ``(0, 1)`` collapsed it onto the sentinel's own
-        literal denominator (issue #1105).
+        No truncation: ``_max_degrees()`` — the mode-max resolver this hook
+        falls back to — is typed ``-> float``, the denominator wants the
+        precision, and an ``int()`` cast here bought nothing except producing
+        the literal ``int`` ``0`` for any fractional value in ``(0, 1)``. That
+        literal ``0`` is NOT the sentinel's denominator (the sentinel routes
+        to ``_max_degrees()``'s 90°/180°, never to a literal ``0``) — it was
+        simply the truncated value itself, used directly as the tilt%→angle
+        denominator (issue #1105).
         """
         m = self.roof_config.max_slat_angle
-        return m if m else self._max_degrees()
+        return float(m) if m else self._max_degrees()
 
     @property
     def fov_angle(self) -> float:

--- a/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
@@ -167,10 +167,11 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
 
         ``0`` (the sentinel default) falls back to the mode's 90°/180°; a nonzero
         value becomes BOTH the clamp ceiling and the tilt%→angle denominator.
-        No truncation: the base hook is typed ``-> float`` and every call site
-        immediately re-wraps the result in ``float(...)``, so an ``int()`` cast
-        here bought nothing except silently collapsing a fractional value in
-        ``(0, 1)`` onto the ``0`` sentinel's literal denominator (issue #1105).
+        No truncation: the base hook ``_max_degrees()`` is typed ``-> float``,
+        the denominator wants the precision, and an ``int()`` cast here bought
+        nothing except disagreeing with the ``0`` sentinel — truncating a
+        fractional value in ``(0, 1)`` collapsed it onto the sentinel's own
+        literal denominator (issue #1105).
         """
         m = self.roof_config.max_slat_angle
         return m if m else self._max_degrees()

--- a/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/louvered_roof.py
@@ -162,14 +162,18 @@ class AdaptiveLouveredRoofCover(AdaptiveTiltCover):
             return self.depth
         return self.depth + max(0.0, self.depth - self.slat_distance)
 
-    def _effective_max_degrees(self) -> int:
+    def _effective_max_degrees(self) -> float:
         """Honour a configured physical ``max_slat_angle`` over the tilt-mode max.
 
         ``0`` (the sentinel default) falls back to the mode's 90°/180°; a nonzero
         value becomes BOTH the clamp ceiling and the tilt%→angle denominator.
+        No truncation: the base hook is typed ``-> float`` and every call site
+        immediately re-wraps the result in ``float(...)``, so an ``int()`` cast
+        here bought nothing except silently collapsing a fractional value in
+        ``(0, 1)`` onto the ``0`` sentinel's literal denominator (issue #1105).
         """
         m = self.roof_config.max_slat_angle
-        return int(m) if m else self._max_degrees()
+        return m if m else self._max_degrees()
 
     @property
     def fov_angle(self) -> float:

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -413,21 +413,18 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
         position = self.calculate_position()
         pct = self._percentage_from_angle(position)
         if pct is None:
-            # A zero-width scale has no percentage to report. A *negative*
-            # denominator is unreachable from config: both tilt-mode maxima are
-            # nonzero and ``max_slat_angle`` is bounded to [0, 180]. A *zero*
-            # one is reachable via the explicit ``0`` sentinel (or a mocked
-            # ``_effective_max_degrees`` override in tests) — that case already
-            # raises inside ``calculate_position`` above while it builds its
-            # trace, so this is the same failure surfaced at a second seam
-            # rather than a new one. (Issue #1105: a fractional
-            # ``max_slat_angle`` in ``(0, 1)`` used to collapse onto this same
-            # zero denominator via an ``int()`` truncation in
-            # ``AdaptiveLouveredRoofCover._effective_max_degrees`` — that cast
-            # is gone, so only the sentinel/mock paths reach here now.) Raising
-            # keeps the contract ``VenetianCoverCalculation._compute_tilt``
-            # relies on: a tilt geometry that does not resolve falls back to
-            # the default position.
+            # A zero-width scale has no percentage to report. Post-#1105, a
+            # zero (or negative) denominator is unreachable from config at
+            # all: both tilt-mode maxima are nonzero, ``max_slat_angle`` is
+            # bounded to [0, 180], and the ``0`` sentinel routes to the mode
+            # max rather than to a literal zero. (The fractional-truncation
+            # path that used to collapse onto this branch via an ``int()``
+            # cast is gone — see #1105.) This branch is now reachable only
+            # through a mocked ``_effective_max_degrees`` in tests, or a
+            # hand-corrupted stored value. Raising keeps the contract
+            # ``VenetianCoverCalculation._compute_tilt`` relies on: a tilt
+            # geometry that does not resolve falls back to the default
+            # position.
             raise ZeroDivisionError("tilt percentage scale has zero width")
         return self._apply_tilt_axis_limits(pct)
 

--- a/custom_components/adaptive_cover_pro/engine/covers/tilt.py
+++ b/custom_components/adaptive_cover_pro/engine/covers/tilt.py
@@ -416,15 +416,18 @@ class AdaptiveTiltCover(AdaptiveGeneralCover):
             # A zero-width scale has no percentage to report. A *negative*
             # denominator is unreachable from config: both tilt-mode maxima are
             # nonzero and ``max_slat_angle`` is bounded to [0, 180]. A *zero*
-            # one is reachable, though — ``AdaptiveLouveredRoofCover``
-            # truncates ``max_slat_angle`` with ``int()``, so a fractional
-            # value in (0, 1) lands on 0 rather than on the "use the mode max"
-            # sentinel. That case already raises inside ``calculate_position``
-            # above while it builds its trace, so this is the same failure
-            # surfaced at a second seam rather than a new one. Raising keeps
-            # the contract ``VenetianCoverCalculation._compute_tilt`` relies
-            # on: a tilt geometry that does not resolve falls back to the
-            # default position.
+            # one is reachable via the explicit ``0`` sentinel (or a mocked
+            # ``_effective_max_degrees`` override in tests) — that case already
+            # raises inside ``calculate_position`` above while it builds its
+            # trace, so this is the same failure surfaced at a second seam
+            # rather than a new one. (Issue #1105: a fractional
+            # ``max_slat_angle`` in ``(0, 1)`` used to collapse onto this same
+            # zero denominator via an ``int()`` truncation in
+            # ``AdaptiveLouveredRoofCover._effective_max_degrees`` — that cast
+            # is gone, so only the sentinel/mock paths reach here now.) Raising
+            # keeps the contract ``VenetianCoverCalculation._compute_tilt``
+            # relies on: a tilt geometry that does not resolve falls back to
+            # the default position.
             raise ZeroDivisionError("tilt percentage scale has zero width")
         return self._apply_tilt_axis_limits(pct)
 

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -160,7 +160,27 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                     # outright to silently passing.
                     try:
                         FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](value)
+                    except vol.MultipleInvalid:
+                        # Outside the dead zone, ``_max_slat_angle_v`` falls
+                        # through to ``_num()``'s ``vol.Any(None, ...)``
+                        # composition, and voluptuous's ``Any`` keeps the
+                        # "None"-literal alternative's generic fallback
+                        # message ("not a valid value") instead of the real
+                        # ``vol.Range`` one — that's what distinguishes this
+                        # from the branch below (``vol.Any`` failing raises
+                        # ``MultipleInvalid``, a subclass of ``vol.Invalid``).
+                        # Every sibling OPTION_RANGES key on this loop still
+                        # names its bounds on an out-of-range value, so
+                        # reconstruct the same wording here rather than
+                        # surfacing the uninformative fallback to the user.
+                        lo, hi = OPTION_RANGES[key]
+                        validation_errors.append(
+                            f"{key}={value} out of range [{lo}, {hi}]"
+                        )
                     except vol.Invalid as exc:
+                        # The dead-zone branch (naming the ``0`` sentinel) and
+                        # a bad type (via ``vol.Coerce``) both raise directly
+                        # with an already-informative message — keep it as-is.
                         validation_errors.append(f"{key}={value!r}: {exc.msg}")
                 elif key in OPTION_RANGES:
                     lo, hi = OPTION_RANGES[key]

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -34,6 +34,17 @@ IMPORT_CONFIG_SCHEMA = vol.Schema(
 )
 
 
+def _out_of_range_error(key: str, value: object) -> str:
+    """Format the shared "out of range" message for an ``OPTION_RANGES`` key.
+
+    Both the ``CONF_MAX_SLAT_ANGLE`` bespoke-validator branch and the generic
+    ``OPTION_RANGES`` branch below need this exact wording — extracted so the
+    two can never drift apart (issue #1105).
+    """
+    lo, hi = OPTION_RANGES[key]
+    return f"{key}={value} out of range [{lo}, {hi}]"
+
+
 async def async_handle_import_config(call: ServiceCall) -> dict:
     """Handle the import_config service call.
 
@@ -173,10 +184,7 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                         # names its bounds on an out-of-range value, so
                         # reconstruct the same wording here rather than
                         # surfacing the uninformative fallback to the user.
-                        lo, hi = OPTION_RANGES[key]
-                        validation_errors.append(
-                            f"{key}={value} out of range [{lo}, {hi}]"
-                        )
+                        validation_errors.append(_out_of_range_error(key, value))
                     except vol.Invalid as exc:
                         # The dead-zone branch (naming the ``0`` sentinel) and
                         # a bad type (via ``vol.Coerce``) both raise directly
@@ -187,9 +195,7 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
                     try:
                         num = float(value)
                         if not (lo <= num <= hi):
-                            validation_errors.append(
-                                f"{key}={value} out of range [{lo}, {hi}]"
-                            )
+                            validation_errors.append(_out_of_range_error(key, value))
                     except (TypeError, ValueError):
                         validation_errors.append(
                             f"{key}={value!r} is not a valid number"

--- a/custom_components/adaptive_cover_pro/services/import_service.py
+++ b/custom_components/adaptive_cover_pro/services/import_service.py
@@ -14,9 +14,16 @@ from homeassistant.exceptions import ServiceValidationError
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant, ServiceCall
 
-from ..const import DOMAIN, OPTION_RANGES, TIME_OPTION_KEYS, TIME_STRING_RE
+from ..const import (
+    CONF_MAX_SLAT_ANGLE,
+    DOMAIN,
+    OPTION_RANGES,
+    TIME_OPTION_KEYS,
+    TIME_STRING_RE,
+)
 from ..helpers import normalize_time_string
 from .export_service import DEFAULT_EXPORT_PATH
+from .options_service import FIELD_VALIDATORS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +47,9 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
     Numeric keys present in ``OPTION_RANGES`` are validated against their
     declared bounds before the entry is updated; a failed check records
     ``"error: ..."`` for that entry in the result dict without aborting the
-    rest of the import.
+    rest of the import. ``CONF_MAX_SLAT_ANGLE`` is special-cased to route
+    through ``FIELD_VALIDATORS`` instead (issue #1105) so its sub-degree dead
+    zone is rejected the same way here as in ``set_option``.
 
     Time keys (``TIME_OPTION_KEYS``) are **canonicalised, not rejected**, and
     this deliberately differs from ``set_options``: a value that parses is
@@ -135,7 +144,25 @@ async def async_handle_import_config(call: ServiceCall) -> dict:
             for key, value in list(imported_public.items()):
                 if value is None:
                     continue
-                if key in OPTION_RANGES:
+                if key == CONF_MAX_SLAT_ANGLE:
+                    # Bespoke validator (#1105): the plain OPTION_RANGES lo/hi
+                    # check below also admits the sub-degree dead zone between
+                    # the "0 = use tilt mode" sentinel and the smallest usable
+                    # physical angle that ``services.set_option`` now rejects
+                    # via ``FIELD_VALIDATORS``. Routed through the SAME
+                    # validator here so both config boundaries agree. This is
+                    # deliberately special-cased to this one key rather than
+                    # routing every OPTION_RANGES key through FIELD_VALIDATORS
+                    # generically — several other keys (e.g.
+                    # CONF_OUTSIDE_THRESHOLD) also accept a Jinja2 template via
+                    # a *different* bespoke validator, and swapping those over
+                    # would flip values import_config currently rejects
+                    # outright to silently passing.
+                    try:
+                        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](value)
+                    except vol.Invalid as exc:
+                        validation_errors.append(f"{key}={value!r}: {exc.msg}")
+                elif key in OPTION_RANGES:
                     lo, hi = OPTION_RANGES[key]
                     try:
                         num = float(value)

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -173,6 +173,7 @@ from ..const import (
     DAY_NIGHT_CONTROL_MODELS,
     DUAL_PANEL_BLACKOUT_TRIGGERS,
     MANUAL_OVERRIDE_DURATION_MODES,
+    MIN_USABLE_SLAT_ANGLE_DEG,
     SLIDING_SLIDE_DIRECTIONS,
     VENETIAN_MODES,
     VENETIAN_POST_SETTLE_MODES,
@@ -347,19 +348,22 @@ def _time_v():
 
 
 def _max_slat_angle_v():
-    """Validate ``CONF_MAX_SLAT_ANGLE``: ``None``/``0`` sentinel, else ``[1, hi]``.
+    """Validate ``CONF_MAX_SLAT_ANGLE``: ``None``/``0`` sentinel, else ``[MIN, hi]``.
 
     A bespoke validator rather than the generic ``_range()`` helper (issue
     #1105): ``0`` means "use the tilt mode's 90°/180°" and must stay legal, but
     a plain ``vol.Range(min=0, max=hi)`` also admits the open interval ``(0,
-    1)`` — a value that is neither the sentinel nor a usable physical angle
-    (the engine's own ``_effective_max_degrees()`` no longer truncates it, but
-    it is still a misconfiguration worth rejecting at the boundary where it was
-    made). Reads ``hi`` from ``OPTION_RANGES`` rather than a new literal, per
-    the single-source-of-truth rule.
+    MIN_USABLE_SLAT_ANGLE_DEG)`` — a value that is neither the sentinel nor a
+    usable physical angle (the engine's own ``_effective_max_degrees()`` no
+    longer truncates it, but it is still a misconfiguration worth rejecting at
+    the boundary where it was made). ``hi`` comes from ``OPTION_RANGES`` and the
+    lower bound from ``const.MIN_USABLE_SLAT_ANGLE_DEG`` — both single-sourced
+    rather than repeated here.
     """
     _, hi = OPTION_RANGES[CONF_MAX_SLAT_ANGLE]
-    ranged = vol.All(vol.Coerce(float), vol.Range(min=1, max=hi))
+    ranged = vol.All(
+        vol.Coerce(float), vol.Range(min=MIN_USABLE_SLAT_ANGLE_DEG, max=hi)
+    )
 
     def _validate(value):
         if value is None:
@@ -367,9 +371,14 @@ def _max_slat_angle_v():
         coerced = vol.Coerce(float)(value)
         if coerced == 0:
             return value
-        if 0 < coerced < 1:
+        # Redundant with ``vol.Range(min=MIN_USABLE_SLAT_ANGLE_DEG)`` below —
+        # any value here already falls through to it and fails with the same
+        # verdict. Kept only so the sub-degree dead zone gets a message that
+        # names the sentinel, rather than a generic "must be at least 1".
+        if 0 < coerced < MIN_USABLE_SLAT_ANGLE_DEG:
             raise vol.Invalid(
-                f"max_slat_angle must be 0 (use tilt mode) or >= 1, got: {value!r}"
+                f"max_slat_angle must be 0 (use tilt mode) or "
+                f">= {MIN_USABLE_SLAT_ANGLE_DEG}, got: {value!r}"
             )
         return ranged(value)
 

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -361,24 +361,22 @@ def _max_slat_angle_v():
     rather than repeated here.
     """
     _, hi = OPTION_RANGES[CONF_MAX_SLAT_ANGLE]
-    ranged = vol.All(
-        vol.Coerce(float), vol.Range(min=MIN_USABLE_SLAT_ANGLE_DEG, max=hi)
-    )
+    ranged = _num(MIN_USABLE_SLAT_ANGLE_DEG, hi)
 
     def _validate(value):
         if value is None:
             return None
         coerced = vol.Coerce(float)(value)
         if coerced == 0:
-            return value
-        # Redundant with ``vol.Range(min=MIN_USABLE_SLAT_ANGLE_DEG)`` below —
-        # any value here already falls through to it and fails with the same
-        # verdict. Kept only so the sub-degree dead zone gets a message that
-        # names the sentinel, rather than a generic "must be at least 1".
+            return coerced
+        # Redundant with ``vol.Range(min=MIN_USABLE_SLAT_ANGLE_DEG)`` inside
+        # ``ranged`` below — any value here already falls through to it and
+        # fails with the same verdict. Kept only so the sub-degree dead zone
+        # gets a message that names the sentinel, rather than the generic
+        # minimum-bound message ``vol.Range`` would produce on its own.
         if 0 < coerced < MIN_USABLE_SLAT_ANGLE_DEG:
             raise vol.Invalid(
-                f"max_slat_angle must be 0 (use tilt mode) or "
-                f">= {MIN_USABLE_SLAT_ANGLE_DEG}, got: {value!r}"
+                f"must be 0 (use tilt mode) or >= {MIN_USABLE_SLAT_ANGLE_DEG}"
             )
         return ranged(value)
 
@@ -435,8 +433,9 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_ROOF_PITCH: _range(CONF_ROOF_PITCH),
     CONF_ROOF_HEIGHT_ABOVE: _range(CONF_ROOF_HEIGHT_ABOVE),
     # Geometry — louvered roof (#830 follow-up). Bespoke validator (#1105): the
-    # generic _range() also admits the (0, 1) dead zone between the "0 = use
-    # tilt mode" sentinel and the smallest usable physical angle.
+    # generic _range() also admits the (0, MIN_USABLE_SLAT_ANGLE_DEG) dead zone
+    # between the "0 = use tilt mode" sentinel and the smallest usable
+    # physical angle.
     CONF_MAX_SLAT_ANGLE: _max_slat_angle_v(),
     # Geometry — sliding curtain shade area (#829, Part 2)
     CONF_SLIDING_ENABLE_SHADE_AREA: _bool_v(),

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -372,8 +372,13 @@ def _max_slat_angle_v():
         # Redundant with ``vol.Range(min=MIN_USABLE_SLAT_ANGLE_DEG)`` inside
         # ``ranged`` below — any value here already falls through to it and
         # fails with the same verdict. Kept only so the sub-degree dead zone
-        # gets a message that names the sentinel, rather than the generic
-        # minimum-bound message ``vol.Range`` would produce on its own.
+        # gets a message that names the sentinel: ``ranged`` wraps its
+        # ``vol.Range`` in ``_num()``'s ``vol.Any(None, ...)``, and
+        # voluptuous's ``Any`` keeps the "None"-literal alternative's generic
+        # fallback (``MultipleInvalid: "not a valid value"``) over the real
+        # ``vol.Range`` message on a failure — so without this branch, a
+        # value like 0.5 would report no bound at all, let alone the
+        # sentinel (verified empirically, not assumed).
         if 0 < coerced < MIN_USABLE_SLAT_ANGLE_DEG:
             raise vol.Invalid(
                 f"must be 0 (use tilt mode) or >= {MIN_USABLE_SLAT_ANGLE_DEG}"

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -346,6 +346,36 @@ def _time_v():
     return vol.Any(None, _check)
 
 
+def _max_slat_angle_v():
+    """Validate ``CONF_MAX_SLAT_ANGLE``: ``None``/``0`` sentinel, else ``[1, hi]``.
+
+    A bespoke validator rather than the generic ``_range()`` helper (issue
+    #1105): ``0`` means "use the tilt mode's 90°/180°" and must stay legal, but
+    a plain ``vol.Range(min=0, max=hi)`` also admits the open interval ``(0,
+    1)`` — a value that is neither the sentinel nor a usable physical angle
+    (the engine's own ``_effective_max_degrees()`` no longer truncates it, but
+    it is still a misconfiguration worth rejecting at the boundary where it was
+    made). Reads ``hi`` from ``OPTION_RANGES`` rather than a new literal, per
+    the single-source-of-truth rule.
+    """
+    _, hi = OPTION_RANGES[CONF_MAX_SLAT_ANGLE]
+    ranged = vol.All(vol.Coerce(float), vol.Range(min=1, max=hi))
+
+    def _validate(value):
+        if value is None:
+            return None
+        coerced = vol.Coerce(float)(value)
+        if coerced == 0:
+            return value
+        if 0 < coerced < 1:
+            raise vol.Invalid(
+                f"max_slat_angle must be 0 (use tilt mode) or >= 1, got: {value!r}"
+            )
+        return ranged(value)
+
+    return _validate
+
+
 def _select_v(*options: str):
     return vol.Any(None, vol.In(list(options)))
 
@@ -395,8 +425,10 @@ FIELD_VALIDATORS: dict[str, Any] = {
     # Geometry — roof / skylight window (#212)
     CONF_ROOF_PITCH: _range(CONF_ROOF_PITCH),
     CONF_ROOF_HEIGHT_ABOVE: _range(CONF_ROOF_HEIGHT_ABOVE),
-    # Geometry — louvered roof (#830 follow-up)
-    CONF_MAX_SLAT_ANGLE: _range(CONF_MAX_SLAT_ANGLE),
+    # Geometry — louvered roof (#830 follow-up). Bespoke validator (#1105): the
+    # generic _range() also admits the (0, 1) dead zone between the "0 = use
+    # tilt mode" sentinel and the smallest usable physical angle.
+    CONF_MAX_SLAT_ANGLE: _max_slat_angle_v(),
     # Geometry — sliding curtain shade area (#829, Part 2)
     CONF_SLIDING_ENABLE_SHADE_AREA: _bool_v(),
     CONF_SLIDING_SLIDE_DIRECTION: _select_v(*SLIDING_SLIDE_DIRECTIONS),

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -11,11 +11,15 @@ from unittest.mock import MagicMock
 from custom_components.adaptive_cover_pro.config_types import (
     CoverConfig,
     HorizontalConfig,
+    LouveredRoofConfig,
     TiltConfig,
     VerticalConfig,
 )
 from custom_components.adaptive_cover_pro.engine.covers.base import (
     AdaptiveGeneralCover,
+)
+from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
+    AdaptiveLouveredRoofCover,
 )
 
 
@@ -277,11 +281,6 @@ def build_louvered_roof_cover(
     change to ``AdaptiveLouveredRoofCover``'s constructor only needs updating
     here.
     """
-    from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
-    from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
-        AdaptiveLouveredRoofCover,
-    )
-
     return AdaptiveLouveredRoofCover(
         logger=MagicMock(),
         sol_azi=sol_azi,

--- a/tests/cover_helpers.py
+++ b/tests/cover_helpers.py
@@ -254,3 +254,49 @@ def build_tilt_cover(**kwargs):
         tilt_config=make_tilt_config(**tilt_kwargs),
         **direct_kwargs,
     )
+
+
+def build_louvered_roof_cover(
+    *,
+    sol_azi: float,
+    sol_elev: float,
+    roof_pitch: float,
+    slat_distance: float = 0.02,
+    depth: float = 0.03,
+    mode: str = "mode2",
+    win_azi: float = 180.0,
+    fov_left: float = 90.0,
+    fov_right: float = 90.0,
+    max_slat_angle: float = 0.0,
+    safety_margin: float = 0.0,
+):
+    """Build an AdaptiveLouveredRoofCover at an explicit sun/slat geometry.
+
+    Shared by the engine and pipeline-helpers suites (#1105 audit) so the
+    louvered-roof construction isn't reimplemented at each call site — a
+    change to ``AdaptiveLouveredRoofCover``'s constructor only needs updating
+    here.
+    """
+    from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
+    from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
+        AdaptiveLouveredRoofCover,
+    )
+
+    return AdaptiveLouveredRoofCover(
+        logger=MagicMock(),
+        sol_azi=sol_azi,
+        sol_elev=sol_elev,
+        sun_data=MagicMock(),
+        config=make_cover_config(
+            win_azi=win_azi, fov_left=fov_left, fov_right=fov_right
+        ),
+        tilt_config=make_tilt_config(
+            slat_distance=slat_distance,
+            depth=depth,
+            mode=mode,
+            safety_margin=safety_margin,
+        ),
+        roof_config=LouveredRoofConfig(
+            roof_pitch=roof_pitch, max_slat_angle=max_slat_angle
+        ),
+    )

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -464,10 +465,79 @@ class TestImportConfig:
         assert entry.options["max_slat_angle"] == 160
 
     @pytest.mark.asyncio
-    async def test_max_slat_angle_sentinel_and_usable_values_import_cleanly(
+    async def test_max_slat_angle_and_sibling_out_of_range_messages_share_shape(
         self, tmp_path
     ):
-        """Issue #1105: the ``0`` sentinel and a usable angle still import fine."""
+        """Issue #1105 audit: pin the *parity*, not just one key's literal string.
+
+        fc868075 built ``max_slat_angle``'s out-of-range message by hand-copying
+        the generic ``OPTION_RANGES`` branch's f-string thirteen lines below it
+        in the same function.
+        ``test_max_slat_angle_out_of_range_error_names_the_bounds`` above only
+        pins that one copy — a reword of the generic branch's message would
+        silently make ``max_slat_angle`` the odd one out again while that test
+        stayed green, since it never compares the two. Both branches now
+        delegate to a shared ``_out_of_range_error`` helper; this test proves
+        it structurally by asserting ``max_slat_angle`` and a sibling
+        ``OPTION_RANGES`` key (``roof_pitch``) both match the exact same
+        "key=value out of range [lo, hi]" regex shape, with only the
+        key/value/bounds substituted — not by re-pinning two literals that
+        could drift together for the wrong reason.
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry_slat = _make_entry("id-1", "Roof A", {"max_slat_angle": 160})
+        hass_slat = _make_hass([entry_slat], config_dir=str(tmp_path))
+        slat_path = tmp_path / "import_slat.json"
+        self._write_export(
+            slat_path,
+            [{"entry_id": "id-1", "options": {"max_slat_angle": 181}}],
+        )
+        call_slat = MagicMock()
+        call_slat.hass = hass_slat
+        call_slat.data = {"filename": str(slat_path)}
+        slat_msg = (await async_handle_import_config(call_slat))["id-1"]
+
+        entry_pitch = _make_entry("id-2", "Roof B", {"roof_pitch": 45})
+        hass_pitch = _make_hass([entry_pitch], config_dir=str(tmp_path))
+        pitch_path = tmp_path / "import_pitch.json"
+        self._write_export(
+            pitch_path,
+            [{"entry_id": "id-2", "options": {"roof_pitch": 999}}],
+        )
+        call_pitch = MagicMock()
+        call_pitch.hass = hass_pitch
+        call_pitch.data = {"filename": str(pitch_path)}
+        pitch_msg = (await async_handle_import_config(call_pitch))["id-2"]
+
+        shape = re.compile(
+            r"^error: import_config: invalid values for entry '[\w-]+': "
+            r"(?P<key>[a-z_]+)=(?P<value>-?\d+(?:\.\d+)?) "
+            r"out of range \[(?P<lo>-?\d+(?:\.\d+)?), (?P<hi>-?\d+(?:\.\d+)?)\]$"
+        )
+        slat_match = shape.match(slat_msg)
+        pitch_match = shape.match(pitch_msg)
+
+        assert slat_match is not None, slat_msg
+        assert pitch_match is not None, pitch_msg
+        assert slat_match.group("key") == "max_slat_angle"
+        assert pitch_match.group("key") == "roof_pitch"
+        assert (
+            slat_match.group("value"),
+            slat_match.group("lo"),
+            slat_match.group("hi"),
+        ) == ("181", "0", "180")
+        assert (
+            pitch_match.group("value"),
+            pitch_match.group("lo"),
+            pitch_match.group("hi"),
+        ) == ("999", "0", "90")
+
+    @pytest.mark.asyncio
+    async def test_max_slat_angle_sentinel_value_imports_cleanly(self, tmp_path):
+        """Issue #1105: the ``0`` sentinel imports cleanly (does not error)."""
         from custom_components.adaptive_cover_pro.services.import_service import (
             async_handle_import_config,
         )
@@ -489,6 +559,39 @@ class TestImportConfig:
 
         assert result["id-1"] == "updated"
         assert entry.options["max_slat_angle"] == 0
+
+    @pytest.mark.asyncio
+    async def test_max_slat_angle_usable_value_imports_cleanly(self, tmp_path):
+        """Issue #1105 audit: a nonzero in-range angle also imports cleanly.
+
+        The prior test's name and docstring claimed to cover this ("the ``0``
+        sentinel and a usable angle") but only ever imported ``0`` — ``0``
+        returns from ``_max_slat_angle_v``'s sentinel branch before
+        ``ranged(...)`` is ever reached, so the nonzero in-range path through
+        the new ``import_config`` branch had no assertion anywhere. This
+        closes that gap.
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Roof A", {"max_slat_angle": 160})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"max_slat_angle": 45}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"] == "updated"
+        assert entry.options["max_slat_angle"] == 45
 
     @pytest.mark.parametrize("time_key", ["start_time", "end_time"])
     @pytest.mark.parametrize(("raw", "expected"), _RESCUABLE_TIMES)

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -426,6 +426,44 @@ class TestImportConfig:
         assert entry.options["max_slat_angle"] == 0
 
     @pytest.mark.asyncio
+    async def test_max_slat_angle_out_of_range_error_names_the_bounds(self, tmp_path):
+        """Issue #1105 audit: an out-of-range import error must still name [0, 180].
+
+        Routing ``max_slat_angle`` through ``FIELD_VALIDATORS`` (for the dead
+        zone above) means an out-of-range value now fails through
+        ``_num()``'s ``vol.Any(None, ...)`` composition, whose ``exc.msg`` is
+        voluptuous's generic "not a valid value" fallback rather than the
+        real ``vol.Range`` message. Every sibling ``OPTION_RANGES`` key on
+        this same loop still reports ``"out of range [lo, hi]"`` for a
+        bounds violation, and an import validation error aborts the entire
+        entry — so a degraded message here is the only string a user has to
+        debug from. This pins that the bounds survive.
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Roof A", {"max_slat_angle": 160})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"max_slat_angle": 181}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"].startswith("error:")
+        assert "max_slat_angle=181 out of range [0, 180]" in result["id-1"]
+        # entry options must not have been modified
+        assert entry.options["max_slat_angle"] == 160
+
+    @pytest.mark.asyncio
     async def test_max_slat_angle_sentinel_and_usable_values_import_cleanly(
         self, tmp_path
     ):

--- a/tests/services/test_export_import_service.py
+++ b/tests/services/test_export_import_service.py
@@ -390,6 +390,68 @@ class TestImportConfig:
         # entry options must not have been modified
         assert entry.options["set_azimuth"] == 90
 
+    @pytest.mark.asyncio
+    async def test_max_slat_angle_dead_zone_recorded_as_error(self, tmp_path):
+        """Issue #1105: import_config rejects the same dead zone set_option does.
+
+        ``max_slat_angle`` is neither the "0 = use tilt mode" sentinel nor a
+        usable physical angle in the open interval (0, 1) — a plain
+        ``OPTION_RANGES`` lo/hi check (0, 180) would accept it, since it is
+        within bounds. This closes the gap: the two config boundaries
+        (``set_option`` via ``FIELD_VALIDATORS`` and ``import_config``) must
+        agree, both rejecting it.
+        """
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Roof A", {"max_slat_angle": 0})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"max_slat_angle": 0.5}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"].startswith("error:")
+        assert "max_slat_angle" in result["id-1"]
+        # entry options must not have been modified
+        assert entry.options["max_slat_angle"] == 0
+
+    @pytest.mark.asyncio
+    async def test_max_slat_angle_sentinel_and_usable_values_import_cleanly(
+        self, tmp_path
+    ):
+        """Issue #1105: the ``0`` sentinel and a usable angle still import fine."""
+        from custom_components.adaptive_cover_pro.services.import_service import (
+            async_handle_import_config,
+        )
+
+        entry = _make_entry("id-1", "Roof A", {"max_slat_angle": 160})
+        hass = _make_hass([entry], config_dir=str(tmp_path))
+
+        export_path = tmp_path / "import.json"
+        self._write_export(
+            export_path,
+            [{"entry_id": "id-1", "options": {"max_slat_angle": 0}}],
+        )
+
+        call = MagicMock()
+        call.hass = hass
+        call.data = {"filename": str(export_path)}
+
+        result = await async_handle_import_config(call)
+
+        assert result["id-1"] == "updated"
+        assert entry.options["max_slat_angle"] == 0
+
     @pytest.mark.parametrize("time_key", ["start_time", "end_time"])
     @pytest.mark.parametrize(("raw", "expected"), _RESCUABLE_TIMES)
     @pytest.mark.asyncio

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -456,12 +456,14 @@ class TestTiltMode2DirectionalRounding:
     def test_degenerate_scale_falls_back_to_the_axis_rule(self):
         """A zero-width legacy scale has no pivot; the base floor/ceil stands.
 
-        Unreachable from config — the tilt modes are 90°/180° and the louvered
-        roof's ``max_slat_angle`` override is bounded away from zero — but
+        Reachable only via the explicit ``0`` sentinel (both tilt-mode maxima
+        are nonzero, and since issue #1105 a fractional ``max_slat_angle`` in
+        ``(0, 1)`` no longer truncates onto this same zero denominator) — but
         ``_horizontal_percentage`` is the one place that division happens, so the
-        guard is exercised head-on instead of left as an untested branch. It is
-        the legacy/custom-max twin of the ``angle_0 == angle_100`` guard covered
-        by ``TestTiltSpecifyAnglesDirectionalRounding``.
+        guard is exercised head-on via a mocked ``_effective_max_degrees``
+        instead of left as an untested branch. It is the legacy/custom-max twin
+        of the ``angle_0 == angle_100`` guard covered by
+        ``TestTiltSpecifyAnglesDirectionalRounding``.
         """
         cover = _tilt_cover(sol_elev=45.0)
         cover._effective_max_degrees = MagicMock(return_value=0.0)

--- a/tests/test_conservative_rounding.py
+++ b/tests/test_conservative_rounding.py
@@ -456,14 +456,14 @@ class TestTiltMode2DirectionalRounding:
     def test_degenerate_scale_falls_back_to_the_axis_rule(self):
         """A zero-width legacy scale has no pivot; the base floor/ceil stands.
 
-        Reachable only via the explicit ``0`` sentinel (both tilt-mode maxima
-        are nonzero, and since issue #1105 a fractional ``max_slat_angle`` in
-        ``(0, 1)`` no longer truncates onto this same zero denominator) — but
-        ``_horizontal_percentage`` is the one place that division happens, so the
-        guard is exercised head-on via a mocked ``_effective_max_degrees``
-        instead of left as an untested branch. It is the legacy/custom-max twin
-        of the ``angle_0 == angle_100`` guard covered by
-        ``TestTiltSpecifyAnglesDirectionalRounding``.
+        Unreachable from config — since #1105, both tilt-mode maxima are
+        nonzero and the louvered roof's ``max_slat_angle`` override is bounded
+        away from zero (there is no truncation left to collapse a fractional
+        value onto it) — but ``_horizontal_percentage`` is the one place that
+        division happens, so the guard is exercised here via a mocked
+        ``_effective_max_degrees`` instead of left as an untested branch. It
+        is the legacy/custom-max twin of the ``angle_0 == angle_100`` guard
+        covered by ``TestTiltSpecifyAnglesDirectionalRounding``.
         """
         cover = _tilt_cover(sol_elev=45.0)
         cover._effective_max_degrees = MagicMock(return_value=0.0)

--- a/tests/test_cover_types/test_louvered_roof.py
+++ b/tests/test_cover_types/test_louvered_roof.py
@@ -46,6 +46,46 @@ class TestLouveredRoofConfig:
         assert cfg.max_slat_angle == 160.0
 
 
+class TestMaxSlatAngleValidator:
+    """``FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]`` rejects the sub-1° dead zone (#1105).
+
+    ``0`` is the documented sentinel meaning "use the tilt mode's 90°/180°"; a
+    value in the open interval ``(0, 1)`` is neither the sentinel nor a usable
+    physical angle (it would truncate to the sentinel's own literal denominator
+    in the engine before this fix), so the config boundary must reject it
+    outright rather than silently accepting a value that can never resolve to
+    anything but the sentinel's behavior under a naive ``int()`` cast.
+    """
+
+    def test_validator_rejects_sub_one_nonzero(self) -> None:
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            FIELD_VALIDATORS,
+        )
+
+        validator = FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]
+        for value in (0.5, 0.99, -0.1):
+            with pytest.raises(vol.Invalid):
+                validator(value)
+
+    def test_validator_accepts_zero_sentinel_and_none(self) -> None:
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            FIELD_VALIDATORS,
+        )
+
+        validator = FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]
+        validator(0)
+        assert validator(None) is None
+
+    def test_validator_accepts_one_through_max(self) -> None:
+        from custom_components.adaptive_cover_pro.services.options_service import (
+            FIELD_VALIDATORS,
+        )
+
+        validator = FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]
+        validator(1)
+        validator(180)
+
+
 def _schema_keys(schema: vol.Schema) -> set[str]:
     return {(k.schema if isinstance(k, vol.Marker) else k) for k in schema.schema}
 

--- a/tests/test_cover_types/test_louvered_roof.py
+++ b/tests/test_cover_types/test_louvered_roof.py
@@ -46,46 +46,6 @@ class TestLouveredRoofConfig:
         assert cfg.max_slat_angle == 160.0
 
 
-class TestMaxSlatAngleValidator:
-    """``FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]`` rejects the sub-1° dead zone (#1105).
-
-    ``0`` is the documented sentinel meaning "use the tilt mode's 90°/180°"; a
-    value in the open interval ``(0, 1)`` is neither the sentinel nor a usable
-    physical angle (it would truncate to the sentinel's own literal denominator
-    in the engine before this fix), so the config boundary must reject it
-    outright rather than silently accepting a value that can never resolve to
-    anything but the sentinel's behavior under a naive ``int()`` cast.
-    """
-
-    def test_validator_rejects_sub_one_nonzero(self) -> None:
-        from custom_components.adaptive_cover_pro.services.options_service import (
-            FIELD_VALIDATORS,
-        )
-
-        validator = FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]
-        for value in (0.5, 0.99, -0.1):
-            with pytest.raises(vol.Invalid):
-                validator(value)
-
-    def test_validator_accepts_zero_sentinel_and_none(self) -> None:
-        from custom_components.adaptive_cover_pro.services.options_service import (
-            FIELD_VALIDATORS,
-        )
-
-        validator = FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]
-        validator(0)
-        assert validator(None) is None
-
-    def test_validator_accepts_one_through_max(self) -> None:
-        from custom_components.adaptive_cover_pro.services.options_service import (
-            FIELD_VALIDATORS,
-        )
-
-        validator = FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE]
-        validator(1)
-        validator(180)
-
-
 def _schema_keys(schema: vol.Schema) -> set[str]:
     return {(k.schema if isinstance(k, vol.Marker) else k) for k in schema.schema}
 

--- a/tests/test_engine/test_louvered_roof_engine.py
+++ b/tests/test_engine/test_louvered_roof_engine.py
@@ -21,7 +21,6 @@ from unittest.mock import MagicMock
 import numpy as np
 import pytest
 
-from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
 from custom_components.adaptive_cover_pro.const import (
     SAFETY_MARGIN_USER_SLACK_MAX,
     TILT_HORIZONTAL_DEG,
@@ -38,7 +37,11 @@ from custom_components.adaptive_cover_pro.engine.covers.tilt import (
 )
 from custom_components.adaptive_cover_pro.geometry import SafetyMarginCalculator
 
-from tests.cover_helpers import make_cover_config, make_tilt_config
+from tests.cover_helpers import (
+    build_louvered_roof_cover,
+    make_cover_config,
+    make_tilt_config,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -47,40 +50,10 @@ pytestmark = pytest.mark.unit
 # Builders
 # ---------------------------------------------------------------------------
 
-
-def _louvered(
-    *,
-    sol_azi: float,
-    sol_elev: float,
-    roof_pitch: float,
-    slat_distance: float = 0.02,
-    depth: float = 0.03,
-    mode: str = "mode2",
-    win_azi: float = 180.0,
-    fov_left: float = 90.0,
-    fov_right: float = 90.0,
-    max_slat_angle: float = 0.0,
-    safety_margin: float = 0.0,
-) -> AdaptiveLouveredRoofCover:
-    """Build a louvered-roof engine at an explicit sun/slat geometry."""
-    return AdaptiveLouveredRoofCover(
-        logger=MagicMock(),
-        sol_azi=sol_azi,
-        sol_elev=sol_elev,
-        sun_data=MagicMock(),
-        config=make_cover_config(
-            win_azi=win_azi, fov_left=fov_left, fov_right=fov_right
-        ),
-        tilt_config=make_tilt_config(
-            slat_distance=slat_distance,
-            depth=depth,
-            mode=mode,
-            safety_margin=safety_margin,
-        ),
-        roof_config=LouveredRoofConfig(
-            roof_pitch=roof_pitch, max_slat_angle=max_slat_angle
-        ),
-    )
+# Shared with tests/test_pipeline/test_pipeline_helpers.py — the
+# AdaptiveLouveredRoofCover construction lives once in tests/cover_helpers.py
+# (#1105 audit) rather than being reimplemented per test file.
+_louvered = build_louvered_roof_cover
 
 
 def _tilt(
@@ -432,12 +405,29 @@ class TestMaxSlatAngle:
         )
         result = cover.calculate_position()
         assert isinstance(result, float)
+        # Pin the effective ceiling itself, not just "didn't raise" — every
+        # non-raising return path of calculate_position() is a float, so the
+        # isinstance check alone proves nothing about the denominator actually
+        # landing on 0.4 rather than being silently truncated to 0 elsewhere.
+        assert cover._last_calc_details["max_degrees"] == pytest.approx(0.4)
 
     def test_fractional_denominator_is_not_truncated(self) -> None:
         cover = _louvered(
             sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=137.5
         )
         assert cover._effective_max_degrees() == pytest.approx(137.5)
+
+    def test_int_max_slat_angle_returns_float(self) -> None:
+        # ``_effective_max_degrees`` is typed ``-> float``; a plain int
+        # ``max_slat_angle`` (as several tests in this class pass, e.g. 160
+        # above) must actually come back as a float, not just an int that
+        # happens to compare equal to one (issue #1105 audit).
+        cover = _louvered(
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=160
+        )
+        result = cover._effective_max_degrees()
+        assert result == 160
+        assert isinstance(result, float)
 
 
 class TestMaxOpeningObjective:

--- a/tests/test_engine/test_louvered_roof_engine.py
+++ b/tests/test_engine/test_louvered_roof_engine.py
@@ -423,6 +423,22 @@ class TestMaxSlatAngle:
         cover.calculate_position()
         assert cover._last_calc_details["max_degrees"] == 160
 
+    def test_fractional_sub_one_does_not_raise_zero_division(self) -> None:
+        # A fractional max_slat_angle in the open interval (0, 1) is truthy, so
+        # it must NOT be routed to the ``0`` sentinel branch — but it also must
+        # not truncate to a literal ``0`` denominator (issue #1105).
+        cover = _louvered(
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=0.4
+        )
+        result = cover.calculate_position()
+        assert isinstance(result, float)
+
+    def test_fractional_denominator_is_not_truncated(self) -> None:
+        cover = _louvered(
+            sol_azi=180, sol_elev=65, roof_pitch=0, mode="mode2", max_slat_angle=137.5
+        )
+        assert cover._effective_max_degrees() == pytest.approx(137.5)
+
 
 class TestMaxOpeningObjective:
     """The louvered slat objective is MAX OPENING (closest to vertical/90°).

--- a/tests/test_pipeline/test_pipeline_helpers.py
+++ b/tests/test_pipeline/test_pipeline_helpers.py
@@ -7,13 +7,7 @@ and compute_raw_calculated_position.
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
-
-from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
-from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
-    AdaptiveLouveredRoofCover,
-)
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
     SOLAR_TRACKING_FLOOR_PCT,
     apply_snapshot_limits,
@@ -23,7 +17,7 @@ from custom_components.adaptive_cover_pro.pipeline.helpers import (
     solar_floor,
     solar_position_from_geometry,
 )
-from tests.cover_helpers import make_cover_config, make_tilt_config
+from tests.cover_helpers import build_louvered_roof_cover
 
 # ---------------------------------------------------------------------------
 # Minimal snapshot / cover helpers
@@ -232,17 +226,14 @@ class TestComputeSolarPosition:
         ``solar_position_from_geometry`` directly against a real
         ``AdaptiveLouveredRoofCover`` configured with ``max_slat_angle=0.4`` — a
         value the old ``int()`` truncation in ``_effective_max_degrees()``
-        collapsed onto the ``0`` sentinel's literal denominator, raising
-        ``ZeroDivisionError`` uncaught on the tilt-only solar branch.
+        collapsed onto a literal ``0`` denominator, raising
+        ``ZeroDivisionError`` uncaught on the tilt-only solar branch. At this
+        geometry the raw angle (180°) saturates against the 0.4° ceiling, so
+        the concrete answer is pinned at 100 rather than merely "some int in
+        range" — verified empirically, not assumed.
         """
-        cover = AdaptiveLouveredRoofCover(
-            logger=MagicMock(),
-            sol_azi=180,
-            sol_elev=65,
-            sun_data=MagicMock(),
-            config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
-            tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
-            roof_config=LouveredRoofConfig(roof_pitch=0.0, max_slat_angle=0.4),
+        cover = build_louvered_roof_cover(
+            sol_azi=180, sol_elev=65, roof_pitch=0.0, max_slat_angle=0.4
         )
         policy = SimpleNamespace(axes=[SimpleNamespace(open_blocks_sun=False)])
 
@@ -255,8 +246,7 @@ class TestComputeSolarPosition:
             floor_active=False,
         )
 
-        assert isinstance(result, int)
-        assert 0 <= result <= 100
+        assert result == 100
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline/test_pipeline_helpers.py
+++ b/tests/test_pipeline/test_pipeline_helpers.py
@@ -7,8 +7,13 @@ and compute_raw_calculated_position.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 
+from custom_components.adaptive_cover_pro.config_types import LouveredRoofConfig
+from custom_components.adaptive_cover_pro.engine.covers.louvered_roof import (
+    AdaptiveLouveredRoofCover,
+)
 from custom_components.adaptive_cover_pro.pipeline.helpers import (
     SOLAR_TRACKING_FLOOR_PCT,
     apply_snapshot_limits,
@@ -16,7 +21,9 @@ from custom_components.adaptive_cover_pro.pipeline.helpers import (
     compute_raw_calculated_position,
     compute_solar_position,
     solar_floor,
+    solar_position_from_geometry,
 )
+from tests.cover_helpers import make_cover_config, make_tilt_config
 
 # ---------------------------------------------------------------------------
 # Minimal snapshot / cover helpers
@@ -214,6 +221,42 @@ class TestComputeSolarPosition:
         """A sub-1% geometry rounds to 0 and is NOT floored when positionable (#569)."""
         snap = _make_snapshot(calc_pct=0.4, solar_floor_active=False)
         assert compute_solar_position(snap) == 0
+
+    def test_solar_position_from_geometry_survives_fractional_louvered_denominator(
+        self,
+    ):
+        """A sub-1° ``max_slat_angle`` must not crash the pipeline seam (#1105).
+
+        Locks the observable behavior at the exact "propagates uncaught out of
+        pipeline/helpers.py" path the issue describes: this calls
+        ``solar_position_from_geometry`` directly against a real
+        ``AdaptiveLouveredRoofCover`` configured with ``max_slat_angle=0.4`` — a
+        value the old ``int()`` truncation in ``_effective_max_degrees()``
+        collapsed onto the ``0`` sentinel's literal denominator, raising
+        ``ZeroDivisionError`` uncaught on the tilt-only solar branch.
+        """
+        cover = AdaptiveLouveredRoofCover(
+            logger=MagicMock(),
+            sol_azi=180,
+            sol_elev=65,
+            sun_data=MagicMock(),
+            config=make_cover_config(win_azi=180, fov_left=90, fov_right=90),
+            tilt_config=make_tilt_config(slat_distance=0.02, depth=0.03, mode="mode2"),
+            roof_config=LouveredRoofConfig(roof_pitch=0.0, max_slat_angle=0.4),
+        )
+        policy = SimpleNamespace(axes=[SimpleNamespace(open_blocks_sun=False)])
+
+        result = solar_position_from_geometry(
+            cover,
+            _make_config(),
+            minimize_movements=False,
+            max_coverage_steps=1,
+            policy=policy,
+            floor_active=False,
+        )
+
+        assert isinstance(result, int)
+        assert 0 <= result <= 100
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services_options.py
+++ b/tests/test_services_options.py
@@ -47,6 +47,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MANUAL_OVERRIDE_DURATION,
     CONF_MANUAL_OVERRIDE_RESET,
     CONF_MAX_POSITION,
+    CONF_MAX_SLAT_ANGLE,
     CONF_MIN_POSITION,
     CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
@@ -78,6 +79,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_WEATHER_TIMEOUT,
     CONF_WEATHER_WIND_SPEED_THRESHOLD,
     DOMAIN,
+    MIN_USABLE_SLAT_ANGLE_DEG,
     CoverType,
     VENETIAN_MODE_POSITION_AND_TILT,
 )
@@ -93,6 +95,7 @@ from custom_components.adaptive_cover_pro.services.options_service import (
     _SERVICE_FIELD_ALIASES,
     _build_patch,
     _cross_field_validate,
+    _validate_fields,
     apply_options_patch,
     validate_options_patch,
 )
@@ -317,6 +320,72 @@ class TestFieldValidators:
             FIELD_VALIDATORS[key](None)
             FIELD_VALIDATORS[key](5000)
             FIELD_VALIDATORS[key]("{{ states('sensor.x') | float }}")
+
+    def test_max_slat_angle_in_option_ranges(self):
+        """Issue #1105: max_slat_angle range is single-sourced (0, 180)."""
+        from custom_components.adaptive_cover_pro.const import OPTION_RANGES
+
+        assert OPTION_RANGES[CONF_MAX_SLAT_ANGLE] == (0, 180)
+
+    def test_max_slat_angle_accepts_none_and_zero_sentinel(self):
+        """Issue #1105: None (cleared) and the ``0`` sentinel both pass.
+
+        ``0`` means "use the tilt mode's 90°/180°" and must stay legal in every
+        numeric form it can arrive in — int, float, and negative-zero.
+        """
+        assert FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](None) is None
+        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](0)
+        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](0.0)
+        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](-0.0)
+
+    def test_max_slat_angle_accepts_usable_range(self):
+        """Issue #1105: the smallest usable angle through the declared max pass."""
+        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](1)
+        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](180)
+        FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](True)  # bool coerces to 1.0
+
+    def test_max_slat_angle_rejects_sub_one_nonzero(self):
+        """Issue #1105: the dead zone between the sentinel and a usable angle.
+
+        ``0`` is the documented sentinel meaning "use the tilt mode's
+        90°/180°"; a value in the open interval ``(0, 1)`` is neither the
+        sentinel nor a usable physical angle (it would truncate to a literal
+        ``0`` denominator in the engine before this fix), so the config
+        boundary must reject it outright.
+        """
+        for value in (0.5, 0.99, "0.5"):
+            with pytest.raises(Exception):
+                FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](value)
+
+    def test_max_slat_angle_rejects_below_min_and_above_max(self):
+        """Issue #1105: the OLD ``_range()`` boundaries still hold post-swap.
+
+        Distinct from ``test_max_slat_angle_rejects_sub_one_nonzero`` above:
+        these values are rejected by the generic below-min/above-max path, NOT
+        the bespoke dead-zone branch (``-0.1`` is below the dead zone's own
+        floor of 0, so it never enters the ``0 < coerced < MIN`` check).
+        """
+        for value in (-5, -0.1, 181, 180.5):
+            with pytest.raises(Exception):
+                FIELD_VALIDATORS[CONF_MAX_SLAT_ANGLE](value)
+
+    def test_max_slat_angle_dead_zone_message_names_the_sentinel(self):
+        """Issue #1105: the bespoke dead-zone message must survive a refactor.
+
+        Deleting the ``0 < coerced < MIN_USABLE_SLAT_ANGLE_DEG`` branch
+        entirely and falling back to the generic ``vol.Range`` rejection would
+        leave the whole suite green were it not for this test — the generic
+        path rejects the same value but never mentions the ``0`` sentinel, so
+        this pins the one thing the bespoke branch exists to say.
+        """
+        with pytest.raises(ServiceValidationError) as exc_info:
+            _validate_fields({CONF_MAX_SLAT_ANGLE: 0.5})
+
+        message = str(exc_info.value)
+        assert message == (
+            "Invalid value for 'max_slat_angle': must be 0 (use tilt mode) or "
+            f">= {MIN_USABLE_SLAT_ANGLE_DEG} (got 0.5)"
+        )
 
     def test_tilt_mode_select(self):
         FIELD_VALIDATORS["tilt_mode"]("mode1")


### PR DESCRIPTION
## Summary

`AdaptiveLouveredRoofCover._effective_max_degrees()` truncated `max_slat_angle` with `int()`. Since
`0` is the sentinel meaning "use the tilt mode's 90/180 degree maximum", any value in the open
interval (0, 1) was truthy, bypassed the sentinel, and became a literal `0` denominator.
`PositionConverter.to_percentage()` then raised `ZeroDivisionError` on every `calculate_position()`,
propagating uncaught out of `pipeline/helpers.py` on the louvered-roof and tilt-only paths. Venetian
was the only cover type that caught it.

The fix is layered. Dropping the `int()` cast keeps the denominator a float, which also rescues
config entries that already store a sub-degree value, since a validator only gates new writes. On
top of that, a dedicated `max_slat_angle` validator rejects `0 < v < 1` at the config boundary while
still passing `None` and the `0` sentinel through. `OPTION_RANGES` stays `(0, 180)`; the sub-degree
exclusion is validator logic, not a shared-range change.

Follow-on work from four audit rounds: the 1 degree floor lives once in
`const.MIN_USABLE_SLAT_ANGLE_DEG`, `import_config` now agrees with `set_option` on this key, and the
shared out-of-range message has a single definition that a parity test pins across keys.

Note that dropping the cast also stops truncating legitimate non-integer values at or above 1 degree.
A stored `137.5` now yields a `137.5` denominator instead of `137`.

## Testing
- ✅ 9634 tests passing

## Related Issues
Refs #1105