### PR TITLE
feat: change a cover's type from the options flow

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_CALL_SERVICE, Platform
@@ -868,6 +869,41 @@ _RUNTIME_APPLICABLE_OPTIONS: dict[str, str] = {
 }
 
 
+def _changed_option_keys(
+    previous: Mapping[str, Any], current: Mapping[str, Any]
+) -> set[str]:
+    """Keys whose value differs between two option mappings."""
+    return {
+        key
+        for key in current.keys() | previous.keys()
+        if current.get(key) != previous.get(key)
+    }
+
+
+def options_write_reloads(entry: ConfigEntry, new_options: Mapping[str, Any]) -> bool:
+    """Whether writing *new_options* onto *entry* will reload it.
+
+    The single statement of ``_async_update_listener``'s reload rule.
+    ``config_flow`` has to ask this question *before* it writes — a cover-type
+    switch changes ``entry.data``, which the listener does not look at, so it
+    needs its own reload, but only when the options write is not about to
+    produce one anyway (issue #1132). Restating the rule there instead of
+    sharing it is how the two answers drift apart into a double reload.
+
+    Note the answer is *not* "did the options change": a delta confined to
+    ``_RUNTIME_APPLICABLE_OPTIONS`` is applied in place and never reloads.
+    """
+    coordinator = getattr(entry, "runtime_data", None)
+    if coordinator is None:
+        # Nothing is set up, so no update listener is registered to react.
+        return False
+    previous = getattr(coordinator, "_cached_options", None)
+    if previous is None:
+        return True
+    changed = _changed_option_keys(previous, new_options)
+    return bool(changed) and not changed.issubset(_RUNTIME_APPLICABLE_OPTIONS)
+
+
 async def _async_profile_propagate(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Propagate a Building Profile's sensor changes to its linked covers.
 
@@ -892,24 +928,14 @@ async def _async_profile_propagate(hass: HomeAssistant, entry: ConfigEntry) -> N
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
+    if options_write_reloads(entry, entry.options):
+        await hass.config_entries.async_reload(entry.entry_id)
+        return
+
     coordinator = entry.runtime_data
     previous_options = coordinator._cached_options
-    if previous_options is not None:
-        current_options = dict(entry.options)
-        previous_options = dict(previous_options)
-        changed_keys = {
-            key
-            for key in current_options.keys() | previous_options.keys()
-            if current_options.get(key) != previous_options.get(key)
-        }
-
-        if not changed_keys:
-            return
-        if changed_keys.issubset(_RUNTIME_APPLICABLE_OPTIONS):
-            for apply_name in {
-                _RUNTIME_APPLICABLE_OPTIONS[key] for key in changed_keys
-            }:
-                await getattr(coordinator, apply_name)()
-            return
-
-    await hass.config_entries.async_reload(entry.entry_id)
+    if previous_options is None:
+        return
+    changed_keys = _changed_option_keys(previous_options, entry.options)
+    for apply_name in {_RUNTIME_APPLICABLE_OPTIONS[key] for key in changed_keys}:
+        await getattr(coordinator, apply_name)()

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any
 
 import voluptuous as vol
@@ -2221,3 +2221,182 @@ CUSTOM_POSITION_TILT_KEYS: tuple[str, ...] = tuple(
     for slot in CUSTOM_POSITION_SLOTS.values()
     for k in (slot["tilt"], slot["tilt_only"])
 ) + (CONF_DEFAULT_TILT, CONF_SUNSET_TILT)
+
+
+# =============================================================================
+# Position roles (axis semantics of every stored 0-100 % option)
+# =============================================================================
+# Changing a cover's type can flip which end of its primary axis means "let the
+# sun through" — a blind is out of the way at 100 %, an awning at 0 %. Every
+# stored percentage that names a position on that axis therefore means the
+# opposite after such a switch, and the "Change Cover Type" confirm screen has
+# to say so (issue #1132). Which ones those are is declared once, here, next to
+# the fields themselves; ``percentage_option_keys()`` below is the structural
+# enumeration that proves the declaration complete.
+
+
+class PositionRole(StrEnum):
+    """What a stored 0-100 % option means on a cover's travel axes.
+
+    ``RESEED`` is reserved for the one case where a policy already owns the
+    correct value: ``default_percentage`` is seeded at creation from
+    ``position_for_intent(sun_through=True)`` (``__init__._seed_default_position``,
+    issue #1126), so a type switch can re-seed it from the same hook without
+    inventing an answer. Every other primary-axis position is the user's own
+    choice with no policy counterpart — rewriting a deliberate travel limit or
+    scene value would be worse than the flip — so they are disclosed instead.
+    """
+
+    #: Primary-axis position with a policy-defined correct value.
+    RESEED = "reseed"
+    #: Primary-axis lower clamp; neutral (nothing to disclose) at its range floor.
+    FLOOR = "floor"
+    #: Primary-axis upper clamp; neutral at its range ceiling.
+    CEILING = "ceiling"
+    #: A commanded primary-axis position — any stored value inverts.
+    VALUE = "value"
+    #: Primary-axis position that is migration-read-only and no longer applied.
+    LEGACY = "legacy"
+    #: A position on the secondary (tilt) axis, not the primary one.
+    TILT = "tilt"
+    #: A percentage that is not a travel position (delta, threshold, opacity).
+    NEUTRAL = "neutral"
+
+    @classmethod
+    def disclosed_roles(cls) -> frozenset[PositionRole]:
+        """Roles whose stored value must be named when the polarity flips."""
+        return frozenset({cls.FLOOR, cls.CEILING, cls.VALUE})
+
+
+def _slot_roles() -> dict[str, PositionRole]:
+    """Per-slot custom-position roles, generated from the slot key map.
+
+    Slot values are user-authored scene positions and slot ceilings are
+    user-authored clamps; neither has a policy answer, so both are disclosed.
+    The per-slot tilt keys ride the secondary axis.
+    """
+    roles: dict[str, PositionRole] = {}
+    for slot in CUSTOM_POSITION_SLOTS.values():
+        roles[slot["position"]] = PositionRole.VALUE
+        roles[slot["position_max"]] = PositionRole.CEILING
+        for tilt_key in ("tilt", "tilt_min", "tilt_max"):
+            roles[slot[tilt_key]] = PositionRole.TILT
+    return roles
+
+
+#: ``{option key: PositionRole}`` for every stored 0-100 % option.
+#: Completeness (in both directions) is locked by
+#: ``tests/test_config_flow_change_cover_type.py::
+#: test_every_percentage_option_declares_a_position_role``.
+_POSITION_ROLES: dict[str, PositionRole] = {
+    # ---- primary axis ----------------------------------------------------
+    CONF_DEFAULT_HEIGHT: PositionRole.RESEED,
+    CONF_MIN_POSITION: PositionRole.FLOOR,
+    CONF_MIN_POSITION_SUN_TRACKING: PositionRole.FLOOR,
+    CONF_MAX_POSITION: PositionRole.CEILING,
+    CONF_SUNSET_POS: PositionRole.VALUE,
+    CONF_END_OF_WINDOW_POS: PositionRole.VALUE,
+    CONF_MY_POSITION_VALUE: PositionRole.VALUE,
+    CONF_CLOUDY_POSITION: PositionRole.VALUE,
+    CONF_WEATHER_OVERRIDE_POSITION: PositionRole.VALUE,
+    CONF_EXTREME_HEAT_POSITION: PositionRole.VALUE,
+    # Superseded by custom-position slot 5 (v3.2 migration) and never read at
+    # runtime since. Disclosing a key the options UI no longer shows would send
+    # the user looking for a screen that does not exist; the slot it was copied
+    # into is disclosed in its place.
+    CONF_FORCE_OVERRIDE_POSITION: PositionRole.LEGACY,
+    # ---- secondary (tilt) axis -------------------------------------------
+    # Every tilt-capable policy shares one tilt convention, so a switch between
+    # them does not invert these. They are classified, not disclosed.
+    CONF_DEFAULT_TILT: PositionRole.TILT,
+    CONF_SUNSET_TILT: PositionRole.TILT,
+    CONF_MIN_TILT: PositionRole.TILT,
+    CONF_MAX_TILT: PositionRole.TILT,
+    # ---- percentages that are not travel positions -----------------------
+    # Magnitudes and hardware-frame thresholds. A type switch changes which end
+    # of the axis shades the window; it does not renumber the axis, so a delta,
+    # a movement tolerance, an open/closed cut-off and the interpolation domain
+    # (which calibrates commanded % against the same physical travel) all keep
+    # meaning exactly what they meant. The day/night values are fabric opacity
+    # percentages, not positions at all.
+    CONF_DELTA_POSITION: PositionRole.NEUTRAL,
+    CONF_POSITION_TOLERANCE: PositionRole.NEUTRAL,
+    CONF_MANUAL_THRESHOLD: PositionRole.NEUTRAL,
+    CONF_OPEN_CLOSE_THRESHOLD: PositionRole.NEUTRAL,
+    CONF_INTERP_START: PositionRole.NEUTRAL,
+    CONF_INTERP_END: PositionRole.NEUTRAL,
+    CONF_DAY_NIGHT_OPACITY_SHEER: PositionRole.NEUTRAL,
+    CONF_DAY_NIGHT_OPACITY_BLACKOUT: PositionRole.NEUTRAL,
+    CONF_DAY_NIGHT_BLACKOUT_THRESHOLD: PositionRole.NEUTRAL,
+    **_slot_roles(),
+}
+
+
+def position_roles() -> dict[str, PositionRole]:
+    """Return the declared ``{option key: PositionRole}`` map (a copy)."""
+    return dict(_POSITION_ROLES)
+
+
+def disclosed_position_keys() -> tuple[str, ...]:
+    """Primary-axis positions to name when a switch flips the axis polarity.
+
+    Registry order, so the confirm screen lists them the way the options
+    screens do: Position, then the handler sections, then the slots.
+    """
+    disclosed = PositionRole.disclosed_roles()
+    ordered = [k for k in FIELD_SPECS if _POSITION_ROLES.get(k) in disclosed]
+    # Every key declared today also has a ``FieldSpec``, but a field emitted
+    # only by a dynamic section builder would not — and quietly dropping it
+    # here is exactly the short list this whole seam exists to prevent.
+    ordered += sorted(
+        k
+        for k, role in _POSITION_ROLES.items()
+        if role in disclosed and k not in ordered
+    )
+    return tuple(ordered)
+
+
+def reseeded_position_keys() -> tuple[str, ...]:
+    """Primary-axis positions a switch rewrites to the new type's own value."""
+    return tuple(
+        k for k, role in _POSITION_ROLES.items() if role is PositionRole.RESEED
+    )
+
+
+def polarity_neutral_value(key: str) -> float | None:
+    """Return the value of *key* that constrains nothing under either polarity.
+
+    A floor at its range minimum and a ceiling at its range maximum clamp
+    nothing whichever end means "out of the way", so they have nothing to
+    disclose. Derived from ``OPTION_RANGES`` rather than restated, so a widened
+    bound cannot leave a stale neutral behind. ``None`` = no neutral value; any
+    stored value inverts.
+    """
+    role = _POSITION_ROLES.get(key)
+    rng = OPTION_RANGES.get(key)
+    if rng is None:
+        return None
+    if role is PositionRole.FLOOR:
+        return rng[0]
+    if role is PositionRole.CEILING:
+        return rng[1]
+    return None
+
+
+def is_percentage_marker(validator: Any) -> bool:
+    """Whether a rendered schema value stores a 0-100 % axis percentage.
+
+    Two shapes, because the field registry has two: the shared ``%``-unit
+    ``NumberSelector`` (``position_slider`` and friends) and the raw
+    ``vol.Range`` a couple of geometry builders still emit. Used by
+    ``cover_types.percentage_option_keys`` to enumerate the options
+    ``_POSITION_ROLES`` must classify.
+    """
+    config = getattr(validator, "config", None)
+    if isinstance(config, dict) and config.get("unit_of_measurement") == "%":
+        return True
+    parts = validator.validators if isinstance(validator, vol.All) else (validator,)
+    return any(
+        isinstance(part, vol.Range) and part.min == 0 and part.max in (99, 100)
+        for part in parts
+    )

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -256,6 +256,7 @@ from .engine.sun_geometry import computed_fov_line, fov_from_reveal
 from .i18n_bundle import flatten_bundle, load_bundle_overlay, merge_labels
 from .troubleshoot_i18n import load_troubleshoot_labels
 from .helpers import (
+    bound_cover_capabilities,
     check_cover_capabilities,
     clear_custom_position_slot,
     clear_slot,
@@ -3614,6 +3615,74 @@ def _extract_shared_options(
     return result
 
 
+# Fallback line for a destination type that is filtered out but whose policy
+# offers no capability warning of its own — the blocked list must always say
+# something rather than list a bare label (issue #1132).
+_BLOCKED_TYPE_GENERIC_REASON = (
+    "⚠️ The covers bound to this instance do not advertise the features this "
+    "cover type requires."
+)
+
+
+def _eligible_cover_types(
+    current_type: str | None,
+    known: Mapping[str, Mapping[str, bool] | None],
+) -> tuple[list[str], list[str]]:
+    """Split the offerable cover types into ``(eligible, blocked)`` (issue #1132).
+
+    Starts from ``SENSOR_TYPE_MENU`` — the same registry-derived list the create
+    flow offers, so virtual entry types (Building Profile, Group) can never
+    appear — drops the type this instance already is, and asks each remaining
+    candidate policy whether its own entity picker would have admitted the
+    covers already bound here.
+    """
+    eligible: list[str] = []
+    blocked: list[str] = []
+    for candidate in SENSOR_TYPE_MENU:
+        if candidate == current_type:
+            continue
+        if get_policy(candidate).entities_satisfy_selector(known):
+            eligible.append(candidate)
+        else:
+            blocked.append(candidate)
+    return eligible, blocked
+
+
+def _blocked_types_text(
+    blocked: list[str],
+    known: Mapping[str, Mapping[str, bool] | None],
+    labels: dict[str, str] | None = None,
+) -> str:
+    """Render one explained line per cover type the bound covers rule out.
+
+    Each policy states its own requirement through
+    ``cover_capability_warnings`` — the same advisory text the create flow and
+    the configuration summary render — so this never grows a second capability
+    matrix.
+    """
+    lines: list[str] = []
+    for cover_type in blocked:
+        policy = get_policy(cover_type)
+        reasons = policy.cover_capability_warnings(dict(known))
+        reason = reasons[0] if reasons else _BLOCKED_TYPE_GENERIC_REASON
+        lines.append(f"- **{policy.display_label(labels)}** — {reason}")
+    return "\n".join(lines)
+
+
+def _stranded_option_keys(
+    current_type: str | None, new_type: str, options: Mapping[str, Any]
+) -> list[str]:
+    """Return stored keys the outgoing type reads and the incoming one does not.
+
+    Advisory only (issue #1132): nothing is deleted, so switching back finds the
+    configuration intact. Both sides come from ``live_option_keys()`` so the
+    comparison stays on the policy layer.
+    """
+    outgoing = get_policy(current_type).live_option_keys()
+    incoming = get_policy(new_type).live_option_keys()
+    return sorted((outgoing - incoming) & set(options))
+
+
 def _build_cover_entity_schema(
     sensor_type: str,
     devices: dict[str, str] | None = None,
@@ -4447,6 +4516,13 @@ class OptionsFlowHandler(OptionsFlow):
         # step id so the translation block is authored once, so the area lives
         # here instead of in the step id.
         self._delete_area: str = ""
+        # "Change Cover Type" (issue #1132). ``_pending_cover_type`` carries the
+        # picked destination from the picker to the confirm screen;
+        # ``_cover_type_changed`` records that ``entry.data`` was rewritten, so
+        # Save & Close knows it must schedule a reload even when no option value
+        # changed.
+        self._pending_cover_type: str | None = None
+        self._cover_type_changed: bool = False
 
     def __getattr__(self, name: str):
         """Dispatch dynamic per-slot options steps (issue #945).
@@ -4565,6 +4641,11 @@ class OptionsFlowHandler(OptionsFlow):
         # ── Layer 1: What am I? (physical setup) ─────────────────────
         keys = [
             "cover_entities",
+            # Switch this instance to another cover type in place, keeping every
+            # entity_id (issue #1132). Offered unconditionally on the cover menu
+            # so "nothing you can switch to" is an explained screen rather than
+            # a silently missing row.
+            "change_cover_type",
             "geometry",
             "sun_tracking",
         ]
@@ -4704,6 +4785,112 @@ class OptionsFlowHandler(OptionsFlow):
             data_schema=self.add_suggested_values_to_schema(schema, suggested),
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/First-Time-Setup"
+            },
+        )
+
+    async def async_step_change_cover_type(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Pick a new cover type for this instance (issue #1132).
+
+        Offers every registry type whose own entity picker would have admitted
+        the covers already bound here, and explains the ones it filtered out
+        instead of hiding them. The dropdown reuses the ``selector.mode`` label
+        bundle the create flow already ships, so no per-type string is added.
+        """
+        known = bound_cover_capabilities(self.hass, self.options)
+        eligible, blocked = _eligible_cover_types(self.sensor_type, known)
+        if not eligible:
+            return self.async_abort(reason="no_eligible_cover_types")  # type: ignore[return-value]
+
+        if user_input is not None:
+            self._pending_cover_type = user_input[CONF_SENSOR_TYPE]
+            return await self.async_step_change_cover_type_confirm()
+
+        labels = await _load_summary_labels(
+            self.hass, _resolve_summary_language(self.hass, self.context)
+        )
+        return self.async_show_form(  # type: ignore[return-value]
+            step_id="change_cover_type",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_SENSOR_TYPE): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=eligible, translation_key="mode"
+                        )
+                    )
+                }
+            ),
+            description_placeholders={
+                "current_type": get_policy(self.sensor_type).display_label(labels),
+                "blocked_types": _blocked_types_text(blocked, known, labels),
+                "learn_more": f"{_WIKI_BASE_URL}/Cover-Types",
+            },
+        )
+
+    async def async_step_change_cover_type_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the cover-type switch before anything is written (issue #1132).
+
+        Same one-extra-click shape as ``async_step_sync_confirm``. Unticking the
+        box returns to the menu with nothing changed.
+        """
+        new_type = self._pending_cover_type
+        if new_type is None:
+            return await self.async_step_init()
+
+        if user_input is not None:
+            if not user_input.get("confirm"):
+                self._pending_cover_type = None
+                return await self.async_step_init()
+            # ``CONF_SENSOR_TYPE`` lives in ``entry.data``, so this is the one
+            # post-creation ``data`` write in the integration. Unique IDs are
+            # ``f"{entry_id}_{suffix}"`` — never keyed on the cover type — so
+            # every entity that exists under both types keeps its entity_id.
+            # Options are left alone: the outgoing type's keys stay stored so
+            # switching back finds its configuration intact.
+            #
+            # Deliberately NO reload here. ``_async_update_listener`` diffs
+            # options only, so a data-only write leaves the coordinator running
+            # the OUTGOING policy while the user fills in the incoming type's
+            # geometry. Reloading now would bring it up on a half-configured
+            # type that can already command hardware. The reload is scheduled
+            # once, at Save & Close, in ``_update_options``.
+            self.hass.config_entries.async_update_entry(
+                self._config_entry,
+                data={**self._config_entry.data, CONF_SENSOR_TYPE: new_type},
+            )
+            self.current_config[CONF_SENSOR_TYPE] = new_type
+            self.sensor_type = new_type  # type: ignore[assignment]
+            self._cover_type_changed = True
+            self._pending_cover_type = None
+            # Straight into the EXISTING generic geometry step, which renders
+            # ``_get_geometry_schema(self.sensor_type, …)`` — the incoming
+            # type's own schema, including its type-specific keys. No bespoke
+            # per-type collection form is needed.
+            return await self.async_step_geometry()
+
+        labels = await _load_summary_labels(
+            self.hass, _resolve_summary_language(self.hass, self.context)
+        )
+        stranded = _stranded_option_keys(self.sensor_type, new_type, self.options)
+        # Capability advice for the DESTINATION type, from the same helper the
+        # create flow and the configuration summary already render.
+        _, capability_notes = check_cover_capabilities(
+            self.options, new_type, self.hass
+        )
+        return self.async_show_form(  # type: ignore[return-value]
+            step_id="change_cover_type_confirm",
+            data_schema=vol.Schema(
+                {vol.Required("confirm", default=False): selector.BooleanSelector()}
+            ),
+            description_placeholders={
+                "from_type": get_policy(self.sensor_type).display_label(labels),
+                "to_type": get_policy(new_type).display_label(labels),
+                "stranded_options": "\n".join(f"- `{k}`" for k in stranded) or "—",
+                "capability_notes": "\n".join(f"- {n}" for n in capability_notes)
+                or "—",
             },
         )
 
@@ -5934,6 +6121,18 @@ class OptionsFlowHandler(OptionsFlow):
         """Update config entry options."""
         self._recompute_profile_overrides()
         self._propagate_profile_clears()
+        if self._cover_type_changed:
+            # A cover-type switch writes ``entry.data``, which
+            # ``_async_update_listener`` does not look at — it diffs options and
+            # early-returns on an empty set. So the reload has to be explicit:
+            # if the geometry form came back byte-identical, nothing else would
+            # reload and the coordinator would keep running the OUTGOING policy
+            # until the next restart. Scheduling here is safe even though the
+            # options write happens afterwards, in
+            # ``OptionsFlowManager.async_finish_flow`` — there is no await
+            # between this step returning and that write, so the reloaded
+            # coordinator sees both the new ``data`` and the new ``options``.
+            self.hass.config_entries.async_schedule_reload(self._config_entry.entry_id)
         return self.async_create_entry(title="", data=self.options)  # type: ignore[return-value]
 
     def _recompute_profile_overrides(self) -> None:

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -372,6 +372,7 @@ from .profile_link import (  # noqa: E402
     clear_cover_override,
     cleared_profile_keys,
     compute_override_keys,
+    effective_profile_overrides,
     merge_profile_into_config,
     profile_for_cover,
     propagate_profile_clears,
@@ -5695,22 +5696,40 @@ class OptionsFlowHandler(OptionsFlow):
             if chosen != _PROFILE_NONE_SENTINEL:
                 profile = self.hass.config_entries.async_get_entry(chosen)
                 if profile is not None:
-                    before = dict(self._config_entry.options)
+                    overridden = effective_profile_overrides(self._config_entry.options)
                     _copy_profile_to_cover(self.hass, profile, self._config_entry)
-                    # Take what the copier changed, not the whole entry.
+                    # Stage the write the copier just made to disk, over the
+                    # keys the copier owns and no others.
+                    #
                     # Re-reading ``self.options`` wholesale discarded every
                     # unsaved edit in this dialog — including a pending
                     # cover-type switch's re-seed and the incoming type's
                     # geometry, while the switch itself stayed pending, so Save
                     # & Close flipped ``data`` to a type whose options
                     # contradicted the disclosure the user had just read.
-                    self.options.update(
-                        {
-                            key: value
-                            for key, value in self._config_entry.options.items()
-                            if key not in before or before[key] != value
-                        }
-                    )
+                    # Diffing what the copier changed fixes that but makes
+                    # linking mean two things: an unsaved edit to a
+                    # profile-owned key survives when the profile happens to
+                    # name what is already stored (empty diff) and is
+                    # overwritten when it does not — same gesture, opposite
+                    # outcome, decided by state the user cannot see. The
+                    # survivor then reads as a local override, because
+                    # ``_recompute_profile_overrides`` is a pure value-diff
+                    # against the profile at save.
+                    #
+                    # Linking means adopt, which is what the copier does on disk
+                    # for a cover with no recorded overrides, so staging it here
+                    # lands where hitting Save first would have.
+                    # ``merge_profile_into_config`` is the single source of
+                    # truth for the subset (profile-defined, non-empty, not
+                    # already overridden); nothing else in ``self.options`` is
+                    # touched, so a pending switch's keys — positions and the
+                    # incoming type's geometry, never shared sensors — stay put.
+                    adopted: dict[str, Any] = {
+                        CONF_BUILDING_PROFILE_ID: profile.entry_id
+                    }
+                    merge_profile_into_config(profile, adopted, overridden=overridden)
+                    self.options.update(adopted)
             elif self.options.pop(CONF_BUILDING_PROFILE_ID, None) is not None:
                 self._persist_entry()
             return await self.async_step_init()

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -245,8 +245,6 @@ from .const import (
     MAX_TRANSIT_TIMEOUT,
     MIN_TRANSIT_TIMEOUT,
     MODE2_OPEN_HORIZONTAL_PERCENT,
-    POSITION_CLOSED,
-    POSITION_OPEN,
     DOMAIN,
     TIME_OPTION_KEYS,
     TIME_STRING_RE,
@@ -3667,11 +3665,20 @@ def _blocked_types_text(
     ``cover_capability_warnings`` — the same advisory text the create flow and
     the configuration summary render — so this never grows a second capability
     matrix.
+
+    Covers HA cannot read yet (``None`` caps) are dropped first, exactly as
+    ``helpers.check_cover_capabilities`` drops them before the same call. The
+    warning builders read a missing capability as an absent one, so an
+    unavailable entity would otherwise be reported as "does not support
+    set_position" — and it is the one entity ``entities_satisfy_selector``
+    deliberately skips, so blaming it here contradicts the filter that produced
+    this list.
     """
+    readable = {eid: caps for eid, caps in known.items() if caps is not None}
     lines: list[str] = []
     for cover_type in blocked:
         policy = get_policy(cover_type)
-        reasons = policy.cover_capability_warnings(dict(known))
+        reasons = policy.cover_capability_warnings(readable)
         reason = reasons[0] if reasons else _BLOCKED_TYPE_GENERIC_REASON
         lines.append(f"- **{policy.display_label(labels)}** — {reason}")
     return "\n".join(lines)
@@ -3691,16 +3698,6 @@ def _stranded_option_keys(
     return sorted((outgoing - incoming) & set(options))
 
 
-# Stored positions whose meaning inverts with the axis, mapped to the value that
-# means "no constraint" and is therefore polarity-neutral. ``min_position`` at
-# 0 % and ``max_position`` at 100 % clamp nothing under either polarity, so they
-# have nothing to disclose; any other value does (issue #1132).
-_POLARITY_NEUTRAL_POSITIONS: dict[str, int | None] = {
-    CONF_MIN_POSITION: POSITION_CLOSED,
-    CONF_MAX_POSITION: POSITION_OPEN,
-    CONF_SUNSET_POS: None,
-}
-
 _POLARITY_DEFAULT_LINE = (
     "⚠️ **0 % and 100 % mean the opposite on the new type.** The default "
     "position is re-seeded from **{old}%** to **{new}%** — the value a cover "
@@ -3708,7 +3705,8 @@ _POLARITY_DEFAULT_LINE = (
 )
 _POLARITY_CARRIED_LINE = (
     "⚠️ These stored positions now mean the opposite of what they did. They "
-    "are left exactly as they are — check them on the Position screen: {keys}."
+    "are left exactly as they are — check them on the Position screen and on "
+    "the screen that owns each one: {keys}."
 )
 
 
@@ -3723,6 +3721,40 @@ def _no_coverage_position(cover_type: str | None) -> int:
     return get_policy(cover_type).position_for_intent(sun_through=True)
 
 
+def _polarity_reseed(current_type: str | None, new_type: str) -> dict[str, int]:
+    """Option values a switch to *new_type* rewrites, or ``{}`` if none.
+
+    Only ``default_percentage`` qualifies (``PositionRole.RESEED``): it is the
+    one primary-axis position a policy already owns an answer for, seeded at
+    creation from the very endpoint compared here. Empty when the two types
+    share a polarity — a switch that changes nothing about positions rewrites
+    nothing.
+    """
+    endpoint = _no_coverage_position(new_type)
+    if _no_coverage_position(current_type) == endpoint:
+        return {}
+    return dict.fromkeys(config_fields.reseeded_position_keys(), endpoint)
+
+
+def _inverted_position_keys(new_type: str, options: Mapping[str, Any]) -> list[str]:
+    """Return stored primary-axis positions that will mean the opposite.
+
+    Every disclosed key comes from ``config_fields.disclosed_position_keys()``,
+    so a percentage option added to the registry cannot go unnamed here — the
+    completeness guard fails first. Filtered to keys the INCOMING type actually
+    reads: one the new type ignores is inert, and ``{stranded_options}`` already
+    says so.
+    """
+    live = get_policy(new_type).live_option_keys()
+    return [
+        key
+        for key in config_fields.disclosed_position_keys()
+        if key in live
+        and options.get(key) is not None
+        and options.get(key) != config_fields.polarity_neutral_value(key)
+    ]
+
+
 def _position_polarity_text(
     current_type: str | None, new_type: str, options: Mapping[str, Any]
 ) -> str:
@@ -3732,25 +3764,23 @@ def _position_polarity_text(
     in ``{stranded_options}`` — yet on a blind 100 % is the no-coverage end and
     on an awning that end is 0 %. Carried over silently, "stay out of the way"
     becomes "shade as hard as you can" on every fallback (outside the time
-    window, ``return_sunset``, sun tracking off).
+    window, ``return_sunset``, sun tracking off). Every other stored
+    primary-axis position inverts the same way and is named rather than
+    rewritten, because none of them has a policy-defined answer to re-seed from.
 
     Empty when the two types share a polarity, so a switch that changes nothing
     about positions says nothing about them.
     """
-    new_endpoint = _no_coverage_position(new_type)
-    old_endpoint = _no_coverage_position(current_type)
-    if old_endpoint == new_endpoint:
+    reseed = _polarity_reseed(current_type, new_type)
+    if not reseed:
         return ""
     lines = [
         _POLARITY_DEFAULT_LINE.format(
-            old=options.get(CONF_DEFAULT_HEIGHT, old_endpoint), new=new_endpoint
+            old=options.get(CONF_DEFAULT_HEIGHT, _no_coverage_position(current_type)),
+            new=reseed[CONF_DEFAULT_HEIGHT],
         )
     ]
-    carried = [
-        key
-        for key, neutral in _POLARITY_NEUTRAL_POSITIONS.items()
-        if options.get(key, neutral) != neutral
-    ]
+    carried = _inverted_position_keys(new_type, options)
     if carried:
         lines.append(
             _POLARITY_CARRIED_LINE.format(keys=", ".join(f"`{k}`" for k in carried))
@@ -4592,12 +4622,17 @@ class OptionsFlowHandler(OptionsFlow):
         # here instead of in the step id.
         self._delete_area: str = ""
         # "Change Cover Type" (issue #1132). ``_pending_cover_type`` carries the
-        # picked destination from the picker to the confirm screen;
-        # ``_cover_type_changed`` records that ``entry.data`` was rewritten, so
-        # Save & Close knows it must schedule a reload even when no option value
-        # changed.
+        # picked destination from the picker to the confirm screen. A switch is
+        # pending whenever ``self.sensor_type`` has moved away from the stored
+        # one — see ``_cover_type_changed``; there is no sticky flag, so a round
+        # trip back to the original type is simply not a switch any more.
+        #
+        # ``_pre_switch_options`` snapshots the option values a pending switch is
+        # allowed to touch, taken the first time one is confirmed. It is what
+        # lets a mid-dialog entry write persist the pre-switch configuration,
+        # and what a round trip restores from.
         self._pending_cover_type: str | None = None
-        self._cover_type_changed: bool = False
+        self._pre_switch_options: dict[str, Any] | None = None
 
     def __getattr__(self, name: str):
         """Dispatch dynamic per-slot options steps (issue #945).
@@ -4927,15 +4962,7 @@ class OptionsFlowHandler(OptionsFlow):
             # ``_update_options``; until then the coordinator keeps running the
             # OUTGOING policy, which is what a half-configured type must never
             # be allowed to do.
-            self.current_config[CONF_SENSOR_TYPE] = new_type
-            no_coverage = _no_coverage_position(new_type)
-            if _no_coverage_position(self.sensor_type) != no_coverage:
-                # Polarity flip: the stored number now means the opposite. Land
-                # on the value a cover created as the new type would get — the
-                # confirm screen the user just read named this exact change.
-                self.options[CONF_DEFAULT_HEIGHT] = no_coverage
-            self.sensor_type = new_type  # type: ignore[assignment]
-            self._cover_type_changed = True
+            self._apply_pending_cover_type(new_type)
             self._pending_cover_type = None
             # Straight into the EXISTING generic geometry step, which renders
             # ``_get_geometry_schema(self.sensor_type, …)`` — the incoming
@@ -4946,9 +4973,16 @@ class OptionsFlowHandler(OptionsFlow):
         labels = await _load_summary_labels(
             self.hass, _resolve_summary_language(self.hass, self.context)
         )
-        stranded = _stranded_option_keys(self.sensor_type, new_type, self.options)
+        # Everything this screen states is the NET change against what is
+        # actually stored, not against a previous hop inside the same dialog:
+        # nothing has been written yet, so "switching from X to Y" is only true
+        # of the stored type and the pre-switch values.
+        stored_type = self._stored_cover_type
+        baseline = self._switch_baseline_options()
+        stranded = _stranded_option_keys(stored_type, new_type, baseline)
         # Capability advice for the DESTINATION type, from the same helper the
-        # create flow and the configuration summary already render.
+        # create flow and the configuration summary already render. Read from
+        # the live options — which covers are bound is not part of the switch.
         _, capability_notes = check_cover_capabilities(
             self.options, new_type, self.hass
         )
@@ -4958,17 +4992,98 @@ class OptionsFlowHandler(OptionsFlow):
                 {vol.Required("confirm", default=False): selector.BooleanSelector()}
             ),
             description_placeholders={
-                "from_type": get_policy(self.sensor_type).display_label(labels),
+                "from_type": get_policy(stored_type).display_label(labels),
                 "to_type": get_policy(new_type).display_label(labels),
                 "stranded_options": "\n".join(f"- `{k}`" for k in stranded) or "—",
                 "capability_notes": "\n".join(f"- {n}" for n in capability_notes)
                 or "—",
                 "position_polarity": _position_polarity_text(
-                    self.sensor_type, new_type, self.options
+                    stored_type, new_type, baseline
                 )
                 or "—",
             },
         )
+
+    # ---- Pending cover-type switch (issue #1132) ------------------------- #
+
+    @property
+    def _stored_cover_type(self) -> str:
+        """The cover type this entry currently is on disk."""
+        return self._config_entry.data.get(CONF_SENSOR_TYPE) or CoverType.BLIND
+
+    @property
+    def _cover_type_changed(self) -> bool:
+        """Whether a cover-type switch is pending.
+
+        Derived, never sticky: a dialog that switches A → B → A has nothing
+        left to apply, so it must not write ``data`` (a no-op) and must not
+        schedule the reload that write would otherwise need.
+        """
+        return self.sensor_type != self._stored_cover_type
+
+    def _switch_baseline_options(self) -> dict[str, Any]:
+        """``self.options`` as they stood before any pending switch touched them."""
+        if self._pre_switch_options is None:
+            return self.options
+        return self._pre_switch_options
+
+    def _pending_switch_option_keys(self) -> set[str]:
+        """Option keys a pending switch has already changed in ``self.options``.
+
+        Two ways a confirmed-but-unsaved switch shows up: the polarity re-seed
+        it applied itself, and the incoming type's own keys, collected by the
+        follow-on geometry step. Both belong to the switch, so both unwind with
+        it — and neither may ride along on a write that leaves ``data`` alone.
+        """
+        stored = self._stored_cover_type
+        if self.sensor_type == stored:
+            return set()
+        incoming_only = (
+            get_policy(self.sensor_type).live_option_keys()
+            - get_policy(stored).live_option_keys()
+        )
+        return set(_polarity_reseed(stored, self.sensor_type)) | incoming_only
+
+    def _options_without_pending_switch(self) -> dict[str, Any]:
+        """``self.options`` with a pending switch's contribution rolled back.
+
+        What a mid-dialog write persists. The invariant is that the type change
+        and the option values it implies are either both stored or neither is;
+        only ``_update_options`` can store the type, so every other write takes
+        the "neither" side. Ordinary edits made in the same dialog are
+        untouched — they belong to the entry as it stands, not to the switch.
+        """
+        baseline = self._pre_switch_options
+        options = dict(self.options)
+        if baseline is None:
+            return options
+        for key in self._pending_switch_option_keys():
+            if key in baseline:
+                options[key] = baseline[key]
+            else:
+                options.pop(key, None)
+        return options
+
+    def _apply_pending_cover_type(self, new_type: str) -> None:
+        """Move the flow onto *new_type* in memory and re-derive its option delta.
+
+        The delta is always computed against the STORED type and the pre-switch
+        option values, never against a previous hop's result. Chaining instead
+        would re-seed once per flip — blind(50) → awning → blind lands on 100,
+        a value neither type asked for and the user never chose — and would
+        leave a round trip looking like a switch that still has to be written.
+        """
+        if self._pre_switch_options is None:
+            self._pre_switch_options = dict(self.options)
+        stored = self._stored_cover_type
+        # Unwind whatever the previous hop (if any) applied, then apply the
+        # single net switch stored → new_type.
+        self.options = self._options_without_pending_switch()
+        self.current_config[CONF_SENSOR_TYPE] = new_type
+        self.sensor_type = new_type  # type: ignore[assignment]
+        self.options.update(_polarity_reseed(stored, new_type))
+        if new_type == stored:
+            self._pre_switch_options = None
 
     async def async_step_geometry(self, user_input: dict[str, Any] | None = None):
         """Adjust geometry parameters."""
@@ -5556,12 +5671,24 @@ class OptionsFlowHandler(OptionsFlow):
             if chosen != _PROFILE_NONE_SENTINEL:
                 profile = self.hass.config_entries.async_get_entry(chosen)
                 if profile is not None:
+                    before = dict(self._config_entry.options)
                     _copy_profile_to_cover(self.hass, profile, self._config_entry)
-                    self.options = dict(self._config_entry.options)
+                    # Take what the copier changed, not the whole entry.
+                    # Re-reading ``self.options`` wholesale discarded every
+                    # unsaved edit in this dialog — including a pending
+                    # cover-type switch's re-seed and the incoming type's
+                    # geometry, while the switch itself stayed pending, so Save
+                    # & Close flipped ``data`` to a type whose options
+                    # contradicted the disclosure the user had just read.
+                    self.options.update(
+                        {
+                            key: value
+                            for key, value in self._config_entry.options.items()
+                            if key not in before or before[key] != value
+                        }
+                    )
             elif self.options.pop(CONF_BUILDING_PROFILE_ID, None) is not None:
-                self.hass.config_entries.async_update_entry(
-                    self._config_entry, options=dict(self.options)
-                )
+                self._persist_entry()
             return await self.async_step_init()
 
         profiles = _building_profile_entries(self.hass)
@@ -5957,11 +6084,10 @@ class OptionsFlowHandler(OptionsFlow):
         """Confirm and execute sync to selected covers."""
         if user_input is not None:
             if user_input.get("confirm"):
-                # Save current cover's settings first so sync copies the latest values
-                self.hass.config_entries.async_update_entry(
-                    self._config_entry,
-                    options=dict(self.options),
-                )
+                # Save current cover's settings first so sync copies the latest
+                # values. Through the seam: a pending cover-type switch is not
+                # one of this cover's settings until Save & Close writes it.
+                self._persist_entry()
                 shared_options = _extract_shared_options(
                     self._config_entry, categories=self.selected_sync_categories
                 )
@@ -6201,42 +6327,61 @@ class OptionsFlowHandler(OptionsFlow):
         self._recompute_profile_overrides()
         self._propagate_profile_clears()
         if self._cover_type_changed:
-            self._apply_cover_type_change()
+            self._persist_entry(commit_cover_type=True)
         return self.async_create_entry(title="", data=self.options)  # type: ignore[return-value]
 
-    def _apply_cover_type_change(self) -> None:
-        """Land a pending cover-type switch with exactly one reload (issue #1132).
+    def _persist_entry(self, *, commit_cover_type: bool = False) -> None:
+        """Write this flow's own config entry — the single seam (issue #1132).
 
-        ``data`` and ``options`` go out in a single ``async_update_entry`` rather
-        than letting ``OptionsFlowManager.async_finish_flow`` write the options a
-        moment later. Two writes would mean two update-listener runs, and — worse
-        — ``async_schedule_reload`` starts its reload task eagerly, so a reload
-        scheduled here begins unloading before ``async_finish_flow`` gets to
-        write the options (there *is* an await between this step returning and
-        that write). The rebuilt coordinator could then read pre-edit options.
-        One write, one listener run, no ordering to reason about.
+        Two kinds of write reach the same config entry, and only one of them
+        may land a cover-type switch:
 
-        ``_async_update_listener`` diffs options only, so it never reacts to the
-        ``data`` half — but it may well reload for the options half. Asking it
-        first, through the shared predicate, is what keeps this from becoming a
-        second reload stacked on the one the write already causes. "Options
-        changed" is not the question: a delta confined to the runtime-applicable
-        keys is applied in place and never reloads.
+        * ``commit_cover_type=True`` — Save & Close. ``data`` and ``options`` go
+          out in a single ``async_update_entry`` rather than letting
+          ``OptionsFlowManager.async_finish_flow`` write the options a moment
+          later. Two writes would mean two update-listener runs, and — worse —
+          ``async_schedule_reload`` starts its reload task eagerly, so a reload
+          scheduled here begins unloading before ``async_finish_flow`` gets to
+          write the options (there *is* an await between this step returning and
+          that write). The rebuilt coordinator could then read pre-edit options.
+          One write, one listener run, no ordering to reason about.
+
+          ``_async_update_listener`` diffs options only, so it never reacts to
+          the ``data`` half — but it may well reload for the options half.
+          Asking it first, through the shared predicate, is what keeps this from
+          becoming a second reload stacked on the one the write already causes.
+          "Options changed" is not the question: a delta confined to the
+          runtime-applicable keys is applied in place and never reloads.
+
+        * everything else — a mid-dialog write ("Copy to other covers" saving
+          this cover first, a Building Profile unlink). These leave ``data``
+          alone, so they must also leave behind the option values a pending
+          switch implies; otherwise the entry reloads as the OLD type carrying
+          the NEW type's numbers, and a blind comes back up with a no-sun
+          default of 0 % — fully closed on every fallback. Routing them through
+          here rather than guarding each one is what makes that true of a write
+          site added later, too, and is locked by
+          ``test_options_flow_writes_its_own_entry_through_one_seam``.
         """
+        if not (commit_cover_type and self._cover_type_changed):
+            self.hass.config_entries.async_update_entry(
+                self._config_entry, options=self._options_without_pending_switch()
+            )
+            return
+
         # Imported here, not at module scope: ``config_flow`` is loaded by HA's
         # platform loader, and reaching into the package root at import time is
         # the one edge that could reintroduce a cycle.
         from . import options_write_reloads
 
-        entry = self._config_entry
-        reload_needed = not options_write_reloads(entry, self.options)
+        reload_needed = not options_write_reloads(self._config_entry, self.options)
         self.hass.config_entries.async_update_entry(
-            entry,
-            data={**entry.data, CONF_SENSOR_TYPE: self.sensor_type},
+            self._config_entry,
+            data={**self._config_entry.data, CONF_SENSOR_TYPE: self.sensor_type},
             options=dict(self.options),
         )
         if reload_needed:
-            self.hass.config_entries.async_schedule_reload(entry.entry_id)
+            self.hass.config_entries.async_schedule_reload(self._config_entry.entry_id)
 
     def _recompute_profile_overrides(self) -> None:
         """Refresh the cover's local-override list against its profile on save.

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -245,6 +245,8 @@ from .const import (
     MAX_TRANSIT_TIMEOUT,
     MIN_TRANSIT_TIMEOUT,
     MODE2_OPEN_HORIZONTAL_PERCENT,
+    POSITION_CLOSED,
+    POSITION_OPEN,
     DOMAIN,
     TIME_OPTION_KEYS,
     TIME_STRING_RE,
@@ -3618,6 +3620,12 @@ def _extract_shared_options(
 # Fallback line for a destination type that is filtered out but whose policy
 # offers no capability warning of its own — the blocked list must always say
 # something rather than list a bare label (issue #1132).
+#
+# Reachable, and not rarely: the two sides disagree on quantifier.
+# ``entities_satisfy_selector`` blocks a type when ANY bound cover misses the
+# feature, while ``TiltPolicy`` / ``LouveredRoofPolicy.cover_capability_warnings``
+# only warn when NO bound cover has it. A two-cover instance where exactly one
+# advertises set_tilt_position blocks Tilt and produces an empty warning list.
 _BLOCKED_TYPE_GENERIC_REASON = (
     "⚠️ The covers bound to this instance do not advertise the features this "
     "cover type requires."
@@ -3681,6 +3689,73 @@ def _stranded_option_keys(
     outgoing = get_policy(current_type).live_option_keys()
     incoming = get_policy(new_type).live_option_keys()
     return sorted((outgoing - incoming) & set(options))
+
+
+# Stored positions whose meaning inverts with the axis, mapped to the value that
+# means "no constraint" and is therefore polarity-neutral. ``min_position`` at
+# 0 % and ``max_position`` at 100 % clamp nothing under either polarity, so they
+# have nothing to disclose; any other value does (issue #1132).
+_POLARITY_NEUTRAL_POSITIONS: dict[str, int | None] = {
+    CONF_MIN_POSITION: POSITION_CLOSED,
+    CONF_MAX_POSITION: POSITION_OPEN,
+    CONF_SUNSET_POS: None,
+}
+
+_POLARITY_DEFAULT_LINE = (
+    "⚠️ **0 % and 100 % mean the opposite on the new type.** The default "
+    "position is re-seeded from **{old}%** to **{new}%** — the value a cover "
+    "created as this type would start with."
+)
+_POLARITY_CARRIED_LINE = (
+    "⚠️ These stored positions now mean the opposite of what they did. They "
+    "are left exactly as they are — check them on the Position screen: {keys}."
+)
+
+
+def _no_coverage_position(cover_type: str | None) -> int:
+    """Return the position that means "no coverage" for *cover_type*.
+
+    ``position_for_intent(sun_through=True)`` is the same seam ``#1126``'s
+    ``_seed_default_position`` uses, so the answer here can never disagree with
+    the value a freshly created cover of this type is given. It is also the
+    polarity test itself: the endpoint moves iff the primary axis flips.
+    """
+    return get_policy(cover_type).position_for_intent(sun_through=True)
+
+
+def _position_polarity_text(
+    current_type: str | None, new_type: str, options: Mapping[str, Any]
+) -> str:
+    """Disclose a switch that inverts what a stored position means (issue #1132).
+
+    ``default_percentage`` is stored by every cover type, so it can never appear
+    in ``{stranded_options}`` — yet on a blind 100 % is the no-coverage end and
+    on an awning that end is 0 %. Carried over silently, "stay out of the way"
+    becomes "shade as hard as you can" on every fallback (outside the time
+    window, ``return_sunset``, sun tracking off).
+
+    Empty when the two types share a polarity, so a switch that changes nothing
+    about positions says nothing about them.
+    """
+    new_endpoint = _no_coverage_position(new_type)
+    old_endpoint = _no_coverage_position(current_type)
+    if old_endpoint == new_endpoint:
+        return ""
+    lines = [
+        _POLARITY_DEFAULT_LINE.format(
+            old=options.get(CONF_DEFAULT_HEIGHT, old_endpoint), new=new_endpoint
+        )
+    ]
+    carried = [
+        key
+        for key, neutral in _POLARITY_NEUTRAL_POSITIONS.items()
+        if options.get(key, neutral) != neutral
+    ]
+    if carried:
+        lines.append(
+            _POLARITY_CARRIED_LINE.format(keys=", ".join(f"`{k}`" for k in carried))
+        )
+    return "\n\n".join(lines)
 
 
 def _build_cover_entity_schema(
@@ -4823,7 +4898,7 @@ class OptionsFlowHandler(OptionsFlow):
             ),
             description_placeholders={
                 "current_type": get_policy(self.sensor_type).display_label(labels),
-                "blocked_types": _blocked_types_text(blocked, known, labels),
+                "blocked_types": _blocked_types_text(blocked, known, labels) or "—",
                 "learn_more": f"{_WIKI_BASE_URL}/Cover-Types",
             },
         )
@@ -4844,24 +4919,21 @@ class OptionsFlowHandler(OptionsFlow):
             if not user_input.get("confirm"):
                 self._pending_cover_type = None
                 return await self.async_step_init()
-            # ``CONF_SENSOR_TYPE`` lives in ``entry.data``, so this is the one
-            # post-creation ``data`` write in the integration. Unique IDs are
-            # ``f"{entry_id}_{suffix}"`` — never keyed on the cover type — so
-            # every entity that exists under both types keeps its entity_id.
-            # Options are left alone: the outgoing type's keys stay stored so
-            # switching back finds its configuration intact.
-            #
-            # Deliberately NO reload here. ``_async_update_listener`` diffs
-            # options only, so a data-only write leaves the coordinator running
-            # the OUTGOING policy while the user fills in the incoming type's
-            # geometry. Reloading now would bring it up on a half-configured
-            # type that can already command hardware. The reload is scheduled
-            # once, at Save & Close, in ``_update_options``.
-            self.hass.config_entries.async_update_entry(
-                self._config_entry,
-                data={**self._config_entry.data, CONF_SENSOR_TYPE: new_type},
-            )
+            # In-memory only. ``CONF_SENSOR_TYPE`` lives in ``entry.data``, and
+            # persisting it here would strand every non-Save exit from the
+            # dialog — abandoning it, or any step that aborts — with an entry
+            # permanently switched, never reloaded, and missing the geometry the
+            # user was on their way to enter. The whole switch lands together in
+            # ``_update_options``; until then the coordinator keeps running the
+            # OUTGOING policy, which is what a half-configured type must never
+            # be allowed to do.
             self.current_config[CONF_SENSOR_TYPE] = new_type
+            no_coverage = _no_coverage_position(new_type)
+            if _no_coverage_position(self.sensor_type) != no_coverage:
+                # Polarity flip: the stored number now means the opposite. Land
+                # on the value a cover created as the new type would get — the
+                # confirm screen the user just read named this exact change.
+                self.options[CONF_DEFAULT_HEIGHT] = no_coverage
             self.sensor_type = new_type  # type: ignore[assignment]
             self._cover_type_changed = True
             self._pending_cover_type = None
@@ -4890,6 +4962,10 @@ class OptionsFlowHandler(OptionsFlow):
                 "to_type": get_policy(new_type).display_label(labels),
                 "stranded_options": "\n".join(f"- `{k}`" for k in stranded) or "—",
                 "capability_notes": "\n".join(f"- {n}" for n in capability_notes)
+                or "—",
+                "position_polarity": _position_polarity_text(
+                    self.sensor_type, new_type, self.options
+                )
                 or "—",
             },
         )
@@ -5094,7 +5170,7 @@ class OptionsFlowHandler(OptionsFlow):
 
     def _custom_position_include_tilt(self) -> bool:
         """Whether this cover type carries per-slot / global tilt fields."""
-        sensor_type = self._config_entry.data.get(CONF_SENSOR_TYPE)
+        sensor_type = self.sensor_type
         return sensor_type in POLICY_REGISTRY and bool(
             get_policy(sensor_type).extra_field_keys(
                 config_fields.SECTION_CUSTOM_POSITION
@@ -5787,7 +5863,6 @@ class OptionsFlowHandler(OptionsFlow):
             self.optional_entities(_PIPELINE_PRIORITY_OPTIONAL_KEYS, user_input)
             self.options.update(user_input)
             return await self.async_step_init()
-        sensor_type = self._config_entry.data.get(CONF_SENSOR_TYPE)
         return self.async_show_form(
             step_id="pipeline_priorities",
             data_schema=self.add_suggested_values_to_schema(
@@ -5796,7 +5871,7 @@ class OptionsFlowHandler(OptionsFlow):
             description_placeholders={
                 "learn_more": "https://github.com/jrhubott/adaptive-cover-pro/wiki/How-It-Decides",
                 "priority_scale": _render_priority_scale(
-                    self.options, get_policy(sensor_type)
+                    self.options, get_policy(self.sensor_type)
                 ),
             },
         )
@@ -5805,7 +5880,11 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Select target covers and setting categories to sync."""
-        current_type = self._config_entry.data.get(CONF_SENSOR_TYPE)
+        # ``self.sensor_type``, not ``entry.data`` — a pending cover-type switch
+        # (issue #1132) is not persisted until Save & Close, and syncing this
+        # instance's settings into covers of the type it is about to stop being
+        # is not what the user asked for.
+        current_type = self.sensor_type
         other_entries = [
             e
             for e in self.hass.config_entries.async_entries(DOMAIN)
@@ -6122,18 +6201,42 @@ class OptionsFlowHandler(OptionsFlow):
         self._recompute_profile_overrides()
         self._propagate_profile_clears()
         if self._cover_type_changed:
-            # A cover-type switch writes ``entry.data``, which
-            # ``_async_update_listener`` does not look at — it diffs options and
-            # early-returns on an empty set. So the reload has to be explicit:
-            # if the geometry form came back byte-identical, nothing else would
-            # reload and the coordinator would keep running the OUTGOING policy
-            # until the next restart. Scheduling here is safe even though the
-            # options write happens afterwards, in
-            # ``OptionsFlowManager.async_finish_flow`` — there is no await
-            # between this step returning and that write, so the reloaded
-            # coordinator sees both the new ``data`` and the new ``options``.
-            self.hass.config_entries.async_schedule_reload(self._config_entry.entry_id)
+            self._apply_cover_type_change()
         return self.async_create_entry(title="", data=self.options)  # type: ignore[return-value]
+
+    def _apply_cover_type_change(self) -> None:
+        """Land a pending cover-type switch with exactly one reload (issue #1132).
+
+        ``data`` and ``options`` go out in a single ``async_update_entry`` rather
+        than letting ``OptionsFlowManager.async_finish_flow`` write the options a
+        moment later. Two writes would mean two update-listener runs, and — worse
+        — ``async_schedule_reload`` starts its reload task eagerly, so a reload
+        scheduled here begins unloading before ``async_finish_flow`` gets to
+        write the options (there *is* an await between this step returning and
+        that write). The rebuilt coordinator could then read pre-edit options.
+        One write, one listener run, no ordering to reason about.
+
+        ``_async_update_listener`` diffs options only, so it never reacts to the
+        ``data`` half — but it may well reload for the options half. Asking it
+        first, through the shared predicate, is what keeps this from becoming a
+        second reload stacked on the one the write already causes. "Options
+        changed" is not the question: a delta confined to the runtime-applicable
+        keys is applied in place and never reloads.
+        """
+        # Imported here, not at module scope: ``config_flow`` is loaded by HA's
+        # platform loader, and reaching into the package root at import time is
+        # the one edge that could reintroduce a cycle.
+        from . import options_write_reloads
+
+        entry = self._config_entry
+        reload_needed = not options_write_reloads(entry, self.options)
+        self.hass.config_entries.async_update_entry(
+            entry,
+            data={**entry.data, CONF_SENSOR_TYPE: self.sensor_type},
+            options=dict(self.options),
+        )
+        if reload_needed:
+            self.hass.config_entries.async_schedule_reload(entry.entry_id)
 
     def _recompute_profile_overrides(self) -> None:
         """Refresh the cover's local-override list against its profile on save.

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4631,8 +4631,14 @@ class OptionsFlowHandler(OptionsFlow):
         # allowed to touch, taken the first time one is confirmed. It is what
         # lets a mid-dialog entry write persist the pre-switch configuration,
         # and what a round trip restores from.
+        #
+        # ``_switch_applied_values`` is the other half: the values the switch
+        # itself wrote. A rollback needs both — the baseline to restore to, and
+        # what the switch put there, so it can tell its own value from one the
+        # user has since typed over.
         self._pending_cover_type: str | None = None
         self._pre_switch_options: dict[str, Any] | None = None
+        self._switch_applied_values: dict[str, Any] = {}
 
     def __getattr__(self, name: str):
         """Dispatch dynamic per-slot options steps (issue #945).
@@ -5052,12 +5058,26 @@ class OptionsFlowHandler(OptionsFlow):
         only ``_update_options`` can store the type, so every other write takes
         the "neither" side. Ordinary edits made in the same dialog are
         untouched — they belong to the entry as it stands, not to the switch.
+
+        Which is why a re-seeded key is restored only while the re-seeded value
+        is still the one sitting there. Confirm blind → awning, then open
+        Position and type 30: ``default_percentage`` no longer holds anything
+        the switch put there, so there is nothing of the switch's left to roll
+        back and 30 is an ordinary edit like any other. Restoring the baseline
+        50 over it would discard a value the user typed — recoverable only by
+        going on to Save & Close, and lost outright if the dialog is abandoned.
+        The incoming type's own keys carry no such test and unwind
+        unconditionally: the stored type does not read them at all, so no value
+        of theirs can be an edit to the entry as it stands.
         """
         baseline = self._pre_switch_options
         options = dict(self.options)
         if baseline is None:
             return options
+        applied = self._switch_applied_values
         for key in self._pending_switch_option_keys():
+            if key in applied and options.get(key) != applied[key]:
+                continue
             if key in baseline:
                 options[key] = baseline[key]
             else:
@@ -5081,7 +5101,11 @@ class OptionsFlowHandler(OptionsFlow):
         self.options = self._options_without_pending_switch()
         self.current_config[CONF_SENSOR_TYPE] = new_type
         self.sensor_type = new_type  # type: ignore[assignment]
-        self.options.update(_polarity_reseed(stored, new_type))
+        reseed = _polarity_reseed(stored, new_type)
+        self.options.update(reseed)
+        # Remember what the switch wrote, not just which keys it touched, so a
+        # later rollback can tell its own value from one the user typed over.
+        self._switch_applied_values = dict(reseed)
         if new_type == stored:
             self._pre_switch_options = None
 
@@ -6007,11 +6031,17 @@ class OptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Select target covers and setting categories to sync."""
-        # ``self.sensor_type``, not ``entry.data`` — a pending cover-type switch
-        # (issue #1132) is not persisted until Save & Close, and syncing this
-        # instance's settings into covers of the type it is about to stop being
-        # is not what the user asked for.
-        current_type = self.sensor_type
+        # The STORED type, not ``self.sensor_type`` (issue #1132). What this
+        # step copies is whatever ``_persist_entry`` just wrote, and that write
+        # deliberately rolls a pending switch back out — so the values leaving
+        # here are the outgoing type's. Filtering targets by the type the user
+        # is about to switch to would offer covers of one type and hand them
+        # another type's positions: a blind's "raised 80 %" written onto an
+        # awning as "extended 80 %", on someone else's cover. The filter and
+        # the copied values have to name the same type, and only the stored one
+        # is on both sides. ``available`` below already reads the stored
+        # options for the same reason.
+        current_type = self._stored_cover_type
         other_entries = [
             e
             for e in self.hass.config_entries.async_entries(DOMAIN)

--- a/custom_components/adaptive_cover_pro/cover_types/__init__.py
+++ b/custom_components/adaptive_cover_pro/cover_types/__init__.py
@@ -56,6 +56,38 @@ def get_policy(cover_type) -> CoverTypePolicy:
     return cls()
 
 
+def percentage_option_keys() -> frozenset[str]:
+    """Every option any registered cover type stores as a 0-100 % value.
+
+    The structural enumeration behind ``config_fields._POSITION_ROLES``'
+    completeness guard (issue #1132): a new percentage option shows up here the
+    moment its section renders it, and the guard fails until it is classified as
+    re-seeded / disclosed / neutral.
+
+    Rendering the sections rather than reading ``FieldSpec.rng`` is what makes
+    it exhaustive. Several percentage fields are built by the dynamic section
+    builders and carry no range on their spec at all — ``cloudy_position`` has
+    neither a range nor a static selector — so a registry-only sweep would
+    quietly miss exactly the fields most likely to be forgotten.
+
+    Lives here rather than in ``config_fields`` because it is a cross-policy
+    question: ``config_fields`` must never import ``cover_types``.
+    """
+    from ..config_fields import is_percentage_marker
+
+    keys: set[str] = set()
+    for cover_type in POLICY_REGISTRY:
+        policy = get_policy(cover_type)
+        for section in policy.section_order():
+            schema = policy.build_section_schema(section)
+            keys.update(
+                str(marker)
+                for marker, validator in schema.schema.items()
+                if is_percentage_marker(validator)
+            )
+    return frozenset(keys)
+
+
 __all__ = [
     "POLICY_REGISTRY",
     "AwningPolicy",
@@ -72,4 +104,5 @@ __all__ = [
     "TiltPolicy",
     "VenetianPolicy",
     "get_policy",
+    "percentage_option_keys",
 ]

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -14,6 +14,7 @@ overrides everything.
 from __future__ import annotations
 
 import dataclasses
+import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -46,6 +47,8 @@ if TYPE_CHECKING:
     from ..engine.covers import AdaptiveGeneralCover
     from ..pipeline.types import PipelineResult
     from ..services.configuration_service import ConfigurationService
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _as_optional(marker: vol.Marker) -> vol.Optional:
@@ -121,8 +124,9 @@ POSITION_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
 # flag ``check_cover_features`` sets for it. Lets
 # ``CoverTypePolicy.entities_satisfy_selector`` turn any policy's picker filter
 # back into a predicate over already-bound covers (issue #1132) without a second
-# capability matrix. A feature name with no CAP_* counterpart imposes no
-# requirement — the picker would still have offered the entity.
+# capability matrix. Every feature any registered policy filters on must appear
+# here — locked by
+# ``tests/test_cover_types/test_invariants.py::test_entity_filter_features_are_all_mapped``.
 ENTITY_FILTER_FEATURE_CAPS: dict[str, str] = {
     "cover.CoverEntityFeature.SET_POSITION": CAP_HAS_SET_POSITION,
     "cover.CoverEntityFeature.SET_TILT_POSITION": CAP_HAS_SET_TILT_POSITION,
@@ -1455,12 +1459,25 @@ class CoverTypePolicy(ABC):
         HA's ``supported_features`` filter is OR-of-listed, so the predicate
         mirrors that — an entity satisfies the filter when it advertises at
         least one of the listed features.
+
+        A feature name with no ``CAP_*`` counterpart is a bug, not a no-op: it
+        would answer "satisfied" for a requirement nothing tested, offering the
+        type to hardware that cannot drive it *and* dropping it from the
+        explained blocked list. It fails the type shut and says so.
         """
-        required = [
-            ENTITY_FILTER_FEATURE_CAPS[feature]
-            for feature in self.entity_selector_filter().get("supported_features", ())
-            if feature in ENTITY_FILTER_FEATURE_CAPS
-        ]
+        required: list[str] = []
+        for feature in self.entity_selector_filter().get("supported_features") or ():
+            cap = ENTITY_FILTER_FEATURE_CAPS.get(feature)
+            if cap is None:
+                _LOGGER.warning(
+                    "Cover type %s filters its entity picker on %s, which "
+                    "ENTITY_FILTER_FEATURE_CAPS does not map to a capability "
+                    "flag; treating the type as ineligible",
+                    self.cover_type,
+                    feature,
+                )
+                return False
+            required.append(cap)
         if not required:
             return True
         return all(

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -117,6 +117,20 @@ POSITION_CAPABLE_ENTITY_FILTER = selector.EntityFilterSelectorConfig(
     supported_features=["cover.CoverEntityFeature.SET_POSITION"],
 )
 
+# Inverse of the filters above: HA ``supported_features`` name → the ``CAP_*``
+# flag ``check_cover_features`` sets for it. Lets
+# ``CoverTypePolicy.entities_satisfy_selector`` turn any policy's picker filter
+# back into a predicate over already-bound covers (issue #1132) without a second
+# capability matrix. A feature name with no CAP_* counterpart imposes no
+# requirement — the picker would still have offered the entity.
+ENTITY_FILTER_FEATURE_CAPS: dict[str, str] = {
+    "cover.CoverEntityFeature.SET_POSITION": CAP_HAS_SET_POSITION,
+    "cover.CoverEntityFeature.SET_TILT_POSITION": CAP_HAS_SET_TILT_POSITION,
+    "cover.CoverEntityFeature.OPEN": CAP_HAS_OPEN,
+    "cover.CoverEntityFeature.CLOSE": CAP_HAS_CLOSE,
+    "cover.CoverEntityFeature.STOP": CAP_HAS_STOP,
+}
+
 
 @dataclass(frozen=True, slots=True)
 class CoverAxis:
@@ -1420,6 +1434,40 @@ class CoverTypePolicy(ABC):
         entities).
         """
         return selector.EntityFilterSelectorConfig(domain="cover")
+
+    def entities_satisfy_selector(
+        self, known: Mapping[str, Mapping[str, bool] | None]
+    ) -> bool:
+        """Report whether this policy's picker would admit every bound cover.
+
+        The predicate form of :meth:`entity_selector_filter`, used by the
+        "Change Cover Type" options step (issue #1132) to decide whether an
+        instance's already-bound covers could switch to this type. Derived
+        generically from the filter, so a new cover type answers it for free —
+        there is no second capability matrix to keep in sync.
+
+        *known* is the ``entity_id → capability dict`` map
+        ``helpers.check_cover_features`` produces. A ``None`` entry (entity
+        unavailable / not yet initialised) is **skipped, not failed**: the
+        create-time picker could not have judged it either. An empty map is
+        satisfied.
+
+        HA's ``supported_features`` filter is OR-of-listed, so the predicate
+        mirrors that — an entity satisfies the filter when it advertises at
+        least one of the listed features.
+        """
+        required = [
+            ENTITY_FILTER_FEATURE_CAPS[feature]
+            for feature in self.entity_selector_filter().get("supported_features", ())
+            if feature in ENTITY_FILTER_FEATURE_CAPS
+        ]
+        if not required:
+            return True
+        return all(
+            any(caps_get(caps, cap) for cap in required)
+            for caps in known.values()
+            if caps is not None
+        )
 
     def geometry_schema(
         self,

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -604,6 +604,23 @@ def check_cover_features(hass: HomeAssistant, entity_id: str) -> dict[str, bool]
     }
 
 
+def bound_cover_capabilities(
+    hass: HomeAssistant | None, config: dict
+) -> dict[str, dict[str, bool] | None]:
+    """Map every cover bound to *config* to its detected capabilities.
+
+    ``entity_id → feature dict``, or ``None`` for an entity HA cannot read yet.
+    Extracted from :func:`check_cover_capabilities` (issue #1132) so the
+    "Change Cover Type" options step can ask a candidate policy whether the
+    already-bound covers satisfy its entity filter without also building the
+    warning lines.
+    """
+    entities: list[str] = config.get(CONF_ENTITIES) or []
+    if hass is None or not entities:
+        return {}
+    return {eid: check_cover_features(hass, eid) for eid in entities}
+
+
 def check_cover_capabilities(
     config: dict,
     sensor_type: str | None,
@@ -644,9 +661,7 @@ def check_cover_capabilities(
     # keeps its exact ordering (and its interleaving with the open/close-only and
     # assumed_state lines). Rendered in English to match the legacy raw f-string,
     # which was hardcoded English regardless of the summary language.
-    cap_map: dict[str, dict[str, bool] | None] = {
-        eid: check_cover_features(hass, eid) for eid in entities
-    }
+    cap_map = bound_cover_capabilities(hass, config)
     _not_ready = {
         f.reason.params["eid"]: f
         for f in run_triage({"capabilities": cap_map}, only=RuleInput.CONFIG)

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -307,7 +307,8 @@
           "profile_overrides": "🧹 Lokale Übersteuerungen",
           "group_membership": "👥 Gruppenmitglieder",
           "group_arbitration": "⚖️ Schiedsverfahren & Zeitplanung",
-          "group_entities": "🧩 Verfügbar gemachte Entitäten"
+          "group_entities": "🧩 Verfügbar gemachte Entitäten",
+          "change_cover_type": "🔁 Beschattungstyp ändern"
         },
         "description": "Konfiguration: **{instance_name}**{profile_line}\n\nWenn Adaptive Cover Pro hilfreich für dich war, kannst du [☕ Buy Me a Coffee]({coffee_url}) unterstützen."
       },
@@ -1047,6 +1048,23 @@
       "delete_slot": {
         "title": "Eintrag löschen",
         "description": "Wählen Sie den Eintrag aus, den Sie löschen möchten. Alle gespeicherten Einstellungen werden entfernt — Auslösesensoren, Vorlage, Position, Priorität, Achsengrenzen und alle Flags, die von der Karte oder einem Service gesetzt wurden. Dies kann nicht rückgängig gemacht werden. Die Slot-Nummer wird für einen neuen Eintrag verfügbar."
+      },
+      "change_cover_type": {
+        "data": {
+          "sensor_type": "Neuer Beschattungstyp"
+        },
+        "data_description": {
+          "sensor_type": "Der Beschattungstyp, zu dem diese Instanz wechselt. Sie bestätigen im nächsten Bildschirm und geben dann die Geometrie des neuen Typs ein."
+        },
+        "description": "Diese Instanz ist derzeit eine **{current_type}**. Wählen Sie den Beschattungstyp aus, zu dem sie werden soll – jede Entität behält ihre aktuelle Entitäts-ID, damit Ihre Dashboards und Automatisierungen weiterhin funktionieren.\n\nEs werden nur Typen aufgelistet, die Ihre gebundenen Beschattungen tatsächlich steuern können. Hier nicht angeboten:\n\n{blocked_types}\n\n[Mehr erfahren]({learn_more})",
+        "title": "Beschattungstyp ändern"
+      },
+      "change_cover_type_confirm": {
+        "data": {
+          "confirm": "Beschattungstypänderung bestätigen"
+        },
+        "description": "Wechsel von **{from_type}** zu **{to_type}**.\n\nEinstellungen, die nur der alte Typ verwendet, bleiben gespeichert und werden nicht gelöscht, sodass ein Zurückwechsel sie intakt vorfindet. Nach dem Wechsel derzeit inaktiv:\n\n{stranded_options}\n\nFunktionseigenschaften für den neuen Typ:\n\n{capability_notes}\n\nJede Entität behält ihre Entitäts-ID. Typspezifische Entitäten, die der neue Typ nicht bereitstellt, bleiben in der Entitätsregistrierung als nicht verfügbar und werden wiederhergestellt, wenn Sie zurückwechseln. Füllen Sie nach der Bestätigung die Geometrie des neuen Typs aus und beenden Sie mit Speichern und schließen, um die Änderung anzuwenden.",
+        "title": "Beschattungstyp ändern – Bestätigung"
       }
     },
     "abort": {
@@ -1054,7 +1072,8 @@
       "no_targets_selected": "Es wurden keine Beschattungen zum Synchronisieren ausgewählt.",
       "no_categories_selected": "Es wurden keine Kategorien zum Synchronisieren ausgewählt.",
       "user_cancelled": "Synchronisierung abgebrochen.",
-      "sync_complete": "Einstellungen erfolgreich synchronisiert."
+      "sync_complete": "Einstellungen erfolgreich synchronisiert.",
+      "no_eligible_cover_types": "Kein anderer Beschattungstyp kann die an diese Instanz gebundenen Beschattungen steuern, daher gibt es nichts zum Wechseln."
     }
   },
   "entity": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1056,14 +1056,14 @@
         "data_description": {
           "sensor_type": "Der Beschattungstyp, zu dem diese Instanz wechselt. Sie bestätigen im nächsten Bildschirm und geben dann die Geometrie des neuen Typs ein."
         },
-        "description": "Diese Instanz ist derzeit eine **{current_type}**. Wählen Sie den Beschattungstyp aus, zu dem sie werden soll – jede Entität behält ihre aktuelle Entitäts-ID, damit Ihre Dashboards und Automatisierungen weiterhin funktionieren.\n\nEs werden nur Typen aufgelistet, die Ihre gebundenen Beschattungen tatsächlich steuern können. Hier nicht angeboten:\n\n{blocked_types}\n\n[Mehr erfahren]({learn_more})",
+        "description": "Diese Instanz ist derzeit vom Typ **{current_type}**. Wählen Sie den Beschattungstyp aus, zu dem sie werden soll – jede Entität behält ihre aktuelle Entitäts-ID, damit Ihre Dashboards und Automatisierungen weiterhin funktionieren.\n\nEs werden nur Typen aufgelistet, die Ihre gebundenen Beschattungen tatsächlich steuern können. Hier nicht angeboten:\n\n{blocked_types}\n\n[Mehr erfahren]({learn_more})",
         "title": "Beschattungstyp ändern"
       },
       "change_cover_type_confirm": {
         "data": {
           "confirm": "Beschattungstypänderung bestätigen"
         },
-        "description": "Wechsel von **{from_type}** zu **{to_type}**.\n\nEinstellungen, die nur der alte Typ verwendet, bleiben gespeichert und werden nicht gelöscht, sodass ein Zurückwechsel sie intakt vorfindet. Nach dem Wechsel derzeit inaktiv:\n\n{stranded_options}\n\nFunktionseigenschaften für den neuen Typ:\n\n{capability_notes}\n\nJede Entität behält ihre Entitäts-ID. Typspezifische Entitäten, die der neue Typ nicht bereitstellt, bleiben in der Entitätsregistrierung als nicht verfügbar und werden wiederhergestellt, wenn Sie zurückwechseln. Füllen Sie nach der Bestätigung die Geometrie des neuen Typs aus und beenden Sie mit Speichern und schließen, um die Änderung anzuwenden.",
+        "description": "Wechsel von **{from_type}** zu **{to_type}**.\n\nEinstellungen, die nur der alte Typ verwendet, bleiben gespeichert und werden nicht gelöscht, sodass ein Zurückwechsel sie intakt vorfindet. Nach dem Wechsel derzeit inaktiv:\n\n{stranded_options}\n\nFunktionseigenschaften für den neuen Typ:\n\n{capability_notes}\n\nPositionspolarität:\n\n{position_polarity}\n\nJede Entität behält ihre Entitäts-ID. Typspezifische Entitäten, die der neue Typ nicht bereitstellt, bleiben in der Entitätsregistrierung als nicht verfügbar und werden wiederhergestellt, wenn Sie zurückwechseln. Füllen Sie nach der Bestätigung die Geometrie des neuen Typs aus und beenden Sie mit Speichern und schließen, um die Änderung anzuwenden.",
         "title": "Beschattungstyp ändern – Bestätigung"
       }
     },

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -360,7 +360,7 @@
       },
       "change_cover_type": {
         "title": "Change Cover Type",
-        "description": "This instance is currently a **{current_type}**. Pick the cover type it should become — every entity keeps its current entity ID, so your dashboards and automations keep working.\n\nOnly types your bound covers can actually drive are listed. Not offered here:\n\n{blocked_types}\n\n[Learn more]({learn_more})",
+        "description": "This instance is currently of type **{current_type}**. Pick the cover type it should become — every entity keeps its current entity ID, so your dashboards and automations keep working.\n\nOnly types your bound covers can actually drive are listed. Not offered here:\n\n{blocked_types}\n\n[Learn more]({learn_more})",
         "data": {
           "sensor_type": "New Cover Type"
         },
@@ -370,7 +370,7 @@
       },
       "change_cover_type_confirm": {
         "title": "Change Cover Type — Confirm",
-        "description": "Switching from **{from_type}** to **{to_type}**.\n\nSettings only the old type uses stay stored and are not deleted, so switching back finds them intact. Currently inert after the switch:\n\n{stranded_options}\n\nCapability notes for the new type:\n\n{capability_notes}\n\nEvery entity keeps its entity ID. Type-specific entities the new type does not provide stay in the entity registry as unavailable, and return if you switch back. After confirming, fill in the new type's geometry and finish with Save & Close to apply the change.",
+        "description": "Switching from **{from_type}** to **{to_type}**.\n\nSettings only the old type uses stay stored and are not deleted, so switching back finds them intact. Currently inert after the switch:\n\n{stranded_options}\n\nCapability notes for the new type:\n\n{capability_notes}\n\nPosition polarity:\n\n{position_polarity}\n\nEvery entity keeps its entity ID. Type-specific entities the new type does not provide stay in the entity registry as unavailable, and return if you switch back. After confirming, fill in the new type's geometry and finish with Save & Close to apply the change.",
         "data": {
           "confirm": "Confirm cover type change"
         }

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -281,6 +281,7 @@
         "description": "Configuring: **{instance_name}**{profile_line}\n\nIf Adaptive Cover Pro has been useful, you can [☕ Buy Me a Coffee]({coffee_url}).",
         "menu_options": {
           "cover_entities": "🪟 Covers & Device",
+          "change_cover_type": "🔁 Change Cover Type",
           "geometry": "📐 Cover Geometry",
           "sun_tracking": "☀️ Sun Tracking",
           "position": "📊 Position Settings",
@@ -355,6 +356,23 @@
           "end_entity": "Entity representing ending time state, overriding the fixed end time set above. Useful for automating the end time with an entity (e.g., sensor that provides bedtime based on calendar or daily routine).",
           "minimize_movements": "Reduce how often the cover repositions while tracking the sun by snapping to a few fixed coverage levels instead of following the sun continuously. Rounds toward MORE coverage, so direct sun is never let in by the rounding. Trades some natural light for far fewer motor movements. Default: off.",
           "max_coverage_steps": "How many distinct positions the cover may use on its way to full coverage when 'Minimize movements' is on (1-10). 1 = jump straight to full coverage the moment the sun enters the sun acceptance angle and hold there until it leaves (fewest movements). Higher values track the sun more gradually in that many steps. Default: 1."
+        }
+      },
+      "change_cover_type": {
+        "title": "Change Cover Type",
+        "description": "This instance is currently a **{current_type}**. Pick the cover type it should become — every entity keeps its current entity ID, so your dashboards and automations keep working.\n\nOnly types your bound covers can actually drive are listed. Not offered here:\n\n{blocked_types}\n\n[Learn more]({learn_more})",
+        "data": {
+          "sensor_type": "New Cover Type"
+        },
+        "data_description": {
+          "sensor_type": "The cover type this instance will switch to. You confirm on the next screen, then fill in the new type's geometry."
+        }
+      },
+      "change_cover_type_confirm": {
+        "title": "Change Cover Type — Confirm",
+        "description": "Switching from **{from_type}** to **{to_type}**.\n\nSettings only the old type uses stay stored and are not deleted, so switching back finds them intact. Currently inert after the switch:\n\n{stranded_options}\n\nCapability notes for the new type:\n\n{capability_notes}\n\nEvery entity keeps its entity ID. Type-specific entities the new type does not provide stay in the entity registry as unavailable, and return if you switch back. After confirming, fill in the new type's geometry and finish with Save & Close to apply the change.",
+        "data": {
+          "confirm": "Confirm cover type change"
         }
       },
       "cover_entities": {
@@ -1050,6 +1068,7 @@
       }
     },
     "abort": {
+      "no_eligible_cover_types": "No other cover type can drive the covers bound to this instance, so there is nothing to switch to.",
       "no_covers_to_sync": "No other covers of the same type exist to sync to.",
       "no_targets_selected": "No covers were selected to sync to.",
       "no_categories_selected": "No categories were selected to sync.",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -307,7 +307,8 @@
           "profile_overrides": "🧹 Dérogations locales",
           "group_membership": "👥 Membres du groupe",
           "group_arbitration": "⚖️ Arbitrage & Synchronisation",
-          "group_entities": "🧩 Entités exposées"
+          "group_entities": "🧩 Entités exposées",
+          "change_cover_type": "🔁 Modifier le type de store"
         },
         "description": "Configuration : **{instance_name}**{profile_line}\n\nSi Adaptive Cover Pro vous a été utile, vous pouvez [☕ Buy Me a Coffee]({coffee_url})."
       },
@@ -1047,6 +1048,23 @@
       "delete_slot": {
         "title": "Supprimer un emplacement",
         "description": "Choisissez l'emplacement à supprimer. Chaque paramètre stocké pour celui-ci est supprimé — capteurs déclencheurs, modèle, position, priorité, limites d'axe et tous les indicateurs définis par la carte ou un service. Cela ne peut pas être annulé. Le numéro d'emplacement devient disponible pour un nouvel emplacement."
+      },
+      "change_cover_type": {
+        "data": {
+          "sensor_type": "Nouveau type de store"
+        },
+        "data_description": {
+          "sensor_type": "Le type de store vers lequel cette instance basculera. Vous confirmerez sur l'écran suivant, puis remplirez la géométrie du nouveau type."
+        },
+        "description": "Cette instance est actuellement un **{current_type}**. Choisissez le type de store qu'elle devrait devenir — chaque entité conserve son ID d'entité actuel, donc vos tableaux de bord et automations continuent de fonctionner.\n\nSeuls les types que vos protections peuvent réellement gérer sont énumérés. Non proposés ici :\n\n{blocked_types}\n\n[En savoir plus]({learn_more})",
+        "title": "Modifier le type de store"
+      },
+      "change_cover_type_confirm": {
+        "data": {
+          "confirm": "Confirmer le changement de type de store"
+        },
+        "description": "Basculement de **{from_type}** vers **{to_type}**.\n\nLes paramètres que seul l'ancien type utilise restent stockés et ne sont pas supprimés, ainsi revenir en arrière les retrouve intacts. Actuellement inactifs après le basculement :\n\n{stranded_options}\n\nNotes de capacité pour le nouveau type :\n\n{capability_notes}\n\nChaque entité conserve son ID d'entité. Les entités spécifiques au type que le nouveau type ne fournit pas restent dans le registre des entités comme indisponibles et reviennent si vous revenez à l'ancien type. Après confirmation, remplissez la géométrie du nouveau type et terminez avec Enregistrer et fermer pour appliquer la modification.",
+        "title": "Modifier le type de store — Confirmer"
       }
     },
     "abort": {
@@ -1054,7 +1072,8 @@
       "no_targets_selected": "Aucun store n'a été sélectionné comme cible.",
       "no_categories_selected": "Aucune catégorie n'a été sélectionnée pour la synchronisation.",
       "user_cancelled": "Synchronisation annulée.",
-      "sync_complete": "Paramètres synchronisés avec succès."
+      "sync_complete": "Paramètres synchronisés avec succès.",
+      "no_eligible_cover_types": "Aucun autre type de store ne peut gérer les protections liées à cette instance, il n'y a donc rien vers quoi basculer."
     }
   },
   "entity": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1056,14 +1056,14 @@
         "data_description": {
           "sensor_type": "Le type de store vers lequel cette instance basculera. Vous confirmerez sur l'écran suivant, puis remplirez la géométrie du nouveau type."
         },
-        "description": "Cette instance est actuellement un **{current_type}**. Choisissez le type de store qu'elle devrait devenir — chaque entité conserve son ID d'entité actuel, donc vos tableaux de bord et automations continuent de fonctionner.\n\nSeuls les types que vos protections peuvent réellement gérer sont énumérés. Non proposés ici :\n\n{blocked_types}\n\n[En savoir plus]({learn_more})",
+        "description": "Cette instance est actuellement de type **{current_type}**. Choisissez le type de store qu'elle devrait devenir — chaque entité conserve son ID d'entité actuel, donc vos tableaux de bord et automations continuent de fonctionner.\n\nSeuls les types que vos protections peuvent réellement gérer sont énumérés. Non proposés ici :\n\n{blocked_types}\n\n[En savoir plus]({learn_more})",
         "title": "Modifier le type de store"
       },
       "change_cover_type_confirm": {
         "data": {
           "confirm": "Confirmer le changement de type de store"
         },
-        "description": "Basculement de **{from_type}** vers **{to_type}**.\n\nLes paramètres que seul l'ancien type utilise restent stockés et ne sont pas supprimés, ainsi revenir en arrière les retrouve intacts. Actuellement inactifs après le basculement :\n\n{stranded_options}\n\nNotes de capacité pour le nouveau type :\n\n{capability_notes}\n\nChaque entité conserve son ID d'entité. Les entités spécifiques au type que le nouveau type ne fournit pas restent dans le registre des entités comme indisponibles et reviennent si vous revenez à l'ancien type. Après confirmation, remplissez la géométrie du nouveau type et terminez avec Enregistrer et fermer pour appliquer la modification.",
+        "description": "Basculement de **{from_type}** vers **{to_type}**.\n\nLes paramètres que seul l'ancien type utilise restent stockés et ne sont pas supprimés, ainsi revenir en arrière les retrouve intacts. Actuellement inactifs après le basculement :\n\n{stranded_options}\n\nNotes de capacité pour le nouveau type :\n\n{capability_notes}\n\nPolarité des positions :\n\n{position_polarity}\n\nChaque entité conserve son ID d'entité. Les entités spécifiques au type que le nouveau type ne fournit pas restent dans le registre des entités comme indisponibles et reviennent si vous revenez à l'ancien type. Après confirmation, remplissez la géométrie du nouveau type et terminez avec Enregistrer et fermer pour appliquer la modification.",
         "title": "Modifier le type de store — Confirmer"
       }
     },

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -992,7 +992,9 @@ async def _confirm_and_return_to_menu(
 
 
 def _add_profile(
-    hass: HomeAssistant, entry_id: str = "profile_for_link"
+    hass: HomeAssistant,
+    entry_id: str = "profile_for_link",
+    extra_options: dict | None = None,
 ) -> MockConfigEntry:
     """Register a Building Profile entry (options-only; never set up)."""
     from custom_components.adaptive_cover_pro.const import CONF_TEMP_ENTITY
@@ -1000,7 +1002,7 @@ def _add_profile(
     profile = MockConfigEntry(
         domain=DOMAIN,
         data={"name": "HQ", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
-        options={CONF_TEMP_ENTITY: "sensor.outside_temp"},
+        options={CONF_TEMP_ENTITY: "sensor.outside_temp", **(extra_options or {})},
         entry_id=entry_id,
         title="HQ",
     )
@@ -1222,6 +1224,124 @@ async def test_profile_link_does_not_strand_a_pending_switch(
     assert entry.options[CONF_BUILDING_PROFILE_ID] == profile.entry_id
 
 
+async def _link_profile_after_editing(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    profile: MockConfigEntry,
+    edit: dict,
+) -> None:
+    """Make *edit* in an open dialog, link *profile*, then Save & Close.
+
+    The edit is injected through a patched step rather than a real form so the
+    test says "an unsaved edit to this key" without dragging in whichever form
+    happens to own the field today.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+    from custom_components.adaptive_cover_pro.const import CONF_BUILDING_PROFILE_ID
+
+    async def _edit(self, user_input=None):
+        self.options.update(edit)
+        return await self.async_step_init()
+
+    with patch.object(OptionsFlowHandler, "async_step_geometry", _edit):
+        menu = await hass.config_entries.options.async_init(entry.entry_id)
+        menu = await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "geometry"}
+        )
+        form = await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "building_profile"}
+        )
+        menu = await hass.config_entries.options.async_configure(
+            form["flow_id"], {CONF_BUILDING_PROFILE_ID: profile.entry_id}
+        )
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+
+@pytest.mark.integration
+async def test_profile_link_adopts_the_profile_over_an_unsaved_edit(
+    hass: HomeAssistant,
+) -> None:
+    """With no switch pending, linking still means "adopt the profile".
+
+    The keys a profile owns are the whole point of linking, and on disk
+    ``_copy_profile_to_cover`` overwrites the cover's stored value with the
+    profile's (a cover being linked for the first time has no recorded
+    overrides for the copier to spare). Staging that write in the dialog must
+    reach the same place, or the outcome of "type a value, link a profile"
+    depends on whether the user happened to hit Save in between — inherit if
+    they did, a manufactured local override if they did not.
+
+    ``compute_override_keys`` is a pure value-diff at save time, so whatever
+    ``self.options`` holds at Save & Close decides inherit-vs-override. Leaving
+    the typed-over value there records an override the user never asked for.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_BUILDING_PROFILE_ID,
+        CONF_OUTSIDETEMP_ENTITY,
+        CONF_PROFILE_SENSOR_OVERRIDES,
+    )
+
+    # The profile names the same sensor the cover already has stored, so the
+    # copier changes nothing on disk and the "what did the copier change?" diff
+    # is empty for this key — the case the delta merge cannot see.
+    profile = _add_profile(
+        hass,
+        entry_id="profile_owns_outside_temp",
+        extra_options={CONF_OUTSIDETEMP_ENTITY: "sensor.hq_outside"},
+    )
+    entry = await _setup_entry(
+        hass,
+        entry_id="link_adopts_profile_key",
+        extra_options={CONF_OUTSIDETEMP_ENTITY: "sensor.hq_outside"},
+    )
+
+    await _link_profile_after_editing(
+        hass, entry, profile, {CONF_OUTSIDETEMP_ENTITY: "sensor.typed_in_dialog"}
+    )
+
+    assert entry.options[CONF_BUILDING_PROFILE_ID] == profile.entry_id
+    assert entry.options[CONF_OUTSIDETEMP_ENTITY] == "sensor.hq_outside"
+    assert CONF_PROFILE_SENSOR_OVERRIDES not in entry.options
+
+
+@pytest.mark.integration
+async def test_profile_link_keeps_an_unsaved_edit_the_profile_does_not_own(
+    hass: HomeAssistant,
+) -> None:
+    """Adopting is scoped to what the profile actually defines, not a category.
+
+    A blank profile key means "the profile does not define this" — indistinguishable
+    from never filled in — so ``merge_profile_into_config`` skips it and the
+    cover keeps its own value. An unsaved edit to such a key is the cover's own
+    just the same, and linking says nothing about it.
+    """
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_LUX_ENTITY,
+        CONF_OUTSIDETEMP_ENTITY,
+        CONF_PROFILE_SENSOR_OVERRIDES,
+    )
+
+    profile = _add_profile(
+        hass,
+        entry_id="profile_leaves_lux_blank",
+        extra_options={CONF_OUTSIDETEMP_ENTITY: "sensor.hq_outside"},
+    )
+    entry = await _setup_entry(hass, entry_id="link_keeps_local_key")
+
+    await _link_profile_after_editing(
+        hass, entry, profile, {CONF_LUX_ENTITY: "sensor.my_own_lux"}
+    )
+
+    assert entry.options[CONF_LUX_ENTITY] == "sensor.my_own_lux"
+    # The profile leaves it blank, so it is "local", never an override.
+    assert CONF_PROFILE_SENSOR_OVERRIDES not in entry.options
+    # And the key the profile does own was adopted.
+    assert entry.options[CONF_OUTSIDETEMP_ENTITY] == "sensor.hq_outside"
+
+
 @pytest.mark.integration
 async def test_mid_flow_write_without_a_pending_switch_is_unchanged(
     hass: HomeAssistant,
@@ -1308,7 +1428,22 @@ async def test_mid_flow_write_keeps_a_position_re_entered_after_the_switch(
     assert entry.options[CONF_DEFAULT_HEIGHT] == 30
 
 
-_OWN_ENTRY_ATTR = "_config_entry"
+# Both attributes reach the SAME ``ConfigEntry`` object, so a guard that knows
+# only one of them can be walked past by spelling the other.
+#
+# ``_config_entry`` is what ``OptionsFlowHandler.__init__`` stores: HA's
+# ``OptionsFlowManager.async_create_flow`` resolves the entry with
+# ``hass.config_entries.async_get_known_entry(handler_key)`` and hands that
+# object to ``async_get_options_flow(entry)`` (homeassistant/config_entries.py).
+# ``config_entry`` is HA's own ``OptionsFlow.config_entry`` property, which is a
+# live ``hass.config_entries.async_get_known_entry(self._config_entry_id)``
+# lookup with ``_config_entry_id`` returning ``self.handler`` — the same
+# ``handler_key``. Both therefore resolve to ``ConfigEntries._entries.data[
+# entry_id]``, and ``async_update_entry`` mutates that object in place rather
+# than replacing it, so the identity holds for the life of the flow.
+#
+# Not hypothetical: ``async_step_init`` already reads ``self.config_entry.title``.
+_OWN_ENTRY_ATTRS = frozenset({"_config_entry", "config_entry"})
 
 
 def _called_name(call: ast.Call) -> str | None:
@@ -1320,7 +1455,7 @@ def _is_own_entry(node: ast.AST | None, aliases: set[str]) -> bool:
     """Whether *node* evaluates to this flow's own config entry."""
     if isinstance(node, ast.Attribute):
         return (
-            node.attr == _OWN_ENTRY_ATTR
+            node.attr in _OWN_ENTRY_ATTRS
             and isinstance(node.value, ast.Name)
             and node.value.id == "self"
         )
@@ -1328,12 +1463,12 @@ def _is_own_entry(node: ast.AST | None, aliases: set[str]) -> bool:
 
 
 def _own_entry_aliases(func: ast.AST) -> set[str]:
-    """Local names bound to ``self._config_entry`` anywhere inside *func*.
+    """Local names bound to this flow's own entry anywhere inside *func*.
 
     Assigning to a local is the cheapest way to walk past a guard that only
-    looks at ``self._config_entry`` literally, so the alias set is transitive
-    (``a = self._config_entry`` then ``b = a``) and is rebuilt to a fixpoint
-    rather than in source order.
+    looks at ``self._config_entry`` (or ``self.config_entry``) literally, so the
+    alias set is transitive (``a = self._config_entry`` then ``b = a``) and is
+    rebuilt to a fixpoint rather than in source order.
     """
     aliases: set[str] = set()
     grew = True
@@ -1357,26 +1492,116 @@ def _own_entry_aliases(func: ast.AST) -> set[str]:
     return aliases
 
 
+def _writer_closure(calls: dict[str, set[str]]) -> frozenset[str]:
+    """Names in *calls* that reach ``async_update_entry``, however many hops.
+
+    ``calls`` maps a function name to the bare names it calls. One hop is not
+    enough: ``def _sync_now(entry): _copy_profile_to_cover(hass, p, entry)``
+    writes the entry it is handed just as surely as the copier does, so handing
+    it this flow's own entry is the same bypass — invisible to a set built only
+    from direct callers of ``async_update_entry``.
+
+    Seeded with ``async_update_entry`` itself so direct and indirect writers
+    fall out of one rule, then dropped from the result — it is HA's method, not
+    a helper of ours anyone could hand an entry to.
+    """
+    reaching = {"async_update_entry"}
+    grew = True
+    while grew:
+        grew = False
+        for name, called in calls.items():
+            if name not in reaching and called & reaching:
+                reaching.add(name)
+                grew = True
+    return frozenset(reaching - {"async_update_entry"})
+
+
 def _entry_writing_helpers() -> frozenset[str]:
-    """Every function in the integration that calls ``async_update_entry``.
+    """Every function in the integration that can end up writing a config entry.
 
     Derived, not listed: a helper added later that writes an entry is picked up
     without anyone remembering to name it here.
+
+    Names are matched bare, so two same-named functions in different modules
+    merge into one entry. That over-approximates, which is the safe direction —
+    it can make the guard demand a review that was not strictly needed, never
+    let an unreviewed write past.
     """
     import pathlib
 
     from custom_components.adaptive_cover_pro import config_flow as cf
 
-    names: set[str] = set()
+    calls: dict[str, set[str]] = {}
     for path in sorted(pathlib.Path(cf.__file__).parent.rglob("*.py")):
         for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
-            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and any(
-                isinstance(call, ast.Call)
-                and _called_name(call) == "async_update_entry"
+            if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                continue
+            calls.setdefault(node.name, set()).update(
+                name
                 for call in ast.walk(node)
-            ):
-                names.add(node.name)
-    return frozenset(names)
+                if isinstance(call, ast.Call) and (name := _called_name(call))
+            )
+    return _writer_closure(calls)
+
+
+def test_entry_writing_helpers_follow_calls_more_than_one_hop() -> None:
+    """The indirect check is only as deep as the set of helpers it is given.
+
+    A one-hop set names the copier but not the wrapper around it, so the
+    wrapper becomes a free bypass. The closure is the same fixpoint the alias
+    tracker uses, one level up.
+    """
+    calls = {
+        "_copy_profile_to_cover": {"async_update_entry"},
+        "_sync_now": {"_copy_profile_to_cover"},
+        "_and_its_caller": {"_sync_now"},
+        "_unrelated": {"dict"},
+    }
+
+    assert _writer_closure(calls) == {
+        "_copy_profile_to_cover",
+        "_sync_now",
+        "_and_its_caller",
+    }
+    # And the real derivation is wired to it: ``_persist_entry`` writes
+    # directly, ``_update_options`` only by calling it.
+    assert {"_persist_entry", "_update_options"} <= _entry_writing_helpers()
+
+
+def _base_names(cls: ast.ClassDef) -> set[str]:
+    """Bare names of *cls*'s declared bases (``a.B`` counts as ``B``)."""
+    return {
+        name
+        for base in cls.bases
+        if (name := getattr(base, "attr", None) or getattr(base, "id", None))
+    }
+
+
+def _handler_classes(tree: ast.Module, class_name: str) -> list[ast.ClassDef]:
+    """*class_name* plus every class in the module that descends from it.
+
+    A method that writes the entry is no less a write for being declared on a
+    subclass, so matching one ``ClassDef`` by name leaves a bypass that costs
+    one ``class Foo(OptionsFlowHandler):`` to take. The fixpoint over declared
+    bases is ten lines and needs no assumption stated in prose — which is the
+    argument for deriving it rather than asserting "no subclass exists today"
+    and leaving the next author to discover that a correct extension fails a
+    guard they then have to edit. Resolution is limited to what the module AST
+    shows: a subclass declared in another module is out of reach, which is
+    fine — this guard is about *this* module's writes.
+    """
+    classes = [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]
+    assert any(c.name == class_name for c in classes), f"no class {class_name}"
+
+    family = {class_name}
+    grew = True
+    while grew:
+        grew = False
+        for cls in classes:
+            if cls.name not in family and _base_names(cls) & family:
+                family.add(cls.name)
+                grew = True
+    return [c for c in classes if c.name in family]
 
 
 def _seam_violations(
@@ -1388,22 +1613,22 @@ def _seam_violations(
     ``async_update_entry`` on their own entry, and ``(method, helper)`` pairs
     that hand their own entry to something that writes it for them.
 
-    Only methods declared directly on the class are iterated, so a call inside
-    a nested closure is attributed to the method that contains it rather than
-    to the closure's own name.
+    Only methods declared directly on the class (or on a subclass of it — see
+    :func:`_handler_classes`) are iterated, so a call inside a nested closure is
+    attributed to the method that contains it rather than to the closure's own
+    name.
     """
     tree = ast.parse(source)
-    cls = next(
-        n
-        for n in ast.walk(tree)
-        if isinstance(n, ast.ClassDef) and n.name == class_name
-    )
+    methods = [
+        node
+        for cls in _handler_classes(tree, class_name)
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef)
+    ]
 
     direct: set[str] = set()
     indirect: set[tuple[str, str]] = set()
-    for method in cls.body:
-        if not isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue
+    for method in methods:
         aliases = _own_entry_aliases(method)
         for node in ast.walk(method):
             if not isinstance(node, ast.Call):
@@ -1472,14 +1697,39 @@ class OptionsFlowHandler:
 
         _inner()
 
+    def ha_property(self):
+        self.hass.config_entries.async_update_entry(self.config_entry, options={})
+
+    def aliased_ha_property(self):
+        entry = self.config_entry
+        self.hass.config_entries.async_update_entry(entry, options={})
+
     def indirect(self):
         _copy_profile_to_cover(self.hass, profile, self._config_entry)
+
+    def indirect_via_ha_property(self):
+        _copy_profile_to_cover(self.hass, profile, self.config_entry)
 
     def hands_it_over_as_a_non_target(self, target):
         _copy_profile_to_cover(self.hass, self._config_entry, target)
 
     def writes_someone_else(self, target):
         self.hass.config_entries.async_update_entry(target, options={})
+
+
+class _LaterSubclass(OptionsFlowHandler):
+    def subclass_write(self):
+        self.hass.config_entries.async_update_entry(self._config_entry, options={})
+
+
+class _DeeperStill(_LaterSubclass):
+    def deeper_subclass_write(self):
+        self.hass.config_entries.async_update_entry(self.config_entry, options={})
+
+
+class _SomeOtherFlow:
+    def unrelated_write(self):
+        self.hass.config_entries.async_update_entry(self._config_entry, options={})
 """
 
 
@@ -1495,6 +1745,11 @@ def test_seam_guard_sees_through_aliases_keywords_closures_and_helpers() -> None
     argument is the written one is the helper's business and can change. That
     is what ``_ALLOWED_INDIRECT_WRITES`` is for: each reviewed call site says
     in prose why it is safe, and an unreviewed one fails.
+
+    Subclassing is the same bypass one level up: a method that writes the entry
+    is no less a write for being declared on a subclass of the handler, so the
+    scan follows ``bases`` rather than matching one class by name. A class that
+    does not descend from the handler is nobody's business here.
     """
     direct, indirect = _seam_violations(
         _SEAM_EVASIONS,
@@ -1502,10 +1757,21 @@ def test_seam_guard_sees_through_aliases_keywords_closures_and_helpers() -> None
         writer_helpers=frozenset({"_copy_profile_to_cover"}),
     )
 
-    assert direct == {"_persist_entry", "aliased", "keyword", "nested"}
+    assert direct == {
+        "_persist_entry",
+        "aliased",
+        "keyword",
+        "nested",
+        "ha_property",
+        "aliased_ha_property",
+        "subclass_write",
+        "deeper_subclass_write",
+    }
     assert "writes_someone_else" not in direct
+    assert "unrelated_write" not in direct
     assert indirect == {
         ("indirect", "_copy_profile_to_cover"),
+        ("indirect_via_ha_property", "_copy_profile_to_cover"),
         ("hands_it_over_as_a_non_target", "_copy_profile_to_cover"),
     }
 
@@ -1530,8 +1796,13 @@ def test_options_flow_writes_its_own_entry_through_one_seam() -> None:
         "_persist_entry"
     }, f"self._config_entry is written outside the seam: {sorted(direct)}"
     assert indirect <= _ALLOWED_INDIRECT_WRITES, (
-        "self._config_entry is handed to an entry-writing helper from a call "
+        "this flow's own entry is handed to an entry-writing helper from a call "
         f"site that has not been reviewed: {sorted(indirect - _ALLOWED_INDIRECT_WRITES)}"
+    )
+    assert indirect >= _ALLOWED_INDIRECT_WRITES, (
+        "reviewed-call-site notes that no longer describe a real call site — a "
+        "stale exemption is one a future write can land in without review: "
+        f"{sorted(_ALLOWED_INDIRECT_WRITES - indirect)}"
     )
 
 

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -5,20 +5,27 @@ post-creation write path touched ``data`` — so a cover's type could only chang
 by deleting and re-adding the entry, which re-mints every ACP entity's
 ``unique_id`` (``entity_base.py``: ``f"{entry_id}_{suffix}"``) and breaks every
 dashboard and automation referencing them. These tests pin the new options-flow
-step that rewrites ``entry.data[CONF_SENSOR_TYPE]`` in place.
+step that rewrites ``entry.data[CONF_SENSOR_TYPE]`` in place — picked and
+confirmed in memory, persisted (with exactly one reload) only at Save & Close.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import contextlib
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DEFAULT_HEIGHT,
+    CONF_ENABLE_SUN_TRACKING,
     CONF_ENTITIES,
+    CONF_MAX_POSITION,
+    CONF_MIN_POSITION,
     CONF_SENSOR_TYPE,
+    CONF_SUNSET_POS,
     DOMAIN,
     CoverType,
 )
@@ -118,12 +125,14 @@ async def _setup_entry(
     options = dict(VERTICAL_OPTIONS)
     options[CONF_ENTITIES] = list(entities)
     # Model an entry that has already completed its one-time orphan-prune
-    # migrations. Without these, the prune passes write ``entry.options`` DURING
-    # setup — after the coordinator snapshotted ``_cached_options`` — leaving the
-    # cache permanently stale, so the update listener sees a non-empty diff and
-    # reloads on the next ``async_update_entry`` no matter what changed. That is
-    # pre-existing first-boot behaviour unrelated to the cover-type switch; a
-    # settled entry is what these tests need to measure.
+    # migrations. In production the prunes are harmless: they write
+    # ``entry.options`` during setup, and ``_async_update_data`` re-snapshots
+    # ``_cached_options`` on the first refresh right afterwards. Here
+    # ``_patch_coordinator_refresh`` replaces that first refresh with an
+    # ``AsyncMock``, so the snapshot never happens and the cache stays stale for
+    # the life of the test — the update listener would then see a non-empty diff
+    # and reload on any ``async_update_entry``. Pre-seeding the flags keeps the
+    # harness honest about what a settled entry does.
     options[_PRUNE_V1_FLAG] = True
     options[_PRUNE_SENSORS_V1_FLAG] = True
     options[_PRUNE_SENSORS_V2_FLAG] = True
@@ -292,6 +301,36 @@ async def test_picker_lists_blocked_types_with_reason(hass: HomeAssistant) -> No
 
 
 @pytest.mark.integration
+async def test_picker_blocked_list_never_renders_a_dangling_heading(
+    hass: HomeAssistant,
+) -> None:
+    """Nothing blocked still needs a placeholder — the heading is unconditional."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    entry = await _setup_entry(hass, entry_id="change_type_nothing_blocked")
+    # A cover that can do everything satisfies every policy's entity filter.
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {
+            "current_position": 100,
+            "current_tilt_position": 100,
+            "supported_features": int(
+                CoverEntityFeature.OPEN
+                | CoverEntityFeature.CLOSE
+                | CoverEntityFeature.STOP
+                | CoverEntityFeature.SET_POSITION
+                | CoverEntityFeature.SET_TILT_POSITION
+            ),
+        },
+    )
+
+    result = await _open_picker(hass, entry)
+
+    assert result["description_placeholders"]["blocked_types"] == "—"
+
+
+@pytest.mark.integration
 async def test_picker_uses_mode_translation_key(hass: HomeAssistant) -> None:
     """Reuse the ten already-translated selector.mode labels — no new strings."""
     entry = await _setup_entry(hass, entry_id="change_type_i18n")
@@ -408,7 +447,7 @@ async def test_declining_confirm_leaves_type_unchanged(hass: HomeAssistant) -> N
 
 
 # ---------------------------------------------------------------------------
-# Step 6 — the entry.data write and in-memory propagation
+# Step 6 — in-memory propagation; nothing is persisted before Save & Close
 # ---------------------------------------------------------------------------
 
 
@@ -420,17 +459,55 @@ async def _confirm(hass: HomeAssistant, entry: MockConfigEntry, new_type: str) -
     )
 
 
+def _handler(hass: HomeAssistant, flow_id: str):
+    """Return the live OptionsFlowHandler behind *flow_id*."""
+    return hass.config_entries.options._progress[flow_id]
+
+
+@contextlib.contextmanager
+def _count_reloads(hass: HomeAssistant):
+    """Count reloads from BOTH paths that can trigger one.
+
+    ``async_schedule_reload`` calls ``async_reload`` inside a task and
+    ``_async_update_listener`` awaits it directly, so patching the one method
+    both go through is the only way to see the total. Patching
+    ``async_schedule_reload`` alone counts the explicit path and misses the
+    listener entirely — which is exactly how a double reload hides.
+    """
+    with patch.object(
+        hass.config_entries, "async_reload", new_callable=AsyncMock
+    ) as reload:
+        yield reload
+
+
+def _reloads(reload_mock, entry: MockConfigEntry) -> int:
+    """How many times *entry* specifically was reloaded."""
+    return sum(
+        1 for call in reload_mock.call_args_list if call.args[0] == entry.entry_id
+    )
+
+
 @pytest.mark.integration
-async def test_confirm_writes_entry_data(hass: HomeAssistant) -> None:
-    """Confirming rewrites entry.data in place and leaves options untouched."""
+async def test_confirm_switches_the_flow_but_not_the_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Confirming moves the in-memory type only — ``entry.data`` is untouched.
+
+    Persisting at confirm time would leave every non-Save exit (abandon the
+    dialog, hit an aborting step) with an entry permanently switched, never
+    reloaded, and missing the geometry the user was about to enter.
+    """
     entry = await _setup_entry(hass, entry_id="write_data")
     options_before = dict(entry.options)
 
-    await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+    result = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
 
-    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
     assert entry.data["name"] == "Switchable"
     assert dict(entry.options) == options_before
+    handler = _handler(hass, result["flow_id"])
+    assert handler.sensor_type == CoverType.DAY_NIGHT_SHADE
+    assert handler._cover_type_changed is True
 
 
 @pytest.mark.integration
@@ -492,16 +569,108 @@ async def test_menu_after_switch_reflects_new_type(hass: HomeAssistant) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 7 — exactly one reload, at Save & Close
+# Step 7 — nothing persists unless the user reaches Save & Close
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.integration
-async def test_done_schedules_reload_after_type_change(hass: HomeAssistant) -> None:
-    """Save & Close applies the switch with exactly one scheduled reload."""
+async def test_abandoning_after_confirm_leaves_type_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """Closing the dialog on the geometry step must not leave a switched entry.
+
+    A ``data`` write at confirm time survives an abandoned flow: the entry is
+    permanently the new type, never reloaded, and missing every key the geometry
+    step was about to collect. On the next HA restart the coordinator comes up
+    on a half-configured type that already drives hardware.
+    """
+    entry = await _setup_entry(hass, entry_id="abandon_after_confirm")
+    options_before = dict(entry.options)
+
+    with _count_reloads(hass) as reload:
+        geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        assert geometry["step_id"] == "geometry"
+        hass.config_entries.options.async_abort(geometry["flow_id"])
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert dict(entry.options) == options_before
+    assert _reloads(reload, entry) == 0
+
+
+@pytest.mark.integration
+async def test_confirm_then_aborting_step_leaves_type_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """An aborting step after confirm ends the flow without ever writing options.
+
+    ``async_step_sync`` filters sibling covers on this instance's own type. Once
+    the switch is pending there is no sibling of the new type, so it aborts —
+    and ``OptionsFlowManager.async_finish_flow`` returns on an ABORT without
+    writing options or running ``_update_options``. Everything the flow did must
+    unwind with it.
+    """
+    entry = await _setup_entry(hass, entry_id="abort_via_sync")
+    options_before = dict(entry.options)
+
+    with _count_reloads(hass) as reload:
+        geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        menu = await hass.config_entries.options.async_configure(
+            geometry["flow_id"], {}
+        )
+        result = await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "sync"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "no_covers_to_sync"
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert dict(entry.options) == options_before
+    assert _reloads(reload, entry) == 0
+
+
+@pytest.mark.integration
+async def test_data_written_only_at_save_and_close(hass: HomeAssistant) -> None:
+    """``entry.data`` flips on Save & Close, together with exactly one reload."""
+    entry = await _setup_entry(hass, entry_id="data_at_save")
+
+    with _count_reloads(hass) as reload:
+        geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+        menu = await hass.config_entries.options.async_configure(
+            geometry["flow_id"], {}
+        )
+        assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert entry.data["name"] == "Switchable"
+    assert _reloads(reload, entry) == 1
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — exactly one reload, however the options happen to fall
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_type_change_with_option_edits_reloads_once(
+    hass: HomeAssistant,
+) -> None:
+    """A switch that also edits options reloads once, not twice.
+
+    The incoming type's geometry form writes its own defaults, so the options
+    write at Save & Close already reloads the entry through
+    ``_async_update_listener``. Scheduling a reload unconditionally on top of it
+    takes every entity through unavailable → available twice.
+    """
     entry = await _setup_entry(hass, entry_id="reload_on_done")
 
-    with patch.object(hass.config_entries, "async_schedule_reload") as sched:
+    with _count_reloads(hass) as reload:
         geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
         menu = await hass.config_entries.options.async_configure(
             geometry["flow_id"], {}
@@ -511,28 +680,65 @@ async def test_done_schedules_reload_after_type_change(hass: HomeAssistant) -> N
         )
         await hass.async_block_till_done()
 
-    sched.assert_called_once_with(entry.entry_id)
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    # The geometry step really did move options — this is the double-reload case.
+    assert entry.options["day_night_control_model"]
+    assert _reloads(reload, entry) == 1
 
 
 @pytest.mark.integration
-async def test_done_does_not_schedule_reload_without_type_change(
+async def test_type_change_with_runtime_only_option_edits_still_reloads_once(
+    hass: HomeAssistant,
+) -> None:
+    """A runtime-applicable-only delta never reloads, so the switch must.
+
+    ``_async_update_listener`` applies a change confined to
+    ``_RUNTIME_APPLICABLE_OPTIONS`` in place and returns. "Options changed" is
+    therefore not the same question as "the write will reload".
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    entry = await _setup_entry(hass, entry_id="reload_runtime_only")
+
+    async def _runtime_only_edit(self, user_input=None):
+        self.options[CONF_ENABLE_SUN_TRACKING] = False
+        return await self.async_step_init()
+
+    with (
+        _count_reloads(hass) as reload,
+        patch.object(OptionsFlowHandler, "async_step_geometry", _runtime_only_edit),
+    ):
+        menu = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        assert menu["type"] == "menu"
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert entry.options[CONF_ENABLE_SUN_TRACKING] is False
+    assert _reloads(reload, entry) == 1
+
+
+@pytest.mark.integration
+async def test_done_does_not_reload_without_type_change(
     hass: HomeAssistant,
 ) -> None:
     """An ordinary Save & Close does not gain a reload it never had."""
     entry = await _setup_entry(hass, entry_id="reload_no_change")
 
-    with patch.object(hass.config_entries, "async_schedule_reload") as sched:
+    with _count_reloads(hass) as reload:
         menu = await hass.config_entries.options.async_init(entry.entry_id)
         await hass.config_entries.options.async_configure(
             menu["flow_id"], {"next_step_id": "done"}
         )
         await hass.async_block_till_done()
 
-    sched.assert_not_called()
+    assert _reloads(reload, entry) == 0
 
 
 @pytest.mark.integration
-async def test_reload_scheduled_even_when_options_unchanged(
+async def test_reload_happens_even_when_options_unchanged(
     hass: HomeAssistant,
 ) -> None:
     """The reload must be explicit, not left to the options-write listener.
@@ -549,7 +755,7 @@ async def test_reload_scheduled_even_when_options_unchanged(
         return await self.async_step_init()
 
     with (
-        patch.object(hass.config_entries, "async_schedule_reload") as sched,
+        _count_reloads(hass) as reload,
         patch.object(OptionsFlowHandler, "async_step_geometry", _straight_back_to_menu),
     ):
         options_before = dict(entry.options)
@@ -561,11 +767,129 @@ async def test_reload_scheduled_even_when_options_unchanged(
         await hass.async_block_till_done()
 
     assert dict(entry.options) == options_before
-    sched.assert_called_once_with(entry.entry_id)
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert _reloads(reload, entry) == 1
 
 
 # ---------------------------------------------------------------------------
-# Step 8 — entity-ID preservation, end to end (the acceptance test)
+# Step 9 — position polarity across the switch
+# ---------------------------------------------------------------------------
+#
+# ``default_percentage`` is stored by every cover type, so it can never show up
+# in ``{stranded_options}`` — yet its correct value is the opposite across a
+# polarity flip. On a blind 100 % is the no-coverage end; on an awning that end
+# is 0 %. Carrying the number over silently turns "stay out of the way" into
+# "shade as hard as you can".
+
+
+async def _polarity_note(
+    hass: HomeAssistant, entry: MockConfigEntry, new_type: str
+) -> str:
+    """Return the confirm screen's polarity disclosure for a switch to *new_type*."""
+    confirm = await _pick(hass, entry, new_type)
+    note = confirm["description_placeholders"]["position_polarity"]
+    hass.config_entries.options.async_abort(confirm["flow_id"])
+    return note
+
+
+async def _switch_and_save(
+    hass: HomeAssistant, entry: MockConfigEntry, new_type: str
+) -> None:
+    """Run the whole switch through to Save & Close."""
+    geometry = await _confirm(hass, entry, new_type)
+    menu = await hass.config_entries.options.async_configure(geometry["flow_id"], {})
+    await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.mark.integration
+async def test_polarity_flip_reseeds_default_position_blind_to_awning(
+    hass: HomeAssistant,
+) -> None:
+    """Blind → awning re-seeds the default to the awning's no-coverage end."""
+    entry = await _setup_entry(hass, entry_id="polarity_to_awning")
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+
+    note = await _polarity_note(hass, entry, CoverType.AWNING)
+    assert "50" in note
+    assert "0" in note
+
+    await _switch_and_save(hass, entry, CoverType.AWNING)
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.AWNING
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 0
+
+
+@pytest.mark.integration
+async def test_polarity_flip_reseeds_default_position_awning_to_blind(
+    hass: HomeAssistant,
+) -> None:
+    """Awning → blind re-seeds the other way, to the blind's no-coverage end."""
+    entry = await _setup_entry(
+        hass,
+        cover_type=CoverType.AWNING,
+        entry_id="polarity_to_blind",
+        extra_options={"length_awning": 2.1, "angle": 0},
+    )
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+
+    note = await _polarity_note(hass, entry, CoverType.BLIND)
+    assert "100" in note
+
+    await _switch_and_save(hass, entry, CoverType.BLIND)
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 100
+
+
+@pytest.mark.integration
+async def test_non_flipping_switch_leaves_default_position_alone(
+    hass: HomeAssistant,
+) -> None:
+    """Blind → dual panel shares a polarity — say nothing, change nothing."""
+    entry = await _setup_entry(hass, entry_id="polarity_none")
+
+    note = await _polarity_note(hass, entry, CoverType.DUAL_PANEL)
+    assert note == "—"
+
+    await _switch_and_save(hass, entry, CoverType.DUAL_PANEL)
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DUAL_PANEL
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+
+
+@pytest.mark.integration
+async def test_polarity_flip_names_the_positions_it_does_not_change(
+    hass: HomeAssistant,
+) -> None:
+    """Travel limits have no policy answer, so they are disclosed, not rewritten."""
+    entry = await _setup_entry(
+        hass,
+        entry_id="polarity_limits",
+        extra_options={
+            CONF_MIN_POSITION: 20,
+            CONF_MAX_POSITION: 100,
+            CONF_SUNSET_POS: 30,
+        },
+    )
+
+    note = await _polarity_note(hass, entry, CoverType.AWNING)
+
+    assert CONF_MIN_POSITION in note
+    assert CONF_SUNSET_POS in note
+    # 100 % is "no upper clamp" under either polarity — nothing to disclose.
+    assert CONF_MAX_POSITION not in note
+
+    await _switch_and_save(hass, entry, CoverType.AWNING)
+
+    assert entry.options[CONF_MIN_POSITION] == 20
+    assert entry.options[CONF_SUNSET_POS] == 30
+
+
+# ---------------------------------------------------------------------------
+# Step 10 — entity-ID preservation, end to end (the acceptance test)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -967,3 +967,444 @@ def test_config_entry_version_unchanged() -> None:
 
     assert ConfigFlowHandler.VERSION == 3
     assert ConfigFlowHandler.MINOR_VERSION == 13
+
+
+# ---------------------------------------------------------------------------
+# Step 11 — a pending switch never leaks through a mid-flow entry write
+# ---------------------------------------------------------------------------
+#
+# ``_update_options`` is not the only place this flow writes its own entry:
+# ``async_step_sync_confirm`` and ``async_step_building_profile``'s unlink
+# branch both persist ``self.options`` mid-dialog, and each write fires the
+# update listener (so it can reload). A confirmed-but-unsaved switch must not
+# ride along on either — the entry would come back up on the OLD type carrying
+# the NEW type's derived values (a blind whose no-sun default is 0 %, i.e.
+# fully closed on every fallback).
+
+
+async def _confirm_and_return_to_menu(
+    hass: HomeAssistant, entry: MockConfigEntry, new_type: str
+) -> dict:
+    """Confirm a switch, submit the incoming type's geometry, land on the menu."""
+    geometry = await _confirm(hass, entry, new_type)
+    return await hass.config_entries.options.async_configure(geometry["flow_id"], {})
+
+
+def _add_profile(
+    hass: HomeAssistant, entry_id: str = "profile_for_link"
+) -> MockConfigEntry:
+    """Register a Building Profile entry (options-only; never set up)."""
+    from custom_components.adaptive_cover_pro.const import CONF_TEMP_ENTITY
+
+    profile = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "HQ", CONF_SENSOR_TYPE: CoverType.BUILDING_PROFILE},
+        options={CONF_TEMP_ENTITY: "sensor.outside_temp"},
+        entry_id=entry_id,
+        title="HQ",
+    )
+    profile.add_to_hass(hass)
+    return profile
+
+
+@pytest.mark.integration
+async def test_sync_confirm_does_not_persist_a_pending_switch(
+    hass: HomeAssistant,
+) -> None:
+    """Sync saves this cover's settings first — but not a pending switch.
+
+    ``async_step_sync_confirm`` writes ``options=dict(self.options)`` so the
+    copy sees the latest values. With a switch pending those options already
+    carry the awning re-seed, so the write leaves a BLIND whose no-sun default
+    is 0 % — and reloads it straight into that state.
+    """
+    sibling = await _setup_entry(
+        hass,
+        cover_type=CoverType.AWNING,
+        entities=["cover.awning_a"],
+        extra_options={"length_awning": 2.1, "angle": 0},
+        entry_id="sync_sibling_awning",
+    )
+    entry = await _setup_entry(hass, entry_id="sync_pending_switch")
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+
+    menu = await _confirm_and_return_to_menu(hass, entry, CoverType.AWNING)
+    sync = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "sync"}
+    )
+    confirm = await hass.config_entries.options.async_configure(
+        sync["flow_id"],
+        {"target_entries": [sibling.entry_id], "sync_categories": ["position"]},
+    )
+    await hass.config_entries.options.async_configure(
+        confirm["flow_id"], {"confirm": True}
+    )
+    await hass.async_block_till_done()
+
+    # data and options must agree with each other: both still the blind's.
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+    # The incoming type's geometry is part of the same pending switch.
+    assert "length_awning" not in entry.options
+
+
+@pytest.mark.integration
+async def test_profile_unlink_does_not_persist_a_pending_switch(
+    hass: HomeAssistant,
+) -> None:
+    """The Building Profile unlink branch is the same write, narrower gate."""
+    from custom_components.adaptive_cover_pro.config_flow import _PROFILE_NONE_SENTINEL
+    from custom_components.adaptive_cover_pro.const import CONF_BUILDING_PROFILE_ID
+
+    profile = _add_profile(hass, entry_id="profile_for_unlink")
+    entry = await _setup_entry(
+        hass,
+        entry_id="unlink_pending_switch",
+        extra_options={CONF_BUILDING_PROFILE_ID: profile.entry_id},
+    )
+
+    menu = await _confirm_and_return_to_menu(hass, entry, CoverType.AWNING)
+    form = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "building_profile"}
+    )
+    await hass.config_entries.options.async_configure(
+        form["flow_id"], {CONF_BUILDING_PROFILE_ID: _PROFILE_NONE_SENTINEL}
+    )
+    await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+    assert "length_awning" not in entry.options
+    # The unlink itself still happened.
+    assert CONF_BUILDING_PROFILE_ID not in entry.options
+
+
+@pytest.mark.integration
+async def test_profile_link_does_not_strand_a_pending_switch(
+    hass: HomeAssistant,
+) -> None:
+    """Linking a profile re-reads the entry — it must not drop the pending switch.
+
+    The link branch replaces ``self.options`` wholesale from the freshly written
+    entry, discarding the polarity re-seed and the new type's geometry while the
+    switch stays pending. Save & Close then flips ``data`` to the new type with
+    options that contradict the disclosure the user just read.
+    """
+    from custom_components.adaptive_cover_pro.const import CONF_BUILDING_PROFILE_ID
+
+    profile = _add_profile(hass)
+    entry = await _setup_entry(hass, entry_id="link_pending_switch")
+
+    menu = await _confirm_and_return_to_menu(hass, entry, CoverType.AWNING)
+    form = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "building_profile"}
+    )
+    back = await hass.config_entries.options.async_configure(
+        form["flow_id"], {CONF_BUILDING_PROFILE_ID: profile.entry_id}
+    )
+    await hass.config_entries.options.async_configure(
+        back["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.AWNING
+    # The confirm screen promised this re-seed; the switch landed, so must it.
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 0
+    assert "length_awning" in entry.options
+    assert entry.options[CONF_BUILDING_PROFILE_ID] == profile.entry_id
+
+
+@pytest.mark.integration
+async def test_mid_flow_write_without_a_pending_switch_is_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """No pending switch → a mid-flow write still persists every unsaved edit.
+
+    The regression risk of routing the writes through one seam: it must strip
+    only what a pending switch put there, never an ordinary edit.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    sibling = await _setup_entry(
+        hass, entities=["cover.other_blind"], entry_id="plain_sync_sibling"
+    )
+    entry = await _setup_entry(hass, entry_id="plain_sync_source")
+
+    async def _edit(self, user_input=None):
+        self.options[CONF_DEFAULT_HEIGHT] = 33
+        return await self.async_step_init()
+
+    with patch.object(OptionsFlowHandler, "async_step_geometry", _edit):
+        menu = await hass.config_entries.options.async_init(entry.entry_id)
+        menu = await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "geometry"}
+        )
+        sync = await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "sync"}
+        )
+        confirm = await hass.config_entries.options.async_configure(
+            sync["flow_id"],
+            {"target_entries": [sibling.entry_id], "sync_categories": ["position"]},
+        )
+        await hass.config_entries.options.async_configure(
+            confirm["flow_id"], {"confirm": True}
+        )
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 33
+    assert sibling.options[CONF_DEFAULT_HEIGHT] == 33
+
+
+def test_options_flow_writes_its_own_entry_through_one_seam() -> None:
+    """Every ``async_update_entry(self._config_entry, …)`` goes through the seam.
+
+    The drift guard for the fix: a future step that persists ``self.options``
+    directly would silently reintroduce the half-applied switch.
+    """
+    import ast
+    import inspect
+
+    from custom_components.adaptive_cover_pro import config_flow as cf
+
+    tree = ast.parse(inspect.getsource(cf))
+    handler = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == "OptionsFlowHandler"
+    )
+
+    callers: set[str] = set()
+    for func in ast.walk(handler):
+        if not isinstance(func, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Call):
+                continue
+            if getattr(node.func, "attr", None) != "async_update_entry":
+                continue
+            first = node.args[0] if node.args else None
+            if (
+                isinstance(first, ast.Attribute)
+                and first.attr == "_config_entry"
+                and isinstance(first.value, ast.Name)
+                and first.value.id == "self"
+            ):
+                callers.add(func.name)
+
+    assert callers == {
+        "_persist_entry"
+    }, f"self._config_entry is written outside the seam: {sorted(callers)}"
+
+
+# ---------------------------------------------------------------------------
+# Step 12 — a switch round trip inside one dialog is a no-op
+# ---------------------------------------------------------------------------
+
+
+async def _switch_to(
+    hass: HomeAssistant, flow_id: str, new_type: str, *, geometry: bool = True
+) -> dict:
+    """Drive an already-open flow from the menu through a switch to *new_type*."""
+    picker = await hass.config_entries.options.async_configure(
+        flow_id, {"next_step_id": "change_cover_type"}
+    )
+    confirm = await hass.config_entries.options.async_configure(
+        picker["flow_id"], {CONF_SENSOR_TYPE: new_type}
+    )
+    result = await hass.config_entries.options.async_configure(
+        confirm["flow_id"], {"confirm": True}
+    )
+    if not geometry:
+        return result
+    return await hass.config_entries.options.async_configure(result["flow_id"], {})
+
+
+@pytest.mark.integration
+async def test_round_trip_switch_restores_the_original_default(
+    hass: HomeAssistant,
+) -> None:
+    """Blind → awning → blind must land back on the user's stored default.
+
+    Each hop re-seeds against the type it is leaving, so a round trip walks
+    50 → 0 → 100 and the original value is gone. The re-seed belongs to the
+    pending switch, so unwinding the switch must unwind it too.
+    """
+    entry = await _setup_entry(hass, entry_id="round_trip_default")
+
+    menu = await hass.config_entries.options.async_init(entry.entry_id)
+    menu = await _switch_to(hass, menu["flow_id"], CoverType.AWNING)
+    menu = await _switch_to(hass, menu["flow_id"], CoverType.BLIND)
+    await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+
+
+@pytest.mark.integration
+async def test_round_trip_switch_reloads_nothing(hass: HomeAssistant) -> None:
+    """Back on the type it started as, Save & Close has nothing to apply.
+
+    Counted across BOTH reload paths: the sticky flag writes ``data`` (a no-op)
+    and schedules an explicit reload, and the re-seed round trip leaves a
+    ``default_percentage`` delta the update listener reloads for on its own.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    entry = await _setup_entry(hass, entry_id="round_trip_reload")
+    options_before = dict(entry.options)
+
+    async def _straight_back_to_menu(self, user_input=None):
+        return await self.async_step_init()
+
+    with (
+        patch.object(OptionsFlowHandler, "async_step_geometry", _straight_back_to_menu),
+        _count_reloads(hass) as reload,
+    ):
+        menu = await hass.config_entries.options.async_init(entry.entry_id)
+        menu = await _switch_to(hass, menu["flow_id"], CoverType.AWNING, geometry=False)
+        menu = await _switch_to(hass, menu["flow_id"], CoverType.BLIND, geometry=False)
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert dict(entry.options) == options_before
+    assert _reloads(reload, entry) == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 13 — the polarity screen names every stored position, not four of them
+# ---------------------------------------------------------------------------
+#
+# ``_POLARITY_CARRIED_LINE`` says "these stored positions now mean the
+# opposite". Naming three keys out of ten makes it worse than silence: a user
+# who checks exactly what they were told to check is left with the rest
+# inverted.
+
+
+@pytest.mark.integration
+async def test_polarity_disclosure_names_weather_override_position(
+    hass: HomeAssistant,
+) -> None:
+    """A blind's "raise fully in wind/rain" becomes "extend fully" on an awning."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_WEATHER_OVERRIDE_POSITION,
+    )
+
+    entry = await _setup_entry(
+        hass,
+        entry_id="polarity_weather",
+        extra_options={CONF_WEATHER_OVERRIDE_POSITION: 100},
+    )
+
+    note = await _polarity_note(hass, entry, CoverType.AWNING)
+
+    assert CONF_WEATHER_OVERRIDE_POSITION in note
+
+
+@pytest.mark.integration
+async def test_polarity_disclosure_names_custom_position_slots(
+    hass: HomeAssistant,
+) -> None:
+    """Custom-position scene values and their ceilings invert too."""
+    entry = await _setup_entry(
+        hass,
+        entry_id="polarity_custom_slots",
+        extra_options={
+            "custom_position_1": 100,
+            "custom_position_position_max_1": 40,
+        },
+    )
+
+    note = await _polarity_note(hass, entry, CoverType.AWNING)
+
+    assert "custom_position_1" in note
+    assert "custom_position_position_max_1" in note
+
+
+@pytest.mark.integration
+async def test_polarity_disclosure_names_every_stored_position(
+    hass: HomeAssistant,
+) -> None:
+    """The completeness assertion, driven off the field registry itself."""
+    from custom_components.adaptive_cover_pro.config_fields import (
+        PositionRole,
+        position_roles,
+    )
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    disclosed = {
+        key
+        for key, role in position_roles().items()
+        if role in PositionRole.disclosed_roles()
+    }
+    assert disclosed, "no disclosed primary-axis positions declared"
+
+    # A value that is not the polarity-neutral no-op for any of them.
+    stored = dict.fromkeys(disclosed, 40)
+    entry = await _setup_entry(
+        hass, entry_id="polarity_completeness", extra_options=stored
+    )
+
+    note = await _polarity_note(hass, entry, CoverType.AWNING)
+
+    live = get_policy(CoverType.AWNING).live_option_keys()
+    missing = sorted(k for k in disclosed if k in live and k not in note)
+    assert not missing, f"undisclosed inverting positions: {missing}"
+
+
+def test_every_percentage_option_declares_a_position_role() -> None:
+    """A new 0-100 % option must be classified before it can ship.
+
+    The drift guard: without it the disclosure list is a second hand-maintained
+    tuple that falls behind ``const.py`` exactly the way the first one did.
+    """
+    from custom_components.adaptive_cover_pro.config_fields import position_roles
+    from custom_components.adaptive_cover_pro.cover_types import percentage_option_keys
+
+    classified = set(position_roles())
+    candidates = percentage_option_keys()
+
+    assert not (candidates - classified), (
+        "percentage options with no PositionRole: " f"{sorted(candidates - classified)}"
+    )
+    assert not (classified - candidates), (
+        f"PositionRole declared for non-percentage keys: "
+        f"{sorted(classified - candidates)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Step 14 — the blocked-type reason and the filter must agree on unavailability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_blocked_type_reason_ignores_unavailable_covers(
+    hass: HomeAssistant,
+) -> None:
+    """An unreadable cover is skipped by the filter, so it must not be blamed.
+
+    ``entities_satisfy_selector`` skips a ``None`` cap entry; the warning
+    builder does not, and ``caps_get(None, …)`` is False — so a merely
+    unavailable entity gets reported as "does not support set_position".
+    """
+    from homeassistant.const import STATE_UNAVAILABLE
+
+    entry = await _setup_entry(
+        hass,
+        entities=["cover.readable", "cover.offline"],
+        entry_id="blocked_unavailable",
+    )
+    hass.states.async_set("cover.offline", STATE_UNAVAILABLE, {})
+
+    result = await _open_picker(hass, entry)
+
+    blocked = result["description_placeholders"]["blocked_types"]
+    assert "cover.offline" not in blocked
+    assert "cover.readable" in blocked

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -11,6 +11,7 @@ confirmed in memory, persisted (with exactly one reload) only at Save & Close.
 
 from __future__ import annotations
 
+import ast
 import contextlib
 from unittest.mock import AsyncMock, patch
 
@@ -1007,6 +1008,14 @@ def _add_profile(
     return profile
 
 
+def _sync_target_options(result: dict) -> list[dict]:
+    """Return the covers the sync step offers as copy targets."""
+    for marker, value in result["data_schema"].schema.items():
+        if str(marker) == "target_entries":
+            return list(value.config["options"])
+    raise AssertionError(f"no target_entries field in {result['data_schema'].schema}")
+
+
 @pytest.mark.integration
 async def test_sync_confirm_does_not_persist_a_pending_switch(
     hass: HomeAssistant,
@@ -1016,14 +1025,14 @@ async def test_sync_confirm_does_not_persist_a_pending_switch(
     ``async_step_sync_confirm`` writes ``options=dict(self.options)`` so the
     copy sees the latest values. With a switch pending those options already
     carry the awning re-seed, so the write leaves a BLIND whose no-sun default
-    is 0 % — and reloads it straight into that state.
+    is 0 % — and reloads it straight into that state, and hands that 0 % on to
+    every cover it then copies into.
     """
     sibling = await _setup_entry(
         hass,
-        cover_type=CoverType.AWNING,
-        entities=["cover.awning_a"],
-        extra_options={"length_awning": 2.1, "angle": 0},
-        entry_id="sync_sibling_awning",
+        entities=["cover.blind_a"],
+        extra_options={CONF_DEFAULT_HEIGHT: 90},
+        entry_id="sync_sibling_blind",
     )
     entry = await _setup_entry(hass, entry_id="sync_pending_switch")
     assert entry.options[CONF_DEFAULT_HEIGHT] == 50
@@ -1046,6 +1055,105 @@ async def test_sync_confirm_does_not_persist_a_pending_switch(
     assert entry.options[CONF_DEFAULT_HEIGHT] == 50
     # The incoming type's geometry is part of the same pending switch.
     assert "length_awning" not in entry.options
+    # What the source persisted is what the target receives — the copy reads
+    # the source entry back off disk, so a leaked re-seed lands here too.
+    assert sibling.options[CONF_DEFAULT_HEIGHT] == 50
+    assert "length_awning" not in sibling.options
+
+
+@pytest.mark.integration
+async def test_sync_targets_are_filtered_by_the_stored_type(
+    hass: HomeAssistant,
+) -> None:
+    """A pending switch must not re-aim "Copy to other covers" at the new type.
+
+    The write that precedes the copy rolls the pending switch back out, so what
+    ``_extract_shared_options`` reads off the entry is the OUTGOING type's
+    values. Offering the incoming type's covers as targets would copy one type's
+    positions onto another's — the target filter and the copied values have to
+    describe the same cover type, and only the stored one is on both sides.
+    """
+    awning_sibling = await _setup_entry(
+        hass,
+        cover_type=CoverType.AWNING,
+        entities=["cover.probe_awning"],
+        extra_options={"length_awning": 2.1, "angle": 0, CONF_DEFAULT_HEIGHT: 10},
+        entry_id="probe_sibling_awning",
+    )
+    blind_sibling = await _setup_entry(
+        hass,
+        entities=["cover.probe_blind"],
+        extra_options={CONF_DEFAULT_HEIGHT: 90},
+        entry_id="probe_sibling_blind",
+    )
+    entry = await _setup_entry(
+        hass,
+        extra_options={CONF_DEFAULT_HEIGHT: 80},
+        entry_id="probe_sync_source",
+    )
+
+    menu = await _confirm_and_return_to_menu(hass, entry, CoverType.AWNING)
+    sync = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "sync"}
+    )
+
+    offered = {opt["value"] for opt in _sync_target_options(sync)}
+    assert offered == {blind_sibling.entry_id}
+    assert awning_sibling.entry_id not in offered
+
+
+@pytest.mark.integration
+async def test_sync_does_not_write_inverted_positions_to_siblings(
+    hass: HomeAssistant,
+) -> None:
+    """The copy must never land a blind's 80 % on an awning as "extended 80 %".
+
+    ``SYNC_CATEGORIES["position"]`` carries every polarity-sensitive key
+    (``default_percentage``, ``min_position``, ``max_position``,
+    ``sunset_position``, ``my_position_value``), so a target of the wrong type
+    gets the whole inverted block — silently, on someone else's cover.
+    """
+    awning_sibling = await _setup_entry(
+        hass,
+        cover_type=CoverType.AWNING,
+        entities=["cover.inverted_awning"],
+        extra_options={"length_awning": 2.1, "angle": 0, CONF_DEFAULT_HEIGHT: 10},
+        entry_id="inverted_sibling_awning",
+    )
+    blind_sibling = await _setup_entry(
+        hass,
+        entities=["cover.inverted_blind"],
+        extra_options={CONF_DEFAULT_HEIGHT: 90},
+        entry_id="inverted_sibling_blind",
+    )
+    entry = await _setup_entry(
+        hass,
+        extra_options={CONF_DEFAULT_HEIGHT: 80},
+        entry_id="inverted_sync_source",
+    )
+
+    menu = await _confirm_and_return_to_menu(hass, entry, CoverType.AWNING)
+    sync = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "sync"}
+    )
+    targets = [opt["value"] for opt in _sync_target_options(sync)]
+    confirm = await hass.config_entries.options.async_configure(
+        sync["flow_id"],
+        {"target_entries": targets, "sync_categories": ["position"]},
+    )
+    await hass.config_entries.options.async_configure(
+        confirm["flow_id"], {"confirm": True}
+    )
+    await hass.async_block_till_done()
+
+    # The awning is a different cover type — nothing of this blind's belongs
+    # in it, least of all a position whose ends mean the opposite.
+    assert awning_sibling.options[CONF_DEFAULT_HEIGHT] == 10
+    # The same-type sibling gets the source's stored (blind) value.
+    assert blind_sibling.options[CONF_DEFAULT_HEIGHT] == 80
+    # And the source is untouched: still a blind, still 80.
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 80
 
 
 @pytest.mark.integration
@@ -1156,45 +1264,275 @@ async def test_mid_flow_write_without_a_pending_switch_is_unchanged(
     assert sibling.options[CONF_DEFAULT_HEIGHT] == 33
 
 
+@pytest.mark.integration
+async def test_mid_flow_write_keeps_a_position_re_entered_after_the_switch(
+    hass: HomeAssistant,
+) -> None:
+    """A value the user typed after confirming is an edit, not the switch's.
+
+    The rollback restores what the switch put there. Once the user has typed
+    over the re-seeded ``default_percentage``, the switch's contribution to that
+    key is gone — what is there is an ordinary edit, and the seam promises those
+    survive a mid-dialog write like any other.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import _PROFILE_NONE_SENTINEL
+    from custom_components.adaptive_cover_pro.const import CONF_BUILDING_PROFILE_ID
+
+    profile = _add_profile(hass, entry_id="profile_for_reentry")
+    entry = await _setup_entry(
+        hass,
+        entry_id="reentered_default",
+        extra_options={CONF_BUILDING_PROFILE_ID: profile.entry_id},
+    )
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 50
+
+    menu = await _confirm_and_return_to_menu(hass, entry, CoverType.AWNING)
+    position = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "position"}
+    )
+    menu = await hass.config_entries.options.async_configure(
+        position["flow_id"], {CONF_DEFAULT_HEIGHT: 30}
+    )
+    form = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "building_profile"}
+    )
+    await hass.config_entries.options.async_configure(
+        form["flow_id"], {CONF_BUILDING_PROFILE_ID: _PROFILE_NONE_SENTINEL}
+    )
+    await hass.async_block_till_done()
+
+    # The switch itself is still pending, and its own contribution still unwinds.
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    assert "length_awning" not in entry.options
+    # But the typed-over position is the user's, not the switch's.
+    assert entry.options[CONF_DEFAULT_HEIGHT] == 30
+
+
+_OWN_ENTRY_ATTR = "_config_entry"
+
+
+def _called_name(call: ast.Call) -> str | None:
+    """Return the bare name of what *call* invokes (``a.b.c()`` → ``"c"``)."""
+    return getattr(call.func, "attr", None) or getattr(call.func, "id", None)
+
+
+def _is_own_entry(node: ast.AST | None, aliases: set[str]) -> bool:
+    """Whether *node* evaluates to this flow's own config entry."""
+    if isinstance(node, ast.Attribute):
+        return (
+            node.attr == _OWN_ENTRY_ATTR
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+        )
+    return isinstance(node, ast.Name) and node.id in aliases
+
+
+def _own_entry_aliases(func: ast.AST) -> set[str]:
+    """Local names bound to ``self._config_entry`` anywhere inside *func*.
+
+    Assigning to a local is the cheapest way to walk past a guard that only
+    looks at ``self._config_entry`` literally, so the alias set is transitive
+    (``a = self._config_entry`` then ``b = a``) and is rebuilt to a fixpoint
+    rather than in source order.
+    """
+    aliases: set[str] = set()
+    grew = True
+    while grew:
+        grew = False
+        for node in ast.walk(func):
+            if isinstance(node, ast.Assign):
+                targets, value = node.targets, node.value
+            elif isinstance(node, ast.AnnAssign | ast.NamedExpr):
+                if node.value is None:
+                    continue
+                targets, value = [node.target], node.value
+            else:
+                continue
+            if not _is_own_entry(value, aliases):
+                continue
+            for target in targets:
+                if isinstance(target, ast.Name) and target.id not in aliases:
+                    aliases.add(target.id)
+                    grew = True
+    return aliases
+
+
+def _entry_writing_helpers() -> frozenset[str]:
+    """Every function in the integration that calls ``async_update_entry``.
+
+    Derived, not listed: a helper added later that writes an entry is picked up
+    without anyone remembering to name it here.
+    """
+    import pathlib
+
+    from custom_components.adaptive_cover_pro import config_flow as cf
+
+    names: set[str] = set()
+    for path in sorted(pathlib.Path(cf.__file__).parent.rglob("*.py")):
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and any(
+                isinstance(call, ast.Call)
+                and _called_name(call) == "async_update_entry"
+                for call in ast.walk(node)
+            ):
+                names.add(node.name)
+    return frozenset(names)
+
+
+def _seam_violations(
+    source: str, *, class_name: str, writer_helpers: frozenset[str]
+) -> tuple[set[str], set[tuple[str, str]]]:
+    """Find every place *class_name* writes its own config entry.
+
+    Returns ``(direct, indirect)``: method names that call
+    ``async_update_entry`` on their own entry, and ``(method, helper)`` pairs
+    that hand their own entry to something that writes it for them.
+
+    Only methods declared directly on the class are iterated, so a call inside
+    a nested closure is attributed to the method that contains it rather than
+    to the closure's own name.
+    """
+    tree = ast.parse(source)
+    cls = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.ClassDef) and n.name == class_name
+    )
+
+    direct: set[str] = set()
+    indirect: set[tuple[str, str]] = set()
+    for method in cls.body:
+        if not isinstance(method, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        aliases = _own_entry_aliases(method)
+        for node in ast.walk(method):
+            if not isinstance(node, ast.Call):
+                continue
+            name = _called_name(node)
+            if name == "async_update_entry":
+                # ``entry`` is positional-or-keyword on HA's signature.
+                entry = (
+                    node.args[0]
+                    if node.args
+                    else next(
+                        (kw.value for kw in node.keywords if kw.arg == "entry"), None
+                    )
+                )
+                if _is_own_entry(entry, aliases):
+                    direct.add(method.name)
+            elif name in writer_helpers and (
+                any(_is_own_entry(arg, aliases) for arg in node.args)
+                or any(_is_own_entry(kw.value, aliases) for kw in node.keywords)
+            ):
+                indirect.add((method.name, name))
+    return direct, indirect
+
+
+# Helpers that write a config entry and are handed this flow's own entry. Each
+# is listed with the reason it cannot land a pending cover-type switch:
+#
+# * ``_copy_profile_to_cover`` really does write ``self._config_entry`` — but it
+#   builds the new options from ``cover_entry.options``, i.e. what is on disk,
+#   never from ``self.options``, which is the only place a pending switch
+#   exists. ``async_step_building_profile`` then merges back only the keys the
+#   copier changed, so the switch stays pending and is still committed by the
+#   seam at Save & Close.
+# * ``clear_cover_override`` and ``propagate_profile_clears`` receive
+#   ``self._config_entry`` as the *profile* argument and write the covers linked
+#   to it. A profile is never linked to itself, so this flow's own entry is not
+#   among the entries they write.
+_ALLOWED_INDIRECT_WRITES = {
+    ("async_step_building_profile", "_copy_profile_to_cover"),
+    ("async_step_profile_overrides", "clear_cover_override"),
+    ("_propagate_profile_clears", "propagate_profile_clears"),
+}
+
+
+# A class shaped like every way a future edit could write its own entry without
+# writing the literal ``async_update_entry(self._config_entry, …)`` the first
+# version of this guard looked for.
+_SEAM_EVASIONS = """
+class OptionsFlowHandler:
+    def _persist_entry(self):
+        self.hass.config_entries.async_update_entry(self._config_entry, options={})
+
+    def aliased(self):
+        entry = self._config_entry
+        also = entry
+        self.hass.config_entries.async_update_entry(also, options={})
+
+    def keyword(self):
+        self.hass.config_entries.async_update_entry(
+            entry=self._config_entry, options={}
+        )
+
+    def nested(self):
+        def _inner():
+            self.hass.config_entries.async_update_entry(self._config_entry, options={})
+
+        _inner()
+
+    def indirect(self):
+        _copy_profile_to_cover(self.hass, profile, self._config_entry)
+
+    def hands_it_over_as_a_non_target(self, target):
+        _copy_profile_to_cover(self.hass, self._config_entry, target)
+
+    def writes_someone_else(self, target):
+        self.hass.config_entries.async_update_entry(target, options={})
+"""
+
+
+def test_seam_guard_sees_through_aliases_keywords_closures_and_helpers() -> None:
+    """The guard is only worth having if it cannot be stepped around.
+
+    Assigning the entry to a local, passing it by keyword, writing it from a
+    nested closure, or handing it to a helper that writes it are all the same
+    bypass. A guard that matches one literal call shape catches none of them.
+
+    Indirect writes are flagged wherever the entry appears in the argument
+    list, not just in the position the helper happens to write today — which
+    argument is the written one is the helper's business and can change. That
+    is what ``_ALLOWED_INDIRECT_WRITES`` is for: each reviewed call site says
+    in prose why it is safe, and an unreviewed one fails.
+    """
+    direct, indirect = _seam_violations(
+        _SEAM_EVASIONS,
+        class_name="OptionsFlowHandler",
+        writer_helpers=frozenset({"_copy_profile_to_cover"}),
+    )
+
+    assert direct == {"_persist_entry", "aliased", "keyword", "nested"}
+    assert "writes_someone_else" not in direct
+    assert indirect == {
+        ("indirect", "_copy_profile_to_cover"),
+        ("hands_it_over_as_a_non_target", "_copy_profile_to_cover"),
+    }
+
+
 def test_options_flow_writes_its_own_entry_through_one_seam() -> None:
-    """Every ``async_update_entry(self._config_entry, …)`` goes through the seam.
+    """Every write of this flow's own entry goes through ``_persist_entry``.
 
     The drift guard for the fix: a future step that persists ``self.options``
     directly would silently reintroduce the half-applied switch.
     """
-    import ast
     import inspect
 
     from custom_components.adaptive_cover_pro import config_flow as cf
 
-    tree = ast.parse(inspect.getsource(cf))
-    handler = next(
-        n
-        for n in ast.walk(tree)
-        if isinstance(n, ast.ClassDef) and n.name == "OptionsFlowHandler"
+    direct, indirect = _seam_violations(
+        inspect.getsource(cf),
+        class_name="OptionsFlowHandler",
+        writer_helpers=_entry_writing_helpers(),
     )
 
-    callers: set[str] = set()
-    for func in ast.walk(handler):
-        if not isinstance(func, ast.FunctionDef | ast.AsyncFunctionDef):
-            continue
-        for node in ast.walk(func):
-            if not isinstance(node, ast.Call):
-                continue
-            if getattr(node.func, "attr", None) != "async_update_entry":
-                continue
-            first = node.args[0] if node.args else None
-            if (
-                isinstance(first, ast.Attribute)
-                and first.attr == "_config_entry"
-                and isinstance(first.value, ast.Name)
-                and first.value.id == "self"
-            ):
-                callers.add(func.name)
-
-    assert callers == {
+    assert direct == {
         "_persist_entry"
-    }, f"self._config_entry is written outside the seam: {sorted(callers)}"
+    }, f"self._config_entry is written outside the seam: {sorted(direct)}"
+    assert indirect <= _ALLOWED_INDIRECT_WRITES, (
+        "self._config_entry is handed to an entry-writing helper from a call "
+        f"site that has not been reviewed: {sorted(indirect - _ALLOWED_INDIRECT_WRITES)}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1248,9 +1586,12 @@ async def test_round_trip_switch_restores_the_original_default(
 async def test_round_trip_switch_reloads_nothing(hass: HomeAssistant) -> None:
     """Back on the type it started as, Save & Close has nothing to apply.
 
-    Counted across BOTH reload paths: the sticky flag writes ``data`` (a no-op)
-    and schedules an explicit reload, and the re-seed round trip leaves a
-    ``default_percentage`` delta the update listener reloads for on its own.
+    Counted across BOTH reload paths, because a round trip can trip either.
+    ``_cover_type_changed`` is derived from ``self.sensor_type`` against the
+    stored one, so A → B → A must read as "no switch" and skip the ``data``
+    write and the explicit reload it schedules; and the re-seed each hop applied
+    must unwind, or the leftover ``default_percentage`` delta has the update
+    listener reloading on its own.
     """
     from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
 

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -1,0 +1,645 @@
+"""Options-flow "Change Cover Type" step (issue #1132).
+
+``CONF_SENSOR_TYPE`` lives in ``config_entry.data`` and, before this feature, no
+post-creation write path touched ``data`` — so a cover's type could only change
+by deleting and re-adding the entry, which re-mints every ACP entity's
+``unique_id`` (``entity_base.py``: ``f"{entry_id}_{suffix}"``) and breaks every
+dashboard and automation referencing them. These tests pin the new options-flow
+step that rewrites ``entry.data[CONF_SENSOR_TYPE]`` in place.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.helpers import bound_cover_capabilities
+from custom_components.adaptive_cover_pro.migrations import (
+    _PRUNE_SENSORS_V1_FLAG,
+    _PRUNE_SENSORS_V2_FLAG,
+    _PRUNE_V1_FLAG,
+)
+
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+# ---------------------------------------------------------------------------
+# Step 2 — shared cap-map builder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_bound_cover_capabilities_maps_each_entity(hass: HomeAssistant) -> None:
+    """Each bound entity maps to its feature dict; unreadable ones map to None."""
+    from homeassistant.components.cover import CoverEntityFeature
+    from homeassistant.const import STATE_UNAVAILABLE
+
+    hass.states.async_set(
+        "cover.a",
+        "open",
+        {"supported_features": int(CoverEntityFeature.SET_POSITION)},
+    )
+    hass.states.async_set("cover.b", STATE_UNAVAILABLE, {})
+
+    known = bound_cover_capabilities(hass, {CONF_ENTITIES: ["cover.a", "cover.b"]})
+
+    assert set(known) == {"cover.a", "cover.b"}
+    assert known["cover.a"]["has_set_position"] is True
+    assert known["cover.a"]["has_set_tilt_position"] is False
+    assert known["cover.b"] is None
+
+
+@pytest.mark.integration
+async def test_bound_cover_capabilities_empty_without_hass_or_entities(
+    hass: HomeAssistant,
+) -> None:
+    """No hass or no bound entities → an empty map, never a crash."""
+    assert bound_cover_capabilities(None, {CONF_ENTITIES: ["cover.a"]}) == {}
+    assert bound_cover_capabilities(hass, {}) == {}
+    assert bound_cover_capabilities(hass, {CONF_ENTITIES: []}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers for the options-flow tests
+# ---------------------------------------------------------------------------
+
+
+def _position_only_cover(hass: HomeAssistant, entity_id: str) -> None:
+    """Register a cover that supports set_position but not set_tilt_position."""
+    from homeassistant.components.cover import CoverEntityFeature
+
+    features = (
+        CoverEntityFeature.OPEN
+        | CoverEntityFeature.CLOSE
+        | CoverEntityFeature.STOP
+        | CoverEntityFeature.SET_POSITION
+    )
+    hass.states.async_set(
+        entity_id,
+        "open",
+        {"current_position": 100, "supported_features": int(features)},
+    )
+
+
+async def _setup_entry(
+    hass: HomeAssistant,
+    *,
+    cover_type: str = CoverType.BLIND,
+    entities: list[str] | None = None,
+    extra_options: dict | None = None,
+    entry_id: str = "change_type_01",
+) -> MockConfigEntry:
+    """Register + set up an entry whose covers are position-capable."""
+    import datetime
+
+    entities = entities or ["cover.test_blind"]
+    hass.states.async_set(
+        "sun.sun",
+        "above_horizon",
+        {
+            "azimuth": 180.0,
+            "elevation": 45.0,
+            "rising": True,
+            "next_rising": datetime.datetime.now(datetime.UTC).isoformat(),
+            "next_setting": datetime.datetime.now(datetime.UTC).isoformat(),
+        },
+    )
+    for eid in entities:
+        _position_only_cover(hass, eid)
+
+    options = dict(VERTICAL_OPTIONS)
+    options[CONF_ENTITIES] = list(entities)
+    # Model an entry that has already completed its one-time orphan-prune
+    # migrations. Without these, the prune passes write ``entry.options`` DURING
+    # setup — after the coordinator snapshotted ``_cached_options`` — leaving the
+    # cache permanently stale, so the update listener sees a non-empty diff and
+    # reloads on the next ``async_update_entry`` no matter what changed. That is
+    # pre-existing first-boot behaviour unrelated to the cover-type switch; a
+    # settled entry is what these tests need to measure.
+    options[_PRUNE_V1_FLAG] = True
+    options[_PRUNE_SENSORS_V1_FLAG] = True
+    options[_PRUNE_SENSORS_V2_FLAG] = True
+    options.update(extra_options or {})
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Switchable", CONF_SENSOR_TYPE: cover_type},
+        options=options,
+        entry_id=entry_id,
+        title="Switchable",
+    )
+    entry.add_to_hass(hass)
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _en_json() -> dict:
+    """Load the English translation bundle."""
+    import json
+    import os
+
+    path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "custom_components",
+        "adaptive_cover_pro",
+        "translations",
+        "en.json",
+    )
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# Step 3 — menu entry + label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_change_cover_type_in_cover_menu(hass: HomeAssistant) -> None:
+    """A real cover's options menu offers the change-cover-type row."""
+    entry = await _setup_entry(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "menu"
+    menu = result["menu_options"]
+    assert "change_cover_type" in menu
+    # Layer 1 placement: right after "Covers & Device", before geometry.
+    assert (
+        menu.index("cover_entities")
+        < menu.index("change_cover_type")
+        < menu.index("geometry")
+    )
+
+
+@pytest.mark.integration
+async def test_change_cover_type_absent_from_profile_and_group_menus(
+    hass: HomeAssistant,
+) -> None:
+    """Virtual entry types (profile, group) never offer a cover-type switch."""
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    for cover_type, entry_id in (
+        (CoverType.BUILDING_PROFILE, "virtual_profile"),
+        (CoverType.GROUP, "virtual_group"),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"name": "Virtual", CONF_SENSOR_TYPE: cover_type},
+            options={},
+            entry_id=entry_id,
+            title="Virtual",
+        )
+        entry.add_to_hass(hass)
+        flow = OptionsFlowHandler(entry)
+        flow.hass = hass
+        result = await flow.async_step_init()
+        assert "change_cover_type" not in result["menu_options"], cover_type
+
+
+def test_change_cover_type_has_menu_label() -> None:
+    """The new menu entry needs an en.json label or it renders as a blank row."""
+    labels = _en_json()["options"]["step"]["init"]["menu_options"]
+    assert labels.get("change_cover_type", "").strip()
+
+
+# ---------------------------------------------------------------------------
+# Step 4 — the picker
+# ---------------------------------------------------------------------------
+
+
+def _type_selector(result: dict):
+    """Return the cover-type SelectSelector rendered by the picker step."""
+    for marker, value in result["data_schema"].schema.items():
+        if str(marker) == CONF_SENSOR_TYPE:
+            return value
+    raise AssertionError(
+        f"no {CONF_SENSOR_TYPE} field in {result['data_schema'].schema}"
+    )
+
+
+async def _open_picker(hass: HomeAssistant, entry: MockConfigEntry) -> dict:
+    """Walk the options flow from the menu into the change-cover-type picker."""
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    return await hass.config_entries.options.async_configure(
+        result["flow_id"], {"next_step_id": "change_cover_type"}
+    )
+
+
+@pytest.mark.integration
+async def test_picker_offers_capability_compatible_types_only(
+    hass: HomeAssistant,
+) -> None:
+    """Only types whose entity filter the bound covers satisfy are offered."""
+    entry = await _setup_entry(hass)
+
+    result = await _open_picker(hass, entry)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "change_cover_type"
+    offered = _type_selector(result).config["options"]
+    # Position-capable, no tilt: every plain-domain and position-filtered type.
+    assert CoverType.DAY_NIGHT_SHADE in offered
+    assert CoverType.DUAL_PANEL in offered
+    assert CoverType.AWNING in offered
+    # Tilt-filtered types cannot take a position-only cover.
+    assert CoverType.TILT not in offered
+    assert CoverType.VENETIAN not in offered
+    assert CoverType.LOUVERED_ROOF not in offered
+    # Never offer the type it already is.
+    assert CoverType.BLIND not in offered
+
+
+@pytest.mark.integration
+async def test_picker_excludes_virtual_types(hass: HomeAssistant) -> None:
+    """Building Profile / Group are virtual entry types, never switch targets."""
+    entry = await _setup_entry(hass, entry_id="change_type_virtual")
+
+    offered = _type_selector(await _open_picker(hass, entry)).config["options"]
+
+    assert CoverType.BUILDING_PROFILE not in offered
+    assert CoverType.GROUP not in offered
+
+
+@pytest.mark.integration
+async def test_picker_lists_blocked_types_with_reason(hass: HomeAssistant) -> None:
+    """Filtered-out types are explained, not silently absent."""
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    entry = await _setup_entry(hass, entry_id="change_type_blocked")
+
+    result = await _open_picker(hass, entry)
+
+    blocked_text = result["description_placeholders"]["blocked_types"]
+    assert get_policy(CoverType.VENETIAN).display_label() in blocked_text
+    assert "set_tilt_position" in blocked_text
+    # The current type names itself in the description.
+    assert (
+        get_policy(CoverType.BLIND).display_label()
+        in result["description_placeholders"]["current_type"]
+    )
+
+
+@pytest.mark.integration
+async def test_picker_uses_mode_translation_key(hass: HomeAssistant) -> None:
+    """Reuse the ten already-translated selector.mode labels — no new strings."""
+    entry = await _setup_entry(hass, entry_id="change_type_i18n")
+
+    selector_ = _type_selector(await _open_picker(hass, entry))
+
+    assert selector_.config["translation_key"] == "mode"
+    mode_options = _en_json()["selector"]["mode"]["options"]
+    assert set(selector_.config["options"]).issubset(mode_options)
+
+
+@pytest.mark.integration
+async def test_picker_aborts_when_nothing_eligible(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No destination type → an explained abort, not an empty dropdown."""
+    from custom_components.adaptive_cover_pro import config_flow as cf
+
+    entry = await _setup_entry(hass, entry_id="change_type_abort")
+    monkeypatch.setattr(cf, "SENSOR_TYPE_MENU", [CoverType.BLIND])
+
+    result = await _open_picker(hass, entry)
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "no_eligible_cover_types"
+    assert _en_json()["options"]["abort"]["no_eligible_cover_types"].strip()
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — the confirm screen
+# ---------------------------------------------------------------------------
+
+
+async def _pick(hass: HomeAssistant, entry: MockConfigEntry, new_type: str) -> dict:
+    """Open the picker and submit *new_type*, landing on the confirm screen."""
+    picker = await _open_picker(hass, entry)
+    return await hass.config_entries.options.async_configure(
+        picker["flow_id"], {CONF_SENSOR_TYPE: new_type}
+    )
+
+
+@pytest.mark.integration
+async def test_confirm_step_shown_after_pick(hass: HomeAssistant) -> None:
+    """Picking a destination type lands on an explicit confirm screen."""
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    entry = await _setup_entry(hass, entry_id="confirm_shown")
+
+    result = await _pick(hass, entry, CoverType.AWNING)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "change_cover_type_confirm"
+    assert "confirm" in {str(m) for m in result["data_schema"].schema}
+    placeholders = result["description_placeholders"]
+    assert placeholders["from_type"] == get_policy(CoverType.BLIND).display_label()
+    assert placeholders["to_type"] == get_policy(CoverType.AWNING).display_label()
+    # Nothing is written until the user confirms.
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+
+
+@pytest.mark.integration
+async def test_confirm_lists_stranded_options(hass: HomeAssistant) -> None:
+    """Options only the outgoing type reads are named — non-blocking."""
+    entry = await _setup_entry(
+        hass,
+        entry_id="confirm_stranded",
+        extra_options={
+            "enable_glare_zones": True,
+            "glare_zone_1_name": "Sofa",
+        },
+    )
+
+    result = await _pick(hass, entry, CoverType.AWNING)
+
+    stranded = result["description_placeholders"]["stranded_options"]
+    assert "enable_glare_zones" in stranded
+    assert "glare_zone_1_name" in stranded
+
+
+@pytest.mark.integration
+async def test_confirm_shows_capability_notes(hass: HomeAssistant) -> None:
+    """Capability advice is evaluated against the DESTINATION type."""
+    entry = await _setup_entry(hass, entry_id="confirm_caps")
+
+    result = await _pick(hass, entry, CoverType.DAY_NIGHT_SHADE)
+
+    notes = result["description_placeholders"]["capability_notes"]
+    assert "set_tilt_position" in notes
+
+
+@pytest.mark.integration
+async def test_declining_confirm_leaves_type_unchanged(hass: HomeAssistant) -> None:
+    """Unticking confirm returns to the menu with nothing written."""
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    entry = await _setup_entry(hass, entry_id="confirm_declined")
+    confirmed = await _pick(hass, entry, CoverType.AWNING)
+
+    result = await hass.config_entries.options.async_configure(
+        confirmed["flow_id"], {"confirm": False}
+    )
+
+    assert result["type"] == "menu"
+    assert result["step_id"] == "init"
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.BLIND
+    flow = next(
+        f
+        for f in hass.config_entries.options.async_progress()
+        if f["flow_id"] == confirmed["flow_id"]
+    )
+    handler = hass.config_entries.options._progress[flow["flow_id"]]
+    assert isinstance(handler, OptionsFlowHandler)
+    assert handler._cover_type_changed is False
+
+
+# ---------------------------------------------------------------------------
+# Step 6 — the entry.data write and in-memory propagation
+# ---------------------------------------------------------------------------
+
+
+async def _confirm(hass: HomeAssistant, entry: MockConfigEntry, new_type: str) -> dict:
+    """Pick *new_type* and tick the confirm box."""
+    confirm = await _pick(hass, entry, new_type)
+    return await hass.config_entries.options.async_configure(
+        confirm["flow_id"], {"confirm": True}
+    )
+
+
+@pytest.mark.integration
+async def test_confirm_writes_entry_data(hass: HomeAssistant) -> None:
+    """Confirming rewrites entry.data in place and leaves options untouched."""
+    entry = await _setup_entry(hass, entry_id="write_data")
+    options_before = dict(entry.options)
+
+    await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert entry.data["name"] == "Switchable"
+    assert dict(entry.options) == options_before
+
+
+@pytest.mark.integration
+async def test_confirm_routes_into_geometry_with_new_type_schema(
+    hass: HomeAssistant,
+) -> None:
+    """The follow-on step is the existing geometry form, rendered for the new type."""
+    entry = await _setup_entry(hass, entry_id="route_geometry")
+
+    result = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "geometry"
+    markers = {str(m) for m in result["data_schema"].schema}
+    assert "day_night_control_model" in markers
+    assert "day_night_middle_rail_entity" in markers
+
+
+@pytest.mark.integration
+async def test_confirm_alone_does_not_reload(hass: HomeAssistant) -> None:
+    """The coordinator keeps running the OLD policy until Save & Close.
+
+    A reload at confirm time would bring the coordinator up on the new type with
+    none of its geometry collected yet — for Day/Night that means defaulting to
+    Model A on position-only hardware and driving both rails together.
+    """
+    entry = await _setup_entry(hass, entry_id="no_reload_yet")
+
+    with (
+        patch.object(hass.config_entries, "async_schedule_reload") as sched,
+        patch.object(hass.config_entries, "async_reload") as reload,
+    ):
+        await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        await hass.async_block_till_done()
+
+    sched.assert_not_called()
+    reload.assert_not_called()
+
+
+@pytest.mark.integration
+async def test_menu_after_switch_reflects_new_type(hass: HomeAssistant) -> None:
+    """Back at the menu, every gate reads the incoming type's policy."""
+    entry = await _setup_entry(
+        hass,
+        entry_id="menu_after_switch",
+        extra_options={"enable_glare_zones": True},
+    )
+    menu_before = await hass.config_entries.options.async_init(entry.entry_id)
+    assert "glare_zones" in menu_before["menu_options"]
+    hass.config_entries.options.async_abort(menu_before["flow_id"])
+
+    geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+    menu = await hass.config_entries.options.async_configure(geometry["flow_id"], {})
+
+    assert menu["type"] == "menu"
+    assert menu["step_id"] == "init"
+    # Day/Night has no glare zones — the row is gone even though the option is on.
+    assert "glare_zones" not in menu["menu_options"]
+
+
+# ---------------------------------------------------------------------------
+# Step 7 — exactly one reload, at Save & Close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_done_schedules_reload_after_type_change(hass: HomeAssistant) -> None:
+    """Save & Close applies the switch with exactly one scheduled reload."""
+    entry = await _setup_entry(hass, entry_id="reload_on_done")
+
+    with patch.object(hass.config_entries, "async_schedule_reload") as sched:
+        geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        menu = await hass.config_entries.options.async_configure(
+            geometry["flow_id"], {}
+        )
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+    sched.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.integration
+async def test_done_does_not_schedule_reload_without_type_change(
+    hass: HomeAssistant,
+) -> None:
+    """An ordinary Save & Close does not gain a reload it never had."""
+    entry = await _setup_entry(hass, entry_id="reload_no_change")
+
+    with patch.object(hass.config_entries, "async_schedule_reload") as sched:
+        menu = await hass.config_entries.options.async_init(entry.entry_id)
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+    sched.assert_not_called()
+
+
+@pytest.mark.integration
+async def test_reload_scheduled_even_when_options_unchanged(
+    hass: HomeAssistant,
+) -> None:
+    """The reload must be explicit, not left to the options-write listener.
+
+    If the geometry form comes back byte-identical, ``_async_update_listener``
+    sees an empty diff and reloads nothing — the coordinator would keep running
+    the OLD policy until the next HA restart.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    entry = await _setup_entry(hass, entry_id="reload_options_same")
+
+    async def _straight_back_to_menu(self, user_input=None):
+        return await self.async_step_init()
+
+    with (
+        patch.object(hass.config_entries, "async_schedule_reload") as sched,
+        patch.object(OptionsFlowHandler, "async_step_geometry", _straight_back_to_menu),
+    ):
+        options_before = dict(entry.options)
+        menu = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+        assert menu["type"] == "menu"
+        await hass.config_entries.options.async_configure(
+            menu["flow_id"], {"next_step_id": "done"}
+        )
+        await hass.async_block_till_done()
+
+    assert dict(entry.options) == options_before
+    sched.assert_called_once_with(entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# Step 8 — entity-ID preservation, end to end (the acceptance test)
+# ---------------------------------------------------------------------------
+
+
+def _registry_snapshot(hass: HomeAssistant, entry: MockConfigEntry) -> dict[str, str]:
+    """Map ``unique_id → entity_id`` for every registry row owned by *entry*."""
+    from homeassistant.helpers import entity_registry as er
+
+    reg = er.async_get(hass)
+    return {
+        e.unique_id: e.entity_id
+        for e in er.async_entries_for_config_entry(reg, entry.entry_id)
+    }
+
+
+@pytest.mark.integration
+async def test_entity_ids_survive_a_cover_type_switch(hass: HomeAssistant) -> None:
+    """The whole point of the feature: no entity is re-minted by a type switch."""
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_DUAL_PANEL_BLACKOUT_TRIGGERS,
+        CONF_DUAL_PANEL_FRONT_ENTITY,
+    )
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    entry = await _setup_entry(
+        hass,
+        cover_type=CoverType.DUAL_PANEL,
+        entities=["cover.panel_front", "cover.panel_back"],
+        extra_options={
+            CONF_DUAL_PANEL_FRONT_ENTITY: "cover.panel_front",
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["night"],
+        },
+        entry_id="e2e_switch",
+    )
+    await hass.async_block_till_done()
+
+    before = _registry_snapshot(hass, entry)
+    assert before, "no entities registered for the entry"
+    tilt_uid = f"{entry.entry_id}_Cover_Tilt"
+    rtd_uid = f"{entry.entry_id}_Return to default when disabled"
+    assert tilt_uid not in before  # dual panel is single-axis
+    assert rtd_uid in before  # dual panel offers return-to-default
+
+    geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+    menu = await hass.config_entries.options.async_configure(geometry["flow_id"], {})
+    await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+    after = _registry_snapshot(hass, entry)
+
+    shared = set(before) & set(after)
+    assert shared
+    for uid in shared:
+        assert after[uid] == before[uid], f"{uid} was re-minted"
+    assert not [e for e in after.values() if e.endswith("_2")]
+
+    # Day/Night exposes the dual-axis Target Tilt sensor; dual panel does not.
+    assert tilt_uid in after
+    # The dual-panel-only switch row is preserved, not deleted — deleting would
+    # release the entity_id and re-mint it as `_2` if the user switches back.
+    assert rtd_uid in after
+    assert after[rtd_uid] == before[rtd_uid]
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert (
+        entry.runtime_data._policy.cover_type
+        == get_policy(CoverType.DAY_NIGHT_SHADE).cover_type
+    )
+
+
+def test_config_entry_version_unchanged() -> None:
+    """No new option key → no migration, no version bump (rollback safety)."""
+    from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
+
+    assert ConfigFlowHandler.VERSION == 3
+    assert ConfigFlowHandler.MINOR_VERSION == 13

--- a/tests/test_config_flow_summary.py
+++ b/tests/test_config_flow_summary.py
@@ -4069,3 +4069,44 @@ def test_manual_override_summary_tolerates_an_unknown_duration_mode():
 
     assert isinstance(summary, str)
     assert "pauses for 3 h" in _manual_block(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Issue #1132 — the summary must follow a mid-dialog cover-type switch
+# ---------------------------------------------------------------------------
+
+
+async def test_summary_renders_incoming_type_after_switch(hass) -> None:
+    """After a cover-type switch the summary describes the INCOMING type.
+
+    ``_build_config_summary`` reads the in-memory ``self.sensor_type``, which the
+    change-cover-type step rewrites, so this needs no summary-side change — it
+    pins that the two stay wired together.
+    """
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+    from tests.test_config_flow_change_cover_type import _confirm, _setup_entry
+
+    entry = await _setup_entry(
+        hass,
+        cover_type=CoverType.DUAL_PANEL,
+        entities=["cover.panel_front", "cover.panel_back"],
+        extra_options={
+            CONF_DUAL_PANEL_FRONT_ENTITY: "cover.panel_front",
+            CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: ["night"],
+        },
+        entry_id="summary_after_switch",
+    )
+
+    geometry = await _confirm(hass, entry, CoverType.DAY_NIGHT_SHADE)
+    menu = await hass.config_entries.options.async_configure(geometry["flow_id"], {})
+    summary_step = await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "summary"}
+    )
+
+    summary = summary_step["description_placeholders"]["summary"]
+    incoming = get_policy(CoverType.DAY_NIGHT_SHADE)
+    outgoing = get_policy(CoverType.DUAL_PANEL)
+    assert incoming.display_label() in summary
+    assert outgoing.display_label() not in summary
+    for line in incoming.summary_geometry_lines(dict(entry.options)):
+        assert line in summary

--- a/tests/test_cover_types/test_config_flow_dispatch.py
+++ b/tests/test_cover_types/test_config_flow_dispatch.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from custom_components.adaptive_cover_pro.cover_types import (
+    POLICY_REGISTRY,
     AwningPolicy,
     BlindPolicy,
     TiltPolicy,
@@ -72,6 +73,73 @@ class TestEntitySelectorFilter:
         # not AND, so we filter on the rarer capability and surface the
         # missing-set_position case via cover_capability_warnings).
         assert VenetianPolicy().entity_selector_filter() is TILT_CAPABLE_ENTITY_FILTER
+
+
+@pytest.mark.unit
+class TestEntitiesSatisfySelector:
+    """``entities_satisfy_selector`` inverts the selector filter into a predicate.
+
+    The "Change Cover Type" options step (issue #1132) needs to ask "would this
+    candidate policy's entity picker have admitted the covers already bound to
+    this instance?" without re-implementing the capability matrix. The predicate
+    is derived generically from ``entity_selector_filter()`` on the base class,
+    so an eleventh cover type answers it for free.
+    """
+
+    def test_plain_domain_filter_admits_open_close_only(self):
+        assert BlindPolicy().entities_satisfy_selector(
+            {
+                "cover.a": {
+                    "has_set_position": False,
+                    "has_set_tilt_position": False,
+                    "has_open": True,
+                    "has_close": True,
+                }
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "cover_type",
+        ["cover_tilt", "cover_venetian", "cover_louvered_roof"],
+    )
+    def test_tilt_filter_rejects_position_only(self, cover_type):
+        assert not get_policy(cover_type).entities_satisfy_selector(
+            {"cover.a": {"has_set_position": True, "has_set_tilt_position": False}}
+        )
+
+    @pytest.mark.parametrize(
+        "cover_type",
+        ["cover_tilt", "cover_venetian", "cover_louvered_roof"],
+    )
+    def test_tilt_filter_accepts_tilt_capable(self, cover_type):
+        assert get_policy(cover_type).entities_satisfy_selector(
+            {"cover.a": {"has_set_position": True, "has_set_tilt_position": True}}
+        )
+
+    def test_position_filter_rejects_open_close_only(self):
+        policy = get_policy("cover_day_night_shade")
+        assert not policy.entities_satisfy_selector(
+            {"cover.a": {"has_set_position": False, "has_open": True}}
+        )
+        assert policy.entities_satisfy_selector(
+            {"cover.a": {"has_set_position": True, "has_open": True}}
+        )
+
+    def test_unavailable_entity_is_skipped_not_failed(self):
+        # ``None`` caps mean "entity not readable right now" — create-time could
+        # not have judged it either, so it must not block the switch.
+        assert get_policy("cover_tilt").entities_satisfy_selector({"cover.a": None})
+
+    def test_empty_map_is_satisfied(self):
+        for cover_type in POLICY_REGISTRY:
+            assert get_policy(cover_type).entities_satisfy_selector({}) is True
+
+    @pytest.mark.parametrize("cover_type", list(POLICY_REGISTRY))
+    def test_every_registered_policy_answers(self, cover_type):
+        result = get_policy(cover_type).entities_satisfy_selector(
+            {"cover.a": {"has_set_position": True, "has_set_tilt_position": True}}
+        )
+        assert isinstance(result, bool)
 
 
 @pytest.mark.unit

--- a/tests/test_cover_types/test_config_flow_dispatch.py
+++ b/tests/test_cover_types/test_config_flow_dispatch.py
@@ -141,6 +141,38 @@ class TestEntitiesSatisfySelector:
         )
         assert isinstance(result, bool)
 
+    def test_unmapped_filter_feature_blocks_the_type(self, caplog):
+        """An unmappable filter feature makes the type ineligible, loudly.
+
+        Dropping it instead would answer "yes, these covers satisfy me" for a
+        requirement nothing checked — offering the type to hardware it cannot
+        drive, and hiding it from the explained blocked list at the same time.
+        """
+        import logging
+
+        from homeassistant.helpers import selector
+
+        from custom_components.adaptive_cover_pro.cover_types.base import (
+            CoverTypePolicy,
+        )
+
+        class _OpenTiltPolicy(BlindPolicy):
+            def entity_selector_filter(self):
+                return selector.EntityFilterSelectorConfig(
+                    domain="cover",
+                    supported_features=["cover.CoverEntityFeature.OPEN_TILT"],
+                )
+
+        with caplog.at_level(logging.WARNING, logger=CoverTypePolicy.__module__):
+            assert (
+                _OpenTiltPolicy().entities_satisfy_selector(
+                    {"cover.a": {"has_set_position": True}}
+                )
+                is False
+            )
+
+        assert "OPEN_TILT" in caplog.text
+
 
 @pytest.mark.unit
 class TestSummaryGeometryLines:

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -26,6 +26,7 @@ from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.cover_types.base import (
     CAP_HAS_SET_POSITION,
     CAP_HAS_SET_TILT_POSITION,
+    ENTITY_FILTER_FEATURE_CAPS,
     AxisDescriptor,
     CoverAxis,
     CoverDescriptor,
@@ -91,6 +92,23 @@ def test_entity_selector_filter_targets_cover_domain(
     """Every policy targets HA cover entities — the selector must say so."""
     flt = policy.entity_selector_filter()
     assert flt.get("domain") == "cover"
+
+
+@pytest.mark.unit
+def test_entity_filter_features_are_all_mapped(policy: CoverTypePolicy) -> None:
+    """Every feature a policy's picker filters on must have a ``CAP_*`` counterpart.
+
+    ``entities_satisfy_selector`` inverts the picker filter into a predicate via
+    ``ENTITY_FILTER_FEATURE_CAPS``. A feature name missing from that map — a new
+    cover type filtering on ``OPEN_TILT``, or a typo in an existing name — has no
+    capability to test, so the "would the picker have admitted these covers?"
+    question silently loses its content (issue #1132).
+    """
+    for feature in policy.entity_selector_filter().get("supported_features") or ():
+        assert feature in ENTITY_FILTER_FEATURE_CAPS, (
+            f"{policy.cover_type} filters on {feature!r}, which "
+            "ENTITY_FILTER_FEATURE_CAPS does not map to a CAP_* flag"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

A cover's type lives in `config_entry.data` and nothing wrote that key after creation, so the only way to retarget one was to delete the entry and add it again. That re-mints every ACP entity ID on the device and breaks the dashboards and automations pointing at them.

This adds a **Change Cover Type** step to the options flow. It offers only the types whose capability requirements the already-bound entities satisfy (reusing each policy's `entity_selector_filter()` through a new generic `entities_satisfy_selector()`), explains every type it filtered out rather than hiding it, warns about options that go inert on the destination type, discloses which stored positions invert their meaning, and gates the switch behind an explicit confirm. On Save & Close it writes `entry.data` and the options in one `async_update_entry` and reloads the entry exactly once.

Entity `unique_id`s are keyed on `entry_id`, never on the cover type, so every entity ID survives the switch. Outgoing option keys are left in place, so switching back finds its config intact.

No new config key, no `MINOR_VERSION` bump, `ConfigFlowHandler.VERSION` stays 3.

Four audit passes shaped the rest of the diff. Persisting the switch at confirm time leaked a half-applied type through every non-Save exit, so all writes of this flow's own entry now go through one `_persist_entry()` seam that rolls a pending switch back out unless it is the commit, with an AST guard that fails the suite if a new write site appears outside it. The polarity disclosure was enumerating 3 of ~10 inverting positions while claiming completeness, so positions are now enumerated structurally from the rendered policy sections and each carries a declared `PositionRole`, with a drift guard for unclassified additions. Sync target selection read the pending type while the values copied were the stored ones, which wrote inverted positions onto sibling covers.

## Testing
- ✅ 11759 tests passing

## Related Issues
Refs #1132