### PR TITLE
fix: confirm a Model C rail start from its transit state (#1145)

### DIFF
--- a/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/day_night_shade/policy.py
@@ -52,6 +52,7 @@ from ...const import (
     DEFAULT_DAY_NIGHT_OPACITY_SHEER,
     POSITION_CLOSED,
     POSITION_OPEN,
+    VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS,
     ControlMethod,
 )
 from ...engine.covers import AdaptiveVerticalCover, DayNightShadeCalculation
@@ -60,6 +61,7 @@ from ...engine.covers.day_night_shade import (
     DAY_NIGHT_SHEER,
     FabricSelection,
 )
+from ...managers.cover_command.transit import transit_wire_sign
 from ...managers.manual_override import (
     SecondaryAxisCheck,
     resolve_dispatched_secondary_expected,
@@ -1525,21 +1527,22 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         direction: int,
         inverse: bool,
         tolerance: int,
+        leading_rail: str,
     ) -> Callable[[int], bool]:
         """Wrap a clearance predicate so leader MOTION also releases the gate.
 
         The relaxation behind concurrent rail travel (#1140), expressed as a
         strict WEAKENING of the branch's own predicate: ``cleared`` still
-        releases exactly when it did, and a second disjunct releases earlier
+        releases exactly when it did, and two further disjuncts release earlier
         when the leading rail is demonstrably under way and ahead.
 
-        "Under way and ahead" is the leader's live OPEN-PERCENT reading having
-        moved from its FIRST sampled value, by more than ``tolerance``, toward
-        satisfying ``cleared``'s own inequality. ``direction`` is the sign of
-        that inequality — ``-1`` where clearance needs the leader's open percent
-        to fall (the middle rail's branch, a lowering), ``+1`` where it needs it
-        to rise (the bottom rail's branch, a raising). It is derived from the
-        branch's own release test and NOT from
+        **Signal 1 — a position delta.** The leader's live OPEN-PERCENT reading
+        having moved from its FIRST sampled value, by more than ``tolerance``,
+        toward satisfying ``cleared``'s own inequality. ``direction`` is the sign
+        of that inequality — ``-1`` where clearance needs the leader's open
+        percent to fall (the middle rail's branch, a lowering), ``+1`` where it
+        needs it to rise (the bottom rail's branch, a raising). It is derived
+        from the branch's own release test and NOT from
         :meth:`_dual_entity_middle_leads`; a leader moving the wrong way can
         therefore never confirm, which is what stops this becoming the back door
         that ungates the middle rail during a lowering (issue #1115).
@@ -1548,17 +1551,67 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         the threshold does — a delta computed on raw wire numbers inverts its
         own sign on every inverse-state install (the #993 bug class).
 
+        **Signal 2 — a transit STATE.** ``opening``/``closing`` on the leading
+        rail, read through the shared :func:`transit_wire_sign` table. Some
+        actuators publish no intermediate ``current_position`` at all: the
+        ZVIDAR WB04V (zwave_js) reports ``closing`` the instant the motor
+        engages and then holds its pre-move position for the whole ~36 s
+        traverse, jumping to the final number on arrival. Signal 1 sees a delta
+        of exactly 0 on every poll of such a rail and can NEVER fire, which is
+        issue #1145. A transit state needs NO baseline sample, because unlike a
+        bare position number it is already a started-moving REPORT rather than
+        evidence one has to be differenced out of two readings.
+
+        **The frame conversion is the same #993 bug class, in sign space.** HA's
+        transit strings describe the WIRE: ``"opening"`` means the entity's raw
+        ``current_position`` is RISING, whatever the install's inverse-state
+        flag says "open" means. ``direction`` lives in open-percent / dispatch
+        frame. Flipping the frame negates every delta and therefore every
+        direction, so the conversion — stated once, here — is::
+
+            expected_wire_sign = -direction if inverse else direction
+
+        On an inverse install a lowering (``direction == -1``, open percent must
+        fall) is confirmed by the wire state ``"opening"``. The naive
+        ``direction == -1 → "closing"`` mapping is the same silent inversion
+        ``flip_if`` exists to prevent, reintroduced on a new code path.
+
+        A wrong-signed transit state is NOT a confirmation, exactly as a
+        wrong-signed delta is not: a rail under power moving away from the
+        follower's target is the #1115 collision, not clearance of it.
+
+        **The trust boundary.** A stale ``opening``/``closing`` — an actuator
+        that never publishes its terminal state — reads as motion that is not
+        happening, and confirms a start that already finished. That is
+        deliberately accepted: the ``cleared`` short-circuit is evaluated FIRST,
+        so a leader that has actually vacated releases through the real
+        predicate; and a leader stalled mid-travel while still claiming to move
+        is no worse than the delta path's own stale-reading exposure, both
+        bounded by the gate's budget.
+
         The start reference lives in this closure, so it is scoped to ONE
         invocation of the gate: a single-shot ``wait=False`` pass takes one
-        reading, records it as the reference, and returns ``False``, exactly as
-        the un-wrapped predicate would have. Nothing survives to the next pass,
-        so a delta can never be accumulated across cycles.
+        reading, and signal 1 can only record it as the reference and return
+        ``False``, exactly as the un-wrapped predicate would have. Nothing
+        survives to the next pass, so a delta can never be accumulated across
+        cycles. Signal 2 is different by design — it carries no cross-reading
+        state, so a single ``wait=False`` read CAN confirm through it. That is
+        intended: one look at a rail that says ``closing`` is the whole
+        observation, and there is no second sample that would make it more true.
         """
+        seq = self._sequencer
         start_open: int | None = None
 
         def _done(wire: int) -> bool:
             nonlocal start_open
             if cleared(wire):
+                return True
+            sign = (
+                transit_wire_sign(seq._get_state(leading_rail))
+                if seq._get_state
+                else None
+            )
+            if sign is not None and (-sign if inverse else sign) == direction:
                 return True
             live_open = flip_if(wire, inverted=inverse)
             if start_open is None:
@@ -1622,17 +1675,22 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
            the reading it sees. Branch selection is untouched by the option:
            ``is_middle`` and :meth:`_dual_entity_middle_leads` are evaluated
            before the predicate is ever wrapped.
-        2. On the FIRST reading the concurrent disjunct is structurally
-           ``False`` — there is no start reference yet, so
-           :meth:`_start_confirmation` records one and returns. The very first
-           verdict is therefore pointwise identical to ``_cleared``'s, which is
-           the only verdict the single-read ``wait=False`` path ever produces
-           and the only one the grid the theorem quantifies over ever asks for.
-        3. The wrapper is a monotone WEAKENING: ``cleared(w) or delta(w)``
-           accepts a superset of what ``cleared(w)`` accepts. It can only
-           release an armed gate EARLIER; it can never arm one that was not
-           already armed, so no pair of block conditions it produces was
-           unreachable before.
+        2. On the FIRST reading the DELTA disjunct is structurally ``False`` —
+           there is no start reference yet, so :meth:`_start_confirmation`
+           records one and returns. Against that disjunct alone the very first
+           verdict is pointwise identical to ``_cleared``'s, which is the only
+           verdict the single-read ``wait=False`` path ever produces and the
+           only one the grid the theorem quantifies over ever asks for. The
+           TRANSIT disjunct (#1145) carries no cross-reading state, so it CAN
+           fire on a first read and that pointwise identity does not extend to
+           it — only point 3 does, which is all the theorem needs.
+        3. The wrapper is a monotone WEAKENING:
+           ``cleared(w) or transit() or delta(w)`` accepts a superset of what
+           ``cleared(w)`` accepts. It can only release an armed gate EARLIER; it
+           can never arm one that was not already armed, so no pair of block
+           conditions it produces was unreachable before. The two-stage budget
+           below is a weakening of the same kind, in time rather than in the
+           predicate: it only adds chances to release.
 
         The option therefore changes how long a follower waits and what
         threshold ends that wait — never which rail is the follower.
@@ -1731,10 +1789,28 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         Serialized, it is a whole travel, so it takes the sequencer's settle cap
         (``timeout_seconds=None``). Confirming a START only has to outlast the
         actuator's command latency plus one state publish, so it takes the far
-        shorter :data:`DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS` — which
-        also bounds the cost of a rail that has gone silent, since expiry lands
-        on the same fail-closed path either way. Both are still hard-capped by
-        the settle cap inside ``wait_until_position``.
+        shorter :data:`DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS`.
+
+        **Concurrent travel therefore waits in TWO stages** (issue #1145). The
+        short budget buys a chance at an EARLY release and nothing else; failing
+        to take it must not cost the follower more than switching the option OFF
+        would have. So an unconfirmed start falls back onto the clearance
+        budget — the settle cap MINUS what confirming already spent, because the
+        seconds spent watching for a start are part of the same physical wait
+        for the same rail. The per-gate total stays exactly the serialized
+        bound rather than becoming cap-plus-confirmation, which keeps
+        ``wait_until_position``'s promise that the settle cap "bounds every wait
+        this class can perform" true of the gate and not merely of each call.
+        Without that second stage a rail that publishes NO intermediate
+        ``current_position`` while travelling — it reports ``closing`` and holds
+        its pre-move number until arrival — could satisfy neither disjunct
+        inside the short budget and got latched pending until whatever fired the
+        coordinator next, making the default-on option a strict regression on
+        that hardware. Both stages are still hard-capped by the settle cap
+        inside ``wait_until_position``, so the ~19 tests that shrink the cap keep
+        bounding the whole gate. ``wait=False`` takes neither stage: it is a
+        single read with ``timeout_seconds=0`` and no fallback, byte-identical
+        to what it was.
 
         Returns ``True`` to let the command through, ``False`` to withhold it.
         Withholding latches the entity pending so the coordinator keeps
@@ -1792,11 +1868,31 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
         done = _cleared
         budget: float | None = None if wait else 0
         if self._dual_entity_concurrent_travel:
-            done = self._start_confirmation(_cleared, direction, inverse, tolerance)
+            done = self._start_confirmation(
+                _cleared, direction, inverse, tolerance, leading_rail
+            )
             if wait:
                 budget = DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS
 
-        if await seq.wait_until_position(leading_rail, done, timeout_seconds=budget):
+        released = await seq.wait_until_position(
+            leading_rail, done, timeout_seconds=budget
+        )
+        if not released and wait and self._dual_entity_concurrent_travel:
+            # The confirmation budget bought a chance at an EARLY release and
+            # did not get one. Fall back onto the clearance budget the option
+            # OFF would have spent, minus what confirming already spent, so the
+            # follower never waits LONGER than the serialized path for the same
+            # rail (issue #1145).
+            released = await seq.wait_until_position(
+                leading_rail,
+                done,
+                timeout_seconds=max(
+                    0.0,
+                    VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
+                    - DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS,
+                ),
+            )
+        if released:
             self._pending_rail_command.discard(entity_id)
             return True
         self._pending_rail_command.add(entity_id)
@@ -1807,7 +1903,11 @@ class DayNightShadePolicy(CoverTypePolicy, register=True):
             position,
             reason,
             leading_rail,
-            "started clearing" if self._dual_entity_concurrent_travel else "cleared",
+            (
+                "confirmed a start toward, nor cleared,"
+                if self._dual_entity_concurrent_travel
+                else "cleared"
+            ),
         )
         return False
 

--- a/custom_components/adaptive_cover_pro/managers/cover_command/transit.py
+++ b/custom_components/adaptive_cover_pro/managers/cover_command/transit.py
@@ -14,11 +14,19 @@ paths need the same policy, extract one helper and have both call it.
 
 from __future__ import annotations
 
+# The direction each HA transit state reports, as the sign of the change in
+# the entity's raw ``current_position``. This is a WIRE fact: HA's convention
+# ties "opening" to that number RISING, whatever the install's inverse-state
+# flag says about what "open" means. A caller comparing it against a direction
+# expressed in open-percent space has to flip it (see #993).
+_TRANSIT_WIRE_SIGN: dict[str, int] = {"opening": 1, "closing": -1}
+
 # HA cover states that indicate the motor is actively moving the carriage.
 # Kept as a module-level frozenset so callers that need set membership
 # (e.g. existing tests that monkeypatched ``_COVER_MOVING_STATES``) can
-# still poke a single attribute.
-_MOVING_STATES: frozenset[str] = frozenset({"opening", "closing"})
+# still poke a single attribute. Derived from the sign table rather than
+# restated, so the two can never drift apart.
+_MOVING_STATES: frozenset[str] = frozenset(_TRANSIT_WIRE_SIGN)
 
 
 def is_state_in_transit(state: str | None) -> bool:
@@ -38,3 +46,23 @@ def is_state_in_transit(state: str | None) -> bool:
       override-suppression tier (a) for the tilt axis.
     """
     return state in _MOVING_STATES
+
+
+def transit_wire_sign(state: str | None) -> int | None:
+    """Return which way ``state`` says the raw ``current_position`` is moving.
+
+    ``+1`` for ``"opening"`` (the wire number rising), ``-1`` for ``"closing"``
+    (falling), ``None`` for every state that is not a transit state. By
+    construction ``transit_wire_sign(s) is not None`` holds for exactly the same
+    ``s`` as :func:`is_state_in_transit` — both read the one
+    :data:`_TRANSIT_WIRE_SIGN` table — so a caller that needs the direction as
+    well as the fact of motion asks this and does not also ask the predicate.
+
+    The sign is in WIRE space. Code comparing it against a direction expressed
+    in open-percent / dispatch frame must negate it on an inverse-state install:
+    flipping the frame negates every delta and therefore every direction. Used
+    by ``DayNightShadePolicy._start_confirmation`` (issues #1145, #993), where a
+    rail that publishes a transit state but no intermediate position is the
+    only evidence that the leading rail has started to move.
+    """
+    return _TRANSIT_WIRE_SIGN.get(state)

--- a/tests/test_day_night_rail_sequencing.py
+++ b/tests/test_day_night_rail_sequencing.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import ast
 import datetime as dt
+import importlib
 import pathlib
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -567,6 +568,7 @@ def _rail_harness(
     inverse: bool = False,
     interp: bool = False,
     concurrent: bool | None = None,
+    rail_states: dict[str, str] | None = None,
 ):
     """Real ``CoverCommandService`` + real Model C policy over a scripted motor.
 
@@ -577,6 +579,13 @@ def _rail_harness(
 
     ``concurrent`` is forwarded to :func:`_dual_policy` — ``None`` leaves the
     rail-travel key absent so the option's own default governs.
+
+    ``rail_states`` maps an entity id onto the HA cover state its ``get_state``
+    accessor reports (``"opening"`` / ``"closing"`` / ``"open"`` / ...). ``None``
+    — the default — leaves the sequencer's ``_get_state`` UNSET, exactly as
+    every rail test predating issue #1145 had it, so the transit disjunct is
+    structurally inert and those tests keep their original behaviour. An entity
+    absent from a supplied mapping reads ``None``, which is not a transit state.
     """
     from custom_components.adaptive_cover_pro.managers.cover_command import (
         CoverCommandService,
@@ -621,6 +630,10 @@ def _rail_harness(
         events.append(f"poll:{entity_id}")
         return rails.read(entity_id)
 
+    attach_kwargs: dict = {}
+    if rail_states is not None:
+        attach_kwargs["get_state"] = lambda eid: rail_states.get(eid)
+
     policy.attach(
         hass=hass,
         logger=MagicMock(),
@@ -630,6 +643,7 @@ def _rail_harness(
         position_tolerance=2,
         is_dry_run=lambda: False,
         entities=[_BOTTOM, _MIDDLE],
+        **attach_kwargs,
     )
     return cmd_svc, policy, rails, events
 
@@ -2104,17 +2118,216 @@ async def test_wrong_direction_motion_keeps_the_middle_rail_gated(monkeypatch) -
 
 
 @pytest.mark.asyncio
-async def test_start_confirmation_times_out_and_latches(monkeypatch) -> None:
-    """A leader that reports nothing new falls into today's exact fail-closed path.
+async def test_transit_state_confirms_a_start_with_no_position_delta(
+    monkeypatch,
+) -> None:
+    """A rail that publishes ``closing`` but no intermediate position still confirms.
 
-    The start confirmation gets its own short budget, not the settle cap: the
-    cap is left at 2 s here and the confirmation timeout patched to 0.05 s, so a
-    wait that honours the settle cap instead would take more than a second. The
-    outcome on expiry is unchanged — ``policy_deferred``, latched pending, retried
-    next cycle. No new way to hang.
+    Issue #1145's reproduction. The ZVIDAR WB04V (zwave_js) reports
+    ``state: closing`` the moment the motor engages and then holds
+    ``current_position`` at its pre-move value for the whole ~36 s traverse,
+    jumping straight to the final number on arrival. Every poll therefore sees
+    ``live_open == start_open``, the delta is exactly 0 forever, and a
+    delta-only start confirmation can never fire on this hardware — it expires
+    and latches the follower pending instead.
+
+    The state itself is the started-moving report, so it releases the gate with
+    no baseline sample at all.
     """
     monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
-    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 2.0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        # The leader's position is CONSTANT across every poll — the whole point.
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+        rail_states={_BOTTOM: "closing"},
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_transit_state_confirms_in_the_dispatch_frame_on_inverse_installs(
+    monkeypatch,
+) -> None:
+    """The transit state is a WIRE fact and has to be flipped like every other one.
+
+    The mirror of ``test_start_confirmation_compares_in_open_percent_not_raw_wire``
+    for the transit disjunct, on the same inverse-state numbers. HA's transit
+    strings describe the entity's raw ``current_position``: ``"opening"`` means
+    that number is RISING. The branch's ``direction`` lives in open-percent /
+    dispatch frame, and flipping the frame negates every delta and therefore
+    every direction — so the conversion is
+    ``expected_wire_sign = -direction if inverse else direction``.
+
+    Here the middle rail's branch needs the bottom rail's OPEN percent to fall
+    (``direction == -1``) on an inverse install, so the confirming wire state is
+    ``"opening"``. The naive ``direction == -1 → "closing"`` mapping gets this
+    exactly backwards and withholds a command that is already under way — the
+    #993 bug class, pointed at the new predicate. No position delta is ever
+    available (the wire reading is constant), so the transit disjunct is the
+    only thing that can release the gate.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.05)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [50]},
+        position=70,  # wire 70 == open 30 for the bottom rail
+        blend=50,
+        inverse=True,
+        concurrent=True,
+        # Wire rising == open percent falling == a genuine descent.
+        rail_states={_BOTTOM: "opening"},
+    )
+    ctx = _rail_context(policy, inverse=True)
+    wire_middle = policy.resolve_entity_target(_MIDDLE, 70)
+    assert wire_middle == 35  # open 65 on an inverse install
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, wire_middle, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_wrong_direction_transit_state_keeps_the_middle_rail_gated(
+    monkeypatch,
+) -> None:
+    """#1115's back door, transit edition: moving is not the same as clearing.
+
+    A lowering cycle with the bottom rail reporting ``"opening"`` — it is
+    demonstrably under power, but every turn of the motor takes it further from
+    vacating the middle rail's target. An UNSIGNED ``is_state_in_transit``
+    disjunct would wave the middle rail straight into it; the direction-signed
+    one must not.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.02)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+        rail_states={_BOTTOM: "opening"},
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
+
+
+@pytest.mark.asyncio
+async def test_wrong_direction_transit_state_stays_gated_on_inverse_installs(
+    monkeypatch,
+) -> None:
+    """The fourth cell of the 2×2: inverse install, wire state the wrong way.
+
+    Same inverse geometry as
+    ``test_transit_state_confirms_in_the_dispatch_frame_on_inverse_installs``,
+    with the bottom rail reporting ``"closing"`` instead. On an inverse install
+    a falling wire number is a RISING open percent — the leader retreating from
+    the middle rail's target, not approaching it. Together with the three
+    siblings this pins both signs against both frames, so neither a dropped
+    flip nor an inverted one can pass.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.02)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [10], _MIDDLE: [50]},
+        position=70,
+        blend=50,
+        inverse=True,
+        concurrent=True,
+        rail_states={_BOTTOM: "closing"},
+    )
+    ctx = _rail_context(policy, inverse=True)
+    wire_middle = policy.resolve_entity_target(_MIDDLE, 70)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, wire_middle, "solar", ctx)
+
+    assert outcome == ("skipped", "policy_deferred")
+    assert f"send:{_MIDDLE}" not in events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is True
+
+
+@pytest.mark.asyncio
+async def test_confirm_timeout_falls_back_to_the_clearance_budget(monkeypatch) -> None:
+    """An unconfirmed start must not cost the follower MORE than the option off.
+
+    Part 2 of issue #1145. With concurrent travel OFF the gate waits out the
+    settle cap against the bare clearance predicate, so a rail that goes quiet
+    for the whole traverse and then jumps to its final number still releases the
+    follower the moment it lands. With the option ON the wrapped predicate got
+    the short confirmation budget and NOTHING else — expiry latched the follower
+    pending and handed it back to whenever the coordinator next happened to
+    fire. The default-on feature was therefore a strict regression on hardware
+    that cannot satisfy the confirmation.
+
+    The confirmation budget is spent first, and what it buys is an EARLIER
+    release; failing to confirm falls back onto the clearance budget rather than
+    replacing it. Scripted as the reported shape: constant through the
+    confirmation window, then the jump to cleared.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.5)
+    # 0 makes the confirmation wait single-shot: one read, which the delta path
+    # consumes as its baseline and can never confirm from.
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0)
+    cmd_svc, policy, _rails, events = _rail_harness(
+        script={_BOTTOM: [100, 100, 0], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+    )
+    ctx = _rail_context(policy)
+
+    with _patch_caps():
+        outcome = await cmd_svc.apply_position(_MIDDLE, 65, "solar", ctx)
+
+    assert outcome == ("sent", "set_cover_position")
+    assert f"send:{_MIDDLE}" in events, events
+    assert policy.has_pending_secondary_axis(_MIDDLE) is False
+
+
+@pytest.mark.asyncio
+async def test_gate_defers_only_after_the_clearance_fallback_also_expires(
+    monkeypatch,
+) -> None:
+    """The fail-closed terminal path survives — it is just reached later.
+
+    A leader that reports nothing new for its whole budget still lands on
+    today's exact outcome: ``policy_deferred``, latched pending, retried next
+    cycle. No new way to hang. What issue #1145 changed is WHEN that outcome is
+    reached — the confirmation budget expiring is no longer the end of the
+    question, only the end of the fast answer, so the gate must also have burnt
+    the clearance budget before it withholds.
+
+    Confirmation patched to 0.05 s and the settle cap to 0.2 s: giving up at the
+    confirmation budget alone would return in ~0.05 s, so the lower bound is
+    what distinguishes the two behaviours. The upper bound still proves the
+    fallback is bounded by the settle cap rather than unbounded.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.2)
     monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.05)
     cmd_svc, policy, _rails, events = _rail_harness(
         script={_BOTTOM: [100], _MIDDLE: [100]},
@@ -2133,7 +2346,66 @@ async def test_start_confirmation_times_out_and_latches(monkeypatch) -> None:
     assert f"send:{_MIDDLE}" not in events
     assert policy.has_pending_secondary_axis(_MIDDLE) is True
     assert cmd_svc.last_skipped_action["reason"] == "policy_deferred"
-    assert elapsed < 1.0, elapsed
+    assert 0.2 <= elapsed < 1.0, elapsed
+
+
+@pytest.mark.asyncio
+async def test_clearance_fallback_keeps_the_settle_cap_as_the_total_budget(
+    monkeypatch,
+) -> None:
+    """Two waits, one budget: the fallback gets the cap MINUS what confirming spent.
+
+    ``wait_until_position``'s contract is that the settle cap "bounds every wait
+    this class can perform". Composing a second wait after the confirmation one
+    would raise the per-gate worst case from the cap to cap-plus-confirmation
+    unless the second wait is handed the remainder — and the seconds spent
+    confirming a start are part of the same physical wait for the same rail. So
+    the total stays exactly the serialized bound.
+
+    Asserted on the arguments rather than the clock: a wall-clock check of a sum
+    of two timeouts is a race, an argument check is not.
+    """
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_POLL_SECONDS", 0)
+    monkeypatch.setattr(f"{_SEQ}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(f"{_POLICY}.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS", 0.05)
+    monkeypatch.setattr(f"{_POLICY}.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS", 0.02)
+    _cmd_svc, policy, _rails, _events = _rail_harness(
+        script={_BOTTOM: [100], _MIDDLE: [100]},
+        position=30,
+        blend=50,
+        concurrent=True,
+    )
+
+    budgets: list[float | None] = []
+    real_wait = policy.sequencer.wait_until_position
+
+    async def _spy(entity_id, done, *, timeout_seconds=None):
+        budgets.append(timeout_seconds)
+        return await real_wait(entity_id, done, timeout_seconds=timeout_seconds)
+
+    policy.sequencer.wait_until_position = _spy
+
+    assert (
+        await policy.await_dispatch_clearance(
+            _MIDDLE, position=65, reason="t", wait=True
+        )
+        is False
+    )
+
+    policy_mod = importlib.import_module(_POLICY)
+    confirm = policy_mod.DAY_NIGHT_RAIL_START_CONFIRM_TIMEOUT_SECONDS
+    settle = policy_mod.VENETIAN_POSITION_SETTLE_TIMEOUT_SECONDS
+    assert budgets == [confirm, pytest.approx(settle - confirm)], budgets
+
+    # The single-shot reconciliation path is untouched: one read, no fallback.
+    budgets.clear()
+    assert (
+        await policy.await_dispatch_clearance(
+            _MIDDLE, position=65, reason="t", wait=False
+        )
+        is False
+    )
+    assert budgets == [0], budgets
 
 
 @pytest.mark.asyncio
@@ -2171,15 +2443,24 @@ async def test_start_confirmation_compares_in_open_percent_not_raw_wire(
 
 @pytest.mark.asyncio
 async def test_start_confirmation_needs_two_samples() -> None:
-    """One reading can never confirm motion — which is what keeps arming intact.
+    """One reading can never confirm a DELTA — no baseline exists to differ from.
 
-    The mutual-exclusion theorem is a statement about when a gate ARMS, and the
-    relaxation must not touch that. It doesn't, structurally: on the first read
-    there is no start reference yet, so the concurrent disjunct is ``False`` and
-    the verdict is exactly ``_cleared``'s. The single-shot reconciliation path
-    is therefore byte-for-byte today's, and — because the reference lives in a
-    per-invocation closure — a second single-shot pass cannot inherit the first
-    one's sample and release on a delta that spans two cycles.
+    Scoped to the delta disjunct, which is the only one this harness can reach:
+    it wires no ``get_state``, so the transit disjunct (#1145) is structurally
+    inert here. On the first read there is no start reference yet, so the delta
+    disjunct is ``False`` and the verdict is exactly ``_cleared``'s. The
+    single-shot reconciliation path is therefore byte-for-byte today's, and —
+    because the reference lives in a per-invocation closure — a second
+    single-shot pass cannot inherit the first one's sample and release on a
+    delta that spans two cycles.
+
+    The transit disjunct deliberately does NOT share that property: a state
+    string is a started-moving report rather than something differenced out of
+    two readings, so one look at a rail saying ``closing`` is the whole
+    observation and a single ``wait=False`` read may confirm through it. The
+    arming theorem is untouched either way — both disjuncts are release-side
+    weakenings, and a weakening can release an armed gate earlier but never arm
+    one that was not already armed.
     """
     _cmd_svc, policy, _rails, _events = _rail_harness(
         script={_BOTTOM: [10], _MIDDLE: [20, 30, 40]},


### PR DESCRIPTION
## Summary

The concurrent-travel start confirmation from #1140 released only on a `current_position` delta, so a rail that reports no intermediate position could never confirm a start. A ZVIDAR WB04V day/night shade on `zwave_js` pins `current_position` at its pre-move value for the whole 36s travel and signals motion through `state: closing` instead. Every poll read the same number, the delta stayed at exactly zero, the gate expired at the 10s confirm budget, and the follower rail latched pending for 14 minutes until an unrelated coordinator cycle fired. Serialized mode would have released it at 38s on the 60s settle cap, so the default-on option was a strict regression on that hardware.

Two changes. The gate now also accepts the leader's transit state, which is the signal HA was publishing all along: `transit_wire_sign` in `transit.py` maps `opening`/`closing` to a wire sign, and `_MOVING_STATES` is now derived from that same table so the two cannot drift. `_start_confirmation` converts wire sign into dispatch frame with `-sign if inverse else sign`, the sign-space image of `flip_if`, so an inverse install cannot be misread as the wrong direction.

Second, failing to confirm a start now falls back to the clearance budget instead of deferring outright, so a cover that cannot confirm degrades to the old behaviour rather than to something slower. The fallback takes the settle cap minus the confirm budget, holding the total per-gate wait at 60s rather than 70s, and `wait=False` stays single-shot for the reconciliation caller.

Arming is unchanged: branch selection still runs before the predicate is wrapped, and both new paths only add release conditions to an already-armed gate. The middle rail's gate still never consults `_dual_entity_middle_leads`, preserving the #1115 direction asymmetry.

## Testing
- ✅ 11907 tests passing

## Related Issues
Refs #1145