### PR TITLE
fix: admit position-only covers to the day/night cover picker (#1114)

### DIFF
--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -3197,6 +3197,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if event_buffer is not None and rc.event_buffer_size != event_buffer.maxlen:
             event_buffer.resize(rc.event_buffer_size)
 
+        # Let the active policy refresh whatever option-derived state it caches
+        # for hooks that receive no ``options`` (issue #1114). Deliberately
+        # generic: the coordinator hands over the whole dict and knows nothing
+        # about which cover types cache what. Runs here, at the coordinator's
+        # per-cycle options seam, so the value is resolved on the event loop and
+        # before both the pipeline and ``_evaluate_health_checks`` — including on
+        # the very first cycle of this coordinator's lifetime. Base
+        # implementation is a no-op, so most policies pay nothing.
+        self._policy.sync_runtime_options(options)
+
     def _update_manager_and_covers(self):
         """Update manager with cover entities.
 

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -78,17 +78,6 @@ CAP_HAS_OPEN = "has_open"
 CAP_HAS_CLOSE = "has_close"
 CAP_HAS_STOP = "has_stop"
 
-# Filter for cover types whose control models all need only ``set_position``
-# (e.g. Day/Night Models B/C, #1114). Cover types that drive tilt
-# unconditionally use the stricter ``TILT_CAPABLE_ENTITY_FILTER``
-# (``cover_types/tilt.py``) instead — this one intentionally admits
-# position-only hardware (``supported_features`` with no tilt bit) that the
-# stricter filter would exclude.
-POSITION_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
-    domain="cover",
-    supported_features=["cover.CoverEntityFeature.SET_POSITION"],
-)
-
 AXIS_NAME_POSITION = "position"
 AXIS_NAME_TILT = "tilt"
 
@@ -98,6 +87,35 @@ AXIS_NAME_TILT = "tilt"
 AXIS_VALUE_MIN = 0
 AXIS_VALUE_MAX = 100
 AXIS_VALUE_UNIT = "%"
+
+
+# ---------------------------------------------------------------------------
+# Config-flow entity-selector filters
+# ---------------------------------------------------------------------------
+# The ``EntityFilterSelectorConfig`` structures returned by
+# ``entity_selector_filter()``, built from HA's own ``CoverEntityFeature`` names.
+# They belong here rather than in ``const.py`` for the same reason as the
+# capability flags above — they define the cover-type abstraction boundary — and
+# because they are schema structures assembled at import time, not plain values.
+# Both strictness levels sit together so a policy author reads them side by side
+# and picks deliberately (#1114).
+
+# Cover types that drive a tilt axis unconditionally (tilt, venetian, louvered
+# roof). HA's ``supported_features`` filter is OR-of-listed, not AND, so the
+# venetian's additional ``set_position`` need is surfaced as a config-flow
+# capability warning rather than by a second entry here.
+TILT_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
+    domain="cover",
+    supported_features=["cover.CoverEntityFeature.SET_TILT_POSITION"],
+)
+
+# Cover types whose control models all need only ``set_position`` (e.g. Day/Night
+# Models B/C, #1114) — intentionally admits position-only hardware
+# (``supported_features`` with no tilt bit) that the tilt filter would exclude.
+POSITION_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
+    domain="cover",
+    supported_features=["cover.CoverEntityFeature.SET_POSITION"],
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -428,6 +446,26 @@ class CoverTypePolicy(ABC):
         if not inserted:
             rebuilt[toggle_marker] = toggle_selector
         return vol.Schema(rebuilt)
+
+    def sync_runtime_options(self, options: dict) -> None:  # noqa: ARG002
+        """Refresh option-derived policy state for this update cycle.
+
+        The coordinator calls this once per cycle from ``_update_options`` — on
+        the event loop, before the pipeline runs and before the health checks
+        ask their predicates — so a policy that caches an option-derived mode
+        has it resolved before anything reads it, including on the coordinator's
+        very first cycle. Generic on purpose: the coordinator must not know
+        which cover types cache what, and must never call a type-specific method
+        (CODING_GUIDELINES.md "No String Branches Outside ``cover_types/``").
+
+        Default: no-op. Most policies derive everything from the ``options``
+        dict each hook already receives and need no cache.
+
+        This exists so ``build_calc_engine`` can stay a pure builder:
+        ``forecast.build_forecast_for_coord`` calls it ~289× per forecast from
+        an executor thread, so mutating live policy state there would write
+        off the event loop.
+        """
 
     @abstractmethod
     def build_calc_engine(

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -78,6 +78,17 @@ CAP_HAS_OPEN = "has_open"
 CAP_HAS_CLOSE = "has_close"
 CAP_HAS_STOP = "has_stop"
 
+# Filter for cover types whose control models all need only ``set_position``
+# (e.g. Day/Night Models B/C, #1114). Cover types that drive tilt
+# unconditionally use the stricter ``TILT_CAPABLE_ENTITY_FILTER``
+# (``cover_types/tilt.py``) instead — this one intentionally admits
+# position-only hardware (``supported_features`` with no tilt bit) that the
+# stricter filter would exclude.
+POSITION_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
+    domain="cover",
+    supported_features=["cover.CoverEntityFeature.SET_POSITION"],
+)
+
 AXIS_NAME_POSITION = "position"
 AXIS_NAME_TILT = "tilt"
 

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -384,6 +384,25 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
 
     # ---- Calculation engine ------------------------------------------- #
 
+    def _set_control_model(self, options: dict) -> None:
+        """Cache the per-instance control model from ``options``.
+
+        Single source for the ``options.get(...)`` read, called from BOTH
+        :meth:`build_calc_engine` and :meth:`post_pipeline_resolve` (the
+        no-duplication rule) so the model is never stale when either hook's
+        caller needs it. ``build_calc_engine`` runs first each cycle (via the
+        coordinator's ``get_blind_data``), *before* ``_evaluate_health_checks``
+        — including on the coordinator's very first update cycle, before
+        ``post_pipeline_resolve`` has ever run. Without this call there,
+        ``_control_model`` would still read the ``__init__`` Model A default
+        when the A3 health check asks ``tilt_capability_contradiction``,
+        falsely flagging a Model B/C position-only cover as a contradiction
+        (#1114 audit finding).
+        """
+        self._control_model = str(
+            options.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
+        )
+
     def build_calc_engine(
         self,
         *,
@@ -395,7 +414,13 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         config_service: ConfigurationService,
         options: dict,
     ) -> AdaptiveGeneralCover:
-        """Build a vertical calc engine; the blend is filled post-pipeline."""
+        """Build a vertical calc engine; the blend is filled post-pipeline.
+
+        Also caches the control model from ``options`` — see
+        :meth:`_set_control_model` for why this hook, not just
+        ``post_pipeline_resolve``, must set it.
+        """
+        self._set_control_model(options)
         return AdaptiveVerticalCover(
             logger=logger,
             sol_azi=sol_azi,
@@ -555,21 +580,22 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """Resolve the fabric blend, then map it onto the configured control model.
 
         The blend resolution (:meth:`_resolve_blend`) is model-independent and
-        byte-identical to Model A. The per-instance control model is cached here
-        from ``options`` — the downstream dispatch hooks don't receive
-        ``options``, so they read the cached value. In ``split_range`` (Model B)
-        a single physical axis encodes BOTH coverage and fabric, so the resolved
-        blend is folded into ``result.position`` via :meth:`_split_range_wire`
-        while the abstract blend is kept on ``result.tilt`` for the Target Tilt
-        sensor / forecast / diagnostics. In ``position_tilt`` (Model A, default)
-        the resolved result passes straight through.
+        byte-identical to Model A. The per-instance control model is re-cached
+        here from ``options`` (see :meth:`_set_control_model`; ``build_calc_engine``
+        already set it once earlier this cycle, but options can change between
+        config-entry reloads, so this call keeps it current) — the downstream
+        dispatch hooks don't receive ``options``, so they read the cached value.
+        In ``split_range`` (Model B) a single physical axis encodes BOTH coverage
+        and fabric, so the resolved blend is folded into ``result.position`` via
+        :meth:`_split_range_wire` while the abstract blend is kept on
+        ``result.tilt`` for the Target Tilt sensor / forecast / diagnostics. In
+        ``position_tilt`` (Model A, default) the resolved result passes straight
+        through.
         """
         if result is None:
             return result
 
-        self._control_model = str(
-            options.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
-        )
+        self._set_control_model(options)
         resolved = self._resolve_blend(
             result,
             logger=logger,

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -194,10 +194,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # branch of ``post_pipeline_resolve`` (mirrors venetian's ``_last_tilt``).
         self._last_blend: int | None = None
         self._schedule_refresh_after: Any | None = None
-        # Per-instance control model (Model A vs B). Read from options and cached
-        # once per cycle in ``post_pipeline_resolve`` so the downstream dispatch
-        # hooks — which don't receive ``options`` — can gate on it. Defaults to
-        # the dual-axis Model A so an un-resolved cycle behaves like Phase A.
+        # Per-instance control model (Model A vs B vs C). Read from options and
+        # cached once per cycle in ``sync_runtime_options`` — the generic hook the
+        # coordinator drives before the pipeline and the health checks — so the
+        # downstream dispatch hooks, which don't receive ``options``, can gate on
+        # it. Defaults to the dual-axis Model A so an un-resolved cycle behaves
+        # like Phase A.
         self._control_model: str = DEFAULT_DAY_NIGHT_CONTROL_MODEL
         # Model C (dual_entity) dispatch cache, filled in ``post_pipeline_resolve``
         # and read by ``resolve_entity_target`` at the coordinator dispatch seam
@@ -226,6 +228,38 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """User-facing label for day/night shades."""
         L = {**COVER_TYPE_LABELS_EN, **(labels or {})}
         return L["cover_types.day_night_shade"]
+
+    # ---- Control model ------------------------------------------------ #
+
+    @staticmethod
+    def _read_control_model(source: dict) -> str:
+        """Read the control model out of an options/config mapping.
+
+        The single source for the ``CONF_DAY_NIGHT_CONTROL_MODEL`` read — every
+        consumer routes through here rather than repeating the key + default
+        (CODING_GUIDELINES.md "No Code Duplication"). The parameter is *source*,
+        not *options*, because :meth:`summary_geometry_lines` passes the
+        config-flow ``config`` mapping while :meth:`_set_control_model` and
+        :meth:`capability_warnings_for_options` pass ``options``: same key, same
+        default, two mappings.
+        """
+        return str(
+            source.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
+        )
+
+    def _set_control_model(self, options: dict) -> None:
+        """Cache the per-instance control model from ``options``.
+
+        The downstream dispatch hooks (``resolve_entity_target``,
+        ``after_position_command``, the A3 ``tilt_capability_contradiction``
+        predicate) receive no ``options``, so they read ``_control_model``. This
+        writes it, and is called from :meth:`sync_runtime_options` — the generic
+        per-cycle hook the coordinator drives on the event loop before the
+        pipeline and the health checks — and again from
+        :meth:`post_pipeline_resolve` so that hook is self-sufficient when
+        called directly.
+        """
+        self._control_model = self._read_control_model(options)
 
     # ---- Geometry / config-flow surfaces ------------------------------ #
 
@@ -273,9 +307,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """Render the window-dimensions block plus the control-model line."""
         lines = window_dimensions_lines(config, labels)
         L = {**GEOMETRY_LABELS_EN, **(labels or {})}
-        model = config.get(
-            CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL
-        )
+        model = self._read_control_model(config)
         model_label = {
             DAY_NIGHT_MODEL_POSITION_TILT: L["geometry.day_night.model_position_tilt"],
             DAY_NIGHT_MODEL_SPLIT_RANGE: L["geometry.day_night.model_split_range"],
@@ -353,9 +385,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         warns when ``CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY`` names an entity that is
         not among the instance's configured covers (a typo / stale pick).
         """
-        model = str(
-            options.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
-        )
+        model = self._read_control_model(options)
         single_axis_label = (
             "dual-entity" if model == DAY_NIGHT_MODEL_DUAL_ENTITY else "split-range"
         )
@@ -384,24 +414,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
 
     # ---- Calculation engine ------------------------------------------- #
 
-    def _set_control_model(self, options: dict) -> None:
-        """Cache the per-instance control model from ``options``.
+    def sync_runtime_options(self, options: dict) -> None:
+        """Resolve the control model for this cycle (base hook, #1114).
 
-        Single source for the ``options.get(...)`` read, called from BOTH
-        :meth:`build_calc_engine` and :meth:`post_pipeline_resolve` (the
-        no-duplication rule) so the model is never stale when either hook's
-        caller needs it. ``build_calc_engine`` runs first each cycle (via the
-        coordinator's ``get_blind_data``), *before* ``_evaluate_health_checks``
-        — including on the coordinator's very first update cycle, before
-        ``post_pipeline_resolve`` has ever run. Without this call there,
-        ``_control_model`` would still read the ``__init__`` Model A default
-        when the A3 health check asks ``tilt_capability_contradiction``,
-        falsely flagging a Model B/C position-only cover as a contradiction
-        (#1114 audit finding).
+        The coordinator drives this from ``_update_options``, on the event loop,
+        before the pipeline and before ``_evaluate_health_checks`` — so the A3
+        ``tilt_capability_contradiction`` predicate already knows it is looking
+        at a single-carriage Model B/C on the coordinator's very first cycle,
+        rather than reporting a position-only cover as a contradiction against
+        the ``__init__`` Model A default.
         """
-        self._control_model = str(
-            options.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
-        )
+        self._set_control_model(options)
 
     def build_calc_engine(
         self,
@@ -416,11 +439,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
     ) -> AdaptiveGeneralCover:
         """Build a vertical calc engine; the blend is filled post-pipeline.
 
-        Also caches the control model from ``options`` — see
-        :meth:`_set_control_model` for why this hook, not just
-        ``post_pipeline_resolve``, must set it.
+        A pure builder — it mutates no policy state. ``forecast`` calls this
+        ~289× per strip from an executor thread, so a write here would land off
+        the event loop; the control model is cached by
+        :meth:`sync_runtime_options` instead.
         """
-        self._set_control_model(options)
         return AdaptiveVerticalCover(
             logger=logger,
             sol_azi=sol_azi,
@@ -580,11 +603,20 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """Resolve the fabric blend, then map it onto the configured control model.
 
         The blend resolution (:meth:`_resolve_blend`) is model-independent and
-        byte-identical to Model A. The per-instance control model is re-cached
-        here from ``options`` (see :meth:`_set_control_model`; ``build_calc_engine``
-        already set it once earlier this cycle, but options can change between
-        config-entry reloads, so this call keeps it current) — the downstream
-        dispatch hooks don't receive ``options``, so they read the cached value.
+        byte-identical to Model A. The downstream dispatch hooks don't receive
+        ``options``, so they read the cached ``_control_model``.
+
+        The :meth:`_set_control_model` call below is a **defensive no-op in
+        production**: ``sync_runtime_options`` already resolved the model from
+        the same per-cycle ``options`` object before the pipeline ran, and a
+        model change is not runtime-applicable — it reloads the config entry
+        (``__init__.async_update_options``) and yields a fresh policy, so the
+        value can't drift mid-lifetime. It is retained because this hook is also
+        exercised directly, without the coordinator's per-cycle seam: the
+        ``post_pipeline_resolve`` unit tests pass ``options`` straight in and
+        expect the model to take effect. Keeping it here means the hook is
+        self-sufficient rather than order-dependent on its caller.
+
         In ``split_range`` (Model B) a single physical axis encodes BOTH coverage
         and fabric, so the resolved blend is folded into ``result.position`` via
         :meth:`_split_range_wire` while the abstract blend is kept on

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -67,6 +67,7 @@ from ..base import (
     CAP_HAS_SET_POSITION,
     CAP_HAS_SET_TILT_POSITION,
     POSITION_AXIS,
+    POSITION_CAPABLE_ENTITY_FILTER,
     TILT_AXIS,
     CoverAxis,
     CoverTypePolicy,
@@ -74,7 +75,6 @@ from ..base import (
     caps_get,
 )
 from ..blind import VERTICAL_LENGTH_KEYS, geometry_vertical_schema
-from ..tilt import TILT_CAPABLE_ENTITY_FILTER
 from ..venetian import DualAxisSequencer
 
 if TYPE_CHECKING:
@@ -258,8 +258,14 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         return VERTICAL_LENGTH_KEYS
 
     def entity_selector_filter(self) -> selector.EntityFilterSelectorConfig:
-        """Require entities that advertise ``set_tilt_position`` (both axes needed)."""
-        return TILT_CAPABLE_ENTITY_FILTER
+        """Require ``set_position`` — every control model needs it.
+
+        Only Model A (``position_tilt``) additionally needs
+        ``set_tilt_position``; that case is surfaced by
+        ``capability_warnings_for_options`` and the A3 Repair, so the
+        single-carriage models are not locked out of the picker.
+        """
+        return POSITION_CAPABLE_ENTITY_FILTER
 
     def summary_geometry_lines(
         self, config: dict[str, Any], labels: dict[str, str] | None = None

--- a/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
+++ b/custom_components/adaptive_cover_pro/cover_types/louvered_roof.py
@@ -38,17 +38,13 @@ from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from .base import (
     CAP_HAS_SET_TILT_POSITION,
     TILT_AXIS_PRIMARY,
+    TILT_CAPABLE_ENTITY_FILTER,
     CoverAxis,
     CoverTypePolicy,
     caps_get,
 )
 from .roof_window import _roof_pitch_selector
-from .tilt import (
-    TILT_CAPABLE_ENTITY_FILTER,
-    TILT_SLAT_KEYS,
-    TiltPolicy,
-    geometry_tilt_schema,
-)
+from .tilt import TILT_SLAT_KEYS, TiltPolicy, geometry_tilt_schema
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/adaptive_cover_pro/cover_types/tilt.py
+++ b/custom_components/adaptive_cover_pro/cover_types/tilt.py
@@ -39,6 +39,7 @@ from ._summary_labels import COVER_TYPE_LABELS_EN, GEOMETRY_LABELS_EN
 from .base import (
     CAP_HAS_SET_TILT_POSITION,
     TILT_AXIS_PRIMARY,
+    TILT_CAPABLE_ENTITY_FILTER,
     CoverAxis,
     CoverTypePolicy,
     caps_get,
@@ -141,16 +142,6 @@ def geometry_tilt_schema(hass: HomeAssistant | None = None) -> vol.Schema:
 # Module-level constant for backward compatibility with tests / re-exports.
 # Built without hass (== metric labels), identical to the historical schema.
 GEOMETRY_TILT_SCHEMA = geometry_tilt_schema()
-
-
-# Filter shared by tilt and venetian: cover entities that expose
-# ``set_tilt_position``. HA's ``supported_features`` filter is OR-of-listed,
-# not AND, so venetian uses this same filter and surfaces the
-# missing-set_position case as a config-flow capability warning.
-TILT_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
-    domain="cover",
-    supported_features=["cover.CoverEntityFeature.SET_TILT_POSITION"],
-)
 
 
 class TiltPolicy(CoverTypePolicy, register=True):

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -95,12 +95,13 @@ from ..base import (
     CAP_HAS_SET_TILT_POSITION,
     POSITION_AXIS,
     TILT_AXIS,
+    TILT_CAPABLE_ENTITY_FILTER,
     CoverAxis,
     CoverTypePolicy,
     caps_get,
 )
 from ..blind import geometry_vertical_schema
-from ..tilt import TILT_CAPABLE_ENTITY_FILTER, geometry_tilt_schema
+from ..tilt import geometry_tilt_schema
 from .sequencer import DualAxisSequencer
 
 if TYPE_CHECKING:

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -11,6 +11,11 @@ The tests drive ``_evaluate_health_checks`` directly against a minimal
 coordinator stub (built without ``__init__``) wired with real
 ``SensorHealthManager`` / ``RepairManager`` instances (debounce 0 so a raise
 lands after one event-loop drain), patching the issue registry.
+
+Because these stubs set ``policy._control_model`` by hand, they cannot observe
+the *coordinator ordering* the A3 model-aware relaxation depends on. That guard
+is an integration test and lives in
+``tests/test_issue_1114_control_model_ordering.py``.
 """
 
 from __future__ import annotations

--- a/tests/test_cover_types/test_config_flow_dispatch.py
+++ b/tests/test_cover_types/test_config_flow_dispatch.py
@@ -19,12 +19,14 @@ from custom_components.adaptive_cover_pro.cover_types import (
 from custom_components.adaptive_cover_pro.cover_types.awning import (
     GEOMETRY_HORIZONTAL_SCHEMA,
 )
+from custom_components.adaptive_cover_pro.cover_types.base import (
+    TILT_CAPABLE_ENTITY_FILTER,
+)
 from custom_components.adaptive_cover_pro.cover_types.blind import (
     GEOMETRY_VERTICAL_SCHEMA,
 )
 from custom_components.adaptive_cover_pro.cover_types.tilt import (
     GEOMETRY_TILT_SCHEMA,
-    TILT_CAPABLE_ENTITY_FILTER,
 )
 from custom_components.adaptive_cover_pro.cover_types.venetian import (
     GEOMETRY_VENETIAN_SCHEMA,

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.const import SERVICE_SET_COVER_POSITION
+from homeassistant.helpers.selector import ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD,
@@ -45,6 +46,9 @@ from custom_components.adaptive_cover_pro.cover_types.base import (
 )
 from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
     DayNightShadePolicy,
+)
+from custom_components.adaptive_cover_pro.cover_types.tilt import (
+    TILT_CAPABLE_ENTITY_FILTER,
 )
 from custom_components.adaptive_cover_pro.engine.covers import (
     DayNightShadeCalculation,
@@ -584,15 +588,29 @@ class TestSchemas:
         )
 
     def test_entity_selector_filter_admits_position_only_cover(self) -> None:
-        """A supported_features=15 cover (open+close+set_position+stop, no
-        tilt) is exactly the Model B/C hardware #1114 reports as locked out
-        of the picker. The filter's declared ``supported_features`` list must
-        not require the tilt bit, so this shape is admitted.
+        """A ``supported_features=15`` cover (open+close+set_position+stop, no
+        tilt) is exactly the Model B/C hardware #1114 reports as locked out of
+        the picker. Resolve the filter through HA's own
+        ``ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA`` validator — the same
+        machinery ``EntitySelector`` construction uses — to get the real
+        bitmask, then check it against mask 15 with a bitwise AND. This
+        exercises the actual mask HA computes (not just the declared string
+        list) and would fail if the enum path were ever mistyped, since the
+        validator raises ``vol.Invalid`` on an unresolvable feature string.
         """
         flt = DayNightShadePolicy().entity_selector_filter()
-        declared = flt.get("supported_features", [])
-        assert "cover.CoverEntityFeature.SET_POSITION" in declared
-        assert "cover.CoverEntityFeature.SET_TILT_POSITION" not in declared
+        mask = ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA(flt)["supported_features"][0]
+        assert 15 & mask, f"position-only cover (mask 15) not admitted by {mask=}"
+
+        # The stricter tilt filter must NOT admit the same position-only
+        # cover — regression guard for a revert of the #1114 fix back onto
+        # TILT_CAPABLE_ENTITY_FILTER.
+        tilt_mask = ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA(TILT_CAPABLE_ENTITY_FILTER)[
+            "supported_features"
+        ][0]
+        assert not (
+            15 & tilt_mask
+        ), f"tilt filter unexpectedly admits mask 15: {tilt_mask=}"
 
     def test_capability_warnings_flag_missing_axes(self) -> None:
         policy = DayNightShadePolicy()
@@ -894,6 +912,33 @@ class TestTiltCapabilityContradiction:
         policy = DayNightShadePolicy()
         assert policy._control_model == DAY_NIGHT_MODEL_POSITION_TILT
         assert policy.tilt_capability_contradiction(self._NO_TILT) is True
+
+    @pytest.mark.parametrize(
+        "model", [DAY_NIGHT_MODEL_SPLIT_RANGE, DAY_NIGHT_MODEL_DUAL_ENTITY]
+    )
+    def test_build_calc_engine_sets_model_before_first_health_check(
+        self, model: str
+    ) -> None:
+        """#1114 audit MUST-FIX 1 (coordinator's cycle-1 false Repair).
+
+        The coordinator calls ``build_calc_engine`` (via ``get_blind_data``)
+        BEFORE ``_evaluate_health_checks`` on every cycle, including the very
+        first one of the coordinator's lifetime — which is also before
+        ``post_pipeline_resolve`` has ever run. A Model B/C policy whose
+        ``_control_model`` is still the ``__init__`` Model A default at that
+        point would make ``_drives_dual_axis()`` return True and
+        ``tilt_capability_contradiction`` falsely report a contradiction for
+        a position-only cover, raising a ``cover_tilt_unsupported`` Repair
+        that never clears. ``build_calc_engine`` must resolve the model from
+        ``options`` itself so cycle 1 already knows it's Model B/C.
+        """
+        policy = DayNightShadePolicy()
+        kw = _resolve_kwargs(options={CONF_DAY_NIGHT_CONTROL_MODEL: model})
+        policy.build_calc_engine(**kw)
+        # No post_pipeline_resolve call yet — this simulates the coordinator's
+        # first update cycle, where the health check runs right after
+        # build_calc_engine and before post_pipeline_resolve ever executes.
+        assert policy.tilt_capability_contradiction(self._NO_TILT) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -43,12 +43,10 @@ from custom_components.adaptive_cover_pro.cover_types.base import (
     CAP_HAS_SET_TILT_POSITION,
     POSITION_AXIS,
     TILT_AXIS,
+    TILT_CAPABLE_ENTITY_FILTER,
 )
 from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
     DayNightShadePolicy,
-)
-from custom_components.adaptive_cover_pro.cover_types.tilt import (
-    TILT_CAPABLE_ENTITY_FILTER,
 )
 from custom_components.adaptive_cover_pro.engine.covers import (
     DayNightShadeCalculation,
@@ -916,29 +914,44 @@ class TestTiltCapabilityContradiction:
     @pytest.mark.parametrize(
         "model", [DAY_NIGHT_MODEL_SPLIT_RANGE, DAY_NIGHT_MODEL_DUAL_ENTITY]
     )
-    def test_build_calc_engine_sets_model_before_first_health_check(
+    def test_sync_runtime_options_sets_model_before_first_health_check(
         self, model: str
     ) -> None:
         """#1114 audit MUST-FIX 1 (coordinator's cycle-1 false Repair).
 
-        The coordinator calls ``build_calc_engine`` (via ``get_blind_data``)
-        BEFORE ``_evaluate_health_checks`` on every cycle, including the very
-        first one of the coordinator's lifetime — which is also before
+        The coordinator calls the generic ``sync_runtime_options`` hook (from
+        ``_update_options``) BEFORE ``_evaluate_health_checks`` on every cycle,
+        including the very first one of its lifetime — which is also before
         ``post_pipeline_resolve`` has ever run. A Model B/C policy whose
         ``_control_model`` is still the ``__init__`` Model A default at that
         point would make ``_drives_dual_axis()`` return True and
         ``tilt_capability_contradiction`` falsely report a contradiction for
         a position-only cover, raising a ``cover_tilt_unsupported`` Repair
-        that never clears. ``build_calc_engine`` must resolve the model from
-        ``options`` itself so cycle 1 already knows it's Model B/C.
+        that never clears. The hook must resolve the model from ``options`` so
+        cycle 1 already knows it's Model B/C.
         """
         policy = DayNightShadePolicy()
-        kw = _resolve_kwargs(options={CONF_DAY_NIGHT_CONTROL_MODEL: model})
-        policy.build_calc_engine(**kw)
+        policy.sync_runtime_options({CONF_DAY_NIGHT_CONTROL_MODEL: model})
         # No post_pipeline_resolve call yet — this simulates the coordinator's
-        # first update cycle, where the health check runs right after
-        # build_calc_engine and before post_pipeline_resolve ever executes.
+        # first update cycle, where the health check runs after the hook and
+        # before post_pipeline_resolve ever executes.
         assert policy.tilt_capability_contradiction(self._NO_TILT) is False
+
+    def test_build_calc_engine_does_not_mutate_control_model(self) -> None:
+        """``build_calc_engine`` is a pure builder — no policy-state writes.
+
+        ``forecast.build_forecast_for_coord`` calls it ~289× per strip from an
+        executor thread, so caching the control model there would write live
+        dispatch state off the event loop. Pinned by observing that a Model B
+        ``options`` dict passed to the builder leaves ``_control_model``
+        untouched; only ``sync_runtime_options`` moves it.
+        """
+        policy = DayNightShadePolicy()
+        kw = _resolve_kwargs(
+            options={CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_SPLIT_RANGE}
+        )
+        policy.build_calc_engine(**kw)
+        assert policy._control_model == DAY_NIGHT_MODEL_POSITION_TILT
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -573,12 +573,26 @@ class TestSchemas:
             == DEFAULT_DAY_NIGHT_BLACKOUT_THRESHOLD
         )
 
-    def test_entity_selector_filter_requires_tilt(self) -> None:
+    def test_entity_selector_filter_requires_position(self) -> None:
         flt = DayNightShadePolicy().entity_selector_filter()
         assert flt.get("domain") == "cover"
-        assert "cover.CoverEntityFeature.SET_TILT_POSITION" in flt.get(
+        assert "cover.CoverEntityFeature.SET_POSITION" in flt.get(
             "supported_features", []
         )
+        assert "cover.CoverEntityFeature.SET_TILT_POSITION" not in flt.get(
+            "supported_features", []
+        )
+
+    def test_entity_selector_filter_admits_position_only_cover(self) -> None:
+        """A supported_features=15 cover (open+close+set_position+stop, no
+        tilt) is exactly the Model B/C hardware #1114 reports as locked out
+        of the picker. The filter's declared ``supported_features`` list must
+        not require the tilt bit, so this shape is admitted.
+        """
+        flt = DayNightShadePolicy().entity_selector_filter()
+        declared = flt.get("supported_features", [])
+        assert "cover.CoverEntityFeature.SET_POSITION" in declared
+        assert "cover.CoverEntityFeature.SET_TILT_POSITION" not in declared
 
     def test_capability_warnings_flag_missing_axes(self) -> None:
         policy = DayNightShadePolicy()

--- a/tests/test_issue_1114_control_model_ordering.py
+++ b/tests/test_issue_1114_control_model_ordering.py
@@ -1,0 +1,98 @@
+"""Coordinator ordering guard for the day/night control-model cache (#1114).
+
+``DayNightShadePolicy`` caches its control model per instance because the
+downstream dispatch hooks — ``resolve_entity_target``, ``after_position_command``,
+and the A3 ``tilt_capability_contradiction`` predicate — receive no ``options``.
+The cache is filled by the generic ``CoverTypePolicy.sync_runtime_options`` hook,
+which the coordinator drives from ``_update_options``.
+
+What that buys is ordering: ``sync_runtime_options`` runs before
+``_evaluate_health_checks``, so a single-carriage Model B/C instance is already
+known to be single-carriage the first time A3 asks. ``post_pipeline_resolve``
+also fills the cache, but it runs *after* the health checks inside the same
+``_calculate_cover_state`` call, so it cannot rescue cycle 1.
+
+The stub-driven A3 tests in ``tests/test_coordinator_healthchecks.py`` assign
+``policy._control_model`` by hand and therefore stay green no matter where the
+coordinator resolves it. Nothing pinned the coordinator side until this file: move
+the seam after ``_calculate_cover_state``, or add an earlier caller that passes
+stale options, and a Model B/C user on position-only hardware gets a
+``cover_tilt_unsupported`` Repair on startup for hardware that is exactly what
+Models B/C exist to support.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONTROL_MODEL,
+    CONF_ENTITIES,
+    DAY_NIGHT_MODEL_DUAL_ENTITY,
+    DAY_NIGHT_MODEL_SPLIT_RANGE,
+    ISSUE_COVER_TILT_UNSUPPORTED,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.managers.repair import RepairManager
+from tests.ha_helpers import VERTICAL_OPTIONS, setup_integration
+
+# open + close + set_position + stop, with no set_tilt_position bit — the
+# position-only hardware #1114 reports as locked out of the Model B/C picker.
+_POSITION_ONLY_FEATURES = 15
+
+
+@pytest.mark.parametrize(
+    "model", [DAY_NIGHT_MODEL_SPLIT_RANGE, DAY_NIGHT_MODEL_DUAL_ENTITY]
+)
+async def test_cycle_one_control_model_beats_the_a3_health_check(hass, model):
+    """A real Model B/C entry on a position-only cover must not flag A3 on cycle 1.
+
+    Drives a real config entry through setup (which runs the coordinator's first
+    update cycle) and captures every A3 predicate verdict. The spy is installed on
+    ``RepairManager`` *before* setup because that first cycle happens while the
+    entry is still being created, so there is no coordinator instance to patch yet.
+
+    Asserting the recorded predicate rather than ``ir.async_create_issue`` is
+    deliberate: the real ``RepairManager`` debounces for 15 minutes, so the raise
+    a wrong verdict would eventually produce is invisible inside one cycle. The
+    predicate is the decision; the debounce only delays acting on it.
+    """
+    # Its own entity id, so ``setup_integration``'s tilt-capable
+    # ``cover.test_blind`` fixture state cannot overwrite these capabilities.
+    cover_id = "cover.position_only"
+    hass.states.async_set(
+        cover_id,
+        "open",
+        {"current_position": 100, "supported_features": _POSITION_ONLY_FEATURES},
+    )
+
+    records: list[tuple[str, bool]] = []
+    real_update = RepairManager.update_predicate
+
+    def _spy(self, issue_key, unhealthy, **kwargs):
+        records.append((issue_key, unhealthy))
+        return real_update(self, issue_key, unhealthy, **kwargs)
+
+    entry_id = f"a3_order_{model}"
+    with patch.object(RepairManager, "update_predicate", _spy):
+        await setup_integration(
+            hass,
+            name="Day Night",
+            cover_type=CoverType.DAY_NIGHT_SHADE,
+            options={
+                **VERTICAL_OPTIONS,
+                CONF_ENTITIES: [cover_id],
+                CONF_DAY_NIGHT_CONTROL_MODEL: model,
+            },
+            entry_id=entry_id,
+        )
+
+    key = f"{ISSUE_COVER_TILT_UNSUPPORTED}_{entry_id}_{cover_id}"
+    verdicts = [unhealthy for issue_key, unhealthy in records if issue_key == key]
+    assert verdicts, f"A3 never evaluated for {cover_id}: {records}"
+    assert verdicts[0] is False, (
+        f"cycle-1 A3 false contradiction for {model} — the control model was not "
+        "resolved before _evaluate_health_checks ran"
+    )

--- a/tests/test_quick_setup_defaults.py
+++ b/tests/test_quick_setup_defaults.py
@@ -264,6 +264,32 @@ def _make_coordinator_with_options(options: dict):
     return coord
 
 
+def _coordinator_for_update_options():
+    """Build an ``__init__``-bypassed coordinator wired for ``_update_options``.
+
+    One place listing the collaborators ``_update_options`` reaches for, so a new
+    one is added here instead of in each test that drives it. Every attribute the
+    real ``__init__`` assigns before the first ``_update_options`` call belongs
+    here, ``_policy`` included — the method ends by handing the options dict to
+    ``policy.sync_runtime_options`` (issue #1114).
+    """
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    coord = object.__new__(AdaptiveDataUpdateCoordinator)
+    coord._cmd_svc = MagicMock()
+    coord._time_mgr = MagicMock()
+    coord._motion_mgr = MagicMock()
+    coord._weather_mgr = MagicMock()
+    coord._cloud_mgr = MagicMock()
+    coord._climate_smoothing_mgr = MagicMock()
+    coord._climate_smoothing_mgr.resolved_flags = None
+    coord.manager = MagicMock()
+    coord._policy = MagicMock()
+    return coord
+
+
 # ---------------------------------------------------------------------------
 # Group 1 — Options builder never stores None for critical keys
 # ---------------------------------------------------------------------------
@@ -416,19 +442,7 @@ class TestCoordinatorInitWithNoneOptions:
     @pytest.mark.unit
     def test_update_options_resolves_none_delta_position(self):
         """_update_options must resolve None delta_position to 1."""
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        coord._cmd_svc = MagicMock()
-        coord._time_mgr = MagicMock()
-        coord._motion_mgr = MagicMock()
-        coord._weather_mgr = MagicMock()
-        coord._cloud_mgr = MagicMock()
-        coord._climate_smoothing_mgr = MagicMock()
-        coord._climate_smoothing_mgr.resolved_flags = None
-        coord.manager = MagicMock()
+        coord = _coordinator_for_update_options()
 
         coord._update_options(self._POISONED_OPTIONS)
 
@@ -444,19 +458,7 @@ class TestCoordinatorInitWithNoneOptions:
     @pytest.mark.unit
     def test_update_options_resolves_none_delta_time(self):
         """_update_options must resolve None delta_time to 2."""
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        coord._cmd_svc = MagicMock()
-        coord._time_mgr = MagicMock()
-        coord._motion_mgr = MagicMock()
-        coord._weather_mgr = MagicMock()
-        coord._cloud_mgr = MagicMock()
-        coord._climate_smoothing_mgr = MagicMock()
-        coord._climate_smoothing_mgr.resolved_flags = None
-        coord.manager = MagicMock()
+        coord = _coordinator_for_update_options()
 
         coord._update_options(self._POISONED_OPTIONS)
 
@@ -472,19 +474,7 @@ class TestCoordinatorInitWithNoneOptions:
     @pytest.mark.unit
     def test_update_options_resolves_none_manual_duration(self):
         """_update_options must resolve None manual_duration to {'hours': 2}."""
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        coord._cmd_svc = MagicMock()
-        coord._time_mgr = MagicMock()
-        coord._motion_mgr = MagicMock()
-        coord._weather_mgr = MagicMock()
-        coord._cloud_mgr = MagicMock()
-        coord._climate_smoothing_mgr = MagicMock()
-        coord._climate_smoothing_mgr.resolved_flags = None
-        coord.manager = MagicMock()
+        coord = _coordinator_for_update_options()
 
         coord._update_options(self._POISONED_OPTIONS)
 
@@ -497,19 +487,8 @@ class TestCoordinatorInitWithNoneOptions:
     def test_update_options_forwards_configured_position_tolerance(self):
         """_update_options pushes the configured tolerance to the command service (issue #507)."""
         from custom_components.adaptive_cover_pro.const import CONF_POSITION_TOLERANCE
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
 
-        coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        coord._cmd_svc = MagicMock()
-        coord._time_mgr = MagicMock()
-        coord._motion_mgr = MagicMock()
-        coord._weather_mgr = MagicMock()
-        coord._cloud_mgr = MagicMock()
-        coord._climate_smoothing_mgr = MagicMock()
-        coord._climate_smoothing_mgr.resolved_flags = None
-        coord.manager = MagicMock()
+        coord = _coordinator_for_update_options()
 
         coord._update_options({**self._POISONED_OPTIONS, CONF_POSITION_TOLERANCE: 12})
 
@@ -518,19 +497,7 @@ class TestCoordinatorInitWithNoneOptions:
     @pytest.mark.unit
     def test_update_options_position_tolerance_defaults_to_three(self):
         """Absent tolerance option resolves to the default (3) on options change (issue #507)."""
-        from custom_components.adaptive_cover_pro.coordinator import (
-            AdaptiveDataUpdateCoordinator,
-        )
-
-        coord = object.__new__(AdaptiveDataUpdateCoordinator)
-        coord._cmd_svc = MagicMock()
-        coord._time_mgr = MagicMock()
-        coord._motion_mgr = MagicMock()
-        coord._weather_mgr = MagicMock()
-        coord._cloud_mgr = MagicMock()
-        coord._climate_smoothing_mgr = MagicMock()
-        coord._climate_smoothing_mgr.resolved_flags = None
-        coord.manager = MagicMock()
+        coord = _coordinator_for_update_options()
 
         coord._update_options(self._POISONED_OPTIONS)
 


### PR DESCRIPTION
## Summary

A Day/Night Shade running Model B (`split_range`) or Model C (`dual_entity`) drives a single carriage and needs only `set_position`, but `DayNightShadePolicy.entity_selector_filter()` returned `TILT_CAPABLE_ENTITY_FILTER` unconditionally. All three cover pickers (create flow, options flow, duplicate flow) therefore demanded `SET_TILT_POSITION`, so position-only hardware never appeared in the list and the rails those two models exist to drive could not be selected from any UI path. `day_night_control_model` lives on the geometry step, after the picker, so no model choice could precede the filter; `CONF_ENTITIES` being in `IDENTITY_KEYS` closed the service escape hatch too.

This adds a shared `POSITION_CAPABLE_ENTITY_FILTER` in `cover_types/base.py` and points the day/night policy at it. `SET_POSITION` is the intersection of all three control models' requirements and already what `_missing_axis_warnings` demands of every model. `TiltPolicy`, `LouveredRoofPolicy` and `VenetianPolicy` keep the strict tilt filter, since all three drive tilt unconditionally.

The pre-merge audit surfaced a regression the filter change would have introduced on its own: `_control_model` was cached only in `post_pipeline_resolve`, which the coordinator calls *after* `_evaluate_health_checks`, so on the first cycle of every coordinator lifetime the A3 predicate evaluated a Model B/C instance against the `__init__` Model A default and reported a false tilt contradiction. That raises a spurious `cover_tilt_unsupported` Repair for exactly the hardware this PR unblocks, and since the integration has no `update_interval` the sun-driven refresh cadence can exceed the 900s health debounce, so cycle 2's recovery was not guaranteed to beat it. The model now resolves through a new generic `CoverTypePolicy.sync_runtime_options(options)` hook (no-op by default) that the coordinator drives from `_update_options`, on the event loop, before both the pipeline and the health checks. `build_calc_engine` is a pure builder again, which also removes an off-event-loop write: `forecast.build_forecast_for_coord` calls it around 289 times per forecast from an executor thread.

Also folded in, from the same audit: `TILT_CAPABLE_ENTITY_FILTER` moved from `cover_types/tilt.py` to sit beside its new sibling in `base.py` so a policy author sees both strictness levels together, the three duplicate `CONF_DAY_NIGHT_CONTROL_MODEL` reads are unified behind `_read_control_model`, and `tests/test_issue_1114_control_model_ordering.py` pins the coordinator ordering the fix depends on by driving a real Model B/C entry on a `supported_features: 15` cover through setup and asserting the first A3 verdict is negative.

One correction to the first commit's message, which overstates slightly: it says the new filter still excludes "open/close-only covers that no model can drive". The exclusion is real and unchanged from the old filter, but the reasoning is loose. `POSITION_AXIS.drive_fallbacks` does make the position axis drivable via `open_cover`/`close_cover`. Excluding endpoint-only covers from Day/Night remains correct, because no control model can encode both coverage and fabric on an endpoint-only carriage.

## Testing
- ✅ 11553 tests passing

## Related Issues
Refs #1114