### PR TITLE
fix: sequence Model C day/night rail travel (#1115)

### DIFF
--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -120,7 +120,14 @@ class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):
                 "My Position button pressed but my_position_value is not configured"
             )
             return
-        for entity_id in self._entities:
+        # Policy-mandated dispatch order, shared with every other dispatch seam
+        # (issue #1115): a Model C day/night shade's bottom rail must be
+        # commanded before its middle rail, which cannot physically travel past
+        # it. Identity for every cover type whose entities are independent.
+        ordered = self.coordinator._policy.order_for_dispatch(  # noqa: SLF001
+            self._entities
+        )
+        for entity_id in ordered:
             await self.coordinator.async_apply_user_position(
                 entity_id,
                 int(my_position_value),

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -830,6 +830,11 @@ ISSUE_COVER_NOT_MOVING = (
 ISSUE_COVER_TILT_UNSUPPORTED = (
     "cover_tilt_unsupported"  # tilt cover type bound to a non-tilt device (issue #991)
 )
+# B3 — a cover type that binds a SECOND entity to a named physical role has that
+# role unfilled (issue #1115). Today's only such role is the Model C day/night
+# middle rail: unset (or naming a cover outside the instance's list) leaves the
+# shade silently behaving like a plain vertical blind.
+ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET = "day_night_middle_rail_unset"
 # Generous debounce so integration restarts / device re-adds don't nag before
 # a genuinely dead sensor is flagged.
 DEFAULT_SENSOR_HEALTH_DEBOUNCE_SECONDS = 900.0

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -104,6 +104,7 @@ from .const import (
     ISSUE_COVER_NOT_MOVING,
     ISSUE_COVER_TILT_UNSUPPORTED,
     ISSUE_COVER_UNAVAILABLE,
+    ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
     LOGGER,
@@ -383,6 +384,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self._sun_issue_key = f"{ISSUE_SUN_UNAVAILABLE}_{entry_id}"
         self._envelope_issue_key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{entry_id}"
         self._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{entry_id}"
+        # B3 (issue #1115): entry-scoped like B1/B2 — the cover-type policy owns
+        # the "is a bound role entity unfilled?" decision, so no cover-type
+        # knowledge lands here.
+        self._role_entity_issue_key = f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{entry_id}"
         # Namespaced cover-availability watch keys currently registered, so a
         # cover dropped from config gets unwatched (its Repair cleared) next cycle.
         self._cover_issue_keys: set[str] = set()
@@ -587,6 +592,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             hass=self.hass,
             logger=self.logger,
             grace_mgr=self._grace_mgr,
+            # The instance's covers. A cover type that binds several entities to
+            # distinct physical roles resolves them from this list (the Model C
+            # day/night bottom rail is "whichever cover isn't the middle rail",
+            # issue #1115). Additive: every other policy ignores it.
+            entities=self.entities,
             get_current_position=self._cmd_svc.get_current_position,
             set_commanded_position=self._cmd_svc.set_target,
             position_tolerance=POSITION_TOLERANCE_PERCENT,
@@ -1679,6 +1689,30 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 self._repair.clear_predicate(stale)
             self._a3_issue_keys = a3_desired
 
+            # B3 — a cover type binds a second entity to a named physical role and
+            # that role is unfilled (issue #1115). Entry-scoped like B1/B2, but
+            # sourced from a polymorphic policy predicate like A3
+            # (``required_role_entity_missing``) so the coordinator never branches
+            # on cover type. Today's only such role is the Model C day/night
+            # middle rail: unset — or naming a cover outside this instance's list
+            # — leaves BOTH rails driven to the bottom rail's position, i.e. the
+            # shade silently behaves like a plain vertical blind. Same narrow
+            # per-check guard as A2/A3 so a policy blowing up here cannot starve
+            # ``evaluate()`` and strand every other Repair.
+            try:
+                role_entity_missing = self._policy.required_role_entity_missing(
+                    options, self.entities
+                )
+            except Exception:  # noqa: BLE001 — one check must not starve the rest
+                self.logger.debug("B3 predicate failed; skipping", exc_info=True)
+            else:
+                self._repair.update_predicate(
+                    self._role_entity_issue_key,
+                    role_entity_missing,
+                    translation_key=ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET,
+                    placeholders={"name": name},
+                )
+
             self._sensor_health.evaluate()
             self._repair.evaluate()
 
@@ -2529,7 +2563,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             entities that were gated or skipped.
 
         """
-        target_covers = entities if entities is not None else list(self.entities)
+        # Policy-mandated dispatch order (issue #1115) — applied to an explicitly
+        # supplied subset too, since a Model C subset can hold both rails.
+        target_covers = self._policy.order_for_dispatch(
+            entities if entities is not None else self.entities
+        )
 
         if respect_manual_override:
             # Pre-filter rather than lean on the manual-override gate inside
@@ -2835,7 +2873,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 if self._pipeline_bypasses_auto_control
                 else "solar"
             )
-        for cover in self.entities:
+        for cover in self._policy.order_for_dispatch(self.entities):
             ctx = self._build_position_context(
                 cover,
                 options,
@@ -3027,7 +3065,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return
 
         sun_just_appeared = self._check_sun_validity_transition()
-        for cover in self.entities:
+        for cover in self._policy.order_for_dispatch(self.entities):
             if self.manager.is_cover_manual(cover):
                 self.logger.debug(
                     "Startup: skipping position command for %s (manual override active/restored)",
@@ -4155,7 +4193,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     "cover_count": len(self.entities),
                 }
             )
-            for cover_entity in self.entities:
+            for cover_entity in self._policy.order_for_dispatch(self.entities):
                 ctx = self._build_position_context(cover_entity, options, force=False)
                 await self._cmd_svc.apply_position(
                     cover_entity,
@@ -4441,7 +4479,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             sunset_pos_cfg=options.get(CONF_SUNSET_POS),
             options=options,
             inverse_state_enabled=self._inverse_state,
-            entities=self.entities,
+            # Same policy-mandated rail order as every other dispatch seam
+            # (issue #1115) — the tracker fans the sunset position out in the
+            # order it receives, so the ordering is applied here.
+            entities=self._policy.order_for_dispatch(self.entities),
             is_cover_manual=self.manager.is_cover_manual,
             has_active_override=self._pipeline_has_active_override(),
             build_position_context=lambda c, o: self._build_position_context(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -543,6 +543,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             hass=self.hass,
             logger=self.logger,
             cover_type=self._cover_type,
+            # Share THIS entry's policy object rather than letting the manager
+            # build a private one. Anything the manager asks a stateful policy
+            # — the Model C rail order and travel clearance its reconciliation
+            # pass consults — is only answerable on the instance the dispatch
+            # path primes and ``attach``es (issue #1115).
+            policy=self._policy,
             grace_mgr=self._grace_mgr,
             open_close_threshold=self.config_entry.options.get(
                 CONF_OPEN_CLOSE_THRESHOLD, 50

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -777,10 +777,13 @@ class CoverTypePolicy(ABC):
         out (issue #1115, the #993 inversion class).
 
         So the transform travels WITH the value instead. ``CoverCommandService``
-        asks for this stamp once per dispatch, stores it beside the target it
-        books, and hands it back verbatim to :meth:`await_dispatch_clearance`
-        when the reconciliation timer re-sends that target. The manager never
-        interprets it — it is this policy's own datum, round-tripped.
+        asks for this stamp ONCE per dispatch, and asks for it BEFORE it puts
+        :meth:`await_dispatch_clearance`'s question: one stamp both answers that
+        dispatch's own clearance question and is stored beside the target it
+        books, so the number is gated and recorded against a single frame rather
+        than two reads of a moving one. The reconciliation timer then hands the
+        stored stamp back verbatim when it re-sends that target. The manager
+        never interprets it — it is this policy's own datum, round-tripped.
 
         Liskov-safe default: ``None``, i.e. "no provenance needed", which is
         every cover type whose dispatched values need no later un-transforming.
@@ -815,14 +818,21 @@ class CoverTypePolicy(ABC):
         two live passes mutating the same per-entity state (issue #1115). Same
         eventual behaviour either way; the next tick re-asks.
 
-        ``dispatch_token`` replays the stamp :meth:`capture_dispatch_token`
-        minted for the dispatch that BOOKED ``position`` — the resend path hands
-        back what it stored, so the answer is computed against the dispatch the
-        number actually came from rather than against whatever a later resolve
-        left in the policy's per-cycle cache (issue #1115). ``None`` means the
-        caller has no stamp to offer: the dispatch path, which is asking about a
-        value it resolved a moment ago, and any target seeded from outside a
-        dispatch.
+        ``dispatch_token`` names the dispatch that produced ``position`` — the
+        stamp :meth:`capture_dispatch_token` minted for it. BOTH position paths
+        supply one: ``apply_position`` captures the stamp just before asking
+        this question and books that same stamp with the target, and the resend
+        hands the stored stamp straight back. So the answer is computed against
+        the dispatch the number actually came from rather than against whatever
+        a later resolve left in the policy's per-cycle cache (issue #1115).
+
+        ``None`` therefore does NOT mean "the dispatch path". It means the
+        number has no dispatch behind it to describe: a target booked from
+        outside one — ``CoverCommandService.restore_target`` rehydrating a
+        persisted target after a reload, the coordinator recording an
+        externally-observed My move, ``send_my_position`` booking the user's
+        configured My percent. A policy that needs provenance has to fall back
+        to whatever it can still infer for those.
 
         Returns ``False`` to withhold, ``True`` to proceed. Withholding is
         expected to latch (:meth:`has_pending_secondary_axis`) so a later pass

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -761,6 +761,32 @@ class CoverTypePolicy(ABC):
         """
         return None
 
+    async def await_dispatch_clearance(
+        self,
+        entity_id: str,  # noqa: ARG002
+        *,
+        position: int,  # noqa: ARG002
+        reason: str,  # noqa: ARG002
+    ) -> bool:
+        """Whether this entity may be driven to ``position`` right now.
+
+        The physical-coupling question on its own, separated from
+        :meth:`before_position_command` because that hook also carries pre-send
+        SIDE EFFECTS (the venetian tilt-first command). A caller that only needs
+        the go/no-go — ``CoverCommandService.run_reconciliation_pass``, which
+        re-sends a recorded target on a timer without any of the dispatch path's
+        context — asks this instead, and so cannot accidentally trigger another
+        cover type's pre-send. Both callers funnel into ONE implementation per
+        policy; the rule is never written twice (issue #1115).
+
+        Returns ``False`` to withhold, ``True`` to proceed. Withholding is
+        expected to latch, exactly as it does through
+        ``before_position_command``, so a later pass re-attempts the command.
+        Liskov-safe default: a cover type whose entities are physically
+        independent is always clear.
+        """
+        return True
+
     async def after_position_command(
         self,
         cmd_svc,

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -831,8 +831,10 @@ class CoverTypePolicy(ABC):
         outside one — ``CoverCommandService.restore_target`` rehydrating a
         persisted target after a reload, the coordinator recording an
         externally-observed My move, ``send_my_position`` booking the user's
-        configured My percent. A policy that needs provenance has to fall back
-        to whatever it can still infer for those.
+        configured My percent. Those are raw cover-frame numbers, so a policy
+        that needs provenance answers them from what it knows about the INSTALL
+        rather than from any one dispatch — nothing expressed them in a
+        dispatch's frame for a stamp to name.
 
         Returns ``False`` to withhold, ``True`` to proceed. Withholding is
         expected to latch (:meth:`has_pending_secondary_axis`) so a later pass

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import dataclasses
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -575,6 +575,59 @@ class CoverTypePolicy(ABC):
         """
         return position
 
+    def dispatch_order_key(
+        self,
+        entity_id: str,  # noqa: ARG002
+    ) -> int:
+        """Sort key ordering this cover type's entities within one dispatch cycle.
+
+        The coordinator resolves one position per cycle and fans it out to every
+        bound entity. A cover type whose entities are PHYSICALLY coupled — the
+        Model C day/night shade's stacked rails, where the middle rail cannot
+        travel past the bottom rail — needs its blocking entity commanded first,
+        because the per-entity command hooks cannot reach back and reorder the
+        caller's loop. Overriding this hook expresses that constraint once; every
+        dispatch seam consumes the same ordered view (issue #1115).
+
+        The Liskov-safe default is a constant, which makes ``sorted(...)`` a
+        stable-sort no-op: the user's config-flow pick order survives verbatim
+        for every cover type with independent entities.
+        """
+        return 0
+
+    def order_for_dispatch(self, entities: Iterable[str]) -> list[str]:
+        """Return ``entities`` in this cover type's mandated dispatch order.
+
+        The single shared ordering mechanism every dispatch seam consumes — the
+        main state-change loop, the startup loop, the force-send path, the
+        end-time-default and sunset-window broadcasts, and the auto-control-off
+        return loop. One view, six consumers: the ordering rule is stated once
+        as :meth:`dispatch_order_key` rather than mirrored per seam
+        (CODING_GUIDELINES.md "No Code Duplication", issue #1115).
+
+        ``sorted`` is stable, so a policy that leaves ``dispatch_order_key`` at
+        its constant default gets the input order back unchanged.
+        """
+        return sorted(entities, key=self.dispatch_order_key)
+
+    def required_role_entity_missing(
+        self,
+        options: Mapping[str, Any],  # noqa: ARG002
+        entities: Iterable[str],  # noqa: ARG002
+    ) -> bool:
+        """Whether an entity this cover type binds to a named role is unfilled (B3).
+
+        A cover type may bind a SECOND entity to a specific physical role — the
+        Model C day/night shade's middle rail. With that pick unset, or naming a
+        cover outside the instance's own list, the cover type cannot do its job
+        and degrades silently into a lesser one. This predicate is the single
+        source of truth behind the cover-type boundary for the B3 runtime Repair,
+        so the coordinator never branches on cover type (mirrors A3's
+        ``tilt_capability_contradiction``). Liskov-safe default: cover types that
+        bind no role entity have nothing to report (issue #1115).
+        """
+        return False
+
     def attach(self, **kwargs: Any) -> None:
         """Bind late-resolved dependencies (cmd_svc, grace_mgr, …).
 
@@ -691,14 +744,22 @@ class CoverTypePolicy(ABC):
         position: int,  # noqa: ARG002
         context,  # noqa: ARG002
         reason: str,  # noqa: ARG002
-    ) -> None:
+    ) -> bool | None:
         """Run any pre-command work before the position service fires.
 
-        Default: no-op. ``VenetianPolicy`` overrides this to send tilt-first
-        on opening transitions (issue #33) so the actuator's slats reach the
-        target angle before the carriage starts moving.
+        Returns ``False`` to WITHHOLD this position command; ``None`` (or
+        ``True``) to let it proceed. Withholding is for a policy whose entities
+        are physically coupled and cannot be commanded independently right now —
+        the Model C day/night middle rail waiting for its bottom rail to clear
+        (issue #1115). A withheld command is skipped, not dropped: the policy is
+        expected to latch it via :meth:`has_pending_secondary_axis` so the
+        coordinator re-attempts it on a later cycle.
+
+        Default: no-op, proceed. ``VenetianPolicy`` overrides this to send
+        tilt-first on opening transitions (issue #33) so the actuator's slats
+        reach the target angle before the carriage starts moving.
         """
-        return
+        return None
 
     async def after_position_command(
         self,

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -760,6 +760,33 @@ class CoverTypePolicy(ABC):
         """
         return
 
+    def capture_dispatch_token(
+        self,
+        entity_id: str,  # noqa: ARG002
+    ) -> Any:
+        """Return an opaque stamp describing HOW this dispatch expressed its value.
+
+        The provenance half of :meth:`await_dispatch_clearance`. A policy that
+        has to un-transform a dispatched number later — the Model C day/night
+        middle rail, whose clearance test compares its target against a live rail
+        reading in open-percent space — cannot re-derive the transform after the
+        fact: its own per-cycle cache describes the last RESOLUTION, and
+        ``resolve_entity_target`` runs as an ARGUMENT to
+        ``CoverCommandService.apply_position``, so a cycle that resolves and then
+        skips on a delta gate restates that cache for a command which never went
+        out (issue #1115, the #993 inversion class).
+
+        So the transform travels WITH the value instead. ``CoverCommandService``
+        asks for this stamp once per dispatch, stores it beside the target it
+        books, and hands it back verbatim to :meth:`await_dispatch_clearance`
+        when the reconciliation timer re-sends that target. The manager never
+        interprets it — it is this policy's own datum, round-tripped.
+
+        Liskov-safe default: ``None``, i.e. "no provenance needed", which is
+        every cover type whose dispatched values need no later un-transforming.
+        """
+        return None
+
     async def await_dispatch_clearance(
         self,
         entity_id: str,  # noqa: ARG002
@@ -767,6 +794,7 @@ class CoverTypePolicy(ABC):
         position: int,  # noqa: ARG002
         reason: str,  # noqa: ARG002
         wait: bool = True,  # noqa: ARG002
+        dispatch_token: Any = None,  # noqa: ARG002
     ) -> bool:
         """Whether this entity may be driven to ``position`` right now.
 
@@ -786,6 +814,15 @@ class CoverTypePolicy(ABC):
         pass whose budget matches the timer interval overlap the next one, with
         two live passes mutating the same per-entity state (issue #1115). Same
         eventual behaviour either way; the next tick re-asks.
+
+        ``dispatch_token`` replays the stamp :meth:`capture_dispatch_token`
+        minted for the dispatch that BOOKED ``position`` — the resend path hands
+        back what it stored, so the answer is computed against the dispatch the
+        number actually came from rather than against whatever a later resolve
+        left in the policy's per-cycle cache (issue #1115). ``None`` means the
+        caller has no stamp to offer: the dispatch path, which is asking about a
+        value it resolved a moment ago, and any target seeded from outside a
+        dispatch.
 
         Returns ``False`` to withhold, ``True`` to proceed. Withholding is
         expected to latch (:meth:`has_pending_secondary_axis`) so a later pass

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -744,22 +744,21 @@ class CoverTypePolicy(ABC):
         position: int,  # noqa: ARG002
         context,  # noqa: ARG002
         reason: str,  # noqa: ARG002
-    ) -> bool | None:
-        """Run any pre-command work before the position service fires.
+    ) -> None:
+        """Run any pre-command SIDE EFFECTS before the position service fires.
 
-        Returns ``False`` to WITHHOLD this position command; ``None`` (or
-        ``True``) to let it proceed. Withholding is for a policy whose entities
-        are physically coupled and cannot be commanded independently right now —
-        the Model C day/night middle rail waiting for its bottom rail to clear
-        (issue #1115). A withheld command is skipped, not dropped: the policy is
-        expected to latch it via :meth:`has_pending_secondary_axis` so the
-        coordinator re-attempts it on a later cycle.
+        Effects only — whether the command may go out at all is
+        :meth:`await_dispatch_clearance`'s question, asked earlier and against a
+        command that has not been booked yet. Keeping the two apart is what lets
+        this hook run after the dry-run gate (a simulated command must not
+        pre-send anything) while the decision runs before the outbound command
+        is recorded.
 
-        Default: no-op, proceed. ``VenetianPolicy`` overrides this to send
-        tilt-first on opening transitions (issue #33) so the actuator's slats
-        reach the target angle before the carriage starts moving.
+        Default: no-op. ``VenetianPolicy`` overrides this to send tilt-first on
+        opening transitions (issue #33) so the actuator's slats reach the target
+        angle before the carriage starts moving.
         """
-        return None
+        return
 
     async def await_dispatch_clearance(
         self,
@@ -767,23 +766,31 @@ class CoverTypePolicy(ABC):
         *,
         position: int,  # noqa: ARG002
         reason: str,  # noqa: ARG002
+        wait: bool = True,  # noqa: ARG002
     ) -> bool:
         """Whether this entity may be driven to ``position`` right now.
 
         The physical-coupling question on its own, separated from
-        :meth:`before_position_command` because that hook also carries pre-send
-        SIDE EFFECTS (the venetian tilt-first command). A caller that only needs
-        the go/no-go — ``CoverCommandService.run_reconciliation_pass``, which
-        re-sends a recorded target on a timer without any of the dispatch path's
-        context — asks this instead, and so cannot accidentally trigger another
-        cover type's pre-send. Both callers funnel into ONE implementation per
-        policy; the rule is never written twice (issue #1115).
+        :meth:`before_position_command` because that hook carries pre-send SIDE
+        EFFECTS (the venetian tilt-first command) a caller asking only for the
+        go/no-go must not trigger. Both position paths —
+        ``CoverCommandService.apply_position`` and its reconciliation resend —
+        funnel into ONE implementation per policy; the rule is never written
+        twice (issue #1115).
+
+        ``wait`` says whether the caller can afford to BLOCK until the coupled
+        entity clears. The dispatch path can and must: it has just issued the
+        blocking entity's command and nothing else will re-drive this one this
+        cycle. A caller that is itself a periodic retry loop passes ``False``
+        for a single-shot "is it clear right now?" — blocking there would let a
+        pass whose budget matches the timer interval overlap the next one, with
+        two live passes mutating the same per-entity state (issue #1115). Same
+        eventual behaviour either way; the next tick re-asks.
 
         Returns ``False`` to withhold, ``True`` to proceed. Withholding is
-        expected to latch, exactly as it does through
-        ``before_position_command``, so a later pass re-attempts the command.
-        Liskov-safe default: a cover type whose entities are physically
-        independent is always clear.
+        expected to latch (:meth:`has_pending_secondary_axis`) so a later pass
+        re-attempts the command. Liskov-safe default: a cover type whose
+        entities are physically independent is always clear.
         """
         return True
 

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -706,11 +706,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
         # NB: ``_dual_entity_dispatch_inverse`` is deliberately NOT reset here.
         # It records the frame of the last middle-rail RESOLUTION — which is
-        # exactly right for its one reader, the DISPATCH path: ``apply_position``
-        # asks the travel gate immediately after ``resolve_entity_target``
-        # restated it for the very value being dispatched, with nothing in
-        # between. Clearing it here would hand that gate a cached per-cycle
-        # decision instead of the seam's own answer (issue #1115).
+        # exactly right for its one reader, ``capture_dispatch_token`` on the
+        # DISPATCH path: ``apply_position`` takes the stamp immediately after
+        # ``resolve_entity_target`` restated this field for the very value being
+        # dispatched, with nothing in between. Clearing it here would stamp that
+        # command with a cached per-cycle decision instead of the seam's own
+        # answer (issue #1115).
         #
         # It is emphatically NOT the frame a RESEND speaks. ``resolve_entity_target``
         # is evaluated as an argument to ``apply_position``, so a cycle that
@@ -755,9 +756,10 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
     def _dispatch_frame(self, inverted: bool | None) -> bool:
         """Resolve which inversion frame a dispatched middle-rail value speaks.
 
-        The ONE place that answer is computed. ``None`` means "the caller did
-        not name a frame, so reuse this cycle's cached decision" (the main
-        pipeline path); an explicit ``True``/``False`` is a seam naming its own
+        The ONE place that answer is computed. ``None`` means "nobody named a
+        frame, so use this cycle's cached ``axis_inverted`` decision" — the main
+        pipeline path, and equally a target that no dispatch ever expressed in a
+        frame at all; an explicit ``True``/``False`` is a seam naming its own
         divergent space. Both ``resolve_entity_target`` — which produces the
         wire value — and :meth:`_gate_middle_rail_clearance` — which has to
         un-transform it to compare against a live rail reading — go through
@@ -1243,27 +1245,36 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         value with the target, and the resend replays what was stored, because
         the number it is putting back on the wire is the one that dispatch
         produced. On a Model C middle rail the stamp is always a ``bool``, so
-        neither position path ever reaches the fallback below.
+        neither position path ever hands this method a ``None``.
 
         ``None`` reaches here only for a target no dispatch produced, and the
         callers that book one are countable: ``restore_target`` rehydrating a
         persisted target after a reload, the coordinator recording an
         externally-observed My move, and ``send_my_position`` booking the user's
         configured My percent — a number ``stop_cover`` puts on the wire without
-        a position, so nothing ever expressed it in a frame. There is no stamp
-        to replay for those, so the live per-cycle record answers: it is the
-        only frame evidence left, and unlike a frozen stamp invented at booking
-        time it re-converges on the install's own frame the moment the pipeline
-        resolves this rail again. Reading that record on a RESEND that DOES have
-        a stamp is the provenance bug this parameter exists to close: the record
-        belongs to the last RESOLUTION, and one resolve-then-skip cycle is
-        enough to flip the verdict on a target no resolve has touched
-        (issue #1115).
+        a position, so nothing ever expressed it in a frame. What all three
+        record is a raw COVER-frame number: the space ``get_current_position``
+        reports in and ``_at_target`` compares against. Mapping that onto
+        open-percent is the install's own inversion flag by definition — which
+        is exactly what ``_dispatch_frame(None)`` returns, so the ``None`` stamp
+        is forwarded unchanged and no second answer is computed here.
 
-        It is emphatically NOT ``context.inverse_state``. That names the
-        install's configured flag, and the broadcast seams dispatch in a
-        divergent space on purpose — the auto-control-off return loop sends the
-        raw default un-inverted. Flipping the middle rail's target against the
+        The live ``_dual_entity_dispatch_inverse`` record is deliberately NOT
+        read for those. It describes the last middle-rail RESOLUTION — a
+        different number — and one seam resolve is enough to leave it naming a
+        divergent space: the sunset/end-time loops invert iff inverse-state is
+        CONFIGURED, so an install running interpolation (where ``axis_inverted``
+        is False) parks a ``True`` there. Gating a token-less My percent against
+        that ``True`` inverts the verdict and waves the middle rail into a
+        bottom rail it cannot pass. Reading the record on a RESEND that DOES
+        have a stamp is the same defect one step earlier — the provenance bug
+        this parameter exists to close (issue #1115).
+
+        For a number a dispatch DID produce, the frame is emphatically NOT
+        ``context.inverse_state`` — nor the install flag a stamp-less target
+        lands on above. That names the install's configured flag, and the
+        broadcast seams dispatch in a divergent space on purpose — the
+        auto-control-off return loop sends the raw default un-inverted. Flipping the middle rail's target against the
         install flag while the seam built it un-inverted withholds a command
         that is already physically clear, on every inverse-state Model C
         install. Both sides of the comparison ride the same frame: the bottom
@@ -1293,11 +1304,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             )
             return True
 
-        inverse = self._dispatch_frame(
-            self._dual_entity_dispatch_inverse
-            if dispatch_token is None
-            else dispatch_token
-        )
+        inverse = self._dispatch_frame(dispatch_token)
         middle_open = flip_if(position, inverted=inverse)
         tolerance = self._position_tolerance
 
@@ -1348,9 +1355,10 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         the resend path the stamp it stored. So the gate un-transforms the
         number against the frame it is actually expressed in rather than
         against a per-cycle record a later resolve may have restated
-        (issue #1115). ``None`` arrives only from a target no dispatch produced
-        — see :meth:`_gate_middle_rail_clearance` for the fallback and who
-        relies on it.
+        (issue #1115). ``None`` arrives only from a target no dispatch produced,
+        and resolves to the install's own frame like every other unnamed frame
+        — see :meth:`_gate_middle_rail_clearance` for who books one and why the
+        install flag, not the per-cycle record, is the honest answer there.
         """
         if not self._is_dual_entity_middle_rail(entity_id):
             return True

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -238,6 +238,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_blend: int | None = None
         self._dual_entity_inverse: bool = False
         self._dual_entity_middle_rail: str | None = None
+        # The inversion frame the most recent middle-rail dispatch was resolved
+        # in, recorded by ``resolve_entity_target`` and replayed by the travel
+        # gate so both read the SAME answer (issue #1115). ``None`` = no dispatch
+        # resolved yet this cycle, which ``_dispatch_frame`` maps back onto the
+        # cached per-cycle decision — the identical rule the dispatch seam uses.
+        self._dual_entity_dispatch_inverse: bool | None = None
         # The instance's configured covers, snapshotted in ``attach``. Model C
         # needs to know which entity is the BOTTOM rail (the one that isn't the
         # middle rail) to gate the middle rail's travel against it. Every options
@@ -695,6 +701,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_blend = resolved.tilt
         self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
+        # Drop the previous cycle's dispatch frame so a seam that reaches
+        # ``apply_position`` without going through ``resolve_entity_target``
+        # (reconciliation) falls back to this cycle's cached decision rather
+        # than to a frame some earlier broadcast seam happened to name.
+        self._dual_entity_dispatch_inverse = None
 
     def _is_dual_entity_middle_rail(self, entity_id: str) -> bool:
         """Whether ``entity_id`` is THIS cycle's Model C middle rail.
@@ -726,6 +737,20 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         neither binds a second rail entity.
         """
         return 1 if self._is_dual_entity_middle_rail(entity_id) else 0
+
+    def _dispatch_frame(self, inverted: bool | None) -> bool:
+        """Resolve which inversion frame a dispatched middle-rail value speaks.
+
+        The ONE place that answer is computed. ``None`` means "the caller did
+        not name a frame, so reuse this cycle's cached decision" (the main
+        pipeline path); an explicit ``True``/``False`` is a seam naming its own
+        divergent space. Both ``resolve_entity_target`` — which produces the
+        wire value — and :meth:`_gate_middle_rail_clearance` — which has to
+        un-transform it to compare against a live rail reading — go through
+        here, so the two can never disagree about what frame the number in
+        flight is in (the #993 bug class; issue #1115).
+        """
+        return self._dual_entity_inverse if inverted is None else inverted
 
     def resolve_entity_target(
         self,
@@ -768,12 +793,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """
         if (
             self._control_model != DAY_NIGHT_MODEL_DUAL_ENTITY
-            or self._dual_entity_blend is None
             or entity_id != self._dual_entity_middle_rail
         ):
             return position
+        # Record the frame BEFORE the blend check: even a cycle that resolves no
+        # blend still dispatches this rail, and the travel gate that follows has
+        # to un-transform that value against the same frame this call named.
+        inverse = self._dispatch_frame(inverted)
+        self._dual_entity_dispatch_inverse = inverse
+        if self._dual_entity_blend is None:
+            return position
         blend = self._dual_entity_blend
-        inverse = self._dual_entity_inverse if inverted is None else inverted
         p_open = flip_if(position, inverted=inverse)
         m_open = round(
             POSITION_OPEN - blend * (POSITION_OPEN - p_open) / DAY_NIGHT_SHEER
@@ -1137,7 +1167,6 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self,
         entity_id: str,
         position: int,
-        context,
         reason: str,
     ) -> bool:
         """Hold the middle rail until the bottom rail has cleared its target.
@@ -1160,11 +1189,21 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         calibration (issue #1115).
 
         The comparison is in OPEN-PERCENT space on both sides, via ``flip_if``
-        against ``context.inverse_state`` — the frame of the exact wire value
-        ``apply_position`` is about to send on THIS seam. ``M >= P`` in
-        open-percent is ``M <= P`` on the wire, so a raw comparison inverts the
-        verdict for every inverse-state install (the #993 bug class), and a
-        second, divergent inversion path is exactly what must not be introduced.
+        against the DISPATCH FRAME — whatever ``resolve_entity_target`` resolved
+        for this very command, replayed through the one shared
+        :meth:`_dispatch_frame` rule. ``M >= P`` in open-percent is ``M <= P``
+        on the wire, so a raw comparison inverts the verdict for every
+        inverse-state install (the #993 bug class), and a second, divergent
+        inversion path is exactly what must not be introduced.
+
+        It is emphatically NOT ``context.inverse_state``. That names the
+        install's configured flag, and the broadcast seams dispatch in a
+        divergent space on purpose — the auto-control-off return loop sends the
+        raw default un-inverted. Flipping the middle rail's target against the
+        install flag while the seam built it un-inverted withholds a command
+        that is already physically clear, on every inverse-state Model C
+        install. Both sides of the comparison ride the same frame: the bottom
+        rail was commanded by the same seam, so its live reading speaks it too.
 
         Returns ``True`` to let the command through, ``False`` to withhold it.
         Withholding latches the entity pending so the coordinator keeps
@@ -1182,7 +1221,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             )
             return True
 
-        inverse = bool(getattr(context, "inverse_state", False))
+        inverse = self._dispatch_frame(self._dual_entity_dispatch_inverse)
         middle_open = flip_if(position, inverted=inverse)
         tolerance = self._position_tolerance
 
@@ -1202,6 +1241,23 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             bottom_rail,
         )
         return False
+
+    async def await_dispatch_clearance(
+        self,
+        entity_id: str,
+        *,
+        position: int,
+        reason: str,
+    ) -> bool:
+        """Hold a Model C middle-rail command until the bottom rail has cleared.
+
+        The same gate ``before_position_command`` runs, reachable without its
+        Model A blend pre-send — for callers that re-send a position outside the
+        dispatch path (reconciliation) and must not trigger anything else.
+        """
+        if not self._is_dual_entity_middle_rail(entity_id):
+            return True
+        return await self._gate_middle_rail_clearance(entity_id, position, reason)
 
     def _debug(self, msg: str, *args) -> None:
         """Emit a debug line once ``attach`` has supplied a logger."""
@@ -1234,9 +1290,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # models are mutually exclusive per coordinator instance, so this branch
         # can never intercept a blend pre-send.
         if self._is_dual_entity_middle_rail(entity_id):
-            return await self._gate_middle_rail_clearance(
-                entity_id, position, context, reason
-            )
+            return await self._gate_middle_rail_clearance(entity_id, position, reason)
         # Single-carriage models (B, C) have no separate blend axis to pre-send
         # — the position command carries everything on one carriage move.
         if not self._drives_dual_axis():

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -240,9 +240,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_middle_rail: str | None = None
         # The inversion frame the most recent middle-rail dispatch was resolved
         # in, recorded by ``resolve_entity_target`` and replayed by the travel
-        # gate so both read the SAME answer (issue #1115). ``None`` = no dispatch
-        # resolved yet this cycle, which ``_dispatch_frame`` maps back onto the
-        # cached per-cycle decision — the identical rule the dispatch seam uses.
+        # gate so both read the SAME answer (issue #1115). Scoped to the
+        # DISPATCH, not to a resolve cycle: reconciliation re-sends the number
+        # that dispatch produced, so that dispatch's frame is the one the number
+        # speaks. ``None`` = no middle rail has been dispatched at all yet, which
+        # ``_dispatch_frame`` maps onto the cached per-cycle decision — the
+        # identical rule the dispatch seam uses.
         self._dual_entity_dispatch_inverse: bool | None = None
         # The instance's configured covers, snapshotted in ``attach``. Model C
         # needs to know which entity is the BOTTOM rail (the one that isn't the
@@ -701,11 +704,14 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_blend = resolved.tilt
         self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
-        # Drop the previous cycle's dispatch frame so a seam that reaches
-        # ``apply_position`` without going through ``resolve_entity_target``
-        # (reconciliation) falls back to this cycle's cached decision rather
-        # than to a frame some earlier broadcast seam happened to name.
-        self._dual_entity_dispatch_inverse = None
+        # NB: ``_dual_entity_dispatch_inverse`` is deliberately NOT reset here.
+        # It belongs to the last middle-rail DISPATCH, not to a resolve cycle,
+        # and the one caller that reads it without a fresh dispatch of its own —
+        # reconciliation — re-sends the number that dispatch put on the wire. Its
+        # frame is therefore the only one that number is expressed in; clearing
+        # it would hand the gate this cycle's cached decision for a dispatch that
+        # never happened (issue #1115). The dispatch path re-states it every time
+        # through ``resolve_entity_target``, so it can never be stale there.
 
     def _is_dual_entity_middle_rail(self, entity_id: str) -> bool:
         """Whether ``entity_id`` is THIS cycle's Model C middle rail.
@@ -1168,6 +1174,8 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         entity_id: str,
         position: int,
         reason: str,
+        *,
+        wait: bool,
     ) -> bool:
         """Hold the middle rail until the bottom rail has cleared its target.
 
@@ -1205,6 +1213,14 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         install. Both sides of the comparison ride the same frame: the bottom
         rail was commanded by the same seam, so its live reading speaks it too.
 
+        ``wait`` picks how long the bottom rail gets. The dispatch path waits
+        out the full budget: it has just issued the bottom rail's command and
+        nothing else will re-drive the middle rail this cycle. A caller that is
+        already a periodic retry loop passes ``False`` and takes a single read —
+        see :meth:`await_dispatch_clearance`. The clearance PREDICATE is
+        identical in both modes; only the number of chances the rail gets to
+        satisfy it differs.
+
         Returns ``True`` to let the command through, ``False`` to withhold it.
         Withholding latches the entity pending so the coordinator keeps
         re-attempting on later cycles; it never drops the command. Unreadable or
@@ -1228,7 +1244,9 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         def _cleared(bottom_wire: int) -> bool:
             return flip_if(bottom_wire, inverted=inverse) <= middle_open + tolerance
 
-        if await seq.wait_until_position(bottom_rail, _cleared):
+        if await seq.wait_until_position(
+            bottom_rail, _cleared, timeout_seconds=None if wait else 0
+        ):
             self._pending_middle_rail.discard(entity_id)
             return True
         self._pending_middle_rail.add(entity_id)
@@ -1248,16 +1266,26 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         *,
         position: int,
         reason: str,
+        wait: bool = True,
     ) -> bool:
         """Hold a Model C middle-rail command until the bottom rail has cleared.
 
-        The same gate ``before_position_command`` runs, reachable without its
-        Model A blend pre-send — for callers that re-send a position outside the
-        dispatch path (reconciliation) and must not trigger anything else.
+        The single gate every position path consults: ``apply_position`` before
+        it books an outbound command, and ``run_reconciliation_pass`` before it
+        re-sends a recorded target. Neither can trigger the Model A blend
+        pre-send that lives in ``before_position_command``.
+
+        ``wait=False`` takes ONE reading instead of polling out the budget —
+        what the reconciliation timer passes, because that budget is its own
+        interval and a blocked rail would otherwise keep a pass alive into the
+        next one. The bottom rail is not going anywhere in the meantime: the
+        withhold latches and the next tick re-asks.
         """
         if not self._is_dual_entity_middle_rail(entity_id):
             return True
-        return await self._gate_middle_rail_clearance(entity_id, position, reason)
+        return await self._gate_middle_rail_clearance(
+            entity_id, position, reason, wait=wait
+        )
 
     def _debug(self, msg: str, *args) -> None:
         """Emit a debug line once ``attach`` has supplied a logger."""
@@ -1273,24 +1301,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         position: int,
         context,
         reason: str,
-    ) -> bool | None:
-        """Gate the Model C middle rail, or send Model A's blend first.
+    ) -> None:
+        """Send Model A's blend before the carriage command fires.
 
-        Returns ``False`` to withhold this position command (the Model C travel
-        gate); ``None`` to proceed, which is what every other path returns.
+        Mirrors the venetian tilt-first order (issue #33): sending the fabric
+        before the carriage starts opening lets the actuator settle the blend
+        into the target rather than reasserting a cached value mid-travel.
 
-        Mirrors the venetian tilt-first order (issue #33) for Model A: sending
-        the fabric before the carriage starts opening lets the actuator settle
-        the blend into the target rather than reasserting a cached value
-        mid-travel.
+        Model C's rail-travel gate is deliberately NOT here — it is a decision,
+        not an effect, and lives in :meth:`await_dispatch_clearance`, which the
+        dispatch path asks before it books the outbound command (issue #1115).
         """
-        # Model C: the middle rail shares a track with the bottom rail and cannot
-        # pass below it, so its command waits for physical clearance (#1115).
-        # Checked first, above an otherwise untouched Model A path — the two
-        # models are mutually exclusive per coordinator instance, so this branch
-        # can never intercept a blend pre-send.
-        if self._is_dual_entity_middle_rail(entity_id):
-            return await self._gate_middle_rail_clearance(entity_id, position, reason)
         # Single-carriage models (B, C) have no separate blend axis to pre-send
         # — the position command carries everything on one carriage move.
         if not self._drives_dual_axis():

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -1271,14 +1271,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         this parameter exists to close (issue #1115).
 
         For a number a dispatch DID produce, the frame is emphatically NOT
-        ``context.inverse_state`` — nor the install flag a stamp-less target
-        lands on above. That names the install's configured flag, and the
-        broadcast seams dispatch in a divergent space on purpose — the
-        auto-control-off return loop sends the raw default un-inverted. Flipping the middle rail's target against the
-        install flag while the seam built it un-inverted withholds a command
-        that is already physically clear, on every inverse-state Model C
-        install. Both sides of the comparison ride the same frame: the bottom
-        rail was commanded by the same seam, so its live reading speaks it too.
+        ``context.inverse_state``. That names ``CONF_INVERSE_STATE``
+        unconditionally — a different answer again from the ``axis_inverted``
+        one a stamp-less target lands on above, which additionally folds in
+        interpolation's suppression of inverse-state. The broadcast seams
+        dispatch in a divergent space on purpose: the auto-control-off return
+        loop sends the raw default un-inverted. Flipping the middle rail's
+        target against the configured flag while the seam built it un-inverted
+        withholds a command that is already physically clear, on every
+        inverse-state Model C install. Both sides of the comparison ride the
+        same frame: the bottom rail was commanded by the same seam, so its live
+        reading speaks it too.
 
         ``wait`` picks how long the bottom rail gets. The dispatch path waits
         out the full budget: it has just issued the bottom rail's command and

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -17,6 +17,7 @@ math is replaced by a pure fabric-choice decision keyed on the season.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -170,7 +171,33 @@ GEOMETRY_DAY_NIGHT_SHADE_SCHEMA = geometry_day_night_shade_schema()
 
 
 class DayNightShadePolicy(CoverTypePolicy, register=True):
-    """Dual-fabric shade (single HA entity, position + sheer/blackout blend)."""
+    """Dual-fabric shade (single HA entity, position + sheer/blackout blend).
+
+    **The physical shade, and why Model C is not just arithmetic.** All three
+    control models describe the same hardware: one headbox, sheer fabric spanning
+    the head rail down to a MIDDLE rail, blackout fabric spanning the middle rail
+    down to the BOTTOM rail. Coverage is set by how far the bottom rail has
+    descended; the sheer-vs-blackout blend is set by where the middle rail sits
+    between the head rail and the bottom rail. Model A encodes the blend on a
+    tilt axis and Model B folds it into one carriage's split travel range, so
+    both drive a single HA entity and the blend is a number.
+
+    Model C (``dual_entity``) drives the two rails as two real HA cover entities
+    on a SHARED TRACK, which adds a constraint no arithmetic can express:
+
+    * the middle rail can never be below the bottom rail (hence the no-pass
+      clamp ``M >= P`` in :meth:`resolve_entity_target`, in open-percent space);
+    * and, because they are physically stacked, the middle rail cannot TRAVEL to
+      a target the bottom rail is currently sitting above — so on any cycle that
+      lowers the shade the bottom rail must start positioning first, and the
+      middle rail is free to move only once the bottom rail is below the middle
+      rail's target.
+
+    Those last two are what :meth:`dispatch_order_key` and
+    :meth:`_gate_middle_rail_clearance` enforce (issue #1115). Without them a
+    perfectly valid target pair still drives the middle motor into a mechanical
+    block: stall, over-current trip, or lost calibration.
+    """
 
     cover_type = "cover_day_night_shade"
     # Position drives the carriage; the tilt axis carries the fabric blend. Order
@@ -189,6 +216,10 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """Initialise without a sequencer; ``attach()`` wires one up later."""
         self._sequencer: DualAxisSequencer | None = None
         self._grace_mgr = None
+        # Both bound in ``attach``; only the Model C travel gate reads them, and
+        # it never runs before ``attach`` (it needs the sequencer).
+        self._logger: Any | None = None
+        self._position_tolerance: int = 0
         # Last resolved fabric blend, replayed by ``maybe_update_tilt_only`` when
         # the position axis won't fire this cycle. Cleared on every suppressed
         # branch of ``post_pipeline_resolve`` (mirrors venetian's ``_last_tilt``).
@@ -207,6 +238,19 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_blend: int | None = None
         self._dual_entity_inverse: bool = False
         self._dual_entity_middle_rail: str | None = None
+        # The instance's configured covers, snapshotted in ``attach``. Model C
+        # needs to know which entity is the BOTTOM rail (the one that isn't the
+        # middle rail) to gate the middle rail's travel against it. Every options
+        # change except the sun-tracking toggle reloads the config entry, which
+        # rebuilds the coordinator and re-runs ``attach``, so the snapshot cannot
+        # go stale behind a changed cover list.
+        self._attached_entities: tuple[str, ...] = ()
+        # Middle-rail position commands withheld because the bottom rail had not
+        # cleared the target yet (issue #1115). Drives
+        # ``has_pending_secondary_axis``, which makes the coordinator withhold
+        # this cycle's dispatched-target signature so the next cycle re-attempts
+        # the send — the same defer-and-retry latch shape as #756's tilt tail.
+        self._pending_middle_rail: set[str] = set()
 
     # ---- Identity / labels -------------------------------------------- #
 
@@ -345,7 +389,13 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         single-carriage models (``split_range``, ``dual_entity``) need only
         ``set_position``. Model C additionally binds a second rail entity, so it
         warns when ``CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY`` names an entity that is
-        not among the instance's configured covers (a typo / stale pick).
+        not among the instance's configured covers (a typo / stale pick) — and,
+        since issue #1115, when the middle rail is not configured AT ALL. The old
+        ``if middle and middle not in known`` short-circuited on the absent value,
+        so an unset rail warned about nothing and the shade then silently ran as a
+        plain vertical blind (both rails driven to the bottom rail's position).
+        The runtime twin of this warning is the B3 Repair fed by
+        :meth:`required_role_entity_missing`.
         """
         model = str(
             options.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
@@ -360,13 +410,45 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         )
         if model == DAY_NIGHT_MODEL_DUAL_ENTITY:
             middle = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
-            if middle and middle not in known:
+            if not middle:
+                warnings.append(
+                    "⚠️ Configured as a dual-entity day/night shade but no "
+                    "middle-rail entity is selected — without it both rails get "
+                    "the same position and the shade behaves like a plain "
+                    "vertical blind."
+                )
+            elif middle not in known:
                 warnings.append(
                     "⚠️ Configured as a dual-entity day/night shade but the "
                     f"middle-rail entity {middle} is not one of this instance's "
                     "covers — add it to the cover list or pick a configured cover."
                 )
         return warnings
+
+    def required_role_entity_missing(
+        self, options: Mapping[str, Any], entities: Iterable[str]
+    ) -> bool:
+        """Report an unfilled Model C middle-rail role (B3 Repair, issue #1115).
+
+        True when the control model is ``dual_entity`` and the middle-rail pick is
+        either absent or names a cover outside this instance's own list. Both
+        cases collapse to the same runtime symptom: ``resolve_entity_target``
+        never matches an entity, so both rails are driven to the bottom rail's
+        position and the shade silently degrades into a plain vertical blind — no
+        warning, no log line, until #1115 no Repair either.
+
+        Reads the model from ``options`` rather than the cached
+        ``_control_model`` so the health check is correct on the very first cycle,
+        before ``post_pipeline_resolve`` has run. Models A and B bind no second
+        rail, so they always report ``False``.
+        """
+        model = str(
+            options.get(CONF_DAY_NIGHT_CONTROL_MODEL, DEFAULT_DAY_NIGHT_CONTROL_MODEL)
+        )
+        if model != DAY_NIGHT_MODEL_DUAL_ENTITY:
+            return False
+        middle = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
+        return not middle or middle not in set(entities)
 
     def lift_travel_metres(
         self,
@@ -614,6 +696,37 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
 
+    def _is_dual_entity_middle_rail(self, entity_id: str) -> bool:
+        """Whether ``entity_id`` is THIS cycle's Model C middle rail.
+
+        Single source of truth for "is this the rail that must not pass the
+        bottom rail?", consumed by the dispatch-ordering key and the travel gate
+        so neither re-states the model/role test (issue #1115). False for every
+        other model — a coordinator instance has exactly one control model — and
+        for an unconfigured middle rail, which is Defect 2's silent-degradation
+        case rather than something the gate can fix.
+        """
+        return (
+            self._control_model == DAY_NIGHT_MODEL_DUAL_ENTITY
+            and self._dual_entity_middle_rail is not None
+            and entity_id == self._dual_entity_middle_rail
+        )
+
+    def dispatch_order_key(self, entity_id: str) -> int:
+        """Command the bottom rail before the middle rail (Model C, issue #1115).
+
+        The two rails share one track: the middle rail cannot travel below the
+        bottom rail. When a cycle lowers both, the bottom rail must START moving
+        first — otherwise the middle rail is commanded toward a target the
+        still-stacked bottom rail is physically blocking. The per-entity command
+        hooks fire inside the caller's loop and cannot reorder it, so the order
+        has to be expressed here, where the rail roles are known.
+
+        Model A and Model B keep the constant default (a stable-sort no-op):
+        neither binds a second rail entity.
+        """
+        return 1 if self._is_dual_entity_middle_rail(entity_id) else 0
+
     def resolve_entity_target(
         self,
         entity_id: str,
@@ -839,6 +952,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         for a day/night entry that never configures them.
         """
         self._grace_mgr = kwargs.get("grace_mgr")
+        self._logger = kwargs["logger"]
+        self._position_tolerance = kwargs["position_tolerance"]
+        # Model C rail-role resolution needs the instance's cover list; additive
+        # kwarg, read via ``kwargs.get`` so every other policy ignores it.
+        self._attached_entities = tuple(kwargs.get("entities") or ())
         self._sequencer = DualAxisSequencer(
             hass=kwargs["hass"],
             logger=kwargs["logger"],
@@ -958,7 +1076,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         )
 
     def has_pending_secondary_axis(self, entity_id: str) -> bool:
-        """Return True while a deferred blend-only update is queued (#756)."""
+        """Return True while a deferred axis/rail command is queued.
+
+        Two deferral sources share this latch, because the coordinator's response
+        to both is identical — withhold this cycle's dispatched-target signature
+        so the command is re-attempted next cycle: a Model A blend-only update
+        deferred by the back-rotate suppression window (#756), and a Model C
+        middle-rail position command withheld while the bottom rail still blocks
+        its target (#1115).
+        """
+        if entity_id in self._pending_middle_rail:
+            return True
         if self._sequencer is None:
             return False
         return self._sequencer.has_pending_tilt(entity_id)
@@ -993,6 +1121,93 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         )
         return True
 
+    @property
+    def _dual_entity_bottom_rail(self) -> str | None:
+        """The Model C bottom (primary) rail — the configured cover that isn't middle.
+
+        Derived rather than stored: the middle rail is the only role the user
+        picks, so the bottom rail is whatever else this instance controls. ``None``
+        when ``attach`` was never given the cover list, or the list holds nothing
+        but the middle rail — a degenerate config the travel gate cannot act on.
+        """
+        middle = self._dual_entity_middle_rail
+        return next((eid for eid in self._attached_entities if eid != middle), None)
+
+    async def _gate_middle_rail_clearance(
+        self,
+        entity_id: str,
+        position: int,
+        context,
+        reason: str,
+    ) -> bool:
+        """Hold the middle rail until the bottom rail has cleared its target.
+
+        **The physical model.** One headbox carries two rails on a shared track.
+        Sheer fabric spans head rail → middle rail; blackout fabric spans middle
+        rail → bottom rail. The bottom rail is the lower of the two and the
+        middle rail cannot pass below it: whatever the arithmetic says, the middle
+        rail can only reach a target the bottom rail is not currently occupying or
+        sitting above. So the bottom rail has to start positioning first, and the
+        middle rail is free to move the moment the bottom rail is below the middle
+        rail's target.
+
+        The no-pass clamp in :meth:`resolve_entity_target` (``M >= P``) states
+        that invariant about two NUMBERS — the two eventual targets. It cannot see
+        where either rail actually IS. When a cycle lowers a shade whose bottom
+        rail is currently stacked up near the head rail, the middle rail's target
+        sits BELOW the bottom rail's live position, and commanding it there drives
+        a motor into a mechanical block: stall, over-current trip, or lost
+        calibration (issue #1115).
+
+        The comparison is in OPEN-PERCENT space on both sides, via ``flip_if``
+        against ``context.inverse_state`` — the frame of the exact wire value
+        ``apply_position`` is about to send on THIS seam. ``M >= P`` in
+        open-percent is ``M <= P`` on the wire, so a raw comparison inverts the
+        verdict for every inverse-state install (the #993 bug class), and a
+        second, divergent inversion path is exactly what must not be introduced.
+
+        Returns ``True`` to let the command through, ``False`` to withhold it.
+        Withholding latches the entity pending so the coordinator keeps
+        re-attempting on later cycles; it never drops the command. Unreadable or
+        never-clearing is deliberately fail-CLOSED (withhold), because a rail
+        whose position cannot be read cannot be proven safe to drive into — while
+        an un-resolvable bottom rail is fail-OPEN (proceed), because there is then
+        no coupled rail to protect and withholding forever would brick the shade.
+        """
+        seq = self._sequencer
+        bottom_rail = self._dual_entity_bottom_rail
+        if seq is None or bottom_rail is None:
+            self._debug(
+                "Model C rail gate inert for %s: no bottom rail resolved", entity_id
+            )
+            return True
+
+        inverse = bool(getattr(context, "inverse_state", False))
+        middle_open = flip_if(position, inverted=inverse)
+        tolerance = self._position_tolerance
+
+        def _cleared(bottom_wire: int) -> bool:
+            return flip_if(bottom_wire, inverted=inverse) <= middle_open + tolerance
+
+        if await seq.wait_until_position(bottom_rail, _cleared):
+            self._pending_middle_rail.discard(entity_id)
+            return True
+        self._pending_middle_rail.add(entity_id)
+        self._debug(
+            "Model C rail gate deferring %s → %s%% (%s): bottom rail %s has not "
+            "cleared the middle rail's target",
+            entity_id,
+            position,
+            reason,
+            bottom_rail,
+        )
+        return False
+
+    def _debug(self, msg: str, *args) -> None:
+        """Emit a debug line once ``attach`` has supplied a logger."""
+        if self._logger is not None:
+            self._logger.debug(msg, *args)
+
     async def before_position_command(
         self,
         cmd_svc,  # noqa: ARG002
@@ -1002,13 +1217,26 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         position: int,
         context,
         reason: str,
-    ) -> None:
-        """Send the blend FIRST on opening transitions, before the carriage moves.
+    ) -> bool | None:
+        """Gate the Model C middle rail, or send Model A's blend first.
 
-        Mirrors the venetian tilt-first order (issue #33): sending the fabric
-        before the carriage starts opening lets the actuator settle the blend
-        into the target rather than reasserting a cached value mid-travel.
+        Returns ``False`` to withhold this position command (the Model C travel
+        gate); ``None`` to proceed, which is what every other path returns.
+
+        Mirrors the venetian tilt-first order (issue #33) for Model A: sending
+        the fabric before the carriage starts opening lets the actuator settle
+        the blend into the target rather than reasserting a cached value
+        mid-travel.
         """
+        # Model C: the middle rail shares a track with the bottom rail and cannot
+        # pass below it, so its command waits for physical clearance (#1115).
+        # Checked first, above an otherwise untouched Model A path — the two
+        # models are mutually exclusive per coordinator instance, so this branch
+        # can never intercept a blend pre-send.
+        if self._is_dual_entity_middle_rail(entity_id):
+            return await self._gate_middle_rail_clearance(
+                entity_id, position, context, reason
+            )
         # Single-carriage models (B, C) have no separate blend axis to pre-send
         # — the position command carries everything on one carriage move.
         if not self._drives_dual_axis():

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -705,13 +705,21 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
         # NB: ``_dual_entity_dispatch_inverse`` is deliberately NOT reset here.
-        # It belongs to the last middle-rail DISPATCH, not to a resolve cycle,
-        # and the one caller that reads it without a fresh dispatch of its own —
-        # reconciliation — re-sends the number that dispatch put on the wire. Its
-        # frame is therefore the only one that number is expressed in; clearing
-        # it would hand the gate this cycle's cached decision for a dispatch that
-        # never happened (issue #1115). The dispatch path re-states it every time
-        # through ``resolve_entity_target``, so it can never be stale there.
+        # It records the frame of the last middle-rail RESOLUTION — which is
+        # exactly right for its one reader, the DISPATCH path: ``apply_position``
+        # asks the travel gate immediately after ``resolve_entity_target``
+        # restated it for the very value being dispatched, with nothing in
+        # between. Clearing it here would hand that gate a cached per-cycle
+        # decision instead of the seam's own answer (issue #1115).
+        #
+        # It is emphatically NOT the frame a RESEND speaks. ``resolve_entity_target``
+        # is evaluated as an argument to ``apply_position``, so a cycle that
+        # resolves and then skips on a delta gate restates this field for a
+        # command that never went out, while the recorded target reconciliation
+        # replays still belongs to an older dispatch in an older frame. That
+        # provenance travels with the target instead: ``capture_dispatch_token``
+        # stamps the frame onto the command as it is BOOKED, and the gate
+        # un-transforms the number it is really resending against that stamp.
 
     def _is_dual_entity_middle_rail(self, entity_id: str) -> bool:
         """Whether ``entity_id`` is THIS cycle's Model C middle rail.
@@ -757,6 +765,27 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         flight is in (the #993 bug class; issue #1115).
         """
         return self._dual_entity_inverse if inverted is None else inverted
+
+    def capture_dispatch_token(self, entity_id: str) -> bool | None:
+        """Stamp the middle rail's dispatch frame onto the command being booked.
+
+        Resolves the frame through the SAME :meth:`_dispatch_frame` rule the
+        gate and ``resolve_entity_target`` use, so the stamp is literally the
+        answer the dispatch-path gate computed for this command — no second
+        inversion path (the #993 bug class; issue #1115).
+
+        ``CoverCommandService`` stores the returned bool beside the target it
+        books and hands it back when the reconciliation timer re-sends that
+        target, which is the only way the gate can un-transform a number
+        dispatched by an earlier seam: this policy's own per-cycle cache has by
+        then been restated by every intervening resolve, dispatched or skipped.
+
+        ``None`` for the bottom rail and for every non-Model-C instance — no
+        rail there needs its dispatched value un-transformed later.
+        """
+        if not self._is_dual_entity_middle_rail(entity_id):
+            return None
+        return self._dispatch_frame(self._dual_entity_dispatch_inverse)
 
     def resolve_entity_target(
         self,
@@ -1176,6 +1205,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         reason: str,
         *,
         wait: bool,
+        dispatch_token: bool | None,
     ) -> bool:
         """Hold the middle rail until the bottom rail has cleared its target.
 
@@ -1197,12 +1227,23 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         calibration (issue #1115).
 
         The comparison is in OPEN-PERCENT space on both sides, via ``flip_if``
-        against the DISPATCH FRAME — whatever ``resolve_entity_target`` resolved
-        for this very command, replayed through the one shared
-        :meth:`_dispatch_frame` rule. ``M >= P`` in open-percent is ``M <= P``
-        on the wire, so a raw comparison inverts the verdict for every
-        inverse-state install (the #993 bug class), and a second, divergent
-        inversion path is exactly what must not be introduced.
+        against the DISPATCH FRAME — the frame of the dispatch that produced
+        THIS number, replayed through the one shared :meth:`_dispatch_frame`
+        rule. ``M >= P`` in open-percent is ``M <= P`` on the wire, so a raw
+        comparison inverts the verdict for every inverse-state install (the #993
+        bug class), and a second, divergent inversion path is exactly what must
+        not be introduced.
+
+        Which dispatch that is depends on the caller, so the caller says.
+        ``dispatch_token`` is the stamp :meth:`capture_dispatch_token` minted
+        when the command was BOOKED — what the resend path replays, because the
+        number it is putting back on the wire is the one that dispatch produced.
+        ``None`` means the caller is the dispatch path itself, asking about a
+        value ``resolve_entity_target`` resolved a moment ago, so the live
+        per-cycle record answers. Reading that record on a resend instead is the
+        provenance bug this parameter exists to close: it belongs to the last
+        RESOLUTION, and one resolve-then-skip cycle is enough to flip the
+        verdict on a target no resolve has touched (issue #1115).
 
         It is emphatically NOT ``context.inverse_state``. That names the
         install's configured flag, and the broadcast seams dispatch in a
@@ -1237,7 +1278,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             )
             return True
 
-        inverse = self._dispatch_frame(self._dual_entity_dispatch_inverse)
+        inverse = self._dispatch_frame(
+            self._dual_entity_dispatch_inverse
+            if dispatch_token is None
+            else dispatch_token
+        )
         middle_open = flip_if(position, inverted=inverse)
         tolerance = self._position_tolerance
 
@@ -1267,6 +1312,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         position: int,
         reason: str,
         wait: bool = True,
+        dispatch_token: bool | None = None,
     ) -> bool:
         """Hold a Model C middle-rail command until the bottom rail has cleared.
 
@@ -1280,11 +1326,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         interval and a blocked rail would otherwise keep a pass alive into the
         next one. The bottom rail is not going anywhere in the meantime: the
         withhold latches and the next tick re-asks.
+
+        ``dispatch_token`` names WHICH dispatch ``position`` came from — the
+        resend path replays the stamp :meth:`capture_dispatch_token` minted when
+        that command was booked, so the gate un-transforms the number against
+        the frame it is actually expressed in rather than against a per-cycle
+        record a later resolve may have restated (issue #1115).
         """
         if not self._is_dual_entity_middle_rail(entity_id):
             return True
         return await self._gate_middle_rail_clearance(
-            entity_id, position, reason, wait=wait
+            entity_id, position, reason, wait=wait, dispatch_token=dispatch_token
         )
 
     def _debug(self, msg: str, *args) -> None:

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -774,11 +774,13 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         answer the dispatch-path gate computed for this command — no second
         inversion path (the #993 bug class; issue #1115).
 
-        ``CoverCommandService`` stores the returned bool beside the target it
-        books and hands it back when the reconciliation timer re-sends that
-        target, which is the only way the gate can un-transform a number
-        dispatched by an earlier seam: this policy's own per-cycle cache has by
-        then been restated by every intervening resolve, dispatched or skipped.
+        ``CoverCommandService`` takes the stamp once per dispatch — before the
+        gate, so the same bool answers that dispatch's own clearance question
+        and is stored beside the target it books — and hands it back when the
+        reconciliation timer re-sends that target, which is the only way the
+        gate can un-transform a number dispatched by an earlier seam: this
+        policy's own per-cycle cache has by then been restated by every
+        intervening resolve, dispatched or skipped.
 
         ``None`` for the bottom rail and for every non-Model-C instance — no
         rail there needs its dispatched value un-transformed later.
@@ -1236,14 +1238,27 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
 
         Which dispatch that is depends on the caller, so the caller says.
         ``dispatch_token`` is the stamp :meth:`capture_dispatch_token` minted
-        when the command was BOOKED — what the resend path replays, because the
-        number it is putting back on the wire is the one that dispatch produced.
-        ``None`` means the caller is the dispatch path itself, asking about a
-        value ``resolve_entity_target`` resolved a moment ago, so the live
-        per-cycle record answers. Reading that record on a resend instead is the
-        provenance bug this parameter exists to close: it belongs to the last
-        RESOLUTION, and one resolve-then-skip cycle is enough to flip the
-        verdict on a target no resolve has touched (issue #1115).
+        when the command was BOOKED. BOTH position paths pass one: the dispatch
+        path captures the stamp immediately before this gate and books that very
+        value with the target, and the resend replays what was stored, because
+        the number it is putting back on the wire is the one that dispatch
+        produced. On a Model C middle rail the stamp is always a ``bool``, so
+        neither position path ever reaches the fallback below.
+
+        ``None`` reaches here only for a target no dispatch produced, and the
+        callers that book one are countable: ``restore_target`` rehydrating a
+        persisted target after a reload, the coordinator recording an
+        externally-observed My move, and ``send_my_position`` booking the user's
+        configured My percent — a number ``stop_cover`` puts on the wire without
+        a position, so nothing ever expressed it in a frame. There is no stamp
+        to replay for those, so the live per-cycle record answers: it is the
+        only frame evidence left, and unlike a frozen stamp invented at booking
+        time it re-converges on the install's own frame the moment the pipeline
+        resolves this rail again. Reading that record on a RESEND that DOES have
+        a stamp is the provenance bug this parameter exists to close: the record
+        belongs to the last RESOLUTION, and one resolve-then-skip cycle is
+        enough to flip the verdict on a target no resolve has touched
+        (issue #1115).
 
         It is emphatically NOT ``context.inverse_state``. That names the
         install's configured flag, and the broadcast seams dispatch in a
@@ -1328,10 +1343,14 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         withhold latches and the next tick re-asks.
 
         ``dispatch_token`` names WHICH dispatch ``position`` came from — the
-        resend path replays the stamp :meth:`capture_dispatch_token` minted when
-        that command was booked, so the gate un-transforms the number against
-        the frame it is actually expressed in rather than against a per-cycle
-        record a later resolve may have restated (issue #1115).
+        stamp :meth:`capture_dispatch_token` minted when that command was
+        booked. Both paths supply it: the dispatch path the stamp it just took,
+        the resend path the stamp it stored. So the gate un-transforms the
+        number against the frame it is actually expressed in rather than
+        against a per-cycle record a later resolve may have restated
+        (issue #1115). ``None`` arrives only from a target no dispatch produced
+        — see :meth:`_gate_middle_rail_clearance` for the fallback and who
+        relies on it.
         """
         if not self._is_dual_entity_middle_rail(entity_id):
             return True

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -1211,6 +1211,44 @@ class DualAxisSequencer:
         )
         return False, last_position
 
+    async def wait_until_position(
+        self, entity_id: str, done: Callable[[int], bool]
+    ) -> bool:
+        """Poll ``current_position`` until ``done`` accepts a reading, or time out.
+
+        A ONE-SIDED threshold wait, deliberately NOT
+        :meth:`_wait_for_position_settle`: that method declares success only
+        within tolerance OF A TARGET, so it would sail straight past a cover
+        that merely *transits* the threshold on its way somewhere else — exactly
+        what a day/night bottom rail does while descending past the middle
+        rail's target (issue #1115). Same poll interval and same 60 s budget
+        (:data:`VENETIAN_POSITION_SETTLE_POLL_SECONDS` /
+        :data:`VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS`) — the semantics differ,
+        the tuning does not, so no parallel constant is introduced.
+
+        ``done`` is evaluated BEFORE the first sleep, so an already-satisfied
+        condition returns on one read with no waiting at all. Returns ``True``
+        when ``done`` accepted a reading, ``False`` on timeout or when the
+        position is unreadable — an unreadable cover cannot be proven to have
+        cleared, and the caller decides what to do about that.
+        """
+        deadline = dt.datetime.now(dt.UTC) + dt.timedelta(
+            seconds=VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
+        )
+        while dt.datetime.now(dt.UTC) < deadline:
+            current = self._get_current_position(entity_id)
+            if current is None:
+                return False
+            if done(current):
+                return True
+            await asyncio.sleep(VENETIAN_POSITION_SETTLE_POLL_SECONDS)
+        self._logger.debug(
+            "Position wait: %s never satisfied its threshold within %.0fs",
+            entity_id,
+            VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
+        )
+        return False
+
     @staticmethod
     def _seconds_since(stamp: dt.datetime) -> float:
         """Return wall-clock seconds since ``stamp`` (UTC).

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -1212,7 +1212,11 @@ class DualAxisSequencer:
         return False, last_position
 
     async def wait_until_position(
-        self, entity_id: str, done: Callable[[int], bool]
+        self,
+        entity_id: str,
+        done: Callable[[int], bool],
+        *,
+        timeout_seconds: float | None = None,
     ) -> bool:
         """Poll ``current_position`` until ``done`` accepts a reading, or time out.
 
@@ -1226,26 +1230,39 @@ class DualAxisSequencer:
         :data:`VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS`) — the semantics differ,
         the tuning does not, so no parallel constant is introduced.
 
+        ``timeout_seconds`` overrides that budget; ``None`` (the default) uses
+        it. ``0`` makes this a SINGLE-SHOT read — the loop is a do-while, so
+        ``done`` is always evaluated at least once — which is what a caller that
+        is itself a periodic retry loop wants: it asks whether the threshold is
+        satisfied right now and re-asks on its own next tick, instead of
+        blocking for a budget that may be as long as its own interval. One
+        implementation either way; the predicate is never re-stated.
+
         ``done`` is evaluated BEFORE the first sleep, so an already-satisfied
         condition returns on one read with no waiting at all. Returns ``True``
         when ``done`` accepted a reading, ``False`` on timeout or when the
         position is unreadable — an unreadable cover cannot be proven to have
         cleared, and the caller decides what to do about that.
         """
-        deadline = dt.datetime.now(dt.UTC) + dt.timedelta(
-            seconds=VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
+        budget = (
+            VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
+            if timeout_seconds is None
+            else timeout_seconds
         )
-        while dt.datetime.now(dt.UTC) < deadline:
+        deadline = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=budget)
+        while True:
             current = self._get_current_position(entity_id)
             if current is None:
                 return False
             if done(current):
                 return True
+            if dt.datetime.now(dt.UTC) >= deadline:
+                break
             await asyncio.sleep(VENETIAN_POSITION_SETTLE_POLL_SECONDS)
         self._logger.debug(
-            "Position wait: %s never satisfied its threshold within %.0fs",
+            "Position wait: %s did not satisfy its threshold within %.1fs",
             entity_id,
-            VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
+            budget,
         )
         return False
 

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -375,7 +375,13 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """
 
         async def _member(entry, coordinator) -> None:
-            for entity_id in entry.options.get(CONF_ENTITIES, []):
+            # Each member's OWN policy decides its rail order (issue #1115) —
+            # a Model C day/night member inside a group needs its bottom rail
+            # commanded first exactly as it does standalone.
+            ordered = coordinator._policy.order_for_dispatch(  # noqa: SLF001
+                entry.options.get(CONF_ENTITIES, [])
+            )
+            for entity_id in ordered:
                 await coordinator.async_apply_user_position(
                     entity_id, position, trigger=TRIGGER_GROUP_COVER
                 )
@@ -396,7 +402,11 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """
 
         async def _member(entry, coordinator) -> None:
-            for entity_id in entry.options.get(CONF_ENTITIES, []):
+            # Same per-member ordered view as the position slider (issue #1115).
+            ordered = coordinator._policy.order_for_dispatch(  # noqa: SLF001
+                entry.options.get(CONF_ENTITIES, [])
+            )
+            for entity_id in ordered:
                 await coordinator.async_apply_user_tilt(
                     entity_id, tilt, trigger=TRIGGER_GROUP_COVER_TILT
                 )

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -332,9 +332,26 @@ class CoverCommandService:
         s = self._state.get(entity_id)
         return None if s is None else s.target
 
-    def set_target(self, entity_id: str, position: int | None) -> None:
-        """Set the commanded target position. ``None`` clears the target."""
-        self.state(entity_id).target = position
+    def set_target(
+        self,
+        entity_id: str,
+        position: int | None,
+        *,
+        dispatch_token: Any = None,
+    ) -> None:
+        """Set the commanded target position. ``None`` clears the target.
+
+        The ONE writer of the ``(target, dispatch_token)`` pair (issue #1115).
+        ``dispatch_token`` is the cover-type policy's opaque stamp for the
+        dispatch that produced ``position`` — see ``PerEntityState`` — and it is
+        written here, beside the target, precisely so no code path can record
+        one without the other. Callers with no dispatch behind the write (a
+        rehydrated target, an externally-observed My move, a clear) leave it at
+        ``None``: no provenance is the honest answer there.
+        """
+        s = self.state(entity_id)
+        s.target = position
+        s.dispatch_token = dispatch_token
 
     def restore_target(self, entity_id: str, target: int | None) -> bool:
         """Rehydrate a persisted command target after an ACP reload (issue #1022).
@@ -720,8 +737,8 @@ class CoverCommandService:
             if s.target is not None and not s.is_safety
         ]
         for eid in stale:
+            self.set_target(eid, None)
             s = self._state[eid]
-            s.target = None
             self._clear_waiting(s)
             s.retry_count = 0
             s.gave_up = False
@@ -967,7 +984,13 @@ class CoverCommandService:
         # toward My during the transit window.
         prior_position = self._get_current_position(entity_id)
         s = self.state(entity_id)
-        s.target = target
+        # A real outbound command, so it books real dispatch provenance — same
+        # rule as ``_prepare_service_call`` (issue #1115).
+        self.set_target(
+            entity_id,
+            target,
+            dispatch_token=self._policy.capture_dispatch_token(entity_id),
+        )
         s.waiting = True
         s.sent_at = now
         s.last_progress_at = None
@@ -1652,11 +1675,28 @@ class CoverCommandService:
         # Skipped entirely in a dry run: the answer is a wall-clock wait on a
         # physical rail, and a simulated command moves nothing for it to wait on
         # — the dry-run gate below owns that path.
+        #
+        # The policy's provenance stamp for THIS dispatch is taken first, ONCE,
+        # and used for both the gate and the booking below (issue #1115). Taken
+        # before the gate rather than at the booking because the gate may await
+        # a physical rail for its whole budget, and a policy's per-cycle view can
+        # be restated by another cycle across that await — reading it twice would
+        # stamp the booked target with a dispatch that did not produce it, which
+        # is the exact provenance bug this stamp exists to close. Opaque here:
+        # this service stores and replays it, never interprets it.
+        dispatch_token = (
+            None
+            if context.policy is None
+            else context.policy.capture_dispatch_token(entity_id)
+        )
         if (
             not self._dry_run
             and context.policy is not None
             and not await context.policy.await_dispatch_clearance(
-                entity_id, position=position, reason=reason
+                entity_id,
+                position=position,
+                reason=reason,
+                dispatch_token=dispatch_token,
             )
         ):
             return self._skip(
@@ -1682,6 +1722,7 @@ class CoverCommandService:
             plan=_plan,
             is_safety=context.is_safety,
             use_my_position=context.use_my_position,
+            dispatch_token=dispatch_token,
         )
         if service is None:
             return self._skip(
@@ -2133,8 +2174,21 @@ class CoverCommandService:
             # running when the next one starts, and the two mutate the same
             # per-entity state (issue #1115). One reading, withhold, re-ask in a
             # minute: identical eventual behaviour, no overlap.
+            #
+            # ``dispatch_token``: a resend re-states the number the ORIGINAL
+            # dispatch put on the wire, so the policy is handed back that
+            # dispatch's own stamp rather than being left to infer one from a
+            # per-cycle view a later resolve may have restated. Without it a
+            # single resolve-then-skip cycle — routine under the default 2 %/2 min
+            # delta gates — flips the verdict either way: withholding a rail
+            # nothing will ever re-target, or resending into a rail that is
+            # physically blocked (issue #1115).
             if not await self._policy.await_dispatch_clearance(
-                entity_id, position=target, reason="reconcile", wait=False
+                entity_id,
+                position=target,
+                reason="reconcile",
+                wait=False,
+                dispatch_token=s.dispatch_token,
             ):
                 self._logger.debug(
                     "Reconcile: %s withheld by the cover-type policy — a coupled "
@@ -2328,6 +2382,7 @@ class CoverCommandService:
         is_safety: bool = False,
         use_my_position: bool = False,  # noqa: FBT001
         plan: ServiceCallPlan | None = None,
+        dispatch_token: Any = None,
     ) -> tuple[str | None, dict | None, bool]:
         """Build the HA service call for this cover/state.
 
@@ -2361,6 +2416,14 @@ class CoverCommandService:
                 Recomputed internally when omitted, preserving the original
                 call contract for every other caller (e.g.
                 ``_execute_command``).
+            dispatch_token: Opaque cover-type-policy stamp describing the
+                dispatch that produced ``state``, recorded alongside the booked
+                target so a later resend can hand it back to the policy that
+                minted it (issue #1115). ``apply_position`` passes the stamp it
+                took for THIS dispatch; ``_execute_command`` passes the stored
+                one forward, because a resend puts the same number back on the
+                wire and therefore speaks the same dispatch. Never interpreted
+                here.
 
         Returns:
             (service_name, service_data, supports_position).
@@ -2422,7 +2485,10 @@ class CoverCommandService:
         # comparison stays in the raw display frame.
         prior_position = self._read_position_with_capabilities(entity, caps)
         s = self.state(entity)
-        s.target = plan.routed_target
+        # The booking chokepoint: the target and the dispatch provenance that
+        # explains it are recorded by the same call, so a resend can never be
+        # gated against a dispatch that did not produce it (issue #1115).
+        self.set_target(entity, plan.routed_target, dispatch_token=dispatch_token)
         self._set_transit_direction_if_blind(
             entity, plan.routed_target, prior_position, caps
         )
@@ -2462,7 +2528,13 @@ class CoverCommandService:
         ``apply_position`` (issue #342), so no duplicate gate is needed here.
         """
         service, service_data, _ = self._prepare_service_call(
-            entity_id, target, reset_retries=False
+            entity_id,
+            target,
+            reset_retries=False,
+            # A resend re-books the SAME number, so it carries the original
+            # dispatch's provenance forward rather than re-stamping it with
+            # whatever the policy's per-cycle view says now (issue #1115).
+            dispatch_token=self._get(entity_id).dispatch_token,
         )
         if service is None:
             return

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1482,9 +1482,14 @@ class CoverCommandService:
         # check_cover_features + route_service_call work entirely for a
         # value it would never read (issue #1095 audit finding 4).
         # route_service_call is pure/side-effect-free (routing.py's module
-        # docstring); no `await` occurs between this line and either of its
-        # uses (this gate, and the dispatch call further down that reuses
-        # this same `_plan`/`_caps_for_plan`), so both stay valid for both.
+        # docstring), and nothing between this line and either of its uses
+        # (this gate, and the dispatch call further down that reuses this
+        # same `_plan`/`_caps_for_plan`) can invalidate it. The one await
+        # that can intervene is the physical-clearance gate below, and a
+        # policy with no coupled entities returns from it without ever
+        # suspending; a policy that does suspend is waiting on ANOTHER
+        # entity's travel, not on this one's `supported_features`, which is
+        # all `_plan` is derived from.
         _caps_for_plan = self.get_cover_capabilities(entity_id)
         _plan = route_service_call(
             entity_id,
@@ -1618,12 +1623,57 @@ class CoverCommandService:
                     current_position=_current,
                 )
 
+        # ----- physical-clearance gate -----
+        # Cover-type policy question: may this entity be driven to `position`
+        # right now? A cover type whose entities are physically coupled may need
+        # one of them to move first — the Model C day/night middle rail cannot
+        # travel past its bottom rail (issue #1115). Cover-type-agnostic,
+        # exactly like the ``full_endpoint_target`` flag: the bool carries the
+        # decision and this service never inspects the cover type. Every other
+        # policy answers True unconditionally.
+        #
+        # Asked HERE, ahead of _prepare_service_call, because withheld means
+        # SKIPPED and a skip must leave NOTHING behind: _prepare_service_call
+        # books the outbound command (target, waiting, sent_at, the command
+        # grace window, the on_command_sent tick), and every one of those has a
+        # live consequence for a command that never goes out — the grace window
+        # suppresses genuine manual-override detection, ``waiting`` makes the
+        # next reconciliation pass skip the entity, and once it lapses A2 raises
+        # "cover not moving" about a rail ACP is deliberately holding still.
+        # Nothing recorded, nothing to unwind. The policy latches the withheld
+        # command (``has_pending_secondary_axis``) so a later cycle re-attempts
+        # it.
+        #
+        # This is the go/no-go question ONLY — the pre-send SIDE EFFECTS
+        # (venetian's tilt-first) stay in ``before_position_command`` below,
+        # which is why they can keep running after the dry-run gate while the
+        # decision runs before it.
+        #
+        # Skipped entirely in a dry run: the answer is a wall-clock wait on a
+        # physical rail, and a simulated command moves nothing for it to wait on
+        # — the dry-run gate below owns that path.
+        if (
+            not self._dry_run
+            and context.policy is not None
+            and not await context.policy.await_dispatch_clearance(
+                entity_id, position=position, reason=reason
+            )
+        ):
+            return self._skip(
+                entity_id,
+                "policy_deferred",
+                position,
+                trigger=_trigger,
+                inverse_state=_inverse,
+                current_position=_current,
+            )
+
         # ----- send command -----
         # Reuses _caps_for_plan/_plan from the gate above (issue #1095 audit
         # finding 5) instead of a fresh get_cover_capabilities +
-        # route_service_call — safe because nothing between that computation
-        # and this call awaits (confirmed above and in apply_position's
-        # docstring-adjacent comment on `_plan`).
+        # route_service_call — safe for the reason spelled out where `_plan` is
+        # built: nothing that can intervene between there and here changes this
+        # entity's capabilities.
         service, service_data, supports_position = self._prepare_service_call(
             entity_id,
             position,
@@ -1675,18 +1725,11 @@ class CoverCommandService:
         # Cover-type policy hook: dual-axis covers (venetian) pre-send tilt
         # on opening transitions so the actuator's slats are at the target
         # angle before the carriage starts moving (issue #33). Default
-        # policies are no-ops.
-        #
-        # The hook can also WITHHOLD the command by returning False: a cover type
-        # whose entities are physically coupled may need one of them to move
-        # first (the Model C day/night middle rail cannot travel past its bottom
-        # rail — issue #1115). Cover-type-agnostic, exactly like the
-        # ``full_endpoint_target`` flag: the bool carries the decision and this
-        # service never inspects the cover type. Withheld means SKIPPED, not
-        # sent — no target is tracked, no ``after_position_command`` runs — and
-        # the policy latches the command so a later cycle re-attempts it.
+        # policies are no-ops. Pure SIDE EFFECT — the go/no-go decision was
+        # settled by ``await_dispatch_clearance`` above, before anything about
+        # this command was recorded.
         if context.policy is not None:
-            proceed = await context.policy.before_position_command(
+            await context.policy.before_position_command(
                 self,
                 entity_id,
                 service=service,
@@ -1694,15 +1737,6 @@ class CoverCommandService:
                 context=context,
                 reason=reason,
             )
-            if proceed is False:
-                return self._skip(
-                    entity_id,
-                    "policy_deferred",
-                    position,
-                    trigger=_trigger,
-                    inverse_state=_inverse,
-                    current_position=_current,
-                )
 
         ctx = Context()
         self._position_context_tracker.record(ctx.id)
@@ -2091,8 +2125,16 @@ class CoverCommandService:
             # inspects the cover type. Asked before the retry is counted so a
             # withheld resend does not burn one of the pass's attempts; the
             # policy latches it and the next pass re-attempts.
+            #
+            # ``wait=False``: this pass IS the retry loop. Its clearance budget
+            # would otherwise be the reconciliation interval itself, and HA
+            # re-arms the interval listener before dispatching each fire as its
+            # own background task — so a pass blocked on a pinned rail is still
+            # running when the next one starts, and the two mutate the same
+            # per-entity state (issue #1115). One reading, withhold, re-ask in a
+            # minute: identical eventual behaviour, no overlap.
             if not await self._policy.await_dispatch_clearance(
-                entity_id, position=target, reason="reconcile"
+                entity_id, position=target, reason="reconcile", wait=False
             ):
                 self._logger.debug(
                     "Reconcile: %s withheld by the cover-type policy — a coupled "

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -990,8 +990,9 @@ class CoverCommandService:
         # expressed in a frame. Stamping it with the policy's current view would
         # attribute it to the last unrelated dispatch AND freeze that attribution
         # for every later resend — the exact provenance defect the stamp exists
-        # to close, pointed the other way. ``None`` is the honest answer; the
-        # policy then falls back to a live reading it can at least re-derive.
+        # to close, pointed the other way. ``None`` is the honest answer: the
+        # policy then maps it with the install's own axis inversion, which is
+        # the right frame for a raw cover-frame percent nothing resolved.
         self.set_target(entity_id, target)
         s.waiting = True
         s.sent_at = now

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -984,13 +984,15 @@ class CoverCommandService:
         # toward My during the transit window.
         prior_position = self._get_current_position(entity_id)
         s = self.state(entity_id)
-        # A real outbound command, so it books real dispatch provenance — same
-        # rule as ``_prepare_service_call`` (issue #1115).
-        self.set_target(
-            entity_id,
-            target,
-            dispatch_token=self._policy.capture_dispatch_token(entity_id),
-        )
+        # No dispatch produced this number, so it books no provenance (issue
+        # #1115). ``stop_cover`` carries no position: what lands here is the
+        # user's configured My percent, which nothing resolved and no seam ever
+        # expressed in a frame. Stamping it with the policy's current view would
+        # attribute it to the last unrelated dispatch AND freeze that attribution
+        # for every later resend — the exact provenance defect the stamp exists
+        # to close, pointed the other way. ``None`` is the honest answer; the
+        # policy then falls back to a live reading it can at least re-derive.
+        self.set_target(entity_id, target)
         s.waiting = True
         s.sent_at = now
         s.last_progress_at = None
@@ -2183,12 +2185,34 @@ class CoverCommandService:
             # delta gates — flips the verdict either way: withholding a rail
             # nothing will ever re-target, or resending into a rail that is
             # physically blocked (issue #1115).
+            #
+            # Target and stamp are read HERE, together, rather than the target
+            # coming from the pass-start snapshot. ``recorded`` was taken before
+            # the loop ran, and the loop awaits — this gate, and every earlier
+            # entity's own resend. A concurrent ``apply_position`` landing in one
+            # of those windows re-books this entity, and pairing the snapshot's
+            # target with a stamp read now describes one number with another's
+            # frame; ``_prepare_service_call`` would then persist that mismatched
+            # pair as the record the NEXT pass gates against. One read, one pair,
+            # carried through the gate and back into the booking below. Which
+            # entities the pass acts on is still the snapshot's call — only the
+            # value going back on the wire moves.
+            resend_target = s.target
+            resend_token = s.dispatch_token
+            if resend_target is None:
+                # Cleared out from under the pass (time-window close, reload).
+                # There is no longer a target to restate.
+                self._logger.debug(
+                    "Reconcile: %s target cleared mid-pass — skipping resend",
+                    entity_id,
+                )
+                continue
             if not await self._policy.await_dispatch_clearance(
                 entity_id,
-                position=target,
+                position=resend_target,
                 reason="reconcile",
                 wait=False,
-                dispatch_token=s.dispatch_token,
+                dispatch_token=resend_token,
             ):
                 self._logger.debug(
                     "Reconcile: %s withheld by the cover-type policy — a coupled "
@@ -2202,11 +2226,13 @@ class CoverCommandService:
                 "Reconcile: %s missed target (actual=%s target=%s) — retry %d/%d",
                 entity_id,
                 actual,
-                target,
+                resend_target,
                 s.retry_count,
                 self._max_retries,
             )
-            await self._execute_command(entity_id, target)
+            await self._execute_command(
+                entity_id, resend_target, dispatch_token=resend_token
+            )
 
     # ------------------------------------------------------------------ #
     # Diagnostic helpers
@@ -2420,10 +2446,10 @@ class CoverCommandService:
                 dispatch that produced ``state``, recorded alongside the booked
                 target so a later resend can hand it back to the policy that
                 minted it (issue #1115). ``apply_position`` passes the stamp it
-                took for THIS dispatch; ``_execute_command`` passes the stored
-                one forward, because a resend puts the same number back on the
-                wire and therefore speaks the same dispatch. Never interpreted
-                here.
+                took for THIS dispatch; ``_execute_command`` passes the one its
+                caller read alongside the target it is restating, because a
+                resend puts the same number back on the wire and therefore
+                speaks the same dispatch. Never interpreted here.
 
         Returns:
             (service_name, service_data, supports_position).
@@ -2517,11 +2543,22 @@ class CoverCommandService:
 
         return plan.service, plan.service_data, plan.supports_position
 
-    async def _execute_command(self, entity_id: str, target: int) -> None:
+    async def _execute_command(
+        self, entity_id: str, target: int, *, dispatch_token: Any = None
+    ) -> None:
         """Send command directly, bypassing gate checks (reconciliation use only).
 
         Does NOT reset the retry count — the caller
         (``run_reconciliation_pass``) owns that.
+
+        ``dispatch_token`` is the provenance of ``target``: a resend re-books the
+        SAME number, so the original dispatch's stamp travels forward instead of
+        the number being re-stamped with whatever the policy's per-cycle view
+        says now (issue #1115). It is supplied by the caller rather than re-read
+        here so that the target and the stamp explaining it come from a single
+        read — re-reading the record would let a re-booking that landed during
+        the caller's clearance await pair this target with another number's
+        frame. A caller with no dispatch behind ``target`` leaves it ``None``.
 
         NB: callers are responsible for entity-loaded-ness. Reconciliation only
         runs for entities that already passed the cover_unavailable gate in
@@ -2531,10 +2568,7 @@ class CoverCommandService:
             entity_id,
             target,
             reset_retries=False,
-            # A resend re-books the SAME number, so it carries the original
-            # dispatch's provenance forward rather than re-stamping it with
-            # whatever the policy's per-cycle view says now (issue #1115).
-            dispatch_token=self._get(entity_id).dispatch_token,
+            dispatch_token=dispatch_token,
         )
         if service is None:
             return

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -90,6 +90,7 @@ class CoverCommandService:
         on_tick=None,
         endpoint_use_open_close: bool = DEFAULT_ENDPOINT_USE_OPEN_CLOSE,
         *,
+        policy=None,
         event_buffer=None,
         debug_log=None,
         on_command_sent=None,
@@ -126,6 +127,15 @@ class CoverCommandService:
                 the command grace period start).  The coordinator wires this to
                 ``AdaptiveCoverManager.note_command_sent`` so time-based
                 manual-override detectors can clock the post-command window.
+            policy: The config entry's OWN ``CoverTypePolicy`` instance. Pass it
+                whenever one exists (the coordinator does) so this manager and
+                the dispatch path share one object: a policy that carries
+                per-cycle state — the Model C day/night rail roles behind
+                ``order_for_dispatch`` / ``await_dispatch_clearance`` — answers
+                from a private instance nobody primes, and every question this
+                manager asks it silently degrades to the default (issue #1115).
+                Omitted, a fresh instance is built from ``cover_type``, which is
+                still correct for the stateless axis/capability queries.
 
         """
         # Local import: ``cover_types.venetian.sequencer`` imports
@@ -144,7 +154,7 @@ class CoverCommandService:
         # policy carries the axis descriptors that control which HA service
         # this manager calls — see ``_prepare_service_call`` and
         # ``_read_position_with_capabilities``.
-        self._policy = get_policy(cover_type)
+        self._policy = policy if policy is not None else get_policy(cover_type)
         self._grace_mgr = grace_mgr
         self._open_close_threshold = open_close_threshold
         self._endpoint_use_open_close = endpoint_use_open_close
@@ -1896,10 +1906,17 @@ class CoverCommandService:
            → skip.  Prevents stale daytime targets from being resent overnight.
         6. Compare actual position to ``target_call`` within tolerance.
         7. If match → reset retry count, done.
-        8. If mismatch → resend the same target (up to ``max_retries``).
+        8. If mismatch → ask the cover-type policy whether the entity is
+           physically clear to move; withhold if not.
+        9. Resend the same target (up to ``max_retries``).
 
-        Note: reconciliation does *not* go through gate checks — the target
-        was already validated when ``apply_position`` was called.
+        Note: reconciliation does *not* go through the ``apply_position`` gate
+        checks — the target was already validated when ``apply_position`` was
+        called. It DOES honour the policy's dispatch order and its
+        physical-clearance answer, because those describe the hardware rather
+        than the decision that produced the target: a Model C day/night middle
+        rail cannot travel past its bottom rail no matter which timer asked it
+        to (issue #1115).
 
         """
         # Coordinator hook: time window transition checks, etc.
@@ -1910,7 +1927,13 @@ class CoverCommandService:
         if not self._enabled:
             return
 
-        for entity_id, target in list(self.iter_targets()):
+        # Same policy-mandated dispatch order as every other fan-out seam
+        # (issue #1115): a Model C day/night shade's bottom rail must be resent
+        # before its middle rail, which cannot physically travel past it.
+        # Identity for every cover type whose entities are independent.
+        recorded = dict(self.iter_targets())
+        for entity_id in self._policy.order_for_dispatch(recorded):
+            target = recorded[entity_id]
             s = self.state(entity_id)
             s.last_reconcile_at = now
 
@@ -2056,6 +2079,26 @@ class CoverCommandService:
                         actual,
                         target,
                     )
+                continue
+
+            # 9. Physically-coupled entities: a resend is still a position
+            # command, so it obeys the same clearance the dispatch path does —
+            # a Model C day/night middle rail must not be driven while its
+            # bottom rail is stacked above the target (issue #1115). Ordering
+            # alone cannot fix this: the loop does not wait for the bottom
+            # rail's resend to ARRIVE before issuing the middle rail's.
+            # Cover-type-agnostic — the policy answers, this loop never
+            # inspects the cover type. Asked before the retry is counted so a
+            # withheld resend does not burn one of the pass's attempts; the
+            # policy latches it and the next pass re-attempts.
+            if not await self._policy.await_dispatch_clearance(
+                entity_id, position=target, reason="reconcile"
+            ):
+                self._logger.debug(
+                    "Reconcile: %s withheld by the cover-type policy — a coupled "
+                    "entity has not cleared the target yet",
+                    entity_id,
+                )
                 continue
 
             s.retry_count += 1

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1666,8 +1666,17 @@ class CoverCommandService:
         # on opening transitions so the actuator's slats are at the target
         # angle before the carriage starts moving (issue #33). Default
         # policies are no-ops.
+        #
+        # The hook can also WITHHOLD the command by returning False: a cover type
+        # whose entities are physically coupled may need one of them to move
+        # first (the Model C day/night middle rail cannot travel past its bottom
+        # rail — issue #1115). Cover-type-agnostic, exactly like the
+        # ``full_endpoint_target`` flag: the bool carries the decision and this
+        # service never inspects the cover type. Withheld means SKIPPED, not
+        # sent — no target is tracked, no ``after_position_command`` runs — and
+        # the policy latches the command so a later cycle re-attempts it.
         if context.policy is not None:
-            await context.policy.before_position_command(
+            proceed = await context.policy.before_position_command(
                 self,
                 entity_id,
                 service=service,
@@ -1675,6 +1684,15 @@ class CoverCommandService:
                 context=context,
                 reason=reason,
             )
+            if proceed is False:
+                return self._skip(
+                    entity_id,
+                    "policy_deferred",
+                    position,
+                    trigger=_trigger,
+                    inverse_state=_inverse,
+                    current_position=_current,
+                )
 
         ctx = Context()
         self._position_context_tracker.record(ctx.id)

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -49,7 +49,10 @@ class PerEntityState:
     # two can never drift apart. NEVER interpreted by this manager: it stores
     # and replays the value and nothing else (no cover-type knowledge here).
     # ``None`` means "no dispatch provenance recorded" — every policy that does
-    # not need one, plus rehydrated/externally-seeded targets.
+    # not need one, plus every target no dispatch produced: rehydrated after a
+    # reload, observed on the cover from outside, or the user's configured My
+    # percent, which ``stop_cover`` puts on the wire without a position for any
+    # frame to describe.
     dispatch_token: Any = None
     sent_at: dt.datetime | None = None
     waiting: bool = False

--- a/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/state_store.py
@@ -37,6 +37,20 @@ class PerEntityState:
     """
 
     target: int | None = None
+    # Opaque provenance stamp for ``target``, minted by the cover-type policy
+    # (``CoverTypePolicy.capture_dispatch_token``) at the moment the command was
+    # booked and handed straight back to that policy when the target is later
+    # re-sent (issue #1115). It describes HOW the dispatch that produced
+    # ``target`` expressed it — a Model C day/night middle rail's inversion
+    # frame, say — which a policy asked to re-gate a resend cannot re-derive:
+    # its own per-cycle cache belongs to the last RESOLUTION, and one
+    # resolve-then-skip cycle is enough to make the two disagree. Written and
+    # cleared by exactly the statements that write and clear ``target`` so the
+    # two can never drift apart. NEVER interpreted by this manager: it stores
+    # and replays the value and nothing else (no cover-type knowledge here).
+    # ``None`` means "no dispatch provenance recorded" — every policy that does
+    # not need one, plus rehydrated/externally-seeded targets.
+    dispatch_token: Any = None
     sent_at: dt.datetime | None = None
     waiting: bool = False
     last_progress_at: dt.datetime | None = None

--- a/custom_components/adaptive_cover_pro/services/set_axes_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_axes_service.py
@@ -84,7 +84,11 @@ async def async_handle_set_axes(call: ServiceCall) -> None:
             list(entity_filter) if entity_filter is not None else list(coord.entities)
         )
         policy = coord._policy  # noqa: SLF001
-        for entity_id in entity_ids:
+        # Policy-mandated dispatch order, shared with every other dispatch seam
+        # (issue #1115). Applied here rather than at the dispatch loop below so
+        # ``resolved`` — which the loop iterates — carries the order through
+        # validation. Identity for every cover type with independent entities.
+        for entity_id in policy.order_for_dispatch(entity_ids):
             caps = coord._cover_provider.read_single_capabilities(  # noqa: SLF001
                 entity_id
             )

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -58,7 +58,12 @@ async def async_handle_set_position(call: ServiceCall) -> None:
         entity_ids: list[str] = (
             list(entity_filter) if entity_filter is not None else list(coord.entities)
         )
-        for entity_id in entity_ids:
+        # Policy-mandated dispatch order, shared with every other dispatch seam
+        # (issue #1115) — applied to an explicit entity filter too, since a
+        # Model C target block can name both rails. Identity for every cover
+        # type whose entities are physically independent.
+        ordered = coord._policy.order_for_dispatch(entity_ids)  # noqa: SLF001
+        for entity_id in ordered:
             await coord.async_apply_user_axis(
                 entity_id,
                 AXIS_NAME_POSITION,

--- a/custom_components/adaptive_cover_pro/services/set_tilt_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_tilt_service.py
@@ -59,7 +59,11 @@ async def async_handle_set_tilt(call: ServiceCall) -> None:
         entity_ids: list[str] = (
             list(entity_filter) if entity_filter is not None else list(coord.entities)
         )
-        for entity_id in entity_ids:
+        # Same policy-mandated dispatch order as ``set_position`` (issue #1115):
+        # the tilt axis falls back to the position axis on an entity without
+        # slat support, so this seam can put a real position on the wire too.
+        ordered = coord._policy.order_for_dispatch(entity_ids)  # noqa: SLF001
+        for entity_id in ordered:
             await coord.async_apply_user_axis(
                 entity_id, AXIS_NAME_TILT, requested, trigger="set_tilt", force=force
             )

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -390,7 +390,15 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
                     "Returning covers to default position: %s", default_position
                 )
                 options = self.coordinator.config_entry.options
-                for entity in self.coordinator.entities:
+                # Policy-mandated dispatch order, shared with every other
+                # dispatch seam (issue #1115): a Model C day/night shade's
+                # bottom rail must be commanded before its middle rail, which
+                # cannot physically travel past it. Identity for every cover
+                # type whose entities are independent.
+                ordered = self.coordinator._policy.order_for_dispatch(  # noqa: SLF001
+                    self.coordinator.entities
+                )
+                for entity in ordered:
                     # Sanctioned one-shot transition: auto_control was just
                     # toggled OFF; honor the user's "return to default" choice
                     # by bypassing the auto_control gate exactly once.  Without

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -28,6 +28,10 @@
     "cover_tilt_unsupported": {
       "title": "Neigung wird nicht unterstützt",
       "description": "**{name}** ist als neigungsfähiger Beschattungstyp konfiguriert, aber die Beschattung `{entity_id}` bietet keine Neigungssteuerung an (set_tilt_position). Neigungspositionen können nicht angewendet werden. Wählen Sie eine Beschattungsentität, die Neigung unterstützt, oder ändern Sie den Beschattungstyp in einen ohne Neigung."
+    },
+    "day_night_middle_rail_unset": {
+      "title": "Tag/Nacht-Mittelschiene nicht ausgewählt",
+      "description": "**{name}** ist als zweigeteiltes Tag/Nacht-Rollo konfiguriert, aber seine Mittelschienen-Beschattung ist nicht ausgewählt – oder verweist auf eine Beschattung, die nicht in der Beschattungsliste dieser Instanz enthalten ist. Beide Schienen erhalten dieselbe Position, daher verhält sich das Rollo wie eine normale Jalousie und die Mischung aus transparent und Verdunkelung wird nie angewendet. Wählen Sie die Mittelschienen-Beschattung in den Optionen der Beschattung aus, und stellen Sie sicher, dass sie auch als eine der gesteuerten Beschattungen aufgeführt ist."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -28,6 +28,10 @@
     "cover_tilt_unsupported": {
       "title": "Cover cannot tilt",
       "description": "**{name}** is configured as a tilt-capable cover type, but the cover `{entity_id}` does not advertise tilt control (set_tilt_position). Tilt positions cannot be applied to it. Pick a cover entity that supports tilt, or change the cover type to one that does not use tilt."
+    },
+    "day_night_middle_rail_unset": {
+      "title": "Day/night middle rail not selected",
+      "description": "**{name}** is configured as a two-rail day/night shade, but its middle-rail cover is not selected — or names a cover that is not in this instance's cover list. Both rails are being sent the same position, so the shade is behaving like a plain blind and the sheer/blackout blend is never applied. Pick the middle-rail cover in the cover's options, and make sure it is also listed as one of the controlled covers."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -28,6 +28,10 @@
     "cover_tilt_unsupported": {
       "title": "La protection ne peut pas s'incliner",
       "description": "**{name}** est configuré en tant que type de protection capable d'inclinaison, mais la protection `{entity_id}` n'annonce pas le contrôle d'inclinaison (set_tilt_position). Les positions d'inclinaison ne peuvent pas lui être appliquées. Sélectionnez une entité de protection qui prend en charge l'inclinaison, ou changez le type de protection pour un qui n'utilise pas l'inclinaison."
+    },
+    "day_night_middle_rail_unset": {
+      "title": "Barre intermédiaire du store jour/nuit non sélectionnée",
+      "description": "**{name}** est configuré comme store jour/nuit à deux barres, mais la protection de la barre intermédiaire n'est pas sélectionnée — ou fait référence à une protection qui ne figure pas dans la liste des protections de cette instance. Les deux barres reçoivent la même position, le store se comporte donc comme une simple protection et le mélange voilage/occultant ne sera jamais appliqué. Sélectionnez la protection de la barre intermédiaire dans les options de cette protection, et assurez-vous qu'elle figure aussi parmi les protections contrôlées."
     }
   },
   "config": {

--- a/tests/services/test_set_tilt_service.py
+++ b/tests/services/test_set_tilt_service.py
@@ -22,12 +22,17 @@ from custom_components.adaptive_cover_pro.const import (
 
 
 def _make_coord(*, entities: list[str] | None = None):
+    from custom_components.adaptive_cover_pro.const import CoverType
     from custom_components.adaptive_cover_pro.coordinator import (
         AdaptiveDataUpdateCoordinator,
     )
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
 
     coord = MagicMock()
     coord.entities = entities or ["cover.venetian"]
+    # The service reads the policy's ordered dispatch view (#1115); a MagicMock
+    # policy would hand back a MagicMock that iterates as empty.
+    coord._policy = get_policy(CoverType.VENETIAN)
     coord.async_apply_user_tilt = AsyncMock(return_value=("sent", ""))
     coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
     # set_tilt now routes through the axis collapse point (issue #725); bind the

--- a/tests/test_coordinator_coverage.py
+++ b/tests/test_coordinator_coverage.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.managers.toggles import ToggleManager
 
 
@@ -433,6 +434,8 @@ async def test_window_close_skips_reposition_when_auto_control_off():
     config_entry.options = {}
     coord.config_entry = config_entry
     coord.entities = []
+    # Real policy: the dispatch loops ask it for the entity order (#1115).
+    coord._policy = get_policy("cover_blind")
     coord._inverse_state = False
     from custom_components.adaptive_cover_pro.diagnostics.event_buffer import (
         EventBuffer,
@@ -598,6 +601,8 @@ async def test_window_close_skips_reposition_when_custom_position_active():
     coord._track_end_time = True
     coord._inverse_state = False
     coord.entities = [MagicMock()]
+    # Real policy: the dispatch loops ask it for the entity order (#1115).
+    coord._policy = get_policy("cover_blind")
     coord.hass = MagicMock()
     coord._pipeline_result = SimpleNamespace(
         control_method=ControlMethod.CUSTOM_POSITION

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -24,6 +24,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONTROL_MODEL,
+    CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_MAX_POSITION,
     CONF_MIN_POSITION,
     CUSTOM_POSITION_SAFETY_PRIORITY,
@@ -36,6 +38,7 @@ from custom_components.adaptive_cover_pro.const import (
     ISSUE_COVER_NOT_MOVING,
     ISSUE_COVER_TILT_UNSUPPORTED,
     ISSUE_COVER_UNAVAILABLE,
+    ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
 )
@@ -140,6 +143,9 @@ def _make_coord(
     # tilt-declaring policy explicitly.
     coord._policy = policy if policy is not None else get_policy("cover_blind")
     coord._a3_issue_keys = set()
+    # B3 (issue #1115): entry-scoped like B1/B2 — the policy answers whether a
+    # required role entity (the Model C day/night middle rail) is unfilled.
+    coord._role_entity_issue_key = f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{_ENTRY}"
     coord._resolved_options = options or {}
     return coord
 
@@ -908,3 +914,102 @@ async def test_a3_fail_open_on_predicate_exception():
     coord.logger.debug.assert_called_once()
     assert "A3 predicate failed" in coord.logger.debug.call_args.args[0]
     assert coord.logger.debug.call_args.args[1] == "cover.a"
+
+
+# --- B3: a bound role entity the cover type requires is unfilled (issue #1115)
+#
+# B3 is entry-scoped config coherence, shaped like B1/B2 but sourced from a
+# polymorphic policy predicate like A3. A Model C (dual_entity) day/night shade
+# binds a SECOND cover entity to the middle-rail role; with that pick unset — or
+# naming a cover outside this instance's list — the middle rail is never remapped
+# and the shade silently behaves like a plain vertical blind. The coordinator
+# never branches on cover type: it asks ``required_role_entity_missing``.
+
+_DUAL_ENTITIES = ["cover.bottom_rail", "cover.middle_rail"]
+
+
+def _dual_entity_coord(*, middle: str | None, entities: list[str] | None = None):
+    """Coordinator stub carrying a Model C day/night policy + its options."""
+    policy = get_policy("cover_day_night_shade")
+    coord = _make_coord(
+        states={
+            "sun.sun": "above_horizon",
+            "cover.bottom_rail": "open",
+            "cover.middle_rail": "open",
+        },
+        entities=_DUAL_ENTITIES if entities is None else entities,
+        policy=policy,
+    )
+    options: dict = {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY}
+    if middle is not None:
+        options[CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY] = middle
+    return coord, options
+
+
+async def test_b3_raises_when_middle_rail_unset():
+    """A Model C entry with no middle rail configured raises the B3 Repair."""
+    coord, options = _dual_entity_coord(middle=None)
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_b3_raises_when_middle_rail_not_among_covers():
+    """A middle rail naming a cover outside the instance's list also raises."""
+    coord, options = _dual_entity_coord(middle="cover.not_configured")
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{_ENTRY}" in _raised_keys(create)
+
+
+async def test_b3_no_raise_when_middle_rail_set():
+    """A coherent Model C entry raises nothing."""
+    coord, options = _dual_entity_coord(middle="cover.middle_rail")
+    create, _delete = await _run(coord, options)
+    assert f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b3_no_raise_for_other_cover_types():
+    """A blind (no bound role entity) never raises B3, whatever the options."""
+    coord = _make_coord(
+        states={"sun.sun": "above_horizon", "cover.a": "open"},
+        entities=["cover.a"],
+    )  # default policy = blind
+    create, _delete = await _run(coord, {})
+    assert f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{_ENTRY}" not in _raised_keys(create)
+
+
+async def test_b3_clears_on_recovery():
+    """Once the middle rail is picked, the B3 Repair is deleted."""
+    coord, options = _dual_entity_coord(middle=None)
+    key = f"{ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET}_{_ENTRY}"
+    await _run(coord, options)  # cycle 1: raise
+    options[CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY] = "cover.middle_rail"
+    _create, delete = await _run(coord, options)  # cycle 2: recovered
+    assert key in {call.args[2] for call in delete.call_args_list}
+
+
+async def test_b3_fail_open_on_predicate_exception():
+    """A raising B3 predicate must not starve A1/A2/A3/B1/B2/C1.
+
+    Same per-check guard shape as A2/A3: the predicate call sits in its own
+    narrow try, so a policy blowing up is logged and skipped while
+    ``evaluate()`` still runs and a concurrently-unhealthy C1 still raises.
+    """
+    coord, options = _dual_entity_coord(middle=None)
+    coord.hass.states._d["sun.sun"] = _State("unavailable")
+    coord.logger = MagicMock()
+    coord._policy = MagicMock()
+    coord._policy.tilt_capability_contradiction.return_value = False
+    coord._policy.required_role_entity_missing.side_effect = RuntimeError("boom")
+    with (
+        patch(f"{_BASE}.ir.async_create_issue") as create,
+        patch(f"{_BASE}.ir.async_delete_issue"),
+        patch(f"{_COORD}.ir.async_get", return_value=SimpleNamespace(issues={})),
+        patch(f"{_COORD}.ir.async_delete_issue"),
+    ):
+        coord._evaluate_health_checks(options)
+        await _drain()
+    assert f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}" in _raised_keys(create)
+    assert any(
+        "B3 predicate failed" in str(call.args[0])
+        for call in coord.logger.debug.call_args_list
+    )

--- a/tests/test_coordinator_integration.py
+++ b/tests/test_coordinator_integration.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 
 # ---------------------------------------------------------------------------
@@ -99,6 +100,9 @@ def _make_coordinator(
     coordinator._pending_cover_events = [state_data]
     coordinator._target_just_reached = set()
     coordinator._cover_type = "cover_blind"
+    # Real policy: the dispatch loops ask it for the entity order (issue #1115),
+    # so a bare MagicMock would hand back an unusable sort key.
+    coordinator._policy = get_policy(coordinator._cover_type)
     coordinator.manual_reset = False
     coordinator.manual_threshold = None
     coordinator.manager = MagicMock()

--- a/tests/test_coordinator_lifecycle.py
+++ b/tests/test_coordinator_lifecycle.py
@@ -534,3 +534,41 @@ async def test_coordinator_wires_post_settle_mode_into_sequencer(
     seq = coordinator._policy.sequencer
     assert seq is not None
     assert seq._post_settle_mode == VENETIAN_POST_SETTLE_MODE_ENTITY_STATE
+
+
+async def test_coordinator_shares_its_own_policy_with_the_command_service(
+    hass: HomeAssistant,
+) -> None:
+    """The command service gets the entry's OWN policy object (issue #1115).
+
+    ``CoverCommandService`` falls back to building a private policy from the
+    cover-type string when none is passed. That fallback is fine for the
+    stateless axis/capability queries, and silently wrong for everything else:
+    the private instance is never primed by ``post_pipeline_resolve`` and never
+    ``attach``ed, so a stateful policy answers every question this manager asks
+    with its unprimed default. The Model C day/night rail order
+    (``order_for_dispatch``) collapses to identity and the travel clearance
+    (``await_dispatch_clearance``) to an unconditional yes — the manager keeps
+    running, silently unsequenced.
+
+    Identity, not equality: a fresh ``get_policy()`` compares indistinguishable
+    while being exactly the wrong object.
+    """
+    from homeassistant import config_entries as ha_config_entries
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Policy Cover", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=dict(VERTICAL_OPTIONS),
+        entry_id="policy_share_01",
+        title="Policy Cover",
+    )
+    entry.add_to_hass(hass)
+
+    token = ha_config_entries.current_entry.set(entry)
+    try:
+        coordinator = AdaptiveDataUpdateCoordinator(hass)
+    finally:
+        ha_config_entries.current_entry.reset(token)
+
+    assert coordinator._cmd_svc._policy is coordinator._policy

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -1199,6 +1199,91 @@ class TestDualEntityCapabilityWarnings:
         )
         assert warn == []
 
+    def test_warns_when_middle_rail_unset(self) -> None:
+        """An ABSENT middle rail must warn too (issue #1115).
+
+        ``if middle and middle not in known`` short-circuits on the unset value,
+        so a Model C instance with no middle rail configured used to pass config
+        validation silently and then behave like a plain vertical blind at
+        runtime — both rails driven to the bottom rail's position.
+        """
+        policy = DayNightShadePolicy()
+        opts = {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY}
+        warn = policy.capability_warnings_for_options(
+            {
+                _BOTTOM: {"has_set_position": True, "has_set_tilt_position": True},
+                _MIDDLE: {"has_set_position": True, "has_set_tilt_position": True},
+            },
+            opts,
+        )
+        assert any("middle-rail" in w for w in warn)
+
+    def test_no_unset_warning_for_other_models(self) -> None:
+        """Models A and B bind no middle rail — an absent value is not a problem."""
+        policy = DayNightShadePolicy()
+        known = {
+            _BOTTOM: {"has_set_position": True, "has_set_tilt_position": True},
+            _MIDDLE: {"has_set_position": True, "has_set_tilt_position": True},
+        }
+        for model in (DAY_NIGHT_MODEL_POSITION_TILT, DAY_NIGHT_MODEL_SPLIT_RANGE):
+            warn = policy.capability_warnings_for_options(
+                known, {CONF_DAY_NIGHT_CONTROL_MODEL: model}
+            )
+            assert warn == []
+
+
+class TestDualEntityRequiredRoleEntity:
+    """``required_role_entity_missing`` drives the B3 runtime Repair (issue #1115)."""
+
+    def test_true_when_middle_rail_unset(self) -> None:
+        policy = DayNightShadePolicy()
+        assert (
+            policy.required_role_entity_missing(
+                {CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY},
+                [_BOTTOM, _MIDDLE],
+            )
+            is True
+        )
+
+    def test_true_when_middle_rail_not_among_covers(self) -> None:
+        policy = DayNightShadePolicy()
+        assert (
+            policy.required_role_entity_missing(
+                {
+                    CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+                    CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: "cover.not_configured",
+                },
+                [_BOTTOM, _MIDDLE],
+            )
+            is True
+        )
+
+    def test_false_when_coherent(self) -> None:
+        policy = DayNightShadePolicy()
+        assert (
+            policy.required_role_entity_missing(
+                {
+                    CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+                    CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _MIDDLE,
+                },
+                [_BOTTOM, _MIDDLE],
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "model", [DAY_NIGHT_MODEL_POSITION_TILT, DAY_NIGHT_MODEL_SPLIT_RANGE]
+    )
+    def test_false_for_models_a_and_b(self, model: str) -> None:
+        """Only Model C binds a second rail entity — A/B never report a gap."""
+        policy = DayNightShadePolicy()
+        assert (
+            policy.required_role_entity_missing(
+                {CONF_DAY_NIGHT_CONTROL_MODEL: model}, [_BOTTOM]
+            )
+            is False
+        )
+
 
 def test_geometry_schema_has_middle_rail_picker() -> None:
     import voluptuous as vol

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -144,6 +144,31 @@ def test_resolve_entity_target_identity_default(policy: CoverTypePolicy) -> None
 
 
 @pytest.mark.unit
+def test_dispatch_order_key_default_is_zero(policy: CoverTypePolicy) -> None:
+    """Every policy leaves the dispatch order untouched by default (issue #1115).
+
+    ``dispatch_order_key`` feeds ``sorted(...)`` at the coordinator's dispatch
+    seams. A constant key makes that a stable-sort no-op, so the user's
+    config-flow pick order survives for every cover type that does not need
+    rail sequencing.
+    """
+    assert policy.dispatch_order_key("cover.x") == 0
+    assert policy.dispatch_order_key("cover.y") == 0
+
+
+@pytest.mark.unit
+def test_required_role_entity_missing_default_false(policy: CoverTypePolicy) -> None:
+    """No cover type reports a missing role entity by default (B3, issue #1115).
+
+    Only a cover type that binds a SECOND entity to a named physical role (the
+    Model C day/night middle rail) can have that role unfilled. Every other
+    policy — and a coherent day/night entry — must answer ``False`` so the
+    generic B3 Repair never false-fires.
+    """
+    assert policy.required_role_entity_missing({}, ["cover.x", "cover.y"]) is False
+
+
+@pytest.mark.unit
 def test_position_for_intent_returns_open_or_closed(policy: CoverTypePolicy) -> None:
     """``position_for_intent`` returns 0 or 100, and the two intents differ."""
     pos_through = policy.position_for_intent(sun_through=True)

--- a/tests/test_day_night_dual_entity.py
+++ b/tests/test_day_night_dual_entity.py
@@ -564,3 +564,60 @@ async def test_auto_control_off_seam_never_inverts_middle_rail() -> None:
     assert cmd_svc.get_target(_BOTTOM) == 60
     assert cmd_svc.get_target(_MIDDLE) == 80  # open-space, never inverted
     assert cmd_svc.get_target(_MIDDLE) >= cmd_svc.get_target(_BOTTOM)
+
+
+# ---------------------------------------------------------------------------
+# A withheld middle-rail command keeps the cycle's target signature unrecorded
+# so the next cycle re-attempts it (issue #1115, reusing #756's latch)
+# ---------------------------------------------------------------------------
+
+
+def _latch_coordinator(policy: DayNightShadePolicy) -> MagicMock:
+    coord = MagicMock()
+    coord.entities = [_BOTTOM, _MIDDLE]
+    coord._policy = policy
+    coord.state_change = False
+    coord._last_dispatched_target_sig = None
+    coord._resolved_target_signature = MagicMock(return_value=("solar", 40))
+    coord.async_handle_state_change = AsyncMock()
+    coord._async_force_send_pipeline_position = AsyncMock()
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_pending_middle_rail_withholds_dispatched_target_signature() -> None:
+    """A deferred middle-rail command must not look "already dispatched".
+
+    ``_dispatch_for_cycle`` records this cycle's resolved-target signature only
+    when no cover still has a pending secondary-axis/rail command. Recording it
+    while the middle rail's command is withheld would make the next cycle see an
+    unchanged target and never retry, stranding the middle rail (the #756 failure
+    mode, reached here through the #1115 travel gate).
+    """
+    policy = _dual_policy(position=40, blend=50)
+    policy._pending_middle_rail.add(_MIDDLE)
+    coord = _latch_coordinator(policy)
+
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coord,
+        40,
+        {},
+        auto_expired=False,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+    assert coord._last_dispatched_target_sig is None
+
+    # Once the gate clears the latch, the signature is recorded as normal.
+    policy._pending_middle_rail.clear()
+    await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
+        coord,
+        40,
+        {},
+        auto_expired=False,
+        custom_position_released_entities=set(),
+        safety_release=False,
+        template_release=False,
+    )
+    assert coord._last_dispatched_target_sig == ("solar", 40)

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -23,6 +23,8 @@ Two independent mechanisms fix that, and this module covers both:
 
 from __future__ import annotations
 
+import ast
+import pathlib
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,7 +33,9 @@ import pytest
 from custom_components.adaptive_cover_pro.const import (
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+    CONF_ENTITIES,
     CONF_INVERSE_STATE,
+    CONF_MY_POSITION_VALUE,
     DAY_NIGHT_MODEL_DUAL_ENTITY,
     ControlMethod,
 )
@@ -208,6 +212,165 @@ async def test_force_send_commands_bottom_rail_before_middle() -> None:
 
     assert sent == {_BOTTOM, _MIDDLE}
     assert [eid for eid, _pos in coordinator._cmd_svc.calls] == [_BOTTOM, _MIDDLE]
+
+
+# ---------------------------------------------------------------------------
+# Ordering — the user-command fan-out seams
+# ---------------------------------------------------------------------------
+# A user command is the worst place to lose the rail order, because the same
+# press engages manual override: the middle rail's command gets dropped by the
+# clearance gate (it polls a bottom rail that has not been commanded yet and
+# times out), and the override then blocks the pending-latch retry on every
+# later cycle. The shade stays in a wrong split until the user intervenes again.
+
+
+def _record_user_commands(coordinator, method_name: str) -> list[str]:
+    """Replace one user-command entry point with an order-recording stub."""
+    sent: list[str] = []
+
+    async def _record(entity_id, *_args, **_kwargs):
+        sent.append(entity_id)
+
+    setattr(coordinator, method_name, AsyncMock(side_effect=_record))
+    return sent
+
+
+@pytest.mark.asyncio
+async def test_my_position_button_commands_bottom_rail_before_middle() -> None:
+    """The My Position button fans its preset out in policy-mandated rail order."""
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverMyPositionButton,
+    )
+
+    button = MagicMock()
+    button._entities = [_MIDDLE, _BOTTOM]
+    button.config_entry.options = {CONF_MY_POSITION_VALUE: 60}
+    button.coordinator._policy = _dual_policy(position=40, blend=50)
+    sent = _record_user_commands(button.coordinator, "async_apply_user_position")
+
+    await AdaptiveCoverMyPositionButton.async_press(button)
+
+    assert sent == [_BOTTOM, _MIDDLE]
+
+
+@pytest.mark.asyncio
+async def test_set_position_service_commands_bottom_rail_before_middle(
+    monkeypatch,
+) -> None:
+    """``adaptive_cover_pro.set_position`` over a whole instance orders its fan-out."""
+    from custom_components.adaptive_cover_pro.services import set_position_service
+
+    coord = MagicMock()
+    coord.entities = [_MIDDLE, _BOTTOM]
+    coord._policy = _dual_policy(position=40, blend=50)
+    sent = _record_user_commands(coord, "async_apply_user_axis")
+    monkeypatch.setattr(
+        set_position_service, "_resolve_targets", lambda _hass, _call: {coord: None}
+    )
+    call = MagicMock()
+    call.data = {"position": 40, "force": False}
+
+    await set_position_service.async_handle_set_position(call)
+
+    assert sent == [_BOTTOM, _MIDDLE]
+
+
+@pytest.mark.asyncio
+async def test_set_tilt_service_commands_bottom_rail_before_middle(
+    monkeypatch,
+) -> None:
+    """``set_tilt`` shares the collapse point, so it shares the ordering too.
+
+    The tilt axis falls back to the position axis on an entity without slat
+    support (#684), which puts a real position on the wire — the same seam
+    shape, and the same reason to order it.
+    """
+    from custom_components.adaptive_cover_pro.services import set_tilt_service
+
+    coord = MagicMock()
+    coord.entities = [_MIDDLE, _BOTTOM]
+    coord._policy = _dual_policy(position=40, blend=50)
+    sent = _record_user_commands(coord, "async_apply_user_axis")
+    monkeypatch.setattr(
+        set_tilt_service, "_resolve_targets", lambda _hass, _call: {coord: None}
+    )
+    call = MagicMock()
+    call.data = {"tilt": 30, "force": False}
+
+    await set_tilt_service.async_handle_set_tilt(call)
+
+    assert sent == [_BOTTOM, _MIDDLE]
+
+
+@pytest.mark.asyncio
+async def test_set_axes_service_commands_bottom_rail_before_middle(
+    monkeypatch,
+) -> None:
+    """``set_axes`` validates up front, then dispatches in rail order."""
+    from custom_components.adaptive_cover_pro.services import set_axes_service
+
+    coord = MagicMock()
+    coord.entities = [_MIDDLE, _BOTTOM]
+    coord._policy = _dual_policy(position=40, blend=50)
+    coord._cover_provider.read_single_capabilities = MagicMock(
+        return_value={"has_set_position": True, "has_set_tilt_position": True}
+    )
+    sent = _record_user_commands(coord, "async_apply_user_axis")
+    monkeypatch.setattr(
+        set_axes_service, "_resolve_targets", lambda _hass, _call: {coord: None}
+    )
+    call = MagicMock()
+    call.data = {"axes": {"position": 40}, "force": False}
+
+    await set_axes_service.async_handle_set_axes(call)
+
+    assert sent == [_BOTTOM, _MIDDLE]
+
+
+def _group_fan_out_to_one_member(member_coord) -> MagicMock:
+    """Build a GroupCoordinator-shaped stub that fans out to one ACP member."""
+    member_entry = MagicMock()
+    member_entry.options = {CONF_ENTITIES: [_MIDDLE, _BOTTOM]}
+
+    async def _fan_out(member, _generic, **_kwargs):
+        await member(member_entry, member_coord)
+
+    group = MagicMock()
+    group._fan_out_commands = AsyncMock(side_effect=_fan_out)
+    group.async_refresh = AsyncMock()
+    return group
+
+
+@pytest.mark.asyncio
+async def test_group_cover_slider_commands_bottom_rail_before_middle() -> None:
+    """A cover group dragging its slider orders each member's own rails."""
+    from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+
+    member_coord = MagicMock()
+    member_coord._policy = _dual_policy(position=40, blend=50)
+    sent = _record_user_commands(member_coord, "async_apply_user_position")
+
+    await GroupCoordinator.async_set_position(
+        _group_fan_out_to_one_member(member_coord), 40
+    )
+
+    assert sent == [_BOTTOM, _MIDDLE]
+
+
+@pytest.mark.asyncio
+async def test_group_cover_tilt_commands_bottom_rail_before_middle() -> None:
+    """The group tilt slider rides the same per-member ordered view."""
+    from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
+
+    member_coord = MagicMock()
+    member_coord._policy = _dual_policy(position=40, blend=50)
+    sent = _record_user_commands(member_coord, "async_apply_user_tilt")
+
+    await GroupCoordinator.async_set_tilt(
+        _group_fan_out_to_one_member(member_coord), 30
+    )
+
+    assert sent == [_BOTTOM, _MIDDLE]
 
 
 # ---------------------------------------------------------------------------
@@ -609,3 +772,166 @@ async def test_model_a_before_position_command_still_pre_sends_blend() -> None:
 
     assert result is not False  # never withholds
     seq._send_tilt_command.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Structural guard — every position fan-out seam consumes order_for_dispatch
+# ---------------------------------------------------------------------------
+# Converting the seams one at a time is an enumeration, and an enumeration is
+# only ever as complete as the last person who read the codebase: three
+# user-command seams (My Position, set_position, set_axes) were missed on the
+# first pass at issue #1115. This scan closes the CLASS of mistake — a new
+# dispatch seam that iterates the raw config pick order fails here rather than
+# shipping and stalling somebody's shade.
+#
+# Same shape as the source-scan guards in ``tests/test_cover_types/test_axes.py``
+# (hardcoded ``caps.get("has_*")``, cover-type literals, tilt-mode strings):
+# walk the production tree, collect offenders, assert the list is empty with a
+# message that says what to do instead.
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+_PRODUCTION_ROOT = _REPO_ROOT / "custom_components" / "adaptive_cover_pro"
+
+# Calls that put a position on the wire for ONE cover. A ``for`` loop whose body
+# reaches any of these is fanning a position out over a collection of the
+# instance's covers, which is exactly where the rail order has to be decided.
+#
+# ``async_apply_user_tilt`` is in the set because the tilt axis falls back to the
+# position axis on an entity without slat support (#684). Stop dispatch
+# (``async_apply_user_stop``, ``stop_all``) is deliberately absent: a stop has no
+# travel target, so there is no clearance to sequence against.
+_POSITION_DISPATCH_CALLS = frozenset(
+    {
+        "apply_position",  # CoverCommandService — the real chokepoint
+        "_dispatch_to_cover",  # coordinator's per-cover dispatch helper
+        "async_apply_user_position",  # user-command entry point
+        "async_apply_user_axis",  # axis-generic user-command entry point
+        "async_apply_user_tilt",  # falls back to the position axis (#684)
+    }
+)
+_ORDER_VIEW = "order_for_dispatch"
+
+# Raw entity-collection expressions. A matched loop iterating one of these is
+# unordered by construction, whatever else its enclosing function does — this
+# catches a half-converted function that still has one raw loop in it.
+_RAW_ENTITY_ATTRS = frozenset({"entities", "_entities"})
+
+# Modules expected to contain at least one seam. A rename that makes the scan
+# stop matching (say ``apply_position`` gets renamed) would otherwise leave this
+# guard silently green over zero call sites.
+_SEAM_MODULES = frozenset(
+    {
+        "button.py",
+        "coordinator.py",
+        "group_coordinator.py",
+        "switch.py",
+        "services/set_position_service.py",
+        "services/set_tilt_service.py",
+        "services/set_axes_service.py",
+        "state/window_transition_tracker.py",
+    }
+)
+
+# (module path relative to the production root, innermost enclosing function) →
+# why that seam legitimately does not call ``order_for_dispatch`` itself.
+_ORDERING_EXEMPT = {
+    ("state/window_transition_tracker.py", "check_sunset_window"): (
+        "Receives an already-ordered entity list. The tracker is HA-boundary "
+        "code with no policy handle, so the coordinator applies "
+        "order_for_dispatch at the call site "
+        "(_check_sunset_window_transition, entities=...)."
+    ),
+}
+
+
+def _called_names(node: ast.AST) -> set[str]:
+    """Every callee name reachable from ``node`` (attribute or bare name)."""
+    names: set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            func = sub.func
+            if isinstance(func, ast.Attribute):
+                names.add(func.attr)
+            elif isinstance(func, ast.Name):
+                names.add(func.id)
+    return names
+
+
+def _is_raw_entity_collection(node: ast.expr) -> bool:
+    """Whether this ``for`` iterable is a raw, unordered entity collection."""
+    # self.entities / coord.entities / self.coordinator.entities / self._entities
+    if isinstance(node, ast.Attribute) and node.attr in _RAW_ENTITY_ATTRS:
+        return True
+    # entry.options.get(CONF_ENTITIES, [])
+    return bool(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "get"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "CONF_ENTITIES"
+    )
+
+
+def _dispatch_loops(tree: ast.AST) -> list[tuple[ast.stmt, ast.AST | None]]:
+    """Every position fan-out loop, paired with its innermost enclosing function."""
+    found: list[tuple[ast.stmt, ast.AST | None]] = []
+
+    def walk(node: ast.AST, enclosing: ast.AST | None) -> None:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            enclosing = node
+        if isinstance(node, ast.For | ast.AsyncFor) and (
+            _called_names(node) & _POSITION_DISPATCH_CALLS
+        ):
+            found.append((node, enclosing))
+        for child in ast.iter_child_nodes(node):
+            walk(child, enclosing)
+
+    walk(tree, None)
+    return found
+
+
+@pytest.mark.unit
+def test_every_position_fan_out_seam_consumes_order_for_dispatch() -> None:
+    """Fail if a loop fans a position out over covers without the ordered view.
+
+    Wrap the iteration in ``self._policy.order_for_dispatch(...)`` — the single
+    shared view that expresses ``dispatch_order_key`` once (CODING_GUIDELINES.md
+    "No Code Duplication", issue #1115). It is a stable sort with a constant
+    default key, so it is an exact no-op for every cover type whose entities are
+    physically independent. If a seam genuinely receives an already-ordered list
+    from its caller, add it to ``_ORDERING_EXEMPT`` with the reason.
+    """
+    offenders: list[str] = []
+    seen_modules: set[str] = set()
+
+    for path in sorted(_PRODUCTION_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        module = path.relative_to(_PRODUCTION_ROOT).as_posix()
+        for loop, enclosing in _dispatch_loops(tree):
+            seen_modules.add(module)
+            fn_name = getattr(enclosing, "name", "<module>")
+            where = f"{path.relative_to(_REPO_ROOT)}:{loop.lineno} ({fn_name})"
+            if _is_raw_entity_collection(loop.iter):
+                offenders.append(
+                    f"{where}: iterates the raw collection "
+                    f"{ast.unparse(loop.iter)!r}"
+                )
+                continue
+            if (module, fn_name) in _ORDERING_EXEMPT:
+                continue
+            if enclosing is None or _ORDER_VIEW not in _called_names(enclosing):
+                offenders.append(f"{where}: never calls {_ORDER_VIEW}")
+
+    missing = _SEAM_MODULES - seen_modules
+    assert not missing, (
+        "The dispatch-seam scan found no position fan-out in: "
+        f"{sorted(missing)}. Either the seam moved (update _SEAM_MODULES) or a "
+        f"dispatch entry point was renamed (update _POSITION_DISPATCH_CALLS) — "
+        "until then this guard is watching nothing."
+    )
+    assert not offenders, (
+        "Position fan-out seams that skip the policy's dispatch order "
+        "(issue #1115) — wrap the iteration in "
+        "self._policy.order_for_dispatch(...):\n  " + "\n  ".join(offenders)
+    )

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -767,12 +767,25 @@ def _reconcile_harness(
     position: int,
     blend: int | None,
     targets: dict[str, int],
+    tokens: dict[str, bool] | None = None,
 ):
     """Build a ``CoverCommandService`` primed for a reconciliation pass.
 
     ``targets`` is inserted in the given order, which is the order
     ``iter_targets`` yields — pass the middle rail first to model the user's
     config pick order putting it there.
+
+    Seeding goes through ``set_target``, the single production writer of the
+    ``(target, dispatch_token)`` pair, so this harness cannot manufacture a
+    state production could not reach. A raw ``s.target = ...`` leaves the stamp
+    at ``None``, and every pass built on it quietly exercises the policy's
+    no-provenance fallback instead of the stamp mechanism the tests are named
+    after (issue #1115).
+
+    ``tokens`` names the frame a rail's target was booked in, for a test
+    modelling a seam that dispatched in its own space. A rail left out of it
+    gets the stamp ``capture_dispatch_token`` mints right now — which is what a
+    dispatch in the install's own frame books.
     """
     cmd_svc, policy, rails, events = _rail_harness(
         script=script, position=position, blend=blend
@@ -780,10 +793,16 @@ def _reconcile_harness(
     cmd_svc._enable_position_matching = True
     cmd_svc._auto_control_enabled = True
     cmd_svc._in_time_window = True
+    tokens = tokens or {}
     for entity_id, target in targets.items():
-        s = cmd_svc.state(entity_id)
-        s.target = target
-        s.waiting = False
+        cmd_svc.set_target(
+            entity_id,
+            target,
+            dispatch_token=tokens.get(
+                entity_id, policy.capture_dispatch_token(entity_id)
+            ),
+        )
+        cmd_svc.state(entity_id).waiting = False
     return cmd_svc, policy, rails, events
 
 
@@ -1320,16 +1339,22 @@ async def test_reconciliation_gate_keeps_the_frame_of_the_seam_it_resends() -> N
 
     Reconciliation re-sends the number a broadcast seam put on the wire — so
     that seam's inversion frame is the one the number is expressed in, and the
-    only one the gate can legitimately un-transform it against. This cycle's
-    cached decision describes a dispatch that never happened.
+    only one the gate can legitimately un-transform it against. That frame
+    travels with the booked target as its dispatch stamp, and the stamp is what
+    the pass hands back.
 
     Here the install has inverse-state suppressed for this cycle (interpolation
-    forces ``axis_inverted`` False) while the recorded middle-rail target came
-    from a seam that named ``inverted=True`` explicitly. Read in the seam's
+    forces ``axis_inverted`` False) while the recorded middle-rail target was
+    booked by a seam that named ``inverted=True`` explicitly. Read in the seam's
     frame the bottom rail is at the very bottom of its travel and the middle
-    rail is clear; read in the cycle's frame the two swap and the rail is
+    rail is clear; read in the install's own frame the two swap and the rail is
     withheld — and, since the seam is the only thing that will ever refresh that
     target, withheld forever.
+
+    The neighbouring
+    ``test_reconciliation_resends_when_a_later_resolve_flips_the_cached_frame``
+    covers the other half: the stamp beating a policy view that has since moved
+    on. Here the point is simply that the stamp is what the pass consults.
     """
     cmd_svc, policy, _rails, events = _reconcile_harness(
         # Wire 80 == open 20 in the seam's frame: the bottom rail is low, well
@@ -1338,14 +1363,17 @@ async def test_reconciliation_gate_keeps_the_frame_of_the_seam_it_resends() -> N
         position=20,
         blend=100,  # all sheer → the middle rail's remap is identity
         targets={_MIDDLE: 20},
+        # The seam that booked this target dispatched in ITS own frame, so that
+        # is the stamp ``capture_dispatch_token`` minted for it.
+        tokens={_MIDDLE: True},
     )
     assert policy._dual_entity_inverse is False
 
-    # The broadcast seam dispatched in ITS own frame and recorded the target.
+    # The broadcast seam's remap: wire 20 is what it put on the wire.
     assert policy.resolve_entity_target(_MIDDLE, 20, inverted=True) == 20
 
     # A later cycle resolves normally but dispatches nothing (every rail held by
-    # a gate upstream of dispatch), so nothing re-states the frame.
+    # a gate upstream of dispatch), so nothing re-books this target.
     _dual_policy(position=20, blend=100, policy=policy)
 
     with _patch_caps():
@@ -1565,11 +1593,15 @@ async def test_dispatch_provenance_is_written_and_cleared_with_the_target() -> N
     cmd_svc.set_target(_MIDDLE, 40)
     assert cmd_svc.state(_MIDDLE).dispatch_token is None
 
-    # A My move IS a real outbound command, so it books a real stamp.
+    # A My move is a real outbound command but NOT a real dispatch of a number:
+    # ``stop_cover`` carries no position, so the recorded target is the user's
+    # configured My percent and no seam ever expressed it in a frame. Stamping
+    # it with the frame of the last unrelated middle-rail resolve would invent
+    # provenance — and freeze it — so it books none.
     policy.resolve_entity_target(_MIDDLE, 20, inverted=False)
     with _patch_caps():
         assert await cmd_svc.send_my_position(_MIDDLE, 55) is True
-    assert cmd_svc.state(_MIDDLE).dispatch_token is False
+    assert cmd_svc.state(_MIDDLE).dispatch_token is None
 
     # Clearing the target clears the stamp with it.
     cmd_svc.state(_MIDDLE).is_safety = False
@@ -1581,6 +1613,56 @@ async def test_dispatch_provenance_is_written_and_cleared_with_the_target() -> N
     cmd_svc.set_target(_MIDDLE, 40, dispatch_token=True)
     cmd_svc.discard_target(_MIDDLE)
     assert cmd_svc.state(_MIDDLE).dispatch_token is None
+
+
+@pytest.mark.asyncio
+async def test_my_preset_books_no_frame_so_its_gate_stays_live() -> None:
+    """A My preset has no dispatch frame, so it must not be stamped with one.
+
+    ``send_my_position`` sends ``stop_cover``, which carries no position: the
+    number it records is the user's configured My percent, and nothing resolved
+    it or expressed it in an inversion frame. Stamping it with the frame of the
+    last middle-rail RESOLVE attributes it to a dispatch that never produced it
+    — and freezes that attribution, so every later resend of that target is
+    gated against a frame chosen by an unrelated command.
+
+    Inverse-state Model C install whose last middle-rail resolve came from the
+    auto-control-off return loop, a deliberately divergent ``inverted=False``
+    space. A frozen ``False`` reads My=30 as open 30 and the bottom rail's 80 as
+    open 80, calls a clear rail blocked and withholds the resend — and, since
+    only the user's My button ever refreshes that target, withholds it forever.
+    With no stamp the policy falls back to its live record, which the next
+    ordinary cycle restates to the install's own frame: My=30 is open 70, the
+    bottom rail is open 20, and the resend goes out.
+    """
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [80], _MIDDLE: [90]},
+        position=60,
+        blend=50,
+        inverse=True,
+    )
+    assert policy._dual_entity_inverse is True
+
+    # The divergent seam resolves the middle rail un-inverted...
+    policy.resolve_entity_target(_MIDDLE, 60, inverted=False)
+    # ...and the user's My preset is recorded immediately after it.
+    with _patch_caps():
+        assert await cmd_svc.send_my_position(_MIDDLE, 30) is True
+    assert cmd_svc.get_target(_MIDDLE) == 30
+    assert cmd_svc.state(_MIDDLE).dispatch_token is None
+
+    # An ordinary later cycle resolves the rail in the install's own frame.
+    _dual_policy(position=20, blend=50, inverse=True, policy=policy)
+    policy.resolve_entity_target(_MIDDLE, 20)
+
+    cmd_svc.state(_MIDDLE).waiting = False
+    events.clear()
+    _arm_reconciliation(cmd_svc)
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
 
 
 @pytest.mark.asyncio
@@ -1621,3 +1703,145 @@ async def test_a_resend_carries_the_original_dispatch_frame_forward(
 
     assert f"send:{_MIDDLE}" in events, events
     assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_resends_the_pair_it_read_not_the_snapshot_target() -> (
+    None
+):
+    """The resent number and the stamp explaining it come from one read.
+
+    The pass takes its target snapshot before the loop starts and then awaits —
+    on the clearance gate, and on every earlier rail's own resend. An
+    ``apply_position`` landing in one of those windows re-books this entity, and
+    pairing the snapshot's target with a stamp read afterwards describes one
+    number with another number's frame. ``_prepare_service_call`` then persists
+    that mismatched pair as the record the NEXT pass gates against — the #1115
+    provenance defect re-entering through the reconciliation loop's own
+    bookkeeping.
+
+    The bottom rail's resend is the window here: it re-books the middle rail at
+    40 in an explicitly-named frame while the pass is mid-flight. The middle
+    rail must go out at 40 wearing that booking's stamp, not at the snapshot's
+    65 wearing it. Both numbers clear the gate on the readings scripted below,
+    so the verdict is not what separates them — the recorded pair is.
+
+    (A bare ``set_target`` stands in for the concurrent dispatch deliberately: a
+    full ``apply_position`` would also set ``waiting``, and step 1 would skip the
+    rail before the code under test ran.)
+    """
+    cmd_svc, _policy, _rails, events = _reconcile_harness(
+        script={_BOTTOM: [70], _MIDDLE: [90]},
+        position=30,
+        blend=50,
+        targets={_MIDDLE: 65, _BOTTOM: 90},
+    )
+    payloads: dict[str, dict] = {}
+    hass = cmd_svc._hass
+    inner = hass.services.async_call.side_effect
+
+    async def _record_and_rebook(domain, service, data, context=None):
+        await inner(domain, service, data, context=context)
+        payloads[data["entity_id"]] = dict(data)
+        if data["entity_id"] == _BOTTOM:
+            cmd_svc.set_target(_MIDDLE, 40, dispatch_token=True)
+
+    hass.services.async_call = AsyncMock(side_effect=_record_and_rebook)
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert payloads[_MIDDLE]["position"] == 40, payloads
+    assert cmd_svc.get_target(_MIDDLE) == 40
+    assert cmd_svc.state(_MIDDLE).dispatch_token is True
+
+
+@pytest.mark.asyncio
+async def test_a_rebooking_during_the_gate_cannot_split_the_resent_pair() -> None:
+    """The clearance await is a window too, and the resend must survive it intact.
+
+    The gate polls a physical rail, so a dispatch can land between the pass
+    reading its pair and the resend being booked. If the booking re-reads the
+    stamp at that point it pairs the number it is restating with a frame minted
+    for a different one — and that hybrid becomes the record the next pass gates
+    against, which is exactly the provenance defect, one loop further in. The
+    stamp therefore travels down from the same read the target came from instead
+    of being fetched again.
+
+    Which of the two numbers ends up recorded is the pre-existing stale-resend
+    question (a resend restates what the pass read); this asserts only that the
+    two halves belong to each other.
+    """
+    cmd_svc, policy, _rails, events = _reconcile_harness(
+        script={_BOTTOM: [60], _MIDDLE: [90]},
+        position=30,
+        blend=50,
+        targets={_MIDDLE: 65, _BOTTOM: 90},
+    )
+    payloads: dict[str, dict] = {}
+    hass = cmd_svc._hass
+    inner = hass.services.async_call.side_effect
+
+    async def _record(domain, service, data, context=None):
+        await inner(domain, service, data, context=context)
+        payloads[data["entity_id"]] = dict(data)
+
+    hass.services.async_call = AsyncMock(side_effect=_record)
+
+    # A concurrent dispatch re-books the middle rail while the gate is polling
+    # the bottom rail — i.e. after the pass read its pair, before it books.
+    seq = policy._sequencer
+    inner_read = seq._get_current_position
+
+    def _rebook_mid_gate(entity_id: str) -> int | None:
+        value = inner_read(entity_id)
+        if entity_id == _BOTTOM:
+            cmd_svc.set_target(_MIDDLE, 40, dispatch_token=True)
+        return value
+
+    seq._get_current_position = _rebook_mid_gate
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" in events, events
+    recorded = (payloads[_MIDDLE]["position"], cmd_svc.state(_MIDDLE).dispatch_token)
+    assert recorded in {(65, False), (40, True)}, recorded
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_skips_a_target_cleared_out_from_under_the_pass() -> None:
+    """A target cleared mid-pass is not restated from the snapshot.
+
+    Same window as above, used the other way: the bottom rail's resend clears
+    the middle rail's target (a time-window close, a reload) while the pass is
+    between its snapshot and the middle rail's turn. There is no longer a number
+    to put back on the wire, and reviving the snapshot's would re-book a target
+    something deliberately took away.
+
+    The bottom rail is parked low enough that the snapshot's 65 would sail
+    through the clearance gate, so nothing but the cleared target stops it.
+    """
+    cmd_svc, _policy, _rails, events = _reconcile_harness(
+        script={_BOTTOM: [60], _MIDDLE: [90]},
+        position=30,
+        blend=50,
+        targets={_MIDDLE: 65, _BOTTOM: 90},
+    )
+    hass = cmd_svc._hass
+    inner = hass.services.async_call.side_effect
+
+    async def _clear_middle_on_bottom_send(domain, service, data, context=None):
+        await inner(domain, service, data, context=context)
+        if data["entity_id"] == _BOTTOM:
+            cmd_svc.set_target(_MIDDLE, None)
+
+    hass.services.async_call = AsyncMock(side_effect=_clear_middle_on_bottom_send)
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_BOTTOM}" in events, events
+    assert f"send:{_MIDDLE}" not in events, events
+    assert cmd_svc.get_target(_MIDDLE) is None

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -1392,3 +1392,232 @@ async def test_gate_reads_the_seam_frame_even_when_no_blend_resolved(
 
     assert outcome[0] == "sent", outcome
     assert f"send:{_MIDDLE}" in events, events
+
+
+# ---------------------------------------------------------------------------
+# Provenance: the frame belongs to the BOOKED target, not to the last resolve
+# ---------------------------------------------------------------------------
+# ``resolve_entity_target`` runs as an ARGUMENT to ``apply_position``, so a cycle
+# that resolves and then skips on a delta gate still re-states the policy's
+# per-cycle dispatch frame — while the recorded target reconciliation resends was
+# booked by an older dispatch, in an older frame. Reading the frame off the policy
+# at resend time therefore un-transforms the number against a dispatch that never
+# happened. The frame has to travel WITH the booked target (issue #1115).
+
+
+async def _dispatch_middle_rail(
+    cmd_svc,
+    policy,
+    *,
+    position: int,
+    inverted: bool,
+    context_inverse: bool,
+) -> int:
+    """Dispatch the middle rail through the real seam and book its target.
+
+    ``resolve_entity_target`` → ``apply_position`` is exactly the production
+    chain: the remap names the seam's frame, the command service gates on it and
+    then books the resulting wire value. Clears ``waiting`` afterwards so the
+    reconciliation pass under test is not skipped as "still in transit".
+    """
+    wire = policy.resolve_entity_target(_MIDDLE, position, inverted=inverted)
+    ctx = _rail_context(policy, inverse=context_inverse)
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, wire, "end_time", ctx)
+    assert outcome[0] == "sent", outcome
+    cmd_svc.state(_MIDDLE).waiting = False
+    return wire
+
+
+def _arm_reconciliation(cmd_svc) -> None:
+    """Open the reconciliation pass's own gates (matching ``_reconcile_harness``)."""
+    cmd_svc._enable_position_matching = True
+    cmd_svc._auto_control_enabled = True
+    cmd_svc._in_time_window = True
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_never_resends_against_a_frame_the_target_never_used(
+    monkeypatch,
+) -> None:
+    """The dangerous direction: a resolve-then-skip must not unlock a blocked rail.
+
+    Inverse-state install. The auto-control-off return loop dispatches the raw
+    default UN-INVERTED and books wire 80 for the middle rail. The bottom rail
+    then drifts back up to 95 — stacked well above that target. Automatic control
+    comes back on inside the delta window: the main pipeline resolves the middle
+    rail in the install's own (inverted) frame and ``apply_position`` skips, so
+    nothing goes out but the policy's per-cycle frame is now ``True``.
+
+    Read in that frame the recorded 80 looks like open 20 and the bottom rail's
+    95 looks like open 5, so the gate calls a physically blocked rail clear and
+    resends into it — the exact mechanical block #1115 exists to prevent, on the
+    path added to prevent it. Read in the frame the number was actually
+    dispatched in, open 95 is stacked above open 80 and the command is withheld.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, rails, events = _rail_harness(
+        script={_BOTTOM: [30], _MIDDLE: [90]},
+        position=60,
+        blend=50,
+        inverse=True,
+    )
+    assert policy._dual_entity_inverse is True
+
+    # 1. The auto-control-off return loop: un-inverted, bottom rail still low.
+    wire = await _dispatch_middle_rail(
+        cmd_svc, policy, position=60, inverted=False, context_inverse=True
+    )
+    assert wire == 80
+    assert cmd_svc.get_target(_MIDDLE) == 80
+
+    # 2. The bottom rail drifts back up and stacks above that target.
+    rails.park(_BOTTOM, 95)
+
+    # 3. Automatic control returns; the cycle resolves the rail and then skips.
+    _dual_policy(position=20, blend=50, inverse=True, policy=policy)
+    events.clear()
+    policy.resolve_entity_target(_MIDDLE, 20)
+    assert events == [], events
+
+    # 4. Reconciliation resends the number the FIRST seam put on the wire.
+    _arm_reconciliation(cmd_svc)
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" not in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_resends_when_a_later_resolve_flips_the_cached_frame(
+    monkeypatch,
+) -> None:
+    """The regression direction: an unrelated resolve must not strand the rail.
+
+    Same shape as ``test_reconciliation_gate_keeps_the_frame_of_the_seam_it_resends``
+    — a seam dispatched the middle rail naming ``inverted=True`` while the cycle's
+    cached decision is ``False`` — but with one main-pipeline resolve added that
+    never dispatches. Reading the frame off the policy at resend time now flips
+    the verdict to "withhold", and since only that seam ever refreshes this
+    target, the rail is never reconciled again. Before the gate existed the
+    resend simply went out, so withholding here is a NEW regression, not merely
+    unfired protection.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # Wire 80 == open 20 in the seam's frame: the bottom rail is low, well
+        # clear of a middle rail whose wire-20 target is open 80.
+        script={_BOTTOM: [80], _MIDDLE: [90]},
+        position=20,
+        blend=100,  # all sheer → the middle rail's remap is identity
+    )
+    assert policy._dual_entity_inverse is False
+
+    wire = await _dispatch_middle_rail(
+        cmd_svc, policy, position=20, inverted=True, context_inverse=False
+    )
+    assert wire == 20
+    assert cmd_svc.get_target(_MIDDLE) == 20
+
+    # A later cycle resolves the rail in the cached frame and dispatches nothing.
+    _dual_policy(position=20, blend=100, policy=policy)
+    events.clear()
+    policy.resolve_entity_target(_MIDDLE, 20)
+    assert events == [], events
+
+    _arm_reconciliation(cmd_svc)
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_dispatch_provenance_is_written_and_cleared_with_the_target() -> None:
+    """The stamp lives and dies with the target it explains.
+
+    Every path that records a target records its provenance in the SAME call,
+    and every path that clears one clears the stamp with it. Split those apart
+    and a target booked by a path with no dispatch behind it — a rehydrated
+    target, an externally-observed My move, a window-close clear — inherits the
+    stamp of an older command, and the resend gate un-transforms it against a
+    frame it was never expressed in. That is the whole defect (issue #1115),
+    just relocated.
+    """
+    cmd_svc, policy, _rails, _events = _rail_harness(
+        script={_BOTTOM: [80], _MIDDLE: [90]},
+        position=20,
+        blend=100,
+    )
+
+    # A real dispatch stamps the frame the seam resolved the value in.
+    await _dispatch_middle_rail(
+        cmd_svc, policy, position=20, inverted=True, context_inverse=False
+    )
+    assert cmd_svc.state(_MIDDLE).dispatch_token is True
+
+    # A target recorded with no dispatch behind it carries no stamp — it must
+    # not inherit the previous command's.
+    cmd_svc.set_target(_MIDDLE, 40)
+    assert cmd_svc.state(_MIDDLE).dispatch_token is None
+
+    # A My move IS a real outbound command, so it books a real stamp.
+    policy.resolve_entity_target(_MIDDLE, 20, inverted=False)
+    with _patch_caps():
+        assert await cmd_svc.send_my_position(_MIDDLE, 55) is True
+    assert cmd_svc.state(_MIDDLE).dispatch_token is False
+
+    # Clearing the target clears the stamp with it.
+    cmd_svc.state(_MIDDLE).is_safety = False
+    cmd_svc.clear_non_safety_targets()
+    assert cmd_svc.get_target(_MIDDLE) is None
+    assert cmd_svc.state(_MIDDLE).dispatch_token is None
+
+    # ...and discarding the record takes both away outright.
+    cmd_svc.set_target(_MIDDLE, 40, dispatch_token=True)
+    cmd_svc.discard_target(_MIDDLE)
+    assert cmd_svc.state(_MIDDLE).dispatch_token is None
+
+
+@pytest.mark.asyncio
+async def test_a_resend_carries_the_original_dispatch_frame_forward(
+    monkeypatch,
+) -> None:
+    """Re-booking the same number must not re-stamp it with a newer frame.
+
+    A resend routes back through the same booking chokepoint the first dispatch
+    used, so it rewrites the recorded target — and would rewrite its provenance
+    too if the pass did not carry the original forward. Since the number going
+    back on the wire is the one the FIRST dispatch produced, its frame is still
+    that dispatch's; re-stamping it with the policy's current per-cycle view
+    would simply defer the same mismatch by one pass, and the rail would strand
+    on the tick after the one that reconciled it.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [80], _MIDDLE: [90]},
+        position=20,
+        blend=100,
+    )
+    await _dispatch_middle_rail(
+        cmd_svc, policy, position=20, inverted=True, context_inverse=False
+    )
+    _dual_policy(position=20, blend=100, policy=policy)
+    policy.resolve_entity_target(_MIDDLE, 20)
+    _arm_reconciliation(cmd_svc)
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+        # The rail never reaches the target (the script pins it at 90), so the
+        # next tick asks again — against a target the resend just re-booked.
+        cmd_svc.state(_MIDDLE).waiting = False
+        events.clear()
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -1,0 +1,611 @@
+"""Model C (dual_entity) rail travel sequencing — issue #1115.
+
+Two stacked rails hang in one headbox: sheer fabric spans head rail → middle
+rail, blackout spans middle rail → bottom rail. They share a track, so the
+middle rail physically CANNOT pass below the bottom rail. That makes the
+arithmetic no-pass clamp in ``resolve_entity_target`` (``M >= P`` on two
+numbers) necessary but not sufficient: if the bottom rail is currently stacked
+ABOVE the middle rail's target, commanding the middle rail there tells a motor
+to travel somewhere it cannot reach until the bottom rail descends past it —
+stall, over-current trip, or lost calibration.
+
+Two independent mechanisms fix that, and this module covers both:
+
+* **Ordering** — the bottom rail's command must go out before the middle
+  rail's, whatever order the user picked the covers in. Owned by
+  ``CoverTypePolicy.dispatch_order_key`` and applied by the single shared
+  ``order_for_dispatch`` view every dispatch seam consumes.
+* **The wait gate** — the middle rail's command is withheld until the bottom
+  rail's LIVE position has cleared the middle rail's target, compared in
+  open-percent space. Owned by ``DayNightShadePolicy.before_position_command``
+  and enforced at the one real chokepoint, ``CoverCommandService.apply_position``.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONTROL_MODEL,
+    CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+    CONF_INVERSE_STATE,
+    DAY_NIGHT_MODEL_DUAL_ENTITY,
+    ControlMethod,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+from custom_components.adaptive_cover_pro.cover_types.day_night_shade import (
+    DayNightShadePolicy,
+)
+from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
+
+_BOTTOM = "cover.bottom_rail"
+_MIDDLE = "cover.middle_rail"
+_SEQ = "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+
+
+class _FakeCmdSvc:
+    """Minimal command service recording the order targets were sent in."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, int]] = []
+
+    async def apply_position(
+        self, entity_id, position, reason, context=None
+    ):  # noqa: ARG002
+        self.calls.append((entity_id, position))
+        return ("sent", "set_cover_position")
+
+
+def _dual_policy(
+    *,
+    position: int,
+    blend: int,
+    middle: str = _MIDDLE,
+    inverse: bool = False,
+) -> DayNightShadePolicy:
+    """Build a real Model C policy with its per-cycle dispatch cache primed."""
+    from tests.cover_helpers import make_cover_config, make_vertical_config
+
+    policy = DayNightShadePolicy()
+    svc = MagicMock()
+    svc.get_vertical_data.return_value = make_vertical_config()
+    sun_data = MagicMock()
+    sun_data.timezone = "UTC"
+    options: dict = {
+        CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+        CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: middle,
+    }
+    if inverse:
+        options[CONF_INVERSE_STATE] = True
+    policy.post_pipeline_resolve(
+        PipelineResult(
+            position=position,
+            control_method=ControlMethod.CUSTOM_POSITION,
+            reason="custom",
+            tilt=blend,
+        ),
+        logger=MagicMock(),
+        sol_azi=180.0,
+        sol_elev=45.0,
+        sun_data=sun_data,
+        config=make_cover_config(),
+        config_service=svc,
+        options=options,
+        cover=None,
+    )
+    return policy
+
+
+# ---------------------------------------------------------------------------
+# Ordering — the bottom rail is always commanded first
+# ---------------------------------------------------------------------------
+
+
+def test_order_for_dispatch_preserves_order_for_default_policy() -> None:
+    """A cover type with independent entities keeps the user's pick order.
+
+    ``dispatch_order_key`` is a constant for every policy that does not need
+    rail sequencing, so the sort is a stable-sort no-op.
+    """
+    picked = ["cover.c", "cover.a", "cover.b"]
+    assert get_policy("cover_blind").order_for_dispatch(picked) == picked
+
+
+def test_order_for_dispatch_preserves_order_for_day_night_model_a() -> None:
+    """A day/night Model A instance drives ONE entity — nothing to reorder."""
+    policy = DayNightShadePolicy()  # default model = position_tilt (A)
+    picked = [_MIDDLE, _BOTTOM]
+    assert policy.order_for_dispatch(picked) == picked
+
+
+def test_order_for_dispatch_puts_bottom_rail_first_under_model_c() -> None:
+    """Model C sorts the middle rail last, whatever order it was picked in."""
+    policy = _dual_policy(position=40, blend=50)
+    assert policy.order_for_dispatch([_MIDDLE, _BOTTOM]) == [_BOTTOM, _MIDDLE]
+    assert policy.order_for_dispatch([_BOTTOM, _MIDDLE]) == [_BOTTOM, _MIDDLE]
+
+
+def _ordering_coordinator(policy: DayNightShadePolicy, *, entities: list[str]):
+    coordinator = MagicMock()
+    coordinator.entities = entities
+    coordinator.logger = MagicMock()
+    coordinator._policy = policy
+    coordinator._cmd_svc = _FakeCmdSvc()
+    coordinator._pipeline_result = PipelineResult(
+        position=40, control_method=ControlMethod.SOLAR, reason="solar"
+    )
+    coordinator._pipeline_is_safety_handler = False
+    coordinator._pipeline_bypasses_auto_control = False
+    coordinator.clock_window_open = True
+    coordinator.state_change = True
+    coordinator._last_state_change_entity = None
+    coordinator._custom_position_template_trigger = False
+    coordinator._check_sun_validity_transition = MagicMock(return_value=False)
+    coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
+    coordinator._build_position_context = MagicMock(return_value=MagicMock())
+    coordinator._entity_target = types.MethodType(
+        AdaptiveDataUpdateCoordinator._entity_target, coordinator
+    )
+    coordinator._dispatch_to_cover = types.MethodType(
+        AdaptiveDataUpdateCoordinator._dispatch_to_cover, coordinator
+    )
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_dispatch_cycle_commands_bottom_rail_before_middle() -> None:
+    """The main dispatch loop honours the policy's rail order (issue #1115).
+
+    The user's cover pick order is arbitrary — here the middle rail was picked
+    first. Sending its command before the bottom rail's leaves the middle motor
+    driving toward a target the (still-stacked) bottom rail is blocking, because
+    the bottom rail's own command has not even been issued yet.
+    """
+    policy = _dual_policy(position=40, blend=50)
+    coordinator = _ordering_coordinator(policy, entities=[_MIDDLE, _BOTTOM])
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=40, options={}
+    )
+
+    assert [eid for eid, _pos in coordinator._cmd_svc.calls] == [_BOTTOM, _MIDDLE]
+    # The per-rail arithmetic is unchanged by the reordering.
+    assert dict(coordinator._cmd_svc.calls) == {_BOTTOM: 40, _MIDDLE: 70}
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_commands_bottom_rail_before_middle() -> None:
+    """Startup dispatch rides the same ordered view as the main loop."""
+    policy = _dual_policy(position=40, blend=50)
+    coordinator = _ordering_coordinator(policy, entities=[_MIDDLE, _BOTTOM])
+    coordinator.manager.is_cover_manual = lambda _eid: False
+    coordinator.check_adaptive_time = True
+    coordinator._is_reload = False
+
+    await AdaptiveDataUpdateCoordinator.async_handle_first_refresh(coordinator, 40, {})
+
+    assert [eid for eid, _pos in coordinator._cmd_svc.calls] == [_BOTTOM, _MIDDLE]
+
+
+@pytest.mark.asyncio
+async def test_force_send_commands_bottom_rail_before_middle() -> None:
+    """The force-send seam orders an explicitly-supplied cover subset too."""
+    policy = _dual_policy(position=40, blend=50)
+    coordinator = _ordering_coordinator(policy, entities=[_MIDDLE, _BOTTOM])
+    coordinator.manager.is_cover_manual = lambda _eid: False
+    coordinator.clock_window_open = True
+    coordinator.automatic_control = True
+
+    sent = await AdaptiveDataUpdateCoordinator._async_force_send_pipeline_position(
+        coordinator, 40, {}, entities=[_MIDDLE, _BOTTOM]
+    )
+
+    assert sent == {_BOTTOM, _MIDDLE}
+    assert [eid for eid, _pos in coordinator._cmd_svc.calls] == [_BOTTOM, _MIDDLE]
+
+
+# ---------------------------------------------------------------------------
+# The wait gate — the middle rail waits for the bottom rail to clear its target
+# ---------------------------------------------------------------------------
+
+
+class _Rails:
+    """Scripted per-entity position readings; the final value repeats forever.
+
+    Models real motor travel: each read of the bottom rail during its descent
+    returns the next sampled position. ``log`` records every read so a test can
+    tell "gate polled and waited" from "gate proceeded immediately".
+    """
+
+    def __init__(self, script: dict[str, list[int | None]]) -> None:
+        self._script = {k: list(v) for k, v in script.items()}
+        self.log: list[str] = []
+
+    def read(self, entity_id: str) -> int | None:
+        self.log.append(entity_id)
+        values = self._script.get(entity_id) or [None]
+        return values.pop(0) if len(values) > 1 else values[0]
+
+    def park(self, entity_id: str, position: int) -> None:
+        """Park one rail at a fixed position for every subsequent read."""
+        self._script[entity_id] = [position]
+
+
+def _rail_harness(
+    *,
+    script: dict[str, list[int | None]],
+    position: int,
+    blend: int,
+    inverse: bool = False,
+):
+    """Real ``CoverCommandService`` + real Model C policy over a scripted motor.
+
+    Returns ``(cmd_svc, policy, rails, events)``. ``events`` interleaves the
+    gate's position polls (``poll:<entity>``) with the actual service calls
+    (``send:<entity>``), which is exactly the ordering the physical constraint
+    is about.
+    """
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        CoverCommandService,
+    )
+
+    rails = _Rails(script)
+    events: list[str] = []
+
+    async def _async_call(_domain, _service, data, context=None):  # noqa: ARG001
+        events.append(f"send:{data['entity_id']}")
+
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock(side_effect=_async_call)
+    state_obj = MagicMock()
+    state_obj.state = "open"
+    hass.states.get = MagicMock(return_value=state_obj)
+
+    cmd_svc = CoverCommandService(
+        hass=hass,
+        logger=MagicMock(),
+        cover_type="cover_day_night_shade",
+        grace_mgr=MagicMock(),
+        open_close_threshold=50,
+        position_tolerance=2,
+    )
+    cmd_svc._enabled = True
+    cmd_svc._get_current_position = MagicMock(side_effect=rails.read)
+
+    policy = _dual_policy(position=position, blend=blend, inverse=inverse)
+
+    def _gate_read(entity_id: str) -> int | None:
+        events.append(f"poll:{entity_id}")
+        return rails.read(entity_id)
+
+    policy.attach(
+        hass=hass,
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=_gate_read,
+        set_commanded_position=MagicMock(),
+        position_tolerance=2,
+        is_dry_run=lambda: False,
+        entities=[_BOTTOM, _MIDDLE],
+    )
+    return cmd_svc, policy, rails, events
+
+
+def _rail_context(policy, *, inverse: bool = False):
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        PositionContext,
+    )
+
+    return PositionContext(
+        auto_control=True,
+        manual_override=False,
+        sun_just_appeared=False,
+        min_change=1,
+        time_threshold=0,
+        special_positions=[0, 100],
+        inverse_state=inverse,
+        force=True,
+        policy=policy,
+    )
+
+
+def _patch_caps():
+    return patch(
+        "custom_components.adaptive_cover_pro.managers.cover_command"
+        ".check_cover_features",
+        return_value={
+            "has_set_position": True,
+            "has_set_tilt_position": False,
+            "has_open": True,
+            "has_close": True,
+            "has_stop": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_middle_rail_waits_for_bottom_rail_to_descend_past_it(
+    monkeypatch,
+) -> None:
+    """The crash repro: bottom rail stacked ABOVE the middle rail's target.
+
+    Bottom rail live at 100 (fully up), this cycle's targets are bottom 30 /
+    middle 65 (blend 50). The middle rail cannot reach 65 while the bottom rail
+    sits at 100 above it — commanding it there stalls the motor. The gate must
+    hold the middle rail's ``set_cover_position`` until a live reading shows the
+    bottom rail has descended to (or past) 65.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # Bottom: apply_position's own read, then the gate's descent samples.
+        script={_BOTTOM: [100, 100, 80, 60], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        bottom_outcome = await cmd_svc.apply_position(_BOTTOM, 30, "solar", ctx)
+        middle_outcome = await cmd_svc.apply_position(
+            _MIDDLE, policy.resolve_entity_target(_MIDDLE, 30), "solar", ctx
+        )
+
+    assert bottom_outcome[0] == "sent"
+    assert middle_outcome[0] == "sent"
+    # The bottom rail's command goes out first, then the gate polls it until the
+    # reading clears 65, and only then does the middle rail's command fire.
+    assert events.index(f"send:{_BOTTOM}") < events.index(f"send:{_MIDDLE}")
+    polls_before_send = [
+        e for e in events[: events.index(f"send:{_MIDDLE}")] if e == f"poll:{_BOTTOM}"
+    ]
+    assert len(polls_before_send) >= 2, events
+
+
+@pytest.mark.asyncio
+async def test_middle_rail_proceeds_immediately_when_bottom_already_clear(
+    monkeypatch,
+) -> None:
+    """Steady state: bottom rail already below the middle target → no waiting."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [40], _MIDDLE: [100]},
+        position=40,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 70, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    # One confirming read, no polling loop.
+    assert events.count(f"poll:{_BOTTOM}") == 1
+    assert events[-1] == f"send:{_MIDDLE}"
+
+
+@pytest.mark.asyncio
+async def test_bottom_rail_is_never_gated(monkeypatch) -> None:
+    """Only the middle rail is gated — the blocking rail must move freely."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_BOTTOM, 30, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert events == [f"send:{_BOTTOM}"]
+
+
+@pytest.mark.asyncio
+async def test_middle_rail_defers_and_latches_pending_on_timeout(
+    monkeypatch,
+) -> None:
+    """A bottom rail that never clears defers the middle command, not sends it.
+
+    The command is withheld with a ``policy_deferred`` skip and the entity is
+    latched pending, which keeps the coordinator withholding this cycle's
+    dispatched-target signature so the next cycle re-attempts the send.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
+    assert cmd_svc.last_skipped_action["reason"] == "policy_deferred"
+
+
+@pytest.mark.asyncio
+async def test_pending_latch_clears_once_the_bottom_rail_has_cleared(
+    monkeypatch,
+) -> None:
+    """The next cycle's retry sends the middle command and clears the latch."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        assert (await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx))[1] == (
+            "policy_deferred"
+        )
+        assert policy.has_pending_secondary_axis(_MIDDLE) is True
+        # Cycle 2: the bottom rail has descended to 20 — well clear of 65.
+        rails.park(_BOTTOM, 20)
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+    assert f"send:{_MIDDLE}" in events
+
+
+@pytest.mark.asyncio
+async def test_middle_rail_defers_when_bottom_rail_position_unreadable(
+    monkeypatch,
+) -> None:
+    """An unreadable bottom rail cannot be proven clear — withhold, don't guess."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [None], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+
+
+@pytest.mark.asyncio
+async def test_gate_is_inert_without_a_second_rail(monkeypatch) -> None:
+    """A degenerate Model C entry (no identifiable bottom rail) must not stall.
+
+    ``entities`` carries only the middle rail, so there is nothing to sequence
+    against. Withholding forever would brick the shade; the gate proceeds.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    policy.attach(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=MagicMock(return_value=100),
+        set_commanded_position=MagicMock(),
+        position_tolerance=2,
+        is_dry_run=lambda: False,
+        entities=[_MIDDLE],
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_MIDDLE}" in events
+
+
+# ---------------------------------------------------------------------------
+# Inverse state — the clearance test is an OPEN-PERCENT comparison (#993 class)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gate_compares_in_open_percent_not_raw_wire(monkeypatch) -> None:
+    """Inverse state on: wire numbers say "wait", open-percent says "clear".
+
+    Mirrors the existing raw middle-0 / bottom-100 inverse pair: with inversion
+    the middle rail's wire target 0 IS fully open (open 100) and the bottom
+    rail's wire reading 100 IS fully closed (open 0). The bottom rail is at the
+    very bottom of its travel — as clear of the middle rail as it can possibly
+    be — so the gate must proceed with no waiting. A naive raw comparison
+    (100 > 0) would wait forever and defer a command that is already safe.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [50]},
+        position=100,  # wire 100 == open 0 for the bottom rail
+        blend=0,  # all blackout → middle fully open (open 100 → wire 0)
+        inverse=True,
+    )
+    ctx = _rail_context(policy, inverse=True)
+    wire_middle = policy.resolve_entity_target(_MIDDLE, 100)
+    assert wire_middle == 0  # fully open on the wire
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, wire_middle, "solar", ctx)
+
+    # A wire target of 0 routes through ``close_cover`` under the endpoint
+    # substitution — the gate runs identically whichever service is emitted.
+    assert outcome[0] == "sent"
+    assert events.count(f"poll:{_BOTTOM}") == 1  # proceeded on the first read
+
+
+@pytest.mark.asyncio
+async def test_gate_still_waits_when_open_percent_is_stacked_under_inverse(
+    monkeypatch,
+) -> None:
+    """The converse: raw numbers say "clear", open-percent says "wait".
+
+    Inverse state on, middle wire target 100 (open 0 — fully closed / at the
+    bottom) while the bottom rail reads wire 0 (open 100 — fully up, stacked
+    above it). Raw ``0 <= 100`` would wave the command through into a stall; the
+    open-percent comparison correctly withholds it.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [0], _MIDDLE: [50]},
+        position=100,
+        blend=100,  # all sheer → middle coincides with the bottom rail
+        inverse=True,
+    )
+    ctx = _rail_context(policy, inverse=True)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 100, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+
+
+# ---------------------------------------------------------------------------
+# Model A must be untouched — the blend pre-send path stays byte-identical
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_model_a_before_position_command_still_pre_sends_blend() -> None:
+    """Inserting the Model C branch must not disturb Model A's tilt-first send."""
+    policy = get_policy("cover_day_night_shade")  # default model = position_tilt
+    seq = MagicMock()
+    seq._get_current_position = MagicMock(return_value=10)
+    seq._send_tilt_command = AsyncMock()
+    policy._sequencer = seq
+    ctx = MagicMock()
+    ctx.tilt = 80
+
+    result = await policy.before_position_command(
+        MagicMock(),
+        "cover.shade",
+        service="set_cover_position",
+        position=60,
+        context=ctx,
+        reason="solar",
+    )
+
+    assert result is not False  # never withholds
+    seq._send_tilt_command.assert_awaited_once()

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -15,12 +15,13 @@ Two independent mechanisms fix that, and this module covers both:
   rail's, whatever order the user picked the covers in. Owned by
   ``CoverTypePolicy.dispatch_order_key`` and applied by the single shared
   ``order_for_dispatch`` view every dispatch seam consumes.
-* **The wait gate** — the middle rail's command is withheld until the bottom
-  rail's LIVE position has cleared the middle rail's target, compared in
+* **The clearance gate** — the middle rail's command is withheld until the
+  bottom rail's LIVE position has cleared the middle rail's target, compared in
   open-percent space against the frame the DISPATCHING SEAM expressed its value
-  in. Owned by ``DayNightShadePolicy``, reached from ``before_position_command``
-  on the dispatch path (``CoverCommandService.apply_position``) and from
-  ``await_dispatch_clearance`` on the reconciliation resend path.
+  in. Owned by ``DayNightShadePolicy`` and reached through the one
+  ``await_dispatch_clearance`` hook, which ``CoverCommandService.apply_position``
+  asks before it books an outbound command and ``run_reconciliation_pass`` asks
+  (single-shot) before it re-sends a recorded one.
 
 Both mechanisms apply to every seam that puts a position on the wire, including
 the reconciliation timer — the motor does not care which code path asked.
@@ -76,14 +77,20 @@ class _FakeCmdSvc:
 def _dual_policy(
     *,
     position: int,
-    blend: int,
+    blend: int | None,
     middle: str = _MIDDLE,
     inverse: bool = False,
+    policy: DayNightShadePolicy | None = None,
 ) -> DayNightShadePolicy:
-    """Build a real Model C policy with its per-cycle dispatch cache primed."""
+    """Build a real Model C policy with its per-cycle dispatch cache primed.
+
+    Pass ``policy`` to run a LATER resolve cycle on an existing instance —
+    everything ``post_pipeline_resolve`` refreshes per cycle, without a fresh
+    object.
+    """
     from tests.cover_helpers import make_cover_config, make_vertical_config
 
-    policy = DayNightShadePolicy()
+    policy = policy if policy is not None else DayNightShadePolicy()
     svc = MagicMock()
     svc.get_vertical_data.return_value = make_vertical_config()
     sun_data = MagicMock()
@@ -411,7 +418,7 @@ def _rail_harness(
     *,
     script: dict[str, list[int | None]],
     position: int,
-    blend: int,
+    blend: int | None,
     inverse: bool = False,
 ):
     """Real ``CoverCommandService`` + real Model C policy over a scripted motor.
@@ -758,7 +765,7 @@ def _reconcile_harness(
     *,
     script: dict[str, list[int | None]],
     position: int,
-    blend: int,
+    blend: int | None,
     targets: dict[str, int],
 ):
     """Build a ``CoverCommandService`` primed for a reconciliation pass.
@@ -1180,3 +1187,208 @@ async def test_sunset_window_transition_hands_the_tracker_an_ordered_list() -> N
 
     kwargs = coord._window_tracker.check_sunset_window.await_args.kwargs
     assert kwargs["entities"] == [_BOTTOM, _MIDDLE]
+
+
+# ---------------------------------------------------------------------------
+# A withheld command must leave NOTHING behind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_policy_deferred_skip_records_no_command_state(monkeypatch) -> None:
+    """Withholding is a SKIP, so nothing about a sent command may be recorded.
+
+    A ``policy_deferred`` rail never reaches the wire. If the clearance question
+    is asked after the outbound command has already been booked, the withheld
+    rail is left carrying a tracked target, a ``waiting`` flag, a ``sent_at``
+    stamp, an open command-grace window and an ``on_command_sent`` tick — for a
+    command that does not exist. Every one of those has a live consequence: the
+    grace window suppresses genuine manual-override detection, ``waiting`` makes
+    the next reconciliation pass skip the entity, and once ``waiting`` lapses the
+    A2 health check raises "cover not moving" about a rail ACP is deliberately
+    holding still.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    cmd_svc._on_command_sent = MagicMock()
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+        # A2 reads the predicate once the transit window has lapsed; force that
+        # lapse rather than sleeping for the real backstop.
+        cmd_svc._clear_waiting(cmd_svc.state(_MIDDLE))
+        unreached = cmd_svc.is_target_unreached(_MIDDLE)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+    assert cmd_svc.get_target(_MIDDLE) is None
+    assert cmd_svc.state(_MIDDLE).waiting is False
+    assert cmd_svc.state(_MIDDLE).sent_at is None
+    cmd_svc._grace_mgr.start_command_grace_period.assert_not_called()
+    cmd_svc._on_command_sent.assert_not_called()
+    assert unreached is False
+
+
+@pytest.mark.asyncio
+async def test_dry_run_never_waits_on_the_rail_gate(monkeypatch) -> None:
+    """A simulated command must not block on a physical clearance it can't cause.
+
+    Dry run books the target so the card display stays honest, then skips
+    without touching the wire. Asking the rail gate first would stall the cycle
+    for the whole wait budget on a bottom rail nothing is going to move, and
+    report ``policy_deferred`` for a command that was never going to be sent.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # Bottom rail parked above the middle rail's target — the gate would
+        # withhold if it ran.
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    cmd_svc.dry_run = True
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome[0] == "skipped"
+    assert outcome[1] == "dry_run"
+    assert f"poll:{_BOTTOM}" not in events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation asks; it never waits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_clearance_check_never_blocks_the_timer() -> None:
+    """The reconciliation pass must not hold the timer for the wait budget.
+
+    The gate's budget (``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS``, 60 s) is
+    the reconciliation interval (``POSITION_CHECK_INTERVAL_MINUTES``, 1 min).
+    HA re-arms the interval listener before dispatching each fire, and each fire
+    is its own background task — so a pass that blocks for its whole budget on a
+    middle rail whose bottom rail is pinned (manual override, step 2 skips its
+    resend forever) is still running when the next pass starts. Two live passes
+    then mutate ``retry_count``, ``last_reconcile_at`` and the pending latch,
+    and can both drive the bottom rail.
+
+    A periodic retry loop has no business waiting: it asks "is it clear right
+    now?", withholds if not, and re-asks on the next tick. Same eventual
+    behaviour, no overlap. The settle constants are deliberately NOT patched
+    down here — the point is that the real 60 s budget is never entered.
+    """
+    cmd_svc, _policy, _rails, events = _reconcile_harness(
+        script={_BOTTOM: [95], _MIDDLE: [95]},
+        position=30,
+        blend=50,
+        targets={_MIDDLE: 65, _BOTTOM: 30},
+    )
+
+    started = dt.datetime.now(dt.UTC)
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    # One read of the bottom rail, no poll loop.
+    assert events.count(f"poll:{_BOTTOM}") == 1, events
+    assert elapsed < 10, elapsed
+    # ...and the middle rail is still withheld, exactly as a blocking wait
+    # would have withheld it.
+    assert f"send:{_MIDDLE}" not in events, events
+    assert cmd_svc.state(_MIDDLE).retry_count == 0
+
+
+# ---------------------------------------------------------------------------
+# The recorded dispatch frame belongs to the SEAM whose target is being resent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_gate_keeps_the_frame_of_the_seam_it_resends() -> None:
+    """A resend rides the frame of the dispatch that recorded the target.
+
+    Reconciliation re-sends the number a broadcast seam put on the wire — so
+    that seam's inversion frame is the one the number is expressed in, and the
+    only one the gate can legitimately un-transform it against. This cycle's
+    cached decision describes a dispatch that never happened.
+
+    Here the install has inverse-state suppressed for this cycle (interpolation
+    forces ``axis_inverted`` False) while the recorded middle-rail target came
+    from a seam that named ``inverted=True`` explicitly. Read in the seam's
+    frame the bottom rail is at the very bottom of its travel and the middle
+    rail is clear; read in the cycle's frame the two swap and the rail is
+    withheld — and, since the seam is the only thing that will ever refresh that
+    target, withheld forever.
+    """
+    cmd_svc, policy, _rails, events = _reconcile_harness(
+        # Wire 80 == open 20 in the seam's frame: the bottom rail is low, well
+        # clear of a middle rail whose wire-20 target is open 80.
+        script={_BOTTOM: [80], _MIDDLE: [90]},
+        position=20,
+        blend=100,  # all sheer → the middle rail's remap is identity
+        targets={_MIDDLE: 20},
+    )
+    assert policy._dual_entity_inverse is False
+
+    # The broadcast seam dispatched in ITS own frame and recorded the target.
+    assert policy.resolve_entity_target(_MIDDLE, 20, inverted=True) == 20
+
+    # A later cycle resolves normally but dispatches nothing (every rail held by
+    # a gate upstream of dispatch), so nothing re-states the frame.
+    _dual_policy(position=20, blend=100, policy=policy)
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_gate_reads_the_seam_frame_even_when_no_blend_resolved(
+    monkeypatch,
+) -> None:
+    """A blend-less cycle still dispatches the middle rail, so it still names a frame.
+
+    ``resolve_entity_target`` returns the position untouched when no blend
+    resolved — but the rail is dispatched all the same, and the gate that
+    follows has to un-transform that value against the frame THIS call named.
+    Recording the frame only on the remapping path leaves the gate reading
+    whatever the last dispatch (or nothing at all) left behind, which for a seam
+    naming a frame that differs from the cached flag is the wrong one.
+
+    Cycle: no blend (a non-solar, non-climate method clears it), inverse-state
+    suppressed for the cycle, and a seam dispatching with ``inverted=True``. In
+    the seam's frame the bottom rail is low and clear; in the cached frame it is
+    stacked on top of the middle rail's target and the command is withheld.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [80], _MIDDLE: [90]},
+        position=20,
+        blend=None,  # no fabric resolved this cycle
+    )
+    assert policy._dual_entity_blend is None
+    assert policy._dual_entity_inverse is False
+    ctx = _rail_context(policy, inverse=True)
+
+    wire = policy.resolve_entity_target(_MIDDLE, 20, inverted=True)
+    assert wire == 20  # identity — no blend to fold in
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, wire, "end_time", ctx)
+
+    assert outcome[0] == "sent", outcome
+    assert f"send:{_MIDDLE}" in events, events

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -17,13 +17,19 @@ Two independent mechanisms fix that, and this module covers both:
   ``order_for_dispatch`` view every dispatch seam consumes.
 * **The wait gate** — the middle rail's command is withheld until the bottom
   rail's LIVE position has cleared the middle rail's target, compared in
-  open-percent space. Owned by ``DayNightShadePolicy.before_position_command``
-  and enforced at the one real chokepoint, ``CoverCommandService.apply_position``.
+  open-percent space against the frame the DISPATCHING SEAM expressed its value
+  in. Owned by ``DayNightShadePolicy``, reached from ``before_position_command``
+  on the dispatch path (``CoverCommandService.apply_position``) and from
+  ``await_dispatch_clearance`` on the reconciliation resend path.
+
+Both mechanisms apply to every seam that puts a position on the wire, including
+the reconciliation timer — the motor does not care which code path asked.
 """
 
 from __future__ import annotations
 
 import ast
+import datetime as dt
 import pathlib
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -33,6 +39,7 @@ import pytest
 from custom_components.adaptive_cover_pro.const import (
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+    CONF_DEFAULT_HEIGHT,
     CONF_ENTITIES,
     CONF_INVERSE_STATE,
     CONF_MY_POSITION_VALUE,
@@ -430,18 +437,22 @@ def _rail_harness(
     state_obj.state = "open"
     hass.states.get = MagicMock(return_value=state_obj)
 
+    policy = _dual_policy(position=position, blend=blend, inverse=inverse)
+
     cmd_svc = CoverCommandService(
         hass=hass,
         logger=MagicMock(),
         cover_type="cover_day_night_shade",
+        # Production shares ONE policy object between the coordinator and this
+        # manager; a private instance would answer every rail question with the
+        # unprimed default.
+        policy=policy,
         grace_mgr=MagicMock(),
         open_close_threshold=50,
         position_tolerance=2,
     )
     cmd_svc._enabled = True
     cmd_svc._get_current_position = MagicMock(side_effect=rails.read)
-
-    policy = _dual_policy(position=position, blend=blend, inverse=inverse)
 
     def _gate_read(entity_id: str) -> int | None:
         events.append(f"poll:{entity_id}")
@@ -476,6 +487,58 @@ def _rail_context(policy, *, inverse: bool = False):
         force=True,
         policy=policy,
     )
+
+
+def _auto_control_off_switch(cmd_svc, policy, *, default_position: int):
+    """Build the real auto-control switch over a real cmd_svc + Model C policy.
+
+    Reproduces the return-to-default seam end to end: the switch orders the
+    rails, remaps the middle one through ``_entity_target(..., inverted=False)``
+    and dispatches both through ``apply_position`` — the chokepoint the travel
+    gate hangs off. The context carries the install's real ``inverse_state``,
+    which is exactly what diverges from the frame this seam dispatches in.
+    """
+    from custom_components.adaptive_cover_pro.managers.cover_command import (
+        PositionContext,
+    )
+    from custom_components.adaptive_cover_pro.switch import AdaptiveCoverSwitch
+
+    coord = MagicMock()
+    coord.logger = MagicMock()
+    coord.entities = [_MIDDLE, _BOTTOM]
+    coord._policy = policy
+    coord._cmd_svc = cmd_svc
+    coord.return_to_default_toggle = True
+    coord.automatic_control = False
+    coord.manager.manual_controlled = []
+    coord.config_entry.options = {CONF_DEFAULT_HEIGHT: default_position}
+    coord.async_refresh = AsyncMock()
+    coord._entity_target = types.MethodType(
+        AdaptiveDataUpdateCoordinator._entity_target, coord
+    )
+    coord._build_position_context = (
+        lambda entity, options, **kw: PositionContext(  # noqa: ARG005
+            auto_control=False,
+            manual_override=False,
+            sun_just_appeared=False,
+            min_change=1,
+            time_threshold=0,
+            special_positions=[0, 100],
+            inverse_state=True,
+            force=kw.get("force", False),
+            bypass_auto_control=kw.get("bypass_auto_control", False),
+            policy=policy,
+        )
+    )
+
+    switch = object.__new__(AdaptiveCoverSwitch)
+    switch.coordinator = coord
+    switch._key = "automatic_control"
+    switch._name = "test_switch"
+    switch._initial_state = True
+    switch._option_key = None
+    switch.schedule_update_ha_state = MagicMock()
+    return switch
 
 
 def _patch_caps():
@@ -681,6 +744,95 @@ async def test_gate_is_inert_without_a_second_rail(monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Reconciliation resends are a dispatch seam too
+# ---------------------------------------------------------------------------
+# ``run_reconciliation_pass`` re-sends recorded targets on its own timer, over
+# its own loop, through ``_execute_command`` — which never reaches
+# ``apply_position``. Both rails drifting off target therefore replay the exact
+# #1115 collision unless the pass honours the same order and the same clearance
+# the dispatch path does. Opt-in (``enable_position_matching``), but the physics
+# do not care how the command was triggered.
+
+
+def _reconcile_harness(
+    *,
+    script: dict[str, list[int | None]],
+    position: int,
+    blend: int,
+    targets: dict[str, int],
+):
+    """Build a ``CoverCommandService`` primed for a reconciliation pass.
+
+    ``targets`` is inserted in the given order, which is the order
+    ``iter_targets`` yields — pass the middle rail first to model the user's
+    config pick order putting it there.
+    """
+    cmd_svc, policy, rails, events = _rail_harness(
+        script=script, position=position, blend=blend
+    )
+    cmd_svc._enable_position_matching = True
+    cmd_svc._auto_control_enabled = True
+    cmd_svc._in_time_window = True
+    for entity_id, target in targets.items():
+        s = cmd_svc.state(entity_id)
+        s.target = target
+        s.waiting = False
+    return cmd_svc, policy, rails, events
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_resends_the_bottom_rail_before_the_middle(
+    monkeypatch,
+) -> None:
+    """A reconciliation pass fans its resends out in policy-mandated rail order."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, _policy, _rails, events = _reconcile_harness(
+        # Bottom rail already well clear of the middle rail's 65 target.
+        script={_BOTTOM: [30], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        targets={_MIDDLE: 65, _BOTTOM: 90},
+    )
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_BOTTOM}" in events, events
+    assert f"send:{_MIDDLE}" in events, events
+    assert events.index(f"send:{_BOTTOM}") < events.index(f"send:{_MIDDLE}")
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_withholds_the_middle_rail_until_the_bottom_clears(
+    monkeypatch,
+) -> None:
+    """The stall repro on the reconciliation path (issue #1115).
+
+    Both rails hold recorded targets and the bottom rail has drifted back up to
+    95, dragging the middle rail with it. Resending the middle rail's 65 while
+    the bottom is still stacked above drives the motor into a mechanical block —
+    and ``_is_cover_in_transit`` cannot save it, because a mechanically-dragged
+    rail reports ``open``, never ``closing``.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, _policy, _rails, events = _reconcile_harness(
+        script={_BOTTOM: [95], _MIDDLE: [95]},
+        position=30,
+        blend=50,
+        targets={_MIDDLE: 65, _BOTTOM: 30},
+    )
+
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_BOTTOM}" in events, events
+    assert f"send:{_MIDDLE}" not in events, events
+    # A withheld resend must not burn one of the pass's limited retries.
+    assert cmd_svc.state(_MIDDLE).retry_count == 0
+
+
+# ---------------------------------------------------------------------------
 # Inverse state — the clearance test is an OPEN-PERCENT comparison (#993 class)
 # ---------------------------------------------------------------------------
 
@@ -745,6 +897,45 @@ async def test_gate_still_waits_when_open_percent_is_stacked_under_inverse(
     assert f"send:{_MIDDLE}" not in events
 
 
+@pytest.mark.asyncio
+async def test_gate_uses_the_dispatching_seams_frame_not_the_install_flag(
+    monkeypatch,
+) -> None:
+    """Auto-control-OFF on an inverse-state install must still send the middle rail.
+
+    The return-to-default seam dispatches the raw default UN-inverted
+    (``_entity_target(..., inverted=False)``) — a deliberate contract locked by
+    ``test_auto_control_off_seam_never_inverts_middle_rail``. The
+    ``PositionContext`` it builds still carries the install's real
+    ``inverse_state=True``, so a gate that flips against THAT reads the middle
+    rail's open-space target 80 as open 20 and then waits for a bottom rail that
+    is already parked exactly where the same seam put it. The command is
+    withheld for the full wait budget and the rail never returns to default.
+
+    The gate must flip against the frame the dispatched value is actually
+    expressed in — the one ``_entity_target`` named for this very dispatch.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # The bottom rail is parked at the un-inverted default this seam sends.
+        script={_BOTTOM: [60], _MIDDLE: [100]},
+        position=60,
+        blend=50,
+        inverse=True,
+    )
+    switch = _auto_control_off_switch(cmd_svc, policy, default_position=60)
+
+    with _patch_caps():
+        await switch.async_turn_off()
+
+    # Middle rail open-space target 80 >= bottom rail 60 — already clear.
+    assert cmd_svc.get_target(_MIDDLE) == 80
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
 # ---------------------------------------------------------------------------
 # Model A must be untouched — the blend pre-send path stays byte-identical
 # ---------------------------------------------------------------------------
@@ -803,6 +994,7 @@ _PRODUCTION_ROOT = _REPO_ROOT / "custom_components" / "adaptive_cover_pro"
 _POSITION_DISPATCH_CALLS = frozenset(
     {
         "apply_position",  # CoverCommandService — the real chokepoint
+        "_execute_command",  # reconciliation's resend, which BYPASSES the above
         "_dispatch_to_cover",  # coordinator's per-cover dispatch helper
         "async_apply_user_position",  # user-command entry point
         "async_apply_user_axis",  # axis-generic user-command entry point
@@ -824,6 +1016,7 @@ _SEAM_MODULES = frozenset(
         "button.py",
         "coordinator.py",
         "group_coordinator.py",
+        "managers/cover_command/__init__.py",
         "switch.py",
         "services/set_position_service.py",
         "services/set_tilt_service.py",
@@ -833,13 +1026,20 @@ _SEAM_MODULES = frozenset(
 )
 
 # (module path relative to the production root, innermost enclosing function) →
-# why that seam legitimately does not call ``order_for_dispatch`` itself.
+# (the test in THIS module that covers the compensating control, why that seam
+# legitimately does not call ``order_for_dispatch`` itself).
+#
+# The second half of that pair is not documentation. An exemption moves the
+# ordering obligation onto some OTHER function, and nothing in this scan can see
+# whether that function still honours it — so each exemption must name a test
+# that does. See test_every_ordering_exemption_names_a_test_that_covers_its_caller.
 _ORDERING_EXEMPT = {
     ("state/window_transition_tracker.py", "check_sunset_window"): (
+        "test_sunset_window_transition_hands_the_tracker_an_ordered_list",
         "Receives an already-ordered entity list. The tracker is HA-boundary "
         "code with no policy handle, so the coordinator applies "
         "order_for_dispatch at the call site "
-        "(_check_sunset_window_transition, entities=...)."
+        "(_check_sunset_window_transition, entities=...).",
     ),
 }
 
@@ -935,3 +1135,48 @@ def test_every_position_fan_out_seam_consumes_order_for_dispatch() -> None:
         "(issue #1115) — wrap the iteration in "
         "self._policy.order_for_dispatch(...):\n  " + "\n  ".join(offenders)
     )
+
+
+@pytest.mark.unit
+def test_every_ordering_exemption_names_a_test_that_covers_its_caller() -> None:
+    """An exemption's claimed compensating control must itself be covered.
+
+    ``_ORDERING_EXEMPT`` silences the structural scan for a seam whose CALLER
+    does the ordering on its behalf. Nothing in the scan can check that claim —
+    so without a behavioural test on the caller, deleting its
+    ``order_for_dispatch(...)`` wrap leaves the entire suite green while the rail
+    order is silently gone. Every exemption therefore has to name a test in this
+    module that exercises the caller, and that name has to resolve.
+    """
+    unproven = {
+        f"{module}::{fn_name}": covered_by
+        for (module, fn_name), (covered_by, _reason) in _ORDERING_EXEMPT.items()
+        if not callable(globals().get(covered_by))
+    }
+    assert not unproven, (
+        "_ORDERING_EXEMPT entries whose compensating control names a test that "
+        "does not exist in this module — write it, or drop the exemption and "
+        f"order the seam itself: {unproven}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sunset_window_transition_hands_the_tracker_an_ordered_list() -> None:
+    """The compensating control behind the one ordering exemption (issue #1115).
+
+    ``WindowTransitionTracker.check_sunset_window`` fans the sunset position out
+    in the order it is handed, and has no policy handle of its own — so the
+    coordinator has to order the list at the call site. This is the only thing
+    that notices when that wrap goes away.
+    """
+    coord = MagicMock()
+    coord.entities = [_MIDDLE, _BOTTOM]
+    coord._policy = _dual_policy(position=40, blend=50)
+    coord.config_entry.options = {}
+    coord._inverse_state = False
+    coord._window_tracker.check_sunset_window = AsyncMock()
+
+    await AdaptiveDataUpdateCoordinator._check_sunset_window_transition(coord)
+
+    kwargs = coord._window_tracker.check_sunset_window.await_args.kwargs
+    assert kwargs["entities"] == [_BOTTOM, _MIDDLE]

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -42,6 +42,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DEFAULT_HEIGHT,
     CONF_ENTITIES,
+    CONF_INTERP,
     CONF_INVERSE_STATE,
     CONF_MY_POSITION_VALUE,
     DAY_NIGHT_MODEL_DUAL_ENTITY,
@@ -80,6 +81,7 @@ def _dual_policy(
     blend: int | None,
     middle: str = _MIDDLE,
     inverse: bool = False,
+    interp: bool = False,
     policy: DayNightShadePolicy | None = None,
 ) -> DayNightShadePolicy:
     """Build a real Model C policy with its per-cycle dispatch cache primed.
@@ -87,6 +89,12 @@ def _dual_policy(
     Pass ``policy`` to run a LATER resolve cycle on an existing instance —
     everything ``post_pipeline_resolve`` refreshes per cycle, without a fresh
     object.
+
+    ``interp`` turns interpolation on, which is how an install can have
+    inverse-state CONFIGURED while ``axis_inverted`` — and therefore the cached
+    ``_dual_entity_inverse`` — answers ``False``. That split is what makes the
+    seams' "invert iff configured" contract diverge from the install's own
+    frame.
     """
     from tests.cover_helpers import make_cover_config, make_vertical_config
 
@@ -101,6 +109,8 @@ def _dual_policy(
     }
     if inverse:
         options[CONF_INVERSE_STATE] = True
+    if interp:
+        options[CONF_INTERP] = True
     policy.post_pipeline_resolve(
         PipelineResult(
             position=position,
@@ -420,6 +430,7 @@ def _rail_harness(
     position: int,
     blend: int | None,
     inverse: bool = False,
+    interp: bool = False,
 ):
     """Real ``CoverCommandService`` + real Model C policy over a scripted motor.
 
@@ -444,7 +455,9 @@ def _rail_harness(
     state_obj.state = "open"
     hass.states.get = MagicMock(return_value=state_obj)
 
-    policy = _dual_policy(position=position, blend=blend, inverse=inverse)
+    policy = _dual_policy(
+        position=position, blend=blend, inverse=inverse, interp=interp
+    )
 
     cmd_svc = CoverCommandService(
         hass=hass,
@@ -1339,22 +1352,22 @@ async def test_reconciliation_gate_keeps_the_frame_of_the_seam_it_resends() -> N
 
     Reconciliation re-sends the number a broadcast seam put on the wire — so
     that seam's inversion frame is the one the number is expressed in, and the
-    only one the gate can legitimately un-transform it against. That frame
-    travels with the booked target as its dispatch stamp, and the stamp is what
-    the pass hands back.
+    only one the gate can legitimately un-transform it against.
 
-    Here the install has inverse-state suppressed for this cycle (interpolation
-    forces ``axis_inverted`` False) while the recorded middle-rail target was
-    booked by a seam that named ``inverted=True`` explicitly. Read in the seam's
-    frame the bottom rail is at the very bottom of its travel and the middle
-    rail is clear; read in the install's own frame the two swap and the rail is
-    withheld — and, since the seam is the only thing that will ever refresh that
-    target, withheld forever.
+    Here the recorded middle-rail target was booked by a seam that named
+    ``inverted=True`` explicitly, while this cycle's own ``axis_inverted``
+    answer is ``False``. Read in the seam's frame the bottom rail is at the very
+    bottom of its travel and the middle rail is clear; read in the install's own
+    frame the two swap and the rail is withheld — and, since the seam is the
+    only thing that will ever refresh that target, withheld forever.
 
-    The neighbouring
-    ``test_reconciliation_resends_when_a_later_resolve_flips_the_cached_frame``
-    covers the other half: the stamp beating a policy view that has since moved
-    on. Here the point is simply that the stamp is what the pass consults.
+    Scope, stated plainly: the seam's ``True`` reaches the gate here as BOTH the
+    booked stamp and the policy's live per-cycle record, which still agree — so
+    this test cannot tell those two apart and does not claim to. What it pins is
+    the narrower thing: the resend is gated in the SEAM's frame and not in the
+    install's own. Separating stamp from record is the neighbouring
+    ``test_reconciliation_resends_when_a_later_resolve_flips_the_cached_frame``,
+    which adds the later resolve that moves the record off the stamp.
     """
     cmd_svc, policy, _rails, events = _reconcile_harness(
         # Wire 80 == open 20 in the seam's frame: the bottom rail is low, well
@@ -1631,9 +1644,10 @@ async def test_my_preset_books_no_frame_so_its_gate_stays_live() -> None:
     space. A frozen ``False`` reads My=30 as open 30 and the bottom rail's 80 as
     open 80, calls a clear rail blocked and withholds the resend — and, since
     only the user's My button ever refreshes that target, withholds it forever.
-    With no stamp the policy falls back to its live record, which the next
-    ordinary cycle restates to the install's own frame: My=30 is open 70, the
-    bottom rail is open 20, and the resend goes out.
+    With no stamp the gate reads the install's own frame instead, which is the
+    frame a raw My percent is genuinely in: My=30 is open 70, the bottom rail is
+    open 20, and the resend goes out. The ordinary cycle run at the end is a
+    negative control — an unrelated later resolve must not disturb that answer.
     """
     cmd_svc, policy, _rails, events = _rail_harness(
         script={_BOTTOM: [80], _MIDDLE: [90]},
@@ -1663,6 +1677,59 @@ async def test_my_preset_books_no_frame_so_its_gate_stays_live() -> None:
 
     assert f"send:{_MIDDLE}" in events, events
     assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_an_unstamped_target_is_gated_in_the_installs_own_frame() -> None:
+    """A stamp-less target rides the INSTALL's frame, never the live record.
+
+    ``restore_target``, the coordinator's externally-observed My move and
+    ``send_my_position`` each book a raw COVER-frame number — the space
+    ``get_current_position`` reports in and ``_at_target`` compares against —
+    with no dispatch behind it. The only honest way to map that onto
+    open-percent is the install's own ``axis_inverted`` answer, which is what an
+    unnamed frame resolves to everywhere else in this policy.
+
+    The live ``_dual_entity_dispatch_inverse`` record is not a substitute, and
+    this is the case that separates them. Inverse-state is CONFIGURED but
+    suppressed by interpolation, so the install's own frame is ``False`` — while
+    the sunset/end-time seam inverts iff inverse-state is CONFIGURED and so
+    leaves ``True`` on the record. The coordinator then books My=30 from an
+    externally-observed stop, and reconciliation fires before any ordinary
+    resolve restates the record.
+
+    Read in the install's frame the bottom rail's 60 is open 60, stacked above
+    the middle rail's open-30 target, and the resend must be withheld. Read
+    against the record's ``True`` the two swap — open 40 under open 70 — and a
+    physically blocked rail is waved through: the mechanical block #1115 exists
+    to prevent, reached through the gate added to prevent it.
+    """
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [60], _MIDDLE: [90]},
+        position=30,
+        blend=100,  # all sheer → the middle rail's remap is identity
+        inverse=True,
+        interp=True,
+    )
+    assert policy._dual_entity_inverse is False
+
+    # 1. The sunset seam resolves the middle rail in the CONFIGURED frame.
+    assert policy.resolve_entity_target(_MIDDLE, 40, inverted=True) == 40
+    assert policy._dual_entity_dispatch_inverse is True
+
+    # 2. The coordinator records an externally-observed My move through the one
+    #    writer of the pair — no dispatch produced it, so it books no stamp.
+    cmd_svc.set_target(_MIDDLE, 30)
+    assert cmd_svc.state(_MIDDLE).dispatch_token is None
+
+    cmd_svc.state(_MIDDLE).waiting = False
+    events.clear()
+    _arm_reconciliation(cmd_svc)
+    with _patch_caps():
+        await cmd_svc.run_reconciliation_pass(dt.datetime.now(dt.UTC))
+
+    assert f"send:{_MIDDLE}" not in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_group_coordinator.py
+++ b/tests/test_group_coordinator.py
@@ -76,7 +76,13 @@ def _member_entry(
 
 
 def _mock_member_coordinator() -> MagicMock:
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
     coord = MagicMock()
+    # The group's per-member fan-out reads each member's own ordered dispatch
+    # view (#1115), so the mock needs the real default policy the member
+    # coordinator would carry — a MagicMock policy iterates as empty.
+    coord._policy = get_policy(CoverType.BLIND)
     coord.async_apply_user_position = AsyncMock(return_value=("sent", ""))
     coord.async_reset_manual_overrides = AsyncMock(return_value=[])
     coord.async_refresh = AsyncMock()

--- a/tests/test_issue_1045_force_apply_button.py
+++ b/tests/test_issue_1045_force_apply_button.py
@@ -32,6 +32,7 @@ from custom_components.adaptive_cover_pro import const
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.managers.cover_command import (
     CoverCommandService,
     PositionContext,
@@ -75,6 +76,8 @@ def _make_coordinator(
     )
     # The per-entity dispatch seam is identity for a blind (no rail remap).
     coordinator._entity_target = lambda cover, state: state
+    # Real policy: the dispatch loops ask it for the entity order (issue #1115).
+    coordinator._policy = get_policy("cover_blind")
     # No hold in play by default; bind the real hold-aware dispatch seam so
     # honor_holds=True runs the production code rather than a bare MagicMock.
     coordinator._pipeline_result = None

--- a/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
+++ b/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
@@ -52,6 +52,9 @@ def _make_coord_with_stale_default():
     coord._policy.resolve_entity_target = (
         lambda entity_id, position, *, inverted=None, interpolated=False: position
     )
+    # The dispatch loop asks the policy for the entity order (#1115); a blind's
+    # answer is identity, so mirror that on the stub.
+    coord._policy.order_for_dispatch = lambda entities: list(entities)
     coord._inverse_state = False
     coord._use_interpolation = False  # ``coord.state`` post-processing
     coord._pending_cover_events = []

--- a/tests/test_issue_756_override_dispatch_during_sequence.py
+++ b/tests/test_issue_756_override_dispatch_during_sequence.py
@@ -51,6 +51,9 @@ def _make_dispatch_coordinator(
     coordinator._async_force_send_pipeline_position = AsyncMock()
     coordinator._policy = MagicMock()
     coordinator._policy.has_pending_secondary_axis = MagicMock(return_value=has_pending)
+    # The dispatch loops ask the policy for the entity order (#1115); a blind's
+    # answer is identity, so mirror that on the stub.
+    coordinator._policy.order_for_dispatch = lambda entities: list(entities)
     return coordinator
 
 
@@ -254,6 +257,9 @@ def _make_state_change_coordinator(*, pipeline_result: PipelineResult):
     coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
     coordinator._dispatch_to_cover = AsyncMock()
+    # The dispatch loop asks the policy for the entity order (#1115); a blind's
+    # answer is identity, so mirror that on the stub.
+    coordinator._policy.order_for_dispatch = lambda entities: list(entities)
     return coordinator
 
 

--- a/tests/test_issue_814_force_release_holds_manual_override.py
+++ b/tests/test_issue_814_force_release_holds_manual_override.py
@@ -35,6 +35,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from custom_components.adaptive_cover_pro.const import ControlMethod
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.pipeline.handlers import ManualOverrideHandler
 
 from tests.test_pipeline.conftest import make_snapshot
@@ -60,6 +61,8 @@ def _make_release_coordinator(pipeline_result):
     coord.logger = MagicMock()
     coord._inverse_state = False
     coord.entities = ["cover.bedroom"]
+    # Real policy: the dispatch loop asks it for the entity order (#1115).
+    coord._policy = get_policy("cover_blind")
     coord.state_change = True
     coord._last_state_change_entity = None
     coord._custom_position_template_trigger = False

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -1501,6 +1501,7 @@ def _endpoint_service(
     is_safety=False,
     use_my_position=False,
     plan=None,
+    dispatch_token=None,
 ):
     """_prepare_service_call side_effect: route 0→close, 100→open, else set_position."""
     if position == 0:

--- a/tests/test_manual_override_persistence.py
+++ b/tests/test_manual_override_persistence.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -189,6 +191,8 @@ async def test_first_refresh_skips_apply_position_for_manual_cover():
 
     coordinator = MagicMock()
     coordinator.entities = [eid_manual, eid_auto]
+    # Real policy: the startup loop asks it for the entity order (#1115).
+    coordinator._policy = get_policy("cover_blind")
     coordinator.check_adaptive_time = True
     coordinator._is_reload = False
     coordinator.first_refresh = True

--- a/tests/test_my_position_button.py
+++ b/tests/test_my_position_button.py
@@ -16,7 +16,9 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_INTERP_LIST_NEW,
     CONF_INVERSE_STATE,
     ControlMethod,
+    CoverType,
 )
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from tests.ha_helpers import wire_dispatch_frame
 
 # ---------------------------------------------------------------------------
@@ -89,6 +91,10 @@ def _make_my_position_button(*, options=None, entities=None):
     coordinator.async_apply_user_position = AsyncMock(
         return_value=("sent", "set_cover_position")
     )
+    # The button reads the policy's ordered dispatch view (#1115), so the mock
+    # needs the real default policy the coordinator would carry — a MagicMock
+    # policy hands back a MagicMock that iterates as empty.
+    coordinator._policy = get_policy(CoverType.BLIND)
 
     button = AdaptiveCoverMyPositionButton.__new__(AdaptiveCoverMyPositionButton)
     button.coordinator = coordinator
@@ -295,6 +301,7 @@ async def test_my_position_button_passes_bypass_kwargs():
     coordinator.async_apply_user_position = AsyncMock(
         return_value=("sent", "set_cover_position")
     )
+    coordinator._policy = get_policy(CoverType.BLIND)
 
     button = AdaptiveCoverMyPositionButton.__new__(AdaptiveCoverMyPositionButton)
     button.coordinator = coordinator

--- a/tests/test_override_expiry_time_window.py
+++ b/tests/test_override_expiry_time_window.py
@@ -22,6 +22,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from freezegun import freeze_time
 
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+
 UTC = dt.UTC
 
 
@@ -51,6 +53,8 @@ def _make_coordinator(
     coordinator.automatic_control = automatic_control
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
+    # Real policy: the dispatch loops ask it for the entity order (#1115).
+    coordinator._policy = get_policy("cover_blind")
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
     coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
@@ -397,6 +401,8 @@ def _make_state_change_coordinator(
     )
     coordinator.logger = MagicMock()
     coordinator.entities = ["cover.test_blind"]
+    # Real policy: the dispatch loops ask it for the entity order (#1115).
+    coordinator._policy = get_policy("cover_blind")
     coordinator._check_sun_validity_transition = MagicMock(return_value=False)
     coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())

--- a/tests/test_reset_button_time_window.py
+++ b/tests/test_reset_button_time_window.py
@@ -11,6 +11,8 @@ shared gate for both the auto-expiry path and the button path.
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
+from custom_components.adaptive_cover_pro.cover_types import get_policy
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -37,6 +39,8 @@ def _make_coordinator(
     coordinator.automatic_control = automatic_control
     coordinator.entities = ["cover.test"]
     coordinator.logger = MagicMock()
+    # Real policy: the dispatch loops ask it for the entity order (#1115).
+    coordinator._policy = get_policy("cover_blind")
     coordinator._check_sun_validity_transition.return_value = False
     coordinator._build_position_context.return_value = PositionContext(
         auto_control=True,

--- a/tests/test_services_set_position.py
+++ b/tests/test_services_set_position.py
@@ -181,9 +181,14 @@ async def test_set_position_routes_through_axis_dispatch() -> None:
         async_handle_set_position,
     )
 
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
     coord = MagicMock()
     coord.entities = ["cover.blind_a"]
     coord.async_apply_user_axis = AsyncMock(return_value=("sent", "position"))
+    # The service reads the policy's ordered dispatch view (#1115); a MagicMock
+    # policy would hand back a MagicMock that iterates as empty.
+    coord._policy = get_policy(CoverType.BLIND)
     call = MagicMock()
     call.data = {"position": 55}
 

--- a/tests/test_skip_reason_guard.py
+++ b/tests/test_skip_reason_guard.py
@@ -41,6 +41,7 @@ _EXPECTED_SKIP_CODES: frozenset[str] = frozenset(
         "dry_run",
         "service_call_failed",
         "cover_unavailable",
+        "policy_deferred",
     }
 )
 

--- a/tests/test_switch_actions.py
+++ b/tests/test_switch_actions.py
@@ -19,6 +19,7 @@ from custom_components.adaptive_cover_pro.const import (
     DOMAIN,
     CoverType,
 )
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.switch import (
     AdaptiveCoverSwitch,
     _has_irradiance_feature,
@@ -45,6 +46,9 @@ def _make_coordinator(mock_hass=None):
     # Return-to-default routes each target through the polymorphic
     # ``_entity_target`` (identity for every non-dual-entity cover type).
     coord._entity_target = lambda _entity, position, *, inverted=None: position
+    # Real policy: the return-to-default loop asks it for the entity order
+    # (issue #1115). Tests that spy on a sequencer replace this themselves.
+    coord._policy = get_policy("cover_blind")
     coord.manager = MagicMock()
     coord.manager.is_cover_manual = MagicMock(return_value=False)
     coord.manager.manual_controlled = []

--- a/tests/test_switch_auto_control_off_return.py
+++ b/tests/test_switch_auto_control_off_return.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.managers.cover_command import (
     CoverCommandService,
     PositionContext,
@@ -48,6 +49,8 @@ def _make_coord_with_real_cmd_svc(hass):
     # The return-to-default loop routes each target through the polymorphic
     # ``_entity_target`` (identity for every non-dual-entity cover type).
     coord._entity_target = lambda _entity, position, *, inverted=None: position
+    # Real policy: the return-to-default loop asks it for the entity order (#1115).
+    coord._policy = get_policy("cover_blind")
 
     cmd_svc = CoverCommandService(
         hass=hass,


### PR DESCRIPTION
## Summary

Model C (`dual_entity`) day/night shades enforced the no-pass invariant `M >= P` only as arithmetic on the two targets, never as a physical constraint on two motors. Both rails were commanded in the same event-loop tick, so when the bottom rail sat above the middle rail's target the middle rail was told to travel somewhere it could not reach: stall, over-current trip, or lost calibration.

Two mechanisms fix it. `CoverTypePolicy.dispatch_order_key` plus one shared `order_for_dispatch` puts the bottom rail first at every position fan-out seam, and a clearance gate on `await_dispatch_clearance` holds the middle rail until the bottom rail's live position has cleared the middle rail's target in open-percent space. The gate reuses the venetian settle constants, and a timeout latches into the existing #756 pending mechanism rather than adding a timer, so `_drives_dual_axis()` is untouched. An AST guard fails the suite if a future fan-out seam skips the ordering.

The inversion frame travels with the booked target as `PerEntityState.dispatch_token`, with `set_target` the single writer of the pair, so the frame a number was dispatched in cannot drift from the number itself.

Second defect, same seam: an unset `day_night_middle_rail_entity` warned about nothing and silently degraded the shade to a plain vertical blind. The config-flow warning now fires on an absent value, and a new `ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET` Repair surfaces it for installs already misconfigured in the field. Translated to DE and FR.

## Testing

- ✅ 11629 tests passing

## Related Issues

Refs #1115