### PR TITLE
fix: lead with the middle rail when Model C raises (#1118)

### DIFF
--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -126,13 +126,13 @@ class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):
         # Identity for every cover type whose entities are independent.
         #
         # Name the number and frame this loop fans out so the ordering view can
-        # tell a raise from a lower (issue #1118) — the same pair
-        # ``async_apply_user_position`` hands ``_entity_target`` below.
+        # tell a raise from a lower (issue #1118). ``user_dispatch_position`` is
+        # the shared derivation ``async_apply_user_position`` runs below, floor
+        # clamp included — naming the raw preset instead lets a floor flip the
+        # direction between the ordering view and the gate.
         ordered = self.coordinator._policy.order_for_dispatch(  # noqa: SLF001
             self._entities,
-            position=self.coordinator._to_cover_frame(  # noqa: SLF001
-                int(my_position_value)
-            ),
+            position=self.coordinator.user_dispatch_position(int(my_position_value)),
             inverted=self.coordinator.position_axis_inverted,
         )
         for entity_id in ordered:

--- a/custom_components/adaptive_cover_pro/button.py
+++ b/custom_components/adaptive_cover_pro/button.py
@@ -121,11 +121,19 @@ class AdaptiveCoverMyPositionButton(AdaptiveCoverBaseEntity, ButtonEntity):
             )
             return
         # Policy-mandated dispatch order, shared with every other dispatch seam
-        # (issue #1115): a Model C day/night shade's bottom rail must be
-        # commanded before its middle rail, which cannot physically travel past
-        # it. Identity for every cover type whose entities are independent.
+        # (issue #1115): a Model C day/night shade commands the rail DOWNSTREAM
+        # of the move first, because neither rail can travel past the other.
+        # Identity for every cover type whose entities are independent.
+        #
+        # Name the number and frame this loop fans out so the ordering view can
+        # tell a raise from a lower (issue #1118) — the same pair
+        # ``async_apply_user_position`` hands ``_entity_target`` below.
         ordered = self.coordinator._policy.order_for_dispatch(  # noqa: SLF001
-            self._entities
+            self._entities,
+            position=self.coordinator._to_cover_frame(  # noqa: SLF001
+                int(my_position_value)
+            ),
+            inverted=self.coordinator.position_axis_inverted,
         )
         for entity_id in ordered:
             await self.coordinator.async_apply_user_position(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -143,7 +143,7 @@ from .pipeline.handlers import (
 from .pipeline.floors import effective_floor, gather_active_floors
 from .pipeline.registry import PipelineRegistry
 from .pipeline.snapshot_builder import PipelineSnapshotBuilder
-from .pipeline.types import CustomPositionSensorState, GroupIntent
+from .pipeline.types import CustomPositionSensorState, GroupIntent, PipelineSnapshot
 from .templates import TemplateResolver, render_condition_or_none
 from .const import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
@@ -3367,6 +3367,127 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             state_attr(self.hass, "sun.sun", "elevation"),
         ]
 
+    def _build_user_command_snapshot(self, opts: dict) -> PipelineSnapshot:
+        """Assemble the off-cycle snapshot a user command is judged against.
+
+        One build serves the whole command: the min-mode floor gather and the
+        pipeline-preemption check both read it, and so does
+        :meth:`user_dispatch_position` when a fan-out seam asks what it is about
+        to dispatch. The instance's floors and their priorities are the same for
+        every cover the seam is about to command, so the answer is too.
+        """
+        return self._snapshot_builder.build(
+            opts,
+            cover_data=self._cover_data,
+            cover_type=self._cover_type,
+            climate_readings=self._weather_readings,
+            manual_override_active=False,
+            motion_timeout_active=self.is_motion_timeout_active,
+            weather_override_active=self.is_weather_override_active,
+            # Pure property read — the ad-hoc/preemption build must NOT
+            # re-evaluate the managers (that would advance latches off-cycle).
+            # One latch it does advance: the custom-position per-input hold
+            # (#1012) arms on any read, so an ad-hoc build can anchor the hold
+            # window at the tap rather than at the next regular cycle. That is
+            # the documented contract — the window starts at the first
+            # indeterminate sighting, and the tap is one — but it also means no
+            # hold wake is scheduled here.
+            cloud_suppression_active=self._cloud_mgr.is_suppression_active,
+            climate_temp_flags=self._climate_smoothing_mgr.resolved_flags,
+            in_time_window=self.check_adaptive_time,
+            current_cover_position=self._compute_mean_cover_position(),
+            is_glare_zone_enabled=self._is_glare_zone_enabled,
+            cover_capabilities=getattr(
+                getattr(self, "_snapshot", None), "cover_capabilities", None
+            ),
+            group_intent=self.effective_group_intent,
+        )
+
+    def _clamp_to_active_floor(
+        self,
+        requested: int,
+        snapshot: PipelineSnapshot,
+        *,
+        trigger: str | None = None,
+    ) -> int:
+        """Raise a user request to the highest floor that outranks manual override.
+
+        Priority-aware user-move clamp (issue #472): a floor only clamps a
+        manual/user command when it strictly outranks manual override — the same
+        predicate the preemption check in :meth:`async_apply_user_position` uses.
+        A default-priority (77) floor yields to the manual move; a floor above 80
+        clamps it up *before* dispatch. The pipeline-winner clamp
+        (``registry.py``) stays unconditional so auto-rule composition is
+        unaffected (issue #463).
+
+        ``trigger`` names the command for the log line. Callers that are only
+        ASKING what a command would dispatch (:meth:`user_dispatch_position`)
+        omit it: same arithmetic, but one press should not log its clamp twice.
+        """
+        effective_floor_pos, floor_info = effective_floor(
+            gather_active_floors(snapshot)
+        )
+        floor_applies = (
+            floor_info is not None
+            and floor_info.priority > ManualOverrideHandler.priority
+        )
+        clamped = (
+            max(int(requested), effective_floor_pos)
+            if floor_applies
+            else int(requested)
+        )
+        if trigger is None:
+            return clamped
+        if clamped != requested:
+            _LOGGER.info(
+                "%s: requested %d clamped to %d (active min-mode floor)",
+                trigger,
+                requested,
+                clamped,
+            )
+        else:
+            _LOGGER.debug(
+                "%s: requested %d, floor %d — no clamping needed",
+                trigger,
+                requested,
+                effective_floor_pos,
+            )
+        return clamped
+
+    def user_dispatch_position(
+        self, requested: int, *, options: dict | None = None
+    ) -> int:
+        """Return the cover-frame number a user command for ``requested`` will send.
+
+        Every seam that fans a user command out over several covers — the My
+        button, ``set_position`` / ``set_tilt`` / ``set_axes``, both group
+        sliders — has to hand the policy's dispatch-ordering view the number the
+        travel gate will later be asked about, because for a physically coupled
+        cover type that number is what tells a raise from a lower (issue #1118).
+
+        It is not ``requested``. An active min-mode floor that outranks manual
+        override raises it first (#472), and the calibration curve reshapes it
+        after (#1027) — and either transform can flip the direction:
+
+        * a floor above the current position turns a lower into a raise;
+        * a DESCENDING interpolation curve (``np.interp`` imposes no
+          monotonicity on the user's table) lowers the dispatched value as the
+          floor raises the logical one, inventing a raise out of a lowering.
+
+        So this and :meth:`async_apply_user_position` reach that number through
+        the SAME clamp and the SAME frame mapping. Ordering and gating cannot
+        disagree about the direction of travel because there is only one
+        derivation for them to disagree over. The clamp is a property of the
+        INSTANCE — the composed floors and their priorities — not of any one
+        cover, so a single answer serves the whole fan-out.
+        """
+        opts = options if options is not None else self._resolved_options
+        return self._to_cover_frame(
+            self._clamp_to_active_floor(
+                int(requested), self._build_user_command_snapshot(opts)
+            )
+        )
+
     async def async_apply_user_position(
         self,
         entity_id: str,
@@ -3381,9 +3502,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         Single delegation point for any user-facing command (the
         ``set_position`` service, the opt-in proxy cover entity, the My
-        Position button, future external triggers). Owns the min-mode floor
+        Position button, future external triggers). Runs the min-mode floor
         clamp, the pipeline preemption check, manual-override engagement, and
         dispatch to ``CoverCommandService.apply_position``.
+
+        The clamp and the frame mapping are shared with
+        :meth:`user_dispatch_position`, so a fan-out seam can name the number
+        this method will really dispatch rather than the one it was handed
+        (issue #1118) — the two cannot diverge because there is one derivation.
 
         ``requested`` is a LOGICAL position — HA's convention, 0 = closed /
         100 = open — like every other user-facing number in this integration.
@@ -3412,63 +3538,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         opt in.
         """
         opts = options if options is not None else self._resolved_options
-        snapshot = self._snapshot_builder.build(
-            opts,
-            cover_data=self._cover_data,
-            cover_type=self._cover_type,
-            climate_readings=self._weather_readings,
-            manual_override_active=False,
-            motion_timeout_active=self.is_motion_timeout_active,
-            weather_override_active=self.is_weather_override_active,
-            # Pure property read — the ad-hoc/preemption build must NOT
-            # re-evaluate the managers (that would advance latches off-cycle).
-            # One latch it does advance: the custom-position per-input hold
-            # (#1012) arms on any read, so an ad-hoc build can anchor the hold
-            # window at the tap rather than at the next regular cycle. That is
-            # the documented contract — the window starts at the first
-            # indeterminate sighting, and the tap is one — but it also means no
-            # hold wake is scheduled here.
-            cloud_suppression_active=self._cloud_mgr.is_suppression_active,
-            climate_temp_flags=self._climate_smoothing_mgr.resolved_flags,
-            in_time_window=self.check_adaptive_time,
-            current_cover_position=self._compute_mean_cover_position(),
-            is_glare_zone_enabled=self._is_glare_zone_enabled,
-            cover_capabilities=getattr(
-                getattr(self, "_snapshot", None), "cover_capabilities", None
-            ),
-            group_intent=self.effective_group_intent,
-        )
-        floors = gather_active_floors(snapshot)
-        effective_floor_pos, floor_info = effective_floor(floors)
-        # Priority-aware user-move clamp (issue #472): a floor only clamps a
-        # manual/user command when it strictly outranks manual override — the
-        # same predicate the preemption check below uses. A default-priority
-        # (77) floor yields to the manual move; a floor above 80 clamps it up
-        # *before* dispatch. The pipeline-winner clamp (registry.py) stays
-        # unconditional so auto-rule composition is unaffected (issue #463).
-        floor_applies = (
-            floor_info is not None
-            and floor_info.priority > ManualOverrideHandler.priority
-        )
-        clamped = (
-            max(int(requested), effective_floor_pos)
-            if floor_applies
-            else int(requested)
-        )
-        if clamped != requested:
-            _LOGGER.info(
-                "%s: requested %d clamped to %d (active min-mode floor)",
-                trigger,
-                requested,
-                clamped,
-            )
-        else:
-            _LOGGER.debug(
-                "%s: requested %d, floor %d — no clamping needed",
-                trigger,
-                requested,
-                effective_floor_pos,
-            )
+        snapshot = self._build_user_command_snapshot(opts)
+        # Shared with ``user_dispatch_position``, which is how the fan-out seams
+        # name the number this dispatch will really use rather than the one the
+        # user asked for (issue #1118).
+        clamped = self._clamp_to_active_floor(int(requested), snapshot, trigger=trigger)
 
         if not force:
             result = self._pipeline.evaluate(snapshot)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -4504,16 +4504,34 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         (issue #895).
         """
         options = self.config_entry.options
+        sunset_pos_cfg = options.get(CONF_SUNSET_POS)
         await self._window_tracker.check_sunset_window(
             track_end_time=self._track_end_time,
             automatic_control=self.automatic_control,
-            sunset_pos_cfg=options.get(CONF_SUNSET_POS),
+            sunset_pos_cfg=sunset_pos_cfg,
             options=options,
             inverse_state_enabled=self._inverse_state,
             # Same policy-mandated rail order as every other dispatch seam
             # (issue #1115) — the tracker fans the sunset position out in the
             # order it receives, so the ordering is applied here.
-            entities=self._policy.order_for_dispatch(self.entities),
+            #
+            # Name the number and frame it will fan out so the ordering view can
+            # tell a raise from a lower (issue #1118). This seam inverts iff
+            # inverse-state is CONFIGURED — unconditional of interpolation, like
+            # the end-time loop above and unlike ``_to_cover_frame`` (#993) — so
+            # the pair is stated in that space. A raising sunset position
+            # ordered bottom-first would park the bottom rail's gate on a middle
+            # rail nothing has commanded for a whole settle budget, and this
+            # runs on the reconciliation tick.
+            entities=self._policy.order_for_dispatch(
+                self.entities,
+                position=(
+                    None
+                    if sunset_pos_cfg is None
+                    else flip_if(int(sunset_pos_cfg), inverted=self._inverse_state)
+                ),
+                inverted=self._inverse_state,
+            ),
             is_cover_manual=self.manager.is_cover_manual,
             has_active_override=self._pipeline_has_active_override(),
             build_position_context=lambda c, o: self._build_position_context(

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2570,9 +2570,13 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         """
         # Policy-mandated dispatch order (issue #1115) — applied to an explicitly
-        # supplied subset too, since a Model C subset can hold both rails.
+        # supplied subset too, since a Model C subset can hold both rails. Name
+        # the number and frame this loop fans out so the ordering view can tell a
+        # raise from a lower (issue #1118) — the same pair ``_entity_target``
+        # gets below.
         target_covers = self._policy.order_for_dispatch(
-            entities if entities is not None else self.entities
+            entities if entities is not None else self.entities,
+            position=state,
         )
 
         if respect_manual_override:
@@ -2879,7 +2883,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 if self._pipeline_bypasses_auto_control
                 else "solar"
             )
-        for cover in self._policy.order_for_dispatch(self.entities):
+        # Name the number and frame this loop fans out so the ordering view can
+        # tell a raise from a lower (issue #1118) — the same pair
+        # ``_entity_target`` gets below.
+        for cover in self._policy.order_for_dispatch(self.entities, position=state):
             ctx = self._build_position_context(
                 cover,
                 options,
@@ -3071,7 +3078,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             return
 
         sun_just_appeared = self._check_sun_validity_transition()
-        for cover in self._policy.order_for_dispatch(self.entities):
+        # Name the number and frame this loop fans out so the ordering view can
+        # tell a raise from a lower (issue #1118) — the same pair
+        # ``_entity_target`` gets below.
+        for cover in self._policy.order_for_dispatch(self.entities, position=state):
             if self.manager.is_cover_manual(cover):
                 self.logger.debug(
                     "Startup: skipping position command for %s (manual override active/restored)",
@@ -4209,7 +4219,12 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                     "cover_count": len(self.entities),
                 }
             )
-            for cover_entity in self._policy.order_for_dispatch(self.entities):
+            # Name the number and frame this loop fans out so the ordering view
+            # can tell a raise from a lower (issue #1118) — the same pair
+            # ``_entity_target`` gets below.
+            for cover_entity in self._policy.order_for_dispatch(
+                self.entities, position=pos_to_send, inverted=self._inverse_state
+            ):
                 ctx = self._build_position_context(cover_entity, options, force=False)
                 await self._cmd_svc.apply_position(
                     cover_entity,

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -627,6 +627,9 @@ class CoverTypePolicy(ABC):
     def dispatch_order_key(
         self,
         entity_id: str,  # noqa: ARG002
+        *,
+        position: int | None = None,  # noqa: ARG002
+        inverted: bool | None = None,  # noqa: ARG002
     ) -> int:
         """Sort key ordering this cover type's entities within one dispatch cycle.
 
@@ -638,13 +641,30 @@ class CoverTypePolicy(ABC):
         caller's loop. Overriding this hook expresses that constraint once; every
         dispatch seam consumes the same ordered view (issue #1115).
 
+        Which entity blocks can depend on the DIRECTION of travel: on a stacked
+        pair the rail downstream of the move has to vacate first, and that is the
+        bottom rail when the shade lowers but the middle rail when it raises
+        (issue #1118). So a seam may NAME the number it is about to fan out and
+        the inversion frame it is fanning it out in — the same ``(position,
+        inverted)`` pair it hands ``resolve_entity_target`` in the same loop
+        body. Omitting them is legal and yields the cover type's
+        direction-blind default order; a seam whose per-entity value only comes
+        into existence further down its own call chain has no honest pair to
+        name and should not invent one.
+
         The Liskov-safe default is a constant, which makes ``sorted(...)`` a
         stable-sort no-op: the user's config-flow pick order survives verbatim
         for every cover type with independent entities.
         """
         return 0
 
-    def order_for_dispatch(self, entities: Iterable[str]) -> list[str]:
+    def order_for_dispatch(
+        self,
+        entities: Iterable[str],
+        *,
+        position: int | None = None,
+        inverted: bool | None = None,
+    ) -> list[str]:
         """Return ``entities`` in this cover type's mandated dispatch order.
 
         The single shared ordering mechanism every dispatch seam consumes — the
@@ -654,10 +674,19 @@ class CoverTypePolicy(ABC):
         as :meth:`dispatch_order_key` rather than mirrored per seam
         (CODING_GUIDELINES.md "No Code Duplication", issue #1115).
 
+        ``position`` / ``inverted`` are forwarded verbatim to
+        :meth:`dispatch_order_key`; see there for what naming them buys and when
+        a seam legitimately cannot.
+
         ``sorted`` is stable, so a policy that leaves ``dispatch_order_key`` at
         its constant default gets the input order back unchanged.
         """
-        return sorted(entities, key=self.dispatch_order_key)
+        return sorted(
+            entities,
+            key=lambda entity_id: self.dispatch_order_key(
+                entity_id, position=position, inverted=inverted
+            ),
+        )
 
     def required_role_entity_missing(
         self,
@@ -816,10 +845,11 @@ class CoverTypePolicy(ABC):
         """Return an opaque stamp describing HOW this dispatch expressed its value.
 
         The provenance half of :meth:`await_dispatch_clearance`. A policy that
-        has to un-transform a dispatched number later — the Model C day/night
-        middle rail, whose clearance test compares its target against a live rail
-        reading in open-percent space — cannot re-derive the transform after the
-        fact: its own per-cycle cache describes the last RESOLUTION, and
+        has to un-transform a dispatched number later — either rail of a Model C
+        day/night pair, whose clearance test compares its target against the
+        OTHER rail's live reading in open-percent space — cannot re-derive the
+        transform after the fact: its own per-cycle cache describes the last
+        RESOLUTION, and
         ``resolve_entity_target`` runs as an ARGUMENT to
         ``CoverCommandService.apply_position``, so a cycle that resolves and then
         skips on a delta gate restates that cache for a command which never went
@@ -853,7 +883,10 @@ class CoverTypePolicy(ABC):
         The physical-coupling question on its own, separated from
         :meth:`before_position_command` because that hook carries pre-send SIDE
         EFFECTS (the venetian tilt-first command) a caller asking only for the
-        go/no-go must not trigger. Both position paths —
+        go/no-go must not trigger. Which entity gets withheld may depend on the
+        direction of travel — on a Model C pair the rail downstream of the move
+        leads and the other one waits, so EITHER rail can be the one gated
+        (issue #1118). Both position paths —
         ``CoverCommandService.apply_position`` and its reconciliation resend —
         funnel into ONE implementation per policy; the rule is never written
         twice (issue #1115).

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -187,16 +187,17 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
 
     * the middle rail can never be below the bottom rail (hence the no-pass
       clamp ``M >= P`` in :meth:`resolve_entity_target`, in open-percent space);
-    * and, because they are physically stacked, the middle rail cannot TRAVEL to
-      a target the bottom rail is currently sitting above — so on any cycle that
-      lowers the shade the bottom rail must start positioning first, and the
-      middle rail is free to move only once the bottom rail is below the middle
-      rail's target.
+    * and, because they are physically stacked, neither rail can TRAVEL through
+      the space the other is currently occupying — so the rail DOWNSTREAM of the
+      move has to start positioning first and the other one waits. Lowering,
+      that is the bottom rail leading and the middle rail waiting (#1115);
+      raising, it is the middle rail leading and the bottom rail waiting
+      (#1118).
 
     Those last two are what :meth:`dispatch_order_key` and
-    :meth:`_gate_middle_rail_clearance` enforce (issue #1115). Without them a
-    perfectly valid target pair still drives the middle motor into a mechanical
-    block: stall, over-current trip, or lost calibration.
+    :meth:`_gate_rail_clearance` enforce. Without them a perfectly valid target
+    pair still drives a motor into a mechanical block: stall, over-current trip,
+    or lost calibration.
     """
 
     cover_type = "cover_day_night_shade"
@@ -256,12 +257,15 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # rebuilds the coordinator and re-runs ``attach``, so the snapshot cannot
         # go stale behind a changed cover list.
         self._attached_entities: tuple[str, ...] = ()
-        # Middle-rail position commands withheld because the bottom rail had not
-        # cleared the target yet (issue #1115). Drives
-        # ``has_pending_secondary_axis``, which makes the coordinator withhold
-        # this cycle's dispatched-target signature so the next cycle re-attempts
-        # the send — the same defer-and-retry latch shape as #756's tilt tail.
-        self._pending_middle_rail: set[str] = set()
+        # Rail position commands withheld because the rail LEADING this move had
+        # not cleared the target yet — the middle rail on a lowering (#1115), the
+        # bottom rail on a raising (#1118). Rail-agnostic on purpose: which rail
+        # ends up in here is a property of the direction of travel, not of a
+        # role. Drives ``has_pending_secondary_axis``, which makes the
+        # coordinator withhold this cycle's dispatched-target signature so the
+        # next cycle re-attempts the send — the same defer-and-retry latch shape
+        # as #756's tilt tail.
+        self._pending_rail_command: set[str] = set()
 
     # ---- Identity / labels -------------------------------------------- #
 
@@ -769,7 +773,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         self._dual_entity_inverse = axis_inverted(self.axes[0], options)
         self._dual_entity_middle_rail = options.get(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY)
         # NB: ``_dual_entity_dispatch_inverse`` is deliberately NOT reset here.
-        # It records the frame of the last middle-rail RESOLUTION — which is
+        # It records the frame of the last Model C rail RESOLUTION — which is
         # exactly right for its one reader, ``capture_dispatch_token`` on the
         # DISPATCH path: ``apply_position`` takes the stamp immediately after
         # ``resolve_entity_target`` restated this field for the very value being
@@ -802,30 +806,127 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             and entity_id == self._dual_entity_middle_rail
         )
 
-    def dispatch_order_key(self, entity_id: str) -> int:
-        """Command the bottom rail before the middle rail (Model C, issue #1115).
+    def _is_dual_entity_bottom_rail(self, entity_id: str) -> bool:
+        """Whether ``entity_id`` is THIS cycle's Model C bottom rail.
 
-        The two rails share one track: the middle rail cannot travel below the
-        bottom rail. When a cycle lowers both, the bottom rail must START moving
-        first — otherwise the middle rail is commanded toward a target the
-        still-stacked bottom rail is physically blocking. The per-entity command
-        hooks fire inside the caller's loop and cannot reorder it, so the order
-        has to be expressed here, where the rail roles are known.
+        The mirror of :meth:`_is_dual_entity_middle_rail`, and the reason it
+        exists separately from "not the middle rail": the travel gate has to
+        distinguish the paired bottom rail — which CAN be withheld when the
+        shade raises past the middle rail (issue #1118) — from every other
+        entity, which is never gated at all.
+        """
+        return (
+            self._control_model == DAY_NIGHT_MODEL_DUAL_ENTITY
+            and self._dual_entity_bottom_rail is not None
+            and entity_id == self._dual_entity_bottom_rail
+        )
+
+    def dispatch_order_key(
+        self,
+        entity_id: str,
+        *,
+        position: int | None = None,
+        inverted: bool | None = None,
+    ) -> int:
+        """Command the rail DOWNSTREAM of this move first (Model C, #1115/#1118).
+
+        The two rails share one track and neither can pass the other, so the one
+        the move is travelling toward has to start vacating before the other can
+        follow it. Which rail that is depends on the direction:
+
+        * lowering (the bottom rail's target is below where it sits) — the
+          bottom rail is downstream and leads, the middle rail follows (#1115);
+        * raising (the bottom rail's target is above where the MIDDLE rail
+          sits) — the middle rail is downstream and leads, the bottom rail
+          follows (#1118).
+
+        The direction question is answered by the one shared
+        :meth:`_dual_entity_middle_leads` predicate, which the travel gate
+        consults too — so ordering and gating can never disagree about which
+        rail leads, and the pair can never both wait on each other.
+
+        ``position`` is the number the calling seam is fanning out and
+        ``inverted`` the frame it is expressed in — the same pair the seam hands
+        ``resolve_entity_target`` in the same loop. With no ``position`` named
+        there is nothing to compare a live reading against, so the key falls
+        back to #1115's shipped constant (bottom rail first) WITHOUT reading
+        anything: ordering is a latency mechanism and the gates stay
+        authoritative either way, so a fallback costs at worst a deferred cycle.
 
         Model A and Model B keep the constant default (a stable-sort no-op):
         neither binds a second rail entity.
         """
-        return 1 if self._is_dual_entity_middle_rail(entity_id) else 0
+        if (
+            self._control_model != DAY_NIGHT_MODEL_DUAL_ENTITY
+            or self._dual_entity_middle_rail is None
+        ):
+            return 0
+        inverse = self._dispatch_frame(inverted)
+        target_open = None if position is None else flip_if(position, inverted=inverse)
+        middle_leads = self._dual_entity_middle_leads(target_open, inverse)
+        is_middle = entity_id == self._dual_entity_middle_rail
+        return 0 if is_middle == middle_leads else 1
+
+    def _dual_entity_middle_leads(
+        self, bottom_target_open: int | None, inverse: bool
+    ) -> bool:
+        """Whether a RAISE-direction collision exists right now (issue #1118).
+
+        The single direction predicate, consulted by :meth:`dispatch_order_key`
+        (which rail to command first) and by :meth:`_gate_rail_clearance` (which
+        rail to withhold). One answer, two readers, so the two can never
+        disagree — a disagreement is precisely what would leave both rails
+        waiting on each other.
+
+        The question is target-vs-live, not live-vs-live: the bottom rail is
+        blocked exactly when the position it is being driven to sits above where
+        the middle rail currently IS, i.e. ``m_open + tol < P_target_open``. That
+        is the exact complement of the follower's clearance predicate in
+        :meth:`_gate_rail_clearance` — one inequality, stated once, used twice.
+
+        ``bottom_target_open`` is the bottom rail's target for the dispatch in
+        question, already in OPEN-PERCENT space; ``inverse`` names the frame the
+        live wire reading is un-flipped through, and is the SAME frame that
+        open-percent target was derived in. Comparing a raw wire number against
+        an open-percent one inverts the verdict on every inverse-state install
+        (the #993 bug class), so both sides ride ``flip_if`` against one frame.
+
+        Every ``False`` here means "no raise collision can be evidenced", which
+        leaves the bottom rail ungated:
+
+        * no ``bottom_target_open`` — the caller named no target, so there is
+          nothing to compare (the ordering fallback);
+        * no sequencer, or no resolvable rail pair — the same degenerate config
+          the travel gate is inert for;
+        * an unreadable middle rail — deliberately fail-OPEN. The middle rail's
+          own gate is fail-CLOSED on an unreadable bottom rail because there the
+          collision geometry is already known and cannot be disproven; here the
+          reading IS the evidence of a collision, and withholding the bottom
+          rail on every cycle while the middle-rail entity is unavailable would
+          stop the whole shade, including for safe lowering moves.
+        """
+        if bottom_target_open is None:
+            return False
+        seq = self._sequencer
+        middle = self._dual_entity_middle_rail
+        if seq is None or middle is None or self._dual_entity_bottom_rail is None:
+            return False
+        live = seq._get_current_position(middle)  # noqa: SLF001
+        if live is None:
+            return False
+        return flip_if(live, inverted=inverse) + self._position_tolerance < (
+            bottom_target_open
+        )
 
     def _dispatch_frame(self, inverted: bool | None) -> bool:
-        """Resolve which inversion frame a dispatched middle-rail value speaks.
+        """Resolve which inversion frame a dispatched rail value speaks.
 
         The ONE place that answer is computed. ``None`` means "nobody named a
         frame, so use this cycle's cached ``axis_inverted`` decision" — the main
         pipeline path, and equally a target that no dispatch ever expressed in a
         frame at all; an explicit ``True``/``False`` is a seam naming its own
         divergent space. Both ``resolve_entity_target`` — which produces the
-        wire value — and :meth:`_gate_middle_rail_clearance` — which has to
+        wire value — and :meth:`_gate_rail_clearance` — which has to
         un-transform it to compare against a live rail reading — go through
         here, so the two can never disagree about what frame the number in
         flight is in (the #993 bug class; issue #1115).
@@ -833,7 +934,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         return self._dual_entity_inverse if inverted is None else inverted
 
     def capture_dispatch_token(self, entity_id: str) -> bool | None:
-        """Stamp the middle rail's dispatch frame onto the command being booked.
+        """Stamp a Model C rail's dispatch frame onto the command being booked.
 
         Resolves the frame through the SAME :meth:`_dispatch_frame` rule the
         gate and ``resolve_entity_target`` use, so the stamp is literally the
@@ -848,10 +949,21 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         policy's own per-cycle cache has by then been restated by every
         intervening resolve, dispatched or skipped.
 
-        ``None`` for the bottom rail and for every non-Model-C instance — no
-        rail there needs its dispatched value un-transformed later.
+        BOTH rails are stamped, because either can be the gated one: the middle
+        rail when the shade lowers, the bottom rail when it raises past a middle
+        rail that has not vacated yet (issue #1118). Leaving the bottom rail
+        unstamped would resolve its gate against the cached ``axis_inverted``
+        flag rather than the dispatching seam's own space — and the seams that
+        dispatch in a divergent space are real (the auto-control-off return loop
+        sends the raw default un-inverted), so that is the #993 bug class
+        pointed at the new direction.
+
+        ``None`` for every non-rail entity and for every non-Model-C instance —
+        no cover there needs its dispatched value un-transformed later.
         """
-        if not self._is_dual_entity_middle_rail(entity_id):
+        if not self._is_dual_entity_middle_rail(
+            entity_id
+        ) and not self._is_dual_entity_bottom_rail(entity_id):
             return None
         return self._dispatch_frame(self._dual_entity_dispatch_inverse)
 
@@ -894,16 +1006,20 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         either way. Mapping a motor reading back onto the linear scale is
         #925's territory, not this hook's.
         """
-        if (
-            self._control_model != DAY_NIGHT_MODEL_DUAL_ENTITY
-            or entity_id != self._dual_entity_middle_rail
-        ):
+        if self._control_model != DAY_NIGHT_MODEL_DUAL_ENTITY:
             return position
-        # Record the frame BEFORE the blend check: even a cycle that resolves no
-        # blend still dispatches this rail, and the travel gate that follows has
-        # to un-transform that value against the same frame this call named.
+        # Record the frame BEFORE the role check and BEFORE the blend check:
+        # every Model C rail this seam resolves is about to be dispatched, and
+        # EITHER of them may be the one the travel gate withholds (issue #1118),
+        # so both need their value un-transformable against the frame this call
+        # named. A seam names one frame for its whole loop, so the bottom rail's
+        # call and the middle rail's call write the same value — the field means
+        # "the frame of the last Model C rail resolution", and its one reader
+        # (``capture_dispatch_token``) still re-states it immediately after.
         inverse = self._dispatch_frame(inverted)
         self._dual_entity_dispatch_inverse = inverse
+        if entity_id != self._dual_entity_middle_rail:
+            return position
         if self._dual_entity_blend is None:
             return position
         blend = self._dual_entity_blend
@@ -1214,11 +1330,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         Two deferral sources share this latch, because the coordinator's response
         to both is identical — withhold this cycle's dispatched-target signature
         so the command is re-attempted next cycle: a Model A blend-only update
-        deferred by the back-rotate suppression window (#756), and a Model C
-        middle-rail position command withheld while the bottom rail still blocks
-        its target (#1115).
+        deferred by the back-rotate suppression window (#756), and a Model C rail
+        position command withheld while the rail leading this move still blocks
+        its target (#1115 lowering, #1118 raising).
         """
-        if entity_id in self._pending_middle_rail:
+        if entity_id in self._pending_rail_command:
             return True
         if self._sequencer is None:
             return False
@@ -1266,7 +1382,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         middle = self._dual_entity_middle_rail
         return next((eid for eid in self._attached_entities if eid != middle), None)
 
-    async def _gate_middle_rail_clearance(
+    async def _gate_rail_clearance(
         self,
         entity_id: str,
         position: int,
@@ -1274,17 +1390,53 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         *,
         wait: bool,
         dispatch_token: bool | None,
+        is_middle: bool,
     ) -> bool:
-        """Hold the middle rail until the bottom rail has cleared its target.
+        """Hold a Model C rail until the rail leading this move has cleared it.
 
         **The physical model.** One headbox carries two rails on a shared track.
         Sheer fabric spans head rail → middle rail; blackout fabric spans middle
-        rail → bottom rail. The bottom rail is the lower of the two and the
-        middle rail cannot pass below it: whatever the arithmetic says, the middle
-        rail can only reach a target the bottom rail is not currently occupying or
-        sitting above. So the bottom rail has to start positioning first, and the
-        middle rail is free to move the moment the bottom rail is below the middle
-        rail's target.
+        rail → bottom rail. The bottom rail is the lower of the two and neither
+        rail can pass the other: whatever the arithmetic says, a rail can only
+        reach a target its partner is not currently occupying or standing
+        between it and.
+
+        Which rail leads therefore depends on the DIRECTION of travel — the rail
+        downstream of the move has to vacate first:
+
+        | Travel            | Downstream | Leads  | Follower waits until          |
+        |-------------------|------------|--------|-------------------------------|
+        | Lowering (P < p)  | bottom     | bottom | p_open <= M_target_open + tol |
+        | Raising  (P > m)  | middle     | middle | m_open + tol >= P_target_open |
+
+        The lowering row is #1115; the raising row is #1118, and its predicate is
+        the exact complement of :meth:`_dual_entity_middle_leads`'s collision
+        test — one inequality, stated once, read from both ends.
+
+        **The two gates are never both armed.** The bottom rail blocks only when
+        ``m + tol < P``; the middle rail blocks only when ``p > M + tol``. Both
+        at once needs ``p > M + tol >= P + tol > m + 2·tol``, i.e. the bottom
+        rail physically ABOVE the middle rail — while ``M >= P`` holds for every
+        target pair the no-pass clamp in :meth:`resolve_entity_target` can emit.
+        Within one dispatch the two are mutually exclusive by the same clamp that
+        makes the target pair physically legal. Two states sit outside that
+        guarantee and both are bounded: crossed targets booked across ERAS (only
+        reachable on the reconciliation path, where every gate runs ``wait=False``
+        — a single read, so both rails simply defer for one tick and the next
+        pass re-asks), and crossed RAILS (``p > m``, physically impossible for an
+        intact shade on one track — both rails would defer after their budget,
+        latch pending, and retry next cycle).
+
+        **The asymmetry is deliberate.** The middle rail's branch does NOT
+        consult :meth:`_dual_entity_middle_leads`; it gates unconditionally,
+        exactly as #1115 shipped it. The direction predicate needs the BOTTOM
+        rail's target, and the middle rail's gate is only ever handed its own —
+        so answering the direction question for it would mean reading a cached
+        number that is stale at four seams, and a stale "middle leads" would
+        UNGATE the middle rail during a lowering, re-opening #1115 through the
+        very mechanism built to close it. The middle rail is therefore never
+        ungated by a direction reading; only the bottom rail's gate is
+        conditional, and it is conditional on a number it holds authoritatively.
 
         The no-pass clamp in :meth:`resolve_entity_target` (``M >= P``) states
         that invariant about two NUMBERS — the two eventual targets. It cannot see
@@ -1308,7 +1460,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         path captures the stamp immediately before this gate and books that very
         value with the target, and the resend replays what was stored, because
         the number it is putting back on the wire is the one that dispatch
-        produced. On a Model C middle rail the stamp is always a ``bool``, so
+        produced. On either Model C rail the stamp is always a ``bool``, so
         neither position path ever hands this method a ``None``.
 
         ``None`` reaches here only for a target no dispatch produced, and the
@@ -1324,7 +1476,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         is forwarded unchanged and no second answer is computed here.
 
         The live ``_dual_entity_dispatch_inverse`` record is deliberately NOT
-        read for those. It describes the last middle-rail RESOLUTION — a
+        read for those. It describes the last rail RESOLUTION — a
         different number — and one seam resolve is enough to leave it naming a
         divergent space: the sunset/end-time loops invert iff inverse-state is
         CONFIGURED, so an install running interpolation (where ``axis_inverted``
@@ -1344,53 +1496,79 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         target against the configured flag while the seam built it un-inverted
         withholds a command that is already physically clear, on every
         inverse-state Model C install. Both sides of the comparison ride the
-        same frame: the bottom rail was commanded by the same seam, so its live
+        same frame: the leading rail was commanded by the same seam, so its live
         reading speaks it too.
 
-        ``wait`` picks how long the bottom rail gets. The dispatch path waits
-        out the full budget: it has just issued the bottom rail's command and
-        nothing else will re-drive the middle rail this cycle. A caller that is
-        already a periodic retry loop passes ``False`` and takes a single read —
-        see :meth:`await_dispatch_clearance`. The clearance PREDICATE is
-        identical in both modes; only the number of chances the rail gets to
-        satisfy it differs.
+        ``wait`` picks how long the leading rail gets. The dispatch path waits
+        out the full budget: it has just issued that rail's command and nothing
+        else will re-drive this one this cycle. A caller that is already a
+        periodic retry loop passes ``False`` and takes a single read — see
+        :meth:`await_dispatch_clearance`. The clearance PREDICATE is identical in
+        both modes; only the number of chances the rail gets to satisfy it
+        differs.
 
         Returns ``True`` to let the command through, ``False`` to withhold it.
         Withholding latches the entity pending so the coordinator keeps
-        re-attempting on later cycles; it never drops the command. Unreadable or
-        never-clearing is deliberately fail-CLOSED (withhold), because a rail
-        whose position cannot be read cannot be proven safe to drive into — while
-        an un-resolvable bottom rail is fail-OPEN (proceed), because there is then
-        no coupled rail to protect and withholding forever would brick the shade.
+        re-attempting on later cycles; it never drops the command. Once a
+        clearance question is answered "proceed" the latch is cleared, whichever
+        branch answered it — a rail withheld by one cycle's raise must not stay
+        latched through the next cycle's lower.
+
+        A leading rail that is unreadable or never clears is fail-CLOSED
+        (withhold), because a rail whose position cannot be read cannot be proven
+        safe to drive into. Two things are fail-OPEN instead: an unresolvable
+        rail PAIR (there is then no coupled rail to protect, and withholding
+        forever would brick the shade), and an unreadable MIDDLE rail on the
+        bottom rail's direction check — see :meth:`_dual_entity_middle_leads`,
+        where the reading is the evidence of a collision rather than the
+        disproof of a known one.
         """
         seq = self._sequencer
+        middle_rail = self._dual_entity_middle_rail
         bottom_rail = self._dual_entity_bottom_rail
-        if seq is None or bottom_rail is None:
+        if seq is None or bottom_rail is None or middle_rail is None:
             self._debug(
-                "Model C rail gate inert for %s: no bottom rail resolved", entity_id
+                "Model C rail gate inert for %s: no paired rail resolved", entity_id
             )
             return True
 
         inverse = self._dispatch_frame(dispatch_token)
-        middle_open = flip_if(position, inverted=inverse)
+        target_open = flip_if(position, inverted=inverse)
         tolerance = self._position_tolerance
 
-        def _cleared(bottom_wire: int) -> bool:
-            return flip_if(bottom_wire, inverted=inverse) <= middle_open + tolerance
+        if is_middle:
+            leading_rail = bottom_rail
+
+            def _cleared(wire: int) -> bool:
+                return flip_if(wire, inverted=inverse) <= target_open + tolerance
+
+        elif self._dual_entity_middle_leads(target_open, inverse):
+            leading_rail = middle_rail
+
+            def _cleared(wire: int) -> bool:
+                return flip_if(wire, inverted=inverse) + tolerance >= target_open
+
+        else:
+            # The bottom rail leads this move: nothing is downstream of it, so
+            # it is unconditionally ungated — #1115's behaviour, now stated as a
+            # direction rather than as a rail. Clear any latch a previous
+            # raising cycle left on it; this command is going out.
+            self._pending_rail_command.discard(entity_id)
+            return True
 
         if await seq.wait_until_position(
-            bottom_rail, _cleared, timeout_seconds=None if wait else 0
+            leading_rail, _cleared, timeout_seconds=None if wait else 0
         ):
-            self._pending_middle_rail.discard(entity_id)
+            self._pending_rail_command.discard(entity_id)
             return True
-        self._pending_middle_rail.add(entity_id)
+        self._pending_rail_command.add(entity_id)
         self._debug(
-            "Model C rail gate deferring %s → %s%% (%s): bottom rail %s has not "
-            "cleared the middle rail's target",
+            "Model C rail gate deferring %s → %s%% (%s): leading rail %s has not "
+            "cleared this rail's target",
             entity_id,
             position,
             reason,
-            bottom_rail,
+            leading_rail,
         )
         return False
 
@@ -1403,17 +1581,24 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         wait: bool = True,
         dispatch_token: bool | None = None,
     ) -> bool:
-        """Hold a Model C middle-rail command until the bottom rail has cleared.
+        """Hold a Model C rail until the rail leading this move has cleared.
 
         The single gate every position path consults: ``apply_position`` before
         it books an outbound command, and ``run_reconciliation_pass`` before it
         re-sends a recorded target. Neither can trigger the Model A blend
         pre-send that lives in ``before_position_command``.
 
+        EITHER rail of the pair may be the one held: the middle rail when the
+        shade lowers (#1115), the bottom rail when it raises past a middle rail
+        that has not vacated yet (#1118). Every other entity — Models A and B,
+        an unconfigured middle rail, a cover outside the pair — is always clear.
+        Which of the two is being asked about is passed down rather than
+        re-derived, so the role test is stated once.
+
         ``wait=False`` takes ONE reading instead of polling out the budget —
         what the reconciliation timer passes, because that budget is its own
         interval and a blocked rail would otherwise keep a pass alive into the
-        next one. The bottom rail is not going anywhere in the meantime: the
+        next one. The leading rail is not going anywhere in the meantime: the
         withhold latches and the next tick re-asks.
 
         ``dispatch_token`` names WHICH dispatch ``position`` came from — the
@@ -1424,13 +1609,19 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         against a per-cycle record a later resolve may have restated
         (issue #1115). ``None`` arrives only from a target no dispatch produced,
         and resolves to the install's own frame like every other unnamed frame
-        — see :meth:`_gate_middle_rail_clearance` for who books one and why the
+        — see :meth:`_gate_rail_clearance` for who books one and why the
         install flag, not the per-cycle record, is the honest answer there.
         """
-        if not self._is_dual_entity_middle_rail(entity_id):
+        is_middle = self._is_dual_entity_middle_rail(entity_id)
+        if not is_middle and not self._is_dual_entity_bottom_rail(entity_id):
             return True
-        return await self._gate_middle_rail_clearance(
-            entity_id, position, reason, wait=wait, dispatch_token=dispatch_token
+        return await self._gate_rail_clearance(
+            entity_id,
+            position,
+            reason,
+            wait=wait,
+            dispatch_token=dispatch_token,
+            is_middle=is_middle,
         )
 
     def _debug(self, msg: str, *args) -> None:

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -379,11 +379,13 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             # a Model C day/night member inside a group sequences its rails
             # exactly as it does standalone, and names the number and frame this
             # loop fans out so the ordering view can tell a raise from a lower
-            # (issue #1118). Same pair ``async_apply_user_position`` hands
-            # ``_entity_target`` below, resolved against the MEMBER's own frame.
+            # (issue #1118). ``user_dispatch_position`` is the MEMBER's own
+            # shared derivation — its floors, its frame — which is the same one
+            # ``async_apply_user_position`` runs below; the group's would answer
+            # for the wrong instance.
             ordered = coordinator._policy.order_for_dispatch(  # noqa: SLF001
                 entry.options.get(CONF_ENTITIES, []),
-                position=coordinator._to_cover_frame(position),  # noqa: SLF001
+                position=coordinator.user_dispatch_position(position),
                 inverted=coordinator.position_axis_inverted,
             )
             for entity_id in ordered:
@@ -410,11 +412,13 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
             # Same per-member ordered view as the position slider (issue #1115),
             # naming the tilt value for the direction check (issue #1118): on a
             # single-carriage type the tilt axis falls back to the position path
-            # (#684), so that IS the number reaching ``_entity_target``; a type
-            # with a real tilt axis ignores the pair entirely.
+            # (#684), so that IS the number reaching ``_entity_target`` — via
+            # the same ``async_apply_user_position`` tail, hence the same
+            # ``user_dispatch_position`` derivation, floor clamp included. A
+            # type with a real tilt axis ignores the pair entirely.
             ordered = coordinator._policy.order_for_dispatch(  # noqa: SLF001
                 entry.options.get(CONF_ENTITIES, []),
-                position=coordinator._to_cover_frame(tilt),  # noqa: SLF001
+                position=coordinator.user_dispatch_position(tilt),
                 inverted=coordinator.position_axis_inverted,
             )
             for entity_id in ordered:

--- a/custom_components/adaptive_cover_pro/group_coordinator.py
+++ b/custom_components/adaptive_cover_pro/group_coordinator.py
@@ -376,10 +376,15 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
 
         async def _member(entry, coordinator) -> None:
             # Each member's OWN policy decides its rail order (issue #1115) —
-            # a Model C day/night member inside a group needs its bottom rail
-            # commanded first exactly as it does standalone.
+            # a Model C day/night member inside a group sequences its rails
+            # exactly as it does standalone, and names the number and frame this
+            # loop fans out so the ordering view can tell a raise from a lower
+            # (issue #1118). Same pair ``async_apply_user_position`` hands
+            # ``_entity_target`` below, resolved against the MEMBER's own frame.
             ordered = coordinator._policy.order_for_dispatch(  # noqa: SLF001
-                entry.options.get(CONF_ENTITIES, [])
+                entry.options.get(CONF_ENTITIES, []),
+                position=coordinator._to_cover_frame(position),  # noqa: SLF001
+                inverted=coordinator.position_axis_inverted,
             )
             for entity_id in ordered:
                 await coordinator.async_apply_user_position(
@@ -402,9 +407,15 @@ class GroupCoordinator(DataUpdateCoordinator[GroupAggregates]):
         """
 
         async def _member(entry, coordinator) -> None:
-            # Same per-member ordered view as the position slider (issue #1115).
+            # Same per-member ordered view as the position slider (issue #1115),
+            # naming the tilt value for the direction check (issue #1118): on a
+            # single-carriage type the tilt axis falls back to the position path
+            # (#684), so that IS the number reaching ``_entity_target``; a type
+            # with a real tilt axis ignores the pair entirely.
             ordered = coordinator._policy.order_for_dispatch(  # noqa: SLF001
-                entry.options.get(CONF_ENTITIES, [])
+                entry.options.get(CONF_ENTITIES, []),
+                position=coordinator._to_cover_frame(tilt),  # noqa: SLF001
+                inverted=coordinator.position_axis_inverted,
             )
             for entity_id in ordered:
                 await coordinator.async_apply_user_tilt(

--- a/custom_components/adaptive_cover_pro/services/set_axes_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_axes_service.py
@@ -88,7 +88,19 @@ async def async_handle_set_axes(call: ServiceCall) -> None:
         # (issue #1115). Applied here rather than at the dispatch loop below so
         # ``resolved`` — which the loop iterates — carries the order through
         # validation. Identity for every cover type with independent entities.
-        for entity_id in policy.order_for_dispatch(entity_ids):
+        #
+        # Name the number this call fans out so the ordering view can tell a
+        # raise from a lower (issue #1118). The position axis when it is
+        # requested; otherwise the tilt value, which on a single-carriage type
+        # falls back to the position path and lands on the carriage anyway
+        # (#684). A type with a real tilt axis ignores the pair entirely.
+        for entity_id in policy.order_for_dispatch(
+            entity_ids,
+            position=coord._to_cover_frame(  # noqa: SLF001
+                axes.get(AXIS_NAME_POSITION, axes.get(AXIS_NAME_TILT))
+            ),
+            inverted=coord.position_axis_inverted,
+        ):
             caps = coord._cover_provider.read_single_capabilities(  # noqa: SLF001
                 entity_id
             )

--- a/custom_components/adaptive_cover_pro/services/set_axes_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_axes_service.py
@@ -94,9 +94,12 @@ async def async_handle_set_axes(call: ServiceCall) -> None:
         # requested; otherwise the tilt value, which on a single-carriage type
         # falls back to the position path and lands on the carriage anyway
         # (#684). A type with a real tilt axis ignores the pair entirely.
+        # ``user_dispatch_position`` is the shared derivation the dispatch loop
+        # below runs, floor clamp included — naming the raw request instead lets
+        # a floor flip the direction between the ordering view and the gate.
         for entity_id in policy.order_for_dispatch(
             entity_ids,
-            position=coord._to_cover_frame(  # noqa: SLF001
+            position=coord.user_dispatch_position(
                 axes.get(AXIS_NAME_POSITION, axes.get(AXIS_NAME_TILT))
             ),
             inverted=coord.position_axis_inverted,

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -64,11 +64,13 @@ async def async_handle_set_position(call: ServiceCall) -> None:
         # type whose entities are physically independent.
         #
         # Name the number and frame this loop fans out so the ordering view can
-        # tell a raise from a lower (issue #1118) — the same pair
-        # ``async_apply_user_position`` hands ``_entity_target`` downstream.
+        # tell a raise from a lower (issue #1118). ``user_dispatch_position`` is
+        # the shared derivation ``async_apply_user_position`` runs downstream,
+        # floor clamp included — naming the raw request instead lets a floor
+        # flip the direction between the ordering view and the gate.
         ordered = coord._policy.order_for_dispatch(  # noqa: SLF001
             entity_ids,
-            position=coord._to_cover_frame(requested),  # noqa: SLF001
+            position=coord.user_dispatch_position(requested),
             inverted=coord.position_axis_inverted,
         )
         for entity_id in ordered:

--- a/custom_components/adaptive_cover_pro/services/set_position_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_position_service.py
@@ -62,7 +62,15 @@ async def async_handle_set_position(call: ServiceCall) -> None:
         # (issue #1115) — applied to an explicit entity filter too, since a
         # Model C target block can name both rails. Identity for every cover
         # type whose entities are physically independent.
-        ordered = coord._policy.order_for_dispatch(entity_ids)  # noqa: SLF001
+        #
+        # Name the number and frame this loop fans out so the ordering view can
+        # tell a raise from a lower (issue #1118) — the same pair
+        # ``async_apply_user_position`` hands ``_entity_target`` downstream.
+        ordered = coord._policy.order_for_dispatch(  # noqa: SLF001
+            entity_ids,
+            position=coord._to_cover_frame(requested),  # noqa: SLF001
+            inverted=coord.position_axis_inverted,
+        )
         for entity_id in ordered:
             await coord.async_apply_user_axis(
                 entity_id,

--- a/custom_components/adaptive_cover_pro/services/set_tilt_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_tilt_service.py
@@ -65,11 +65,13 @@ async def async_handle_set_tilt(call: ServiceCall) -> None:
         #
         # That fallback is also why the tilt value is the number named for the
         # direction check (issue #1118): on a single-carriage type it IS what
-        # reaches ``_entity_target``, and a type with a real tilt axis ignores
-        # the pair entirely.
+        # reaches ``_entity_target``, through the very same
+        # ``async_apply_user_position`` tail — so it is derived here by the same
+        # ``user_dispatch_position``, floor clamp included. A type with a real
+        # tilt axis ignores the pair entirely.
         ordered = coord._policy.order_for_dispatch(  # noqa: SLF001
             entity_ids,
-            position=coord._to_cover_frame(requested),  # noqa: SLF001
+            position=coord.user_dispatch_position(requested),
             inverted=coord.position_axis_inverted,
         )
         for entity_id in ordered:

--- a/custom_components/adaptive_cover_pro/services/set_tilt_service.py
+++ b/custom_components/adaptive_cover_pro/services/set_tilt_service.py
@@ -62,7 +62,16 @@ async def async_handle_set_tilt(call: ServiceCall) -> None:
         # Same policy-mandated dispatch order as ``set_position`` (issue #1115):
         # the tilt axis falls back to the position axis on an entity without
         # slat support, so this seam can put a real position on the wire too.
-        ordered = coord._policy.order_for_dispatch(entity_ids)  # noqa: SLF001
+        #
+        # That fallback is also why the tilt value is the number named for the
+        # direction check (issue #1118): on a single-carriage type it IS what
+        # reaches ``_entity_target``, and a type with a real tilt axis ignores
+        # the pair entirely.
+        ordered = coord._policy.order_for_dispatch(  # noqa: SLF001
+            entity_ids,
+            position=coord._to_cover_frame(requested),  # noqa: SLF001
+            inverted=coord.position_axis_inverted,
+        )
         for entity_id in ordered:
             await coord.async_apply_user_axis(
                 entity_id, AXIS_NAME_TILT, requested, trigger="set_tilt", force=force

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -395,8 +395,13 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
                 # bottom rail must be commanded before its middle rail, which
                 # cannot physically travel past it. Identity for every cover
                 # type whose entities are independent.
+                # Name the number and frame this loop fans out so the ordering
+                # view can tell a raise from a lower (issue #1118) — the same
+                # pair ``_entity_target`` gets below.
                 ordered = self.coordinator._policy.order_for_dispatch(  # noqa: SLF001
-                    self.coordinator.entities
+                    self.coordinator.entities,
+                    position=default_position,
+                    inverted=False,
                 )
                 for entity in ordered:
                     # Sanctioned one-shot transition: auto_control was just

--- a/tests/ha_helpers.py
+++ b/tests/ha_helpers.py
@@ -213,6 +213,13 @@ def wire_dispatch_frame(
     derives it, and ``position_axis_inverted`` is evaluated through the real
     property, so no fixture ever hand-rolls the inversion formula it is meant
     to be exercising.
+
+    The min-mode floor clamp is bound for the same reason (#1118). It runs
+    before the frame mapping on every user command and is shared with
+    ``user_dispatch_position``, the accessor the fan-out seams name their
+    dispatched target through — so a mock that binds the real
+    ``async_apply_user_position`` but leaves the clamp mocked dispatches
+    ``int(MagicMock())`` instead of a position.
     """
     from custom_components.adaptive_cover_pro.const import (
         CONF_INTERP,
@@ -239,6 +246,14 @@ def wire_dispatch_frame(
     )
     coord._to_cover_frame = AdaptiveDataUpdateCoordinator._to_cover_frame.__get__(coord)
     coord._entity_target = AdaptiveDataUpdateCoordinator._entity_target.__get__(coord)
+    for name in (
+        "_build_user_command_snapshot",
+        "_clamp_to_active_floor",
+        "user_dispatch_position",
+    ):
+        setattr(
+            coord, name, getattr(AdaptiveDataUpdateCoordinator, name).__get__(coord)
+        )
     return coord
 
 

--- a/tests/test_day_night_dual_entity.py
+++ b/tests/test_day_night_dual_entity.py
@@ -595,7 +595,7 @@ async def test_pending_middle_rail_withholds_dispatched_target_signature() -> No
     mode, reached here through the #1115 travel gate).
     """
     policy = _dual_policy(position=40, blend=50)
-    policy._pending_middle_rail.add(_MIDDLE)
+    policy._pending_rail_command.add(_MIDDLE)
     coord = _latch_coordinator(policy)
 
     await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
@@ -610,7 +610,7 @@ async def test_pending_middle_rail_withholds_dispatched_target_signature() -> No
     assert coord._last_dispatched_target_sig is None
 
     # Once the gate clears the latch, the signature is recorded as normal.
-    policy._pending_middle_rail.clear()
+    policy._pending_rail_command.clear()
     await AdaptiveDataUpdateCoordinator._dispatch_for_cycle(
         coord,
         40,

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -1201,7 +1201,24 @@ async def test_bottom_rail_proceeds_immediately_when_the_middle_is_already_clear
 # lead instead, and the whole failure disappears.
 
 
-def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch):
+def _min_mode_floor(position: int, priority: int):
+    """One active min-mode floor, shaped exactly as the pipeline hands it over.
+
+    ``priority`` above :class:`ManualOverrideHandler`'s 80 is what makes the
+    floor clamp a user command at all (#472). A weather override with min-mode
+    (90) or any custom-position slot configured above 80 produces this.
+    """
+    from custom_components.adaptive_cover_pro.pipeline.floors import FloorClampInfo
+
+    return FloorClampInfo(
+        source="weather_override_min_mode",
+        label="Weather override",
+        position=position,
+        priority=priority,
+    )
+
+
+def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch, floors=()):
     """Build a coordinator over the REAL ``async_apply_user_position`` tail.
 
     Everything a user command actually crosses on its way to the wire is
@@ -1209,6 +1226,14 @@ def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch):
     remap, the command service and the policy's travel gate. Only the
     snapshot / pipeline / manager collaborators around the floor clamp are
     stubbed, because none of them has anything to say about the rails.
+
+    ``floors`` declares what the min-mode gatherer finds. The gatherer itself
+    has to be stubbed either way — the snapshot here is a ``MagicMock`` and the
+    real one would walk it — but everything downstream of it stays production
+    code: ``effective_floor``'s max-of-floors composition, the
+    outranks-manual-override predicate and the ``max()`` clamp. That arithmetic
+    is precisely what the ordering view has to agree with, so it must not be
+    stubbed alongside the walk.
     """
     from custom_components.adaptive_cover_pro import coordinator as coordinator_module
 
@@ -1228,15 +1253,22 @@ def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch):
     coord._build_position_context = lambda _entity, _options, **_kw: _rail_context(
         policy
     )  # noqa: ARG005
-    for name in ("_entity_target", "_to_cover_frame", "async_apply_user_position"):
+    for name in (
+        "_entity_target",
+        "_to_cover_frame",
+        "_build_user_command_snapshot",
+        "_clamp_to_active_floor",
+        "user_dispatch_position",
+        "async_apply_user_position",
+    ):
         setattr(
             coord,
             name,
             types.MethodType(getattr(AdaptiveDataUpdateCoordinator, name), coord),
         )
-    # No min-mode floor is configured here, and the real gatherer would otherwise
-    # walk the stubbed snapshot.
-    monkeypatch.setattr(coordinator_module, "gather_active_floors", lambda _s: [])
+    monkeypatch.setattr(
+        coordinator_module, "gather_active_floors", lambda _s: list(floors)
+    )
     return coord
 
 
@@ -1300,6 +1332,170 @@ async def test_my_position_button_raise_sends_both_rails_without_stalling(
     # Nothing was withheld, so nothing is left latched waiting for a retry that
     # manual override has already blocked.
     assert policy.has_pending_secondary_axis(_BOTTOM) is False
+    assert elapsed < 10, elapsed
+
+
+# ---------------------------------------------------------------------------
+# The ordering view and the gate must be asked about the SAME number
+# ---------------------------------------------------------------------------
+# A user command's dispatched value is not the value the user asked for: an
+# active min-mode floor that outranks manual override raises it before dispatch
+# (#472), and the interpolation curve reshapes it again (#1027). The travel gate
+# is asked about the number that actually goes on the wire, so if the ordering
+# view is handed the raw request instead, the two can disagree about which way
+# the shade is travelling — in EITHER direction:
+#
+#   * a floor turning a lower into a raise: ordering sees a lower and leads with
+#     the bottom rail, whose gate then finds the real (clamped) target above the
+#     middle rail and withholds it;
+#   * a DESCENDING interpolation curve (np.interp puts no monotonicity on
+#     new_range): the floor raises the logical number while the curve lowers the
+#     dispatched one, so ordering INVENTS a raise, leads with the middle rail,
+#     and stalls the middle rail's unconditional gate instead.
+#
+# Both are the same bug — two derivations of one number — so both are fixed by
+# naming it once. Both cost a full settle budget and then drop the withheld
+# rail's command, which at a user seam nothing re-sends.
+
+
+@pytest.mark.asyncio
+async def test_my_position_button_raise_under_a_floor_sends_both_rails(
+    monkeypatch,
+) -> None:
+    """A floor that turns the user's lower into a raise must reorder the rails.
+
+    The My preset is 20 — below the bottom rail's live 10 is a raise of 10
+    points, and below the middle rail's live 20 it would need no reordering at
+    all. Then a min-mode floor at 80 (priority 90, so it outranks manual
+    override and clamps) turns the dispatch into a raise to 80, well past the
+    middle rail. The gate sees 80 and withholds the bottom rail; the ordering
+    view must see 80 too, or it leads with exactly the rail the gate is about
+    to block.
+
+    The settle budget is left at its real value on purpose — entering it at all
+    is half the failure, and the withheld command is the other half: a
+    ``policy_deferred`` skip books no target, so reconciliation has nothing to
+    re-send and the manual override this very press engaged stops the pipeline
+    driving it either.
+    """
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverMyPositionButton,
+    )
+
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20]},
+        position=20,
+        blend=50,
+    )
+
+    # A rail only moves once it has been commanded.
+    scripted_read = rails.read
+
+    def _read(entity_id: str) -> int | None:
+        if entity_id == _MIDDLE and f"send:{_MIDDLE}" in events:
+            return 90
+        return scripted_read(entity_id)
+
+    rails.read = _read
+
+    coord = _user_seam_coordinator(
+        cmd_svc,
+        policy,
+        entities=[_MIDDLE, _BOTTOM],
+        monkeypatch=monkeypatch,
+        floors=[_min_mode_floor(80, priority=90)],
+    )
+    button = MagicMock()
+    button._entities = [_MIDDLE, _BOTTOM]
+    button.config_entry.options = {CONF_MY_POSITION_VALUE: 20}
+    button.coordinator = coord
+
+    started = dt.datetime.now(dt.UTC)
+    with _patch_caps():
+        await AdaptiveCoverMyPositionButton.async_press(button)
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert f"send:{_BOTTOM}" in events, events
+    assert events.index(f"send:{_MIDDLE}") < events.index(f"send:{_BOTTOM}")
+    # The floor really did clamp — without this the test could pass by the
+    # request and the dispatch happening to agree.
+    assert cmd_svc.get_target(_BOTTOM) == 80
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+    assert elapsed < 10, elapsed
+
+
+@pytest.mark.asyncio
+async def test_my_position_button_lower_under_a_descending_curve_leads_bottom(
+    monkeypatch,
+) -> None:
+    """A descending interpolation curve must not let the floor invent a raise.
+
+    The mirror of the case above, and the reason the fix is "name one number"
+    rather than "apply the clamp at the seam too". Interpolation is the user's
+    own calibration table and ``np.interp`` imposes no monotonicity on it, so a
+    curve mapping 0→100 and 100→0 is legal. Under it the floor raises the
+    LOGICAL request (0 → 80) while the curve lowers the DISPATCHED value
+    (100 → 20), and the two derivations point opposite ways.
+
+    Handed the raw request, the ordering view reads 100 — above the middle
+    rail's live 95 — and leads with the middle rail on what is really a
+    lowering. The middle rail's gate is unconditional (#1115): it waits for the
+    bottom rail to descend past its own target, the bottom rail has not been
+    commanded yet, and the whole settle budget burns before the middle rail's
+    command is dropped.
+    """
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverMyPositionButton,
+    )
+
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, rails, events = _rail_harness(
+        script={_BOTTOM: [90], _MIDDLE: [95]},
+        position=0,
+        blend=50,
+    )
+
+    scripted_read = rails.read
+
+    def _read(entity_id: str) -> int | None:
+        if entity_id == _BOTTOM and f"send:{_BOTTOM}" in events:
+            return 20
+        return scripted_read(entity_id)
+
+    rails.read = _read
+
+    coord = _user_seam_coordinator(
+        cmd_svc,
+        policy,
+        entities=[_MIDDLE, _BOTTOM],
+        monkeypatch=monkeypatch,
+        floors=[_min_mode_floor(80, priority=90)],
+    )
+    # A descending calibration curve: f(0) = 100, f(80) = 20.
+    coord._use_interpolation = True
+    coord.start_value = None
+    coord.end_value = None
+    coord.normal_list = [0, 100]
+    coord.new_list = [100, 0]
+
+    button = MagicMock()
+    button._entities = [_MIDDLE, _BOTTOM]
+    button.config_entry.options = {CONF_MY_POSITION_VALUE: 0}
+    button.coordinator = coord
+
+    started = dt.datetime.now(dt.UTC)
+    with _patch_caps():
+        await AdaptiveCoverMyPositionButton.async_press(button)
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert f"send:{_BOTTOM}" in events, events
+    assert f"send:{_MIDDLE}" in events, events
+    assert events.index(f"send:{_BOTTOM}") < events.index(f"send:{_MIDDLE}")
+    # Curve applied to the CLAMPED request, not the raw one (f(80) = 20).
+    assert cmd_svc.get_target(_BOTTOM) == 20
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
     assert elapsed < 10, elapsed
 
 
@@ -1966,6 +2162,92 @@ def test_pipeline_dispatch_seams_name_their_fanned_out_target() -> None:
         "Dispatch seams that order without naming the number they are fanning "
         "out (issue #1118) — pass position=<the value _entity_target gets>, or "
         "add the seam to _UNNAMED_TARGET_SEAMS with its reason:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural guard — a USER-command seam must name its CLAMPED target
+# ---------------------------------------------------------------------------
+# The scan above proves every seam that can name a number does. This one proves
+# the number is the right one. A user command's dispatched value is not the
+# value the user asked for: ``async_apply_user_position`` raises it to any
+# min-mode floor outranking manual override (#472) before mapping it into the
+# cover's frame. The gate is asked about the result; an ordering view handed the
+# raw request can therefore read the direction backwards — a floor turns a lower
+# into a raise, and a descending interpolation curve turns the clamp itself into
+# an invented raise. Both strand a rail for a settle budget and then drop its
+# command, which at a user seam nothing re-sends.
+#
+# ``Coordinator.user_dispatch_position`` is the shared derivation. Only the My
+# button is covered end to end (both directions, above); the other five sites
+# would regress in silence.
+_USER_COMMAND_ENTRY_POINTS = frozenset(
+    {"async_apply_user_position", "async_apply_user_tilt", "async_apply_user_axis"}
+)
+_USER_DISPATCH_ACCESSOR = "user_dispatch_position"
+
+# (module path relative to the production root, innermost enclosing function).
+_USER_COMMAND_SEAMS = frozenset(
+    {
+        ("button.py", "async_press"),
+        ("services/set_position_service.py", "async_handle_set_position"),
+        ("services/set_tilt_service.py", "async_handle_set_tilt"),
+        ("services/set_axes_service.py", "async_handle_set_axes"),
+        ("group_coordinator.py", "_member"),
+    }
+)
+
+
+@pytest.mark.unit
+def test_user_command_seams_name_the_number_they_will_actually_dispatch() -> None:
+    """Fail if a user-command seam orders on the request instead of the dispatch.
+
+    A seam whose fan-out ends in ``async_apply_user_position`` / ``_tilt`` /
+    ``_axis`` must derive its ``position=`` through
+    ``Coordinator.user_dispatch_position`` — the same clamp and the same frame
+    mapping that tail runs. Calling ``_to_cover_frame`` directly reproduces the
+    frame half and drops the floor clamp, which is exactly enough to make the
+    ordering view and the travel gate disagree about the direction of travel.
+
+    On a group seam the accessor has to be the MEMBER coordinator's: the floors
+    and the frame both belong to the instance being commanded, not to the group.
+    That is not checkable structurally, which is why it is stated here.
+    """
+    offenders: list[str] = []
+    seen: set[tuple[str, str]] = set()
+
+    for path in sorted(_PRODUCTION_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        module = path.relative_to(_PRODUCTION_ROOT).as_posix()
+        for call, enclosing in _order_view_calls(tree):
+            if enclosing is None or not (
+                _called_names(enclosing) & _USER_COMMAND_ENTRY_POINTS
+            ):
+                continue
+            fn_name = enclosing.name
+            seen.add((module, fn_name))
+            named = next(
+                (kw.value for kw in call.keywords if kw.arg == "position"), None
+            )
+            if named is None or _USER_DISPATCH_ACCESSOR not in _called_names(named):
+                offenders.append(
+                    f"{path.relative_to(_REPO_ROOT)}:{call.lineno} ({fn_name})"
+                )
+
+    missing = _USER_COMMAND_SEAMS - seen
+    assert not missing, (
+        "The user-command seam scan found no ordered fan-out in: "
+        f"{sorted(missing)}. Either the seam moved (update _USER_COMMAND_SEAMS) "
+        "or it stopped dispatching through a user-command entry point (update "
+        "_USER_COMMAND_ENTRY_POINTS) — until then this guard is watching "
+        "nothing."
+    )
+    assert not offenders, (
+        "User-command seams ordering on the requested number rather than the "
+        "dispatched one (issue #1118) — pass "
+        f"position=<coord>.{_USER_DISPATCH_ACCESSOR}(<request>) so the ordering "
+        "view and the travel gate are asked about the same value:\n  "
         + "\n  ".join(offenders)
     )
 

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -327,8 +327,10 @@ def _record_user_commands(coordinator, method_name: str) -> list[str]:
 async def test_my_position_button_commands_bottom_rail_before_middle() -> None:
     """The My Position button fans its preset out in policy-mandated rail order.
 
-    This seam does not name its fanned-out target, so it rides the conservative
-    bottom-first fallback (#1118).
+    This seam DOES name its fanned-out target (#1118), but the coordinator here
+    is a stub whose policy was never ``attach``ed, so the direction check has no
+    live reading to work from and lands on the conservative bottom-first
+    fallback — which is what this test is about.
     """
     from custom_components.adaptive_cover_pro.button import (
         AdaptiveCoverMyPositionButton,
@@ -351,8 +353,10 @@ async def test_set_position_service_commands_bottom_rail_before_middle(
 ) -> None:
     """``adaptive_cover_pro.set_position`` over a whole instance orders its fan-out.
 
-    This seam does not name its fanned-out target, so it rides the conservative
-    bottom-first fallback (#1118).
+    This seam DOES name its fanned-out target (#1118), but the coordinator here
+    is a stub whose policy was never ``attach``ed, so the direction check has no
+    live reading to work from and lands on the conservative bottom-first
+    fallback — which is what this test is about.
     """
     from custom_components.adaptive_cover_pro.services import set_position_service
 
@@ -381,8 +385,10 @@ async def test_set_tilt_service_commands_bottom_rail_before_middle(
     support (#684), which puts a real position on the wire — the same seam
     shape, and the same reason to order it.
 
-    This seam does not name its fanned-out target, so it rides the conservative
-    bottom-first fallback (#1118).
+    This seam DOES name its fanned-out target (#1118), but the coordinator here
+    is a stub whose policy was never ``attach``ed, so the direction check has no
+    live reading to work from and lands on the conservative bottom-first
+    fallback — which is what this test is about.
     """
     from custom_components.adaptive_cover_pro.services import set_tilt_service
 
@@ -407,8 +413,10 @@ async def test_set_axes_service_commands_bottom_rail_before_middle(
 ) -> None:
     """``set_axes`` validates up front, then dispatches in rail order.
 
-    This seam does not name its fanned-out target, so it rides the conservative
-    bottom-first fallback (#1118).
+    This seam DOES name its fanned-out target (#1118), but the coordinator here
+    is a stub whose policy was never ``attach``ed, so the direction check has no
+    live reading to work from and lands on the conservative bottom-first
+    fallback — which is what this test is about.
     """
     from custom_components.adaptive_cover_pro.services import set_axes_service
 
@@ -448,8 +456,10 @@ def _group_fan_out_to_one_member(member_coord) -> MagicMock:
 async def test_group_cover_slider_commands_bottom_rail_before_middle() -> None:
     """A cover group dragging its slider orders each member's own rails.
 
-    This seam does not name its fanned-out target, so it rides the conservative
-    bottom-first fallback (#1118).
+    This seam DOES name its fanned-out target (#1118), but the coordinator here
+    is a stub whose policy was never ``attach``ed, so the direction check has no
+    live reading to work from and lands on the conservative bottom-first
+    fallback — which is what this test is about.
     """
     from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
 
@@ -468,8 +478,10 @@ async def test_group_cover_slider_commands_bottom_rail_before_middle() -> None:
 async def test_group_cover_tilt_commands_bottom_rail_before_middle() -> None:
     """The group tilt slider rides the same per-member ordered view.
 
-    This seam does not name its fanned-out target, so it rides the conservative
-    bottom-first fallback (#1118).
+    This seam DOES name its fanned-out target (#1118), but the coordinator here
+    is a stub whose policy was never ``attach``ed, so the direction check has no
+    live reading to work from and lands on the conservative bottom-first
+    fallback — which is what this test is about.
     """
     from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
 
@@ -977,12 +989,14 @@ def test_order_for_dispatch_keeps_bottom_first_when_lowering() -> None:
 def test_order_for_dispatch_falls_back_to_bottom_first_without_a_named_target() -> None:
     """A seam that names no fanned-out target rides the conservative default.
 
-    The sunset broadcast, the user-command seams and the reconciliation pass all
-    dispatch a number that only exists per-entity further down their own call
-    chain, so none of them can hand the ordering view the pair the gate will
-    later be asked about. They get #1115's shipped constant instead — ordering
-    is a LATENCY mechanism, and the gates (which are always authoritative) still
-    withhold anything the fallback order sends too early.
+    The reconciliation pass holds a MAP of per-entity targets booked by
+    different seams in different eras, not one fanned-out number, so it cannot
+    hand the ordering view the pair the gate will later be asked about. It gets
+    #1115's shipped constant instead — ordering is a LATENCY mechanism, and the
+    gates (which are always authoritative) still withhold anything the fallback
+    order sends too early. That deferral is harmless there specifically because
+    every gate on the reconciliation path runs ``wait=False``: one reading, no
+    settle budget, and the recorded target is still booked for the next pass.
 
     The empty event log is load-bearing: the fallback must short-circuit before
     it touches the sequencer, or every poll-count assertion in this module
@@ -1171,6 +1185,122 @@ async def test_bottom_rail_proceeds_immediately_when_the_middle_is_already_clear
     # One confirming read to establish direction, no polling loop.
     assert events.count(f"poll:{_MIDDLE}") == 1, events
     assert events[-1] == f"send:{_BOTTOM}"
+
+
+# ---------------------------------------------------------------------------
+# A raising USER command must not strand the bottom rail
+# ---------------------------------------------------------------------------
+# The user-command seams are the worst place to lose the rail order, because the
+# same press engages manual override. Ordered bottom-first on a RAISE, the bottom
+# rail's gate polls a middle rail that nothing has commanded — it cannot move, so
+# the gate burns its whole settle budget and then withholds. A withheld command
+# is a ``policy_deferred`` SKIP: nothing is booked, so the reconciliation pass
+# has no target to resend, and manual override stops the pipeline re-driving it.
+# The shade half-moves, hangs for the budget, and stays split until the user
+# presses again. Naming the fanned-out number at the seam makes the middle rail
+# lead instead, and the whole failure disappears.
+
+
+def _user_seam_coordinator(cmd_svc, policy, *, entities, monkeypatch):
+    """Build a coordinator over the REAL ``async_apply_user_position`` tail.
+
+    Everything a user command actually crosses on its way to the wire is
+    production code: the logical→cover frame mapping, the per-entity middle-rail
+    remap, the command service and the policy's travel gate. Only the
+    snapshot / pipeline / manager collaborators around the floor clamp are
+    stubbed, because none of them has anything to say about the rails.
+    """
+    from custom_components.adaptive_cover_pro import coordinator as coordinator_module
+
+    coord = MagicMock()
+    coord.logger = MagicMock()
+    coord.entities = list(entities)
+    coord._policy = policy
+    coord._cmd_svc = cmd_svc
+    coord._resolved_options = {}
+    coord.config_entry.options = {}
+    coord._inverse_state = False
+    coord._use_interpolation = False
+    coord.position_axis_inverted = False
+    coord._pipeline.evaluate = MagicMock(
+        return_value=types.SimpleNamespace(decision_trace=[])
+    )
+    coord._build_position_context = lambda _entity, _options, **_kw: _rail_context(
+        policy
+    )  # noqa: ARG005
+    for name in ("_entity_target", "_to_cover_frame", "async_apply_user_position"):
+        setattr(
+            coord,
+            name,
+            types.MethodType(getattr(AdaptiveDataUpdateCoordinator, name), coord),
+        )
+    # No min-mode floor is configured here, and the real gatherer would otherwise
+    # walk the stubbed snapshot.
+    monkeypatch.setattr(coordinator_module, "gather_active_floors", lambda _s: [])
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_my_position_button_raise_sends_both_rails_without_stalling(
+    monkeypatch,
+) -> None:
+    """A raising My press must move BOTH rails, and must not wait out a budget.
+
+    End to end through the real button, the real
+    ``Coordinator.async_apply_user_position``, the real ``CoverCommandService``
+    and the real policy gate — the ordering decision is the seam's own, not a
+    hand-rolled ``order_for_dispatch`` call, which is the point: this is the one
+    thing that notices if the My button stops naming the number it fans out.
+
+    The middle rail is pinned at 20 until its OWN command goes out, which is what
+    makes the failure deterministic rather than a race: dispatched bottom-first,
+    the bottom rail's gate polls a rail that physically cannot have moved and
+    burns the full ``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS``, then withholds.
+    The budget is deliberately left at its real value — entering it at all is the
+    failure this test exists to catch.
+    """
+    from custom_components.adaptive_cover_pro.button import (
+        AdaptiveCoverMyPositionButton,
+    )
+
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20]},
+        position=60,
+        blend=50,
+    )
+
+    # A rail only moves once it has been commanded. Until then the middle rail
+    # sits where it is, however long anything waits on it.
+    scripted_read = rails.read
+
+    def _read(entity_id: str) -> int | None:
+        if entity_id == _MIDDLE and f"send:{_MIDDLE}" in events:
+            return 90
+        return scripted_read(entity_id)
+
+    rails.read = _read
+
+    coord = _user_seam_coordinator(
+        cmd_svc, policy, entities=[_MIDDLE, _BOTTOM], monkeypatch=monkeypatch
+    )
+    button = MagicMock()
+    button._entities = [_MIDDLE, _BOTTOM]
+    button.config_entry.options = {CONF_MY_POSITION_VALUE: 60}
+    button.coordinator = coord
+
+    started = dt.datetime.now(dt.UTC)
+    with _patch_caps():
+        await AdaptiveCoverMyPositionButton.async_press(button)
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert f"send:{_BOTTOM}" in events, events
+    assert f"send:{_MIDDLE}" in events, events
+    assert events.index(f"send:{_MIDDLE}") < events.index(f"send:{_BOTTOM}")
+    # Nothing was withheld, so nothing is left latched waiting for a retry that
+    # manual override has already blocked.
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+    assert elapsed < 10, elapsed
 
 
 # ---------------------------------------------------------------------------
@@ -1763,37 +1893,12 @@ def test_every_ordering_exemption_names_a_test_that_covers_its_caller() -> None:
 # (module path relative to the production root, innermost enclosing function) →
 # why this seam legitimately cannot name the number it is fanning out.
 _UNNAMED_TARGET_SEAMS = {
-    ("coordinator.py", "_check_sunset_window_transition"): (
-        "Orders the list on WindowTransitionTracker.check_sunset_window's "
-        "behalf and holds only the raw config percent — the tracker computes "
-        "the dispatched value itself (flip_if(sunset_pos_cfg, "
-        "inverted=inverse_state_enabled)), so re-deriving it here would "
-        "duplicate that line."
-    ),
-    ("button.py", "async_press"): (
-        "Fans out a logical My percent that only becomes a per-entity framed "
-        "number inside async_apply_user_position, so no single "
-        "(position, inverted) pair exists here."
-    ),
-    ("services/set_position_service.py", "async_handle_set_position"): (
-        "User command: the framed per-entity value is produced downstream in "
-        "async_apply_user_position, not at this call site."
-    ),
-    ("services/set_tilt_service.py", "async_handle_set_tilt"): (
-        "User command: the framed per-entity value is produced downstream in "
-        "async_apply_user_position, not at this call site."
-    ),
-    ("services/set_axes_service.py", "async_handle_set_axes"): (
-        "User command: the framed per-entity value is produced downstream in "
-        "async_apply_user_position, not at this call site."
-    ),
-    ("group_coordinator.py", "_member"): (
-        "Group fan-out hands each member a logical percent; the member "
-        "coordinator frames it per entity further down."
-    ),
     ("managers/cover_command/__init__.py", "run_reconciliation_pass"): (
         "Holds a MAP of per-entity targets booked by different seams in "
-        "different eras, not one fanned-out number."
+        "different eras, not one fanned-out number. Harmless: every gate on "
+        "this path runs wait=False, so a mis-ordered rail takes ONE reading, "
+        "defers for a tick and is re-asked by the next pass — it never enters "
+        "a settle budget and the recorded target is still there to resend."
     ),
 }
 

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -1,27 +1,38 @@
-"""Model C (dual_entity) rail travel sequencing — issue #1115.
+"""Model C (dual_entity) rail travel sequencing — issues #1115 and #1118.
 
 Two stacked rails hang in one headbox: sheer fabric spans head rail → middle
-rail, blackout spans middle rail → bottom rail. They share a track, so the
-middle rail physically CANNOT pass below the bottom rail. That makes the
-arithmetic no-pass clamp in ``resolve_entity_target`` (``M >= P`` on two
-numbers) necessary but not sufficient: if the bottom rail is currently stacked
-ABOVE the middle rail's target, commanding the middle rail there tells a motor
-to travel somewhere it cannot reach until the bottom rail descends past it —
-stall, over-current trip, or lost calibration.
+rail, blackout spans middle rail → bottom rail. They share a track, so neither
+rail can pass the other. That makes the arithmetic no-pass clamp in
+``resolve_entity_target`` (``M >= P`` on two numbers) necessary but not
+sufficient: it says where the two rails will END UP, never where either one
+currently IS, and a rail commanded through a space its partner still occupies
+tells a motor to travel somewhere it cannot reach — stall, over-current trip,
+or lost calibration.
 
-Two independent mechanisms fix that, and this module covers both:
+The rail DOWNSTREAM in the direction of travel has to vacate first, so which
+rail leads depends on which way the shade is going:
 
-* **Ordering** — the bottom rail's command must go out before the middle
-  rail's, whatever order the user picked the covers in. Owned by
+* **lowering** — the bottom rail leads, the middle rail waits until the bottom
+  rail's live position has cleared the middle rail's target (#1115);
+* **raising** — the middle rail leads, the bottom rail waits until the middle
+  rail's live position has cleared the bottom rail's target (#1118).
+
+Two independent mechanisms enforce that, and this module covers both:
+
+* **Ordering** — the leading rail's command must go out first, whatever order
+  the user picked the covers in. Owned by
   ``CoverTypePolicy.dispatch_order_key`` and applied by the single shared
-  ``order_for_dispatch`` view every dispatch seam consumes.
-* **The clearance gate** — the middle rail's command is withheld until the
-  bottom rail's LIVE position has cleared the middle rail's target, compared in
+  ``order_for_dispatch`` view every dispatch seam consumes. A seam that can name
+  the number it is fanning out gets a direction-aware order; one that cannot
+  falls back to bottom-first.
+* **The clearance gate** — the following rail's command is withheld until the
+  leading rail's LIVE position has cleared the follower's target, compared in
   open-percent space against the frame the DISPATCHING SEAM expressed its value
   in. Owned by ``DayNightShadePolicy`` and reached through the one
   ``await_dispatch_clearance`` hook, which ``CoverCommandService.apply_position``
   asks before it books an outbound command and ``run_reconciliation_pass`` asks
-  (single-shot) before it re-sends a recorded one.
+  (single-shot) before it re-sends a recorded one. Always authoritative,
+  whatever order the seam dispatched in.
 
 Both mechanisms apply to every seam that puts a position on the wire, including
 the reconciliation timer — the motor does not care which code path asked.
@@ -152,8 +163,20 @@ def test_order_for_dispatch_preserves_order_for_day_night_model_a() -> None:
     assert policy.order_for_dispatch(picked) == picked
 
 
-def test_order_for_dispatch_puts_bottom_rail_first_under_model_c() -> None:
-    """Model C sorts the middle rail last, whatever order it was picked in."""
+def test_order_for_dispatch_falls_back_to_bottom_first_without_a_live_reading() -> None:
+    """No sequencer and no named target → #1115's shipped constant order.
+
+    Was ``test_order_for_dispatch_puts_bottom_rail_first_under_model_c``. Since
+    #1118 the order depends on the direction of travel, which needs both a live
+    middle-rail reading and the number the seam is fanning out. This policy has
+    neither — it was never ``attach``ed and no ``position=`` is named — so it
+    gets the documented conservative fallback, whatever order it was picked in.
+
+    The assertion this used to carry ("bottom first under Model C") is now
+    carried, with a live reading and a real direction evaluation behind it, by
+    ``test_order_for_dispatch_keeps_bottom_first_when_lowering``; its raise
+    counterpart is ``test_order_for_dispatch_puts_middle_rail_first_when_raising``.
+    """
     policy = _dual_policy(position=40, blend=50)
     assert policy.order_for_dispatch([_MIDDLE, _BOTTOM]) == [_BOTTOM, _MIDDLE]
     assert policy.order_for_dispatch([_BOTTOM, _MIDDLE]) == [_BOTTOM, _MIDDLE]
@@ -208,8 +231,44 @@ async def test_dispatch_cycle_commands_bottom_rail_before_middle() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_cycle_commands_middle_rail_before_bottom_when_raising() -> None:
+    """A RAISING cycle inverts the rail order (issue #1118).
+
+    The mirror of the test above. The bottom rail sits low at 10 and this cycle
+    resolves it up to 60, past a middle rail still parked at 20 — so the middle
+    rail is now the rail downstream of the travel and has to vacate first.
+
+    The main dispatch loop can only get that right if it NAMES the number it is
+    fanning out (``order_for_dispatch(self.entities, position=state)``). Drop
+    that argument and the ordering view falls back to the direction-blind
+    constant: this test goes red while every unit-level ordering test stays
+    green, which is exactly the regression it exists to catch.
+
+    (``_attach_scripted_rails`` is defined further down, beside the ``_Rails``
+    script it wraps — the ordering hook needs a live middle-rail reading, but
+    not the whole command-service harness.)
+    """
+    policy = _dual_policy(position=60, blend=50)
+    _attach_scripted_rails(policy, {_BOTTOM: [10], _MIDDLE: [20]})
+    coordinator = _ordering_coordinator(policy, entities=[_BOTTOM, _MIDDLE])
+
+    await AdaptiveDataUpdateCoordinator.async_handle_state_change(
+        coordinator, state=60, options={}
+    )
+
+    assert [eid for eid, _pos in coordinator._cmd_svc.calls] == [_MIDDLE, _BOTTOM]
+    # The per-rail arithmetic is untouched by the reordering.
+    assert dict(coordinator._cmd_svc.calls) == {_BOTTOM: 60, _MIDDLE: 80}
+
+
+@pytest.mark.asyncio
 async def test_first_refresh_commands_bottom_rail_before_middle() -> None:
-    """Startup dispatch rides the same ordered view as the main loop."""
+    """Startup dispatch rides the same ordered view as the main loop.
+
+    This seam does name its fanned-out target (#1118), but the policy here is
+    never ``attach``ed, so the direction check has no live reading to work from
+    and lands on the conservative bottom-first fallback.
+    """
     policy = _dual_policy(position=40, blend=50)
     coordinator = _ordering_coordinator(policy, entities=[_MIDDLE, _BOTTOM])
     coordinator.manager.is_cover_manual = lambda _eid: False
@@ -223,7 +282,12 @@ async def test_first_refresh_commands_bottom_rail_before_middle() -> None:
 
 @pytest.mark.asyncio
 async def test_force_send_commands_bottom_rail_before_middle() -> None:
-    """The force-send seam orders an explicitly-supplied cover subset too."""
+    """The force-send seam orders an explicitly-supplied cover subset too.
+
+    This seam does name its fanned-out target (#1118), but the policy here is
+    never ``attach``ed, so the direction check has no live reading to work from
+    and lands on the conservative bottom-first fallback.
+    """
     policy = _dual_policy(position=40, blend=50)
     coordinator = _ordering_coordinator(policy, entities=[_MIDDLE, _BOTTOM])
     coordinator.manager.is_cover_manual = lambda _eid: False
@@ -261,7 +325,11 @@ def _record_user_commands(coordinator, method_name: str) -> list[str]:
 
 @pytest.mark.asyncio
 async def test_my_position_button_commands_bottom_rail_before_middle() -> None:
-    """The My Position button fans its preset out in policy-mandated rail order."""
+    """The My Position button fans its preset out in policy-mandated rail order.
+
+    This seam does not name its fanned-out target, so it rides the conservative
+    bottom-first fallback (#1118).
+    """
     from custom_components.adaptive_cover_pro.button import (
         AdaptiveCoverMyPositionButton,
     )
@@ -281,7 +349,11 @@ async def test_my_position_button_commands_bottom_rail_before_middle() -> None:
 async def test_set_position_service_commands_bottom_rail_before_middle(
     monkeypatch,
 ) -> None:
-    """``adaptive_cover_pro.set_position`` over a whole instance orders its fan-out."""
+    """``adaptive_cover_pro.set_position`` over a whole instance orders its fan-out.
+
+    This seam does not name its fanned-out target, so it rides the conservative
+    bottom-first fallback (#1118).
+    """
     from custom_components.adaptive_cover_pro.services import set_position_service
 
     coord = MagicMock()
@@ -308,6 +380,9 @@ async def test_set_tilt_service_commands_bottom_rail_before_middle(
     The tilt axis falls back to the position axis on an entity without slat
     support (#684), which puts a real position on the wire — the same seam
     shape, and the same reason to order it.
+
+    This seam does not name its fanned-out target, so it rides the conservative
+    bottom-first fallback (#1118).
     """
     from custom_components.adaptive_cover_pro.services import set_tilt_service
 
@@ -330,7 +405,11 @@ async def test_set_tilt_service_commands_bottom_rail_before_middle(
 async def test_set_axes_service_commands_bottom_rail_before_middle(
     monkeypatch,
 ) -> None:
-    """``set_axes`` validates up front, then dispatches in rail order."""
+    """``set_axes`` validates up front, then dispatches in rail order.
+
+    This seam does not name its fanned-out target, so it rides the conservative
+    bottom-first fallback (#1118).
+    """
     from custom_components.adaptive_cover_pro.services import set_axes_service
 
     coord = MagicMock()
@@ -367,7 +446,11 @@ def _group_fan_out_to_one_member(member_coord) -> MagicMock:
 
 @pytest.mark.asyncio
 async def test_group_cover_slider_commands_bottom_rail_before_middle() -> None:
-    """A cover group dragging its slider orders each member's own rails."""
+    """A cover group dragging its slider orders each member's own rails.
+
+    This seam does not name its fanned-out target, so it rides the conservative
+    bottom-first fallback (#1118).
+    """
     from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
 
     member_coord = MagicMock()
@@ -383,7 +466,11 @@ async def test_group_cover_slider_commands_bottom_rail_before_middle() -> None:
 
 @pytest.mark.asyncio
 async def test_group_cover_tilt_commands_bottom_rail_before_middle() -> None:
-    """The group tilt slider rides the same per-member ordered view."""
+    """The group tilt slider rides the same per-member ordered view.
+
+    This seam does not name its fanned-out target, so it rides the conservative
+    bottom-first fallback (#1118).
+    """
     from custom_components.adaptive_cover_pro.group_coordinator import GroupCoordinator
 
     member_coord = MagicMock()
@@ -422,6 +509,28 @@ class _Rails:
     def park(self, entity_id: str, position: int) -> None:
         """Park one rail at a fixed position for every subsequent read."""
         self._script[entity_id] = [position]
+
+
+def _attach_scripted_rails(policy, script: dict[str, list[int | None]]) -> _Rails:
+    """Attach ``policy`` over a scripted motor, with no command service at all.
+
+    The ordering hook reads the middle rail's LIVE position to tell a raise from
+    a lower (issue #1118), so even an ordering-only test needs a sequencer. This
+    is the cheap half of ``_rail_harness``: rails and an ``attach``, nothing
+    else.
+    """
+    rails = _Rails(script)
+    policy.attach(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=rails.read,
+        set_commanded_position=MagicMock(),
+        position_tolerance=2,
+        is_dry_run=lambda: False,
+        entities=[_BOTTOM, _MIDDLE],
+    )
+    return rails
 
 
 def _rail_harness(
@@ -636,8 +745,23 @@ async def test_middle_rail_proceeds_immediately_when_bottom_already_clear(
 
 
 @pytest.mark.asyncio
-async def test_bottom_rail_is_never_gated(monkeypatch) -> None:
-    """Only the middle rail is gated — the blocking rail must move freely."""
+async def test_bottom_rail_is_not_gated_when_lowering(monkeypatch) -> None:
+    """The leading rail moves freely — and on a lowering that is the bottom rail.
+
+    Was ``test_bottom_rail_is_never_gated`` (#1115), when the bottom rail led
+    every move by construction. It leads a LOWERING (#1118), so the outcome
+    assertion is preserved verbatim: a lowering move never waits on anything.
+
+    What changed is the cost of establishing that. The bottom rail now reads the
+    middle rail ONCE to settle the direction, finds no raise collision, and is
+    waved straight through — one synchronous read, never a poll loop. The exact
+    event list is what pins that: a regression that turned the direction check
+    into a wait would show up here as extra polls, and one that dropped the
+    check entirely would show up as none.
+
+    The "the bottom rail can be gated" case this used to exclude is covered by
+    the raise-direction suite above.
+    """
     monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
     cmd_svc, policy, _rails, events = _rail_harness(
         script={_BOTTOM: [100], _MIDDLE: [100]},
@@ -650,7 +774,7 @@ async def test_bottom_rail_is_never_gated(monkeypatch) -> None:
         outcome = await cmd_svc.apply_position(_BOTTOM, 30, "solar", ctx)
 
     assert outcome == ("sent", "set_cover_position")
-    assert events == [f"send:{_BOTTOM}"]
+    assert events == [f"poll:{_MIDDLE}", f"send:{_BOTTOM}"]
 
 
 @pytest.mark.asyncio
@@ -761,6 +885,363 @@ async def test_gate_is_inert_without_a_second_rail(monkeypatch) -> None:
 
     assert outcome == ("sent", "set_cover_position")
     assert f"send:{_MIDDLE}" in events
+
+
+# ---------------------------------------------------------------------------
+# The raise direction — the bottom rail is the follower (issue #1118)
+# ---------------------------------------------------------------------------
+# #1115 sequenced one direction. The rail DOWNSTREAM in the direction of travel
+# has to vacate first, and which rail that is depends on where the shade is
+# going: lowering, the bottom rail leads and the middle rail waits; raising, the
+# middle rail leads and the BOTTOM rail waits, because its target now sits above
+# a middle rail that has not moved out of the way yet.
+#
+#   | Travel            | Downstream | Leads  | Follower waits until          |
+#   |-------------------|------------|--------|-------------------------------|
+#   | Lowering (P < p)  | bottom     | bottom | p_open <= M_target_open + tol |
+#   | Raising  (P > m)  | middle     | middle | m_open + tol >= P_target_open |
+#
+# Both mechanisms — ordering and gating — become direction-aware, and both read
+# the direction from ONE predicate so they can never disagree about which rail
+# leads (which is what would deadlock the pair).
+
+
+@pytest.mark.asyncio
+async def test_bottom_rail_is_gated_when_raising_past_the_middle_rail() -> None:
+    """The issue's worked example, at the smallest surface that shows it.
+
+    Bottom rail live at 10, middle rail live at 20 (an intact stack), and this
+    cycle resolves the bottom rail up to 60. Travelling there drags it straight
+    through the middle rail sitting at 20 — the identical mechanical block
+    #1115 closed for the lowering direction, in the opposite direction.
+
+    ``wait=False`` takes the single-shot reading, so this asks the gate's
+    verdict without paying the settle budget.
+    """
+    _cmd_svc, policy, _rails, _events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20]},
+        position=60,
+        blend=50,
+    )
+
+    assert (
+        await policy.await_dispatch_clearance(
+            _BOTTOM, position=60, reason="solar", wait=False
+        )
+        is False
+    )
+
+
+def test_order_for_dispatch_puts_middle_rail_first_when_raising() -> None:
+    """A raising move commands the middle rail first, whatever the pick order.
+
+    The middle rail is the rail downstream of the travel here, so it is the one
+    that has to start vacating before the bottom rail can follow it up.
+    """
+    _cmd_svc, policy, _rails, _events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20]},
+        position=60,
+        blend=50,
+    )
+
+    assert policy.order_for_dispatch([_BOTTOM, _MIDDLE], position=60) == [
+        _MIDDLE,
+        _BOTTOM,
+    ]
+    assert policy.order_for_dispatch([_MIDDLE, _BOTTOM], position=60) == [
+        _MIDDLE,
+        _BOTTOM,
+    ]
+
+
+def test_order_for_dispatch_keeps_bottom_first_when_lowering() -> None:
+    """#1115's order survives, and now for a REASON rather than by construction.
+
+    Same live reading, same evaluation, opposite target: the move lowers, so the
+    bottom rail is downstream and leads. A key that answered "bottom first"
+    unconditionally would pass this too — which is why its raising counterpart
+    above is written against the same harness.
+    """
+    _cmd_svc, policy, _rails, _events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+
+    assert policy.order_for_dispatch([_MIDDLE, _BOTTOM], position=30) == [
+        _BOTTOM,
+        _MIDDLE,
+    ]
+
+
+def test_order_for_dispatch_falls_back_to_bottom_first_without_a_named_target() -> None:
+    """A seam that names no fanned-out target rides the conservative default.
+
+    The sunset broadcast, the user-command seams and the reconciliation pass all
+    dispatch a number that only exists per-entity further down their own call
+    chain, so none of them can hand the ordering view the pair the gate will
+    later be asked about. They get #1115's shipped constant instead — ordering
+    is a LATENCY mechanism, and the gates (which are always authoritative) still
+    withhold anything the fallback order sends too early.
+
+    The empty event log is load-bearing: the fallback must short-circuit before
+    it touches the sequencer, or every poll-count assertion in this module
+    starts drifting.
+    """
+    _cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+
+    assert policy.order_for_dispatch([_MIDDLE, _BOTTOM]) == [_BOTTOM, _MIDDLE]
+    assert events == []
+
+
+@pytest.mark.asyncio
+async def test_a_raising_cycle_dispatches_both_rails_and_neither_deadlocks(
+    monkeypatch,
+) -> None:
+    """End to end: the middle rail leads, the bottom rail waits, both go out.
+
+    The deadlock this design has to avoid is both rails waiting on each other.
+    Ordering and gating read the SAME direction predicate, so exactly one rail
+    is ever the follower — here the bottom rail, which polls the middle rail's
+    ascent (20 → 50 → 80) and only then travels to 60.
+
+    The wall-clock assertion is the deadlock detector: a mutually-blocked pair
+    would each burn the full ``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS``
+    budget, which is deliberately left at its real 60 s here.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # The middle rail climbs once commanded; the bottom rail sits at 10.
+        script={_BOTTOM: [10], _MIDDLE: [20, 20, 20, 20, 20, 50, 80]},
+        position=60,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    started = dt.datetime.now(dt.UTC)
+    with _patch_caps():
+        for eid in policy.order_for_dispatch([_BOTTOM, _MIDDLE], position=60):
+            await cmd_svc.apply_position(
+                eid, policy.resolve_entity_target(eid, 60), "solar", ctx
+            )
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert f"send:{_MIDDLE}" in events, events
+    assert f"send:{_BOTTOM}" in events, events
+    assert events.index(f"send:{_MIDDLE}") < events.index(f"send:{_BOTTOM}")
+    # Neither rail was withheld, so neither latched pending.
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+    # The bottom rail genuinely waited on the ascent rather than sailing
+    # through — counted AFTER the middle rail's send, so the ordering view's own
+    # direction reads cannot satisfy this on their own.
+    ascent = events[events.index(f"send:{_MIDDLE}") : events.index(f"send:{_BOTTOM}")]
+    assert len([e for e in ascent if e == f"poll:{_MIDDLE}"]) >= 2, events
+    assert (
+        len(
+            [
+                e
+                for e in events[: events.index(f"send:{_BOTTOM}")]
+                if e == f"poll:{_MIDDLE}"
+            ]
+        )
+        >= 2
+    ), events
+    # No rail entered the settle budget, i.e. nothing blocked on anything.
+    assert elapsed < 10, elapsed
+
+
+@pytest.mark.asyncio
+async def test_bottom_rail_defers_and_latches_pending_on_timeout(
+    monkeypatch,
+) -> None:
+    """A middle rail that never rises defers the bottom command, not sends it.
+
+    The mirror of ``test_middle_rail_defers_and_latches_pending_on_timeout``:
+    withheld is a ``policy_deferred`` SKIP and the entity latches pending, so
+    the coordinator keeps withholding this cycle's dispatched-target signature
+    and the next cycle re-attempts the send.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20]},
+        position=60,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_BOTTOM, 60, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_BOTTOM}" not in events
+    assert policy.has_pending_secondary_axis(_BOTTOM) is True
+    assert cmd_svc.last_skipped_action["reason"] == "policy_deferred"
+
+
+@pytest.mark.asyncio
+async def test_pending_latch_clears_once_the_middle_rail_has_risen(
+    monkeypatch,
+) -> None:
+    """The next cycle's retry sends the bottom command and clears the latch.
+
+    Proves the withheld bottom-rail command rides the SAME
+    ``_pending_*`` → ``has_pending_secondary_axis`` → withheld-signature →
+    next-cycle-re-dispatch path #1115 built for the middle rail — reused, not
+    rebuilt.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20]},
+        position=60,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        assert (await cmd_svc.apply_position(_BOTTOM, 60, "solar", ctx))[1] == (
+            "policy_deferred"
+        )
+        assert policy.has_pending_secondary_axis(_BOTTOM) is True
+        # Cycle 2: the middle rail has climbed to 90 — well clear of 60.
+        rails.park(_MIDDLE, 90)
+        outcome = await cmd_svc.apply_position(_BOTTOM, 60, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+    assert f"send:{_BOTTOM}" in events
+
+
+@pytest.mark.asyncio
+async def test_bottom_rail_proceeds_when_the_middle_rail_is_unreadable(
+    monkeypatch,
+) -> None:
+    """An unreadable MIDDLE rail is fail-OPEN — the deliberate asymmetry.
+
+    ``_gate_rail_clearance`` is fail-CLOSED on an unreadable bottom rail
+    (``test_middle_rail_defers_when_bottom_rail_position_unreadable``, #1115)
+    because there the collision geometry is already KNOWN and an unreadable rail
+    cannot disprove it. Here the unreadable reading is the collision EVIDENCE
+    itself: with no middle-rail position there is nothing to say the bottom rail
+    is about to run into anything, and withholding it on every cycle while the
+    middle-rail entity is unavailable stops the whole shade — the same
+    "withholding forever would brick the shade" reasoning the gate already
+    applies to an unresolvable bottom rail.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [None]},
+        position=60,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_BOTTOM, 60, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_BOTTOM}" in events
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+
+
+@pytest.mark.asyncio
+async def test_bottom_rail_proceeds_immediately_when_the_middle_is_already_clear(
+    monkeypatch,
+) -> None:
+    """Steady state on a raise: middle rail already above the target → no wait."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [90]},
+        position=60,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_BOTTOM, 60, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    # One confirming read to establish direction, no polling loop.
+    assert events.count(f"poll:{_MIDDLE}") == 1, events
+    assert events[-1] == f"send:{_BOTTOM}"
+
+
+# ---------------------------------------------------------------------------
+# Exactly one rail is ever withheld — the deadlock tiebreak, made mechanical
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_two_rail_gates_are_never_both_armed() -> None:
+    """At most one rail is withheld for any pair a single dispatch can produce.
+
+    The theorem the design rests on, over the whole legal state space. The
+    bottom rail blocks only when ``m + tol < P``; the middle rail blocks only
+    when ``p > M + tol``. Both at once needs
+    ``p > M + tol >= P + tol > m + 2·tol`` — i.e. the bottom rail physically
+    ABOVE the middle rail — while ``M >= P`` holds for every target pair
+    ``resolve_entity_target``'s no-pass clamp can emit. Within one dispatch the
+    two gates are therefore mutually exclusive by the same clamp that makes the
+    target pair physically legal.
+
+    ``wait=False`` keeps the whole grid single-shot and sub-second.
+    """
+    for blend in (0, 50, 100):
+        policy = _dual_policy(position=50, blend=blend)
+        rails = _attach_scripted_rails(policy, {_BOTTOM: [0], _MIDDLE: [0]})
+        for p in range(0, 101, 10):
+            for m in range(p, 101, 10):  # an intact stack: middle at or above bottom
+                rails.park(_BOTTOM, p)
+                rails.park(_MIDDLE, m)
+                for target in range(0, 101, 10):
+                    middle_target = policy.resolve_entity_target(_MIDDLE, target)
+                    bottom_ok = await policy.await_dispatch_clearance(
+                        _BOTTOM, position=target, reason="t", wait=False
+                    )
+                    middle_ok = await policy.await_dispatch_clearance(
+                        _MIDDLE, position=middle_target, reason="t", wait=False
+                    )
+                    assert bottom_ok or middle_ok, (p, m, target, middle_target, blend)
+
+
+@pytest.mark.asyncio
+async def test_a_lowering_cycle_still_leads_with_the_bottom_rail(monkeypatch) -> None:
+    """#1115's whole mechanism survives the generalisation, end to end.
+
+    The mirror of ``test_a_raising_cycle_dispatches_both_rails_and_neither_deadlocks``:
+    both rails start stacked at 100 and the cycle lowers them to 30 / 65, so the
+    bottom rail leads and the middle rail polls its descent. Same ordering view,
+    same gate, opposite roles.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # Bottom: apply_position's own read, then the gate's descent samples.
+        script={_BOTTOM: [100, 100, 100, 80, 60], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        for eid in policy.order_for_dispatch([_MIDDLE, _BOTTOM], position=30):
+            await cmd_svc.apply_position(
+                eid, policy.resolve_entity_target(eid, 30), "solar", ctx
+            )
+
+    assert events.index(f"send:{_BOTTOM}") < events.index(f"send:{_MIDDLE}")
+    descent = [
+        e for e in events[: events.index(f"send:{_MIDDLE}")] if e == f"poll:{_BOTTOM}"
+    ]
+    assert len(descent) >= 2, events
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
 
 
 # ---------------------------------------------------------------------------
@@ -973,6 +1454,74 @@ async def test_gate_uses_the_dispatching_seams_frame_not_the_install_flag(
     assert cmd_svc.get_target(_MIDDLE) == 80
     assert f"send:{_MIDDLE}" in events, events
     assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_raise_gate_compares_in_open_percent_not_raw_wire(monkeypatch) -> None:
+    """The raise predicate is an open-percent comparison too (issue #1118).
+
+    Inverse state on. The middle rail reads wire 80 (= open 20, low down) and
+    the bottom rail's dispatched wire target is 40 (= open 60, high up). Raw
+    wire says ``80 >= 40`` — "the middle rail is already above the target,
+    proceed" — and drives the bottom rail straight into it. Open-percent says
+    ``20 < 60`` and withholds.
+
+    The whole point is that this rides the SAME ``_dispatch_frame``/``flip_if``
+    path the lowering predicate uses; a second, divergent inversion computation
+    would reintroduce the #993 bug class in the new direction.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [90], _MIDDLE: [80]},
+        position=60,
+        blend=50,
+        inverse=True,
+    )
+    ctx = _rail_context(policy, inverse=True)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_BOTTOM, 40, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_BOTTOM}" not in events
+
+
+@pytest.mark.asyncio
+async def test_raise_gate_uses_the_dispatching_seams_frame_not_the_install_flag(
+    monkeypatch,
+) -> None:
+    """The bottom rail's gate un-transforms against the SEAM's frame (issue #1118).
+
+    Inverse-state install, auto-control toggled OFF. The return-to-default seam
+    dispatches the raw default UN-inverted (``_entity_target(..., inverted=False)``),
+    and the middle rail is parked at the un-inverted 80 that same seam put it
+    at. In the seam's frame the middle rail's open 80 is comfortably above the
+    bottom rail's open-60 target, so there is no collision and the command goes
+    out.
+
+    Resolve it against the install flag instead and the numbers swap — middle
+    open 20 under a bottom target of open 40 — so the rail is withheld, and
+    withheld forever, because only that seam ever refreshes the target. That is
+    why ``capture_dispatch_token`` has to stamp the BOTTOM rail as well: with no
+    stamp the gate falls back to the cached ``axis_inverted`` flag, which is the
+    #993 bug class pointed at the new direction.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [80]},
+        position=60,
+        blend=50,
+        inverse=True,
+    )
+    switch = _auto_control_off_switch(cmd_svc, policy, default_position=60)
+
+    with _patch_caps():
+        await switch.async_turn_off()
+
+    assert f"send:{_BOTTOM}" in events, events
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
 
 
 # ---------------------------------------------------------------------------
@@ -1196,6 +1745,123 @@ def test_every_ordering_exemption_names_a_test_that_covers_its_caller() -> None:
         "_ORDERING_EXEMPT entries whose compensating control names a test that "
         "does not exist in this module — write it, or drop the exemption and "
         f"order the seam itself: {unproven}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structural guard — a seam that CAN name its fanned-out target must do so
+# ---------------------------------------------------------------------------
+# The scan above proves every fan-out loop consumes the ordered view. Since
+# #1118 that view also needs to know WHICH WAY the shade is travelling, and the
+# only honest source for that is the number the seam is about to dispatch. Four
+# of the five wired call sites are invisible to every behavioural test in this
+# module — delete ``position=state`` from the startup, force-send, end-time or
+# auto-off seam and the whole suite stays green while a raise silently stalls
+# for a settle budget at that seam. Same class of hole the scan above was
+# written to close, one argument deeper.
+#
+# (module path relative to the production root, innermost enclosing function) →
+# why this seam legitimately cannot name the number it is fanning out.
+_UNNAMED_TARGET_SEAMS = {
+    ("coordinator.py", "_check_sunset_window_transition"): (
+        "Orders the list on WindowTransitionTracker.check_sunset_window's "
+        "behalf and holds only the raw config percent — the tracker computes "
+        "the dispatched value itself (flip_if(sunset_pos_cfg, "
+        "inverted=inverse_state_enabled)), so re-deriving it here would "
+        "duplicate that line."
+    ),
+    ("button.py", "async_press"): (
+        "Fans out a logical My percent that only becomes a per-entity framed "
+        "number inside async_apply_user_position, so no single "
+        "(position, inverted) pair exists here."
+    ),
+    ("services/set_position_service.py", "async_handle_set_position"): (
+        "User command: the framed per-entity value is produced downstream in "
+        "async_apply_user_position, not at this call site."
+    ),
+    ("services/set_tilt_service.py", "async_handle_set_tilt"): (
+        "User command: the framed per-entity value is produced downstream in "
+        "async_apply_user_position, not at this call site."
+    ),
+    ("services/set_axes_service.py", "async_handle_set_axes"): (
+        "User command: the framed per-entity value is produced downstream in "
+        "async_apply_user_position, not at this call site."
+    ),
+    ("group_coordinator.py", "_member"): (
+        "Group fan-out hands each member a logical percent; the member "
+        "coordinator frames it per entity further down."
+    ),
+    ("managers/cover_command/__init__.py", "run_reconciliation_pass"): (
+        "Holds a MAP of per-entity targets booked by different seams in "
+        "different eras, not one fanned-out number."
+    ),
+}
+
+
+def _order_view_calls(tree: ast.AST) -> list[tuple[ast.Call, ast.AST | None]]:
+    """Every ``order_for_dispatch(...)`` call, with its enclosing function."""
+    found: list[tuple[ast.Call, ast.AST | None]] = []
+
+    def walk(node: ast.AST, enclosing: ast.AST | None) -> None:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            enclosing = node
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == _ORDER_VIEW
+        ):
+            found.append((node, enclosing))
+        for child in ast.iter_child_nodes(node):
+            walk(child, enclosing)
+
+    walk(tree, None)
+    return found
+
+
+@pytest.mark.unit
+def test_pipeline_dispatch_seams_name_their_fanned_out_target() -> None:
+    """Fail if a seam that holds its dispatched number orders without naming it.
+
+    Pass ``position=`` (and ``inverted=`` where the seam dispatches in its own
+    divergent space) — the SAME pair the loop body hands ``_entity_target``.
+    Without it the ordering view cannot tell a raise from a lower and falls back
+    to bottom-first, which on a raising cycle commands the follower rail into a
+    middle rail that has not vacated yet: the command is correctly withheld by
+    the gate, but the shade stalls for a whole cycle at that seam.
+
+    If a seam genuinely has no such pair — because the per-entity value is only
+    framed further down its own call chain — add it to
+    ``_UNNAMED_TARGET_SEAMS`` with the reason. Inventing a pair there would buy
+    ordering latency at the cost of naming a number that is not the one being
+    dispatched, which is the exact provenance mistake #1115 closed.
+    """
+    offenders: list[str] = []
+    seen: set[tuple[str, str]] = set()
+
+    for path in sorted(_PRODUCTION_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        module = path.relative_to(_PRODUCTION_ROOT).as_posix()
+        for call, enclosing in _order_view_calls(tree):
+            fn_name = getattr(enclosing, "name", "<module>")
+            seen.add((module, fn_name))
+            if any(kw.arg == "position" for kw in call.keywords):
+                continue
+            if (module, fn_name) in _UNNAMED_TARGET_SEAMS:
+                continue
+            offenders.append(
+                f"{path.relative_to(_REPO_ROOT)}:{call.lineno} ({fn_name})"
+            )
+
+    stale = set(_UNNAMED_TARGET_SEAMS) - seen
+    assert not stale, (
+        "_UNNAMED_TARGET_SEAMS names call sites that no longer exist — the seam "
+        f"moved or was wired up; drop the entry: {sorted(stale)}"
+    )
+    assert not offenders, (
+        "Dispatch seams that order without naming the number they are fanning "
+        "out (issue #1118) — pass position=<the value _entity_target gets>, or "
+        "add the seam to _UNNAMED_TARGET_SEAMS with its reason:\n  "
+        + "\n  ".join(offenders)
     )
 
 

--- a/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
+++ b/tests/test_issue_352_auto_control_on_uses_fresh_solar.py
@@ -52,9 +52,12 @@ def _make_coord_with_stale_default():
     coord._policy.resolve_entity_target = (
         lambda entity_id, position, *, inverted=None, interpolated=False: position
     )
-    # The dispatch loop asks the policy for the entity order (#1115); a blind's
-    # answer is identity, so mirror that on the stub.
-    coord._policy.order_for_dispatch = lambda entities: list(entities)
+    # The dispatch loop asks the policy for the entity order (#1115), naming the
+    # number it is fanning out (#1118); a blind's answer is identity and ignores
+    # both keywords, so mirror that on the stub.
+    coord._policy.order_for_dispatch = (
+        lambda entities, *, position=None, inverted=None: list(entities)  # noqa: ARG005
+    )
     coord._inverse_state = False
     coord._use_interpolation = False  # ``coord.state`` post-processing
     coord._pending_cover_events = []

--- a/tests/test_issue_756_override_dispatch_during_sequence.py
+++ b/tests/test_issue_756_override_dispatch_during_sequence.py
@@ -51,9 +51,12 @@ def _make_dispatch_coordinator(
     coordinator._async_force_send_pipeline_position = AsyncMock()
     coordinator._policy = MagicMock()
     coordinator._policy.has_pending_secondary_axis = MagicMock(return_value=has_pending)
-    # The dispatch loops ask the policy for the entity order (#1115); a blind's
-    # answer is identity, so mirror that on the stub.
-    coordinator._policy.order_for_dispatch = lambda entities: list(entities)
+    # The dispatch loops ask the policy for the entity order (#1115), naming the
+    # number they are fanning out (#1118); a blind's answer is identity and
+    # ignores both keywords, so mirror that on the stub.
+    coordinator._policy.order_for_dispatch = (
+        lambda entities, *, position=None, inverted=None: list(entities)  # noqa: ARG005
+    )
     return coordinator
 
 
@@ -257,9 +260,12 @@ def _make_state_change_coordinator(*, pipeline_result: PipelineResult):
     coordinator._is_custom_position_sensor_trigger = MagicMock(return_value=False)
     coordinator._build_position_context = MagicMock(return_value=MagicMock())
     coordinator._dispatch_to_cover = AsyncMock()
-    # The dispatch loop asks the policy for the entity order (#1115); a blind's
-    # answer is identity, so mirror that on the stub.
-    coordinator._policy.order_for_dispatch = lambda entities: list(entities)
+    # The dispatch loop asks the policy for the entity order (#1115), naming the
+    # number it is fanning out (#1118); a blind's answer is identity and ignores
+    # both keywords, so mirror that on the stub.
+    coordinator._policy.order_for_dispatch = (
+        lambda entities, *, position=None, inverted=None: list(entities)  # noqa: ARG005
+    )
     return coordinator
 
 


### PR DESCRIPTION
## Summary

Model C (`dual_entity`) day/night rail sequencing was one-directional. `dispatch_order_key` always sorted the middle rail last and only the middle rail was ever gated, so a raising move sent the bottom rail straight through the middle rail's parked position. That is the same stall, over-current trip, or lost-calibration event #1115 exists to prevent, in the direction #1115 did not cover.

Ordering now depends on travel direction and the clearance gate handles either rail through one method, one predicate seam, and one latch: the rail downstream of the move leads, the upstream one waits. Exactly one rail is ever gated per dispatch, so the two gates cannot deadlock. A property test pins that over the whole legal target grid.

Two further defects surfaced during the pre-merge audit and are fixed here:

- The ordering fallback was safe only where a later pipeline cycle re-sends a withheld rail. At the user-command seams nothing does, so a raise via the My button, `set_position`/`set_tilt`/`set_axes`, or either group slider burned the full 60s settle budget on a middle rail nothing had commanded, then dropped the command. Those seams, plus the sunset transition, now name the number and frame they fan out.
- The min-mode floor clamp was invisible at those seams, so ordering named the requested position while the gate was asked about the clamped one. `Coordinator.user_dispatch_position` now owns the clamp-then-frame derivation and both `async_apply_user_position` and the seams read from it, so the two views agree by construction.

`capture_dispatch_token` also stamps the bottom rail now, so the raise predicate compares in open-percent against the dispatching seam's frame rather than the install flag (the #993 bug class in the new direction).

Not in scope: #1119's four deferred edges. Its first point assumes the ordering fix guarantees the bottom rail's clearance check fires first, which is now direction-conditional, and the raise direction adds a second instance of its 60s-stall edge. Both want re-reading against #1119. #1120, #1121, #1122 are untouched.

## Testing
- ✅ 11654 tests passing

## Related Issues
Refs #1118, #1115, #993