### PR TITLE
fix: split the position-limits Repair into two messages (#1146)

### DIFF
--- a/custom_components/adaptive_cover_pro/const.py
+++ b/custom_components/adaptive_cover_pro/const.py
@@ -857,7 +857,10 @@ ISSUE_TEMP_SENSOR_UNAVAILABLE = "temp_sensor_unavailable"
 # raise time (`{id}_{entry_id}` — A1 also appends the cover entity_id).
 ISSUE_COVER_UNAVAILABLE = "cover_unavailable"  # a controlled cover is unavailable
 ISSUE_SUN_UNAVAILABLE = "sun_unavailable"  # sun.sun is unavailable/missing
-ISSUE_CONFIG_POSITION_ENVELOPE = "config_position_envelope"  # min>max or slot outside
+ISSUE_CONFIG_POSITION_ENVELOPE = "config_position_envelope"  # min > max
+# slot outside min/max, split from config_position_envelope so each Repair
+# states only its own condition — issue #1146
+ISSUE_CUSTOM_POSITION_OUT_OF_RANGE = "custom_position_out_of_range"
 ISSUE_CONFIG_TIME_WINDOW = "config_time_window"  # start >= end
 ISSUE_COVER_NOT_MOVING = (
     "cover_not_moving"  # commanded but not reaching target (issue #990)

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -2069,20 +2069,23 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     ) -> bool:
         """Whether a fixed custom-position slot is pinned outside the envelope.
 
-        (issue #975/#1146, B1.) False immediately when ``min > max`` — that is
-        ``_min_exceeds_max``'s condition to report, and short-circuiting here
-        keeps the two Repairs mutually exclusive so they never double-fire for
-        one underlying breakage. Otherwise True when an enabled, non-safety slot
-        that would deliver an exact (FIXED) cover position pins it outside
-        ``[min, max]``. Slots that never deliver a fixed position claim —
-        ``use_my``, tilt-only, or a non-FIXED constraint mode (floor / ceiling /
-        range) — are exempt: they compose as constraints the envelope clamps and
-        cannot conflict with it. Cover-type-agnostic: loops the slots generically
-        and delegates the fixed-position determination to the shared helper
-        (same seam the pipeline handler uses), with no branching on cover type
-        or capabilities.
+        (issue #975/#1146, B1.) False immediately when ``_min_exceeds_max``
+        reports the envelope itself inverted — that is the sibling predicate's
+        condition to report, and delegating to the single seam (rather than
+        re-testing ``min > max`` here) keeps the two Repairs mutually exclusive
+        so they never double-fire for one underlying breakage, and keeps the
+        inversion definition in exactly one place. Otherwise True when an
+        enabled, non-safety slot that would deliver an exact (FIXED) cover
+        position pins it outside ``[min, max]``. Slots that never deliver a
+        fixed position claim — ``use_my``, tilt-only, or a non-FIXED constraint
+        mode (floor / ceiling / range) — are exempt: they compose as
+        constraints the envelope clamps and cannot conflict with it.
+        Cover-type-agnostic: loops the slots generically and delegates the
+        fixed-position determination to the shared helper (same seam the
+        pipeline handler uses), with no branching on cover type or
+        capabilities.
         """
-        if min_pos > max_pos:
+        if AdaptiveDataUpdateCoordinator._min_exceeds_max(min_pos, max_pos):
             return False
         for slot_keys in CUSTOM_POSITION_SLOTS.values():
             if not options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED):

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -48,6 +48,7 @@ from .helpers import (
     _read_sun_boundary_options,
     check_cover_features,
     custom_position_slot_delivers_fixed_position,
+    custom_position_slot_name,
     custom_position_slot_sensors,
     has_configured_window_end,
     resolve_override_deadline,
@@ -1890,18 +1891,40 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             cover_cfg = CoverConfig.from_options(options)
             min_pos = int(cover_cfg.min_pos)
             max_pos = int(cover_cfg.max_pos)
-            placeholders = {"name": name, "min": str(min_pos), "max": str(max_pos)}
+            # Each Repair gets its own placeholder dict (issue #1146): the
+            # custom-position description carries `{slot}` but the envelope's
+            # does not, and HA silently drops a description whose placeholder
+            # set differs from the key's, so the two must never share one dict.
+            envelope_placeholders = {
+                "name": name,
+                "min": str(min_pos),
+                "max": str(max_pos),
+            }
             self._repair.update_predicate(
                 self._envelope_issue_key,
                 self._min_exceeds_max(min_pos, max_pos),
                 translation_key=ISSUE_CONFIG_POSITION_ENVELOPE,
-                placeholders=placeholders,
+                placeholders=envelope_placeholders,
             )
+            violating_slot = self._custom_position_out_of_range(
+                options, min_pos, max_pos
+            )
+            custom_position_placeholders = {
+                "name": name,
+                "min": str(min_pos),
+                "max": str(max_pos),
+            }
+            if violating_slot is not None:
+                slot_keys = CUSTOM_POSITION_SLOTS[violating_slot]
+                custom_position_placeholders["slot"] = (
+                    custom_position_slot_name(options, slot_keys)
+                    or f"Slot {violating_slot}"
+                )
             self._repair.update_predicate(
                 self._custom_position_issue_key,
-                self._custom_position_out_of_range(options, min_pos, max_pos),
+                violating_slot is not None,
                 translation_key=ISSUE_CUSTOM_POSITION_OUT_OF_RANGE,
-                placeholders=placeholders,
+                placeholders=custom_position_placeholders,
             )
 
             # B2 — time-window coherence. Only fire when BOTH sides resolve, so an
@@ -2056,9 +2079,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     def _min_exceeds_max(min_pos: int, max_pos: int) -> bool:
         """Whether the position envelope itself is inverted (issue #975/#1146, B1).
 
-        True only when ``min > max``. Split from
-        ``_custom_position_out_of_range`` (issue #1146) so this Repair's message
-        states only this clause — sibling condition (a slot pinned outside a
+        True only when ``min > max``. Split, along with
+        ``_custom_position_out_of_range``, out of the former
+        ``_position_envelope_incoherent`` (issue #1146) so this Repair's message
+        states only this clause — the sibling condition (a slot pinned outside a
         *coherent* envelope) is that method's job, not this one's.
         """
         return min_pos > max_pos
@@ -2066,28 +2090,33 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     @staticmethod
     def _custom_position_out_of_range(
         options: dict, min_pos: int, max_pos: int
-    ) -> bool:
-        """Whether a fixed custom-position slot is pinned outside the envelope.
+    ) -> int | None:
+        """Return the first fixed custom-position slot pinned outside the envelope.
 
-        (issue #975/#1146, B1.) False immediately when ``_min_exceeds_max``
-        reports the envelope itself inverted — that is the sibling predicate's
-        condition to report, and delegating to the single seam (rather than
-        re-testing ``min > max`` here) keeps the two Repairs mutually exclusive
-        so they never double-fire for one underlying breakage, and keeps the
-        inversion definition in exactly one place. Otherwise True when an
-        enabled, non-safety slot that would deliver an exact (FIXED) cover
-        position pins it outside ``[min, max]``. Slots that never deliver a
-        fixed position claim — ``use_my``, tilt-only, or a non-FIXED constraint
-        mode (floor / ceiling / range) — are exempt: they compose as
-        constraints the envelope clamps and cannot conflict with it.
-        Cover-type-agnostic: loops the slots generically and delegates the
-        fixed-position determination to the shared helper (same seam the
-        pipeline handler uses), with no branching on cover type or
-        capabilities.
+        Returns ``None`` if none is (issue #975/#1146, B1). Returns the slot
+        *number*, not a bool, so the caller can name which of up-to-10 slots
+        violated in the Repair's ``{slot}`` placeholder — the message would
+        otherwise give no way to tell which slot is at fault. ``None``
+        immediately when ``_min_exceeds_max`` reports the envelope itself
+        inverted — that is the sibling predicate's condition to report, and
+        delegating to the single seam (rather than re-testing ``min > max``
+        here) keeps the two Repairs mutually exclusive so they never
+        double-fire for one underlying breakage, and keeps the inversion
+        definition in exactly one place. Otherwise the number of the first
+        (lowest-numbered) enabled, non-safety slot that would deliver an exact
+        (FIXED) cover position pinned outside ``[min, max]`` — deterministic
+        when more than one slot violates, since ``CUSTOM_POSITION_SLOTS``
+        iterates in slot order. Slots that never deliver a fixed position
+        claim — ``use_my``, tilt-only, or a non-FIXED constraint mode (floor /
+        ceiling / range) — are exempt: they compose as constraints the
+        envelope clamps and cannot conflict with it. Cover-type-agnostic:
+        loops the slots generically and delegates the fixed-position
+        determination to the shared helper (same seam the pipeline handler
+        uses), with no branching on cover type or capabilities.
         """
         if AdaptiveDataUpdateCoordinator._min_exceeds_max(min_pos, max_pos):
-            return False
-        for slot_keys in CUSTOM_POSITION_SLOTS.values():
+            return None
+        for slot_number, slot_keys in CUSTOM_POSITION_SLOTS.items():
             if not options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED):
                 continue
             priority = options.get(
@@ -2099,8 +2128,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 continue  # only exact-position slots can contradict the envelope
             position = options.get(slot_keys["position"])
             if position < min_pos or position > max_pos:
-                return True
-        return False
+                return slot_number
+        return None
 
     def _calculate_cover_state(self, cover_data, options) -> int:
         """Calculate cover state via pipeline and return final position.

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -112,6 +112,7 @@ from .const import (
     ISSUE_COVER_NOT_MOVING,
     ISSUE_COVER_TILT_UNSUPPORTED,
     ISSUE_COVER_UNAVAILABLE,
+    ISSUE_CUSTOM_POSITION_OUT_OF_RANGE,
     ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
@@ -413,6 +414,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         entry_id = self.config_entry.entry_id
         self._sun_issue_key = f"{ISSUE_SUN_UNAVAILABLE}_{entry_id}"
         self._envelope_issue_key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{entry_id}"
+        self._custom_position_issue_key = (
+            f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{entry_id}"
+        )
         self._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{entry_id}"
         # B3 (issue #1115): entry-scoped like B1/B2 — the cover-type policy owns
         # the "is a bound role entity unfilled?" decision, so no cover-type
@@ -1874,18 +1878,30 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 )
             self._cover_issue_keys = desired
 
-            # B1 — position-envelope coherence. Consume the canonical min/max
-            # resolution from CoverConfig (single source of truth) instead of
-            # re-deriving the defaults here, and render the placeholders as plain
-            # ints so a HA NumberSelector float doesn't surface as "80.0".
+            # B1 — position-envelope coherence, split into two independent
+            # predicates (issue #1146) so each Repair's message states only its
+            # own condition: min>max and slot-outside-envelope are unrelated
+            # misconfigurations that used to share one message asserting both
+            # clauses regardless of which actually fired. Consume the canonical
+            # min/max resolution from CoverConfig (single source of truth)
+            # instead of re-deriving the defaults here, and render the
+            # placeholders as plain ints so a HA NumberSelector float doesn't
+            # surface as "80.0".
             cover_cfg = CoverConfig.from_options(options)
             min_pos = int(cover_cfg.min_pos)
             max_pos = int(cover_cfg.max_pos)
+            placeholders = {"name": name, "min": str(min_pos), "max": str(max_pos)}
             self._repair.update_predicate(
                 self._envelope_issue_key,
-                self._position_envelope_incoherent(options, min_pos, max_pos),
+                self._min_exceeds_max(min_pos, max_pos),
                 translation_key=ISSUE_CONFIG_POSITION_ENVELOPE,
-                placeholders={"name": name, "min": str(min_pos), "max": str(max_pos)},
+                placeholders=placeholders,
+            )
+            self._repair.update_predicate(
+                self._custom_position_issue_key,
+                self._custom_position_out_of_range(options, min_pos, max_pos),
+                translation_key=ISSUE_CUSTOM_POSITION_OUT_OF_RANGE,
+                placeholders=placeholders,
             )
 
             # B2 — time-window coherence. Only fire when BOTH sides resolve, so an
@@ -2037,22 +2053,37 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.logger.debug("Health-check evaluation failed", exc_info=True)
 
     @staticmethod
-    def _position_envelope_incoherent(
+    def _min_exceeds_max(min_pos: int, max_pos: int) -> bool:
+        """Whether the position envelope itself is inverted (issue #975/#1146, B1).
+
+        True only when ``min > max``. Split from
+        ``_custom_position_out_of_range`` (issue #1146) so this Repair's message
+        states only this clause — sibling condition (a slot pinned outside a
+        *coherent* envelope) is that method's job, not this one's.
+        """
+        return min_pos > max_pos
+
+    @staticmethod
+    def _custom_position_out_of_range(
         options: dict, min_pos: int, max_pos: int
     ) -> bool:
-        """Whether the position envelope is self-contradictory (issue #975, B1).
+        """Whether a fixed custom-position slot is pinned outside the envelope.
 
-        True when ``min > max`` or an enabled, non-safety slot that would deliver
-        an exact (FIXED) cover position pins it outside ``[min, max]``. Slots that
-        never deliver a fixed position claim — ``use_my``, tilt-only, or a
-        non-FIXED constraint mode (floor / ceiling / range) — are exempt: they
-        compose as constraints the envelope clamps and cannot conflict with it.
-        Cover-type-agnostic: loops the slots generically and delegates the
-        fixed-position determination to the shared helper (same seam the pipeline
-        handler uses), with no branching on cover type or capabilities.
+        (issue #975/#1146, B1.) False immediately when ``min > max`` — that is
+        ``_min_exceeds_max``'s condition to report, and short-circuiting here
+        keeps the two Repairs mutually exclusive so they never double-fire for
+        one underlying breakage. Otherwise True when an enabled, non-safety slot
+        that would deliver an exact (FIXED) cover position pins it outside
+        ``[min, max]``. Slots that never deliver a fixed position claim —
+        ``use_my``, tilt-only, or a non-FIXED constraint mode (floor / ceiling /
+        range) — are exempt: they compose as constraints the envelope clamps and
+        cannot conflict with it. Cover-type-agnostic: loops the slots generically
+        and delegates the fixed-position determination to the shared helper
+        (same seam the pipeline handler uses), with no branching on cover type
+        or capabilities.
         """
         if min_pos > max_pos:
-            return True
+            return False
         for slot_keys in CUSTOM_POSITION_SLOTS.values():
             if not options.get(slot_keys["enabled"], DEFAULT_CUSTOM_POSITION_ENABLED):
                 continue

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -15,7 +15,7 @@
     },
     "config_position_envelope": {
       "title": "Positionierungsgrenzen sind widersprüchlich",
-      "description": "Die auf **{name}** konfigurierten Positionierungsgrenzen sind inkonsistent: Das Minimum ({min}) liegt über dem Maximum ({max}), oder eine benutzerdefinierte Position ist außerhalb dieses Bereichs festgelegt und würde diese Grenzen außer Kraft setzen. Überprüfen Sie die Einstellungen für Mindest- und Höchstposition sowie benutzerdefinierte Positionen in den Optionen der Beschattung."
+      "description": "Die auf **{name}** konfigurierten Positionierungsgrenzen sind inkonsistent: Das Minimum ({min}) liegt über dem Maximum ({max}). Überprüfen Sie die Einstellungen für Mindest- und Höchstposition in den Optionen der Beschattung."
     },
     "config_time_window": {
       "title": "Betriebszeitfenster ist invertiert",
@@ -32,6 +32,10 @@
     "day_night_middle_rail_unset": {
       "title": "Tag/Nacht-Mittelschiene nicht ausgewählt",
       "description": "**{name}** ist als zweigeteiltes Tag/Nacht-Rollo konfiguriert, aber seine Mittelschienen-Beschattung ist nicht ausgewählt – oder verweist auf eine Beschattung, die nicht in der Beschattungsliste dieser Instanz enthalten ist. Beide Schienen erhalten dieselbe Position, daher verhält sich das Rollo wie eine normale Jalousie und die Mischung aus transparent und Verdunkelung wird nie angewendet. Wählen Sie die Mittelschienen-Beschattung in den Optionen der Beschattung aus, und stellen Sie sicher, dass sie auch als eine der gesteuerten Beschattungen aufgeführt ist."
+    },
+    "custom_position_out_of_range": {
+      "title": "Benutzerdefinierte Position außerhalb der konfigurierten Grenzen",
+      "description": "Eine auf **{name}** konfigurierte benutzerdefinierte Position ist außerhalb des konfigurierten Mindest-/Höchstbereichs ({min}-{max}) festgelegt und würde diese Grenzen außer Kraft setzen. Überprüfen Sie die Einstellungen für Mindest-, Höchst- und benutzerdefinierte Position in den Optionen der Beschattung."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -17,6 +17,10 @@
       "title": "Positionierungsgrenzen sind widersprüchlich",
       "description": "Die auf **{name}** konfigurierten Positionierungsgrenzen sind inkonsistent: Das Minimum ({min}) liegt über dem Maximum ({max}). Überprüfen Sie die Einstellungen für Mindest- und Höchstposition in den Optionen der Beschattung."
     },
+    "custom_position_out_of_range": {
+      "title": "Benutzerdefinierte Position außerhalb der konfigurierten Grenzen",
+      "description": "Die auf **{name}** konfigurierte benutzerdefinierte Position **{slot}** ist außerhalb des konfigurierten Mindest-/Höchstbereichs ({min}-{max}) festgelegt und würde diese Grenzen außer Kraft setzen. Überprüfen Sie die Einstellungen für Mindest-, Höchst- und benutzerdefinierte Position in den Optionen der Beschattung."
+    },
     "config_time_window": {
       "title": "Betriebszeitfenster ist invertiert",
       "description": "Das Betriebszeitfenster auf **{name}** beginnt um {start}, was nach seinem Ende um {end} liegt. Das Fenster öffnet sich nie, daher wird die automatische Sonnenverfolgung nicht ausgeführt. Überprüfen Sie die Start- und Endzeiten in den Optionen der Beschattung."
@@ -32,10 +36,6 @@
     "day_night_middle_rail_unset": {
       "title": "Tag/Nacht-Mittelschiene nicht ausgewählt",
       "description": "**{name}** ist als zweigeteiltes Tag/Nacht-Rollo konfiguriert, aber seine Mittelschienen-Beschattung ist nicht ausgewählt – oder verweist auf eine Beschattung, die nicht in der Beschattungsliste dieser Instanz enthalten ist. Beide Schienen erhalten dieselbe Position, daher verhält sich das Rollo wie eine normale Jalousie und die Mischung aus transparent und Verdunkelung wird nie angewendet. Wählen Sie die Mittelschienen-Beschattung in den Optionen der Beschattung aus, und stellen Sie sicher, dass sie auch als eine der gesteuerten Beschattungen aufgeführt ist."
-    },
-    "custom_position_out_of_range": {
-      "title": "Benutzerdefinierte Position außerhalb der konfigurierten Grenzen",
-      "description": "Eine auf **{name}** konfigurierte benutzerdefinierte Position ist außerhalb des konfigurierten Mindest-/Höchstbereichs ({min}-{max}) festgelegt und würde diese Grenzen außer Kraft setzen. Überprüfen Sie die Einstellungen für Mindest-, Höchst- und benutzerdefinierte Position in den Optionen der Beschattung."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -19,7 +19,7 @@
     },
     "custom_position_out_of_range": {
       "title": "Custom position outside configured limits",
-      "description": "A custom position configured on **{name}** is pinned outside the configured minimum/maximum range ({min}-{max}) and would override those limits. Review the minimum/maximum position and custom-position settings in the cover's options."
+      "description": "The custom position **{slot}** configured on **{name}** is pinned outside the configured minimum/maximum range ({min}-{max}) and would override those limits. Review the minimum/maximum position and custom-position settings in the cover's options."
     },
     "config_time_window": {
       "title": "Operational time window is inverted",

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -15,7 +15,11 @@
     },
     "config_position_envelope": {
       "title": "Position limits are contradictory",
-      "description": "The position limits configured on **{name}** are inconsistent: the minimum ({min}) is above the maximum ({max}), or a custom position is pinned outside that range and would override those limits. Review the minimum/maximum position and custom-position settings in the cover's options."
+      "description": "The position limits configured on **{name}** are inconsistent: the minimum ({min}) is above the maximum ({max}). Review the minimum/maximum position settings in the cover's options."
+    },
+    "custom_position_out_of_range": {
+      "title": "Custom position outside configured limits",
+      "description": "A custom position configured on **{name}** is pinned outside the configured minimum/maximum range ({min}-{max}) and would override those limits. Review the minimum/maximum position and custom-position settings in the cover's options."
     },
     "config_time_window": {
       "title": "Operational time window is inverted",

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -15,7 +15,11 @@
     },
     "config_position_envelope": {
       "title": "Les limites de position sont contradictoires",
-      "description": "Les limites de position configurées sur **{name}** sont incompatibles : le minimum ({min}) est supérieur au maximum ({max}). Vérifiez les paramètres de position minimale/maximale dans les options du store."
+      "description": "Les limites de position configurées sur **{name}** sont incohérentes : le minimum ({min}) est supérieur au maximum ({max}). Vérifiez les paramètres de position minimale/maximale dans les options du store."
+    },
+    "custom_position_out_of_range": {
+      "title": "Position personnalisée en dehors des limites configurées",
+      "description": "La position personnalisée **{slot}** configurée sur **{name}** est en dehors de la plage minimum/maximum configurée ({min}-{max}) et remplacerait ces limites. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
     },
     "config_time_window": {
       "title": "La fenêtre temporelle opérationnelle est inversée",
@@ -32,10 +36,6 @@
     "day_night_middle_rail_unset": {
       "title": "Barre intermédiaire du store jour/nuit non sélectionnée",
       "description": "**{name}** est configuré comme store jour/nuit à deux barres, mais la protection de la barre intermédiaire n'est pas sélectionnée — ou fait référence à une protection qui ne figure pas dans la liste des protections de cette instance. Les deux barres reçoivent la même position, le store se comporte donc comme une simple protection et le mélange voilage/occultant ne sera jamais appliqué. Sélectionnez la protection de la barre intermédiaire dans les options de cette protection, et assurez-vous qu'elle figure aussi parmi les protections contrôlées."
-    },
-    "custom_position_out_of_range": {
-      "title": "Position personnalisée en dehors des limites configurées",
-      "description": "Une position personnalisée configurée sur **{name}** est en dehors de la plage minimum/maximum configurée ({min}-{max}) et remplacerait ces limites. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
     }
   },
   "config": {

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -15,7 +15,7 @@
     },
     "config_position_envelope": {
       "title": "Les limites de position sont contradictoires",
-      "description": "Les limites de position configurées sur **{name}** sont incohérentes : le minimum ({min}) est supérieur au maximum ({max}), ou une position personnalisée est fixée en dehors de cette plage et remplacerait ces limites. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
+      "description": "Les limites de position configurées sur **{name}** sont incompatibles : le minimum ({min}) est supérieur au maximum ({max}). Vérifiez les paramètres de position minimale/maximale dans les options du store."
     },
     "config_time_window": {
       "title": "La fenêtre temporelle opérationnelle est inversée",
@@ -32,6 +32,10 @@
     "day_night_middle_rail_unset": {
       "title": "Barre intermédiaire du store jour/nuit non sélectionnée",
       "description": "**{name}** est configuré comme store jour/nuit à deux barres, mais la protection de la barre intermédiaire n'est pas sélectionnée — ou fait référence à une protection qui ne figure pas dans la liste des protections de cette instance. Les deux barres reçoivent la même position, le store se comporte donc comme une simple protection et le mélange voilage/occultant ne sera jamais appliqué. Sélectionnez la protection de la barre intermédiaire dans les options de cette protection, et assurez-vous qu'elle figure aussi parmi les protections contrôlées."
+    },
+    "custom_position_out_of_range": {
+      "title": "Position personnalisée en dehors des limites configurées",
+      "description": "Une position personnalisée configurée sur **{name}** est en dehors de la plage minimum/maximum configurée ({min}-{max}) et remplacerait ces limites. Vérifiez les paramètres de position minimale/maximale et de position personnalisée dans les options du store."
     }
   },
   "config": {

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -340,12 +340,6 @@ async def test_c1_no_raise_when_sun_healthy():
 # --- B1: position envelope --------------------------------------------------
 
 
-async def test_b1_inverted_envelope_raises():
-    coord = _make_coord(entities=[])
-    create, _delete = await _run(coord, {CONF_MIN_POSITION: 80, CONF_MAX_POSITION: 20})
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
-
-
 def _issue_call(create_mock, key):
     """Return the ir.async_create_issue call that raised the Repair for ``key``."""
     for call in create_mock.call_args_list:
@@ -389,6 +383,97 @@ async def test_b1_pinned_slot_outside_envelope_raises():
     call = _issue_call(create, f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}")
     assert call is not None
     assert call.kwargs["translation_key"] == ISSUE_CUSTOM_POSITION_OUT_OF_RANGE
+
+
+async def test_b1_custom_position_placeholder_names_violating_slot():
+    """The {slot} placeholder names the offending slot by its configured label
+    (issue #1146) so the Repair is directly actionable across up-to-10 slots.
+    """
+    slot = CUSTOM_POSITION_SLOTS[2]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,  # above max
+        slot["name"]: "Canicule",
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    call = _issue_call(create, f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}")
+    assert call is not None
+    assert call.kwargs["translation_placeholders"]["slot"] == "Canicule"
+
+
+async def test_b1_custom_position_placeholder_falls_back_to_slot_number():
+    """An unnamed violating slot names itself "Slot N" — the same fallback
+    ``custom_position_slot_name(...) or f"Slot {n}"`` pattern config_flow
+    already uses, so an unnamed slot is still identifiable.
+    """
+    slot = CUSTOM_POSITION_SLOTS[3]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    call = _issue_call(create, f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}")
+    assert call is not None
+    assert call.kwargs["translation_placeholders"]["slot"] == "Slot 3"
+
+
+async def test_b1_custom_position_names_first_violating_slot_deterministically():
+    """When multiple slots violate the envelope, the lowest-numbered slot is
+    named — deterministic regardless of which slot the user notices first.
+    """
+    slot1 = CUSTOM_POSITION_SLOTS[1]
+    slot4 = CUSTOM_POSITION_SLOTS[4]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot1["enabled"]: True,
+        slot1["position"]: 80,
+        slot1["name"]: "First",
+        slot4["enabled"]: True,
+        slot4["position"]: 90,
+        slot4["name"]: "Fourth",
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    call = _issue_call(create, f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}")
+    assert call is not None
+    assert call.kwargs["translation_placeholders"]["slot"] == "First"
+
+
+async def test_b1_envelope_and_custom_position_placeholder_dicts_are_independent():
+    """The envelope and custom-position Repairs must never share one
+    placeholder dict object (issue #1146). The custom-position description
+    carries ``{slot}`` but the envelope's does not, and HA silently drops a
+    description whose placeholder set differs from the key's — sharing one
+    dict between the two ``update_predicate`` calls would corrupt whichever
+    fires. Patches ``update_predicate`` itself (rather than reading the raised
+    Repair) so both calls are observable even though only one fires here.
+    """
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 0,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 80,
+        slot["name"]: "Canicule",
+    }
+    coord = _make_coord(entities=[])
+    coord._repair.update_predicate = MagicMock(wraps=coord._repair.update_predicate)
+    create, _delete = await _run(coord, options)
+    calls_by_key = {c.args[0]: c for c in coord._repair.update_predicate.call_args_list}
+    envelope_call = calls_by_key[f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}"]
+    custom_call = calls_by_key[f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}"]
+    envelope_placeholders = envelope_call.kwargs["placeholders"]
+    custom_placeholders = custom_call.kwargs["placeholders"]
+    assert envelope_placeholders is not custom_placeholders
+    assert "slot" not in envelope_placeholders
+    assert custom_placeholders["slot"] == "Canicule"
 
 
 async def test_b1_min_exceeds_max_does_not_raise_custom_position_key():

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -346,18 +346,8 @@ async def test_b1_inverted_envelope_raises():
     assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
 
 
-def _envelope_call(create_mock):
-    """Return the ir.async_create_issue call that raised the envelope Repair."""
-    key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}"
-    for call in create_mock.call_args_list:
-        if call.args[2] == key:
-            return call
-    return None
-
-
-def _custom_position_call(create_mock):
-    """Return the create-issue call that raised the custom-position Repair."""
-    key = f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}"
+def _issue_call(create_mock, key):
+    """Return the ir.async_create_issue call that raised the Repair for ``key``."""
     for call in create_mock.call_args_list:
         if call.args[2] == key:
             return call
@@ -371,7 +361,7 @@ async def test_b1_placeholders_render_as_int():
     create, _delete = await _run(
         coord, {CONF_MIN_POSITION: 80.0, CONF_MAX_POSITION: 20.0}
     )
-    call = _envelope_call(create)
+    call = _issue_call(create, f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}")
     assert call is not None
     assert call.kwargs["translation_key"] == ISSUE_CONFIG_POSITION_ENVELOPE
     placeholders = call.kwargs["translation_placeholders"]
@@ -396,7 +386,7 @@ async def test_b1_pinned_slot_outside_envelope_raises():
     raised = _raised_keys(create)
     assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" in raised
     assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
-    call = _custom_position_call(create)
+    call = _issue_call(create, f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}")
     assert call is not None
     assert call.kwargs["translation_key"] == ISSUE_CUSTOM_POSITION_OUT_OF_RANGE
 
@@ -532,6 +522,32 @@ async def test_b1_coherent_envelope_no_raise():
     raised = _raised_keys(create)
     assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
     assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
+
+
+async def test_b1_min_equals_max_is_coherent_and_slot_check_runs():
+    """``min == max`` is a degenerate but coherent envelope, not an inversion.
+
+    ``_min_exceeds_max`` is ``min_pos > max_pos`` (strictly greater) — the
+    boundary case where they're equal must read as coherent, so the envelope
+    Repair stays quiet and the slot check still runs (rather than
+    short-circuiting) and correctly flags a slot pinned outside the
+    single-point envelope. A `>=` mutant would flip both: it would fire the
+    envelope Repair with a false "the minimum (50) is above the maximum (50)"
+    message, and its short-circuit would suppress the accurate
+    custom-position Repair.
+    """
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 50,
+        CONF_MAX_POSITION: 50,
+        slot["enabled"]: True,
+        slot["position"]: 30,  # outside the degenerate [50, 50] envelope
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" in raised
 
 
 # --- B2: time window --------------------------------------------------------

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -355,6 +355,15 @@ def _envelope_call(create_mock):
     return None
 
 
+def _custom_position_call(create_mock):
+    """Return the create-issue call that raised the custom-position Repair."""
+    key = f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}"
+    for call in create_mock.call_args_list:
+        if call.args[2] == key:
+            return call
+    return None
+
+
 async def test_b1_placeholders_render_as_int():
     """min/max placeholders render as plain ints even when HA stores floats."""
     coord = _make_coord(entities=[])
@@ -364,6 +373,7 @@ async def test_b1_placeholders_render_as_int():
     )
     call = _envelope_call(create)
     assert call is not None
+    assert call.kwargs["translation_key"] == ISSUE_CONFIG_POSITION_ENVELOPE
     placeholders = call.kwargs["translation_placeholders"]
     assert placeholders["min"] == "80"
     assert placeholders["max"] == "20"
@@ -386,6 +396,9 @@ async def test_b1_pinned_slot_outside_envelope_raises():
     raised = _raised_keys(create)
     assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" in raised
     assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    call = _custom_position_call(create)
+    assert call is not None
+    assert call.kwargs["translation_key"] == ISSUE_CUSTOM_POSITION_OUT_OF_RANGE
 
 
 async def test_b1_min_exceeds_max_does_not_raise_custom_position_key():

--- a/tests/test_coordinator_healthchecks.py
+++ b/tests/test_coordinator_healthchecks.py
@@ -43,6 +43,7 @@ from custom_components.adaptive_cover_pro.const import (
     ISSUE_COVER_NOT_MOVING,
     ISSUE_COVER_TILT_UNSUPPORTED,
     ISSUE_COVER_UNAVAILABLE,
+    ISSUE_CUSTOM_POSITION_OUT_OF_RANGE,
     ISSUE_DAY_NIGHT_MIDDLE_RAIL_UNSET,
     ISSUE_SUN_UNAVAILABLE,
     ISSUE_TEMP_SENSOR_UNAVAILABLE,
@@ -133,6 +134,7 @@ def _make_coord(
     coord._temp_issue_key = f"{ISSUE_TEMP_SENSOR_UNAVAILABLE}_{_ENTRY}"
     coord._sun_issue_key = f"{ISSUE_SUN_UNAVAILABLE}_{_ENTRY}"
     coord._envelope_issue_key = f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}"
+    coord._custom_position_issue_key = f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}"
     coord._time_window_issue_key = f"{ISSUE_CONFIG_TIME_WINDOW}_{_ENTRY}"
     coord._cover_issue_keys = set()
     coord._a1_orphans_swept = False
@@ -368,6 +370,10 @@ async def test_b1_placeholders_render_as_int():
 
 
 async def test_b1_pinned_slot_outside_envelope_raises():
+    """A slot outside a *coherent* envelope raises only the custom-position
+    Repair — the envelope key must not also fire, since min <= max here and
+    that clause of the (now-split) message would be false (issue #1146).
+    """
     slot = CUSTOM_POSITION_SLOTS[1]
     options = {
         CONF_MIN_POSITION: 0,
@@ -377,7 +383,39 @@ async def test_b1_pinned_slot_outside_envelope_raises():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" in raised
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+
+
+async def test_b1_min_exceeds_max_does_not_raise_custom_position_key():
+    """An inverted envelope (no slot involved) raises only the envelope
+    Repair — the custom-position key must not also fire.
+    """
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, {CONF_MIN_POSITION: 80, CONF_MAX_POSITION: 20})
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
+
+
+async def test_b1_min_exceeds_max_suppresses_slot_check():
+    """When the envelope itself is broken, the slot check short-circuits so
+    the two Repairs never double-fire for one underlying breakage — only the
+    envelope key raises, even with a slot present.
+    """
+    slot = CUSTOM_POSITION_SLOTS[1]
+    options = {
+        CONF_MIN_POSITION: 80,
+        CONF_MAX_POSITION: 20,
+        slot["enabled"]: True,
+        slot["position"]: 50,
+    }
+    coord = _make_coord(entities=[])
+    create, _delete = await _run(coord, options)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 async def test_b1_use_my_slot_outside_envelope_no_raise():
@@ -394,7 +432,9 @@ async def test_b1_use_my_slot_outside_envelope_no_raise():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 async def test_b1_tilt_only_slot_outside_envelope_no_raise():
@@ -411,7 +451,9 @@ async def test_b1_tilt_only_slot_outside_envelope_no_raise():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 async def test_b1_nonfixed_mode_slot_outside_envelope_no_raise():
@@ -428,7 +470,9 @@ async def test_b1_nonfixed_mode_slot_outside_envelope_no_raise():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 async def test_b1_safety_slot_ignored():
@@ -442,7 +486,9 @@ async def test_b1_safety_slot_ignored():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 async def test_b1_disabled_slot_ignored():
@@ -455,7 +501,9 @@ async def test_b1_disabled_slot_ignored():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 async def test_b1_coherent_envelope_no_raise():
@@ -468,7 +516,9 @@ async def test_b1_coherent_envelope_no_raise():
     }
     coord = _make_coord(entities=[])
     create, _delete = await _run(coord, options)
-    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in _raised_keys(create)
+    raised = _raised_keys(create)
+    assert f"{ISSUE_CONFIG_POSITION_ENVELOPE}_{_ENTRY}" not in raised
+    assert f"{ISSUE_CUSTOM_POSITION_OUT_OF_RANGE}_{_ENTRY}" not in raised
 
 
 # --- B2: time window --------------------------------------------------------

--- a/tests/test_health_issue_translations.py
+++ b/tests/test_health_issue_translations.py
@@ -29,6 +29,7 @@ _HEALTH_ISSUES = {
     "cover_unavailable": {"{name}", "{entity_id}"},
     "sun_unavailable": {"{name}"},
     "config_position_envelope": {"{name}", "{min}", "{max}"},
+    "custom_position_out_of_range": {"{name}", "{min}", "{max}"},
     "config_time_window": {"{name}", "{start}", "{end}"},
     "cover_not_moving": {"{name}", "{entity_id}"},
     "cover_tilt_unsupported": {"{name}", "{entity_id}"},

--- a/tests/test_health_issue_translations.py
+++ b/tests/test_health_issue_translations.py
@@ -26,13 +26,15 @@ _EN = (
 
 # {translation_key: required placeholder tokens in the description}
 _HEALTH_ISSUES = {
+    "temp_sensor_unavailable": {"{name}", "{entity_id}"},
     "cover_unavailable": {"{name}", "{entity_id}"},
     "sun_unavailable": {"{name}"},
     "config_position_envelope": {"{name}", "{min}", "{max}"},
-    "custom_position_out_of_range": {"{name}", "{min}", "{max}"},
+    "custom_position_out_of_range": {"{name}", "{min}", "{max}", "{slot}"},
     "config_time_window": {"{name}", "{start}", "{end}"},
     "cover_not_moving": {"{name}", "{entity_id}"},
     "cover_tilt_unsupported": {"{name}", "{entity_id}"},
+    "day_night_middle_rail_unset": {"{name}"},
 }
 
 


### PR DESCRIPTION
## Summary

The B1 health check ORed two unrelated conditions into one predicate (`min > max`, or a fixed custom-position slot pinned outside `[min, max]`) and raised a single Repair whose description asserted the min/max clause unconditionally. A slot-only violation therefore rendered a false statement with the user's real values in it: "the minimum (0) is above the maximum (90)".

There are now two predicates and two translation keys, each stating only its own condition. `_custom_position_out_of_range` short-circuits through the single `_min_exceeds_max` seam when the envelope is inverted, so the two Repairs are mutually exclusive and never double-fire for one underlying breakage. The custom-position message also names which slot is at fault via a new `{slot}` placeholder, since with up to ten slots "a custom position" gave the user nothing to act on. Each Repair gets its own placeholder dict, because HA silently drops a description whose placeholder set differs from the key's.

DE and FR are synced. Existing users' stale Repairs self-clear on the first cycle after upgrade: clearing is unconditional, not debounced.

Four audit rounds; every must-fix item was reproduced by mutation before being fixed and re-killed after. New tests pin the translation key on both `update_predicate` calls, the `min == max` boundary, mutual exclusivity, and the `{slot}` label including its fallback and its tie-break.

## Testing
- ✅ 11,919 tests passing (4 skipped, 1 xfailed)

## Related Issues
Refs #1146