### PR TITLE
fix: seed the default position when a cover is created (#1126)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -617,14 +617,47 @@ def _seed_default_position(sensor_type: str | None, options: dict) -> bool:
 
     ``setdefault``-shaped: a no-op when the key is already present. Returns
     whether the key was seeded, for the migration log.
+
+    ``sensor_type`` can be ``None``, ``""``, or any string that was never
+    registered — a malformed or pre-#1126-window entry, or simply a value
+    this migration has no opinion on. ``get_policy`` raises ``ValueError``
+    for all of those; that must not propagate out of this function (and
+    therefore out of ``async_migrate_entry``), or it parks the whole entry in
+    ``ConfigEntryState.MIGRATION_ERROR`` and discards every other repair in
+    the same migration cascade.
     """
     if CONF_DEFAULT_HEIGHT in options:
         return False
-    policy = get_policy(sensor_type)
+    try:
+        policy = get_policy(sensor_type)
+    except ValueError:
+        return False
     if not (policy.controls_cover and not policy.is_orchestrator):
         return False
     options[CONF_DEFAULT_HEIGHT] = policy.position_for_intent(sun_through=True)
     return True
+
+
+def _seed_default_position_and_log(entry: ConfigEntry, options: dict) -> None:
+    """Seed default_percentage and log when it was actually seeded (issue #1126).
+
+    Wraps ``_seed_default_position`` so the v3.12 → v3.13 block in
+    ``async_migrate_entry`` stays a single call — matching every sibling
+    repair's shape — instead of adding its own conditional to an already-long
+    linear migration cascade. This is the riskiest repair in that cascade (it
+    deliberately moves an already-bitten cover from an effective 0 % to its
+    per-type default), so unlike a silent ``setdefault``, it must leave a log
+    line pointing at the entry, its cover type, and the value seeded — the
+    same pattern every other gated repair in the cascade already follows.
+    """
+    if _seed_default_position(entry.data.get(CONF_SENSOR_TYPE), options):
+        _LOGGER.info(
+            "Seeded default position of %s (%s) to %s%% — was silently"
+            " fully closed until now",
+            entry.data.get("name", entry.entry_id),
+            entry.data.get(CONF_SENSOR_TYPE),
+            options.get(CONF_DEFAULT_HEIGHT),
+        )
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -798,7 +831,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # staying fully closed forever. See ``_seed_default_position`` for the
     # additive/setdefault-shaped, gated details.
     if new_version == 3 and new_minor < 13:
-        _seed_default_position(entry.data.get(CONF_SENSOR_TYPE), new_options)
+        _seed_default_position_and_log(entry, new_options)
         new_minor = 13
 
     hass.config_entries.async_update_entry(

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -65,6 +65,7 @@ from .const import (
     CUSTOM_POSITION_SLOTS,
     DIAG_CACHE_KEY,
     DOMAIN,
+    POSITION_CLOSED,
     TIME_STRING_RE,
     _LOGGER,
     blind_spot_legacy_to_gamma,
@@ -644,20 +645,36 @@ def _seed_default_position_and_log(entry: ConfigEntry, options: dict) -> None:
     Wraps ``_seed_default_position`` so the v3.12 → v3.13 block in
     ``async_migrate_entry`` stays a single call — matching every sibling
     repair's shape — instead of adding its own conditional to an already-long
-    linear migration cascade. This is the riskiest repair in that cascade (it
-    deliberately moves an already-bitten cover from an effective 0 % to its
-    per-type default), so unlike a silent ``setdefault``, it must leave a log
-    line pointing at the entry, its cover type, and the value seeded — the
-    same pattern every other gated repair in the cascade already follows.
+    linear migration cascade. Unlike a silent ``setdefault``, it must leave a
+    log line pointing at the entry, its cover type, and the value seeded —
+    the same pattern every other gated repair in the cascade already follows.
+
+    The pre-fix runtime fallback for a key-less entry was a hard-coded
+    literal 0 (``POSITION_CLOSED``). For most types (blind/tilt/venetian,
+    ``open_blocks_sun=False``) the seeded no-coverage endpoint is 100, so this
+    genuinely is the riskiest repair in the cascade — it moves an
+    already-bitten cover from effectively fully closed to fully open. For the
+    ``open_blocks_sun=True`` types (awning, oscillating awning) the
+    no-coverage endpoint IS 0 — identical to the pre-fix fallback — so the
+    key gets written but nothing actually moves. The message distinguishes
+    the two rather than asserting "was silently fully closed" for a cover
+    that never moved.
     """
-    if _seed_default_position(entry.data.get(CONF_SENSOR_TYPE), options):
-        _LOGGER.info(
-            "Seeded default position of %s (%s) to %s%% — was silently"
-            " fully closed until now",
-            entry.data.get("name", entry.entry_id),
-            entry.data.get(CONF_SENSOR_TYPE),
-            options.get(CONF_DEFAULT_HEIGHT),
-        )
+    if not _seed_default_position(entry.data.get(CONF_SENSOR_TYPE), options):
+        return
+    seeded = options.get(CONF_DEFAULT_HEIGHT)
+    outcome = (
+        "was silently kept fully closed until this migration ran"
+        if seeded != POSITION_CLOSED
+        else "matches the pre-fix runtime fallback, so this cover did not move"
+    )
+    _LOGGER.info(
+        "Seeded default position of %s (%s) to %s%% — %s",
+        entry.data.get("name", entry.entry_id),
+        entry.data.get(CONF_SENSOR_TYPE),
+        seeded,
+        outcome,
+    )
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -25,6 +25,7 @@ from .const import (
     CONF_CLOUD_COVERAGE_ENTITY,
     CONF_DAYTIME_GATE_SENSORS,
     CONF_DAYTIME_GATE_TEMPLATE,
+    CONF_DEFAULT_HEIGHT,
     CONF_DEVICE_ID,
     CONF_ENABLE_MY_POSITION_ENTITIES,
     CONF_ENABLE_POSITION_MATCHING,
@@ -603,6 +604,29 @@ def _repair_malformed_times(options: dict) -> list[str]:
     return changes
 
 
+def _seed_default_position(sensor_type: str | None, options: dict) -> bool:
+    """Seed default_percentage from the policy's no-coverage endpoint (issue #1126).
+
+    The minimal create wizard (#945 Part 2) has no position step, so an entry
+    created since then never got ``default_percentage`` written — every
+    runtime read then falls back to a hard-coded 0, driving the cover fully
+    closed until a user opens Options -> Position and saves. Gated on
+    ``controls_cover and not is_orchestrator`` — the same gate the create
+    finalizer uses — because a Building Profile or Group policy has no axes
+    and ``position_for_intent`` would raise ``IndexError``.
+
+    ``setdefault``-shaped: a no-op when the key is already present. Returns
+    whether the key was seeded, for the migration log.
+    """
+    if CONF_DEFAULT_HEIGHT in options:
+        return False
+    policy = get_policy(sensor_type)
+    if not (policy.controls_cover and not policy.is_orchestrator):
+        return False
+    options[CONF_DEFAULT_HEIGHT] = policy.position_for_intent(sun_through=True)
+    return True
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old config entries to the current schema version."""
     new_options = dict(entry.options)
@@ -766,6 +790,16 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 ", ".join(repaired),
             )
         new_minor = 12
+
+    # v3.12 → v3.13: seed default_percentage for entries the minimal create
+    # wizard left key-less (issue #1126). Backfill the policy's no-coverage
+    # endpoint (100 for most cover types, 0 for the polarity-flipped awning
+    # types) so an already-bitten entry is repaired on upgrade instead of
+    # staying fully closed forever. See ``_seed_default_position`` for the
+    # additive/setdefault-shaped, gated details.
+    if new_version == 3 and new_minor < 13:
+        _seed_default_position(entry.data.get(CONF_SENSOR_TYPE), new_options)
+        new_minor = 13
 
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -602,7 +602,7 @@ _POSITION_SPECS = _spec(
         SECTION_POSITION,
         ValidatorKind.RANGE,
         rng=const._RANGE_DEFAULT_HEIGHT,
-        default=60,
+        default=const.DEFAULT_POSITION_SELECTOR_FALLBACK,
         required=True,
         make_selector=_number(minimum=0, maximum=100, step=1, unit="%"),
     ),

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -328,7 +328,6 @@ CONFIG_SCHEMA = vol.Schema(
 from .cover_types import (  # noqa: E402
     POLICY_REGISTRY,
     BlindPolicy,
-    CoverTypePolicy,
     TiltPolicy,
     get_policy,
 )
@@ -3886,7 +3885,7 @@ def _area_menu(area: str) -> str:
     return "glare_zones" if area == "glare_zone" else area
 
 
-def _apply_create_defaults(options: dict, policy: CoverTypePolicy) -> None:
+def _apply_create_defaults(options: dict, sensor_type: str | None) -> None:
     """Seed the create wizard's constant-backed defaults (issue #133 / #1126).
 
     Quick setup skips some steps (e.g. automation, position) leaving critical
@@ -3897,9 +3896,18 @@ def _apply_create_defaults(options: dict, policy: CoverTypePolicy) -> None:
     extended = maximum shading) still yields the "leave it alone" value (0,
     not 100).
 
-    Virtual entry types are skipped by the caller's ``controls_cover and not
-    is_orchestrator`` gate: a Building Profile builds no coordinator, and a
-    cover group builds a ``GroupCoordinator`` that reads none of these keys.
+    Resolves the policy itself and early-returns on
+    ``not (controls_cover and not is_orchestrator)`` — mirrors the gate
+    ``__init__.py:_seed_default_position`` applies for the same reason: a
+    Building Profile builds no coordinator, and a cover group builds a
+    ``GroupCoordinator`` that reads none of these keys, so neither wants any
+    of the seven defaults below. Unlike that migration-side helper, this one
+    does not catch ``ValueError`` from ``get_policy`` — every call site here
+    is a live wizard step where ``sensor_type`` is always a just-selected or
+    already-loaded-and-valid cover type, and the surrounding config-flow code
+    already calls ``get_policy`` unguarded on the same value, so letting an
+    unknown type raise here matches the pre-refactor failure mode instead of
+    silently skipping the defaults.
 
     Shared by all three sites that can mint a fresh entry's options —
     ``async_step_update`` (the entry the normal create wizard actually
@@ -3910,6 +3918,9 @@ def _apply_create_defaults(options: dict, policy: CoverTypePolicy) -> None:
     disabled source entry is never migrated, so an old, still-broken copy
     would otherwise propagate the missing key forever).
     """
+    policy = get_policy(sensor_type)
+    if not (policy.controls_cover and not policy.is_orchestrator):
+        return
     options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
     options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
     options.setdefault(CONF_MANUAL_OVERRIDE_DURATION, DEFAULT_MANUAL_OVERRIDE_DURATION)
@@ -4199,9 +4210,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         # never disagree about the default position — otherwise the summary
         # would still render "Default → 0 %" for a quick-setup cover that is
         # actually about to be created at its per-type no-coverage endpoint.
-        _summary_policy = get_policy(self.type_blind)
-        if _summary_policy.controls_cover and not _summary_policy.is_orchestrator:
-            _apply_create_defaults(self.config, _summary_policy)
+        _apply_create_defaults(self.config, self.type_blind)
 
         sun_times = await _compute_todays_sun_times(self.hass, self.config)
         _language = _resolve_summary_language(self.hass, self.context)
@@ -4269,9 +4278,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         # group builds a GroupCoordinator that reads none of the
         # cover-automation options — both keep only what their create step
         # collected.
-        _finalize_policy = get_policy(self.type_blind)
-        if _finalize_policy.controls_cover and not _finalize_policy.is_orchestrator:
-            _apply_create_defaults(options, _finalize_policy)
+        _apply_create_defaults(options, self.type_blind)
 
         # If the user linked a Building Profile during creation, merge its
         # non-empty shared-sensor keys into options now — after all form steps
@@ -4354,9 +4361,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             # _extract_shared_options can copy nothing for the key. Route
             # through the same seed helper the other two create sites use
             # instead of relying on that accident (#1126).
-            _dup_policy = get_policy(sensor_type)
-            if _dup_policy.controls_cover and not _dup_policy.is_orchestrator:
-                _apply_create_defaults(new_options, _dup_policy)
+            _apply_create_defaults(new_options, sensor_type)
 
             return self.async_create_entry(  # type: ignore[return-value]
                 title=f"{_cover_type_label(sensor_type)} {new_name}",

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -225,6 +225,7 @@ from .const import (
     DEFAULT_MANUAL_OVERRIDE_DURATION,
     DEFAULT_MANUAL_OVERRIDE_DURATION_MODE,
     DEFAULT_MOTION_TIMEOUT,
+    DEFAULT_POSITION_SELECTOR_FALLBACK,
     GLARE_ZONE_FORM_KEYS,
     GLARE_ZONE_SLOT_NUMBERS,
     GLARE_ZONE_SLOTS,
@@ -327,6 +328,7 @@ CONFIG_SCHEMA = vol.Schema(
 from .cover_types import (  # noqa: E402
     POLICY_REGISTRY,
     BlindPolicy,
+    CoverTypePolicy,
     TiltPolicy,
     get_policy,
 )
@@ -597,7 +599,9 @@ def _template_combine_mode_selector() -> selector.SelectSelector:
 # the behavior step reference these positions; they never redefine one.
 POSITION_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_DEFAULT_HEIGHT, default=60): selector.NumberSelector(
+        vol.Required(
+            CONF_DEFAULT_HEIGHT, default=DEFAULT_POSITION_SELECTOR_FALLBACK
+        ): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
                 max=100,
@@ -3882,6 +3886,36 @@ def _area_menu(area: str) -> str:
     return "glare_zones" if area == "glare_zone" else area
 
 
+def _apply_create_defaults(options: dict, policy: CoverTypePolicy) -> None:
+    """Seed the create wizard's constant-backed defaults (issue #133 / #1126).
+
+    Quick setup skips some steps (e.g. automation, position) leaving critical
+    keys absent from the accumulated config. ``setdefault`` so an already
+    collected value always wins. ``CONF_DEFAULT_HEIGHT`` seeds the policy's
+    no-coverage endpoint — ``position_for_intent(sun_through=True)`` — rather
+    than a literal, so awning's polarity-flipped position axis (100 % = fully
+    extended = maximum shading) still yields the "leave it alone" value (0,
+    not 100).
+
+    Virtual entry types are skipped by the caller's ``controls_cover and not
+    is_orchestrator`` gate: a Building Profile builds no coordinator, and a
+    cover group builds a ``GroupCoordinator`` that reads none of these keys.
+
+    Shared by ``async_step_update`` (the entry actually created) and
+    ``async_step_summary`` (the pre-create preview), so the two can never
+    disagree about the seeded default position.
+    """
+    options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
+    options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
+    options.setdefault(CONF_MANUAL_OVERRIDE_DURATION, DEFAULT_MANUAL_OVERRIDE_DURATION)
+    options.setdefault(CONF_MOTION_SENSORS, [])
+    options.setdefault(CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT)
+    options.setdefault(CONF_ENABLE_POSITION_MATCHING, DEFAULT_ENABLE_POSITION_MATCHING)
+    options.setdefault(
+        CONF_DEFAULT_HEIGHT, policy.position_for_intent(sun_through=True)
+    )
+
+
 # Wiki link surfaced as the ``{learn_more}`` placeholder on each slot sub-menu.
 _SLOT_AREA_WIKI: dict[str, str] = {
     "custom_position": "https://github.com/jrhubott/adaptive-cover-pro/wiki/Configuration-Custom-Position",
@@ -3927,7 +3961,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     # Rollback-safe: every other migration block is additive (existing keys
     # retained), and the v3.12 rewrite only ever moves a value into the format
     # older builds already expect.
-    MINOR_VERSION = 12
+    # 3.13 (issue #1126): the minimal create wizard (#945 Part 2) has no
+    # position step, so an entry created since then never got
+    # default_percentage written and every runtime read fell back to a
+    # hard-coded 0 (fully closed). The v3.12→v3.13 block setdefault-seeds the
+    # policy's no-coverage endpoint (position_for_intent(sun_through=True));
+    # an older build already understands default_percentage.
+    MINOR_VERSION = 13
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()
@@ -4149,6 +4189,15 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_update()
         from .troubleshoot_i18n import load_troubleshoot_labels
 
+        # Seed the same constant-backed defaults async_step_update applies
+        # (issue #1126) so the pre-create preview and the created entry can
+        # never disagree about the default position — otherwise the summary
+        # would still render "Default → 0 %" for a quick-setup cover that is
+        # actually about to be created at its per-type no-coverage endpoint.
+        _summary_policy = get_policy(self.type_blind)
+        if _summary_policy.controls_cover and not _summary_policy.is_orchestrator:
+            _apply_create_defaults(self.config, _summary_policy)
+
         sun_times = await _compute_todays_sun_times(self.hass, self.config)
         _language = _resolve_summary_language(self.hass, self.context)
         labels = await _load_summary_labels(self.hass, _language)
@@ -4206,25 +4255,18 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         # entry.options["mode"] must carry the strategy mode ("basic" / "advanced").
         options[CONF_MODE] = self.mode
 
-        # Quick setup skips some steps (e.g. automation) leaving critical keys
-        # absent from self.config.  Apply constant-backed defaults so the
-        # coordinator never receives None for gating values (issue #133).
-        # Virtual entry types skip this: a Building Profile builds no
-        # coordinator, and a cover group builds a GroupCoordinator that reads
-        # none of the cover-automation options — both keep only what their
-        # create step collected.
+        # Quick setup skips some steps (e.g. automation, position) leaving
+        # critical keys absent from self.config.  Apply constant-backed
+        # defaults so the coordinator never receives None for gating values,
+        # and so a newly created cover starts at its per-type no-coverage
+        # position instead of 0 % (issues #133 / #1126). Virtual entry types
+        # skip this: a Building Profile builds no coordinator, and a cover
+        # group builds a GroupCoordinator that reads none of the
+        # cover-automation options — both keep only what their create step
+        # collected.
         _finalize_policy = get_policy(self.type_blind)
         if _finalize_policy.controls_cover and not _finalize_policy.is_orchestrator:
-            options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
-            options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
-            options.setdefault(
-                CONF_MANUAL_OVERRIDE_DURATION, DEFAULT_MANUAL_OVERRIDE_DURATION
-            )
-            options.setdefault(CONF_MOTION_SENSORS, [])
-            options.setdefault(CONF_MOTION_TIMEOUT, DEFAULT_MOTION_TIMEOUT)
-            options.setdefault(
-                CONF_ENABLE_POSITION_MATCHING, DEFAULT_ENABLE_POSITION_MATCHING
-            )
+            _apply_create_defaults(options, _finalize_policy)
 
         # If the user linked a Building Profile during creation, merge its
         # non-empty shared-sensor keys into options now — after all form steps

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3901,9 +3901,14 @@ def _apply_create_defaults(options: dict, policy: CoverTypePolicy) -> None:
     is_orchestrator`` gate: a Building Profile builds no coordinator, and a
     cover group builds a ``GroupCoordinator`` that reads none of these keys.
 
-    Shared by ``async_step_update`` (the entry actually created) and
-    ``async_step_summary`` (the pre-create preview), so the two can never
-    disagree about the seeded default position.
+    Shared by all three sites that can mint a fresh entry's options —
+    ``async_step_update`` (the entry the normal create wizard actually
+    creates), ``async_step_summary`` (the pre-create preview, so it can never
+    disagree with what ``async_step_update`` is about to write), and
+    ``async_step_duplicate_configure`` (the Duplicate-cover create path,
+    which cannot rely on the source entry already carrying the key — a
+    disabled source entry is never migrated, so an old, still-broken copy
+    would otherwise propagate the missing key forever).
     """
     options.setdefault(CONF_DELTA_POSITION, DEFAULT_DELTA_POSITION)
     options.setdefault(CONF_DELTA_TIME, DEFAULT_DELTA_TIME)
@@ -4337,15 +4342,26 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             sensor_type = source_entry.data.get(CONF_SENSOR_TYPE)
             new_name = await self._ensure_unique_name(user_input["name"], suffix="Copy")
 
+            new_options = {
+                **shared_options,
+                CONF_ENTITIES: user_input.get(CONF_ENTITIES, []),
+                CONF_AZIMUTH: user_input[CONF_AZIMUTH],
+                # CONF_DEVICE_ID intentionally omitted — device association skipped for duplicates
+            }
+            # The source entry may itself be missing CONF_DEFAULT_HEIGHT — a
+            # cover created during the #1126 window and then disabled is
+            # never migrated (HA does not migrate disabled entries), so
+            # _extract_shared_options can copy nothing for the key. Route
+            # through the same seed helper the other two create sites use
+            # instead of relying on that accident (#1126).
+            _dup_policy = get_policy(sensor_type)
+            if _dup_policy.controls_cover and not _dup_policy.is_orchestrator:
+                _apply_create_defaults(new_options, _dup_policy)
+
             return self.async_create_entry(  # type: ignore[return-value]
                 title=f"{_cover_type_label(sensor_type)} {new_name}",
                 data={"name": new_name, CONF_SENSOR_TYPE: sensor_type},
-                options={
-                    **shared_options,
-                    CONF_ENTITIES: user_input.get(CONF_ENTITIES, []),
-                    CONF_AZIMUTH: user_input[CONF_AZIMUTH],
-                    # CONF_DEVICE_ID intentionally omitted — device association skipped for duplicates
-                },
+                options=new_options,
             )
 
         source_azimuth = source_entry.options.get(CONF_AZIMUTH, 180)

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -483,6 +483,18 @@ CONF_DEFAULT_HEIGHT = "default_percentage"
 # Effective default position when no `default_percentage` is configured.
 # 0 % = closed; matches the historical fallback in coordinator.get_blind_data.
 DEFAULT_DEFAULT_HEIGHT = 0
+# Legacy generic (type-agnostic) fallback for default_percentage, used only by
+# code paths that build a schema or read options without cover-type context —
+# POSITION_SCHEMA's selector default, config_fields._POSITION_SPECS, and
+# switch.py's return-to-default-when-disabled read. The real create-time
+# default is per-cover-type (issue #1126): CoverTypePolicy.position_for_intent
+# seeds the actual value at create time and via the v3.12->v3.13 migration, so
+# this constant is a last-resort placeholder that should be unreachable for a
+# well-formed entry. Distinct in meaning from DEFAULT_DEFAULT_HEIGHT (the
+# coordinator's "nothing configured" runtime fallback) even though the values
+# happen to differ — collapses three previously-duplicated `60` literals into
+# one named constant (No Magic Numbers).
+DEFAULT_POSITION_SELECTOR_FALLBACK = 60
 CONF_INVERSE_STATE = "inverse_state"  # True if cover reports 0=open, 100=closed
 CONF_INVERSE_TILT = "inverse_tilt"  # True if tilt reports 0=open, 100=closed
 

--- a/custom_components/adaptive_cover_pro/switch.py
+++ b/custom_components/adaptive_cover_pro/switch.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_OUTSIDETEMP_ENTITY,
     CONF_SENSOR_TYPE,
     CONF_WEATHER_ENTITY,
+    DEFAULT_POSITION_SELECTOR_FALLBACK,
 )
 from .coordinator import AdaptiveConfigEntry, AdaptiveDataUpdateCoordinator
 from .cover_types import get_policy
@@ -384,7 +385,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverBaseEntity, SwitchEntity, RestoreEntity):
                 and self.coordinator.return_to_default_toggle
             ):
                 default_position = self.coordinator.config_entry.options.get(
-                    CONF_DEFAULT_HEIGHT, 60
+                    CONF_DEFAULT_HEIGHT, DEFAULT_POSITION_SELECTOR_FALLBACK
                 )
                 self.coordinator.logger.debug(
                     "Returning covers to default position: %s", default_position

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -1201,21 +1201,32 @@ async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_awning(
     assert entry.options[CONF_DEFAULT_HEIGHT] == 0
 
 
+@pytest.mark.parametrize("stored_default", [0, 42, 100])
 async def test_migrate_v3_13_does_not_overwrite_existing_default_position(
-    hass: HomeAssistant,
+    hass: HomeAssistant, stored_default: int
 ) -> None:
-    """An entry that already has a configured default position keeps it (setdefault)."""
+    """An entry that already has a configured default position keeps it (setdefault).
+
+    Parametrized over 0, 42, and 100 rather than a single value: 0 is the
+    value most at risk of a regression here. ``_seed_default_position`` gates
+    on ``CONF_DEFAULT_HEIGHT in options`` — a true membership check — but if
+    that ever degraded into a truthiness check
+    (``if not options.get(CONF_DEFAULT_HEIGHT)``), a stored 0 would read as
+    falsy and get silently reseeded to the blind's no-coverage endpoint
+    (100), overwriting a user's deliberately configured fully-closed default.
+    42 and 100 keep the ordinary and boundary-open cases covered alongside it.
+    """
     from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
 
     entry = _make_entry(
         hass,
-        {CONF_DEFAULT_HEIGHT: 42},
+        {CONF_DEFAULT_HEIGHT: stored_default},
         version=3,
         minor_version=12,
         sensor_type=CoverType.BLIND,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.options[CONF_DEFAULT_HEIGHT] == 42
+    assert entry.options[CONF_DEFAULT_HEIGHT] == stored_default
 
 
 async def test_migrate_v3_13_skips_virtual_entry_types(hass: HomeAssistant) -> None:
@@ -1326,12 +1337,59 @@ async def test_migrate_v3_13_logs_seeded_default_position(
     matching = [
         r.message
         for r in caplog.records
-        if "Migration Test" in r.message and "100" in r.message
+        if "Migration Test" in r.message
+        and "100" in r.message
+        and "was silently kept fully closed until this migration ran" in r.message
     ]
     assert matching, (
-        "Expected a log line naming the entry and the seeded value, got: "
+        "Expected a log line naming the entry, the seeded value, and the"
+        " fact that this repair genuinely moved the cover, got: "
         f"{[r.message for r in caplog.records]}"
     )
+
+
+async def test_migrate_v3_13_logs_no_movement_for_open_blocks_sun_seed(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An awning's 0% seed is logged as a no-op, not a "was closed" repair (#1126).
+
+    Awning and oscillating-awning have ``open_blocks_sun=True``, so their
+    no-coverage endpoint is 0 — identical to the pre-fix runtime fallback of
+    a hard-coded 0. The migration still writes the key (so future reads no
+    longer depend on the fallback), but the cover itself never moves, so the
+    log line must say so rather than reusing the "was silently kept fully
+    closed" wording that is only true for the 100%-seeded types. A maintainer
+    reading this log for an awning-only bug report must not be misdirected
+    toward a repair that moved nothing.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {"length_awning": 3.0},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.AWNING,
+    )
+    with caplog.at_level(logging.INFO):
+        assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 0
+    matching = [
+        r.message
+        for r in caplog.records
+        if "Migration Test" in r.message
+        and "matches the pre-fix runtime fallback, so this cover did not move"
+        in r.message
+    ]
+    assert matching, (
+        "Expected a log line naming the entry and stating the cover did not"
+        f" move, got: {[r.message for r in caplog.records]}"
+    )
+    assert not any(
+        "was silently kept fully closed until this migration ran" in r.message
+        for r in caplog.records
+    ), "The awning seed did not move the cover — the log must not claim it did"
 
 
 async def test_migrate_v3_13_does_not_log_when_key_already_present(

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -9,6 +9,8 @@ Exercises async_migrate_entry directly to verify:
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -1255,6 +1257,101 @@ async def test_migrate_v3_13_is_idempotent(hass: HomeAssistant) -> None:
     first = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert dict(entry.options) == first
+
+
+@pytest.mark.parametrize("bad_sensor_type", [None, "", "not_a_registered_type"])
+async def test_migrate_v3_13_unknown_sensor_type_does_not_abort_cascade(
+    hass: HomeAssistant, bad_sensor_type
+) -> None:
+    """A missing/unknown sensor_type must not abort the whole migration cascade.
+
+    ``get_policy`` raises ``ValueError`` for ``None``, ``""``, and any
+    unregistered string. Before this fix, ``_seed_default_position`` called
+    ``get_policy`` before checking whether the type even resolves, so the
+    exception propagated straight out of ``async_migrate_entry`` — parking
+    the entry in ``ConfigEntryState.MIGRATION_ERROR`` and silently discarding
+    every OTHER repair in the same cascade (cm→m conversion, force-override
+    slot-5 copy, blind-spot gamma, the v3.12 malformed-time repair). Pairing
+    a malformed end_time (repaired by the v3.11 → v3.12 sibling block) with
+    the bad sensor_type proves the *sibling* repair still lands — not merely
+    that no exception was raised, which is the actual damage a bare
+    "did it raise" assertion would miss.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {"end_time": "00:00"},
+        version=3,
+        minor_version=11,
+        sensor_type=bad_sensor_type,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 13
+    # The v3.11 → v3.12 sibling repair still landed — proof the cascade
+    # continued past the bad sensor_type instead of aborting.
+    assert entry.options["end_time"] == "00:00:00"
+    # default_percentage can't be resolved for an unknown type, so it is
+    # correctly left unseeded rather than raising.
+    assert CONF_DEFAULT_HEIGHT not in entry.options
+
+
+async def test_migrate_v3_13_logs_seeded_default_position(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The riskiest repair in the migration cascade must not be silent (#1126).
+
+    ``_seed_default_position`` moves an already-bitten cover from an
+    effective 0 % (fully closed) to its per-type default — the largest blast
+    radius of any repair in ``async_migrate_entry`` — yet, unlike every
+    sibling repair (``_merge_force_override_into_slot_5``,
+    ``copy_legacy_slot_sensors_to_list``, ``_seed_signed_gamma_blind_spots``,
+    ``_repair_malformed_times``), the caller ignored its return value and
+    logged nothing. When a user reports "all my blinds opened after the
+    update" there must be a log line to point at.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.BLIND,
+    )
+    with caplog.at_level(logging.INFO):
+        assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 100
+    matching = [
+        r.message
+        for r in caplog.records
+        if "Migration Test" in r.message and "100" in r.message
+    ]
+    assert matching, (
+        "Expected a log line naming the entry and the seeded value, got: "
+        f"{[r.message for r in caplog.records]}"
+    )
+
+
+async def test_migrate_v3_13_does_not_log_when_key_already_present(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No log line when default_percentage was already configured (no-op setdefault)."""
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {CONF_DEFAULT_HEIGHT: 42},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.BLIND,
+    )
+    with caplog.at_level(logging.INFO):
+        assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 42
+    assert not any("Seeded default position" in r.message for r in caplog.records)
 
 
 async def test_migrate_v3_9_preserves_user_set_constraints(

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -15,6 +15,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro import async_migrate_entry
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
     CONF_SENSOR_TYPE,
     CONF_WINDOW_WIDTH,
     DOMAIN,
@@ -250,7 +251,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -286,7 +287,7 @@ async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -299,7 +300,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -326,7 +327,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -363,7 +364,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -405,7 +406,7 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
@@ -428,7 +429,7 @@ async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
@@ -441,7 +442,7 @@ async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -454,7 +455,7 @@ async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
@@ -463,7 +464,7 @@ async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> 
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
     assert entry.version == 3
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 # ---------------------------------------------------------------------------
@@ -485,7 +486,7 @@ async def test_migrate_v3_6_sets_weather_enabled_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=5)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -498,7 +499,7 @@ async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is False
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
@@ -511,7 +512,7 @@ async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> None:
@@ -520,7 +521,7 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
     assert entry.version == 3
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +532,7 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
 
 
 async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
-    """A minor-6 entry advances to minor 7 without altering any option."""
+    """A minor-6 entry advances to minor 7 without altering any v3.7-owned option."""
     entry = _make_entry(
         hass,
         {"azimuth": 180, CONF_WEATHER_ENABLED: True},
@@ -541,10 +542,11 @@ async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     # Additive/no-op: no outside_temp_source key seeded, options untouched.
     assert "outside_temp_source" not in entry.options
-    assert entry.options == before
+    # Cascades on through v3.13 too, which seeds default_percentage (#1126).
+    assert entry.options == {**before, CONF_DEFAULT_HEIGHT: 100}
 
 
 async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
@@ -557,9 +559,9 @@ async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert entry.options == first
 
 
@@ -575,7 +577,7 @@ async def test_migrate_v3_6_to_3_7_preserves_explicit_source(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options["outside_temp_source"] == "max_of_live_and_forecast"
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
 
 
 # ---------------------------------------------------------------------------
@@ -592,8 +594,10 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     """A minor-4 entry cascades through minor 5 gaining no retraction-toggle key.
 
     The v3.4→v3.5 block is a no-op (it must not seed the removed
-    show_weather_retraction key). The entry continues through the v3.5→v3.6
-    block, which is the *only* addition to its options — weather_enabled=True.
+    show_weather_retraction key). The entry continues cascading through
+    v3.5→v3.6 (weather_enabled=True) and v3.12→v3.13, which seeds
+    default_percentage to this awning's polarity-flipped no-coverage endpoint,
+    0 (#1126).
     """
     entry = _make_entry(
         hass,
@@ -604,11 +608,14 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     # No dead key seeded by the v3.4→v3.5 block.
     assert "show_weather_retraction" not in entry.options
-    # The only key added across the cascade is the v3.5→v3.6 weather toggle.
-    assert entry.options == {**before, CONF_WEATHER_ENABLED: True}
+    assert entry.options == {
+        **before,
+        CONF_WEATHER_ENABLED: True,
+        CONF_DEFAULT_HEIGHT: 0,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -641,7 +648,7 @@ async def test_migrate_v3_7_to_v3_8_converts_blind_spots(hass: HomeAssistant) ->
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     opts = entry.options
     # Slot 1 converted (new_left = 45-10 = 35, new_right = 30-45 = -15).
     assert opts["blind_spot_left_gamma"] == 35
@@ -674,9 +681,9 @@ async def test_migrate_v3_7_to_v3_8_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert entry.options == first
 
 
@@ -703,7 +710,7 @@ async def test_migrate_v3_7_to_v3_8_preserves_existing_gamma_keys(
 
 
 async def test_migrate_v3_7_to_v3_8_no_blind_spot_is_noop(hass: HomeAssistant) -> None:
-    """An entry without any blind-spot edges only bumps the minor version."""
+    """An entry without any blind-spot edges gains only the v3.13 default position."""
     entry = _make_entry(
         hass,
         {"azimuth": 180},
@@ -712,8 +719,8 @@ async def test_migrate_v3_7_to_v3_8_no_blind_spot_is_noop(hass: HomeAssistant) -
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
-    assert entry.options == before
+    assert entry.minor_version == 13
+    assert entry.options == {**before, CONF_DEFAULT_HEIGHT: 100}
 
 
 async def test_migrate_v3_7_to_v3_8_tolerates_none_fov_left(
@@ -739,7 +746,7 @@ async def test_migrate_v3_7_to_v3_8_tolerates_none_fov_left(
         minor_version=7,
     )
     assert await async_migrate_entry(hass, entry) is True  # no TypeError
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert entry.options["blind_spot_left_gamma"] == 80  # 90 - 10
     assert entry.options["blind_spot_right_gamma"] == -60  # 30 - 90
 
@@ -788,13 +795,14 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 12 (the v3.11 → v3.12 block that repairs
-    malformed start_time/end_time values, per issue #1049).
+    Currently the highest target is 13 (the v3.12 → v3.13 block that seeds
+    default_percentage for entries the minimal create wizard left key-less,
+    per issue #1126).
     Raise this assertion whenever a new minor migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 12
+    assert ConfigFlowHandler.MINOR_VERSION == 13
 
 
 # ---------------------------------------------------------------------------
@@ -850,8 +858,8 @@ async def test_migrate_v3_8_to_v3_9_is_additive_noop(hass: HomeAssistant) -> Non
     entry = _make_entry(hass, dict(options), version=3, minor_version=8)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 12
-    assert dict(entry.options) == options
+    assert entry.minor_version == 13
+    assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
 async def test_migrate_v3_8_to_v3_9_seeds_no_constraint_keys(
@@ -879,8 +887,8 @@ async def test_migrate_v3_9_to_v3_10_additive_noop_without_legacy_margin(
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=9)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
-    assert dict(entry.options) == options
+    assert entry.minor_version == 13
+    assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
 async def test_migrate_v3_9_to_v3_10_copies_legacy_safety_margin(
@@ -903,7 +911,7 @@ async def test_migrate_v3_9_to_v3_10_copies_legacy_safety_margin(
         minor_version=9,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     # New neutral key seeded from the legacy value.
     assert entry.options[CONF_TILT_SAFETY_MARGIN] == 0.5
     # Legacy key retained unchanged (additive / rollback-safe).
@@ -942,8 +950,8 @@ async def test_migrate_v3_10_is_idempotent(hass: HomeAssistant) -> None:
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
-    assert dict(entry.options) == options
+    assert entry.minor_version == 13
+    assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
 async def test_migrate_v3_10_to_v3_11_seeds_shade_mode_for_awning(
@@ -967,22 +975,23 @@ async def test_migrate_v3_10_to_v3_11_seeds_shade_mode_for_awning(
         minor_version=10,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert entry.options[CONF_AWNING_SHADE_MODE] == AWNING_SHADE_MODE_WINDOW
 
 
 async def test_migrate_v3_10_to_v3_11_skips_non_awning(
     hass: HomeAssistant,
 ) -> None:
-    """A non-awning entry (no length_awning) is not seeded — options untouched."""
+    """A non-awning entry (no length_awning) gets no shade-mode key seeded (#1025)."""
     from custom_components.adaptive_cover_pro.const import CONF_AWNING_SHADE_MODE
 
     options = {"azimuth": 180, "custom_position_sensors_1": ["binary_sensor.door"]}
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert CONF_AWNING_SHADE_MODE not in entry.options
-    assert dict(entry.options) == options
+    # Cascades on through v3.13, which seeds this blind's default position (#1126).
+    assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
 async def test_migrate_v3_11_does_not_overwrite_existing_shade_mode(
@@ -1054,7 +1063,7 @@ async def test_migrate_v3_11_to_v3_12_repairs_malformed_time(
     """
     entry = _make_entry(hass, {time_key: stored}, version=3, minor_version=11)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 12
+    assert entry.minor_version == 13
     assert entry.options[time_key] == expected
 
 
@@ -1065,7 +1074,7 @@ async def test_migrate_v3_11_to_v3_12_leaves_canonical_times_alone(
     options = {"start_time": "07:00:00", "end_time": "22:30:00", "azimuth": 180}
     entry = _make_entry(hass, dict(options), version=3, minor_version=11)
     assert await async_migrate_entry(hass, entry) is True
-    assert dict(entry.options) == options
+    assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
 @pytest.mark.parametrize("stored", ["garbage", "25:00:00", "24:99:99", ""])
@@ -1134,6 +1143,116 @@ async def test_migrate_v3_12_is_idempotent(hass: HomeAssistant) -> None:
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
     assert entry.options["end_time"] == "00:00:00"
+    assert await async_migrate_entry(hass, entry) is True
+    assert dict(entry.options) == first
+
+
+# ---------------------------------------------------------------------------
+# v3.12 → v3.13: seed default_percentage for the minimal create wizard (#1126)
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_blind(
+    hass: HomeAssistant,
+) -> None:
+    """A key-less blind entry is backfilled to its no-coverage endpoint (100).
+
+    The minimal create wizard (#945 Part 2) has no position step, so every
+    entry created since then never got default_percentage written — every
+    runtime read then fell back to a hard-coded 0, driving the cover fully
+    closed until Options -> Position was opened and saved (#1126).
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.BLIND,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 13
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 100
+
+
+async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_awning(
+    hass: HomeAssistant,
+) -> None:
+    """A key-less awning entry is backfilled to 0, its polarity-flipped endpoint.
+
+    Awning's position axis has ``open_blocks_sun=True`` (100 % = fully
+    extended = maximum shading), so its no-coverage endpoint is 0, not 100 —
+    the opposite of every other registered cover type.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {"length_awning": 3.0},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.AWNING,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 13
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 0
+
+
+async def test_migrate_v3_13_does_not_overwrite_existing_default_position(
+    hass: HomeAssistant,
+) -> None:
+    """An entry that already has a configured default position keeps it (setdefault)."""
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    entry = _make_entry(
+        hass,
+        {CONF_DEFAULT_HEIGHT: 42},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.BLIND,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 42
+
+
+async def test_migrate_v3_13_skips_virtual_entry_types(hass: HomeAssistant) -> None:
+    """Building Profile and Group entries control no cover and are left untouched.
+
+    Their policies declare no axes, so calling ``position_for_intent`` on them
+    raises ``IndexError`` — the same ``controls_cover and not is_orchestrator``
+    gate the create finalizer uses (#133) must guard the migration too.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_DEFAULT_HEIGHT
+
+    profile_entry = _make_entry(
+        hass,
+        {},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.BUILDING_PROFILE,
+    )
+    assert await async_migrate_entry(hass, profile_entry) is True
+    assert CONF_DEFAULT_HEIGHT not in profile_entry.options
+
+    group_entry = _make_entry(
+        hass, {}, version=3, minor_version=12, sensor_type=CoverType.GROUP
+    )
+    assert await async_migrate_entry(hass, group_entry) is True
+    assert CONF_DEFAULT_HEIGHT not in group_entry.options
+
+
+async def test_migrate_v3_13_is_idempotent(hass: HomeAssistant) -> None:
+    """Re-running the migration on an already-seeded entry is stable."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=12,
+        sensor_type=CoverType.BLIND,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    first = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert dict(entry.options) == first
 

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -228,6 +228,61 @@ async def test_minimal_create_wizard_geometry_only(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.integration
+@pytest.mark.parametrize(
+    ("cover_type", "geometry_input", "expected_default_height"),
+    [
+        (CoverType.BLIND, _VERTICAL_GEOMETRY, 100),
+        (CoverType.AWNING, {"length_awning": 2.1, "angle": 0}, 0),
+    ],
+)
+async def test_create_seeds_default_position_per_cover_type(
+    hass: HomeAssistant,
+    cover_type: str,
+    geometry_input: dict,
+    expected_default_height: int,
+) -> None:
+    """A newly created cover starts at its per-type no-coverage endpoint (#1126).
+
+    The minimal create wizard has no position step, so ``CONF_DEFAULT_HEIGHT``
+    must be seeded by the finalizer — like a blind's fully-open 100, not a
+    literal 60 and not an absent key (which every runtime read falls back to
+    0 for, driving the cover fully closed until Options -> Position is opened
+    and saved). Awning's position axis is polarity-flipped (100 % = fully
+    extended = maximum shading), so its no-coverage endpoint is 0, not 100.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "create_new"}
+        )
+    assert result["step_id"] == "create_new"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"name": "Test Cover", CONF_MODE: cover_type}
+    )
+    assert result["step_id"] == "cover_entities"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_ENTITIES: []}
+    )
+    assert result["step_id"] == "geometry"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], geometry_input
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "summary"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.data[CONF_SENSOR_TYPE] == cover_type
+    assert entry.options.get(CONF_DEFAULT_HEIGHT) == expected_default_height
+
+
+@pytest.mark.integration
 async def test_quick_setup_horizontal_creates_entry(hass: HomeAssistant) -> None:
     """Quick-setup path for a horizontal awning creates a config entry."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -275,6 +275,13 @@ async def test_create_seeds_default_position_per_cover_type(
     assert result["type"] == "form"
     assert result["step_id"] == "summary"
 
+    # The pre-create preview must show the same per-type default the entry is
+    # about to be created with (#1126) — async_step_summary seeds
+    # self.config via _apply_create_defaults before rendering, precisely so
+    # the summary and the created entry can't disagree.
+    summary_text = result["description_placeholders"]["summary"]
+    assert f"🌙 Default (no rule matches) → {expected_default_height}%" in summary_text
+
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
     assert result["type"] == "create_entry"
     entry = result["result"]
@@ -434,6 +441,63 @@ async def test_duplicate_oscillating_awning(hass: HomeAssistant) -> None:
     )
     assert result["type"] == "create_entry"
     assert result["title"].startswith("Oscillating Awning")
+
+
+@pytest.mark.integration
+async def test_duplicate_seeds_default_position_when_source_lacks_it(
+    hass: HomeAssistant,
+) -> None:
+    """Duplicating a key-less source entry must not propagate the missing key (#1126).
+
+    ``profile_link._cover_entries`` (the duplicate-source picker) enumerates
+    sources via ``hass.config_entries.async_entries(DOMAIN)``, which includes
+    disabled entries — and HA never runs ``async_migrate_entry`` on a
+    disabled entry. So a cover created during the #1126 window and then
+    disabled would, pre-fix, be duplicated straight through
+    ``_extract_shared_options`` with no ``CONF_DEFAULT_HEIGHT`` key at all,
+    stamping the copy at the current ``MINOR_VERSION`` — already past the
+    v3.13 migration threshold, so the copy would never self-heal and stays
+    stuck at an effective 0 % (fully closed) forever. A test that duplicates
+    a well-formed source (which already carries the key via
+    ``_extract_shared_options``) would not catch this — only a source
+    missing the key exercises the bug.
+    """
+    from tests.ha_helpers import VERTICAL_OPTIONS
+
+    source_options = {
+        k: v for k, v in VERTICAL_OPTIONS.items() if k != CONF_DEFAULT_HEIGHT
+    }
+    assert CONF_DEFAULT_HEIGHT not in source_options
+    source_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Bitten Blind", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=source_options,
+        version=3,
+        minor_version=13,
+        entry_id="dup_src_no_default_height",
+        title="Vertical Blind Bitten Blind",
+    )
+    source_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    if result["type"] == "menu":
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "duplicate_existing"}
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"source_entry": source_entry.entry_id}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"name": "Bitten Blind Copy", CONF_AZIMUTH: 180},
+    )
+    assert result["type"] == "create_entry"
+    entry = result["result"]
+    assert entry.options.get(CONF_DEFAULT_HEIGHT) == 100
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -243,16 +243,15 @@ def test_create_summary_shows_seeded_default_position():
     from custom_components.adaptive_cover_pro.config_flow import (
         _apply_create_defaults,
     )
-    from custom_components.adaptive_cover_pro.cover_types import get_policy
 
     blind_cfg: dict = {}
-    _apply_create_defaults(blind_cfg, get_policy(CoverType.BLIND))
+    _apply_create_defaults(blind_cfg, CoverType.BLIND)
     blind_summary = _build_config_summary(blind_cfg, CoverType.BLIND)
     assert "🌙 Default (no rule matches) → 100%" in blind_summary
     assert "🌙 Default (no rule matches) → 0%" not in blind_summary
 
     awning_cfg: dict = {}
-    _apply_create_defaults(awning_cfg, get_policy(CoverType.AWNING))
+    _apply_create_defaults(awning_cfg, CoverType.AWNING)
     awning_summary = _build_config_summary(awning_cfg, CoverType.AWNING)
     assert "🌙 Default (no rule matches) → 0%" in awning_summary
 

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -252,6 +252,11 @@ def test_create_summary_shows_seeded_default_position():
 
     awning_cfg: dict = {}
     _apply_create_defaults(awning_cfg, CoverType.AWNING)
+    # The summary text alone can't distinguish "seeded 0" from "never seeded"
+    # — _build_config_summary falls back to config.get(CONF_DEFAULT_HEIGHT, 0)
+    # for an absent key too. Assert the seeded key directly so this test
+    # fails if the awning seed stops happening, not just if it seeds wrong.
+    assert awning_cfg[CONF_DEFAULT_HEIGHT] == 0
     awning_summary = _build_config_summary(awning_cfg, CoverType.AWNING)
     assert "🌙 Default (no rule matches) → 0%" in awning_summary
 

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -228,6 +228,35 @@ def test_empty_config_returns_string():
     assert len(summary) > 0
 
 
+def test_create_summary_shows_seeded_default_position():
+    """A quick-setup summary shows the seeded per-type default, not 0 % (#1126).
+
+    ``async_step_summary`` seeds ``self.config`` via ``_apply_create_defaults``
+    before rendering (issue #1126) so the pre-create preview matches the entry
+    ``async_step_update`` actually creates. Model that seeding directly against
+    an empty (quick-setup) config dict, which never collected
+    ``CONF_DEFAULT_HEIGHT`` because the minimal create wizard has no position
+    step. A blind's no-coverage endpoint is 100 (not the old literal 60, and
+    not the 0 the unseeded summary used to fall back to); an awning's position
+    axis is polarity-flipped, so its no-coverage endpoint is 0.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import (
+        _apply_create_defaults,
+    )
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    blind_cfg: dict = {}
+    _apply_create_defaults(blind_cfg, get_policy(CoverType.BLIND))
+    blind_summary = _build_config_summary(blind_cfg, CoverType.BLIND)
+    assert "🌙 Default (no rule matches) → 100%" in blind_summary
+    assert "🌙 Default (no rule matches) → 0%" not in blind_summary
+
+    awning_cfg: dict = {}
+    _apply_create_defaults(awning_cfg, get_policy(CoverType.AWNING))
+    awning_summary = _build_config_summary(awning_cfg, CoverType.AWNING)
+    assert "🌙 Default (no rule matches) → 0%" in awning_summary
+
+
 def test_dry_run_banner_shown_when_enabled():
     """Dry-run banner is surfaced (and first) when dry_run is on."""
     from custom_components.adaptive_cover_pro.const import CONF_DRY_RUN

--- a/tests/test_quick_setup_defaults.py
+++ b/tests/test_quick_setup_defaults.py
@@ -65,8 +65,12 @@ from custom_components.adaptive_cover_pro.const import (
 # Helpers
 # ---------------------------------------------------------------------------
 
-# Keys set by the quick-setup steps (cover_entities, geometry, sun_tracking,
-# position).  Every other key in the options builder is absent from this dict.
+# Keys set by the quick-setup steps (cover_entities, geometry, sun_tracking).
+# Every other key in the options builder is absent from this dict. Notably
+# absent: CONF_DEFAULT_HEIGHT — the minimal create wizard (#945 Part 2) has no
+# position step at all, so self.config never carries it; _build_options_from_
+# config seeds it the same way ConfigFlowHandler._apply_create_defaults does
+# (issue #1126).
 _QUICK_SETUP_CONFIG: dict = {
     CONF_ENTITIES: ["cover.living_room"],
     CONF_AZIMUTH: 180,
@@ -74,7 +78,6 @@ _QUICK_SETUP_CONFIG: dict = {
     CONF_DISTANCE: 0.5,
     CONF_FOV_LEFT: 30,
     CONF_FOV_RIGHT: 30,
-    CONF_DEFAULT_HEIGHT: 60,
     CONF_INVERSE_STATE: False,
     CONF_OPEN_CLOSE_THRESHOLD: 50,
 }
@@ -159,6 +162,8 @@ def _build_options_from_config(config: dict) -> dict:
         CONF_RETURN_SUNSET,
         CONF_CLOUD_SUPPRESSION,
     )
+    from custom_components.adaptive_cover_pro.const import CoverType
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
 
     DEFAULT_MOTION_TIMEOUT = 300
 
@@ -168,7 +173,13 @@ def _build_options_from_config(config: dict) -> dict:
         CONF_DISTANCE: config.get(CONF_DISTANCE),
         CONF_WINDOW_DEPTH: config.get(CONF_WINDOW_DEPTH),
         CONF_SILL_HEIGHT: config.get(CONF_SILL_HEIGHT),
-        CONF_DEFAULT_HEIGHT: config.get(CONF_DEFAULT_HEIGHT),
+        # _apply_create_defaults seeds this from the policy's no-coverage
+        # endpoint, not a literal (issue #1126); mirrored fixtures are always
+        # a blind, so position_for_intent(sun_through=True) == 100.
+        CONF_DEFAULT_HEIGHT: config.get(
+            CONF_DEFAULT_HEIGHT,
+            get_policy(CoverType.BLIND).position_for_intent(sun_through=True),
+        ),
         CONF_MAX_POSITION: config.get(CONF_MAX_POSITION),
         CONF_ENABLE_MAX_POSITION: config.get(CONF_ENABLE_MAX_POSITION),
         CONF_MIN_POSITION: config.get(CONF_MIN_POSITION),
@@ -604,6 +615,22 @@ class TestQuickVsFullSetupParity:
             assert (
                 options[key] is not None
             ), f"{key} was None in full-setup options — schema defaults not applied"
+
+    @pytest.mark.unit
+    def test_quick_setup_default_height_seeded_per_cover_type(self):
+        """CONF_DEFAULT_HEIGHT is seeded from the policy, not left None (#1126).
+
+        Neither quick nor full setup collects a position input anymore (#945
+        Part 2 removed the position step from the create wizard entirely), so
+        ``_QUICK_SETUP_CONFIG``/``_FULL_SETUP_CONFIG`` correctly omit the key —
+        the mirrored builder must fill it in the same way
+        ``ConfigFlowHandler._apply_create_defaults`` does: the policy's
+        no-coverage endpoint, not a bare ``None``.
+        """
+        quick_options = _build_options_from_config(_QUICK_SETUP_CONFIG)
+        full_options = _build_options_from_config(_FULL_SETUP_CONFIG)
+        assert quick_options[CONF_DEFAULT_HEIGHT] == 100
+        assert full_options[CONF_DEFAULT_HEIGHT] == 100
 
     @pytest.mark.unit
     def test_quick_setup_delta_position_is_valid_int(self):


### PR DESCRIPTION
## Summary
The create finalizer was seeding six constant-backed option keys but skipping CONF_DEFAULT_HEIGHT entirely. Since the no-step create wizard (from #945 Part 2) never collected it either, fresh entries had no key at all. Every runtime read then hit a hard-coded fallback of 0, so DefaultHandler drove the cover fully closed until the user opened Options and saved for the first time (the only other write site).

The fix seeds CONF_DEFAULT_HEIGHT at cover create time using the policy-derived default for each cover type: 100 for blinds, tilts, venetians, roof windows, sliding curtains, louvered roofs, day/night shades, and dual panels; 0 for awnings and oscillating awnings, which have open_blocks_sun so 0 is the retracted position. The seed helper now gates on cover type once and is called from all three entry-minting paths (update, summary, duplicate). An additive config-entry migration (v3.12 to v3.13) repairs entries already created by the broken wizard. Three duplicated literal `60` values collapsed into one named constant.

On upgrade, covers created during the buggy window will open to their type's default on the first load. Awnings do not move.

## Testing
- ✅ 11653 tests passing

## Related Issues
Refs #1126