### PR TITLE
fix: stop losing handlers leaking tilt onto the winner (#1153)

### DIFF
--- a/custom_components/adaptive_cover_pro/config_flow.py
+++ b/custom_components/adaptive_cover_pro/config_flow.py
@@ -1616,9 +1616,9 @@ _SUMMARY_LABELS_EN: dict[str, str] = {
     "blind_spot.elevation_above": "above {elev}° elevation",
     # --- Default fallback (0) ---
     "rules.default": "🌙 Default (no rule matches) → {default_pos}%",
-    "default.tilt": ("  ↳ Default tilt: {tilt}% (explicit; overrides solar-computed)"),
+    "default.tilt": ("  ↳ Default tilt: {tilt}% (used when no handler wins control)"),
     "default.sunset_tilt": (
-        "  ↳ Sunset tilt: {tilt}% (explicit; overrides solar-computed)"
+        "  ↳ Sunset tilt: {tilt}% (used when no handler wins control, during sunset)"
     ),
     # --- Position limits ---
     "headers.position_limits": "**Position Limits**",

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -581,7 +581,11 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         manual/custom-position carriage move is intentional) and while a
         tilt-only Custom Position slot's own FIXED contribution is already
         driving the carriage (``tilt_only_contribution_active``), matching
-        the original per-branch guards this replaces.
+        the original per-branch guards this replaces — except on the engine
+        branch, whose original guard carried no
+        ``_EXPLICIT_USER_POSITION_METHODS`` check at all; adding one there is
+        harmless only because ``SOLAR`` is the sole control method that ever
+        reaches that branch, so the guard has nothing else to exclude.
 
         Also skipped for ``ControlMethod.DEFAULT`` (issue #1153 finding 2).
         Tilt-only is a sun-tracking-*window* behavior; ``DEFAULT`` is by

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -552,6 +552,49 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             return True
         return cover is None or not cover.direct_sun_valid
 
+    def _pin_tilt_only_carriage(
+        self,
+        result: PipelineResult,
+        position: int,
+        tilt: int | None,
+        trace: list[DecisionStep],
+    ) -> int:
+        """Pin the carriage closed in tilt-only mode; append the trace step in place.
+
+        Tilt-only mode's defining behavior (issue #514) is that the carriage
+        stays closed and only the slats move — that must hold on EVERY exit
+        path out of ``post_pipeline_resolve``, not just the ones that happen
+        to produce a tilt. Before issue #1153's fix this pin only ran as a
+        side effect of the "handler tilt" and "engine tilt" branches; the
+        engine-suppressed no-tilt branch (a non-SOLAR winner, or SOLAR
+        without direct sun) returned early and skipped it entirely, so a
+        tilt-only install's carriage opened whenever no tilt happened to be
+        available. Skipped for explicit user position methods (a
+        manual/custom-position carriage move is intentional) and while a
+        tilt-only Custom Position slot's own FIXED contribution is already
+        driving the carriage (``tilt_only_contribution_active``), matching
+        the original per-branch guards this replaces.
+        """
+        if (
+            self._venetian_mode != VENETIAN_MODE_TILT_ONLY
+            or result.control_method in _EXPLICIT_USER_POSITION_METHODS
+            or result.tilt_only_contribution_active
+        ):
+            return position
+        trace.append(
+            DecisionStep(
+                handler="venetian_mode",
+                matched=True,
+                reason=(
+                    f"tilt-only mode: position {position}% → {POSITION_CLOSED}% "
+                    "(closed); tilt drives the slats"
+                ),
+                position=POSITION_CLOSED,
+                tilt=tilt,
+            )
+        )
+        return POSITION_CLOSED
+
     def _compose_tilt(
         self,
         position: int,
@@ -670,24 +713,9 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             handler_tilt = result.tilt
             position = result.position
             trace = list(result.decision_trace)
-            if (
-                self._venetian_mode == VENETIAN_MODE_TILT_ONLY
-                and result.control_method not in _EXPLICIT_USER_POSITION_METHODS
-                and not result.tilt_only_contribution_active
-            ):
-                trace.append(
-                    DecisionStep(
-                        handler="venetian_mode",
-                        matched=True,
-                        reason=(
-                            f"tilt-only mode: position {position}% → {POSITION_CLOSED}% "
-                            "(closed); tilt drives the slats"
-                        ),
-                        position=POSITION_CLOSED,
-                        tilt=handler_tilt,
-                    )
-                )
-                position = POSITION_CLOSED
+            position = self._pin_tilt_only_carriage(
+                result, position, handler_tilt, trace
+            )
             trace.append(
                 DecisionStep(
                     handler="venetian_handler_tilt",
@@ -705,7 +733,10 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         # No handler tilt: engine fallback runs only when SOLAR + direct sun.
         if self._engine_tilt_suppressed(result, cover):
             self._clear_last_tilt()
-            return replace(result, tilt=None)
+            position = result.position
+            trace = list(result.decision_trace)
+            position = self._pin_tilt_only_carriage(result, position, None, trace)
+            return replace(result, position=position, tilt=None, decision_trace=trace)
 
         # Compose the engine slat angle (+ movement-minimization quantize) via
         # the shared seam the forecast hook also uses, so the projected tilt
@@ -759,23 +790,7 @@ class VenetianPolicy(CoverTypePolicy, register=True):
             )
             tilt = bounded
 
-        if (
-            self._venetian_mode == VENETIAN_MODE_TILT_ONLY
-            and not result.tilt_only_contribution_active
-        ):
-            trace.append(
-                DecisionStep(
-                    handler="venetian_mode",
-                    matched=True,
-                    reason=(
-                        f"tilt-only mode: position {position}% → {POSITION_CLOSED}% "
-                        "(closed); tilt drives the slats"
-                    ),
-                    position=POSITION_CLOSED,
-                    tilt=tilt,
-                )
-            )
-            position = POSITION_CLOSED
+        position = self._pin_tilt_only_carriage(result, position, tilt, trace)
 
         trace.append(
             DecisionStep(

--- a/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
+++ b/custom_components/adaptive_cover_pro/cover_types/venetian/policy.py
@@ -139,6 +139,12 @@ _VENETIAN_EXTRA_KEYS = (
 # Control methods that carry an explicit, user-specified position.
 # The tilt-only carriage-close rewrite does not apply to these — the
 # user's position wins over "close carriage, let tilt filter".
+# GROUP_SCENE and GROUP_LOCK carry the same "explicit user intent" semantics
+# as CUSTOM_POSITION and MANUAL (issue #1153 finding 1): both handlers set
+# ``bypass_auto_control=True`` for exactly that reason (see their own
+# docstrings in pipeline/handlers/group_scene.py and group_lock.py), and
+# GROUP_LOCK's held position must not contradict itself by being reported as
+# force-closed while skip_command=True holds the carriage where it is.
 _EXPLICIT_USER_POSITION_METHODS = frozenset(
     {
         ControlMethod.CUSTOM_POSITION,
@@ -146,6 +152,8 @@ _EXPLICIT_USER_POSITION_METHODS = frozenset(
         ControlMethod.WEATHER,
         ControlMethod.MANUAL,
         ControlMethod.MOTION,
+        ControlMethod.GROUP_SCENE,
+        ControlMethod.GROUP_LOCK,
     }
 )
 
@@ -574,10 +582,21 @@ class VenetianPolicy(CoverTypePolicy, register=True):
         tilt-only Custom Position slot's own FIXED contribution is already
         driving the carriage (``tilt_only_contribution_active``), matching
         the original per-branch guards this replaces.
+
+        Also skipped for ``ControlMethod.DEFAULT`` (issue #1153 finding 2).
+        Tilt-only is a sun-tracking-*window* behavior; ``DEFAULT`` is by
+        definition the no-handler-fired fallback that wins precisely OUTSIDE
+        that window, and it is the carrier for ``sunset_position`` /
+        ``return_sunset`` / ``default_percentage`` — pinning it would
+        silently disable all three documented carriage-movement options on a
+        tilt-only install. This is deliberately a separate condition rather
+        than a member of ``_EXPLICIT_USER_POSITION_METHODS``: DEFAULT is not
+        explicit user intent, it is the absence of any handler intent.
         """
         if (
             self._venetian_mode != VENETIAN_MODE_TILT_ONLY
             or result.control_method in _EXPLICIT_USER_POSITION_METHODS
+            or result.control_method == ControlMethod.DEFAULT
             or result.tilt_only_contribution_active
         ):
             return position

--- a/custom_components/adaptive_cover_pro/pipeline/registry.py
+++ b/custom_components/adaptive_cover_pro/pipeline/registry.py
@@ -185,22 +185,19 @@ def _inactive_tilt_steps(
 def _tilt_to_clamp(
     tilt_overlay: int | None,
     winner_tilt: int | None,
-    merged: dict[str, object],
 ) -> int | None:
     """Return the tilt a bound should clamp, in precedence order.
 
-    The FIXED overlay we just filled wins; then the winner's own tilt; then a
-    tilt merged onto the result from a lower-priority handler or ``contribute()``
-    (the ``_MERGEABLE`` fill). The merged case is the one the pre-audit code
-    skipped, letting a configured minimum be silently violated (audit finding
-    2). Returns None when nothing has set a tilt yet (the venetian engine will).
+    The FIXED overlay (issue #514) we just filled wins; otherwise the
+    winner's own tilt. There is no third, merged-from-a-loser source: a
+    handler the pipeline outprioritized never contributes a tilt (issue
+    #1153) — ``_MERGEABLE`` no longer includes ``"tilt"``, so nothing else
+    could have set one by this point. Returns None when nothing has set a
+    tilt yet (the venetian engine will, post-pipeline).
     """
     if tilt_overlay is not None:
         return tilt_overlay
-    if winner_tilt is not None:
-        return winner_tilt
-    merged_tilt = merged.get("tilt")
-    return int(merged_tilt) if merged_tilt is not None else None  # type: ignore[arg-type]
+    return winner_tilt
 
 
 class PipelineRegistry:
@@ -301,7 +298,15 @@ class PipelineRegistry:
         #      from evaluate() (e.g. ClimateHandler deferring GLARE_CONTROL) can
         #      still surface metadata this way (Issue #240).
         # Winner's non-None values are never overwritten.
-        _MERGEABLE = ("climate_state", "climate_strategy", "climate_data", "tilt")
+        #
+        # ``tilt`` is deliberately NOT in this tuple (issue #1153). Unlike
+        # climate_state/climate_strategy/climate_data, tilt is an actuation
+        # output, not diagnostic metadata — a handler the pipeline explicitly
+        # outprioritized must never drive the tilt axis. Tilt is owned by
+        # exactly two sources: the winner's own ``PipelineResult.tilt``, and
+        # the priority-independent tilt-axis pass below (the #514 FIXED
+        # overlay and #943 bounds composition; see ``_tilt_to_clamp``).
+        _MERGEABLE = ("climate_state", "climate_strategy", "climate_data")
         contributions: list[dict[str, object]] = [
             h.contribute(snapshot) for h, _ in evaluated
         ]
@@ -515,12 +520,12 @@ class PipelineRegistry:
             },
         )
         # The tilt to clamp is, in precedence order: the FIXED overlay we just
-        # filled, the winner's own tilt, or a tilt merged from a lower-priority
-        # handler / contribute() (the ``_MERGEABLE`` fill). The merged case is
-        # the one the pre-audit code missed — a configured minimum was silently
-        # violated whenever a handler-supplied tilt reached the result by merge
-        # (audit finding 2). One clamp site covers all three.
-        resolved_tilt = _tilt_to_clamp(tilt_overlay, winner.tilt, merged)
+        # filled, or the winner's own tilt (see ``_tilt_to_clamp``). #943's
+        # audit finding 2 — a configured minimum silently violated by a tilt
+        # that reached the result via merge from a lower-priority handler —
+        # no longer applies: issue #1153 removed that merge path entirely, so
+        # there is nothing left for a bound to miss.
+        resolved_tilt = _tilt_to_clamp(tilt_overlay, winner.tilt)
         tilt_clamped = False
         carried_low: int | None = None
         carried_high: int | None = None
@@ -615,9 +620,11 @@ class PipelineRegistry:
         if tilt_clamped:
             # Same rule on the tilt axis: a clamp is a command, not a no-op.
             winner = dataclasses.replace(winner, skip_command=False)
-        # The dedicated tilt-axis overlay (issue #514) wins the tilt field over
-        # the generic _MERGEABLE tilt fill — both only fire when the winner's
-        # own tilt is None, but a tilt-only contribution is explicit user intent.
+        # The tilt-axis overlay (issue #514) is how a FIXED contribution
+        # reaches the result's tilt field. It can never collide with the
+        # bound-clamp write above (the ``else: merged["tilt"] = bounded_tilt``
+        # branch only fires when ``tilt_overlay`` is None) — this is simply
+        # the transport for a (possibly bound-clamped) tilt-only contribution.
         if tilt_overlay is not None:
             merged["tilt"] = tilt_overlay
         result = dataclasses.replace(

--- a/custom_components/adaptive_cover_pro/summary_i18n/de.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/de.json
@@ -190,8 +190,8 @@
     "elevation_above": "ab {elev}° Höhe"
   },
   "default": {
-    "tilt": "  ↳ Standard-Neigung: {tilt}% (explizit; überschreibt sonnenberechnet)",
-    "sunset_tilt": "  ↳ Sonnenuntergangsneigung: {tilt}% (explizit; überschreibt sonnenberechnet)"
+    "tilt": "  ↳ Standard-Neigung: {tilt}% (gilt, wenn kein Handler die Kontrolle übernimmt)",
+    "sunset_tilt": "  ↳ Sonnenuntergangsneigung: {tilt}% (gilt bei Sonnenuntergang, wenn kein Handler die Kontrolle übernimmt)"
   },
   "limits": {
     "range": "Bereich: {lo}–{hi}{qualifier}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/en.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/en.json
@@ -190,8 +190,8 @@
     "elevation_above": "above {elev}° elevation"
   },
   "default": {
-    "tilt": "  ↳ Default tilt: {tilt}% (explicit; overrides solar-computed)",
-    "sunset_tilt": "  ↳ Sunset tilt: {tilt}% (explicit; overrides solar-computed)"
+    "tilt": "  ↳ Default tilt: {tilt}% (used when no handler wins control)",
+    "sunset_tilt": "  ↳ Sunset tilt: {tilt}% (used when no handler wins control, during sunset)"
   },
   "limits": {
     "range": "Range: {lo}–{hi}{qualifier}",

--- a/custom_components/adaptive_cover_pro/summary_i18n/fr.json
+++ b/custom_components/adaptive_cover_pro/summary_i18n/fr.json
@@ -190,8 +190,8 @@
     "elevation_above": "au-dessus de {elev}° élévation"
   },
   "default": {
-    "tilt": "  ↳ Inclinaison par défaut : {tilt}% (explicite ; remplace calculé solaire)",
-    "sunset_tilt": "  ↳ Inclinaison coucher : {tilt}% (explicite ; remplace calculé solaire)"
+    "tilt": "  ↳ Inclinaison par défaut : {tilt}% (utilisée quand aucun gestionnaire ne prend le contrôle)",
+    "sunset_tilt": "  ↳ Inclinaison coucher : {tilt}% (utilisée au coucher du soleil, quand aucun gestionnaire ne prend le contrôle)"
   },
   "limits": {
     "range": "Plage : {lo}–{hi}{qualifier}",

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1017,7 +1017,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Standard- & Sonnenuntergangs-Neigung",
-        "description": "Standard-Lamellenneigung, die nur gilt, wenn kein anderer Handler die Kontrolle übernimmt – derselbe Fallback wie die Standardposition. Die eigene Neigung eines Custom-Position-Slots oder die automatische Sonnenberechnung übernimmt, sobald dieser Slot oder ein anderer Handler aktiv ist.",
+        "description": "Standard-Lamellenneigung, die nur gilt, wenn kein anderer Handler die Kontrolle übernimmt – derselbe Fallback wie die Standardposition. Gewinnt ein Custom-Position-Slot, übernimmt dessen eigene Neigung; gewinnt die Sonnenverfolgung, übernimmt die automatische Sonnenberechnung; jeder andere Handler lässt die Lamellen ihren aktuellen Winkel beibehalten.",
         "data": {
           "default_tilt": "Standard-Neigung",
           "sunset_tilt": "Sonnenuntergangs-Neigung"

--- a/custom_components/adaptive_cover_pro/translations/de.json
+++ b/custom_components/adaptive_cover_pro/translations/de.json
@@ -1017,7 +1017,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Standard- & Sonnenuntergangs-Neigung",
-        "description": "Globale Standardeinstellungen für Lamellenneigung, die auf alle Custom-Position-Slots angewendet werden, wenn ein Slot keine eigene Neigung festlegt.",
+        "description": "Standard-Lamellenneigung, die nur gilt, wenn kein anderer Handler die Kontrolle übernimmt – derselbe Fallback wie die Standardposition. Die eigene Neigung eines Custom-Position-Slots oder die automatische Sonnenberechnung übernimmt, sobald dieser Slot oder ein anderer Handler aktiv ist.",
         "data": {
           "default_tilt": "Standard-Neigung",
           "sunset_tilt": "Sonnenuntergangs-Neigung"

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1038,7 +1038,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Default & Sunset Tilt",
-        "description": "Slat-tilt defaults applied only when no other handler wins control — the same fallback as Default Position. A custom-position slot's own Tilt, or the automatic solar calculation, takes over whenever that slot or any other handler is active.",
+        "description": "Slat-tilt defaults applied only when no other handler wins control — the same fallback as Default Position. When a custom-position slot wins, its own Tilt takes over; when solar tracking wins, the automatic solar calculation takes over; any other handler leaves the slats holding their current angle.",
         "data": {
           "default_tilt": "Default Tilt",
           "sunset_tilt": "Sunset Tilt"

--- a/custom_components/adaptive_cover_pro/translations/en.json
+++ b/custom_components/adaptive_cover_pro/translations/en.json
@@ -1038,7 +1038,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Default & Sunset Tilt",
-        "description": "Global slat-tilt defaults applied across custom-position slots when a slot does not set its own tilt.",
+        "description": "Slat-tilt defaults applied only when no other handler wins control — the same fallback as Default Position. A custom-position slot's own Tilt, or the automatic solar calculation, takes over whenever that slot or any other handler is active.",
         "data": {
           "default_tilt": "Default Tilt",
           "sunset_tilt": "Sunset Tilt"

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1017,7 +1017,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Inclinaison par Défaut et Coucher du Soleil",
-        "description": "Valeurs par défaut globales d'inclinaison des lamelles appliquées sur tous les emplacements de position personnalisée lorsqu'un emplacement ne définit pas sa propre inclinaison.",
+        "description": "Inclinaison des lamelles par défaut appliquée uniquement lorsqu'aucun autre gestionnaire ne prend le contrôle — le même repli que la Position par défaut. L'inclinaison propre d'un emplacement de position personnalisée, ou le calcul solaire automatique, prend le relais dès que cet emplacement ou un autre gestionnaire est actif.",
         "data": {
           "default_tilt": "Inclinaison par Défaut",
           "sunset_tilt": "Inclinaison Coucher du Soleil"

--- a/custom_components/adaptive_cover_pro/translations/fr.json
+++ b/custom_components/adaptive_cover_pro/translations/fr.json
@@ -1017,7 +1017,7 @@
       },
       "custom_position_tilt_defaults": {
         "title": "Inclinaison par Défaut et Coucher du Soleil",
-        "description": "Inclinaison des lamelles par défaut appliquée uniquement lorsqu'aucun autre gestionnaire ne prend le contrôle — le même repli que la Position par défaut. L'inclinaison propre d'un emplacement de position personnalisée, ou le calcul solaire automatique, prend le relais dès que cet emplacement ou un autre gestionnaire est actif.",
+        "description": "Inclinaison des lamelles par défaut appliquée uniquement lorsqu'aucun autre gestionnaire ne prend le contrôle — le même repli que la Position par défaut. Quand un emplacement de position personnalisée gagne, sa propre inclinaison prend le relais ; quand le suivi solaire gagne, le calcul solaire automatique prend le relais ; tout autre gestionnaire laisse les lamelles conserver leur angle actuel.",
         "data": {
           "default_tilt": "Inclinaison par Défaut",
           "sunset_tilt": "Inclinaison Coucher du Soleil"

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -177,6 +177,100 @@ class TestPostPipelineResolveTiltOnlyMode:
         assert out.tilt is None
         assert "venetian_mode" in [s.handler for s in out.decision_trace]
 
+    def test_tilt_only_does_not_pin_group_scene_winner(self):
+        """Issue #1153 round-2 finding 1: GROUP_SCENE is explicit user intent.
+
+        ``GroupSceneHandler`` sets ``bypass_auto_control=True`` with the
+        comment "Explicit user intent: runs even with automatic control off
+        — same semantics as custom-position slots"
+        (pipeline/handlers/group_scene.py) and never supplies a tilt, so this
+        exercises the engine-suppressed exit path (finding 1's probe:
+        ``engine_suppressed contrib=0 group_scene out_pos=100 -> out_pos=0``
+        before this fix). A user picking a scene like "All open" must not
+        have the venetian tilt-only pin silently rewrite the carriage back
+        to closed.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.GROUP_SCENE, position=100),
+            **_non_solar_kwargs(),
+        )
+        assert out.position == 100
+        assert out.tilt is None
+        assert "venetian_mode" not in [s.handler for s in out.decision_trace]
+
+    def test_tilt_only_does_not_pin_group_lock_winner(self):
+        """Issue #1153 round-2 finding 1: GROUP_LOCK holds the current position.
+
+        ``GroupLockHandler`` carries ``skip_command=True`` — nothing
+        physically moves — but the published target must still agree with
+        its own ``held_position`` rather than being rewritten to
+        ``POSITION_CLOSED``. It is the third member of the hold family;
+        ``MANUAL`` and ``MOTION`` are both already exempt.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.GROUP_LOCK, position=65),
+            **_non_solar_kwargs(),
+        )
+        assert out.position == 65
+        assert out.tilt is None
+        assert "venetian_mode" not in [s.handler for s in out.decision_trace]
+
+    def test_tilt_only_does_not_pin_default_winner_at_default_percentage(self):
+        """Issue #1153 round-2 finding 2: DEFAULT is not a tilt-only-pinned method.
+
+        Tilt-only mode is a sun-tracking-*window* behavior; ``DEFAULT`` is by
+        definition the no-handler-fired fallback that wins OUTSIDE that
+        window and carries ``default_percentage``. Pinning it would silently
+        disable the option's documented carriage movement for every
+        tilt-only install (probe:
+        ``engine_suppressed contrib=0 default out_pos=100 -> out_pos=0``
+        before this fix — including the reporter's own diagnostics:
+        ``default_percentage = 100``, ``venetian_mode = tilt_only``).
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.DEFAULT, position=100), **_non_solar_kwargs()
+        )
+        assert out.position == 100
+        assert out.tilt is None
+        assert "venetian_mode" not in [s.handler for s in out.decision_trace]
+
+    def test_tilt_only_does_not_pin_default_winner_during_sunset(self):
+        """Issue #1153 round-2 finding 2: DEFAULT carries sunset_position too.
+
+        ``post_pipeline_resolve`` only sees the resolved ``PipelineResult`` —
+        ``is_sunset_active`` is upstream state ``DefaultHandler`` consulted
+        when it picked ``sunset_position`` for ``position`` — but the same
+        DEFAULT exemption must hold regardless of which of the three
+        fallback options (default_percentage / sunset_position /
+        return_sunset) supplied the value.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        result = PipelineResult(
+            position=45,
+            control_method=ControlMethod.DEFAULT,
+            reason="test",
+            is_sunset_active=True,
+        )
+        out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+        assert out.position == 45
+        assert out.tilt is None
+        assert "venetian_mode" not in [s.handler for s in out.decision_trace]
+
 
 class TestPostPipelineResolveCoverageSteps:
     """Movement minimization quantizes the slat tilt toward full coverage."""

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -152,6 +152,31 @@ class TestPostPipelineResolveTiltOnlyMode:
         assert out.position == 80
         assert out.tilt is None
 
+    def test_tilt_only_pins_carriage_for_non_solar_non_explicit_winner(self):
+        """Issue #1153 finding 2: the pin must not depend on a leaked tilt.
+
+        A non-SOLAR, non-explicit-user-position winner (e.g. a climate SUMMER
+        decision) reaches the engine-suppressed early-return branch with
+        ``result.tilt`` genuinely ``None`` — no handler and no engine ever
+        supply one. Before the fix, that branch returned early and skipped
+        the tilt-only carriage pin entirely, so the carriage opened to the
+        winner's raw position instead of staying closed — the pin only
+        worked when a (possibly leaked) tilt happened to route through the
+        handler-tilt branch instead. ``ControlMethod.WEATHER`` above is
+        exempt (an explicit user position, see ``_EXPLICIT_USER_POSITION_METHODS``);
+        SUMMER is not, so the pin must apply here.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        out = policy.post_pipeline_resolve(
+            _make_result(ControlMethod.SUMMER, position=70), **_non_solar_kwargs()
+        )
+        assert out.position == 0
+        assert out.tilt is None
+        assert "venetian_mode" in [s.handler for s in out.decision_trace]
+
 
 class TestPostPipelineResolveCoverageSteps:
     """Movement minimization quantizes the slat tilt toward full coverage."""

--- a/tests/test_cover_types/test_venetian_post_pipeline.py
+++ b/tests/test_cover_types/test_venetian_post_pipeline.py
@@ -255,6 +255,16 @@ class TestPostPipelineResolveTiltOnlyMode:
         DEFAULT exemption must hold regardless of which of the three
         fallback options (default_percentage / sunset_position /
         return_sunset) supplied the value.
+
+        This is an intent-documenting test, not independent coverage: it
+        rides the exact same code path as
+        ``test_tilt_only_does_not_pin_default_winner_at_default_percentage``
+        above — ``_pin_tilt_only_carriage`` never reads ``is_sunset_active``,
+        so nothing here can fail in a way that test wouldn't already catch.
+        It stays because ``sunset_position`` / ``return_sunset`` are exactly
+        the fallback options the DEFAULT exemption was written to rescue,
+        and a future reader should not have to re-derive that from the
+        production code.
         """
         from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
 
@@ -270,6 +280,40 @@ class TestPostPipelineResolveTiltOnlyMode:
         assert out.position == 45
         assert out.tilt is None
         assert "venetian_mode" not in [s.handler for s in out.decision_trace]
+
+    def test_tilt_only_does_not_pin_default_winner_with_handler_tilt(self):
+        """Issue #1153 audit finding 1: the DEFAULT exemption on the OTHER exit path.
+
+        The two tests above both exercise the *engine-suppressed* branch
+        (``result.tilt is None`` going in). This test drives
+        ``default_tilt`` being configured, so ``DefaultHandler`` stamps a
+        non-``None`` tilt directly onto its own winning result — that routes
+        ``post_pipeline_resolve`` through the *handler-tilt* branch instead
+        (``result.tilt is not None`` at the top of the method), a different
+        call site of ``_pin_tilt_only_carriage``. Before this issue's fix
+        that branch had no DEFAULT exemption at all: the develop code pinned
+        the carriage shut here, silently disabling ``default_tilt`` on every
+        tilt-only install. It is safe today only because one shared helper
+        now serves all three call sites — this test locks that coverage
+        down instead of leaving it to depend on that fact.
+        """
+        from custom_components.adaptive_cover_pro.const import VENETIAN_MODE_TILT_ONLY
+
+        policy = _make_policy()
+        policy._venetian_mode = VENETIAN_MODE_TILT_ONLY
+        result = PipelineResult(
+            position=100,
+            tilt=55,
+            control_method=ControlMethod.DEFAULT,
+            reason="test",
+        )
+        out = policy.post_pipeline_resolve(result, **_non_solar_kwargs())
+        handler_names = [s.handler for s in out.decision_trace]
+        # Prove the handler-tilt branch ran, not the engine-suppressed one.
+        assert "venetian_handler_tilt" in handler_names
+        assert out.position == 100
+        assert out.tilt == 55
+        assert "venetian_mode" not in handler_names
 
 
 class TestPostPipelineResolveCoverageSteps:

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -21,6 +21,7 @@ from custom_components.adaptive_cover_pro.pipeline.handlers import DefaultHandle
 from custom_components.adaptive_cover_pro.pipeline.handlers.custom_position import (
     CustomPositionHandler,
 )
+from custom_components.adaptive_cover_pro.pipeline.handlers.solar import SolarHandler
 from custom_components.adaptive_cover_pro.pipeline.registry import PipelineRegistry
 from custom_components.adaptive_cover_pro.pipeline.types import (
     CustomPositionSensorState,
@@ -101,12 +102,11 @@ def _evaluate(
     sensors,
     *,
     winner: _StubWinner | None = None,
-    extra: list[OverrideHandler] | None = None,
     default_tilt: int | None = None,
 ):
     """Run a registry with a stub winner plus one handler per slot."""
     win = winner or _StubWinner()
-    handlers: list[OverrideHandler] = [win, DefaultHandler(), *(extra or [])]
+    handlers: list[OverrideHandler] = [win, DefaultHandler()]
     for s in sensors:
         handlers.append(
             CustomPositionHandler(
@@ -435,26 +435,35 @@ class TestLosingHandlerTiltDoesNotLeak:
     def test_losing_custom_position_tilt_does_not_leak(self) -> None:
         """A losing CustomPositionHandler's tilt does not reach the winner.
 
-        Mirrors the reporter's exact scenario: solar (priority 40) wins the
-        position with tilt=None (the venetian engine resolves it later);
-        custom_position_1 (priority 1) is triggered and loses, but its
-        tilt=100 must not leak onto the winner.
+        Mirrors the reporter's exact scenario: solar (``SolarHandler.priority``)
+        wins the position with tilt=None (the venetian engine resolves it
+        later); custom_position_1 (priority 1) is triggered and loses, but
+        its tilt=100 must not leak onto the winner.
         """
         res = _evaluate(
             [_slot(1, position=0, tilt=100, priority=1)],
-            winner=_StubWinner(0, priority=40),
+            winner=_StubWinner(0, priority=SolarHandler.priority),
         )
         assert res.tilt is None
 
     def test_losing_custom_position_stays_outprioritized_in_trace(self) -> None:
-        """The trace still records the loser as outprioritized, not merged."""
+        """The trace records the loser as outprioritized, AND its tilt is gone.
+
+        Trace-shape alone (``matched is False`` / ``REGISTRY_OUTPRIORITIZED``)
+        passes identically whether or not the #1153 leak is present — the
+        leak never touched the trace, only ``result.tilt``. The
+        ``res.tilt is None`` assertion is what actually depends on the fix:
+        drop it and this test would keep passing against the pre-fix
+        ``_MERGEABLE`` that included ``"tilt"``.
+        """
         res = _evaluate(
             [_slot(1, position=0, tilt=100, priority=1)],
-            winner=_StubWinner(0, priority=40),
+            winner=_StubWinner(0, priority=SolarHandler.priority),
         )
         step = next(s for s in res.decision_trace if s.handler == "custom_position_1")
         assert step.matched is False
         assert step.reason_payload.code is ReasonCode.REGISTRY_OUTPRIORITIZED
+        assert res.tilt is None
 
     def test_default_tilt_does_not_leak_onto_a_winning_handler(self) -> None:
         """DefaultHandler's default_tilt must not reach a result it did not win.
@@ -464,7 +473,9 @@ class TestLosingHandlerTiltDoesNotLeak:
         any other handler wins — and its ``default_tilt`` used to leak in
         exactly the same way.
         """
-        res = _evaluate([], winner=_StubWinner(0, priority=40), default_tilt=42)
+        res = _evaluate(
+            [], winner=_StubWinner(0, priority=SolarHandler.priority), default_tilt=42
+        )
         assert res.tilt is None
 
     def test_winning_custom_position_slot_with_no_tilt_stays_untilted(self) -> None:

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -315,6 +315,15 @@ class TestTiltBounds:
         res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(80, tilt=20))
         assert res.position == 80
 
+    def test_bounds_are_not_also_carried(self) -> None:
+        """Once a tilt is clamped there is exactly one clamp site — not two.
+
+        Carrying the bounds as well would let the venetian policy clamp the
+        already-clamped tilt a second time.
+        """
+        res = _evaluate([_slot(1, tilt_min=50)], winner=_StubWinner(50, tilt=20))
+        assert (res.tilt_low, res.tilt_high) == (None, None)
+
 
 class TestTiltOnlyOverlayThenClamp:
     """FIXED fills when unset; bounds then clamp the filled value."""
@@ -456,6 +465,31 @@ class TestLosingHandlerTiltDoesNotLeak:
         exactly the same way.
         """
         res = _evaluate([], winner=_StubWinner(0, priority=40), default_tilt=42)
+        assert res.tilt is None
+
+    def test_winning_custom_position_slot_with_no_tilt_stays_untilted(self) -> None:
+        """A WINNING custom-position slot with no tilt of its own stays tilt=None.
+
+        Makes the approved #1153 behavior change explicit rather than
+        incidental: unlike the two tests above (a synthetic ``_StubWinner``),
+        here the WINNER itself is a real ``CustomPositionHandler`` slot that
+        simply never configured a tilt. ``default_tilt`` must not fill the
+        hole via the (now-removed) merge just because ``DefaultHandler``
+        lost and left a value on the table.
+        """
+        res = _evaluate(
+            [
+                _slot(
+                    1,
+                    position=30,
+                    tilt=None,
+                    priority=DEFAULT_CUSTOM_POSITION_PRIORITY,
+                )
+            ],
+            default_tilt=42,
+        )
+        assert res.control_method == ControlMethod.CUSTOM_POSITION
+        assert res.position == 30
         assert res.tilt is None
 
 

--- a/tests/test_pipeline/test_axis_constraint_composition.py
+++ b/tests/test_pipeline/test_axis_constraint_composition.py
@@ -97,36 +97,12 @@ def _slot(
     )
 
 
-class _StubTiltContributor(OverrideHandler):
-    """A lower-priority handler that matches and supplies only a tilt.
-
-    Reproduces the ``_MERGEABLE`` fill path: the winner leaves ``tilt`` unset
-    and this handler's tilt is merged onto the result.
-    """
-
-    name = "stub_tilt"
-
-    def __init__(self, tilt: int, *, priority: int = 50) -> None:
-        self._tilt = tilt
-        self.priority = priority
-
-    def evaluate(self, snapshot) -> PipelineResult:  # noqa: ARG002
-        return PipelineResult(
-            position=99,
-            tilt=self._tilt,
-            control_method=ControlMethod.SOLAR,
-            reason="stub tilt",
-        )
-
-    def describe_skip(self, snapshot):  # noqa: ARG002
-        return "stub tilt skip"
-
-
 def _evaluate(
     sensors,
     *,
     winner: _StubWinner | None = None,
     extra: list[OverrideHandler] | None = None,
+    default_tilt: int | None = None,
 ):
     """Run a registry with a stub winner plus one handler per slot."""
     win = winner or _StubWinner()
@@ -140,7 +116,9 @@ def _evaluate(
                 tilt=s.tilt,
             )
         )
-    snap = make_snapshot(custom_position_sensors=sensors, default_position=0)
+    snap = make_snapshot(
+        custom_position_sensors=sensors, default_position=0, default_tilt=default_tilt
+    )
     return PipelineRegistry(handlers).evaluate(snap)
 
 
@@ -422,41 +400,63 @@ class TestWinnerTraceStepSurvivesItsOwnConstraint:
         assert [s.handler for s in matched] == ["custom_position_1"]
 
 
-class TestMergedTiltIsClamped:
-    """A tilt reaching the result via the _MERGEABLE fill must be clamped.
+class TestLosingHandlerTiltDoesNotLeak:
+    """A losing (outprioritized) handler's tilt must NOT reach the result.
 
-    Audit finding 2 — the headline feature failing at its own job: the registry
-    clamped only ``winner.tilt`` / the FIXED overlay, so a tilt merged from a
-    lower-priority handler (or a ``contribute()``) sailed past the bound.
+    Issue #1153 — ``_MERGEABLE`` used to include ``"tilt"``, so a handler the
+    pipeline explicitly outprioritized could still supply the tilt that
+    reached ``PipelineResult.tilt``. ``VenetianPolicy.post_pipeline_resolve``
+    treats any non-None ``result.tilt`` as explicit user intent and honors it
+    unconditionally, skipping its own solar tilt engine — so the leaked tilt
+    from a *loser* silently disabled solar tilt tracking. Tilt is an
+    actuation output, not diagnostic metadata like climate_state /
+    climate_strategy / climate_data (which legitimately still merge from a
+    deferred/outprioritized handler): it is owned by exactly two sources, the
+    winner's own tilt and the priority-independent tilt-axis pass (#514 /
+    #943) — never a lower-priority loser.
+
+    This replaces the old ``TestMergedTiltIsClamped`` — that class pinned the
+    contract this issue found wrong (a merged tilt gets clamped) rather than
+    the correct one (a losing handler's tilt never reaches the result at
+    all). Coverage that a *winner's own* tilt still gets clamped by #943
+    bounds survives in ``TestTiltBounds`` above, which exercises
+    ``_StubWinner(..., tilt=...)`` directly — unaffected by this change.
     """
 
-    def _res(self, tilt_min=50):
-        return _evaluate(
-            [_slot(3, tilt_min=tilt_min)],
-            winner=_StubWinner(70, priority=80),
-            extra=[_StubTiltContributor(30, priority=50)],
-        )
+    def test_losing_custom_position_tilt_does_not_leak(self) -> None:
+        """A losing CustomPositionHandler's tilt does not reach the winner.
 
-    def test_merged_tilt_is_raised_to_the_bound(self) -> None:
-        """Merged tilt 30 under a minimum of 50 → 50."""
-        assert self._res().tilt == 50
-
-    def test_bounds_are_not_also_carried(self) -> None:
-        """Once a tilt is clamped there is exactly one clamp site — not two.
-
-        Carrying the bounds as well would let the venetian policy clamp the
-        already-clamped tilt a second time.
+        Mirrors the reporter's exact scenario: solar (priority 40) wins the
+        position with tilt=None (the venetian engine resolves it later);
+        custom_position_1 (priority 1) is triggered and loses, but its
+        tilt=100 must not leak onto the winner.
         """
-        res = self._res()
-        assert (res.tilt_low, res.tilt_high) == (None, None)
+        res = _evaluate(
+            [_slot(1, position=0, tilt=100, priority=1)],
+            winner=_StubWinner(0, priority=40),
+        )
+        assert res.tilt is None
 
-    def test_merged_tilt_within_bounds_survives(self) -> None:
-        """A merged tilt already inside the bound is untouched."""
-        assert self._res(tilt_min=20).tilt == 30
+    def test_losing_custom_position_stays_outprioritized_in_trace(self) -> None:
+        """The trace still records the loser as outprioritized, not merged."""
+        res = _evaluate(
+            [_slot(1, position=0, tilt=100, priority=1)],
+            winner=_StubWinner(0, priority=40),
+        )
+        step = next(s for s in res.decision_trace if s.handler == "custom_position_1")
+        assert step.matched is False
+        assert step.reason_payload.code is ReasonCode.REGISTRY_OUTPRIORITIZED
 
-    def test_clamped_merge_emits_the_trace_step(self) -> None:
-        """The clamp is visible rather than a silent value change."""
-        assert ReasonCode.REGISTRY_TILT_CLAMPED in _codes(self._res())
+    def test_default_tilt_does_not_leak_onto_a_winning_handler(self) -> None:
+        """DefaultHandler's default_tilt must not reach a result it did not win.
+
+        The second manifestation of the same root cause: DefaultHandler
+        always matches (priority 0), so it is always among the "losers" when
+        any other handler wins — and its ``default_tilt`` used to leak in
+        exactly the same way.
+        """
+        res = _evaluate([], winner=_StubWinner(0, priority=40), default_tilt=42)
+        assert res.tilt is None
 
 
 class TestBindingBoundIsNamed:

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -44,7 +44,6 @@ def _cps(
     priority: int = 77,
     *,
     tilt: int | None = None,
-    slot: int = 1,
 ) -> CustomPositionSensorState:
     return CustomPositionSensorState(
         entity_ids=(entity_id,),
@@ -54,7 +53,7 @@ def _cps(
         min_mode=False,
         use_my=False,
         tilt=tilt,
-        slot=slot,
+        slot=1,
         active_entity_ids=(entity_id,) if is_on else (),
     )
 

--- a/tests/test_pipeline/test_tilt_integration.py
+++ b/tests/test_pipeline/test_tilt_integration.py
@@ -44,6 +44,7 @@ def _cps(
     priority: int = 77,
     *,
     tilt: int | None = None,
+    slot: int = 1,
 ) -> CustomPositionSensorState:
     return CustomPositionSensorState(
         entity_ids=(entity_id,),
@@ -53,7 +54,7 @@ def _cps(
         min_mode=False,
         use_my=False,
         tilt=tilt,
-        slot=1,
+        slot=slot,
         active_entity_ids=(entity_id,) if is_on else (),
     )
 
@@ -212,6 +213,69 @@ class TestCustomPositionTiltEndToEnd:
         policy = VenetianPolicy()
         resolved = policy.post_pipeline_resolve(result, **_solar_kwargs())
         assert resolved.tilt == 70
+
+
+class TestLosingCustomPositionTiltDoesNotSuppressSolarEngine:
+    """Full-stack regression for issue #1153.
+
+    Reproduces the reporter's exact configuration end-to-end: a
+    CustomPositionHandler slot is triggered but loses on priority (1) to
+    SolarHandler (40), which wins with tilt=None (a venetian resolves its
+    slat angle after the pipeline). Before the fix, the registry's
+    ``_MERGEABLE`` fill copied the *losing* slot's tilt onto the winner, and
+    ``VenetianPolicy.post_pipeline_resolve`` treated that non-None tilt as
+    explicit user intent — honoring it and never running the solar tilt
+    engine, even though solar unambiguously won the decision trace.
+    """
+
+    def _resolved(self):
+        from custom_components.adaptive_cover_pro.cover_types.venetian import (
+            VenetianPolicy,
+        )
+
+        registry = PipelineRegistry(
+            [
+                SolarHandler(),
+                DefaultHandler(),
+                CustomPositionHandler(slot=1, position=0, priority=1, tilt=100),
+            ]
+        )
+        snap = make_snapshot(
+            custom_position_sensors=[
+                _cps(
+                    "binary_sensor.slot1",
+                    is_on=True,
+                    position=0,
+                    priority=1,
+                    tilt=100,
+                )
+            ],
+            direct_sun_valid=True,
+        )
+        pipeline_result = registry.evaluate(snap)
+        assert pipeline_result.control_method == ControlMethod.SOLAR
+        assert pipeline_result.tilt is None
+
+        policy = VenetianPolicy()
+        return policy.post_pipeline_resolve(pipeline_result, **_solar_kwargs())
+
+    def test_resolved_tilt_is_the_engine_tilt_not_the_losing_slot(self):
+        """The resolved tilt comes from the solar engine, never the loser's 100."""
+        resolved = self._resolved()
+        assert resolved.tilt is not None
+        assert resolved.tilt != 100
+
+    def test_handler_tilt_honored_step_is_absent(self):
+        """'venetian_handler_tilt' must not appear — the loser never won the tilt."""
+        resolved = self._resolved()
+        handler_names = [s.handler for s in resolved.decision_trace]
+        assert "venetian_handler_tilt" not in handler_names
+
+    def test_engine_step_is_present(self):
+        """The solar tilt engine step must run instead."""
+        resolved = self._resolved()
+        handler_names = [s.handler for s in resolved.decision_trace]
+        assert "venetian_engine" in handler_names
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
`_MERGEABLE` in `pipeline/registry.py` carried `"tilt"`, so the registry's field-fill loop copied a tilt from handlers the pipeline had explicitly outprioritized onto the winning `PipelineResult`. `SolarHandler` returns `tilt=None` by design (the venetian engine resolves the slat angle post-pipeline), so a losing custom-position slot's tilt filled the hole and `VenetianPolicy.post_pipeline_resolve` read it as explicit user intent, skipping the solar tilt engine entirely. The reporter's own decision trace was right that solar won; the tilt just leaked across the arbitration.

The same line leaked `default_tilt`: `DefaultHandler` always matches, so any venetian with a default tilt configured had no solar tilt tracking at all.

Dropping `"tilt"` from `_MERGEABLE` leaves tilt with exactly two owners, both already correct: the winner's own `PipelineResult.tilt`, and the deliberately priority-independent FIXED tilt-axis overlay (#514) plus the #943 bounds. The `merged["tilt"]` writes stay, since they are the transport for those two.

That exposed a latent venetian bug. In `tilt_only` mode the carriage pin had only ever worked because the leaked `default_tilt` forced the handler-tilt branch; the engine-suppressed early return bypassed the pin. I extracted one `_pin_tilt_only_carriage` helper and routed every exit path through it, which also folds two near-identical guard blocks into one. Then I kept that pin off the winners it must not touch: `GROUP_SCENE` and `GROUP_LOCK` (both set `bypass_auto_control=True` and describe themselves as explicit user intent, like the already-exempt custom-position slots), and `DEFAULT` (the out-of-window fallback that carries `sunset_position`, `return_sunset` and `default_percentage`).

### Behaviour changes worth a release-note line
- `default_tilt` no longer applies when a non-DEFAULT handler wins. Solar tilt tracking is restored, and hold-type winners now hold their slats instead of snapping to the default.
- On a tilt-only install, `CLOUD` and `WINTER` now leave the carriage closed uniformly (previously they moved it only when `default_tilt` was unset).
- A tilt-only install with `default_tilt` set now gets its nightly `default_percentage` / `sunset_position` carriage move, which was previously suppressed.
- Config copy for Default/Sunset Tilt and the config-summary strings were reworded in en/de/fr; both had described behaviour that only ever existed via the leak.

## Testing
- ✅ 11945 tests passing (4 skipped, 1 xfailed)

Four audit passes; the last two returned no must-fix findings. AST-equivalence checked the polish commit for zero runtime change, and both new guard tests were proven discriminating by mutation.

## Related Issues
Refs #1153