### PR TITLE
fix: distinguish assumed open/closed from a real position in the command gates (#1130)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING, Any, ClassVar
 
 import voluptuous as vol
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
@@ -37,7 +36,12 @@ from ..const import (
     POSITION_OPEN,
     GroupScene,
 )
-from ..helpers import get_open_close_state, should_use_tilt, state_attr
+from ..helpers import (
+    get_open_close_state,
+    is_assumed_state,
+    should_use_tilt,
+    state_attr,
+)
 from ._summary_labels import AXIS_LABELS_EN
 
 if TYPE_CHECKING:
@@ -1219,7 +1223,7 @@ class CoverTypePolicy(ABC):
         live = get_open_close_state(hass, entity, state_obj=state_obj)
         if assumed is not None:
             st = state_obj if state_obj is not None else hass.states.get(entity)
-            if st is not None and st.attributes.get(ATTR_ASSUMED_STATE):
+            if is_assumed_state(st):
                 # Issue #888 follow-up: for an assumed-state cover, open/closed is
                 # the last-command direction, not a real position. A recorded
                 # high-confidence assumed value (a My arrival) is more specific, so

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -12,6 +12,7 @@ import pandas as pd
 from dateutil import parser
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -665,7 +666,7 @@ def check_cover_capabilities(
                     "threshold compare, not set_position."
                 )
             state = hass.states.get(eid)
-            if state and state.attributes.get("assumed_state"):
+            if is_assumed_state(state):
                 warnings.append(
                     f"⚠️ {eid} has assumed_state — real position cannot be "
                     "read back, which may affect position verification and delta-bypass."
@@ -1328,6 +1329,19 @@ def get_open_close_state(
         return 100
 
     return None
+
+
+def is_assumed_state(state: "State | None") -> bool:
+    """Return True if *state* reports HA's ``assumed_state`` attribute.
+
+    Single source of truth for the assumed-state check duplicated at three
+    sites: ``CoverTypePolicy.read_axis_value``'s open/close fallback,
+    ``CoverCommandService``'s same-position gate (``_current_is_assumed_mapping``,
+    issue #1130), and this module's ``check_cover_capabilities`` summary
+    warning. ``state=None`` (entity not yet resolved) reports False, matching
+    every prior call site's guard.
+    """
+    return state is not None and bool(state.attributes.get(ATTR_ASSUMED_STATE))
 
 
 def climate_mode_from_diagnostics(diagnostics: dict | None) -> str | None:

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -1489,8 +1489,9 @@ class CoverCommandService:
         #
         # A third condition narrows entry into arms one and two, and widens
         # entry into the third arm's fallback, beyond "not
-        # position-capable" alone: an `assumed_state` cover routed through a
-        # non-position-capable service has its `_current` sourced from
+        # position-capable" alone: an `assumed_state` cover whose default
+        # axis has NO position-capability (its `capability_key`, e.g.
+        # CAP_HAS_SET_POSITION, is false) has its `_current` sourced from
         # `get_open_close_state`'s raw open/close→100/0 mapping, not a
         # genuine position reading (issue #1130). RFXtrx-style Somfy RTS
         # covers report HA state "open" after every stop_cover regardless
@@ -1551,27 +1552,45 @@ class CoverCommandService:
         # entity's travel, not on this one's `supported_features`, which is
         # all `_plan` is derived from.
         _caps_for_plan = self.get_cover_capabilities(entity_id)
+        _axis_for_plan = self._policy.select_default_axis(_caps_for_plan)
         _plan = route_service_call(
             entity_id,
             position,
             _caps_for_plan,
-            axis=self._policy.select_default_axis(_caps_for_plan),
+            axis=_axis_for_plan,
             use_my_position=context.use_my_position,
             open_close_threshold=self._open_close_threshold,
             endpoint_use_open_close=self._endpoint_use_open_close,
         )
 
-        # Issue #1130: an assumed_state, non-position-capable cover's
-        # `_current` came from the open/close→100/0 mapping
-        # (get_open_close_state), not a genuine position reading. Trust
-        # that mapping for the same-position gate's direct-equality arms
-        # only when the cover is NOT assumed_state; otherwise fall through
-        # to the stored-target-vs-routed-target comparison (arm three,
-        # #779/#1095), which is the correct comparison for a synthetic
-        # reading.
+        # Issue #1130 (narrowed post-audit): an assumed_state cover whose
+        # default axis is genuinely NOT position-capable has its `_current`
+        # sourced from the open/close→100/0 mapping (get_open_close_state),
+        # not a genuine position reading. The predicate checks the axis
+        # CAPABILITY (`caps_get(..., _axis_for_plan.capability_key)`) rather
+        # than `_plan.supports_position` (a routing OUTCOME): a
+        # position-capable cover that also sets assumed_state — an
+        # MQTT/template optimistic cover, or a `cover` group containing an
+        # RTS member — can still route through open_cover/close_cover under
+        # endpoint_use_open_close (the default) at a mechanical endpoint,
+        # yet its `_current` there IS a genuine position read and must not
+        # be treated as synthetic (it would otherwise re-dispatch
+        # open_cover/close_cover on every cycle and disturb a venetian's
+        # slats, weakening the #985 guarantee). This mirrors the branch
+        # `read_axis_value` (cover_types/base.py) itself takes when deciding
+        # whether to read a genuine position attribute or fall back to
+        # `get_open_close_state` — the gate should classify `_current` the
+        # same way the reader that produced it did. Trust the open/close
+        # mapping for the same-position gate's direct-equality arms only
+        # when the cover is NOT assumed_state on a non-position-capable
+        # axis; otherwise fall through to the stored-target-vs-routed-target
+        # comparison (arm three, #779/#1095), which is the correct
+        # comparison for a synthetic reading.
         _current_is_assumed_mapping = (
             _current is not None
-            and not _plan.supports_position
+            and not caps_get(
+                _caps_for_plan, _axis_for_plan.capability_key, default=True
+            )
             and bool(state_obj.attributes.get(ATTR_ASSUMED_STATE))
         )
         if (

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -7,7 +7,12 @@ from collections.abc import Iterable, Iterator
 from typing import Any
 
 from homeassistant.components.cover.const import DOMAIN as COVER_DOMAIN
-from homeassistant.const import STATE_CLOSED, STATE_OPEN, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ASSUMED_STATE,
+    STATE_CLOSED,
+    STATE_OPEN,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
@@ -1190,20 +1195,30 @@ class CoverCommandService:
         (issue #779 follow-up regression from PR #781, which hand-rolled a
         partial copy of this math and ignored ``use_my_position``).
 
-        Consulted only when ``_current is None`` — a *resolved* ``_current``
-        is compared directly against ``plan.routed_target`` by the caller
-        instead (issue #1095; see the same-position gate's comment in
-        ``apply_position`` for the "not position-capable" routing-algebra
-        explanation of which routes ``routed_target`` can actually diverge
-        from ``position`` on). A resolved live reading that contradicts the
-        stored target (e.g. the cover reports mechanically closed while the
-        last commanded target was "open") must be free to fall through and
-        dispatch; routing it through the last-*commanded*-target comparison
-        here would let a stale stored target mask a genuine state change.
-        This fallback exists solely for the case where there is no live
-        reading to compare at all. The delta/time gates and reconciliation
-        intentionally keep reading the real current position and are
-        untouched by this fallback.
+        Consulted when ``_current is None``, and also when ``_current`` is
+        not ``None`` but is a *synthetic* mapping rather than a genuine
+        reading — an ``assumed_state`` cover routed through a
+        non-position-capable service, whose raw HA open/closed state was
+        mapped straight to 100/0 by ``get_open_close_state`` (issue #1130).
+        A *resolved, genuine* ``_current`` is still compared directly
+        against ``plan.routed_target`` by the caller instead (issue #1095;
+        see the same-position gate's comment in ``apply_position`` for the
+        "not position-capable" routing-algebra explanation of which routes
+        ``routed_target`` can actually diverge from ``position`` on). A
+        genuine live reading that contradicts the stored target (e.g. the
+        cover reports mechanically closed while the last commanded target
+        was "open") must be free to fall through and dispatch; routing it
+        through the last-*commanded*-target comparison here would let a
+        stale stored target mask a genuine state change. That reasoning
+        does not hold for the synthetic open/close mapping — it is not a
+        genuine position reading at all, so it must not be allowed to
+        contradict the stored target either; falling back to the
+        commanded-target comparison is the correct behavior for it too.
+        This fallback's "no live reading to compare" framing therefore now
+        covers both "no reading at all" and "a reading that cannot be
+        trusted as a real position." The delta/time gates and
+        reconciliation intentionally keep reading the real current position
+        and are untouched by this fallback.
 
         Args:
             entity_id: Cover entity ID.
@@ -1471,6 +1486,25 @@ class CoverCommandService:
         # cheap, explicit boolean check that states the case up front and
         # defends against a future route_service_call change breaking that
         # invariant on a position-capable route.
+        #
+        # A third condition narrows entry into arms one and two, and widens
+        # entry into the third arm's fallback, beyond "not
+        # position-capable" alone: an `assumed_state` cover routed through a
+        # non-position-capable service has its `_current` sourced from
+        # `get_open_close_state`'s raw open/close→100/0 mapping, not a
+        # genuine position reading (issue #1130). RFXtrx-style Somfy RTS
+        # covers report HA state "open" after every stop_cover regardless
+        # of where the motor actually parked, so a My-route move to (say)
+        # 10% reads back as `_current = 100` forever — arms one and two can
+        # never match (100 != 10), so the same command re-fires every
+        # cycle, and a later genuine return to the default 100 is wrongly
+        # swallowed as same_position because 100 == 100 even though the
+        # cover physically sits elsewhere. `_current_is_assumed_mapping`
+        # (computed just below, right after `_plan`) detects this shape and
+        # routes it to the stored-target-vs-routed-target comparison
+        # instead — the same fallback #779/#1095 already use for `_current
+        # is None` — which is the correct comparison for a synthetic
+        # reading rather than a genuine one.
         # An explicit user command (context.user_command) must ALWAYS dispatch —
         # a user pressing Open/Close/Set from the card is never "already there"
         # as far as ACP is entitled to decide, especially on a no-feedback cover
@@ -1526,6 +1560,20 @@ class CoverCommandService:
             open_close_threshold=self._open_close_threshold,
             endpoint_use_open_close=self._endpoint_use_open_close,
         )
+
+        # Issue #1130: an assumed_state, non-position-capable cover's
+        # `_current` came from the open/close→100/0 mapping
+        # (get_open_close_state), not a genuine position reading. Trust
+        # that mapping for the same-position gate's direct-equality arms
+        # only when the cover is NOT assumed_state; otherwise fall through
+        # to the stored-target-vs-routed-target comparison (arm three,
+        # #779/#1095), which is the correct comparison for a synthetic
+        # reading.
+        _current_is_assumed_mapping = (
+            _current is not None
+            and not _plan.supports_position
+            and bool(state_obj.attributes.get(ATTR_ASSUMED_STATE))
+        )
         if (
             not sun_reconfirm
             and not force_endpoint
@@ -1533,6 +1581,7 @@ class CoverCommandService:
             and (
                 (
                     _current is not None
+                    and not _current_is_assumed_mapping
                     and (
                         _current == position
                         or (
@@ -1543,10 +1592,11 @@ class CoverCommandService:
                 or (
                     _current is not None
                     and not _plan.supports_position
+                    and not _current_is_assumed_mapping
                     and _current == _plan.routed_target
                 )
                 or (
-                    _current is None
+                    (_current is None or _current_is_assumed_mapping)
                     and self._same_position_via_target_fallback(
                         entity_id, position, context, plan=_plan
                     )

--- a/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/__init__.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from homeassistant.components.cover.const import DOMAIN as COVER_DOMAIN
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
     STATE_CLOSED,
     STATE_OPEN,
     STATE_UNAVAILABLE,
@@ -34,6 +33,7 @@ from ...diagnostics.event_buffer import EventBuffer
 from ...helpers import (
     check_cover_features,
     get_last_updated,
+    is_assumed_state,
 )
 from . import gates
 from .diagnostics import DiagnosticsRecorder
@@ -1197,9 +1197,10 @@ class CoverCommandService:
 
         Consulted when ``_current is None``, and also when ``_current`` is
         not ``None`` but is a *synthetic* mapping rather than a genuine
-        reading — an ``assumed_state`` cover routed through a
-        non-position-capable service, whose raw HA open/closed state was
-        mapped straight to 100/0 by ``get_open_close_state`` (issue #1130).
+        reading — an ``assumed_state`` cover whose default axis is not
+        position-capable (``caps_get(caps, axis.capability_key)`` is
+        false), whose raw HA open/closed state was mapped straight to
+        100/0 by ``get_open_close_state`` (issue #1130).
         A *resolved, genuine* ``_current`` is still compared directly
         against ``plan.routed_target`` by the caller instead (issue #1095;
         see the same-position gate's comment in ``apply_position`` for the
@@ -1474,10 +1475,13 @@ class CoverCommandService:
         # below only ever compares a *resolved* `_current` directly against
         # `_plan.routed_target` — it never calls
         # _same_position_via_target_fallback. That fallback (see its
-        # docstring) is reserved for the third arm, `_current is None`,
-        # where there is no live reading to compare at all. Delta/time gates
-        # and reconciliation deliberately keep reading the real `_current` —
-        # this routed comparison is scoped to the same-position gate only.
+        # docstring) is reserved for the third arm: `_current is None`, and,
+        # per the #1130 carve-out below, a resolved `_current` that is a
+        # synthetic open/close mapping rather than a genuine reading — in
+        # both cases there is no trustworthy live reading to compare
+        # against. Delta/time gates and reconciliation deliberately keep
+        # reading the real `_current` — this routed comparison is scoped to
+        # the same-position gate only.
         #
         # The second arm keeps `not _plan.supports_position` even though it
         # is currently provably redundant there (a position-capable route's
@@ -1506,6 +1510,7 @@ class CoverCommandService:
         # instead — the same fallback #779/#1095 already use for `_current
         # is None` — which is the correct comparison for a synthetic
         # reading rather than a genuine one.
+        #
         # An explicit user command (context.user_command) must ALWAYS dispatch —
         # a user pressing Open/Close/Set from the card is never "already there"
         # as far as ACP is entitled to decide, especially on a no-feedback cover
@@ -1591,7 +1596,7 @@ class CoverCommandService:
             and not caps_get(
                 _caps_for_plan, _axis_for_plan.capability_key, default=True
             )
-            and bool(state_obj.attributes.get(ATTR_ASSUMED_STATE))
+            and is_assumed_state(state_obj)
         )
         if (
             not sun_reconfirm

--- a/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/routing.py
@@ -119,7 +119,7 @@ def route_service_call(
         :class:`ServiceCallPlan` describing what the orchestrator must do.
 
     """
-    supports_position = caps.get(axis.capability_key, True)
+    supports_position = caps_get(caps, axis.capability_key, default=True)
 
     if (
         supports_position

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -24,6 +24,7 @@ from custom_components.adaptive_cover_pro.helpers import (
     get_open_close_state,
     get_safe_state,
     get_timedelta_str,
+    is_assumed_state,
     motion_entities,
     resolve_sun_boundaries,
     should_use_tilt,
@@ -591,6 +592,42 @@ def test_get_open_close_state_returns_none_for_other_states(mock_hass):
     result = get_open_close_state(mock_hass, "cover.test")
 
     assert result is None
+
+
+# --- is_assumed_state ---
+
+
+@pytest.mark.unit
+def test_is_assumed_state_returns_true_when_attribute_truthy():
+    """Test is_assumed_state returns True when assumed_state attribute is truthy."""
+    state_obj = MagicMock()
+    state_obj.attributes = {"assumed_state": True}
+
+    assert is_assumed_state(state_obj) is True
+
+
+@pytest.mark.unit
+def test_is_assumed_state_returns_false_when_attribute_absent():
+    """Test is_assumed_state returns False when assumed_state attribute is missing."""
+    state_obj = MagicMock()
+    state_obj.attributes = {}
+
+    assert is_assumed_state(state_obj) is False
+
+
+@pytest.mark.unit
+def test_is_assumed_state_returns_false_when_attribute_explicitly_false():
+    """Test is_assumed_state returns False when assumed_state is explicitly False."""
+    state_obj = MagicMock()
+    state_obj.attributes = {"assumed_state": False}
+
+    assert is_assumed_state(state_obj) is False
+
+
+@pytest.mark.unit
+def test_is_assumed_state_returns_false_when_state_is_none():
+    """Test is_assumed_state returns False when state is None (entity not resolved)."""
+    assert is_assumed_state(None) is False
 
 
 # --- should_use_tilt ---

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -7,11 +7,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
     CONF_MOTION_MEDIA_PLAYERS,
     CONF_MOTION_SENSORS,
     CUSTOM_POSITION_SLOTS,
 )
 from custom_components.adaptive_cover_pro.helpers import (
+    check_cover_capabilities,
     check_cover_features,
     check_time_passed,
     custom_position_slot_configured,
@@ -628,6 +630,44 @@ def test_is_assumed_state_returns_false_when_attribute_explicitly_false():
 def test_is_assumed_state_returns_false_when_state_is_none():
     """Test is_assumed_state returns False when state is None (entity not resolved)."""
     assert is_assumed_state(None) is False
+
+
+# --- check_cover_capabilities: assumed_state warning ---
+
+
+@pytest.mark.unit
+def test_check_cover_capabilities_warns_when_assumed_state(mock_hass):
+    """check_cover_capabilities appends the assumed_state warning for a ready cover whose state carries assumed_state=True."""
+    state_obj = MagicMock()
+    state_obj.state = "closed"
+    state_obj.attributes = {"assumed_state": True}
+    mock_hass.states.get.return_value = state_obj
+
+    cap_map, warnings = check_cover_capabilities(
+        {CONF_ENTITIES: ["cover.test"]}, None, mock_hass
+    )
+
+    assert cap_map["cover.test"] is not None
+    assert warnings == [
+        "⚠️ cover.test has assumed_state — real position cannot be "
+        "read back, which may affect position verification and delta-bypass."
+    ]
+
+
+@pytest.mark.unit
+def test_check_cover_capabilities_no_warning_without_assumed_state(mock_hass):
+    """check_cover_capabilities does not warn when the state has no assumed_state attribute."""
+    state_obj = MagicMock()
+    state_obj.state = "closed"
+    state_obj.attributes = {}
+    mock_hass.states.get.return_value = state_obj
+
+    cap_map, warnings = check_cover_capabilities(
+        {CONF_ENTITIES: ["cover.test"]}, None, mock_hass
+    )
+
+    assert cap_map["cover.test"] is not None
+    assert warnings == []
 
 
 # --- should_use_tilt ---

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -2512,6 +2512,170 @@ async def test_apply_position_endpoint_contradicted_by_current_dispatches_after_
     mock_hass.services.async_call.assert_called_once()
 
 
+# --- same-position gate: assumed_state cover's synthetic open/close mapping
+# is not a genuine reading (issue #1130) ---
+#
+# `get_open_close_state` maps a no-feedback cover's raw HA state string
+# (open/closed) to a synthetic `_current` of 100/0. RFXtrx-style Somfy RTS
+# covers clear `is_closed` on every stop_cover, so an `assumed_state` cover
+# parked at My~=10% still reads back `_current = 100` forever. Arms one and
+# two of the same-position gate treat that synthetic value as a genuine
+# reading, which produces two symptoms: a My-route repeat is never
+# suppressed (100 never equals the My target), and a genuine return to the
+# default (100) is wrongly swallowed as same_position (100 == 100) even
+# though the cover physically sits elsewhere. The fix routes an
+# assumed_state, non-position-capable cover's `_current` through the
+# stored-target-vs-routed-target fallback instead (the same comparison
+# #779/#1095 already use for `_current is None`).
+
+
+@pytest.mark.asyncio
+async def test_apply_position_assumed_state_my_route_repeat_suppressed(
+    cmd_svc, mock_hass
+):
+    """Issue #1130 symptom 1: a repeated identical My-preset move on an
+    assumed_state cover must be suppressed as same_position, not resent
+    every cycle.
+
+    The cover's raw HA state is "open" (assumed_state=True), so
+    `_current` resolves to 100 via the open/close mapping -- not a genuine
+    reading. On the My route `routed_target == position` by construction,
+    so arms one and two both degenerate to `100 != 10` and can never
+    match. Without the widened fallback, `sun.sun`'s frequent tracked
+    updates would re-fire stop_cover every cycle, interrupting the
+    cover's own travel.
+    """
+    mock_hass.states.get.return_value = MagicMock(
+        state="open", attributes={"assumed_state": True}
+    )
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=100),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_assumed", 10, "solar", _ctx_with_special(use_my_position=True)
+        )
+        assert (outcome, reason) == ("sent", "stop_cover")
+        assert cmd_svc.get_target("cover.rts_assumed") == 10
+
+        mock_hass.services.async_call.reset_mock()
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.rts_assumed", 10, "solar", _ctx_with_special(use_my_position=True)
+        )
+
+    assert (outcome2, reason2) == ("skipped", "same_position")
+    mock_hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_assumed_state_return_to_default_dispatches(
+    cmd_svc, mock_hass
+):
+    """Issue #1130 symptom 2: a pipeline-driven return to the default (100)
+    must dispatch, not be swallowed as same_position, even though the
+    assumed_state cover's synthetic `_current` also reads 100.
+
+    The stored *commanded* target is 10 (a prior My move); the newly
+    routed target is 100 (open_cover). Those genuinely differ, so the
+    widened fallback must let this through -- unlike the un-widened arm
+    one, which would wrongly match on `_current(100) == position(100)`
+    alone and drop the reopen.
+    """
+    mock_hass.states.get.return_value = MagicMock(
+        state="open", attributes={"assumed_state": True}
+    )
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+    cmd_svc.set_target("cover.rts_assumed_default", 10)
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=100),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_assumed_default", 100, "solar", _ctx_with_special()
+        )
+
+    assert (outcome, reason) == ("sent", "open_cover")
+    mock_hass.services.async_call.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_apply_position_non_assumed_open_close_cover_unaffected(
+    cmd_svc, mock_hass
+):
+    """Regression guard: the widening must key off assumed_state, not "resolved
+    _current on a non-position-capable route" alone.
+
+    Identical shape to the symptom-1 test above -- same My-route repeat,
+    same open/close-only caps, same synthetic `_current = 100` from the
+    open state -- but with no `assumed_state` attribute. Without that
+    flag, `_current_is_assumed_mapping` must stay False and arms one/two
+    must behave exactly as before this fix: neither matches (100 != 10),
+    so the repeat is NOT suppressed. This proves the new branch is scoped
+    to genuinely assumed_state covers and does not change behavior for
+    every open/close-only cover.
+    """
+    mock_hass.states.get.return_value = MagicMock(state="open", attributes={})
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": False,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=100),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.rts_not_assumed",
+            10,
+            "solar",
+            _ctx_with_special(use_my_position=True),
+        )
+        assert (outcome, reason) == ("sent", "stop_cover")
+
+        mock_hass.services.async_call.reset_mock()
+        outcome2, reason2 = await cmd_svc.apply_position(
+            "cover.rts_not_assumed",
+            10,
+            "solar",
+            _ctx_with_special(use_my_position=True),
+        )
+
+    assert (outcome2, reason2) == ("sent", "stop_cover")
+
+
 # --- is_target_unreached: A2 read-only "commanded but not reached" predicate ---
 # Issue #990. Read-only predicate the coordinator polls each cycle to raise the
 # cover_not_moving Repair. True iff a target is set, the cover has settled

--- a/tests/test_managers/test_cover_command.py
+++ b/tests/test_managers/test_cover_command.py
@@ -2676,6 +2676,56 @@ async def test_apply_position_non_assumed_open_close_cover_unaffected(
     assert (outcome2, reason2) == ("sent", "stop_cover")
 
 
+@pytest.mark.asyncio
+async def test_apply_position_position_capable_assumed_state_still_same_position(
+    cmd_svc, mock_hass
+):
+    """Post-audit regression guard: a position-capable, assumed_state cover
+    must NOT have its genuine `_current` reading treated as a synthetic
+    open/close mapping.
+
+    An MQTT/template optimistic cover (or a `cover` group containing an RTS
+    member) can advertise `has_set_position: True` AND `assumed_state:
+    True` at once. Routed to the 100 endpoint under
+    `endpoint_use_open_close` (the default), it goes through `open_cover`
+    just like a genuinely non-position-capable cover would --
+    `_plan.supports_position` is False either way -- but here `_current`
+    (100) IS a real position read, not a synthetic mapping. The
+    #1130-widened gate must not misclassify it: `_current_is_assumed_mapping`
+    has to key off the axis's actual position CAPABILITY
+    (`caps_get(..., axis.capability_key)`), not the routing outcome, or this
+    shape re-dispatches `open_cover` every cycle and disturbs a coupled
+    venetian's slats -- exactly the #985 guarantee the same-position gate
+    exists to protect.
+    """
+    mock_hass.states.get.return_value = MagicMock(
+        state="open", attributes={"assumed_state": True}
+    )
+    mock_hass.services.async_call = AsyncMock(return_value=None)
+    caps = {
+        "has_set_position": True,
+        "has_set_tilt_position": False,
+        "has_open": True,
+        "has_close": True,
+        "has_stop": True,
+    }
+
+    with (
+        patch.object(cmd_svc, "_get_current_position", return_value=100),
+        patch.object(cmd_svc, "_check_time_delta", return_value=True),
+        patch(
+            "custom_components.adaptive_cover_pro.managers.cover_command.check_cover_features",
+            return_value=caps,
+        ),
+    ):
+        outcome, reason = await cmd_svc.apply_position(
+            "cover.pos_assumed", 100, "solar", _ctx_with_special()
+        )
+
+    assert (outcome, reason) == ("skipped", "same_position")
+    mock_hass.services.async_call.assert_not_called()
+
+
 # --- is_target_unreached: A2 read-only "commanded but not reached" predicate ---
 # Issue #990. Read-only predicate the coordinator polls each cycle to raise the
 # cover_not_moving Repair. True iff a target is set, the cover has settled

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -1301,6 +1301,10 @@ async def test_same_position_skips_even_for_special_target(svc, mock_hass):
     guard in apply_position that applies even to force=True callers).
     """
     _patch_position(svc, 100)  # cover is already at 100%
+    # Real attributes dict (not an unconfigured MagicMock, whose auto-created
+    # `.attributes.get(...)` return value is truthy) so the assumed_state
+    # carve-out (issue #1130) reads a genuine falsy absence here.
+    mock_hass.states.get.return_value = MagicMock(state="open", attributes={})
     outcome, reason = await svc.apply_position(
         "cover.test",
         100,  # same as current → short-circuit fires
@@ -1315,6 +1319,8 @@ async def test_same_position_skips_even_for_special_target(svc, mock_hass):
 async def test_same_position_skips_for_zero_special(svc, mock_hass):
     """Cover at 0% targeting 0% is short-circuited (no command sent)."""
     _patch_position(svc, 0)
+    # See the attributes-dict note above (issue #1130).
+    mock_hass.states.get.return_value = MagicMock(state="closed", attributes={})
     outcome, reason = await svc.apply_position(
         "cover.test",
         0,
@@ -1415,6 +1421,10 @@ async def test_sun_just_appeared_no_resend_at_mechanical_stop(svc, mock_hass):
     _patch_position(svc, 0)  # carriage already at 0
     state = MagicMock()
     state.state = "closed"  # STATE_CLOSED -> _is_at_mechanical_stop True
+    # Real attributes dict (not an unconfigured MagicMock — issue #1130's
+    # assumed_state carve-out reads `.attributes.get(...)`, and an
+    # auto-created Mock there would be spuriously truthy).
+    state.attributes = {}
     mock_hass.states.get.return_value = state
     svc._service_secondary_axis = AsyncMock()  # spy: tilt must still get a turn
     with (

--- a/tests/test_position_reconciliation.py
+++ b/tests/test_position_reconciliation.py
@@ -1301,10 +1301,6 @@ async def test_same_position_skips_even_for_special_target(svc, mock_hass):
     guard in apply_position that applies even to force=True callers).
     """
     _patch_position(svc, 100)  # cover is already at 100%
-    # Real attributes dict (not an unconfigured MagicMock, whose auto-created
-    # `.attributes.get(...)` return value is truthy) so the assumed_state
-    # carve-out (issue #1130) reads a genuine falsy absence here.
-    mock_hass.states.get.return_value = MagicMock(state="open", attributes={})
     outcome, reason = await svc.apply_position(
         "cover.test",
         100,  # same as current → short-circuit fires
@@ -1319,8 +1315,6 @@ async def test_same_position_skips_even_for_special_target(svc, mock_hass):
 async def test_same_position_skips_for_zero_special(svc, mock_hass):
     """Cover at 0% targeting 0% is short-circuited (no command sent)."""
     _patch_position(svc, 0)
-    # See the attributes-dict note above (issue #1130).
-    mock_hass.states.get.return_value = MagicMock(state="closed", attributes={})
     outcome, reason = await svc.apply_position(
         "cover.test",
         0,
@@ -1421,10 +1415,6 @@ async def test_sun_just_appeared_no_resend_at_mechanical_stop(svc, mock_hass):
     _patch_position(svc, 0)  # carriage already at 0
     state = MagicMock()
     state.state = "closed"  # STATE_CLOSED -> _is_at_mechanical_stop True
-    # Real attributes dict (not an unconfigured MagicMock — issue #1130's
-    # assumed_state carve-out reads `.attributes.get(...)`, and an
-    # auto-created Mock there would be spuriously truthy).
-    state.attributes = {}
     mock_hass.states.get.return_value = state
     svc._service_secondary_axis = AsyncMock()  # spy: tilt must still get a turn
     with (


### PR DESCRIPTION
## Summary

On covers that do not report a position (`assumed_state: true`, e.g. Somfy RTS via RFXtrx), the command-dispatch read path maps HA's state string to an endpoint (`open` to 100, `closed` to 0), and the three-arm same-position gate in `apply_position` treated that synthetic value as a genuine reading.

`_same_position_via_target_fallback` was gated on `_current is None` alone, so once RFXtrx's post-stop write made HA report `open`, `_current` resolved to 100 and arm 3 never ran. Two symptoms followed: a My-position route re-fired `stop_cover` every cycle (arm 2's #1095 fix is structurally inert there, since `routed_target == position` by construction on that route), and a pipeline-driven return to the default 100 was dropped as `same_position` while the cover sat at My.

Arms 1 and 2 now exclude a synthetic reading and arm 3 admits it. The check keys on the axis capability, mirroring the branch `read_axis_value` takes to produce the value in the first place, rather than on the routing outcome: a position-capable cover that also sets `assumed_state` (an MQTT optimistic cover, or a group holding an RTS member) must not be misclassified, or a venetian at an endpoint would be re-sent `close_cover` and lose its slat position (#985).

The three `ATTR_ASSUMED_STATE` sites are collapsed into one `is_assumed_state()` helper along the way.

Out of scope: `_execute_command`'s missing `use_my_position` in position reconciliation, noted on the issue and getting its own follow-up.

## Testing
- ✅ 11682 tests passing

## Related Issues
Refs #1130