### PR TITLE
fix: sort develop builds as -alpha and prune superseded betas

### DIFF
--- a/.github/workflows/develop-build.yml
+++ b/.github/workflows/develop-build.yml
@@ -1,13 +1,13 @@
-# Develop build — a `.dev` pre-release built from the tip of `develop` whenever
-# develop changes (every push), gated on the test suite.
+# Develop build — an `-alpha.<date>` pre-release built from the tip of `develop`
+# whenever develop changes (every push), gated on the test suite.
 #
 # This workflow is push-triggered, so GitHub runs the copy of this file that
 # lives on `develop` — push events use the workflow from the pushed branch, so
 # there's no dependence on the default branch the way `on: schedule` has.
 #
-# Flow: compute a `.dev<date>` (PEP440) version → run the test suite as a gate →
-# make an ephemeral manifest-bump commit, tag it, and push ONLY the tag. The
-# existing `publish-release.yml` then builds + publishes the pre-release.
+# Flow: compute an `-alpha.<date>` (SemVer pre-release) version → run the test
+# suite as a gate → make an ephemeral manifest-bump commit, tag it, and push ONLY
+# the tag. The existing `publish-release.yml` then builds + publishes it.
 #
 # Retention: keep the 7 most recent develop builds; older ones are pruned.
 #
@@ -46,28 +46,41 @@ jobs:
         run: |
           set -euo pipefail
 
-          # PEP440 dev release of the in-progress target. A `.dev<date>` suffix
-          # sorts BELOW the current beta and the eventual stable in AwesomeVersion
-          # (the library HACS uses), so dev builds never appear as the newest
-          # version to stable/beta users. Two traps this avoids: `nightly` is NOT
-          # an AwesomeVersion modifier (sorts alphabetically high), and bumping the
-          # patch makes the base outrank everything before the modifier is checked.
+          # SemVer pre-release of the in-progress target. An `-alpha.<date>` suffix
+          # sorts BELOW the current beta and the eventual stable, so develop builds
+          # never appear as the newest version to stable/beta users. It holds that
+          # ordering under BOTH sorters that matter, which is why it's `-alpha` and
+          # not something else:
+          #   - AwesomeVersion (the library HACS uses) ranks the `alpha.N` modifier
+          #     below `beta.N`, and both below the bare base version.
+          #   - Generic version sorts — GitHub's /tags page, `git --sort=version:refname`
+          #     — compare the identifier alphabetically, and `alpha` < `beta`. The
+          #     leading hyphen also keeps it below the bare `X.Y.Z` base.
+          #
+          # Three traps this avoids, all previously hit:
+          #   - `nightly` is NOT an AwesomeVersion modifier (sorts alphabetically high).
+          #   - A PEP440 `.dev<date>` suffix sorts correctly in AwesomeVersion but WRONG
+          #     everywhere else: `dev` > `beta` alphabetically and the dot-separated
+          #     segment isn't a pre-release at all to a generic sorter, so a freshly cut
+          #     beta sank below develop builds made hours earlier on GitHub's /tags page.
+          #   - Bumping the patch makes the base outrank everything before the modifier
+          #     is even compared.
           BASE=$(jq -r '.version' custom_components/adaptive_cover_pro/manifest.json)
           CORE=${BASE%%-*}   # strip any -beta.N suffix
           TS=$(date -u +%Y%m%d%H%M)
 
-          # Decide the dev base by asking the real question the suffix used to
+          # Decide the alpha base by asking the real question the suffix used to
           # proxy: has CORE already SHIPPED as a stable (non-prerelease) release?
-          #   - shipped   → dev of the NEXT patch, so it outsorts that stable.
-          #   - unshipped → dev of CORE itself (mid-cycle beta OR bare target).
+          #   - shipped   → alpha of the NEXT patch, so it outsorts that stable.
+          #   - unshipped → alpha of CORE itself (mid-cycle beta OR bare target).
           # This is robust to a bare, not-yet-shipped target version on develop
           # (e.g. the CalVer month rollover sets `YYYY.M.0` with no -beta suffix),
-          # which the old string test mislabeled as `YYYY.M.1.dev`.
+          # which the old string test mislabeled as `YYYY.M.1`.
           if gh release view "v${CORE}" --json isPrerelease --jq '.isPrerelease==false' 2>/dev/null | grep -q true; then
             IFS=. read -r MAJ MIN PAT <<< "$CORE"
-            VERSION="${MAJ}.${MIN}.$((PAT + 1)).dev${TS}"
+            VERSION="${MAJ}.${MIN}.$((PAT + 1))-alpha.${TS}"
           else
-            VERSION="${CORE}.dev${TS}"
+            VERSION="${CORE}-alpha.${TS}"
           fi
           TAG="v${VERSION}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -116,22 +129,39 @@ jobs:
           git push origin "refs/tags/${TAG}"
           echo "Pushed ${TAG}; publish-release.yml will build the pre-release."
 
-      - name: Prune old develop builds (keep newest 7)
+      - name: Prune old develop builds
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ needs.version.outputs.tag }}
         run: |
           set -euo pipefail
-          # Keep the 7 most recent develop builds; delete the rest (and any legacy
-          # -nightly. stragglers). gh release list returns newest-first, so we keep
-          # the first 7 and delete from there. --cleanup-tag removes the git tag
-          # along with the release, so no orphan tags are left behind.
+          KEEP=7
+
+          # Retain the newest KEEP develop builds, counting the one this run just
+          # made. That build's RELEASE is created asynchronously by
+          # publish-release.yml, which this step races and reliably LOSES — the tag
+          # push and this prune are seconds apart, so `gh release list` here almost
+          # never sees it yet. Counting on it being present kept KEEP *previous*
+          # builds and then let the new one land on top, so the population sat at
+          # KEEP+1 and wobbled with whoever won the race.
+          #
+          # So: drop $TAG from the list if it happens to be there, keep KEEP-1 of
+          # the remainder, and let the new build be the KEEPth. Same outcome either
+          # way the race falls.
+          #
+          # The selector matches develop builds only — `-alpha.` plus stragglers
+          # from the two earlier grammars (`.dev<date>`, `-nightly.N`). It must
+          # never match `-beta.`: those are real releases.
           mapfile -t TAGS < <(gh release list --limit 100 --json tagName \
-            --jq '.[].tagName | select(test("\\.dev|-nightly\\."))')
+            --jq '.[].tagName | select(test("-alpha\\.|\\.dev|-nightly\\."))' \
+            | grep -vxF "$TAG" || true)
+
           i=0
           for t in "${TAGS[@]:-}"; do
             [ -z "$t" ] && continue
             i=$((i + 1))
-            [ "$i" -le 7 ] && continue
-            echo "Deleting old develop build ${t} (beyond newest 7)"
+            [ "$i" -lt "$KEEP" ] && continue
+            echo "Deleting old develop build ${t} (beyond newest ${KEEP})"
+            # --cleanup-tag removes the git tag too, so no orphan tags are left.
             gh release delete "${t}" --cleanup-tag --yes
           done

--- a/.github/workflows/mark-awaiting-release.yml
+++ b/.github/workflows/mark-awaiting-release.yml
@@ -134,7 +134,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: num,
-                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\nIt is also included in the latest [develop build](https://github.com/${context.repo.owner}/${context.repo.repo}/releases) (a \`.dev\` pre-release built from \`develop\` on every merge) if you'd like to test it early.`,
+                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\nIt is also included in the latest [develop build](https://github.com/${context.repo.owner}/${context.repo.repo}/releases) (an \`-alpha\` pre-release built from \`develop\` on every merge) if you'd like to test it early.`,
                 });
                 console.log(`Labeled issue #${num} as awaiting-release.`);
               } else if (item.state_reason === 'completed') {
@@ -157,7 +157,7 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: num,
-                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\nIt is also included in the latest [develop build](https://github.com/${context.repo.owner}/${context.repo.repo}/releases) (a \`.dev\` pre-release built from \`develop\` on every merge) if you'd like to test it early.\n\n_(This issue was briefly auto-closed by a commit keyword and has been reopened to follow the normal release lifecycle.)_`,
+                  body: `A fix for this issue has been merged and will ship in the next stable release.\n\nIt is also included in the latest [develop build](https://github.com/${context.repo.owner}/${context.repo.repo}/releases) (an \`-alpha\` pre-release built from \`develop\` on every merge) if you'd like to test it early.\n\n_(This issue was briefly auto-closed by a commit keyword and has been reopened to follow the normal release lifecycle.)_`,
                 });
                 console.log(`Reopened and labeled issue #${num} as awaiting-release.`);
               } else {

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,10 +31,11 @@ jobs:
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
 
-          # Pre-release tags carry a hyphenated identifier (-beta.N) OR a PEP440
-          # dev suffix (.dev<date>, the develop builds). The dev suffix has NO
-          # hyphen, so it must be matched explicitly or dev builds would publish
-          # as stable releases and leak to stable-channel users.
+          # Pre-release tags carry a hyphenated identifier: -beta.N (hand-cut betas)
+          # or -alpha.<date> (the develop builds). The legacy PEP440 .dev<date>
+          # grammar has NO hyphen, so it stays matched explicitly until the last of
+          # those tags ages out — without it a dev build would publish as a stable
+          # release and leak to stable-channel users.
           EXTRA=""
           NOTES="Release $TAG - See full changelog below"
           NOTES_START=""
@@ -42,7 +43,7 @@ jobs:
             *-* | *.dev*) EXTRA="--prerelease --latest=false" ;;
           esac
           case "$TAG" in
-            *.dev*)
+            *-alpha.* | *.dev*)
               NOTES=$(printf '%s\n' \
                 '> 🛠️ **Develop build from `develop` — unstable, for testing.**' \
                 '> Auto-generated from the latest development code. Expect rough edges — not for production use.' \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -87,3 +87,54 @@ jobs:
         run: |
           gh release upload "${{ steps.tag.outputs.tag }}" \
             "${{ github.workspace }}/custom_components/adaptive_cover_pro/adaptive_cover_pro.zip"
+
+      # Runs last, after the release exists and the ZIP is attached, so a failure
+      # here can never cost us the release itself.
+      - name: "Prune betas superseded by this stable"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # A stable just shipped, so every beta cut FOR THAT SAME VERSION is now
+          # a rehearsal for something users can install directly — v2026.8.0-beta.1
+          # through -beta.N are dead weight next to v2026.8.0. Delete them so the
+          # Releases page tracks shipped versions instead of accumulating every
+          # intermediate cut. Betas of versions that have NOT shipped are left
+          # alone: they're still the newest thing on their line.
+          #
+          # Guard 1: bail unless $TAG is a bare stable. A hyphen means this run is
+          # itself a pre-release (-beta./-alpha.), and `.dev` catches the legacy
+          # develop-build grammar.
+          case "$TAG" in
+            *-* | *.dev*)
+              echo "$TAG is a pre-release; nothing to prune."
+              exit 0
+              ;;
+          esac
+
+          # Guard 2: literal prefix match, not a regex. $TAG is full of dots that
+          # would otherwise match any character, so this compares "${TAG}-beta."
+          # as text. A v2026.8.0 release therefore cannot reach v2026.8.1's betas,
+          # another stable, or a develop build.
+          BETAS=()
+          while read -r r; do
+            [ -z "$r" ] && continue
+            case "$r" in
+              "${TAG}-beta."*) BETAS+=("$r") ;;
+            esac
+          done < <(gh api --paginate "repos/${REPO}/releases" --jq '.[].tag_name')
+
+          if [ ${#BETAS[@]} -eq 0 ]; then
+            echo "No superseded betas found for ${TAG}."
+            exit 0
+          fi
+
+          for b in "${BETAS[@]}"; do
+            echo "Deleting superseded beta ${b} (${TAG} has now shipped)"
+            # --cleanup-tag removes the git tag too, so no orphan tags are left.
+            gh release delete "${b}" --cleanup-tag --yes
+          done
+          echo "Pruned ${#BETAS[@]} beta(s) superseded by ${TAG}."

--- a/.github/workflows/release-issue-lifecycle.yml
+++ b/.github/workflows/release-issue-lifecycle.yml
@@ -36,9 +36,9 @@ jobs:
           CURRENT_TAG="${{ github.event.release.tag_name || inputs.tag_name }}"
 
           # Find the previous stable tag (exclude pre-release AND develop builds).
-          # Develop builds are PEP440 .dev builds (no hyphen) plus legacy -nightly.;
-          # both must be excluded or one could be picked as PREV_TAG, yielding an
-          # empty commit range and zero issue refs.
+          # Develop builds are -alpha.<date>, plus legacy PEP440 .dev<date> (no
+          # hyphen) and -nightly. stragglers; all must be excluded or one could be
+          # picked as PREV_TAG, yielding an empty commit range and zero issue refs.
           PREV_TAG=$(git tag --sort=-version:refname \
             | grep -v -E '\-(beta|alpha|rc|nightly)\.|\.dev' \
             | grep -v "^${CURRENT_TAG}$" \


### PR DESCRIPTION
## Summary

Two release-plumbing fixes, both CI-only — no integration code changes, no version bump.

**1. Develop builds now tag as `-alpha.<ts>` instead of PEP 440 `.dev<ts>`.**
The old grammar sorted correctly in AwesomeVersion (HACS) but nowhere else: to a generic version sorter `dev` beats `beta` alphabetically, and a dot-separated segment isn't a pre-release at all. A freshly cut beta sank below develop builds made hours earlier on GitHub's `/tags` page, and `git tag --sort=version:refname` put it below every single one. `-alpha.` holds the ordering under both sorters — AwesomeVersion ranks `alpha.N` under `beta.N`, and generic sorts get it right because `alpha` < `beta` and the leading hyphen keeps it under the bare base.

**2. Retention off-by-one.** The prune step races `publish-release.yml`, which creates the release for the tag it just pushed, and reliably loses — the two are seconds apart. So it kept 7 *previous* builds and let the new one land on top, holding the population at 8. It now excludes the current tag and keeps `KEEP-1` of the rest, landing on 7 either way the race falls.

**3. Beta retention (new).** Nothing had ever pruned betas — they'd reached 142 releases, 116 of them rehearsals for a version users can now install directly. `publish-release.yml` now deletes a version's betas once that version's stable ships.

## Testing

- ✅ All four workflow files parse; every embedded script passes `bash -n`
- ✅ Prune logic simulated across 5 cases — race won, race lost, betas/stables present, cold start, legacy stragglers — lands on 7 survivors in every case and never selects a beta or stable
- ✅ Beta prune simulated against the live 273-release list: `v2026.8.0`→1 beta, `v2.30.0`→4 betas, pre-release tags skip, and `v2.3.0` correctly does **not** reach `v2.30.0-beta.*` (the literal-prefix guard)
- ✅ AwesomeVersion ordering verified: `2026.8.0` > `-beta.2` > `-beta.1` > `-alpha.<ts>`

## Notes

Legacy `.dev` and `-nightly.` matchers stay in the prune selector and prerelease detection as a safety net. The 8 existing `.dev` builds were deleted manually, so the tags page now leads with `v2026.8.0-beta.1`.

Wiki updated: Installation, Developer-Release-Process.
