### PR TITLE
feat: start Model C rails in order and let them travel concurrently (#1140)

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -678,6 +678,24 @@ def _seed_default_position_and_log(entry: ConfigEntry, options: dict) -> None:
     )
 
 
+def _advance_noop_minor(version: int, minor: int, target: int) -> int:
+    """Advance a stale minor past an ADDITIVE option that needs no seeding.
+
+    Several schema additions store a key whose ABSENCE already reads as the
+    default, so there is nothing for migration to write — but the minor still
+    has to advance, or HA sees the entry as stale and re-runs the whole cascade
+    on every restart. Four blocks in ``async_migrate_entry`` are exactly that
+    bump and nothing else (v3.4→v3.5, v3.6→v3.7, v3.8→v3.9, v3.13→v3.14), so
+    the condition-and-assignment is stated once here and called four times
+    rather than copied (CODING_GUIDELINES.md "No Code Duplication"). Each call
+    site keeps its own comment explaining which option it is advancing past.
+
+    Returns the new minor, unchanged when the entry is already at or past
+    ``target`` — which is what makes every call idempotent.
+    """
+    return target if version == 3 and minor < target else minor
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old config entries to the current schema version."""
     new_options = dict(entry.options)
@@ -750,8 +768,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # retraction pickers are always shown), so this is a no-op minor bump kept
     # only to advance entries sitting at minor 4 to 5 — without it they would
     # stay below MINOR_VERSION and re-trigger migration every restart.
-    if new_version == 3 and new_minor < 5:
-        new_minor = 5
+    new_minor = _advance_noop_minor(new_version, new_minor, 5)
 
     # v3.5 → v3.6: enable the weather override by default for every pre-existing
     # entry so upgrading covers keep firing weather safety overrides (issue
@@ -765,8 +782,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # An absent key already reads as "live" (the default), so nothing needs
     # seeding — this is a no-op minor bump kept only to advance entries sitting
     # at minor 6 to 7 so they stop re-triggering migration every restart.
-    if new_version == 3 and new_minor < 7:
-        new_minor = 7
+    new_minor = _advance_noop_minor(new_version, new_minor, 7)
 
     # v3.7 → v3.8: convert legacy FOV-relative blind-spot edges to signed gamma
     # from the window normal (issue #247). Additive + rollback-safe: the new
@@ -789,8 +805,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # precedent). Rollback-safe: min_mode / tilt_only remain the stored wire
     # format and are untouched, so an older build finds its config exactly as it
     # left it and simply ignores the new keys.
-    if new_version == 3 and new_minor < 9:
-        new_minor = 9
+    new_minor = _advance_noop_minor(new_version, new_minor, 9)
 
     # v3.9 → v3.10: the tilt safety margin was renamed from the venetian-prefixed
     # key to the neutral CONF_TILT_SAFETY_MARGIN now that tilt-only and
@@ -851,6 +866,14 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if new_version == 3 and new_minor < 13:
         _seed_default_position_and_log(entry, new_options)
         new_minor = 13
+
+    # v3.13 → v3.14: added the additive day_night_concurrent_rail_travel option
+    # (issue #1140). An absent key already reads as "on" — the default — so
+    # nothing needs seeding; this is a no-op minor bump kept only to advance
+    # entries sitting at minor 13 to 14 so they stop re-triggering migration
+    # every restart (the v3.6 → v3.7 precedent). Rollback-safe: an older build
+    # finds every key exactly as it left it and ignores the one it doesn't know.
+    new_minor = _advance_noop_minor(new_version, new_minor, 14)
 
     hass.config_entries.async_update_entry(
         entry, options=new_options, version=new_version, minor_version=new_minor

--- a/custom_components/adaptive_cover_pro/config_fields.py
+++ b/custom_components/adaptive_cover_pro/config_fields.py
@@ -58,6 +58,7 @@ from .const import (
     CONF_CLOUD_SUPPRESSION_HOLD_TIME,
     CONF_CLOUDY_POSITION,
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD,
+    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DAY_NIGHT_OPACITY_BLACKOUT,
@@ -1926,6 +1927,13 @@ _GEOMETRY_SPECS = _spec(
         SECTION_GEOMETRY,
         ValidatorKind.ENTITY,
         make_selector=_entity("cover"),
+    ),
+    # Model C concurrent rail travel (#1140). Boolean, so no OPTION_RANGES entry
+    # — this spec exists to single-source the options-service validator.
+    FieldSpec(
+        CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+        SECTION_GEOMETRY,
+        ValidatorKind.BOOL,
     ),
     FieldSpec(
         CONF_TILT_DEPTH,

--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -4158,7 +4158,11 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     # hard-coded 0 (fully closed). The v3.12→v3.13 block setdefault-seeds the
     # policy's no-coverage endpoint (position_for_intent(sun_through=True));
     # an older build already understands default_percentage.
-    MINOR_VERSION = 13
+    # 3.14 (issue #1140): added the additive day_night_concurrent_rail_travel
+    # option. An absent key already reads as "on" (the default), so the
+    # v3.13→v3.14 block seeds nothing and exists only to advance a stale minor
+    # so it stops re-triggering migration every restart.
+    MINOR_VERSION = 14
 
     def __init__(self) -> None:  # noqa: D107
         super().__init__()

--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -248,6 +248,17 @@ DAY_NIGHT_SPLIT_MIDPOINT = 50  # % — split-range fabric boundary (blackout bel
 # Model C middle-rail entity: which of the instance's cover entities is the
 # middle rail (the other configured cover is the bottom rail / primary).
 CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY = "day_night_middle_rail_entity"
+# Model C rail travel: may the FOLLOWING rail start moving while the leading
+# rail is still under way, or must it wait for full clearance first (#1140)?
+# The two rails share one track at one speed and the no-pass clamp already
+# guarantees their two TARGETS never cross, so once the leader is under way and
+# ahead of the follower in the direction of travel, separation holds for the
+# rest of the move — the pair can travel concurrently and the shade reaches its
+# position in one travel time instead of two. Off, the follower waits for the
+# leader's live position to clear the follower's own target, which is the
+# conservative #1115/#1118 behaviour. An absent key reads as ON.
+CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL = "day_night_concurrent_rail_travel"
+DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL = True
 
 # --- Dual-panel shade (#996) ------------------------------------------------
 # Two INDEPENDENT HA shade entities over one window: a sheer FRONT that
@@ -1472,6 +1483,14 @@ DEFAULT_ENABLE_POSITION_MATCHING = False
 VENETIAN_POSITION_SETTLE_POLL_SECONDS = 0.5  # poll interval while settling
 VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS = 60.0  # hard cap on settle wait
 VENETIAN_POSITION_SETTLE_NO_CHANGE_SAMPLES = 3  # samples → "settled"
+
+# How long a day/night Model C follower rail waits for the LEADING rail to be
+# seen under way, when concurrent rail travel is enabled (#1140). This is a
+# start confirmation, not a travel wait: it only has to outlast the actuator's
+# command latency plus one state publish, so it is an order of magnitude below
+# the settle cap above (which still hard-caps it — see ``wait_until_position``).
+# Internal tuning, deliberately not user-configurable.
+DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS = 10.0
 
 # Suppress tilt-axis manual override detection for this many seconds after a
 # venetian position command. Real motors back-rotate the slats while moving

--- a/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
+++ b/custom_components/adaptive_cover_pro/cover_types/_summary_labels.py
@@ -124,6 +124,14 @@ GEOMETRY_LABELS_EN: dict[str, str] = {
     "geometry.day_night.model_position_tilt": "position and tilt (dual axis)",
     "geometry.day_night.model_split_range": "split range (single axis)",
     "geometry.day_night.model_dual_entity": "two rail entities (dual entity)",
+    # Model C rail-travel sequencing (#1140). Only rendered for dual_entity.
+    "geometry.day_night.rail_travel": "rail travel: {v}",
+    "geometry.day_night.rail_travel_concurrent": (
+        "both rails move concurrently once the leading rail is under way"
+    ),
+    "geometry.day_night.rail_travel_serialized": (
+        "rails move one at a time — the following rail waits for full clearance"
+    ),
     # Dual-panel shade (#996): the front/sheer designator + the blackout
     # trigger list rendered on the config summary.
     "geometry.dual_panel.front_entity": "front (sheer) panel: {v}",

--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -17,7 +17,7 @@ math is replaced by a pure fabric-choice decision keyed on the season.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -32,6 +32,7 @@ from homeassistant.helpers import selector
 from ...config_types import DayNightShadeConfig
 from ...const import (
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD,
+    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DAY_NIGHT_OPACITY_BLACKOUT,
@@ -40,8 +41,10 @@ from ...const import (
     DAY_NIGHT_MODEL_DUAL_ENTITY,
     DAY_NIGHT_MODEL_POSITION_TILT,
     DAY_NIGHT_MODEL_SPLIT_RANGE,
+    DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS,
     DAY_NIGHT_SPLIT_MIDPOINT,
     DEFAULT_DAY_NIGHT_BLACKOUT_THRESHOLD,
+    DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     DEFAULT_DAY_NIGHT_CONTROL_MODEL,
     DEFAULT_DAY_NIGHT_OPACITY_BLACKOUT,
     DEFAULT_DAY_NIGHT_OPACITY_SHEER,
@@ -161,6 +164,13 @@ def geometry_day_night_shade_schema(hass: HomeAssistant | None = None) -> vol.Sc
             # select itself. Optional with no default so an un-set value is
             # simply absent from options.
             vol.Optional(CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY): _middle_rail_select(),
+            # Model C: may the following rail start while the leading rail is
+            # still travelling (#1140)? Inert for Models A and B, which have no
+            # second rail to sequence against.
+            vol.Optional(
+                CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+                default=DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+            ): selector.BooleanSelector(),
         }
     )
 
@@ -233,6 +243,13 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         # it. Defaults to the dual-axis Model A so an un-resolved cycle behaves
         # like Phase A.
         self._control_model: str = DEFAULT_DAY_NIGHT_CONTROL_MODEL
+        # Model C rail-travel policy: may the following rail start before the
+        # leading one has fully cleared it (#1140)? Cached from options by the
+        # same pair of hooks that resolve the control model, because the travel
+        # gate runs at the dispatch seam, which receives no ``options``.
+        self._dual_entity_concurrent_travel: bool = (
+            DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL
+        )
         # Model C (dual_entity) dispatch cache, filled in ``post_pipeline_resolve``
         # and read by ``resolve_entity_target`` at the coordinator dispatch seam
         # (which receives no ``options``). The blend folds into the middle rail's
@@ -318,6 +335,28 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         """
         self._control_model = self._read_control_model(options)
 
+    def _cache_runtime_options(self, options: dict) -> None:
+        """Cache every per-instance option the option-less hooks downstream read.
+
+        The single seam for "read the raw options dict into policy state" —
+        both :meth:`sync_runtime_options` (the coordinator's per-cycle hook) and
+        :meth:`post_pipeline_resolve` (self-sufficiency for direct callers) go
+        through here rather than each listing the reads, so a new per-instance
+        option lands in one place (CODING_GUIDELINES.md "No Code Duplication").
+
+        These deliberately do NOT ride ``RuntimeConfig.from_options``: that hook
+        covers the options the COORDINATOR reads, and these are read by the
+        policy itself at seams the coordinator hands no ``options`` to — the
+        control-model precedent (#1114).
+        """
+        self._set_control_model(options)
+        self._dual_entity_concurrent_travel = bool(
+            options.get(
+                CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+                DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+            )
+        )
+
     # ---- Geometry / config-flow surfaces ------------------------------ #
 
     def disallowed_geometry_fields(
@@ -361,7 +400,12 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
     def summary_geometry_lines(
         self, config: dict[str, Any], labels: dict[str, str] | None = None
     ) -> list[str]:
-        """Render the window-dimensions block plus the control-model line."""
+        """Render the window-dimensions block plus the control-model line.
+
+        Model C additionally renders the rail-travel policy (#1140), which the
+        single-carriage models have no second rail to apply — rendering it for
+        them would describe behaviour they cannot exhibit.
+        """
         lines = window_dimensions_lines(config, labels)
         L = {**GEOMETRY_LABELS_EN, **(labels or {})}
         model = self._read_control_model(config)
@@ -371,6 +415,16 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             DAY_NIGHT_MODEL_DUAL_ENTITY: L["geometry.day_night.model_dual_entity"],
         }.get(model, model)
         lines.append(L["geometry.slat.mode"].format(v=model_label))
+        if model == DAY_NIGHT_MODEL_DUAL_ENTITY:
+            travel = (
+                "geometry.day_night.rail_travel_concurrent"
+                if config.get(
+                    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+                    DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+                )
+                else "geometry.day_night.rail_travel_serialized"
+            )
+            lines.append(L["geometry.day_night.rail_travel"].format(v=L[travel]))
         return lines
 
     def _missing_axis_warnings(
@@ -510,7 +564,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
     # ---- Calculation engine ------------------------------------------- #
 
     def sync_runtime_options(self, options: dict) -> None:
-        """Resolve the control model for this cycle (base hook, #1114).
+        """Resolve the per-instance options for this cycle (base hook, #1114).
 
         The coordinator drives this from ``_update_options``, on the event loop,
         before the pipeline and before ``_evaluate_health_checks`` — so the A3
@@ -519,7 +573,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         rather than reporting a position-only cover as a contradiction against
         the ``__init__`` Model A default.
         """
-        self._set_control_model(options)
+        self._cache_runtime_options(options)
 
     def build_calc_engine(
         self,
@@ -701,7 +755,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         byte-identical to Model A. The downstream dispatch hooks don't receive
         ``options``, so they read the cached ``_control_model``.
 
-        The :meth:`_set_control_model` call below is a **defensive no-op in
+        The :meth:`_cache_runtime_options` call below is a **defensive no-op in
         production**: ``sync_runtime_options`` already resolved the model from
         the same per-cycle ``options`` object before the pipeline ran, and a
         model change is not runtime-applicable — it reloads the config entry
@@ -722,7 +776,7 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         if result is None:
             return result
 
-        self._set_control_model(options)
+        self._cache_runtime_options(options)
         resolved = self._resolve_blend(
             result,
             logger=logger,
@@ -1382,6 +1436,55 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         middle = self._dual_entity_middle_rail
         return next((eid for eid in self._attached_entities if eid != middle), None)
 
+    def _start_confirmation(
+        self,
+        cleared: Callable[[int], bool],
+        direction: int,
+        inverse: bool,
+        tolerance: int,
+    ) -> Callable[[int], bool]:
+        """Wrap a clearance predicate so leader MOTION also releases the gate.
+
+        The relaxation behind concurrent rail travel (#1140), expressed as a
+        strict WEAKENING of the branch's own predicate: ``cleared`` still
+        releases exactly when it did, and a second disjunct releases earlier
+        when the leading rail is demonstrably under way and ahead.
+
+        "Under way and ahead" is the leader's live OPEN-PERCENT reading having
+        moved from its FIRST sampled value, by more than ``tolerance``, toward
+        satisfying ``cleared``'s own inequality. ``direction`` is the sign of
+        that inequality — ``-1`` where clearance needs the leader's open percent
+        to fall (the middle rail's branch, a lowering), ``+1`` where it needs it
+        to rise (the bottom rail's branch, a raising). It is derived from the
+        branch's own release test and NOT from
+        :meth:`_dual_entity_middle_leads`; a leader moving the wrong way can
+        therefore never confirm, which is what stops this becoming the back door
+        that ungates the middle rail during a lowering (issue #1115).
+
+        Both sides of the delta ride ``flip_if`` against the SAME dispatch frame
+        the threshold does — a delta computed on raw wire numbers inverts its
+        own sign on every inverse-state install (the #993 bug class).
+
+        The start reference lives in this closure, so it is scoped to ONE
+        invocation of the gate: a single-shot ``wait=False`` pass takes one
+        reading, records it as the reference, and returns ``False``, exactly as
+        the un-wrapped predicate would have. Nothing survives to the next pass,
+        so a delta can never be accumulated across cycles.
+        """
+        start_open: int | None = None
+
+        def _done(wire: int) -> bool:
+            nonlocal start_open
+            if cleared(wire):
+                return True
+            live_open = flip_if(wire, inverted=inverse)
+            if start_open is None:
+                start_open = live_open
+                return False
+            return (live_open - start_open) * direction > tolerance
+
+        return _done
+
     async def _gate_rail_clearance(
         self,
         entity_id: str,
@@ -1427,6 +1530,30 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         intact shade on one track — both rails would defer after their budget,
         latch pending, and retry next cycle).
 
+        **That theorem survives concurrent travel (#1140) unchanged**, and the
+        re-derivation is worth stating because the proof above is phrased in
+        terms of ``_cleared``'s specific inequalities. Three facts carry it:
+
+        1. It is a theorem about ARMING, not about release — which branch a
+           dispatch selects, and whether that branch's block condition holds on
+           the reading it sees. Branch selection is untouched by the option:
+           ``is_middle`` and :meth:`_dual_entity_middle_leads` are evaluated
+           before the predicate is ever wrapped.
+        2. On the FIRST reading the concurrent disjunct is structurally
+           ``False`` — there is no start reference yet, so
+           :meth:`_start_confirmation` records one and returns. The very first
+           verdict is therefore pointwise identical to ``_cleared``'s, which is
+           the only verdict the single-read ``wait=False`` path ever produces
+           and the only one the grid the theorem quantifies over ever asks for.
+        3. The wrapper is a monotone WEAKENING: ``cleared(w) or delta(w)``
+           accepts a superset of what ``cleared(w)`` accepts. It can only
+           release an armed gate EARLIER; it can never arm one that was not
+           already armed, so no pair of block conditions it produces was
+           unreachable before.
+
+        The option therefore changes how long a follower waits and what
+        threshold ends that wait — never which rail is the follower.
+
         **The asymmetry is deliberate.** The middle rail's branch does NOT
         consult :meth:`_dual_entity_middle_leads`; it gates unconditionally,
         exactly as #1115 shipped it. The direction predicate needs the BOTTOM
@@ -1437,6 +1564,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         very mechanism built to close it. The middle rail is therefore never
         ungated by a direction reading; only the bottom rail's gate is
         conditional, and it is conditional on a number it holds authoritatively.
+        Concurrent travel keeps that intact: the ``direction`` sign each branch
+        hands :meth:`_start_confirmation` is read off that branch's OWN release
+        inequality, never off :meth:`_dual_entity_middle_leads`, so the middle
+        rail's gate still consults nothing but the bottom rail's live motion
+        relative to its own target.
 
         The no-pass clamp in :meth:`resolve_entity_target` (``M >= P``) states
         that invariant about two NUMBERS — the two eventual targets. It cannot see
@@ -1507,6 +1639,15 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         both modes; only the number of chances the rail gets to satisfy it
         differs.
 
+        Which budget the waiting mode gets depends on what it is waiting FOR.
+        Serialized, it is a whole travel, so it takes the sequencer's settle cap
+        (``timeout_seconds=None``). Confirming a START only has to outlast the
+        actuator's command latency plus one state publish, so it takes the far
+        shorter :data:`DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS` — which
+        also bounds the cost of a rail that has gone silent, since expiry lands
+        on the same fail-closed path either way. Both are still hard-capped by
+        the settle cap inside ``wait_until_position``.
+
         Returns ``True`` to let the command through, ``False`` to withhold it.
         Withholding latches the entity pending so the coordinator keeps
         re-attempting on later cycles; it never drops the command. Once a
@@ -1538,12 +1679,16 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
 
         if is_middle:
             leading_rail = bottom_rail
+            # Clearance needs the bottom rail's open percent to FALL.
+            direction = -1
 
             def _cleared(wire: int) -> bool:
                 return flip_if(wire, inverted=inverse) <= target_open + tolerance
 
         elif self._dual_entity_middle_leads(target_open, inverse):
             leading_rail = middle_rail
+            # Clearance needs the middle rail's open percent to RISE.
+            direction = 1
 
             def _cleared(wire: int) -> bool:
                 return flip_if(wire, inverted=inverse) + tolerance >= target_open
@@ -1556,19 +1701,25 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             self._pending_rail_command.discard(entity_id)
             return True
 
-        if await seq.wait_until_position(
-            leading_rail, _cleared, timeout_seconds=None if wait else 0
-        ):
+        done = _cleared
+        budget: float | None = None if wait else 0
+        if self._dual_entity_concurrent_travel:
+            done = self._start_confirmation(_cleared, direction, inverse, tolerance)
+            if wait:
+                budget = DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS
+
+        if await seq.wait_until_position(leading_rail, done, timeout_seconds=budget):
             self._pending_rail_command.discard(entity_id)
             return True
         self._pending_rail_command.add(entity_id)
         self._debug(
             "Model C rail gate deferring %s → %s%% (%s): leading rail %s has not "
-            "cleared this rail's target",
+            "%s this rail's target",
             entity_id,
             position,
             reason,
             leading_rail,
+            "started clearing" if self._dual_entity_concurrent_travel else "cleared",
         )
         return False
 

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/sequencer.py
@@ -1230,13 +1230,20 @@ class DualAxisSequencer:
         :data:`VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS`) — the semantics differ,
         the tuning does not, so no parallel constant is introduced.
 
-        ``timeout_seconds`` overrides that budget; ``None`` (the default) uses
-        it. ``0`` makes this a SINGLE-SHOT read — the loop is a do-while, so
-        ``done`` is always evaluated at least once — which is what a caller that
-        is itself a periodic retry loop wants: it asks whether the threshold is
-        satisfied right now and re-asks on its own next tick, instead of
-        blocking for a budget that may be as long as its own interval. One
-        implementation either way; the predicate is never re-stated.
+        ``timeout_seconds`` SHORTENS that budget; ``None`` (the default) takes
+        it whole. It is a ceiling, not a swap: an explicit number is clamped by
+        ``min`` to :data:`VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS`, so the
+        settle cap remains the one number that bounds every wait this class can
+        perform. That matters because the cap is what the test suite shrinks to
+        keep the day/night rail gate sub-second — a caller-supplied budget that
+        won outright would silently reinstate the real multi-second wait
+        wherever a test patched only the cap. ``0`` makes this a SINGLE-SHOT
+        read — the loop is a do-while, so ``done`` is always evaluated at least
+        once — which is what a caller that is itself a periodic retry loop
+        wants: it asks whether the threshold is satisfied right now and re-asks
+        on its own next tick, instead of blocking for a budget that may be as
+        long as its own interval. One implementation either way; the predicate
+        is never re-stated.
 
         ``done`` is evaluated BEFORE the first sleep, so an already-satisfied
         condition returns on one read with no waiting at all. Returns ``True``
@@ -1247,7 +1254,7 @@ class DualAxisSequencer:
         budget = (
             VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
             if timeout_seconds is None
-            else timeout_seconds
+            else min(timeout_seconds, VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS)
         )
         deadline = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=budget)
         while True:

--- a/custom_components/adaptive_cover_pro/services/options_service.py
+++ b/custom_components/adaptive_cover_pro/services/options_service.py
@@ -45,6 +45,7 @@ from ..const import (
     CONF_CLOUD_SUPPRESSION_HOLD_TIME,
     CONF_CLOUD_SUPPRESSION_PRIORITY,
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD,
+    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DAY_NIGHT_OPACITY_BLACKOUT,
@@ -455,6 +456,7 @@ FIELD_VALIDATORS: dict[str, Any] = {
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD: _range(CONF_DAY_NIGHT_BLACKOUT_THRESHOLD),
     CONF_DAY_NIGHT_CONTROL_MODEL: _select_v(*DAY_NIGHT_CONTROL_MODELS),
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: _entity_v(),
+    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL: _bool_v(),
     # Geometry — dual-panel shade (#996)
     CONF_DUAL_PANEL_FRONT_ENTITY: _entity_v(),
     CONF_DUAL_PANEL_BLACKOUT_TRIGGERS: _list_subset_v(*DUAL_PANEL_BLACKOUT_TRIGGERS),
@@ -928,6 +930,8 @@ _SECTION_GEOMETRY_DAY_NIGHT = frozenset(
         # Model C middle-rail entity — has a FIELD_VALIDATORS entry, so it must
         # be service-settable too (else the validator is dead code) (#993).
         CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
+        # Model C rail-travel policy, same wiring rule (#1140).
+        CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     }
 )
 _SECTION_GEOMETRY_DUAL_PANEL = frozenset(

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -59,7 +59,7 @@
     "until_sunrise": "hält bis zum nächsten Sonnenaufgang",
     "until_next_sun_event": "hält bis zum nächsten Sonnenauf- oder -untergang",
     "until_window_end": "hält bis zum Ende des Zeitfensters",
-    "until_window_end_no_window": "\u26a0\ufe0f Die manuelle Übersteuerung soll bis zum Ende des Zeitfensters halten, es ist aber keine Endzeit konfiguriert \u2014 stattdessen wird die eingestellte Dauer verwendet",
+    "until_window_end_no_window": "⚠️ Die manuelle Übersteuerung soll bis zum Ende des Zeitfensters halten, es ist aber keine Endzeit konfiguriert — stattdessen wird die eingestellte Dauer verwendet",
     "threshold": "Schwellwert {threshold}%",
     "resets_on_move": "setzt bei nächster Bewegung zurück",
     "ignore_intermediate": "ignoriert Zwischenpositionen",
@@ -294,7 +294,10 @@
     "day_night": {
       "model_position_tilt": "position und neigung (zweiachsig)",
       "model_split_range": "geteilter bereich (einachsig)",
-      "model_dual_entity": "zwei Schienen-Entitäten (Doppelentität)"
+      "model_dual_entity": "zwei Schienen-Entitäten (Doppelentität)",
+      "rail_travel": "Schienenbewegung: {v}",
+      "rail_travel_concurrent": "beide Schienen bewegen sich gleichzeitig, sobald die führende Schiene unterwegs ist",
+      "rail_travel_serialized": "Schienen bewegen sich nacheinander — die nachfolgende Schiene wartet auf vollständige Freigabe"
     },
     "dual_panel": {
       "front_entity": "transparentes Frontpaneel: {v}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -295,7 +295,10 @@
     "day_night": {
       "model_position_tilt": "position and tilt (dual axis)",
       "model_split_range": "split range (single axis)",
-      "model_dual_entity": "two rail entities (dual entity)"
+      "model_dual_entity": "two rail entities (dual entity)",
+      "rail_travel": "rail travel: {v}",
+      "rail_travel_concurrent": "both rails move concurrently once the leading rail is under way",
+      "rail_travel_serialized": "rails move one at a time — the following rail waits for full clearance"
     },
     "dual_panel": {
       "front_entity": "front (sheer) panel: {v}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -59,7 +59,7 @@
     "until_sunrise": "maintient jusqu'au prochain lever de soleil",
     "until_next_sun_event": "maintient jusqu'au prochain lever ou coucher de soleil",
     "until_window_end": "maintient jusqu'à la fin de la fenêtre de temps",
-    "until_window_end_no_window": "\u26a0\ufe0f La dérogation manuelle doit maintenir jusqu'à la fin de la fenêtre de temps, mais aucune heure de fin n'est configurée \u2014 la durée configurée est utilisée à la place",
+    "until_window_end_no_window": "⚠️ La dérogation manuelle doit maintenir jusqu'à la fin de la fenêtre de temps, mais aucune heure de fin n'est configurée — la durée configurée est utilisée à la place",
     "threshold": "seuil {threshold}%",
     "resets_on_move": "réinitialise au prochain mouvement",
     "ignore_intermediate": "ignore les positions intermédiaires",
@@ -294,7 +294,10 @@
     "day_night": {
       "model_position_tilt": "position et inclinaison (à deux axes)",
       "model_split_range": "plage fractionnée (à un seul axe)",
-      "model_dual_entity": "deux entités de rail (double entité)"
+      "model_dual_entity": "deux entités de rail (double entité)",
+      "rail_travel": "déplacement du rail : {v}",
+      "rail_travel_concurrent": "les deux rails se déplacent simultanément une fois que le rail de tête est en mouvement",
+      "rail_travel_serialized": "les rails se déplacent à tour de rôle — le rail suivant attend le dégagement complet"
     },
     "dual_panel": {
       "front_entity": "panneau avant (voile) : {v}",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -125,7 +125,8 @@
           "day_night_middle_rail_entity": "Mittlere Schiene-Entität (Doppelentitäts-Modell)",
           "dual_panel_front_entity": "Transparentes Frontpaneel",
           "dual_panel_blackout_triggers": "Verdunkelungs-Auslöser",
-          "awning_shade_mode": "Markisen-Beschattungsmodus"
+          "awning_shade_mode": "Markisen-Beschattungsmodus",
+          "day_night_concurrent_rail_travel": "Schienen gemeinsam bewegen (zwei Schienen-Entitäten)"
         },
         "data_description": {
           "window_height": "Höhe Ihres Fensters (von unten bis oben des Glasbereichs). In der von Home Assistant konfigurierten Einheit angezeigt. Beispiele: Standard-Tür = 2,0 m / 79 in, Kleines Fenster = 1,5 m / 59 in, Vom Boden bis zur Decke = 2,5 m / 98 in. Messen Sie von dort, wo die Beschattung beginnt, bis dort, wo sie endet, wenn sie vollständig ausgefahren ist.",
@@ -181,7 +182,8 @@
           "day_night_middle_rail_entity": "Nur für das **Zwei Schienen-Entitäten**-Modell: Welche Beschattung dieser Instanz ist die mittlere Schiene. Die andere konfigurierte Beschattung ist die untere Schiene. Die mittlere Schiene wird garantiert nicht unter die untere Schiene fallen.",
           "dual_panel_front_entity": "Welches der Covers dieser Instanz ist das **transparente Frontpaneel**. Es folgt der Sonne wie eine normale Jalousie. Alle anderen konfigurierten Covers sind das **Verdunkelungspaneel**. Lassen Sie diesen Wert leer, um als normale Jalousie zu funktionieren.",
           "dual_panel_blackout_triggers": "Wenn das **Verdunkelungspaneel** schließt. **Wärme**: Klima-Sommer / extreme Hitze Block. **Datenschutz**: Sonnenuntergangsfenster. **Nacht**: Sonne unter dem Horizont. Wählen Sie eine beliebige Kombination – das Verdunkelungspaneel öffnet sich, wenn keiner der ausgewählten Auslöser aktiv ist. Die beiden Paneele sind unabhängig.",
-          "awning_shade_mode": "Ob die Markise das Fenster-Glas oder den gesamten Bereich davor beschattet. **Fenster beschatten** (Standard): Gerade weit genug ausfahren, um die direkte Sonne vom Fenster fernzuhalten, und einfahren, wenn die Sonne zur Seite des Fensters wandert – am besten zur Verringerung von Blendung und Wärmeeintrag am Glas. **Bereich davor beschatten (Terrasse)**: Vollständig ausgefahren bleiben, wenn die Sonne vor der Markise steht, um eine Terrasse oder einen Sitzbereich statt des Fensters zu beschatten."
+          "awning_shade_mode": "Ob die Markise das Fenster-Glas oder den gesamten Bereich davor beschattet. **Fenster beschatten** (Standard): Gerade weit genug ausfahren, um die direkte Sonne vom Fenster fernzuhalten, und einfahren, wenn die Sonne zur Seite des Fensters wandert – am besten zur Verringerung von Blendung und Wärmeeintrag am Glas. **Bereich davor beschatten (Terrasse)**: Vollständig ausgefahren bleiben, wenn die Sonne vor der Markise steht, um eine Terrasse oder einen Sitzbereich statt des Fensters zu beschatten.",
+          "day_night_concurrent_rail_travel": "Nur für das Modell **Zwei Schienen-Entitäten**: ob die beiden Schienen gleichzeitig bewegt werden dürfen. **An** (Standard): Die nachfolgende Schiene beginnt, sobald die führende Schiene bestätigt ist, unterwegs und vor ihr liegt, damit die Beschattung ihre Position in einer Reisedauer statt zwei erreicht. Die Schienen teilen sich eine Bahn und ihre Ziele können sich nie kreuzen, der Abstand bleibt also für den Rest der Bewegung erhalten. **Aus**: Die nachfolgende Schiene wartet, bis die führende Schiene ihr Ziel vollständig freigegeben hat, bevor sie sich überhaupt bewegt — langsamer, aber die konservativste Option, wenn Ihre beiden Schienen mit merklich unterschiedlichen Geschwindigkeiten fahren oder Ihre Motoren die Position mit einer langen Verzögerung melden."
         }
       },
       "duplicate_select": {
@@ -407,7 +409,8 @@
           "day_night_middle_rail_entity": "Mittlere Schiene-Entität (Doppelentitäts-Modell)",
           "dual_panel_front_entity": "Transparentes Frontpaneel",
           "dual_panel_blackout_triggers": "Verdunkelungs-Auslöser",
-          "awning_shade_mode": "Markisen-Beschattungsmodus"
+          "awning_shade_mode": "Markisen-Beschattungsmodus",
+          "day_night_concurrent_rail_travel": "Schienen gemeinsam bewegen (zwei Schienen-Entitäten)"
         },
         "data_description": {
           "window_height": "Höhe Ihres Fensters (von unten bis oben des Glasbereichs). In der von Home Assistant konfigurierten Einheit angezeigt. Beispiele: Standard-Tür = 2,0 m / 79 in, Kleines Fenster = 1,5 m / 59 in, Vom Boden bis zur Decke = 2,5 m / 98 in. Messen Sie von dort, wo die Beschattung beginnt, bis dort, wo sie endet, wenn sie vollständig ausgefahren ist.",
@@ -463,7 +466,8 @@
           "day_night_middle_rail_entity": "Nur für das **Zwei Schienen-Entitäten**-Modell: Welche Beschattung dieser Instanz ist die mittlere Schiene. Die andere konfigurierte Beschattung ist die untere Schiene. Die mittlere Schiene wird garantiert nicht unter die untere Schiene fallen.",
           "dual_panel_front_entity": "Welches der Covers dieser Instanz ist das **transparente Frontpaneel**. Es folgt der Sonne wie eine normale Jalousie. Alle anderen konfigurierten Covers sind das **Verdunkelungspaneel**. Lassen Sie diesen Wert leer, um als normale Jalousie zu funktionieren.",
           "dual_panel_blackout_triggers": "Wenn das **Verdunkelungspaneel** schließt. **Wärme**: Klima-Sommer / extreme Hitze Block. **Datenschutz**: Sonnenuntergangsfenster. **Nacht**: Sonne unter dem Horizont. Wählen Sie eine beliebige Kombination – das Verdunkelungspaneel öffnet sich, wenn keiner der ausgewählten Auslöser aktiv ist. Die beiden Paneele sind unabhängig.",
-          "awning_shade_mode": "Ob die Markise das Fenster-Glas oder den gesamten Bereich davor beschattet. **Fenster beschatten** (Standard): Gerade weit genug ausfahren, um die direkte Sonne vom Fenster fernzuhalten, und einfahren, wenn die Sonne zur Seite des Fensters wandert – am besten zur Verringerung von Blendung und Wärmeeintrag am Glas. **Bereich davor beschatten (Terrasse)**: Vollständig ausgefahren bleiben, wenn die Sonne vor der Markise steht, um eine Terrasse oder einen Sitzbereich statt des Fensters zu beschatten."
+          "awning_shade_mode": "Ob die Markise das Fenster-Glas oder den gesamten Bereich davor beschattet. **Fenster beschatten** (Standard): Gerade weit genug ausfahren, um die direkte Sonne vom Fenster fernzuhalten, und einfahren, wenn die Sonne zur Seite des Fensters wandert – am besten zur Verringerung von Blendung und Wärmeeintrag am Glas. **Bereich davor beschatten (Terrasse)**: Vollständig ausgefahren bleiben, wenn die Sonne vor der Markise steht, um eine Terrasse oder einen Sitzbereich statt des Fensters zu beschatten.",
+          "day_night_concurrent_rail_travel": "Nur für das Modell **Zwei Schienen-Entitäten**: ob die beiden Schienen gleichzeitig bewegt werden dürfen. **An** (Standard): Die nachfolgende Schiene beginnt, sobald die führende Schiene bestätigt ist, unterwegs und vor ihr liegt, damit die Beschattung ihre Position in einer Reisedauer statt zwei erreicht. Die Schienen teilen sich eine Bahn und ihre Ziele können sich nie kreuzen, der Abstand bleibt also für den Rest der Bewegung erhalten. **Aus**: Die nachfolgende Schiene wartet, bis die führende Schiene ihr Ziel vollständig freigegeben hat, bevor sie sich überhaupt bewegt — langsamer, aber die konservativste Option, wenn Ihre beiden Schienen mit merklich unterschiedlichen Geschwindigkeiten fahren oder Ihre Motoren die Position mit einer langen Verzögerung melden."
         }
       },
       "sun_tracking": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -124,6 +124,7 @@
           "day_night_blackout_threshold": "Blackout Engage Threshold (%)",
           "day_night_control_model": "Control Model",
           "day_night_middle_rail_entity": "Middle Rail Entity (dual-entity model)",
+          "day_night_concurrent_rail_travel": "Move Both Rails Together (dual-entity model)",
           "dual_panel_front_entity": "Front (Sheer) Panel Entity",
           "dual_panel_blackout_triggers": "Blackout Deploy Triggers"
         },
@@ -180,6 +181,7 @@
           "day_night_blackout_threshold": "When the sun is in the tracking window during summer and the sheer fabric's opacity is **below** this value, the shade escalates to the blackout fabric to block the heat. Default 65. Raise it to reach for blackout sooner; lower it to keep the sheer fabric longer.",
           "day_night_control_model": "How the abstract coverage + fabric pair maps onto your physical cover. **Position + tilt** (default): the shade drives set_position for coverage and set_tilt_position for the sheer/blackout fabric blend — for hardware exposing both axes. **Split range**: a single-axis cover whose position range encodes both — the lower half (0–50%) selects the blackout fabric, the upper half (50–100%) the sheer fabric — for hardware with only one motor. **Two rail entities**: two separate cover entities — a bottom rail and a middle rail — where the fabric blend folds into the middle rail's absolute position.",
           "day_night_middle_rail_entity": "For the **Two rail entities** model only: which of this instance's covers is the middle rail. The other configured cover is the bottom rail. The middle rail is guaranteed never to drop below the bottom rail.",
+          "day_night_concurrent_rail_travel": "For the **Two rail entities** model only: whether the two rails may travel at the same time. **On** (default): the following rail starts as soon as the leading rail is confirmed under way and ahead of it, so the shade reaches its position in one travel time instead of two. The rails share one track and their targets can never cross, so the separation holds for the rest of the move. **Off**: the following rail waits until the leading rail has fully cleared its target before moving at all — slower, but the most conservative option if your two rails travel at noticeably different speeds or your motors report position with a long lag.",
           "dual_panel_front_entity": "Which of this instance's covers is the **front / sheer** panel. It sun-tracks like a plain vertical blind. Every other configured cover is the **back / blackout** panel. Leave unset to run as a plain vertical blind.",
           "dual_panel_blackout_triggers": "When the back **blackout** panel deploys (closes). **Heat**: a climate summer / extreme-heat full block. **Privacy**: the sunset window. **Night**: the sun is below the horizon. Select any combination — the back retracts (opens) whenever none of the selected triggers is active. The two panels are independent (no no-pass coupling)."
         }
@@ -445,6 +447,7 @@
           "day_night_blackout_threshold": "Blackout Engage Threshold (%)",
           "day_night_control_model": "Control Model",
           "day_night_middle_rail_entity": "Middle Rail Entity (dual-entity model)",
+          "day_night_concurrent_rail_travel": "Move Both Rails Together (dual-entity model)",
           "dual_panel_front_entity": "Front (Sheer) Panel Entity",
           "dual_panel_blackout_triggers": "Blackout Deploy Triggers"
         },
@@ -501,6 +504,7 @@
           "day_night_blackout_threshold": "When the sun is in the tracking window during summer and the sheer fabric's opacity is **below** this value, the shade escalates to the blackout fabric to block the heat. Default 65. Raise it to reach for blackout sooner; lower it to keep the sheer fabric longer.",
           "day_night_control_model": "How the abstract coverage + fabric pair maps onto your physical cover. **Position + tilt** (default): the shade drives set_position for coverage and set_tilt_position for the sheer/blackout fabric blend — for hardware exposing both axes. **Split range**: a single-axis cover whose position range encodes both — the lower half (0–50%) selects the blackout fabric, the upper half (50–100%) the sheer fabric — for hardware with only one motor. **Two rail entities**: two separate cover entities — a bottom rail and a middle rail — where the fabric blend folds into the middle rail's absolute position.",
           "day_night_middle_rail_entity": "For the **Two rail entities** model only: which of this instance's covers is the middle rail. The other configured cover is the bottom rail. The middle rail is guaranteed never to drop below the bottom rail.",
+          "day_night_concurrent_rail_travel": "For the **Two rail entities** model only: whether the two rails may travel at the same time. **On** (default): the following rail starts as soon as the leading rail is confirmed under way and ahead of it, so the shade reaches its position in one travel time instead of two. The rails share one track and their targets can never cross, so the separation holds for the rest of the move. **Off**: the following rail waits until the leading rail has fully cleared its target before moving at all — slower, but the most conservative option if your two rails travel at noticeably different speeds or your motors report position with a long lag.",
           "dual_panel_front_entity": "Which of this instance's covers is the **front / sheer** panel. It sun-tracks like a plain vertical blind. Every other configured cover is the **back / blackout** panel. Leave unset to run as a plain vertical blind.",
           "dual_panel_blackout_triggers": "When the back **blackout** panel deploys (closes). **Heat**: a climate summer / extreme-heat full block. **Privacy**: the sunset window. **Night**: the sun is below the horizon. Select any combination — the back retracts (opens) whenever none of the selected triggers is active. The two panels are independent (no no-pass coupling)."
         }

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -125,7 +125,8 @@
           "day_night_middle_rail_entity": "Entité du Rail Central (modèle double entité)",
           "dual_panel_front_entity": "Entité du panneau avant (voile)",
           "dual_panel_blackout_triggers": "Déclencheurs du déploiement de l'occultant",
-          "awning_shade_mode": "Mode Store Banne"
+          "awning_shade_mode": "Mode Store Banne",
+          "day_night_concurrent_rail_travel": "Déplacer les deux rails ensemble (modèle double entité)"
         },
         "data_description": {
           "window_height": "Hauteur de votre fenêtre (de bas en haut de la zone vitrée). Affiché dans l'unité configurée dans Home Assistant. Exemples : Porte standard = 2,0 m / 79 in, Petite fenêtre = 1,5 m / 59 in, Du sol au plafond = 2,5 m / 98 in. Mesurez d'où la protection commence à d'où elle finit lorsqu'elle est complètement étendue.",
@@ -181,7 +182,8 @@
           "day_night_middle_rail_entity": "Pour le modèle **Deux entités de rail** uniquement : laquelle des stores configurées de cette instance est le rail central. L'autre store configurée est le rail inférieur. Le rail central est garanti de ne jamais descendre en dessous du rail inférieur.",
           "dual_panel_front_entity": "Quel store de cette instance est le panneau **avant / voile**. Il suit le soleil comme un store vertical simple. Tous les autres stores configurés sont le panneau **arrière / occultant**. Laissez non défini pour fonctionner comme un store vertical simple.",
           "dual_panel_blackout_triggers": "Quand le panneau **occultant** arrière se déploie (se ferme). **Chaleur** : un été climatique / blocage total chaleur extrême. **Confidentialité** : la fenêtre du coucher du soleil. **Nuit** : le soleil est sous l'horizon. Sélectionnez n'importe quelle combinaison — l'arrière se rétracte (s'ouvre) chaque fois qu'aucun des déclencheurs sélectionnés n'est actif. Les deux panneaux sont indépendants (aucun couplage no-pass).",
-          "awning_shade_mode": "Détermine si la store banne protège la vitre de la fenêtre ou toute la zone devant elle. **Ombrager la vitre** (par défaut) : déployez juste assez pour garder le soleil direct loin de la fenêtre, se rétractant à mesure que le soleil se déplace vers le côté de la fenêtre — idéal pour réduire l'éblouissement et la chaleur à la vitre. **Ombrage de la zone avant (terrasse)** : rester complètement déployé chaque fois que le soleil est devant la store banne, pour ombrager une terrasse ou un espace assis plutôt que la fenêtre."
+          "awning_shade_mode": "Détermine si la store banne protège la vitre de la fenêtre ou toute la zone devant elle. **Ombrager la vitre** (par défaut) : déployez juste assez pour garder le soleil direct loin de la fenêtre, se rétractant à mesure que le soleil se déplace vers le côté de la fenêtre — idéal pour réduire l'éblouissement et la chaleur à la vitre. **Ombrage de la zone avant (terrasse)** : rester complètement déployé chaque fois que le soleil est devant la store banne, pour ombrager une terrasse ou un espace assis plutôt que la fenêtre.",
+          "day_night_concurrent_rail_travel": "Pour le modèle **Deux entités de rail** uniquement : permettre aux deux rails de se déplacer au même moment. **Activé** (par défaut) : le rail suivant démarre dès que le rail de tête est confirmé en mouvement et le devance, de sorte que le store atteigne sa position en un seul temps de déplacement au lieu de deux. Les rails partagent une seule piste et leurs cibles ne peuvent jamais se croiser, de sorte que la séparation est maintenue pour le reste du déplacement. **Désactivé** : le rail suivant attend que le rail de tête ait complètement quitté sa position cible avant de se déplacer du tout — plus lent, mais l'option la plus prudente si vos deux rails se déplacent à des vitesses notablement différentes ou si vos moteurs rapportent la position avec un long délai."
         }
       },
       "duplicate_select": {
@@ -407,7 +409,8 @@
           "day_night_middle_rail_entity": "Entité du Rail Central (modèle double entité)",
           "dual_panel_front_entity": "Entité du panneau avant (voile)",
           "dual_panel_blackout_triggers": "Déclencheurs du déploiement de l'occultant",
-          "awning_shade_mode": "Mode Store Banne"
+          "awning_shade_mode": "Mode Store Banne",
+          "day_night_concurrent_rail_travel": "Déplacer les deux rails ensemble (modèle double entité)"
         },
         "data_description": {
           "window_height": "Hauteur de votre fenêtre (de bas en haut de la zone vitrée). Affiché dans l'unité configurée dans Home Assistant. Exemples : Porte standard = 2,0 m / 79 in, Petite fenêtre = 1,5 m / 59 in, Du sol au plafond = 2,5 m / 98 in. Mesurez d'où la protection commence à d'où elle finit lorsqu'elle est complètement étendue.",
@@ -463,7 +466,8 @@
           "day_night_middle_rail_entity": "Pour le modèle **Deux entités de rail** uniquement : laquelle des stores configurées de cette instance est le rail central. L'autre store configurée est le rail inférieur. Le rail central est garanti de ne jamais descendre en dessous du rail inférieur.",
           "dual_panel_front_entity": "Quel store de cette instance est le panneau **avant / voile**. Il suit le soleil comme un store vertical simple. Tous les autres stores configurés sont le panneau **arrière / occultant**. Laissez non défini pour fonctionner comme un store vertical simple.",
           "dual_panel_blackout_triggers": "Quand le panneau **occultant** arrière se déploie (se ferme). **Chaleur** : un été climatique / blocage total chaleur extrême. **Confidentialité** : la fenêtre du coucher du soleil. **Nuit** : le soleil est sous l'horizon. Sélectionnez n'importe quelle combinaison — l'arrière se rétracte (s'ouvre) chaque fois qu'aucun des déclencheurs sélectionnés n'est actif. Les deux panneaux sont indépendants (aucun couplage no-pass).",
-          "awning_shade_mode": "Détermine si la store banne protège la vitre de la fenêtre ou toute la zone devant elle. **Ombrager la vitre** (par défaut) : déployez juste assez pour garder le soleil direct loin de la fenêtre, se rétractant à mesure que le soleil se déplace vers le côté de la fenêtre — idéal pour réduire l'éblouissement et la chaleur à la vitre. **Ombrage de la zone avant (terrasse)** : rester complètement déployé chaque fois que le soleil est devant la store banne, pour ombrager une terrasse ou un espace assis plutôt que la fenêtre."
+          "awning_shade_mode": "Détermine si la store banne protège la vitre de la fenêtre ou toute la zone devant elle. **Ombrager la vitre** (par défaut) : déployez juste assez pour garder le soleil direct loin de la fenêtre, se rétractant à mesure que le soleil se déplace vers le côté de la fenêtre — idéal pour réduire l'éblouissement et la chaleur à la vitre. **Ombrage de la zone avant (terrasse)** : rester complètement déployé chaque fois que le soleil est devant la store banne, pour ombrager une terrasse ou un espace assis plutôt que la fenêtre.",
+          "day_night_concurrent_rail_travel": "Pour le modèle **Deux entités de rail** uniquement : permettre aux deux rails de se déplacer au même moment. **Activé** (par défaut) : le rail suivant démarre dès que le rail de tête est confirmé en mouvement et le devance, de sorte que le store atteigne sa position en un seul temps de déplacement au lieu de deux. Les rails partagent une seule piste et leurs cibles ne peuvent jamais se croiser, de sorte que la séparation est maintenue pour le reste du déplacement. **Désactivé** : le rail suivant attend que le rail de tête ait complètement quitté sa position cible avant de se déplacer du tout — plus lent, mais l'option la plus prudente si vos deux rails se déplacent à des vitesses notablement différentes ou si vos moteurs rapportent la position avec un long délai."
         }
       },
       "sun_tracking": {

--- a/tests/test_config_entry_migration.py
+++ b/tests/test_config_entry_migration.py
@@ -253,7 +253,7 @@ async def test_migrate_v3_2_copies_force_override_into_slot_5(
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
     assert entry.options[_SLOT5["min_mode"]] is True
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_2_preserves_legacy_keys_for_rollback(
@@ -289,7 +289,7 @@ async def test_migrate_v3_2_no_force_config_is_a_noop(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
     assert _SLOT5["position"] not in entry.options
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> None:
@@ -302,7 +302,7 @@ async def test_migrate_v3_2_empty_sensor_list_is_a_noop(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert _SLOT5["sensors"] not in entry.options
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_2_missing_position_defaults_to_zero(
@@ -329,7 +329,7 @@ async def test_migrate_v1_cascades_through_v3_2(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options[CONF_WINDOW_WIDTH] == 2.0
     assert entry.options[_SLOT5["priority"]] == CUSTOM_POSITION_SAFETY_PRIORITY
 
@@ -366,7 +366,7 @@ async def test_migrate_v3_3_copies_legacy_single_sensor_into_list(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CUSTOM_POSITION_SLOTS[1]["sensors"]] == ["binary_sensor.table"]
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_3_leaves_legacy_key_intact(hass: HomeAssistant) -> None:
@@ -408,7 +408,7 @@ async def test_migrate_v3_3_no_legacy_is_noop(hass: HomeAssistant) -> None:
         minor_version=2,
     )
     await async_migrate_entry(hass, entry)
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     for slot_n in (1, 2, 3, 4, 5):
         assert CUSTOM_POSITION_SLOTS[slot_n]["sensors"] not in entry.options
 
@@ -431,7 +431,7 @@ async def test_migrate_v3_4_sets_position_matching_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=3)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> None:
@@ -444,7 +444,7 @@ async def test_migrate_v3_4_no_op_when_key_already_true(hass: HomeAssistant) -> 
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -457,7 +457,7 @@ async def test_migrate_v3_4_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is False
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> None:
@@ -466,7 +466,7 @@ async def test_migrate_v1_cascades_to_position_matching(hass: HomeAssistant) -> 
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_ENABLE_POSITION_MATCHING] is True
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 # ---------------------------------------------------------------------------
@@ -488,7 +488,7 @@ async def test_migrate_v3_6_sets_weather_enabled_true_for_existing_entry(
     entry = _make_entry(hass, {"azimuth": 180}, version=3, minor_version=5)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) -> None:
@@ -501,7 +501,7 @@ async def test_migrate_v3_6_no_op_when_key_already_false(hass: HomeAssistant) ->
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is False
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
@@ -514,7 +514,7 @@ async def test_migrate_v3_6_explicit_true_survives(hass: HomeAssistant) -> None:
     )
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> None:
@@ -523,7 +523,7 @@ async def test_migrate_v1_cascades_to_weather_enabled(hass: HomeAssistant) -> No
     await async_migrate_entry(hass, entry)
     assert entry.options[CONF_WEATHER_ENABLED] is True
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 # ---------------------------------------------------------------------------
@@ -544,7 +544,7 @@ async def test_migrate_v3_6_to_3_7_is_noop_bump(hass: HomeAssistant) -> None:
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     # Additive/no-op: no outside_temp_source key seeded, options untouched.
     assert "outside_temp_source" not in entry.options
     # Cascades on through v3.13 too, which seeds default_percentage (#1126).
@@ -561,9 +561,9 @@ async def test_migrate_v3_6_to_3_7_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options == first
 
 
@@ -579,7 +579,7 @@ async def test_migrate_v3_6_to_3_7_preserves_explicit_source(
     )
     await async_migrate_entry(hass, entry)
     assert entry.options["outside_temp_source"] == "max_of_live_and_forecast"
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
 
 
 # ---------------------------------------------------------------------------
@@ -610,7 +610,7 @@ async def test_migrate_v3_4_bumps_through_minor_5_without_seeding(
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     # No dead key seeded by the v3.4→v3.5 block.
     assert "show_weather_retraction" not in entry.options
     assert entry.options == {
@@ -650,7 +650,7 @@ async def test_migrate_v3_7_to_v3_8_converts_blind_spots(hass: HomeAssistant) ->
     )
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     opts = entry.options
     # Slot 1 converted (new_left = 45-10 = 35, new_right = 30-45 = -15).
     assert opts["blind_spot_left_gamma"] == 35
@@ -683,9 +683,9 @@ async def test_migrate_v3_7_to_v3_8_is_idempotent(hass: HomeAssistant) -> None:
     )
     assert await async_migrate_entry(hass, entry) is True
     first = dict(entry.options)
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options == first
 
 
@@ -721,7 +721,7 @@ async def test_migrate_v3_7_to_v3_8_no_blind_spot_is_noop(hass: HomeAssistant) -
     )
     before = dict(entry.options)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options == {**before, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -748,7 +748,7 @@ async def test_migrate_v3_7_to_v3_8_tolerates_none_fov_left(
         minor_version=7,
     )
     assert await async_migrate_entry(hass, entry) is True  # no TypeError
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options["blind_spot_left_gamma"] == 80  # 90 - 10
     assert entry.options["blind_spot_right_gamma"] == -60  # 30 - 90
 
@@ -797,14 +797,14 @@ def test_config_flow_minor_version_reaches_highest_migration_target() -> None:
     that minor are never seen as stale and the migration is dead code in
     production.
 
-    Currently the highest target is 13 (the v3.12 → v3.13 block that seeds
-    default_percentage for entries the minimal create wizard left key-less,
-    per issue #1126).
+    Currently the highest target is 14 (the v3.13 → v3.14 no-op block that
+    advances entries past the additive day_night_concurrent_rail_travel
+    option, per issue #1140).
     Raise this assertion whenever a new minor migration block is added.
     """
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
-    assert ConfigFlowHandler.MINOR_VERSION == 13
+    assert ConfigFlowHandler.MINOR_VERSION == 14
 
 
 # ---------------------------------------------------------------------------
@@ -860,7 +860,7 @@ async def test_migrate_v3_8_to_v3_9_is_additive_noop(hass: HomeAssistant) -> Non
     entry = _make_entry(hass, dict(options), version=3, minor_version=8)
     assert await async_migrate_entry(hass, entry) is True
     assert entry.version == 3
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -889,7 +889,7 @@ async def test_migrate_v3_9_to_v3_10_additive_noop_without_legacy_margin(
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=9)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -913,7 +913,7 @@ async def test_migrate_v3_9_to_v3_10_copies_legacy_safety_margin(
         minor_version=9,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     # New neutral key seeded from the legacy value.
     assert entry.options[CONF_TILT_SAFETY_MARGIN] == 0.5
     # Legacy key retained unchanged (additive / rollback-safe).
@@ -952,7 +952,7 @@ async def test_migrate_v3_10_is_idempotent(hass: HomeAssistant) -> None:
     }
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
 
 
@@ -977,7 +977,7 @@ async def test_migrate_v3_10_to_v3_11_seeds_shade_mode_for_awning(
         minor_version=10,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options[CONF_AWNING_SHADE_MODE] == AWNING_SHADE_MODE_WINDOW
 
 
@@ -990,7 +990,7 @@ async def test_migrate_v3_10_to_v3_11_skips_non_awning(
     options = {"azimuth": 180, "custom_position_sensors_1": ["binary_sensor.door"]}
     entry = _make_entry(hass, dict(options), version=3, minor_version=10)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert CONF_AWNING_SHADE_MODE not in entry.options
     # Cascades on through v3.13, which seeds this blind's default position (#1126).
     assert dict(entry.options) == {**options, CONF_DEFAULT_HEIGHT: 100}
@@ -1065,7 +1065,7 @@ async def test_migrate_v3_11_to_v3_12_repairs_malformed_time(
     """
     entry = _make_entry(hass, {time_key: stored}, version=3, minor_version=11)
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options[time_key] == expected
 
 
@@ -1174,7 +1174,7 @@ async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_blind(
         sensor_type=CoverType.BLIND,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options[CONF_DEFAULT_HEIGHT] == 100
 
 
@@ -1197,7 +1197,7 @@ async def test_migrate_v3_12_to_v3_13_seeds_default_position_for_awning(
         sensor_type=CoverType.AWNING,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     assert entry.options[CONF_DEFAULT_HEIGHT] == 0
 
 
@@ -1298,7 +1298,7 @@ async def test_migrate_v3_13_unknown_sensor_type_does_not_abort_cascade(
         sensor_type=bad_sensor_type,
     )
     assert await async_migrate_entry(hass, entry) is True
-    assert entry.minor_version == 13
+    assert entry.minor_version == 14
     # The v3.11 → v3.12 sibling repair still landed — proof the cascade
     # continued past the bad sensor_type instead of aborting.
     assert entry.options["end_time"] == "00:00:00"
@@ -1429,3 +1429,61 @@ async def test_migrate_v3_9_preserves_user_set_constraints(
     assert await async_migrate_entry(hass, entry) is True
     assert entry.options["custom_position_tilt_min_1"] == 50
     assert entry.options["custom_position_position_max_1"] == 60
+
+
+# ---------------------------------------------------------------------------
+# Migration: v3.13 → v3.14 — no-op minor bump for the additive
+# day_night_concurrent_rail_travel option (issue #1140). An absent key already
+# reads as "on" (the default), so nothing needs seeding; the block only advances
+# a stale minor-13 entry to 14 so it stops re-triggering migration every restart
+# (the v3.6 → v3.7 precedent).
+# ---------------------------------------------------------------------------
+
+
+async def test_migrate_v3_13_advances_to_14_without_seeding(
+    hass: HomeAssistant,
+) -> None:
+    """A minor-13 entry reaches minor 14 with its options untouched."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180, CONF_DEFAULT_HEIGHT: 60},
+        version=3,
+        minor_version=13,
+    )
+    before = dict(entry.options)
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 3
+    assert entry.minor_version == 14
+    assert "day_night_concurrent_rail_travel" not in entry.options
+    assert entry.options == before
+
+
+async def test_migrate_v3_13_to_v3_14_is_idempotent(hass: HomeAssistant) -> None:
+    """Re-running the migration on an already-advanced entry is stable."""
+    entry = _make_entry(
+        hass,
+        {"azimuth": 180},
+        version=3,
+        minor_version=13,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    first = dict(entry.options)
+    assert entry.minor_version == 14
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.minor_version == 14
+    assert entry.options == first
+
+
+async def test_migrate_v3_13_to_v3_14_preserves_an_explicit_choice(
+    hass: HomeAssistant,
+) -> None:
+    """An entry that already turned concurrent rail travel off keeps it off."""
+    entry = _make_entry(
+        hass,
+        {"day_night_concurrent_rail_travel": False},
+        version=3,
+        minor_version=13,
+    )
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.options["day_night_concurrent_rail_travel"] is False
+    assert entry.minor_version == 14

--- a/tests/test_config_flow_change_cover_type.py
+++ b/tests/test_config_flow_change_cover_type.py
@@ -967,7 +967,7 @@ def test_config_entry_version_unchanged() -> None:
     from custom_components.adaptive_cover_pro.config_flow import ConfigFlowHandler
 
     assert ConfigFlowHandler.VERSION == 3
-    assert ConfigFlowHandler.MINOR_VERSION == 13
+    assert ConfigFlowHandler.MINOR_VERSION == 14
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_types/test_day_night_shade.py
+++ b/tests/test_cover_types/test_day_night_shade.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.selector import ENTITY_FILTER_SELECTOR_CONFIG_SCHEMA
 
 from custom_components.adaptive_cover_pro.const import (
     CONF_DAY_NIGHT_BLACKOUT_THRESHOLD,
+    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DAY_NIGHT_OPACITY_BLACKOUT,
@@ -28,6 +29,7 @@ from custom_components.adaptive_cover_pro.const import (
     DAY_NIGHT_MODEL_POSITION_TILT,
     DAY_NIGHT_MODEL_SPLIT_RANGE,
     DEFAULT_DAY_NIGHT_BLACKOUT_THRESHOLD,
+    DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     DEFAULT_DAY_NIGHT_OPACITY_BLACKOUT,
     DEFAULT_DAY_NIGHT_OPACITY_SHEER,
     OPTION_RANGES,
@@ -1400,3 +1402,106 @@ def test_dual_entity_labels_present_in_en_translations() -> None:
     # The middle-rail field label in both config + options geometry steps.
     assert en["config"]["step"]["geometry"]["data"][CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY]
     assert en["options"]["step"]["geometry"]["data"][CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY]
+
+
+# ---------------------------------------------------------------------------
+# Step 22 — concurrent rail travel (#1140)
+# ---------------------------------------------------------------------------
+# Model C's two rails share one track and their targets can never cross, so the
+# follower can start as soon as the leader is under way instead of waiting out
+# its whole travel. Default ON; the switch keeps the conservative #1115/#1118
+# full-clearance wait available for hardware that needs it.
+
+
+def test_geometry_schema_has_concurrent_rail_travel_toggle() -> None:
+    import voluptuous as vol
+
+    schema = DayNightShadePolicy().geometry_schema()
+    keys = {(k.schema if isinstance(k, vol.Marker) else k) for k in schema.schema}
+    assert CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL in keys
+    # Default ON — an upgraded install gets the faster behaviour.
+    assert schema({})[CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL] is True
+    assert (
+        schema({CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL: False})[
+            CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL
+        ]
+        is False
+    )
+
+
+def test_concurrent_rail_travel_option_registered() -> None:
+    """A boolean option: a FIELD_VALIDATORS entry, and no OPTION_RANGES entry.
+
+    Being in ``FIELD_VALIDATORS`` is not enough — a key the ``set_geometry``
+    service does not accept is silently dropped and its validator is dead code,
+    the wiring the middle-rail picker documents (#993). It also has to be in the
+    policy's own live-option set, which the geometry schema supplies.
+    """
+    import voluptuous as vol
+
+    from custom_components.adaptive_cover_pro.services.options_service import (
+        ALL_SETTABLE_KEYS,
+        FIELD_VALIDATORS,
+    )
+
+    assert DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL is True
+    assert CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL not in OPTION_RANGES
+
+    validator = FIELD_VALIDATORS[CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL]
+    assert validator(True) is True
+    assert validator(False) is False
+    with pytest.raises(vol.Invalid):
+        validator("not a boolean")
+
+    assert CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL in ALL_SETTABLE_KEYS
+    assert (
+        CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL
+        in DayNightShadePolicy().live_option_keys()
+    )
+
+
+def test_summary_renders_rail_travel_for_dual_entity_only() -> None:
+    """The rail-travel line is rendered for Model C, in both states — and only
+    for Model C, since it describes a two-entity sequencing policy the
+    single-carriage models have no rails to apply.
+    """
+    policy = DayNightShadePolicy()
+    base = {
+        CONF_HEIGHT_WIN: 2.0,
+        CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+    }
+
+    default_on = policy.summary_geometry_lines(base)
+    assert any("concurrently" in line for line in default_on), default_on
+
+    explicit_off = policy.summary_geometry_lines(
+        {**base, CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL: False}
+    )
+    assert any("one at a time" in line for line in explicit_off), explicit_off
+
+    model_a = policy.summary_geometry_lines(
+        {
+            CONF_HEIGHT_WIN: 2.0,
+            CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_POSITION_TILT,
+        }
+    )
+    assert not any("rail travel" in line for line in model_a), model_a
+
+
+def test_concurrent_rail_travel_label_present_in_en_translations() -> None:
+    import json
+    import pathlib
+
+    en = json.loads(
+        (
+            pathlib.Path(__file__).resolve().parent.parent.parent
+            / "custom_components"
+            / "adaptive_cover_pro"
+            / "translations"
+            / "en.json"
+        ).read_text(encoding="utf-8")
+    )
+    for flow in ("config", "options"):
+        step = en[flow]["step"]["geometry"]
+        assert step["data"][CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL]
+        assert step["data_description"][CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL]

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -49,6 +49,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from custom_components.adaptive_cover_pro.const import (
+    CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
     CONF_DAY_NIGHT_CONTROL_MODEL,
     CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY,
     CONF_DEFAULT_HEIGHT,
@@ -71,6 +72,7 @@ from custom_components.adaptive_cover_pro.pipeline.types import PipelineResult
 _BOTTOM = "cover.bottom_rail"
 _MIDDLE = "cover.middle_rail"
 _SEQ = "custom_components.adaptive_cover_pro.cover_types.venetian.sequencer"
+_POLICY = "custom_components.adaptive_cover_pro.cover_types.day_night_shade.policy"
 
 
 class _FakeCmdSvc:
@@ -93,6 +95,7 @@ def _dual_policy(
     middle: str = _MIDDLE,
     inverse: bool = False,
     interp: bool = False,
+    concurrent: bool | None = None,
     policy: DayNightShadePolicy | None = None,
 ) -> DayNightShadePolicy:
     """Build a real Model C policy with its per-cycle dispatch cache primed.
@@ -106,6 +109,10 @@ def _dual_policy(
     ``_dual_entity_inverse`` — answers ``False``. That split is what makes the
     seams' "invert iff configured" contract diverge from the install's own
     frame.
+
+    ``concurrent`` writes ``CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL`` explicitly;
+    ``None`` (the default) leaves the key absent, which is how an upgraded
+    install arrives and therefore what the option's own default governs.
     """
     from tests.cover_helpers import make_cover_config, make_vertical_config
 
@@ -118,6 +125,8 @@ def _dual_policy(
         CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
         CONF_DAY_NIGHT_MIDDLE_RAIL_ENTITY: middle,
     }
+    if concurrent is not None:
+        options[CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL] = concurrent
     if inverse:
         options[CONF_INVERSE_STATE] = True
     if interp:
@@ -552,6 +561,7 @@ def _rail_harness(
     blend: int | None,
     inverse: bool = False,
     interp: bool = False,
+    concurrent: bool | None = None,
 ):
     """Real ``CoverCommandService`` + real Model C policy over a scripted motor.
 
@@ -559,6 +569,9 @@ def _rail_harness(
     gate's position polls (``poll:<entity>``) with the actual service calls
     (``send:<entity>``), which is exactly the ordering the physical constraint
     is about.
+
+    ``concurrent`` is forwarded to :func:`_dual_policy` — ``None`` leaves the
+    rail-travel key absent so the option's own default governs.
     """
     from custom_components.adaptive_cover_pro.managers.cover_command import (
         CoverCommandService,
@@ -577,7 +590,11 @@ def _rail_harness(
     hass.states.get = MagicMock(return_value=state_obj)
 
     policy = _dual_policy(
-        position=position, blend=blend, inverse=inverse, interp=interp
+        position=position,
+        blend=blend,
+        inverse=inverse,
+        interp=interp,
+        concurrent=concurrent,
     )
 
     cmd_svc = CoverCommandService(
@@ -696,17 +713,77 @@ def _patch_caps():
     )
 
 
+# ---------------------------------------------------------------------------
+# The concurrent-rail-travel option is cached by the same hooks the model is
+# ---------------------------------------------------------------------------
+# The gate runs at the coordinator's dispatch seam, which is handed no
+# ``options``. Model C's control model solves that by caching from
+# ``sync_runtime_options`` (the coordinator's per-cycle hook) and again from
+# ``post_pipeline_resolve`` (so the hook is self-sufficient when a test drives
+# it directly). The rail-travel option rides exactly that path — no second
+# mechanism, no ``RuntimeConfig`` entry.
+
+
+def test_concurrent_travel_option_is_cached_by_runtime_hooks() -> None:
+    """Both option-reading hooks cache the flag; an absent key reads as ON."""
+    off = _dual_policy(position=30, blend=50, concurrent=False)
+    assert off._dual_entity_concurrent_travel is False
+
+    on = _dual_policy(position=30, blend=50, concurrent=True)
+    assert on._dual_entity_concurrent_travel is True
+
+    # An upgraded install has no key at all — the new behaviour is the default.
+    absent = _dual_policy(position=30, blend=50)
+    assert absent._dual_entity_concurrent_travel is True
+
+    # The coordinator's own per-cycle hook writes it too, not just the
+    # post-pipeline one, and a later cycle can flip it back.
+    off.sync_runtime_options(
+        {
+            CONF_DAY_NIGHT_CONTROL_MODEL: DAY_NIGHT_MODEL_DUAL_ENTITY,
+            CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL: True,
+        }
+    )
+    assert off._dual_entity_concurrent_travel is True
+    assert off._control_model == DAY_NIGHT_MODEL_DUAL_ENTITY
+    off.sync_runtime_options({CONF_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL: False})
+    assert off._dual_entity_concurrent_travel is False
+
+
+def test_concurrent_travel_defaults_on_for_a_fresh_policy() -> None:
+    """Before any options are seen the policy already answers with the default."""
+    from custom_components.adaptive_cover_pro.const import (
+        DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL,
+    )
+
+    assert DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL is True
+    assert (
+        DayNightShadePolicy()._dual_entity_concurrent_travel
+        is DEFAULT_DAY_NIGHT_CONCURRENT_RAIL_TRAVEL
+    )
+
+
 @pytest.mark.asyncio
-async def test_middle_rail_waits_for_bottom_rail_to_descend_past_it(
+async def test_middle_rail_waits_for_bottom_rail_to_start_descending(
     monkeypatch,
 ) -> None:
     """The crash repro: bottom rail stacked ABOVE the middle rail's target.
 
     Bottom rail live at 100 (fully up), this cycle's targets are bottom 30 /
     middle 65 (blend 50). The middle rail cannot reach 65 while the bottom rail
-    sits at 100 above it — commanding it there stalls the motor. The gate must
-    hold the middle rail's ``set_cover_position`` until a live reading shows the
-    bottom rail has descended to (or past) 65.
+    still sits at 100 above it — commanding it there stalls the motor. The gate
+    must hold the middle rail's ``set_cover_position`` until live readings prove
+    the bottom rail is descending out of the way.
+
+    Under the default concurrent-travel policy (#1140) "out of the way" means
+    under way and ahead: the two rails share one track at one speed and their
+    two TARGETS can never cross, so a bottom rail that has demonstrably started
+    down stays ahead for the rest of the move. What the gate withholds against
+    is therefore a bottom rail that has not moved at all — which is exactly the
+    #1115 state, a rail parked in the space the middle rail is being driven
+    into. The full-clearance wait this used to demand is still available and
+    pinned by ``test_middle_rail_waits_for_full_clearance_when_concurrent``
+    ``_travel_off``.
     """
     monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
     cmd_svc, policy, _rails, events = _rail_harness(
@@ -725,13 +802,44 @@ async def test_middle_rail_waits_for_bottom_rail_to_descend_past_it(
 
     assert bottom_outcome[0] == "sent"
     assert middle_outcome[0] == "sent"
-    # The bottom rail's command goes out first, then the gate polls it until the
-    # reading clears 65, and only then does the middle rail's command fire.
+    # The bottom rail's command goes out first, then the gate polls its descent,
+    # and only then does the middle rail's command fire.
     assert events.index(f"send:{_BOTTOM}") < events.index(f"send:{_MIDDLE}")
     polls_before_send = [
         e for e in events[: events.index(f"send:{_MIDDLE}")] if e == f"poll:{_BOTTOM}"
     ]
     assert len(polls_before_send) >= 2, events
+
+
+@pytest.mark.asyncio
+async def test_middle_rail_waits_for_full_clearance_when_concurrent_travel_off(
+    monkeypatch,
+) -> None:
+    """With the option off, the follower waits out the leader's WHOLE travel.
+
+    The conservative #1115 semantics, kept verbatim behind the switch. The
+    bottom rail descends 100 → 90 → 80 → 70 → 60 and only the last reading is
+    at-or-below the middle rail's 65 target (+2 tolerance). Start confirmation
+    would have released on the 90; full clearance holds all five readings, which
+    is what the exact poll count pins.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100, 90, 80, 70, 60], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=False,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    polls_before_send = [
+        e for e in events[: events.index(f"send:{_MIDDLE}")] if e == f"poll:{_BOTTOM}"
+    ]
+    assert len(polls_before_send) == 5, events
 
 
 @pytest.mark.asyncio
@@ -1538,6 +1646,39 @@ async def test_the_two_rail_gates_are_never_both_armed() -> None:
 
 
 @pytest.mark.asyncio
+async def test_the_two_rail_gates_are_never_both_armed_under_concurrent_travel() -> (
+    None
+):
+    """The same theorem, over the same grid, with concurrent travel switched on.
+
+    The proof above is stated in terms of ``_cleared``'s inequalities, so the
+    relaxed predicate does not inherit it for free — it has to be re-derived,
+    and re-derived proofs deserve the same exhaustive check the original got.
+    It holds for three reasons: branch selection is untouched by the option; on
+    the FIRST reading the concurrent disjunct is structurally ``False`` (there
+    is no start reference yet), which is the only reading a ``wait=False`` pass
+    takes; and the disjunct is a monotone weakening, so it can release an armed
+    gate earlier but never arm one that was not already armed.
+    """
+    for blend in (0, 50, 100):
+        policy = _dual_policy(position=50, blend=blend, concurrent=True)
+        rails = _attach_scripted_rails(policy, {_BOTTOM: [0], _MIDDLE: [0]})
+        for p in range(0, 101, 10):
+            for m in range(p, 101, 10):  # an intact stack: middle at or above bottom
+                rails.park(_BOTTOM, p)
+                rails.park(_MIDDLE, m)
+                for target in range(0, 101, 10):
+                    middle_target = policy.resolve_entity_target(_MIDDLE, target)
+                    bottom_ok = await policy.await_dispatch_clearance(
+                        _BOTTOM, position=target, reason="t", wait=False
+                    )
+                    middle_ok = await policy.await_dispatch_clearance(
+                        _MIDDLE, position=middle_target, reason="t", wait=False
+                    )
+                    assert bottom_ok or middle_ok, (p, m, target, middle_target, blend)
+
+
+@pytest.mark.asyncio
 async def test_a_lowering_cycle_still_leads_with_the_bottom_rail(monkeypatch) -> None:
     """#1115's whole mechanism survives the generalisation, end to end.
 
@@ -1851,6 +1992,207 @@ async def test_raise_gate_uses_the_dispatching_seams_frame_not_the_install_flag(
 
 
 # ---------------------------------------------------------------------------
+# Concurrent rail travel — the follower starts once the leader is under way
+# ---------------------------------------------------------------------------
+# Both rails hang on one track and travel at one speed, and the no-pass clamp
+# already guarantees their two TARGETS never cross. So the moment the leader is
+# under way AND ahead of the follower in the direction of travel, the separation
+# holds for the whole remaining move: there is nothing left for the follower to
+# wait for, and waiting doubles the time the shade takes to reach position.
+#
+# "Under way and ahead" is the leader's live OPEN-PERCENT reading having moved
+# from its first sampled value, by more than the position tolerance, TOWARD
+# satisfying that branch's own ``_cleared`` inequality. The direction comes from
+# the branch's own release predicate, never from ``_dual_entity_middle_leads`` —
+# consulting it from the middle rail's branch is the #1115 back door the
+# asymmetry at ``policy.py``'s gate docstring exists to keep shut.
+
+
+@pytest.mark.asyncio
+async def test_middle_rail_starts_once_bottom_rail_is_underway(monkeypatch) -> None:
+    """The middle rail is released by MOTION, not by full clearance.
+
+    Same crash geometry as ``test_middle_rail_waits_for_bottom_rail_to_descend``
+    ``_past_it``: bottom rail stacked at 100, middle target 65. The scripted
+    descent stops at 90 and stays there — it NEVER reaches the 67 that the
+    full-clearance predicate needs. Under the serialized gate that is a timeout
+    and a deferral; with concurrent travel the 10-point descent is proof the
+    bottom rail is under way and ahead, so the middle rail's command goes out.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100, 90], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+    # Two readings minimum: the first only establishes the start reference.
+    polls = [
+        e for e in events[: events.index(f"send:{_MIDDLE}")] if e == f"poll:{_BOTTOM}"
+    ]
+    assert len(polls) >= 2, events
+
+
+@pytest.mark.asyncio
+async def test_bottom_rail_starts_once_middle_rail_is_underway(monkeypatch) -> None:
+    """The raise mirror: the bottom rail is released by the middle rail's ascent.
+
+    Bottom rail live at 10 with a target of 60, middle rail live at 20 — the
+    #1118 collision. The middle rail rises to 30 and stops, never reaching the
+    58 full clearance would demand, and the bottom rail's command still goes
+    out.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # First middle read settles the direction; the rest are the gate's.
+        script={_BOTTOM: [10], _MIDDLE: [20, 20, 30]},
+        position=60,
+        blend=50,
+        concurrent=True,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_BOTTOM, 60, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_BOTTOM}" in events, events
+    assert policy.has_pending_secondary_axis(_BOTTOM) is False
+
+
+@pytest.mark.asyncio
+async def test_wrong_direction_motion_keeps_the_middle_rail_gated(monkeypatch) -> None:
+    """The #1115 back door, nailed shut: motion the WRONG way never releases.
+
+    A lowering cycle with the bottom rail RISING — nudged up by a user or a
+    stray command while the cycle is in flight. It moves, and moves by far more
+    than the tolerance, but every step takes it further from vacating the middle
+    rail's target. A bare "has the leader started moving at all" predicate would
+    wave the middle rail straight into it; the direction-signed one must not.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [70, 80, 90, 100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
+
+
+@pytest.mark.asyncio
+async def test_start_confirmation_times_out_and_latches(monkeypatch) -> None:
+    """A leader that reports nothing new falls into today's exact fail-closed path.
+
+    The start confirmation gets its own short budget, not the settle cap: the
+    cap is left at 2 s here and the confirmation timeout patched to 0.05 s, so a
+    wait that honours the settle cap instead would take more than a second. The
+    outcome on expiry is unchanged — ``policy_deferred``, latched pending, retried
+    next cycle. No new way to hang.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 2.0)
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+    )
+    ctx = _rail_context(policy)
+
+    started = dt.datetime.now(dt.UTC)
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
+    assert cmd_svc.last_skipped_action["reason"] == "policy_deferred"
+    assert elapsed < 1.0, elapsed
+
+
+@pytest.mark.asyncio
+async def test_start_confirmation_compares_in_open_percent_not_raw_wire(
+    monkeypatch,
+) -> None:
+    """The motion delta rides the same open-percent frame the threshold does.
+
+    Inverse state on, so the wire runs backwards: the bottom rail's readings
+    CLIMB from wire 10 to wire 25 while its open percent FALLS from 90 to 75 —
+    a genuine descent toward the middle rail's open-65 target, which it never
+    actually reaches. A delta computed on raw wire numbers gets the sign exactly
+    backwards, reads a descent as a retreat, and withholds a command that is
+    already safe (the #993 bug class, pointed at the new predicate).
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10, 25], _MIDDLE: [50]},
+        position=70,  # wire 70 == open 30 for the bottom rail
+        blend=50,
+        inverse=True,
+        concurrent=True,
+    )
+    ctx = _rail_context(policy, inverse=True)
+    wire_middle = policy.resolve_entity_target(_MIDDLE, 70)
+    assert wire_middle == 35  # open 65 on an inverse install
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, wire_middle, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_MIDDLE}" in events, events
+
+
+@pytest.mark.asyncio
+async def test_start_confirmation_needs_two_samples() -> None:
+    """One reading can never confirm motion — which is what keeps arming intact.
+
+    The mutual-exclusion theorem is a statement about when a gate ARMS, and the
+    relaxation must not touch that. It doesn't, structurally: on the first read
+    there is no start reference yet, so the concurrent disjunct is ``False`` and
+    the verdict is exactly ``_cleared``'s. The single-shot reconciliation path
+    is therefore byte-for-byte today's, and — because the reference lives in a
+    per-invocation closure — a second single-shot pass cannot inherit the first
+    one's sample and release on a delta that spans two cycles.
+    """
+    _cmd_svc, policy, _rails, _events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [20, 30, 40]},
+        position=60,
+        blend=50,
+        concurrent=True,
+    )
+
+    for _pass in range(3):
+        assert (
+            await policy.await_dispatch_clearance(
+                _BOTTOM, position=60, reason="t", wait=False
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
 # Model A must be untouched — the blend pre-send path stays byte-identical
 # ---------------------------------------------------------------------------
 
@@ -1877,6 +2219,79 @@ async def test_model_a_before_position_command_still_pre_sends_blend() -> None:
 
     assert result is not False  # never withholds
     seq._send_tilt_command.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# The settle cap is a CEILING, not merely a fallback (issue #1140)
+# ---------------------------------------------------------------------------
+# ``wait_until_position`` used to treat an explicit ``timeout_seconds`` as the
+# whole answer and only reach for ``VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS``
+# when the caller passed ``None``. The start-confirmation gate introduces the
+# first caller that passes a real number, and ~19 existing tests shrink the
+# settle cap via ``monkeypatch`` to keep the suite sub-second. If the explicit
+# number won outright, every one of those tests would silently start paying the
+# real 10 s budget. The cap therefore has to bound BOTH forms.
+
+
+def _bare_sequencer(read):
+    """Build a ``DualAxisSequencer`` wired to nothing but a position reader."""
+    from custom_components.adaptive_cover_pro.cover_types.venetian import (
+        DualAxisSequencer,
+    )
+
+    return DualAxisSequencer(
+        hass=MagicMock(),
+        logger=MagicMock(),
+        grace_mgr=MagicMock(),
+        get_current_position=read,
+        set_commanded_position=MagicMock(),
+        position_tolerance=2,
+        is_dry_run=lambda: False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_until_position_explicit_timeout_is_clamped_by_settle_cap(
+    monkeypatch,
+) -> None:
+    """An explicit budget above the settle cap is clamped down to the cap.
+
+    The predicate never accepts, so the wait can only end on the deadline. With
+    the cap patched to 0.05 s, a caller asking for 10 s must still give up
+    almost immediately — proof the cap bounds an explicit number rather than
+    only filling in for ``None``.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    seq = _bare_sequencer(lambda _eid: 50)
+
+    started = dt.datetime.now(dt.UTC)
+    cleared = await seq.wait_until_position(
+        _BOTTOM, lambda _pos: False, timeout_seconds=10.0
+    )
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert cleared is False
+    assert elapsed < 1.0, elapsed
+
+
+@pytest.mark.asyncio
+async def test_wait_until_position_explicit_timeout_below_the_cap_is_honoured(
+    monkeypatch,
+) -> None:
+    """A budget under the cap still wins — the clamp is a ``min``, not a swap."""
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 30.0)
+    seq = _bare_sequencer(lambda _eid: 50)
+
+    started = dt.datetime.now(dt.UTC)
+    assert (
+        await seq.wait_until_position(_BOTTOM, lambda _pos: False, timeout_seconds=0)
+        is False
+    )
+    elapsed = (dt.datetime.now(dt.UTC) - started).total_seconds()
+
+    assert elapsed < 1.0, elapsed
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Model C (`dual_entity`) clearance gate held the follower rail until the leading rail's live position had passed the follower's own final target, waiting out the full 60s settle budget. On real hardware that turns a roughly 43s concurrent move into a roughly 75s serial one, and it is what makes the 60s stall in #1119 item 1 so easy to reach: a leader that stops short of the follower's target never satisfies the predicate at all.

The rails ride one track at one speed, and the no-pass clamp in `resolve_entity_target` already guarantees the two targets never cross. Once the leader is confirmed under way, the follower can start safely.

New default-on option `day_night_concurrent_rail_travel` relaxes the release predicate to a short start confirmation: the leader's open-percent reading must have moved past tolerance from its first sample, in the direction that satisfies that branch's own clearance inequality. With the option off, today's full-clearance behaviour is preserved byte for byte in the same method.

`wait_until_position` now clamps an explicit timeout to the settle cap, which keeps the 19 existing settle-patching tests fast without editing any of them.

**Invariants preserved.** Arming is pointwise unchanged: on the first read the start reference is unset, so the new disjunct is structurally false, and the disjunct only ever weakens release. The mutual-exclusion theorem from #1118 therefore transfers rather than holding by accident. The middle rail's gate still never consults `_dual_entity_middle_leads`, so the direction asymmetry that #1115 depends on stays intact.

Config entry minor version goes 13 to 14 with a purely additive no-op block; `VERSION` stays 3, so rollback to an older stable is unaffected.

## Testing
- 11788 tests passing (1 xfailed, pre-existing and unrelated: #996's dual-panel timing gap)
- Deep audit before merge returned zero must-fix findings, and mutation-tested four guards to confirm they are not vacuous

## Related Issues
Refs #1140
Part of #1138 (item 2, the external-command interlock, stays on the parent)