### PR TITLE
fix: ask the destination policy a model-neutral capability question (#1137)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -3663,9 +3663,10 @@ def _blocked_types_text(
     """Render one explained line per cover type the bound covers rule out.
 
     Each policy states its own requirement through
-    ``cover_capability_warnings`` — the same advisory text the create flow and
-    the configuration summary render — so this never grows a second capability
-    matrix.
+    ``prospective_capability_warnings`` — the same pre-configuration hook the
+    "Change Cover Type" confirm screen asks (issue #1137) — so this explains a
+    decision ``entities_satisfy_selector`` made using the same matrix that
+    made it, and never grows a second one.
 
     Covers HA cannot read yet (``None`` caps) are dropped first, exactly as
     ``helpers.check_cover_capabilities`` drops them before the same call. The
@@ -3679,7 +3680,7 @@ def _blocked_types_text(
     lines: list[str] = []
     for cover_type in blocked:
         policy = get_policy(cover_type)
-        reasons = policy.cover_capability_warnings(readable)
+        reasons = policy.prospective_capability_warnings(readable)
         reason = reasons[0] if reasons else _BLOCKED_TYPE_GENERIC_REASON
         lines.append(f"- **{policy.display_label(labels)}** — {reason}")
     return "\n".join(lines)
@@ -4990,8 +4991,13 @@ class OptionsFlowHandler(OptionsFlow):
         # Capability advice for the DESTINATION type, from the same helper the
         # create flow and the configuration summary already render. Read from
         # the live options — which covers are bound is not part of the switch.
+        # ``prospective=True`` (issue #1137): ``self.options`` still belong to
+        # the OUTGOING type here (the destination's own options, e.g. a
+        # day/night control model, aren't collected until the geometry step
+        # that follows), so an option-aware capability question would judge
+        # the destination against options it doesn't own yet.
         _, capability_notes = check_cover_capabilities(
-            self.options, new_type, self.hass
+            self.options, new_type, self.hass, prospective=True
         )
         return self.async_show_form(  # type: ignore[return-value]
             step_id="change_cover_type_confirm",

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -1443,9 +1443,7 @@ class CoverTypePolicy(ABC):
         """
         return selector.EntityFilterSelectorConfig(domain="cover")
 
-    def prospective_capability_warnings(
-        self, known: Mapping[str, Mapping[str, bool] | None]
-    ) -> list[str]:
+    def prospective_capability_warnings(self, known: dict[str, dict]) -> list[str]:
         """Capability advice valid for EVERY configuration of this type.
 
         Asked before the type's own options exist — the "Change Cover Type"
@@ -1462,6 +1460,13 @@ class CoverTypePolicy(ABC):
         this to relax the tilt requirement, since its control model — the
         thing that decides whether tilt is required — is not chosen until the
         following geometry step.
+
+        Unlike :meth:`entities_satisfy_selector`'s *known*, entries here must
+        already be resolved capability dicts, not ``None`` — the delegate,
+        :meth:`cover_capability_warnings`, has no unavailable-entity skip, and
+        ``caps_get(None, key)`` silently reads as "missing every capability".
+        The only caller (``helpers.check_cover_capabilities``) already filters
+        ``None`` entries out before calling this hook.
         """
         return self.cover_capability_warnings(known)
 

--- a/custom_components/adaptive_cover_pro/cover_types/base.py
+++ b/custom_components/adaptive_cover_pro/cover_types/base.py
@@ -1443,6 +1443,28 @@ class CoverTypePolicy(ABC):
         """
         return selector.EntityFilterSelectorConfig(domain="cover")
 
+    def prospective_capability_warnings(
+        self, known: Mapping[str, Mapping[str, bool] | None]
+    ) -> list[str]:
+        """Capability advice valid for EVERY configuration of this type.
+
+        Asked before the type's own options exist — the "Change Cover Type"
+        confirm step (#1132/#1135) evaluates the DESTINATION type while
+        ``self.options`` still belong to the outgoing one, so an option-aware
+        question (:meth:`capability_warnings_for_options`) cannot be asked yet
+        (issue #1137). Must agree with :meth:`entities_satisfy_selector`: a
+        type the picker admitted cannot be told on the next screen that its
+        covers are unfit for it.
+
+        The Liskov-safe default delegates to :meth:`cover_capability_warnings`,
+        so every policy that has no per-instance option affecting its
+        capability requirement is unchanged. ``DayNightShadePolicy`` overrides
+        this to relax the tilt requirement, since its control model — the
+        thing that decides whether tilt is required — is not chosen until the
+        following geometry step.
+        """
+        return self.cover_capability_warnings(known)
+
     def entities_satisfy_selector(
         self, known: Mapping[str, Mapping[str, bool] | None]
     ) -> bool:

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -378,24 +378,27 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         known: dict[str, dict],
         *,
         require_tilt: bool,
-        single_axis_label: str = "split-range",
+        single_axis_label: str | None = "split-range",
     ) -> list[str]:
         """Warn about covers missing the axes this control model needs.
 
-        Single source for both the default (dual-axis, Model A) requirement and
-        the single-carriage (split-range / dual-entity) relaxation — the
+        Single source for the default (dual-axis, Model A) requirement, the
+        single-carriage (split-range / dual-entity) relaxation, and the
+        model-neutral pre-configuration phrasing (issue #1137) — the
         ``require_tilt`` flag is the only behavioural difference, so the
         warning-building logic isn't duplicated (CODING_GUIDELINES.md "No Code
         Duplication"). ``single_axis_label`` names the model in the
         set_position tail so a dual-entity shade isn't mislabelled as
-        split-range (only consulted when ``require_tilt`` is False).
+        split-range (only consulted when ``require_tilt`` is False); ``None``
+        means no model is known yet, so the tail names no model at all.
         """
         both = "day/night shade requires both set_position and set_tilt_position."
-        pos_tail = (
-            both
-            if require_tilt
-            else f"a {single_axis_label} day/night shade requires set_position."
-        )
+        if require_tilt:
+            pos_tail = both
+        elif single_axis_label is None:
+            pos_tail = "a day/night shade requires set_position."
+        else:
+            pos_tail = f"a {single_axis_label} day/night shade requires set_position."
         warnings: list[str] = []
         missing_pos = [
             eid
@@ -430,6 +433,23 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         the single-axis split-range model.
         """
         return self._missing_axis_warnings(known, require_tilt=True)
+
+    def prospective_capability_warnings(self, known: dict[str, dict]) -> list[str]:
+        """Warn on ``set_position`` only — the control model isn't chosen yet.
+
+        Issue #1137: the "Change Cover Type" confirm step asks this before the
+        instance has any options of its own, so
+        :meth:`capability_warnings_for_options` can't be asked — there is no
+        control model to read yet; it lives on the geometry step that
+        follows. Only Model A needs tilt, so assuming it here would reject
+        Model B/C hardware the picker just admitted via
+        :meth:`entity_selector_filter` — exactly the all-models intersection
+        that filter already encodes. ``single_axis_label=None`` keeps the
+        tail model-neutral, since no model has been picked yet.
+        """
+        return self._missing_axis_warnings(
+            known, require_tilt=False, single_axis_label=None
+        )
 
     def capability_warnings_for_options(
         self, known: dict[str, dict], options: dict

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -378,7 +378,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         known: dict[str, dict],
         *,
         require_tilt: bool,
-        single_axis_label: str | None = "split-range",
+        single_axis_label: str | None,
     ) -> list[str]:
         """Warn about covers missing the axes this control model needs.
 
@@ -390,7 +390,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         Duplication"). ``single_axis_label`` names the model in the
         set_position tail so a dual-entity shade isn't mislabelled as
         split-range (only consulted when ``require_tilt`` is False); ``None``
-        means no model is known yet, so the tail names no model at all.
+        means no model is known yet, so the tail names no model at all. No
+        default: every caller states its own tail explicitly, even
+        ``cover_capability_warnings`` below, where ``require_tilt=True`` makes
+        the value inert — a future fourth caller must decide on purpose
+        rather than silently inheriting whatever the last caller needed.
         """
         both = "day/night shade requires both set_position and set_tilt_position."
         if require_tilt:
@@ -432,7 +436,9 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         :meth:`capability_warnings_for_options` relaxes the tilt requirement for
         the single-axis split-range model.
         """
-        return self._missing_axis_warnings(known, require_tilt=True)
+        return self._missing_axis_warnings(
+            known, require_tilt=True, single_axis_label=None
+        )
 
     def prospective_capability_warnings(self, known: dict[str, dict]) -> list[str]:
         """Warn on ``set_position`` only — the control model isn't chosen yet.
@@ -446,6 +452,18 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         :meth:`entity_selector_filter` — exactly the all-models intersection
         that filter already encodes. ``single_axis_label=None`` keeps the
         tail model-neutral, since no model has been picked yet.
+
+        This hook takes no ``config``/``options`` argument at all, so it
+        ignores a ``day_night_control_model`` that may already be sitting in
+        the entry's stored options — e.g. a Day/Night → Blind → Day/Night
+        round trip, where ``_stranded_option_keys`` only advises about the
+        stale key and never deletes it. A confirm screen reached that way
+        still gets the model-neutral answer, not whatever the leftover key
+        says. That's deliberate, not an oversight: the information isn't
+        lost, only deferred — the next geometry step re-collects (or
+        re-defaults) the control model, and both the option-aware
+        configuration summary and the A3 Repair evaluate the model that is
+        actually saved, not this screen's guess.
         """
         return self._missing_axis_warnings(
             known, require_tilt=False, single_axis_label=None

--- a/custom_components/adaptive_cover_pro/helpers.py
+++ b/custom_components/adaptive_cover_pro/helpers.py
@@ -626,6 +626,8 @@ def check_cover_capabilities(
     config: dict,
     sensor_type: str | None,
     hass: HomeAssistant | None,
+    *,
+    prospective: bool = False,
 ) -> tuple[dict[str, dict[str, bool] | None], list[str]]:
     """Inspect bound cover entities and return capabilities + warning lines.
 
@@ -641,6 +643,19 @@ def check_cover_capabilities(
     ``cover_types`` import below stays function-local: ``cover_types.base``
     imports THIS module at module level, so importing ``cover_types`` back from
     here at module scope would be circular.
+
+    ``prospective`` (issue #1137): when True, the policy-level capability line
+    is asked via :meth:`CoverTypePolicy.prospective_capability_warnings`
+    instead of :meth:`CoverTypePolicy.capability_warnings_for_options`. The
+    "Change Cover Type" confirm step asks about a DESTINATION type before any
+    of its own options exist — ``config`` still belongs to the outgoing type
+    — so an option-aware question would silently assume whatever the
+    destination's schema defaults to. Every generic per-entity note above
+    (unavailable / open-close-only / ``assumed_state`` / mixed capabilities /
+    position limits) is unaffected; only the policy line's source hook
+    changes. Default ``False`` leaves every existing caller's behaviour
+    unchanged (CODING_GUIDELINES.md "No Code Duplication" — generalize with a
+    safe default rather than branch at each call site).
 
     """
     entities: list[str] = config.get(CONF_ENTITIES) or []
@@ -708,8 +723,11 @@ def check_cover_capabilities(
             )
 
         if sensor_type is not None:
+            policy = get_policy(sensor_type)
             warnings.extend(
-                get_policy(sensor_type).capability_warnings_for_options(known, config)
+                policy.prospective_capability_warnings(known)
+                if prospective
+                else policy.capability_warnings_for_options(known, config)
             )
 
         min_pos_val = config.get(CONF_MIN_POSITION)

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -305,6 +305,53 @@ async def test_picker_lists_blocked_types_with_reason(hass: HomeAssistant) -> No
 
 
 @pytest.mark.integration
+async def test_blocked_type_reason_names_set_position_for_day_night(
+    hass: HomeAssistant,
+) -> None:
+    """Day/Night's blocked reason names ``set_position``, not ``set_tilt_position`` (#1137).
+
+    ``_blocked_types_text`` explains a decision ``entities_satisfy_selector``
+    already made, so it must read the SAME capability matrix that made that
+    decision: ``prospective_capability_warnings``, not
+    ``cover_capability_warnings``. Day/Night's ``entity_selector_filter`` only
+    requires ``set_position`` (issue #1114/#1117 — every control model needs
+    it, only Model A additionally needs tilt), so an ordinary open/close-only
+    cover (no ``set_position``, no ``set_tilt_position``) is blocked here
+    because it lacks ``set_position`` — not because it lacks tilt. Naming
+    ``set_tilt_position`` in this line would blame the wrong axis and
+    contradict ``entity_selector_filter``, the same inconsistency the confirm
+    screen had before this fix.
+    """
+    from homeassistant.components.cover import CoverEntityFeature
+
+    from custom_components.adaptive_cover_pro.cover_types import get_policy
+
+    entry = await _setup_entry(hass, entry_id="blocked_open_close_only")
+    # Ordinary open/close-only hardware: OPEN | CLOSE | STOP, no SET_POSITION
+    # and no SET_TILT_POSITION.
+    features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": int(features)},
+    )
+
+    result = await _open_picker(hass, entry)
+
+    blocked_text = result["description_placeholders"]["blocked_types"]
+    day_night_label = get_policy(CoverType.DAY_NIGHT_SHADE).display_label()
+    assert day_night_label in blocked_text
+
+    day_night_line = next(
+        line for line in blocked_text.splitlines() if day_night_label in line
+    )
+    assert "set_position" in day_night_line
+    assert "set_tilt_position" not in day_night_line
+
+
+@pytest.mark.integration
 async def test_picker_blocked_list_never_renders_a_dangling_heading(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -480,6 +480,52 @@ async def test_confirm_shows_capability_notes(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.integration
+async def test_confirm_shows_generic_open_close_only_note(hass: HomeAssistant) -> None:
+    """A real-flow positive on ``capability_notes`` (#1137 audit item D).
+
+    Every other assertion on ``capability_notes`` reached through the real
+    options flow (``test_confirm_shows_capability_notes``,
+    ``test_confirm_to_save_model_c_no_capability_warning``) is negative —
+    "this note is NOT there". The only positive assertion
+    (``test_confirm_still_warns_for_tilt_only_destination``) runs against a
+    hand-constructed ``OptionsFlowHandler`` with ``_pending_cover_type`` set
+    directly, bypassing ``hass.config_entries.options.async_configure``
+    entirely. Nothing proves the placeholder still carries real advice
+    through the actual flow users take — which is the exact property that
+    ruled out "remove ``capability_notes`` from the confirm screen" as a fix
+    for #1137.
+
+    Awning's ``entity_selector_filter`` is the plain ``cover``-domain default
+    (no capability requirement), so an open/close-only cover — no
+    ``set_position``, no ``set_tilt_position`` — reaches the real confirm
+    screen for it rather than being blocked at the picker. The generic
+    per-entity note this exercises (``helpers.check_cover_capabilities``'s
+    "is open/close-only" line) is untouched by the #1137 fix — it fires for
+    every destination type, not just Day/Night — so this is coverage for the
+    screen's continued usefulness, not a regression guard for this change.
+    """
+    from homeassistant.components.cover import CoverEntityFeature
+
+    entry = await _setup_entry(hass, entry_id="confirm_open_close_only")
+    # Ordinary open/close-only hardware: OPEN | CLOSE | STOP, no SET_POSITION.
+    features = (
+        CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
+    )
+    hass.states.async_set(
+        "cover.test_blind",
+        "open",
+        {"supported_features": int(features)},
+    )
+
+    result = await _pick(hass, entry, CoverType.AWNING)
+
+    assert result["step_id"] == "change_cover_type_confirm"
+    notes = result["description_placeholders"]["capability_notes"]
+    assert "cover.test_blind is open/close-only" in notes
+    assert "will be driven via threshold compare" in notes
+
+
+@pytest.mark.integration
 async def test_confirm_still_warns_for_tilt_only_destination(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -20,6 +20,8 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONTROL_MODEL,
+    CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DEFAULT_HEIGHT,
     CONF_ENABLE_SUN_TRACKING,
     CONF_ENTITIES,
@@ -27,6 +29,7 @@ from custom_components.adaptive_cover_pro.const import (
     CONF_MIN_POSITION,
     CONF_SENSOR_TYPE,
     CONF_SUNSET_POS,
+    DAY_NIGHT_MODEL_DUAL_ENTITY,
     DOMAIN,
     CoverType,
 )
@@ -413,10 +416,46 @@ async def test_confirm_lists_stranded_options(hass: HomeAssistant) -> None:
 
 @pytest.mark.integration
 async def test_confirm_shows_capability_notes(hass: HomeAssistant) -> None:
-    """Capability advice is evaluated against the DESTINATION type."""
+    """The confirm screen must not assume a control model before one is picked (#1137).
+
+    The bound covers are position-only — exactly the Model B/C hardware
+    #1114/#1117 exist to support. Day/Night's control model is chosen on the
+    NEXT screen (geometry), so the confirm screen must not warn about a tilt
+    requirement only Model A has; the picker already admitted this type via
+    the same all-models intersection ``entity_selector_filter()`` encodes.
+    """
     entry = await _setup_entry(hass, entry_id="confirm_caps")
 
     result = await _pick(hass, entry, CoverType.DAY_NIGHT_SHADE)
+
+    notes = result["description_placeholders"]["capability_notes"]
+    assert "set_tilt_position" not in notes
+
+
+@pytest.mark.integration
+async def test_confirm_still_warns_for_tilt_only_destination(
+    hass: HomeAssistant,
+) -> None:
+    """The Day/Night tilt relaxation must not leak to a type that always needs it.
+
+    Venetian genuinely needs tilt on every configuration — #1117's
+    intersection filter is specific to Day/Night's multiple control models, so
+    Venetian keeps the strict, unconditional both-axes requirement. The
+    reporter's position-only covers cannot reach Venetian through the real
+    picker at all (Venetian's own ``entity_selector_filter`` blocks them
+    there — see ``test_picker_offers_capability_compatible_types_only``), so
+    this constructs the flow handler directly and sets the pending type by
+    hand, to isolate the confirm screen's capability advice from the picker's
+    eligibility gate.
+    """
+    from custom_components.adaptive_cover_pro.config_flow import OptionsFlowHandler
+
+    entry = await _setup_entry(hass, entry_id="confirm_caps_venetian")
+    flow = OptionsFlowHandler(entry)
+    flow.hass = hass
+    flow._pending_cover_type = CoverType.VENETIAN
+
+    result = await flow.async_step_change_cover_type_confirm()
 
     notes = result["description_placeholders"]["capability_notes"]
     assert "set_tilt_position" in notes
@@ -651,6 +690,55 @@ async def test_data_written_only_at_save_and_close(hass: HomeAssistant) -> None:
     assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
     assert entry.data["name"] == "Switchable"
     assert _reloads(reload, entry) == 1
+
+
+@pytest.mark.integration
+async def test_confirm_to_save_model_c_no_capability_warning(
+    hass: HomeAssistant,
+) -> None:
+    """End-to-end (#1137): position-only covers, Model C, no false warning.
+
+    Exactly the reporter's Smartwings/ZVIDAR two-motor day/night shade
+    (#1114/#1117): two position-only rails, switching to Day/Night and
+    picking Model C (``dual_entity``) plus a middle rail on the geometry
+    step. The confirm screen must show no tilt warning (the control model
+    isn't known yet), and the switch must save cleanly through to
+    ``entry.data``.
+    """
+    entry = await _setup_entry(
+        hass,
+        entry_id="model_c_e2e",
+        entities=["cover.bottom_rail", "cover.middle_rail"],
+    )
+
+    confirm = await _pick(hass, entry, CoverType.DAY_NIGHT_SHADE)
+    assert (
+        "set_tilt_position"
+        not in confirm["description_placeholders"]["capability_notes"]
+    )
+
+    geometry = await hass.config_entries.options.async_configure(
+        confirm["flow_id"], {"confirm": True}
+    )
+    assert geometry["step_id"] == "geometry"
+
+    menu = await hass.config_entries.options.async_configure(
+        geometry["flow_id"],
+        {
+            CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+            CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: "cover.middle_rail",
+        },
+    )
+    assert menu["type"] == "menu"
+
+    await hass.config_entries.options.async_configure(
+        menu["flow_id"], {"next_step_id": "done"}
+    )
+    await hass.async_block_till_done()
+
+    assert entry.data[CONF_SENSOR_TYPE] == CoverType.DAY_NIGHT_SHADE
+    assert entry.options[CONF_DAY_NIGHT_CONTROL_MODEL] == DAY_NIGHT_MODEL_DUAL_ENTITY
+    assert entry.options[CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY] == "cover.middle_rail"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -1009,6 +1009,47 @@ class TestCapabilityWarningsPerModel:
 
 
 # ---------------------------------------------------------------------------
+# Issue #1137 — prospective capability warnings (pre-configuration confirm
+# screen). The "Change Cover Type" confirm step (#1132/#1135) asks the
+# DESTINATION policy a capability question before any of its own options
+# exist, so it cannot know the control model yet. ``prospective_capability_
+# warnings`` answers with the all-models intersection ``entity_selector_
+# filter()`` already encodes — set_position only — rather than assuming
+# Model A via ``DEFAULT_DAY_NIGHT_CONTROL_MODEL``.
+# ---------------------------------------------------------------------------
+
+
+class TestProspectiveCapabilityWarnings:
+    """``DayNightShadePolicy.prospective_capability_warnings`` is tilt-relaxed."""
+
+    def test_prospective_capability_warnings_omit_tilt(self) -> None:
+        """A position-only cover (Model B/C hardware) draws no tilt warning.
+
+        The control model is chosen on the NEXT screen (geometry_schema), so
+        the pre-configuration question must not assume Model A.
+        """
+        policy = DayNightShadePolicy()
+        known = {"cover.a": {"has_set_position": True, "has_set_tilt_position": False}}
+        assert policy.prospective_capability_warnings(known) == []
+
+    def test_prospective_capability_warnings_still_flag_missing_position(
+        self,
+    ) -> None:
+        """Missing ``set_position`` still warns — every control model needs it.
+
+        The tail wording must stay model-neutral (no "split-range" / "dual-
+        entity" / "position_tilt" name) since no model has been chosen yet.
+        """
+        policy = DayNightShadePolicy()
+        known = {"cover.a": {"has_set_position": False, "has_set_tilt_position": True}}
+        warnings = policy.prospective_capability_warnings(known)
+        assert any("set_position" in w for w in warnings)
+        joined = " ".join(warnings)
+        assert "split-range" not in joined
+        assert "dual-entity" not in joined
+
+
+# ---------------------------------------------------------------------------
 # Step 18 — control-model select in the geometry schema + summary + labels
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -68,6 +68,30 @@ def test_capability_warnings_for_options_matches_plain_by_default(
 
 
 @pytest.mark.unit
+def test_prospective_capability_warnings_returns_list(policy: CoverTypePolicy) -> None:
+    """Always a list — the "Change Cover Type" confirm step extends it (#1137)."""
+    assert isinstance(policy.prospective_capability_warnings(known={}), list)
+
+
+@pytest.mark.unit
+def test_prospective_defaults_to_plain_warnings(policy: CoverTypePolicy) -> None:
+    """The pre-configuration hook defaults to the plain warnings (Liskov, #1137).
+
+    A fully-capable cover draws no warning from either hook for ANY policy,
+    including ``DayNightShadePolicy`` — whose override is deliberately
+    tilt-relaxed and therefore only equals ``cover_capability_warnings`` in
+    cases like this one with nothing to warn about. Every other registered
+    policy, and both stub policies, delegate outright and would match on any
+    input; this is the strongest input every policy can agree on.
+    """
+    known = {"cover.x": {"has_set_position": True, "has_set_tilt_position": True}}
+    assert policy.prospective_capability_warnings(
+        known
+    ) == policy.cover_capability_warnings(known)
+    assert policy.prospective_capability_warnings(known) == []
+
+
+@pytest.mark.unit
 def test_disallowed_geometry_fields_returns_list(policy: CoverTypePolicy) -> None:
     """``options_service.validate_options_patch`` iterates this — never None."""
     result = policy.disallowed_geometry_fields(

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -22,6 +22,7 @@ from unittest.mock import MagicMock
 import pytest
 import voluptuous as vol
 
+from custom_components.adaptive_cover_pro.const import CoverType
 from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.cover_types.base import (
     CAP_HAS_SET_POSITION,
@@ -95,11 +96,14 @@ def test_prospective_defaults_to_plain_warnings(
     the geometry step — opts itself out of this invariant by definition and
     is skipped. Every non-overriding policy must match
     ``cover_capability_warnings`` across every combination of the two
-    capability flags, not just "everything present": that single case is
-    what every policy (including a hook that always returns ``[]``) answers
-    identically, so it cannot tell a real delegation from a hook that has
-    quietly stopped delegating — see the regression this replaces, flagged
-    in the issue #1137 audit.
+    capability flags, not just "everything present": with both flags
+    ``True`` every real policy already returns ``[]`` from both methods, so a
+    hook silently rewritten to ``return []`` unconditionally — no longer
+    delegating at all — would still pass that one case. Only the
+    missing-capability combinations exercise the branches where a genuine
+    delegation and a hardcoded empty list disagree, so a failure here means
+    the hook has drifted from the plain method it is supposed to mirror by
+    default.
     """
     if (
         type(policy).prospective_capability_warnings
@@ -109,6 +113,39 @@ def test_prospective_defaults_to_plain_warnings(
     assert policy.prospective_capability_warnings(
         known
     ) == policy.cover_capability_warnings(known)
+
+
+@pytest.mark.unit
+def test_prospective_capability_warnings_override_allowlist() -> None:
+    """Pin exactly which policies may opt out of the Liskov invariant above.
+
+    ``test_prospective_defaults_to_plain_warnings`` skips any policy that
+    overrides ``prospective_capability_warnings`` instead of failing it — a
+    deliberate exemption for ``DayNightShadePolicy`` (#1137), whose control
+    model isn't known until the following geometry step. But a ``skip`` has
+    no failure mode of its own: nothing else pins *which* policies are
+    allowed to take that exemption, so a future policy that overrides the
+    hook for an unrelated reason would silently drop out of the invariant
+    with no signal anywhere in the suite.
+
+    This test closes that gap. It derives the overriding set reflectively
+    from the same ``ALL_POLICIES_WITH_STUBS`` registry the parametrized test
+    above draws its ``policy`` fixture from, and asserts it is exactly
+    ``{CoverType.DAY_NIGHT_SHADE}``.
+
+    Adding a legitimate second override is a deliberate act: when it
+    happens, extend the right-hand side here on purpose, with the same kind
+    of justification ``DayNightShadePolicy.prospective_capability_warnings``
+    carries in its own docstring — don't widen this set to make a failure
+    go away without reading why it fired.
+    """
+    overriding = {
+        policy_cls.cover_type
+        for policy_cls in ALL_POLICIES_WITH_STUBS
+        if policy_cls.prospective_capability_warnings
+        is not CoverTypePolicy.prospective_capability_warnings
+    }
+    assert overriding == {CoverType.DAY_NIGHT_SHADE}
 
 
 @pytest.mark.unit

--- a/tests/test_cover_types/test_invariants.py
+++ b/tests/test_cover_types/test_invariants.py
@@ -74,21 +74,41 @@ def test_prospective_capability_warnings_returns_list(policy: CoverTypePolicy) -
 
 
 @pytest.mark.unit
-def test_prospective_defaults_to_plain_warnings(policy: CoverTypePolicy) -> None:
+@pytest.mark.parametrize(
+    "known",
+    [
+        {"cover.x": {"has_set_position": False, "has_set_tilt_position": False}},
+        {"cover.x": {"has_set_position": True, "has_set_tilt_position": False}},
+        {"cover.x": {"has_set_position": False, "has_set_tilt_position": True}},
+        {"cover.x": {"has_set_position": True, "has_set_tilt_position": True}},
+    ],
+    ids=["both_missing", "position_only", "tilt_only", "both_present"],
+)
+def test_prospective_defaults_to_plain_warnings(
+    policy: CoverTypePolicy, known: dict
+) -> None:
     """The pre-configuration hook defaults to the plain warnings (Liskov, #1137).
 
-    A fully-capable cover draws no warning from either hook for ANY policy,
-    including ``DayNightShadePolicy`` — whose override is deliberately
-    tilt-relaxed and therefore only equals ``cover_capability_warnings`` in
-    cases like this one with nothing to warn about. Every other registered
-    policy, and both stub policies, delegate outright and would match on any
-    input; this is the strongest input every policy can agree on.
+    Gated reflectively, not by cover-type name: a policy that overrides
+    ``prospective_capability_warnings`` — today only ``DayNightShadePolicy``,
+    deliberately tilt-relaxed because the control model isn't known before
+    the geometry step — opts itself out of this invariant by definition and
+    is skipped. Every non-overriding policy must match
+    ``cover_capability_warnings`` across every combination of the two
+    capability flags, not just "everything present": that single case is
+    what every policy (including a hook that always returns ``[]``) answers
+    identically, so it cannot tell a real delegation from a hook that has
+    quietly stopped delegating — see the regression this replaces, flagged
+    in the issue #1137 audit.
     """
-    known = {"cover.x": {"has_set_position": True, "has_set_tilt_position": True}}
+    if (
+        type(policy).prospective_capability_warnings
+        is not CoverTypePolicy.prospective_capability_warnings
+    ):
+        pytest.skip("policy legitimately overrides the hook")
     assert policy.prospective_capability_warnings(
         known
     ) == policy.cover_capability_warnings(known)
-    assert policy.prospective_capability_warnings(known) == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
The "Change Cover Type" confirm step added by #1135 passed the outgoing type's options to the destination policy's capability check. With `day_night_control_model` absent, `_read_control_model` fell back to `DEFAULT_DAY_NIGHT_CONTROL_MODEL` (Model A, `position_tilt`), so the screen demanded `set_tilt_position` from position-only rails the user was about to drive with Model B/C. The control model is only collected on the next step, so the confirm screen committed the user to Model A on their behalf and then told them their hardware could not drive it, contradicting the previous screen that offered Day/Night as eligible.

I added `CoverTypePolicy.prospective_capability_warnings`, defaulting to `cover_capability_warnings` so the other ten policies and both stubs are unchanged, and overrode it in `DayNightShadePolicy` with the all-models intersection `entity_selector_filter()` already encodes. `check_cover_capabilities` grows a keyword-only `prospective` defaulting to `False`, so the three existing callers are byte-identical. `_blocked_types_text` now reads the same hook, so the explanation comes from the same matrix as the decision.

`cover_capability_warnings` and `capability_warnings_for_options` are untouched, keeping the Liskov invariant in `test_capability_warnings_for_options_matches_plain_by_default` green and leaving healthcheck A3 alone.

## Testing
- ✅ 11832 tests passing (4 skipped, 1 xfailed)
- Patch coverage 100%; two opus audit passes returned zero must-fix findings
- Regression guards re-verified: #1114/#1117 picker filter tests, healthcheck A3 (#991/#1004), `test_axes.py`

## Related Issues
Refs #1137