### PR TITLE
feat: reference ACP's own entities from option templates

### DIFF
--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -186,7 +186,10 @@ def _coalesce_namespace_refreshes(
         function=_run_latest,
     )
     # Cancels the pending trailing timer, so an unload can never leave one
-    # scheduled against a torn-down coordinator.
+    # scheduled against a torn-down coordinator. Guarded by
+    # ``test_unload_cancels_the_coalescer_pending_trailing_run`` — the
+    # integration-marked suite tolerates lingering timers, so nothing else
+    # would notice this line going missing.
     entry.async_on_unload(debouncer.async_shutdown)
     _LOGGER.debug(
         "%s references the acp namespace — coalescing its refreshes to %ss",

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -85,7 +85,12 @@ from .helpers import (
     normalize_time_string,
 )
 from .profile_link import _copy_profile_to_cover, _covers_linked_to
-from .templates import is_template_string
+from .templates import (
+    ACP_NAMESPACE_RATE_LIMIT,
+    build_acp_template_variables,
+    is_template_string,
+    uses_acp_namespace,
+)
 from .migrations import (
     async_prune_legacy_entities,
     async_prune_legacy_sensor_entities,
@@ -138,13 +143,28 @@ def _register_template_tracker(
     a template-only override sensor-grade immediacy — the cover reacts the
     instant the template flips, with no companion binary sensor and no polling.
     Non-templates are skipped; render/parse failures are logged and skipped.
+
+    Every tracker gets the same ``acp`` render context the managers use (#1159),
+    built from the one factory so the tracker's render and the cycle render can
+    never disagree. A template that actually uses the namespace additionally
+    gets the loop-guard rate limit; everything else stays unthrottled.
     """
     if not is_template_string(template_str):
         return
     try:
         _track_info = async_track_template_result(
             hass,
-            [TrackTemplate(Template(template_str, hass), None)],
+            [
+                TrackTemplate(
+                    Template(template_str, hass),
+                    build_acp_template_variables(hass, entry.entry_id),
+                    (
+                        ACP_NAMESPACE_RATE_LIMIT
+                        if uses_acp_namespace(template_str)
+                        else None
+                    ),
+                )
+            ],
             action,
         )
     except (TemplateError, ValueError) as err:
@@ -153,6 +173,91 @@ def _register_template_tracker(
         )
     else:
         entry.async_on_unload(_track_info.async_remove)
+
+
+def _register_option_template_trackers(
+    hass: HomeAssistant,
+    entry: AdaptiveConfigEntry,
+    coordinator: AdaptiveDataUpdateCoordinator,
+) -> None:
+    """Register every option-template result tracker for this entry.
+
+    Called *after* ``async_forward_entry_setups`` on purpose (issue #1159). HA
+    blocks entry setup on entity addition, so by this point this instance's own
+    entities have entity-registry rows and a template written against the
+    ``acp`` namespace resolves to a real entity_id on its **first** render —
+    the render whose ``RenderInfo`` fixes the tracker's listener set for the
+    life of the setup (HA ``helpers/event.py``). Registering before platform
+    forwarding left a self-reference with no listeners at all on a first-ever
+    setup, until the next reload.
+
+    Teardown is unchanged: each ``_register_template_tracker`` call wires its
+    own ``entry.async_on_unload``.
+    """
+    # The optional manual-override input template (issue #974). The template
+    # counterpart to the input sensors: tracking the rendered result engages
+    # manual override the instant the template flips truthy, with sensor-grade
+    # immediacy and no polling.
+    _register_template_tracker(
+        hass,
+        entry,
+        entry.options.get(CONF_MANUAL_OVERRIDE_INPUT_TEMPLATE),
+        coordinator.async_check_manual_override_input_template_change,
+        "Manual override input template",
+    )
+
+    # The optional occupancy template (issue #577 follow-up). Tracking the
+    # rendered result means the cover reacts the instant the template flips
+    # truthy — same immediacy as a motion sensor, no polling. Re-registered on
+    # every reload (options changes trigger a full reload).
+    _register_template_tracker(
+        hass,
+        entry,
+        entry.options.get(CONF_MOTION_TEMPLATE),
+        coordinator.async_check_motion_template_change,
+        "Motion occupancy template",
+    )
+
+    # Each custom-position slot's optional condition template (issue #563).
+    # Same pattern as the occupancy template above: tracking the rendered
+    # result gives sensor-grade immediacy when a template flips.
+    for _slot_keys in CUSTOM_POSITION_SLOTS.values():
+        _register_template_tracker(
+            hass,
+            entry,
+            entry.options.get(_slot_keys["template"]),
+            coordinator.async_check_custom_position_template_change,
+            "Custom position template",
+        )
+
+    # The optional is-raining / is-windy / severe condition templates (issue
+    # #639). Tracking the rendered result lets a template-only weather override
+    # engage and react the instant the template flips, with no companion binary
+    # sensor.
+    for _weather_template in [
+        entry.options.get(CONF_WEATHER_IS_RAINING_TEMPLATE),
+        entry.options.get(CONF_WEATHER_IS_WINDY_TEMPLATE),
+        entry.options.get(CONF_WEATHER_SEVERE_TEMPLATE),
+    ]:
+        _register_template_tracker(
+            hass,
+            entry,
+            _weather_template,
+            coordinator.async_check_weather_template_change,
+            "Weather condition template",
+        )
+
+    # The optional daytime-gate template (issue #632). Tracking the rendered
+    # result gives the gate the same sensor-grade immediacy as the occupancy and
+    # weather templates — the cover repositions the instant the template flips
+    # dark, with no polling.
+    _register_template_tracker(
+        hass,
+        entry,
+        entry.options.get(CONF_DAYTIME_GATE_TEMPLATE),
+        coordinator.async_check_daytime_gate_template_change,
+        "Daytime gate template",
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> bool:
@@ -274,42 +379,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
             )
         )
 
-    # Register the optional manual-override input template (issue #974). The
-    # template counterpart to the input sensors above: tracking the rendered
-    # result engages manual override the instant the template flips truthy, with
-    # sensor-grade immediacy and no polling.
-    _register_template_tracker(
-        hass,
-        entry,
-        entry.options.get(CONF_MANUAL_OVERRIDE_INPUT_TEMPLATE),
-        coordinator.async_check_manual_override_input_template_change,
-        "Manual override input template",
-    )
-
-    # Register the optional occupancy template (issue #577 follow-up). Tracking
-    # the rendered result means the cover reacts the instant the template flips
-    # truthy — same immediacy as a motion sensor, no polling. Re-registered on
-    # every reload (options changes trigger a full reload).
-    _register_template_tracker(
-        hass,
-        entry,
-        entry.options.get(CONF_MOTION_TEMPLATE),
-        coordinator.async_check_motion_template_change,
-        "Motion occupancy template",
-    )
-
-    # Register each custom-position slot's optional condition template (issue
-    # #563). Same pattern as the occupancy template above: tracking the
-    # rendered result gives sensor-grade immediacy when a template flips.
-    for _slot_keys in CUSTOM_POSITION_SLOTS.values():
-        _register_template_tracker(
-            hass,
-            entry,
-            entry.options.get(_slot_keys["template"]),
-            coordinator.async_check_custom_position_template_change,
-            "Custom position template",
-        )
-
     # Register weather sensor listeners separately (need custom handler for clear-delay)
     _weather_sensor_ids: list[str] = []
     for _key in [
@@ -332,35 +401,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
                 coordinator.async_check_weather_state_change,
             )
         )
-
-    # Register the optional is-raining / is-windy condition templates (issue
-    # #639). Same pattern as the occupancy/custom-position templates above:
-    # tracking the rendered result lets a template-only weather override engage
-    # and react the instant the template flips, with no companion binary sensor.
-    for _weather_template in [
-        entry.options.get(CONF_WEATHER_IS_RAINING_TEMPLATE),
-        entry.options.get(CONF_WEATHER_IS_WINDY_TEMPLATE),
-        entry.options.get(CONF_WEATHER_SEVERE_TEMPLATE),
-    ]:
-        _register_template_tracker(
-            hass,
-            entry,
-            _weather_template,
-            coordinator.async_check_weather_template_change,
-            "Weather condition template",
-        )
-
-    # Register the optional daytime-gate template (issue #632). Tracking the
-    # rendered result gives the gate the same sensor-grade immediacy as the
-    # occupancy and weather templates — the cover repositions the instant the
-    # template flips dark, with no polling.
-    _register_template_tracker(
-        hass,
-        entry,
-        entry.options.get(CONF_DAYTIME_GATE_TEMPLATE),
-        coordinator.async_check_daytime_gate_template_change,
-        "Daytime gate template",
-    )
 
     # Register cleanup for cover command service reconciliation timer
     entry.async_on_unload(coordinator._cmd_svc.stop)
@@ -406,6 +446,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: AdaptiveConfigEntry) -> 
     await async_prune_legacy_sensor_entities_v2(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Option-template result trackers register here, after platform forwarding,
+    # so this instance's own entities are already in the entity registry and an
+    # ``acp`` self-reference resolves on the first render — the render that
+    # fixes the tracker's listener set (issue #1159).
+    _register_option_template_trackers(hass, entry, coordinator)
 
     # First refresh runs after platform setup so that RestoreEntity hooks in
     # async_added_to_hass have already repopulated the manual-override manager

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -10,6 +10,7 @@ from homeassistant.const import EVENT_CALL_SERVICE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import (
     TrackTemplate,
     async_track_state_change_event,
@@ -86,7 +87,6 @@ from .helpers import (
 )
 from .profile_link import _copy_profile_to_cover, _covers_linked_to
 from .templates import (
-    ACP_NAMESPACE_RATE_LIMIT,
     build_acp_template_variables,
     is_template_string,
     uses_acp_namespace,
@@ -129,6 +129,78 @@ async def async_initialize_integration(
     return True
 
 
+#: Seconds. The floor on how often one tracked template that references the
+#: ``acp`` namespace may drive a coordinator refresh (issue #1159).
+ACP_NAMESPACE_REFRESH_COOLDOWN: float = 1.0
+
+
+def _coalesce_namespace_refreshes(
+    hass: HomeAssistant,
+    entry: AdaptiveConfigEntry,
+    action: Callable,
+    description: str,
+) -> Callable:
+    """Wrap a self-referencing template's tracker action in a leading throttle.
+
+    **Do not "simplify" this back to ``TrackTemplate.rate_limit``.** That field
+    cannot do this job: HA's ``_rate_limit_for_event``
+    (``homeassistant/helpers/event.py``) starts with *"Specifically referenced
+    entities are excluded from the rate limit"* and returns ``None`` whenever
+    the entity that changed is in ``RenderInfo.entities`` — and
+    ``is_state(acp.control_status, …)`` puts exactly that entity_id there. A
+    ``rate_limit`` on these trackers is dead weight; six flips inside one second
+    still invoke the action six times.
+
+    So the guard sits one step later, on the action the tracker invokes — which
+    is where the unbounded work actually is, because every one of these actions
+    ends in ``coordinator.async_refresh()`` and the coordinator has no
+    debouncer. HA's :class:`~homeassistant.helpers.debounce.Debouncer` with
+    ``immediate=True`` is a leading-edge throttle: the first flip after a quiet
+    ``ACP_NAMESPACE_REFRESH_COOLDOWN`` runs straight away, so a self-reference
+    keeps the same sensor-grade immediacy as any other template; flips inside
+    that window collapse into a single **trailing** run once it closes, so
+    nothing is lost and the ``template → refresh → ACP entity writes → template``
+    cycle settles to one refresh per second instead of spinning.
+
+    Only namespace templates are wrapped. A plain template cannot be driven by
+    ACP's own output, and its unthrottled immediacy is the contract shipped
+    across #577/#563/#639/#632/#974.
+
+    The trailing run replays the *newest* ``(event, updates)`` pair, not the one
+    that opened the window — the tracked result only signals *that* a template
+    changed and every action re-reads live state, so the freshest signal is the
+    only one worth keeping.
+    """
+    latest: list[tuple[Any, Any]] = []
+
+    async def _run_latest() -> None:
+        event, updates = latest[-1]
+        latest.clear()
+        await action(event, updates)
+
+    debouncer = Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=ACP_NAMESPACE_REFRESH_COOLDOWN,
+        immediate=True,
+        function=_run_latest,
+    )
+    # Cancels the pending trailing timer, so an unload can never leave one
+    # scheduled against a torn-down coordinator.
+    entry.async_on_unload(debouncer.async_shutdown)
+    _LOGGER.debug(
+        "%s references the acp namespace — coalescing its refreshes to %ss",
+        description,
+        ACP_NAMESPACE_REFRESH_COOLDOWN,
+    )
+
+    async def _coalesced(event, updates) -> None:
+        latest.append((event, updates))
+        await debouncer.async_call()
+
+    return _coalesced
+
+
 def _register_template_tracker(
     hass: HomeAssistant,
     entry: AdaptiveConfigEntry,
@@ -146,11 +218,14 @@ def _register_template_tracker(
 
     Every tracker gets the same ``acp`` render context the managers use (#1159),
     built from the one factory so the tracker's render and the cycle render can
-    never disagree. A template that actually uses the namespace additionally
-    gets the loop-guard rate limit; everything else stays unthrottled.
+    never disagree. A template that actually *uses* the namespace additionally
+    gets its refreshes coalesced — see :func:`_coalesce_namespace_refreshes` for
+    why the guard lives on the action and not on ``TrackTemplate.rate_limit``.
     """
     if not is_template_string(template_str):
         return
+    if uses_acp_namespace(template_str):
+        action = _coalesce_namespace_refreshes(hass, entry, action, description)
     try:
         _track_info = async_track_template_result(
             hass,
@@ -158,11 +233,6 @@ def _register_template_tracker(
                 TrackTemplate(
                     Template(template_str, hass),
                     build_acp_template_variables(hass, entry.entry_id),
-                    (
-                        ACP_NAMESPACE_RATE_LIMIT
-                        if uses_acp_namespace(template_str)
-                        else None
-                    ),
                 )
             ],
             action,

--- a/custom_components/adaptive_cover_pro/__init__.py
+++ b/custom_components/adaptive_cover_pro/__init__.py
@@ -166,24 +166,22 @@ def _coalesce_namespace_refreshes(
     ACP's own output, and its unthrottled immediacy is the contract shipped
     across #577/#563/#639/#632/#974.
 
-    The trailing run replays the *newest* ``(event, updates)`` pair, not the one
-    that opened the window — the tracked result only signals *that* a template
-    changed and every action re-reads live state, so the freshest signal is the
-    only one worth keeping.
+    Both tracker arguments are dropped rather than queued for replay. Every one
+    of the five actions this wraps ignores ``event`` and ``updates`` and re-reads
+    live state instead — the tracked result only signals *that* a template
+    changed — so a coalesced run has nothing to carry forward and calls the
+    action with the same empty signal a fresh render would give it.
     """
-    latest: list[tuple[Any, Any]] = []
 
-    async def _run_latest() -> None:
-        event, updates = latest[-1]
-        latest.clear()
-        await action(event, updates)
+    async def _run_action() -> None:
+        await action(None, [])
 
     debouncer = Debouncer(
         hass,
         _LOGGER,
         cooldown=ACP_NAMESPACE_REFRESH_COOLDOWN,
         immediate=True,
-        function=_run_latest,
+        function=_run_action,
     )
     # Cancels the pending trailing timer, so an unload can never leave one
     # scheduled against a torn-down coordinator. Guarded by
@@ -197,8 +195,7 @@ def _coalesce_namespace_refreshes(
         ACP_NAMESPACE_REFRESH_COOLDOWN,
     )
 
-    async def _coalesced(event, updates) -> None:
-        latest.append((event, updates))
+    async def _coalesced(_event, _updates) -> None:
         await debouncer.async_call()
 
     return _coalesced

--- a/custom_components/adaptive_cover_pro/coordinator.py
+++ b/custom_components/adaptive_cover_pro/coordinator.py
@@ -157,7 +157,11 @@ from .pipeline.floors import effective_floor, gather_active_floors
 from .pipeline.registry import PipelineRegistry
 from .pipeline.snapshot_builder import PipelineSnapshotBuilder
 from .pipeline.types import CustomPositionSensorState, GroupIntent, PipelineSnapshot
-from .templates import TemplateResolver, render_condition_or_none
+from .templates import (
+    TemplateResolver,
+    build_acp_template_variables,
+    render_condition_or_none,
+)
 from .const import ControlMethod
 from .state.climate_provider import ClimateProvider, ClimateReadings
 from .state.cover_provider import CoverProvider
@@ -348,6 +352,24 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Cover engine object — populated at start of each update cycle
         self._cover_data = None
 
+        # The ``acp`` self-reference render context (issue #1159), built once
+        # here — before every collaborator that renders an option template — and
+        # threaded into all of them, so every render site shares one context.
+        # Nothing is cached inside it: each key access re-reads the entity
+        # registry, so a rename lands on the next render.
+        #
+        # Two shapes. Condition/tracked fields get the entity_id forms only:
+        # ``acp_state``'s value reads are invisible to ``RenderInfo``, so a
+        # tracked template written against them would register no state
+        # listeners and silently lose its sensor-grade immediacy. The untracked
+        # numeric threshold renders are the one flavour that also gets it.
+        self._template_variables = build_acp_template_variables(
+            self.hass, self.config_entry.entry_id
+        )
+        self._template_variables_with_state = build_acp_template_variables(
+            self.hass, self.config_entry.entry_id, include_state=True
+        )
+
         # Shared diagnostic ring buffer — owned here, injected into all writers
         self._event_buffer = EventBuffer(
             maxlen=self.config_entry.options.get(
@@ -382,11 +404,17 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         # Motion control tracking
         self._motion_mgr = MotionManager(
-            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+            hass=self.hass,
+            logger=self.logger,
+            event_buffer=self._event_buffer,
+            template_variables=self._template_variables,
         )
         # Weather override tracking
         self._weather_mgr = WeatherManager(
-            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+            hass=self.hass,
+            logger=self.logger,
+            event_buffer=self._event_buffer,
+            template_variables=self._template_variables,
         )
         # Cloud-suppression smoothing — hysteresis latch + hold-time debounce
         # (issue #864). Consumes provider booleans; never reads HA directly.
@@ -475,10 +503,16 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
 
         # Climate state provider
-        self._climate_provider = ClimateProvider(hass=self.hass, logger=self.logger)
+        self._climate_provider = ClimateProvider(
+            hass=self.hass,
+            logger=self.logger,
+            template_variables=self._template_variables,
+        )
 
         # Renders templated threshold options to numbers once per cycle (#577).
-        self._template_resolver = TemplateResolver(self.hass)
+        self._template_resolver = TemplateResolver(
+            self.hass, self._template_variables_with_state
+        )
         # Current cycle's options after template resolution (for diagnostics).
         # Resolved at construction so apply_user_position sees float thresholds
         # even before the first _async_update_data cycle runs (#643).
@@ -496,7 +530,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # snapshot builder, because the builder's effective-default fallback
         # reads the live window state off it (issue #1055).
         self._time_mgr = TimeWindowManager(
-            hass=self.hass, logger=self.logger, event_buffer=self._event_buffer
+            hass=self.hass,
+            logger=self.logger,
+            event_buffer=self._event_buffer,
+            template_variables=self._template_variables,
         )
 
         # Pipeline snapshot builder — owns the HA reads + assembly for each
@@ -511,6 +548,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             policy=self._policy,
             config_service=self._config_service,
             time_mgr=self._time_mgr,
+            template_variables=self._template_variables,
         )
 
         # Current state snapshot (built at start of each update cycle)
@@ -1557,7 +1595,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         the template is re-rendered here rather than trusting the tracked value.
         """
         if (
-            render_condition_or_none(self.hass, self.manual_override_input_template)
+            render_condition_or_none(
+                self.hass,
+                self.manual_override_input_template,
+                variables=self._template_variables,
+            )
             is not True
         ):
             return

--- a/custom_components/adaptive_cover_pro/managers/motion.py
+++ b/custom_components/adaptive_cover_pro/managers/motion.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import datetime as dt
-from typing import TYPE_CHECKING
-from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Mapping
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -29,18 +29,29 @@ class MotionManager:
 
     """
 
-    def __init__(self, hass: HomeAssistant, logger, *, event_buffer=None) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger,
+        *,
+        event_buffer=None,
+        template_variables: Mapping[str, Any] | None = None,
+    ) -> None:
         """Initialize the MotionManager.
 
         Args:
             hass: Home Assistant instance used to read sensor states
             logger: Logger instance for debug/info output
             event_buffer: Shared diagnostic ring buffer (optional, reserved for future events).
+            template_variables: Opaque render context threaded into the occupancy
+                template — the ``acp`` self-reference namespace built once by the
+                coordinator (issue #1159). The manager never inspects it.
 
         """
         self._hass = hass
         self._logger = logger
         self._event_buffer = event_buffer
+        self._template_variables = template_variables
         self._events = EventRecorder(event_buffer, now_fn=self._now)
 
         self._sensors: list[str] = []
@@ -112,7 +123,9 @@ class MotionManager:
     @property
     def template_active(self) -> bool:
         """Return True when the occupancy template is set and renders truthy."""
-        return render_condition(self._hass, self._template)
+        return render_condition(
+            self._hass, self._template, variables=self._template_variables
+        )
 
     @property
     def template_mode(self) -> str:

--- a/custom_components/adaptive_cover_pro/managers/time_window.py
+++ b/custom_components/adaptive_cover_pro/managers/time_window.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import datetime as dt
 import time
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -41,6 +41,7 @@ class TimeWindowManager:
         *,
         event_buffer=None,
         clock: Callable[[], float] = time.monotonic,
+        template_variables: Mapping[str, Any] | None = None,
     ) -> None:
         """Initialize time window manager.
 
@@ -50,11 +51,15 @@ class TimeWindowManager:
             event_buffer: Shared diagnostic ring buffer (optional).
             clock: Monotonic time source (seconds) for the daytime-gate grace
                 window. Injected so tests drive the grace timer deterministically.
+            template_variables: Opaque render context threaded into the
+                daytime-gate template — the ``acp`` self-reference namespace
+                built once by the coordinator (issue #1159).
 
         """
         self._hass = hass
         self.logger = logger
         self._event_buffer = event_buffer
+        self._template_variables = template_variables
         self._events = EventRecorder(event_buffer)
         self._last_time_window_state: bool | None = None
 
@@ -183,7 +188,9 @@ class TimeWindowManager:
         sensor_opinion: bool | None = (
             None if not valid_states else any(s == "on" for s in valid_states)
         )
-        template_opinion = render_condition_or_none(self._hass, self._gate_template)
+        template_opinion = render_condition_or_none(
+            self._hass, self._gate_template, variables=self._template_variables
+        )
 
         if sensor_opinion is None and template_opinion is None:
             return None

--- a/custom_components/adaptive_cover_pro/managers/weather.py
+++ b/custom_components/adaptive_cover_pro/managers/weather.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any
 
 from ..const import (
     DEFAULT_TEMPLATE_COMBINE_MODE,
@@ -53,18 +53,29 @@ class WeatherManager:
     retract covers on sensor failure).
     """
 
-    def __init__(self, hass: HomeAssistant, logger, *, event_buffer=None) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger,
+        *,
+        event_buffer=None,
+        template_variables: Mapping[str, Any] | None = None,
+    ) -> None:
         """Initialize the WeatherManager.
 
         Args:
             hass: Home Assistant instance used to read sensor states
             logger: Logger instance for debug/info output
             event_buffer: Shared diagnostic ring buffer (optional).
+            template_variables: Opaque render context threaded into every
+                condition-template fold — the ``acp`` self-reference namespace
+                built once by the coordinator (issue #1159).
 
         """
         self._hass = hass
         self._logger = logger
         self._event_buffer = event_buffer
+        self._template_variables = template_variables
         self._events = EventRecorder(event_buffer)
 
         # Config (updated via update_config)
@@ -324,6 +335,7 @@ class WeatherManager:
             mode,
             others_truthy=self._is_binary_on(entity_id),
             has_others=bool(entity_id),
+            variables=self._template_variables,
         )
         return bool(result)
 
@@ -360,6 +372,7 @@ class WeatherManager:
                 self._is_binary_on(entity_id) for entity_id in self._severe_sensors
             ),
             has_others=bool(self._severe_sensors),
+            variables=self._template_variables,
         )
         return bool(result)
 

--- a/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
+++ b/custom_components/adaptive_cover_pro/pipeline/snapshot_builder.py
@@ -34,8 +34,8 @@ the same composed-class pattern that Phase B established with
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
-from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Mapping
 
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_ON
 
@@ -188,6 +188,7 @@ class PipelineSnapshotBuilder:
         config_service: ConfigurationService,
         time_mgr: TimeWindowManager | None = None,
         clock: Callable[[], float] = time.monotonic,
+        template_variables: Mapping[str, Any] | None = None,
     ) -> None:
         """Bind the builder to its long-lived collaborators.
 
@@ -195,6 +196,10 @@ class PipelineSnapshotBuilder:
         custom-position hold window (issue #1012) — injected so tests can
         advance it deterministically, matching the convention already used by
         ``TimeWindowManager`` / ``GracefulSource`` for their grace windows.
+
+        ``template_variables`` is the ``acp`` self-reference render context
+        built once by the coordinator (issue #1159), threaded into each
+        custom-position slot's condition template. Opaque here.
         """
         self._hass = hass
         self._logger = logger
@@ -204,6 +209,7 @@ class PipelineSnapshotBuilder:
         self._config_service = config_service
         self._time_mgr = time_mgr
         self._clock = clock
+        self._template_variables = template_variables
         # Last VALID per-slot read, keyed by slot number (issue #1005). Written
         # only on a valid read; on an invalid read (transient unavailable /
         # unknown / missing sensor) the slot's activation is held to this so a
@@ -460,7 +466,11 @@ class PipelineSnapshotBuilder:
             # render (no opinion). A rendered opinion is both the activation
             # signal and a valid input for the slot.
             template_opinion = (
-                render_condition_or_none(self._hass, template) if has_template else None
+                render_condition_or_none(
+                    self._hass, template, variables=self._template_variables
+                )
+                if has_template
+                else None
             )
             template_active = bool(template_opinion) if has_template else None
             template_valid = template_opinion is not None

--- a/custom_components/adaptive_cover_pro/state/climate_provider.py
+++ b/custom_components/adaptive_cover_pro/state/climate_provider.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from operator import ge, le
-from typing import TYPE_CHECKING
-from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+from collections.abc import Callable, Mapping
 
 from ..const import DEFAULT_TEMPLATE_COMBINE_MODE
 from ..engine.climate_crossings import (
@@ -80,10 +80,22 @@ class ClimateReadings:
 class ClimateProvider:
     """Reads climate-related HA entities and returns a ClimateReadings snapshot."""
 
-    def __init__(self, hass: HomeAssistant, logger: ConfigContextAdapter) -> None:
-        """Initialize with HA instance and logger."""
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        *,
+        template_variables: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Initialize with HA instance, logger, and the shared render context.
+
+        ``template_variables`` is the ``acp`` self-reference namespace built once
+        by the coordinator (issue #1159), threaded into the is_sunny / presence
+        condition templates. Opaque here — the provider never inspects it.
+        """
         self._hass = hass
         self._logger = logger
+        self._template_variables = template_variables
         self._area_resolver = AreaSensorResolver(hass)
         # Last authoritative is_sunny opinion, held across a transient invalid
         # sensor/template read so a blip cannot substitute a lower-authority
@@ -341,6 +353,7 @@ class ClimateProvider:
             presence_template_mode,
             others_truthy=is_entity_active(self._hass, presence_entity),
             has_others=bool(presence_entity),
+            variables=self._template_variables,
         )
         if combined is not None:
             return combined
@@ -380,6 +393,7 @@ class ClimateProvider:
             is_sunny_template_mode,
             others_truthy=sensor_state == "on",
             has_others=has_sensor,
+            variables=self._template_variables,
         )
         if combined is not None:
             self._logger.debug(

--- a/custom_components/adaptive_cover_pro/templates.py
+++ b/custom_components/adaptive_cover_pro/templates.py
@@ -13,21 +13,241 @@ Two flavours of optional template field share this module:
 
 Rendering failures never propagate: a numeric failure drops the key (field falls
 back to its default); a condition failure returns the supplied default.
+
+Both flavours render against the per-instance ``acp`` namespace (issue #1159)
+built by :func:`build_acp_template_variables` — see that function for the
+contract.
 """
 
 import logging
+import re
+from collections.abc import Mapping
+from typing import Any
 
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.template import Template, result_as_boolean
+from jinja2.exceptions import UndefinedError
 
 from .config_fields import TEMPLATABLE_KEYS
 
 _LOGGER = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# The ``acp`` self-reference namespace (issue #1159)
+# ---------------------------------------------------------------------------
+
+#: Canonical namespace key → ``(entity domain, registry translation_key)``.
+#:
+#: The resolver keys on ``RegistryEntry.translation_key`` and NEVER on
+#: ``unique_id``: unique_id is not uniform across ACP's platforms (switches and
+#: one button derive theirs from the English display name, spaces and all)
+#: whereas every platform sets ``_attr_translation_key`` to its key. Canonical
+#: key and translation_key are therefore the same token today; the pair is kept
+#: explicit so the map states the full registry coordinate it matches on.
+#:
+#: The map is uniform across cover types on purpose. Which of these entities a
+#: given instance actually publishes is decided by the platform gates (glare
+#: zones, climate mode, motion sensors …); the resolver answers that question by
+#: looking the row up in the registry, never by branching on the cover type.
+ACP_TEMPLATE_ENTITY_KEYS: dict[str, tuple[str, str]] = {
+    # binary_sensor
+    "sun_motion": ("binary_sensor", "sun_motion"),
+    "manual_override": ("binary_sensor", "manual_override"),
+    "glare_active": ("binary_sensor", "glare_active"),
+    "position_mismatch": ("binary_sensor", "position_mismatch"),
+    # switch
+    "enabled_toggle": ("switch", "enabled_toggle"),
+    "automatic_control": ("switch", "automatic_control"),
+    "sun_tracking": ("switch", "sun_tracking"),
+    "manual_toggle": ("switch", "manual_toggle"),
+    "return_to_default_toggle": ("switch", "return_to_default_toggle"),
+    "motion_control": ("switch", "motion_control"),
+    "switch_mode": ("switch", "switch_mode"),
+    "temp_toggle": ("switch", "temp_toggle"),
+    "lux_toggle": ("switch", "lux_toggle"),
+    "irradiance_toggle": ("switch", "irradiance_toggle"),
+    "glare_zone_0": ("switch", "glare_zone_0"),
+    "glare_zone_1": ("switch", "glare_zone_1"),
+    "glare_zone_2": ("switch", "glare_zone_2"),
+    "glare_zone_3": ("switch", "glare_zone_3"),
+    # sensor — discrete/enum only. Continuously-varying sensors (target
+    # position, solar calculation, sun position, forecasts) are deliberately
+    # excluded: a template reading one would re-render on every cycle and, via
+    # the tracked-template refresh, drive its own input.
+    "control_status": ("sensor", "control_status"),
+    "motion_status": ("sensor", "motion_status"),
+    "climate_status": ("sensor", "climate_status"),
+}
+
+#: Display-slug → canonical key. The ONLY place the "what the user sees in the
+#: entity_id" / "what the code calls it" mismatch is encoded — e.g. the Sun
+#: Infront binary sensor's internal key is ``sun_motion``, and the Occupancy
+#: Status sensor's is ``motion_status``.
+ACP_TEMPLATE_KEY_ALIASES: dict[str, str] = {
+    "sun_infront": "sun_motion",
+    "occupancy_status": "motion_status",
+    "integration_enabled": "enabled_toggle",
+    "manual_override_detection": "manual_toggle",
+    "return_to_default_when_disabled": "return_to_default_toggle",
+    "climate_mode": "switch_mode",
+    "outside_temperature": "temp_toggle",
+    "lux": "lux_toggle",
+    "irradiance": "irradiance_toggle",
+}
+
+#: Seconds. Applied to a tracked template that uses the namespace, and only to
+#: those — a self-reference can drive its own input (gate on ``control_status``,
+#: invert ``motion_status``) and the coordinator has no debouncer. HA's
+#: ``KeyedRateLimit`` fires the first change after a quiet window immediately
+#: and defers only within-window re-renders to a trailing render, so a single
+#: flip keeps full immediacy. Templates that do not use the namespace get no
+#: rate limit at all, leaving the existing immediacy contract untouched.
+ACP_NAMESPACE_RATE_LIMIT: float = 1.0
+
+_ACP_NAMESPACE_RE = re.compile(r"\bacp(?:_entity|_state)?\b")
+
+
+def uses_acp_namespace(template_str) -> bool:
+    """Return True when *template_str* references the ``acp`` namespace.
+
+    Deliberately a cheap textual test rather than a Jinja parse: it only drives
+    the tracked-template rate limit, where a false positive costs at most a 1 s
+    trailing render and a false negative is what we must not have.
+    """
+    return isinstance(template_str, str) and bool(
+        _ACP_NAMESPACE_RE.search(template_str)
+    )
+
+
+class _AcpNamespaceBase:
+    """Attribute/item access facade over a single ``_lookup`` implementation.
+
+    ``acp.sun_infront`` and ``acp['sun_infront']`` are the same lookup, so the
+    access plumbing lives here once and each concrete namespace supplies only
+    what a resolved key yields.
+    """
+
+    def _lookup(self, key: str) -> str:
+        # Abstract: every concrete namespace overrides it, so this never runs.
+        raise NotImplementedError  # pragma: no cover
+
+    def __getattr__(self, name: str) -> str:
+        # Private / dunder probes (the Jinja sandbox's ``unsafe_callable`` and
+        # ``alters_data`` checks, copy, pickle) must read as ordinary missing
+        # attributes — not as a bad template key.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        return self._lookup(name)
+
+    def __getitem__(self, key: str) -> str:
+        return self._lookup(key)
+
+
+class _AcpEntityNamespace(_AcpNamespaceBase):
+    """Resolve one config entry's own entity_ids by canonical namespace key.
+
+    Every access does a fresh entity-registry lookup — nothing is cached — so a
+    rename, or an entity that only appears once its platform gate opens, is
+    picked up on the next render with no reload.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Bind the namespace to *hass* and the owning config entry."""
+        self._hass = hass
+        self._entry_id = entry_id
+
+    def resolve(self, key: str) -> str:
+        """Return the entity_id this instance publishes for *key*.
+
+        Raises :exc:`jinja2.exceptions.UndefinedError` — a ``TemplateError``
+        subclass, so HA converts it and the caller's existing fail-soft contract
+        applies — when *key* is unknown, or when this instance publishes no such
+        entity (a gated feature that is switched off).
+        """
+        canonical = ACP_TEMPLATE_KEY_ALIASES.get(key, key)
+        spec = ACP_TEMPLATE_ENTITY_KEYS.get(canonical)
+        if spec is None:
+            raise UndefinedError(
+                f"'{key}' is not an Adaptive Cover Pro entity key "
+                f"(instance {self._instance_label()})"
+            )
+        domain, translation_key = spec
+        registry = er.async_get(self._hass)
+        for entry in er.async_entries_for_config_entry(registry, self._entry_id):
+            if entry.domain == domain and entry.translation_key == translation_key:
+                return entry.entity_id
+        raise UndefinedError(
+            f"Adaptive Cover Pro instance {self._instance_label()} publishes no "
+            f"{domain} entity for '{key}'"
+        )
+
+    def _lookup(self, key: str) -> str:
+        return self.resolve(key)
+
+    def _instance_label(self) -> str:
+        """Name the instance in an error message, falling back to its entry id."""
+        entry = self._hass.config_entries.async_get_entry(self._entry_id)
+        return entry.title if entry is not None else self._entry_id
+
+
+class _AcpStateNamespace(_AcpNamespaceBase):
+    """Read the *state* of one config entry's own entities by namespace key.
+
+    Composed on :class:`_AcpEntityNamespace` so there is exactly one resolve
+    path. Only ever handed to untracked numeric renders — see
+    :func:`build_acp_template_variables`.
+    """
+
+    def __init__(self, hass: HomeAssistant, entities: _AcpEntityNamespace) -> None:
+        """Bind to *hass* and the entity namespace that does the resolving."""
+        self._hass = hass
+        self._entities = entities
+
+    def _lookup(self, key: str) -> str:
+        state = self._hass.states.get(self._entities.resolve(key))
+        return STATE_UNKNOWN if state is None else state.state
+
+
+def build_acp_template_variables(
+    hass: HomeAssistant, entry_id: str, *, include_state: bool = False
+) -> dict[str, Any]:
+    """Build the ``acp`` render context for one config entry (issue #1159).
+
+    The single factory behind every render site and every ``TrackTemplate``, so
+    the tracker's render and the manager's cycle render can never disagree.
+
+    Always returns the two *entity_id* forms:
+
+    * ``acp.<key>`` — the entity_id string, e.g.
+      ``{{ is_state(acp.sun_infront, 'on') }}``
+    * ``acp_entity('<key>')`` — the same resolve, spelled as a call
+
+    ``acp_state.<key>`` (the *value*) is added only when *include_state* is set,
+    and is set only for the untracked numeric threshold renders. A value read is
+    invisible to ``RenderInfo``, so a *tracked* template written against
+    ``acp_state`` would register zero state listeners and silently lose the
+    sensor-grade immediacy that ``_register_template_tracker`` exists to provide
+    (#577/#563/#639/#632/#974). Withholding it turns that silent regression into
+    a visible render failure. Uniform rule: condition fields get the entity
+    forms, numeric fields get all three.
+    """
+    entities = _AcpEntityNamespace(hass, entry_id)
+    variables: dict[str, Any] = {"acp": entities, "acp_entity": entities.resolve}
+    if include_state:
+        variables["acp_state"] = _AcpStateNamespace(hass, entities)
+    return variables
+
+
 def render_condition(
-    hass: HomeAssistant, template_str, *, default: bool = False
+    hass: HomeAssistant,
+    template_str,
+    *,
+    default: bool = False,
+    variables: Mapping[str, Any] | None = None,
 ) -> bool:
     """Render an optional Jinja2 *condition* template to a boolean.
 
@@ -36,18 +256,28 @@ def render_condition(
     *default* when the value is empty / not a template, or when rendering fails.
     HA's :func:`result_as_boolean` decides truthiness (``"on"``/``"true"``/``1``
     → True), matching how conditions read elsewhere in Home Assistant.
+
+    *variables* is the extra render context — in practice the ``acp``
+    self-reference namespace from :func:`build_acp_template_variables` (#1159).
+    An unresolvable namespace key raises ``UndefinedError``, a ``TemplateError``
+    subclass, so it lands on the same fail-soft path as any other bad template.
     """
     if not is_template_string(template_str):
         return default
     try:
-        result = Template(template_str, hass).async_render()
+        result = Template(template_str, hass).async_render(variables)
     except TemplateError as err:
         _LOGGER.debug("Condition template %r failed to render: %s", template_str, err)
         return default
     return result_as_boolean(result)
 
 
-def render_condition_or_none(hass: HomeAssistant, template_str) -> bool | None:
+def render_condition_or_none(
+    hass: HomeAssistant,
+    template_str,
+    *,
+    variables: Mapping[str, Any] | None = None,
+) -> bool | None:
     """Render an optional condition template to a tri-state boolean-or-None.
 
     The "no opinion" counterpart to :func:`render_condition`: returns ``None``
@@ -63,8 +293,10 @@ def render_condition_or_none(hass: HomeAssistant, template_str) -> bool | None:
     """
     if not is_template_string(template_str):
         return None
-    rendered = render_condition(hass, template_str, default=False)
-    if rendered != render_condition(hass, template_str, default=True):
+    rendered = render_condition(hass, template_str, default=False, variables=variables)
+    if rendered != render_condition(
+        hass, template_str, default=True, variables=variables
+    ):
         return None  # unstable across defaults → render failed → no opinion
     return rendered
 
@@ -105,6 +337,7 @@ def fold_condition_template(
     *,
     others_truthy: bool,
     has_others: bool,
+    variables: Mapping[str, Any] | None = None,
 ) -> bool | None:
     """Fold an optional condition template with a screen's other source.
 
@@ -123,7 +356,7 @@ def fold_condition_template(
       other source either — to ``None`` so the caller uses its own fallback.
     """
     others = others_truthy if has_others else False
-    template_opinion = render_condition_or_none(hass, template_str)
+    template_opinion = render_condition_or_none(hass, template_str, variables=variables)
     if template_opinion is None:
         return others if has_others else None
     return combine_with_mode(
@@ -160,9 +393,17 @@ def _looks_templated(value) -> bool:
 class TemplateResolver:
     """Render templated threshold options to numbers, once per cycle."""
 
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Store *hass* for template rendering."""
+    def __init__(
+        self, hass: HomeAssistant, variables: Mapping[str, Any] | None = None
+    ) -> None:
+        """Store *hass* and the shared render context for template rendering.
+
+        *variables* is the ``acp`` self-reference namespace (#1159). These
+        renders are untracked and happen once per coordinator cycle, so they are
+        the one flavour that also gets the ``acp_state`` value form.
+        """
         self._hass = hass
+        self._variables = variables
         # Keys currently in a failed-render state — used to log each failure
         # transition once instead of every cycle.
         self._failed: set[str] = set()
@@ -194,7 +435,9 @@ class TemplateResolver:
     def _render(self, key: str, value: str) -> float | None:
         """Render *value* to a float, or None on failure."""
         try:
-            result = Template(value, self._hass).async_render(parse_result=False)
+            result = Template(value, self._hass).async_render(
+                self._variables, parse_result=False
+            )
             number = float(str(result).strip())
         except (TemplateError, ValueError, TypeError) as err:
             if key not in self._failed:

--- a/custom_components/adaptive_cover_pro/templates.py
+++ b/custom_components/adaptive_cover_pro/templates.py
@@ -140,9 +140,11 @@ class _AcpMissingKeyAttributeError(UndefinedError, AttributeError):
     inventing another probe cannot reintroduce the misdirection.
 
     :meth:`_AcpNamespaceBase.__getitem__` raises a plain ``UndefinedError``
-    instead: ``SandboxedEnvironment.getitem`` swallows ``AttributeError``, so
-    ``{{ acp['nope'] }}`` would degrade into a generic undefined if this class
-    were used there too.
+    instead, simply because it has no probe surface to defend against:
+    ``SandboxedEnvironment.getitem`` catches only ``(TypeError, LookupError)``
+    around ``obj[argument]``, so nothing reaches this class by way of a
+    ``hasattr`` check there. The second base would propagate unchanged; it just
+    buys nothing.
     """
 
 

--- a/custom_components/adaptive_cover_pro/templates.py
+++ b/custom_components/adaptive_cover_pro/templates.py
@@ -119,28 +119,97 @@ def uses_acp_namespace(template_str) -> bool:
     )
 
 
+class _AcpMissingKeyAttributeError(UndefinedError, AttributeError):
+    """An unresolvable namespace key, raised from *attribute* access.
+
+    Two bases, deliberately:
+
+    * as an ``UndefinedError`` (a ``TemplateError``) a bad key still fails the
+      render on this module's normal fail-soft path, with the message naming
+      the key and the instance;
+    * as an ``AttributeError`` it also satisfies ``hasattr(obj, name)`` /
+      ``getattr(obj, name, default)``, which is how Jinja and Home Assistant
+      probe an object on the way to calling it — ``jinja_pass_arg``
+      (``jinja2.utils._PassArg.from_obj``), ``unsafe_callable`` and
+      ``alters_data`` (``SandboxedEnvironment.is_safe_callable``). Those probes
+      must take their default. Without the second base they surfaced the
+      probe's own name as the failure, so ``{{ acp('sun_infront') }}`` told the
+      user ``'jinja_pass_arg' is not an Adaptive Cover Pro entity key``.
+
+    One rule instead of a list of probe names, so a future Jinja or HA release
+    inventing another probe cannot reintroduce the misdirection.
+
+    :meth:`_AcpNamespaceBase.__getitem__` raises a plain ``UndefinedError``
+    instead: ``SandboxedEnvironment.getitem`` swallows ``AttributeError``, so
+    ``{{ acp['nope'] }}`` would degrade into a generic undefined if this class
+    were used there too.
+    """
+
+
 class _AcpNamespaceBase:
     """Attribute/item access facade over a single ``_lookup`` implementation.
 
     ``acp.sun_infront`` and ``acp['sun_infront']`` are the same lookup, so the
     access plumbing lives here once and each concrete namespace supplies only
     what a resolved key yields.
+
+    The rest of the class is misuse handling. Anything that is *not* a key
+    lookup — calling the namespace, iterating it, testing membership — used to
+    fall through ``__getattr__``/``__getitem__`` and be reported as a bad entity
+    key, naming a token the user never wrote (``unsafe_callable``, ``0``). Each
+    of those surfaces is answered explicitly below so the error names what the
+    template actually did wrong.
     """
+
+    #: How this namespace is spelled in a template, and how to use it properly.
+    #: Only ever read to build a misuse message.
+    _NAMESPACE = "acp"
+    _USAGE = "reference a key with acp.<key> or acp_entity('<key>')"
 
     def _lookup(self, key: str) -> str:
         # Abstract: every concrete namespace overrides it, so this never runs.
         raise NotImplementedError  # pragma: no cover
 
     def __getattr__(self, name: str) -> str:
-        # Private / dunder probes (the Jinja sandbox's ``unsafe_callable`` and
-        # ``alters_data`` checks, copy, pickle) must read as ordinary missing
-        # attributes — not as a bad template key.
+        """Resolve ``acp.<key>``; report anything unresolvable as missing too.
+
+        Private / dunder probes (copy, pickle, ``__html__``) are ordinary
+        missing attributes. Everything else goes through the one resolve path,
+        and a failure is re-raised as :class:`_AcpMissingKeyAttributeError` so a
+        Jinja/HA capability probe landing here takes its default instead of
+        surfacing the probe's own name to the user. The message is unchanged.
+        """
         if name.startswith("_"):
             raise AttributeError(name)
-        return self._lookup(name)
+        try:
+            return self._lookup(name)
+        except UndefinedError as err:
+            raise _AcpMissingKeyAttributeError(*err.args) from None
 
     def __getitem__(self, key: str) -> str:
         return self._lookup(key)
+
+    def __call__(self, *_args: Any, **_kwargs: Any) -> str:
+        """Reject ``{{ acp('sun_infront') }}``, the natural ``acp_entity`` typo."""
+        raise UndefinedError(self._misuse("is not callable"))
+
+    def __iter__(self):
+        """Reject ``{% for k in acp %}`` and ``'key' in acp``.
+
+        Without this, Python falls back to the legacy ``__getitem__(0)``
+        iteration protocol for both spellings and the user is told ``'0' is not
+        an Adaptive Cover Pro entity key``. The namespace deliberately does not
+        enumerate: which keys an instance publishes depends on its feature
+        gates, and a template that loops over them is not something to encourage.
+        """
+        raise UndefinedError(self._misuse("is not iterable"))
+
+    def _misuse(self, problem: str) -> str:
+        """Build a misuse message that names the namespace and the way out."""
+        return (
+            f"The Adaptive Cover Pro '{self._NAMESPACE}' namespace {problem} — "
+            f"{self._USAGE}"
+        )
 
 
 class _AcpEntityNamespace(_AcpNamespaceBase):
@@ -197,6 +266,9 @@ class _AcpStateNamespace(_AcpNamespaceBase):
     path. Only ever handed to untracked numeric renders — see
     :func:`build_acp_template_variables`.
     """
+
+    _NAMESPACE = "acp_state"
+    _USAGE = "reference a key with acp_state.<key>"
 
     def __init__(self, hass: HomeAssistant, entities: _AcpEntityNamespace) -> None:
         """Bind to *hass* and the entity namespace that does the resolving."""

--- a/custom_components/adaptive_cover_pro/templates.py
+++ b/custom_components/adaptive_cover_pro/templates.py
@@ -99,24 +99,20 @@ ACP_TEMPLATE_KEY_ALIASES: dict[str, str] = {
     "irradiance": "irradiance_toggle",
 }
 
-#: Seconds. Applied to a tracked template that uses the namespace, and only to
-#: those — a self-reference can drive its own input (gate on ``control_status``,
-#: invert ``motion_status``) and the coordinator has no debouncer. HA's
-#: ``KeyedRateLimit`` fires the first change after a quiet window immediately
-#: and defers only within-window re-renders to a trailing render, so a single
-#: flip keeps full immediacy. Templates that do not use the namespace get no
-#: rate limit at all, leaving the existing immediacy contract untouched.
-ACP_NAMESPACE_RATE_LIMIT: float = 1.0
-
 _ACP_NAMESPACE_RE = re.compile(r"\bacp(?:_entity|_state)?\b")
 
 
 def uses_acp_namespace(template_str) -> bool:
     """Return True when *template_str* references the ``acp`` namespace.
 
-    Deliberately a cheap textual test rather than a Jinja parse: it only drives
-    the tracked-template rate limit, where a false positive costs at most a 1 s
-    trailing render and a false negative is what we must not have.
+    Selects which tracked templates get the refresh coalescer in
+    ``__init__._coalesce_namespace_refreshes`` — a self-reference is the one
+    shape that can drive its own input, so it is the one shape whose refreshes
+    need bounding. Everything else keeps its untouched immediacy.
+
+    Deliberately a cheap textual test rather than a Jinja parse: a false
+    positive costs at most a one-second trailing refresh on a template that
+    never needed it, and a false negative is what we must not have.
     """
     return isinstance(template_str, str) and bool(
         _ACP_NAMESPACE_RE.search(template_str)

--- a/tests/_helpers/acp_namespace.py
+++ b/tests/_helpers/acp_namespace.py
@@ -20,6 +20,7 @@ from custom_components.adaptive_cover_pro.const import (
     DOMAIN,
     CoverType,
 )
+from custom_components.adaptive_cover_pro.cover_types import get_policy
 from custom_components.adaptive_cover_pro.templates import (
     build_acp_template_variables,
 )
@@ -30,15 +31,22 @@ def make_acp_entry(
     entry_id: str,
     *,
     name: str = "Dining Room Shade",
-    title: str = "Vertical Dining Room Shade",
+    title: str | None = None,
     options: dict | None = None,
 ) -> MockConfigEntry:
     """Register a config entry for seeded namespace rows to hang off.
 
-    ``title`` is deliberately different from ``data["name"]`` — that is the real
-    shape (``config_flow`` builds the title as ``"<type label> <name>"``), and
-    the namespace's error messages name the instance by title.
+    ``title`` is deliberately different from ``data["name"]`` — the namespace's
+    error messages name the instance by title, and getting that difference wrong
+    in a fixture would lock the tests to a shape no real install produces. It is
+    therefore *derived* rather than typed: ``config_flow`` builds the title as
+    ``f"{_cover_type_label(sensor_type)} {name}"``, and ``_cover_type_label``
+    delegates to ``get_policy(sensor_type).display_label()``. For a blind that
+    label is "Vertical Blind", so the default title here is
+    "Vertical Blind Dining Room Shade" — not "Vertical Dining Room Shade".
     """
+    if title is None:
+        title = f"{get_policy(CoverType.BLIND).display_label()} {name}"
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={"name": name, CONF_SENSOR_TYPE: CoverType.BLIND},

--- a/tests/_helpers/acp_namespace.py
+++ b/tests/_helpers/acp_namespace.py
@@ -1,0 +1,101 @@
+"""Seed an ACP instance's own entity-registry rows for ``acp`` namespace tests.
+
+The ``acp`` self-reference namespace (issue #1159) resolves a canonical key to
+this config entry's own ``entity_id`` by matching ``RegistryEntry.translation_key``.
+Every test that renders a template against the namespace therefore needs two
+things: a registered config entry, and at least one registry row hanging off it.
+
+Per CODING_GUIDELINES § cross-file test helpers, these live here rather than
+being copied into each of the eight test modules that need them.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    CoverType,
+)
+from custom_components.adaptive_cover_pro.templates import (
+    build_acp_template_variables,
+)
+
+
+def make_acp_entry(
+    hass: HomeAssistant,
+    entry_id: str,
+    *,
+    name: str = "Dining Room Shade",
+    title: str = "Vertical Dining Room Shade",
+    options: dict | None = None,
+) -> MockConfigEntry:
+    """Register a config entry for seeded namespace rows to hang off.
+
+    ``title`` is deliberately different from ``data["name"]`` — that is the real
+    shape (``config_flow`` builds the title as ``"<type label> <name>"``), and
+    the namespace's error messages name the instance by title.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": name, CONF_SENSOR_TYPE: CoverType.BLIND},
+        options=options if options is not None else {},
+        entry_id=entry_id,
+        title=title,
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def seed_acp_row(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    domain: str,
+    translation_key: str,
+    object_id: str,
+) -> str:
+    """Seed one entity-registry row the way a real ACP platform would.
+
+    Returns the assigned ``entity_id``. The unique_id is given the real
+    ``f"{entry_id}_{key}"`` shape so a subsequent real platform setup adopts this
+    exact row — but the resolver never reads it, only ``translation_key``.
+    """
+    reg = er.async_get(hass)
+    return reg.async_get_or_create(
+        domain,
+        DOMAIN,
+        f"{entry.entry_id}_{translation_key}",
+        config_entry=entry,
+        translation_key=translation_key,
+        suggested_object_id=object_id,
+    ).entity_id
+
+
+def seed_sun_infront(
+    hass: HomeAssistant,
+    entry: MockConfigEntry,
+    state: str | None = None,
+    *,
+    object_id: str = "dining_room_shade_sun_infront",
+) -> str:
+    """Seed the Sun Infront binary sensor (key ``sun_motion``) and optionally its state.
+
+    The canonical namespace example from issue #1159, and the one key whose
+    display slug (``sun_infront``) and internal key (``sun_motion``) differ.
+    """
+    entity_id = seed_acp_row(hass, entry, "binary_sensor", "sun_motion", object_id)
+    if state is not None:
+        hass.states.async_set(entity_id, state)
+    return entity_id
+
+
+def acp_variables(
+    hass: HomeAssistant, entry: MockConfigEntry, *, include_state: bool = False
+) -> dict:
+    """Build the render context for *entry* — the same factory production uses."""
+    return build_acp_template_variables(
+        hass, entry.entry_id, include_state=include_state
+    )

--- a/tests/test_init_entity_tracking.py
+++ b/tests/test_init_entity_tracking.py
@@ -379,3 +379,69 @@ async def test_manual_override_input_template_registered(hass) -> None:
         "async_track_template_result so the override engages the instant the "
         "template flips truthy (issue #974)."
     )
+
+
+async def test_acp_namespace_tracked_on_a_brand_new_entry(hass) -> None:
+    """A self-reference is tracked on the FIRST-EVER setup, not just after a reload.
+
+    ``TrackTemplateResultInfo.async_setup`` fixes the listener set from what the
+    *first* render touched, so a namespace key that resolves to nothing on that
+    render contributes no listener for the life of the setup. Registering the
+    option-template trackers after ``async_forward_entry_setups`` is what makes
+    the registry rows exist by then (issue #1159).
+    """
+    from unittest.mock import AsyncMock, patch as mock_patch
+
+    from homeassistant.helpers import entity_registry as er
+
+    from custom_components.adaptive_cover_pro.const import CONF_MOTION_TEMPLATE
+    from custom_components.adaptive_cover_pro.coordinator import (
+        AdaptiveDataUpdateCoordinator,
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Brand New Shade", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={
+            **VERTICAL_OPTIONS,
+            CONF_MOTION_TEMPLATE: "{{ is_state(acp.sun_infront, 'on') }}",
+        },
+        entry_id="track_acp_bootstrap_01",
+        title="Vertical Brand New Shade",
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set(
+        "sun.sun", "above_horizon", {"azimuth": 180.0, "elevation": 45.0}
+    )
+    hass.states.async_set(
+        "cover.test_blind", "open", {"current_position": 100, "supported_features": 143}
+    )
+
+    with (
+        mock_patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "async_check_motion_template_change",
+            new_callable=AsyncMock,
+        ) as fired,
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        reg = er.async_get(hass)
+        sun_infront = next(
+            e.entity_id
+            for e in er.async_entries_for_config_entry(reg, entry.entry_id)
+            if e.domain == "binary_sensor" and e.translation_key == "sun_motion"
+        )
+
+        fired.reset_mock()
+        hass.states.async_set(sun_infront, "on")
+        await hass.async_block_till_done()
+
+    assert fired.called, (
+        "On a first-ever setup the entity registry is empty when trackers are "
+        "registered before platform forwarding, so acp.sun_infront resolves to "
+        "nothing and the template records no listener. Register the option "
+        "template trackers after async_forward_entry_setups (issue #1159)."
+    )

--- a/tests/test_manual_override_input.py
+++ b/tests/test_manual_override_input.py
@@ -379,3 +379,66 @@ async def test_options_flow_manual_override_clears_input_template(hass) -> None:
     )
     assert result["type"] == "create_entry"
     assert result["data"].get(CONF_MANUAL_OVERRIDE_INPUT_TEMPLATE) is None
+
+
+# ---------------------------------------------------------------------------
+# acp self-reference namespace in the input template (issue #1159)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_input_template_resolves_the_acp_namespace(hass) -> None:
+    """The input template can name this instance's own entity, end to end (#1159).
+
+    Exercises the real coordinator render site with the context the coordinator
+    builds for itself — no patched renderer.
+    """
+    from unittest.mock import patch
+
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.adaptive_cover_pro.const import (
+        CONF_MANUAL_OVERRIDE_INPUT_TEMPLATE,
+        CONF_SENSOR_TYPE,
+        DOMAIN,
+        CoverType,
+    )
+    from tests._helpers.acp_namespace import seed_sun_infront
+    from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Dining Room Shade", CONF_SENSOR_TYPE: CoverType.BLIND},
+        options={
+            **VERTICAL_OPTIONS,
+            CONF_MANUAL_OVERRIDE_INPUT_TEMPLATE: (
+                "{{ is_state(acp.sun_infront, 'on') }}"
+            ),
+        },
+        entry_id="mo_input_acp_01",
+        title="Vertical Dining Room Shade",
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set(
+        "sun.sun", "above_horizon", {"azimuth": 180.0, "elevation": 45.0}
+    )
+    hass.states.async_set(
+        "cover.test_blind", "open", {"current_position": 100, "supported_features": 143}
+    )
+    seed_sun_infront(hass, entry, "off")
+
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data
+    with patch.object(coordinator, "async_refresh", new=AsyncMock()):
+        # Falsy render → no engagement.
+        await coordinator.async_check_manual_override_input_template_change(None, [])
+        assert coordinator.manager.binary_cover_manual is False
+
+        hass.states.async_set("binary_sensor.dining_room_shade_sun_infront", "on")
+        await hass.async_block_till_done()
+        await coordinator.async_check_manual_override_input_template_change(None, [])
+
+    assert coordinator.manager.binary_cover_manual is True

--- a/tests/test_manual_override_input.py
+++ b/tests/test_manual_override_input.py
@@ -416,7 +416,7 @@ async def test_input_template_resolves_the_acp_namespace(hass) -> None:
             ),
         },
         entry_id="mo_input_acp_01",
-        title="Vertical Dining Room Shade",
+        title="Vertical Blind Dining Room Shade",
     )
     entry.add_to_hass(hass)
     hass.states.async_set(

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1434,10 +1434,19 @@ class TestMotionTemplate:
         await hass.async_block_till_done()
         assert mgr.template_active is False
 
-    async def test_occupancy_template_without_context_is_no_opinion(self, hass):
-        """No context threaded in → the namespace is undefined → falsy, never a crash."""
+    async def test_occupancy_template_without_context_reads_as_unoccupied(self, hass):
+        """No context threaded in → the namespace is undefined → *not occupied*.
+
+        Emphatically NOT "no opinion". ``template_active`` goes through
+        ``render_condition(default=False)``, so a failed render is a substantive
+        verdict: with no companion sensors ``is_motion_detected`` is False and
+        the motion-timeout handler can take the cover. The tri-state
+        ``render_condition_or_none`` / ``fold_condition_template`` path is the
+        one that abstains; this field does not use it.
+        """
         mgr = self._mgr(hass, template="{{ is_state(acp.sun_infront, 'on') }}")
         assert mgr.template_active is False
+        assert mgr.is_motion_detected is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1403,6 +1403,42 @@ class TestMotionTemplate:
         mgr_off = self._mgr(hass, template="{{ false }}", template_mode="and")
         assert mgr_off.is_motion_detected is False
 
+    async def test_occupancy_template_can_reference_this_instances_own_entity(
+        self, hass
+    ):
+        """The occupancy template resolves the ``acp`` namespace (issue #1159)."""
+        from tests._helpers.acp_namespace import (
+            acp_variables,
+            make_acp_entry,
+            seed_sun_infront,
+        )
+
+        entry = make_acp_entry(hass, "motion_acp_01")
+        entity_id = seed_sun_infront(hass, entry, "on")
+        await hass.async_block_till_done()
+
+        mgr = MotionManager(
+            hass=hass,
+            logger=MagicMock(),
+            template_variables=acp_variables(hass, entry),
+        )
+        mgr.update_config(
+            sensors=[],
+            timeout_seconds=300,
+            template="{{ is_state(acp.sun_infront, 'on') }}",
+        )
+        assert mgr.template_active is True
+        assert mgr.is_motion_detected is True
+
+        hass.states.async_set(entity_id, "off")
+        await hass.async_block_till_done()
+        assert mgr.template_active is False
+
+    async def test_occupancy_template_without_context_is_no_opinion(self, hass):
+        """No context threaded in → the namespace is undefined → falsy, never a crash."""
+        mgr = self._mgr(hass, template="{{ is_state(acp.sun_infront, 'on') }}")
+        assert mgr.template_active is False
+
 
 @pytest.mark.asyncio
 async def test_async_check_motion_template_change_truthy_refreshes():

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1439,14 +1439,51 @@ class TestMotionTemplate:
 
         Emphatically NOT "no opinion". ``template_active`` goes through
         ``render_condition(default=False)``, so a failed render is a substantive
-        verdict: with no companion sensors ``is_motion_detected`` is False and
-        the motion-timeout handler can take the cover. The tri-state
-        ``render_condition_or_none`` / ``fold_condition_template`` path is the
-        one that abstains; this field does not use it.
+        verdict rather than a shrug: ``is_motion_detected`` goes False. The
+        tri-state ``render_condition_or_none`` / ``fold_condition_template``
+        path is the one that abstains; this field does not use it.
+
+        Whether that verdict reaches the cover is a separate question, and with
+        the template as the *only* occupancy source the answer is no.
+        ``is_motion_timeout_active`` hard-returns False whenever no sensors are
+        configured, so ``snapshot.motion_timeout_active`` stays False and
+        ``MotionTimeoutHandler.evaluate`` returns None. A typo'd key costs a
+        template-only instance its occupancy signal, not its position — see
+        ``test_and_mode_failed_render_reaches_the_timeout_gate`` for the one
+        shape where it does park the cover.
         """
         mgr = self._mgr(hass, template="{{ is_state(acp.sun_infront, 'on') }}")
         assert mgr.template_active is False
         assert mgr.is_motion_detected is False
+        mgr.set_no_motion()  # what a completed no-motion timeout leaves behind
+        assert mgr.is_motion_timeout_active is False, (
+            "No sensors → the timeout gate is off, so the unoccupied verdict "
+            "never reaches MotionTimeoutHandler."
+        )
+
+    async def test_and_mode_failed_render_reaches_the_timeout_gate(self, hass):
+        """AND mode *with sensors* is the shape where a bad template parks the cover.
+
+        The failed render folds to False through the AND, which overrides an
+        active sensor (``test_and_mode_template_falsy_blocks_active_sensor``),
+        and because sensors are configured the ``is_motion_timeout_active``
+        gate is open — so once the no-motion timeout completes the snapshot
+        carries True and ``MotionTimeoutHandler`` returns the default position.
+        """
+        hass.states.async_set("binary_sensor.motion", "on")
+        await hass.async_block_till_done()
+        mgr = self._mgr(
+            hass,
+            sensors=["binary_sensor.motion"],
+            # No render context threaded in, so `acp` is undefined and the
+            # render fails — the same shape as a typo'd namespace key.
+            template="{{ is_state(acp.sun_infront, 'on') }}",
+            template_mode="and",
+        )
+        assert mgr.template_active is False
+        assert mgr.is_motion_detected is False
+        mgr.set_no_motion()
+        assert mgr.is_motion_timeout_active is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_motion_control.py
+++ b/tests/test_motion_control.py
@@ -1464,11 +1464,14 @@ class TestMotionTemplate:
     async def test_and_mode_failed_render_reaches_the_timeout_gate(self, hass):
         """AND mode *with sensors* is the shape where a bad template parks the cover.
 
-        The failed render folds to False through the AND, which overrides an
-        active sensor (``test_and_mode_template_falsy_blocks_active_sensor``),
-        and because sensors are configured the ``is_motion_timeout_active``
-        gate is open — so once the no-motion timeout completes the snapshot
-        carries True and ``MotionTimeoutHandler`` returns the default position.
+        Pins the two manager-level facts that make that shape reachable: the
+        failed render folds to False through the AND, overriding an active
+        sensor (``test_and_mode_template_falsy_blocks_active_sensor``), and
+        because sensors are configured the ``is_motion_timeout_active`` gate is
+        open rather than short-circuited off. ``set_no_motion()`` stands in for
+        a completed timeout, so what is asserted is that the gate would be open
+        — the expiry path and ``MotionTimeoutHandler`` itself are covered
+        elsewhere.
         """
         hass.states.async_set("binary_sensor.motion", "on")
         await hass.async_block_till_done()

--- a/tests/test_pipeline/test_snapshot_builder.py
+++ b/tests/test_pipeline/test_snapshot_builder.py
@@ -1366,3 +1366,48 @@ def test_tilt_only_wins_over_tilt_bounds():
     assert state.tilt_mode is AxisConstraintMode.FIXED
     assert state.tilt_min is None
     assert state.tilt_max is None
+
+
+# ---------------------------------------------------------------------------
+# acp self-reference namespace in custom-position slot templates (issue #1159)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_custom_position_slot_template_resolves_the_acp_namespace(hass):
+    """A slot's condition template can name this instance's own entity (#1159)."""
+    from tests._helpers.acp_namespace import (
+        acp_variables,
+        make_acp_entry,
+        seed_sun_infront,
+    )
+
+    entry = make_acp_entry(hass, "slot_acp_01")
+    entity_id = seed_sun_infront(hass, entry, "on")
+    await hass.async_block_till_done()
+
+    climate_provider = MagicMock(spec=ClimateProvider)
+    climate_provider.read.return_value = _dummy_readings()
+    policy = MagicMock()
+    policy.glare_zones_config.return_value = None
+
+    builder = PipelineSnapshotBuilder(
+        hass=hass,
+        logger=MagicMock(),
+        climate_provider=climate_provider,
+        toggles=MagicMock(),
+        policy=policy,
+        config_service=MagicMock(),
+        template_variables=acp_variables(hass, entry),
+    )
+
+    slot_keys = next(iter(CUSTOM_POSITION_SLOTS.values()))
+    opts = {
+        slot_keys["template"]: "{{ is_state(acp.sun_infront, 'on') }}",
+        slot_keys["position"]: 42,
+    }
+    assert builder.read_custom_position_sensors(opts)[0].is_on is True
+
+    hass.states.async_set(entity_id, "off")
+    await hass.async_block_till_done()
+    assert builder.read_custom_position_sensors(opts)[0].is_on is False

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -1,6 +1,6 @@
 """Entity spec translation_key consistency guard.
 
-Two guards:
+Three guards:
 
 1. Sensor specs with ``translation_key`` must reference a key that exists in
    ``en.json["entity"]["sensor"]``. Fails when a new sensor spec is added with
@@ -9,6 +9,14 @@ Two guards:
 2. Non-glare switch translation keys in ``en.json["entity"]["switch"]`` must
    correspond to an actual switch spec ``key`` value. Fails when an entry is
    added to en.json without a matching spec (orphaned translation) or vice versa.
+
+3. Every key in ``templates.ACP_TEMPLATE_ENTITY_KEYS`` must name a
+   ``(domain, translation_key)`` pair some platform really registers, and every
+   registered translation_key must be either exposed there or explicitly
+   withheld (issue #1159). The ``acp`` namespace resolves by matching
+   ``RegistryEntry.translation_key``, so a key renamed in ``switch.py`` /
+   ``sensor.py`` / ``binary_sensor.py`` silently breaks every template that
+   references it — this is the guard that turns that into a red test.
 
 When you add a new sensor spec with a translation_key:
   - Add the entry to translations/en.json under entity.sensor
@@ -20,7 +28,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from custom_components.adaptive_cover_pro.binary_sensor import (
+    _BINARY_SENSOR_SPECS,
+    AdaptiveCoverPositionMismatchSensor,
+)
+from custom_components.adaptive_cover_pro.const import (
+    CONF_ENABLE_GLARE_ZONES,
+    CONF_SENSOR_TYPE,
+    GLARE_ZONE_SLOT_NUMBERS,
+    CoverType,
+)
 from custom_components.adaptive_cover_pro.group_entities import (
     GroupActiveSceneSensor,
     GroupAutomationSwitch,
@@ -35,7 +54,8 @@ from custom_components.adaptive_cover_pro.sensor import (
     _DIAGNOSTIC_SPECS,
     _STANDARD_SPECS,
 )
-from custom_components.adaptive_cover_pro.switch import _SWITCH_SPECS
+from custom_components.adaptive_cover_pro.switch import _SWITCH_SPECS, _glare_zone_specs
+from custom_components.adaptive_cover_pro.templates import ACP_TEMPLATE_ENTITY_KEYS
 
 _EN_JSON: dict = json.loads(
     (
@@ -153,6 +173,99 @@ class TestSensorSpecTranslationKeys:
             f"en.json entity.sensor contains entries with no matching sensor spec "
             f"translation_key: {sorted(orphaned)}\n"
             "Remove the orphaned entry from en.json (and de.json, fr.json)."
+        )
+
+
+def _registered_translation_keys() -> dict[str, frozenset[str]]:
+    """Every ``(domain → translation_keys)`` pair the platforms really register.
+
+    Read off the same spec tuples and entity classes ``async_setup_entry`` uses,
+    so a renamed key shows up here without anyone updating a literal list. The
+    glare-zone switches are built dynamically, so they are produced by calling
+    the real builder against an entry with every zone slot named.
+    """
+    glare_entry = MagicMock()
+    glare_entry.data = {CONF_SENSOR_TYPE: CoverType.BLIND}
+    glare_entry.options = {
+        CONF_ENABLE_GLARE_ZONES: True,
+        **{f"glare_zone_{idx}_name": f"Zone {idx}" for idx in GLARE_ZONE_SLOT_NUMBERS},
+    }
+
+    return {
+        "binary_sensor": frozenset(
+            {s.key for s in _BINARY_SENSOR_SPECS}
+            | {_class_translation_key(AdaptiveCoverPositionMismatchSensor)}
+        ),
+        "switch": frozenset(
+            {s.key for s in _SWITCH_SPECS}
+            | {s.key for s in _glare_zone_specs(glare_entry)}
+        ),
+        "sensor": frozenset(
+            s.translation_key
+            for s in (*_STANDARD_SPECS, *_DIAGNOSTIC_SPECS)
+            if getattr(s, "translation_key", None)
+        ),
+    }
+
+
+# Registered translation_keys deliberately kept OUT of the ``acp`` namespace
+# (issue #1159). All three are continuously-varying: a tracked template reading
+# one would re-render every cycle and drive its own refresh. Adding an entity
+# without deciding either way is what the guard below is for.
+_WITHHELD_FROM_NAMESPACE: dict[str, frozenset[str]] = {
+    "binary_sensor": frozenset(),
+    "switch": frozenset(),
+    "sensor": frozenset({"solar_calculation", "decision_trace", "position_forecast"}),
+}
+
+
+class TestAcpNamespaceKeys:
+    """``ACP_TEMPLATE_ENTITY_KEYS`` must track what the platforms register."""
+
+    def test_every_namespace_key_is_registered_by_its_platform(self) -> None:
+        """Each exposed key must resolve to a real ``(domain, translation_key)``.
+
+        The resolver matches ``RegistryEntry.translation_key``, so renaming a
+        key in ``switch.py`` / ``sensor.py`` / ``binary_sensor.py`` without
+        updating the namespace map turns every template that references it into
+        a permanent render failure — with no other test noticing.
+        """
+        registered = _registered_translation_keys()
+        unresolvable = [
+            f"{key!r} → {domain}.{translation_key!r}"
+            for key, (domain, translation_key) in ACP_TEMPLATE_ENTITY_KEYS.items()
+            if translation_key not in registered.get(domain, frozenset())
+        ]
+        assert not unresolvable, (
+            "templates.ACP_TEMPLATE_ENTITY_KEYS names entities no platform "
+            "registers:\n"
+            + "\n".join(f"  {u}" for u in unresolvable)
+            + "\nEither the platform's translation_key was renamed (update the "
+            "namespace map and the wiki page) or the entity was removed."
+        )
+
+    def test_every_registered_key_is_exposed_or_explicitly_withheld(self) -> None:
+        """A new entity forces a decision instead of silently missing the namespace."""
+        registered = _registered_translation_keys()
+        exposed: dict[str, set[str]] = {
+            "binary_sensor": set(),
+            "switch": set(),
+            "sensor": set(),
+        }
+        for domain, translation_key in ACP_TEMPLATE_ENTITY_KEYS.values():
+            exposed[domain].add(translation_key)
+
+        undecided = {
+            domain: sorted(keys - exposed[domain] - _WITHHELD_FROM_NAMESPACE[domain])
+            for domain, keys in registered.items()
+        }
+        undecided = {domain: keys for domain, keys in undecided.items() if keys}
+        assert not undecided, (
+            f"These registered entities are neither in the acp namespace nor "
+            f"listed as deliberately withheld: {undecided}\n"
+            "Add them to templates.ACP_TEMPLATE_ENTITY_KEYS (and the "
+            "Template-Self-References wiki page), or to _WITHHELD_FROM_NAMESPACE "
+            "here with the reason."
         )
 
 

--- a/tests/test_spec_translation_keys.py
+++ b/tests/test_spec_translation_keys.py
@@ -176,13 +176,22 @@ class TestSensorSpecTranslationKeys:
         )
 
 
-def _registered_translation_keys() -> dict[str, frozenset[str]]:
-    """Every ``(domain → translation_keys)`` pair the platforms really register.
+def _registered_entities() -> dict[str, dict[str, str | None]]:
+    """Every entity the platforms register, as ``domain → {name: translation_key}``.
 
     Read off the same spec tuples and entity classes ``async_setup_entry`` uses,
     so a renamed key shows up here without anyone updating a literal list. The
     glare-zone switches are built dynamically, so they are produced by calling
     the real builder against an entry with every zone slot named.
+
+    *name* is the spec's stable identifier — the sensor spec ``suffix``, the
+    switch / binary-sensor ``key``. *translation_key* is what the ``acp``
+    resolver matches on, and is ``None`` for a spec that sets none. Carrying
+    both is what makes the exposed-or-withheld guard below non-vacuous:
+    enumerating only the specs that *have* a translation_key let the nine
+    sensors that don't (``sun_position``, ``Cover_Position``,
+    ``last_cover_action`` …) escape the forced decision entirely, so a new
+    sensor added without one would have escaped it too.
     """
     glare_entry = MagicMock()
     glare_entry.data = {CONF_SENSOR_TYPE: CoverType.BLIND}
@@ -190,32 +199,54 @@ def _registered_translation_keys() -> dict[str, frozenset[str]]:
         CONF_ENABLE_GLARE_ZONES: True,
         **{f"glare_zone_{idx}_name": f"Zone {idx}" for idx in GLARE_ZONE_SLOT_NUMBERS},
     }
+    mismatch_key = _class_translation_key(AdaptiveCoverPositionMismatchSensor)
 
     return {
-        "binary_sensor": frozenset(
-            {s.key for s in _BINARY_SENSOR_SPECS}
-            | {_class_translation_key(AdaptiveCoverPositionMismatchSensor)}
-        ),
-        "switch": frozenset(
-            {s.key for s in _SWITCH_SPECS}
-            | {s.key for s in _glare_zone_specs(glare_entry)}
-        ),
-        "sensor": frozenset(
-            s.translation_key
+        "binary_sensor": {
+            **{s.key: s.key for s in _BINARY_SENSOR_SPECS},
+            mismatch_key: mismatch_key,
+        },
+        "switch": {
+            **{s.key: s.key for s in _SWITCH_SPECS},
+            **{s.key: s.key for s in _glare_zone_specs(glare_entry)},
+        },
+        "sensor": {
+            s.suffix: getattr(s, "translation_key", None)
             for s in (*_STANDARD_SPECS, *_DIAGNOSTIC_SPECS)
-            if getattr(s, "translation_key", None)
-        ),
+        },
     }
 
 
-# Registered translation_keys deliberately kept OUT of the ``acp`` namespace
-# (issue #1159). All three are continuously-varying: a tracked template reading
-# one would re-render every cycle and drive its own refresh. Adding an entity
-# without deciding either way is what the guard below is for.
+# Registered entities deliberately kept OUT of the ``acp`` namespace (issue
+# #1159), listed by the spec name ``_registered_entities`` reports.
+#
+# Every one is continuously-varying, a timestamp, or an event echo: a tracked
+# template reading one would re-render every cycle and drive its own refresh.
+# The nine with no translation_key at all are additionally unresolvable by a
+# translation_key-keyed resolver, so exposing them would not work even if we
+# wanted to. Adding an entity without deciding either way is what the guard
+# below is for.
 _WITHHELD_FROM_NAMESPACE: dict[str, frozenset[str]] = {
     "binary_sensor": frozenset(),
     "switch": frozenset(),
-    "sensor": frozenset({"solar_calculation", "decision_trace", "position_forecast"}),
+    "sensor": frozenset(
+        {
+            # Have a translation_key, deliberately not exposed.
+            "solar_calculation",
+            "decision_trace",
+            "position_forecast",
+            # No translation_key — unresolvable by the namespace resolver.
+            "Cover_Position",
+            "Cover_Tilt",
+            "Start Sun",
+            "End Sun",
+            "sun_position",
+            "last_skipped_action",
+            "last_cover_action",
+            "manual_override_end_time",
+            "position_verification",
+        }
+    ),
 }
 
 
@@ -230,11 +261,14 @@ class TestAcpNamespaceKeys:
         updating the namespace map turns every template that references it into
         a permanent render failure — with no other test noticing.
         """
-        registered = _registered_translation_keys()
+        resolvable = {
+            domain: {key for key in entities.values() if key}
+            for domain, entities in _registered_entities().items()
+        }
         unresolvable = [
             f"{key!r} → {domain}.{translation_key!r}"
             for key, (domain, translation_key) in ACP_TEMPLATE_ENTITY_KEYS.items()
-            if translation_key not in registered.get(domain, frozenset())
+            if translation_key not in resolvable.get(domain, set())
         ]
         assert not unresolvable, (
             "templates.ACP_TEMPLATE_ENTITY_KEYS names entities no platform "
@@ -244,9 +278,14 @@ class TestAcpNamespaceKeys:
             "namespace map and the wiki page) or the entity was removed."
         )
 
-    def test_every_registered_key_is_exposed_or_explicitly_withheld(self) -> None:
-        """A new entity forces a decision instead of silently missing the namespace."""
-        registered = _registered_translation_keys()
+    def test_every_registered_entity_is_exposed_or_explicitly_withheld(self) -> None:
+        """A new entity forces a decision instead of silently missing the namespace.
+
+        Every spec counts, including one that sets no ``translation_key``. Such a
+        spec can never be reached by the resolver, so it must be listed as
+        withheld — which is the moment somebody notices that adding a
+        translation_key is what it would take to expose it.
+        """
         exposed: dict[str, set[str]] = {
             "binary_sensor": set(),
             "switch": set(),
@@ -255,17 +294,23 @@ class TestAcpNamespaceKeys:
         for domain, translation_key in ACP_TEMPLATE_ENTITY_KEYS.values():
             exposed[domain].add(translation_key)
 
-        undecided = {
-            domain: sorted(keys - exposed[domain] - _WITHHELD_FROM_NAMESPACE[domain])
-            for domain, keys in registered.items()
-        }
-        undecided = {domain: keys for domain, keys in undecided.items() if keys}
+        undecided = {}
+        for domain, entities in _registered_entities().items():
+            withheld = _WITHHELD_FROM_NAMESPACE[domain]
+            names = sorted(
+                name
+                for name, translation_key in entities.items()
+                if translation_key not in exposed[domain] and name not in withheld
+            )
+            if names:
+                undecided[domain] = names
         assert not undecided, (
             f"These registered entities are neither in the acp namespace nor "
             f"listed as deliberately withheld: {undecided}\n"
             "Add them to templates.ACP_TEMPLATE_ENTITY_KEYS (and the "
             "Template-Self-References wiki page), or to _WITHHELD_FROM_NAMESPACE "
-            "here with the reason."
+            "here with the reason. A spec with no translation_key cannot be "
+            "resolved by the namespace at all, so it can only be withheld."
         )
 
 

--- a/tests/test_state/test_climate_provider.py
+++ b/tests/test_state/test_climate_provider.py
@@ -772,7 +772,7 @@ class TestSunnyTemplateTransientHold:
         sunny_template = "{{ states('sensor.elev') | float > 10 }}"
         render_results = iter([True, None, True])
 
-        def fake_render(_hass, template_str):
+        def fake_render(_hass, template_str, **_kwargs):
             # Only intercept the is_sunny template read; a bare call also
             # runs for the (unused) presence template each cycle and must
             # keep returning None like the real function does for "no
@@ -1234,3 +1234,42 @@ class TestReleaseClearedHysteresis:
         readings = provider.read(use_lux=False, use_irradiance=False)
         assert readings.lux_release_cleared is True
         assert readings.irradiance_release_cleared is True
+
+
+# ---------------------------------------------------------------------------
+# acp self-reference namespace in is_sunny / presence templates (issue #1159)
+# ---------------------------------------------------------------------------
+
+
+class TestAcpNamespaceInClimateTemplates:
+    """Both climate condition-template fold sites thread the render context."""
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        ("field", "reading"),
+        [("is_sunny_template", "is_sunny"), ("presence_template", "is_presence")],
+    )
+    async def test_condition_template_resolves_the_acp_namespace(
+        self, hass, field, reading
+    ):
+        from tests._helpers.acp_namespace import (
+            acp_variables,
+            make_acp_entry,
+            seed_sun_infront,
+        )
+
+        entry = make_acp_entry(hass, f"climate_acp_{field}")
+        entity_id = seed_sun_infront(hass, entry, "on")
+        await hass.async_block_till_done()
+
+        provider = ClimateProvider(
+            hass=hass,
+            logger=MagicMock(),
+            template_variables=acp_variables(hass, entry),
+        )
+        tmpl = "{{ is_state(acp.sun_infront, 'on') }}"
+        assert getattr(provider.read(**{field: tmpl}), reading) is True
+
+        hass.states.async_set(entity_id, "off")
+        await hass.async_block_till_done()
+        assert getattr(provider.read(**{field: tmpl}), reading) is False

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -12,15 +12,23 @@ same context.
 
 from __future__ import annotations
 
+import datetime as dt
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant.helpers.event import async_track_state_change_event
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.adaptive_cover_pro.const import (
+    BLANK_TIME,
     CONF_DAYTIME_GATE_TEMPLATE,
+    CONF_END_TIME,
     CONF_MOTION_TEMPLATE,
+    CONF_START_TIME,
 )
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
@@ -128,12 +136,16 @@ async def test_acp_namespace_template_tracker_fires_on_own_entity_change(
         )
 
 
-async def test_rate_limit_only_on_namespace_templates(hass: HomeAssistant) -> None:
-    """Only namespace templates carry the loop-guard rate limit.
+async def test_track_template_never_carries_a_rate_limit(hass: HomeAssistant) -> None:
+    """``TrackTemplate.rate_limit`` stays unset — it cannot guard a self-reference.
 
-    A self-reference can drive its own input and the coordinator has no
-    debouncer, so those get a 1 s trailing-render cap. Everything else keeps the
-    existing byte-for-byte behaviour: no rate limit at all.
+    HA's ``_rate_limit_for_event`` (``homeassistant/helpers/event.py``) opens with
+    *"Specifically referenced entities are excluded from the rate limit"* and
+    returns ``None`` whenever the entity that changed is in
+    ``RenderInfo.entities``. ``is_state(acp.sun_infront, …)`` puts exactly that
+    entity_id there, so a ``rate_limit`` on these trackers would be inert — it
+    would read as protection while providing none. The real guard is the refresh
+    coalescer; this test exists so nobody re-adds the decoration.
     """
     acp_template = "{{ is_state(acp.sun_infront, 'on') }}"
     plain_template = "{{ states('sensor.lux') | int > 100 }}"
@@ -168,13 +180,182 @@ async def test_rate_limit_only_on_namespace_templates(hass: HomeAssistant) -> No
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert (
-        captured[acp_template] == 1.0
-    ), "A template using the acp namespace must carry the loop-guard rate limit."
+    assert captured[acp_template] is None, (
+        "HA bypasses TrackTemplate.rate_limit for a specifically-referenced "
+        "entity, which is exactly what acp.<key> resolves to — do not set it."
+    )
     assert captured[plain_template] is None, (
         "A template that does not use the acp namespace must keep its unthrottled "
         "immediacy — no rate limit."
     )
+
+
+async def test_only_namespace_templates_have_their_refreshes_coalesced(
+    hass: HomeAssistant, freezer
+) -> None:
+    """A namespace template's action is throttled; a plain one's is not.
+
+    The leading edge is immediate for both — that is the whole immediacy
+    contract. The difference is what happens to the *second* and *third* flip
+    inside one cooldown: the plain template still runs its action once per flip,
+    while the namespace template collapses them into a single trailing run once
+    the window closes. Nothing is dropped; the trailing run is asserted.
+    """
+    acp_template = "{{ is_state(acp.sun_infront, 'on') }}"
+    plain_template = "{{ is_state('input_boolean.guests', 'on') }}"
+    entry = _make_entry(
+        hass,
+        "tt_coalesce_01",
+        {
+            CONF_MOTION_TEMPLATE: acp_template,
+            CONF_DAYTIME_GATE_TEMPLATE: plain_template,
+        },
+    )
+    sun_infront = _preseed_sun_infront(hass, entry)
+    hass.states.async_set(sun_infront, "off")
+    hass.states.async_set("input_boolean.guests", "off")
+
+    with (
+        patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "async_check_motion_template_change",
+            new_callable=AsyncMock,
+        ) as acp_fired,
+        patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "async_check_daytime_gate_template_change",
+            new_callable=AsyncMock,
+        ) as plain_fired,
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        acp_fired.reset_mock()
+        plain_fired.reset_mock()
+
+        # Three rendered-result flips each, all inside one cooldown window.
+        for state in ("on", "off", "on"):
+            hass.states.async_set(sun_infront, state)
+            hass.states.async_set("input_boolean.guests", state)
+            await hass.async_block_till_done()
+
+        assert plain_fired.call_count == 3, (
+            "A plain template keeps one action per flip — the immediacy contract "
+            "shipped across #577/#563/#639/#632/#974 is untouched."
+        )
+        assert acp_fired.call_count == 1, (
+            "A namespace template runs its leading flip immediately and coalesces "
+            "the rest of the window into one deferred run."
+        )
+
+        freezer.tick(1.2)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert acp_fired.call_count == 2, (
+            "The coalesced flips must still produce a trailing run when the "
+            "window closes — coalescing drops nothing."
+        )
+
+
+#: The canonical reachable self-reference loop (issue #1159 review). The gate
+#: template reads ``control_status``; a True verdict opens the time window,
+#: which makes ``control_status`` stop reporting ``outside_time_window``, which
+#: renders the template False, which closes the window again. A true 2-cycle
+#: with no fixed point.
+_LOOPING_GATE_TEMPLATE = "{{ is_state(acp.control_status, 'outside_time_window') }}"
+
+#: Refreshes past this many mean the loop is running away. The counting stub
+#: stops calling through at the cap instead of letting an unguarded regression
+#: hang the suite.
+_REFRESH_CAP = 60
+
+
+async def test_self_referencing_gate_template_refresh_is_bounded(
+    hass: HomeAssistant, freezer
+) -> None:
+    """The real control_status feedback loop settles at one refresh per window.
+
+    Everything here is production wiring: the real daytime-gate template, the
+    real tracker, the real ``sensor.…_control_status``, the real coordinator
+    refresh. Only two things are instrumented — a counter around
+    ``async_refresh`` (which stops calling through at ``_REFRESH_CAP`` so a
+    regression fails fast instead of hanging), and one asynchronously-dispatched
+    consumer of the control-status sensor.
+
+    That consumer matters. A real install always has one (the recorder, a
+    template sensor, an automation), and it is what keeps every flip visible to
+    the tracker. With only synchronous callbacks on the bus the loop happens to
+    die out after a handful of iterations and the test would pass vacuously;
+    with one, the *unguarded* loop is unbounded — measured at >9000 refreshes
+    before the harness timed out, versus the five below.
+
+    The start/end clock is blanked so ``is_active`` reduces to the gate verdict
+    alone; otherwise the loop's existence would depend on the machine's local
+    timezone (``TimeWindowManager.before_end_time`` reads a naive
+    ``datetime.now()``).
+    """
+    freezer.move_to(dt.datetime(2026, 6, 15, 17, 0, 0, tzinfo=dt.UTC))
+    entry = _make_entry(
+        hass,
+        "tt_loop_01",
+        {
+            CONF_START_TIME: BLANK_TIME,
+            CONF_END_TIME: BLANK_TIME,
+            CONF_DAYTIME_GATE_TEMPLATE: _LOOPING_GATE_TEMPLATE,
+        },
+    )
+
+    def _async_consumer(_event) -> None:
+        """Stand in for a real install's async consumer of the sensor.
+
+        Deliberately *not* ``@callback``-decorated — HA dispatches an
+        undecorated listener off the event loop, and that extra hop is what
+        keeps each flip in its own pass instead of letting the bus collapse
+        pairs of them.
+        """
+
+    async_track_state_change_event(
+        hass, ["sensor.dining_room_shade_control_status"], _async_consumer
+    )
+
+    refreshes: list[None] = []
+    real_refresh = AdaptiveDataUpdateCoordinator.async_refresh
+
+    async def _counting_refresh(self) -> None:
+        refreshes.append(None)
+        if len(refreshes) > _REFRESH_CAP:
+            return
+        await real_refresh(self)
+
+    with patch.object(
+        AdaptiveDataUpdateCoordinator, "async_refresh", _counting_refresh
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        settled = len(refreshes)
+        assert settled <= 8, (
+            f"Setup drove {settled} refreshes — the self-referencing gate template "
+            "is spinning instead of being coalesced."
+        )
+
+        per_window: list[int] = []
+        for _ in range(5):
+            before = len(refreshes)
+            freezer.tick(1.2)
+            async_fire_time_changed(hass)
+            await hass.async_block_till_done()
+            per_window.append(len(refreshes) - before)
+
+        assert per_window == [1, 1, 1, 1, 1], (
+            "Each cooldown window must yield exactly one refresh: >1 means the "
+            "loop is not bounded, 0 means the deferred flip was dropped instead "
+            f"of deferred. Got {per_window}."
+        )
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
 
 
 async def test_namespace_context_is_passed_to_every_tracker(

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -67,9 +67,8 @@ async def test_plain_template_tracker_fires_on_dependency_change(
 ) -> None:
     """A template over an ordinary entity still reaches the coordinator callback.
 
-    The invariant guard for the whole #1159 change: passing a render context and
-    a rate limit to ``TrackTemplate`` must not cost an ordinary template its
-    immediacy.
+    The invariant guard for the whole #1159 change: passing a render context to
+    ``TrackTemplate`` must not cost an ordinary template its immediacy.
     """
     entry = _make_entry(
         hass,

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.event import async_track_state_change_event
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
@@ -255,6 +256,90 @@ async def test_only_namespace_templates_have_their_refreshes_coalesced(
         assert acp_fired.call_count == 2, (
             "The coalesced flips must still produce a trailing run when the "
             "window closes — coalescing drops nothing."
+        )
+
+
+async def test_unload_cancels_the_coalescer_pending_trailing_run(
+    hass: HomeAssistant, freezer
+) -> None:
+    """Unloading the entry must kill the coalescer's deferred run.
+
+    ``_coalesce_namespace_refreshes`` schedules a trailing timer that outlives
+    the tracker: HA's :class:`~homeassistant.helpers.debounce.Debouncer` owns its
+    own ``loop.call_later`` handle, so removing the template tracker on unload
+    does nothing to it. Without ``entry.async_on_unload(debouncer.async_shutdown)``
+    that timer still fires after teardown and replays the deferred flip into a
+    coordinator that has already been unloaded.
+
+    The suite cannot catch that leak by accident: ``conftest`` returns
+    ``expected_lingering_timers = True`` for every ``@pytest.mark.integration``
+    test, which is every test that reaches ``_register_template_tracker``. So the
+    guard has to be explicit — drive the debouncer into a pending state, unload,
+    then let the window close and assert nothing ran.
+    """
+    entry = _make_entry(
+        hass,
+        "tt_unload_01",
+        {CONF_MOTION_TEMPLATE: "{{ is_state(acp.sun_infront, 'on') }}"},
+    )
+    sun_infront = _preseed_sun_infront(hass, entry)
+    hass.states.async_set(sun_infront, "off")
+
+    debouncers: list[Debouncer] = []
+
+    class _RecordingDebouncer(Debouncer):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            debouncers.append(self)
+
+    with (
+        patch("custom_components.adaptive_cover_pro.Debouncer", _RecordingDebouncer),
+        patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "async_check_motion_template_change",
+            new_callable=AsyncMock,
+        ) as fired,
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        fired.reset_mock()
+
+        # Two flips inside one cooldown: the first runs on the leading edge, the
+        # second is deferred — which is the state that leaks.
+        for state in ("on", "off"):
+            hass.states.async_set(sun_infront, state)
+            await hass.async_block_till_done()
+
+        assert len(debouncers) == 1, (
+            "Exactly one namespace template is configured, so exactly one "
+            f"coalescing Debouncer should exist. Got {len(debouncers)}."
+        )
+        debouncer = debouncers[0]
+        assert fired.call_count == 1
+        assert debouncer._timer_task is not None, (
+            "Precondition: the second flip must leave a live trailing timer, "
+            "otherwise this test proves nothing about cancelling one."
+        )
+        assert (
+            debouncer._execute_at_end_of_timer is True
+        ), "Precondition: a run must actually be queued for the trailing edge."
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert debouncer._timer_task is None, (
+            "Unload must cancel the coalescer's scheduled trailing timer — the "
+            "entry.async_on_unload(debouncer.async_shutdown) wiring."
+        )
+
+        freezer.tick(1.2)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        assert fired.call_count == 1, (
+            "The deferred flip must not be replayed after unload: that runs a "
+            "refresh against a torn-down coordinator."
         )
 
 

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -1,0 +1,257 @@
+"""Tracked-template immediacy and ``acp`` context wiring (issue #1159).
+
+``_register_template_tracker`` exists to give a template-only override
+sensor-grade immediacy — the cover reacts the instant the template flips, with
+no companion binary sensor and no polling (#577/#563/#639/#632/#974). That
+property is invisible to every other test in the suite: they assert the
+manager-level fold, not the tracker's listener set. This file guards it
+directly, for plain templates and for templates written against the ``acp``
+namespace, plus the coordinator-side wiring that hands every render site the
+same context.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.adaptive_cover_pro.const import (
+    CONF_DAYTIME_GATE_TEMPLATE,
+    CONF_MOTION_TEMPLATE,
+)
+from custom_components.adaptive_cover_pro.coordinator import (
+    AdaptiveDataUpdateCoordinator,
+)
+from tests._helpers.acp_namespace import make_acp_entry, seed_sun_infront
+from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
+
+pytestmark = pytest.mark.integration
+
+
+def _make_entry(hass: HomeAssistant, entry_id: str, options: dict) -> MockConfigEntry:
+    entry = make_acp_entry(hass, entry_id, options={**VERTICAL_OPTIONS, **options})
+    hass.states.async_set(
+        "sun.sun", "above_horizon", {"azimuth": 180.0, "elevation": 45.0}
+    )
+    hass.states.async_set(
+        "cover.test_blind", "open", {"current_position": 100, "supported_features": 143}
+    )
+    return entry
+
+
+def _preseed_sun_infront(hass: HomeAssistant, entry: MockConfigEntry) -> str:
+    """Create the Sun Infront registry row ahead of setup.
+
+    Mirrors the common real-world case (HA restart / options save): the entity
+    registry is loaded early and already holds this entry's rows, so the
+    namespace resolves at tracker-registration time. The unique_id matches what
+    ``binary_sensor.py`` builds, so the real entity adopts this exact row.
+    """
+    return seed_sun_infront(hass, entry)
+
+
+async def test_plain_template_tracker_fires_on_dependency_change(
+    hass: HomeAssistant,
+) -> None:
+    """A template over an ordinary entity still reaches the coordinator callback.
+
+    The invariant guard for the whole #1159 change: passing a render context and
+    a rate limit to ``TrackTemplate`` must not cost an ordinary template its
+    immediacy.
+    """
+    entry = _make_entry(
+        hass,
+        "tt_plain_01",
+        {CONF_MOTION_TEMPLATE: "{{ is_state('input_boolean.guests', 'on') }}"},
+    )
+    hass.states.async_set("input_boolean.guests", "off")
+
+    with (
+        patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "async_check_motion_template_change",
+            new_callable=AsyncMock,
+        ) as fired,
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        fired.reset_mock()
+        hass.states.async_set("input_boolean.guests", "on")
+        await hass.async_block_till_done()
+
+        assert fired.called, (
+            "A plain motion template must still fire its tracked-result callback "
+            "when its dependency flips (immediacy contract, #577)."
+        )
+
+
+async def test_acp_namespace_template_tracker_fires_on_own_entity_change(
+    hass: HomeAssistant,
+) -> None:
+    """A namespace self-reference records a real state listener (#1159).
+
+    ``acp.sun_infront`` resolves to an entity_id *string*, so ``is_state()``
+    still records the dependency in ``RenderInfo`` — which is the only reason
+    the tracker fires at all.
+    """
+    entry = _make_entry(
+        hass,
+        "tt_acp_01",
+        {CONF_MOTION_TEMPLATE: "{{ is_state(acp.sun_infront, 'on') }}"},
+    )
+    entity_id = _preseed_sun_infront(hass, entry)
+    hass.states.async_set(entity_id, "off")
+
+    with (
+        patch.object(
+            AdaptiveDataUpdateCoordinator,
+            "async_check_motion_template_change",
+            new_callable=AsyncMock,
+        ) as fired,
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        fired.reset_mock()
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+
+        assert fired.called, (
+            "A template using the acp namespace must be tracked through the "
+            "resolved entity_id, so flipping that entity fires the callback."
+        )
+
+
+async def test_rate_limit_only_on_namespace_templates(hass: HomeAssistant) -> None:
+    """Only namespace templates carry the loop-guard rate limit.
+
+    A self-reference can drive its own input and the coordinator has no
+    debouncer, so those get a 1 s trailing-render cap. Everything else keeps the
+    existing byte-for-byte behaviour: no rate limit at all.
+    """
+    acp_template = "{{ is_state(acp.sun_infront, 'on') }}"
+    plain_template = "{{ states('sensor.lux') | int > 100 }}"
+    entry = _make_entry(
+        hass,
+        "tt_rate_01",
+        {
+            CONF_MOTION_TEMPLATE: acp_template,
+            CONF_DAYTIME_GATE_TEMPLATE: plain_template,
+        },
+    )
+    _preseed_sun_infront(hass, entry)
+
+    captured: dict[str, float | None] = {}
+
+    from homeassistant.helpers import event as ha_event
+
+    original = ha_event.async_track_template_result
+
+    def _capture(hass_, track_templates, action, **kwargs):
+        for tt in track_templates:
+            captured[tt.template.template] = tt.rate_limit
+        return original(hass_, track_templates, action, **kwargs)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.async_track_template_result",
+            side_effect=_capture,
+        ),
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        captured[acp_template] == 1.0
+    ), "A template using the acp namespace must carry the loop-guard rate limit."
+    assert captured[plain_template] is None, (
+        "A template that does not use the acp namespace must keep its unthrottled "
+        "immediacy — no rate limit."
+    )
+
+
+async def test_namespace_context_is_passed_to_every_tracker(
+    hass: HomeAssistant,
+) -> None:
+    """Every registration gets the same context, namespace-using or not.
+
+    One context for the tracker's render and the manager's cycle render is what
+    keeps the two from ever disagreeing.
+    """
+    plain_template = "{{ states('sensor.lux') | int > 100 }}"
+    entry = _make_entry(hass, "tt_ctx_01", {CONF_DAYTIME_GATE_TEMPLATE: plain_template})
+
+    captured: dict[str, object] = {}
+
+    from homeassistant.helpers import event as ha_event
+
+    original = ha_event.async_track_template_result
+
+    def _capture(hass_, track_templates, action, **kwargs):
+        for tt in track_templates:
+            captured[tt.template.template] = tt.variables
+        return original(hass_, track_templates, action, **kwargs)
+
+    with (
+        patch(
+            "custom_components.adaptive_cover_pro.async_track_template_result",
+            side_effect=_capture,
+        ),
+        _patch_coordinator_refresh(),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert set(captured[plain_template]) == {"acp", "acp_entity"}, (
+        "Tracked templates get the entity forms only — never acp_state, whose "
+        "value reads are invisible to RenderInfo."
+    )
+
+
+async def test_coordinator_threads_one_context_to_every_render_site(
+    hass: HomeAssistant,
+) -> None:
+    """Every collaborator that renders an option template shares the coordinator's context.
+
+    The no-duplication guard for #1159: one factory, one context per flavour, no
+    render site building its own. ``acp_state`` reaches only the untracked
+    numeric resolver.
+    """
+    entry = _make_entry(hass, "tt_wiring_01", {})
+
+    with _patch_coordinator_refresh():
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data
+    entity_ctx = coordinator._template_variables
+    assert set(entity_ctx) == {"acp", "acp_entity"}
+    assert set(coordinator._template_variables_with_state) == {
+        "acp",
+        "acp_entity",
+        "acp_state",
+    }
+
+    for owner, attr in (
+        (coordinator._motion_mgr, "_template_variables"),
+        (coordinator._weather_mgr, "_template_variables"),
+        (coordinator._time_mgr, "_template_variables"),
+        (coordinator._climate_provider, "_template_variables"),
+        (coordinator._snapshot_builder, "_template_variables"),
+    ):
+        assert getattr(owner, attr) is entity_ctx, (
+            f"{type(owner).__name__} must render against the coordinator's one "
+            "entity-form context, not its own."
+        )
+
+    assert (
+        coordinator._template_resolver._variables
+        is coordinator._template_variables_with_state
+    ), "The numeric resolver is the one render site that also gets acp_state."

--- a/tests/test_template_tracker_immediacy.py
+++ b/tests/test_template_tracker_immediacy.py
@@ -34,7 +34,12 @@ from custom_components.adaptive_cover_pro.const import (
 from custom_components.adaptive_cover_pro.coordinator import (
     AdaptiveDataUpdateCoordinator,
 )
-from tests._helpers.acp_namespace import make_acp_entry, seed_sun_infront
+from tests._helpers.acp_namespace import (
+    acp_variables,
+    make_acp_entry,
+    seed_acp_row,
+    seed_sun_infront,
+)
 from tests.ha_helpers import VERTICAL_OPTIONS, _patch_coordinator_refresh
 
 pytestmark = pytest.mark.integration
@@ -389,6 +394,17 @@ async def test_self_referencing_gate_template_refresh_is_bounded(
             CONF_DAYTIME_GATE_TEMPLATE: _LOOPING_GATE_TEMPLATE,
         },
     )
+    # Seed the row the gate template references, then ask the *production*
+    # resolver what entity_id that is. The consumer has to be subscribed before
+    # setup — it is what keeps each flip in its own pass — so the id cannot be
+    # read back after the platform registers, and hardcoding it would let an
+    # entity-naming change quietly unsubscribe the consumer. The loop would then
+    # die out and this test would fail as ``per_window == [0, 0, 0, 0, 0]``,
+    # reading as a coalescer regression rather than a broken fixture.
+    control_status = seed_acp_row(
+        hass, entry, "sensor", "control_status", "dining_room_shade_control_status"
+    )
+    assert control_status == acp_variables(hass, entry)["acp_entity"]("control_status")
 
     def _async_consumer(_event) -> None:
         """Stand in for a real install's async consumer of the sensor.
@@ -399,9 +415,7 @@ async def test_self_referencing_gate_template_refresh_is_bounded(
         pairs of them.
         """
 
-    async_track_state_change_event(
-        hass, ["sensor.dining_room_shade_control_status"], _async_consumer
-    )
+    unsub = async_track_state_change_event(hass, [control_status], _async_consumer)
 
     refreshes: list[None] = []
     real_refresh = AdaptiveDataUpdateCoordinator.async_refresh
@@ -412,34 +426,44 @@ async def test_self_referencing_gate_template_refresh_is_bounded(
             return
         await real_refresh(self)
 
-    with patch.object(
-        AdaptiveDataUpdateCoordinator, "async_refresh", _counting_refresh
-    ):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-        settled = len(refreshes)
-        assert settled <= 8, (
-            f"Setup drove {settled} refreshes — the self-referencing gate template "
-            "is spinning instead of being coalesced."
-        )
-
-        per_window: list[int] = []
-        for _ in range(5):
-            before = len(refreshes)
-            freezer.tick(1.2)
-            async_fire_time_changed(hass)
+    try:
+        with patch.object(
+            AdaptiveDataUpdateCoordinator, "async_refresh", _counting_refresh
+        ):
+            await hass.config_entries.async_setup(entry.entry_id)
             await hass.async_block_till_done()
-            per_window.append(len(refreshes) - before)
 
-        assert per_window == [1, 1, 1, 1, 1], (
-            "Each cooldown window must yield exactly one refresh: >1 means the "
-            "loop is not bounded, 0 means the deferred flip was dropped instead "
-            f"of deferred. Got {per_window}."
-        )
+            assert hass.states.get(control_status) is not None, (
+                "Precondition: the real control_status sensor must publish under "
+                f"{control_status!r}, the entity_id the stand-in consumer is "
+                "subscribed to. Without that the loop never reaches the consumer "
+                "and every assertion below passes or fails for fixture reasons."
+            )
 
-    await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
+            settled = len(refreshes)
+            assert settled <= 8, (
+                f"Setup drove {settled} refreshes — the self-referencing gate "
+                "template is spinning instead of being coalesced."
+            )
+
+            per_window: list[int] = []
+            for _ in range(5):
+                before = len(refreshes)
+                freezer.tick(1.2)
+                async_fire_time_changed(hass)
+                await hass.async_block_till_done()
+                per_window.append(len(refreshes) - before)
+
+            assert per_window == [1, 1, 1, 1, 1], (
+                "Each cooldown window must yield exactly one refresh: >1 means the "
+                "loop is not bounded, 0 means the deferred flip was dropped instead "
+                f"of deferred. Got {per_window}."
+            )
+
+        await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+    finally:
+        unsub()
 
 
 async def test_namespace_context_is_passed_to_every_tracker(

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,14 +1,17 @@
 """Tests for templated threshold options (issue #577).
 
 Covers the runtime resolver, the ``is_template_string`` predicate, the
-number-or-template service validators, the ``_num_or`` setup-time guard, and an
-end-to-end check that a templated lux threshold drives the climate read.
+number-or-template service validators, the ``_num_or`` setup-time guard, the
+``acp`` self-reference namespace (issue #1159), and an end-to-end check that a
+templated lux threshold drives the climate read.
 """
 
 import logging
 
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from jinja2.exceptions import UndefinedError
 
 from custom_components.adaptive_cover_pro.config_types import RuntimeConfig, _num_or
 from custom_components.adaptive_cover_pro.const import (
@@ -27,12 +30,19 @@ from custom_components.adaptive_cover_pro.services.options_service import (
 )
 from custom_components.adaptive_cover_pro.state.climate_provider import ClimateProvider
 from custom_components.adaptive_cover_pro.templates import (
+    ACP_TEMPLATE_ENTITY_KEYS,
+    ACP_TEMPLATE_KEY_ALIASES,
     TemplateResolver,
+    build_acp_template_variables,
     combine_with_mode,
+    fold_condition_template,
     is_template_string,
     render_condition,
+    render_condition_or_none,
+    uses_acp_namespace,
 )
 from homeassistant.exceptions import ServiceValidationError
+from tests._helpers.acp_namespace import make_acp_entry, seed_acp_row
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,6 +153,81 @@ class TestTemplateResolver:
         out = resolver.resolve({CONF_TEMP_EXTREME_HEAT: "{{ 30 }}"})
         assert out[CONF_TEMP_EXTREME_HEAT] == 30.0
 
+    @pytest.mark.parametrize(
+        ("state", "expected"),
+        [("on", 80.0), ("off", 30.0)],
+    )
+    async def test_acp_state_drives_a_numeric_threshold(
+        self, hass: HomeAssistant, state, expected
+    ):
+        """Numeric renders get all three forms, including the value form (#1159)."""
+        entry = make_acp_entry(hass, f"acp_num_{state}")
+        entity_id = seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", f"shade_{state}_sun_infront"
+        )
+        hass.states.async_set(entity_id, state)
+        await hass.async_block_till_done()
+
+        resolver = TemplateResolver(
+            hass,
+            variables=build_acp_template_variables(
+                hass, entry.entry_id, include_state=True
+            ),
+        )
+        out = resolver.resolve(
+            {CONF_LUX_THRESHOLD: "{{ 80 if acp_state.sun_infront == 'on' else 30 }}"}
+        )
+        assert out[CONF_LUX_THRESHOLD] == expected
+
+    async def test_acp_entity_form_drives_a_numeric_threshold(
+        self, hass: HomeAssistant
+    ):
+        """The entity_id forms work in numeric renders too, not just conditions."""
+        entry = make_acp_entry(hass, "acp_num_entity_form")
+        entity_id = seed_acp_row(
+            hass, entry, "switch", "sun_tracking", "shade_sun_tracking"
+        )
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+
+        resolver = TemplateResolver(
+            hass,
+            variables=build_acp_template_variables(
+                hass, entry.entry_id, include_state=True
+            ),
+        )
+        out = resolver.resolve(
+            {
+                CONF_LUX_THRESHOLD: (
+                    "{{ 900 if is_state(acp.sun_tracking, 'on') else 100 }}"
+                )
+            }
+        )
+        assert out[CONF_LUX_THRESHOLD] == 900.0
+
+    async def test_acp_unknown_key_drops_key_and_warns_once(
+        self, hass: HomeAssistant, caplog
+    ):
+        """Unresolvable key → field default, warned once per failure transition."""
+        entry = make_acp_entry(hass, "acp_num_bad")
+        resolver = TemplateResolver(
+            hass,
+            variables=build_acp_template_variables(
+                hass, entry.entry_id, include_state=True
+            ),
+        )
+        options = {CONF_LUX_THRESHOLD: "{{ acp_state.no_such_key }}", "name": "x"}
+        with caplog.at_level(logging.WARNING):
+            out = resolver.resolve(options)
+        assert CONF_LUX_THRESHOLD not in out
+        assert out["name"] == "x"
+        assert caplog.text.count("failed to render to a number") == 1
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            resolver.resolve(options)
+        assert "failed to render to a number" not in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # render_condition — boolean condition templates (motion occupancy, #577 f/u)
@@ -180,6 +265,94 @@ class TestRenderCondition:
     async def test_render_error_returns_default(self, hass: HomeAssistant):
         # References an undefined function → render raises → default.
         assert render_condition(hass, "{{ nonexistent_fn() }}") is False
+
+    async def test_acp_namespace_variables_resolve(self, hass: HomeAssistant):
+        """A condition template can name this instance's own binary sensor (#1159)."""
+        entry = make_acp_entry(hass, "acp_cond_ok")
+        entity_id = seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert (
+            render_condition(
+                hass, "{{ is_state(acp.sun_infront, 'on') }}", variables=ctx
+            )
+            is True
+        )
+        assert (
+            render_condition(
+                hass,
+                "{{ is_state(acp_entity('sun_infront'), 'on') }}",
+                variables=ctx,
+            )
+            is True
+        )
+        hass.states.async_set(entity_id, "off")
+        await hass.async_block_till_done()
+        assert (
+            render_condition(
+                hass, "{{ is_state(acp.sun_infront, 'on') }}", variables=ctx
+            )
+            is False
+        )
+
+    async def test_acp_unknown_key_falls_back_to_default(self, hass: HomeAssistant):
+        """UndefinedError is a TemplateError → the existing fail-soft path runs."""
+        entry = make_acp_entry(hass, "acp_cond_bad")
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        tmpl = "{{ is_state(acp.no_such_key, 'on') }}"
+        assert render_condition(hass, tmpl, variables=ctx) is False
+        assert render_condition(hass, tmpl, default=True, variables=ctx) is True
+
+    async def test_acp_or_none_unknown_key_has_no_opinion(self, hass: HomeAssistant):
+        entry = make_acp_entry(hass, "acp_cond_none")
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert (
+            render_condition_or_none(
+                hass, "{{ is_state(acp.no_such_key, 'on') }}", variables=ctx
+            )
+            is None
+        )
+
+    async def test_acp_or_none_renders_through(self, hass: HomeAssistant):
+        entry = make_acp_entry(hass, "acp_cond_or_none")
+        entity_id = seed_acp_row(
+            hass, entry, "switch", "automatic_control", "shade_automatic_control"
+        )
+        hass.states.async_set(entity_id, "off")
+        await hass.async_block_till_done()
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert (
+            render_condition_or_none(
+                hass, "{{ is_state(acp.automatic_control, 'on') }}", variables=ctx
+            )
+            is False
+        )
+
+    async def test_fold_condition_template_passes_variables_through(
+        self, hass: HomeAssistant
+    ):
+        entry = make_acp_entry(hass, "acp_cond_fold")
+        entity_id = seed_acp_row(
+            hass, entry, "binary_sensor", "manual_override", "shade_manual_override"
+        )
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert (
+            fold_condition_template(
+                hass,
+                "{{ is_state(acp.manual_override, 'on') }}",
+                "or",
+                others_truthy=False,
+                has_others=False,
+                variables=ctx,
+            )
+            is True
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -437,3 +610,170 @@ class TestEndToEnd:
         )
         # 500 lux <= 1000 threshold → sun considered absent (suppression fires).
         assert readings.lux_below_threshold is True
+
+
+# ---------------------------------------------------------------------------
+# acp self-reference namespace (issue #1159)
+# ---------------------------------------------------------------------------
+
+
+class TestAcpNamespace:
+    """The ``acp`` / ``acp_entity`` / ``acp_state`` self-reference namespace."""
+
+    async def test_canonical_key_resolves_to_entity_id(self, hass: HomeAssistant):
+        entry = make_acp_entry(hass, "acp_ns_01")
+        expected = seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert ctx["acp"].sun_motion == expected
+
+    async def test_alias_resolves_to_the_same_entity_id(self, hass: HomeAssistant):
+        """The maintainer's own ``sun_infront`` spelling must work (#1159)."""
+        entry = make_acp_entry(hass, "acp_ns_alias")
+        expected = seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert ctx["acp"].sun_infront == expected
+        assert ctx["acp"]["sun_infront"] == expected
+
+    async def test_acp_entity_callable_matches_attribute_form(
+        self, hass: HomeAssistant
+    ):
+        entry = make_acp_entry(hass, "acp_ns_callable")
+        expected = seed_acp_row(
+            hass, entry, "switch", "enabled_toggle", "dining_room_shade_integration"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert ctx["acp_entity"]("enabled_toggle") == expected
+        assert ctx["acp_entity"]("integration_enabled") == expected
+        assert ctx["acp_entity"]("enabled_toggle") == ctx["acp"].enabled_toggle
+
+    async def test_unknown_key_raises_undefined_error(self, hass: HomeAssistant):
+        entry = make_acp_entry(hass, "acp_ns_unknown")
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        with pytest.raises(UndefinedError) as err:
+            ctx["acp"].not_a_real_key
+        assert "not_a_real_key" in str(err.value)
+        assert "Vertical Dining Room Shade" in str(err.value)
+
+    async def test_known_key_without_an_entity_raises_undefined_error(
+        self, hass: HomeAssistant
+    ):
+        """``glare_active`` only exists when glare zones are on — absent → error."""
+        entry = make_acp_entry(hass, "acp_ns_absent")
+        seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        with pytest.raises(UndefinedError) as err:
+            ctx["acp"].glare_active
+        assert "glare_active" in str(err.value)
+        assert "Vertical Dining Room Shade" in str(err.value)
+
+    async def test_rename_is_picked_up_on_the_next_access(self, hass: HomeAssistant):
+        """No caching: a mid-run entity rename resolves on the very next read."""
+        entry = make_acp_entry(hass, "acp_ns_rename")
+        original = seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert ctx["acp"].sun_infront == original
+
+        reg = er.async_get(hass)
+        reg.async_update_entity(original, new_entity_id="binary_sensor.renamed_by_user")
+        await hass.async_block_till_done()
+
+        assert ctx["acp"].sun_infront == "binary_sensor.renamed_by_user"
+
+    async def test_acp_state_returns_the_state_string(self, hass: HomeAssistant):
+        entry = make_acp_entry(hass, "acp_ns_state")
+        entity_id = seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        hass.states.async_set(entity_id, "on")
+        await hass.async_block_till_done()
+
+        ctx = build_acp_template_variables(hass, entry.entry_id, include_state=True)
+        assert ctx["acp_state"].sun_infront == "on"
+
+    async def test_acp_state_is_unknown_when_the_entity_has_no_state(
+        self, hass: HomeAssistant
+    ):
+        entry = make_acp_entry(hass, "acp_ns_stateless")
+        seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id, include_state=True)
+        assert ctx["acp_state"].sun_infront == "unknown"
+
+    @pytest.mark.parametrize("namespace", ["acp", "acp_state"])
+    async def test_private_probes_look_like_ordinary_missing_attributes(
+        self, hass: HomeAssistant, namespace
+    ):
+        """The Jinja sandbox probes ``unsafe_callable``/``alters_data`` style names.
+
+        Those, and copy/pickle's dunder lookups, must raise ``AttributeError`` so
+        ``getattr(obj, name, default)`` returns the default — an ``UndefinedError``
+        there would escape from inside HA's sandbox checks.
+        """
+        entry = make_acp_entry(hass, f"acp_ns_probe_{namespace}")
+        ctx = build_acp_template_variables(hass, entry.entry_id, include_state=True)
+        ns = ctx[namespace]
+        with pytest.raises(AttributeError):
+            ns._not_a_public_key
+        assert getattr(ns, "__deepcopy__", "fallback") == "fallback"
+
+    async def test_state_namespace_is_withheld_unless_requested(
+        self, hass: HomeAssistant
+    ):
+        """Tracked/condition fields get the entity forms only — never ``acp_state``."""
+        entry = make_acp_entry(hass, "acp_ns_withheld")
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        assert set(ctx) == {"acp", "acp_entity"}
+        with_state = build_acp_template_variables(
+            hass, entry.entry_id, include_state=True
+        )
+        assert set(with_state) == {"acp", "acp_entity", "acp_state"}
+
+    async def test_another_entrys_entities_are_not_visible(self, hass: HomeAssistant):
+        """The namespace is per-instance: a sibling entry's row must not leak in."""
+        mine = make_acp_entry(hass, "acp_ns_mine")
+        theirs = make_acp_entry(hass, "acp_ns_theirs")
+        seed_acp_row(
+            hass, theirs, "binary_sensor", "sun_motion", "other_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, mine.entry_id)
+        with pytest.raises(UndefinedError):
+            ctx["acp"].sun_infront
+
+    @pytest.mark.parametrize(
+        ("template_str", "expected"),
+        [
+            ("{{ acp.sun_infront }}", True),
+            ("{{ is_state(acp_entity('sun_infront'), 'on') }}", True),
+            ("{{ acp_state.sun_infront == 'on' }}", True),
+            ("{{ states('sensor.acp_foo') }}", False),
+            ("{{ states('sensor.lux') | int > 100 }}", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_uses_acp_namespace(self, template_str, expected):
+        assert uses_acp_namespace(template_str) is expected
+
+    def test_every_alias_targets_a_real_key(self):
+        for alias, canonical in ACP_TEMPLATE_KEY_ALIASES.items():
+            assert (
+                canonical in ACP_TEMPLATE_ENTITY_KEYS
+            ), f"alias {alias!r} points at unknown key {canonical!r}"
+            assert (
+                alias not in ACP_TEMPLATE_ENTITY_KEYS
+            ), f"alias {alias!r} shadows a canonical key"
+
+    def test_key_map_records_its_own_translation_key(self):
+        """Canonical key == translation_key for every platform (the #1159 premise)."""
+        for key, (domain, translation_key) in ACP_TEMPLATE_ENTITY_KEYS.items():
+            assert translation_key == key
+            assert domain in ("binary_sensor", "switch", "sensor")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -773,7 +773,15 @@ class TestAcpNamespace:
             ), f"alias {alias!r} shadows a canonical key"
 
     def test_key_map_records_its_own_translation_key(self):
-        """Canonical key == translation_key for every platform (the #1159 premise)."""
+        """Canonical key == translation_key, on a domain some platform serves.
+
+        Only the map's internal shape — deliberately, because it is checked
+        against the platforms themselves in
+        ``test_spec_translation_keys.TestAcpNamespaceKeys``. That is the canary
+        that catches a key renamed in ``switch.py`` / ``sensor.py`` /
+        ``binary_sensor.py``; this one only keeps the map's two columns from
+        drifting apart.
+        """
         for key, (domain, translation_key) in ACP_TEMPLATE_ENTITY_KEYS.items():
             assert translation_key == key
             assert domain in ("binary_sensor", "switch", "sensor")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -656,7 +656,7 @@ class TestAcpNamespace:
         with pytest.raises(UndefinedError) as err:
             ctx["acp"].not_a_real_key
         assert "not_a_real_key" in str(err.value)
-        assert "Vertical Dining Room Shade" in str(err.value)
+        assert "Vertical Blind Dining Room Shade" in str(err.value)
 
     async def test_known_key_without_an_entity_raises_undefined_error(
         self, hass: HomeAssistant
@@ -670,7 +670,7 @@ class TestAcpNamespace:
         with pytest.raises(UndefinedError) as err:
             ctx["acp"].glare_active
         assert "glare_active" in str(err.value)
-        assert "Vertical Dining Room Shade" in str(err.value)
+        assert "Vertical Blind Dining Room Shade" in str(err.value)
 
     async def test_rename_is_picked_up_on_the_next_access(self, hass: HomeAssistant):
         """No caching: a mid-run entity rename resolves on the very next read."""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -41,7 +41,7 @@ from custom_components.adaptive_cover_pro.templates import (
     render_condition_or_none,
     uses_acp_namespace,
 )
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError, TemplateError
 from tests._helpers.acp_namespace import make_acp_entry, seed_acp_row
 
 _LOGGER = logging.getLogger(__name__)
@@ -724,6 +724,94 @@ class TestAcpNamespace:
         with pytest.raises(AttributeError):
             ns._not_a_public_key
         assert getattr(ns, "__deepcopy__", "fallback") == "fallback"
+
+    @pytest.mark.parametrize("namespace", ["acp", "acp_state"])
+    @pytest.mark.parametrize("probe", ["jinja_pass_arg", "unsafe_callable"])
+    async def test_capability_probes_take_their_default(
+        self, hass: HomeAssistant, namespace, probe
+    ):
+        """Jinja/HA capability probes must not be answered as bad entity keys.
+
+        ``jinja2.utils._PassArg.from_obj`` does ``hasattr(obj, "jinja_pass_arg")``
+        and ``SandboxedEnvironment.is_safe_callable`` does
+        ``getattr(obj, "unsafe_callable", False)`` — both on the way to calling
+        an object. Neither name starts with an underscore, so both used to reach
+        the resolver and be reported to the user as a key they never wrote.
+        """
+        entry = make_acp_entry(hass, f"acp_ns_cap_{namespace}_{probe}")
+        ctx = build_acp_template_variables(hass, entry.entry_id, include_state=True)
+        ns = ctx[namespace]
+        assert getattr(ns, probe, "fallback") == "fallback"
+        assert hasattr(ns, probe) is False
+
+    async def test_unknown_key_message_survives_the_attribute_error_base(
+        self, hass: HomeAssistant
+    ):
+        """A missing key still raises ``UndefinedError`` with the same message.
+
+        The probe fix gives attribute-access failures an ``AttributeError`` base;
+        this pins that it did not weaken the key error itself, which several
+        tests and the wiki's failure-mode section describe verbatim.
+        """
+        entry = make_acp_entry(hass, "acp_ns_dual_base")
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        with pytest.raises(UndefinedError) as err:
+            ctx["acp"].nope
+        assert str(err.value) == (
+            "'nope' is not an Adaptive Cover Pro entity key "
+            "(instance Vertical Blind Dining Room Shade)"
+        )
+        with pytest.raises(AttributeError):
+            ctx["acp"].nope
+
+    @pytest.mark.parametrize(
+        ("template_str", "expected_fragment"),
+        [
+            ("{{ acp('sun_infront') }}", "'acp' namespace is not callable"),
+            ("{{ acp_state('sun_infront') }}", "'acp_state' namespace is not callable"),
+            (
+                "{% for k in acp %}{{ k }}{% endfor %}",
+                "'acp' namespace is not iterable",
+            ),
+            ("{{ 'sun_infront' in acp }}", "'acp' namespace is not iterable"),
+            ("{{ acp | list }}", "'acp' namespace is not iterable"),
+        ],
+    )
+    async def test_namespace_misuse_names_the_real_problem(
+        self, hass: HomeAssistant, template_str, expected_fragment
+    ):
+        """Calling or iterating the namespace must not be reported as a bad key.
+
+        Before this, ``{{ acp('x') }}`` failed with ``'jinja_pass_arg' is not an
+        Adaptive Cover Pro entity key`` and both iteration spellings failed with
+        ``'0' is not …`` — Python's legacy ``__getitem__(0)`` iteration protocol.
+        Every one of these is fail-soft either way; the fix is the message.
+        """
+        from homeassistant.helpers.template import Template
+
+        entry = make_acp_entry(hass, "acp_ns_misuse")
+        seed_acp_row(
+            hass, entry, "binary_sensor", "sun_motion", "dining_room_shade_sun_infront"
+        )
+        ctx = build_acp_template_variables(hass, entry.entry_id, include_state=True)
+        with pytest.raises(TemplateError) as err:
+            Template(template_str, hass).async_render(ctx)
+        assert expected_fragment in str(err.value)
+
+    async def test_bracket_form_still_reports_an_unknown_key(self, hass: HomeAssistant):
+        """``acp['nope']`` keeps the key error rather than degrading to undefined.
+
+        ``SandboxedEnvironment.getitem`` swallows ``AttributeError``, so item
+        access must keep raising a plain ``UndefinedError`` — otherwise the
+        bracket spelling the wiki documents would silently render nothing.
+        """
+        from homeassistant.helpers.template import Template
+
+        entry = make_acp_entry(hass, "acp_ns_bracket_miss")
+        ctx = build_acp_template_variables(hass, entry.entry_id)
+        with pytest.raises(TemplateError) as err:
+            Template("{{ acp['nope'] }}", hass).async_render(ctx)
+        assert "'nope' is not an Adaptive Cover Pro entity key" in str(err.value)
 
     async def test_state_namespace_is_withheld_unless_requested(
         self, hass: HomeAssistant

--- a/tests/test_time_window_manager.py
+++ b/tests/test_time_window_manager.py
@@ -956,3 +956,45 @@ def test_after_start_time_with_utc_iso_sun_sensor_string():
         result = mgr.after_start_time
 
     assert result is True
+
+
+# ---------------------------------------------------------------------------
+# acp self-reference namespace in the daytime-gate template (issue #1159)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+async def test_gate_template_resolves_the_acp_namespace(hass):
+    """The daytime-gate template can name this instance's own entity (#1159)."""
+    from tests._helpers.acp_namespace import (
+        acp_variables,
+        make_acp_entry,
+        seed_acp_row,
+    )
+
+    entry = make_acp_entry(hass, "gate_acp_01")
+    entity_id = seed_acp_row(
+        hass, entry, "switch", "sun_tracking", "dining_room_shade_sun_tracking"
+    )
+    hass.states.async_set(entity_id, "on")
+    await hass.async_block_till_done()
+
+    mgr = TimeWindowManager(
+        hass=hass,
+        logger=MagicMock(),
+        template_variables=acp_variables(hass, entry),
+    )
+    mgr.update_config(
+        start_time=None,
+        start_time_entity=None,
+        end_time=None,
+        end_time_entity=None,
+        gate_sensors=[],
+        gate_template="{{ is_state(acp.sun_tracking, 'on') }}",
+        gate_template_mode="or",
+    )
+    assert mgr.effective_daytime_gate is True
+
+    hass.states.async_set(entity_id, "off")
+    await hass.async_block_till_done()
+    assert mgr.effective_daytime_gate is False

--- a/tests/test_weather_override.py
+++ b/tests/test_weather_override.py
@@ -691,3 +691,64 @@ def test_severe_template_in_building_profile_schema():
     keys = _schema_keys(building_profile_sensors_schema())
     assert CONF_WEATHER_SEVERE_TEMPLATE in keys
     assert CONF_WEATHER_SEVERE_TEMPLATE_MODE in keys
+
+
+# --- acp self-reference namespace in weather condition templates (issue #1159) ---
+
+
+def _make_weather_mgr_with_ctx(
+    hass,
+    entry,
+    *,
+    is_raining_template=None,
+    is_windy_template=None,
+    severe_template=None,
+):
+    """Build a real WeatherManager wired to *entry*'s acp render context."""
+    from tests._helpers.acp_namespace import acp_variables
+
+    mgr = WeatherManager(
+        hass=hass,
+        logger=MagicMock(),
+        template_variables=acp_variables(hass, entry),
+    )
+    mgr.update_config(
+        wind_speed_sensor=None,
+        wind_direction_sensor=None,
+        wind_speed_threshold=50.0,
+        wind_direction_tolerance=45,
+        win_azi=180,
+        rain_sensor=None,
+        rain_threshold=1.0,
+        is_raining_sensor=None,
+        is_windy_sensor=None,
+        severe_sensors=[],
+        timeout_seconds=300,
+        is_raining_template=is_raining_template,
+        is_windy_template=is_windy_template,
+        severe_template=severe_template,
+        enabled=True,
+    )
+    return mgr
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field", ["is_raining_template", "is_windy_template", "severe_template"]
+)
+async def test_weather_templates_resolve_the_acp_namespace(hass, field):
+    """All three weather fold sites thread the same render context (#1159)."""
+    from tests._helpers.acp_namespace import make_acp_entry, seed_sun_infront
+
+    entry = make_acp_entry(hass, f"weather_acp_{field}")
+    entity_id = seed_sun_infront(hass, entry, "on")
+    await hass.async_block_till_done()
+
+    mgr = _make_weather_mgr_with_ctx(
+        hass, entry, **{field: "{{ is_state(acp.sun_infront, 'on') }}"}
+    )
+    assert mgr.is_any_condition_active is True
+
+    hass.states.async_set(entity_id, "off")
+    await hass.async_block_till_done()
+    assert mgr.is_any_condition_active is False


### PR DESCRIPTION
## Summary

Option templates can now refer to this instance's own entities without a hardcoded, install-specific entity ID that breaks on rename. Three forms, one shared resolver keyed on `translation_key` via the entity registry:

- `acp.<key>` gives the entity ID, so `{{ is_state(acp.sun_infront, 'on') }}` works
- `acp_entity('<key>')` is the same thing, late bound
- `acp_state.<key>` gives the value directly, on the untracked numeric threshold fields only

`acp_state` is deliberately withheld from the tracked and condition fields. A value read is invisible to `RenderInfo`, so a tracked template using it would register no listeners and silently lose the sensor-grade immediacy shipped across #577/#563/#639/#632/#974.

Only discrete entities are exposed. Continuously varying sensors stay out, and refreshes driven by a namespace template run through a per-template `Debouncer(cooldown=1.0, immediate=True)` so a self reference cannot spin the coordinator. `TrackTemplate.rate_limit` was tried first and removed: HA's `_rate_limit_for_event` returns `None` whenever the changed entity is in `RenderInfo.entities`, which is exactly the `is_state(acp.x, ...)` shape, so it never fired.

The five option-template tracker registrations moved into one function called after `async_forward_entry_setups`, so a first-ever setup resolves the namespace and captures its dependency without needing a reload.

No new config option, no migration, no `MINOR_VERSION` bump, no new user-visible string.

Docs: [Template Self-References](https://github.com/jrhubott/adaptive-cover-pro/wiki/Template-Self-References).

## Testing

- ✅ 12008 tests passing

Three audit rounds. New guards include the `_register_template_tracker` immediacy invariant (previously uncovered), a real-loop boundedness test, the debouncer teardown, and a canary cross-checking all 22 namespace keys against the `translation_key` values the platforms actually register.

## Related Issues

Refs #1159
